### PR TITLE
ref: Use atexit only in init

### DIFF
--- a/sentry_sdk/_compat.py
+++ b/sentry_sdk/_compat.py
@@ -53,3 +53,27 @@ def with_metaclass(meta, *bases):
             return meta(name, bases, d)
 
     return type.__new__(metaclass, "temporary_class", (), {})
+
+
+def check_thread_support():
+    try:
+        from uwsgi import opt
+    except ImportError:
+        return
+
+    # When `threads` is passed in as a uwsgi option,
+    # `enable-threads` is implied on.
+    if "threads" in opt:
+        return
+
+    if str(opt.get("enable-threads", "0")).lower() in ("false", "off", "no", "0"):
+        from warnings import warn
+
+        warn(
+            Warning(
+                "We detected the use of uwsgi with disabled threads.  "
+                "This will cause issues with the transport you are "
+                "trying to use.  Please enable threading for uwsgi.  "
+                '(Enable the "enable-threads" flag).'
+            )
+        )

--- a/sentry_sdk/api.py
+++ b/sentry_sdk/api.py
@@ -1,5 +1,3 @@
-import atexit
-
 from .hub import Hub
 from .utils import EventHint
 from .client import Client, get_options
@@ -29,9 +27,7 @@ def _init_on_hub(hub, args, kwargs):
 
 def init(*args, **kwargs):
     """Initializes the SDK and optionally integrations."""
-    guard = _init_on_hub(Hub.main, args, kwargs)
-    atexit.register(guard._client.close)
-    return guard
+    return _init_on_hub(Hub.main, args, kwargs)
 
 
 def _init_on_current(*args, **kwargs):

--- a/sentry_sdk/api.py
+++ b/sentry_sdk/api.py
@@ -1,3 +1,5 @@
+import atexit
+
 from .hub import Hub
 from .utils import EventHint
 from .client import Client, get_options
@@ -27,7 +29,9 @@ def _init_on_hub(hub, args, kwargs):
 
 def init(*args, **kwargs):
     """Initializes the SDK and optionally integrations."""
-    return _init_on_hub(Hub.main, args, kwargs)
+    guard = _init_on_hub(Hub.main, args, kwargs)
+    atexit.register(guard._client.close)
+    return guard
 
 
 def _init_on_current(*args, **kwargs):

--- a/sentry_sdk/client.py
+++ b/sentry_sdk/client.py
@@ -11,9 +11,13 @@ from .utils import (
     convert_types,
     handle_in_app,
     get_type_name,
+    get_logger,
 )
 from .transport import make_transport
 from .consts import DEFAULT_OPTIONS, SDK_INFO
+
+
+logger = get_logger("sentry_sdk.errors")
 
 
 def get_options(*args, **kwargs):
@@ -81,7 +85,10 @@ class Client(object):
 
         before_send = self.options["before_send"]
         if before_send is not None:
-            event = before_send(event)
+            new_event = before_send(event)
+            if new_event is None:
+                logger.info("before send dropped event (%s)", event)
+            event = new_event
 
         # Postprocess the event in the very end so that annotated types do
         # generally not surface in before_send

--- a/sentry_sdk/client.py
+++ b/sentry_sdk/client.py
@@ -42,7 +42,7 @@ def get_options(*args, **kwargs):
 class Client(object):
     def __init__(self, *args, **kwargs):
         self.options = options = get_options(*args, **kwargs)
-        self._transport = make_transport(options)
+        self.transport = make_transport(options)
 
         request_bodies = ("always", "never", "small", "medium")
         if options["request_bodies"] not in request_bodies:
@@ -51,9 +51,6 @@ class Client(object):
                     request_bodies
                 )
             )
-
-        # XXX: we should probably only do this for the init()ed client
-        atexit.register(self.close)
 
     @property
     def dsn(self):
@@ -129,7 +126,7 @@ class Client(object):
 
     def capture_event(self, event, hint=None, scope=None):
         """Captures an event."""
-        if self._transport is None:
+        if self.transport is None:
             return
         rv = event.get("event_id")
         if rv is None:
@@ -137,16 +134,5 @@ class Client(object):
         if self._should_capture(event, hint, scope):
             event = self._prepare_event(event, hint, scope)
             if event is not None:
-                self._transport.capture_event(event)
+                self.transport.capture_event(event)
         return rv
-
-    def drain_events(self, timeout=None):
-        if timeout is None:
-            timeout = self.options["shutdown_timeout"]
-        if self._transport is not None:
-            self._transport.drain_events(timeout)
-
-    def close(self):
-        self.drain_events()
-        if self._transport is not None:
-            self._transport.close()

