### PR TITLE
fix: Do not capture handled exceptions in sanic

### DIFF
--- a/sentry_sdk/integrations/sanic.py
+++ b/sentry_sdk/integrations/sanic.py
@@ -68,10 +68,10 @@ class SanicIntegration(Integration):
         old_error_handler_lookup = ErrorHandler.lookup
 
         def sentry_error_handler_lookup(self, exception):
-            _capture_exception(exception)
             old_error_handler = old_error_handler_lookup(self, exception)
 
             if old_error_handler is None:
+                _capture_exception(exception)
                 return None
 
             if Hub.current.get_integration(SanicIntegration) is None:


### PR DESCRIPTION
Ignore exceptions with error handlers defined by the sanic application.

Proposing this change in behavior when handling exceptions thrown by a Sanic application as the current implementation triggers issue events for "known" and gracefully handled exceptions and does not allow these to be suppressed at the client side. An example of this, is a case where a client request to a websocket route causes an `InvalidHandshake` exception which in turn, is handled by sanic to raise an `InvalidUsage` exception. These exceptions, if a handler is registered explicitly in the application, should not create an issue event as this can lead to a large number of events generated for a heavily used websocket endpoint. Additionally, in any such scenarios an event can be captured by either explicitly using a `capture_message` or initializing the  logging integration and logging an error.

The proposed change retains capturing any errors that may be encountered during the error handler execution.
