### PR TITLE
fix: Dont crash when client is bound inside of push_scope

### DIFF
--- a/sentry_sdk/hub.py
+++ b/sentry_sdk/hub.py
@@ -90,7 +90,16 @@ class _ScopeManager(object):
         return scope
 
     def __exit__(self, exc_type, exc_value, tb):
-        assert self._hub.pop_scope_unsafe() == self._layer, "popped wrong scope"
+        layer = self._hub.pop_scope_unsafe()
+        assert layer[1] == self._layer[1], "popped wrong scope"
+        if layer[0] != self._layer[0]:
+            warning = (
+                "init() called inside of pushed scope. This might be entirely "
+                "legitimate but usually occurs when initializing the SDK inside "
+                "a request handler or task/job function. Try to initialize the "
+                "SDK as early as possible instead."
+            )
+            logger.warning(warning)
 
 
 class Hub(with_metaclass(HubMeta)):

--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -224,3 +224,16 @@ def test_integration_scoping():
     logger.warning("This is not a warning")
 
     assert len(events) == 1
+
+
+def test_client_initialized_within_scope(sentry_init, capture_events, caplog):
+    caplog.set_level(logging.WARNING)
+
+    sentry_init(debug=True)
+
+    with push_scope():
+        sentry_init()
+
+    record, = (x for x in caplog.records if x.levelname == "WARNING")
+
+    assert record.msg.startswith("init() called inside of pushed scope.")


### PR DESCRIPTION
See #159