### PR TITLE
beam extra should install apache-beam

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup(
         "django": ["django>=1.8"],
         "sanic": ["sanic>=0.8"],
         "celery": ["celery>=3"],
-        "beam": ["beam>=2.12"],
+        "beam": ["apache-beam>=2.12"],
         "rq": ["rq>=0.6"],
         "aiohttp": ["aiohttp>=3.5"],
         "tornado": ["tornado>=5"],


### PR DESCRIPTION
https://pypi.org/project/beam/
https://pypi.org/project/apache-beam/

tox.ini gets this right, I guess nothing tests the setup extra.