### PR TITLE
feat: ASGI middleware

### DIFF
--- a/sentry_sdk/integrations/asgi.py
+++ b/sentry_sdk/integrations/asgi.py
@@ -1,3 +1,9 @@
+"""
+An ASGI middleware.
+
+Based on Tom Christie's `sentry-asgi <https://github.com/encode/sentry-asgi>`_.
+"""
+
 import functools
 import urllib
 

--- a/sentry_sdk/integrations/asgi.py
+++ b/sentry_sdk/integrations/asgi.py
@@ -1,0 +1,92 @@
+import functools
+import urllib
+
+from sentry_sdk._types import MYPY
+from sentry_sdk.hub import Hub, _should_send_default_pii
+from sentry_sdk.integrations._wsgi_common import _filter_headers
+from sentry_sdk.utils import transaction_from_function
+
+if MYPY:
+    from typing import Dict
+
+
+class SentryAsgiMiddleware:
+    __slots__ = ("app",)
+
+    def __init__(self, app):
+        self.app = app
+
+    async def __call__(self, scope, receive, send):
+        hub = Hub.current
+        with Hub(hub) as hub:
+            with hub.configure_scope() as sentry_scope:
+                sentry_scope._name = "asgi"
+                processor = functools.partial(self.event_processor, asgi_scope=scope)
+                sentry_scope.add_event_processor(processor)
+
+            try:
+                await self.app(scope, receive, send)
+            except Exception as exc:
+                hub.capture_exception(exc)
+                raise exc from None
+
+    def event_processor(self, event, hint, asgi_scope):
+        if asgi_scope["type"] in ("http", "websocket"):
+            event["request"] = {
+                "url": self.get_url(asgi_scope),
+                "method": asgi_scope["method"],
+                "headers": _filter_headers(self.get_headers(asgi_scope)),
+                "query_string": self.get_query(asgi_scope),
+            }
+        if asgi_scope.get("client") and _should_send_default_pii():
+            event["request"]["env"] = {"REMOTE_ADDR": asgi_scope["client"][0]}
+        if asgi_scope.get("endpoint"):
+            event["transaction"] = self.get_transaction(asgi_scope)
+        return event
+
+    def get_url(self, scope):
+        """
+        Extract URL from the ASGI scope, without also including the querystring.
+        """
+        scheme = scope.get("scheme", "http")
+        server = scope.get("server", None)
+        path = scope.get("root_path", "") + scope["path"]
+
+        for key, value in scope["headers"]:
+            if key == b"host":
+                host_header = value.decode("latin-1")
+                return "%s://%s%s" % (scheme, host_header, path)
+
+        if server is not None:
+            host, port = server
+            default_port = {"http": 80, "https": 443, "ws": 80, "wss": 443}[scheme]
+            if port != default_port:
+                return "%s://%s:%s%s" % (scheme, host, port, path)
+            return "%s://%s%s" % (scheme, host, path)
+        return path
+
+    def get_query(self, scope):
+        """
+        Extract querystring from the ASGI scope, in the format that the Sentry protocol expects.
+        """
+        return urllib.parse.unquote(scope["query_string"].decode("latin-1"))
+
+    def get_headers(self, scope):
+        """
+        Extract headers from the ASGI scope, in the format that the Sentry protocol expects.
+        """
+        headers = {}  # type: Dict[str, str]
+        for raw_key, raw_value in scope["headers"]:
+            key = raw_key.decode("latin-1")
+            value = raw_value.decode("latin-1")
+            if key in headers:
+                headers[key] = headers[key] + ", " + value
+            else:
+                headers[key] = value
+        return headers
+
+    def get_transaction(self, scope):
+        """
+        Return a transaction string to identify the routed endpoint.
+        """
+        return transaction_from_function(scope["endpoint"])

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -97,6 +97,9 @@ def _capture_internal_warnings():
         if "SessionAuthenticationMiddleware" in str(warning.message):
             continue
 
+        if "Something has already installed a non-asyncio" in str(warning.message):
+            continue
+
         raise AssertionError(warning)
 
 

