### PR TITLE
Handle iteration errors during frame traversal

### DIFF
--- a/sentry_sdk/utils.py
+++ b/sentry_sdk/utils.py
@@ -311,6 +311,8 @@ def object_to_json(obj):
     def _walk(obj, depth):
         if depth < 4:
             if isinstance(obj, (list, tuple)):
+                # It is not safe to iterate over another sequence types as this may raise errors or
+                # bring undesired side-effects (e.g. Django querysets are executed during iteration)
                 return [_walk(x, depth + 1) for x in obj]
             if isinstance(obj, Mapping):
                 return {safe_str(k): _walk(v, depth + 1) for k, v in obj.items()}

--- a/sentry_sdk/utils.py
+++ b/sentry_sdk/utils.py
@@ -310,22 +310,10 @@ def safe_repr(value):
 def object_to_json(obj):
     def _walk(obj, depth):
         if depth < 4:
-            if isinstance(obj, Sequence) and not isinstance(obj, (bytes, text_type)):
-                result = []
-                try:
-                    for x in obj:
-                        result.append(_walk(x, depth + 1))
-                except Exception as e:
-                    return safe_repr(e)
-                return result
+            if isinstance(obj, (list, tuple)):
+                return [_walk(x, depth + 1) for x in obj]
             if isinstance(obj, Mapping):
-                result = {}
-                try:
-                    for k, v in obj.items():
-                        result[safe_str(k)] = _walk(v, depth + 1)
-                except Exception as e:
-                    return safe_repr(e)
-                return result
+                return {safe_str(k): _walk(v, depth + 1) for k, v in obj.items()}
 
         if obj is CYCLE_MARKER:
             return obj

--- a/sentry_sdk/utils.py
+++ b/sentry_sdk/utils.py
@@ -311,9 +311,21 @@ def object_to_json(obj):
     def _walk(obj, depth):
         if depth < 4:
             if isinstance(obj, Sequence) and not isinstance(obj, (bytes, text_type)):
-                return [_walk(x, depth + 1) for x in obj]
+                result = []
+                try:
+                    for x in obj:
+                        result.append(_walk(x, depth + 1))
+                except Exception as e:
+                    return safe_repr(e)
+                return result
             if isinstance(obj, Mapping):
-                return {safe_str(k): _walk(v, depth + 1) for k, v in obj.items()}
+                result = {}
+                try:
+                    for k, v in obj.items():
+                        result[safe_str(k)] = _walk(v, depth + 1)
+                except Exception as e:
+                    return safe_repr(e)
+                return result
 
         if obj is CYCLE_MARKER:
             return obj

--- a/tests/integrations/django/myapp/views.py
+++ b/tests/integrations/django/myapp/views.py
@@ -1,7 +1,7 @@
 from django.contrib.auth import login
 from django.contrib.auth.models import User
 from django.http import HttpResponse, HttpResponseServerError, HttpResponseNotFound
-from django.shortcuts import render_to_response
+from django.shortcuts import render
 from django.views.generic import ListView
 
 import sentry_sdk
@@ -45,5 +45,5 @@ def handler404(*args, **kwargs):
     return HttpResponseNotFound("404")
 
 
-def template_exc(*args, **kwargs):
-    return render_to_response("error.html")
+def template_exc(request, *args, **kwargs):
+    return render(request, "error.html")


### PR DESCRIPTION
Fixes #238

Not sure if this is the best way to show it, i think it is better than showing just empty list. But maybe there could be some better way to show that exception occured during traversal.

There is more general problem that it is probably good to not iterate over queryset, so DB is not queried. Any ideas on how to do that?