### PR TITLE
fix: Make contextvars-detection more readable

### DIFF
--- a/sentry_sdk/utils.py
+++ b/sentry_sdk/utils.py
@@ -748,11 +748,20 @@ def _get_contextvars():
     https://github.com/gevent/gevent/issues/1407
     """
     if not _is_threading_local_monkey_patched():
+        # aiocontextvars is a PyPI package that ensures that the contextvars
+        # backport (also a PyPI package) works with asyncio under Python 3.6
+        #
+        # Import it if available.
+        if not PY2 and sys.version_info < (3, 7):
+            try:
+                from aiocontextvars import ContextVar  # noqa
+
+                return True, ContextVar
+            except ImportError:
+                pass
+
         try:
             from contextvars import ContextVar
-
-            if not PY2 and sys.version_info < (3, 7):
-                import aiocontextvars  # noqa
 
             return True, ContextVar
         except ImportError:


### PR DESCRIPTION
@rhcarvalho and I were guessing at how the code actually worked. It seemed like it only did so accidentally because the import of `aiocontextvars` has the side effect of monkeypatching `contextvars` (the PyPI package, not the stdlib module!) which is one of its dependencies.