### PR TITLE
fix: Do not call before_send for transactions

### DIFF
--- a/sentry_sdk/client.py
+++ b/sentry_sdk/client.py
@@ -199,7 +199,7 @@ class _Client(object):
             event = serialize(event)
 
         before_send = self.options["before_send"]
-        if before_send is not None:
+        if before_send is not None and event.get("type") != "transaction":
             new_event = None
             with capture_internal_exceptions():
                 new_event = before_send(event, hint or {})

--- a/tests/test_tracing.py
+++ b/tests/test_tracing.py
@@ -167,3 +167,16 @@ def test_no_double_sampling(sentry_init, capture_events):
         pass
 
     assert len(events) == 1
+
+
+def test_transactions_do_not_go_through_before_send(sentry_init, capture_events):
+    def before_send(event, hint):
+        raise RuntimeError("should not be called")
+
+    sentry_init(traces_sample_rate=1.0, before_send=before_send)
+    events = capture_events()
+
+    with Hub.current.start_span(transaction="/"):
+        pass
+
+    assert len(events) == 1


### PR DESCRIPTION
This matches the behavior with JS and [the specs](https://develop.sentry.dev/sdk/unified-api/tracing).

The change in JS was introduced in https://github.com/getsentry/sentry-javascript/pull/2600.
See notes under "Few other fixes".