### PR TITLE
Allow push_scope to act as a decorator

### DIFF
--- a/sentry_sdk/_compat.py
+++ b/sentry_sdk/_compat.py
@@ -15,6 +15,35 @@ if MYPY:
 
 PY2 = sys.version_info[0] == 2
 
+if not PY2 and sys.version_info >= (3, 2):
+    from contextlib import ContextDecorator
+else:
+    from functools import wraps
+
+
+    class ContextDecorator(object):
+        "A base class or mixin that enables context managers to work as decorators."
+
+        def _recreate_cm(self):
+            """Return a recreated instance of self.
+
+            Allows an otherwise one-shot context manager like
+            _GeneratorContextManager to support use as
+            a decorator via implicit recreation.
+
+            This is a private interface just for _GeneratorContextManager.
+            See issue #11647 for details.
+            """
+            return self
+
+        def __call__(self, func):
+            @wraps(func)
+            def inner(*args, **kwds):
+                with self._recreate_cm():
+                    return func(*args, **kwds)
+
+            return inner
+
 if PY2:
     import urlparse  # noqa
 

--- a/sentry_sdk/_compat.py
+++ b/sentry_sdk/_compat.py
@@ -20,7 +20,6 @@ if not PY2 and sys.version_info >= (3, 2):
 else:
     from functools import wraps
 
-
     class ContextDecorator(object):
         "A base class or mixin that enables context managers to work as decorators."
 
@@ -43,6 +42,7 @@ else:
                     return func(*args, **kwds)
 
             return inner
+
 
 if PY2:
     import urlparse  # noqa

--- a/sentry_sdk/api.py
+++ b/sentry_sdk/api.py
@@ -1,7 +1,7 @@
 import inspect
 from contextlib import contextmanager
 
-from sentry_sdk.hub import Hub
+from sentry_sdk.hub import Hub, ScopeManager
 from sentry_sdk.scope import Scope
 
 from sentry_sdk._types import MYPY
