### PR TITLE
Fix for timeout warning parameter for GCP integration & UTC time zone for AWS integration

### DIFF
--- a/sentry_sdk/integrations/aws_lambda.py
+++ b/sentry_sdk/integrations/aws_lambda.py
@@ -318,7 +318,7 @@ def _get_cloudwatch_logs_url(context, start_time):
     Returns:
         str -- AWS Console URL to logs.
     """
-    formatstring = "%Y-%m-%dT%H:%M:%S"
+    formatstring = "%Y-%m-%dT%H:%M:%SZ"
 
     url = (
         "https://console.aws.amazon.com/cloudwatch/home?region={region}"

--- a/sentry_sdk/integrations/aws_lambda.py
+++ b/sentry_sdk/integrations/aws_lambda.py
@@ -237,7 +237,7 @@ class AwsLambdaIntegration(Integration):
 
 def _make_request_event_processor(aws_event, aws_context, configured_timeout):
     # type: (Any, Any, Any) -> EventProcessor
-    start_time = datetime.now()
+    start_time = datetime.utcnow()
 
     def event_processor(event, hint, start_time=start_time):
         # type: (Event, Hint, datetime) -> Optional[Event]
@@ -329,7 +329,7 @@ def _get_cloudwatch_logs_url(context, start_time):
         log_group=context.log_group_name,
         log_stream=context.log_stream_name,
         start_time=(start_time - timedelta(seconds=1)).strftime(formatstring),
-        end_time=(datetime.now() + timedelta(seconds=2)).strftime(formatstring),
+        end_time=(datetime.utcnow() + timedelta(seconds=2)).strftime(formatstring),
     )
 
     return url

--- a/sentry_sdk/integrations/gcp.py
+++ b/sentry_sdk/integrations/gcp.py
@@ -91,6 +91,10 @@ def _wrap_func(func):
 class GcpIntegration(Integration):
     identifier = "gcp"
 
+    def __init__(self, timeout_warning=False):
+        # type: (bool) -> None
+        self.timeout_warning = timeout_warning
+
     @staticmethod
     def setup_once():
         # type: () -> None


### PR DESCRIPTION
Changes:
1) Converted local time format to UTC time format for AWS Lambda integration, and verified it on cloudwatch logs.
2) Added code for timeout_warning parameter in class GcpIntegration.

Fix #796 