### PR TITLE
ref: Typehints cleanup

### DIFF
--- a/sentry_sdk/_compat.py
+++ b/sentry_sdk/_compat.py
@@ -1,10 +1,7 @@
 import sys
 
 if False:
-    from typing import Optional
-    from typing import Tuple
-    from typing import Any
-    from typing import Type
+    pass
 
 
 PY2 = sys.version_info[0] == 2

--- a/sentry_sdk/_compat.py
+++ b/sentry_sdk/_compat.py
@@ -1,7 +1,6 @@
 import sys
 
-if False:
-    pass
+
 
 
 PY2 = sys.version_info[0] == 2

--- a/sentry_sdk/_compat.py
+++ b/sentry_sdk/_compat.py
@@ -33,8 +33,8 @@ else:
     import queue  # noqa
 
     text_type = str
-    string_types = (text_type,)  # type: Tuple[type]
-    number_types = (int, float)  # type: Tuple[type, type]
+    string_types = (text_type,)  
+    number_types = (int, float)  
     int_types = (int,)  # noqa
     iteritems = lambda x: x.items()
 
@@ -45,7 +45,7 @@ else:
         return x
 
     def reraise(tp, value, tb=None):
-        # type: (Optional[Type[BaseException]], Optional[BaseException], Optional[Any]) -> None
+        
         assert value is not None
         if value.__traceback__ is not tb:
             raise value.with_traceback(tb)
@@ -61,9 +61,9 @@ def with_metaclass(meta, *bases):
 
 
 def check_thread_support():
-    # type: () -> None
+    
     try:
-        from uwsgi import opt  # type: ignore
+        from uwsgi import opt  #type: ignore
     except ImportError:
         return
 

--- a/sentry_sdk/_compat.py
+++ b/sentry_sdk/_compat.py
@@ -33,8 +33,8 @@ else:
     import queue  # noqa
 
     text_type = str
-    string_types = (text_type,)  
-    number_types = (int, float)  
+    string_types = (text_type,)
+    number_types = (int, float)
     int_types = (int,)  # noqa
     iteritems = lambda x: x.items()
 
@@ -45,7 +45,7 @@ else:
         return x
 
     def reraise(tp, value, tb=None):
-        
+
         assert value is not None
         if value.__traceback__ is not tb:
             raise value.with_traceback(tb)
@@ -61,9 +61,9 @@ def with_metaclass(meta, *bases):
 
 
 def check_thread_support():
-    
+
     try:
-        from uwsgi import opt  #type: ignore
+        from uwsgi import opt  # type: ignore
     except ImportError:
         return
 

--- a/sentry_sdk/_compat.py
+++ b/sentry_sdk/_compat.py
@@ -1,8 +1,6 @@
 import sys
 
 
-
-
 PY2 = sys.version_info[0] == 2
 
 if PY2:

--- a/sentry_sdk/api.py
+++ b/sentry_sdk/api.py
@@ -36,7 +36,7 @@ def hubmethod(f):
 
 @hubmethod
 def capture_event(event, hint=None):
-    # type: (Dict[str, Any], Dict[str, Any]) -> Optional[str]
+    
     hub = Hub.current
     if hub is not None:
         return hub.capture_event(event, hint)
@@ -45,7 +45,7 @@ def capture_event(event, hint=None):
 
 @hubmethod
 def capture_message(message, level=None):
-    # type: (str, Optional[Any]) -> Optional[str]
+    
     hub = Hub.current
     if hub is not None:
         return hub.capture_message(message, level)
@@ -54,7 +54,7 @@ def capture_message(message, level=None):
 
 @hubmethod
 def capture_exception(error=None):
-    # type: (Optional[BaseException]) -> Optional[str]
+    
     hub = Hub.current
     if hub is not None:
         return hub.capture_exception(error)
@@ -63,7 +63,7 @@ def capture_exception(error=None):
 
 @hubmethod
 def add_breadcrumb(crumb=None, hint=None, **kwargs):
-    # type: (Dict[str, Any], Dict[str, Any], **Any) -> None
+    
     hub = Hub.current
     if hub is not None:
         return hub.add_breadcrumb(crumb, hint, **kwargs)
@@ -71,13 +71,13 @@ def add_breadcrumb(crumb=None, hint=None, **kwargs):
 
 @overload  # noqa
 def configure_scope():
-    # type: () -> ContextManager[Scope]
+    
     pass
 
 
 @overload  # noqa
 def configure_scope(callback):
-    # type: (Callable[[Scope], None]) -> None
+    
     pass
 
 
@@ -100,13 +100,13 @@ def configure_scope(callback=None):
 
 @overload  # noqa
 def push_scope():
-    # type: () -> ContextManager[Scope]
+    
     pass
 
 
 @overload  # noqa
 def push_scope(callback):
-    # type: (Callable[[Scope], None]) -> None
+    
     pass
 
 
@@ -136,7 +136,7 @@ def flush(timeout=None, callback=None):
 
 @hubmethod
 def last_event_id():
-    # type: () -> Optional[str]
+    
     hub = Hub.current
     if hub is not None:
         return hub.last_event_id()

--- a/sentry_sdk/api.py
+++ b/sentry_sdk/api.py
@@ -36,7 +36,7 @@ def hubmethod(f):
 
 @hubmethod
 def capture_event(event, hint=None):
-    
+
     hub = Hub.current
     if hub is not None:
         return hub.capture_event(event, hint)
@@ -45,7 +45,7 @@ def capture_event(event, hint=None):
 
 @hubmethod
 def capture_message(message, level=None):
-    
+
     hub = Hub.current
     if hub is not None:
         return hub.capture_message(message, level)
@@ -54,7 +54,7 @@ def capture_message(message, level=None):
 
 @hubmethod
 def capture_exception(error=None):
-    
+
     hub = Hub.current
     if hub is not None:
         return hub.capture_exception(error)
@@ -63,7 +63,7 @@ def capture_exception(error=None):
 
 @hubmethod
 def add_breadcrumb(crumb=None, hint=None, **kwargs):
-    
+
     hub = Hub.current
     if hub is not None:
         return hub.add_breadcrumb(crumb, hint, **kwargs)
@@ -71,13 +71,13 @@ def add_breadcrumb(crumb=None, hint=None, **kwargs):
 
 @overload  # noqa
 def configure_scope():
-    
+
     pass
 
 
 @overload  # noqa
 def configure_scope(callback):
-    
+
     pass
 
 
@@ -100,13 +100,13 @@ def configure_scope(callback=None):
 
 @overload  # noqa
 def push_scope():
-    
+
     pass
 
 
 @overload  # noqa
 def push_scope(callback):
-    
+
     pass
 
 
@@ -136,7 +136,7 @@ def flush(timeout=None, callback=None):
 
 @hubmethod
 def last_event_id():
-    
+
     hub = Hub.current
     if hub is not None:
         return hub.last_event_id()

--- a/sentry_sdk/api.py
+++ b/sentry_sdk/api.py
@@ -6,12 +6,7 @@ from sentry_sdk.scope import Scope
 
 
 if False:
-    from typing import Any
-    from typing import Optional
     from typing import overload
-    from typing import Callable
-    from typing import Dict
-    from contextlib import ContextManager
 else:
 
     def overload(x):

--- a/sentry_sdk/client.py
+++ b/sentry_sdk/client.py
@@ -31,22 +31,22 @@ _client_init_debug = ContextVar("client_init_debug")
 
 
 def get_options(*args, **kwargs):
-    
+
     if args and (isinstance(args[0], string_types) or args[0] is None):
-        dsn = args[0]  
+        dsn = args[0]
         args = args[1:]
     else:
         dsn = None
 
     rv = dict(DEFAULT_OPTIONS)
-    options = dict(*args, **kwargs)  
+    options = dict(*args, **kwargs)
     if dsn is not None and options.get("dsn") is None:
-        options["dsn"] = dsn  
+        options["dsn"] = dsn
 
     for key, value in options.items():
         if key not in rv:
             raise TypeError("Unknown option %r" % (key,))
-        rv[key] = value  
+        rv[key] = value
 
     if rv["dsn"] is None:
         rv["dsn"] = os.environ.get("SENTRY_DSN")
@@ -57,7 +57,7 @@ def get_options(*args, **kwargs):
     if rv["environment"] is None:
         rv["environment"] = os.environ.get("SENTRY_ENVIRONMENT")
 
-    return rv  
+    return rv
 
 
 class Client(object):
@@ -68,7 +68,7 @@ class Client(object):
     """
 
     def __init__(self, *args, **kwargs):
-        
+
         old_debug = _client_init_debug.get(False)
         try:
             self.options = options = get_options(*args, **kwargs)
@@ -96,11 +96,11 @@ class Client(object):
 
     def _prepare_event(
         self,
-        event,  #type: Dict[str, Any]
-        hint,  
-        scope,  
+        event,  # type: Dict[str, Any]
+        hint,
+        scope,
     ):
-        
+
         if event.get("timestamp") is None:
             event["timestamp"] = datetime.utcnow()
 
@@ -129,8 +129,8 @@ class Client(object):
                 }
 
         for key in "release", "environment", "server_name", "dist":
-            if event.get(key) is None and self.options[key] is not None:  
-                event[key] = text_type(self.options[key]).strip()  
+            if event.get(key) is None and self.options[key] is not None:
+                event[key] = text_type(self.options[key]).strip()
         if event.get("sdk") is None:
             sdk_info = dict(SDK_INFO)
             sdk_info["integrations"] = sorted(self.integrations.keys())
@@ -157,12 +157,12 @@ class Client(object):
                 new_event = before_send(event, hint)
             if new_event is None:
                 logger.info("before send dropped event (%s)", event)
-            event = new_event  #type: ignore
+            event = new_event  # type: ignore
 
         return event
 
     def _is_ignored_error(self, event, hint):
-        
+
         exc_info = hint.get("exc_info")
         if exc_info is None:
             return False
@@ -182,13 +182,8 @@ class Client(object):
 
         return False
 
-    def _should_capture(
-        self,
-        event,  
-        hint,  
-        scope=None,  
-    ):
-        
+    def _should_capture(self, event, hint, scope=None):
+
         if scope is not None and not scope._should_capture:
             return False
 
@@ -204,7 +199,7 @@ class Client(object):
         return True
 
     def capture_event(self, event, hint=None, scope=None):
-        
+
         """Captures an event.
 
         This takes the ready made event and an optoinal hint and scope.  The
@@ -224,7 +219,7 @@ class Client(object):
             event["event_id"] = rv = uuid.uuid4().hex
         if not self._should_capture(event, hint, scope):
             return None
-        event = self._prepare_event(event, hint, scope)  
+        event = self._prepare_event(event, hint, scope)
         if event is None:
             return None
         self.transport.capture_event(event)

--- a/sentry_sdk/client.py
+++ b/sentry_sdk/client.py
@@ -31,22 +31,22 @@ _client_init_debug = ContextVar("client_init_debug")
 
 
 def get_options(*args, **kwargs):
-    # type: (*str, **ClientOptions) -> ClientOptions
+    
     if args and (isinstance(args[0], string_types) or args[0] is None):
-        dsn = args[0]  # type: Optional[str]
+        dsn = args[0]  
         args = args[1:]
     else:
         dsn = None
 
     rv = dict(DEFAULT_OPTIONS)
-    options = dict(*args, **kwargs)  # type: ignore
+    options = dict(*args, **kwargs)  
     if dsn is not None and options.get("dsn") is None:
-        options["dsn"] = dsn  # type: ignore
+        options["dsn"] = dsn  
 
     for key, value in options.items():
         if key not in rv:
             raise TypeError("Unknown option %r" % (key,))
-        rv[key] = value  # type: ignore
+        rv[key] = value  
 
     if rv["dsn"] is None:
         rv["dsn"] = os.environ.get("SENTRY_DSN")
@@ -57,7 +57,7 @@ def get_options(*args, **kwargs):
     if rv["environment"] is None:
         rv["environment"] = os.environ.get("SENTRY_ENVIRONMENT")
 
-    return rv  # type: ignore
+    return rv  
 
 
 class Client(object):
@@ -68,7 +68,7 @@ class Client(object):
     """
 
     def __init__(self, *args, **kwargs):
-        # type: (*str, **ClientOptions) -> None
+        
         old_debug = _client_init_debug.get(False)
         try:
             self.options = options = get_options(*args, **kwargs)
@@ -96,11 +96,11 @@ class Client(object):
 
     def _prepare_event(
         self,
-        event,  # type: Dict[str, Any]
-        hint,  # type: Optional[Dict[str, Any]]
-        scope,  # type: Optional[Scope]
+        event,  #type: Dict[str, Any]
+        hint,  
+        scope,  
     ):
-        # type: (...) -> Optional[Dict[str, Any]]
+        
         if event.get("timestamp") is None:
             event["timestamp"] = datetime.utcnow()
 
@@ -129,8 +129,8 @@ class Client(object):
                 }
 
         for key in "release", "environment", "server_name", "dist":
-            if event.get(key) is None and self.options[key] is not None:  # type: ignore
-                event[key] = text_type(self.options[key]).strip()  # type: ignore
+            if event.get(key) is None and self.options[key] is not None:  
+                event[key] = text_type(self.options[key]).strip()  
         if event.get("sdk") is None:
             sdk_info = dict(SDK_INFO)
             sdk_info["integrations"] = sorted(self.integrations.keys())
@@ -157,12 +157,12 @@ class Client(object):
                 new_event = before_send(event, hint)
             if new_event is None:
                 logger.info("before send dropped event (%s)", event)
-            event = new_event  # type: ignore
+            event = new_event  #type: ignore
 
         return event
 
     def _is_ignored_error(self, event, hint):
-        # type: (Dict[str, Any], Dict[str, Any]) -> bool
+        
         exc_info = hint.get("exc_info")
         if exc_info is None:
             return False
@@ -184,11 +184,11 @@ class Client(object):
 
     def _should_capture(
         self,
-        event,  # type: Dict[str, Any]
-        hint,  # type: Dict[str, Any]
-        scope=None,  # type: Scope
+        event,  
+        hint,  
+        scope=None,  
     ):
-        # type: (...) -> bool
+        
         if scope is not None and not scope._should_capture:
             return False
 
@@ -204,7 +204,7 @@ class Client(object):
         return True
 
     def capture_event(self, event, hint=None, scope=None):
-        # type: (Dict[str, Any], Any, Scope) -> Optional[str]
+        
         """Captures an event.
 
         This takes the ready made event and an optoinal hint and scope.  The
@@ -224,7 +224,7 @@ class Client(object):
             event["event_id"] = rv = uuid.uuid4().hex
         if not self._should_capture(event, hint, scope):
             return None
-        event = self._prepare_event(event, hint, scope)  # type: ignore
+        event = self._prepare_event(event, hint, scope)  
         if event is None:
             return None
         self.transport.capture_event(event)

--- a/sentry_sdk/client.py
+++ b/sentry_sdk/client.py
@@ -20,11 +20,8 @@ from sentry_sdk.integrations import setup_integrations
 from sentry_sdk.utils import ContextVar
 
 if False:
-    from sentry_sdk.consts import ClientOptions
-    from sentry_sdk.scope import Scope
     from typing import Any
     from typing import Dict
-    from typing import Optional
 
 
 _client_init_debug = ContextVar("client_init_debug")

--- a/sentry_sdk/debug.py
+++ b/sentry_sdk/debug.py
@@ -5,7 +5,6 @@ from sentry_sdk import utils
 from sentry_sdk.hub import Hub
 from sentry_sdk.utils import logger
 from sentry_sdk.client import _client_init_debug
-from logging import LogRecord
 
 
 class _HubBasedClientFilter(logging.Filter):

--- a/sentry_sdk/debug.py
+++ b/sentry_sdk/debug.py
@@ -10,7 +10,7 @@ from logging import LogRecord
 
 class _HubBasedClientFilter(logging.Filter):
     def filter(self, record):
-        # type: (LogRecord) -> bool
+        
         if _client_init_debug.get(False):
             return True
         hub = Hub.current

--- a/sentry_sdk/debug.py
+++ b/sentry_sdk/debug.py
@@ -10,7 +10,7 @@ from logging import LogRecord
 
 class _HubBasedClientFilter(logging.Filter):
     def filter(self, record):
-        
+
         if _client_init_debug.get(False):
             return True
         hub = Hub.current

--- a/sentry_sdk/hub.py
+++ b/sentry_sdk/hub.py
@@ -38,7 +38,7 @@ _initial_client = None
 
 
 def _should_send_default_pii():
-    # type: () -> bool
+    
     client = Hub.current.client
     if not client:
         return False
@@ -75,7 +75,7 @@ def init(*args, **kwargs):
 class HubMeta(type):
     @property
     def current(self):
-        # type: () -> Hub
+        
         """Returns the current instance of the hub."""
         rv = _local.get(None)
         if rv is None:
@@ -105,7 +105,7 @@ class _ScopeManager(object):
         self._layer = hub._stack[-1]
 
     def __enter__(self):
-        # type: () -> Scope
+        
         scope = self._layer[1]
         assert scope is not None
         return scope
@@ -144,7 +144,7 @@ class _ScopeManager(object):
             logger.warning(warning)
 
 
-class Hub(with_metaclass(HubMeta)):  # type: ignore
+class Hub(with_metaclass(HubMeta)):  #type: ignore
     """The hub wraps the concurrency management of the SDK.  Each thread has
     its own hub but the hub might transfer with the flow of execution if
     context vars are available.
@@ -152,10 +152,10 @@ class Hub(with_metaclass(HubMeta)):  # type: ignore
     If the hub is used with a with statement it's temporarily activated.
     """
 
-    _stack = None  # type: List[Tuple[Optional[Client], Scope]]
+    _stack = None  #type: List[Tuple[Optional[Client], Scope]]
 
     def __init__(self, client_or_hub=None, scope=None):
-        # type: (Union[Hub, Client], Optional[Any]) -> None
+        
         if isinstance(client_or_hub, Hub):
             hub = client_or_hub
             client, other_scope = hub._stack[-1]
@@ -167,22 +167,22 @@ class Hub(with_metaclass(HubMeta)):  # type: ignore
             scope = Scope()
 
         self._stack = [(client, scope)]
-        self._last_event_id = None  # type: Optional[str]
-        self._old_hubs = []  # type: List[Hub]
+        self._last_event_id = None  
+        self._old_hubs = []  
 
     def __enter__(self):
-        # type: () -> Hub
+        
         self._old_hubs.append(Hub.current)
         _local.set(self)
         return self
 
     def __exit__(
         self,
-        exc_type,  # type: Optional[type]
-        exc_value,  # type: Optional[BaseException]
-        tb,  # type: Optional[Any]
+        exc_type,  
+        exc_value,  
+        tb,  
     ):
-        # type: (...) -> None
+        
         old = self._old_hubs.pop()
         _local.set(old)
 
@@ -194,7 +194,7 @@ class Hub(with_metaclass(HubMeta)):  # type: ignore
             return callback()
 
     def get_integration(self, name_or_class):
-        # type: (Union[str, Integration]) -> Any
+        
         """Returns the integration for this hub by name or class.  If there
         is no client bound or the client does not have that integration
         then `None` is returned.
@@ -236,12 +236,12 @@ class Hub(with_metaclass(HubMeta)):  # type: ignore
 
     @property
     def client(self):
-        # type: () -> Optional[Client]
+        
         """Returns the current client on the hub."""
         return self._stack[-1][0]
 
     def last_event_id(self):
-        # type: () -> Optional[str]
+        
         """Returns the last event ID."""
         return self._last_event_id
 
@@ -251,7 +251,7 @@ class Hub(with_metaclass(HubMeta)):  # type: ignore
         self._stack[-1] = (new, top[1])
 
     def capture_event(self, event, hint=None):
-        # type: (Dict[str, Any], Dict[str, Any]) -> Optional[str]
+        
         """Captures an event.  The return value is the ID of the event.
 
         The event is a dictionary following the Sentry v7/v8 protocol
@@ -268,7 +268,7 @@ class Hub(with_metaclass(HubMeta)):  # type: ignore
         return None
 
     def capture_message(self, message, level=None):
-        # type: (str, Optional[Any]) -> Optional[str]
+        
         """Captures a message.  The message is just a string.  If no level
         is provided the default level is `info`.
         """
@@ -279,7 +279,7 @@ class Hub(with_metaclass(HubMeta)):  # type: ignore
         return self.capture_event({"message": message, "level": level})
 
     def capture_exception(self, error=None):
-        # type: (Optional[BaseException]) -> Optional[str]
+        
         """Captures an exception.
 
         The argument passed can be `None` in which case the last exception
@@ -308,7 +308,7 @@ class Hub(with_metaclass(HubMeta)):  # type: ignore
         logger.error("Internal error in sentry_sdk", exc_info=exc_info)
 
     def add_breadcrumb(self, crumb=None, hint=None, **kwargs):
-        # type: (Dict[str, Any], Dict[str, Any], **Any) -> None
+        
         """Adds a breadcrumb.  The breadcrumbs are a dictionary with the
         data as the sentry v7/v8 protocol expects.  `hint` is an optional
         value that can be used by `before_breadcrumb` to customize the
@@ -319,7 +319,7 @@ class Hub(with_metaclass(HubMeta)):  # type: ignore
             logger.info("Dropped breadcrumb because no client bound")
             return
 
-        crumb = dict(crumb or ())  # type: Dict[str, Any]
+        crumb = dict(crumb or ())  
         crumb.update(kwargs)
         if not crumb:
             return
@@ -340,18 +340,18 @@ class Hub(with_metaclass(HubMeta)):  # type: ignore
         else:
             logger.info("before breadcrumb dropped breadcrumb (%s)", original_crumb)
 
-        max_breadcrumbs = client.options["max_breadcrumbs"]  # type: int
+        max_breadcrumbs = client.options["max_breadcrumbs"]  
         while len(scope._breadcrumbs) > max_breadcrumbs:
             scope._breadcrumbs.popleft()
 
     @overload  # noqa
     def push_scope(self):
-        # type: () -> ContextManager[Scope]
+        
         pass
 
     @overload  # noqa
     def push_scope(self, callback):
-        # type: (Callable[[Scope], None]) -> None
+        
         pass
 
     def push_scope(self, callback=None):  # noqa
@@ -382,12 +382,12 @@ class Hub(with_metaclass(HubMeta)):  # type: ignore
 
     @overload  # noqa
     def configure_scope(self):
-        # type: () -> ContextManager[Scope]
+        
         pass
 
     @overload  # noqa
     def configure_scope(self, callback):
-        # type: (Callable[[Scope], None]) -> None
+        
         pass
 
     def configure_scope(self, callback=None):  # noqa

