### PR TITLE
Use sentry_init fixture in tests instead of using Hub directly

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -182,11 +182,12 @@ def relay_normalize(tmpdir):
 
 @pytest.fixture
 def sentry_init(monkeypatch_test_transport, request):
-    def inner(*a, **kw):
+    def inner(*a, transport=None, **kw):
         hub = sentry_sdk.Hub.current
-        client = sentry_sdk.Client(*a, **kw)
+        client = sentry_sdk.Client(*a, transport=transport, **kw)
         hub.bind_client(client)
-        monkeypatch_test_transport(sentry_sdk.Hub.current.client)
+        if transport is None:
+            monkeypatch_test_transport(sentry_sdk.Hub.current.client)
 
     if request.node.get_closest_marker("forked"):
         # Do not run isolation if the test is already running in

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -182,11 +182,11 @@ def relay_normalize(tmpdir):
 
 @pytest.fixture
 def sentry_init(monkeypatch_test_transport, request):
-    def inner(*a, transport=None, **kw):
+    def inner(*a, **kw):
         hub = sentry_sdk.Hub.current
-        client = sentry_sdk.Client(*a, transport=transport, **kw)
+        client = sentry_sdk.Client(*a, **kw)
         hub.bind_client(client)
-        if transport is None:
+        if "transport" not in kw:
             monkeypatch_test_transport(sentry_sdk.Hub.current.client)
 
     if request.node.get_closest_marker("forked"):

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -7,7 +7,14 @@ import sys
 import time
 
 from textwrap import dedent
-from sentry_sdk import Hub, Client, configure_scope, capture_message, capture_exception
+from sentry_sdk import (
+    Hub,
+    Client,
+    configure_scope,
+    capture_message,
+    capture_exception,
+    capture_event,
+)
 from sentry_sdk.transport import Transport
 from sentry_sdk._compat import reraise, text_type, PY2
 from sentry_sdk.utils import HAS_CHAINED_EXCEPTIONS
@@ -149,41 +156,41 @@ def test_proxy_httpsselect_bothenv_http(monkeypatch):
     assert client.transport._pool.proxy.scheme == "http"
 
 
-def test_simple_transport():
+def test_simple_transport(sentry_init):
     events = []
-    with Hub(Client(transport=events.append)):
-        capture_message("Hello World!")
+    sentry_init(transport=events.append)
+    capture_message("Hello World!")
     assert events[0]["message"] == "Hello World!"
 
 
-def test_ignore_errors():
+def test_ignore_errors(sentry_init, capture_events):
     class MyDivisionError(ZeroDivisionError):
         pass
 
     def raise_it(exc_info):
         reraise(*exc_info)
 
-    hub = Hub(Client(ignore_errors=[ZeroDivisionError], transport=_TestTransport()))
-    hub._capture_internal_exception = raise_it
+    sentry_init(ignore_errors=[ZeroDivisionError], transport=_TestTransport())
+    Hub.current._capture_internal_exception = raise_it
 
     def e(exc):
         try:
             raise exc
         except Exception:
-            hub.capture_exception()
+            capture_exception()
 
     e(ZeroDivisionError())
     e(MyDivisionError())
     pytest.raises(EventCaptured, lambda: e(ValueError()))
 
 
-def test_with_locals_enabled():
-    events = []
-    hub = Hub(Client(with_locals=True, transport=events.append))
+def test_with_locals_enabled(sentry_init, capture_events):
+    sentry_init(with_locals=True)
+    events = capture_events()
     try:
         1 / 0
     except Exception:
-        hub.capture_exception()
+        capture_exception()
 
     (event,) = events
 
@@ -193,13 +200,13 @@ def test_with_locals_enabled():
     )
 
 
-def test_with_locals_disabled():
-    events = []
-    hub = Hub(Client(with_locals=False, transport=events.append))
+def test_with_locals_disabled(sentry_init, capture_events):
+    sentry_init(with_locals=False)
+    events = capture_events()
     try:
         1 / 0
     except Exception:
-        hub.capture_exception()
+        capture_exception()
 
     (event,) = events
 
@@ -209,15 +216,15 @@ def test_with_locals_disabled():
     )
 
 
-def test_attach_stacktrace_enabled():
-    events = []
-    hub = Hub(Client(attach_stacktrace=True, transport=events.append))
+def test_attach_stacktrace_enabled(sentry_init, capture_events):
+    sentry_init(attach_stacktrace=True)
+    events = capture_events()
 
     def foo():
         bar()
 
     def bar():
-        hub.capture_message("HI")
+        capture_message("HI")
 
     foo()
 
@@ -227,17 +234,15 @@ def test_attach_stacktrace_enabled():
     assert functions[-2:] == ["foo", "bar"]
 
 
-def test_attach_stacktrace_enabled_no_locals():
-    events = []
-    hub = Hub(
-        Client(attach_stacktrace=True, with_locals=False, transport=events.append)
-    )
+def test_attach_stacktrace_enabled_no_locals(sentry_init, capture_events):
+    sentry_init(attach_stacktrace=True, with_locals=False)
+    events = capture_events()
 
     def foo():
         bar()
 
     def bar():
-        hub.capture_message("HI")
+        capture_message("HI")
 
     foo()
 
@@ -262,19 +267,19 @@ def test_attach_stacktrace_in_app(sentry_init, capture_events):
     assert any(f["in_app"] for f in frames)
 
 
-def test_attach_stacktrace_disabled():
-    events = []
-    hub = Hub(Client(attach_stacktrace=False, transport=events.append))
-    hub.capture_message("HI")
+def test_attach_stacktrace_disabled(sentry_init, capture_events):
+    sentry_init(attach_stacktrace=False)
+    events = capture_events()
+    capture_message("HI")
 
     (event,) = events
     assert "threads" not in event
 
 
-def test_capture_event_works():
-    c = Client(transport=_TestTransport())
-    pytest.raises(EventCaptured, lambda: c.capture_event({}))
-    pytest.raises(EventCaptured, lambda: c.capture_event({}))
+def test_capture_event_works(sentry_init):
+    sentry_init(transport=_TestTransport())
+    pytest.raises(EventCaptured, lambda: capture_event({}))
+    pytest.raises(EventCaptured, lambda: capture_event({}))
 
 
 @pytest.mark.parametrize("num_messages", [10, 20])


### PR DESCRIPTION
@untitaker how's this?

Based on https://github.com/getsentry/sentry-python/pull/749#issuecomment-656827764