### PR TITLE
feat: Add integration for parsing GNU-style backtrace dumps

### DIFF
--- a/sentry_sdk/integrations/django/__init__.py
+++ b/sentry_sdk/integrations/django/__init__.py
@@ -141,19 +141,23 @@ class DjangoIntegration(Integration):
         @add_global_event_processor
         def process_django_templates(event, hint):
             # type: (Dict[str, Any], Dict[str, Any]) -> Dict[str, Any]
-            if hint.get("exc_info", None) is None:
+            exc_info = hint.get("exc_info", None)
+
+            if exc_info is None:
                 return event
 
-            if "exception" not in event:
+            exception = event.get("exception", None)
+
+            if exception is None:
                 return event
 
-            exception = event["exception"]
+            values = exception.get("values", None)
 
-            if "values" not in exception:
+            if values is None:
                 return event
 
             for exception, (_, exc_value, _) in zip(
-                exception["values"], walk_exception_chain(hint["exc_info"])
+                values, walk_exception_chain(exc_info)
             ):
                 frame = get_template_frame_from_exception(exc_value)
                 if frame is not None:

--- a/sentry_sdk/integrations/gnu_backtrace.py
+++ b/sentry_sdk/integrations/gnu_backtrace.py
@@ -84,6 +84,7 @@ def _process_gnu_backtrace(event, hint):
                         {
                             "package": match.group("package") or None,
                             "function": match.group("function") or None,
+                            "platform": "native",
                         },
                     )
                 )

--- a/sentry_sdk/integrations/gnu_backtrace.py
+++ b/sentry_sdk/integrations/gnu_backtrace.py
@@ -1,0 +1,103 @@
+import re
+
+from sentry_sdk.hub import Hub
+from sentry_sdk.integrations import Integration
+from sentry_sdk.scope import add_global_event_processor
+from sentry_sdk.utils import walk_exception_chain, capture_internal_exceptions
+
+if False:
+    from typing import Any
+    from typing import Dict
+
+
+MODULE_RE = r"[a-zA-Z0-9/._:\\-]+"
+TYPE_RE = r"[a-zA-Z0-9._:<>,-]+"
+HEXVAL_RE = r"[A-Fa-f0-9]+"
+
+
+FRAME_RE = r"""
+^(?P<index>\d+)\.\ 
+(?P<package>""" + MODULE_RE + r""")\(
+  (?P<retval>""" + TYPE_RE + r"""\ )?
+  ((?P<function>""" + TYPE_RE + r""")
+    (?P<args>\([^)]*\))?
+  )?
+  ((?P<constoffset>\ const)?\+0x(?P<offset>""" + HEXVAL_RE + r"""))?
+\)\ 
+\[0x(?P<retaddr>""" + HEXVAL_RE + r""")\]$
+"""
+
+FRAME_RE = re.compile(FRAME_RE, re.MULTILINE | re.VERBOSE)
+
+
+class GnuBacktraceIntegration(Integration):
+    identifier = "gnu_backtrace"
+
+    @staticmethod
+    def setup_once():
+        @add_global_event_processor
+        def process_gnu_backtrace(event, hint):
+            with capture_internal_exceptions():
+                return _process_gnu_backtrace(event, hint)
+
+
+def _process_gnu_backtrace(event, hint):
+    # type: (Dict[str, Any], Dict[str, Any]) -> Dict[str, Any]
+    if Hub.current.get_integration(GnuBacktraceIntegration) is None:
+        return event
+
+    exc_info = hint.get('exc_info', None)
+
+    if exc_info is None:
+        return event
+
+    exception = event.get("exception", None)
+
+    if exception is None:
+        return event
+
+    values = exception.get("values", None)
+
+    if values is None:
+        return event
+
+    for exception in values:
+        frames = exception.get("stacktrace", {}).get("frames", [])
+        if not frames:
+            continue
+
+        msg = exception.get('value', None)
+        if not msg:
+            continue
+
+        additional_frames = []
+        new_msg = []
+
+        for line in msg.splitlines():
+            match = FRAME_RE.match(line)
+            if match:
+                additional_frames.append((
+                    int(match['index']),
+                    {
+                        "package": match['package'] or None,
+                        "function": match["function"] or None,
+                    }
+                ))
+            elif additional_frames and line.strip():
+                # If we already started parsing a stacktrace, it must be at the
+                # end of the message and must not contain random garbage lines
+                # between the frames
+                del additional_frames[:]
+                break
+            else:
+                new_msg.append(line)
+
+        if additional_frames:
+            additional_frames.sort(key=lambda x: -x[0])
+            for _, frame in additional_frames:
+                frames.append(frame)
+
+            new_msg.append("<stacktrace parsed and removed by GnuBacktraceIntegration>")
+            exception['value'] = '\n'.join(new_msg)
+
+    return event

