### PR TITLE
Add the stack option back to the Logging integration

### DIFF
--- a/sentry_sdk/integrations/logging.py
+++ b/sentry_sdk/integrations/logging.py
@@ -7,6 +7,7 @@ from sentry_sdk.hub import Hub
 from sentry_sdk.utils import (
     to_string,
     event_from_exception,
+    current_stacktrace,
     capture_internal_exceptions,
 )
 from sentry_sdk.integrations import Integration
@@ -145,6 +146,17 @@ class EventHandler(logging.Handler, object):
                 client_options=hub.client.options,
                 mechanism={"type": "logging", "handled": True},
             )
+        elif record.exc_info and record.exc_info[0] is None:
+            event = {}
+            hint = None
+            with capture_internal_exceptions():
+                event["threads"] = [
+                    {
+                        "stacktrace": current_stacktrace(),
+                        "crashed": False,
+                        "current": True,
+                    }
+                ]
         else:
             event = {}
             hint = None

--- a/tests/integrations/logging/test_logging.py
+++ b/tests/integrations/logging/test_logging.py
@@ -1,3 +1,5 @@
+import sys
+
 import pytest
 import logging
 
@@ -56,6 +58,7 @@ def test_logging_extra_data(sentry_init, capture_events):
     )
 
 
+@pytest.mark.xfail(sys.version_info[:2] == (3, 4), reason="buggy logging module")
 def test_logging_stack(sentry_init, capture_events):
     sentry_init(integrations=[LoggingIntegration()], default_integrations=False)
     events = capture_events()

--- a/tests/integrations/logging/test_logging.py
+++ b/tests/integrations/logging/test_logging.py
@@ -36,6 +36,7 @@ def test_logging_defaults(integrations, sentry_init, capture_events):
     assert event["level"] == "fatal"
     assert any(crumb["message"] == "bread" for crumb in event["breadcrumbs"])
     assert not any(crumb["message"] == "LOL" for crumb in event["breadcrumbs"])
+    assert "threads" not in event
 
 
 def test_logging_extra_data(sentry_init, capture_events):
@@ -53,3 +54,19 @@ def test_logging_extra_data(sentry_init, capture_events):
         crumb["message"] == "bread" and crumb["data"] == {"foo": 42}
         for crumb in event["breadcrumbs"]
     )
+
+
+def test_logging_stack(sentry_init, capture_events):
+    sentry_init(integrations=[LoggingIntegration()], default_integrations=False)
+    events = capture_events()
+
+    logger.error("first", exc_info=True)
+    logger.error("second")
+
+    event_with, event_without, = events
+
+    assert event_with["level"] == "error"
+    assert event_with["threads"][0]["stacktrace"]["frames"]
+
+    assert event_without["level"] == "error"
+    assert "threads" not in event_without


### PR DESCRIPTION
In Raven, you could do this:

```
logger.warning('things happened', extra={'stack': True})
```

And the stack would be collected. This adds back that feature.