--- a/sentry_sdk/hub.py
+++ b/sentry_sdk/hub.py
@@ -17,16 +17,10 @@ from sentry_sdk.utils import (
 
 
 if False:
-    from typing import Union
-    from typing import Any
     from typing import Optional
-    from typing import Dict
     from typing import Tuple
     from typing import List
-    from typing import Callable
     from typing import overload
-    from contextlib import ContextManager
-    from sentry_sdk.integrations import Integration
 else:
 
     def overload(x):

--- a/sentry_sdk/hub.py
+++ b/sentry_sdk/hub.py
@@ -38,7 +38,7 @@ _initial_client = None
 
 
 def _should_send_default_pii():
-    
+
     client = Hub.current.client
     if not client:
         return False
@@ -75,7 +75,7 @@ def init(*args, **kwargs):
 class HubMeta(type):
     @property
     def current(self):
-        
+
         """Returns the current instance of the hub."""
         rv = _local.get(None)
         if rv is None:
@@ -105,7 +105,7 @@ class _ScopeManager(object):
         self._layer = hub._stack[-1]
 
     def __enter__(self):
-        
+
         scope = self._layer[1]
         assert scope is not None
         return scope
@@ -144,7 +144,7 @@ class _ScopeManager(object):
             logger.warning(warning)
 
 
-class Hub(with_metaclass(HubMeta)):  #type: ignore
+class Hub(with_metaclass(HubMeta)):  # type: ignore
     """The hub wraps the concurrency management of the SDK.  Each thread has
     its own hub but the hub might transfer with the flow of execution if
     context vars are available.
@@ -152,10 +152,10 @@ class Hub(with_metaclass(HubMeta)):  #type: ignore
     If the hub is used with a with statement it's temporarily activated.
     """
 
-    _stack = None  #type: List[Tuple[Optional[Client], Scope]]
+    _stack = None  # type: List[Tuple[Optional[Client], Scope]]
 
     def __init__(self, client_or_hub=None, scope=None):
-        
+
         if isinstance(client_or_hub, Hub):
             hub = client_or_hub
             client, other_scope = hub._stack[-1]
@@ -167,22 +167,17 @@ class Hub(with_metaclass(HubMeta)):  #type: ignore
             scope = Scope()
 
         self._stack = [(client, scope)]
-        self._last_event_id = None  
-        self._old_hubs = []  
+        self._last_event_id = None
+        self._old_hubs = []
 
     def __enter__(self):
-        
+
         self._old_hubs.append(Hub.current)
         _local.set(self)
         return self
 
-    def __exit__(
-        self,
-        exc_type,  
-        exc_value,  
-        tb,  
-    ):
-        
+    def __exit__(self, exc_type, exc_value, tb):
+
         old = self._old_hubs.pop()
         _local.set(old)
 
@@ -194,7 +189,7 @@ class Hub(with_metaclass(HubMeta)):  #type: ignore
             return callback()
 
     def get_integration(self, name_or_class):
-        
+
         """Returns the integration for this hub by name or class.  If there
         is no client bound or the client does not have that integration
         then `None` is returned.
@@ -236,12 +231,12 @@ class Hub(with_metaclass(HubMeta)):  #type: ignore
 
     @property
     def client(self):
-        
+
         """Returns the current client on the hub."""
         return self._stack[-1][0]
 
     def last_event_id(self):
-        
+
         """Returns the last event ID."""
         return self._last_event_id
 
@@ -251,7 +246,7 @@ class Hub(with_metaclass(HubMeta)):  #type: ignore
         self._stack[-1] = (new, top[1])
 
     def capture_event(self, event, hint=None):
-        
+
         """Captures an event.  The return value is the ID of the event.
 
         The event is a dictionary following the Sentry v7/v8 protocol
@@ -268,7 +263,7 @@ class Hub(with_metaclass(HubMeta)):  #type: ignore
         return None
 
     def capture_message(self, message, level=None):
-        
+
         """Captures a message.  The message is just a string.  If no level
         is provided the default level is `info`.
         """
@@ -279,7 +274,7 @@ class Hub(with_metaclass(HubMeta)):  #type: ignore
         return self.capture_event({"message": message, "level": level})
 
     def capture_exception(self, error=None):
-        
+
         """Captures an exception.
 
         The argument passed can be `None` in which case the last exception
@@ -308,7 +303,7 @@ class Hub(with_metaclass(HubMeta)):  #type: ignore
         logger.error("Internal error in sentry_sdk", exc_info=exc_info)
 
     def add_breadcrumb(self, crumb=None, hint=None, **kwargs):
-        
+
         """Adds a breadcrumb.  The breadcrumbs are a dictionary with the
         data as the sentry v7/v8 protocol expects.  `hint` is an optional
         value that can be used by `before_breadcrumb` to customize the
@@ -319,7 +314,7 @@ class Hub(with_metaclass(HubMeta)):  #type: ignore
             logger.info("Dropped breadcrumb because no client bound")
             return
 
-        crumb = dict(crumb or ())  
+        crumb = dict(crumb or ())
         crumb.update(kwargs)
         if not crumb:
             return
@@ -340,18 +335,18 @@ class Hub(with_metaclass(HubMeta)):  #type: ignore
         else:
             logger.info("before breadcrumb dropped breadcrumb (%s)", original_crumb)
 
-        max_breadcrumbs = client.options["max_breadcrumbs"]  
+        max_breadcrumbs = client.options["max_breadcrumbs"]
         while len(scope._breadcrumbs) > max_breadcrumbs:
             scope._breadcrumbs.popleft()
 
     @overload  # noqa
     def push_scope(self):
-        
+
         pass
 
     @overload  # noqa
     def push_scope(self, callback):
-        
+
         pass
 
     def push_scope(self, callback=None):  # noqa
@@ -382,12 +377,12 @@ class Hub(with_metaclass(HubMeta)):  #type: ignore
 
     @overload  # noqa
     def configure_scope(self):
-        
+
         pass
 
     @overload  # noqa
     def configure_scope(self, callback):
-        
+
         pass
 
     def configure_scope(self, callback=None):  # noqa

--- a/sentry_sdk/integrations/__init__.py
+++ b/sentry_sdk/integrations/__init__.py
@@ -7,12 +7,7 @@ from sentry_sdk._compat import iteritems
 from sentry_sdk.utils import logger
 
 if False:
-    from typing import Iterator
-    from typing import Dict
-    from typing import List
     from typing import Set
-    from typing import Type
-    from typing import Callable
 
 
 _installer_lock = Lock()

--- a/sentry_sdk/integrations/__init__.py
+++ b/sentry_sdk/integrations/__init__.py
@@ -16,13 +16,12 @@ if False:
 
 
 _installer_lock = Lock()
-_installed_integrations = set()  #type: Set[str]
+_installed_integrations = set()  # type: Set[str]
 
 
 def _generate_default_integrations_iterator(*import_strings):
-    
     def iter_default_integrations():
-        
+
         """Returns an iterator of the default integration classes:
         """
         from importlib import import_module
@@ -33,9 +32,7 @@ def _generate_default_integrations_iterator(*import_strings):
 
     if isinstance(iter_default_integrations.__doc__, str):
         for import_string in import_strings:
-            iter_default_integrations.__doc__ += "\n- `{}`".format(  
-                import_string
-            )
+            iter_default_integrations.__doc__ += "\n- `{}`".format(import_string)
 
     return iter_default_integrations
 
@@ -55,7 +52,7 @@ del _generate_default_integrations_iterator
 
 
 def setup_integrations(integrations, with_defaults=True):
-    
+
     """Given a list of integration instances this installs them all.  When
     `with_defaults` is set to `True` then all default integrations are added
     unless they were already provided before.
@@ -108,7 +105,7 @@ class Integration(object):
     install = None
     """Legacy method, do not implement."""
 
-    identifier = None  #type: str
+    identifier = None  # type: str
     """String unique ID of integration type"""
 
     @staticmethod

--- a/sentry_sdk/integrations/__init__.py
+++ b/sentry_sdk/integrations/__init__.py
@@ -16,13 +16,13 @@ if False:
 
 
 _installer_lock = Lock()
-_installed_integrations = set()  # type: Set[str]
+_installed_integrations = set()  #type: Set[str]
 
 
 def _generate_default_integrations_iterator(*import_strings):
-    # type: (*str) -> Callable[[], Iterator[Type[Integration]]]
+    
     def iter_default_integrations():
-        # type: () -> Iterator[Type[Integration]]
+        
         """Returns an iterator of the default integration classes:
         """
         from importlib import import_module
@@ -33,7 +33,7 @@ def _generate_default_integrations_iterator(*import_strings):
 
     if isinstance(iter_default_integrations.__doc__, str):
         for import_string in import_strings:
-            iter_default_integrations.__doc__ += "\n- `{}`".format(  # type: ignore
+            iter_default_integrations.__doc__ += "\n- `{}`".format(  
                 import_string
             )
 
@@ -55,7 +55,7 @@ del _generate_default_integrations_iterator
 
 
 def setup_integrations(integrations, with_defaults=True):
-    # type: (List[Integration], bool) -> Dict[str, Integration]
+    
     """Given a list of integration instances this installs them all.  When
     `with_defaults` is set to `True` then all default integrations are added
     unless they were already provided before.
@@ -108,7 +108,7 @@ class Integration(object):
     install = None
     """Legacy method, do not implement."""
 
-    identifier = None  # type: str
+    identifier = None  #type: str
     """String unique ID of integration type"""
 
     @staticmethod

--- a/sentry_sdk/integrations/_wsgi_common.py
+++ b/sentry_sdk/integrations/_wsgi_common.py
@@ -13,16 +13,16 @@ if False:
 
 class RequestExtractor(object):
     def __init__(self, request):
-        # type: (Any) -> None
+        
         self.request = request
 
     def extract_into_event(self, event):
-        # type: (Dict[str, Any]) -> None
+        
         client = Hub.current.client
         if client is None:
             return
 
-        data = None  # type: Optional[Union[AnnotatedValue, Dict[str, Any]]]
+        data = None  
 
         content_length = self.content_length()
         request_info = event.setdefault("request", {})
@@ -55,7 +55,7 @@ class RequestExtractor(object):
         request_info["data"] = data
 
     def content_length(self):
-        # type: () -> int
+        
         try:
             return int(self.env().get("CONTENT_LENGTH", 0))
         except ValueError:
@@ -71,7 +71,7 @@ class RequestExtractor(object):
         raise NotImplementedError()
 
     def parsed_body(self):
-        # type: () -> Optional[Dict[str, Any]]
+        
         form = self.form()
         files = self.files()
         if form or files:
@@ -87,11 +87,11 @@ class RequestExtractor(object):
         return self.json()
 
     def is_json(self):
-        # type: () -> bool
+        
         return _is_json_content_type(self.env().get("CONTENT_TYPE"))
 
     def json(self):
-        # type: () -> Optional[Any]
+        
         try:
             if self.is_json():
                 raw_data = self.raw_data()
@@ -114,7 +114,7 @@ class RequestExtractor(object):
 
 
 def _is_json_content_type(ct):
-    # type: (str) -> bool
+    
     mt = (ct or "").split(";", 1)[0]
     return (
         mt == "application/json"
@@ -124,7 +124,7 @@ def _is_json_content_type(ct):
 
 
 def _filter_headers(headers):
-    # type: (Dict[str, str]) -> Dict[str, str]
+    
     if _should_send_default_pii():
         return headers
 

--- a/sentry_sdk/integrations/_wsgi_common.py
+++ b/sentry_sdk/integrations/_wsgi_common.py
@@ -5,10 +5,7 @@ from sentry_sdk.utils import AnnotatedValue
 from sentry_sdk._compat import text_type
 
 if False:
-    from typing import Any
-    from typing import Dict
-    from typing import Optional
-    from typing import Union
+    pass
 
 
 class RequestExtractor(object):

--- a/sentry_sdk/integrations/_wsgi_common.py
+++ b/sentry_sdk/integrations/_wsgi_common.py
@@ -5,8 +5,6 @@ from sentry_sdk.utils import AnnotatedValue
 from sentry_sdk._compat import text_type
 
 
-
-
 class RequestExtractor(object):
     def __init__(self, request):
 

--- a/sentry_sdk/integrations/_wsgi_common.py
+++ b/sentry_sdk/integrations/_wsgi_common.py
@@ -4,8 +4,7 @@ from sentry_sdk.hub import Hub, _should_send_default_pii
 from sentry_sdk.utils import AnnotatedValue
 from sentry_sdk._compat import text_type
 
-if False:
-    pass
+
 
 
 class RequestExtractor(object):

--- a/sentry_sdk/integrations/_wsgi_common.py
+++ b/sentry_sdk/integrations/_wsgi_common.py
@@ -13,16 +13,16 @@ if False:
 
 class RequestExtractor(object):
     def __init__(self, request):
-        
+
         self.request = request
 
     def extract_into_event(self, event):
-        
+
         client = Hub.current.client
         if client is None:
             return
 
-        data = None  
+        data = None
 
         content_length = self.content_length()
         request_info = event.setdefault("request", {})
@@ -55,7 +55,7 @@ class RequestExtractor(object):
         request_info["data"] = data
 
     def content_length(self):
-        
+
         try:
             return int(self.env().get("CONTENT_LENGTH", 0))
         except ValueError:
@@ -71,7 +71,7 @@ class RequestExtractor(object):
         raise NotImplementedError()
 
     def parsed_body(self):
-        
+
         form = self.form()
         files = self.files()
         if form or files:
@@ -87,11 +87,11 @@ class RequestExtractor(object):
         return self.json()
 
     def is_json(self):
-        
+
         return _is_json_content_type(self.env().get("CONTENT_TYPE"))
 
     def json(self):
-        
+
         try:
             if self.is_json():
                 raw_data = self.raw_data()
@@ -114,7 +114,7 @@ class RequestExtractor(object):
 
 
 def _is_json_content_type(ct):
-    
+
     mt = (ct or "").split(";", 1)[0]
     return (
         mt == "application/json"
@@ -124,7 +124,7 @@ def _is_json_content_type(ct):
 
 
 def _filter_headers(headers):
-    
+
     if _should_send_default_pii():
         return headers
 

--- a/sentry_sdk/integrations/aiohttp.py
+++ b/sentry_sdk/integrations/aiohttp.py
@@ -13,10 +13,10 @@ from sentry_sdk.utils import (
 )
 
 import asyncio
-from aiohttp.web import Application, HTTPException  # type: ignore
+from aiohttp.web import Application, HTTPException  #type: ignore
 
 if False:
-    from aiohttp.web_request import Request  # type: ignore
+    from aiohttp.web_request import Request  #type: ignore
     from typing import Any
     from typing import Dict
     from typing import Tuple
@@ -30,7 +30,7 @@ class AioHttpIntegration(Integration):
 
     @staticmethod
     def setup_once():
-        # type: () -> None
+        
         if not HAS_REAL_CONTEXTVARS:
             # We better have contextvars or we're going to leak state between
             # requests.
@@ -44,9 +44,9 @@ class AioHttpIntegration(Integration):
         old_handle = Application._handle
 
         async def sentry_app_handle(self, request, *args, **kwargs):
-            # type: (Any, Request, *Any, **Any) -> Any
+            
             async def inner():
-                # type: () -> Any
+                
                 hub = Hub.current
                 if hub.get_integration(AioHttpIntegration) is None:
                     return await old_handle(self, request, *args, **kwargs)
@@ -76,12 +76,12 @@ class AioHttpIntegration(Integration):
 
 
 def _make_request_processor(weak_request):
-    # type: (Callable[[], Request]) -> Callable
+    
     def aiohttp_processor(
-        event,  # type: Dict[str, Any]
-        hint,  # type: Dict[str, Tuple[type, BaseException, Any]]
+        event,  
+        hint,  
     ):
-        # type: (...) -> Dict[str, Any]
+        
         request = weak_request()
         if request is None:
             return event
@@ -109,11 +109,11 @@ def _make_request_processor(weak_request):
 
 
 def _capture_exception(hub):
-    # type: (Hub) -> ExcInfo
+    
     exc_info = sys.exc_info()
     event, hint = event_from_exception(
         exc_info,
-        client_options=hub.client.options,  # type: ignore
+        client_options=hub.client.options,  
         mechanism={"type": "aiohttp", "handled": False},
     )
     hub.capture_event(event, hint=hint)

--- a/sentry_sdk/integrations/aiohttp.py
+++ b/sentry_sdk/integrations/aiohttp.py
@@ -15,15 +15,6 @@ from sentry_sdk.utils import (
 import asyncio
 from aiohttp.web import Application, HTTPException  # type: ignore
 
-if False:
-    from aiohttp.web_request import Request  # type: ignore
-    from typing import Any
-    from typing import Dict
-    from typing import Tuple
-    from typing import Callable
-
-    from sentry_sdk.utils import ExcInfo
-
 
 class AioHttpIntegration(Integration):
     identifier = "aiohttp"

--- a/sentry_sdk/integrations/aiohttp.py
+++ b/sentry_sdk/integrations/aiohttp.py
@@ -13,10 +13,10 @@ from sentry_sdk.utils import (
 )
 
 import asyncio
-from aiohttp.web import Application, HTTPException  #type: ignore
+from aiohttp.web import Application, HTTPException  # type: ignore
 
 if False:
-    from aiohttp.web_request import Request  #type: ignore
+    from aiohttp.web_request import Request  # type: ignore
     from typing import Any
     from typing import Dict
     from typing import Tuple
@@ -30,7 +30,7 @@ class AioHttpIntegration(Integration):
 
     @staticmethod
     def setup_once():
-        
+
         if not HAS_REAL_CONTEXTVARS:
             # We better have contextvars or we're going to leak state between
             # requests.
@@ -44,9 +44,8 @@ class AioHttpIntegration(Integration):
         old_handle = Application._handle
 
         async def sentry_app_handle(self, request, *args, **kwargs):
-            
             async def inner():
-                
+
                 hub = Hub.current
                 if hub.get_integration(AioHttpIntegration) is None:
                     return await old_handle(self, request, *args, **kwargs)
@@ -76,12 +75,8 @@ class AioHttpIntegration(Integration):
 
 
 def _make_request_processor(weak_request):
-    
-    def aiohttp_processor(
-        event,  
-        hint,  
-    ):
-        
+    def aiohttp_processor(event, hint):
+
         request = weak_request()
         if request is None:
             return event
@@ -109,11 +104,11 @@ def _make_request_processor(weak_request):
 
 
 def _capture_exception(hub):
-    
+
     exc_info = sys.exc_info()
     event, hint = event_from_exception(
         exc_info,
-        client_options=hub.client.options,  
+        client_options=hub.client.options,
         mechanism={"type": "aiohttp", "handled": False},
     )
     hub.capture_event(event, hint=hint)

--- a/sentry_sdk/integrations/argv.py
+++ b/sentry_sdk/integrations/argv.py
@@ -16,10 +16,10 @@ class ArgvIntegration(Integration):
 
     @staticmethod
     def setup_once():
-        # type: () -> None
+        
         @add_global_event_processor
         def processor(event, hint):
-            # type: (Dict[str, Any], Dict[str, Any]) -> Dict[str, Any]
+            
             if Hub.current.get_integration(ArgvIntegration) is not None:
                 extra = event.setdefault("extra", {})
                 # If some event processor decided to set extra to e.g. an

--- a/sentry_sdk/integrations/argv.py
+++ b/sentry_sdk/integrations/argv.py
@@ -6,8 +6,7 @@ from sentry_sdk.hub import Hub
 from sentry_sdk.integrations import Integration
 from sentry_sdk.scope import add_global_event_processor
 
-if False:
-    pass
+
 
 
 class ArgvIntegration(Integration):

--- a/sentry_sdk/integrations/argv.py
+++ b/sentry_sdk/integrations/argv.py
@@ -7,8 +7,7 @@ from sentry_sdk.integrations import Integration
 from sentry_sdk.scope import add_global_event_processor
 
 if False:
-    from typing import Any
-    from typing import Dict
+    pass
 
 
 class ArgvIntegration(Integration):

--- a/sentry_sdk/integrations/argv.py
+++ b/sentry_sdk/integrations/argv.py
@@ -16,10 +16,9 @@ class ArgvIntegration(Integration):
 
     @staticmethod
     def setup_once():
-        
         @add_global_event_processor
         def processor(event, hint):
-            
+
             if Hub.current.get_integration(ArgvIntegration) is not None:
                 extra = event.setdefault("extra", {})
                 # If some event processor decided to set extra to e.g. an

--- a/sentry_sdk/integrations/argv.py
+++ b/sentry_sdk/integrations/argv.py
@@ -7,8 +7,6 @@ from sentry_sdk.integrations import Integration
 from sentry_sdk.scope import add_global_event_processor
 
 
-
-
 class ArgvIntegration(Integration):
     identifier = "argv"
 

--- a/sentry_sdk/integrations/atexit.py
+++ b/sentry_sdk/integrations/atexit.py
@@ -8,8 +8,7 @@ from sentry_sdk.hub import Hub
 from sentry_sdk.utils import logger
 from sentry_sdk.integrations import Integration
 
-if False:
-    pass
+
 
 
 def default_callback(pending, timeout):

--- a/sentry_sdk/integrations/atexit.py
+++ b/sentry_sdk/integrations/atexit.py
@@ -32,14 +32,13 @@ class AtexitIntegration(Integration):
     identifier = "atexit"
 
     def __init__(self, callback=None):
-        
+
         if callback is None:
             callback = default_callback
         self.callback = callback
 
     @staticmethod
     def setup_once():
-        
         @atexit.register
         def _shutdown():
             logger.debug("atexit: got shutdown signal")

--- a/sentry_sdk/integrations/atexit.py
+++ b/sentry_sdk/integrations/atexit.py
@@ -32,14 +32,14 @@ class AtexitIntegration(Integration):
     identifier = "atexit"
 
     def __init__(self, callback=None):
-        # type: (Optional[Any]) -> None
+        
         if callback is None:
             callback = default_callback
         self.callback = callback
 
     @staticmethod
     def setup_once():
-        # type: () -> None
+        
         @atexit.register
         def _shutdown():
             logger.debug("atexit: got shutdown signal")

--- a/sentry_sdk/integrations/atexit.py
+++ b/sentry_sdk/integrations/atexit.py
@@ -9,8 +9,6 @@ from sentry_sdk.utils import logger
 from sentry_sdk.integrations import Integration
 
 
-
-
 def default_callback(pending, timeout):
     """This is the default shutdown callback that is set on the options.
     It prints out a message to stderr that informs the user that some events

--- a/sentry_sdk/integrations/atexit.py
+++ b/sentry_sdk/integrations/atexit.py
@@ -9,8 +9,7 @@ from sentry_sdk.utils import logger
 from sentry_sdk.integrations import Integration
 
 if False:
-    from typing import Any
-    from typing import Optional
+    pass
 
 
 def default_callback(pending, timeout):

--- a/sentry_sdk/integrations/aws_lambda.py
+++ b/sentry_sdk/integrations/aws_lambda.py
@@ -55,13 +55,13 @@ class AwsLambdaIntegration(Integration):
 
     @staticmethod
     def setup_once():
-        import __main__ as lambda_bootstrap  #type: ignore
+        import __main__ as lambda_bootstrap  # type: ignore
 
         pre_37 = True  # Python 3.6 or 2.7
 
         if not hasattr(lambda_bootstrap, "handle_http_request"):
             try:
-                import bootstrap as lambda_bootstrap  #type: ignore
+                import bootstrap as lambda_bootstrap  # type: ignore
 
                 pre_37 = False  # Python 3.7
             except ImportError:
@@ -104,7 +104,7 @@ class AwsLambdaIntegration(Integration):
         else:
             old_handle_event_request = lambda_bootstrap.handle_event_request
 
-            def sentry_handle_event_request(  #type: ignore
+            def sentry_handle_event_request(  # type: ignore
                 lambda_runtime_client, request_handler, *args, **kwargs
             ):
                 request_handler = _wrap_handler(request_handler)

--- a/sentry_sdk/integrations/aws_lambda.py
+++ b/sentry_sdk/integrations/aws_lambda.py
@@ -55,13 +55,13 @@ class AwsLambdaIntegration(Integration):
 
     @staticmethod
     def setup_once():
-        import __main__ as lambda_bootstrap  # type: ignore
+        import __main__ as lambda_bootstrap  #type: ignore
 
         pre_37 = True  # Python 3.6 or 2.7
 
         if not hasattr(lambda_bootstrap, "handle_http_request"):
             try:
-                import bootstrap as lambda_bootstrap  # type: ignore
+                import bootstrap as lambda_bootstrap  #type: ignore
 
                 pre_37 = False  # Python 3.7
             except ImportError:
@@ -104,7 +104,7 @@ class AwsLambdaIntegration(Integration):
         else:
             old_handle_event_request = lambda_bootstrap.handle_event_request
 
-            def sentry_handle_event_request(  # type: ignore
+            def sentry_handle_event_request(  #type: ignore
                 lambda_runtime_client, request_handler, *args, **kwargs
             ):
                 request_handler = _wrap_handler(request_handler)

--- a/sentry_sdk/integrations/bottle.py
+++ b/sentry_sdk/integrations/bottle.py
@@ -16,14 +16,14 @@ if False:
     from typing import Dict
     from typing import Callable
     from typing import Optional
-    from bottle import FileUpload, FormsDict, LocalRequest  # type: ignore
+    from bottle import FileUpload, FormsDict, LocalRequest  #type: ignore
 
 from bottle import (
     Bottle,
     Route,
     request as bottle_request,
     HTTPResponse,
-)  # type: ignore
+)  
 
 
 class BottleIntegration(Integration):
@@ -32,7 +32,7 @@ class BottleIntegration(Integration):
     transaction_style = None
 
     def __init__(self, transaction_style="endpoint"):
-        # type: (str) -> None
+        
         TRANSACTION_STYLE_VALUES = ("endpoint", "url")
         if transaction_style not in TRANSACTION_STYLE_VALUES:
             raise ValueError(
@@ -43,13 +43,13 @@ class BottleIntegration(Integration):
 
     @staticmethod
     def setup_once():
-        # type: () -> None
+        
 
         # monkey patch method Bottle.__call__
         old_app = Bottle.__call__
 
         def sentry_patched_wsgi_app(self, environ, start_response):
-            # type: (Any, Dict[str, str], Callable) -> _ScopedResponse
+            
 
             hub = Hub.current
             integration = hub.get_integration(BottleIntegration)
@@ -60,7 +60,7 @@ class BottleIntegration(Integration):
                 environ, start_response
             )
 
-        Bottle.__call__ = sentry_patched_wsgi_app  # type: ignore
+        Bottle.__call__ = sentry_patched_wsgi_app  
 
         # monkey patch method Bottle._handle
         old_handle = Bottle._handle
@@ -124,39 +124,39 @@ class BottleIntegration(Integration):
 
 class BottleRequestExtractor(RequestExtractor):
     def env(self):
-        # type: () -> Dict[str, str]
+        
         return self.request.environ
 
     def cookies(self):
-        # type: () -> Dict[str, str]
+        
         return self.request.cookies
 
     def raw_data(self):
-        # type: () -> bytes
+        
         return self.request.body.read()
 
     def form(self):
-        # type: () -> FormsDict
+        
         if self.is_json():
             return None
         return self.request.forms.decode()
 
     def files(self):
-        # type: () -> Optional[Dict[str, str]]
+        
         if self.is_json():
             return None
 
         return self.request.files
 
     def size_of_file(self, file):
-        # type: (FileUpload) -> int
+        
         return file.content_length
 
 
 def _make_request_event_processor(app, request, integration):
-    # type: (Bottle, LocalRequest, BottleIntegration) -> Callable
+    
     def inner(event, hint):
-        # type: (Dict[str, Any], Dict[str, Any]) -> Dict[str, Any]
+        
 
         try:
             if integration.transaction_style == "endpoint":
@@ -164,7 +164,7 @@ def _make_request_event_processor(app, request, integration):
                     request.route.callback
                 )
             elif integration.transaction_style == "url":
-                event["transaction"] = request.route.rule  # type: ignore
+                event["transaction"] = request.route.rule  
         except Exception:
             pass
 

--- a/sentry_sdk/integrations/bottle.py
+++ b/sentry_sdk/integrations/bottle.py
@@ -11,11 +11,6 @@ from sentry_sdk.integrations.wsgi import SentryWsgiMiddleware
 from sentry_sdk.integrations._wsgi_common import RequestExtractor
 
 if False:
-    from sentry_sdk.integrations.wsgi import _ScopedResponse
-    from typing import Any
-    from typing import Dict
-    from typing import Callable
-    from typing import Optional
     from bottle import FileUpload, FormsDict, LocalRequest  # type: ignore
 
 from bottle import Bottle, Route, request as bottle_request, HTTPResponse

--- a/sentry_sdk/integrations/bottle.py
+++ b/sentry_sdk/integrations/bottle.py
@@ -10,10 +10,13 @@ from sentry_sdk.integrations import Integration
 from sentry_sdk.integrations.wsgi import SentryWsgiMiddleware
 from sentry_sdk.integrations._wsgi_common import RequestExtractor
 
-if False:
-    from bottle import FileUpload, FormsDict, LocalRequest  # type: ignore
 
-from bottle import Bottle, Route, request as bottle_request, HTTPResponse
+from bottle import (  # type: ignore
+    Bottle,
+    Route,
+    request as bottle_request,
+    HTTPResponse,
+)
 
 
 class BottleIntegration(Integration):

--- a/sentry_sdk/integrations/celery.py
+++ b/sentry_sdk/integrations/celery.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import
 
 import sys
 
-from celery.exceptions import (  #type: ignore
+from celery.exceptions import (  # type: ignore
     SoftTimeLimitExceeded,
     Retry,
     Ignore,
@@ -28,7 +28,7 @@ class CeleryIntegration(Integration):
 
     @staticmethod
     def setup_once():
-        import celery.app.trace as trace  #type: ignore
+        import celery.app.trace as trace  # type: ignore
 
         old_build_tracer = trace.build_tracer
 
@@ -162,7 +162,7 @@ def _capture_exception(task, exc_info):
 def _patch_worker_exit():
     # Need to flush queue before worker shutdown because a crashing worker will
     # call os._exit
-    from billiard.pool import Worker  #type: ignore
+    from billiard.pool import Worker  # type: ignore
 
     old_workloop = Worker.workloop
 

--- a/sentry_sdk/integrations/celery.py
+++ b/sentry_sdk/integrations/celery.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import
 
 import sys
 
-from celery.exceptions import (  # type: ignore
+from celery.exceptions import (  #type: ignore
     SoftTimeLimitExceeded,
     Retry,
     Ignore,
@@ -28,7 +28,7 @@ class CeleryIntegration(Integration):
 
     @staticmethod
     def setup_once():
-        import celery.app.trace as trace  # type: ignore
+        import celery.app.trace as trace  #type: ignore
 
         old_build_tracer = trace.build_tracer
 
@@ -162,7 +162,7 @@ def _capture_exception(task, exc_info):
 def _patch_worker_exit():
     # Need to flush queue before worker shutdown because a crashing worker will
     # call os._exit
-    from billiard.pool import Worker  # type: ignore
+    from billiard.pool import Worker  #type: ignore
 
     old_workloop = Worker.workloop
 

--- a/sentry_sdk/integrations/dedupe.py
+++ b/sentry_sdk/integrations/dedupe.py
@@ -4,8 +4,6 @@ from sentry_sdk.integrations import Integration
 from sentry_sdk.scope import add_global_event_processor
 
 
-
-
 class DedupeIntegration(Integration):
     identifier = "dedupe"
 

--- a/sentry_sdk/integrations/dedupe.py
+++ b/sentry_sdk/integrations/dedupe.py
@@ -13,15 +13,14 @@ class DedupeIntegration(Integration):
     identifier = "dedupe"
 
     def __init__(self):
-        
+
         self._last_seen = ContextVar("last-seen")
 
     @staticmethod
     def setup_once():
-        
         @add_global_event_processor
         def processor(event, hint):
-            
+
             integration = Hub.current.get_integration(DedupeIntegration)
             if integration is not None:
                 exc_info = hint.get("exc_info", None)

--- a/sentry_sdk/integrations/dedupe.py
+++ b/sentry_sdk/integrations/dedupe.py
@@ -4,9 +4,7 @@ from sentry_sdk.integrations import Integration
 from sentry_sdk.scope import add_global_event_processor
 
 if False:
-    from typing import Any
-    from typing import Dict
-    from typing import Optional
+    pass
 
 
 class DedupeIntegration(Integration):

--- a/sentry_sdk/integrations/dedupe.py
+++ b/sentry_sdk/integrations/dedupe.py
@@ -3,8 +3,7 @@ from sentry_sdk.utils import ContextVar
 from sentry_sdk.integrations import Integration
 from sentry_sdk.scope import add_global_event_processor
 
-if False:
-    pass
+
 
 
 class DedupeIntegration(Integration):

--- a/sentry_sdk/integrations/dedupe.py
+++ b/sentry_sdk/integrations/dedupe.py
@@ -13,15 +13,15 @@ class DedupeIntegration(Integration):
     identifier = "dedupe"
 
     def __init__(self):
-        # type: () -> None
+        
         self._last_seen = ContextVar("last-seen")
 
     @staticmethod
     def setup_once():
-        # type: () -> None
+        
         @add_global_event_processor
         def processor(event, hint):
-            # type: (Dict[str, Any], Dict[str, Any]) -> Optional[Dict[str, Any]]
+            
             integration = Hub.current.get_integration(DedupeIntegration)
             if integration is not None:
                 exc_info = hint.get("exc_info", None)

--- a/sentry_sdk/integrations/django/__init__.py
+++ b/sentry_sdk/integrations/django/__init__.py
@@ -4,9 +4,9 @@ from __future__ import absolute_import
 import sys
 import weakref
 
-from django import VERSION as DJANGO_VERSION  # type: ignore
-from django.db.models.query import QuerySet  # type: ignore
-from django.core import signals  # type: ignore
+from django import VERSION as DJANGO_VERSION  #type: ignore
+from django.db.models.query import QuerySet  #type: ignore
+from django.core import signals  #type: ignore
 
 if False:
     from typing import Any
@@ -15,17 +15,17 @@ if False:
     from typing import Union
     from sentry_sdk.integrations.wsgi import _ScopedResponse
     from typing import Callable
-    from django.core.handlers.wsgi import WSGIRequest  # type: ignore
-    from django.http.response import HttpResponse  # type: ignore
-    from django.http.request import QueryDict  # type: ignore
-    from django.utils.datastructures import MultiValueDict  # type: ignore
+    from django.core.handlers.wsgi import WSGIRequest  #type: ignore
+    from django.http.response import HttpResponse  #type: ignore
+    from django.http.request import QueryDict  #type: ignore
+    from django.utils.datastructures import MultiValueDict  #type: ignore
     from typing import List
 
 
 try:
-    from django.urls import resolve  # type: ignore
+    from django.urls import resolve  #type: ignore
 except ImportError:
-    from django.core.urlresolvers import resolve  # type: ignore
+    from django.core.urlresolvers import resolve  #type: ignore
 
 from sentry_sdk import Hub
 from sentry_sdk.hub import _should_send_default_pii
@@ -50,14 +50,14 @@ from sentry_sdk.integrations.django.templates import get_template_frame_from_exc
 if DJANGO_VERSION < (1, 10):
 
     def is_authenticated(request_user):
-        # type: (Any) -> bool
+        #type: (Any) -> bool
         return request_user.is_authenticated()
 
 
 else:
 
     def is_authenticated(request_user):
-        # type: (Any) -> bool
+        #type: (Any) -> bool
         return request_user.is_authenticated
 
 
@@ -67,7 +67,7 @@ class DjangoIntegration(Integration):
     transaction_style = None
 
     def __init__(self, transaction_style="url"):
-        # type: (str) -> None
+        
         TRANSACTION_STYLE_VALUES = ("function_name", "url")
         if transaction_style not in TRANSACTION_STYLE_VALUES:
             raise ValueError(
@@ -78,7 +78,7 @@ class DjangoIntegration(Integration):
 
     @staticmethod
     def setup_once():
-        # type: () -> None
+        
         install_sql_hook()
         # Patch in our custom middleware.
 
@@ -91,7 +91,7 @@ class DjangoIntegration(Integration):
         old_app = WSGIHandler.__call__
 
         def sentry_patched_wsgi_handler(self, environ, start_response):
-            # type: (Any, Dict[str, str], Callable) -> _ScopedResponse
+            
             if Hub.current.get_integration(DjangoIntegration) is None:
                 return old_app(self, environ, start_response)
 
@@ -103,12 +103,12 @@ class DjangoIntegration(Integration):
 
         # patch get_response, because at that point we have the Django request
         # object
-        from django.core.handlers.base import BaseHandler  # type: ignore
+        from django.core.handlers.base import BaseHandler  #type: ignore
 
         old_get_response = BaseHandler.get_response
 
         def sentry_patched_get_response(self, request):
-            # type: (Any, WSGIRequest) -> Union[HttpResponse, BaseException]
+            
             hub = Hub.current
             integration = hub.get_integration(DjangoIntegration)
             if integration is not None:
@@ -124,7 +124,7 @@ class DjangoIntegration(Integration):
 
         @add_global_event_processor
         def process_django_templates(event, hint):
-            # type: (Dict[str, Any], Dict[str, Any]) -> Dict[str, Any]
+            
             exc_info = hint.get("exc_info", None)
 
             if exc_info is None:
@@ -180,9 +180,9 @@ class DjangoIntegration(Integration):
 
 
 def _make_event_processor(weak_request, integration):
-    # type: (Callable[[], WSGIRequest], DjangoIntegration) -> Callable
+    
     def event_processor(event, hint):
-        # type: (Dict[str, Any], Dict[str, Any]) -> Dict[str, Any]
+        
         # if the request is gone we are fine not logging the data from
         # it.  This might happen if the processor is pushed away to
         # another thread.
@@ -213,7 +213,7 @@ def _make_event_processor(weak_request, integration):
 
 
 def _got_request_exception(request=None, **kwargs):
-    # type: (WSGIRequest, **Any) -> None
+    
     hub = Hub.current
     integration = hub.get_integration(DjangoIntegration)
     if integration is not None:
@@ -227,23 +227,23 @@ def _got_request_exception(request=None, **kwargs):
 
 class DjangoRequestExtractor(RequestExtractor):
     def env(self):
-        # type: () -> Dict[str, str]
+        
         return self.request.META
 
     def cookies(self):
-        # type: () -> Dict[str, str]
+        
         return self.request.COOKIES
 
     def raw_data(self):
-        # type: () -> bytes
+        
         return self.request.body
 
     def form(self):
-        # type: () -> QueryDict
+        
         return self.request.POST
 
     def files(self):
-        # type: () -> MultiValueDict
+        
         return self.request.FILES
 
     def size_of_file(self, file):
@@ -257,7 +257,7 @@ class DjangoRequestExtractor(RequestExtractor):
 
 
 def _set_user_info(request, event):
-    # type: (WSGIRequest, Dict[str, Any]) -> None
+    
     user_info = event.setdefault("user", {})
 
     user = getattr(request, "user", None)
@@ -283,19 +283,19 @@ def _set_user_info(request, event):
 
 class _FormatConverter(object):
     def __init__(self, param_mapping):
-        # type: (Dict[str, int]) -> None
+        
 
         self.param_mapping = param_mapping
-        self.params = []  # type: List[Any]
+        self.params = []  
 
     def __getitem__(self, val):
-        # type: (str) -> str
+        
         self.params.append(self.param_mapping.get(val))
         return "%s"
 
 
 def format_sql(sql, params):
-    # type: (Any, Any) -> Tuple[str, List[str]]
+    
     rv = []
 
     if isinstance(params, dict):
@@ -317,7 +317,7 @@ def format_sql(sql, params):
 
 
 def record_sql(sql, params, cursor=None):
-    # type: (Any, Any, Any) -> None
+    
     hub = Hub.current
     if hub.get_integration(DjangoIntegration) is None:
         return
@@ -357,12 +357,12 @@ def record_sql(sql, params, cursor=None):
 
 
 def install_sql_hook():
-    # type: () -> None
+    
     """If installed this causes Django's queries to be captured."""
     try:
-        from django.db.backends.utils import CursorWrapper  # type: ignore
+        from django.db.backends.utils import CursorWrapper  #type: ignore
     except ImportError:
-        from django.db.backends.util import CursorWrapper  # type: ignore
+        from django.db.backends.util import CursorWrapper  #type: ignore
 
     try:
         real_execute = CursorWrapper.execute

--- a/sentry_sdk/integrations/django/__init__.py
+++ b/sentry_sdk/integrations/django/__init__.py
@@ -4,9 +4,9 @@ from __future__ import absolute_import
 import sys
 import weakref
 
-from django import VERSION as DJANGO_VERSION  #type: ignore
-from django.db.models.query import QuerySet  #type: ignore
-from django.core import signals  #type: ignore
+from django import VERSION as DJANGO_VERSION  # type: ignore
+from django.db.models.query import QuerySet  # type: ignore
+from django.core import signals  # type: ignore
 
 if False:
     from typing import Any
@@ -15,17 +15,17 @@ if False:
     from typing import Union
     from sentry_sdk.integrations.wsgi import _ScopedResponse
     from typing import Callable
-    from django.core.handlers.wsgi import WSGIRequest  #type: ignore
-    from django.http.response import HttpResponse  #type: ignore
-    from django.http.request import QueryDict  #type: ignore
-    from django.utils.datastructures import MultiValueDict  #type: ignore
+    from django.core.handlers.wsgi import WSGIRequest  # type: ignore
+    from django.http.response import HttpResponse  # type: ignore
+    from django.http.request import QueryDict  # type: ignore
+    from django.utils.datastructures import MultiValueDict  # type: ignore
     from typing import List
 
 
 try:
-    from django.urls import resolve  #type: ignore
+    from django.urls import resolve  # type: ignore
 except ImportError:
-    from django.core.urlresolvers import resolve  #type: ignore
+    from django.core.urlresolvers import resolve  # type: ignore
 
 from sentry_sdk import Hub
 from sentry_sdk.hub import _should_send_default_pii
@@ -50,14 +50,14 @@ from sentry_sdk.integrations.django.templates import get_template_frame_from_exc
 if DJANGO_VERSION < (1, 10):
 
     def is_authenticated(request_user):
-        #type: (Any) -> bool
+        # type: (Any) -> bool
         return request_user.is_authenticated()
 
 
 else:
 
     def is_authenticated(request_user):
-        #type: (Any) -> bool
+        # type: (Any) -> bool
         return request_user.is_authenticated
 
 
@@ -67,7 +67,7 @@ class DjangoIntegration(Integration):
     transaction_style = None
 
     def __init__(self, transaction_style="url"):
-        
+
         TRANSACTION_STYLE_VALUES = ("function_name", "url")
         if transaction_style not in TRANSACTION_STYLE_VALUES:
             raise ValueError(
@@ -78,7 +78,7 @@ class DjangoIntegration(Integration):
 
     @staticmethod
     def setup_once():
-        
+
         install_sql_hook()
         # Patch in our custom middleware.
 
@@ -91,7 +91,7 @@ class DjangoIntegration(Integration):
         old_app = WSGIHandler.__call__
 
         def sentry_patched_wsgi_handler(self, environ, start_response):
-            
+
             if Hub.current.get_integration(DjangoIntegration) is None:
                 return old_app(self, environ, start_response)
 
@@ -103,12 +103,12 @@ class DjangoIntegration(Integration):
 
         # patch get_response, because at that point we have the Django request
         # object
-        from django.core.handlers.base import BaseHandler  #type: ignore
+        from django.core.handlers.base import BaseHandler  # type: ignore
 
         old_get_response = BaseHandler.get_response
 
         def sentry_patched_get_response(self, request):
-            
+
             hub = Hub.current
             integration = hub.get_integration(DjangoIntegration)
             if integration is not None:
@@ -124,7 +124,7 @@ class DjangoIntegration(Integration):
 
         @add_global_event_processor
         def process_django_templates(event, hint):
-            
+
             exc_info = hint.get("exc_info", None)
 
             if exc_info is None:
@@ -180,9 +180,8 @@ class DjangoIntegration(Integration):
 
 
 def _make_event_processor(weak_request, integration):
-    
     def event_processor(event, hint):
-        
+
         # if the request is gone we are fine not logging the data from
         # it.  This might happen if the processor is pushed away to
         # another thread.
@@ -213,7 +212,7 @@ def _make_event_processor(weak_request, integration):
 
 
 def _got_request_exception(request=None, **kwargs):
-    
+
     hub = Hub.current
     integration = hub.get_integration(DjangoIntegration)
     if integration is not None:
@@ -227,23 +226,23 @@ def _got_request_exception(request=None, **kwargs):
 
 class DjangoRequestExtractor(RequestExtractor):
     def env(self):
-        
+
         return self.request.META
 
     def cookies(self):
-        
+
         return self.request.COOKIES
 
     def raw_data(self):
-        
+
         return self.request.body
 
     def form(self):
-        
+
         return self.request.POST
 
     def files(self):
-        
+
         return self.request.FILES
 
     def size_of_file(self, file):
@@ -257,7 +256,7 @@ class DjangoRequestExtractor(RequestExtractor):
 
 
 def _set_user_info(request, event):
-    
+
     user_info = event.setdefault("user", {})
 
     user = getattr(request, "user", None)
@@ -283,19 +282,18 @@ def _set_user_info(request, event):
 
 class _FormatConverter(object):
     def __init__(self, param_mapping):
-        
 
         self.param_mapping = param_mapping
-        self.params = []  
+        self.params = []
 
     def __getitem__(self, val):
-        
+
         self.params.append(self.param_mapping.get(val))
         return "%s"
 
 
 def format_sql(sql, params):
-    
+
     rv = []
 
     if isinstance(params, dict):
@@ -317,7 +315,7 @@ def format_sql(sql, params):
 
 
 def record_sql(sql, params, cursor=None):
-    
+
     hub = Hub.current
     if hub.get_integration(DjangoIntegration) is None:
         return
@@ -357,12 +355,12 @@ def record_sql(sql, params, cursor=None):
 
 
 def install_sql_hook():
-    
+
     """If installed this causes Django's queries to be captured."""
     try:
-        from django.db.backends.utils import CursorWrapper  #type: ignore
+        from django.db.backends.utils import CursorWrapper  # type: ignore
     except ImportError:
-        from django.db.backends.util import CursorWrapper  #type: ignore
+        from django.db.backends.util import CursorWrapper  # type: ignore
 
     try:
         real_execute = CursorWrapper.execute

--- a/sentry_sdk/integrations/django/__init__.py
+++ b/sentry_sdk/integrations/django/__init__.py
@@ -10,10 +10,6 @@ from django.core import signals  # type: ignore
 
 if False:
     from typing import Any
-    from django.core.handlers.wsgi import WSGIRequest  # type: ignore
-    from django.http.response import HttpResponse  # type: ignore
-    from django.http.request import QueryDict  # type: ignore
-    from django.utils.datastructures import MultiValueDict  # type: ignore
 
 
 try:
@@ -80,7 +76,7 @@ class DjangoIntegration(Integration):
         ignore_logger("django.server")
         ignore_logger("django.request")
 
-        from django.core.handlers.wsgi import WSGIHandler
+        from django.core.handlers.wsgi import WSGIHandler  # type: ignore
 
         old_app = WSGIHandler.__call__
 

--- a/sentry_sdk/integrations/django/__init__.py
+++ b/sentry_sdk/integrations/django/__init__.py
@@ -10,16 +10,10 @@ from django.core import signals  # type: ignore
 
 if False:
     from typing import Any
-    from typing import Dict
-    from typing import Tuple
-    from typing import Union
-    from sentry_sdk.integrations.wsgi import _ScopedResponse
-    from typing import Callable
     from django.core.handlers.wsgi import WSGIRequest  # type: ignore
     from django.http.response import HttpResponse  # type: ignore
     from django.http.request import QueryDict  # type: ignore
     from django.utils.datastructures import MultiValueDict  # type: ignore
-    from typing import List
 
 
 try:

--- a/sentry_sdk/integrations/django/templates.py
+++ b/sentry_sdk/integrations/django/templates.py
@@ -1,9 +1,7 @@
 from django.template import TemplateSyntaxError  # type: ignore
 
 if False:
-    from typing import Any
-    from typing import Dict
-    from typing import Optional
+    pass
 
 try:
     # support Django 1.9

--- a/sentry_sdk/integrations/django/templates.py
+++ b/sentry_sdk/integrations/django/templates.py
@@ -1,7 +1,6 @@
 from django.template import TemplateSyntaxError  # type: ignore
 
-if False:
-    pass
+
 
 try:
     # support Django 1.9

--- a/sentry_sdk/integrations/django/templates.py
+++ b/sentry_sdk/integrations/django/templates.py
@@ -1,4 +1,4 @@
-from django.template import TemplateSyntaxError  # type: ignore
+from django.template import TemplateSyntaxError  #type: ignore
 
 if False:
     from typing import Any
@@ -7,25 +7,25 @@ if False:
 
 try:
     # support Django 1.9
-    from django.template.base import Origin  # type: ignore
+    from django.template.base import Origin  #type: ignore
 except ImportError:
     # backward compatibility
-    from django.template.loader import LoaderOrigin as Origin  # type: ignore
+    from django.template.loader import LoaderOrigin as Origin  #type: ignore
 
 
 def get_template_frame_from_exception(exc_value):
-    # type: (Optional[BaseException]) -> Optional[Dict[str, Any]]
+    
 
     # As of Django 1.9 or so the new template debug thing showed up.
     if hasattr(exc_value, "template_debug"):
-        return _get_template_frame_from_debug(exc_value.template_debug)  # type: ignore
+        return _get_template_frame_from_debug(exc_value.template_debug)  
 
     # As of r16833 (Django) all exceptions may contain a
     # ``django_template_source`` attribute (rather than the legacy
     # ``TemplateSyntaxError.source`` check)
     if hasattr(exc_value, "django_template_source"):
         return _get_template_frame_from_source(
-            exc_value.django_template_source  # type: ignore
+            exc_value.django_template_source  
         )
 
     if isinstance(exc_value, TemplateSyntaxError) and hasattr(exc_value, "source"):
@@ -37,7 +37,7 @@ def get_template_frame_from_exception(exc_value):
 
 
 def _get_template_frame_from_debug(debug):
-    # type: (Dict[str, Any]) -> Dict[str, Any]
+    
     if debug is None:
         return None
 

--- a/sentry_sdk/integrations/django/templates.py
+++ b/sentry_sdk/integrations/django/templates.py
@@ -1,7 +1,6 @@
 from django.template import TemplateSyntaxError  # type: ignore
 
 
-
 try:
     # support Django 1.9
     from django.template.base import Origin  # type: ignore

--- a/sentry_sdk/integrations/django/templates.py
+++ b/sentry_sdk/integrations/django/templates.py
@@ -1,4 +1,4 @@
-from django.template import TemplateSyntaxError  #type: ignore
+from django.template import TemplateSyntaxError  # type: ignore
 
 if False:
     from typing import Any
@@ -7,26 +7,23 @@ if False:
 
 try:
     # support Django 1.9
-    from django.template.base import Origin  #type: ignore
+    from django.template.base import Origin  # type: ignore
 except ImportError:
     # backward compatibility
-    from django.template.loader import LoaderOrigin as Origin  #type: ignore
+    from django.template.loader import LoaderOrigin as Origin  # type: ignore
 
 
 def get_template_frame_from_exception(exc_value):
-    
 
     # As of Django 1.9 or so the new template debug thing showed up.
     if hasattr(exc_value, "template_debug"):
-        return _get_template_frame_from_debug(exc_value.template_debug)  
+        return _get_template_frame_from_debug(exc_value.template_debug)
 
     # As of r16833 (Django) all exceptions may contain a
     # ``django_template_source`` attribute (rather than the legacy
     # ``TemplateSyntaxError.source`` check)
     if hasattr(exc_value, "django_template_source"):
-        return _get_template_frame_from_source(
-            exc_value.django_template_source  
-        )
+        return _get_template_frame_from_source(exc_value.django_template_source)
 
     if isinstance(exc_value, TemplateSyntaxError) and hasattr(exc_value, "source"):
         source = exc_value.source
@@ -37,7 +34,7 @@ def get_template_frame_from_exception(exc_value):
 
 
 def _get_template_frame_from_debug(debug):
-    
+
     if debug is None:
         return None
 

--- a/sentry_sdk/integrations/django/transactions.py
+++ b/sentry_sdk/integrations/django/transactions.py
@@ -10,11 +10,7 @@ import re
 if False:
     from django.urls.resolvers import URLResolver  # type: ignore
     from typing import Dict
-    from typing import List
-    from typing import Optional
     from django.urls.resolvers import URLPattern
-    from typing import Tuple
-    from typing import Union
     from re import Pattern  # type: ignore
 
 try:

--- a/sentry_sdk/integrations/django/transactions.py
+++ b/sentry_sdk/integrations/django/transactions.py
@@ -8,23 +8,23 @@ from __future__ import absolute_import
 import re
 
 if False:
-    from django.urls.resolvers import URLResolver  # type: ignore
+    from django.urls.resolvers import URLResolver  #type: ignore
     from typing import Dict
     from typing import List
     from typing import Optional
-    from django.urls.resolvers import URLPattern  # type: ignore
+    from django.urls.resolvers import URLPattern  
     from typing import Tuple
     from typing import Union
-    from re import Pattern  # type: ignore
+    from re import Pattern  #type: ignore
 
 try:
-    from django.urls import get_resolver  # type: ignore
+    from django.urls import get_resolver  #type: ignore
 except ImportError:
-    from django.core.urlresolvers import get_resolver  # type: ignore
+    from django.core.urlresolvers import get_resolver  #type: ignore
 
 
 def get_regex(resolver_or_pattern):
-    # type: (Union[URLPattern, URLResolver]) -> Pattern
+    
     """Utility method for django's deprecated resolver.regex"""
     try:
         regex = resolver_or_pattern.regex
@@ -41,10 +41,10 @@ class RavenResolver(object):
     _either_option_matcher = re.compile(r"\[([^\]]+)\|([^\]]+)\]")
     _camel_re = re.compile(r"([A-Z]+)([a-z])")
 
-    _cache = {}  # type: Dict[URLPattern, str]
+    _cache = {}  #type: Dict[URLPattern, str]
 
     def _simplify(self, pattern):
-        # type: (str) -> str
+        
         r"""
         Clean up urlpattern regexes into something readable by humans:
 
@@ -81,7 +81,7 @@ class RavenResolver(object):
         return result
 
     def _resolve(self, resolver, path, parents=None):
-        # type: (URLResolver, str, Optional[List[URLResolver]]) -> Optional[str]
+        
 
         match = get_regex(resolver).search(path)  # Django < 2.0
 
@@ -120,10 +120,10 @@ class RavenResolver(object):
 
     def resolve(
         self,
-        path,  # type: str
-        urlconf=None,  # type: Union[None, Tuple[URLPattern, URLPattern, URLResolver], Tuple[URLPattern]]
+        path,  
+        urlconf=None,  
     ):
-        # type: (...) -> str
+        
         resolver = get_resolver(urlconf)
         match = self._resolve(resolver, path)
         return match or path

--- a/sentry_sdk/integrations/django/transactions.py
+++ b/sentry_sdk/integrations/django/transactions.py
@@ -8,23 +8,23 @@ from __future__ import absolute_import
 import re
 
 if False:
-    from django.urls.resolvers import URLResolver  #type: ignore
+    from django.urls.resolvers import URLResolver  # type: ignore
     from typing import Dict
     from typing import List
     from typing import Optional
-    from django.urls.resolvers import URLPattern  
+    from django.urls.resolvers import URLPattern
     from typing import Tuple
     from typing import Union
-    from re import Pattern  #type: ignore
+    from re import Pattern  # type: ignore
 
 try:
-    from django.urls import get_resolver  #type: ignore
+    from django.urls import get_resolver  # type: ignore
 except ImportError:
-    from django.core.urlresolvers import get_resolver  #type: ignore
+    from django.core.urlresolvers import get_resolver  # type: ignore
 
 
 def get_regex(resolver_or_pattern):
-    
+
     """Utility method for django's deprecated resolver.regex"""
     try:
         regex = resolver_or_pattern.regex
@@ -41,10 +41,10 @@ class RavenResolver(object):
     _either_option_matcher = re.compile(r"\[([^\]]+)\|([^\]]+)\]")
     _camel_re = re.compile(r"([A-Z]+)([a-z])")
 
-    _cache = {}  #type: Dict[URLPattern, str]
+    _cache = {}  # type: Dict[URLPattern, str]
 
     def _simplify(self, pattern):
-        
+
         r"""
         Clean up urlpattern regexes into something readable by humans:
 
@@ -81,7 +81,6 @@ class RavenResolver(object):
         return result
 
     def _resolve(self, resolver, path, parents=None):
-        
 
         match = get_regex(resolver).search(path)  # Django < 2.0
 
@@ -118,12 +117,8 @@ class RavenResolver(object):
 
         return None
 
-    def resolve(
-        self,
-        path,  
-        urlconf=None,  
-    ):
-        
+    def resolve(self, path, urlconf=None):
+
         resolver = get_resolver(urlconf)
         match = self._resolve(resolver, path)
         return match or path

--- a/sentry_sdk/integrations/django/transactions.py
+++ b/sentry_sdk/integrations/django/transactions.py
@@ -8,10 +8,8 @@ from __future__ import absolute_import
 import re
 
 if False:
-    from django.urls.resolvers import URLResolver  # type: ignore
     from typing import Dict
-    from django.urls.resolvers import URLPattern
-    from re import Pattern  # type: ignore
+    from django.urls.resolvers import URLPattern  # type: ignore
 
 try:
     from django.urls import get_resolver  # type: ignore

--- a/sentry_sdk/integrations/excepthook.py
+++ b/sentry_sdk/integrations/excepthook.py
@@ -5,8 +5,6 @@ from sentry_sdk.utils import capture_internal_exceptions, event_from_exception
 from sentry_sdk.integrations import Integration
 
 
-
-
 class ExcepthookIntegration(Integration):
     identifier = "excepthook"
 

--- a/sentry_sdk/integrations/excepthook.py
+++ b/sentry_sdk/integrations/excepthook.py
@@ -5,7 +5,7 @@ from sentry_sdk.utils import capture_internal_exceptions, event_from_exception
 from sentry_sdk.integrations import Integration
 
 if False:
-    from typing import Callable
+    pass
 
 
 class ExcepthookIntegration(Integration):

--- a/sentry_sdk/integrations/excepthook.py
+++ b/sentry_sdk/integrations/excepthook.py
@@ -4,8 +4,7 @@ from sentry_sdk.hub import Hub
 from sentry_sdk.utils import capture_internal_exceptions, event_from_exception
 from sentry_sdk.integrations import Integration
 
-if False:
-    pass
+
 
 
 class ExcepthookIntegration(Integration):

--- a/sentry_sdk/integrations/excepthook.py
+++ b/sentry_sdk/integrations/excepthook.py
@@ -13,12 +13,12 @@ class ExcepthookIntegration(Integration):
 
     @staticmethod
     def setup_once():
-        # type: () -> None
+        
         sys.excepthook = _make_excepthook(sys.excepthook)
 
 
 def _make_excepthook(old_excepthook):
-    # type: (Callable) -> Callable
+    
     def sentry_sdk_excepthook(exctype, value, traceback):
         hub = Hub.current
         integration = hub.get_integration(ExcepthookIntegration)

--- a/sentry_sdk/integrations/excepthook.py
+++ b/sentry_sdk/integrations/excepthook.py
@@ -13,12 +13,11 @@ class ExcepthookIntegration(Integration):
 
     @staticmethod
     def setup_once():
-        
+
         sys.excepthook = _make_excepthook(sys.excepthook)
 
 
 def _make_excepthook(old_excepthook):
-    
     def sentry_sdk_excepthook(exctype, value, traceback):
         hub = Hub.current
         integration = hub.get_integration(ExcepthookIntegration)

--- a/sentry_sdk/integrations/falcon.py
+++ b/sentry_sdk/integrations/falcon.py
@@ -8,8 +8,7 @@ from sentry_sdk.integrations._wsgi_common import RequestExtractor
 from sentry_sdk.integrations.wsgi import SentryWsgiMiddleware
 from sentry_sdk.utils import capture_internal_exceptions, event_from_exception
 
-if False:
-    pass
+
 
 
 class FalconRequestExtractor(RequestExtractor):

--- a/sentry_sdk/integrations/falcon.py
+++ b/sentry_sdk/integrations/falcon.py
@@ -9,9 +9,7 @@ from sentry_sdk.integrations.wsgi import SentryWsgiMiddleware
 from sentry_sdk.utils import capture_internal_exceptions, event_from_exception
 
 if False:
-    from typing import Any
-    from typing import Callable
-    from typing import Dict
+    pass
 
 
 class FalconRequestExtractor(RequestExtractor):

--- a/sentry_sdk/integrations/falcon.py
+++ b/sentry_sdk/integrations/falcon.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import
 
-import falcon  #type: ignore
-import falcon.api_helpers  #type: ignore
+import falcon  # type: ignore
+import falcon.api_helpers  # type: ignore
 from sentry_sdk.hub import Hub
 from sentry_sdk.integrations import Integration
 from sentry_sdk.integrations._wsgi_common import RequestExtractor
@@ -69,7 +69,7 @@ class FalconIntegration(Integration):
     transaction_style = None
 
     def __init__(self, transaction_style="uri_template"):
-        
+
         TRANSACTION_STYLE_VALUES = ("uri_template", "path")
         if transaction_style not in TRANSACTION_STYLE_VALUES:
             raise ValueError(
@@ -80,7 +80,7 @@ class FalconIntegration(Integration):
 
     @staticmethod
     def setup_once():
-        
+
         _patch_wsgi_app()
         _patch_handle_exception()
         _patch_prepare_middleware()
@@ -154,10 +154,8 @@ def _is_falcon_http_error(ex):
 
 
 def _make_request_event_processor(req, integration):
-    
-
     def inner(event, hint):
-        
+
         if integration.transaction_style == "uri_template":
             event["transaction"] = req.uri_template
         elif integration.transaction_style == "path":

--- a/sentry_sdk/integrations/falcon.py
+++ b/sentry_sdk/integrations/falcon.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import
 
-import falcon  # type: ignore
-import falcon.api_helpers  # type: ignore
+import falcon  #type: ignore
+import falcon.api_helpers  #type: ignore
 from sentry_sdk.hub import Hub
 from sentry_sdk.integrations import Integration
 from sentry_sdk.integrations._wsgi_common import RequestExtractor
@@ -69,7 +69,7 @@ class FalconIntegration(Integration):
     transaction_style = None
 
     def __init__(self, transaction_style="uri_template"):
-        # type: (str) -> None
+        
         TRANSACTION_STYLE_VALUES = ("uri_template", "path")
         if transaction_style not in TRANSACTION_STYLE_VALUES:
             raise ValueError(
@@ -80,7 +80,7 @@ class FalconIntegration(Integration):
 
     @staticmethod
     def setup_once():
-        # type: () -> None
+        
         _patch_wsgi_app()
         _patch_handle_exception()
         _patch_prepare_middleware()
@@ -154,10 +154,10 @@ def _is_falcon_http_error(ex):
 
 
 def _make_request_event_processor(req, integration):
-    # type: (falcon.Request, FalconIntegration) -> Callable
+    
 
     def inner(event, hint):
-        # type: (Dict[str, Any], Dict[str, Any]) -> Dict[str, Any]
+        
         if integration.transaction_style == "uri_template":
             event["transaction"] = req.uri_template
         elif integration.transaction_style == "path":

--- a/sentry_sdk/integrations/falcon.py
+++ b/sentry_sdk/integrations/falcon.py
@@ -9,8 +9,6 @@ from sentry_sdk.integrations.wsgi import SentryWsgiMiddleware
 from sentry_sdk.utils import capture_internal_exceptions, event_from_exception
 
 
-
-
 class FalconRequestExtractor(RequestExtractor):
     def env(self):
         return self.request.env

--- a/sentry_sdk/integrations/flask.py
+++ b/sentry_sdk/integrations/flask.py
@@ -9,7 +9,6 @@ from sentry_sdk.integrations.wsgi import SentryWsgiMiddleware
 from sentry_sdk.integrations._wsgi_common import RequestExtractor
 
 
-
 try:
     import flask_login  # type: ignore
 except ImportError:

--- a/sentry_sdk/integrations/flask.py
+++ b/sentry_sdk/integrations/flask.py
@@ -8,8 +8,7 @@ from sentry_sdk.integrations import Integration
 from sentry_sdk.integrations.wsgi import SentryWsgiMiddleware
 from sentry_sdk.integrations._wsgi_common import RequestExtractor
 
-if False:
-    pass
+
 
 try:
     import flask_login  # type: ignore

--- a/sentry_sdk/integrations/flask.py
+++ b/sentry_sdk/integrations/flask.py
@@ -9,14 +9,7 @@ from sentry_sdk.integrations.wsgi import SentryWsgiMiddleware
 from sentry_sdk.integrations._wsgi_common import RequestExtractor
 
 if False:
-    from sentry_sdk.integrations.wsgi import _ScopedResponse
-    from typing import Any
-    from typing import Dict
-    from werkzeug.datastructures import ImmutableTypeConversionDict
-    from werkzeug.datastructures import ImmutableMultiDict
-    from werkzeug.datastructures import FileStorage
-    from typing import Union
-    from typing import Callable
+    pass
 
 try:
     import flask_login  # type: ignore

--- a/sentry_sdk/integrations/flask.py
+++ b/sentry_sdk/integrations/flask.py
@@ -19,11 +19,11 @@ if False:
     from typing import Callable
 
 try:
-    import flask_login  # type: ignore
+    import flask_login  #type: ignore
 except ImportError:
     flask_login = None
 
-from flask import Request, Flask, _request_ctx_stack, _app_ctx_stack  # type: ignore
+from flask import Request, Flask, _request_ctx_stack, _app_ctx_stack  #type: ignore
 from flask.signals import (
     appcontext_pushed,
     appcontext_tearing_down,
@@ -38,7 +38,7 @@ class FlaskIntegration(Integration):
     transaction_style = None
 
     def __init__(self, transaction_style="endpoint"):
-        # type: (str) -> None
+        
         TRANSACTION_STYLE_VALUES = ("endpoint", "url")
         if transaction_style not in TRANSACTION_STYLE_VALUES:
             raise ValueError(
@@ -49,7 +49,7 @@ class FlaskIntegration(Integration):
 
     @staticmethod
     def setup_once():
-        # type: () -> None
+        
         appcontext_pushed.connect(_push_appctx)
         appcontext_tearing_down.connect(_pop_appctx)
         request_started.connect(_request_started)
@@ -58,7 +58,7 @@ class FlaskIntegration(Integration):
         old_app = Flask.__call__
 
         def sentry_patched_wsgi_app(self, environ, start_response):
-            # type: (Any, Dict[str, str], Callable) -> _ScopedResponse
+            
             if Hub.current.get_integration(FlaskIntegration) is None:
                 return old_app(self, environ, start_response)
 
@@ -66,11 +66,11 @@ class FlaskIntegration(Integration):
                 environ, start_response
             )
 
-        Flask.__call__ = sentry_patched_wsgi_app  # type: ignore
+        Flask.__call__ = sentry_patched_wsgi_app  
 
 
 def _push_appctx(*args, **kwargs):
-    # type: (*Flask, **Any) -> None
+    
     hub = Hub.current
     if hub.get_integration(FlaskIntegration) is not None:
         # always want to push scope regardless of whether WSGI app might already
@@ -83,14 +83,14 @@ def _push_appctx(*args, **kwargs):
 
 
 def _pop_appctx(*args, **kwargs):
-    # type: (*Flask, **Any) -> None
+    
     scope_manager = getattr(_app_ctx_stack.top, "sentry_sdk_scope_manager", None)
     if scope_manager is not None:
         scope_manager.__exit__(None, None, None)
 
 
 def _request_started(sender, **kwargs):
-    # type: (Flask, **Any) -> None
+    
     hub = Hub.current
     integration = hub.get_integration(FlaskIntegration)
     if integration is None:
@@ -101,7 +101,7 @@ def _request_started(sender, **kwargs):
         request = _request_ctx_stack.top.request
         weak_request = weakref.ref(request)
         scope.add_event_processor(
-            _make_request_event_processor(  # type: ignore
+            _make_request_event_processor(  
                 app, weak_request, integration
             )
         )
@@ -109,23 +109,23 @@ def _request_started(sender, **kwargs):
 
 class FlaskRequestExtractor(RequestExtractor):
     def env(self):
-        # type: () -> Dict[str, str]
+        
         return self.request.environ
 
     def cookies(self):
-        # type: () -> ImmutableTypeConversionDict
+        
         return self.request.cookies
 
     def raw_data(self):
-        # type: () -> bytes
+        
         return self.request.data
 
     def form(self):
-        # type: () -> ImmutableMultiDict
+        
         return self.request.form
 
     def files(self):
-        # type: () -> ImmutableMultiDict
+        
         return self.request.files
 
     def is_json(self):
@@ -135,14 +135,14 @@ class FlaskRequestExtractor(RequestExtractor):
         return self.request.get_json()
 
     def size_of_file(self, file):
-        # type: (FileStorage) -> int
+        
         return file.content_length
 
 
 def _make_request_event_processor(app, weak_request, integration):
-    # type: (Flask, Callable[[], Request], FlaskIntegration) -> Callable
+    
     def inner(event, hint):
-        # type: (Dict[str, Any], Dict[str, Any]) -> Dict[str, Any]
+        
         request = weak_request()
 
         # if the request is gone we are fine not logging the data from
@@ -153,9 +153,9 @@ def _make_request_event_processor(app, weak_request, integration):
 
         try:
             if integration.transaction_style == "endpoint":
-                event["transaction"] = request.url_rule.endpoint  # type: ignore
+                event["transaction"] = request.url_rule.endpoint  
             elif integration.transaction_style == "url":
-                event["transaction"] = request.url_rule.rule  # type: ignore
+                event["transaction"] = request.url_rule.rule  
         except Exception:
             pass
 
@@ -172,7 +172,7 @@ def _make_request_event_processor(app, weak_request, integration):
 
 
 def _capture_exception(sender, exception, **kwargs):
-    # type: (Flask, Union[ValueError, BaseException], **Any) -> None
+    
     hub = Hub.current
     if hub.get_integration(FlaskIntegration) is None:
         return
@@ -186,7 +186,7 @@ def _capture_exception(sender, exception, **kwargs):
 
 
 def _add_user_to_event(event):
-    # type: (Dict[str, Any]) -> None
+    
     if flask_login is None:
         return
 

--- a/sentry_sdk/integrations/flask.py
+++ b/sentry_sdk/integrations/flask.py
@@ -14,7 +14,7 @@ try:
 except ImportError:
     flask_login = None
 
-from flask import Request, Flask, _request_ctx_stack, _app_ctx_stack  # type: ignore
+from flask import Flask, _request_ctx_stack, _app_ctx_stack  # type: ignore
 from flask.signals import (
     appcontext_pushed,
     appcontext_tearing_down,

--- a/sentry_sdk/integrations/gnu_backtrace.py
+++ b/sentry_sdk/integrations/gnu_backtrace.py
@@ -44,7 +44,7 @@ class GnuBacktraceIntegration(Integration):
 
 
 def _process_gnu_backtrace(event, hint):
-    # type: (Dict[str, Any], Dict[str, Any]) -> Dict[str, Any]
+    
     if Hub.current.get_integration(GnuBacktraceIntegration) is None:
         return event
 

--- a/sentry_sdk/integrations/gnu_backtrace.py
+++ b/sentry_sdk/integrations/gnu_backtrace.py
@@ -6,8 +6,7 @@ from sentry_sdk.scope import add_global_event_processor
 from sentry_sdk.utils import capture_internal_exceptions
 
 if False:
-    from typing import Any
-    from typing import Dict
+    pass
 
 
 MODULE_RE = r"[a-zA-Z0-9/._:\\-]+"

--- a/sentry_sdk/integrations/gnu_backtrace.py
+++ b/sentry_sdk/integrations/gnu_backtrace.py
@@ -44,7 +44,7 @@ class GnuBacktraceIntegration(Integration):
 
 
 def _process_gnu_backtrace(event, hint):
-    
+
     if Hub.current.get_integration(GnuBacktraceIntegration) is None:
         return event
 

--- a/sentry_sdk/integrations/gnu_backtrace.py
+++ b/sentry_sdk/integrations/gnu_backtrace.py
@@ -6,8 +6,6 @@ from sentry_sdk.scope import add_global_event_processor
 from sentry_sdk.utils import capture_internal_exceptions
 
 
-
-
 MODULE_RE = r"[a-zA-Z0-9/._:\\-]+"
 TYPE_RE = r"[a-zA-Z0-9._:<>,-]+"
 HEXVAL_RE = r"[A-Fa-f0-9]+"

--- a/sentry_sdk/integrations/gnu_backtrace.py
+++ b/sentry_sdk/integrations/gnu_backtrace.py
@@ -5,8 +5,7 @@ from sentry_sdk.integrations import Integration
 from sentry_sdk.scope import add_global_event_processor
 from sentry_sdk.utils import capture_internal_exceptions
 
-if False:
-    pass
+
 
 
 MODULE_RE = r"[a-zA-Z0-9/._:\\-]+"

--- a/sentry_sdk/integrations/logging.py
+++ b/sentry_sdk/integrations/logging.py
@@ -25,7 +25,7 @@ _IGNORED_LOGGERS = set(["sentry_sdk.errors"])
 
 
 def ignore_logger(name):
-    
+
     """This disables the breadcrumb integration for a logger of a specific
     name.  This primary use is for some integrations to disable breadcrumbs
     of this integration.
@@ -37,7 +37,7 @@ class LoggingIntegration(Integration):
     identifier = "logging"
 
     def __init__(self, level=DEFAULT_LEVEL, event_level=DEFAULT_EVENT_LEVEL):
-        
+
         self._handler = None
         self._breadcrumb_handler = None
 
@@ -48,7 +48,7 @@ class LoggingIntegration(Integration):
             self._handler = EventHandler(level=event_level)
 
     def _handle_record(self, record):
-        
+
         if self._handler is not None and record.levelno >= self._handler.level:
             self._handler.handle(record)
 
@@ -60,11 +60,11 @@ class LoggingIntegration(Integration):
 
     @staticmethod
     def setup_once():
-        
-        old_callhandlers = logging.Logger.callHandlers  
+
+        old_callhandlers = logging.Logger.callHandlers
 
         def sentry_patched_callhandlers(self, record):
-            
+
             try:
                 return old_callhandlers(self, record)
             finally:
@@ -77,16 +77,16 @@ class LoggingIntegration(Integration):
                     if integration is not None:
                         integration._handle_record(record)
 
-        logging.Logger.callHandlers = sentry_patched_callhandlers  
+        logging.Logger.callHandlers = sentry_patched_callhandlers
 
 
 def _can_record(record):
-    
+
     return record.name not in _IGNORED_LOGGERS
 
 
 def _breadcrumb_from_record(record):
-    
+
     return {
         "ty": "log",
         "level": _logging_to_event_level(record.levelname),
@@ -98,7 +98,7 @@ def _breadcrumb_from_record(record):
 
 
 def _logging_to_event_level(levelname):
-    
+
     return {"critical": "fatal"}.get(levelname.lower(), levelname.lower())
 
 
@@ -132,7 +132,7 @@ COMMON_RECORD_ATTRS = frozenset(
 
 
 def _extra_from_record(record):
-    
+
     return {
         k: v
         for k, v in vars(record).items()
@@ -142,13 +142,13 @@ def _extra_from_record(record):
 
 class EventHandler(logging.Handler, object):
     def emit(self, record):
-        
+
         with capture_internal_exceptions():
             self.format(record)
             return self._emit(record)
 
     def _emit(self, record):
-        
+
         if not _can_record(record):
             return
 
@@ -156,7 +156,7 @@ class EventHandler(logging.Handler, object):
         if hub.client is None:
             return
 
-        hint = None  
+        hint = None
         client_options = hub.client.options
 
         # exc_info might be None or (None, None, None)
@@ -198,13 +198,13 @@ SentryHandler = EventHandler
 
 class BreadcrumbHandler(logging.Handler, object):
     def emit(self, record):
-        
+
         with capture_internal_exceptions():
             self.format(record)
             return self._emit(record)
 
     def _emit(self, record):
-        
+
         if not _can_record(record):
             return
 

--- a/sentry_sdk/integrations/logging.py
+++ b/sentry_sdk/integrations/logging.py
@@ -25,7 +25,7 @@ _IGNORED_LOGGERS = set(["sentry_sdk.errors"])
 
 
 def ignore_logger(name):
-    # type: (str) -> None
+    
     """This disables the breadcrumb integration for a logger of a specific
     name.  This primary use is for some integrations to disable breadcrumbs
     of this integration.
@@ -37,7 +37,7 @@ class LoggingIntegration(Integration):
     identifier = "logging"
 
     def __init__(self, level=DEFAULT_LEVEL, event_level=DEFAULT_EVENT_LEVEL):
-        # type: (int, int) -> None
+        
         self._handler = None
         self._breadcrumb_handler = None
 
@@ -48,7 +48,7 @@ class LoggingIntegration(Integration):
             self._handler = EventHandler(level=event_level)
 
     def _handle_record(self, record):
-        # type: (LogRecord) -> None
+        
         if self._handler is not None and record.levelno >= self._handler.level:
             self._handler.handle(record)
 
@@ -60,11 +60,11 @@ class LoggingIntegration(Integration):
 
     @staticmethod
     def setup_once():
-        # type: () -> None
-        old_callhandlers = logging.Logger.callHandlers  # type: ignore
+        
+        old_callhandlers = logging.Logger.callHandlers  
 
         def sentry_patched_callhandlers(self, record):
-            # type: (Any, LogRecord) -> Any
+            
             try:
                 return old_callhandlers(self, record)
             finally:
@@ -77,16 +77,16 @@ class LoggingIntegration(Integration):
                     if integration is not None:
                         integration._handle_record(record)
 
-        logging.Logger.callHandlers = sentry_patched_callhandlers  # type: ignore
+        logging.Logger.callHandlers = sentry_patched_callhandlers  
 
 
 def _can_record(record):
-    # type: (LogRecord) -> bool
+    
     return record.name not in _IGNORED_LOGGERS
 
 
 def _breadcrumb_from_record(record):
-    # type: (LogRecord) -> Dict[str, Any]
+    
     return {
         "ty": "log",
         "level": _logging_to_event_level(record.levelname),
@@ -98,7 +98,7 @@ def _breadcrumb_from_record(record):
 
 
 def _logging_to_event_level(levelname):
-    # type: (str) -> str
+    
     return {"critical": "fatal"}.get(levelname.lower(), levelname.lower())
 
 
@@ -132,7 +132,7 @@ COMMON_RECORD_ATTRS = frozenset(
 
 
 def _extra_from_record(record):
-    # type: (LogRecord) -> Dict[str, None]
+    
     return {
         k: v
         for k, v in vars(record).items()
@@ -142,13 +142,13 @@ def _extra_from_record(record):
 
 class EventHandler(logging.Handler, object):
     def emit(self, record):
-        # type: (LogRecord) -> Any
+        
         with capture_internal_exceptions():
             self.format(record)
             return self._emit(record)
 
     def _emit(self, record):
-        # type: (LogRecord) -> None
+        
         if not _can_record(record):
             return
 
@@ -156,7 +156,7 @@ class EventHandler(logging.Handler, object):
         if hub.client is None:
             return
 
-        hint = None  # type: Optional[Dict[str, Any]]
+        hint = None  
         client_options = hub.client.options
 
         # exc_info might be None or (None, None, None)
@@ -198,13 +198,13 @@ SentryHandler = EventHandler
 
 class BreadcrumbHandler(logging.Handler, object):
     def emit(self, record):
-        # type: (LogRecord) -> Any
+        
         with capture_internal_exceptions():
             self.format(record)
             return self._emit(record)
 
     def _emit(self, record):
-        # type: (LogRecord) -> None
+        
         if not _can_record(record):
             return
 

--- a/sentry_sdk/integrations/logging.py
+++ b/sentry_sdk/integrations/logging.py
@@ -13,7 +13,6 @@ from sentry_sdk.utils import (
 from sentry_sdk.integrations import Integration
 
 
-
 DEFAULT_LEVEL = logging.INFO
 DEFAULT_EVENT_LEVEL = logging.ERROR
 

--- a/sentry_sdk/integrations/logging.py
+++ b/sentry_sdk/integrations/logging.py
@@ -13,10 +13,7 @@ from sentry_sdk.utils import (
 from sentry_sdk.integrations import Integration
 
 if False:
-    from logging import LogRecord
-    from typing import Any
-    from typing import Dict
-    from typing import Optional
+    pass
 
 DEFAULT_LEVEL = logging.INFO
 DEFAULT_EVENT_LEVEL = logging.ERROR

--- a/sentry_sdk/integrations/logging.py
+++ b/sentry_sdk/integrations/logging.py
@@ -12,8 +12,7 @@ from sentry_sdk.utils import (
 )
 from sentry_sdk.integrations import Integration
 
-if False:
-    pass
+
 
 DEFAULT_LEVEL = logging.INFO
 DEFAULT_EVENT_LEVEL = logging.ERROR

--- a/sentry_sdk/integrations/modules.py
+++ b/sentry_sdk/integrations/modules.py
@@ -14,7 +14,7 @@ _installed_modules = None
 
 
 def _generate_installed_modules():
-    
+
     try:
         import pkg_resources
     except ImportError:
@@ -25,7 +25,7 @@ def _generate_installed_modules():
 
 
 def _get_installed_modules():
-    
+
     global _installed_modules
     if _installed_modules is None:
         _installed_modules = dict(_generate_installed_modules())
@@ -37,10 +37,9 @@ class ModulesIntegration(Integration):
 
     @staticmethod
     def setup_once():
-        
         @add_global_event_processor
         def processor(event, hint):
-            
+
             if Hub.current.get_integration(ModulesIntegration) is not None:
                 event["modules"] = dict(_get_installed_modules())
             return event

--- a/sentry_sdk/integrations/modules.py
+++ b/sentry_sdk/integrations/modules.py
@@ -4,8 +4,7 @@ from sentry_sdk.hub import Hub
 from sentry_sdk.integrations import Integration
 from sentry_sdk.scope import add_global_event_processor
 
-if False:
-    pass
+
 
 _installed_modules = None
 

--- a/sentry_sdk/integrations/modules.py
+++ b/sentry_sdk/integrations/modules.py
@@ -5,7 +5,6 @@ from sentry_sdk.integrations import Integration
 from sentry_sdk.scope import add_global_event_processor
 
 
-
 _installed_modules = None
 
 

--- a/sentry_sdk/integrations/modules.py
+++ b/sentry_sdk/integrations/modules.py
@@ -5,10 +5,7 @@ from sentry_sdk.integrations import Integration
 from sentry_sdk.scope import add_global_event_processor
 
 if False:
-    from typing import Any
-    from typing import Dict
-    from typing import Tuple
-    from typing import Iterator
+    pass
 
 _installed_modules = None
 

--- a/sentry_sdk/integrations/modules.py
+++ b/sentry_sdk/integrations/modules.py
@@ -14,7 +14,7 @@ _installed_modules = None
 
 
 def _generate_installed_modules():
-    # type: () -> Iterator[Tuple[str, str]]
+    
     try:
         import pkg_resources
     except ImportError:
@@ -25,7 +25,7 @@ def _generate_installed_modules():
 
 
 def _get_installed_modules():
-    # type: () -> Dict[str, str]
+    
     global _installed_modules
     if _installed_modules is None:
         _installed_modules = dict(_generate_installed_modules())
@@ -37,10 +37,10 @@ class ModulesIntegration(Integration):
 
     @staticmethod
     def setup_once():
-        # type: () -> None
+        
         @add_global_event_processor
         def processor(event, hint):
-            # type: (Dict[str, Any], Dict[str, Any]) -> Dict[str, Any]
+            
             if Hub.current.get_integration(ModulesIntegration) is not None:
                 event["modules"] = dict(_get_installed_modules())
             return event

--- a/sentry_sdk/integrations/pyramid.py
+++ b/sentry_sdk/integrations/pyramid.py
@@ -21,7 +21,6 @@ if False:
     from webob.compat import cgi_FieldStorage  # type: ignore
 
 
-
 if getattr(Request, "authenticated_userid", None):
 
     def authenticated_userid(request):

--- a/sentry_sdk/integrations/pyramid.py
+++ b/sentry_sdk/integrations/pyramid.py
@@ -15,11 +15,6 @@ from sentry_sdk.integrations import Integration
 from sentry_sdk.integrations._wsgi_common import RequestExtractor
 from sentry_sdk.integrations.wsgi import SentryWsgiMiddleware
 
-if False:
-    from pyramid.response import Response  # type: ignore
-    from webob.cookies import RequestCookies  # type: ignore
-    from webob.compat import cgi_FieldStorage  # type: ignore
-
 
 if getattr(Request, "authenticated_userid", None):
 

--- a/sentry_sdk/integrations/pyramid.py
+++ b/sentry_sdk/integrations/pyramid.py
@@ -4,8 +4,8 @@ import os
 import sys
 import weakref
 
-from pyramid.httpexceptions import HTTPException  # type: ignore
-from pyramid.request import Request  # type: ignore
+from pyramid.httpexceptions import HTTPException  #type: ignore
+from pyramid.request import Request  #type: ignore
 
 from sentry_sdk.hub import Hub, _should_send_default_pii
 from sentry_sdk.utils import capture_internal_exceptions, event_from_exception
@@ -16,14 +16,14 @@ from sentry_sdk.integrations._wsgi_common import RequestExtractor
 from sentry_sdk.integrations.wsgi import SentryWsgiMiddleware
 
 if False:
-    from pyramid.response import Response  # type: ignore
+    from pyramid.response import Response  #type: ignore
     from typing import Any
     from sentry_sdk.integrations.wsgi import _ScopedResponse
     from typing import Callable
     from typing import Dict
     from typing import Optional
-    from webob.cookies import RequestCookies  # type: ignore
-    from webob.compat import cgi_FieldStorage  # type: ignore
+    from webob.cookies import RequestCookies  #type: ignore
+    from webob.compat import cgi_FieldStorage  #type: ignore
 
     from sentry_sdk.utils import ExcInfo
 
@@ -31,13 +31,13 @@ if False:
 if getattr(Request, "authenticated_userid", None):
 
     def authenticated_userid(request):
-        # type: (Request) -> Optional[Any]
+        
         return request.authenticated_userid
 
 
 else:
     # bw-compat for pyramid < 1.5
-    from pyramid.security import authenticated_userid  # type: ignore
+    from pyramid.security import authenticated_userid  #type: ignore
 
 
 class PyramidIntegration(Integration):
@@ -46,7 +46,7 @@ class PyramidIntegration(Integration):
     transaction_style = None
 
     def __init__(self, transaction_style="route_name"):
-        # type: (str) -> None
+        
         TRANSACTION_STYLE_VALUES = ("route_name", "route_pattern")
         if transaction_style not in TRANSACTION_STYLE_VALUES:
             raise ValueError(
@@ -57,13 +57,13 @@ class PyramidIntegration(Integration):
 
     @staticmethod
     def setup_once():
-        # type: () -> None
-        from pyramid.router import Router  # type: ignore
+        
+        from pyramid.router import Router  #type: ignore
 
         old_handle_request = Router.handle_request
 
         def sentry_patched_handle_request(self, request, *args, **kwargs):
-            # type: (Any, Request, *Any, **Any) -> Response
+            
             hub = Hub.current
             integration = hub.get_integration(PyramidIntegration)
             if integration is None:
@@ -86,7 +86,7 @@ class PyramidIntegration(Integration):
         old_wsgi_call = Router.__call__
 
         def sentry_patched_wsgi_call(self, environ, start_response):
-            # type: (Any, Dict[str, str], Callable) -> _ScopedResponse
+            
             hub = Hub.current
             integration = hub.get_integration(PyramidIntegration)
             if integration is None:
@@ -100,7 +100,7 @@ class PyramidIntegration(Integration):
 
 
 def _capture_exception(exc_info, **kwargs):
-    # type: (ExcInfo, **Any) -> None
+    
     if exc_info[0] is None or issubclass(exc_info[0], HTTPException):
         return
     hub = Hub.current
@@ -120,19 +120,19 @@ class PyramidRequestExtractor(RequestExtractor):
         return self.request.path_url
 
     def env(self):
-        # type: () -> Dict[str, str]
+        
         return self.request.environ
 
     def cookies(self):
-        # type: () -> RequestCookies
+        
         return self.request.cookies
 
     def raw_data(self):
-        # type: () -> str
+        
         return self.request.text
 
     def form(self):
-        # type: () -> Dict[str, str]
+        
         return {
             key: value
             for key, value in self.request.POST.items()
@@ -140,7 +140,7 @@ class PyramidRequestExtractor(RequestExtractor):
         }
 
     def files(self):
-        # type: () -> Dict[str, cgi_FieldStorage]
+        
         return {
             key: value
             for key, value in self.request.POST.items()
@@ -148,7 +148,7 @@ class PyramidRequestExtractor(RequestExtractor):
         }
 
     def size_of_file(self, postdata):
-        # type: (cgi_FieldStorage) -> int
+        
         file = postdata.file
         try:
             return os.fstat(file.fileno()).st_size
@@ -157,9 +157,9 @@ class PyramidRequestExtractor(RequestExtractor):
 
 
 def _make_event_processor(weak_request, integration):
-    # type: (Callable[[], Request], PyramidIntegration) -> Callable
+    
     def event_processor(event, hint):
-        # type: (Dict[str, Any], Dict[str, Any]) -> Dict[str, Any]
+        
         request = weak_request()
         if request is None:
             return event

--- a/sentry_sdk/integrations/pyramid.py
+++ b/sentry_sdk/integrations/pyramid.py
@@ -4,8 +4,8 @@ import os
 import sys
 import weakref
 
-from pyramid.httpexceptions import HTTPException  #type: ignore
-from pyramid.request import Request  #type: ignore
+from pyramid.httpexceptions import HTTPException  # type: ignore
+from pyramid.request import Request  # type: ignore
 
 from sentry_sdk.hub import Hub, _should_send_default_pii
 from sentry_sdk.utils import capture_internal_exceptions, event_from_exception
@@ -16,14 +16,14 @@ from sentry_sdk.integrations._wsgi_common import RequestExtractor
 from sentry_sdk.integrations.wsgi import SentryWsgiMiddleware
 
 if False:
-    from pyramid.response import Response  #type: ignore
+    from pyramid.response import Response  # type: ignore
     from typing import Any
     from sentry_sdk.integrations.wsgi import _ScopedResponse
     from typing import Callable
     from typing import Dict
     from typing import Optional
-    from webob.cookies import RequestCookies  #type: ignore
-    from webob.compat import cgi_FieldStorage  #type: ignore
+    from webob.cookies import RequestCookies  # type: ignore
+    from webob.compat import cgi_FieldStorage  # type: ignore
 
     from sentry_sdk.utils import ExcInfo
 
@@ -31,13 +31,13 @@ if False:
 if getattr(Request, "authenticated_userid", None):
 
     def authenticated_userid(request):
-        
+
         return request.authenticated_userid
 
 
 else:
     # bw-compat for pyramid < 1.5
-    from pyramid.security import authenticated_userid  #type: ignore
+    from pyramid.security import authenticated_userid  # type: ignore
 
 
 class PyramidIntegration(Integration):
@@ -46,7 +46,7 @@ class PyramidIntegration(Integration):
     transaction_style = None
 
     def __init__(self, transaction_style="route_name"):
-        
+
         TRANSACTION_STYLE_VALUES = ("route_name", "route_pattern")
         if transaction_style not in TRANSACTION_STYLE_VALUES:
             raise ValueError(
@@ -57,13 +57,13 @@ class PyramidIntegration(Integration):
 
     @staticmethod
     def setup_once():
-        
-        from pyramid.router import Router  #type: ignore
+
+        from pyramid.router import Router  # type: ignore
 
         old_handle_request = Router.handle_request
 
         def sentry_patched_handle_request(self, request, *args, **kwargs):
-            
+
             hub = Hub.current
             integration = hub.get_integration(PyramidIntegration)
             if integration is None:
@@ -86,7 +86,7 @@ class PyramidIntegration(Integration):
         old_wsgi_call = Router.__call__
 
         def sentry_patched_wsgi_call(self, environ, start_response):
-            
+
             hub = Hub.current
             integration = hub.get_integration(PyramidIntegration)
             if integration is None:
@@ -100,7 +100,7 @@ class PyramidIntegration(Integration):
 
 
 def _capture_exception(exc_info, **kwargs):
-    
+
     if exc_info[0] is None or issubclass(exc_info[0], HTTPException):
         return
     hub = Hub.current
@@ -120,19 +120,19 @@ class PyramidRequestExtractor(RequestExtractor):
         return self.request.path_url
 
     def env(self):
-        
+
         return self.request.environ
 
     def cookies(self):
-        
+
         return self.request.cookies
 
     def raw_data(self):
-        
+
         return self.request.text
 
     def form(self):
-        
+
         return {
             key: value
             for key, value in self.request.POST.items()
@@ -140,7 +140,7 @@ class PyramidRequestExtractor(RequestExtractor):
         }
 
     def files(self):
-        
+
         return {
             key: value
             for key, value in self.request.POST.items()
@@ -148,7 +148,7 @@ class PyramidRequestExtractor(RequestExtractor):
         }
 
     def size_of_file(self, postdata):
-        
+
         file = postdata.file
         try:
             return os.fstat(file.fileno()).st_size
@@ -157,9 +157,8 @@ class PyramidRequestExtractor(RequestExtractor):
 
 
 def _make_event_processor(weak_request, integration):
-    
     def event_processor(event, hint):
-        
+
         request = weak_request()
         if request is None:
             return event

--- a/sentry_sdk/integrations/pyramid.py
+++ b/sentry_sdk/integrations/pyramid.py
@@ -17,15 +17,9 @@ from sentry_sdk.integrations.wsgi import SentryWsgiMiddleware
 
 if False:
     from pyramid.response import Response  # type: ignore
-    from typing import Any
-    from sentry_sdk.integrations.wsgi import _ScopedResponse
-    from typing import Callable
-    from typing import Dict
-    from typing import Optional
     from webob.cookies import RequestCookies  # type: ignore
     from webob.compat import cgi_FieldStorage  # type: ignore
 
-    from sentry_sdk.utils import ExcInfo
 
 
 if getattr(Request, "authenticated_userid", None):

--- a/sentry_sdk/integrations/rq.py
+++ b/sentry_sdk/integrations/rq.py
@@ -6,16 +6,16 @@ from sentry_sdk.hub import Hub
 from sentry_sdk.integrations import Integration
 from sentry_sdk.utils import capture_internal_exceptions, event_from_exception
 
-from rq.timeouts import JobTimeoutException  # type: ignore
-from rq.worker import Worker  # type: ignore
+from rq.timeouts import JobTimeoutException  #type: ignore
+from rq.worker import Worker  #type: ignore
 
 if False:
     from typing import Any
     from typing import Dict
     from typing import Callable
 
-    from rq.job import Job  # type: ignore
-    from rq.queue import Queue  # type: ignore
+    from rq.job import Job  #type: ignore
+    from rq.queue import Queue  #type: ignore
 
     from sentry_sdk.utils import ExcInfo
 
@@ -25,12 +25,12 @@ class RqIntegration(Integration):
 
     @staticmethod
     def setup_once():
-        # type: () -> None
+        
 
         old_perform_job = Worker.perform_job
 
         def sentry_patched_perform_job(self, job, *args, **kwargs):
-            # type: (Any, Job, *Queue, **Any) -> bool
+            
             hub = Hub.current
             integration = hub.get_integration(RqIntegration)
 
@@ -62,9 +62,9 @@ class RqIntegration(Integration):
 
 
 def _make_event_processor(weak_job):
-    # type: (Callable[[], Job]) -> Callable
+    
     def event_processor(event, hint):
-        # type: (Dict[str, Any], Dict[str, Any]) -> Dict[str, Any]
+        
         job = weak_job()
         if job is not None:
             with capture_internal_exceptions():
@@ -91,7 +91,7 @@ def _make_event_processor(weak_job):
 
 
 def _capture_exception(exc_info, **kwargs):
-    # type: (ExcInfo, **Any) -> None
+    
     hub = Hub.current
     if hub.get_integration(RqIntegration) is None:
         return

--- a/sentry_sdk/integrations/rq.py
+++ b/sentry_sdk/integrations/rq.py
@@ -10,10 +10,9 @@ from rq.timeouts import JobTimeoutException  # type: ignore
 from rq.worker import Worker  # type: ignore
 
 
-
+if False:
     from rq.job import Job  # type: ignore
     from rq.queue import Queue  # type: ignore
-
 
 
 class RqIntegration(Integration):

--- a/sentry_sdk/integrations/rq.py
+++ b/sentry_sdk/integrations/rq.py
@@ -9,8 +9,7 @@ from sentry_sdk.utils import capture_internal_exceptions, event_from_exception
 from rq.timeouts import JobTimeoutException  # type: ignore
 from rq.worker import Worker  # type: ignore
 
-if False:
-    pass
+
 
     from rq.job import Job  # type: ignore
     from rq.queue import Queue  # type: ignore

--- a/sentry_sdk/integrations/rq.py
+++ b/sentry_sdk/integrations/rq.py
@@ -6,16 +6,16 @@ from sentry_sdk.hub import Hub
 from sentry_sdk.integrations import Integration
 from sentry_sdk.utils import capture_internal_exceptions, event_from_exception
 
-from rq.timeouts import JobTimeoutException  #type: ignore
-from rq.worker import Worker  #type: ignore
+from rq.timeouts import JobTimeoutException  # type: ignore
+from rq.worker import Worker  # type: ignore
 
 if False:
     from typing import Any
     from typing import Dict
     from typing import Callable
 
-    from rq.job import Job  #type: ignore
-    from rq.queue import Queue  #type: ignore
+    from rq.job import Job  # type: ignore
+    from rq.queue import Queue  # type: ignore
 
     from sentry_sdk.utils import ExcInfo
 
@@ -25,12 +25,11 @@ class RqIntegration(Integration):
 
     @staticmethod
     def setup_once():
-        
 
         old_perform_job = Worker.perform_job
 
         def sentry_patched_perform_job(self, job, *args, **kwargs):
-            
+
             hub = Hub.current
             integration = hub.get_integration(RqIntegration)
 
@@ -62,9 +61,8 @@ class RqIntegration(Integration):
 
 
 def _make_event_processor(weak_job):
-    
     def event_processor(event, hint):
-        
+
         job = weak_job()
         if job is not None:
             with capture_internal_exceptions():
@@ -91,7 +89,7 @@ def _make_event_processor(weak_job):
 
 
 def _capture_exception(exc_info, **kwargs):
-    
+
     hub = Hub.current
     if hub.get_integration(RqIntegration) is None:
         return

--- a/sentry_sdk/integrations/rq.py
+++ b/sentry_sdk/integrations/rq.py
@@ -10,14 +10,11 @@ from rq.timeouts import JobTimeoutException  # type: ignore
 from rq.worker import Worker  # type: ignore
 
 if False:
-    from typing import Any
-    from typing import Dict
-    from typing import Callable
+    pass
 
     from rq.job import Job  # type: ignore
     from rq.queue import Queue  # type: ignore
 
-    from sentry_sdk.utils import ExcInfo
 
 
 class RqIntegration(Integration):

--- a/sentry_sdk/integrations/rq.py
+++ b/sentry_sdk/integrations/rq.py
@@ -10,11 +10,6 @@ from rq.timeouts import JobTimeoutException  # type: ignore
 from rq.worker import Worker  # type: ignore
 
 
-if False:
-    from rq.job import Job  # type: ignore
-    from rq.queue import Queue  # type: ignore
-
-
 class RqIntegration(Integration):
     identifier = "rq"
 

--- a/sentry_sdk/integrations/sanic.py
+++ b/sentry_sdk/integrations/sanic.py
@@ -18,17 +18,6 @@ from sanic.exceptions import SanicException  # type: ignore
 from sanic.router import Router  # type: ignore
 from sanic.handlers import ErrorHandler  # type: ignore
 
-if False:
-    from sanic.request import Request  # type: ignore
-
-    from typing import Any
-    from typing import Callable
-    from typing import Dict
-    from typing import Optional
-    from typing import Union
-    from typing import Tuple
-    from sanic.request import RequestParameters
-
 
 class SanicIntegration(Integration):
     identifier = "sanic"

--- a/sentry_sdk/integrations/sanic.py
+++ b/sentry_sdk/integrations/sanic.py
@@ -13,13 +13,13 @@ from sentry_sdk.integrations import Integration
 from sentry_sdk.integrations._wsgi_common import RequestExtractor, _filter_headers
 from sentry_sdk.integrations.logging import ignore_logger
 
-from sanic import Sanic, __version__ as VERSION  # type: ignore
-from sanic.exceptions import SanicException  # type: ignore
-from sanic.router import Router  # type: ignore
-from sanic.handlers import ErrorHandler  # type: ignore
+from sanic import Sanic, __version__ as VERSION  #type: ignore
+from sanic.exceptions import SanicException  #type: ignore
+from sanic.router import Router  #type: ignore
+from sanic.handlers import ErrorHandler  #type: ignore
 
 if False:
-    from sanic.request import Request  # type: ignore
+    from sanic.request import Request  #type: ignore
 
     from typing import Any
     from typing import Callable
@@ -35,7 +35,7 @@ class SanicIntegration(Integration):
 
     @staticmethod
     def setup_once():
-        # type: () -> None
+        
         if not HAS_REAL_CONTEXTVARS:
             # We better have contextvars or we're going to leak state between
             # requests.
@@ -59,7 +59,7 @@ class SanicIntegration(Integration):
         old_handle_request = Sanic.handle_request
 
         async def sentry_handle_request(self, request, *args, **kwargs):
-            # type: (Any, Request, *Any, **Any) -> Any
+            
             hub = Hub.current
             if hub.get_integration(SanicIntegration) is None:
                 return old_handle_request(self, request, *args, **kwargs)
@@ -82,7 +82,7 @@ class SanicIntegration(Integration):
         old_router_get = Router.get
 
         def sentry_router_get(self, request):
-            # type: (Any, Request) -> Any
+            
             rv = old_router_get(self, request)
             hub = Hub.current
             if hub.get_integration(SanicIntegration) is not None:
@@ -96,7 +96,7 @@ class SanicIntegration(Integration):
         old_error_handler_lookup = ErrorHandler.lookup
 
         def sentry_error_handler_lookup(self, exception):
-            # type: (Any, Exception) -> Optional[Callable]
+            
             _capture_exception(exception)
             old_error_handler = old_error_handler_lookup(self, exception)
 
@@ -107,7 +107,7 @@ class SanicIntegration(Integration):
                 return old_error_handler
 
             async def sentry_wrapped_error_handler(request, exception):
-                # type: (Request, Exception) -> Any
+                
                 try:
                     response = old_error_handler(request, exception)
                     if isawaitable(response):
@@ -127,7 +127,7 @@ class SanicIntegration(Integration):
 
 
 def _capture_exception(exception):
-    # type: (Union[Tuple[Optional[type], Optional[BaseException], Any], BaseException]) -> None
+    
     hub = Hub.current
     integration = hub.get_integration(SanicIntegration)
     if integration is None:
@@ -143,9 +143,9 @@ def _capture_exception(exception):
 
 
 def _make_request_processor(weak_request):
-    # type: (Callable[[], Request]) -> Callable
+    
     def sanic_processor(event, hint):
-        # type: (Dict[str, Any], Dict[str, Any]) -> Optional[Dict[str, Any]]
+        
 
         try:
             if issubclass(hint["exc_info"][0], SanicException):
@@ -182,7 +182,7 @@ def _make_request_processor(weak_request):
 
 class SanicRequestExtractor(RequestExtractor):
     def content_length(self):
-        # type: () -> int
+        
         if self.request.body is None:
             return 0
         return len(self.request.body)
@@ -191,22 +191,22 @@ class SanicRequestExtractor(RequestExtractor):
         return dict(self.request.cookies)
 
     def raw_data(self):
-        # type: () -> bytes
+        
         return self.request.body
 
     def form(self):
-        # type: () -> RequestParameters
+        
         return self.request.form
 
     def is_json(self):
         raise NotImplementedError()
 
     def json(self):
-        # type: () -> Optional[Any]
+        
         return self.request.json
 
     def files(self):
-        # type: () -> RequestParameters
+        
         return self.request.files
 
     def size_of_file(self, file):

--- a/sentry_sdk/integrations/sanic.py
+++ b/sentry_sdk/integrations/sanic.py
@@ -13,13 +13,13 @@ from sentry_sdk.integrations import Integration
 from sentry_sdk.integrations._wsgi_common import RequestExtractor, _filter_headers
 from sentry_sdk.integrations.logging import ignore_logger
 
-from sanic import Sanic, __version__ as VERSION  #type: ignore
-from sanic.exceptions import SanicException  #type: ignore
-from sanic.router import Router  #type: ignore
-from sanic.handlers import ErrorHandler  #type: ignore
+from sanic import Sanic, __version__ as VERSION  # type: ignore
+from sanic.exceptions import SanicException  # type: ignore
+from sanic.router import Router  # type: ignore
+from sanic.handlers import ErrorHandler  # type: ignore
 
 if False:
-    from sanic.request import Request  #type: ignore
+    from sanic.request import Request  # type: ignore
 
     from typing import Any
     from typing import Callable
@@ -35,7 +35,7 @@ class SanicIntegration(Integration):
 
     @staticmethod
     def setup_once():
-        
+
         if not HAS_REAL_CONTEXTVARS:
             # We better have contextvars or we're going to leak state between
             # requests.
@@ -59,7 +59,7 @@ class SanicIntegration(Integration):
         old_handle_request = Sanic.handle_request
 
         async def sentry_handle_request(self, request, *args, **kwargs):
-            
+
             hub = Hub.current
             if hub.get_integration(SanicIntegration) is None:
                 return old_handle_request(self, request, *args, **kwargs)
@@ -82,7 +82,7 @@ class SanicIntegration(Integration):
         old_router_get = Router.get
 
         def sentry_router_get(self, request):
-            
+
             rv = old_router_get(self, request)
             hub = Hub.current
             if hub.get_integration(SanicIntegration) is not None:
@@ -96,7 +96,7 @@ class SanicIntegration(Integration):
         old_error_handler_lookup = ErrorHandler.lookup
 
         def sentry_error_handler_lookup(self, exception):
-            
+
             _capture_exception(exception)
             old_error_handler = old_error_handler_lookup(self, exception)
 
@@ -107,7 +107,7 @@ class SanicIntegration(Integration):
                 return old_error_handler
 
             async def sentry_wrapped_error_handler(request, exception):
-                
+
                 try:
                     response = old_error_handler(request, exception)
                     if isawaitable(response):
@@ -127,7 +127,7 @@ class SanicIntegration(Integration):
 
 
 def _capture_exception(exception):
-    
+
     hub = Hub.current
     integration = hub.get_integration(SanicIntegration)
     if integration is None:
@@ -143,9 +143,7 @@ def _capture_exception(exception):
 
 
 def _make_request_processor(weak_request):
-    
     def sanic_processor(event, hint):
-        
 
         try:
             if issubclass(hint["exc_info"][0], SanicException):
@@ -182,7 +180,7 @@ def _make_request_processor(weak_request):
 
 class SanicRequestExtractor(RequestExtractor):
     def content_length(self):
-        
+
         if self.request.body is None:
             return 0
         return len(self.request.body)
@@ -191,22 +189,22 @@ class SanicRequestExtractor(RequestExtractor):
         return dict(self.request.cookies)
 
     def raw_data(self):
-        
+
         return self.request.body
 
     def form(self):
-        
+
         return self.request.form
 
     def is_json(self):
         raise NotImplementedError()
 
     def json(self):
-        
+
         return self.request.json
 
     def files(self):
-        
+
         return self.request.files
 
     def size_of_file(self, file):

--- a/sentry_sdk/integrations/stdlib.py
+++ b/sentry_sdk/integrations/stdlib.py
@@ -3,7 +3,7 @@ from sentry_sdk.integrations import Integration
 
 
 try:
-    from httplib import HTTPConnection  # type: ignore
+    from httplib import HTTPConnection  #type: ignore
 except ImportError:
     from http.client import HTTPConnection
 
@@ -13,12 +13,12 @@ class StdlibIntegration(Integration):
 
     @staticmethod
     def setup_once():
-        # type: () -> None
+        
         install_httplib()
 
 
 def install_httplib():
-    # type: () -> None
+    
     real_putrequest = HTTPConnection.putrequest
     real_getresponse = HTTPConnection.getresponse
 

--- a/sentry_sdk/integrations/stdlib.py
+++ b/sentry_sdk/integrations/stdlib.py
@@ -3,7 +3,7 @@ from sentry_sdk.integrations import Integration
 
 
 try:
-    from httplib import HTTPConnection  #type: ignore
+    from httplib import HTTPConnection  # type: ignore
 except ImportError:
     from http.client import HTTPConnection
 
@@ -13,12 +13,12 @@ class StdlibIntegration(Integration):
 
     @staticmethod
     def setup_once():
-        
+
         install_httplib()
 
 
 def install_httplib():
-    
+
     real_putrequest = HTTPConnection.putrequest
     real_getresponse = HTTPConnection.getresponse
 

--- a/sentry_sdk/integrations/tornado.py
+++ b/sentry_sdk/integrations/tornado.py
@@ -16,8 +16,8 @@ from sentry_sdk.integrations._wsgi_common import (
 )
 from sentry_sdk.integrations.logging import ignore_logger
 
-from tornado.web import RequestHandler, HTTPError  # type: ignore
-from tornado.gen import coroutine  # type: ignore
+from tornado.web import RequestHandler, HTTPError  #type: ignore
+from tornado.gen import coroutine  #type: ignore
 
 if False:
     from typing import Any
@@ -32,8 +32,8 @@ class TornadoIntegration(Integration):
 
     @staticmethod
     def setup_once():
-        # type: () -> None
-        import tornado  # type: ignore
+        
+        import tornado  #type: ignore
 
         tornado_version = getattr(tornado, "version_info", None)
         if tornado_version is None or tornado_version < (5, 0):
@@ -57,7 +57,7 @@ class TornadoIntegration(Integration):
             # Starting Tornado 6 RequestHandler._execute method is a standard Python coroutine (async/await)
             # In that case our method should be a coroutine function too
             async def sentry_execute_request_handler(self, *args, **kwargs):
-                # type: (Any, *List, **Any) -> Any
+                
                 hub = Hub.current
                 integration = hub.get_integration(TornadoIntegration)
                 if integration is None:
@@ -73,7 +73,7 @@ class TornadoIntegration(Integration):
 
         else:
 
-            @coroutine  # type: ignore
+            @coroutine  
             def sentry_execute_request_handler(self, *args, **kwargs):
                 hub = Hub.current
                 integration = hub.get_integration(TornadoIntegration)
@@ -93,7 +93,7 @@ class TornadoIntegration(Integration):
         old_log_exception = RequestHandler.log_exception
 
         def sentry_log_exception(self, ty, value, tb, *args, **kwargs):
-            # type: (Any, type, BaseException, Any, *Any, **Any) -> Optional[Any]
+            
             _capture_exception(ty, value, tb)
             return old_log_exception(self, ty, value, tb, *args, **kwargs)
 
@@ -101,7 +101,7 @@ class TornadoIntegration(Integration):
 
 
 def _capture_exception(ty, value, tb):
-    # type: (type, BaseException, Any) -> None
+    
     hub = Hub.current
     if hub.get_integration(TornadoIntegration) is None:
         return
@@ -118,9 +118,9 @@ def _capture_exception(ty, value, tb):
 
 
 def _make_event_processor(weak_handler):
-    # type: (Callable[[], RequestHandler]) -> Callable
+    
     def tornado_processor(event, hint):
-        # type: (Dict[str, Any], Dict[str, Any]) -> Dict[str, Any]
+        
         handler = weak_handler()
         if handler is None:
             return event
@@ -159,32 +159,32 @@ def _make_event_processor(weak_handler):
 
 class TornadoRequestExtractor(RequestExtractor):
     def content_length(self):
-        # type: () -> int
+        
         if self.request.body is None:
             return 0
         return len(self.request.body)
 
     def cookies(self):
-        # type: () -> Dict
+        
         return {k: v.value for k, v in self.request.cookies.items()}
 
     def raw_data(self):
-        # type: () -> bytes
+        
         return self.request.body
 
     def form(self):
-        # type: () -> Optional[Any]
+        
         return {
             k: [v.decode("latin1", "replace") for v in vs]
             for k, vs in self.request.body_arguments.items()
         }
 
     def is_json(self):
-        # type: () -> bool
+        
         return _is_json_content_type(self.request.headers.get("content-type"))
 
     def files(self):
-        # type: () -> Dict
+        
         return {k: v[0] for k, v in self.request.files.items() if v}
 
     def size_of_file(self, file):

--- a/sentry_sdk/integrations/tornado.py
+++ b/sentry_sdk/integrations/tornado.py
@@ -19,13 +19,6 @@ from sentry_sdk.integrations.logging import ignore_logger
 from tornado.web import RequestHandler, HTTPError  # type: ignore
 from tornado.gen import coroutine  # type: ignore
 
-if False:
-    from typing import Any
-    from typing import List
-    from typing import Optional
-    from typing import Dict
-    from typing import Callable
-
 
 class TornadoIntegration(Integration):
     identifier = "tornado"

--- a/sentry_sdk/integrations/wsgi.py
+++ b/sentry_sdk/integrations/wsgi.py
@@ -7,15 +7,8 @@ from sentry_sdk.tracing import SpanContext
 from sentry_sdk.integrations._wsgi_common import _filter_headers
 
 if False:
-    from typing import Callable
-    from typing import Dict
-    from typing import List
-    from typing import Iterator
-    from typing import Any
-    from typing import Tuple
-    from typing import Optional
+    pass
 
-    from sentry_sdk.utils import ExcInfo
 
 
 if PY2:

--- a/sentry_sdk/integrations/wsgi.py
+++ b/sentry_sdk/integrations/wsgi.py
@@ -6,8 +6,7 @@ from sentry_sdk._compat import PY2, reraise
 from sentry_sdk.tracing import SpanContext
 from sentry_sdk.integrations._wsgi_common import _filter_headers
 
-if False:
-    pass
+
 
 
 

--- a/sentry_sdk/integrations/wsgi.py
+++ b/sentry_sdk/integrations/wsgi.py
@@ -21,19 +21,19 @@ if False:
 if PY2:
 
     def wsgi_decoding_dance(s, charset="utf-8", errors="replace"):
-        # type: (str, str, str) -> str
+        
         return s.decode(charset, errors)
 
 
 else:
 
     def wsgi_decoding_dance(s, charset="utf-8", errors="replace"):
-        # type: (str, str, str) -> str
+        
         return s.encode("latin1").decode(charset, errors)
 
 
 def get_host(environ):
-    # type: (Dict[str, str]) -> str
+    
     """Return the host for the given WSGI environment. Yanked from Werkzeug."""
     if environ.get("HTTP_HOST"):
         rv = environ["HTTP_HOST"]
@@ -56,7 +56,7 @@ def get_host(environ):
 
 
 def get_request_url(environ):
-    # type: (Dict[str, str]) -> str
+    
     """Return the absolute URL without query string for the given WSGI
     environment."""
     return "%s://%s/%s" % (
@@ -70,11 +70,11 @@ class SentryWsgiMiddleware(object):
     __slots__ = ("app",)
 
     def __init__(self, app):
-        # type: (Callable) -> None
+        
         self.app = app
 
     def __call__(self, environ, start_response):
-        # type: (Dict[str, str], Callable) -> _ScopedResponse
+        
         hub = Hub(Hub.current)
 
         with hub:
@@ -94,7 +94,7 @@ class SentryWsgiMiddleware(object):
 
 
 def _get_environ(environ):
-    # type: (Dict[str, str]) -> Iterator[Tuple[str, str]]
+    
     """
     Returns our whitelisted environment variables.
     """
@@ -113,7 +113,7 @@ def _get_environ(environ):
 # We need this function because Django does not give us a "pure" http header
 # dict. So we might as well use it for all WSGI integrations.
 def _get_headers(environ):
-    # type: (Dict[str, str]) -> Iterator[Tuple[str, str]]
+    
     """
     Returns only proper HTTP headers.
 
@@ -130,7 +130,7 @@ def _get_headers(environ):
 
 
 def get_client_ip(environ):
-    # type: (Dict[str, str]) -> Optional[Any]
+    
     """
     Infer the user IP address from various headers. This cannot be used in
     security sensitive situations since the value may be forged from a client,
@@ -150,7 +150,7 @@ def get_client_ip(environ):
 
 
 def _capture_exception(hub):
-    # type: (Hub) -> ExcInfo
+    
     # Check client here as it might have been unset while streaming response
     if hub.client is not None:
         exc_info = sys.exc_info()
@@ -167,12 +167,12 @@ class _ScopedResponse(object):
     __slots__ = ("_response", "_hub")
 
     def __init__(self, hub, response):
-        # type: (Hub, List[bytes]) -> None
+        
         self._hub = hub
         self._response = response
 
     def __iter__(self):
-        # type: () -> Iterator[bytes]
+        
         iterator = iter(self._response)
 
         while True:
@@ -197,7 +197,7 @@ class _ScopedResponse(object):
 
 
 def _make_wsgi_event_processor(environ):
-    # type: (Dict[str, str]) -> Callable
+    
     # It's a bit unfortunate that we have to extract and parse the request data
     # from the environ so eagerly, but there are a few good reasons for this.
     #
@@ -218,7 +218,7 @@ def _make_wsgi_event_processor(environ):
     headers = _filter_headers(dict(_get_headers(environ)))
 
     def event_processor(event, hint):
-        # type: (Dict[str, Any], Dict[str, Any]) -> Dict[str, Any]
+        
         with capture_internal_exceptions():
             # if the code below fails halfway through we at least have some data
             request_info = event.setdefault("request", {})

--- a/sentry_sdk/integrations/wsgi.py
+++ b/sentry_sdk/integrations/wsgi.py
@@ -21,19 +21,19 @@ if False:
 if PY2:
 
     def wsgi_decoding_dance(s, charset="utf-8", errors="replace"):
-        
+
         return s.decode(charset, errors)
 
 
 else:
 
     def wsgi_decoding_dance(s, charset="utf-8", errors="replace"):
-        
+
         return s.encode("latin1").decode(charset, errors)
 
 
 def get_host(environ):
-    
+
     """Return the host for the given WSGI environment. Yanked from Werkzeug."""
     if environ.get("HTTP_HOST"):
         rv = environ["HTTP_HOST"]
@@ -56,7 +56,7 @@ def get_host(environ):
 
 
 def get_request_url(environ):
-    
+
     """Return the absolute URL without query string for the given WSGI
     environment."""
     return "%s://%s/%s" % (
@@ -70,11 +70,11 @@ class SentryWsgiMiddleware(object):
     __slots__ = ("app",)
 
     def __init__(self, app):
-        
+
         self.app = app
 
     def __call__(self, environ, start_response):
-        
+
         hub = Hub(Hub.current)
 
         with hub:
@@ -94,7 +94,7 @@ class SentryWsgiMiddleware(object):
 
 
 def _get_environ(environ):
-    
+
     """
     Returns our whitelisted environment variables.
     """
@@ -113,7 +113,7 @@ def _get_environ(environ):
 # We need this function because Django does not give us a "pure" http header
 # dict. So we might as well use it for all WSGI integrations.
 def _get_headers(environ):
-    
+
     """
     Returns only proper HTTP headers.
 
@@ -130,7 +130,7 @@ def _get_headers(environ):
 
 
 def get_client_ip(environ):
-    
+
     """
     Infer the user IP address from various headers. This cannot be used in
     security sensitive situations since the value may be forged from a client,
@@ -150,7 +150,7 @@ def get_client_ip(environ):
 
 
 def _capture_exception(hub):
-    
+
     # Check client here as it might have been unset while streaming response
     if hub.client is not None:
         exc_info = sys.exc_info()
@@ -167,12 +167,12 @@ class _ScopedResponse(object):
     __slots__ = ("_response", "_hub")
 
     def __init__(self, hub, response):
-        
+
         self._hub = hub
         self._response = response
 
     def __iter__(self):
-        
+
         iterator = iter(self._response)
 
         while True:
@@ -197,7 +197,7 @@ class _ScopedResponse(object):
 
 
 def _make_wsgi_event_processor(environ):
-    
+
     # It's a bit unfortunate that we have to extract and parse the request data
     # from the environ so eagerly, but there are a few good reasons for this.
     #
@@ -218,7 +218,7 @@ def _make_wsgi_event_processor(environ):
     headers = _filter_headers(dict(_get_headers(environ)))
 
     def event_processor(event, hint):
-        
+
         with capture_internal_exceptions():
             # if the code below fails halfway through we at least have some data
             request_info = event.setdefault("request", {})

--- a/sentry_sdk/integrations/wsgi.py
+++ b/sentry_sdk/integrations/wsgi.py
@@ -7,9 +7,6 @@ from sentry_sdk.tracing import SpanContext
 from sentry_sdk.integrations._wsgi_common import _filter_headers
 
 
-
-
-
 if PY2:
 
     def wsgi_decoding_dance(s, charset="utf-8", errors="replace"):

--- a/sentry_sdk/scope.py
+++ b/sentry_sdk/scope.py
@@ -18,7 +18,7 @@ global_event_processors = []
 
 
 def add_global_event_processor(processor):
-    # type: (Callable) -> None
+    
     global_event_processors.append(processor)
 
 
@@ -29,7 +29,7 @@ def _attr_setter(fn):
 def _disable_capture(fn):
     @wraps(fn)
     def wrapper(self, *args, **kwargs):
-        # type: (Any, *Dict[str, Any], **Any) -> Any
+        
         if not self._should_capture:
             return
         try:
@@ -63,8 +63,8 @@ class Scope(object):
     )
 
     def __init__(self):
-        self._event_processors = []  # type: List[Callable]
-        self._error_processors = []  # type: List[Callable]
+        self._event_processors = []  
+        self._error_processors = []  
 
         self._name = None
         self.clear()
@@ -118,16 +118,16 @@ class Scope(object):
         self._extras.pop(key, None)
 
     def clear(self):
-        # type: () -> None
+        
         """Clears the entire scope."""
         self._level = None
         self._fingerprint = None
         self._transaction = None
         self._user = None
 
-        self._tags = {}  # type: Dict[str, Any]
-        self._contexts = {}  # type: Dict[str, Dict]
-        self._extras = {}  # type: Dict[str, Any]
+        self._tags = {}  
+        self._contexts = {}  
+        self._extras = {}  
 
         self.clear_breadcrumbs()
         self._should_capture = True
@@ -135,12 +135,12 @@ class Scope(object):
         self._span = None
 
     def clear_breadcrumbs(self):
-        # type: () -> None
+        
         """Clears breadcrumb buffer."""
-        self._breadcrumbs = deque()  # type: Deque[Dict]
+        self._breadcrumbs = deque()  
 
     def add_event_processor(self, func):
-        # type: (Callable) -> None
+        
         """"Register a scope local event processor on the scope.
 
         This function behaves like `before_send.`
@@ -148,7 +148,7 @@ class Scope(object):
         self._event_processors.append(func)
 
     def add_error_processor(self, func, cls=None):
-        # type: (Callable, Optional[type]) -> None
+        
         """"Register a scope local error processor on the scope.
 
         The error processor works similar to an event processor but is
@@ -170,11 +170,11 @@ class Scope(object):
 
     @_disable_capture
     def apply_to_event(self, event, hint=None):
-        # type: (Dict[str, Any], Dict[str, Any]) -> Optional[Dict[str, Any]]
+        
         """Applies the information contained on the scope to the given event."""
 
         def _drop(event, cause, ty):
-            # type: (Dict[str, Any], Callable, str) -> Optional[Any]
+            
             logger.info("%s (%s) dropped event (%s)", ty, cause, event)
             return None
 
@@ -225,7 +225,7 @@ class Scope(object):
         return event
 
     def __copy__(self):
-        # type: () -> Scope
+        
         rv = object.__new__(self.__class__)
 
         rv._level = self._level

--- a/sentry_sdk/scope.py
+++ b/sentry_sdk/scope.py
@@ -18,7 +18,7 @@ global_event_processors = []
 
 
 def add_global_event_processor(processor):
-    
+
     global_event_processors.append(processor)
 
 
@@ -29,7 +29,7 @@ def _attr_setter(fn):
 def _disable_capture(fn):
     @wraps(fn)
     def wrapper(self, *args, **kwargs):
-        
+
         if not self._should_capture:
             return
         try:
@@ -63,8 +63,8 @@ class Scope(object):
     )
 
     def __init__(self):
-        self._event_processors = []  
-        self._error_processors = []  
+        self._event_processors = []
+        self._error_processors = []
 
         self._name = None
         self.clear()
@@ -118,16 +118,16 @@ class Scope(object):
         self._extras.pop(key, None)
 
     def clear(self):
-        
+
         """Clears the entire scope."""
         self._level = None
         self._fingerprint = None
         self._transaction = None
         self._user = None
 
-        self._tags = {}  
-        self._contexts = {}  
-        self._extras = {}  
+        self._tags = {}
+        self._contexts = {}
+        self._extras = {}
 
         self.clear_breadcrumbs()
         self._should_capture = True
@@ -135,12 +135,12 @@ class Scope(object):
         self._span = None
 
     def clear_breadcrumbs(self):
-        
+
         """Clears breadcrumb buffer."""
-        self._breadcrumbs = deque()  
+        self._breadcrumbs = deque()
 
     def add_event_processor(self, func):
-        
+
         """"Register a scope local event processor on the scope.
 
         This function behaves like `before_send.`
@@ -148,7 +148,7 @@ class Scope(object):
         self._event_processors.append(func)
 
     def add_error_processor(self, func, cls=None):
-        
+
         """"Register a scope local error processor on the scope.
 
         The error processor works similar to an event processor but is
@@ -170,11 +170,11 @@ class Scope(object):
 
     @_disable_capture
     def apply_to_event(self, event, hint=None):
-        
+
         """Applies the information contained on the scope to the given event."""
 
         def _drop(event, cause, ty):
-            
+
             logger.info("%s (%s) dropped event (%s)", ty, cause, event)
             return None
 
@@ -225,7 +225,7 @@ class Scope(object):
         return event
 
     def __copy__(self):
-        
+
         rv = object.__new__(self.__class__)
 
         rv._level = self._level

--- a/sentry_sdk/scope.py
+++ b/sentry_sdk/scope.py
@@ -6,12 +6,7 @@ from itertools import chain
 from sentry_sdk.utils import logger, capture_internal_exceptions, object_to_json
 
 if False:
-    from typing import Any
-    from typing import Callable
-    from typing import Dict
-    from typing import Optional
-    from typing import Deque
-    from typing import List
+    pass
 
 
 global_event_processors = []

--- a/sentry_sdk/scope.py
+++ b/sentry_sdk/scope.py
@@ -6,8 +6,6 @@ from itertools import chain
 from sentry_sdk.utils import logger, capture_internal_exceptions, object_to_json
 
 
-
-
 global_event_processors = []
 
 

--- a/sentry_sdk/scope.py
+++ b/sentry_sdk/scope.py
@@ -5,8 +5,7 @@ from itertools import chain
 
 from sentry_sdk.utils import logger, capture_internal_exceptions, object_to_json
 
-if False:
-    pass
+
 
 
 global_event_processors = []

--- a/sentry_sdk/transport.py
+++ b/sentry_sdk/transport.py
@@ -12,8 +12,6 @@ from sentry_sdk.consts import VERSION
 from sentry_sdk.utils import Dsn, logger, capture_internal_exceptions
 from sentry_sdk.worker import BackgroundWorker
 
-if False:
-    from urllib3.poolmanager import PoolManager  # type: ignore
 
 try:
     from urllib.request import getproxies

--- a/sentry_sdk/transport.py
+++ b/sentry_sdk/transport.py
@@ -13,15 +13,7 @@ from sentry_sdk.utils import Dsn, logger, capture_internal_exceptions
 from sentry_sdk.worker import BackgroundWorker
 
 if False:
-    from sentry_sdk.consts import ClientOptions
-    from typing import Type
-    from typing import Any
-    from typing import Optional
-    from typing import Dict
-    from typing import Union
-    from typing import Callable
     from urllib3.poolmanager import PoolManager  # type: ignore
-    from urllib3.poolmanager import ProxyManager
 
 try:
     from urllib.request import getproxies
@@ -53,12 +45,10 @@ class Transport(object):
 
     def flush(self, timeout, callback=None):
         """Wait `timeout` seconds for the current events to be sent out."""
-        pass
 
     def kill(self):
 
         """Forcefully kills the transport."""
-        pass
 
     def __del__(self):
 

--- a/sentry_sdk/utils.py
+++ b/sentry_sdk/utils.py
@@ -18,16 +18,12 @@ from sentry_sdk._compat import (
 
 if False:
     from typing import Any
-    from typing import Dict
-    from typing import Union
     from typing import Iterator
     from typing import Tuple
     from typing import Optional
-    from typing import List
     from typing import Set
     from typing import Type
 
-    from sentry_sdk.consts import ClientOptions
 
     ExcInfo = Tuple[
         Optional[Type[BaseException]], Optional[BaseException], Optional[Any]

--- a/sentry_sdk/utils.py
+++ b/sentry_sdk/utils.py
@@ -65,7 +65,7 @@ def _get_debug_hub():
 
 @contextmanager
 def capture_internal_exceptions():
-    
+
     try:
         yield
     except Exception:
@@ -79,7 +79,7 @@ def to_timestamp(value):
 
 
 def event_hint_with_exc_info(exc_info=None):
-    
+
     """Creates a hint with the exc info filled in."""
     if exc_info is None:
         exc_info = sys.exc_info()
@@ -201,12 +201,12 @@ class Auth(object):
 
 
 def get_type_name(cls):
-    
+
     return getattr(cls, "__qualname__", None) or getattr(cls, "__name__", None)
 
 
 def get_type_module(cls):
-    
+
     mod = getattr(cls, "__module__", None)
     if mod not in (None, "builtins", "__builtins__"):
         return mod
@@ -214,7 +214,7 @@ def get_type_module(cls):
 
 
 def should_hide_frame(frame):
-    
+
     try:
         mod = frame.f_globals["__name__"]
         return mod.startswith("sentry_sdk.")
@@ -232,7 +232,7 @@ def should_hide_frame(frame):
 
 
 def iter_stacks(tb):
-    
+
     while tb is not None:
         if not should_hide_frame(tb.tb_frame):
             yield tb
@@ -240,7 +240,7 @@ def iter_stacks(tb):
 
 
 def slim_string(value, length=512):
-    
+
     if not value:
         return value
     if len(value) > length:
@@ -248,13 +248,8 @@ def slim_string(value, length=512):
     return value[:length]
 
 
-def get_lines_from_file(
-    filename,  
-    lineno,  
-    loader=None,  
-    module=None,  
-):
-    
+def get_lines_from_file(filename, lineno, loader=None, module=None):
+
     context_lines = 5
     source = None
     if loader is not None and hasattr(loader, "get_source"):
@@ -293,7 +288,7 @@ def get_lines_from_file(
 
 
 def get_source_context(frame, tb_lineno):
-    
+
     try:
         abs_path = frame.f_code.co_filename
     except Exception:
@@ -313,7 +308,7 @@ def get_source_context(frame, tb_lineno):
 
 
 def safe_str(value):
-    
+
     try:
         return text_type(value)
     except Exception:
@@ -321,7 +316,7 @@ def safe_str(value):
 
 
 def safe_repr(value):
-    
+
     try:
         rv = repr(value)
         if isinstance(rv, bytes):
@@ -389,7 +384,7 @@ def object_to_json(obj, remaining_depth=4, memo=None):
 
 
 def extract_locals(frame):
-    
+
     rv = {}
     for key, value in frame.f_locals.items():
         rv[str(key)] = object_to_json(value)
@@ -397,7 +392,7 @@ def extract_locals(frame):
 
 
 def filename_for_module(module, abs_path):
-    
+
     try:
         if abs_path.endswith(".pyc"):
             abs_path = abs_path[:-1]
@@ -415,7 +410,7 @@ def filename_for_module(module, abs_path):
 
 
 def serialize_frame(frame, tb_lineno=None, with_locals=True):
-    
+
     f_code = getattr(frame, "f_code", None)
     if f_code:
         abs_path = frame.f_code.co_filename
@@ -449,7 +444,7 @@ def serialize_frame(frame, tb_lineno=None, with_locals=True):
 
 
 def stacktrace_from_traceback(tb=None, with_locals=True):
-    
+
     return {
         "frames": [
             serialize_frame(
@@ -476,18 +471,14 @@ def current_stacktrace(with_locals=True):
 
 
 def get_errno(exc_value):
-    
+
     return getattr(exc_value, "errno", None)
 
 
 def single_exception_from_error_tuple(
-    exc_type,  
-    exc_value,  
-    tb,  
-    client_options=None,  
-    mechanism=None,  
+    exc_type, exc_value, tb, client_options=None, mechanism=None
 ):
-    
+
     if exc_value is not None:
         errno = get_errno(exc_value)
     else:
@@ -518,11 +509,11 @@ HAS_CHAINED_EXCEPTIONS = hasattr(Exception, "__suppress_context__")
 if HAS_CHAINED_EXCEPTIONS:
 
     def walk_exception_chain(exc_info):
-        #type: (ExcInfo) -> Iterator[ExcInfo]
+        # type: (ExcInfo) -> Iterator[ExcInfo]
         exc_type, exc_value, tb = exc_info
 
         seen_exceptions = []
-        seen_exception_ids = set()  #type: Set[int]
+        seen_exception_ids = set()  # type: Set[int]
 
         while (
             exc_type is not None
@@ -537,7 +528,7 @@ if HAS_CHAINED_EXCEPTIONS:
             seen_exceptions.append(exc_value)
             seen_exception_ids.add(id(exc_value))
 
-            if exc_value.__suppress_context__:  
+            if exc_value.__suppress_context__:
                 cause = exc_value.__cause__
             else:
                 cause = exc_value.__context__
@@ -551,16 +542,12 @@ if HAS_CHAINED_EXCEPTIONS:
 else:
 
     def walk_exception_chain(exc_info):
-        #type: (ExcInfo) -> Iterator[ExcInfo]
+        # type: (ExcInfo) -> Iterator[ExcInfo]
         yield exc_info
 
 
-def exceptions_from_error_tuple(
-    exc_info,  
-    client_options=None,  
-    mechanism=None,  
-):
-    
+def exceptions_from_error_tuple(exc_info, client_options=None, mechanism=None):
+
     exc_type, exc_value, tb = exc_info
     rv = []
     for exc_type, exc_value, tb in walk_exception_chain(exc_info):
@@ -576,7 +563,7 @@ def exceptions_from_error_tuple(
 
 
 def to_string(value):
-    
+
     try:
         return text_type(value)
     except UnicodeDecodeError:
@@ -584,7 +571,7 @@ def to_string(value):
 
 
 def iter_event_stacktraces(event):
-    
+
     if "stacktrace" in event:
         yield event["stacktrace"]
     if "threads" in event:
@@ -598,14 +585,14 @@ def iter_event_stacktraces(event):
 
 
 def iter_event_frames(event):
-    
+
     for stacktrace in iter_event_stacktraces(event):
         for frame in stacktrace.get("frames") or ():
             yield frame
 
 
 def handle_in_app(event, in_app_exclude=None, in_app_include=None):
-    
+
     for stacktrace in iter_event_stacktraces(event):
         handle_in_app_impl(
             stacktrace.get("frames"),
@@ -646,7 +633,7 @@ def handle_in_app_impl(frames, in_app_exclude, in_app_include):
 
 
 def exc_info_from_error(error):
-    
+
     if isinstance(error, tuple) and len(error) == 3:
         exc_type, exc_value, tb = error
     elif isinstance(error, BaseException):
@@ -667,12 +654,8 @@ def exc_info_from_error(error):
     return exc_type, exc_value, tb
 
 
-def event_from_exception(
-    exc_info,  
-    client_options=None,  
-    mechanism=None,  
-):
-    
+def event_from_exception(exc_info, client_options=None, mechanism=None):
+
     exc_info = exc_info_from_error(exc_info)
     hint = event_hint_with_exc_info(exc_info)
     return (
@@ -689,7 +672,7 @@ def event_from_exception(
 
 
 def _module_in_set(name, set):
-    
+
     if not set:
         return False
     for item in set or ():
@@ -700,15 +683,14 @@ def _module_in_set(name, set):
 
 class AnnotatedValue(object):
     def __init__(self, value, metadata):
-        
+
         self.value = value
         self.metadata = metadata
 
 
 def flatten_metadata(obj):
-    
     def inner(obj):
-        
+
         if isinstance(obj, Mapping):
             dict_rv = {}
             meta = {}
@@ -744,7 +726,7 @@ def flatten_metadata(obj):
 
 
 def strip_event_mut(event):
-    
+
     strip_stacktrace_mut(event.get("stacktrace", None))
     exception = event.get("exception", None)
     if exception:
@@ -756,7 +738,7 @@ def strip_event_mut(event):
 
 
 def strip_stacktrace_mut(stacktrace):
-    
+
     if not stacktrace:
         return
     for frame in stacktrace.get("frames", None) or ():
@@ -764,7 +746,7 @@ def strip_stacktrace_mut(stacktrace):
 
 
 def strip_request_mut(request):
-    
+
     if not request:
         return
     data = request.get("data", None)
@@ -782,7 +764,7 @@ def strip_breadcrumbs_mut(breadcrumbs):
 
 
 def strip_frame_mut(frame):
-    
+
     if "vars" in frame:
         frame["vars"] = strip_databag(frame["vars"])
 
@@ -802,7 +784,7 @@ class Memo(object):
 
 
 def convert_types(obj):
-    
+
     if obj is None:
         return None
     if obj is CYCLE_MARKER:
@@ -825,14 +807,14 @@ def convert_types(obj):
 
 
 def strip_databag(obj, remaining_depth=20, max_breadth=20):
-    
+
     assert not isinstance(obj, bytes), "bytes should have been normalized before"
     if remaining_depth <= 0:
         return AnnotatedValue(None, {"rem": [["!limit", "x"]]})
     if isinstance(obj, text_type):
         return strip_string(obj)
     if isinstance(obj, Mapping):
-        rv_dict = {}  
+        rv_dict = {}
         for i, (k, v) in enumerate(obj.items()):
             if i >= max_breadth:
                 return AnnotatedValue(rv_dict, {"len": max_breadth})
@@ -842,7 +824,7 @@ def strip_databag(obj, remaining_depth=20, max_breadth=20):
 
         return rv_dict
     if isinstance(obj, Sequence):
-        rv_list = []  
+        rv_list = []
         for i, v in enumerate(obj):
             if i >= max_breadth:
                 return AnnotatedValue(rv_list, {"len": max_breadth})
@@ -857,7 +839,7 @@ def strip_databag(obj, remaining_depth=20, max_breadth=20):
 
 
 def strip_string(value, max_length=512):
-    
+
     # TODO: read max_length from config
     if not value:
         return value
@@ -933,16 +915,16 @@ def format_and_strip(template, params, strip_string=strip_string):
 HAS_REAL_CONTEXTVARS = True
 
 try:
-    from contextvars import ContextVar  #type: ignore
+    from contextvars import ContextVar  # type: ignore
 
     if not PY2 and sys.version_info < (3, 7):
-        import aiocontextvars  #type: ignore # noqa
+        import aiocontextvars  # type: ignore # noqa
 except ImportError:
     HAS_REAL_CONTEXTVARS = False
 
     from threading import local
 
-    class ContextVar(object):  #type: ignore
+    class ContextVar(object):  # type: ignore
         # Super-limited impl of ContextVar
 
         def __init__(self, name):

--- a/sentry_sdk/utils.py
+++ b/sentry_sdk/utils.py
@@ -65,7 +65,7 @@ def _get_debug_hub():
 
 @contextmanager
 def capture_internal_exceptions():
-    # type: () -> Iterator
+    
     try:
         yield
     except Exception:
@@ -79,7 +79,7 @@ def to_timestamp(value):
 
 
 def event_hint_with_exc_info(exc_info=None):
-    # type: (ExcInfo) -> Dict[str, Optional[ExcInfo]]
+    
     """Creates a hint with the exc info filled in."""
     if exc_info is None:
         exc_info = sys.exc_info()
@@ -201,12 +201,12 @@ class Auth(object):
 
 
 def get_type_name(cls):
-    # type: (Any) -> str
+    
     return getattr(cls, "__qualname__", None) or getattr(cls, "__name__", None)
 
 
 def get_type_module(cls):
-    # type: (Any) -> Optional[Any]
+    
     mod = getattr(cls, "__module__", None)
     if mod not in (None, "builtins", "__builtins__"):
         return mod
@@ -214,7 +214,7 @@ def get_type_module(cls):
 
 
 def should_hide_frame(frame):
-    # type: (Any) -> bool
+    
     try:
         mod = frame.f_globals["__name__"]
         return mod.startswith("sentry_sdk.")
@@ -232,7 +232,7 @@ def should_hide_frame(frame):
 
 
 def iter_stacks(tb):
-    # type: (Any) -> Iterator[Any]
+    
     while tb is not None:
         if not should_hide_frame(tb.tb_frame):
             yield tb
@@ -240,7 +240,7 @@ def iter_stacks(tb):
 
 
 def slim_string(value, length=512):
-    # type: (str, int) -> str
+    
     if not value:
         return value
     if len(value) > length:
@@ -249,12 +249,12 @@ def slim_string(value, length=512):
 
 
 def get_lines_from_file(
-    filename,  # type: str
-    lineno,  # type: int
-    loader=None,  # type: Any
-    module=None,  # type: str
+    filename,  
+    lineno,  
+    loader=None,  
+    module=None,  
 ):
-    # type: (...) -> Tuple[List[str], Optional[str], List[str]]
+    
     context_lines = 5
     source = None
     if loader is not None and hasattr(loader, "get_source"):
@@ -293,7 +293,7 @@ def get_lines_from_file(
 
 
 def get_source_context(frame, tb_lineno):
-    # type: (Any, int) -> Tuple[List[str], Optional[str], List[str]]
+    
     try:
         abs_path = frame.f_code.co_filename
     except Exception:
@@ -313,7 +313,7 @@ def get_source_context(frame, tb_lineno):
 
 
 def safe_str(value):
-    # type: (Any) -> str
+    
     try:
         return text_type(value)
     except Exception:
@@ -321,7 +321,7 @@ def safe_str(value):
 
 
 def safe_repr(value):
-    # type: (Any) -> str
+    
     try:
         rv = repr(value)
         if isinstance(rv, bytes):
@@ -389,7 +389,7 @@ def object_to_json(obj, remaining_depth=4, memo=None):
 
 
 def extract_locals(frame):
-    # type: (Any) -> Dict[str, Any]
+    
     rv = {}
     for key, value in frame.f_locals.items():
         rv[str(key)] = object_to_json(value)
@@ -397,7 +397,7 @@ def extract_locals(frame):
 
 
 def filename_for_module(module, abs_path):
-    # type: (str, str) -> str
+    
     try:
         if abs_path.endswith(".pyc"):
             abs_path = abs_path[:-1]
@@ -415,7 +415,7 @@ def filename_for_module(module, abs_path):
 
 
 def serialize_frame(frame, tb_lineno=None, with_locals=True):
-    # type: (Any, int, bool) -> Dict[str, Any]
+    
     f_code = getattr(frame, "f_code", None)
     if f_code:
         abs_path = frame.f_code.co_filename
@@ -449,7 +449,7 @@ def serialize_frame(frame, tb_lineno=None, with_locals=True):
 
 
 def stacktrace_from_traceback(tb=None, with_locals=True):
-    # type: (Any, bool) -> Dict[str, List[Dict[str, Any]]]
+    
     return {
         "frames": [
             serialize_frame(
@@ -476,18 +476,18 @@ def current_stacktrace(with_locals=True):
 
 
 def get_errno(exc_value):
-    # type: (BaseException) -> Optional[Any]
+    
     return getattr(exc_value, "errno", None)
 
 
 def single_exception_from_error_tuple(
-    exc_type,  # type: Optional[type]
-    exc_value,  # type: Optional[BaseException]
-    tb,  # type: Optional[Any]
-    client_options=None,  # type: Optional[ClientOptions]
-    mechanism=None,  # type: Dict[str, Any]
+    exc_type,  
+    exc_value,  
+    tb,  
+    client_options=None,  
+    mechanism=None,  
 ):
-    # type: (...) -> Dict[str, Any]
+    
     if exc_value is not None:
         errno = get_errno(exc_value)
     else:
@@ -518,11 +518,11 @@ HAS_CHAINED_EXCEPTIONS = hasattr(Exception, "__suppress_context__")
 if HAS_CHAINED_EXCEPTIONS:
 
     def walk_exception_chain(exc_info):
-        # type: (ExcInfo) -> Iterator[ExcInfo]
+        #type: (ExcInfo) -> Iterator[ExcInfo]
         exc_type, exc_value, tb = exc_info
 
         seen_exceptions = []
-        seen_exception_ids = set()  # type: Set[int]
+        seen_exception_ids = set()  #type: Set[int]
 
         while (
             exc_type is not None
@@ -537,7 +537,7 @@ if HAS_CHAINED_EXCEPTIONS:
             seen_exceptions.append(exc_value)
             seen_exception_ids.add(id(exc_value))
 
-            if exc_value.__suppress_context__:  # type: ignore
+            if exc_value.__suppress_context__:  
                 cause = exc_value.__cause__
             else:
                 cause = exc_value.__context__
@@ -551,16 +551,16 @@ if HAS_CHAINED_EXCEPTIONS:
 else:
 
     def walk_exception_chain(exc_info):
-        # type: (ExcInfo) -> Iterator[ExcInfo]
+        #type: (ExcInfo) -> Iterator[ExcInfo]
         yield exc_info
 
 
 def exceptions_from_error_tuple(
-    exc_info,  # type: ExcInfo
-    client_options=None,  # type: Optional[ClientOptions]
-    mechanism=None,  # type: Dict[str, Any]
+    exc_info,  
+    client_options=None,  
+    mechanism=None,  
 ):
-    # type: (...) -> List[Dict[str, Any]]
+    
     exc_type, exc_value, tb = exc_info
     rv = []
     for exc_type, exc_value, tb in walk_exception_chain(exc_info):
@@ -576,7 +576,7 @@ def exceptions_from_error_tuple(
 
 
 def to_string(value):
-    # type: (str) -> str
+    
     try:
         return text_type(value)
     except UnicodeDecodeError:
@@ -584,7 +584,7 @@ def to_string(value):
 
 
 def iter_event_stacktraces(event):
-    # type: (Dict[str, Any]) -> Iterator[Dict[str, Any]]
+    
     if "stacktrace" in event:
         yield event["stacktrace"]
     if "threads" in event:
@@ -598,14 +598,14 @@ def iter_event_stacktraces(event):
 
 
 def iter_event_frames(event):
-    # type: (Dict[str, Any]) -> Iterator[Dict[str, Any]]
+    
     for stacktrace in iter_event_stacktraces(event):
         for frame in stacktrace.get("frames") or ():
             yield frame
 
 
 def handle_in_app(event, in_app_exclude=None, in_app_include=None):
-    # type: (Dict[str, Any], List, List) -> Dict[str, Any]
+    
     for stacktrace in iter_event_stacktraces(event):
         handle_in_app_impl(
             stacktrace.get("frames"),
@@ -646,7 +646,7 @@ def handle_in_app_impl(frames, in_app_exclude, in_app_include):
 
 
 def exc_info_from_error(error):
-    # type: (Union[BaseException, ExcInfo]) -> ExcInfo
+    
     if isinstance(error, tuple) and len(error) == 3:
         exc_type, exc_value, tb = error
     elif isinstance(error, BaseException):
@@ -668,11 +668,11 @@ def exc_info_from_error(error):
 
 
 def event_from_exception(
-    exc_info,  # type: Union[BaseException, ExcInfo]
-    client_options=None,  # type: Optional[ClientOptions]
-    mechanism=None,  # type: Dict[str, Any]
+    exc_info,  
+    client_options=None,  
+    mechanism=None,  
 ):
-    # type: (...) -> Tuple[Dict[str, Any], Dict[str, Any]]
+    
     exc_info = exc_info_from_error(exc_info)
     hint = event_hint_with_exc_info(exc_info)
     return (
@@ -689,7 +689,7 @@ def event_from_exception(
 
 
 def _module_in_set(name, set):
-    # type: (str, Optional[List]) -> bool
+    
     if not set:
         return False
     for item in set or ():
@@ -700,15 +700,15 @@ def _module_in_set(name, set):
 
 class AnnotatedValue(object):
     def __init__(self, value, metadata):
-        # type: (Optional[Any], Dict[str, Any]) -> None
+        
         self.value = value
         self.metadata = metadata
 
 
 def flatten_metadata(obj):
-    # type: (Dict[str, Any]) -> Dict[str, Any]
+    
     def inner(obj):
-        # type: (Any) -> Any
+        
         if isinstance(obj, Mapping):
             dict_rv = {}
             meta = {}
@@ -744,7 +744,7 @@ def flatten_metadata(obj):
 
 
 def strip_event_mut(event):
-    # type: (Dict[str, Any]) -> None
+    
     strip_stacktrace_mut(event.get("stacktrace", None))
     exception = event.get("exception", None)
     if exception:
@@ -756,7 +756,7 @@ def strip_event_mut(event):
 
 
 def strip_stacktrace_mut(stacktrace):
-    # type: (Optional[Dict[str, List[Dict[str, Any]]]]) -> None
+    
     if not stacktrace:
         return
     for frame in stacktrace.get("frames", None) or ():
@@ -764,7 +764,7 @@ def strip_stacktrace_mut(stacktrace):
 
 
 def strip_request_mut(request):
-    # type: (Dict[str, Any]) -> None
+    
     if not request:
         return
     data = request.get("data", None)
@@ -782,7 +782,7 @@ def strip_breadcrumbs_mut(breadcrumbs):
 
 
 def strip_frame_mut(frame):
-    # type: (Dict[str, Any]) -> None
+    
     if "vars" in frame:
         frame["vars"] = strip_databag(frame["vars"])
 
@@ -802,7 +802,7 @@ class Memo(object):
 
 
 def convert_types(obj):
-    # type: (Any) -> Any
+    
     if obj is None:
         return None
     if obj is CYCLE_MARKER:
@@ -825,14 +825,14 @@ def convert_types(obj):
 
 
 def strip_databag(obj, remaining_depth=20, max_breadth=20):
-    # type: (Any, int, int) -> Any
+    
     assert not isinstance(obj, bytes), "bytes should have been normalized before"
     if remaining_depth <= 0:
         return AnnotatedValue(None, {"rem": [["!limit", "x"]]})
     if isinstance(obj, text_type):
         return strip_string(obj)
     if isinstance(obj, Mapping):
-        rv_dict = {}  # type: Dict[Any, Any]
+        rv_dict = {}  
         for i, (k, v) in enumerate(obj.items()):
             if i >= max_breadth:
                 return AnnotatedValue(rv_dict, {"len": max_breadth})
@@ -842,7 +842,7 @@ def strip_databag(obj, remaining_depth=20, max_breadth=20):
 
         return rv_dict
     if isinstance(obj, Sequence):
-        rv_list = []  # type: List[Any]
+        rv_list = []  
         for i, v in enumerate(obj):
             if i >= max_breadth:
                 return AnnotatedValue(rv_list, {"len": max_breadth})
@@ -857,7 +857,7 @@ def strip_databag(obj, remaining_depth=20, max_breadth=20):
 
 
 def strip_string(value, max_length=512):
-    # type: (str, int) -> Union[AnnotatedValue, str]
+    
     # TODO: read max_length from config
     if not value:
         return value
@@ -933,16 +933,16 @@ def format_and_strip(template, params, strip_string=strip_string):
 HAS_REAL_CONTEXTVARS = True
 
 try:
-    from contextvars import ContextVar  # type: ignore
+    from contextvars import ContextVar  #type: ignore
 
     if not PY2 and sys.version_info < (3, 7):
-        import aiocontextvars  # type: ignore # noqa
+        import aiocontextvars  #type: ignore # noqa
 except ImportError:
     HAS_REAL_CONTEXTVARS = False
 
     from threading import local
 
-    class ContextVar(object):  # type: ignore
+    class ContextVar(object):  #type: ignore
         # Super-limited impl of ContextVar
 
         def __init__(self, name):

--- a/sentry_sdk/utils.py
+++ b/sentry_sdk/utils.py
@@ -24,7 +24,6 @@ if False:
     from typing import Set
     from typing import Type
 
-
     ExcInfo = Tuple[
         Optional[Type[BaseException]], Optional[BaseException], Optional[Any]
     ]

--- a/sentry_sdk/worker.py
+++ b/sentry_sdk/worker.py
@@ -5,8 +5,7 @@ from time import sleep, time
 from sentry_sdk._compat import queue, check_thread_support
 from sentry_sdk.utils import logger
 
-if False:
-    pass
+
 
 
 _TERMINATOR = object()

--- a/sentry_sdk/worker.py
+++ b/sentry_sdk/worker.py
@@ -6,8 +6,6 @@ from sentry_sdk._compat import queue, check_thread_support
 from sentry_sdk.utils import logger
 
 
-
-
 _TERMINATOR = object()
 
 

--- a/sentry_sdk/worker.py
+++ b/sentry_sdk/worker.py
@@ -6,10 +6,7 @@ from sentry_sdk._compat import queue, check_thread_support
 from sentry_sdk.utils import logger
 
 if False:
-    from queue import Queue
-    from typing import Any
-    from typing import Optional
-    from typing import Callable
+    pass
 
 
 _TERMINATOR = object()

--- a/sentry_sdk/worker.py
+++ b/sentry_sdk/worker.py
@@ -17,16 +17,16 @@ _TERMINATOR = object()
 
 class BackgroundWorker(object):
     def __init__(self):
-        # type: () -> None
+        
         check_thread_support()
-        self._queue = queue.Queue(-1)  # type: Queue[Any]
+        self._queue = queue.Queue(-1)  
         self._lock = Lock()
-        self._thread = None  # type: Optional[Thread]
-        self._thread_for_pid = None  # type: Optional[int]
+        self._thread = None  
+        self._thread_for_pid = None  
 
     @property
     def is_alive(self):
-        # type: () -> bool
+        
         if self._thread_for_pid != os.getpid():
             return False
         if not self._thread:
@@ -34,27 +34,27 @@ class BackgroundWorker(object):
         return self._thread.is_alive()
 
     def _ensure_thread(self):
-        # type: () -> None
+        
         if not self.is_alive:
             self.start()
 
     def _timed_queue_join(self, timeout):
-        # type: (float) -> bool
+        
         deadline = time() + timeout
         queue = self._queue
-        queue.all_tasks_done.acquire()  # type: ignore
+        queue.all_tasks_done.acquire()  
         try:
-            while queue.unfinished_tasks:  # type: ignore
+            while queue.unfinished_tasks:  
                 delay = deadline - time()
                 if delay <= 0:
                     return False
-                queue.all_tasks_done.wait(timeout=delay)  # type: ignore
+                queue.all_tasks_done.wait(timeout=delay)  
             return True
         finally:
-            queue.all_tasks_done.release()  # type: ignore
+            queue.all_tasks_done.release()  
 
     def start(self):
-        # type: () -> None
+        
         with self._lock:
             if not self.is_alive:
                 self._thread = Thread(
@@ -65,7 +65,7 @@ class BackgroundWorker(object):
                 self._thread_for_pid = os.getpid()
 
     def kill(self):
-        # type: () -> None
+        
         logger.debug("background worker got kill request")
         with self._lock:
             if self._thread:
@@ -74,7 +74,7 @@ class BackgroundWorker(object):
                 self._thread_for_pid = None
 
     def flush(self, timeout, callback=None):
-        # type: (float, Optional[Any]) -> None
+        
         logger.debug("background worker got flush request")
         with self._lock:
             if self.is_alive and timeout > 0.0:
@@ -82,7 +82,7 @@ class BackgroundWorker(object):
         logger.debug("background worker flushed")
 
     def _wait_flush(self, timeout, callback):
-        # type: (float, Optional[Any]) -> None
+        
         initial_timeout = min(0.1, timeout)
         if not self._timed_queue_join(initial_timeout):
             pending = self._queue.qsize()
@@ -92,12 +92,12 @@ class BackgroundWorker(object):
             self._timed_queue_join(timeout - initial_timeout)
 
     def submit(self, callback):
-        # type: (Callable) -> None
+        
         self._ensure_thread()
         self._queue.put_nowait(callback)
 
     def _target(self):
-        # type: () -> None
+        
         while True:
             callback = self._queue.get()
             try:

--- a/sentry_sdk/worker.py
+++ b/sentry_sdk/worker.py
@@ -17,16 +17,16 @@ _TERMINATOR = object()
 
 class BackgroundWorker(object):
     def __init__(self):
-        
+
         check_thread_support()
-        self._queue = queue.Queue(-1)  
+        self._queue = queue.Queue(-1)
         self._lock = Lock()
-        self._thread = None  
-        self._thread_for_pid = None  
+        self._thread = None
+        self._thread_for_pid = None
 
     @property
     def is_alive(self):
-        
+
         if self._thread_for_pid != os.getpid():
             return False
         if not self._thread:
@@ -34,27 +34,27 @@ class BackgroundWorker(object):
         return self._thread.is_alive()
 
     def _ensure_thread(self):
-        
+
         if not self.is_alive:
             self.start()
 
     def _timed_queue_join(self, timeout):
-        
+
         deadline = time() + timeout
         queue = self._queue
-        queue.all_tasks_done.acquire()  
+        queue.all_tasks_done.acquire()
         try:
-            while queue.unfinished_tasks:  
+            while queue.unfinished_tasks:
                 delay = deadline - time()
                 if delay <= 0:
                     return False
-                queue.all_tasks_done.wait(timeout=delay)  
+                queue.all_tasks_done.wait(timeout=delay)
             return True
         finally:
-            queue.all_tasks_done.release()  
+            queue.all_tasks_done.release()
 
     def start(self):
-        
+
         with self._lock:
             if not self.is_alive:
                 self._thread = Thread(
@@ -65,7 +65,7 @@ class BackgroundWorker(object):
                 self._thread_for_pid = os.getpid()
 
     def kill(self):
-        
+
         logger.debug("background worker got kill request")
         with self._lock:
             if self._thread:
@@ -74,7 +74,7 @@ class BackgroundWorker(object):
                 self._thread_for_pid = None
 
     def flush(self, timeout, callback=None):
-        
+
         logger.debug("background worker got flush request")
         with self._lock:
             if self.is_alive and timeout > 0.0:
@@ -82,7 +82,7 @@ class BackgroundWorker(object):
         logger.debug("background worker flushed")
 
     def _wait_flush(self, timeout, callback):
-        
+
         initial_timeout = min(0.1, timeout)
         if not self._timed_queue_join(initial_timeout):
             pending = self._queue.qsize()
@@ -92,12 +92,12 @@ class BackgroundWorker(object):
             self._timed_queue_join(timeout - initial_timeout)
 
     def submit(self, callback):
-        
+
         self._ensure_thread()
         self._queue.put_nowait(callback)
 
     def _target(self):
-        
+
         while True:
             callback = self._queue.get()
             try:


### PR DESCRIPTION
Script used for first n commits:

```sh
set -e

while rg -q '# type:'; do
    (echo y; echo q) | fastmod '# type:' '#WIP:' &> /dev/null
    if ! .tox/linters/bin/mypy sentry_sdk &> /dev/null; then
        echo yay
        fastmod --accept-all '#WIP:' '#type:' &> /dev/null
    else
        echo nay
        fastmod --accept-all '#WIP:.*' '' &> /dev/null
    fi
done
git cam 'ref: Remove useless type annotations'

black .
git cam 'ref: Reformatting (black)'

autoflake -r sentry_sdk --remove-all-unused-imports -i
git cam 'ref: Remove unused imports (autoflake)'

fastmod --accept-all -m 'if False:\n    pass' ''
git cam 'ref: Remove empty if False'

black .
git cam 'ref: Reformatting (black)'
```