### PR TITLE
Clear scopes for wsgi requests and celery tasks

### DIFF
--- a/sentry_sdk/integrations/celery.py
+++ b/sentry_sdk/integrations/celery.py
@@ -42,6 +42,7 @@ def _handle_task_prerun(sender, task, args, kwargs, **_):
     hub = Hub.current
     if hub.get_integration(CeleryIntegration) is not None:
         scope = hub.push_scope().__enter__()
+        scope.clear()
         scope.add_event_processor(_make_event_processor(args, kwargs, task))
 
 

--- a/sentry_sdk/integrations/wsgi.py
+++ b/sentry_sdk/integrations/wsgi.py
@@ -61,6 +61,7 @@ class SentryWsgiMiddleware(object):
         hub.push_scope()
         with capture_internal_exceptions():
             with hub.configure_scope() as scope:
+                scope.clear()
                 scope._name = "wsgi"
                 scope.add_event_processor(_make_wsgi_event_processor(environ))
 


### PR DESCRIPTION
This prevents breadcrumbs produced during process startup from being
attached to events that occur during wsgi requests and celery tasks handling.