### PR TITLE
Fix detection of gevent threading.local monkey-patch

### DIFF
--- a/sentry_sdk/utils.py
+++ b/sentry_sdk/utils.py
@@ -759,7 +759,7 @@ def _is_threading_local_monkey_patched():
     try:
         from gevent.monkey import is_object_patched  # type: ignore
 
-        if is_object_patched("_threading", "local"):
+        if is_object_patched("threading", "local"):
             return True
     except ImportError:
         pass

--- a/sentry_sdk/utils.py
+++ b/sentry_sdk/utils.py
@@ -775,10 +775,6 @@ def _is_threading_local_monkey_patched():
     return False
 
 
-IS_THREADING_LOCAL_MONKEY_PATCHED = _is_threading_local_monkey_patched()
-del _is_threading_local_monkey_patched
-
-
 def _get_contextvars():
     # () -> (bool, Type)
     """
@@ -788,7 +784,7 @@ def _get_contextvars():
 
     https://github.com/gevent/gevent/issues/1407
     """
-    if not IS_THREADING_LOCAL_MONKEY_PATCHED:
+    if not _is_threading_local_monkey_patched():
         try:
             from contextvars import ContextVar  # type: ignore
 
@@ -818,7 +814,6 @@ def _get_contextvars():
 
 
 HAS_REAL_CONTEXTVARS, ContextVar = _get_contextvars()
-del _get_contextvars
 
 
 def transaction_from_function(func):

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -5,3 +5,4 @@ tox==3.7.0
 Werkzeug==0.14.1
 pytest-localserver==0.4.1
 pytest-cov==2.6.0
+gevent

--- a/tests/utils/test_contextvars.py
+++ b/tests/utils/test_contextvars.py
@@ -1,0 +1,58 @@
+import pytest
+import random
+import time
+
+import gevent
+
+
+from sentry_sdk.utils import _is_threading_local_monkey_patched
+
+
+def test_gevent_is_patched():
+    gevent.monkey.patch_all()
+    assert _is_threading_local_monkey_patched()
+
+
+def test_gevent_is_not_patched():
+    assert not _is_threading_local_monkey_patched()
+
+
+@pytest.mark.parametrize("with_gevent", [True, False])
+def test_leaks(with_gevent):
+    if with_gevent:
+        gevent.monkey.patch_all()
+
+    import threading
+
+    # Need to explicitly call _get_contextvars because the SDK has already
+    # decided upon gevent on import.
+
+    from sentry_sdk import utils
+
+    _, ContextVar = utils._get_contextvars()
+
+    ts = []
+
+    var = ContextVar("test_contextvar_leaks")
+
+    success = []
+
+    def run():
+        value = int(random.random() * 1000)
+        var.set(value)
+
+        for _ in range(100):
+            time.sleep(0)
+            assert var.get(None) == value
+
+        success.append(1)
+
+    for _ in range(20):
+        t = threading.Thread(target=run)
+        t.start()
+        ts.append(t)
+
+    for t in ts:
+        t.join()
+
+    assert len(success) == 20


### PR DESCRIPTION
The `_` in `_threading` seems like a mistake and always returns False.
Removing it leads to the detection working properly:

```py
Python 3.7.4 (default, Jul 16 2019, 07:12:58)
[GCC 9.1.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import gevent.monkey
>>> gevent.monkey.is_object_patched('_threading', 'local')
False
>>> gevent.monkey.is_object_patched('threading', 'local')
False
>>> gevent.monkey.patch_all()
True
>>> gevent.monkey.is_object_patched('_threading', 'local')
False
>>> gevent.monkey.is_object_patched('threading', 'local')
True
```