### PR TITLE
ref: Refactor ASGI middleware and improve contextvars error message

### DIFF
--- a/sentry_sdk/integrations/aiohttp.py
+++ b/sentry_sdk/integrations/aiohttp.py
@@ -15,6 +15,7 @@ from sentry_sdk.utils import (
     event_from_exception,
     transaction_from_function,
     HAS_REAL_CONTEXTVARS,
+    CONTEXTVARS_ERROR_MESSAGE,
     AnnotatedValue,
 )
 
@@ -60,9 +61,9 @@ class AioHttpIntegration(Integration):
         if not HAS_REAL_CONTEXTVARS:
             # We better have contextvars or we're going to leak state between
             # requests.
-            raise RuntimeError(
+            raise DidNotEnable(
                 "The aiohttp integration for Sentry requires Python 3.7+ "
-                " or aiocontextvars package"
+                " or aiocontextvars package." + CONTEXTVARS_ERROR_MESSAGE
             )
 
         ignore_logger("aiohttp.server")

--- a/sentry_sdk/integrations/django/__init__.py
+++ b/sentry_sdk/integrations/django/__init__.py
@@ -12,6 +12,7 @@ from sentry_sdk.serializer import add_global_repr_processor
 from sentry_sdk.tracing import record_sql_queries
 from sentry_sdk.utils import (
     HAS_REAL_CONTEXTVARS,
+    CONTEXTVARS_ERROR_MESSAGE,
     logger,
     capture_internal_exceptions,
     event_from_exception,
@@ -301,11 +302,12 @@ def _patch_channels():
         # requests.
         #
         # We cannot hard-raise here because channels may not be used at all in
-        # the current process.
+        # the current process. That is the case when running traditional WSGI
+        # workers in gunicorn+gevent and the websocket stuff in a separate
+        # process.
         logger.warning(
-            "We detected that you are using Django channels 2.0. To get proper "
-            "instrumentation for ASGI requests, the Sentry SDK requires "
-            "Python 3.7+ or the aiocontextvars package from PyPI."
+            "We detected that you are using Django channels 2.0."
+            + CONTEXTVARS_ERROR_MESSAGE
         )
 
     from sentry_sdk.integrations.django.asgi import patch_channels_asgi_handler_impl
@@ -324,12 +326,10 @@ def _patch_django_asgi_handler():
         # We better have contextvars or we're going to leak state between
         # requests.
         #
-        # We cannot hard-raise here because Django may not be used at all in
-        # the current process.
+        # We cannot hard-raise here because Django's ASGI stuff may not be used
+        # at all.
         logger.warning(
-            "We detected that you are using Django 3. To get proper "
-            "instrumentation for ASGI requests, the Sentry SDK requires "
-            "Python 3.7+ or the aiocontextvars package from PyPI."
+            "We detected that you are using Django 3." + CONTEXTVARS_ERROR_MESSAGE
         )
 
     from sentry_sdk.integrations.django.asgi import patch_django_asgi_handler_impl

--- a/sentry_sdk/integrations/django/asgi.py
+++ b/sentry_sdk/integrations/django/asgi.py
@@ -25,7 +25,9 @@ def patch_django_asgi_handler_impl(cls):
         if Hub.current.get_integration(DjangoIntegration) is None:
             return await old_app(self, scope, receive, send)
 
-        middleware = SentryAsgiMiddleware(old_app.__get__(self, cls))._run_asgi3
+        middleware = SentryAsgiMiddleware(
+            old_app.__get__(self, cls), unsafe_context_data=True
+        )._run_asgi3
         return await middleware(scope, receive, send)
 
     cls.__call__ = sentry_patched_asgi_handler
@@ -40,7 +42,9 @@ def patch_channels_asgi_handler_impl(cls):
         if Hub.current.get_integration(DjangoIntegration) is None:
             return await old_app(self, receive, send)
 
-        middleware = SentryAsgiMiddleware(lambda _scope: old_app.__get__(self, cls))
+        middleware = SentryAsgiMiddleware(
+            lambda _scope: old_app.__get__(self, cls), unsafe_context_data=True
+        )
 
         return await middleware(self.scope)(receive, send)
 

--- a/sentry_sdk/integrations/sanic.py
+++ b/sentry_sdk/integrations/sanic.py
@@ -8,6 +8,7 @@ from sentry_sdk.utils import (
     capture_internal_exceptions,
     event_from_exception,
     HAS_REAL_CONTEXTVARS,
+    CONTEXTVARS_ERROR_MESSAGE,
 )
 from sentry_sdk.integrations import Integration, DidNotEnable
 from sentry_sdk.integrations._wsgi_common import RequestExtractor, _filter_headers
@@ -55,7 +56,7 @@ class SanicIntegration(Integration):
             # requests.
             raise DidNotEnable(
                 "The sanic integration for Sentry requires Python 3.7+ "
-                " or aiocontextvars package"
+                " or the aiocontextvars package." + CONTEXTVARS_ERROR_MESSAGE
             )
 
         if SANIC_VERSION.startswith("0.8."):

--- a/sentry_sdk/integrations/tornado.py
+++ b/sentry_sdk/integrations/tornado.py
@@ -4,6 +4,7 @@ from inspect import iscoroutinefunction
 from sentry_sdk.hub import Hub, _should_send_default_pii
 from sentry_sdk.utils import (
     HAS_REAL_CONTEXTVARS,
+    CONTEXTVARS_ERROR_MESSAGE,
     event_from_exception,
     capture_internal_exceptions,
     transaction_from_function,
@@ -48,7 +49,8 @@ class TornadoIntegration(Integration):
             # Tornado is async. We better have contextvars or we're going to leak
             # state between requests.
             raise DidNotEnable(
-                "The tornado integration for Sentry requires Python 3.6+ or the aiocontextvars package"
+                "The tornado integration for Sentry requires Python 3.7+ or the aiocontextvars package"
+                + CONTEXTVARS_ERROR_MESSAGE
             )
 
         ignore_logger("tornado.access")

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -7,3 +7,4 @@ pytest-cov==2.8.1
 gevent
 eventlet
 newrelic
+pytest-randomly==1.2.3

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -7,4 +7,3 @@ pytest-cov==2.8.1
 gevent
 eventlet
 newrelic
-pytest-randomly==1.2.3


### PR DESCRIPTION
Found multiple issues with the asgi middleware:

* lack of warning if contextvars are broken -- as part of that I refactored/unified the error message we give in such situations, also added more information as gevent just recently released a version that deals with contextvars better
* exposed methods that were meant for overriding.. but all that is done in there can be done in event processors, so we make them private

Fix #630
Fix #700 
Fix #694 