--- a/tests/integrations/asgi/__init__.py
+++ b/tests/integrations/asgi/__init__.py
@@ -1,0 +1,3 @@
+import pytest
+
+pytest.importorskip("starlette")

--- a/tests/integrations/asgi/test_asgi.py
+++ b/tests/integrations/asgi/test_asgi.py
@@ -1,0 +1,122 @@
+import asyncio
+import random
+import sys
+
+import pytest
+from sentry_sdk import capture_message
+from sentry_sdk.integrations.asgi import SentryAsgiMiddleware
+from starlette.applications import Starlette
+from starlette.responses import PlainTextResponse
+from starlette.testclient import TestClient
+
+
+@pytest.fixture
+def app():
+    app = Starlette()
+
+    @app.route("/sync-message")
+    def hi(request):
+        capture_message("hi", level="error")
+        return PlainTextResponse("ok")
+
+    @app.route("/async-message")
+    async def hi(request):
+        capture_message("hi", level="error")
+        return PlainTextResponse("ok")
+
+    app.add_middleware(SentryAsgiMiddleware)
+
+    return app
+
+
+@pytest.mark.skipif(sys.version_info < (3, 7), reason="requires python3.7 or higher")
+def test_sync_request_data(sentry_init, app, capture_events):
+    sentry_init(send_default_pii=True)
+    events = capture_events()
+
+    client = TestClient(app)
+    response = client.get("/sync-message?foo=bar")
+
+    assert response.status_code == 200
+
+    event, = events
+    assert event["transaction"] == "tests.integrations.asgi.test_asgi.app.<locals>.hi"
+    assert event["request"]["env"] == {"REMOTE_ADDR": "testclient"}
+    assert set(event["request"]["headers"]) == {
+        "accept",
+        "accept-encoding",
+        "connection",
+        "host",
+        "user-agent",
+    }
+    assert event["request"]["query_string"] == "foo=bar"
+    assert event["request"]["url"].endswith("/sync-message")
+    assert event["request"]["method"] == "GET"
+
+    # Assert that state is not leaked
+    events.clear()
+    capture_message("foo")
+    event, = events
+
+    assert "request" not in event
+    assert "transaction" not in event
+
+
+def test_async_request_data(sentry_init, app, capture_events):
+    sentry_init(send_default_pii=True)
+    events = capture_events()
+
+    client = TestClient(app)
+    response = client.get("/async-message?foo=bar")
+
+    assert response.status_code == 200
+
+    event, = events
+    assert event["transaction"] == "tests.integrations.asgi.test_asgi.app.<locals>.hi"
+    assert event["request"]["env"] == {"REMOTE_ADDR": "testclient"}
+    assert set(event["request"]["headers"]) == {
+        "accept",
+        "accept-encoding",
+        "connection",
+        "host",
+        "user-agent",
+    }
+    assert event["request"]["query_string"] == "foo=bar"
+    assert event["request"]["url"].endswith("/async-message")
+    assert event["request"]["method"] == "GET"
+
+    # Assert that state is not leaked
+    events.clear()
+    capture_message("foo")
+    event, = events
+
+    assert "request" not in event
+    assert "transaction" not in event
+
+
+def test_errors(sentry_init, app, capture_events):
+    sentry_init(send_default_pii=True)
+    events = capture_events()
+
+    @app.route("/error")
+    def myerror(request):
+        raise ValueError("oh no")
+
+    client = TestClient(app, raise_server_exceptions=False)
+    response = client.get("/error")
+
+    assert response.status_code == 500
+
+    event, = events
+    assert (
+        event["transaction"]
+        == "tests.integrations.asgi.test_asgi.test_errors.<locals>.myerror"
+    )
+    exception, = event["exception"]["values"]
+
+    assert exception["type"] == "ValueError"
+    assert exception["value"] == "oh no"
+    assert any(
+        frame["filename"].endswith("tests/integrations/asgi/test_asgi.py")
+        for frame in exception["stacktrace"]["frames"]
+    )

