### PR TITLE
Add tornado 6 support

### DIFF
--- a/sentry_sdk/integrations/tornado.py
+++ b/sentry_sdk/integrations/tornado.py
@@ -46,6 +46,8 @@ class TornadoIntegration(Integration):
         awaitable = iscoroutinefunction(old_execute)
 
         if awaitable:
+            # Starting Tornado 6 RequestHandler._execute method is a standard Python coroutine (async/await)
+            # In that case our method should be a coroutine function too
             async def sentry_execute_request_handler(self, *args, **kwargs):
                 hub = Hub.current
                 integration = hub.get_integration(TornadoIntegration)

--- a/tox.ini
+++ b/tox.ini
@@ -34,7 +34,7 @@ envlist =
     {pypy,py2.7,py3.5,py3.6,py3.7,py3.8}-rq-0.12
 
     py3.7-aiohttp
-    {py3.7,py3.8}-tornado
+    {py3.7,py3.8}-tornado-{5,6}
 
 [testenv]
 deps =
@@ -90,7 +90,8 @@ deps =
     aiohttp: aiohttp>=3.4.0,<3.5.0
     aiohttp: pytest-aiohttp
 
-    tornado: tornado>=5,<6
+    tornado-5: tornado>=5,<6
+    tornado-6: tornado>=6.0a1
 
     linters: black
     linters: flake8


### PR DESCRIPTION
Tornado 6 will remove old coroutine support in respect to standard async/await syntax.

Current TornadoIntegration is not working with Tornado 6 (current alpha release is 6.0a1):

```
[D 190129 13:19:21 logger:68] Started GET /status
/Users/belk/.venv/lib/python3.7/site-packages/sentry_sdk/integrations/tornado.py:57: RuntimeWarning: coroutine 'RequestHandler._execute' was never awaited
  result = yield from old_execute(self, *args, **kwargs)
RuntimeWarning: Enable tracemalloc to get the object allocation traceback
[E 190129 13:19:21 base_events:1608] Exception in callback _HandlerDelegate.execute.<locals>.<lambda>(<Future finis...e generator")>) at /Users/belk/.venv/lib/python3.7/site-packages/tornado/web.py:2329
    handle: <Handle _HandlerDelegate.execute.<locals>.<lambda>(<Future finis...e generator")>) at /Users/belk/.venv/lib/python3.7/site-packages/tornado/web.py:2329>
    Traceback (most recent call last):
      File "/Library/Frameworks/Python.framework/Versions/3.7/lib/python3.7/asyncio/events.py", line 88, in _run
        self._context.run(self._callback, *self._args)
      File "/Users/belk/.venv/lib/python3.7/site-packages/tornado/web.py", line 2329, in <lambda>
        fut.add_done_callback(lambda f: f.result())
      File "/Users/belk/.venv/lib/python3.7/site-packages/tornado/gen.py", line 209, in wrapper
        yielded = next(result)
      File "/Users/belk/.venv/lib/python3.7/site-packages/sentry_sdk/integrations/tornado.py", line 57, in sentry_execute_request_handler
        result = yield from old_execute(self, *args, **kwargs)
    TypeError: cannot 'yield from' a coroutine object in a non-coroutine generator
```

For compatibility with a previous Tornado versions I've added a check for awaitable.