### PR TITLE
fix(celery): Fix dropped transactions under Celery 4.2+

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ dist: xenial
 
 services:
   - postgresql
+  - redis-server
 
 language: python
 

--- a/sentry_sdk/tracing.py
+++ b/sentry_sdk/tracing.py
@@ -318,7 +318,7 @@ class Span(object):
 
     def set_http_status(self, http_status):
         # type: (int) -> None
-        self.set_tag("http.status_code", http_status)
+        self.set_tag("http.status_code", str(http_status))
 
         if http_status < 400:
             self.set_status("ok")

--- a/tests/integrations/celery/test_celery.py
+++ b/tests/integrations/celery/test_celery.py
@@ -23,19 +23,19 @@ def connect_signal(request):
 
 @pytest.fixture
 def init_celery(sentry_init, request):
-    def inner(propagate_traces=True, backend='always_eager', **kwargs):
+    def inner(propagate_traces=True, backend="always_eager", **kwargs):
         sentry_init(
             integrations=[CeleryIntegration(propagate_traces=propagate_traces)],
             **kwargs
         )
         celery = Celery(__name__)
 
-        if backend == 'always_eager':
+        if backend == "always_eager":
             if VERSION < (4,):
                 celery.conf.CELERY_ALWAYS_EAGER = True
             else:
                 celery.conf.task_always_eager = True
-        elif backend == 'redis':
+        elif backend == "redis":
             # requires capture_events_forksafe
             celery.conf.worker_max_tasks_per_child = 1
             celery.conf.broker_url = "redis://127.0.0.1:6379"
@@ -294,7 +294,7 @@ def test_retry(celery, capture_events):
 
 @pytest.mark.forked
 def test_redis_backend(init_celery, capture_events_forksafe, tmpdir):
-    celery = init_celery(traces_sample_rate=1.0, backend='redis', debug=True)
+    celery = init_celery(traces_sample_rate=1.0, backend="redis", debug=True)
 
     events = capture_events_forksafe()
 
@@ -320,7 +320,10 @@ def test_redis_backend(init_celery, capture_events_forksafe, tmpdir):
     assert exception["type"] == "ZeroDivisionError"
 
     transaction = events.read_event()
-    assert transaction['contexts']['trace']['trace_id'] == event['contexts']['trace']['trace_id']
+    assert (
+        transaction["contexts"]["trace"]["trace_id"]
+        == event["contexts"]["trace"]["trace_id"]
+    )
 
     events.read_flush()
 

--- a/tests/integrations/celery/test_celery.py
+++ b/tests/integrations/celery/test_celery.py
@@ -305,7 +305,8 @@ def test_redis_backend(init_celery, capture_events_forksafe, tmpdir):
         runs.append(1)
         1 / 0
 
-    res = dummy_task.delay()
+    # Curious: Cannot use delay() here or py2.7-celery-4.2 crashes
+    res = dummy_task.apply_async()
 
     with pytest.raises(Exception):
         # Celery 4.1 raises a gibberish exception

--- a/tests/integrations/celery/test_celery.py
+++ b/tests/integrations/celery/test_celery.py
@@ -22,17 +22,37 @@ def connect_signal(request):
 
 
 @pytest.fixture
-def init_celery(sentry_init):
-    def inner(propagate_traces=True, **kwargs):
+def init_celery(sentry_init, request):
+    def inner(propagate_traces=True, backend='always_eager', **kwargs):
         sentry_init(
             integrations=[CeleryIntegration(propagate_traces=propagate_traces)],
             **kwargs
         )
         celery = Celery(__name__)
-        if VERSION < (4,):
-            celery.conf.CELERY_ALWAYS_EAGER = True
+
+        if backend == 'always_eager':
+            if VERSION < (4,):
+                celery.conf.CELERY_ALWAYS_EAGER = True
+            else:
+                celery.conf.task_always_eager = True
+        elif backend == 'redis':
+            # requires capture_events_forksafe
+            celery.conf.worker_max_tasks_per_child = 1
+            celery.conf.broker_url = "redis://127.0.0.1:6379"
+            celery.conf.result_backend = "redis://127.0.0.1:6379"
+            celery.conf.task_always_eager = False
+
+            Hub.main.bind_client(Hub.current.client)
+            request.addfinalizer(lambda: Hub.main.bind_client(None))
+
+            # Once we drop celery 3 we can use the celery_worker fixture
+            w = worker.worker(app=celery)
+            t = threading.Thread(target=w.run)
+            t.daemon = True
+            t.start()
         else:
