### PR TITLE
Pass when exception is raised trying to set the transaction name

### DIFF
--- a/sentry_sdk/integrations/pyramid.py
+++ b/sentry_sdk/integrations/pyramid.py
@@ -81,7 +81,7 @@ class PyramidIntegration(Integration):
                         elif integration.transaction_style == "route_pattern":
                             scope.transaction = request.matched_route.pattern
                     except Exception:
-                        raise
+                        pass
 
                     scope.add_event_processor(
                         _make_event_processor(weakref.ref(request), integration)


### PR DESCRIPTION
When Pyramid can't match the route `request.matched_route` is set to `None`. The patched call view is throwing an AttributeException trying to set the transaction name. 