### PR TITLE
fix(tracing) Omit the top level status tag

### DIFF
--- a/sentry_sdk/tracing.py
+++ b/sentry_sdk/tracing.py
@@ -408,7 +408,7 @@ class Span(object):
         }
 
         if "status" in self._tags:
-            rv["status"] = self._tags["status"]
+            rv["status"] = self._tags.pop("status")
 
         return rv
 

--- a/sentry_sdk/tracing.py
+++ b/sentry_sdk/tracing.py
@@ -391,7 +391,7 @@ class Span(object):
             rv["transaction"] = transaction
 
         if self.status:
-            self._tags['status'] = self.status
+            self._tags["status"] = self.status
 
         tags = self._tags
         if tags:

--- a/tests/test_tracing.py
+++ b/tests/test_tracing.py
@@ -12,7 +12,8 @@ def test_basic(sentry_init, capture_events, sample_rate):
     sentry_init(traces_sample_rate=sample_rate)
     events = capture_events()
 
-    with Hub.current.start_span(transaction="hi"):
+    with Hub.current.start_span(transaction="hi") as span:
+        span.set_status('ok')
         with pytest.raises(ZeroDivisionError):
             with Hub.current.start_span(op="foo", description="foodesc"):
                 1 / 0
@@ -32,6 +33,8 @@ def test_basic(sentry_init, capture_events, sample_rate):
         assert span2["op"] == "bar"
         assert span2["description"] == "bardesc"
         assert parent_span["transaction"] == "hi"
+        assert "status" not in event["tags"]
+        assert event["contexts"]["trace"]["status"] == "ok"
     else:
         assert not events
 

--- a/tests/test_tracing.py
+++ b/tests/test_tracing.py
@@ -13,7 +13,7 @@ def test_basic(sentry_init, capture_events, sample_rate):
     events = capture_events()
 
     with Hub.current.start_span(transaction="hi") as span:
-        span.set_status('ok')
+        span.set_status("ok")
         with pytest.raises(ZeroDivisionError):
             with Hub.current.start_span(op="foo", description="foodesc"):
                 1 / 0


### PR DESCRIPTION
In the product side we don't really want people to search by this tag as it is far more expensive than the `transaction.status` property which is indexed separately. By not emitting this tag and only including it in the trace context we won't end up with poor performing tags for users to click on.