### PR TITLE
Order variables by closeness to executing statement in pure_eval

### DIFF
--- a/sentry_sdk/integrations/pure_eval.py
+++ b/sentry_sdk/integrations/pure_eval.py
@@ -1,9 +1,8 @@
 from __future__ import absolute_import
 
 import ast
-from collections import OrderedDict
 
-from sentry_sdk import Hub
+from sentry_sdk import Hub, serializer
 from sentry_sdk._types import MYPY
 from sentry_sdk.integrations import Integration, DidNotEnable
 from sentry_sdk.scope import add_global_event_processor
@@ -127,4 +126,7 @@ def pure_eval_frame(frame):
     atok = source.asttokens()
 
     expressions.sort(key=closeness, reverse=True)
-    return OrderedDict((atok.get_text(nodes[0]), value) for nodes, value in expressions)
+    return {
+        atok.get_text(nodes[0]): value
+        for nodes, value in expressions[: serializer.MAX_DATABAG_BREADTH]
+    }

--- a/tests/integrations/pure_eval/test_pure_eval.py
+++ b/tests/integrations/pure_eval/test_pure_eval.py
@@ -3,7 +3,7 @@ from types import SimpleNamespace
 
 import pytest
 
-from sentry_sdk import capture_exception
+from sentry_sdk import capture_exception, serializer
 from sentry_sdk.integrations.pure_eval import PureEvalIntegration
 
 
@@ -89,4 +89,4 @@ def test_with_locals_enabled(sentry_init, capture_events, integrations):
             "s",
             "events",
         }
-        assert len(frame_vars) == 10
+        assert len(frame_vars) == serializer.MAX_DATABAG_BREADTH


### PR DESCRIPTION
Part of #805 

The idea here is to prioritise values which appear closer to the executing statement. The dict of values is ordered so that trimming removes lower priority values later on.

However this doesn't work in python 3.5 because the ordered dict is actually converted to a regular dict which loses the order:

https://github.com/getsentry/sentry-python/blob/4d91fe0944009a6e02450214f663037dc1ce056c/sentry_sdk/serializer.py#L286-L288

It seems that my options are:

1. Remove the above line and fix the errors that arise.
2. Keep the dict ordered when making the copy.
3. Preemptively trim in the pure_eval integration so order no longer matters.

What do you think @untitaker ?