### PR TITLE
fix(transport): Use correct data category for transaction events

### DIFF
--- a/sentry_sdk/envelope.py
+++ b/sentry_sdk/envelope.py
@@ -242,7 +242,7 @@ class Item(object):
     def get_event(self):
         # type: (...) -> Optional[Event]
         """
-        Returns a regular (non-transaction) event if there is one.
+        Returns an error event if there is one.
         """
         if self.headers.get("type") == "event" and self.payload.json is not None:
             return self.payload.json

--- a/sentry_sdk/envelope.py
+++ b/sentry_sdk/envelope.py
@@ -224,8 +224,12 @@ class Item(object):
     def data_category(self):
         # type: (...) -> EventDataCategory
         ty = self.headers.get("type")
-        if ty in ("session", "attachment", "transaction"):
-            return ty
+        if ty == "session":
+            return "session"
+        elif ty == "attachment":
+            return "attachment"
+        elif ty == "transaction":
+            return "transaction"
         elif ty == "event":
             return "error"
         else:

--- a/sentry_sdk/envelope.py
+++ b/sentry_sdk/envelope.py
@@ -248,7 +248,10 @@ class Item(object):
         Returns a regular event if there is one. Transaction events are exempt
         from this.
         """
-        if self.headers.get("type") in ("event", "transaction") and self.payload.json is not None:
+        if (
+            self.headers.get("type") in ("event", "transaction")
+            and self.payload.json is not None
+        ):
             return self.payload.json
         return None
 

--- a/sentry_sdk/envelope.py
+++ b/sentry_sdk/envelope.py
@@ -248,7 +248,7 @@ class Item(object):
         Returns a regular event if there is one. Transaction events are exempt
         from this.
         """
-        if self.headers.get("type") in "event" and self.payload.json is not None:
+        if self.headers.get("type") in ("event", "transaction") and self.payload.json is not None:
             return self.payload.json
         return None
 

--- a/sentry_sdk/envelope.py
+++ b/sentry_sdk/envelope.py
@@ -20,13 +20,6 @@ if MYPY:
     from sentry_sdk._types import Event, EventDataCategory
 
 
