### PR TITLE
fix(celery): flush queue on worker exit

### DIFF
--- a/sentry_sdk/integrations/celery.py
+++ b/sentry_sdk/integrations/celery.py
@@ -23,11 +23,13 @@ class CeleryIntegration(Integration):
         def sentry_build_tracer(name, task, *args, **kwargs):
             # Need to patch both methods because older celery sometimes
             # short-circuits to task.run if it thinks it's safe.
-            task.__call__ = _wrap_task_call(task.__call__)
-            task.run = _wrap_task_call(task.run)
+            task.__call__ = _wrap_task_call(task, task.__call__)
+            task.run = _wrap_task_call(task, task.run)
             return _wrap_tracer(task, old_build_tracer(name, task, *args, **kwargs))
 
         trace.build_tracer = sentry_build_tracer
+
+        _patch_worker_exit()
 
         # This logger logs every status of every task that ran on the worker.
         # Meaning that every task's breadcrumbs are full of stuff like "Task
@@ -56,14 +58,17 @@ def _wrap_tracer(task, f):
     return _inner
 
 
-def _wrap_task_call(f):
+def _wrap_task_call(task, f):
     # Need to wrap task call because the exception is caught before we get to
     # see it. Also celery's reported stacktrace is untrustworthy.
     def _inner(*args, **kwargs):
         try:
             return f(*args, **kwargs)
         except Exception:
-            reraise(*_capture_exception())
+            exc_info = sys.exc_info()
+            with capture_internal_exceptions():
+                _capture_exception(task, exc_info)
+            reraise(*exc_info)
 
     return _inner
 
@@ -83,15 +88,6 @@ def _make_event_processor(task, uuid, args, kwargs, request=None):
 
         if "exc_info" in hint:
             with capture_internal_exceptions():
