### PR TITLE
Bottle redirect fix

### DIFF
--- a/sentry_sdk/integrations/bottle.py
+++ b/sentry_sdk/integrations/bottle.py
@@ -109,10 +109,8 @@ class BottleIntegration(Integration):
 
                 try:
                     res = prepared_callback(*args, **kwargs)
-                except HTTPResponse as exception:
-                    if exception.status == 500:
-                        capture_exception(exception)
-                    raise exception
+                except HTTPResponse:
+                    raise
                 except Exception as exception:
                     capture_exception(exception)
                     raise exception

--- a/sentry_sdk/integrations/bottle.py
+++ b/sentry_sdk/integrations/bottle.py
@@ -100,7 +100,6 @@ class BottleIntegration(Integration):
 
             def wrapped_callback(*args, **kwargs):
                 def capture_exception(exception):
-                    hub = Hub.current
                     event, hint = event_from_exception(
                         exception,
                         client_options=hub.client.options,

--- a/tests/integrations/bottle/test_bottle.py
+++ b/tests/integrations/bottle/test_bottle.py
@@ -6,7 +6,7 @@ import logging
 pytest.importorskip("bottle")
 
 from io import BytesIO
-from bottle import Bottle, debug as set_debug, abort
+from bottle import Bottle, debug as set_debug, abort, redirect
 from sentry_sdk import capture_message
 
 from sentry_sdk.integrations.logging import LoggingIntegration
@@ -417,6 +417,25 @@ def test_bad_request_not_captured(sentry_init, capture_events, app, get_client):
     @app.route("/")
     def index():
         abort(400, "bad request in")
+
+    client = get_client()
+
+    client.get("/")
+
+    assert not events
+
+
+def test_no_exception_on_redirect(sentry_init, capture_events, app, get_client):
+    sentry_init(integrations=[bottle_sentry.BottleIntegration()])
+    events = capture_events()
+
+    @app.route("/")
+    def index():
+        redirect("/here")
+
+    @app.route("/here")
+    def here():
+        return "here"
 
     client = get_client()
 

--- a/tox.ini
+++ b/tox.ini
@@ -14,7 +14,6 @@ envlist =
     {py3.5,py3.6,py3.7}-django-{2.0,2.1}
     {pypy,py2.7,py3.5}-django-1.11
     {pypy,py2.7,py3.4,py3.5}-django-{1.8,1.9,1.10}
-    {pypy,py2.7,py3.4,py3.5}-django-1.8
     {pypy,py2.7,py3.4}-django-1.7
     {pypy,py2.7}-django-1.6
 


### PR DESCRIPTION
I found out that a sentry record is created when a Bottle redirect is performed.

This MR should fix that.

I also included a small tox.ini update.