-            celery.conf.task_always_eager = True
+            raise ValueError(backend)
+
         return celery
 
     return inner
@@ -273,15 +293,10 @@ def test_retry(celery, capture_events):
 
 
 @pytest.mark.forked
-@pytest.mark.skipif(VERSION < (4,), reason="in-memory backend broken")
-def test_transport_shutdown(request, celery, capture_events_forksafe, tmpdir):
-    events = capture_events_forksafe()
+def test_redis_backend(init_celery, capture_events_forksafe, tmpdir):
+    celery = init_celery(traces_sample_rate=1.0, backend='redis', debug=True)
 
-    celery.conf.worker_max_tasks_per_child = 1
-    celery.conf.broker_url = "memory://localhost/"
-    celery.conf.broker_backend = "memory"
-    celery.conf.result_backend = "file://{}".format(tmpdir.mkdir("celery-results"))
-    celery.conf.task_always_eager = False
+    events = capture_events_forksafe()
 
     runs = []
 
@@ -292,18 +307,19 @@ def test_transport_shutdown(request, celery, capture_events_forksafe, tmpdir):
 
     res = dummy_task.delay()
 
-    w = worker.worker(app=celery)
-    t = threading.Thread(target=w.run)
-    t.daemon = True
-    t.start()
-
     with pytest.raises(Exception):
         # Celery 4.1 raises a gibberish exception
         res.wait()
 
+    # if this is nonempty, the worker never really forked
+    assert not runs
+
     event = events.read_event()
     (exception,) = event["exception"]["values"]
     assert exception["type"] == "ZeroDivisionError"
+
+    transaction = events.read_event()
+    assert transaction['contexts']['trace']['trace_id'] == event['contexts']['trace']['trace_id']
 
     events.read_flush()
 

--- a/tests/integrations/celery/test_celery.py
+++ b/tests/integrations/celery/test_celery.py
@@ -36,7 +36,11 @@ def init_celery(sentry_init, request):
             else:
                 celery.conf.task_always_eager = True
         elif backend == "redis":
-            # requires capture_events_forksafe
+            # broken on celery 3
+            if VERSION < (4,):
+                pytest.skip("Redis backend broken for some reason")
+
+            # this backend requires capture_events_forksafe
             celery.conf.worker_max_tasks_per_child = 1
             celery.conf.broker_url = "redis://127.0.0.1:6379"
             celery.conf.result_backend = "redis://127.0.0.1:6379"

--- a/tox.ini
+++ b/tox.ini
@@ -38,7 +38,8 @@ envlist =
     {py3.6,py3.7}-sanic-19
 
     # TODO: Add py3.9
-    {pypy,py2.7,py3.5,py3.6,py3.7,py3.8}-celery-{4.1,4.2,4.3,4.4}
+    {pypy,py2.7,py3.5,py3.6}-celery-{4.1,4.2}
+    {pypy,py2.7,py3.5,py3.6,py3.7,py3.8}-celery-{4.3,4.4}
     {pypy,py2.7}-celery-3
 
     {py2.7,py3.7}-beam-{2.12,2.13}
@@ -128,6 +129,7 @@ deps =
     beam-2.13: apache-beam>=2.13.0, <2.14.0
     beam-master: git+https://github.com/apache/beam#egg=apache-beam&subdirectory=sdks/python
 
+    celery: redis
     celery-3: Celery>=3.1,<4.0
     celery-4.1: Celery>=4.1,<4.2
     celery-4.2: Celery>=4.2,<4.3


### PR DESCRIPTION
* Work around https://github.com/celery/celery/issues/4875 which causes us to lose transaction events. Fix #824 
* Rewrite celery testsuite to use redis backend and test transactions too. This is better because it works on more celery versions (memory backend is often broken). However, this still does not trigger the bug, so I guess for this to be properly tested we'd need to install rabbitmq into CI? No thanks