### PR TITLE
Include LICENSE in sdist and clarify in README

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include LICENSE

--- a/README.md
+++ b/README.md
@@ -13,4 +13,4 @@
 
 # License
 
-Licensed under the MIT, see `LICENSE`
+Licensed under the BSD license, see `LICENSE`


### PR DESCRIPTION
- Used a MANIFEST.in file to include the LICENSE file in PyPI sdist, as required by the BSD license.
- Corrected README to say BSD not MIT, so it matches the LICENSE file and setup.py.