### PR TITLE
fix: Ignore Celery exceptions used for control flow

### DIFF
--- a/sentry_sdk/integrations/celery.py
+++ b/sentry_sdk/integrations/celery.py
@@ -2,12 +2,12 @@ from __future__ import absolute_import
 
 import sys
 
-from celery.exceptions import (
+from celery.exceptions import (  # type: ignore
     SoftTimeLimitExceeded,
     Retry,
     Ignore,
     Reject,
-)  # type: ignore
+)
 
 from sentry_sdk.hub import Hub
 from sentry_sdk.utils import capture_internal_exceptions, event_from_exception

--- a/sentry_sdk/integrations/celery.py
+++ b/sentry_sdk/integrations/celery.py
@@ -2,13 +2,21 @@ from __future__ import absolute_import
 
 import sys
 
-from celery.exceptions import SoftTimeLimitExceeded, Retry  # type: ignore
+from celery.exceptions import (
+    SoftTimeLimitExceeded,
+    Retry,
+    Ignore,
+    Reject,
+)  # type: ignore
 
 from sentry_sdk.hub import Hub
 from sentry_sdk.utils import capture_internal_exceptions, event_from_exception
 from sentry_sdk._compat import reraise
 from sentry_sdk.integrations import Integration
 from sentry_sdk.integrations.logging import ignore_logger
+
+
+CELERY_CONTROL_FLOW_EXCEPTIONS = (Retry, Ignore, Reject)
 
 
 class CeleryIntegration(Integration):
@@ -106,7 +114,7 @@ def _capture_exception(task, exc_info):
 
     if hub.get_integration(CeleryIntegration) is None:
         return
-    if isinstance(exc_info[1], Retry):
+    if isinstance(exc_info[1], CELERY_CONTROL_FLOW_EXCEPTIONS):
         return
     if hasattr(task, "throws") and isinstance(exc_info[1], task.throws):
         return


### PR DESCRIPTION
Fix #353 