### PR TITLE
fix(serialization): Do not crash if tag is nan

### DIFF
--- a/sentry_sdk/serializer.py
+++ b/sentry_sdk/serializer.py
@@ -1,4 +1,5 @@
 import sys
+import math
 
 from datetime import datetime
 
@@ -273,7 +274,10 @@ def serialize(event, smart_transaction_trimming=False, **kwargs):
                     return _flatten_annotated(result)
 
         if obj is None or isinstance(obj, (bool, number_types)):
-            return obj if not should_repr_strings else safe_repr(obj)
+            if should_repr_strings or (isinstance(obj, float) and (math.isinf(obj) or math.isnan(obj))):
+                return safe_repr(obj)
+            else:
+                return obj
 
         elif isinstance(obj, datetime):
             return (

--- a/sentry_sdk/serializer.py
+++ b/sentry_sdk/serializer.py
@@ -274,7 +274,9 @@ def serialize(event, smart_transaction_trimming=False, **kwargs):
                     return _flatten_annotated(result)
 
         if obj is None or isinstance(obj, (bool, number_types)):
-            if should_repr_strings or (isinstance(obj, float) and (math.isinf(obj) or math.isnan(obj))):
+            if should_repr_strings or (
+                isinstance(obj, float) and (math.isinf(obj) or math.isnan(obj))
+            ):
                 return safe_repr(obj)
             else:
                 return obj

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -15,6 +15,7 @@ from sentry_sdk import (
     capture_exception,
     capture_event,
     start_transaction,
+    set_tag
 )
 from sentry_sdk.integrations.executing import ExecutingIntegration
 from sentry_sdk.transport import Transport
@@ -416,6 +417,10 @@ def test_nan(sentry_init, capture_events):
     events = capture_events()
 
     try:
+        # should_repr_strings=False
+        set_tag("mynan", float("nan"))
+
+        # should_repr_strings=True
         nan = float("nan")  # noqa
         1 / 0
     except Exception:
@@ -425,6 +430,7 @@ def test_nan(sentry_init, capture_events):
     frames = event["exception"]["values"][0]["stacktrace"]["frames"]
     (frame,) = frames
     assert frame["vars"]["nan"] == "nan"
+    assert event['tags']['mynan'] == 'nan'
 
 
 def test_cyclic_frame_vars(sentry_init, capture_events):

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -15,7 +15,7 @@ from sentry_sdk import (
     capture_exception,
     capture_event,
     start_transaction,
-    set_tag
+    set_tag,
 )
 from sentry_sdk.integrations.executing import ExecutingIntegration
 from sentry_sdk.transport import Transport
@@ -430,7 +430,7 @@ def test_nan(sentry_init, capture_events):
     frames = event["exception"]["values"][0]["stacktrace"]["frames"]
     (frame,) = frames
     assert frame["vars"]["nan"] == "nan"
-    assert event['tags']['mynan'] == 'nan'
+    assert event["tags"]["mynan"] == "nan"
 
 
 def test_cyclic_frame_vars(sentry_init, capture_events):


### PR DESCRIPTION
We already had safeguards for this situation, but only for local variables, not tags and extra.