### PR TITLE
Travis CI: Test on Python 3.9 release candidate 1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,10 @@
+os: linux
+
+dist: xenial
+
+services:
+  - postgresql
+
 language: python
 
 python:
@@ -6,6 +13,9 @@ python:
   - "3.4"
   - "3.5"
   - "3.6"
+  - "3.7"
+  - "3.8"
+  - "3.9-dev"
 
 env:
   - SENTRY_PYTHON_TEST_POSTGRES_USER=postgres SENTRY_PYTHON_TEST_POSTGRES_NAME=travis_ci_test
@@ -19,29 +29,22 @@ branches:
     - master
     - /^release\/.+$/
 
-matrix:
+jobs:
+  allow_failures:
+    - python: "3.9-dev"
   include:
-    - python: "3.7"
-      dist: xenial
-
-    - python: "3.8"
-      dist: xenial
-
     - name: Linting
       python: "3.8"
-      dist: xenial
       install:
         - pip install tox
       script: tox -e linters
 
     - python: "3.8"
-      dist: xenial
       name: Distribution packages
       install: []
       script: make travis-upload-dist
 
     - python: "3.8"
-      dist: xenial
       name: Build documentation
       install: []
       script: make travis-upload-docs
@@ -50,12 +53,8 @@ before_script:
   - psql -c 'create database travis_ci_test;' -U postgres
   - psql -c 'create database test_travis_ci_test;' -U postgres
 
-services:
-  - postgresql
-
 install:
-  - pip install tox
-  - pip install codecov
+  - pip install codecov tox
   - make install-zeus-cli
   - bash scripts/download-relay.sh
 

--- a/tox.ini
+++ b/tox.ini
@@ -36,7 +36,8 @@ envlist =
     {py3.5,py3.6,py3.7}-sanic-{0.8,18}
     {py3.6,py3.7}-sanic-19
 
-    {pypy,py2.7,py3.5,py3.6,py3.7,py3.8,py3.9}-celery-{4.1,4.2,4.3,4.4}
+    # TODO: Add py3.9
+    {pypy,py2.7,py3.5,py3.6,py3.7,py3.8}-celery-{4.1,4.2,4.3,4.4}
     {pypy,py2.7}-celery-3
 
     {py2.7,py3.7}-beam-{2.12,2.13}

--- a/tox.ini
+++ b/tox.ini
@@ -67,7 +67,7 @@ envlist =
     {py2.7,py3.7,py3.8,py3.9}-redis
     {py2.7,py3.7,py3.8,py3.9}-rediscluster-{1,2}
 
-    py{3.7,3.8,py3.9}-asgi
+    py{3.7,3.8,3.9}-asgi
 
     {py2.7,py3.7,py3.8,py3.9}-sqlalchemy-{1.2,1.3}
 

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,7 @@
 [tox]
 envlist =
     # === Core ===
-    py{2.7,3.4,3.5,3.6,3.7,3.8}
+    py{2.7,3.4,3.5,3.6,3.7,3.8,3.9}
     pypy
 
 
@@ -23,20 +23,20 @@ envlist =
     {pypy,py2.7}-django-{1.6,1.7}
     {pypy,py2.7,py3.5}-django-{1.8,1.9,1.10,1.11}
     {py3.5,py3.6,py3.7}-django-{2.0,2.1}
-    {py3.7,py3.8}-django-{2.2,3.0,3.1,dev}
+    {py3.7,py3.8,py3.9}-django-{2.2,3.0,3.1,dev}
 
-    {pypy,py2.7,py3.5,py3.6,py3.7,py3.8}-flask-{1.1,1.0,0.11,0.12}
-    {py3.6,py3.7,py3.8}-flask-{1.1,1.0,0.11,0.12,dev}
+    {pypy,py2.7,py3.5,py3.6,py3.7,py3.8,py3.9}-flask-{1.1,1.0,0.11,0.12}
+    {py3.6,py3.7,py3.8,py3.9}-flask-{1.1,1.0,0.11,0.12,dev}
 
-    {pypy,py2.7,py3.5,py3.6,py3.7,py3.8}-bottle-0.12
+    {pypy,py2.7,py3.5,py3.6,py3.7,py3.8,py3.9}-bottle-0.12
 
     {pypy,py2.7,py3.5,py3.6,py3.7}-falcon-1.4
-    {pypy,py2.7,py3.5,py3.6,py3.7,py3.8}-falcon-2.0
+    {pypy,py2.7,py3.5,py3.6,py3.7,py3.8,py3.9}-falcon-2.0
 
     {py3.5,py3.6,py3.7}-sanic-{0.8,18}
     {py3.6,py3.7}-sanic-19
 
-    {pypy,py2.7,py3.5,py3.6,py3.7,py3.8}-celery-{4.1,4.2,4.3,4.4}
+    {pypy,py2.7,py3.5,py3.6,py3.7,py3.8,py3.9}-celery-{4.1,4.2,4.3,4.4}
     {pypy,py2.7}-celery-3
 
     {py2.7,py3.7}-beam-{2.12,2.13}
