### PR TITLE
feat: Automatically instrument ASGI HTTP requests in Django Channels

### DIFF
--- a/sentry_sdk/scope.py
+++ b/sentry_sdk/scope.py
@@ -195,6 +195,13 @@ class Scope(object):
 
         :param func: This function behaves like `before_send.`
         """
+        if len(self._event_processors) > 20:
+            logger.warning(
+                "Too many event processors on scope! Clearing list to free up some memory: %r",
+                self._event_processors
+            )
+            del self._event_processors[:]
+
         self._event_processors.append(func)
 
     def add_error_processor(

--- a/tests/integrations/django/channels/test_channels.py
+++ b/tests/integrations/django/channels/test_channels.py
@@ -3,6 +3,7 @@ import pytest
 
 from channels.testing import HttpCommunicator
 
+from sentry_sdk import capture_message
 from sentry_sdk.integrations.django import DjangoIntegration
 
 from tests.integrations.django.myapp.asgi import application
@@ -32,3 +33,7 @@ async def test_basic(sentry_init, capture_events):
         "query_string": "test=query",
         "url": "/view-exc",
     }
+
+    capture_message("hi")
+    event = events[-1]
+    assert "request" not in event

--- a/tests/integrations/django/myapp/asgi.py
+++ b/tests/integrations/django/myapp/asgi.py
@@ -12,8 +12,4 @@ os.environ.setdefault(
 )
 
 django.setup()
-
-from sentry_sdk.integrations.asgi import SentryAsgiMiddleware
-
 application = get_default_application()
-application = SentryAsgiMiddleware(application)


### PR DESCRIPTION
See #495 

- [x] prevent asgi middleware from applying twice