### PR TITLE
Fix: Fix async jobs in RQ

### DIFF
--- a/sentry_sdk/integrations/rq.py
+++ b/sentry_sdk/integrations/rq.py
@@ -25,9 +25,11 @@ class RqIntegration(Integration):
             if integration is None:
                 return old_perform_job(self, job, *args, **kwargs)
 
-            with hub.push_scope() as scope:
-                scope.add_event_processor(_make_event_processor(weakref.ref(job)))
-                rv = old_perform_job(self, job, *args, **kwargs)
+            with Hub(hub) as hub:
+                with hub.configure_scope() as scope:
+                    scope.add_event_processor(
+                        _make_event_processor(weakref.ref(job)))
+                    rv = old_perform_job(self, job, *args, **kwargs)
 
             if self.is_horse:
                 # We're inside of a forked process and RQ is


### PR DESCRIPTION
Jobs performing async calls (SQL queries or HTTP calls) got `popped wrong scope assertion errors` after dealing with their tasks.
See issue https://github.com/getsentry/sentry-python/issues/159