### PR TITLE
fix: Allow ASGI middleware to capture exceptions in nested call

### DIFF
--- a/tests/integrations/asgi/test_asgi.py
+++ b/tests/integrations/asgi/test_asgi.py
@@ -9,7 +9,6 @@ from starlette.testclient import TestClient
 from starlette.websockets import WebSocket
 
 
-
 @pytest.fixture
 def app():
     app = Starlette()
@@ -198,8 +197,8 @@ def test_starlette_last_event_id(app, sentry_init, capture_events, request):
     response = client.get("/handlederror")
     assert response.status_code == 500
 
-    event, = events
-    assert response.content.strip().decode('ascii') == event['event_id']
+    (event,) = events
+    assert response.content.strip().decode("ascii") == event["event_id"]
     (exception,) = event["exception"]["values"]
-    assert exception['type'] == 'ValueError'
-    assert exception['value'] == 'oh no'
+    assert exception["type"] == "ValueError"
+    assert exception["value"] == "oh no"

--- a/tests/integrations/asgi/test_asgi.py
+++ b/tests/integrations/asgi/test_asgi.py
@@ -1,12 +1,13 @@
 import sys
 
 import pytest
-from sentry_sdk import Hub, capture_message
+from sentry_sdk import Hub, capture_message, last_event_id
 from sentry_sdk.integrations.asgi import SentryAsgiMiddleware
 from starlette.applications import Starlette
 from starlette.responses import PlainTextResponse
 from starlette.testclient import TestClient
 from starlette.websockets import WebSocket
+
 
 
 @pytest.fixture
@@ -179,3 +180,26 @@ def test_websocket(sentry_init, capture_events, request):
             "url": "ws://testserver/",
         }
     )
+
+
+def test_starlette_last_event_id(app, sentry_init, capture_events, request):
+    sentry_init(send_default_pii=True)
+    events = capture_events()
+
+    @app.route("/handlederror")
+    def handlederror(request):
+        raise ValueError("oh no")
+
+    @app.exception_handler(500)
+    def handler(*args, **kwargs):
+        return PlainTextResponse(last_event_id(), status_code=500)
+
+    client = TestClient(SentryAsgiMiddleware(app), raise_server_exceptions=False)
+    response = client.get("/handlederror")
+    assert response.status_code == 500
+
+    event, = events
+    assert response.content.strip().decode('ascii') == event['event_id']
+    (exception,) = event["exception"]["values"]
+    assert exception['type'] == 'ValueError'
+    assert exception['value'] == 'oh no'


### PR DESCRIPTION
When the exception bubbles up we deduplicate it based on object identity, so this should be fine

Fix #816