### PR TITLE
fix: Add missing test requirements

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -7,3 +7,5 @@ pytest-cov==2.8.1
 gevent
 eventlet
 newrelic
+starlette
+requests


### PR DESCRIPTION
They are part of tox.ini, but when running tests outside of tox, without
those, pytest will not run tests in tests/integrations/asgi.

Surprinsingly, running pytest in a parent directory collects other tests
and skips asgi tests, without error.