### PR TITLE
fix: `RuntimeError: dictionary changed size during iteration` raised within extract_locals

### DIFF
--- a/sentry_sdk/utils.py
+++ b/sentry_sdk/utils.py
@@ -376,7 +376,7 @@ def object_to_json(obj, remaining_depth=4, memo=None):
                     safe_str(k): object_to_json(
                         v, remaining_depth=remaining_depth - 1, memo=memo
                     )
-                    for k, v in obj.items()
+                    for k, v in list(obj.items())
                 }
 
         return safe_repr(obj)

--- a/tests/integrations/wsgi/test_wsgi.py
+++ b/tests/integrations/wsgi/test_wsgi.py
@@ -12,6 +12,26 @@ def crashing_app():
     return app
 
 
+@pytest.fixture
+def crashing_env_modifing_app():
+    class TooSmartClass(object):
+        def __init__(self, environ):
+            self.environ = environ
+
+        def __repr__(self):
+            if "my_representation" in self.environ:
+                return self.environ["my_representation"]
+
+            self.environ["my_representation"] = "<This is me>"
+            return self.environ["my_representation"]
+
+    def app(environ, start_response):
+        environ["tsc"] = TooSmartClass(environ)
+        1 / 0
+
+    return app
+
+
 def test_basic(sentry_init, crashing_app, capture_events):
     sentry_init(send_default_pii=True)
     app = SentryWsgiMiddleware(crashing_app)
@@ -30,3 +50,15 @@ def test_basic(sentry_init, crashing_app, capture_events):
         "query_string": "",
         "url": "http://localhost/",
     }
+
+
+def test_env_modifing_app(sentry_init, crashing_env_modifing_app, capture_events):
+    sentry_init(send_default_pii=True)
+    app = SentryWsgiMiddleware(crashing_env_modifing_app)
+    client = Client(app)
+    events = capture_events()
+
+    with pytest.raises(ZeroDivisionError):
+        client.get("/")
+
+    assert len(events) == 1  # only one exception is raised


### PR DESCRIPTION

* affects only python3 because items() in python3 doesn't return list
* note that this situation is actually a simplified example how environ is treated in Bottle framework