### PR TITLE
feat: Access transaction in current scope

### DIFF
--- a/tests/test_tracing.py
+++ b/tests/test_tracing.py
@@ -3,7 +3,7 @@ import gc
 
 import pytest
 
-from sentry_sdk import Hub, capture_message
+from sentry_sdk import Hub, capture_message, start_span
 from sentry_sdk.tracing import Span
 
 
@@ -178,5 +178,19 @@ def test_transactions_do_not_go_through_before_send(sentry_init, capture_events)
 
     with Hub.current.start_span(transaction="/"):
         pass
+
+    assert len(events) == 1
+
+
+def test_get_transaction_from_scope(sentry_init, capture_events):
+    sentry_init(traces_sample_rate=1.0)
+    events = capture_events()
+
+    with start_span(transaction="/"):
+        with start_span(op="child-span"):
+            with start_span(op="child-child-span"):
+                scope = Hub.current.scope
+                assert scope.span.op == "child-child-span"
+                assert scope.transaction.transaction == "/"
 
     assert len(events) == 1


### PR DESCRIPTION
Specially when trying to add spans to automatically instrumented transactions, users need access to the current transaction.

This gives direct access no matter how deep the code is in the transaction/span tree.

This replicates a similar feature in JS: https://github.com/getsentry/sentry-javascript/pull/2668.