### PR TITLE
Replace PyPI page with README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@ raise ValueError()  # Will also create an event.
 
 # Contributing to the SDK
 
-Please refer to [CONTRIBUTING.md](./CONTRIBUTING.md).
+Please refer to [CONTRIBUTING.md](https://github.com/getsentry/sentry-python/blob/master/CONTRIBUTING.md).
 
 # License
 
-Licensed under the BSD license, see [`LICENSE`](./LICENSE)
+Licensed under the BSD license, see [`LICENSE`](https://github.com/getsentry/sentry-python/blob/master/LICENSE)

--- a/setup.py
+++ b/setup.py
@@ -8,8 +8,17 @@ Sentry-Python - Sentry SDK for Python
 <https://github.com/getsentry/sentry-python>`_ to find out more.
 """
 
+import os
 from setuptools import setup, find_packages
 
+here = os.path.abspath(os.path.dirname(__file__))
+
+
+def get_file_text(file_name):
+    with open(os.path.join(here, file_name)) as in_file:
+        return in_file.read()
+
+    
 setup(
     name="sentry-sdk",
     version="0.17.8",
@@ -17,7 +26,8 @@ setup(
     author_email="hello@sentry.io",
     url="https://github.com/getsentry/sentry-python",
     description="Python client for Sentry (https://sentry.io)",
-    long_description=__doc__,
+    long_description="\n".join((get_file_text("README.md"), get_file_text("CHANGES.md")))
+    long_description_content_type='text/markdown',
     packages=find_packages(exclude=("tests", "tests.*")),
     # PEP 561
     package_data={"sentry_sdk": ["py.typed"]},

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
     author_email="hello@sentry.io",
     url="https://github.com/getsentry/sentry-python",
     description="Python client for Sentry (https://sentry.io)",
-    long_description="\n".join((get_file_text("README.md"), get_file_text("CHANGES.md")))
+    long_description="\n".join((get_file_text("README.md"), get_file_text("CHANGES.md"))),
     long_description_content_type='text/markdown',
     packages=find_packages(exclude=("tests", "tests.*")),
     # PEP 561

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
     author_email="hello@sentry.io",
     url="https://github.com/getsentry/sentry-python",
     description="Python client for Sentry (https://sentry.io)",
-    long_description="\n".join((get_file_text("README.md"), get_file_text("CHANGES.md"))),
+    long_description=get_file_text("README.md"),
     long_description_content_type='text/markdown',
     packages=find_packages(exclude=("tests", "tests.*")),
     # PEP 561


### PR DESCRIPTION
https://pypi.org/project/sentry-sdk/ is currently a bit too spartan and requires the user to do extra clicks to determine if they want to install or upgrade this package.

This PR proposes to replace the current one-liner with the markdown content from `README.md`.