@@ -46,42 +46,42 @@ envlist =
 
     py3.7-gcp
 
-    {pypy,py2.7,py3.5,py3.6,py3.7,py3.8}-pyramid-{1.6,1.7,1.8,1.9,1.10}
+    {pypy,py2.7,py3.5,py3.6,py3.7,py3.8,py3.9}-pyramid-{1.6,1.7,1.8,1.9,1.10}
 
     {pypy,py2.7,py3.5,py3.6}-rq-{0.6,0.7,0.8,0.9,0.10,0.11}
-    {pypy,py2.7,py3.5,py3.6,py3.7,py3.8}-rq-{0.12,0.13,1.0,1.1,1.2,1.3}
-    {py3.5,py3.6,py3.7,py3.8}-rq-{1.4,1.5}
+    {pypy,py2.7,py3.5,py3.6,py3.7,py3.8,py3.9}-rq-{0.12,0.13,1.0,1.1,1.2,1.3}
+    {py3.5,py3.6,py3.7,py3.8,py3.9}-rq-{1.4,1.5}
 
     py3.7-aiohttp-3.5
-    {py3.7,py3.8}-aiohttp-3.6
+    {py3.7,py3.8,py3.9}-aiohttp-3.6
 
-    {py3.7,py3.8}-tornado-{5,6}
+    {py3.7,py3.8,py3.9}-tornado-{5,6}
 
-    {py3.4,py3.5,py3.6,py3.7,py3.8}-trytond-{4.6,4.8,5.0}
-    {py3.5,py3.6,py3.7,py3.8}-trytond-{5.2}
-    {py3.6,py3.7,py3.8}-trytond-{5.4}
+    {py3.4,py3.5,py3.6,py3.7,py3.8,py3.9}-trytond-{4.6,4.8,5.0}
+    {py3.5,py3.6,py3.7,py3.8,py3.9}-trytond-{5.2}
+    {py3.6,py3.7,py3.8,py3.9}-trytond-{5.4}
 
-    {py2.7,py3.8}-requests
+    {py2.7,py3.8,py3.9}-requests
 
-    {py2.7,py3.7,py3.8}-redis
-    {py2.7,py3.7,py3.8}-rediscluster-{1,2}
+    {py2.7,py3.7,py3.8,py3.9}-redis
+    {py2.7,py3.7,py3.8,py3.9}-rediscluster-{1,2}
 
-    py{3.7,3.8}-asgi
+    py{3.7,3.8,py3.9}-asgi
 
-    {py2.7,py3.7,py3.8}-sqlalchemy-{1.2,1.3}
+    {py2.7,py3.7,py3.8,py3.9}-sqlalchemy-{1.2,1.3}
 
     py3.7-spark
 
-    {py3.5,py3.6,py3.7,py3.8}-pure_eval
+    {py3.5,py3.6,py3.7,py3.8,py3.9}-pure_eval
 
 [testenv]
 deps =
     -r test-requirements.txt
 
     django-{1.11,2.0,2.1,2.2,3.0,3.1,dev}: djangorestframework>=3.0.0,<4.0.0
-    {py3.7,py3.8}-django-{1.11,2.0,2.1,2.2,3.0,3.1,dev}: channels>2
-    {py3.7,py3.8}-django-{1.11,2.0,2.1,2.2,3.0,3.1,dev}: pytest-asyncio==0.10.0
-    {py2.7,py3.7,py3.8}-django-{1.11,2.2,3.0,3.1,dev}: psycopg2-binary
+    {py3.7,py3.8,py3.9}-django-{1.11,2.0,2.1,2.2,3.0,3.1,dev}: channels>2
+    {py3.7,py3.8,py3.9}-django-{1.11,2.0,2.1,2.2,3.0,3.1,dev}: pytest-asyncio==0.10.0
+    {py2.7,py3.7,py3.8,py3.9}-django-{1.11,2.2,3.0,3.1,dev}: psycopg2-binary
 
     django-{1.6,1.7,1.8}: pytest-django<3.0
     django-{1.9,1.10,1.11,2.0,2.1,2.2,3.0,3.1}: pytest-django>=3.0
@@ -237,6 +237,7 @@ basepython =
     py3.6: python3.6
     py3.7: python3.7
     py3.8: python3.8
+    py3.9: python3.9
     linters: python3
     pypy: pypy
 


### PR DESCRIPTION
Xenial is already the default dist on Travis CI.  (bionic and focal are also available)

Py39 in allow_failures mode until the GA release in one month.  https://devguide.python.org/#status-of-python-branches

Note: Python 3.4 is end of life and 3.5 will be end of life in two weeks.  https://devguide.python.org/devcycle/#end-of-life-branches

Also fixes:
<img width="694" alt="Screenshot 2020-09-02 at 11 59 43" src="https://user-images.githubusercontent.com/3709715/91968621-2d665a00-ed15-11ea-80cf-90332b562d5a.png">