--- a/sentry_sdk/client.py
+++ b/sentry_sdk/client.py
@@ -140,12 +140,14 @@ class Client(object):
                 self.transport.capture_event(event)
         return rv
 
-    def close(self):
+    def close(self, timeout=None, shutdown_callback=None):
         """Closes the client which shuts down the transport in an
         orderly manner.
         """
         if self.transport is not None:
-            self.transport.shutdown()
+            if timeout is None:
+                timeout = self.options["shutdown_timeout"]
+            self.transport.shutdown(timeout=timeout, callback=shutdown_callback)
 
     def __enter__(self):
         return self

--- a/sentry_sdk/client.py
+++ b/sentry_sdk/client.py
@@ -136,3 +136,16 @@ class Client(object):
             if event is not None:
                 self.transport.capture_event(event)
         return rv
+
+    def close(self):
+        """Closes the client which shuts down the transport in an
+        orderly manner.
+        """
+        if self.transport is not None:
+            self.transport.shutdown()
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_value, tb):
+        self.close()

--- a/sentry_sdk/consts.py
+++ b/sentry_sdk/consts.py
@@ -1,4 +1,3 @@
-import os
 import socket
 
 

--- a/sentry_sdk/consts.py
+++ b/sentry_sdk/consts.py
@@ -1,4 +1,12 @@
+import os
 import socket
+
+
+def default_shutdown_callback(pending, timeout):
+    print("Sentry is attempting to send %i pending error messages" % pending)
+    print("Waiting up to %s seconds" % timeout)
+    print("Press Ctrl-%s to quit" % (os.name == "nt" and "Break" or "C"))
+
 
 VERSION = "0.1"
 DEFAULT_SERVER_NAME = socket.gethostname() if hasattr(socket, "gethostname") else None
