### PR TITLE
Add missing await in AioHttpIntegration.

### DIFF
--- a/sentry_sdk/integrations/aiohttp.py
+++ b/sentry_sdk/integrations/aiohttp.py
@@ -32,7 +32,7 @@ class AioHttpIntegration(Integration):
             async def inner():
                 hub = Hub.current
                 if hub.get_integration(AioHttpIntegration) is None:
-                    return old_handle(self, request, *args, **kwargs)
+                    return await old_handle(self, request, *args, **kwargs)
 
                 weak_request = weakref.ref(request)
 

--- a/tests/integrations/aiohttp/test_aiohttp.py
+++ b/tests/integrations/aiohttp/test_aiohttp.py
@@ -53,3 +53,22 @@ async def test_403_not_captured(sentry_init, aiohttp_client, loop, capture_event
     assert resp.status == 403
 
     assert not events
+
+
+async def test_half_initialized(sentry_init, aiohttp_client, loop, capture_events):
+    sentry_init(integrations=[AioHttpIntegration()])
+    sentry_init()
+
+    async def hello(request):
+        return web.Response(text="hello")
+
+    app = web.Application()
+    app.router.add_get("/", hello)
+
+    events = capture_events()
+
+    client = await aiohttp_client(app)
+    resp = await client.get("/")
+    assert resp.status == 200
+
+    assert events == []


### PR DESCRIPTION
The replaced _handle method of aiohttp.web.Application is a coroutine
itself. So it has to await the call to the original handle otherwise its
never awaited.

This fixes #260

Signed-off-by: Jan Losinski <losinski@wh2.tu-dresden.de>