--- a/sentry_sdk/integrations/gnu_backtrace.py
+++ b/sentry_sdk/integrations/gnu_backtrace.py
@@ -80,10 +80,10 @@ def _process_gnu_backtrace(event, hint):
             if match:
                 additional_frames.append(
                     (
-                        int(match["index"]),
+                        int(match.group("index")),
                         {
-                            "package": match["package"] or None,
-                            "function": match["function"] or None,
+                            "package": match.group("package") or None,
+                            "function": match.group("function") or None,
                         },
                     )
                 )

--- a/tests/integrations/test_gnu_backtrace.py
+++ b/tests/integrations/test_gnu_backtrace.py
@@ -43,6 +43,9 @@ def test_basic(sentry_init, capture_events):
         capture_exception()
 
     event, = events
+    import pdb
+
+    pdb.set_trace()
     exception, = event["exception"]["values"]
 
     assert exception["value"] == (
@@ -57,114 +60,140 @@ def test_basic(sentry_init, capture_events):
             "function": "clone",
             "in_app": True,
             "package": "/lib/x86_64-linux-gnu/libc.so.6",
+            "platform": "native",
         },
-        {"in_app": True, "package": "/lib/x86_64-linux-gnu/libpthread.so.0"},
-        {"in_app": True, "package": "clickhouse-server"},
+        {
+            "in_app": True,
+            "package": "/lib/x86_64-linux-gnu/libpthread.so.0",
+            "platform": "native",
+        },
+        {"in_app": True, "package": "clickhouse-server", "platform": "native"},
         {
             "function": "Poco::ThreadImpl::runnableEntry",
             "in_app": True,
             "package": "clickhouse-server",
+            "platform": "native",
         },
         {
             "function": "Poco::PooledThread::run",
             "in_app": True,
             "package": "clickhouse-server",
+            "platform": "native",
         },
         {
             "function": "Poco::Net::TCPServerDispatcher::run",
             "in_app": True,
             "package": "clickhouse-server",
+            "platform": "native",
         },
         {
             "function": "Poco::Net::TCPServerConnection::start",
             "in_app": True,
             "package": "clickhouse-server",
+            "platform": "native",
         },
         {
             "function": "DB::TCPHandler::run",
             "in_app": True,
             "package": "clickhouse-server",
+            "platform": "native",
         },
         {
             "function": "DB::TCPHandler::runImpl",
             "in_app": True,
             "package": "clickhouse-server",
+            "platform": "native",
         },
         {
             "function": "DB::executeQuery",
             "in_app": True,
             "package": "clickhouse-server",
+            "platform": "native",
         },
-        {"in_app": True, "package": "clickhouse-server"},
+        {"in_app": True, "package": "clickhouse-server", "platform": "native"},
         {
             "function": "DB::InterpreterFactory::get",
             "in_app": True,
             "package": "clickhouse-server",
+            "platform": "native",
         },
         {
             "function": "DB::InterpreterSelectWithUnionQuery::InterpreterSelectWithUnionQuery",
             "in_app": True,
             "package": "clickhouse-server",
+            "platform": "native",
         },
         {
             "function": "DB::InterpreterSelectQuery::InterpreterSelectQuery",
             "in_app": True,
             "package": "clickhouse-server",
+            "platform": "native",
         },
         {
             "function": "DB::InterpreterSelectQuery::InterpreterSelectQuery",
             "in_app": True,
             "package": "clickhouse-server",
+            "platform": "native",
         },
         {
             "function": "DB::InterpreterSelectQuery::executeImpl",
             "in_app": True,
             "package": "clickhouse-server",
+            "platform": "native",
         },