-                if isinstance(hint["exc_info"][1], Retry):
-                    return None
-
-                if hasattr(task, "throws") and isinstance(
-                    hint["exc_info"][1], task.throws
-                ):
-                    return None
-
-            with capture_internal_exceptions():
                 if issubclass(hint["exc_info"][0], SoftTimeLimitExceeded):
                     event["fingerprint"] = [
                         "celery",
@@ -104,16 +100,40 @@ def _make_event_processor(task, uuid, args, kwargs, request=None):
     return event_processor
 
 
-def _capture_exception():
+def _capture_exception(task, exc_info):
     hub = Hub.current
-    exc_info = sys.exc_info()
 
-    if hub.get_integration(CeleryIntegration) is not None:
-        event, hint = event_from_exception(
-            exc_info,
-            client_options=hub.client.options,
-            mechanism={"type": "celery", "handled": False},
-        )
-        hub.capture_event(event, hint=hint)
+    if hub.get_integration(CeleryIntegration) is None:
+        return
+    if isinstance(exc_info[1], Retry):
+        return
+    if hasattr(task, "throws") and isinstance(exc_info[1], task.throws):
+        return
 
-    return exc_info
+    event, hint = event_from_exception(
+        exc_info,
+        client_options=hub.client.options,
+        mechanism={"type": "celery", "handled": False},
+    )
+
+    hub.capture_event(event, hint=hint)
+
+
+def _patch_worker_exit():
+    # Need to flush queue before worker shutdown because a crashing worker will
+    # call os._exit
+    from billiard.pool import Worker
+
+    old_workloop = Worker.workloop
+
+    def sentry_workloop(*args, **kwargs):
+        try:
+            return old_workloop(*args, **kwargs)
+        finally:
+            with capture_internal_exceptions():
+                hub = Hub.current
+                if hub.get_integration(CeleryIntegration) is not None:
+                    hub.flush()
+
+
+    Worker.workloop = sentry_workloop

--- a/sentry_sdk/integrations/celery.py
+++ b/sentry_sdk/integrations/celery.py
@@ -122,7 +122,7 @@ def _capture_exception(task, exc_info):
 def _patch_worker_exit():
     # Need to flush queue before worker shutdown because a crashing worker will
     # call os._exit
-    from billiard.pool import Worker
+    from billiard.pool import Worker  # type: ignore
 
     old_workloop = Worker.workloop
 
@@ -134,6 +134,5 @@ def _patch_worker_exit():
                 hub = Hub.current
                 if hub.get_integration(CeleryIntegration) is not None:
                     hub.flush()
-
 
     Worker.workloop = sentry_workloop

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -118,3 +118,38 @@ def capture_events(monkeypatch):
         return events
 
     return inner
+
+
+@pytest.fixture
+def capture_events_forksafe(monkeypatch):
+    def inner():
+        events_r, events_w = os.pipe()
+        events_r = os.fdopen(events_r, "rb", 0)
+        events_w = os.fdopen(events_w, "wb", 0)
+
+        test_client = sentry_sdk.Hub.current.client
+        old_capture_event = test_client.transport.capture_event
+
+        def append(event):
+            events_w.write(json.dumps(event).encode("utf-8"))
+            events_w.write(b"\n")
+
+        def flush(timeout=None, callback=None):
+            events_w.write(b"flush\n")
+
+        monkeypatch.setattr(test_client.transport, "capture_event", append)
+        monkeypatch.setattr(test_client, 'flush', flush)
+
+        return EventStreamReader(events_r)
+
+    return inner
+
+class EventStreamReader(object):
+    def __init__(self, file):
+        self.file = file
+
+    def read_event(self):
+        return json.loads(self.file.readline().decode("utf-8"))
+
+    def read_flush(self):
+        assert self.file.readline() == b'flush\n'

--- a/tests/integrations/celery/test_celery.py
+++ b/tests/integrations/celery/test_celery.py
@@ -176,8 +176,8 @@ def test_transport_shutdown(request, celery, capture_events_forksafe, tmpdir):
         res.wait()
 
     event = events.read_event()
-    exception, = event['exception']['values']
-    assert exception['type'] == 'ZeroDivisionError'
+    exception, = event["exception"]["values"]
+    assert exception["type"] == "ZeroDivisionError"
 
     events.read_flush()
 

--- a/tests/integrations/celery/test_celery.py
+++ b/tests/integrations/celery/test_celery.py
@@ -1,3 +1,5 @@
+import threading
+
 import pytest
 
 pytest.importorskip("celery")
@@ -6,6 +8,7 @@ from sentry_sdk import Hub
 from sentry_sdk.integrations.celery import CeleryIntegration
 
 from celery import Celery, VERSION
+from celery.bin import worker
 
 
 @pytest.fixture
@@ -22,7 +25,7 @@ def init_celery(sentry_init):
     def inner():
         sentry_init(integrations=[CeleryIntegration()])
         celery = Celery(__name__)
-        celery.conf.CELERY_ALWAYS_EAGER = True
+        celery.conf.task_always_eager = True
         return celery
 
     return inner
@@ -92,11 +95,11 @@ def test_broken_prerun(init_celery, connect_signal):
         stack_lengths.append(len(Hub.current._stack))
         return x / y
 
-    try:
+    if VERSION >= (4,):
         dummy_task.delay(2, 2)
-    except ZeroDivisionError:
-        if VERSION >= (4,):
-            raise
+    else:
+        with pytest.raises(ZeroDivisionError):
+            dummy_task.delay(2, 2)
 
     assert len(Hub.current._stack) == 1
     if VERSION < (4,):
@@ -139,3 +142,37 @@ def test_retry(celery, capture_events):
 
     for e in exceptions:
         assert e["type"] == "ZeroDivisionError"
+
+
+def test_transport_shutdown(request, celery, capture_events_forksafe, tmpdir):
+    events = capture_events_forksafe()
+
+    celery.conf.worker_max_tasks_per_child = 1
+    celery.conf.broker_url = "memory://localhost/"
+    celery.conf.task_always_eager = False
+    celery.conf.result_backend = "file://{}".format(tmpdir.mkdir("celery-results"))
+
+    runs = []
+
+    @celery.task(name="dummy_task", bind=True)
+    def dummy_task(self):
+        runs.append(1)
+        1 / 0
+
+    res = dummy_task.delay()
+
+    w = worker.worker(app=celery)
+    t = threading.Thread(target=w.run)
+    t.daemon = True
+    t.start()
+
+    with pytest.raises(ZeroDivisionError):
+        res.wait()
+
+    assert not runs
+
+    event = events.read_event()
+    exception, = event['exception']['values']
+    assert exception['type'] == 'ZeroDivisionError'
+
+    events.read_flush()

--- a/tests/integrations/rq/test_rq.py
+++ b/tests/integrations/rq/test_rq.py
@@ -1,12 +1,7 @@
 from sentry_sdk.integrations.rq import RqIntegration
 
-import os
-import json
-
 from fakeredis import FakeStrictRedis
 import rq
-
-from sentry_sdk import Hub
 
 
 def crashing_job(foo):
@@ -56,4 +51,3 @@ def test_transport_shutdown(sentry_init, capture_events_forksafe):
 
     exception, = event["exception"]["values"]
     assert exception["type"] == "ZeroDivisionError"
-


### PR DESCRIPTION
Patch celery such that it flushes the client when shutting down a worker.

Fix #285