### PR TITLE
fix: Second attempt at fixing trace propagation in Celery 4.2+

### DIFF
--- a/sentry_sdk/integrations/celery.py
+++ b/sentry_sdk/integrations/celery.py
@@ -61,7 +61,6 @@ class CeleryIntegration(Integration):
                 # short-circuits to task.run if it thinks it's safe.
                 task.__call__ = _wrap_task_call(task, task.__call__)
                 task.run = _wrap_task_call(task, task.run)
-                task.apply_async = _wrap_apply_async(task, task.apply_async)
 
                 # `build_tracer` is apparently called for every task
                 # invocation. Can't wrap every celery task for every invocation
@@ -71,6 +70,10 @@ class CeleryIntegration(Integration):
             return _wrap_tracer(task, old_build_tracer(name, task, *args, **kwargs))
 
         trace.build_tracer = sentry_build_tracer
+
+        from celery.app.task import Task
+
+        Task.apply_async = _wrap_apply_async(Task.apply_async)
 
         _patch_worker_exit()
 
@@ -85,19 +88,22 @@ class CeleryIntegration(Integration):
         ignore_logger("celery.redirected")
 
 
-def _wrap_apply_async(task, f):
-    # type: (Any, F) -> F
+def _wrap_apply_async(f):
+    # type: (F) -> F
     @wraps(f)
     def apply_async(*args, **kwargs):
         # type: (*Any, **Any) -> Any
         hub = Hub.current
         integration = hub.get_integration(CeleryIntegration)
         if integration is not None and integration.propagate_traces:
-            with hub.start_span(op="celery.submit", description=task.name):
+            with hub.start_span(op="celery.submit", description=args[0].name) as span:
                 with capture_internal_exceptions():
                     headers = dict(hub.iter_trace_propagation_headers())
+
                     if headers:
-                        kwarg_headers = kwargs.setdefault("headers", {})
+                        # Note: kwargs can contain headers=None, so no setdefault!
+                        # Unsure which backend though.
+                        kwarg_headers = kwargs.get("headers") or {}
                         kwarg_headers.update(headers)
 
                         # https://github.com/celery/celery/issues/4875
@@ -105,10 +111,8 @@ def _wrap_apply_async(task, f):
                         # Need to setdefault the inner headers too since other
                         # tracing tools (dd-trace-py) also employ this exact
                         # workaround and we don't want to break them.
-                        #
-                        # This is not reproducible outside of AMQP, therefore no
-                        # tests!
                         kwarg_headers.setdefault("headers", {}).update(headers)
+                        kwargs['headers'] = kwarg_headers
 
                 return f(*args, **kwargs)
         else:

--- a/sentry_sdk/integrations/celery.py
+++ b/sentry_sdk/integrations/celery.py
@@ -112,7 +112,7 @@ def _wrap_apply_async(f):
                         # tracing tools (dd-trace-py) also employ this exact
                         # workaround and we don't want to break them.
                         kwarg_headers.setdefault("headers", {}).update(headers)
-                        kwargs['headers'] = kwarg_headers
+                        kwargs["headers"] = kwarg_headers
 
                 return f(*args, **kwargs)
         else:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 import os
 import json
+import traceback
 
 import pytest
 import jsonschema
@@ -235,11 +236,7 @@ def capture_envelopes(monkeypatch):
 @pytest.fixture
 def capture_events_forksafe(monkeypatch, capture_events, request):
     def inner():
-        in_process_events = capture_events()
-
-        @request.addfinalizer
-        def _():
-            assert not in_process_events
+        capture_events()
 
         events_r, events_w = os.pipe()
         events_r = os.fdopen(events_r, "rb", 0)

--- a/tests/integrations/celery/test_celery.py
+++ b/tests/integrations/celery/test_celery.py
@@ -42,6 +42,7 @@ def init_celery(sentry_init, request):
 
             # this backend requires capture_events_forksafe
             celery.conf.worker_max_tasks_per_child = 1
+            celery.conf.worker_concurrency = 1
             celery.conf.broker_url = "redis://127.0.0.1:6379"
             celery.conf.result_backend = "redis://127.0.0.1:6379"
             celery.conf.task_always_eager = False
@@ -297,7 +298,7 @@ def test_retry(celery, capture_events):
 
 
 @pytest.mark.forked
-def test_redis_backend(init_celery, capture_events_forksafe, tmpdir):
+def test_redis_backend_trace_propagation(init_celery, capture_events_forksafe, tmpdir):
     celery = init_celery(traces_sample_rate=1.0, backend="redis", debug=True)
 
     events = capture_events_forksafe()
@@ -309,8 +310,10 @@ def test_redis_backend(init_celery, capture_events_forksafe, tmpdir):
         runs.append(1)
         1 / 0
 
-    # Curious: Cannot use delay() here or py2.7-celery-4.2 crashes
-    res = dummy_task.apply_async()
+
+    with start_transaction(name='submit_celery'):
+        # Curious: Cannot use delay() here or py2.7-celery-4.2 crashes
+        res = dummy_task.apply_async()
 
     with pytest.raises(Exception):
         # Celery 4.1 raises a gibberish exception
@@ -318,6 +321,13 @@ def test_redis_backend(init_celery, capture_events_forksafe, tmpdir):
 
     # if this is nonempty, the worker never really forked
     assert not runs
+
+    submit_transaction = events.read_event()
+    assert submit_transaction['type'] == 'transaction'
+    assert submit_transaction['transaction'] == 'submit_celery'
+    span, = submit_transaction['spans']
+    assert span['op'] == 'celery.submit'
+    assert span['description'] == 'dummy_task'
 
     event = events.read_event()
     (exception,) = event["exception"]["values"]
@@ -327,6 +337,7 @@ def test_redis_backend(init_celery, capture_events_forksafe, tmpdir):
     assert (
         transaction["contexts"]["trace"]["trace_id"]
         == event["contexts"]["trace"]["trace_id"]
+        == submit_transaction["contexts"]["trace"]["trace_id"]
     )
 
     events.read_flush()

--- a/tests/integrations/celery/test_celery.py
+++ b/tests/integrations/celery/test_celery.py
@@ -310,8 +310,7 @@ def test_redis_backend_trace_propagation(init_celery, capture_events_forksafe, t
         runs.append(1)
         1 / 0
 
-
-    with start_transaction(name='submit_celery'):
+    with start_transaction(name="submit_celery"):
         # Curious: Cannot use delay() here or py2.7-celery-4.2 crashes
         res = dummy_task.apply_async()
 
@@ -323,11 +322,11 @@ def test_redis_backend_trace_propagation(init_celery, capture_events_forksafe, t
     assert not runs
 
     submit_transaction = events.read_event()
-    assert submit_transaction['type'] == 'transaction'
-    assert submit_transaction['transaction'] == 'submit_celery'
-    span, = submit_transaction['spans']
-    assert span['op'] == 'celery.submit'
-    assert span['description'] == 'dummy_task'
+    assert submit_transaction["type"] == "transaction"
+    assert submit_transaction["transaction"] == "submit_celery"
+    (span,) = submit_transaction["spans"]
+    assert span["op"] == "celery.submit"
+    assert span["description"] == "dummy_task"
 
     event = events.read_event()
     (exception,) = event["exception"]["values"]


### PR DESCRIPTION
It turns out the bug is perfectly reproducible with the Redis backend, I just messed up the test.