### PR TITLE
Feature: HTTP Headers Overrides

### DIFF
--- a/sentry_sdk/consts.py
+++ b/sentry_sdk/consts.py
@@ -9,7 +9,7 @@ if MYPY:
     from typing import Dict
     from typing import Any
     from typing import Sequence
-    from typing_extensions import Final, TypedDict
+    from typing_extensions import TypedDict
 
     from sentry_sdk.transport import Transport
     from sentry_sdk.integrations import Integration

--- a/sentry_sdk/consts.py
+++ b/sentry_sdk/consts.py
@@ -9,7 +9,7 @@ if MYPY:
     from typing import Dict
     from typing import Any
     from typing import Sequence
-    from typing_extensions import TypedDict
+    from typing_extensions import Final, TypedDict
 
     from sentry_sdk.transport import Transport
     from sentry_sdk.integrations import Integration
@@ -54,6 +54,7 @@ class ClientConstructor(object):
         send_default_pii=False,  # type: bool
         http_proxy=None,  # type: Optional[str]
         https_proxy=None,  # type: Optional[str]
+        http_headers=None,  # type: Optional[Dict[str, str]]
         ignore_errors=[],  # type: List[Union[type, str]]  # noqa: B006
         request_bodies="medium",  # type: str
         before_send=None,  # type: Optional[EventProcessor]
@@ -88,7 +89,7 @@ def _get_default_options():
 DEFAULT_OPTIONS = _get_default_options()
 del _get_default_options
 
-
+AUTH_VERSION = 7  # type: Final[int]
 VERSION = "0.14.4"
 SDK_INFO = {
     "name": "sentry.python",

--- a/sentry_sdk/consts.py
+++ b/sentry_sdk/consts.py
@@ -89,7 +89,6 @@ def _get_default_options():
 DEFAULT_OPTIONS = _get_default_options()
 del _get_default_options
 
-AUTH_VERSION = 7  # type: Final[int]
 VERSION = "0.14.4"
 SDK_INFO = {
     "name": "sentry.python",

--- a/sentry_sdk/transport.py
+++ b/sentry_sdk/transport.py
@@ -171,6 +171,15 @@ class HttpTransport(Transport):
                 "X-Sentry-Auth": str(self._auth.to_header()),
             }
         )
+
+        # Override headers from options:
+        if (
+            self.options
+            and "http_headers" in self.options
+            and isinstance(self.options["http_headers"], dict)
+        ):
+            headers.update(self.options["http_headers"])
+
         response = self._pool.request(
             "POST", str(self._auth.store_api_url), body=body, headers=headers
         )

--- a/sentry_sdk/utils.py
+++ b/sentry_sdk/utils.py
@@ -6,6 +6,7 @@ import logging
 from datetime import datetime
 
 import sentry_sdk
+from sentry_sdk.consts import AUTH_VERSION
 from sentry_sdk._compat import urlparse, text_type, implements_str, PY2
 
 from sentry_sdk._types import MYPY
@@ -183,7 +184,7 @@ class Auth(object):
         project_id,
         public_key,
         secret_key=None,
-        version=7,
+        version=AUTH_VERSION,
         client=None,
         path="/",
     ):

--- a/sentry_sdk/utils.py
+++ b/sentry_sdk/utils.py
@@ -6,7 +6,6 @@ import logging
 from datetime import datetime
 
 import sentry_sdk
-from sentry_sdk.consts import AUTH_VERSION
 from sentry_sdk._compat import urlparse, text_type, implements_str, PY2
 
 from sentry_sdk._types import MYPY
@@ -184,7 +183,7 @@ class Auth(object):
         project_id,
         public_key,
         secret_key=None,
-        version=AUTH_VERSION,
+        version=7,
         client=None,
         path="/",
     ):

--- a/tests/test_transport.py
+++ b/tests/test_transport.py
@@ -230,3 +230,4 @@ def test_http_headers_overrides(httpserver, capsys, caplog):
         VERSION,
     )
     assert request.headers["AUTHORIZATION"] == "Bearer MY_TOKEN"
+    assert request.headers["X_SOME_EXTRA_HEADER"] == "value1=1, value2=2"

--- a/tests/test_transport.py
+++ b/tests/test_transport.py
@@ -9,7 +9,7 @@ import pytest
 from sentry_sdk import Hub, Client, add_breadcrumb, capture_message
 from sentry_sdk.transport import _parse_rate_limits
 from sentry_sdk.integrations.logging import LoggingIntegration
-from sentry_sdk.consts import VERSION, AUTH_VERSION
+from sentry_sdk.consts import VERSION
 
 
 @pytest.fixture(params=[True, False])
@@ -199,7 +199,7 @@ def test_http_headers(httpserver, capsys, caplog):
     assert request.headers[
         "X_SENTRY_AUTH"
     ] == "Sentry sentry_key=foobar, sentry_version=%s, sentry_client=sentry.python/%s" % (
-        AUTH_VERSION,
+        7,
         VERSION,
     )
 
@@ -226,7 +226,7 @@ def test_http_headers_overrides(httpserver, capsys, caplog):
     assert request.headers[
         "X_SENTRY_AUTH"
     ] == "Sentry sentry_key=foobar, sentry_version=%s, sentry_client=sentry.python/%s" % (
-        AUTH_VERSION,
+        7,
         VERSION,
     )
     assert request.headers["AUTHORIZATION"] == "Bearer MY_TOKEN"


### PR DESCRIPTION
Add http_headers options to the sentry_sdk.init() method to allow passing extra options to the HTTPTransport. This is for adding Authorization headers to be used when authenticating with a Single Sign-On service that lives in front of a self-hosted Sentry server.

Example:

```
import sentry_sdk
sentry_sdk.init(
    "https://abc123@sentry.example.com/1",
    debug=True,
    http_headers={
        'Authorization': f'Bearer xyz'
    }
)
```