### PR TITLE
fix: Do not unnecessarily ignore tornado.application logger

### DIFF
--- a/sentry_sdk/integrations/tornado.py
+++ b/sentry_sdk/integrations/tornado.py
@@ -50,7 +50,6 @@ class TornadoIntegration(Integration):
                 "The tornado integration for Sentry requires Python 3.6+ or the aiocontextvars package"
             )
 
-        ignore_logger("tornado.application")
         ignore_logger("tornado.access")
 
         old_execute = RequestHandler._execute

--- a/tests/integrations/tornado/test_tornado.py
+++ b/tests/integrations/tornado/test_tornado.py
@@ -54,6 +54,7 @@ def test_basic(tornado_testcase, sentry_init, capture_events):
     event, = events
     exception, = event["exception"]["values"]
     assert exception["type"] == "ZeroDivisionError"
+    assert exception["mechanism"]["type"] == "tornado"
 
     request = event["request"]
     host = request["headers"]["Host"]


### PR DESCRIPTION
Fix #553 