### PR TITLE
fix: Use monotonic clock to compute durations

### DIFF
--- a/sentry_sdk/tracing.py
+++ b/sentry_sdk/tracing.py
@@ -320,8 +320,8 @@ class Span(object):
             return None
 
         try:
-            durationSeconds = time.perf_counter() - self._start_timestamp_monotonic
-            self.timestamp = self.start_timestamp + timedelta(seconds=durationSeconds)
+            duration_seconds = time.perf_counter() - self._start_timestamp_monotonic
+            self.timestamp = self.start_timestamp + timedelta(seconds=duration_seconds)
         except AttributeError:
             self.timestamp = datetime.utcnow()
 

--- a/sentry_sdk/tracing.py
+++ b/sentry_sdk/tracing.py
@@ -1,8 +1,9 @@
 import re
 import uuid
 import contextlib
+import time
 
-from datetime import datetime
+from datetime import datetime, timedelta
 
 import sentry_sdk
 
@@ -101,6 +102,7 @@ class Span(object):
         "op",
         "description",
         "start_timestamp",
+        "_start_timestamp_monotonic",
         "timestamp",
         "_tags",
         "_data",
@@ -134,6 +136,14 @@ class Span(object):
         self._tags = {}  # type: Dict[str, str]
         self._data = {}  # type: Dict[str, Any]
         self.start_timestamp = datetime.utcnow()
+        try:
+            # TODO: For Python 3.7+, we could use a clock with ns resolution:
+            # self._start_timestamp_monotonic = time.perf_counter_ns()
+
+            # Python 3.3+
+            self._start_timestamp_monotonic = time.perf_counter()
+        except AttributeError:
+            pass
 
         #: End timestamp of span
         self.timestamp = None  # type: Optional[datetime]
@@ -309,7 +319,11 @@ class Span(object):
             # This transaction is already finished, so we should not flush it again.
             return None
 
-        self.timestamp = datetime.utcnow()
+        try:
+            durationSeconds = time.perf_counter() - self._start_timestamp_monotonic
+            self.timestamp = self.start_timestamp + timedelta(seconds=durationSeconds)
+        except AttributeError:
+            self.timestamp = datetime.utcnow()
 
         _maybe_create_breadcrumbs_from_span(hub, self)
 


### PR DESCRIPTION
In summary, care must be taken when computing durations. Monotonic
clocks are not subject to system clock adjustments or system clock skew.
The difference between any two chronologically recorded time values is
guaranteed to never be negative.

The same guarantee above does not exist for the difference between two
calls to datetime.now() and friends.

More details and rationale see PEP 418.

Resources:

PEP 418 -- Add monotonic time, performance counter, and process time functions
https://www.python.org/dev/peps/pep-0418/

PEP 564 -- Add new time functions with nanosecond resolution
https://www.python.org/dev/peps/pep-0564/

---

**Know limitation**

At present, we only address timestamp computation within a single span.
A more complete patch should compute all durations in a transaction using a monotonic clock and set all timestamps relative to a single reading of a wall clock time source.