### PR TITLE
fix(django): Support for Django 3.1

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -46,3 +46,5 @@ ignore_missing_imports = True
 ignore_missing_imports = True
 [mypy-pyspark.*]
 ignore_missing_imports = True
+[mypy-asgiref.*]
+ignore_missing_imports = True

--- a/sentry_sdk/integrations/django/__init__.py
+++ b/sentry_sdk/integrations/django/__init__.py
@@ -119,39 +119,9 @@ class DjangoIntegration(Integration):
 
         WSGIHandler.__call__ = sentry_patched_wsgi_handler
 
+        _patch_get_response()
+
         _patch_django_asgi_handler()
-
-        # patch get_response, because at that point we have the Django request
-        # object
-        from django.core.handlers.base import BaseHandler
-
-        old_get_response = BaseHandler.get_response
-
-        def sentry_patched_get_response(self, request):
-            # type: (Any, WSGIRequest) -> Union[HttpResponse, BaseException]
-            hub = Hub.current
-            integration = hub.get_integration(DjangoIntegration)
-            if integration is not None:
-                _patch_drf()
-
-                with hub.configure_scope() as scope:
-                    # Rely on WSGI middleware to start a trace
-                    try:
-                        if integration.transaction_style == "function_name":
-                            scope.transaction = transaction_from_function(
-                                resolve(request.path).func
-                            )
-                        elif integration.transaction_style == "url":
-                            scope.transaction = LEGACY_RESOLVER.resolve(request.path)
-                    except Exception:
-                        pass
-
-                    scope.add_event_processor(
-                        _make_event_processor(weakref.ref(request), integration)
-                    )
-            return old_get_response(self, request)
-
-        BaseHandler.get_response = sentry_patched_get_response
 
         signals.got_request_exception.connect(_got_request_exception)
 
@@ -335,6 +305,51 @@ def _patch_django_asgi_handler():
     from sentry_sdk.integrations.django.asgi import patch_django_asgi_handler_impl
 
     patch_django_asgi_handler_impl(ASGIHandler)
+
+
+def _before_get_response(request):
+    hub = Hub.current
+    integration = hub.get_integration(DjangoIntegration)
+    if integration is None:
+        return
+
+    _patch_drf()
+
+    with hub.configure_scope() as scope:
+        # Rely on WSGI middleware to start a trace
+        try:
+            if integration.transaction_style == "function_name":
+                scope.transaction = transaction_from_function(
+                    resolve(request.path).func
+                )
+            elif integration.transaction_style == "url":
+                scope.transaction = LEGACY_RESOLVER.resolve(request.path)
+        except Exception:
+            pass
+
+        scope.add_event_processor(
+            _make_event_processor(weakref.ref(request), integration)
+        )
+
+
+def _patch_get_response():
+    """
+    patch get_response, because at that point wea have the Django request object
+    """
+    from django.core.handlers.base import BaseHandler
+
+    old_get_response = BaseHandler.get_response
+
+    def sentry_patched_get_response(self, request):
+        # type: (Any, WSGIRequest) -> Union[HttpResponse, BaseException]
+        _before_get_response(request)
+        return old_get_response(self, request)
+
+    BaseHandler.get_response = sentry_patched_get_response
+
+    if hasattr(BaseHandler, "get_response_async"):
+        from sentry_sdk.integrations.django.asgi import patch_get_response_async
+        patch_get_response_async(BaseHandler, _before_get_response)
 
 
 def _make_event_processor(weak_request, integration):

--- a/sentry_sdk/integrations/django/__init__.py
+++ b/sentry_sdk/integrations/django/__init__.py
@@ -308,6 +308,7 @@ def _patch_django_asgi_handler():
 
 
 def _before_get_response(request):
+    # type: (WSGIRequest) -> None
     hub = Hub.current
     integration = hub.get_integration(DjangoIntegration)
     if integration is None:
@@ -333,6 +334,7 @@ def _before_get_response(request):
 
 
 def _patch_get_response():
+    # type: () -> None
     """
     patch get_response, because at that point wea have the Django request object
     """
@@ -349,6 +351,7 @@ def _patch_get_response():
 
     if hasattr(BaseHandler, "get_response_async"):
         from sentry_sdk.integrations.django.asgi import patch_get_response_async
+
         patch_get_response_async(BaseHandler, _before_get_response)
 
 

