### PR TITLE
fix: Allow int keys in extra dict

### DIFF
--- a/sentry_sdk/integrations/logging.py
+++ b/sentry_sdk/integrations/logging.py
@@ -139,7 +139,8 @@ def _extra_from_record(record):
     return {
         k: v
         for k, v in iteritems(vars(record))
-        if k not in COMMON_RECORD_ATTRS and not k.startswith("_")
+        if k not in COMMON_RECORD_ATTRS
+        and (not isinstance(k, str) or not k.startswith("_"))
     }
 
 

--- a/tests/integrations/logging/test_logging.py
+++ b/tests/integrations/logging/test_logging.py
@@ -61,6 +61,17 @@ def test_logging_extra_data(sentry_init, capture_events):
     )
 
 
+def test_logging_extra_data_integer_keys(sentry_init, capture_events):
+    sentry_init(integrations=[LoggingIntegration()], default_integrations=False)
+    events = capture_events()
+
+    logger.critical("integer in extra keys", extra={1: 1})
+
+    event, = events
+
+    assert event["extra"] == {"1": 1}
+
+
 @pytest.mark.xfail(sys.version_info[:2] == (3, 4), reason="buggy logging module")
 def test_logging_stack(sentry_init, capture_events):
     sentry_init(integrations=[LoggingIntegration()], default_integrations=False)


### PR DESCRIPTION
If I pass dict with int keys in extra keyword argument
```
logger.warning('test', extra={1:1})
```
I'll get an exception and event will not be sent.