### PR TITLE
fix: Make filename relative to sys.path

### DIFF
--- a/sentry_sdk/utils.py
+++ b/sentry_sdk/utils.py
@@ -304,10 +304,39 @@ def extract_locals(frame):
     return rv
 
 
+def _get_sanitized_sys_path():
+    for path in sys.path:
+        try:
+            yield os.path.abspath(str(path))
+        except Exception:
+            pass
+
+
+_SANITIZED_SYS_PATH = frozenset(_get_sanitized_sys_path())
+
+
+def filename_from_abs_path(abs_path):
+    try:
+        prefix = abs_path
+        while prefix:
+            if prefix in _SANITIZED_SYS_PATH:
+                return abs_path[len(prefix) :].lstrip(os.sep)
+            new_prefix = prefix.rsplit(os.sep, 1)[0]
+            if new_prefix == prefix:
+                break
+            prefix = new_prefix
+    except Exception:
+        pass
+
+    return abs_path
+
+
 def serialize_frame(frame, tb_lineno=None, with_locals=True):
     f_code = getattr(frame, "f_code", None)
     if f_code:
         abs_path = frame.f_code.co_filename
+        if abs_path:
+            abs_path = os.path.abspath(abs_path)
         function = frame.f_code.co_name
     else:
         abs_path = None
@@ -323,8 +352,8 @@ def serialize_frame(frame, tb_lineno=None, with_locals=True):
     pre_context, context_line, post_context = get_source_context(frame, tb_lineno)
 
     rv = {
-        "filename": abs_path and os.path.basename(abs_path) or None,
-        "abs_path": os.path.abspath(abs_path),
+        "filename": filename_from_abs_path(abs_path) or None,
+        "abs_path": abs_path,
         "function": function or "<unknown>",
         "module": module,
         "lineno": tb_lineno,

--- a/sentry_sdk/utils.py
+++ b/sentry_sdk/utils.py
@@ -306,9 +306,13 @@ def extract_locals(frame):
 
 def filename_for_module(module, abs_path):
     try:
+        if abs_path.endswith(".pyc"):
+            abs_path = abs_path[:-1]
+
         base_module = module.split(".", 1)[0]
         if base_module == module:
             return os.path.basename(abs_path)
+
         base_module_path = sys.modules[base_module].__file__
         return abs_path.split(base_module_path.rsplit(os.sep, 2)[0], 1)[-1].lstrip(
             os.sep

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -12,7 +12,7 @@ from sentry_sdk.utils import (
     exceptions_from_error_tuple,
     format_and_strip,
     strip_string,
-    filename_from_abs_path,
+    filename_for_module,
 )
 from sentry_sdk._compat import text_type
 
@@ -101,14 +101,13 @@ def test_format_and_strip():
 
 
 def test_filename():
-    def x(path):
-        return filename_from_abs_path(os.path.abspath(path))
+    x = filename_for_module
 
-    assert x("bogus") == "bogus"
+    assert x("bogus", "bogus") == "bogus"
 
-    assert x(os.__file__) == "os.py"
-    assert x(pytest.__file__) == "pytest.py"
+    assert x("os", os.__file__) == "os.py"
+    assert x("pytest", pytest.__file__) == "pytest.py"
 
     import sentry_sdk.utils
 
-    assert x(sentry_sdk.utils.__file__) == "sentry_sdk/utils.py"
+    assert x("sentry_sdk.utils", sentry_sdk.utils.__file__) == "sentry_sdk/utils.py"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -12,6 +12,7 @@ from sentry_sdk.utils import (
     exceptions_from_error_tuple,
     format_and_strip,
     strip_string,
+    filename_from_abs_path,
 )
 from sentry_sdk._compat import text_type
 
@@ -41,12 +42,13 @@ def test_abs_path():
         exceptions = exceptions_from_error_tuple(sys.exc_info())
 
     exception, = exceptions
-    frames = exception["stacktrace"]["frames"]
-    assert len(frames) == 2
+    frame1, frame2 = frames = exception["stacktrace"]["frames"]
 
     for frame in frames:
         assert os.path.abspath(frame["abs_path"]) == frame["abs_path"]
-        assert os.path.basename(frame["filename"]) == frame["filename"]
+
+    assert frame1["filename"] == "tests/test_utils.py"
+    assert frame2["filename"] == "test.py"
 
 
 def test_non_string_variables():
@@ -96,3 +98,17 @@ def test_format_and_strip():
         "len": 14,
         "rem": [["!limit", "x", 3, 6], ["!limit", "x", 9, 12]],
     }
+
+
+def test_filename():
+    def x(path):
+        return filename_from_abs_path(os.path.abspath(path))
+
+    assert x("bogus") == "bogus"
+
+    assert x(os.__file__) == "os.py"
+    assert x(pytest.__file__) == "pytest.py"
+
+    import sentry_sdk.utils
+
+    assert x(sentry_sdk.utils.__file__) == "sentry_sdk/utils.py"


### PR DESCRIPTION
Raven behavior for comparison: https://github.com/getsentry/raven-python/blob/719be9afae528962e683d086f9c2ceeda07f881b/raven/utils/stacks.py#L275-L282