### PR TITLE
fix: Beam Integration Tests 

### DIFF
--- a/sentry_sdk/integrations/beam.py
+++ b/sentry_sdk/integrations/beam.py
@@ -79,7 +79,15 @@ def _wrap_inspect_call(cls, func_name):
             process_func = getattr(self, func_name)
             setattr(self, func_name, _wrap_task_call(process_func))
             setattr(self, wrapped_func, process_func)
-        return getfullargspec(process_func)
+
+        # getfullargspec is deprecated in more recent beam versions and get_function_args_defaults
+        # (which uses Signatures internally) should be used instead.
+        try:
+            from apache_beam.transforms.core import get_function_args_defaults
+
+            return get_function_args_defaults(process_func)
+        except ImportError:
+            return getfullargspec(process_func)
 
     setattr(_inspect, USED_FUNC, True)
     return _inspect

--- a/tox.ini
+++ b/tox.ini
@@ -32,8 +32,7 @@ envlist =
     {pypy,py2.7,py3.5,py3.6,py3.7,py3.8}-celery-{4.1,4.2,4.3}
     {pypy,py2.7}-celery-3
 
-    {py2.7,py3.6}-beam-{12,13,master}
-    py3.7-beam-{12,13}
+    py3.7-beam-{12,13, master}
 
     # The aws_lambda tests deploy to the real AWS and have their own matrix of Python versions.
     py3.7-aws_lambda

--- a/tox.ini
+++ b/tox.ini
@@ -32,6 +32,7 @@ envlist =
     {pypy,py2.7,py3.5,py3.6,py3.7,py3.8}-celery-{4.1,4.2,4.3}
     {pypy,py2.7}-celery-3
 
+    py2.7-beam-{12,13}
     py3.7-beam-{12,13, master}
 
     # The aws_lambda tests deploy to the real AWS and have their own matrix of Python versions.

--- a/tox.ini
+++ b/tox.ini
@@ -32,7 +32,7 @@ envlist =
     {pypy,py2.7,py3.5,py3.6,py3.7,py3.8}-celery-{4.1,4.2,4.3}
     {pypy,py2.7}-celery-3
 
-    {py2.7,py3.6}-beam-{12,13}
+    {py2.7,py3.6}-beam-{12,13,master}
     py3.7-beam-{12,13}
 
     # The aws_lambda tests deploy to the real AWS and have their own matrix of Python versions.
@@ -98,6 +98,7 @@ deps =
 
     beam-12: apache-beam>=2.12.0, <2.13.0
     beam-13: apache-beam>=2.13.0, <2.14.0
+    beam-master: git+https://github.com/apache/beam#egg=apache-beam&subdirectory=sdks/python
 
     celery-3: Celery>=3.1,<4.0
     celery-4.1: Celery>=4.1,<4.2


### PR DESCRIPTION
https://getsentry.atlassian.net/browse/SFD-14

This patch fixes the previously disabled beam tests. Running the tests with beam v2.12 and v2.13 was seen to be fine, the tests were experiencing issues with `beam-master`.

```
tests/integrations/beam/test_beam.py:182: in test_invoker_normal
    invoker = init_beam(fn)
tests/integrations/beam/test_beam.py:169: in inner
    pardo = ParDo(fn)
sentry_sdk/integrations/beam.py:60: in sentry_init_pardo
    old_init(self, fn, *args, **kwargs)
.tox/py3.7-beam-master/lib/python3.7/site-packages/apache_beam/transforms/core.py:1117: in __init__
    self._signature = DoFnSignature(self.fn)
.tox/py3.7-beam-master/lib/python3.7/site-packages/apache_beam/runners/common.py:232: in __init__
    self.process_method = MethodWrapper(do_fn, 'process')
.tox/py3.7-beam-master/lib/python3.7/site-packages/apache_beam/runners/common.py:157: in __init__
    method_name)
.tox/py3.7-beam-master/lib/python3.7/site-packages/apache_beam/transforms/core.py:305: in get_function_arguments
    return f()
sentry_sdk/integrations/beam.py:82: in _inspect
    return getfullargspec(process_func)
.tox/py3.7-beam-master/lib/python3.7/site-packages/apache_beam/typehints/decorators.py:135: in getfullargspec
    assert sys.version_info < (3,), 'This method should not be used in Python 3'
E   AssertionError: This method should not be used in Python 3
```

This is caused by https://github.com/apache/beam/pull/9283/commits/b7cb0a190328a79b9a6bc9fc426750c613817e8e

TL;DR:
```
Migrate (almost fully) from using get(full)argspec and getcallargs to
inspect.signature. This simplifies code in some areas, such as: no more
handling of argspecs, no need to figure out if a function is a bound
method, and Signature and Parameter are nicer data structures.
```

I went through some debugging, more details to be found here: https://www.notion.so/sentry/SFD-14-bd6a2a669571416e90905b51971ac8db

To fix this, I now use `get_function_args_defaults` if possible, otherwise fallback to using `getfullargspec` like before.