### PR TITLE
feat: aiohttp request body

### DIFF
--- a/sentry_sdk/integrations/aiohttp.py
+++ b/sentry_sdk/integrations/aiohttp.py
@@ -156,6 +156,9 @@ def _capture_exception(hub):
     return exc_info
 
 
+BODY_NOT_READ_MESSAGE = "[Can't show request body due to implementation details.]"
+
+
 def get_aiohttp_request_data(request):
     # type: (Request) -> Optional[str]
     bytes_body = request._read_bytes
@@ -167,7 +170,7 @@ def get_aiohttp_request_data(request):
 
     if request.can_read_body:
         # body exists but we can't show it
-        return "[Can't show request body due to implementation details.]"
+        return BODY_NOT_READ_MESSAGE
 
     # request has no body
     return None

--- a/sentry_sdk/integrations/aiohttp.py
+++ b/sentry_sdk/integrations/aiohttp.py
@@ -136,6 +136,7 @@ def _make_request_processor(weak_request):
                 _filter_headers(dict(request.headers)),
                 should_repr_strings=False,
             )
+            request_info["data"] = get_aiohttp_request_data(request)
 
         return event
 
@@ -152,3 +153,10 @@ def _capture_exception(hub):
     )
     hub.capture_event(event, hint=hint)
     return exc_info
+
+
+def get_aiohttp_request_data(request):
+    # type: (Request) -> str
+    bytes_body = request._read_bytes or b""
+    encoding = request.charset or "utf-8"
+    return bytes_body.decode(encoding)

--- a/sentry_sdk/integrations/aiohttp.py
+++ b/sentry_sdk/integrations/aiohttp.py
@@ -24,6 +24,7 @@ if MYPY:
     from aiohttp.abc import AbstractMatchInfo
     from typing import Any
     from typing import Dict
+    from typing import Optional
     from typing import Tuple
     from typing import Callable
 
@@ -156,7 +157,17 @@ def _capture_exception(hub):
 
 
 def get_aiohttp_request_data(request):
-    # type: (Request) -> str
-    bytes_body = request._read_bytes or b""
-    encoding = request.charset or "utf-8"
-    return bytes_body.decode(encoding)
+    # type: (Request) -> Optional[str]
+    bytes_body = request._read_bytes
+
+    if bytes_body is not None:
+        # we have body to show
+        encoding = request.charset or "utf-8"
+        return bytes_body.decode(encoding)
+
+    if request.can_read_body:
+        # body exists but we can't show it
+        return "[Can't show request body due to implementation details.]"
+
+    # request has no body
+    return None

--- a/tests/integrations/aiohttp/test_aiohttp.py
+++ b/tests/integrations/aiohttp/test_aiohttp.py
@@ -1,3 +1,5 @@
+import json
+
 from aiohttp import web
 
 from sentry_sdk.integrations.aiohttp import AioHttpIntegration
@@ -33,6 +35,7 @@ async def test_basic(sentry_init, aiohttp_client, loop, capture_events):
     assert request["env"] == {"REMOTE_ADDR": "127.0.0.1"}
     assert request["method"] == "GET"
     assert request["query_string"] == ""
+    assert request["data"] is None
     assert request["url"] == "http://{host}/".format(host=host)
     assert request["headers"] == {
         "Accept": "*/*",
@@ -40,6 +43,59 @@ async def test_basic(sentry_init, aiohttp_client, loop, capture_events):
         "Host": host,
         "User-Agent": request["headers"]["User-Agent"],
     }
+
+
+async def test_post_body_not_read(sentry_init, aiohttp_client, loop, capture_events):
+    sentry_init(integrations=[AioHttpIntegration()])
+
+    async def hello(request):
+        1 / 0
+
+    app = web.Application()
+    app.router.add_post("/", hello)
+
+    events = capture_events()
+
+    client = await aiohttp_client(app)
+    resp = await client.post("/")
+    assert resp.status == 500
+
+    event, = events
+    exception, = event["exception"]["values"]
+    assert exception["type"] == "ZeroDivisionError"
+    request = event["request"]
+
+    assert request["env"] == {"REMOTE_ADDR": "127.0.0.1"}
+    assert request["method"] == "POST"
+    assert request["data"] == "[Can't show request body due to implementation details.]"
+
+
+async def test_post_body_read(sentry_init, aiohttp_client, loop, capture_events):
+    sentry_init(integrations=[AioHttpIntegration()])
+
+    body = {"some": "value"}
+
+    async def hello(request):
+        data = await request.json()
+        1 / 0
+
+    app = web.Application()
+    app.router.add_post("/", hello)
+
+    events = capture_events()
+
+    client = await aiohttp_client(app)
+    resp = await client.post("/", json=body)
+    assert resp.status == 500
+
+    event, = events
+    exception, = event["exception"]["values"]
+    assert exception["type"] == "ZeroDivisionError"
+    request = event["request"]
+
+    assert request["env"] == {"REMOTE_ADDR": "127.0.0.1"}
+    assert request["method"] == "POST"
+    assert request["data"] == json.loads(body)
 
 
 async def test_403_not_captured(sentry_init, aiohttp_client, loop, capture_events):


### PR DESCRIPTION
Partially fixes https://github.com/getsentry/sentry-python/issues/220
In case if the request body has been read at least once, we have it in the `request._read_bytes` attribute. It allows us simply access it from non-async code.