-def get_event_data_category(event):
-    # type: (Event) -> EventDataCategory
-    if event.get("type") == "transaction":
-        return "transaction"
-    return "error"
-
-
 class Envelope(object):
     def __init__(
         self,
@@ -245,8 +238,7 @@ class Item(object):
     def get_event(self):
         # type: (...) -> Optional[Event]
         """
-        Returns a regular event if there is one. Transaction events are exempt
-        from this.
+        Returns a regular event if there is one.
         """
         if (
             self.headers.get("type") in ("event", "transaction")

--- a/sentry_sdk/envelope.py
+++ b/sentry_sdk/envelope.py
@@ -244,7 +244,11 @@ class Item(object):
 
     def get_event(self):
         # type: (...) -> Optional[Event]
-        if self.headers.get("type") in ("event", "transaction") and self.payload.json is not None:
+        """
+        Returns a regular event if there is one. Transaction events are exempt
+        from this.
+        """
+        if self.headers.get("type") in "event" and self.payload.json is not None:
             return self.payload.json
         return None
 

--- a/sentry_sdk/envelope.py
+++ b/sentry_sdk/envelope.py
@@ -238,12 +238,9 @@ class Item(object):
     def get_event(self):
         # type: (...) -> Optional[Event]
         """
-        Returns a regular event if there is one.
+        Returns a regular (non-transaction) event if there is one.
         """
-        if (
-            self.headers.get("type") in ("event", "transaction")
-            and self.payload.json is not None
-        ):
+        if self.headers.get("type") == "event" and self.payload.json is not None:
             return self.payload.json
         return None
 

--- a/sentry_sdk/envelope.py
+++ b/sentry_sdk/envelope.py
@@ -230,15 +230,13 @@ class Item(object):
     @property
     def data_category(self):
         # type: (...) -> EventDataCategory
-        rv = "default"  # type: Any
-        event = self.get_event()
-        if event is not None:
-            rv = get_event_data_category(event)
+        ty = self.headers.get("type")
+        if ty in ("session", "attachment", "transaction"):
+            return ty
+        elif ty == "event":
+            return "error"
         else:
-            ty = self.headers.get("type")
-            if ty in ("session", "attachment"):
-                rv = ty
-        return rv
+            return "default"
 
     def get_bytes(self):
         # type: (...) -> bytes
@@ -246,7 +244,7 @@ class Item(object):
 
     def get_event(self):
         # type: (...) -> Optional[Event]
-        if self.headers.get("type") == "event" and self.payload.json is not None:
+        if self.headers.get("type") in ("event", "transaction") and self.payload.json is not None:
             return self.payload.json
         return None
 

--- a/sentry_sdk/transport.py
+++ b/sentry_sdk/transport.py
@@ -9,7 +9,7 @@ from datetime import datetime, timedelta
 
 from sentry_sdk.utils import Dsn, logger, capture_internal_exceptions, json_dumps
 from sentry_sdk.worker import BackgroundWorker
-from sentry_sdk.envelope import Envelope, get_event_data_category
+from sentry_sdk.envelope import Envelope
 
 from sentry_sdk._types import MYPY
 
@@ -67,17 +67,10 @@ class Transport(object):
         self, envelope  # type: Envelope
     ):
         # type: (...) -> None
-        """This gets invoked with an envelope when an event should
-        be sent to sentry.  The default implementation invokes `capture_event`
-        if the envelope contains an event and ignores all other envelopes.
-
-        Note that this excludes transaction events as they should be sent to
-        the envelopes endpoint always.
+        """This gets invoked with an envelope when a transaction or session should
+        be sent to sentry.
         """
-        event = envelope.get_event()
-        if event is not None:
-            self.capture_event(event)
-        return None
+        raise NotImplementedError()
 
     def flush(
         self,
@@ -211,9 +204,9 @@ class HttpTransport(Transport):
         self, event  # type: Event
     ):
         # type: (...) -> None
-        assert event["type"] != "transaction"
+        assert event.get("type") != "transaction"
 
-        if self._check_disabled(get_event_data_category(event)):
+        if self._check_disabled("error"):
             return None
 
         body = io.BytesIO()

--- a/sentry_sdk/transport.py
+++ b/sentry_sdk/transport.py
@@ -208,6 +208,8 @@ class HttpTransport(Transport):
         self, event  # type: Event
     ):
         # type: (...) -> None
+        assert event['type'] != 'transaction'
+
         if self._check_disabled(get_event_data_category(event)):
             return None
 

--- a/sentry_sdk/transport.py
+++ b/sentry_sdk/transport.py
@@ -58,7 +58,8 @@ class Transport(object):
         self, event  # type: Event
     ):
         # type: (...) -> None
-        """This gets invoked with the event dictionary when an event should
+        """
+        This gets invoked with the event dictionary when an event should
         be sent to sentry.
         """
         raise NotImplementedError()
@@ -67,8 +68,13 @@ class Transport(object):
         self, envelope  # type: Envelope
     ):
         # type: (...) -> None
-        """This gets invoked with an envelope when a transaction or session should
-        be sent to sentry.
+        """
+        Send an envelope to Sentry.
+
+        Envelopes are a data container format that can hold any type of data
+        submitted to Sentry. We use it for transactions and sessions, but
+        regular "error" events should go through `capture_event` for backwards
+        compat.
         """
         raise NotImplementedError()
 
@@ -204,7 +210,6 @@ class HttpTransport(Transport):
         self, event  # type: Event
     ):
         # type: (...) -> None
-        assert event.get("type") != "transaction"
 
         if self._check_disabled("error"):
             return None

--- a/sentry_sdk/transport.py
+++ b/sentry_sdk/transport.py
@@ -211,7 +211,7 @@ class HttpTransport(Transport):
         self, event  # type: Event
     ):
         # type: (...) -> None
-        assert event['type'] != 'transaction'
+        assert event["type"] != "transaction"
 
         if self._check_disabled(get_event_data_category(event)):
             return None

--- a/sentry_sdk/transport.py
+++ b/sentry_sdk/transport.py
@@ -70,6 +70,9 @@ class Transport(object):
         """This gets invoked with an envelope when an event should
         be sent to sentry.  The default implementation invokes `capture_event`
         if the envelope contains an event and ignores all other envelopes.
