### PR TITLE
use contextvars backport for aiohttp and sanic support in py3.6

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ format: .venv
 .PHONY: format
 
 test: .venv
-	@$(VENV_PATH)/bin/tox -e py2.7,py3.7
+	@$(VENV_PATH)/bin/tox -e py2.7,py3.7,py3.6
 .PHONY: test
 
 test-all: .venv

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ format: .venv
 .PHONY: format
 
 test: .venv
-	@$(VENV_PATH)/bin/tox -e py2.7,py3.7,py3.6
+	@$(VENV_PATH)/bin/tox -e py2.7,py3.7
 .PHONY: test
 
 test-all: .venv

--- a/sentry_sdk/integrations/aiohttp.py
+++ b/sentry_sdk/integrations/aiohttp.py
@@ -9,7 +9,7 @@ from sentry_sdk.integrations._wsgi_common import _filter_headers
 from sentry_sdk.utils import (
     capture_internal_exceptions,
     event_from_exception,
-    CONTEXTVARS_BACKPORT_ENABLED,
+    HAS_REAL_CONTEXTVARS,
 )
 
 from aiohttp.web import Application, HTTPException  # type: ignore
@@ -30,7 +30,7 @@ class AioHttpIntegration(Integration):
     @staticmethod
     def setup_once():
         # type: () -> None
