### PR TITLE
fix(apm): Continuation of a trace from another span should use its span id as the parent span id

### DIFF
--- a/sentry_sdk/tracing.py
+++ b/sentry_sdk/tracing.py
@@ -236,7 +236,7 @@ class Span(object):
         else:
             sampled = None
 
-        return cls(trace_id=trace_id, span_id=span_id, sampled=sampled)
+        return cls(trace_id=trace_id, parent_span_id=span_id, sampled=sampled)
 
     def to_traceparent(self):
         # type: () -> str

--- a/sentry_sdk/tracing.py
+++ b/sentry_sdk/tracing.py
@@ -205,7 +205,8 @@ class Span(object):
         parent = cls.from_traceparent(headers.get("sentry-trace"))
         if parent is None:
             return cls()
-        return parent.new_span(same_process_as_parent=False)
+        parent.same_process_as_parent=False
+        return parent
 
     def iter_headers(self):
         # type: () -> Generator[Tuple[str, str], None, None]

--- a/sentry_sdk/tracing.py
+++ b/sentry_sdk/tracing.py
@@ -205,7 +205,7 @@ class Span(object):
         parent = cls.from_traceparent(headers.get("sentry-trace"))
         if parent is None:
             return cls()
-        parent.same_process_as_parent=False
+        parent.same_process_as_parent = False
         return parent
 
     def iter_headers(self):

--- a/tests/test_tracing.py
+++ b/tests/test_tracing.py
@@ -59,6 +59,7 @@ def test_continue_from_headers(sentry_init, capture_events, sampled):
     assert span is not None
     assert span.sampled == sampled
     assert span.trace_id == old_span.trace_id
+    assert span.same_process_as_parent == False
     assert span.parent_span_id == old_span.span_id
     assert span.span_id != old_span.span_id
 

--- a/tests/test_tracing.py
+++ b/tests/test_tracing.py
@@ -59,7 +59,7 @@ def test_continue_from_headers(sentry_init, capture_events, sampled):
     assert span is not None
     assert span.sampled == sampled
     assert span.trace_id == old_span.trace_id
-    assert span.same_process_as_parent == False
+    assert span.same_process_as_parent is False
     assert span.parent_span_id == old_span.span_id
     assert span.span_id != old_span.span_id
 

--- a/tests/test_tracing.py
+++ b/tests/test_tracing.py
@@ -59,6 +59,8 @@ def test_continue_from_headers(sentry_init, capture_events, sampled):
     assert span is not None
     assert span.sampled == sampled
     assert span.trace_id == old_span.trace_id
+    assert span.parent_span_id == old_span.span_id
+    assert span.span_id != old_span.span_id
 
     with Hub.current.start_span(span):
         with Hub.current.configure_scope() as scope:


### PR DESCRIPTION
Correction based on what I see on the JS SDK:

https://github.com/getsentry/sentry-javascript/blob/01cac4ff6c09d7cf4b5e9d6cf595b095a8d036f3/packages/apm/src/span.ts#L202-L207

------

The incorrect mapping (red arrows) I found from my local development. The blue arrow is the supposedly correct mapping.

<img width="1440" alt="Screen Shot 2019-12-03 at 11 04 51 PM copy" src="https://user-images.githubusercontent.com/139499/70111982-f8ac6180-1621-11ea-9de2-8da609125304.png">

## TODO

- [x] test?