### PR TITLE
ref: Remove Hub.current is not None checks

### DIFF
--- a/sentry_sdk/api.py
+++ b/sentry_sdk/api.py
@@ -1,5 +1,4 @@
 import inspect
-from contextlib import contextmanager
 
 from sentry_sdk.hub import Hub
 from sentry_sdk.scope import Scope
@@ -72,10 +71,7 @@ def capture_event(
     **scope_args  # type: Dict[str, Any]
 ):
     # type: (...) -> Optional[str]
-    hub = Hub.current
-    if hub is not None:
-        return hub.capture_event(event, hint, scope=scope, **scope_args)
-    return None
+    return Hub.current.capture_event(event, hint, scope=scope, **scope_args)
 
 
 @hubmethod
@@ -86,10 +82,7 @@ def capture_message(
     **scope_args  # type: Dict[str, Any]
 ):
     # type: (...) -> Optional[str]
-    hub = Hub.current
-    if hub is not None:
-        return hub.capture_message(message, level, scope=scope, **scope_args)
-    return None
+    return Hub.current.capture_message(message, level, scope=scope, **scope_args)
 
 
 @hubmethod
@@ -99,10 +92,7 @@ def capture_exception(
     **scope_args  # type: Dict[str, Any]
 ):
     # type: (...) -> Optional[str]
-    hub = Hub.current
-    if hub is not None:
-        return hub.capture_exception(error, scope=scope, **scope_args)
-    return None
+    return Hub.current.capture_exception(error, scope=scope, **scope_args)
 
 
 @hubmethod
@@ -112,9 +102,7 @@ def add_breadcrumb(
     **kwargs  # type: Any
 ):
     # type: (...) -> None
-    hub = Hub.current
-    if hub is not None:
-        return hub.add_breadcrumb(crumb, hint, **kwargs)
+    return Hub.current.add_breadcrumb(crumb, hint, **kwargs)
 
 
 @overload  # noqa
@@ -136,19 +124,7 @@ def configure_scope(
     callback=None,  # type: Optional[Callable[[Scope], None]]
 ):
     # type: (...) -> Optional[ContextManager[Scope]]
-    hub = Hub.current
-    if hub is not None:
-        return hub.configure_scope(callback)
-    elif callback is None:
-
-        @contextmanager
-        def inner():
-            yield Scope()
-
-        return inner()
-    else:
-        # returned if user provided callback
-        return None
+    return Hub.current.configure_scope(callback)
 
 
 @overload  # noqa
@@ -170,59 +146,37 @@ def push_scope(
     callback=None,  # type: Optional[Callable[[Scope], None]]
 ):
     # type: (...) -> Optional[ContextManager[Scope]]
-    hub = Hub.current
-    if hub is not None:
-        return hub.push_scope(callback)
-    elif callback is None:
-
-        @contextmanager
-        def inner():
-            yield Scope()
-
-        return inner()
-    else:
-        # returned if user provided callback
-        return None
+    return Hub.current.push_scope(callback)
 
 
 @scopemethod  # noqa
 def set_tag(key, value):
     # type: (str, Any) -> None
-    hub = Hub.current
-    if hub is not None:
-        hub.scope.set_tag(key, value)
+    return Hub.current.scope.set_tag(key, value)
 
 
 @scopemethod  # noqa
 def set_context(key, value):
     # type: (str, Any) -> None
-    hub = Hub.current
-    if hub is not None:
-        hub.scope.set_context(key, value)
+    return Hub.current.scope.set_context(key, value)
 
 
 @scopemethod  # noqa
 def set_extra(key, value):
     # type: (str, Any) -> None
-    hub = Hub.current
-    if hub is not None:
-        hub.scope.set_extra(key, value)
+    return Hub.current.scope.set_extra(key, value)
 
 
 @scopemethod  # noqa
 def set_user(value):
     # type: (Dict[str, Any]) -> None
-    hub = Hub.current
-    if hub is not None:
-        hub.scope.set_user(value)
+    return Hub.current.scope.set_user(value)
 
 
 @scopemethod  # noqa
 def set_level(value):
     # type: (str) -> None
-    hub = Hub.current
-    if hub is not None:
-        hub.scope.set_level(value)
+    return Hub.current.scope.set_level(value)
 
 
 @hubmethod
@@ -231,18 +185,13 @@ def flush(
     callback=None,  # type: Optional[Callable[[int, float], None]]
 ):
     # type: (...) -> None
-    hub = Hub.current
-    if hub is not None:
-        return hub.flush(timeout=timeout, callback=callback)
+    return Hub.current.flush(timeout=timeout, callback=callback)
 
 
 @hubmethod
 def last_event_id():
     # type: () -> Optional[str]
-    hub = Hub.current
-    if hub is not None:
-        return hub.last_event_id()
-    return None
+    return Hub.current.last_event_id()
 
 
 @hubmethod
@@ -251,7 +200,4 @@ def start_span(
     **kwargs  # type: Any
 ):
     # type: (...) -> Span
-
-    # TODO: All other functions in this module check for
-    # `Hub.current is None`. That actually should never happen?
     return Hub.current.start_span(span=span, **kwargs)

--- a/sentry_sdk/integrations/serverless.py
+++ b/sentry_sdk/integrations/serverless.py
@@ -69,7 +69,7 @@ def _capture_and_reraise():
     # type: () -> None
     exc_info = sys.exc_info()
     hub = Hub.current
-    if hub is not None and hub.client is not None:
+    if hub.client is not None:
         event, hint = event_from_exception(
             exc_info,
             client_options=hub.client.options,
@@ -82,6 +82,4 @@ def _capture_and_reraise():
 
 def _flush_client():
     # type: () -> None
-    hub = Hub.current
-    if hub is not None:
-        hub.flush()
+    return Hub.current.flush()


### PR DESCRIPTION
By [construction](https://github.com/getsentry/sentry-python/blob/6e378f18919a834d3de50b6f981e332b5094ad83/sentry_sdk/hub.py#L133-L142), Hub.current is never None, such that the expression

    Hub.current is not None

always evaluates to True.

This commit simplifies all uses of Hub.current, and in particular
chooses to write `return Hub.current.method(...)` for every method, even
when the method returns None. The intent is to make it easier to keep
the static API matching the Hub behavior. Without this, if a method
returns anything other than None the static API would silently drop it,
leading to unnecessary debugging time spent trying to identify the
culprit.