### PR TITLE
Add typings for CeleryIntegration.__init__

### DIFF
--- a/sentry_sdk/integrations/celery.py
+++ b/sentry_sdk/integrations/celery.py
@@ -24,6 +24,7 @@ class CeleryIntegration(Integration):
     identifier = "celery"
 
     def __init__(self, propagate_traces=True):
+        # type: (bool) -> None
         self.propagate_traces = propagate_traces
 
     @staticmethod


### PR DESCRIPTION
I have not tested this change but did something similar that the existing typing in `DjangoIntegration`.