### PR TITLE
Add user event data from logging extra

### DIFF
--- a/sentry_sdk/integrations/logging.py
+++ b/sentry_sdk/integrations/logging.py
@@ -145,6 +145,14 @@ def _extra_from_record(record):
     }
 
 
+def _user_from_record(record):
+    # type: (LogRecord) -> Optional[Dict[str, None]]
+    user = vars(record).get("user")
+    if not isinstance(user, dict):
+        return None
+    return user
+
+
 class EventHandler(logging.Handler, object):
     def emit(self, record):
         # type: (LogRecord) -> Any
@@ -194,6 +202,7 @@ class EventHandler(logging.Handler, object):
         event["level"] = _logging_to_event_level(record.levelname)
         event["logger"] = record.name
         event["logentry"] = {"message": to_string(record.msg), "params": record.args}
+        event["user"] = _user_from_record(record)
         event["extra"] = _extra_from_record(record)
 
         hub.capture_event(event, hint=hint)

--- a/tests/integrations/logging/test_logging.py
+++ b/tests/integrations/logging/test_logging.py
@@ -72,6 +72,32 @@ def test_logging_extra_data_integer_keys(sentry_init, capture_events):
     assert event["extra"] == {"1": 1}
 
 
+def test_logging_user_data(sentry_init, capture_events):
+    sentry_init(integrations=[LoggingIntegration()], default_integrations=False)
+    events = capture_events()
+
+    logger.critical(
+        "User error", extra=dict(user=dict(id=123, email="user@example.org"))
+    )
+
+    event, = events
+
+    assert event["user"]["id"] == 123
+    assert event["user"]["email"] == "user@example.org"
+
+
+def test_logging_invalid_user_data(sentry_init, capture_events):
+    sentry_init(integrations=[LoggingIntegration()], default_integrations=False)
+    events = capture_events()
+
+    logger.critical("User error", extra=dict(user=123))
+
+    event, = events
+
+    assert "user" not in event
+    assert event["extra"]["user"] == 123
+
+
 @pytest.mark.xfail(sys.version_info[:2] == (3, 4), reason="buggy logging module")
 def test_logging_stack(sentry_init, capture_events):
     sentry_init(integrations=[LoggingIntegration()], default_integrations=False)


### PR DESCRIPTION
While migrating from `raven` to `sentry-python` I noticed my usage of the `user` key no longer populated the field on the sentry interface :
```python
logger.critical("User error", extra=dict(user=dict(id=123, email="user@example.org")))
```

This PR is an attempt to bring back this behaviour by adding the `user` key to the captured `event`. 

I tried to do my best to respect codestyle and conventions but I'm sure this can be further improved. This is more a proof of concept, wasn't sure if it was better to open an issue or and PR so I chose the option with a bit of code 😊 