--- a/tests/integrations/asgi/test_asgi.py
+++ b/tests/integrations/asgi/test_asgi.py
@@ -70,7 +70,7 @@ def test_async_request_data(sentry_init, app, capture_events):
     assert response.status_code == 200
 
     event, = events
-    assert event["transaction"] == "tests.integrations.asgi.test_asgi.app.<locals>.hi"
+    assert event["transaction"] == "tests.integrations.asgi.test_asgi.app.<locals>.hi2"
     assert event["request"]["env"] == {"REMOTE_ADDR": "testclient"}
     assert set(event["request"]["headers"]) == {
         "accept",

--- a/tests/integrations/asgi/test_asgi.py
+++ b/tests/integrations/asgi/test_asgi.py
@@ -1,5 +1,3 @@
-import asyncio
-import random
 import sys
 
 import pytest
@@ -20,7 +18,7 @@ def app():
         return PlainTextResponse("ok")
 
     @app.route("/async-message")
-    async def hi(request):
+    async def hi2(request):
         capture_message("hi", level="error")
         return PlainTextResponse("ok")
 

--- a/tests/integrations/django/channels/__init__.py
+++ b/tests/integrations/django/channels/__init__.py
@@ -1,0 +1,3 @@
+import pytest
+
+pytest.importorskip("channels")

--- a/tests/integrations/django/channels/test_channels.py
+++ b/tests/integrations/django/channels/test_channels.py
@@ -1,6 +1,5 @@
 import pytest
 
-pytest.importorskip("channels")
 
 from channels.testing import HttpCommunicator
 

--- a/tests/integrations/django/myapp/asgi.py
+++ b/tests/integrations/django/myapp/asgi.py
@@ -13,7 +13,7 @@ os.environ.setdefault(
 
 django.setup()
 
-from sentry_asgi import SentryMiddleware
+from sentry_sdk.integrations.asgi import SentryAsgiMiddleware
 
 application = get_default_application()
-application = SentryMiddleware(application)
+application = SentryAsgiMiddleware(application)

--- a/tests/integrations/django/test_channels.py
+++ b/tests/integrations/django/test_channels.py
@@ -1,0 +1,35 @@
+import pytest
+
+pytest.importorskip("channels")
+
+from channels.testing import HttpCommunicator
+
+from sentry_sdk.integrations.django import DjangoIntegration
+
+from tests.integrations.django.myapp.asgi import application
+
+
+@pytest.mark.asyncio
+async def test_basic(sentry_init, capture_events):
+    sentry_init(integrations=[DjangoIntegration()], send_default_pii=True)
+    events = capture_events()
+
+    comm = HttpCommunicator(application, "GET", "/view-exc?test=query")
+    response = await comm.get_response()
+    assert response["status"] == 500
+
+    event, = events
+
+    exception, = event["exception"]["values"]
+    assert exception["type"] == "ZeroDivisionError"
+
+    # Test that the ASGI middleware got set up correctly. Right now this needs
+    # to be installed manually (see myapp/asgi.py)
+    assert event["transaction"] == "/view-exc"
+    assert event["request"] == {
+        "cookies": {},
+        "headers": {},
+        "method": "GET",
+        "query_string": "test=query",
+        "url": "/view-exc",
+    }

--- a/tox.ini
+++ b/tox.ini
@@ -48,6 +48,8 @@ envlist =
 
     {py2.7,py3.7}-redis
 
+    py3.7-asgi
+
 [testenv]
 deps =
     -r test-requirements.txt
@@ -127,6 +129,9 @@ deps =
 
     redis: fakeredis
 
+    asgi: starlette
+    asgi: requests
+
     linters: black
     linters: flake8
     linters: flake8-import-order
@@ -150,6 +155,7 @@ setenv =
     aiohttp: TESTPATH=tests/integrations/aiohttp
     tornado: TESTPATH=tests/integrations/tornado
     redis: TESTPATH=tests/integrations/redis
+    asgi: TESTPATH=tests/integrations/asgi
 
     COVERAGE_FILE=.coverage-{envname}
 passenv =

--- a/tox.ini
+++ b/tox.ini
@@ -55,6 +55,8 @@ deps =
     -r test-requirements.txt
 
     django-{1.11,2.0,2.1,2.2}: djangorestframework>=3.0.0,<4.0.0
+    py3.7-django-{1.11,2.0,2.1,2.2}: channels>2
+    py3.7-django-{1.11,2.0,2.1,2.2}: pytest-asyncio
 
     django-{1.6,1.7,1.8}: pytest-django<3.0
     django-{1.9,1.10,1.11,2.0,2.1,2.2,dev}: pytest-django>=3.0


### PR DESCRIPTION
Diff to sentry-asgi:

<details><summary>click me</summary>

```diff
diff --git a/../sentry-asgi/sentry_asgi/middleware.py b/sentry_sdk/integrations/asgi.py
index 37d1117..4c40750 100644
--- a/../sentry-asgi/sentry_asgi/middleware.py
+++ b/sentry_sdk/integrations/asgi.py
@@ -1,35 +1,44 @@
 import functools
 import urllib

-import sentry_sdk
-from sentry_sdk.utils import event_from_exception, exc_info_from_error
+from sentry_sdk._types import MYPY
+from sentry_sdk.hub import Hub, _should_send_default_pii
+from sentry_sdk.integrations._wsgi_common import _filter_headers
+from sentry_sdk.utils import transaction_from_function

+if MYPY:
+    from typing import Dict
+
+
+class SentryAsgiMiddleware:
+    __slots__ = ("app",)

-class SentryMiddleware:
     def __init__(self, app):
         self.app = app

     async def __call__(self, scope, receive, send):
-        hub = sentry_sdk.Hub.current
-        with sentry_sdk.Hub(hub) as hub:
+        hub = Hub.current
+        with Hub(hub) as hub:
             with hub.configure_scope() as sentry_scope:
+                sentry_scope._name = "asgi"
                 processor = functools.partial(self.event_processor, asgi_scope=scope)
                 sentry_scope.add_event_processor(processor)
-                try:
-                    await self.app(scope, receive, send)
-                except Exception as exc:
-                    hub.capture_exception(exc)
-                    raise exc from None
+
+            try:
+                await self.app(scope, receive, send)
+            except Exception as exc:
+                hub.capture_exception(exc)
+                raise exc from None

     def event_processor(self, event, hint, asgi_scope):
         if asgi_scope["type"] in ("http", "websocket"):
             event["request"] = {
                 "url": self.get_url(asgi_scope),
                 "method": asgi_scope["method"],
-                "headers": self.get_headers(asgi_scope),
+                "headers": _filter_headers(self.get_headers(asgi_scope)),
                 "query_string": self.get_query(asgi_scope),
             }
-        if asgi_scope.get("client"):
+        if asgi_scope.get("client") and _should_send_default_pii():
             event["request"]["env"] = {"REMOTE_ADDR": asgi_scope["client"][0]}
         if asgi_scope.get("endpoint"):
             event["transaction"] = self.get_transaction(asgi_scope)
@@ -66,7 +75,7 @@ class SentryMiddleware:
         """
         Extract headers from the ASGI scope, in the format that the Sentry protocol expects.
         """
-        headers = {}
+        headers = {}  # type: Dict[str, str]
         for raw_key, raw_value in scope["headers"]:
             key = raw_key.decode("latin-1")
             value = raw_value.decode("latin-1")
@@ -80,12 +89,4 @@ class SentryMiddleware:
         """
         Return a transaction string to identify the routed endpoint.
         """
-        endpoint = scope["endpoint"]
-        qualname = (
-            getattr(endpoint, "__qualname__", None)
-            or getattr(endpoint, "__name__", None)
-            or None
-        )
-        if not qualname:
-            return None
-        return "%s.%s" % (endpoint.__module__, qualname)
+        return transaction_from_function(scope["endpoint"])
```

</details>