### PR TITLE
:bug: [#423] fix reference cycle

### DIFF
--- a/sentry_sdk/integrations/threading.py
+++ b/sentry_sdk/integrations/threading.py
@@ -33,7 +33,7 @@ class RunDescriptor:
         inside closure rather than storing reference of itself into the attribute of instance.
         """
         if instance is None:
-            return self
+            return self.class_func
 
         def run(*a, **kw):
             hub = self.parent_hub or Hub.current
@@ -56,7 +56,6 @@ class ThreadingIntegration(Integration):
     def setup_once():
         # type: () -> None
         old_start = Thread.start
-        old_run = Thread.run
 
         def sentry_start(self, *a, **kw):
             hub = Hub.current
@@ -67,7 +66,7 @@ class ThreadingIntegration(Integration):
                 else:
                     hub_ = Hub(hub)
 
-                self.__class__.run = RunDescriptor(old_run, hub_)
+                self.__class__.run = RunDescriptor(self.__class__.run, hub_)
 
             return old_start(self, *a, **kw)  # type: ignore
 

--- a/sentry_sdk/integrations/threading.py
+++ b/sentry_sdk/integrations/threading.py
@@ -25,7 +25,12 @@ class PatchedInstanceMethodDescriptor(object):
         pass
 
     def __get__(self, instance, owner):
-        """The descriptor which is used to patch instance method is sort of tricky and
+        """
+        Patching instance methods in `start()` creates a reference cycle if
+        done in a naive way. See
+        https://github.com/getsentry/sentry-python/pull/434
+
+        The descriptor which is used to patch instance method is sort of tricky and
         difficult to understand. But according to the `Python Data Model`,
         it is a proper way to prevent reference cycle using this way::
 

--- a/sentry_sdk/integrations/threading.py
+++ b/sentry_sdk/integrations/threading.py
@@ -1,57 +1,16 @@
 from __future__ import absolute_import
 
 import sys
-
-from threading import Thread
-from types import MethodType
+from threading import Thread, current_thread
 
 from sentry_sdk import Hub
 from sentry_sdk._compat import reraise
-from sentry_sdk.utils import event_from_exception
-from sentry_sdk.integrations import Integration
-
 from sentry_sdk._types import MYPY
+from sentry_sdk.integrations import Integration
+from sentry_sdk.utils import event_from_exception
 
 if MYPY:
     from typing import Any
-
-
-class PatchedInstanceMethodDescriptor(object):
-    def __init__(self, class_method, parent_hub):
-        self.origin_class_method = class_method
-        self.parent_hub = parent_hub
-
-    def __set__(self, instance, value):
-        pass
-
-    def __get__(self, instance, owner):
-        """
-        Patching instance methods in `start()` creates a reference cycle if
-        done in a naive way. See
-        https://github.com/getsentry/sentry-python/pull/434
-
-        The descriptor which is used to patch instance method is sort of tricky and
-        difficult to understand. But according to the `Python Data Model`,
-        it is a proper way to prevent reference cycle using this way::
-
-            # reference cycle between self.__dict__ and self.run.__self__
-            self.run = new_run(self.run)
-
-        Using descriptor will patch instance method with holding this instance
-        inside closure rather than storing reference of itself into the attribute of instance.
-        """
-        if instance is None:
-            return self.origin_class_method
-
-        def run(*a, **kw):
-            hub = self.parent_hub or Hub.current
-            with hub:
-                try:
-                    return MethodType(self.origin_class_method, instance)(*a, **kw)
-                except Exception:
-                    reraise(*_capture_exception())
-
-        return run
 
 
 class ThreadingIntegration(Integration):
@@ -73,14 +32,30 @@ class ThreadingIntegration(Integration):
                     hub_ = None
                 else:
                     hub_ = Hub(hub)
-
-                self.__class__.run = PatchedInstanceMethodDescriptor(
-                    self.__class__.run, hub_
-                )
+                # Patching instance methods in `start()` creates a reference cycle if
+                # done in a naive way. See
+                # https://github.com/getsentry/sentry-python/pull/434
+                #
+                # In threading module, using current_thread API will access current thread instance
+                # without holding it to avoid a reference cycle in an easier way.
+                self.run = _wrap_run(hub_, self.run.__func__)
 
             return old_start(self, *a, **kw)  # type: ignore
 
         Thread.start = sentry_start  # type: ignore
+
+
+def _wrap_run(parent_hub, old_run_func):
+    def run(*a, **kw):
+        hub = parent_hub or Hub.current
+        with hub:
+            try:
+                self = current_thread()
+                return old_run_func(self, *a, **kw)
+            except Exception:
+                reraise(*_capture_exception())
+
+    return run
 
 
 def _capture_exception():

--- a/sentry_sdk/integrations/threading.py
+++ b/sentry_sdk/integrations/threading.py
@@ -45,6 +45,7 @@ class ThreadingIntegration(Integration):
 def _wrap_run(parent_hub, old_run):
     def run(*a, **kw):
         hub = parent_hub or Hub.current
+        del old_run.__self__.run
 
         with hub:
             try:

--- a/sentry_sdk/integrations/threading.py
+++ b/sentry_sdk/integrations/threading.py
@@ -74,7 +74,9 @@ class ThreadingIntegration(Integration):
                 else:
                     hub_ = Hub(hub)
 
-                self.__class__.run = PatchedInstanceMethodDescriptor(self.__class__.run, hub_)
+                self.__class__.run = PatchedInstanceMethodDescriptor(
+                    self.__class__.run, hub_
+                )
 
             return old_start(self, *a, **kw)  # type: ignore
 

--- a/tests/integrations/threading/test_threading.py
+++ b/tests/integrations/threading/test_threading.py
@@ -1,3 +1,5 @@
+import gc
+
 from threading import Thread
 
 import pytest
@@ -62,3 +64,45 @@ def test_propagates_hub(sentry_init, capture_events, propagate_hub):
         assert event["tags"]["stage1"] is True
     else:
         assert "stage1" not in event.get("tags", {})
+
+
+def test_circular_references(sentry_init, request):
+    sentry_init(default_integrations=False, integrations=[ThreadingIntegration()])
+
+    gc.collect()
+    gc.disable()
+    request.addfinalizer(gc.enable)
+
+    class MyThread(Thread):
+        def run(self):
+            pass
+
+    t = MyThread()
+    t.start()
+    t.join()
+    del t
+
+    assert not gc.collect()
+
+
+def test_double_patching(sentry_init, capture_events):
+    sentry_init(default_integrations=False, integrations=[ThreadingIntegration()])
+    events = capture_events()
+
+    class MyThread(Thread):
+        def run(self):
+            1 / 0
+
+    ts = []
+    for _ in range(10):
+        t = MyThread()
+        t.start()
+        ts.append(t)
+
+    for t in ts:
+        t.join()
+
+    assert len(events) == 10
+    for event in events:
+        exception, = event['exception']['values']
+        assert exception['type'] == 'ZeroDivisionError'

--- a/tests/integrations/threading/test_threading.py
+++ b/tests/integrations/threading/test_threading.py
@@ -104,5 +104,5 @@ def test_double_patching(sentry_init, capture_events):
 
     assert len(events) == 10
     for event in events:
-        exception, = event['exception']['values']
-        assert exception['type'] == 'ZeroDivisionError'
+        exception, = event["exception"]["values"]
+        assert exception["type"] == "ZeroDivisionError"


### PR DESCRIPTION
Fixes #423 

According to the [Python Data Model](https://docs.python.org/3.7/reference/datamodel.html?#index-35), the code below will cause a reference cycle between  `__self__` and `__dict__`.

```
class Test:
    def start(self, *a, **kw):
        self.run()

    def run(self):
        ...


old_start = Test.start


def _wrap_run(old_run):
    def run(*a, **kw):
        result = old_run(*a, **kw)
        return result
    return run


def test_start(self, *a, **kw):
    self.run = _wrap_run(self.run)
    return old_start(self, *a, **kw) 


Test.start = test_start

if __name__ == "__main__":
    tmp = Test()
    tmp.start()
```
The references graph like this::

![](https://image.instcode.top/ref_cycle.png)

Meantime [Python Standard Library - concurrent.futures](https://github.com/python/cpython/blob/3.7/Lib/concurrent/futures/process.py#L584) used thread to manage tasks queue, therefore when sentry patched start method of `Thread`, it will cause reference cycle and prevent gc from collecting.

So in `concurrent.futures.process`, the `_queue_management_thread` in _threads_wakeups will be discarded until running a full gc collection, if not, exception will be raise when [python exited](https://github.com/python/cpython/blob/3.7/Lib/concurrent/futures/process.py#L102), because the actual manage thread has already stopped.