### PR TITLE
feat(redis): Add tags for more commands

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -27,6 +27,10 @@ sentry-sdk==0.10.1
 
 A major release `N` implies the previous release `N-1` will no longer receive updates. We generally do not backport bugfixes to older versions unless they are security relevant. However, feel free to ask for backports of specific commits on the bugtracker.
 
+## [Unreleased]
+
+* Redis integration: add tags for more commands
+
 ## 0.15.1
 
 * Fix fatal crash in Pyramid integration on 404.

--- a/sentry_sdk/integrations/redis.py
+++ b/sentry_sdk/integrations/redis.py
@@ -9,10 +9,10 @@ from sentry_sdk._types import MYPY
 if MYPY:
     from typing import Any
 
-SINGLE_KEY_COMMANDS = frozenset(
+_SINGLE_KEY_COMMANDS = frozenset(
     ["decr", "decrby", "get", "incr", "incrby", "pttl", "set", "setex", "setnx", "ttl"]
 )
-MULTI_KEY_COMMANDS = frozenset(["del", "touch", "unlink"])
+_MULTI_KEY_COMMANDS = frozenset(["del", "touch", "unlink"])
 
 
 class RedisIntegration(Integration):
@@ -69,8 +69,8 @@ def patch_redis_client(cls):
 
             if name and args:
                 name_low = name.lower()
-                if (name_low in SINGLE_KEY_COMMANDS) or (
-                    name_low in MULTI_KEY_COMMANDS and len(args) == 1
+                if (name_low in _SINGLE_KEY_COMMANDS) or (
+                    name_low in _MULTI_KEY_COMMANDS and len(args) == 1
                 ):
                     span.set_tag("redis.key", args[0])
 


### PR DESCRIPTION
When we deal with multikey commands (e.g. DEL), it's sometimes still useful to have the key as a tag. To make it less ambiguous, let's add the tag only if the command has one argument.