--- a/sentry_sdk/integrations/django/__init__.py
+++ b/sentry_sdk/integrations/django/__init__.py
@@ -336,7 +336,7 @@ def _before_get_response(request):
 def _patch_get_response():
     # type: () -> None
     """
-    patch get_response, because at that point wea have the Django request object
+    patch get_response, because at that point we have the Django request object
     """
     from django.core.handlers.base import BaseHandler
 

--- a/sentry_sdk/integrations/django/asgi.py
+++ b/sentry_sdk/integrations/django/asgi.py
@@ -31,6 +31,17 @@ def patch_django_asgi_handler_impl(cls):
     cls.__call__ = sentry_patched_asgi_handler
 
 
+def patch_get_response_async(cls, _before_get_response):
+    old_get_response_async = cls.get_response_async
+
+    async def sentry_patched_get_response_async(self, request):
+        # type: (Any, WSGIRequest) -> Union[HttpResponse, BaseException]
+        _before_get_response(request)
+        return await old_get_response_async(self, request)
+
+    cls.get_response_async = sentry_patched_get_response_async
+
+
 def patch_channels_asgi_handler_impl(cls):
     # type: (Any) -> None
     old_app = cls.__call__

--- a/sentry_sdk/integrations/django/asgi.py
+++ b/sentry_sdk/integrations/django/asgi.py
@@ -14,6 +14,9 @@ from sentry_sdk.integrations.asgi import SentryAsgiMiddleware
 
 if MYPY:
     from typing import Any
+    from typing import Union
+
+    from django.http.response import HttpResponse
 
 
 def patch_django_asgi_handler_impl(cls):
@@ -32,10 +35,11 @@ def patch_django_asgi_handler_impl(cls):
 
 
 def patch_get_response_async(cls, _before_get_response):
+    # type: (Any, Any) -> None
     old_get_response_async = cls.get_response_async
 
     async def sentry_patched_get_response_async(self, request):
-        # type: (Any, WSGIRequest) -> Union[HttpResponse, BaseException]
+        # type: (Any, Any) -> Union[HttpResponse, BaseException]
         _before_get_response(request)
         return await old_get_response_async(self, request)
 

--- a/sentry_sdk/integrations/django/middleware.py
+++ b/sentry_sdk/integrations/django/middleware.py
@@ -49,11 +49,11 @@ def patch_django_middlewares():
 
     old_load_middleware = base.BaseHandler.load_middleware
 
-    def sentry_patched_load_middleware(self):
-        # type: (base.BaseHandler) -> Any
+    def sentry_patched_load_middleware(*args, **kwargs):
+        # type: (Any, Any) -> Any
         _import_string_should_wrap_middleware.set(True)
         try:
-            return old_load_middleware(self)
+            return old_load_middleware(*args, **kwargs)
         finally:
             _import_string_should_wrap_middleware.set(False)
 

