### PR TITLE
changed logger.warn to logger.warning to remove DeprecationWarning

### DIFF
--- a/sentry_sdk/integrations/aws_lambda.py
+++ b/sentry_sdk/integrations/aws_lambda.py
@@ -20,7 +20,7 @@ class AwsLambdaIntegration(Integration):
         import __main__ as lambda_bootstrap
 
         if not hasattr(lambda_bootstrap, "make_final_handler"):
-            logger.warn(
+            logger.warning(
                 "Not running in AWS Lambda environment, "
                 "AwsLambdaIntegration disabled"
             )


### PR DESCRIPTION
The call to logger.warn causes `DeprecationWarning` when not running in an AWS environment (e.g. local testing environments). `logger.warning` has always been the preferred and documented logger method, and in Python 3.3 and above, `logger.warn` is deprecated.