### PR TITLE
fix event recursion

### DIFF
--- a/sentry_sdk/client.py
+++ b/sentry_sdk/client.py
@@ -156,6 +156,9 @@ class Client(object):
         return False
 
     def _should_capture(self, event, hint, scope=None):
+        if scope is not None and not scope._should_capture:
+            return False
+
         if (
             self.options["sample_rate"] < 1.0
             and random.random() >= self.options["sample_rate"]

--- a/sentry_sdk/integrations/pyramid.py
+++ b/sentry_sdk/integrations/pyramid.py
@@ -16,7 +16,7 @@ from sentry_sdk.integrations._wsgi_common import RequestExtractor
 from sentry_sdk.integrations.wsgi import SentryWsgiMiddleware
 
 
-if getattr(Request, 'authenticated_userid', None):
+if getattr(Request, "authenticated_userid", None):
 
     def authenticated_userid(request):
         return request.authenticated_userid

--- a/sentry_sdk/integrations/pyramid.py
+++ b/sentry_sdk/integrations/pyramid.py
@@ -23,6 +23,7 @@ if getattr(Request, "authenticated_userid", None):
 
 
 else:
+    # bw-compat for pyramid < 1.5
     from pyramid.security import authenticated_userid
 
 

--- a/sentry_sdk/integrations/pyramid.py
+++ b/sentry_sdk/integrations/pyramid.py
@@ -5,6 +5,7 @@ import sys
 import weakref
 
 from pyramid.httpexceptions import HTTPException
+from pyramid.request import Request
 
 from sentry_sdk.hub import Hub, _should_send_default_pii
 from sentry_sdk.utils import capture_internal_exceptions, event_from_exception
@@ -13,6 +14,16 @@ from sentry_sdk._compat import reraise
 from sentry_sdk.integrations import Integration
 from sentry_sdk.integrations._wsgi_common import RequestExtractor
 from sentry_sdk.integrations.wsgi import SentryWsgiMiddleware
+
+
+if getattr(Request, 'authenticated_userid', None):
+
+    def authenticated_userid(request):
+        return request.authenticated_userid
+
+
+else:
+    from pyramid.security import authenticated_userid
 
 
 class PyramidIntegration(Integration):
@@ -142,7 +153,7 @@ def _make_event_processor(weak_request, integration):
             with capture_internal_exceptions():
                 user_info = event.setdefault("user", {})
                 if "id" not in user_info:
-                    user_info["id"] = request.authenticated_userid
+                    user_info["id"] = authenticated_userid(request)
 
         return event
 

--- a/sentry_sdk/scope.py
+++ b/sentry_sdk/scope.py
@@ -27,6 +27,7 @@ def _disable_capture(fn):
             return fn(self, *args, **kwargs)
         finally:
             self._should_capture = True
+
     return wrapper
 
 

--- a/tests/integrations/pyramid/test_pyramid.py
+++ b/tests/integrations/pyramid/test_pyramid.py
@@ -254,7 +254,7 @@ def test_error_in_authenticated_userid(
         integrations=[
             PyramidIntegration(),
             LoggingIntegration(event_level=logging.ERROR),
-        ]
+        ],
     )
     logger = logging.getLogger("test_pyramid")
 

--- a/tests/integrations/pyramid/test_pyramid.py
+++ b/tests/integrations/pyramid/test_pyramid.py
@@ -2,8 +2,11 @@ import json
 
 from io import BytesIO
 
+import logging
+
 import pytest
 
+from pyramid.authorization import ACLAuthorizationPolicy
 import pyramid.testing
 
 from pyramid.response import Response
@@ -239,3 +242,32 @@ def test_error_in_errorhandler(
 
     exception, = event2["exception"]["values"]
     assert exception["type"] == "ZeroDivisionError"
+
+
+def test_error_in_authenticated_userid(
+    sentry_init, pyramid_config, capture_events, route, get_client
+):
+    from sentry_sdk.integrations.logging import LoggingIntegration
+
+    sentry_init(
+        send_default_pii=True,
+        integrations=[
+            PyramidIntegration(),
+            LoggingIntegration(event_level=logging.ERROR),
+        ]
+    )
+    logger = logging.getLogger("test_pyramid")
+
+    class AuthenticationPolicy(object):
+        def authenticated_userid(self, request):
+            logger.error("failed to identify user")
+
+    pyramid_config.set_authorization_policy(ACLAuthorizationPolicy())
+    pyramid_config.set_authentication_policy(AuthenticationPolicy())
+
+    events = capture_events()
+
+    client = get_client()
+    client.get("/message")
+
+    assert len(events) == 1


### PR DESCRIPTION
fixes https://github.com/getsentry/sentry-python/issues/208

I think this is the simplest and most comprehensive fix but let me know what you think.

I looked at fixing it directly in `capture_internal_exceptions` but it felt super awkward. It looked like this, with the import inside to avoid recursive imports between `utils.py` and `hub.py`. This PR does not suffer from that issue and will only avoid creating events while processing one.

```diff
diff --git a/sentry_sdk/utils.py b/sentry_sdk/utils.py
index 6388f96..fadd4bc 100644
--- a/sentry_sdk/utils.py
+++ b/sentry_sdk/utils.py
@@ -39,12 +39,24 @@ def _get_debug_hub():
 
 @contextmanager
 def capture_internal_exceptions():
+    from .api import configure_scope
+
+    # avoid any code inside generating new events
+    with configure_scope() as scope:
+        old_scope = scope
+        old_capture = scope._should_capture
+        scope._should_capture = False
+
     try:
         yield
     except Exception:
         hub = _get_debug_hub()
         if hub is not None:
             hub._capture_internal_exception(sys.exc_info())
+    finally:
+        with configure_scope() as scope:
+            if scope is old_scope:
+                scope._should_capture = old_capture
```