-        {"in_app": True, "package": "clickhouse-server"},
+        {"in_app": True, "package": "clickhouse-server", "platform": "native"},
         {
             "function": "DB::FilterBlockInputStream::FilterBlockInputStream",
             "in_app": True,
             "package": "clickhouse-server",
+            "platform": "native",
         },
         {
             "function": "DB::ExpressionActions::execute",
             "in_app": True,
             "package": "clickhouse-server",
+            "platform": "native",
         },
         {
             "function": "DB::ExpressionAction::execute",
             "in_app": True,
             "package": "clickhouse-server",
+            "platform": "native",
         },
         {
             "function": "DB::PreparedFunctionImpl::execute",
             "in_app": True,
             "package": "clickhouse-server",
+            "platform": "native",
         },
         {
             "function": "DB::NameNotEquals>::executeImpl",
             "in_app": True,
             "package": "clickhouse-server",
+            "platform": "native",
         },
         {
             "function": "DB::NameNotEquals>::executeDateOrDateTimeOrEnumOrUUIDWithConstString",
             "in_app": True,
             "package": "clickhouse-server",
+            "platform": "native",
         },
         {
             "function": "DB::readDateTimeTextFallback<void>",
             "in_app": True,
             "package": "clickhouse-server",
+            "platform": "native",
         },
         {
             "function": "DB::Exception::Exception",
             "in_app": True,
             "package": "clickhouse-server",
+            "platform": "native",
         },
         {
             "function": "StackTrace::StackTrace",
             "in_app": True,
             "package": "clickhouse-server",
+            "platform": "native",
         },
     ]

