### PR TITLE
Capturing Initialization and Timeout errors for AWS Lambda Integration 

### DIFF
--- a/sentry_sdk/integrations/aws_lambda.py
+++ b/sentry_sdk/integrations/aws_lambda.py
@@ -37,13 +37,13 @@ def _wrap_init_error(init_error):
     def sentry_init_error(*args, **kwargs):
         # type: (*Any, **Any) -> Any
 
-        # Fetch Initialization error details from arguments
-        error = json.loads(args[1])
-
         hub = Hub.current
         integration = hub.get_integration(AwsLambdaIntegration)
         if integration is None:
             return init_error(*args, **kwargs)
+
+        # Fetch Initialization error details from arguments
+        error = json.loads(args[1])
 
         # If an integration is there, a client has to be there.
         client = hub.client  # type: Any
@@ -51,13 +51,9 @@ def _wrap_init_error(init_error):
         with hub.push_scope() as scope:
             with capture_internal_exceptions():
                 scope.clear_breadcrumbs()
-            try:
-                # Checking if there is any error/exception which is raised in the runtime
-                # environment from arguments and, re-raising it to capture it as an event.
-                if error.get("errorType"):
-                    exc_info = sys.exc_info()
-                    reraise(*exc_info)
-            except Exception:
+            # Checking if there is any error/exception which is raised in the runtime
+            # environment from arguments and, re-raising it to capture it as an event.
+            if error.get("errorType"):
                 exc_info = sys.exc_info()
                 event, hint = event_from_exception(
                     exc_info,

--- a/sentry_sdk/utils.py
+++ b/sentry_sdk/utils.py
@@ -3,6 +3,8 @@ import linecache
 import logging
 import os
 import sys
+import time
+import threading
 
 from datetime import datetime
 
@@ -870,3 +872,30 @@ def transaction_from_function(func):
 
 
 disable_capture_event = ContextVar("disable_capture_event")
+
+
+class TimeoutThread(threading.Thread):
+    """Creates a Thread."""
+
+    def __init__(self, timeout_duration, configured_timeout):
+        # type: (float, int) -> None
+        threading.Thread.__init__(self)
+        self.timeout_duration = timeout_duration
+        self.configured_timeout = configured_timeout
+
+    def get_timeout_duration(self):
+        # type: () -> float
+        return self.timeout_duration
+
+    def get_configured_timeout(self):
+        # type: () -> int
+        return self.configured_timeout
+
+    def run(self):
+        # type: () -> None
+        time.sleep(self.get_timeout_duration())
+        # Raising Exception after timeout duration is reached
+        raise Exception(
+            "WARNING : Function is expected to get timed out. Configured timeout duration = {} seconds".format(
+                self.get_configured_timeout())
+        )

--- a/tests/integrations/aws_lambda/test_aws.py
+++ b/tests/integrations/aws_lambda/test_aws.py
@@ -63,7 +63,7 @@ def run_lambda_function(tmpdir, lambda_client, request, relay_normalize):
     if request.param == "python3.8":
         pytest.xfail("Python 3.8 is currently broken")
 
-    def inner(code, payload):
+    def inner(code, payload, syntax_check=True):
         runtime = request.param
         tmpdir.ensure_dir("lambda_tmp").remove()
         tmp = tmpdir.ensure_dir("lambda_tmp")


### PR DESCRIPTION
Changes:

1) Added a new wrapper decorator for post_init_error method to capture initialization error for AWS Lambda integration.
2) Modified _wrap_handler decorator to include code which runs a parallel thread to capture timeout error.
3) Modified _make_request_event_processor decorator to include execution duration as parameter.
4) Added TimeoutThread class in utils.py which is useful to capture timeout error.