### PR TITLE
Travis CI: The 'sudo' tag is now deprecated

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: python
-sudo: false
 
 python:
   - "2.7"
@@ -21,10 +20,8 @@ matrix:
   include:
     - python: "3.7"
       dist: xenial
-      sudo: true
     - python: "3.8-dev"
       dist: xenial
-      sudo: true
 
     - name: Linting
       python: "3.6"


### PR DESCRIPTION
[Travis are now recommending removing the __sudo__ tag](https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration).

"_If you currently specify __sudo: false__ in your __.travis.yml__, we recommend removing that configuration_"