### PR TITLE
feat: Auto-enabling integrations behind feature flag

### DIFF
--- a/docs-requirements.txt
+++ b/docs-requirements.txt
@@ -1,3 +1,4 @@
 sphinx==2.3.1
 sphinx-rtd-theme
 sphinx-autodoc-typehints[type_comments]>=1.8.0
+typing-extensions

--- a/sentry_sdk/client.py
+++ b/sentry_sdk/client.py
@@ -107,7 +107,7 @@ class _Client(object):
                 self.options["integrations"],
                 with_defaults=self.options["default_integrations"],
                 with_auto_enabling_integrations=self.options["_experiments"].get(
-                    "auto_enabling_integrations"
+                    "auto_enabling_integrations", False
                 ),
             )
         finally:

--- a/sentry_sdk/client.py
+++ b/sentry_sdk/client.py
@@ -106,6 +106,9 @@ class _Client(object):
             self.integrations = setup_integrations(
                 self.options["integrations"],
                 with_defaults=self.options["default_integrations"],
+                with_auto_enabling_integrations=self.options["_experiments"].get(
+                    "auto_enabling_integrations"
+                ),
             )
         finally:
             _client_init_debug.set(old_debug)

--- a/sentry_sdk/consts.py
+++ b/sentry_sdk/consts.py
@@ -9,11 +9,26 @@ if MYPY:
     from typing import Dict
     from typing import Any
     from typing import Sequence
+    from mypy_extensions import TypedDict
 
     from sentry_sdk.transport import Transport
     from sentry_sdk.integrations import Integration
 
     from sentry_sdk._types import Event, EventProcessor, BreadcrumbProcessor
+
+    # Experiments are feature flags to enable and disable certain unstable SDK
+    # functionality. Changing them from the defaults (`None`) in production
+    # code is highly discouraged. They are not subject to any stability
+    # guarantees such as the ones from semantic versioning.
+    Experiments = TypedDict(
+        "Experiments",
+        {
+            "max_spans": Optional[int],
+            "record_sql_params": Optional[bool],
+            "auto_enabling_integrations": Optional[bool],
+        },
+        total=False,
+    )
 
 
 # This type exists to trick mypy and PyCharm into thinking `init` and `Client`
@@ -49,7 +64,7 @@ class ClientConstructor(object):
         # DO NOT ENABLE THIS RIGHT NOW UNLESS YOU WANT TO EXCEED YOUR EVENT QUOTA IMMEDIATELY
         traces_sample_rate=0.0,  # type: float
         traceparent_v2=False,  # type: bool
-        _experiments={},  # type: Dict[str, Any]  # noqa: B006
+        _experiments={},  # type: Experiments  # noqa: B006
     ):
         # type: (...) -> None
         pass

--- a/sentry_sdk/consts.py
+++ b/sentry_sdk/consts.py
@@ -9,7 +9,7 @@ if MYPY:
     from typing import Dict
     from typing import Any
     from typing import Sequence
-    from mypy_extensions import TypedDict
+    from typing_extensions import TypedDict
 
     from sentry_sdk.transport import Transport
     from sentry_sdk.integrations import Integration

