### PR TITLE
Fixed sentry_patched_popen_init regarding args passed as iterators

### DIFF
--- a/sentry_sdk/integrations/stdlib.py
+++ b/sentry_sdk/integrations/stdlib.py
@@ -111,7 +111,9 @@ def _install_httplib():
     HTTPConnection.getresponse = getresponse
 
 
-def _init_argument(args, kwargs, name, position, setdefault_callback=None, force_setdefault=False):
+def _init_argument(
+    args, kwargs, name, position, setdefault_callback=None, force_setdefault=False
+):
     """
     given (*args, **kwargs) of a function call, retrieve (and optionally set a
     default for) an argument by either name or position.
@@ -157,7 +159,7 @@ def _install_subprocess():
             args = []
         elif args is str:
             args = [args]
-        else: # args could be iterator, reinsert as list via forced setdefault
+        else:  # args could be iterator, reinsert as list via forced setdefault
             args = _init_argument(a, kw, "args", 0, lambda: list(args), True)
 
         env = None


### PR DESCRIPTION
Closes #436 

Didn't want to write another function like `_init_argument` so added a `force_setdefault` param that enacts setting default even if there is a value already.

`_init_argument` with a `setdefault_callback` was currently failing because `a` is a tuple and don't support item assignment. Added conversion to `list` before calling the first `_init_argument`.

In some cases, `args` is not even a list but a string. Wrapped in list so as not to break the formatting of `span.description`.

