### PR TITLE
fix: Do not capture SQL params for now

### DIFF
--- a/sentry_sdk/consts.py
+++ b/sentry_sdk/consts.py
@@ -49,6 +49,7 @@ class ClientConstructor(object):
         # DO NOT ENABLE THIS RIGHT NOW UNLESS YOU WANT TO EXCEED YOUR EVENT QUOTA IMMEDIATELY
         traces_sample_rate=0.0,  # type: float
         traceparent_v2=False,  # type: bool
+        _experiments={},  # type: Dict[str, Any]
     ):
         # type: (...) -> None
         pass

--- a/sentry_sdk/hub.py
+++ b/sentry_sdk/hub.py
@@ -450,7 +450,10 @@ class Hub(with_metaclass(HubMeta)):  # type: ignore
             span.sampled = random.random() < sample_rate
 
         if span.sampled:
-            span.init_finished_spans()
+            max_spans = (
+                client and client.options["_experiments"].get("max_spans") or 1000
+            )
+            span.init_finished_spans(maxlen=max_spans)
 
         return span
 

--- a/sentry_sdk/tracing.py
+++ b/sentry_sdk/tracing.py
@@ -386,10 +386,23 @@ def record_sql_queries(
     executemany,  # type: bool
 ):
     # type: (...) -> Generator[Span, None, None]
-    # TODO: Bring back capturing of params
+
+    # TODO: Bring back capturing of params by default
+    if hub.client and hub.client.options["_experiments"].get(
+        "record_sql_params", False
+    ):
+        if not params_list or params_list == [None]:
+            params_list = None
+
+        if paramstyle == "pyformat":
+            paramstyle = "format"
+    else:
+        params_list = None
+        paramstyle = None
+
     query = _format_sql(cursor, query)
 
-    data = {}
+    data = {"db.params": params_list, "db.paramstyle": paramstyle}
     if executemany:
         data["db.executemany"] = True
 

--- a/tests/integrations/django/test_basic.py
+++ b/tests/integrations/django/test_basic.py
@@ -188,7 +188,6 @@ def test_sql_queries(sentry_init, capture_events, with_integration):
         crumb = event["breadcrumbs"][-1]
 
         assert crumb["message"] == "SELECT count(*) FROM people_person WHERE foo = %s"
-        assert crumb["data"]["db.params"] == [123]
 
 
 @pytest.mark.django_db
@@ -216,7 +215,6 @@ def test_sql_dict_query_params(sentry_init, capture_events):
     assert crumb["message"] == (
         "SELECT count(*) FROM people_person WHERE foo = %(my_foo)s"
     )
-    assert crumb["data"]["db.params"] == {"my_foo": 10}
 
 
 @pytest.mark.parametrize(
@@ -249,7 +247,6 @@ def test_sql_psycopg2_string_composition(sentry_init, capture_events, query):
     event, = events
     crumb = event["breadcrumbs"][-1]
     assert crumb["message"] == ('SELECT %(my_param)s FROM "foobar"')
-    assert crumb["data"]["db.params"] == {"my_param": 10}
 
 
 @pytest.mark.django_db
@@ -288,16 +285,13 @@ def test_sql_psycopg2_placeholders(sentry_init, capture_events):
     assert event["breadcrumbs"][-2:] == [
         {
             "category": "query",
-            "data": {"db.paramstyle": "format"},
+            "data": {},
             "message": "create table my_test_table (foo text, bar date)",
             "type": "default",
         },
         {
             "category": "query",
-            "data": {
-                "db.params": {"first_var": "fizz", "second_var": "not a date"},
-                "db.paramstyle": "format",
-            },
+            "data": {},
             "message": 'insert into my_test_table ("foo", "bar") values (%(first_var)s, '
             "%(second_var)s)",
             "type": "default",

--- a/tests/integrations/sqlalchemy/test_sqlalchemy.py
+++ b/tests/integrations/sqlalchemy/test_sqlalchemy.py
@@ -8,7 +8,9 @@ from sentry_sdk.integrations.sqlalchemy import SqlalchemyIntegration
 
 
 def test_orm_queries(sentry_init, capture_events):
-    sentry_init(integrations=[SqlalchemyIntegration()])
+    sentry_init(
+        integrations=[SqlalchemyIntegration()], _experiments={"record_sql_params": True}
+    )
     events = capture_events()
 
     Base = declarative_base()
@@ -48,13 +50,13 @@ def test_orm_queries(sentry_init, capture_events):
     assert event["breadcrumbs"][-2:] == [
         {
             "category": "query",
-            "data": {},
+            "data": {"db.params": ["Bob"], "db.paramstyle": "qmark"},
             "message": "INSERT INTO person (name) VALUES (?)",
             "type": "default",
         },
         {
             "category": "query",
-            "data": {},
+            "data": {"db.params": [1, 0], "db.paramstyle": "qmark"},
             "message": "SELECT person.id AS person_id, person.name AS person_name \n"
             "FROM person\n"
             " LIMIT ? OFFSET ?",

--- a/tests/integrations/sqlalchemy/test_sqlalchemy.py
+++ b/tests/integrations/sqlalchemy/test_sqlalchemy.py
@@ -48,13 +48,13 @@ def test_orm_queries(sentry_init, capture_events):
     assert event["breadcrumbs"][-2:] == [
         {
             "category": "query",
-            "data": {"db.params": ["Bob"], "db.paramstyle": "qmark"},
+            "data": {},
             "message": "INSERT INTO person (name) VALUES (?)",
             "type": "default",
         },
         {
             "category": "query",
-            "data": {"db.params": [1, 0], "db.paramstyle": "qmark"},
+            "data": {},
             "message": "SELECT person.id AS person_id, person.name AS person_name \n"
             "FROM person\n"
             " LIMIT ? OFFSET ?",


### PR DESCRIPTION
We have memory usage issues for very large queries, because large params are held in memory (spans or breadcrumb buffer). Do not capture SQL params for now.