### PR TITLE
fix: Do not overwrite User data if already set

### DIFF
--- a/sentry_sdk/integrations/aws_lambda.py
+++ b/sentry_sdk/integrations/aws_lambda.py
@@ -202,11 +202,11 @@ def _make_request_event_processor(aws_event, aws_context):
 
             id = aws_event.get("identity", {}).get("userArn")
             if id is not None:
-                user_info["id"] = id
+                user_info.setdefault("id", id)
 
             ip = aws_event.get("identity", {}).get("sourceIp")
             if ip is not None:
-                user_info["ip_address"] = ip
+                user_info.setdefault("ip_address", ip)
 
         event["request"] = request
 

--- a/sentry_sdk/integrations/django/__init__.py
+++ b/sentry_sdk/integrations/django/__init__.py
@@ -425,17 +425,17 @@ def _set_user_info(request, event):
         return
 
     try:
-        user_info["id"] = str(user.pk)
+        user_info.setdefault("id", str(user.pk))
     except Exception:
         pass
 
     try:
-        user_info["email"] = user.email
+        user_info.setdefault("email", user.email)
     except Exception:
         pass
 
     try:
-        user_info["username"] = user.get_username()
+        user_info.setdefault("username", user.get_username())
     except Exception:
         pass
 

--- a/sentry_sdk/integrations/flask.py
+++ b/sentry_sdk/integrations/flask.py
@@ -230,7 +230,7 @@ def _add_user_to_event(event):
         user_info = event.setdefault("user", {})
 
         try:
-            user_info["id"] = user.get_id()
+            user_info.setdefault("id", user.get_id())
             # TODO: more configurable user attrs here
         except AttributeError:
             # might happen if:
@@ -247,11 +247,12 @@ def _add_user_to_event(event):
         # https://github.com/lingthio/Flask-User/blob/a379fa0a281789618c484b459cb41236779b95b1/docs/source/data_models.rst#fixed-data-model-property-names
 
         try:
-            user_info["email"] = user_info["username"] = user.email
+            user_info.setdefault("email", user.email)
         except Exception:
             pass
 
         try:
-            user_info["username"] = user.username
+            user_info.setdefault("username", user.username)
+            user_info.setdefault("username", user.email)
         except Exception:
             pass

--- a/sentry_sdk/integrations/pyramid.py
+++ b/sentry_sdk/integrations/pyramid.py
@@ -208,7 +208,7 @@ def _make_event_processor(weak_request, integration):
         if _should_send_default_pii():
             with capture_internal_exceptions():
                 user_info = event.setdefault("user", {})
-                user_info["id"] = authenticated_userid(request)
+                user_info.setdefault("id", authenticated_userid(request))
 
         return event
 

--- a/sentry_sdk/integrations/tornado.py
+++ b/sentry_sdk/integrations/tornado.py
@@ -158,7 +158,7 @@ def _make_event_processor(weak_handler):
 
         with capture_internal_exceptions():
             if handler.current_user and _should_send_default_pii():
-                event.setdefault("user", {})["is_authenticated"] = True
+                event.setdefault("user", {}).setdefault("is_authenticated", True)
 
         return event
 

--- a/sentry_sdk/integrations/wsgi.py
+++ b/sentry_sdk/integrations/wsgi.py
@@ -293,7 +293,7 @@ def _make_wsgi_event_processor(environ):
             if _should_send_default_pii():
                 user_info = event.setdefault("user", {})
                 if client_ip:
-                    user_info["ip_address"] = client_ip
+                    user_info.setdefault("ip_address", client_ip)
 
             request_info["url"] = request_url
             request_info["query_string"] = query_string


### PR DESCRIPTION
Turns out some users manually set user.id and other fields in the scope,
and those values get overwritten by integrations.

Glanced over places where we could be inadvertently overwriting user
data and changed to use setdefault to avoid overwriting existing values.