### PR TITLE
Fix py.typed not being included in distribution

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,2 @@
 include LICENSE
+include sentry_sdk/py.typed

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
     long_description=__doc__,
     packages=find_packages(exclude=("tests", "tests.*")),
     # PEP 561
-    package_data={"typedpkg": ["py.typed"]},
+    package_data={"sentry_sdk": ["py.typed"]},
     zip_safe=False,
     license="BSD",
     install_requires=["urllib3", "certifi"],


### PR DESCRIPTION
The `typedpkg` example in the PEP is a little misleading unfortunately.

I tested that it is now properly included and properly picked up by mypy.