### PR TITLE
Added the always_run option in excepthook integration

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+## 0.7.15
+
+* Add the always_run option in excepthook integration.
+
 ## 0.7.14
 
 * Fix crash when using Celery integration (`TypeError` when using

--- a/sentry_sdk/integrations/excepthook.py
+++ b/sentry_sdk/integrations/excepthook.py
@@ -19,7 +19,7 @@ class ExcepthookIntegration(Integration):
         if not isinstance(always_run, bool):
             raise ValueError(
                 "Invalid value for always_run: %s (must be type boolean)"
-                % (always_run)
+                % (always_run,)
             )
         self.always_run = always_run
 

--- a/sentry_sdk/integrations/excepthook.py
+++ b/sentry_sdk/integrations/excepthook.py
@@ -11,6 +11,18 @@ if False:
 class ExcepthookIntegration(Integration):
     identifier = "excepthook"
 
+    always_run = False
+
+    def __init__(self, always_run=False):
+        # type: (bool) -> None
+
+        if not isinstance(always_run, bool):
+            raise ValueError(
+                "Invalid value for always_run: %s (must be type boolean)"
+                % (always_run)
+            )
+        self.always_run = always_run
+
     @staticmethod
     def setup_once():
         # type: () -> None
@@ -23,7 +35,7 @@ def _make_excepthook(old_excepthook):
         hub = Hub.current
         integration = hub.get_integration(ExcepthookIntegration)
 
-        if integration is not None and _should_send():
+        if integration is not None and _should_send(integration.always_run):
             with capture_internal_exceptions():
                 event, hint = event_from_exception(
                     (exctype, value, traceback),
@@ -37,7 +49,10 @@ def _make_excepthook(old_excepthook):
     return sentry_sdk_excepthook
 
 
-def _should_send():
+def _should_send(always_run=False):
+    if always_run:
+        return True
+
     if hasattr(sys, "ps1"):
         # Disable the excepthook for interactive Python shells, otherwise
         # every typo gets sent to Sentry.

--- a/tests/integrations/excepthook/test_excepthook.py
+++ b/tests/integrations/excepthook/test_excepthook.py
@@ -36,3 +36,41 @@ def test_excepthook(tmpdir):
     assert b"ZeroDivisionError" in output
     assert b"LOL" in output
     assert b"capture event was called" in output
+
+
+def test_always_value_excepthook(tmpdir):
+    app = tmpdir.join("app.py")
+    app.write(
+        dedent(
+            """
+    import sys
+    from sentry_sdk import init, transport
+    from sentry_sdk.integrations.excepthook import ExcepthookIntegration
+
+    def send_event(self, event):
+        print("capture event was called")
+        print(event)
+
+    transport.HttpTransport._send_event = send_event
+
+    sys.ps1 = "always_value_test"
+    init("http://foobar@localhost/123",
+        integrations=[ExcepthookIntegration(always_run=True)]
+    )
+
+    frame_value = "LOL"
+
+    1/0
+    """
+        )
+    )
+
+    with pytest.raises(subprocess.CalledProcessError) as excinfo:
+        subprocess.check_output([sys.executable, str(app)], stderr=subprocess.STDOUT)
+
+    output = excinfo.value.output
+    print(output)
+
+    assert b"ZeroDivisionError" in output
+    assert b"LOL" in output
+    assert b"capture event was called" in output


### PR DESCRIPTION
```
import sentry_sdk
from sentry_sdk.integrations.excepthook import ExcepthookIntegration

sentry_sdk.init(
    'https...',
    integrations=[ExcepthookIntegration(always_run=True)]
)
```
Fix https://github.com/getsentry/sentry-python/issues/360