--- a/sentry_sdk/utils.py
+++ b/sentry_sdk/utils.py
@@ -780,22 +780,6 @@ def _get_contextvars():
 
     See https://docs.sentry.io/platforms/python/contextvars/ for more information.
     """
-    # Django 3+ uses asgiref which has its own context locals implementation.
-    # Starting with Django 3.1 `asgiref.local` is actually required to have
-    # your errorhandlers be called in the right context.
-    #
-    # XXX: This entire import-time detection is broken. We should figure out an
-    # API for integrations to swap out implementations dynamically. Django and
-    # ASGI may be used in one process, but unused in another.
-    try:
-        from asgiref.local import Local
-    except ImportError:
-        pass
-    else:
-        # Return True here because asgiref.local works correctly for ASGI
-        # environments
-        return True, _make_threadlocal_contextvars(Local)
-
     if not _is_contextvars_broken():
         # aiocontextvars is a PyPI package that ensures that the contextvars
         # backport (also a PyPI package) works with asyncio under Python 3.6

--- a/sentry_sdk/utils.py
+++ b/sentry_sdk/utils.py
@@ -747,6 +747,7 @@ def _is_contextvars_broken():
 
 
 def _make_threadlocal_contextvars(local):
+    # type: (type) -> type
     class ContextVar(object):
         # Super-limited impl of ContextVar
 
@@ -786,13 +787,13 @@ def _get_contextvars():
     # API for integrations to swap out implementations dynamically. Django and
     # ASGI may be used in one process, but unused in another.
     try:
-        from asgiref.local import Local as asgiref_local
+        from asgiref.local import Local
     except ImportError:
         pass
     else:
         # Return True here because asgiref.local works correctly for ASGI
         # environments
-        return True, _make_threadlocal_contextvars(asgiref_local)
+        return True, _make_threadlocal_contextvars(Local)
 
     if not _is_contextvars_broken():
         # aiocontextvars is a PyPI package that ensures that the contextvars
@@ -814,10 +815,7 @@ def _get_contextvars():
         except ImportError:
             pass
 
-    if asgiref_local is not None:
-        local = asgiref_local
-    else:
-        from threading import local
+    from threading import local
 
     return False, _make_threadlocal_contextvars(local)
 

--- a/tests/integrations/django/asgi/test_asgi.py
+++ b/tests/integrations/django/asgi/test_asgi.py
@@ -20,8 +20,6 @@ if django.VERSION >= (3, 0):
 @pytest.mark.asyncio
 async def test_basic(sentry_init, capture_events, application, request):
     sentry_init(integrations=[DjangoIntegration()], send_default_pii=True)
-    Hub.main.bind_client(Hub.current.client)
-    request.addfinalizer(lambda: Hub.main.bind_client(None))
 
     events = capture_events()
 

--- a/tests/integrations/django/asgi/test_asgi.py
+++ b/tests/integrations/django/asgi/test_asgi.py
@@ -4,7 +4,7 @@ import django
 
 from channels.testing import HttpCommunicator
 
-from sentry_sdk import Hub, capture_message
+from sentry_sdk import capture_message
 from sentry_sdk.integrations.django import DjangoIntegration
 
 from tests.integrations.django.myapp.asgi import channels_application

--- a/tox.ini
+++ b/tox.ini
@@ -75,7 +75,7 @@ deps =
 
     django-{1.11,2.0,2.1,2.2,3.0,dev}: djangorestframework>=3.0.0,<4.0.0
     {py3.7,py3.8}-django-{1.11,2.0,2.1,2.2,3.0,dev}: channels>2
-    {py3.8,py3.7}-django-{1.11,2.0,2.1,2.2,3.0,dev}: pytest-asyncio==0.10.0
+    {py3.7,py3.8}-django-{1.11,2.0,2.1,2.2,3.0,dev}: pytest-asyncio==0.10.0
     {py2.7,py3.7,py3.8}-django-{1.11,2.2,3.0,dev}: psycopg2-binary
 
     django-{1.6,1.7,1.8}: pytest-django<3.0

--- a/tox.ini
+++ b/tox.ini
@@ -73,10 +73,10 @@ envlist =
 deps =
     -r test-requirements.txt
 
-    django-{1.11,2.0,2.1,2.2,3.0}: djangorestframework>=3.0.0,<4.0.0
-    py3.7-django-{1.11,2.0,2.1,2.2,3.0}: channels>2
-    py3.7-django-{1.11,2.0,2.1,2.2,3.0}: pytest-asyncio==0.10.0
-    {py2.7,py3.7}-django-{1.11,2.2,3.0}: psycopg2-binary
+    django-{1.11,2.0,2.1,2.2,3.0,dev}: djangorestframework>=3.0.0,<4.0.0
+    {py3.7,py3.8}-django-{1.11,2.0,2.1,2.2,3.0,dev}: channels>2
+    {py3.8,py3.7}-django-{1.11,2.0,2.1,2.2,3.0,dev}: pytest-asyncio==0.10.0
+    {py2.7,py3.7,py3.8}-django-{1.11,2.2,3.0,dev}: psycopg2-binary
 
     django-{1.6,1.7,1.8}: pytest-django<3.0
     django-{1.9,1.10,1.11,2.0,2.1,2.2,3.0,dev}: pytest-django>=3.0


### PR DESCRIPTION
* Django 3.1a1 adds more parameters to `load_middleware` which we do not really care about.

* Django 3.1a1 starts executing exception handlers in a random thread/with the wrong context. Turns out they have their own implementation of context local that is necessary to be able to find the right hub. See also https://github.com/getsentry/sentry-docs/pull/1721

More support is required for supporting async middlewares once Django 3.1 comes out but this should unbreak basic usage of the sdk.

Fix #704