### PR TITLE
perf: Don't unnecessarily capture exceptions that are ignored

### DIFF
--- a/sentry_sdk/integrations/sanic.py
+++ b/sentry_sdk/integrations/sanic.py
@@ -150,6 +150,9 @@ def _capture_exception(exception):
     # If an integration is there, a client has to be there.
     client = hub.client  # type: Any
 
+    if client and exception in client.ignore_errors:
+        return
+
     with capture_internal_exceptions():
         event, hint = event_from_exception(
             exception,


### PR DESCRIPTION
Having the sentry integration enabled with Sanic results in a 10x reduction in requests per second to `@app.exception` routes, even when those route exceptions are ignored.

The main function we're trying to avoid is `exceptions_from_error_tuple`, as illustrated in the flamegraph in #650. In a relatively simple world, the sentry-python package shouldn't execute anything if the error is in the `ignored_exceptions`.

Ideally this change would live inside of `event_from_exception` [here](https://github.com/getsentry/sentry-python/blob/b7679a50f31ef63614da21a6ecda9e4ff43a5754/sentry_sdk/utils.py#L671), but I wasn't sure what would happen in the scenario that either no exception was returned or a mock exception was returned.

In theory every integration should ignore the exception passed back from `event_from_exception` and simply use the `hint` to assess whether or not `_should_capture_exception`, but since `hint` has a default value of `{}` it's possible that some cases might not actually be passing the `hint` correctly.

Fixes #650 

TLDR: This fixes it for Sanic. It would be nice to fix this generally, but I don't have enough context to know whether the change is safe.