### PR TITLE
fix: Wsgi - valid JSONs ([], {}) are evaluated as raw data

### DIFF
--- a/sentry_sdk/integrations/_wsgi_common.py
+++ b/sentry_sdk/integrations/_wsgi_common.py
@@ -42,7 +42,7 @@ class RequestExtractor(object):
             )
         else:
             parsed_body = self.parsed_body()
-            if parsed_body:
+            if parsed_body is not None:
                 data = parsed_body
             elif self.raw_data():
                 data = AnnotatedValue(


### PR DESCRIPTION
It should be evaluated as empty JSON object/array

Note that according to RFC 4627 top level elements can be empty objects or arrays