### PR TITLE
fix: Push scope for each response chunk

### DIFF
--- a/sentry_sdk/_compat.py
+++ b/sentry_sdk/_compat.py
@@ -21,11 +21,6 @@ if PY2:
 
     exec("def reraise(tp, value, tb=None):\n raise tp, value, tb")
 
-    def implements_iterator(cls):
-        cls.next = cls.__next__
-        del cls.__next__
-        return cls
-
 
 else:
     import urllib.parse as urlparse  # noqa
@@ -39,8 +34,6 @@ else:
 
     def _identity(x):
         return x
-
-    implements_iterator = _identity
 
     def implements_str(x):
         return x

--- a/sentry_sdk/integrations/wsgi.py
+++ b/sentry_sdk/integrations/wsgi.py
@@ -2,7 +2,7 @@ import sys
 
 from sentry_sdk.hub import Hub, _should_send_default_pii
 from sentry_sdk.utils import capture_internal_exceptions, event_from_exception
-from sentry_sdk._compat import PY2, reraise, implements_iterator
+from sentry_sdk._compat import PY2, reraise
 from sentry_sdk.integrations._wsgi_common import _filter_headers
 
 
@@ -133,7 +133,6 @@ def _capture_exception(hub):
     return exc_info
 
 
-@implements_iterator
 class _ScopedResponse(object):
     __slots__ = ("_response", "_hub")
 

--- a/sentry_sdk/integrations/wsgi.py
+++ b/sentry_sdk/integrations/wsgi.py
@@ -58,20 +58,21 @@ class SentryWsgiMiddleware(object):
 
     def __call__(self, environ, start_response):
         hub = Hub.current
-        hub.push_scope()
-        with capture_internal_exceptions():
-            with hub.configure_scope() as scope:
-                scope._name = "wsgi"
-                scope.add_event_processor(_make_wsgi_event_processor(environ))
 
-        try:
-            rv = self.app(environ, start_response)
-        except Exception:
-            einfo = _capture_exception(hub)
-            hub.pop_scope_unsafe()
-            reraise(*einfo)
+        with hub.push_scope():
+            with capture_internal_exceptions():
+                with hub.configure_scope() as scope:
+                    scope._name = "wsgi"
+                    scope.add_event_processor(_make_wsgi_event_processor(environ))
 
-        return _ScopePoppingResponse(hub, rv)
+            try:
+                rv = self.app(environ, start_response)
+            except Exception:
+                einfo = _capture_exception(hub)
+                hub.pop_scope_unsafe()
+                reraise(*einfo)
+
+            return _ScopedResponse(Hub(hub), rv)
 
 
 def _get_environ(environ):
@@ -133,44 +134,35 @@ def _capture_exception(hub):
 
 
 @implements_iterator
-class _ScopePoppingResponse(object):
-    __slots__ = ("_response", "_iterator", "_hub", "_popped")
+class _ScopedResponse(object):
+    __slots__ = ("_response", "_hub")
 
     def __init__(self, hub, response):
         self._hub = hub
         self._response = response
-        self._iterator = None
-        self._popped = False
 
     def __iter__(self):
-        try:
-            self._iterator = iter(self._response)
-        except Exception:
-            reraise(*_capture_exception(self._hub))
-        return self
+        iterator = iter(self._response)
 
-    def __next__(self):
-        if self._iterator is None:
-            self.__iter__()
+        while True:
+            with self._hub:
+                try:
+                    chunk = next(iterator)
+                except StopIteration:
+                    break
+                except Exception:
+                    reraise(*_capture_exception(self._hub))
 
-        try:
-            return next(self._iterator)
-        except StopIteration:
-            raise
-        except Exception:
-            reraise(*_capture_exception(self._hub))
+            yield chunk
 
     def close(self):
-        if not self._popped:
-            self._hub.pop_scope_unsafe()
-            self._popped = True
-
-        try:
-            self._response.close()
-        except AttributeError:
-            pass
-        except Exception:
-            reraise(*_capture_exception(self._hub))
+        with self._hub:
+            try:
+                self._response.close()
+            except AttributeError:
+                pass
+            except Exception:
+                reraise(*_capture_exception(self._hub))
 
 
 def _make_wsgi_event_processor(environ):

--- a/tests/integrations/conftest.py
+++ b/tests/integrations/conftest.py
@@ -6,16 +6,16 @@ import sentry_sdk
 def capture_exceptions(monkeypatch):
     def inner():
         errors = set()
-        old_capture_event = sentry_sdk.Hub.current.capture_event
+        old_capture_event = sentry_sdk.Hub.capture_event
 
-        def capture_event(event, hint=None):
+        def capture_event(self, event, hint=None):
             if hint:
                 if "exc_info" in hint:
                     error = hint["exc_info"][1]
                     errors.add(error)
-            return old_capture_event(event, hint=hint)
+            return old_capture_event(self, event, hint=hint)
 
-        monkeypatch.setattr(sentry_sdk.Hub.current, "capture_event", capture_event)
+        monkeypatch.setattr(sentry_sdk.Hub, "capture_event", capture_event)
         return errors
 
     return inner

--- a/tests/integrations/wsgi/test_wsgi.py
+++ b/tests/integrations/wsgi/test_wsgi.py
@@ -1,9 +1,7 @@
 from werkzeug.test import Client
 import pytest
 
-from sentry_sdk import Hub
-
-from sentry_sdk.integrations.wsgi import SentryWsgiMiddleware, _ScopePoppingResponse
+from sentry_sdk.integrations.wsgi import SentryWsgiMiddleware
 
 
 @pytest.fixture
@@ -32,30 +30,3 @@ def test_basic(sentry_init, crashing_app, capture_events):
         "query_string": "",
         "url": "http://localhost/",
     }
-
-
-def test_calls_close():
-    hub = Hub.current
-    stack_size = len(hub._stack)
-    closes = []
-
-    hub.push_scope()
-
-    class Foo(object):
-        def __iter__(self):
-            yield 1
-            yield 2
-            yield 3
-
-        def close(self):
-            closes.append(1)
-
-    response = _ScopePoppingResponse(hub, Foo())
-    list(response)
-    response.close()
-    response.close()
-    response.close()
-
-    # multiple close calls are just forwarded, but the scope is only popped once
-    assert len(closes) == 3
-    assert len(hub._stack) == stack_size


### PR DESCRIPTION
This will make WSGI apps more tolerant against:

* WSGI servers streaming responses from a different thread/from different threads than the one that called `start_response`
* `close` not being called
* WSGI servers streaming responses interleaved from the same thread

I have no idea or opinion about performance impact but I don't think it's much?