### PR TITLE
fix(wsgi): Log SystemExit (with non-zero exit code) and KeyboardInterrupt

### DIFF
--- a/sentry_sdk/integrations/wsgi.py
+++ b/sentry_sdk/integrations/wsgi.py
@@ -90,9 +90,9 @@ class SentryWsgiMiddleware(object):
             except Exception:
                 reraise(*_capture_exception(hub))
             except KeyboardInterrupt:
-                reraise(*_capture_exception(self._hub))
+                reraise(*_capture_exception(hub))
             except SystemExit as e:
-                reraise(*_capture_exception(self._hub, skip_capture=e.code == 0))
+                reraise(*_capture_exception(hub, skip_capture=e.code == 0))
 
         return _ScopedResponse(hub, rv)
 

--- a/sentry_sdk/integrations/wsgi.py
+++ b/sentry_sdk/integrations/wsgi.py
@@ -151,9 +151,10 @@ def get_client_ip(environ):
 
 def _capture_exception(hub, e):
     # type: (Hub) -> ExcInfo
+    exc_info = sys.exc_info()
+
     # Check client here as it might have been unset while streaming response
     if hub.client is not None:
-        exc_info = sys.exc_info()
         # SystemExit(0) is the only uncaught exception that is expected behavior
         should_skip_capture = isinstance(e, SystemExit) and e.code in (0, None)
         if not should_skip_capture:
@@ -163,6 +164,7 @@ def _capture_exception(hub, e):
                 mechanism={"type": "wsgi", "handled": False},
             )
             hub.capture_event(event, hint=hint)
+
     return exc_info
 
 

--- a/sentry_sdk/integrations/wsgi.py
+++ b/sentry_sdk/integrations/wsgi.py
@@ -150,7 +150,7 @@ def get_client_ip(environ):
 
 
 def _capture_exception(hub, e):
-    # type: (Hub) -> ExcInfo
+    # type: (Hub, BaseException) -> ExcInfo
     exc_info = sys.exc_info()
 
     # Check client here as it might have been unset while streaming response

--- a/sentry_sdk/integrations/wsgi.py
+++ b/sentry_sdk/integrations/wsgi.py
@@ -155,7 +155,7 @@ def _capture_exception(hub):
 
     # Check client here as it might have been unset while streaming response
     if hub.client is not None:
-        e = exc_info[2]
+        e = exc_info[1]
 
         # SystemExit(0) is the only uncaught exception that is expected behavior
         should_skip_capture = isinstance(e, SystemExit) and e.code in (0, None)

--- a/sentry_sdk/integrations/wsgi.py
+++ b/sentry_sdk/integrations/wsgi.py
@@ -197,7 +197,7 @@ class _ScopedResponse(object):
                 self._response.close()
             except AttributeError:
                 pass
-            except BaseException:
+            except BaseException as e:
                 reraise(*_capture_exception(self._hub, e))
 
 

--- a/tests/integrations/wsgi/test_wsgi.py
+++ b/tests/integrations/wsgi/test_wsgi.py
@@ -1,5 +1,3 @@
-import logging
-
 from werkzeug.test import Client
 import pytest
 

--- a/tests/integrations/wsgi/test_wsgi.py
+++ b/tests/integrations/wsgi/test_wsgi.py
@@ -1,3 +1,5 @@
+import logging
+
 from werkzeug.test import Client
 import pytest
 
@@ -10,6 +12,28 @@ def crashing_app():
         1 / 0
 
     return app
+
+
+class IterableApp(object):
+    def __init__(self, iterable):
+        self.iterable = iterable
+
+    def __call__(self, environ, start_response):
+        return self.iterable
+
+
+class ExitingIterable(object):
+    def __init__(self, exc_func):
+        self._exc_func = exc_func
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        raise self._exc_func()
+
+    def next(self):
+        return type(self).__next__(self)
 
 
 def test_basic(sentry_init, crashing_app, capture_events):
@@ -30,3 +54,54 @@ def test_basic(sentry_init, crashing_app, capture_events):
         "query_string": "",
         "url": "http://localhost/",
     }
+
+
+def test_systemexit_0_is_ignored(sentry_init, capture_events):
+    sentry_init(send_default_pii=True)
+    iterable = ExitingIterable(lambda: SystemExit(0))
+    app = SentryWsgiMiddleware(IterableApp(iterable))
+    client = Client(app)
+    events = capture_events()
+
+    with pytest.raises(SystemExit):
+        client.get("/")
+
+    assert len(events) == 0
+
+
+def test_systemexit_1_is_captured(sentry_init, capture_events):
+    sentry_init(send_default_pii=True)
+    iterable = ExitingIterable(lambda: SystemExit(1))
+    app = SentryWsgiMiddleware(IterableApp(iterable))
+    client = Client(app)
+    events = capture_events()
+
+    with pytest.raises(SystemExit):
+        client.get("/")
+
+    event, = events
+
+    assert "exception" in event
+    exc = event["exception"]["values"][-1]
+    assert exc["type"] == "SystemExit"
+    assert exc["value"] == "1"
+    assert event["level"] == "error"
+
+
+def test_keyboard_interrupt_is_captured(sentry_init, capture_events):
+    sentry_init(send_default_pii=True)
+    iterable = ExitingIterable(lambda: KeyboardInterrupt())
+    app = SentryWsgiMiddleware(IterableApp(iterable))
+    client = Client(app)
+    events = capture_events()
+
+    with pytest.raises(KeyboardInterrupt):
+        client.get("/")
+
+    event, = events
+
+    assert "exception" in event
+    exc = event["exception"]["values"][-1]
+    assert exc["type"] == "KeyboardInterrupt"
+    assert exc["value"] == ""
+    assert event["level"] == "error"


### PR DESCRIPTION
Neither SystemExit nor KeyboardInterrupt subclass Exception, so we must
explicitly handle these two exception classes in addition to Exception in the
WSGI middleware.

This is notably a direct port from raven-python:
 - https://github.com/getsentry/raven-python/blob/master/raven/middleware.py
 - https://github.com/getsentry/raven-python/blob/master/tests/middleware/tests.py

Fixes: GH-379

There are notably 3 places an exception could be raised, but it looks like we're only
testing one case. If we want to test the other two, would appreciate advice 🙏🏾.