### PR TITLE
Dsn project_id may not be int

### DIFF
--- a/sentry_sdk/utils.py
+++ b/sentry_sdk/utils.py
@@ -89,7 +89,7 @@ class Dsn(object):
         if not parts.path:
             raise BadDsn("Missing project ID in DSN")
         try:
-            self.project_id = text_type(int(parts.path[1:]))
+            self.project_id = text_type(parts.path[1:])
         except (ValueError, TypeError):
             raise BadDsn("Invalid project in DSN (%r)" % (parts.path or "")[1:])
 


### PR DESCRIPTION
support sentry in sub path like `company.io/sentry/project_id`

Refer to sentry-javascript.

#212 

@getsentry/python