@@ -10,6 +18,7 @@ DEFAULT_OPTIONS = {
     "environment": None,
     "server_name": DEFAULT_SERVER_NAME,
     "shutdown_timeout": 2.0,
+    "shutdown_callback": default_shutdown_callback,
     "integrations": [],
     "in_app_include": [],
     "in_app_exclude": [],

--- a/sentry_sdk/consts.py
+++ b/sentry_sdk/consts.py
@@ -2,12 +2,6 @@ import os
 import socket
 
 
-def default_shutdown_callback(pending, timeout):
-    print("Sentry is attempting to send %i pending error messages" % pending)
-    print("Waiting up to %s seconds" % timeout)
-    print("Press Ctrl-%s to quit" % (os.name == "nt" and "Break" or "C"))
-
-
 VERSION = "0.1"
 DEFAULT_SERVER_NAME = socket.gethostname() if hasattr(socket, "gethostname") else None
 DEFAULT_OPTIONS = {
@@ -18,7 +12,6 @@ DEFAULT_OPTIONS = {
     "environment": None,
     "server_name": DEFAULT_SERVER_NAME,
     "shutdown_timeout": 2.0,
-    "shutdown_callback": default_shutdown_callback,
     "integrations": [],
     "in_app_include": [],
     "in_app_exclude": [],

--- a/sentry_sdk/hub.py
+++ b/sentry_sdk/hub.py
@@ -9,8 +9,7 @@ from .utils import exc_info_from_error, event_from_exception, get_logger, Contex
 
 
 _local = ContextVar("sentry_current_hub")
-
-logger = get_logger(__name__)
+logger = get_logger("sentry_sdk.errors")
 
 
 @contextmanager

--- a/sentry_sdk/hub.py
+++ b/sentry_sdk/hub.py
@@ -159,6 +159,7 @@ class Hub(with_metaclass(HubMeta)):
         """Adds a breadcrumb."""
         client, scope = self._stack[-1]
         if client is None:
+            logger.info("Dropped breadcrumb because no client bound")
             return
 
         if not kwargs and len(args) == 1 and callable(args[0]):
@@ -173,11 +174,14 @@ class Hub(with_metaclass(HubMeta)):
         if crumb.get("type") is None:
             crumb["type"] = "default"
 
+        original_crumb = crumb
         if client.options["before_breadcrumb"] is not None:
             crumb = client.options["before_breadcrumb"](crumb)
 
         if crumb is not None:
             scope._breadcrumbs.append(crumb)
+        else:
+            logger.info("before breadcrumb dropped breadcrumb (%s)", original_crumb)
         while len(scope._breadcrumbs) >= client.options["max_breadcrumbs"]:
             scope._breadcrumbs.popleft()
 

--- a/sentry_sdk/integrations/__init__.py
+++ b/sentry_sdk/integrations/__init__.py
@@ -11,10 +11,12 @@ def _get_default_integrations():
     from .logging import LoggingIntegration
     from .excepthook import ExcepthookIntegration
     from .dedupe import DedupeIntegration
+    from .atexit import AtexitIntegration
 
     yield LoggingIntegration
     yield ExcepthookIntegration
     yield DedupeIntegration
+    yield AtexitIntegration
 
 
 def setup_integrations(options):

--- a/sentry_sdk/integrations/atexit.py
+++ b/sentry_sdk/integrations/atexit.py
@@ -1,0 +1,30 @@
+import os
+import atexit
+
+from sentry_sdk.hub import Hub
+from sentry_sdk.utils import logger
+from . import Integration
+
+
+def default_shutdown_callback(pending, timeout):
+    print("Sentry is attempting to send %i pending error messages" % pending)
+    print("Waiting up to %s seconds" % timeout)
+    print("Press Ctrl-%s to quit" % (os.name == "nt" and "Break" or "C"))
+
+
+class AtexitIntegration(Integration):
+    identifier = "atexit"
+
+    def __init__(self, callback=None):
+        if callback is None:
+            callback = default_shutdown_callback
+        self.callback = callback
+
+    def install(self):
+        @atexit.register
+        def _shutdown():
+            main_client = Hub.main.client
+            logger.debug("atexit: got shutdown signal")
+            if main_client is not None:
+                logger.debug("atexit: shutting down client")
+                main_client.close(shutdown_callback=self.callback)

--- a/sentry_sdk/integrations/atexit.py
+++ b/sentry_sdk/integrations/atexit.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import
+
 import os
 import atexit
 

--- a/sentry_sdk/transport.py
+++ b/sentry_sdk/transport.py
@@ -9,13 +9,13 @@ import logging
 import threading
 import certifi
 import sys
-import traceback
 import gzip
 
 from datetime import datetime, timedelta
 
 from ._compat import queue
 from .consts import VERSION
+from .utils import get_logger
 
 try:
     from urllib.request import getproxies
@@ -23,7 +23,7 @@ except ImportError:
     from urllib import getproxies
 
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 
 def _make_pool(dsn, http_proxy, https_proxy):
@@ -108,8 +108,7 @@ def spawn_thread(transport):
             try:
                 disabled_until = send_event(transport._pool, item, auth)
             except Exception:
-                # XXX: use the logger
-                print(traceback.format_exc(), file=sys.stderr)
+                logger.error('Could not send event', exc_info=sys.exc_info())
             finally:
                 q.task_done()
 

--- a/sentry_sdk/transport.py
+++ b/sentry_sdk/transport.py
@@ -1,6 +1,5 @@
 from __future__ import print_function
 
-import atexit
 import json
 import io
 import urllib3

--- a/sentry_sdk/transport.py
+++ b/sentry_sdk/transport.py
@@ -93,7 +93,7 @@ def spawn_thread(transport):
             try:
                 disabled_until = send_event(transport._pool, item, auth)
             except Exception:
-                print("Could not send sentry event", file=sys.stderr)
+                # XXX: use the logger
                 print(traceback.format_exc(), file=sys.stderr)
             finally:
                 queue.task_done()

--- a/sentry_sdk/utils.py
+++ b/sentry_sdk/utils.py
@@ -527,7 +527,9 @@ def strip_string(value, assume_length=None, max_length=512):
 def get_logger(name):
     rv = logging.getLogger(name)
     if not rv.handlers:
-        rv.addHandler(logging.StreamHandler(sys.stderr))
+        handler = logging.StreamHandler(sys.stderr)
+        handler.setFormatter(logging.Formatter(" [sentry] %(levelname)s: %(message)s"))
+        rv.addHandler(handler)
         rv.setLevel(logging.DEBUG)
     return rv
 

--- a/sentry_sdk/utils.py
+++ b/sentry_sdk/utils.py
@@ -523,7 +523,7 @@ def strip_string(value, assume_length=None, max_length=512):
     return value[:max_length]
 
 
-logger = logging.getLogger("sentry.errors")
+logger = logging.getLogger("sentry_sdk.errors")
 if not logger.handlers:
     _handler = logging.StreamHandler(sys.stderr)
     _handler.setFormatter(logging.Formatter(" [sentry] %(levelname)s: %(message)s"))

--- a/sentry_sdk/worker.py
+++ b/sentry_sdk/worker.py
@@ -58,12 +58,10 @@ class BackgroundWorker(object):
                 self._thread.start()
                 self._thread_for_pid = os.getpid()
 
-    def stop(self, timeout=None):
+    def kill(self):
         with self._lock:
             if self._thread:
                 self._queue.put_nowait(_TERMINATOR)
-                if timeout is not None:
-                    self._thread.join(timeout=timeout)
                 self._thread = None
                 self._thread_for_pid = None
 

--- a/sentry_sdk/worker.py
+++ b/sentry_sdk/worker.py
@@ -1,0 +1,99 @@
+import logging
+import threading
+import os
+
+from time import sleep, time
+from ._compat import queue, check_thread_support
+from .utils import get_logger
+
+
+_TERMINATOR = object()
+logger = get_logger("sentry_sdk.errors")
+
+
+class BackgroundWorker(object):
+    def __init__(
+        self, shutdown_timeout=10, initial_timeout=0.2, shutdown_callback=None
+    ):
+        check_thread_support()
+        self._queue = queue.Queue(-1)
+        self._lock = threading.Lock()
+        self._thread = None
+        self._thread_for_pid = None
+        self.initial_timeout = initial_timeout
+        self.shutdown_timeout = shutdown_timeout
+        self.shutdown_callback = shutdown_callback
+
+    @property
+    def is_alive(self):
+        if self._thread_for_pid != os.getpid():
+            return False
+        return self._thread and self._thread.is_alive()
+
+    def _ensure_thread(self):
+        if not self.is_alive:
+            self.start()
+
+    def _timed_queue_join(self, timeout):
+        deadline = time() + timeout
+        queue = self._queue
+        queue.all_tasks_done.acquire()
+        try:
+            while queue.unfinished_tasks:
+                delay = deadline - time()
+                if delay <= 0:
+                    return False
+                queue.all_tasks_done.wait(timeout=delay)
+            return True
+        finally:
+            queue.all_tasks_done.release()
+
+    def start(self):
+        with self._lock:
+            if not self.is_alive:
+                self._thread = threading.Thread(
+                    target=self._target, name="raven-sentry.BackgroundWorker"
+                )
+                self._thread.setDaemon(True)
+                self._thread.start()
+                self._thread_for_pid = os.getpid()
+
+    def stop(self, timeout=None):
+        with self._lock:
+            if self._thread:
+                self._queue.put_nowait(_TERMINATOR)
+                if timeout is not None:
+                    self._thread.join(timeout=timeout)
+                self._thread = None
+                self._thread_for_pid = None
+
+    def shutdown(self):
+        with self._lock:
+            if not self.is_alive:
+                return
+            self._queue.put_nowait(_TERMINATOR)
+            timeout = self.shutdown_timeout
+            initial_timeout = min(self.initial_timeout, timeout)
+            if not self._timed_queue_join(initial_timeout):
+                if self.shutdown_callback is not None:
+                    self.shutdown_callback(self._queue.qsize(), timeout)
+                self._timed_queue_join(timeout - initial_timeout)
+            self._thread = None
+
+    def submit(self, callback):
+        self._ensure_thread()
+        self._queue.put_nowait(callback)
+
+    def _target(self):
+        while True:
+            callback = self._queue.get()
+            try:
+                if callback is _TERMINATOR:
+                    break
+                try:
+                    callback()
+                except Exception:
+                    logger.error("Failed processing job", exc_info=True)
+            finally:
+                self._queue.task_done()
+            sleep(0)

--- a/sentry_sdk/worker.py
+++ b/sentry_sdk/worker.py
@@ -10,17 +10,12 @@ _TERMINATOR = object()
 
 
 class BackgroundWorker(object):
-    def __init__(
-        self, shutdown_timeout=10, initial_timeout=0.2, shutdown_callback=None
-    ):
+    def __init__(self):
         check_thread_support()
         self._queue = queue.Queue(-1)
         self._lock = threading.Lock()
         self._thread = None
         self._thread_for_pid = None
-        self.initial_timeout = initial_timeout
-        self.shutdown_timeout = shutdown_timeout
-        self.shutdown_callback = shutdown_callback
 
     @property
     def is_alive(self):
@@ -57,29 +52,28 @@ class BackgroundWorker(object):
                 self._thread_for_pid = os.getpid()
 
     def kill(self):
-        logger.debug("Transport got kill request")
+        logger.debug("background worker got kill request")
         with self._lock:
             if self._thread:
                 self._queue.put_nowait(_TERMINATOR)
                 self._thread = None
                 self._thread_for_pid = None
 
-    def shutdown(self):
-        logger.debug("Transport got shutdown request")
+    def shutdown(self, timeout, callback=None):
+        logger.debug("background worker got shutdown request")
         with self._lock:
             if not self.is_alive:
                 return
             self._queue.put_nowait(_TERMINATOR)
-            timeout = self.shutdown_timeout
-            initial_timeout = min(self.initial_timeout, timeout)
+            initial_timeout = min(0.1, timeout)
             if not self._timed_queue_join(initial_timeout):
                 pending = self._queue.qsize()
                 logger.debug("%d event(s) pending on shutdown", pending)
-                if self.shutdown_callback is not None:
-                    self.shutdown_callback(pending, timeout)
+                if callback is not None:
+                    callback(pending, timeout)
                 self._timed_queue_join(timeout - initial_timeout)
             self._thread = None
-        logger.debug("Transport shut down")
+        logger.debug("background worker shut down")
 
     def submit(self, callback):
         self._ensure_thread()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -89,16 +89,9 @@ def sentry_init(monkeypatch_test_transport, assert_semaphore_acceptance):
 
 class TestTransport(Transport):
     def __init__(self, capture_event_callback):
+        Transport.__init__(self)
         self.capture_event = capture_event_callback
         self._queue = None
-
-    def start(self):
-        pass
-
-    def close(self):
-        pass
-
-    dsn = "LOL"
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -33,7 +33,7 @@ def reraise_internal_exceptions(request, monkeypatch):
 def monkeypatch_test_transport(monkeypatch, assert_semaphore_acceptance):
     def inner(client):
         monkeypatch.setattr(
-            client, "_transport", TestTransport(assert_semaphore_acceptance)
+            client, "transport", TestTransport(assert_semaphore_acceptance)
         )
 
     return inner
@@ -106,13 +106,13 @@ def capture_events(monkeypatch):
     def inner():
         events = []
         test_client = sentry_sdk.Hub.current.client
-        old_capture_event = test_client._transport.capture_event
+        old_capture_event = test_client.transport.capture_event
 
         def append(event):
             events.append(event)
             return old_capture_event(event)
 
-        monkeypatch.setattr(test_client._transport, "capture_event", append)
+        monkeypatch.setattr(test_client.transport, "capture_event", append)
         return events
 
     return inner

--- a/tests/integrations/excepthook/test_excepthook.py
+++ b/tests/integrations/excepthook/test_excepthook.py
@@ -12,11 +12,11 @@ def test_excepthook(tmpdir):
             """
     from sentry_sdk import init, transport
 
-    def send_event(pool, event, auth):
+    def send_event(self, event):
         print("capture event was called")
         print(event)
 
-    transport.send_event = send_event
+    transport.HttpTransport._send_event = send_event
 
     init("http://foobar@localhost/123")
 
@@ -31,6 +31,7 @@ def test_excepthook(tmpdir):
         subprocess.check_output([sys.executable, str(app)], stderr=subprocess.STDOUT)
 
     output = excinfo.value.output
+    print(output)
 
     assert b"ZeroDivisionError" in output
     assert b"LOL" in output

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -148,7 +148,7 @@ def test_transport_works(httpserver, request, capsys):
 
     add_breadcrumb(level="info", message="i like bread", timestamp=datetime.now())
     capture_message("löl")
-    client.transport.wait_and_close()
+    client.close()
 
     out, err = capsys.readouterr()
     assert not err and not out

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -75,11 +75,11 @@ def test_atexit(tmpdir, monkeypatch, num_messages):
     import time
     from sentry_sdk import init, transport, capture_message
 
-    def send_event(pool, event, auth):
+    def send_event(self, event):
         time.sleep(0.1)
         print(event["message"])
 
-    transport.send_event = send_event
+    transport.HttpTransport._send_event = send_event
     init("http://foobar@localhost/123", shutdown_timeout={num_messages})
 
     for _ in range({num_messages}):
@@ -148,7 +148,7 @@ def test_transport_works(httpserver, request, capsys):
 
     add_breadcrumb(level="info", message="i like bread", timestamp=datetime.now())
     capture_message("löl")
-    client.drain_events()
+    client.transport.wait_and_close()
 
     out, err = capsys.readouterr()
     assert not err and not out


### PR DESCRIPTION
This uses the same logic as the old raven python background worker which is to block in the atexit running thread on the lock the background worker has. This way the demon thread can be kept alive a while longer to orderly start the shutdown.