--- a/tests/integrations/test_gnu_backtrace.py
+++ b/tests/integrations/test_gnu_backtrace.py
@@ -1,0 +1,170 @@
+from sentry_sdk import capture_exception
+from sentry_sdk.integrations.gnu_backtrace import GnuBacktraceIntegration
+
+EXC_VALUE = r"""
+DB::Exception: Cannot parse datetime. Stack trace:
+
+0. clickhouse-server(StackTrace::StackTrace()+0x16) [0x99d31a6]
+1. clickhouse-server(DB::Exception::Exception(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, int)+0x22) [0x3089bb2]
+2. clickhouse-server(void DB::readDateTimeTextFallback<void>(long&, DB::ReadBuffer&, DateLUTImpl const&)+0x318) [0x99ffed8]
+3. clickhouse-server(DB::FunctionComparison<DB::NotEqualsOp, DB::NameNotEquals>::executeDateOrDateTimeOrEnumOrUUIDWithConstString(DB::Block&, unsigned long, DB::IColumn const*, DB::IColumn const*, std::shared_ptr<DB::IDataType const> const&, std::shared_ptr<DB::IDataType const> const&, bool, unsigned long)+0xbb3) [0x411dee3]
+4. clickhouse-server(DB::FunctionComparison<DB::NotEqualsOp, DB::NameNotEquals>::executeImpl(DB::Block&, std::vector<unsigned long, std::allocator<unsigned long> > const&, unsigned long, unsigned long)+0x576) [0x41ab006]
+5. clickhouse-server(DB::PreparedFunctionImpl::execute(DB::Block&, std::vector<unsigned long, std::allocator<unsigned long> > const&, unsigned long, unsigned long)+0x3e2) [0x7933492]
+6. clickhouse-server(DB::ExpressionAction::execute(DB::Block&, std::unordered_map<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, unsigned long, std::hash<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::equal_to<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, unsigned long> > >&) const+0x61a) [0x7ae093a]
+7. clickhouse-server(DB::ExpressionActions::execute(DB::Block&) const+0xe6) [0x7ae1e06]
+8. clickhouse-server(DB::FilterBlockInputStream::FilterBlockInputStream(std::shared_ptr<DB::IBlockInputStream> const&, std::shared_ptr<DB::ExpressionActions> const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, bool)+0x711) [0x79970d1]
+9. clickhouse-server() [0x75bd5a3]
+10. clickhouse-server(DB::InterpreterSelectQuery::executeImpl(DB::InterpreterSelectQuery::Pipeline&, std::shared_ptr<DB::IBlockInputStream> const&, bool)+0x11af) [0x75c68ff]
+11. clickhouse-server(DB::InterpreterSelectQuery::InterpreterSelectQuery(std::shared_ptr<DB::IAST> const&, DB::Context const&, std::shared_ptr<DB::IBlockInputStream> const&, std::shared_ptr<DB::IStorage> const&, std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > const&, DB::QueryProcessingStage::Enum, unsigned long, bool)+0x5e6) [0x75c7516]
+12. clickhouse-server(DB::InterpreterSelectQuery::InterpreterSelectQuery(std::shared_ptr<DB::IAST> const&, DB::Context const&, std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > const&, DB::QueryProcessingStage::Enum, unsigned long, bool)+0x56) [0x75c8276]
+13. clickhouse-server(DB::InterpreterSelectWithUnionQuery::InterpreterSelectWithUnionQuery(std::shared_ptr<DB::IAST> const&, DB::Context const&, std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > const&, DB::QueryProcessingStage::Enum, unsigned long, bool)+0x7e7) [0x75d4067]
+14. clickhouse-server(DB::InterpreterFactory::get(std::shared_ptr<DB::IAST>&, DB::Context&, DB::QueryProcessingStage::Enum)+0x3a8) [0x75b0298]
+15. clickhouse-server() [0x7664c79]
+16. clickhouse-server(DB::executeQuery(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, DB::Context&, bool, DB::QueryProcessingStage::Enum)+0x8a) [0x76669fa]
+17. clickhouse-server(DB::TCPHandler::runImpl()+0x4b9) [0x30973c9]
+18. clickhouse-server(DB::TCPHandler::run()+0x2b) [0x30985ab]
+19. clickhouse-server(Poco::Net::TCPServerConnection::start()+0xf) [0x9b53e4f]
+20. clickhouse-server(Poco::Net::TCPServerDispatcher::run()+0x16a) [0x9b5422a]
+21. clickhouse-server(Poco::PooledThread::run()+0x77) [0x9c70f37]
+22. clickhouse-server(Poco::ThreadImpl::runnableEntry(void*)+0x38) [0x9c6caa8]
+23. clickhouse-server() [0xa3c68cf]
+24. /lib/x86_64-linux-gnu/libpthread.so.0(+0x8184) [0x7fe839d2d184]
+25. /lib/x86_64-linux-gnu/libc.so.6(clone+0x6d) [0x7fe83934803d]
+"""
+
+
+def test_basic(sentry_init, capture_events):
+    sentry_init(integrations=[GnuBacktraceIntegration()])
+    events = capture_events()
+
+    try:
+        raise ValueError(EXC_VALUE)
+    except ValueError:
+        capture_exception()
+
+    event, = events
+    exception, = event["exception"]["values"]
+
+    assert exception["value"] == (
+        "\n"
+        "DB::Exception: Cannot parse datetime. Stack trace:\n"
+        "\n"
+        "<stacktrace parsed and removed by GnuBacktraceIntegration>"
+    )
+
+    assert exception["stacktrace"]["frames"][1:] == [
+        {
+            "function": "clone",
+            "in_app": True,
+            "package": "/lib/x86_64-linux-gnu/libc.so.6",
+        },
+        {"in_app": True, "package": "/lib/x86_64-linux-gnu/libpthread.so.0"},
+        {"in_app": True, "package": "clickhouse-server"},
+        {
+            "function": "Poco::ThreadImpl::runnableEntry",
+            "in_app": True,
+            "package": "clickhouse-server",
+        },
+        {
+            "function": "Poco::PooledThread::run",
+            "in_app": True,
+            "package": "clickhouse-server",
+        },
+        {
+            "function": "Poco::Net::TCPServerDispatcher::run",
+            "in_app": True,
+            "package": "clickhouse-server",
+        },
+        {
+            "function": "Poco::Net::TCPServerConnection::start",
+            "in_app": True,
+            "package": "clickhouse-server",
+        },
+        {
+            "function": "DB::TCPHandler::run",
+            "in_app": True,
+            "package": "clickhouse-server",
+        },
+        {
+            "function": "DB::TCPHandler::runImpl",
+            "in_app": True,
+            "package": "clickhouse-server",
+        },
+        {
+            "function": "DB::executeQuery",
+            "in_app": True,
+            "package": "clickhouse-server",
+        },
+        {"in_app": True, "package": "clickhouse-server"},
+        {
+            "function": "DB::InterpreterFactory::get",
+            "in_app": True,
+            "package": "clickhouse-server",
+        },
+        {
+            "function": "DB::InterpreterSelectWithUnionQuery::InterpreterSelectWithUnionQuery",
+            "in_app": True,
+            "package": "clickhouse-server",
+        },
+        {
+            "function": "DB::InterpreterSelectQuery::InterpreterSelectQuery",
+            "in_app": True,
+            "package": "clickhouse-server",
+        },
+        {
+            "function": "DB::InterpreterSelectQuery::InterpreterSelectQuery",
+            "in_app": True,
+            "package": "clickhouse-server",
+        },
+        {
+            "function": "DB::InterpreterSelectQuery::executeImpl",
+            "in_app": True,
+            "package": "clickhouse-server",
+        },
+        {"in_app": True, "package": "clickhouse-server"},
+        {
+            "function": "DB::FilterBlockInputStream::FilterBlockInputStream",
+            "in_app": True,
+            "package": "clickhouse-server",
+        },
+        {
+            "function": "DB::ExpressionActions::execute",
+            "in_app": True,
+            "package": "clickhouse-server",
+        },
+        {
+            "function": "DB::ExpressionAction::execute",
+            "in_app": True,
+            "package": "clickhouse-server",
+        },
+        {
+            "function": "DB::PreparedFunctionImpl::execute",
+            "in_app": True,
+            "package": "clickhouse-server",
+        },
+        {
+            "function": "DB::NameNotEquals>::executeImpl",
+            "in_app": True,
+            "package": "clickhouse-server",
+        },
+        {
+            "function": "DB::NameNotEquals>::executeDateOrDateTimeOrEnumOrUUIDWithConstString",
+            "in_app": True,
+            "package": "clickhouse-server",
+        },
+        {
+            "function": "DB::readDateTimeTextFallback<void>",
+            "in_app": True,
+            "package": "clickhouse-server",
+        },
+        {
+            "function": "DB::Exception::Exception",
+            "in_app": True,
+            "package": "clickhouse-server",
+        },
+        {
+            "function": "StackTrace::StackTrace",
+            "in_app": True,
+            "package": "clickhouse-server",
+        },
+    ]


