### PR TITLE
clear event and error processors from scope when clear() is called

### DIFF
--- a/sentry_sdk/scope.py
+++ b/sentry_sdk/scope.py
@@ -127,6 +127,9 @@ class Scope(object):
         self.clear_breadcrumbs()
         self._should_capture = True
 
+        self._event_processors = []
+        self._error_processors = []
+
     def clear_breadcrumbs(self):
         # type: () -> None
         """Clears breadcrumb buffer."""

--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -308,6 +308,7 @@ def test_local_event_processors_clear(sentry_init, capture_events):
     events = capture_events()
 
     with push_scope() as scope:
+
         def error_processor(event, exc_info):
             event.setdefault("test_error", {"x": "y"})
             return event


### PR DESCRIPTION
## Description
User-set scope-local event and error processors are not cleaned up when the `clear()` function is called. This creates a situation where only new entries are added, but never cleaned up. This could create a memory leak for long-running processes that assume the scope is cleaned on every `clear()`.

This merge request fixes the issue by clearing the `_event_processors` and `_error_processors` lists in the scope when `clear()` is called.