--- a/sentry_sdk/integrations/__init__.py
+++ b/sentry_sdk/integrations/__init__.py
@@ -52,6 +52,20 @@ def _generate_default_integrations_iterator(integrations, auto_enabling_integrat
     return iter_default_integrations
 
 
+_AUTO_ENABLING_INTEGRATIONS = (
+    "sentry_sdk.integrations.django.DjangoIntegration",
+    "sentry_sdk.integrations.flask.FlaskIntegration",
+    "sentry_sdk.integrations.bottle.BottleIntegration",
+    "sentry_sdk.integrations.falcon.FalconIntegration",
+    "sentry_sdk.integrations.sanic.SanicIntegration",
+    "sentry_sdk.integrations.celery.CeleryIntegration",
+    "sentry_sdk.integrations.rq.RqIntegration",
+    "sentry_sdk.integrations.aiohttp.AioHttpIntegration",
+    "sentry_sdk.integrations.tornado.TornadoIntegration",
+    "sentry_sdk.integrations.sqlalchemy.SqlalchemyIntegration",
+)
+
+
 iter_default_integrations = _generate_default_integrations_iterator(
     integrations=(
         # stdlib/base runtime integrations
@@ -64,19 +78,7 @@ iter_default_integrations = _generate_default_integrations_iterator(
         "sentry_sdk.integrations.argv.ArgvIntegration",
         "sentry_sdk.integrations.threading.ThreadingIntegration",
     ),
-    auto_enabling_integrations=(
-        # "auto-enabling" integrations
-        "sentry_sdk.integrations.django.DjangoIntegration",
-        "sentry_sdk.integrations.flask.FlaskIntegration",
-        "sentry_sdk.integrations.bottle.BottleIntegration",
-        "sentry_sdk.integrations.falcon.FalconIntegration",
-        "sentry_sdk.integrations.sanic.SanicIntegration",
-        "sentry_sdk.integrations.celery.CeleryIntegration",
-        "sentry_sdk.integrations.rq.RqIntegration",
-        "sentry_sdk.integrations.aiohttp.AioHttpIntegration",
-        "sentry_sdk.integrations.tornado.TornadoIntegration",
-        "sentry_sdk.integrations.sqlalchemy.SqlalchemyIntegration",
-    ),
+    auto_enabling_integrations=_AUTO_ENABLING_INTEGRATIONS,
 )
 
 del _generate_default_integrations_iterator

--- a/sentry_sdk/integrations/__init__.py
+++ b/sentry_sdk/integrations/__init__.py
@@ -9,53 +9,83 @@ from sentry_sdk.utils import logger
 from sentry_sdk._types import MYPY
 
 if MYPY:
-    from typing import Iterator
+    from typing import Callable
     from typing import Dict
+    from typing import Iterator
     from typing import List
     from typing import Set
+    from typing import Tuple
     from typing import Type
-    from typing import Callable
 
 
 _installer_lock = Lock()
 _installed_integrations = set()  # type: Set[str]
 
 
-def _generate_default_integrations_iterator(*import_strings):
-    # type: (*str) -> Callable[[], Iterator[Type[Integration]]]
-    def iter_default_integrations():
-        # type: () -> Iterator[Type[Integration]]
+def _generate_default_integrations_iterator(integrations, auto_enabling_integrations):
+    # type: (Tuple[str, ...], Tuple[str, ...]) -> Callable[[bool], Iterator[Type[Integration]]]
+
+    def iter_default_integrations(with_auto_enabling_integrations):
+        # type: (bool) -> Iterator[Type[Integration]]
         """Returns an iterator of the default integration classes:
         """
         from importlib import import_module
 
-        for import_string in import_strings:
-            module, cls = import_string.rsplit(".", 1)
-            yield getattr(import_module(module), cls)
+        if with_auto_enabling_integrations:
+            all_import_strings = integrations + auto_enabling_integrations
+        else:
+            all_import_strings = integrations
+
+        for import_string in all_import_strings:
+            try:
+                module, cls = import_string.rsplit(".", 1)
+                yield getattr(import_module(module), cls)
+            except (DidNotEnable, SyntaxError) as e:
+                logger.debug(
+                    "Did not import default integration %s: %s", import_string, e
+                )
 
     if isinstance(iter_default_integrations.__doc__, str):
-        for import_string in import_strings:
+        for import_string in integrations:
             iter_default_integrations.__doc__ += "\n- `{}`".format(import_string)
 
     return iter_default_integrations
 
 
 iter_default_integrations = _generate_default_integrations_iterator(
-    "sentry_sdk.integrations.logging.LoggingIntegration",
-    "sentry_sdk.integrations.stdlib.StdlibIntegration",
-    "sentry_sdk.integrations.excepthook.ExcepthookIntegration",
-    "sentry_sdk.integrations.dedupe.DedupeIntegration",
-    "sentry_sdk.integrations.atexit.AtexitIntegration",
-    "sentry_sdk.integrations.modules.ModulesIntegration",
-    "sentry_sdk.integrations.argv.ArgvIntegration",
-    "sentry_sdk.integrations.threading.ThreadingIntegration",
+    integrations=(
+        # stdlib/base runtime integrations
+        "sentry_sdk.integrations.logging.LoggingIntegration",
+        "sentry_sdk.integrations.stdlib.StdlibIntegration",
+        "sentry_sdk.integrations.excepthook.ExcepthookIntegration",
+        "sentry_sdk.integrations.dedupe.DedupeIntegration",
+        "sentry_sdk.integrations.atexit.AtexitIntegration",
+        "sentry_sdk.integrations.modules.ModulesIntegration",
+        "sentry_sdk.integrations.argv.ArgvIntegration",
+        "sentry_sdk.integrations.threading.ThreadingIntegration",
+    ),
+    auto_enabling_integrations=(
+        # "auto-enabling" integrations
+        "sentry_sdk.integrations.django.DjangoIntegration",
+        "sentry_sdk.integrations.flask.FlaskIntegration",
+        "sentry_sdk.integrations.bottle.BottleIntegration",
+        "sentry_sdk.integrations.falcon.FalconIntegration",
+        "sentry_sdk.integrations.sanic.SanicIntegration",
+        "sentry_sdk.integrations.celery.CeleryIntegration",
+        "sentry_sdk.integrations.rq.RqIntegration",
+        "sentry_sdk.integrations.aiohttp.AioHttpIntegration",
+        "sentry_sdk.integrations.tornado.TornadoIntegration",
+        "sentry_sdk.integrations.sqlalchemy.SqlalchemyIntegration",
+    ),
 )
 
 del _generate_default_integrations_iterator
 
 
-def setup_integrations(integrations, with_defaults=True):
-    # type: (List[Integration], bool) -> Dict[str, Integration]
+def setup_integrations(
+    integrations, with_defaults=True, with_auto_enabling_integrations=False
+):
+    # type: (List[Integration], bool, bool) -> Dict[str, Integration]
     """Given a list of integration instances this installs them all.  When
     `with_defaults` is set to `True` then all default integrations are added
     unless they were already provided before.
@@ -66,11 +96,17 @@ def setup_integrations(integrations, with_defaults=True):
 
     logger.debug("Setting up integrations (with default = %s)", with_defaults)
 
+    # Integrations that are not explicitly set up by the user.
+    used_as_default_integration = set()
+
     if with_defaults:
-        for integration_cls in iter_default_integrations():
+        for integration_cls in iter_default_integrations(
+            with_auto_enabling_integrations
+        ):
             if integration_cls.identifier not in integrations:
                 instance = integration_cls()
                 integrations[instance.identifier] = instance
+                used_as_default_integration.add(instance.identifier)
 
     for identifier, integration in iteritems(integrations):
         with _installer_lock:
@@ -90,12 +126,30 @@ def setup_integrations(integrations, with_defaults=True):
                         integration.install()
                     else:
                         raise
+                except DidNotEnable as e:
+                    if identifier not in used_as_default_integration:
+                        raise
+
+                    logger.debug(
+                        "Did not enable default integration %s: %s", identifier, e
+                    )
+
                 _installed_integrations.add(identifier)
 
     for identifier in integrations:
         logger.debug("Enabling integration %s", identifier)
 
     return integrations
+
+
+class DidNotEnable(Exception):
+    """
+    The integration could not be enabled due to a trivial user error like
+    `flask` not being installed for the `FlaskIntegration`.
+
+    This exception is silently swallowed for default integrations, but reraised
+    for explicitly enabled integrations.
+    """
 
 
 class Integration(object):

--- a/sentry_sdk/integrations/celery.py
+++ b/sentry_sdk/integrations/celery.py
@@ -23,7 +23,7 @@ if MYPY:
 
 
 try:
-    from celery import VERSION
+    from celery import VERSION  # type: ignore
     from celery.exceptions import (  # type: ignore
         SoftTimeLimitExceeded,
         Retry,

--- a/sentry_sdk/integrations/celery.py
+++ b/sentry_sdk/integrations/celery.py
@@ -23,7 +23,7 @@ if MYPY:
 
 
 try:
-    from celery import VERSION  # type: ignore
+    from celery import VERSION as CELERY_VERSION  # type: ignore
     from celery.exceptions import (  # type: ignore
         SoftTimeLimitExceeded,
         Retry,

--- a/sentry_sdk/integrations/celery.py
+++ b/sentry_sdk/integrations/celery.py
@@ -47,7 +47,7 @@ class CeleryIntegration(Integration):
     @staticmethod
     def setup_once():
         # type: () -> None
-        if VERSION < (3,):
+        if CELERY_VERSION < (3,):
             raise DidNotEnable("Celery 3 or newer required.")
 
         import celery.app.trace as trace  # type: ignore

--- a/sentry_sdk/integrations/django/__init__.py
+++ b/sentry_sdk/integrations/django/__init__.py
@@ -5,11 +5,40 @@ import sys
 import threading
 import weakref
 
-from django import VERSION as DJANGO_VERSION
-from django.core import signals
-
 from sentry_sdk._types import MYPY
-from sentry_sdk.utils import HAS_REAL_CONTEXTVARS, logger
+from sentry_sdk.hub import Hub, _should_send_default_pii
+from sentry_sdk.scope import add_global_event_processor
+from sentry_sdk.serializer import add_global_repr_processor
+from sentry_sdk.tracing import record_sql_queries
+from sentry_sdk.utils import (
+    HAS_REAL_CONTEXTVARS,
+    logger,
+    capture_internal_exceptions,
+    event_from_exception,
+    transaction_from_function,
+    walk_exception_chain,
+)
+from sentry_sdk.integrations import Integration, DidNotEnable
+from sentry_sdk.integrations.logging import ignore_logger
+from sentry_sdk.integrations.wsgi import SentryWsgiMiddleware
+from sentry_sdk.integrations._wsgi_common import RequestExtractor
+
+try:
+    from django import VERSION as DJANGO_VERSION
+    from django.core import signals
+
+    try:
+        from django.urls import resolve
+    except ImportError:
+        from django.core.urlresolvers import resolve
+except ImportError:
+    raise DidNotEnable("Django not installed")
+
+
+from sentry_sdk.integrations.django.transactions import LEGACY_RESOLVER
+from sentry_sdk.integrations.django.templates import get_template_frame_from_exception
+from sentry_sdk.integrations.django.middleware import patch_django_middlewares
+
 
 if MYPY:
     from typing import Any
@@ -26,31 +55,6 @@ if MYPY:
 
     from sentry_sdk.integrations.wsgi import _ScopedResponse
     from sentry_sdk._types import Event, Hint, EventProcessor, NotImplementedType
-
-
-try:
-    from django.urls import resolve
-except ImportError:
-    from django.core.urlresolvers import resolve
-
-from sentry_sdk import Hub
-from sentry_sdk.hub import _should_send_default_pii
-from sentry_sdk.scope import add_global_event_processor
-from sentry_sdk.serializer import add_global_repr_processor
-from sentry_sdk.tracing import record_sql_queries
-from sentry_sdk.utils import (
-    capture_internal_exceptions,
-    event_from_exception,
-    transaction_from_function,
-    walk_exception_chain,
-)
-from sentry_sdk.integrations import Integration
-from sentry_sdk.integrations.logging import ignore_logger
-from sentry_sdk.integrations.wsgi import SentryWsgiMiddleware
-from sentry_sdk.integrations._wsgi_common import RequestExtractor
-from sentry_sdk.integrations.django.transactions import LEGACY_RESOLVER
-from sentry_sdk.integrations.django.templates import get_template_frame_from_exception
-from sentry_sdk.integrations.django.middleware import patch_django_middlewares
 
 
 if DJANGO_VERSION < (1, 10):
@@ -87,6 +91,10 @@ class DjangoIntegration(Integration):
     @staticmethod
     def setup_once():
         # type: () -> None
+
+        if DJANGO_VERSION < (1, 6):
+            raise DidNotEnable("Django 1.6 or newer is required.")
+
         install_sql_hook()
         # Patch in our custom middleware.
 

--- a/sentry_sdk/integrations/sanic.py
+++ b/sentry_sdk/integrations/sanic.py
@@ -58,7 +58,7 @@ class SanicIntegration(Integration):
                 " or aiocontextvars package"
             )
 
-        if VERSION.startswith("0.8."):
+        if SANIC_VERSION.startswith("0.8."):
             # Sanic 0.8 and older creates a logger named "root" and puts a
             # stringified version of every exception in there (without exc_info),
             # which our error deduplication can't detect.

--- a/sentry_sdk/integrations/sanic.py
+++ b/sentry_sdk/integrations/sanic.py
@@ -45,7 +45,7 @@ class SanicIntegration(Integration):
         try:
             version = tuple(map(int, SANIC_VERSION.split(".")))
         except (TypeError, ValueError):
-            raise DidNotEnable("Unparseable Sanic version: {}".format(VERSION))
+            raise DidNotEnable("Unparseable Sanic version: {}".format(SANIC_VERSION))
 
         if version < (0, 8):
             raise DidNotEnable("Sanic 0.8 or newer required.")

--- a/sentry_sdk/integrations/sanic.py
+++ b/sentry_sdk/integrations/sanic.py
@@ -28,7 +28,7 @@ if MYPY:
     from sentry_sdk._types import Event, EventProcessor, Hint
 
 try:
-    from sanic import Sanic, __version__ as VERSION
+    from sanic import Sanic, __version__ as SANIC_VERSION
     from sanic.exceptions import SanicException
     from sanic.router import Router
     from sanic.handlers import ErrorHandler

--- a/sentry_sdk/integrations/sanic.py
+++ b/sentry_sdk/integrations/sanic.py
@@ -9,14 +9,9 @@ from sentry_sdk.utils import (
     event_from_exception,
     HAS_REAL_CONTEXTVARS,
 )
-from sentry_sdk.integrations import Integration
+from sentry_sdk.integrations import Integration, DidNotEnable
 from sentry_sdk.integrations._wsgi_common import RequestExtractor, _filter_headers
 from sentry_sdk.integrations.logging import ignore_logger
-
-from sanic import Sanic, __version__ as VERSION
-from sanic.exceptions import SanicException
-from sanic.router import Router
-from sanic.handlers import ErrorHandler
 
 from sentry_sdk._types import MYPY
 
@@ -32,6 +27,14 @@ if MYPY:
 
     from sentry_sdk._types import Event, EventProcessor, Hint
 
+try:
+    from sanic import Sanic, __version__ as VERSION
+    from sanic.exceptions import SanicException
+    from sanic.router import Router
+    from sanic.handlers import ErrorHandler
+except ImportError:
+    raise DidNotEnable("Sanic not installed")
+
 
 class SanicIntegration(Integration):
     identifier = "sanic"
@@ -39,10 +42,18 @@ class SanicIntegration(Integration):
     @staticmethod
     def setup_once():
         # type: () -> None
+        try:
+            version = tuple(map(int, VERSION))
+        except (TypeError, ValueError):
+            raise DidNotEnable("Unparseable Sanic version: {}".format(version))
+
+        if version < (0, 8):
+            raise DidNotEnable("Sanic 0.8 or newer required.")
+
         if not HAS_REAL_CONTEXTVARS:
             # We better have contextvars or we're going to leak state between
             # requests.
-            raise RuntimeError(
+            raise DidNotEnable(
                 "The sanic integration for Sentry requires Python 3.7+ "
                 " or aiocontextvars package"
             )

--- a/sentry_sdk/integrations/sanic.py
+++ b/sentry_sdk/integrations/sanic.py
@@ -43,7 +43,7 @@ class SanicIntegration(Integration):
     def setup_once():
         # type: () -> None
         try:
-            version = tuple(map(int, VERSION.split(".")))
+            version = tuple(map(int, SANIC_VERSION.split(".")))
         except (TypeError, ValueError):
             raise DidNotEnable("Unparseable Sanic version: {}".format(VERSION))
 

--- a/sentry_sdk/integrations/sanic.py
+++ b/sentry_sdk/integrations/sanic.py
@@ -43,9 +43,9 @@ class SanicIntegration(Integration):
     def setup_once():
         # type: () -> None
         try:
-            version = tuple(map(int, VERSION))
+            version = tuple(map(int, VERSION.split(".")))
         except (TypeError, ValueError):
-            raise DidNotEnable("Unparseable Sanic version: {}".format(version))
+            raise DidNotEnable("Unparseable Sanic version: {}".format(VERSION))
 
         if version < (0, 8):
             raise DidNotEnable("Sanic 0.8 or newer required.")

--- a/sentry_sdk/integrations/sqlalchemy.py
+++ b/sentry_sdk/integrations/sqlalchemy.py
@@ -8,7 +8,7 @@ from sentry_sdk.tracing import record_sql_queries
 try:
     from sqlalchemy.engine import Engine  # type: ignore
     from sqlalchemy.event import listen  # type: ignore
-    from sqlalchemy import __version__ as SQLALCHEMY_VERSION
+    from sqlalchemy import __version__ as SQLALCHEMY_VERSION  # type: ignore
 except ImportError:
     raise DidNotEnable("SQLAlchemy not installed.")
 

--- a/sentry_sdk/integrations/tornado.py
+++ b/sentry_sdk/integrations/tornado.py
@@ -8,7 +8,7 @@ from sentry_sdk.utils import (
     capture_internal_exceptions,
     transaction_from_function,
 )
-from sentry_sdk.integrations import Integration
+from sentry_sdk.integrations import Integration, DidNotEnable
 from sentry_sdk.integrations._wsgi_common import (
     RequestExtractor,
     _filter_headers,
@@ -17,8 +17,12 @@ from sentry_sdk.integrations._wsgi_common import (
 from sentry_sdk.integrations.logging import ignore_logger
 from sentry_sdk._compat import iteritems
 
-from tornado.web import RequestHandler, HTTPError
-from tornado.gen import coroutine
+try:
+    from tornado import version_info as TORNADO_VERSION
+    from tornado.web import RequestHandler, HTTPError
+    from tornado.gen import coroutine
+except ImportError:
+    raise DidNotEnable("Tornado not installed")
 
 from sentry_sdk._types import MYPY
 
@@ -37,16 +41,13 @@ class TornadoIntegration(Integration):
     @staticmethod
     def setup_once():
         # type: () -> None
-        import tornado
-
-        tornado_version = getattr(tornado, "version_info", None)
-        if tornado_version is None or tornado_version < (5, 0):
-            raise RuntimeError("Tornado 5+ required")
+        if TORNADO_VERSION < (5, 0):
+            raise DidNotEnable("Tornado 5+ required")
 
         if not HAS_REAL_CONTEXTVARS:
             # Tornado is async. We better have contextvars or we're going to leak
             # state between requests.
-            raise RuntimeError(
+            raise DidNotEnable(
                 "The tornado integration for Sentry requires Python 3.6+ or the aiocontextvars package"
             )
 

--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -13,6 +13,7 @@ from sentry_sdk import (
     Hub,
 )
 
+from sentry_sdk.integrations import _AUTO_ENABLING_INTEGRATIONS
 from sentry_sdk.integrations.logging import LoggingIntegration
 
 
@@ -38,23 +39,12 @@ def test_processors(sentry_init, capture_events):
     assert event["exception"]["values"][0]["value"] == "aha! whatever"
 
 
-def test_auto_enabling_integrations_does_not_break(sentry_init, caplog):
+def test_auto_enabling_integrations_catches_import_error(sentry_init, caplog):
     caplog.set_level(logging.DEBUG)
 
     sentry_init(_experiments={"auto_enabling_integrations": True}, debug=True)
 
-    for import_string in (
-        "sentry_sdk.integrations.django.DjangoIntegration",
-        "sentry_sdk.integrations.flask.FlaskIntegration",
-        "sentry_sdk.integrations.bottle.BottleIntegration",
-        "sentry_sdk.integrations.falcon.FalconIntegration",
-        "sentry_sdk.integrations.sanic.SanicIntegration",
-        "sentry_sdk.integrations.celery.CeleryIntegration",
-        "sentry_sdk.integrations.rq.RqIntegration",
-        "sentry_sdk.integrations.aiohttp.AioHttpIntegration",
-        "sentry_sdk.integrations.tornado.TornadoIntegration",
-        "sentry_sdk.integrations.sqlalchemy.SqlalchemyIntegration",
-    ):
+    for import_string in _AUTO_ENABLING_INTEGRATIONS:
         assert any(
             record.message.startswith(
                 "Did not import default integration {}:".format(import_string)


### PR DESCRIPTION
The idea is that you can write `init(_experiments={"auto_enabling_integrations": True})` to get maximal instrumentation.

Unsolved questions:

* How to opt out of integrations?