### PR TITLE
feat: Add breadcrumb hints

### DIFF
--- a/sentry_sdk/hub.py
+++ b/sentry_sdk/hub.py
@@ -161,6 +161,12 @@ class Hub(with_metaclass(HubMeta)):
             logger.info("Dropped breadcrumb because no client bound")
             return
 
+        hint = kwargs.pop("hint", None)
+        if not hint:
+            hint = {}
+        else:
+            hint = dict(hint)
+
         if not kwargs and len(args) == 1 and callable(args[0]):
             crumb = args[0]()
         else:
@@ -175,7 +181,7 @@ class Hub(with_metaclass(HubMeta)):
 
         original_crumb = crumb
         if client.options["before_breadcrumb"] is not None:
-            crumb = client.options["before_breadcrumb"](crumb)
+            crumb = client.options["before_breadcrumb"](crumb, hint)
 
         if crumb is not None:
             scope._breadcrumbs.append(crumb)

--- a/sentry_sdk/integrations/logging.py
+++ b/sentry_sdk/integrations/logging.py
@@ -90,7 +90,9 @@ class SentryHandler(logging.Handler, object):
                 capture_event(event, hint=hint)
 
         with _internal_exceptions():
-            add_breadcrumb(self._breadcrumb_from_record(record))
+            add_breadcrumb(
+                self._breadcrumb_from_record(record), hint={"log_record": record}
+            )
 
     def _logging_to_event_level(self, levelname):
         return {"critical": "fatal"}.get(levelname.lower(), levelname.lower())

--- a/sentry_sdk/integrations/requests.py
+++ b/sentry_sdk/integrations/requests.py
@@ -30,6 +30,7 @@ class RequestsIntegration(Integration):
                         or None,
                         "reason": response is not None and response.reason or None,
                     },
+                    hint={"requests_response": response},
                 )
 
             try:

--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -55,7 +55,8 @@ def test_option_callback(sentry_init, capture_events):
             event["extra"] = {"foo": "bar"}
             return event
 
-    def before_breadcrumb(crumb):
+    def before_breadcrumb(crumb, hint):
+        assert hint == {"foo": 42}
         if not drop_breadcrumbs:
             crumb["data"] = {"foo": "bar"}
             return crumb
@@ -64,7 +65,7 @@ def test_option_callback(sentry_init, capture_events):
     events = capture_events()
 
     def do_this():
-        add_breadcrumb(message="Hello")
+        add_breadcrumb(message="Hello", hint={"foo": 42})
         try:
             raise ValueError("aha!")
         except Exception:


### PR DESCRIPTION
I wonder if we could just put the hint on the breadcrumb itself and pop it
before sending? I am unhappy that the hint argument for before_breadcrumb is
now mandatory.