### PR TITLE
Fix 'asyncio.CancelledError' capturing for 'AioHttpIntegration'

### DIFF
--- a/sentry_sdk/integrations/aiohttp.py
+++ b/sentry_sdk/integrations/aiohttp.py
@@ -82,6 +82,8 @@ class AioHttpIntegration(Integration):
                         except HTTPException as e:
                             span.set_http_status(e.status_code)
                             raise
+                        except asyncio.CancelledError:
+                            raise
                         except Exception:
                             # This will probably map to a 500 but seems like we
                             # have no way to tell. Do not set span status.

--- a/sentry_sdk/integrations/aiohttp.py
+++ b/sentry_sdk/integrations/aiohttp.py
@@ -83,6 +83,7 @@ class AioHttpIntegration(Integration):
                             span.set_http_status(e.status_code)
                             raise
                         except asyncio.CancelledError:
+                            span.set_status("cancelled")
                             raise
                         except Exception:
                             # This will probably map to a 500 but seems like we

--- a/tests/integrations/aiohttp/test_aiohttp.py
+++ b/tests/integrations/aiohttp/test_aiohttp.py
@@ -1,6 +1,9 @@
+import asyncio
 import json
+from contextlib import suppress
 
 from aiohttp import web
+from aiohttp.client import ServerDisconnectedError
 
 from sentry_sdk.integrations.aiohttp import AioHttpIntegration
 
@@ -116,6 +119,26 @@ async def test_403_not_captured(sentry_init, aiohttp_client, loop, capture_event
     client = await aiohttp_client(app)
     resp = await client.get("/")
     assert resp.status == 403
+
+    assert not events
+
+
+async def test_cancelled_error_not_captured(sentry_init, aiohttp_client, loop, capture_events):
+    sentry_init(integrations=[AioHttpIntegration()])
+
+    async def hello(request):
+        raise asyncio.CancelledError()
+
+    app = web.Application()
+    app.router.add_get("/", hello)
+
+    events = capture_events()
+    client = await aiohttp_client(app)
+
+    with suppress(ServerDisconnectedError):
+        # Intended `aiohttp` interaction: server will disconnect if it
+        # encounters `asyncio.CancelledError`
+        await client.get("/")
 
     assert not events
 

--- a/tests/integrations/aiohttp/test_aiohttp.py
+++ b/tests/integrations/aiohttp/test_aiohttp.py
@@ -123,7 +123,9 @@ async def test_403_not_captured(sentry_init, aiohttp_client, loop, capture_event
     assert not events
 
 
-async def test_cancelled_error_not_captured(sentry_init, aiohttp_client, loop, capture_events):
+async def test_cancelled_error_not_captured(
+    sentry_init, aiohttp_client, loop, capture_events
+):
     sentry_init(integrations=[AioHttpIntegration()])
 
     async def hello(request):


### PR DESCRIPTION
This PR disables capturing of `asyncio.CancelledError` in `AioHttpIntegration`.

`aiohttp` will raise `asyncio.CancelledError` if clients interrupt request ([ref.](https://aiohttp.readthedocs.io/en/stable/web_advanced.html#web-handler-cancellation)) and this behaviour is considered normal.

In the meanwhile, such aborted requests are getting captured:

<img width="481" alt="Screen Shot 2019-12-03 at 5 35 35 PM" src="https://user-images.githubusercontent.com/8746283/70062437-11535200-15f7-11ea-80f2-e1ee0730d20e.png">