-        if sys.version_info < (3, 7) and not CONTEXTVARS_BACKPORT_ENABLED:
+        if not HAS_REAL_CONTEXTVARS:
             # We better have contextvars or we're going to leak state between
             # requests.
             raise RuntimeError("The aiohttp integration for Sentry requires Python 3.7+ "

--- a/sentry_sdk/integrations/aiohttp.py
+++ b/sentry_sdk/integrations/aiohttp.py
@@ -27,12 +27,11 @@ class AioHttpIntegration(Integration):
     @staticmethod
     def setup_once():
         # type: () -> None
-        if sys.version_info < (3, 7):
+        if sys.version_info < (3, 7) and 'aiocontextvars' not in sys.modules:
             # We better have contextvars or we're going to leak state between
             # requests.
-            raise RuntimeError(
-                "The aiohttp integration for Sentry requires Python 3.7+"
-            )
+            raise RuntimeError("The aiohttp integration for Sentry requires Python 3.7+ "
+                               " or aiocontextvars package")
 
         ignore_logger("aiohttp.server")
 

--- a/sentry_sdk/integrations/aiohttp.py
+++ b/sentry_sdk/integrations/aiohttp.py
@@ -33,8 +33,10 @@ class AioHttpIntegration(Integration):
         if not HAS_REAL_CONTEXTVARS:
             # We better have contextvars or we're going to leak state between
             # requests.
-            raise RuntimeError("The aiohttp integration for Sentry requires Python 3.7+ "
-                               " or aiocontextvars package")
+            raise RuntimeError(
+                "The aiohttp integration for Sentry requires Python 3.7+ "
+                " or aiocontextvars package"
+            )
 
         ignore_logger("aiohttp.server")
 

--- a/sentry_sdk/integrations/sanic.py
+++ b/sentry_sdk/integrations/sanic.py
@@ -34,10 +34,11 @@ class SanicIntegration(Integration):
     @staticmethod
     def setup_once():
         # type: () -> None
-        if sys.version_info < (3, 7):
-            # Sanic is async. We better have contextvars or we're going to leak
-            # state between requests.
-            raise RuntimeError("The sanic integration for Sentry requires Python 3.7+")
+        if sys.version_info < (3, 7) and 'aiocontextvars' not in sys.modules:
+            # We better have contextvars or we're going to leak state between
+            # requests.
+            raise RuntimeError("The sanic integration for Sentry requires Python 3.7+ "
+                               " or aiocontextvars package")
 
         # Sanic 0.8 and older creates a logger named "root" and puts a
         # stringified version of every exception in there (without exc_info),

--- a/sentry_sdk/integrations/sanic.py
+++ b/sentry_sdk/integrations/sanic.py
@@ -4,7 +4,11 @@ from inspect import isawaitable
 
 from sentry_sdk._compat import urlparse, reraise
 from sentry_sdk.hub import Hub
-from sentry_sdk.utils import capture_internal_exceptions, event_from_exception
+from sentry_sdk.utils import (
+    capture_internal_exceptions,
+    event_from_exception,
+    CONTEXTVARS_BACKPORT_ENABLED,
+)
 from sentry_sdk.integrations import Integration
 from sentry_sdk.integrations._wsgi_common import RequestExtractor, _filter_headers
 from sentry_sdk.integrations.logging import ignore_logger
@@ -34,7 +38,7 @@ class SanicIntegration(Integration):
     @staticmethod
     def setup_once():
         # type: () -> None
-        if sys.version_info < (3, 7) and 'aiocontextvars' not in sys.modules:
+        if sys.version_info < (3, 7) and not CONTEXTVARS_BACKPORT_ENABLED:
             # We better have contextvars or we're going to leak state between
             # requests.
             raise RuntimeError("The sanic integration for Sentry requires Python 3.7+ "

--- a/sentry_sdk/integrations/sanic.py
+++ b/sentry_sdk/integrations/sanic.py
@@ -41,8 +41,10 @@ class SanicIntegration(Integration):
         if not HAS_REAL_CONTEXTVARS:
             # We better have contextvars or we're going to leak state between
             # requests.
-            raise RuntimeError("The sanic integration for Sentry requires Python 3.7+ "
-                               " or aiocontextvars package")
+            raise RuntimeError(
+                "The sanic integration for Sentry requires Python 3.7+ "
+                " or aiocontextvars package"
+            )
 
         # Sanic 0.8 and older creates a logger named "root" and puts a
         # stringified version of every exception in there (without exc_info),

--- a/sentry_sdk/integrations/sanic.py
+++ b/sentry_sdk/integrations/sanic.py
@@ -7,7 +7,7 @@ from sentry_sdk.hub import Hub
 from sentry_sdk.utils import (
     capture_internal_exceptions,
     event_from_exception,
-    CONTEXTVARS_BACKPORT_ENABLED,
+    HAS_REAL_CONTEXTVARS,
 )
 from sentry_sdk.integrations import Integration
 from sentry_sdk.integrations._wsgi_common import RequestExtractor, _filter_headers
@@ -38,7 +38,7 @@ class SanicIntegration(Integration):
     @staticmethod
     def setup_once():
         # type: () -> None
-        if sys.version_info < (3, 7) and not CONTEXTVARS_BACKPORT_ENABLED:
+        if not HAS_REAL_CONTEXTVARS:
             # We better have contextvars or we're going to leak state between
             # requests.
             raise RuntimeError("The sanic integration for Sentry requires Python 3.7+ "

--- a/sentry_sdk/utils.py
+++ b/sentry_sdk/utils.py
@@ -868,16 +868,16 @@ def format_and_strip(template, params, strip_string=strip_string):
     )
 
 
-CONTEXTVARS_BACKPORT_ENABLED = False
+HAS_REAL_CONTEXTVARS = True
+
 try:
-    if not PY2 and sys.version_info < (3, 7):
-        try:
-            import aiocontextvars
-            CONTEXTVARS_BACKPORT_ENABLED = True
-        except ImportError:
-            pass
     from contextvars import ContextVar  # type: ignore
+
+    if not PY2 and sys.version_info < (3, 7):
+        import aiocontextvars  # noqa
 except ImportError:
+    HAS_REAL_CONTEXTVARS = False
+
     from threading import local
 
     class ContextVar(object):  # type: ignore

--- a/sentry_sdk/utils.py
+++ b/sentry_sdk/utils.py
@@ -874,7 +874,7 @@ try:
     from contextvars import ContextVar  # type: ignore
 
     if not PY2 and sys.version_info < (3, 7):
-        import aiocontextvars  # noqa
+        import aiocontextvars  # type: ignore # noqa
 except ImportError:
     HAS_REAL_CONTEXTVARS = False
 

--- a/sentry_sdk/utils.py
+++ b/sentry_sdk/utils.py
@@ -867,10 +867,13 @@ def format_and_strip(template, params, strip_string=strip_string):
         value=rv, metadata={"len": rv_original_length, "rem": rv_remarks}
     )
 
+
+CONTEXTVARS_BACKPORT_ENABLED = False
 try:
     if not PY2 and sys.version_info < (3, 7):
         try:
             import aiocontextvars
+            CONTEXTVARS_BACKPORT_ENABLED = True
         except ImportError:
             pass
     from contextvars import ContextVar  # type: ignore

--- a/sentry_sdk/utils.py
+++ b/sentry_sdk/utils.py
@@ -867,8 +867,12 @@ def format_and_strip(template, params, strip_string=strip_string):
         value=rv, metadata={"len": rv_original_length, "rem": rv_remarks}
     )
 
