### PR TITLE
Allow support for user introspection for more than just Flask-Login

### DIFF
--- a/sentry_sdk/integrations/flask.py
+++ b/sentry_sdk/integrations/flask.py
@@ -16,6 +16,7 @@ if MYPY:
     from sentry_sdk.integrations.wsgi import _ScopedResponse
     from typing import Any
     from typing import Dict
+    from typing import Optional
     from werkzeug.datastructures import ImmutableTypeConversionDict
     from werkzeug.datastructures import ImmutableMultiDict
     from werkzeug.datastructures import FileStorage
@@ -57,7 +58,7 @@ class FlaskIntegration(Integration):
         user_object="current_user",
         user_attr_mapping=None,
     ):
-        # type: (str) -> None
+        # type: (Any, str, str, str, Optional[Dict[str, str]]) -> None
         TRANSACTION_STYLE_VALUES = ("endpoint", "url")
         if transaction_style not in TRANSACTION_STYLE_VALUES:
             raise ValueError(

--- a/sentry_sdk/integrations/flask.py
+++ b/sentry_sdk/integrations/flask.py
@@ -29,7 +29,7 @@ except ImportError:
 
 if flask_login is None:
     try:
-        import flask_jwt_extended as flask_login # type: ignore
+        import flask_jwt_extended as flask_login  # type: ignore
     except ImportError:
         pass
 
@@ -50,8 +50,13 @@ class FlaskIntegration(Integration):
     user_object = None
     user_attr_mapping = None
 
-    def __init__(self, transaction_style="endpoint", user_module="flask_login",
-            user_object="current_user", user_attr_mapping=None):
+    def __init__(
+        self,
+        transaction_style="endpoint",
+        user_module="flask_login",
+        user_object="current_user",
+        user_attr_mapping=None,
+    ):
         # type: (str) -> None
         TRANSACTION_STYLE_VALUES = ("endpoint", "url")
         if transaction_style not in TRANSACTION_STYLE_VALUES:
@@ -61,16 +66,13 @@ class FlaskIntegration(Integration):
             )
         self.transaction_style = transaction_style
         try:
-            self.usermodule = importlib.import_module( user_module )
-        except  ImportError:
+            self.usermodule = importlib.import_module(user_module)
+        except ImportError:
             self.usermodule = None
 
         self.user_object = user_object
         if user_attr_mapping is None:
-            self.user_attr_mapping = {
-                'username': 'username',
-                'email': 'email'
-            }
+            self.user_attr_mapping = {"username": "username", "email": "email"}
         else:
             self.user_attr_mapping = user_attr_mapping
 
@@ -247,12 +249,12 @@ def _add_user_to_event(event):
             pass
 
         for attr in integration.user_attr_mapping:
-        # The following attribute accesses are ineffective for the general
-        # Flask-Login case, because the User interface of Flask-Login does not
-        # care about anything but the ID. However, Flask-User (based on
-        # Flask-Login) documents a few optional extra attributes.
-        #
-        # https://github.com/lingthio/Flask-User/blob/a379fa0a281789618c484b459cb41236779b95b1/docs/source/data_models.rst#fixed-data-model-property-names
+            # The following attribute accesses are ineffective for the general
+            # Flask-Login case, because the User interface of Flask-Login does not
+            # care about anything but the ID. However, Flask-User (based on
+            # Flask-Login) documents a few optional extra attributes.
+            #
+            # https://github.com/lingthio/Flask-User/blob/a379fa0a281789618c484b459cb41236779b95b1/docs/source/data_models.rst#fixed-data-model-property-names
 
             try:
                 user_info[attr] = getattr(user, integration.user_attr_mapping.get(attr))

--- a/sentry_sdk/integrations/flask.py
+++ b/sentry_sdk/integrations/flask.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import
 
 import weakref
+import importlib
 
 from sentry_sdk.hub import Hub, _should_send_default_pii
 from sentry_sdk.utils import capture_internal_exceptions, event_from_exception
@@ -26,6 +27,12 @@ try:
 except ImportError:
     flask_login = None
 
+if flask_login is None:
+    try:
+        import flask_jwt_extended as flask_login # type: ignore
+    except ImportError:
+        pass
+
 from flask import Request, Flask, _request_ctx_stack, _app_ctx_stack  # type: ignore
 from flask.signals import (
     appcontext_pushed,
@@ -39,8 +46,12 @@ class FlaskIntegration(Integration):
     identifier = "flask"
 
     transaction_style = None
+    user_module = None
+    user_object = None
+    user_attr_mapping = None
 
-    def __init__(self, transaction_style="endpoint"):
+    def __init__(self, transaction_style="endpoint", user_module="flask_login",
+            user_object="current_user", user_attr_mapping=None):
         # type: (str) -> None
         TRANSACTION_STYLE_VALUES = ("endpoint", "url")
         if transaction_style not in TRANSACTION_STYLE_VALUES:
@@ -49,6 +60,19 @@ class FlaskIntegration(Integration):
                 % (transaction_style, TRANSACTION_STYLE_VALUES)
             )
         self.transaction_style = transaction_style
+        try:
+            self.usermodule = importlib.import_module( user_module )
+        except  ImportError:
+            self.usermodule = None
+
+        self.user_object = user_object
+        if user_attr_mapping is None:
+            self.user_attr_mapping = {
+                'username': 'username',
+                'email': 'email'
+            }
+        else:
+            self.user_attr_mapping = user_attr_mapping
 
     @staticmethod
     def setup_once():
@@ -195,11 +219,14 @@ def _capture_exception(sender, exception, **kwargs):
 
 
 def _add_user_to_event(event):
-    # type: (Dict[str, Any]) -> None
-    if flask_login is None:
+    hub = Hub.current
+    integration = hub.get_integration(FlaskIntegration)
+
+    if integration.usermodule is None:
         return
 
-    user = flask_login.current_user
+    user = getattr(integration.usermodule, integration.user_object)
+
     if user is None:
         return
 
@@ -219,6 +246,7 @@ def _add_user_to_event(event):
             # - no user is logged in
             pass
 
+        for attr in integration.user_attr_mapping:
         # The following attribute accesses are ineffective for the general
         # Flask-Login case, because the User interface of Flask-Login does not
         # care about anything but the ID. However, Flask-User (based on
@@ -226,12 +254,7 @@ def _add_user_to_event(event):
         #
         # https://github.com/lingthio/Flask-User/blob/a379fa0a281789618c484b459cb41236779b95b1/docs/source/data_models.rst#fixed-data-model-property-names
 
-        try:
-            user_info["email"] = user_info["username"] = user.email
-        except Exception:
-            pass
-
-        try:
-            user_info["username"] = user.username
-        except Exception:
-            pass
+            try:
+                user_info[attr] = getattr(user, integration.user_attr_mapping.get(attr))
+            except Exception:
+                pass


### PR DESCRIPTION
There are multiple user management modules for Flask.  This merge allows for the user to define the flask user module, the user object that stores the userinfo, and a mapping from user object attributes to the sentry user_info dict.  Code example to use flask_jwt_extended, instead of flask_login (very similar module):

```python
sentry_sdk.init(
    dsn="https://foobar@sentry.io/000000",
    integrations=[
        FlaskIntegration(
            user_module="flask_jwt_extended",
            user_object="current_user",
            user_attr_mapping={
                "username": "email",
                "email": "email"
            }
        )
    ],
    send_default_pii=True
)
```