### PR TITLE
feat: refactored debug logging and imports

### DIFF
--- a/sentry_sdk/__init__.py
+++ b/sentry_sdk/__init__.py
@@ -22,14 +22,14 @@ uncaught exceptions.  Additionally you can report arbitrary other exceptions:
     except Exception as e:
         sentry_sdk.capture_exception(e)
 """
-from .api import *  # noqa
-from .api import __all__  # noqa
+from sentry_sdk.api import *  # noqa
+from sentry_sdk.api import __all__  # noqa
 
 # modules we consider public
 __all__.append("integrations")
 
 # Initialize the debug support after everything is loaded
-from .debug import init_debug_support
+from sentry_sdk.debug import init_debug_support
 
 init_debug_support()
 del init_debug_support

--- a/sentry_sdk/api.py
+++ b/sentry_sdk/api.py
@@ -1,12 +1,12 @@
 import inspect
 from contextlib import contextmanager
 
-from .hub import Hub
-from .scope import Scope
-from .utils import EventHint
-from .transport import Transport, HttpTransport
-from .client import Client, get_options
-from .integrations import setup_integrations
+from sentry_sdk.hub import Hub
+from sentry_sdk.scope import Scope
+from sentry_sdk.utils import EventHint
+from sentry_sdk.transport import Transport, HttpTransport
+from sentry_sdk.client import Client, get_options
+from sentry_sdk.integrations import setup_integrations
 
 
 __all__ = ["Hub", "Scope", "Client", "EventHint", "Transport", "HttpTransport"]

--- a/sentry_sdk/client.py
+++ b/sentry_sdk/client.py
@@ -3,8 +3,8 @@ import uuid
 import random
 from datetime import datetime
 
-from ._compat import string_types
-from .utils import (
+from sentry_sdk._compat import string_types
+from sentry_sdk.utils import (
     strip_event,
     flatten_metadata,
     convert_types,
@@ -12,8 +12,8 @@ from .utils import (
     get_type_name,
     logger,
 )
-from .transport import make_transport
-from .consts import DEFAULT_OPTIONS, SDK_INFO
+from sentry_sdk.transport import make_transport
+from sentry_sdk.consts import DEFAULT_OPTIONS, SDK_INFO
 
 
 def get_options(*args, **kwargs):

--- a/sentry_sdk/debug.py
+++ b/sentry_sdk/debug.py
@@ -1,8 +1,9 @@
 import sys
 import logging
 
-from .hub import Hub
-from .utils import logger
+from sentry_sdk import utils
+from sentry_sdk.hub import Hub
+from sentry_sdk.utils import logger
 
 
 class _HubBasedClientFilter(logging.Filter):
@@ -14,10 +15,21 @@ class _HubBasedClientFilter(logging.Filter):
 
 
 def init_debug_support():
-    if logger.handlers:
-        return
+    if not logger.handlers:
+        configure_logger()
+    configure_debug_hub()
+
+
+def configure_logger():
     _handler = logging.StreamHandler(sys.stderr)
     _handler.setFormatter(logging.Formatter(" [sentry] %(levelname)s: %(message)s"))
     logger.addHandler(_handler)
     logger.setLevel(logging.DEBUG)
     logger.addFilter(_HubBasedClientFilter())
+
+
+def configure_debug_hub():
+    def _get_debug_hub():
+        return Hub.current
+
+    utils._get_debug_hub = _get_debug_hub

--- a/sentry_sdk/hub.py
+++ b/sentry_sdk/hub.py
@@ -3,22 +3,17 @@ import copy
 from datetime import datetime
 from contextlib import contextmanager
 
-from ._compat import with_metaclass
-from .scope import Scope
-from .utils import exc_info_from_error, event_from_exception, logger, ContextVar
+from sentry_sdk._compat import with_metaclass
+from sentry_sdk.scope import Scope
+from sentry_sdk.utils import (
+    exc_info_from_error,
+    event_from_exception,
+    logger,
+    ContextVar,
+)
 
 
 _local = ContextVar("sentry_current_hub")
-
-
-@contextmanager
-def _internal_exceptions():
-    try:
-        yield
-    except Exception:
-        hub = Hub.current
-        if hub:
-            hub._capture_internal_exception(sys.exc_info())
 
 
 def _get_client_options():

--- a/sentry_sdk/integrations/__init__.py
+++ b/sentry_sdk/integrations/__init__.py
@@ -1,8 +1,8 @@
 """This package"""
 from threading import Lock
 
-from ..utils import logger
-from ..consts import INTEGRATIONS as _installed_integrations
+from sentry_sdk.utils import logger
+from sentry_sdk.consts import INTEGRATIONS as _installed_integrations
 
 
 _installer_lock = Lock()
@@ -18,11 +18,11 @@ def get_default_integrations():
     - `DedupeIntegration`
     - `AtexitIntegration`
     """