-
 try:
+    if not PY2 and sys.version_info < (3, 7):
+        try:
+            import aiocontextvars
+        except ImportError:
+            pass
     from contextvars import ContextVar  # type: ignore
 except ImportError:
     from threading import local

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -5,3 +5,4 @@ tox==3.7.0
 Werkzeug==0.14.1
 pytest-localserver==0.4.1
 pytest-cov==2.6.0
+aiocontextvars==0.2.1

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -5,4 +5,3 @@ tox==3.7.0
 Werkzeug==0.14.1
 pytest-localserver==0.4.1
 pytest-cov==2.6.0
-aiocontextvars==0.2.1

--- a/tests/integrations/aiohttp/test_aiohttp.py
+++ b/tests/integrations/aiohttp/test_aiohttp.py
@@ -28,7 +28,7 @@ async def test_basic(sentry_init, aiohttp_client, loop, capture_events):
     assert request["env"] == {"REMOTE_ADDR": "127.0.0.1"}
     assert request["method"] == "GET"
     assert request["query_string"] == ""
-    assert request["url"] == f"http://{host}/"
+    assert request["url"] == "http://{host}/".format(host=host)
     assert request["headers"] == {
         "Accept": "*/*",
         "Accept-Encoding": "gzip, deflate",

--- a/tests/integrations/sanic/test_sanic.py
+++ b/tests/integrations/sanic/test_sanic.py
@@ -142,7 +142,7 @@ def test_concurrency(sentry_init, app):
 
         await app.handle_request(
             request.Request(
-                url_bytes=f"http://localhost/context-check/{i}".encode("ascii"),
+                url_bytes="http://localhost/context-check/{i}".format(i=i).encode("ascii"),
                 headers={},
                 version="1.1",
                 method="GET",
@@ -159,7 +159,8 @@ def test_concurrency(sentry_init, app):
         await asyncio.gather(*(task(i) for i in range(1000)))
 
     if sys.version_info < (3, 7):
-        loop = asyncio.get_event_loop()
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
         loop.run_until_complete(runner())
     else:
         asyncio.run(runner())

--- a/tests/integrations/sanic/test_sanic.py
+++ b/tests/integrations/sanic/test_sanic.py
@@ -1,3 +1,5 @@
+import sys
+
 import random
 import asyncio
 
@@ -156,7 +158,11 @@ def test_concurrency(sentry_init, app):
     async def runner():
         await asyncio.gather(*(task(i) for i in range(1000)))
 
-    asyncio.run(runner())
+    if sys.version_info < (3, 7):
+        loop = asyncio.get_event_loop()
+        loop.run_until_complete(runner())
+    else:
+        asyncio.run(runner())
 
     with configure_scope() as scope:
         assert not scope._tags

--- a/tests/integrations/sanic/test_sanic.py
+++ b/tests/integrations/sanic/test_sanic.py
@@ -142,7 +142,9 @@ def test_concurrency(sentry_init, app):
 
         await app.handle_request(
             request.Request(
-                url_bytes="http://localhost/context-check/{i}".format(i=i).encode("ascii"),
+                url_bytes="http://localhost/context-check/{i}".format(i=i).encode(
+                    "ascii"
+                ),
                 headers={},
                 version="1.1",
                 method="GET",

--- a/tox.ini
+++ b/tox.ini
@@ -20,7 +20,7 @@ envlist =
 
     {pypy,py2.7,py3.5,py3.6,py3.7,py3.8}-flask-{1.0,0.11,0.12,dev}
 
-    py3.7-sanic-0.8
+    {py3.5,py3.6,py3.7}-sanic-0.8
 
     {pypy,py2.7,py3.5,py3.6,py3.7,py3.8}-celery-{4.1,4.2}
     {pypy,py2.7}-celery-3
@@ -62,6 +62,7 @@ deps =
     flask-dev: git+https://github.com/pallets/flask.git#egg=flask
 
     sanic-0.8: sanic>=0.8,<0.9
+    {py3.5,py3.6}-sanic-0.8: aiocontextvars==0.2.1
     sanic: aiohttp
 
     celery-3: Celery>=3.1,<4.0


### PR DESCRIPTION
Ok, found a workaround for [this](https://github.com/getsentry/sentry-python/issues/289) issue. All tests are passed for py3.7 and py3.6. 