### PR TITLE
improvement: add celery task_id into tags

### DIFF
--- a/sentry_sdk/integrations/celery.py
+++ b/sentry_sdk/integrations/celery.py
@@ -169,6 +169,8 @@ def _make_event_processor(task, uuid, args, kwargs, request=None):
         # type: (Event, Hint) -> Optional[Event]
 
         with capture_internal_exceptions():
+            tags = event.setdefault("tags", {})
+            tags["celery_task_id"] = uuid
             extra = event.setdefault("extra", {})
             extra["celery-job"] = {
                 "task_name": task.name,

--- a/tests/integrations/celery/test_celery.py
+++ b/tests/integrations/celery/test_celery.py
@@ -83,6 +83,7 @@ def test_simple(capture_events, celery, celery_invocation):
     assert event["contexts"]["trace"]["trace_id"] == span.trace_id
     assert event["contexts"]["trace"]["span_id"] != span.span_id
     assert event["transaction"] == "dummy_task"
+    assert "celery_task_id" in event["tags"]
     assert event["extra"]["celery-job"] == dict(
         task_name="dummy_task", **expected_context
     )


### PR DESCRIPTION
Reference to issue: https://github.com/getsentry/sentry-python/issues/552

The task id is very useful for debugging celery tasks. I add it by using `set_tag`.