### PR TITLE
allow sentry to correctly parse events with `datetime`s in them

### DIFF
--- a/sentry_sdk/transport.py
+++ b/sentry_sdk/transport.py
@@ -108,6 +108,11 @@ class HttpTransport(Transport):
 
         self.hub_cls = Hub
 
+    @staticmethod
+    def _convert_datetime(event):
+        if isinstance(event, datetime):
+            return str(event)
+        
     def _send_event(
         self, event  # type: Event
     ):
@@ -119,7 +124,7 @@ class HttpTransport(Transport):
 
         body = io.BytesIO()
         with gzip.GzipFile(fileobj=body, mode="w") as f:
-            f.write(json.dumps(event, allow_nan=False).encode("utf-8"))
+            f.write(json.dumps(event, allow_nan=False, default=self._convert_datetime).encode("utf-8"))
 
         assert self.parsed_dsn is not None
         logger.debug(


### PR DESCRIPTION
We recently came up against a problem where we discovered an error sentry wouldn't report. Turns out, the event had an un-stringified datetime in its breadcrumbs, and sentry was failing to json-ify the event due to that, silencing the error.