### PR TITLE
fix: Do not double sample transactions

### DIFF
--- a/sentry_sdk/client.py
+++ b/sentry_sdk/client.py
@@ -237,6 +237,10 @@ class _Client(object):
         scope=None,  # type: Optional[Scope]
     ):
         # type: (...) -> bool
+        if event.get("type") == "transaction":
+            # Transactions are sampled independent of error events.
+            return True
+
         if scope is not None and not scope._should_capture:
             return False
 

--- a/tests/test_tracing.py
+++ b/tests/test_tracing.py
@@ -155,3 +155,15 @@ def test_nested_span_sampling_override():
         assert span.sampled is True
         with Hub.current.start_span(transaction="inner", sampled=False) as span:
             assert span.sampled is False
+
+
+def test_no_double_sampling(sentry_init, capture_events):
+    # Transactions should not be subject to the global/error sample rate.
+    # Only the traces_sample_rate should apply.
+    sentry_init(traces_sample_rate=1.0, sample_rate=0.0)
+    events = capture_events()
+
+    with Hub.current.start_span(transaction="/"):
+        pass
+
+    assert len(events) == 1


### PR DESCRIPTION
Transactions should be sampled independent of error events. We should never "roll the dice" twice to decide when to send a transaction to Sentry.

This was probably fixed in the JS SDK as part of https://github.com/getsentry/sentry-javascript/pull/2600.
See [diff](https://github.com/getsentry/sentry-javascript/pull/2600/files#diff-377e14ef259b8bd726753063b8658e97).