### PR TITLE
feat: Add status to transactions

### DIFF
--- a/sentry_sdk/hub.py
+++ b/sentry_sdk/hub.py
@@ -516,7 +516,6 @@ class Hub(with_metaclass(HubMeta)):  # type: ignore
                 "type": "transaction",
                 "transaction": span.transaction,
                 "contexts": {"trace": span.get_trace_context()},
-                "tags": span._tags,
                 "timestamp": span.timestamp,
                 "start_timestamp": span.start_timestamp,
                 "spans": [

--- a/sentry_sdk/hub.py
+++ b/sentry_sdk/hub.py
@@ -448,8 +448,6 @@ class Hub(with_metaclass(HubMeta)):  # type: ignore
         except Exception:
             span.set_failure()
             raise
-        else:
-            span.set_success()
         finally:
             try:
                 span.finish()
@@ -518,6 +516,7 @@ class Hub(with_metaclass(HubMeta)):  # type: ignore
                 "type": "transaction",
                 "transaction": span.transaction,
                 "contexts": {"trace": span.get_trace_context()},
+                "tags": span._tags,
                 "timestamp": span.timestamp,
                 "start_timestamp": span.start_timestamp,
                 "spans": [

--- a/sentry_sdk/integrations/celery.py
+++ b/sentry_sdk/integrations/celery.py
@@ -184,6 +184,10 @@ def _capture_exception(task, exc_info):
 
     hub.capture_event(event, hint=hint)
 
+    with capture_internal_exceptions():
+        with hub.configure_scope() as scope:
+            scope.span.set_failure()
+
 
 def _patch_worker_exit():
     # Need to flush queue before worker shutdown because a crashing worker will

--- a/sentry_sdk/integrations/sqlalchemy.py
+++ b/sentry_sdk/integrations/sqlalchemy.py
@@ -49,7 +49,6 @@ def _before_cursor_execute(
     span = ctx_mgr.__enter__()
 
     if span is not None:
-        span.set_success()  # might be overwritten later
         conn._sentry_sql_span = span
 
 

--- a/tests/integrations/celery/test_celery.py
+++ b/tests/integrations/celery/test_celery.py
@@ -123,7 +123,11 @@ def test_transaction_events(capture_events, init_celery, celery_invocation, task
     assert execution_event["contexts"]["trace"]["trace_id"] == span.trace_id
     assert submission_event["contexts"]["trace"]["trace_id"] == span.trace_id
 
-    assert execution_event["contexts"]["trace"].get("status", False) == task_fails
+    if task_fails:
+        assert execution_event["contexts"]["trace"]["status"] == "failure"
+    else:
+        assert "status" not in execution_event["contexts"]["trace"]
+
     assert execution_event["spans"] == []
     assert submission_event["spans"] == [
         {

--- a/tests/integrations/celery/test_celery.py
+++ b/tests/integrations/celery/test_celery.py
@@ -123,6 +123,7 @@ def test_transaction_events(capture_events, init_celery, celery_invocation, task
     assert execution_event["contexts"]["trace"]["trace_id"] == span.trace_id
     assert submission_event["contexts"]["trace"]["trace_id"] == span.trace_id
 
+    assert execution_event["contexts"]["trace"].get("status", False) == task_fails
     assert execution_event["spans"] == []
     assert submission_event["spans"] == [
         {
@@ -133,7 +134,7 @@ def test_transaction_events(capture_events, init_celery, celery_invocation, task
             u"same_process_as_parent": True,
             u"span_id": submission_event["spans"][0]["span_id"],
             u"start_timestamp": submission_event["spans"][0]["start_timestamp"],
-            u"tags": {u"error": False},
+            u"tags": {},
             u"timestamp": submission_event["spans"][0]["timestamp"],
             u"trace_id": text_type(span.trace_id),
         }

--- a/tests/integrations/flask/test_flask.py
+++ b/tests/integrations/flask/test_flask.py
@@ -554,3 +554,47 @@ def test_errorhandler_for_exception_swallows_exception(
         assert response.status_code == 200
 
     assert not events
+
+
+def test_tracing_success(sentry_init, capture_events, app):
+    sentry_init(traces_sample_rate=1.0, integrations=[flask_sentry.FlaskIntegration()])
+
+    events = capture_events()
+
+    with app.test_client() as client:
+        response = client.get("/message")
+        assert response.status_code == 200
+
+    message_event, transaction_event = events
+
+    assert transaction_event["type"] == "transaction"
+    assert transaction_event["transaction"] == "hi"
+    assert "status" not in transaction_event["contexts"]["trace"]
+
+    assert message_event["message"] == "hi"
+    assert message_event["transaction"] == "hi"
+
+
+def test_tracing_error(sentry_init, capture_events, app):
+    sentry_init(traces_sample_rate=1.0, integrations=[flask_sentry.FlaskIntegration()])
+
+    events = capture_events()
+
+    @app.route("/error")
+    def error():
+        1 / 0
+
+    with pytest.raises(ZeroDivisionError):
+        with app.test_client() as client:
+            response = client.get("/error")
+            assert response.status_code == 500
+
+    error_event, transaction_event = events
+
+    assert transaction_event["type"] == "transaction"
+    assert transaction_event["transaction"] == "error"
+    assert transaction_event["contexts"]["trace"]["status"] == "failure"
+
+    assert error_event["transaction"] == "error"
+    exception, = error_event["exception"]["values"]
+    assert exception["type"] == "ZeroDivisionError"

--- a/tests/integrations/redis/test_redis.py
+++ b/tests/integrations/redis/test_redis.py
@@ -18,7 +18,7 @@ def test_basic(sentry_init, capture_events):
 
     assert crumb == {
         "category": "redis",
-        "data": {"error": False, "redis.key": "foobar"},
+        "data": {"redis.key": "foobar"},
         "timestamp": crumb["timestamp"],
         "type": "redis",
     }

--- a/tests/test_tracing.py
+++ b/tests/test_tracing.py
@@ -25,10 +25,10 @@ def test_basic(sentry_init, capture_events, sample_rate):
 
         span1, span2 = event["spans"]
         parent_span = event
-        assert span1["status"] == "failure"
+        assert span1["tags"]["status"] == "failure"
         assert span1["op"] == "foo"
         assert span1["description"] == "foodesc"
-        assert "status" not in span2
+        assert "status" not in span2["tags"]
         assert span2["op"] == "bar"
         assert span2["description"] == "bardesc"
         assert parent_span["transaction"] == "hi"

--- a/tests/test_tracing.py
+++ b/tests/test_tracing.py
@@ -25,10 +25,10 @@ def test_basic(sentry_init, capture_events, sample_rate):
 
         span1, span2 = event["spans"]
         parent_span = event
-        assert span1["tags"]["error"]
+        assert span1["status"] == "failure"
         assert span1["op"] == "foo"
         assert span1["description"] == "foodesc"
-        assert not span2["tags"]["error"]
+        assert "status" not in span2
         assert span2["op"] == "bar"
         assert span2["description"] == "bardesc"
         assert parent_span["transaction"] == "hi"


### PR DESCRIPTION
* Add indicator of failed transactions for both celery and wsgi. This is a context field that will later be promoted as tag or somehow indexed separately.
* Rename `error: bool` to `status: str`