### PR TITLE
Stacktrace: Pass with_locals parameter.

### DIFF
--- a/sentry_sdk/client.py
+++ b/sentry_sdk/client.py
@@ -118,7 +118,7 @@ class Client(object):
             with capture_internal_exceptions():
                 event["threads"] = [
                     {
-                        "stacktrace": current_stacktrace(),
+                        "stacktrace": current_stacktrace(self.options["with_locals"]),
                         "crashed": False,
                         "current": True,
                     }

--- a/sentry_sdk/integrations/logging.py
+++ b/sentry_sdk/integrations/logging.py
@@ -158,12 +158,13 @@ class EventHandler(logging.Handler, object):
             return
 
         hint = None  # type: Optional[Dict[str, Any]]
+        client_options = hub.client.options
 
         # exc_info might be None or (None, None, None)
         if record.exc_info is not None and record.exc_info[0] is not None:
             event, hint = event_from_exception(
                 record.exc_info,
-                client_options=hub.client.options,
+                client_options=client_options,
                 mechanism={"type": "logging", "handled": True},
             )
         elif record.exc_info and record.exc_info[0] is None:
@@ -172,7 +173,7 @@ class EventHandler(logging.Handler, object):
             with capture_internal_exceptions():
                 event["threads"] = [
                     {
-                        "stacktrace": current_stacktrace(),
+                        "stacktrace": current_stacktrace(client_options["with_locals"]),
                         "crashed": False,
                         "current": True,
                     }

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -143,6 +143,24 @@ def test_attach_stacktrace_enabled():
     assert functions[-2:] == ["foo", "bar"]
 
 
+def test_attach_stacktrace_enabled_no_locals():
+    events = []
+    hub = Hub(Client(attach_stacktrace=True, with_locals=False, transport=events.append))
+
+    def foo():
+        bar()
+
+    def bar():
+        hub.capture_message("HI")
+
+    foo()
+
+    event, = events
+    thread, = event["threads"]
+    local_vars = [x.get("vars") for x in thread["stacktrace"]["frames"]]
+    assert local_vars[-2:] == [None, None]
+
+
 def test_attach_stacktrace_disabled():
     events = []
     hub = Hub(Client(attach_stacktrace=False, transport=events.append))

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -145,7 +145,9 @@ def test_attach_stacktrace_enabled():
 
 def test_attach_stacktrace_enabled_no_locals():
     events = []
-    hub = Hub(Client(attach_stacktrace=True, with_locals=False, transport=events.append))
+    hub = Hub(
+        Client(attach_stacktrace=True, with_locals=False, transport=events.append)
+    )
 
     def foo():
         bar()


### PR DESCRIPTION
Currently, `sentry_sdk` is ignoring the `with_locals` option when collecting stacktrace info.
This makes events collect local variables, which in our case creates huge events which are dropped by sentry.

This PR passes the client options to `current_stacktrace` to avoid the problem.

Related to #268 