### PR TITLE
ci: Add "registry" target to Craft config

### DIFF
--- a/.craft.yml
+++ b/.craft.yml
@@ -1,4 +1,5 @@
 ---
+minVersion: '0.5.1'
 github:
   owner: getsentry
   repo: sentry-python
@@ -6,3 +7,7 @@ targets:
   - name: pypi
   - name: github
   - name: gh-pages
+  - name: registry
+    type: sdk
+    config:
+      canonical: pypi:sentry-sdk


### PR DESCRIPTION
@untitaker Before the next release, please check that your `craft` version is at least `0.5.1`.