### PR TITLE
fix: Ignore Celery's retry exceptions

### DIFF
--- a/tests/integrations/celery/test_celery.py
+++ b/tests/integrations/celery/test_celery.py
@@ -103,3 +103,39 @@ def test_broken_prerun(init_celery, connect_signal):
         assert stack_lengths == [2]
     else:
         assert stack_lengths == [2, 2]
+
+
+@pytest.mark.skipif(
+    VERSION in ((4, 2, 0), (4, 2, 1)),
+    reason="https://github.com/celery/celery/issues/4661",
+)
+def test_retry(celery, capture_events):
+    events = capture_events()
+    failures = [True, True, False]
+    runs = []
+
+    @celery.task(name="dummy_task", bind=True)
+    def dummy_task(self):
+        runs.append(1)
+        try:
+            if failures.pop(0):
+                1 / 0
+        except Exception as exc:
+            self.retry(max_retries=2, exc=exc)
+
+    dummy_task.delay()
+
+    assert len(runs) == 3
+    assert not events
+
+    failures = [True, True, True]
+    runs = []
+
+    dummy_task.delay()
+
+    assert len(runs) == 3
+    event, = events
+    exceptions = event["exception"]["values"]
+
+    for e in exceptions:
+        assert e["type"] == "ZeroDivisionError"

--- a/tests/integrations/celery/test_celery.py
+++ b/tests/integrations/celery/test_celery.py
@@ -106,7 +106,7 @@ def test_broken_prerun(init_celery, connect_signal):
 
 
 @pytest.mark.skipif(
-    VERSION in ((4, 2, 0), (4, 2, 1)),
+    (4, 2, 0) <= VERSION < (4, 2, 2),
     reason="https://github.com/celery/celery/issues/4661",
 )
 def test_retry(celery, capture_events):

--- a/tox.ini
+++ b/tox.ini
@@ -22,7 +22,7 @@ envlist =
 
     py3.7-sanic-0.8
 
-    {pypy,py2.7,py3.5,py3.6,py3.7,py3.8}-celery-4
+    {pypy,py2.7,py3.5,py3.6,py3.7,py3.8}-celery-{4.1,4.2}
     {pypy,py2.7}-celery-3
 
     {py2.7,py3.7}-requests
@@ -65,7 +65,8 @@ deps =
     sanic: aiohttp
 
     celery-3: Celery>=3.1,<4.0
-    celery-4: Celery>=4.0,<5.0
+    celery-4.1: Celery>=4.1,<4.2
+    celery-4.2: Celery>=4.2,<4.3
 
     requests: requests>=2.0
 


### PR DESCRIPTION
Fix #252 