### PR TITLE
fix: Allow nested spans to override sampled argument

### DIFF
--- a/sentry_sdk/tracing.py
+++ b/sentry_sdk/tracing.py
@@ -196,12 +196,9 @@ class Span(object):
 
     def new_span(self, **kwargs):
         # type: (**Any) -> Span
+        kwargs.setdefault("sampled", self.sampled)
         rv = type(self)(
-            trace_id=self.trace_id,
-            span_id=None,
-            parent_span_id=self.span_id,
-            sampled=self.sampled,
-            **kwargs
+            trace_id=self.trace_id, span_id=None, parent_span_id=self.span_id, **kwargs
         )
 
         rv._span_recorder = self._span_recorder

--- a/tests/test_tracing.py
+++ b/tests/test_tracing.py
@@ -148,3 +148,10 @@ def test_span_trimming(sentry_init, capture_events):
     span1, span2 = event["spans"]
     assert span1["op"] == "foo0"
     assert span2["op"] == "foo1"
+
+
+def test_nested_span_sampling_override():
+    with Hub.current.start_span(transaction="outer", sampled=True) as span:
+        assert span.sampled is True
+        with Hub.current.start_span(transaction="inner", sampled=False) as span:
+            assert span.sampled is False


### PR DESCRIPTION
Do not crash if nested spans/transactions specify sampled argument.