### PR TITLE
Fix collections import DeprecationWarning

### DIFF
--- a/sentry_sdk/utils.py
+++ b/sentry_sdk/utils.py
@@ -5,7 +5,6 @@ import logging
 
 from contextlib import contextmanager
 from datetime import datetime
-from collections import Mapping, Sequence
 
 from sentry_sdk._compat import (
     urlparse,
@@ -14,13 +13,22 @@ from sentry_sdk._compat import (
     string_types,
     number_types,
     int_types,
+    PY2
 )
 
+if PY2:
+    # Importing ABCs from collections is deprecated, and will stop working in 3.8
+    # https://github.com/python/cpython/blob/master/Lib/collections/__init__.py#L49
+    from collections import Mapping, Sequence
+else:
+    # New in 3.3
+    # https://docs.python.org/3/library/collections.abc.html
+    from collections.abc import Mapping, Sequence
 
 epoch = datetime(1970, 1, 1)
 
 
-# The logger is created here but initializde in the debug support module
+# The logger is created here but initialized in the debug support module
 logger = logging.getLogger("sentry_sdk.errors")
 
 


### PR DESCRIPTION
Import ABCs from `collections` is deprecated and will stop working in python 3.8.
https://github.com/python/cpython/blob/master/Lib/collections/__init__.py#L49

Starting with python 3.3 any imported ABCs should come from `collections.abc`
https://docs.python.org/3/library/collections.abc.html

The warning looks like this:
```
/lib/python3.7/site-packages/sentry_sdk/utils.py:8: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated, and in 3.8 it will stop working
  from collections import Mapping, Sequence
```