@@ -145,7 +145,7 @@ def configure_scope(
 
 @overload  # noqa
 def push_scope():
-    # type: () -> ContextManager[Scope]
+    # type: () -> ScopeManager
     pass
 
 
@@ -161,7 +161,7 @@ def push_scope(
 def push_scope(
     callback=None  # type: Optional[Callable[[Scope], None]]
 ):
-    # type: (...) -> Optional[ContextManager[Scope]]
+    # type: (...) -> Optional[ScopeManager]
     hub = Hub.current
     if hub is not None:
         return hub.push_scope(callback)

--- a/sentry_sdk/api.py
+++ b/sentry_sdk/api.py
@@ -8,6 +8,7 @@ from sentry_sdk._types import MYPY
 
 if MYPY:
     from typing import Any
+    from typing import Dict
     from typing import Optional
     from typing import overload
     from typing import Callable
@@ -36,6 +37,10 @@ __all__ = [
     "flush",
     "last_event_id",
     "start_span",
+    "set_tag",
+    "set_extra",
+    "set_user",
+    "set_level",
 ]
 
 
@@ -44,6 +49,15 @@ def hubmethod(f):
     f.__doc__ = "%s\n\n%s" % (
         "Alias for :py:meth:`sentry_sdk.Hub.%s`" % f.__name__,
         inspect.getdoc(getattr(Hub, f.__name__)),
+    )
+    return f
+
+
+def scopemethod(f):
+    # type: (F) -> F
+    f.__doc__ = "%s\n\n%s" % (
+        "Alias for :py:meth:`sentry_sdk.Scope.%s`" % f.__name__,
+        inspect.getdoc(getattr(Scope, f.__name__)),
     )
     return f
 
@@ -161,6 +175,38 @@ def push_scope(
     else:
         # returned if user provided callback
         return None
+
+
+@scopemethod  # noqa
+def set_tag(key, value):
+    # type: (str, Any) -> None
+    hub = Hub.current
+    if hub is not None:
+        hub.current_scope.set_tag(key, value)
+
+
+@scopemethod  # noqa
+def set_extra(key, value):
+    # type: (str, Any) -> None
+    hub = Hub.current
+    if hub is not None:
+        hub.current_scope.set_extra(key, value)
+
+
+@scopemethod  # noqa
+def set_user(value):
+    # type: (Dict[str, Any]) -> None
+    hub = Hub.current
+    if hub is not None:
+        hub.current_scope.set_user(value)
+
+
+@scopemethod  # noqa
+def set_level(value):
+    # type: (str) -> None
+    hub = Hub.current
+    if hub is not None:
+        hub.current_scope.set_level(value)
 
 
 @hubmethod

--- a/sentry_sdk/hub.py
+++ b/sentry_sdk/hub.py
@@ -1,10 +1,9 @@
 import copy
-import functools
 import random
 import sys
 
 from datetime import datetime
-from contextlib import contextmanager
+from contextlib import ContextDecorator, contextmanager
 
 from sentry_sdk._compat import with_metaclass
 from sentry_sdk.scope import Scope
@@ -124,7 +123,7 @@ class HubMeta(type):
         return GLOBAL_HUB
 
 
-class _PushScopeContextDecorator(object):
+class _PushScopeContextDecorator(ContextDecorator):
     def __init__(self, hub):
         # type: (Hub) -> None
         self._hub = hub
@@ -142,16 +141,6 @@ class _PushScopeContextDecorator(object):
     def __exit__(self, exc_type, exc_val, exc_tb):
         # type: (Any, Any, Any) -> None
         self._scope_manager_instance.__exit__(exc_type, exc_val, exc_tb)
-
-    def __call__(self, f):
-        # type: (Callable[..., Any]) -> Callable[..., None]
-        @functools.wraps(f)
-        def decorated(*args, **kwargs):
-            # type: (*Any, **Any) -> Any
-            with self:
-                return f(*args, **kwargs)
-
-        return decorated
 
 
 class _ScopeManager(object):

--- a/sentry_sdk/hub.py
+++ b/sentry_sdk/hub.py
@@ -3,9 +3,9 @@ import random
 import sys
 
 from datetime import datetime
-from contextlib import ContextDecorator, contextmanager
+from contextlib import contextmanager
 
-from sentry_sdk._compat import with_metaclass
+from sentry_sdk._compat import with_metaclass, ContextDecorator
 from sentry_sdk.scope import Scope
 from sentry_sdk.client import Client
 from sentry_sdk.tracing import Span
@@ -123,7 +123,7 @@ class HubMeta(type):
         return GLOBAL_HUB
 
 
-class _ScopeManager(ContextDecorator):
+class ScopeManager(ContextDecorator):
     def __init__(self, hub):
         # type: (Hub) -> None
         self._hub = hub
@@ -459,7 +459,7 @@ class Hub(with_metaclass(HubMeta)):  # type: ignore
     def push_scope(
         self, callback=None  # type: Optional[None]
     ):
-        # type: (...) -> _ScopeManager
+        # type: (...) -> ScopeManager
         pass
 
     @overload  # noqa
@@ -472,7 +472,7 @@ class Hub(with_metaclass(HubMeta)):  # type: ignore
     def push_scope(  # noqa
         self, callback=None  # type: Optional[Callable[[Scope], None]]
     ):
-        # type: (...) -> Optional[_ScopeManager]
+        # type: (...) -> Optional[ScopeManager]
         """
         Pushes a new layer on the scope stack.
 
@@ -488,7 +488,7 @@ class Hub(with_metaclass(HubMeta)):  # type: ignore
                 callback(scope)
             return None
 
-        return _ScopeManager(self)
+        return ScopeManager(self)
 
     scope = push_scope
 

--- a/sentry_sdk/hub.py
+++ b/sentry_sdk/hub.py
@@ -459,7 +459,7 @@ class Hub(with_metaclass(HubMeta)):  # type: ignore
     def push_scope(
         self, callback=None  # type: Optional[None]
     ):
-        # type: (...) -> ContextManager[Scope]
+        # type: (...) -> _ScopeManager
         pass
 
     @overload  # noqa
@@ -472,7 +472,7 @@ class Hub(with_metaclass(HubMeta)):  # type: ignore
     def push_scope(  # noqa
         self, callback=None  # type: Optional[Callable[[Scope], None]]
     ):
-        # type: (...) -> Optional[ContextDecorator[Scope]]
+        # type: (...) -> Optional[_ScopeManager]
         """
         Pushes a new layer on the scope stack.
 

--- a/sentry_sdk/scope.py
+++ b/sentry_sdk/scope.py
@@ -124,6 +124,12 @@ class Scope(object):
         self._level = value
 
     @_attr_setter
+    def set_level(self, value):
+        # type: (Optional[str]) -> None
+        """When set this overrides the level."""
+        self._level = value
+
+    @_attr_setter
     def fingerprint(self, value):
         # type: (Optional[List[str]]) -> None
         """When set this overrides the default fingerprint."""
@@ -140,6 +146,12 @@ class Scope(object):
 
     @_attr_setter
     def user(self, value):
+        # type: (Dict[str, Any]) -> None
+        """When set a specific user is bound to the scope."""
+        self._user = value
+
+    @_attr_setter
+    def set_user(self, value):
         # type: (Dict[str, Any]) -> None
         """When set a specific user is bound to the scope."""
         self._user = value

--- a/sentry_sdk/scope.py
+++ b/sentry_sdk/scope.py
@@ -123,7 +123,6 @@ class Scope(object):
         """When set this overrides the level."""
         self._level = value
 
-    @_attr_setter
     def set_level(self, value):
         # type: (Optional[str]) -> None
         """When set this overrides the level."""
@@ -150,7 +149,6 @@ class Scope(object):
         """When set a specific user is bound to the scope."""
         self._user = value
 
-    @_attr_setter
     def set_user(self, value):
         # type: (Dict[str, Any]) -> None
         """When set a specific user is bound to the scope."""

--- a/sentry_sdk/utils.py
+++ b/sentry_sdk/utils.py
@@ -7,7 +7,7 @@ import logging
 from datetime import datetime
 
 import sentry_sdk
-from sentry_sdk._compat import urlparse, text_type, implements_str, PY2
+from sentry_sdk._compat import urlparse, text_type, implements_str, PY2, iteritems
 
 from sentry_sdk._types import MYPY
 
@@ -824,10 +824,10 @@ def push_scope_decorator(user=None, level=None, tags=None, extras=None):
                 if level:
                     current_scope.level = level
                 if tags:
-                    for key, value in tags.iteritems():
+                    for key, value in iteritems(tags):
                         current_scope.set_tag(key, value)
                 if extras:
-                    for key, value in extras.iteritems():
+                    for key, value in iteritems(extras):
                         current_scope.set_extra(key, value)
                 f(*args, **kwargs)
         return __inner

--- a/sentry_sdk/utils.py
+++ b/sentry_sdk/utils.py
@@ -801,10 +801,11 @@ disable_capture_event = ContextVar("disable_capture_event")
 
 
 def push_scope_decorator(user=None, level=None, tags=None, extras=None):
+    # type: (Optional[Dict[str, str]], Optional[str], Optional[Dict[str, str]], Optional[Dict[str, str]]) -> Callable[..., Any]  # noqa
     """
     Wrap function in a push_scope.
     :param user: dictionary containing id, username, email, and/or ip_address attributes.
-    :param level: (str) scope level (e.g. 'error')
+    :param level: scope level (e.g. 'error')
     :param tags: dictionary of key/value pairs for scope tags
     :param extras: dictionary of key/value pairs for scope extras
     :return: A proxy method that wraps the decorated function in a usage of the push_scope
@@ -816,8 +817,10 @@ def push_scope_decorator(user=None, level=None, tags=None, extras=None):
         raise Exception("extra must be a dictionary")
 
     def create_sentry_push_scope(f):
+        # type: (Callable[..., Any]) -> Callable[..., None]
         @functools.wraps(f)
         def __inner(*args, **kwargs):
+            # type: (*Any, **Any) -> None
             with sentry_sdk.push_scope() as current_scope:
                 if user:
                     current_scope.user = user
@@ -830,5 +833,7 @@ def push_scope_decorator(user=None, level=None, tags=None, extras=None):
                     for key, value in iteritems(extras):
                         current_scope.set_extra(key, value)
                 f(*args, **kwargs)
+
         return __inner
+
     return create_sentry_push_scope

--- a/sentry_sdk/utils.py
+++ b/sentry_sdk/utils.py
@@ -1,4 +1,3 @@
-import functools
 import os
 import sys
 import linecache
@@ -7,7 +6,7 @@ import logging
 from datetime import datetime
 
 import sentry_sdk
-from sentry_sdk._compat import urlparse, text_type, implements_str, PY2, iteritems
+from sentry_sdk._compat import urlparse, text_type, implements_str, PY2
 
 from sentry_sdk._types import MYPY
 
@@ -798,42 +797,3 @@ def transaction_from_function(func):
 
 
 disable_capture_event = ContextVar("disable_capture_event")
-
-
-def push_scope_decorator(user=None, level=None, tags=None, extras=None):
-    # type: (Optional[Dict[str, str]], Optional[str], Optional[Dict[str, str]], Optional[Dict[str, str]]) -> Callable[..., Any]  # noqa
-    """
-    Wrap function in a push_scope.
-    :param user: dictionary containing id, username, email, and/or ip_address attributes.
-    :param level: scope level (e.g. 'error')
-    :param tags: dictionary of key/value pairs for scope tags
-    :param extras: dictionary of key/value pairs for scope extras
-    :return: A proxy method that wraps the decorated function in a usage of the push_scope
-    context manager.
-    """
-    if tags is not None and type(tags) is not dict:
-        raise Exception("tags must be a dictionary")
-    if extras is not None and type(extras) is not dict:
-        raise Exception("extra must be a dictionary")
-
-    def create_sentry_push_scope(f):
-        # type: (Callable[..., Any]) -> Callable[..., None]
-        @functools.wraps(f)
-        def __inner(*args, **kwargs):
-            # type: (*Any, **Any) -> None
-            with sentry_sdk.push_scope() as current_scope:
-                if user:
-                    current_scope.user = user
-                if level:
-                    current_scope.level = level
-                if tags:
-                    for key, value in iteritems(tags):
-                        current_scope.set_tag(key, value)
-                if extras:
-                    for key, value in iteritems(extras):
-                        current_scope.set_extra(key, value)
-                f(*args, **kwargs)
-
-        return __inner
-
-    return create_sentry_push_scope

--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -240,23 +240,6 @@ def test_client_initialized_within_scope(sentry_init, caplog):
     assert record.msg.startswith("init() called inside of pushed scope.")
 
 
-def test_scope_leaks_cleaned_up(sentry_init, caplog):
-    caplog.set_level(logging.WARNING)
-
-    sentry_init(debug=True)
-
-    old_stack = list(Hub.current._stack)
-
-    with push_scope():
-        push_scope()
-
-    assert Hub.current._stack == old_stack
-
-    record, = (x for x in caplog.records if x.levelname == "WARNING")
-
-    assert record.message.startswith("Leaked 1 scopes:")
-
-
 def test_scope_popped_too_soon(sentry_init, caplog):
     caplog.set_level(logging.ERROR)
 


### PR DESCRIPTION
Currently the only way to temporarily modify sentry scope attributes (user, level, tag, extra) for a function's scope is to call the function within a use of the push_scope context manager. To streamline this operation, this pull request modifies the ScopeManager class to act as both a context manager and a decorator. In order to make scope attribute modifications possible, sentry_sdk/api.py now has the scope attribute setters: set_tag, set_extra, set_user, and set_level. These setters will apply scope attribute changes to the current scope/scope layer.