### PR DESCRIPTION
Value proposition: ClickHouse sends us error messages with stacktrace information. Ideally we would parse this stacktrace information into actual stacktraces. Here is an integration for exactly that. The testcase is ripped straight from https://sentry.io/organizations/sentry/issues/856036064

ClickHouse calls [`backtrace_symbols`](https://linux.die.net/man/3/backtrace_symbols). It already returns a formatted string/list of strings. ClickHouse then parses this string and [replaces symbols with demangled versions](https://github.com/yandex/ClickHouse/blob/1e22b308d9cd974803920c90d968ca89ad36c84f/dbms/src/Common/StackTrace.cpp). I didn't bother with parsing addresses and offsets as I don't see much value in that information (not sure if it's used in grouping) and some of those return addresses (brackets at the end) seem wrong:

```
23. clickhouse-server() [0xa3c68cf]
24. /lib/x86_64-linux-gnu/libpthread.so.0(+0x8184) [0x7fdb108c5184]
25. /lib/x86_64-linux-gnu/libc.so.6(clone+0x6d) [0x7fdb0fee003d]
```

I'm open to alternative naming suggestions. As far as I can tell this function has its origins in glibc. `LibExecInfoBacktraceIntegration` seemed bulky. Perhaps `GlibcBacktraceIntegration` to avoid conflict with GDB's output format, which seems entirely different? I'm generally unsure of `backtrace_symbols`'s origin. It seems to have started as a glibc thing but there are ports for BSD and Darwin. It isn't POSIX though.

When discussing the idea of this with @mitsuhiko there was the idea to have a single `NativeStacktraceIntegration` where we would add new kinds of stacktrace formats over time. However, in order to not break grouping between minor versions, we can't actually add new variants to that "super-integration" without having the user explicitly opt into each of them (just the same reason why we can't make this a default integration). Therefore I see no point in having one integration for multiple formats, and the naming problem persists.

cc @alex-hofsteede