-    from .logging import LoggingIntegration
-    from .stdlib import StdlibIntegration
-    from .excepthook import ExcepthookIntegration
-    from .dedupe import DedupeIntegration
-    from .atexit import AtexitIntegration
+    from sentry_sdk.integrations.logging import LoggingIntegration
+    from sentry_sdk.integrations.stdlib import StdlibIntegration
+    from sentry_sdk.integrations.excepthook import ExcepthookIntegration
+    from sentry_sdk.integrations.dedupe import DedupeIntegration
+    from sentry_sdk.integrations.atexit import AtexitIntegration
 
     yield LoggingIntegration()
     yield StdlibIntegration()

--- a/sentry_sdk/integrations/_wsgi.py
+++ b/sentry_sdk/integrations/_wsgi.py
@@ -2,13 +2,8 @@ import json
 import sys
 
 from sentry_sdk import capture_exception
-from sentry_sdk.hub import (
-    Hub,
-    _internal_exceptions,
-    _should_send_default_pii,
-    _get_client_options,
-)
-from sentry_sdk.utils import AnnotatedValue
+from sentry_sdk.hub import Hub, _should_send_default_pii, _get_client_options
+from sentry_sdk.utils import AnnotatedValue, capture_internal_exceptions
 from sentry_sdk._compat import reraise, implements_iterator
 
 
@@ -153,7 +148,7 @@ def get_client_ip(environ):
 def run_wsgi_app(app, environ, start_response):
     hub = Hub.current
     hub.push_scope()
-    with _internal_exceptions():
+    with capture_internal_exceptions():
         with hub.configure_scope() as scope:
             scope.add_event_processor(_make_wsgi_event_processor(environ))
 
@@ -208,7 +203,7 @@ class _ScopePoppingResponse(object):
 
 def _make_wsgi_event_processor(environ):
     def event_processor(event):
-        with _internal_exceptions():
+        with capture_internal_exceptions():
             # if the code below fails halfway through we at least have some data
             request_info = event.setdefault("request", {})
 

--- a/sentry_sdk/integrations/atexit.py
+++ b/sentry_sdk/integrations/atexit.py
@@ -6,7 +6,7 @@ import atexit
 
 from sentry_sdk.hub import Hub
 from sentry_sdk.utils import logger
-from . import Integration
+from sentry_sdk.integrations import Integration
 
 
 def default_shutdown_callback(pending, timeout):

--- a/sentry_sdk/integrations/celery.py
+++ b/sentry_sdk/integrations/celery.py
@@ -4,9 +4,8 @@ from celery.signals import task_failure, task_prerun, task_postrun
 from celery.exceptions import SoftTimeLimitExceeded
 
 from sentry_sdk import Hub
-from sentry_sdk.hub import _internal_exceptions
-
-from . import Integration
+from sentry_sdk.utils import capture_internal_exceptions
+from sentry_sdk.integrations import Integration
 
 
 class CeleryIntegration(Integration):
@@ -39,7 +38,7 @@ class CeleryIntegration(Integration):
             hub.capture_exception(einfo.exc_info)
 
     def _handle_task_prerun(self, sender, task, **kw):
-        with _internal_exceptions():
+        with capture_internal_exceptions():
             hub = Hub.current
             hub.push_scope()
             with hub.configure_scope() as scope:

--- a/sentry_sdk/integrations/dedupe.py
+++ b/sentry_sdk/integrations/dedupe.py
@@ -1,7 +1,6 @@
 from sentry_sdk.api import configure_scope
 from sentry_sdk.utils import ContextVar
-
-from . import Integration
+from sentry_sdk.integrations import Integration
 
 
 _last_seen = ContextVar("last-seen")

--- a/sentry_sdk/integrations/django.py
+++ b/sentry_sdk/integrations/django.py
@@ -11,9 +11,10 @@ except ImportError:
     from django.core.urlresolvers import resolve
 
 from sentry_sdk import capture_exception, configure_scope
-from sentry_sdk.hub import _internal_exceptions, _should_send_default_pii
-from ._wsgi import RequestExtractor, run_wsgi_app
-from . import Integration
+from sentry_sdk.hub import _should_send_default_pii
+from sentry_sdk.utils import capture_internal_exceptions
+from sentry_sdk.integrations import Integration
+from sentry_sdk.integrations._wsgi import RequestExtractor, run_wsgi_app
 
 
 if DJANGO_VERSION < (1, 10):
@@ -76,11 +77,11 @@ def _make_event_processor(weak_request):
             except Exception:
                 pass
 
-        with _internal_exceptions():
+        with capture_internal_exceptions():
             DjangoRequestExtractor(request).extract_into_event(event)
 
         if _should_send_default_pii():
-            with _internal_exceptions():
+            with capture_internal_exceptions():
                 _set_user_info(request, event)
 
         return event

--- a/sentry_sdk/integrations/excepthook.py
+++ b/sentry_sdk/integrations/excepthook.py
@@ -1,9 +1,8 @@
 import sys
 
 from sentry_sdk import capture_exception
-from sentry_sdk.hub import _internal_exceptions
-
-from . import Integration
+from sentry_sdk.utils import capture_internal_exceptions
+from sentry_sdk.integrations import Integration
 
 
 class ExcepthookIntegration(Integration):
