### PR TITLE
feat: Disable thread joining on transport shutdown if timeout is 0

### DIFF
--- a/sentry_sdk/transport.py
+++ b/sentry_sdk/transport.py
@@ -135,7 +135,10 @@ class HttpTransport(Transport):
 
     def shutdown(self, timeout, callback=None):
         logger.debug("Shutting down HTTP transport orderly")
-        self._worker.shutdown(timeout, callback)
+        if timeout <= 0:
+            self._worker.kill()
+        else:
+            self._worker.shutdown(timeout, callback)
 
     def kill(self):
         logger.debug("Killing HTTP transport")


### PR DESCRIPTION
This solves the case where joining on a thread can have bad consequences on shutdown. If shutdown is disabled with wait 0 it doesn't try to do anything crazy now.