### PR TITLE
fix: types for logging integration args

### DIFF
--- a/sentry_sdk/consts.py
+++ b/sentry_sdk/consts.py
@@ -8,6 +8,7 @@ if MYPY:
     from typing import Type
     from typing import Dict
     from typing import Any
+    from typing import Sequence
 
     from sentry_sdk.transport import Transport
     from sentry_sdk.integrations import Integration

--- a/sentry_sdk/consts.py
+++ b/sentry_sdk/consts.py
@@ -27,7 +27,7 @@ class ClientConstructor(object):
         environment=None,  # type: Optional[str]
         server_name=None,  # type: Optional[str]
         shutdown_timeout=2,  # type: int
-        integrations=[],  # type: List[Integration]
+        integrations=[],  # type: Sequence[Integration]
         in_app_include=[],  # type: List[str]
         in_app_exclude=[],  # type: List[str]
         default_integrations=True,  # type: bool

--- a/sentry_sdk/integrations/logging.py
+++ b/sentry_sdk/integrations/logging.py
@@ -19,6 +19,7 @@ if MYPY:
     from logging import LogRecord
     from typing import Any
     from typing import Dict
+    from typing import Optional
 
 DEFAULT_LEVEL = logging.INFO
 DEFAULT_EVENT_LEVEL = logging.ERROR
@@ -40,7 +41,7 @@ class LoggingIntegration(Integration):
     identifier = "logging"
 
     def __init__(self, level=DEFAULT_LEVEL, event_level=DEFAULT_EVENT_LEVEL):
-        # type: (int, int) -> None
+        # type: (Optional[int], Optional[int]) -> None
         self._handler = None
         self._breadcrumb_handler = None
 


### PR DESCRIPTION
The sdk supports disabling the LoggingIntegration by passing `None` as
arguments; however, the current types require ints.

This behavior is noted in the docs:
https://docs.sentry.io/platforms/python/logging/#options

```
sentry_sdk.init(integrations=[LoggingIntegration(level=None, event_level=None)])
```

edit: when adding `# type: ignore` I found a second issue with the argument `integrations` which mypy recommended as typing as `Sequence` instead of `List`. This fixed the type error.