@@ -20,7 +19,7 @@ class ExcepthookIntegration(Integration):
 
 def _make_excepthook(old_excepthook):
     def sentry_sdk_excepthook(exctype, value, traceback):
-        with _internal_exceptions():
+        with capture_internal_exceptions():
             capture_exception((exctype, value, traceback))
 
         return old_excepthook(exctype, value, traceback)

--- a/sentry_sdk/integrations/flask.py
+++ b/sentry_sdk/integrations/flask.py
@@ -3,9 +3,10 @@ from __future__ import absolute_import
 import weakref
 
 from sentry_sdk import Hub, capture_exception, configure_scope
-from sentry_sdk.hub import _internal_exceptions, _should_send_default_pii
-from ._wsgi import RequestExtractor, run_wsgi_app
-from . import Integration
+from sentry_sdk.hub import _should_send_default_pii
+from sentry_sdk.utils import capture_internal_exceptions
+from sentry_sdk.integrations import Integration
+from sentry_sdk.integrations._wsgi import RequestExtractor, run_wsgi_app
 
 try:
     import flask_login
@@ -70,11 +71,11 @@ def event_processor(event):
             except Exception:
                 pass
 
-        with _internal_exceptions():
+        with capture_internal_exceptions():
             FlaskRequestExtractor(request).extract_into_event(event)
 
     if _should_send_default_pii():
-        with _internal_exceptions():
+        with capture_internal_exceptions():
             _add_user_to_event(event)
 
     return event
@@ -123,7 +124,7 @@ def _make_request_event_processor(app, weak_request):
             except Exception:
                 pass
 
-        with _internal_exceptions():
+        with capture_internal_exceptions():
             FlaskRequestExtractor(request).extract_into_event(event)
 
         return event
@@ -139,7 +140,7 @@ def _add_user_to_event(event):
     if user is None:
         return
 
-    with _internal_exceptions():
+    with capture_internal_exceptions():
         # Access this object as late as possible as accessing the user
         # is relatively costly
 

--- a/sentry_sdk/integrations/stdlib.py
+++ b/sentry_sdk/integrations/stdlib.py
@@ -1,5 +1,5 @@
 from sentry_sdk import add_breadcrumb
-from . import Integration
+from sentry_sdk.integrations import Integration
 
 
 class StdlibIntegration(Integration):

--- a/sentry_sdk/scope.py
+++ b/sentry_sdk/scope.py
@@ -1,4 +1,4 @@
-from .utils import logger
+from sentry_sdk.utils import logger
 
 
 def _attr_setter(fn):

--- a/sentry_sdk/transport.py
+++ b/sentry_sdk/transport.py
@@ -8,10 +8,9 @@ import gzip
 
 from datetime import datetime, timedelta
 
-from .consts import VERSION
-from .utils import Dsn, logger
-from .worker import BackgroundWorker
-from .hub import _internal_exceptions
+from sentry_sdk.consts import VERSION
+from sentry_sdk.utils import Dsn, logger, capture_internal_exceptions
+from sentry_sdk.worker import BackgroundWorker
 
 try:
     from urllib.request import getproxies
@@ -91,7 +90,7 @@ class HttpTransport(Transport):
                 return
             self._disabled_until = None
 
-        with _internal_exceptions():
+        with capture_internal_exceptions():
             body = io.BytesIO()
             with gzip.GzipFile(fileobj=body, mode="w") as f:
                 f.write(json.dumps(event).encode("utf-8"))

--- a/sentry_sdk/utils.py
+++ b/sentry_sdk/utils.py
@@ -3,10 +3,11 @@ import sys
 import linecache
 import logging
 
+from contextlib import contextmanager
 from datetime import datetime
 from collections import Mapping, Sequence
 
-from ._compat import urlparse, text_type, implements_str
+from sentry_sdk._compat import urlparse, text_type, implements_str
 
 
 epoch = datetime(1970, 1, 1)
@@ -14,6 +15,21 @@ epoch = datetime(1970, 1, 1)
 
 # The logger is created here but initializde in the debug support module
 logger = logging.getLogger("sentry_sdk.errors")
+
+
+def _get_debug_hub():
+    # This function is replaced by debug.py
+    pass
+
+
+@contextmanager
+def capture_internal_exceptions():
+    try:
+        yield
+    except Exception:
+        hub = _get_debug_hub()
+        if hub is not None:
+            hub._capture_internal_exception(sys.exc_info())
 
 
 def to_timestamp(value):

--- a/sentry_sdk/worker.py
+++ b/sentry_sdk/worker.py
@@ -2,8 +2,8 @@ import threading
 import os
 
 from time import sleep, time
-from ._compat import queue, check_thread_support
-from .utils import logger
+from sentry_sdk._compat import queue, check_thread_support
+from sentry_sdk.utils import logger
 
 
 _TERMINATOR = object()


### PR DESCRIPTION
This cleans up imports and debug logging slightly.  This is mostly done for consistency
and because I had circular import errors in a PR i'm working on.