### PR TITLE
ref: Use Hub.scope and Hub.client when appropriate

### DIFF
--- a/sentry_sdk/hub.py
+++ b/sentry_sdk/hub.py
@@ -276,7 +276,7 @@ class Hub(with_metaclass(HubMeta)):  # type: ignore
         else:
             raise ValueError("Integration has no name")
 
-        client = self._stack[-1][0]
+        client = self.client
         if client is not None:
             rv = client.integrations.get(integration_name)
             if rv is not None:
@@ -587,7 +587,7 @@ class Hub(with_metaclass(HubMeta)):  # type: ignore
             session.close()
             if client is not None:
                 client.capture_session(session)
-        self._stack[-1][1]._session = None
+        self.scope._session = None
 
     def stop_auto_session_tracking(self):
         # type: (...) -> None

--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -172,13 +172,13 @@ def test_push_scope_callback(sentry_init, null_client, capture_events):
     if null_client:
         Hub.current.bind_client(None)
 
-    outer_scope = Hub.current._stack[-1][1]
+    outer_scope = Hub.current.scope
 
     calls = []
 
     @push_scope
     def _(scope):
-        assert scope is Hub.current._stack[-1][1]
+        assert scope is Hub.current.scope
         assert scope is not outer_scope
         calls.append(1)
 
@@ -188,7 +188,7 @@ def test_push_scope_callback(sentry_init, null_client, capture_events):
     assert calls == [1]
 
     # Assert scope gets popped correctly
-    assert Hub.current._stack[-1][1] is outer_scope
+    assert Hub.current.scope is outer_scope
 
 
 def test_breadcrumbs(sentry_init, capture_events):

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -316,7 +316,7 @@ def test_configure_scope_available(sentry_init, request, monkeypatch):
     sentry_init()
 
     with configure_scope() as scope:
-        assert scope is Hub.current._stack[-1][1]
+        assert scope is Hub.current.scope
         scope.set_tag("foo", "bar")
 
     calls = []
@@ -327,7 +327,7 @@ def test_configure_scope_available(sentry_init, request, monkeypatch):
 
     assert configure_scope(callback) is None
     assert len(calls) == 1
-    assert calls[0] is Hub.current._stack[-1][1]
+    assert calls[0] is Hub.current.scope
 
 
 @pytest.mark.tests_internal_exceptions


### PR DESCRIPTION
For readability's sake.