### PR TITLE
ref: Remove repos interface

### DIFF
--- a/sentry_sdk/client.py
+++ b/sentry_sdk/client.py
@@ -73,7 +73,7 @@ class Client(object):
             if event is None:
                 return
 
-        for key in "release", "environment", "server_name", "repos", "dist":
+        for key in "release", "environment", "server_name", "dist":
             if event.get(key) is None:
                 event[key] = self.options[key]
         if event.get("sdk") is None:

--- a/sentry_sdk/consts.py
+++ b/sentry_sdk/consts.py
@@ -15,7 +15,6 @@ DEFAULT_OPTIONS = {
     "in_app_include": [],
     "in_app_exclude": [],
     "default_integrations": True,
-    "repos": {},
     "dist": None,
     "transport": None,
     "sample_rate": 1.0,


### PR DESCRIPTION
The attribute is unused by Sentry.