+
+        Note that this excludes transaction events as they should be sent to
+        the envelopes endpoint always.
         """
         event = envelope.get_event()
         if event is not None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -137,7 +137,9 @@ def monkeypatch_test_transport(monkeypatch, validate_event_schema):
         pass
 
     def inner(client):
-        monkeypatch.setattr(client, "transport", TestTransport(check_event, check_envelope))
+        monkeypatch.setattr(
+            client, "transport", TestTransport(check_event, check_envelope)
+        )
 
     return inner
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -132,8 +132,12 @@ def monkeypatch_test_transport(monkeypatch, validate_event_schema):
             check_string_keys(event)
             validate_event_schema(event)
 
+    def check_envelope(envelope):
+        # Perhaps one day
+        pass
+
     def inner(client):
-        monkeypatch.setattr(client, "transport", TestTransport(check_event))
+        monkeypatch.setattr(client, "transport", TestTransport(check_event, check_envelope))
 
     return inner
 
@@ -167,9 +171,10 @@ def sentry_init(monkeypatch_test_transport, request):
 
 
 class TestTransport(Transport):
-    def __init__(self, capture_event_callback):
+    def __init__(self, capture_event_callback, capture_envelope_callback):
         Transport.__init__(self)
         self.capture_event = capture_event_callback
+        self.capture_envelope = capture_envelope_callback
         self._queue = None
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -133,8 +133,10 @@ def monkeypatch_test_transport(monkeypatch, validate_event_schema):
             validate_event_schema(event)
 
     def check_envelope(envelope):
-        # Perhaps one day
-        pass
+        with capture_internal_exceptions():
+            # Assert error events are sent without envelope to server, for compat.
+            assert not any(item.data_category == "error" for item in envelope.items)
+            assert not any(item.get_event() is not None for item in envelope.items)
 
     def inner(client):
         monkeypatch.setattr(

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -730,6 +730,11 @@ def test_init_string_types(dsn, sentry_init):
 
 
 def test_envelope_types():
+    """
+    Tests for calling the right transport method (capture_event vs
+    capture_envelope) from the SDK client for different data types.
+    """
+
     envelopes = []
     events = []
 
@@ -743,6 +748,7 @@ def test_envelope_types():
     with Hub(Client(traces_sample_rate=1.0, transport=CustomTransport())):
         event_id = capture_message("hello")
 
+        # Assert error events get passed in via capture_event
         assert not envelopes
         event = events.pop()
 
@@ -752,6 +758,7 @@ def test_envelope_types():
         with start_transaction(name="foo"):
             pass
 
+        # Assert transactions get passed in via capture_envelope
         assert not events
         envelope = envelopes.pop()
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -729,7 +729,6 @@ def test_init_string_types(dsn, sentry_init):
     )
 
 
-
 def test_envelope_types():
     envelopes = []
     events = []
@@ -747,17 +746,17 @@ def test_envelope_types():
         assert not envelopes
         event = events.pop()
 
-        assert event['event_id'] == event_id
-        assert 'type' not in event
+        assert event["event_id"] == event_id
+        assert "type" not in event
 
-        with start_transaction(name='foo'):
+        with start_transaction(name="foo"):
             pass
 
         assert not events
         envelope = envelopes.pop()
 
-        item, = envelope.items
-        assert item.data_category == 'transaction'
+        (item,) = envelope.items
+        assert item.data_category == "transaction"
         assert item.headers.get("type") == "transaction"
 
     assert not envelopes

--- a/tests/test_transport.py
+++ b/tests/test_transport.py
@@ -116,7 +116,7 @@ def test_simple_rate_limits(httpserver, capsys, caplog, make_client):
     client.capture_event({"type": "transaction"})
     client.flush()
 
-    assert len(httpserver.requests) == 1
+    assert list(r.url[-18:] for r in httpserver.requests) == ['/api/132/envelope/']
     del httpserver.requests[:]
 
     assert set(client.transport._disabled_until) == set([None])
@@ -140,13 +140,13 @@ def test_data_category_limits(httpserver, capsys, caplog, response_code, make_cl
     client.capture_event({"type": "transaction"})
     client.flush()
 
-    assert len(httpserver.requests) == 1
+    assert list(r.url[-18:] for r in httpserver.requests) == ['/api/132/envelope/']
     del httpserver.requests[:]
 
     assert set(client.transport._disabled_until) == set(["transaction"])
 
-    client.transport.capture_event({"type": "transaction"})
-    client.transport.capture_event({"type": "transaction"})
+    client.capture_event({"type": "transaction"})
+    client.capture_event({"type": "transaction"})
     client.flush()
 
     assert not httpserver.requests
@@ -171,13 +171,13 @@ def test_complex_limits_without_data_category(
     client.capture_event({"type": "transaction"})
     client.flush()
 
-    assert len(httpserver.requests) == 1
+    assert list(r.url[-18:] for r in httpserver.requests) == ['/api/132/envelope/']
     del httpserver.requests[:]
 
     assert set(client.transport._disabled_until) == set([None])
 
-    client.transport.capture_event({"type": "transaction"})
-    client.transport.capture_event({"type": "transaction"})
+    client.capture_event({"type": "transaction"})
+    client.capture_event({"type": "transaction"})
     client.capture_event({"type": "event"})
     client.flush()
 

--- a/tests/test_transport.py
+++ b/tests/test_transport.py
@@ -116,7 +116,8 @@ def test_simple_rate_limits(httpserver, capsys, caplog, make_client):
     client.capture_event({"type": "transaction"})
     client.flush()
 
-    assert list(r.url[-18:] for r in httpserver.requests) == ["/api/132/envelope/"]
+    assert len(httpserver.requests) == 1
+    assert httpserver.requests[0].url.endswith("/api/132/envelope/")
     del httpserver.requests[:]
 
     assert set(client.transport._disabled_until) == set([None])
@@ -140,7 +141,8 @@ def test_data_category_limits(httpserver, capsys, caplog, response_code, make_cl
     client.capture_event({"type": "transaction"})
     client.flush()
 
-    assert list(r.url[-18:] for r in httpserver.requests) == ["/api/132/envelope/"]
+    assert len(httpserver.requests) == 1
+    assert httpserver.requests[0].url.endswith("/api/132/envelope/")
     del httpserver.requests[:]
 
     assert set(client.transport._disabled_until) == set(["transaction"])
@@ -171,7 +173,8 @@ def test_complex_limits_without_data_category(
     client.capture_event({"type": "transaction"})
     client.flush()
 
-    assert list(r.url[-18:] for r in httpserver.requests) == ["/api/132/envelope/"]
+    assert len(httpserver.requests) == 1
+    assert httpserver.requests[0].url.endswith("/api/132/envelope/")
     del httpserver.requests[:]
 
     assert set(client.transport._disabled_until) == set([None])

--- a/tests/test_transport.py
+++ b/tests/test_transport.py
@@ -116,7 +116,7 @@ def test_simple_rate_limits(httpserver, capsys, caplog, make_client):
     client.capture_event({"type": "transaction"})
     client.flush()
 
-    assert list(r.url[-18:] for r in httpserver.requests) == ['/api/132/envelope/']
+    assert list(r.url[-18:] for r in httpserver.requests) == ["/api/132/envelope/"]
     del httpserver.requests[:]
 
     assert set(client.transport._disabled_until) == set([None])
@@ -140,7 +140,7 @@ def test_data_category_limits(httpserver, capsys, caplog, response_code, make_cl
     client.capture_event({"type": "transaction"})
     client.flush()
 
-    assert list(r.url[-18:] for r in httpserver.requests) == ['/api/132/envelope/']
+    assert list(r.url[-18:] for r in httpserver.requests) == ["/api/132/envelope/"]
     del httpserver.requests[:]
 
     assert set(client.transport._disabled_until) == set(["transaction"])
@@ -171,7 +171,7 @@ def test_complex_limits_without_data_category(
     client.capture_event({"type": "transaction"})
     client.flush()
 
-    assert list(r.url[-18:] for r in httpserver.requests) == ['/api/132/envelope/']
+    assert list(r.url[-18:] for r in httpserver.requests) == ["/api/132/envelope/"]
     del httpserver.requests[:]
 
     assert set(client.transport._disabled_until) == set([None])


### PR DESCRIPTION
While working on https://github.com/getsentry/sentry-python/pull/825 I found a bug that caused us to use the "default" item type for transaction events. The bug happened because there were mismatched expectations as to what Item.get_event should return if the content is a transaction event.

Will add an explicit test later.