### PR TITLE
fix: Fix crash with Django 3.1 async views

### DIFF
--- a/sentry_sdk/integrations/django/asgi.py
+++ b/sentry_sdk/integrations/django/asgi.py
@@ -72,6 +72,7 @@ def patch_channels_asgi_handler_impl(cls):
 
 
 def wrap_async_view(hub, callback):
+    # type: (Hub, Any) -> Any
     @_functools.wraps(callback)
     async def sentry_wrapped_callback(request, *args, **kwargs):
         # type: (Any, *Any, **Any) -> Any

--- a/sentry_sdk/integrations/django/asgi.py
+++ b/sentry_sdk/integrations/django/asgi.py
@@ -6,10 +6,9 @@ Since this file contains `async def` it is conditionally imported in
 `django.core.handlers.asgi`.
 """
 
-from sentry_sdk import Hub
+from sentry_sdk import Hub, _functools
 from sentry_sdk._types import MYPY
 
-from sentry_sdk.integrations.django import DjangoIntegration
 from sentry_sdk.integrations.asgi import SentryAsgiMiddleware
 
 if MYPY:
@@ -21,6 +20,9 @@ if MYPY:
 
 def patch_django_asgi_handler_impl(cls):
     # type: (Any) -> None
+
+    from sentry_sdk.integrations.django import DjangoIntegration
+
     old_app = cls.__call__
 
     async def sentry_patched_asgi_handler(self, scope, receive, send):
@@ -50,6 +52,9 @@ def patch_get_response_async(cls, _before_get_response):
 
 def patch_channels_asgi_handler_impl(cls):
     # type: (Any) -> None
+
+    from sentry_sdk.integrations.django import DjangoIntegration
+
     old_app = cls.__call__
 
     async def sentry_patched_asgi_handler(self, receive, send):
@@ -64,3 +69,16 @@ def patch_channels_asgi_handler_impl(cls):
         return await middleware(self.scope)(receive, send)
 
     cls.__call__ = sentry_patched_asgi_handler
+
+
+def wrap_async_view(hub, callback):
+    @_functools.wraps(callback)
+    async def sentry_wrapped_callback(request, *args, **kwargs):
+        # type: (Any, *Any, **Any) -> Any
+
+        with hub.start_span(
+            op="django.view", description=request.resolver_match.view_name
+        ):
+            return await callback(request, *args, **kwargs)
+
+    return sentry_wrapped_callback

--- a/sentry_sdk/integrations/django/views.py
+++ b/sentry_sdk/integrations/django/views.py
@@ -9,13 +9,13 @@ if MYPY:
 try:
     from asyncio import iscoroutinefunction
 except ImportError:
-    iscoroutinefunction = None
+    iscoroutinefunction = None  # type: ignore
 
 
 try:
     from sentry_sdk.integrations.django.asgi import wrap_async_view
 except (ImportError, SyntaxError):
-    wrap_async_view = None
+    wrap_async_view = None  # type: ignore
 
 
 def patch_views():
@@ -57,6 +57,7 @@ def patch_views():
 
 
 def _wrap_sync_view(hub, callback):
+    # type: (Hub, Any) -> Any
     @_functools.wraps(callback)
     def sentry_wrapped_callback(request, *args, **kwargs):
         # type: (Any, *Any, **Any) -> Any

--- a/sentry_sdk/integrations/django/views.py
+++ b/sentry_sdk/integrations/django/views.py
@@ -39,10 +39,20 @@ def patch_views():
 
         if integration is not None and integration.middleware_spans:
 
-            if iscoroutinefunction is not None and wrap_async_view is not None and iscoroutinefunction(callback):
+            if (
+                iscoroutinefunction is not None
+                and wrap_async_view is not None
+                and iscoroutinefunction(callback)
+            ):
                 sentry_wrapped_callback = wrap_async_view(hub, callback)
             else:
-                print((iscoroutinefunction, wrap_async_view, iscoroutinefunction(callback)))
+                print(
+                    (
+                        iscoroutinefunction,
+                        wrap_async_view,
+                        iscoroutinefunction(callback),
+                    )
+                )
                 sentry_wrapped_callback = _wrap_sync_view(hub, callback)
 
         else:

--- a/sentry_sdk/integrations/django/views.py
+++ b/sentry_sdk/integrations/django/views.py
@@ -6,6 +6,18 @@ if MYPY:
     from typing import Any
 
 
+try:
+    from asyncio import iscoroutinefunction
+except ImportError:
+    iscoroutinefunction = None
+
+
+try:
+    from sentry_sdk.integrations.django.asgi import wrap_async_view
+except (ImportError, SyntaxError):
+    wrap_async_view = None
+
+
 def patch_views():
     # type: () -> None
 
@@ -27,13 +39,11 @@ def patch_views():
 
         if integration is not None and integration.middleware_spans:
 
-            @_functools.wraps(callback)
-            def sentry_wrapped_callback(request, *args, **kwargs):
-                # type: (Any, *Any, **Any) -> Any
-                with hub.start_span(
-                    op="django.view", description=request.resolver_match.view_name
-                ):
-                    return callback(request, *args, **kwargs)
+            if iscoroutinefunction is not None and wrap_async_view is not None and iscoroutinefunction(callback):
+                sentry_wrapped_callback = wrap_async_view(hub, callback)
+            else:
+                print((iscoroutinefunction, wrap_async_view, iscoroutinefunction(callback)))
+                sentry_wrapped_callback = _wrap_sync_view(hub, callback)
 
         else:
             sentry_wrapped_callback = callback
@@ -41,3 +51,15 @@ def patch_views():
         return sentry_wrapped_callback
 
     BaseHandler.make_view_atomic = sentry_patched_make_view_atomic
+
+
+def _wrap_sync_view(hub, callback):
+    @_functools.wraps(callback)
+    def sentry_wrapped_callback(request, *args, **kwargs):
+        # type: (Any, *Any, **Any) -> Any
+        with hub.start_span(
+            op="django.view", description=request.resolver_match.view_name
+        ):
+            return callback(request, *args, **kwargs)
+
+    return sentry_wrapped_callback

--- a/sentry_sdk/integrations/django/views.py
+++ b/sentry_sdk/integrations/django/views.py
@@ -46,13 +46,6 @@ def patch_views():
             ):
                 sentry_wrapped_callback = wrap_async_view(hub, callback)
             else:
-                print(
-                    (
-                        iscoroutinefunction,
-                        wrap_async_view,
-                        iscoroutinefunction(callback),
-                    )
-                )
                 sentry_wrapped_callback = _wrap_sync_view(hub, callback)
 
         else:

--- a/tests/integrations/django/asgi/test_asgi.py
+++ b/tests/integrations/django/asgi/test_asgi.py
@@ -46,7 +46,9 @@ async def test_basic(sentry_init, capture_events, application):
 
 @pytest.mark.parametrize("application", APPS)
 @pytest.mark.asyncio
-@pytest.mark.skipif(django.VERSION < (3,1), reason="async views have been introduced in Django 3.1")
+@pytest.mark.skipif(
+    django.VERSION < (3, 1), reason="async views have been introduced in Django 3.1"
+)
 async def test_async_views(sentry_init, capture_events, application):
     sentry_init(integrations=[DjangoIntegration()], send_default_pii=True)
 

--- a/tests/integrations/django/asgi/test_asgi.py
+++ b/tests/integrations/django/asgi/test_asgi.py
@@ -1,12 +1,8 @@
-import pytest
-
 import django
-
+import pytest
 from channels.testing import HttpCommunicator
-
 from sentry_sdk import capture_message
 from sentry_sdk.integrations.django import DjangoIntegration
-
 from tests.integrations.django.myapp.asgi import channels_application
 
 APPS = [channels_application]
@@ -46,3 +42,8 @@ async def test_basic(sentry_init, capture_events, application, request):
     capture_message("hi")
     event = events[-1]
     assert "request" not in event
+
+    # Test that async views work properly
+    comm = HttpCommunicator(application, "GET", "/async_ok")
+    response = await comm.get_response()
+    assert response["status"] == 200

--- a/tests/integrations/django/asgi/test_asgi.py
+++ b/tests/integrations/django/asgi/test_asgi.py
@@ -55,7 +55,7 @@ async def test_async_views(sentry_init, capture_events, application):
     response = await comm.get_response()
     assert response["status"] == 200
 
-    event, = events
+    (event,) = events
 
     assert event["transaction"] == "/async_message"
     assert event["request"] == {

--- a/tests/integrations/django/asgi/test_asgi.py
+++ b/tests/integrations/django/asgi/test_asgi.py
@@ -43,6 +43,7 @@ async def test_basic(sentry_init, capture_events, application):
     event = events[-1]
     assert "request" not in event
 
+
 @pytest.mark.parametrize("application", APPS)
 @pytest.mark.asyncio
 async def test_async_views(sentry_init, capture_events, application):

--- a/tests/integrations/django/asgi/test_asgi.py
+++ b/tests/integrations/django/asgi/test_asgi.py
@@ -46,6 +46,7 @@ async def test_basic(sentry_init, capture_events, application):
 
 @pytest.mark.parametrize("application", APPS)
 @pytest.mark.asyncio
+@pytest.mark.skipif(django.VERSION < (3,1), reason="async views have been introduced in Django 3.1")
 async def test_async_views(sentry_init, capture_events, application):
     sentry_init(integrations=[DjangoIntegration()], send_default_pii=True)
 

--- a/tests/integrations/django/asgi/test_asgi.py
+++ b/tests/integrations/django/asgi/test_asgi.py
@@ -14,7 +14,7 @@ if django.VERSION >= (3, 0):
 
 @pytest.mark.parametrize("application", APPS)
 @pytest.mark.asyncio
-async def test_basic(sentry_init, capture_events, application, request):
+async def test_basic(sentry_init, capture_events, application):
     sentry_init(integrations=[DjangoIntegration()], send_default_pii=True)
 
     events = capture_events()
@@ -43,7 +43,13 @@ async def test_basic(sentry_init, capture_events, application, request):
     event = events[-1]
     assert "request" not in event
 
-    # Test that async views work properly
+@pytest.mark.parametrize("application", APPS)
+@pytest.mark.asyncio
+async def test_async_views(sentry_init, capture_events, application):
+    sentry_init(integrations=[DjangoIntegration()], send_default_pii=True)
+
+    events = capture_events()
+
     comm = HttpCommunicator(application, "GET", "/async_ok")
     response = await comm.get_response()
     assert response["status"] == 200

--- a/tests/integrations/django/asgi/test_asgi.py
+++ b/tests/integrations/django/asgi/test_asgi.py
@@ -51,6 +51,17 @@ async def test_async_views(sentry_init, capture_events, application):
 
     events = capture_events()
 
-    comm = HttpCommunicator(application, "GET", "/async_ok")
+    comm = HttpCommunicator(application, "GET", "/async_message")
     response = await comm.get_response()
     assert response["status"] == 200
+
+    event, = events
+
+    assert event["transaction"] == "/async_message"
+    assert event["request"] == {
+        "cookies": {},
+        "headers": {},
+        "method": "GET",
+        "query_string": None,
+        "url": "/async_message",
+    }

--- a/tests/integrations/django/myapp/urls.py
+++ b/tests/integrations/django/myapp/urls.py
@@ -55,10 +55,13 @@ urlpatterns = [
         views.csrf_hello_not_exempt,
         name="csrf_hello_not_exempt",
     ),
-    path("async_message", views.async_message, name="async_message"),
 ]
 
+# async views
+if views.async_message is not None:
+    urlpatterns.append(path("async_message", views.async_message, name="async_message"))
 
+# rest framework
 try:
     urlpatterns.append(
         path("rest-framework-exc", views.rest_framework_exc, name="rest_framework_exc")

--- a/tests/integrations/django/myapp/urls.py
+++ b/tests/integrations/django/myapp/urls.py
@@ -55,6 +55,7 @@ urlpatterns = [
         views.csrf_hello_not_exempt,
         name="csrf_hello_not_exempt",
     ),
+    path("async_ok", views.async_ok, name="async_ok"),
 ]
 
 

--- a/tests/integrations/django/myapp/urls.py
+++ b/tests/integrations/django/myapp/urls.py
@@ -55,7 +55,7 @@ urlpatterns = [
         views.csrf_hello_not_exempt,
         name="csrf_hello_not_exempt",
     ),
-    path("async_ok", views.async_ok, name="async_ok"),
+    path("async_message", views.async_message, name="async_message"),
 ]
 
 

--- a/tests/integrations/django/myapp/views.py
+++ b/tests/integrations/django/myapp/views.py
@@ -122,7 +122,8 @@ def permission_denied_exc(*args, **kwargs):
 def csrf_hello_not_exempt(*args, **kwargs):
     return HttpResponse("ok")
 
-if VERSION >= (3,1):
+
+if VERSION >= (3, 1):
     # Use exec to produce valid Python 2
     exec(
         """async def async_message(request):

--- a/tests/integrations/django/myapp/views.py
+++ b/tests/integrations/django/myapp/views.py
@@ -1,3 +1,4 @@
+from django import VERSION
 from django.contrib.auth import login
 from django.contrib.auth.models import User
 from django.core.exceptions import PermissionDenied
@@ -121,13 +122,12 @@ def permission_denied_exc(*args, **kwargs):
 def csrf_hello_not_exempt(*args, **kwargs):
     return HttpResponse("ok")
 
-
-try:
+if VERSION >= (3,1):
+    # Use exec to produce valid Python 2
     exec(
         """async def async_message(request):
     sentry_sdk.capture_message("hi")
     return HttpResponse("ok")"""
     )
-
-except SyntaxError:
+else:
     async_message = None

--- a/tests/integrations/django/myapp/views.py
+++ b/tests/integrations/django/myapp/views.py
@@ -122,6 +122,5 @@ def csrf_hello_not_exempt(*args, **kwargs):
     return HttpResponse("ok")
 
 
-@csrf_exempt
 async def async_ok(request):
     return HttpResponse("ok")

--- a/tests/integrations/django/myapp/views.py
+++ b/tests/integrations/django/myapp/views.py
@@ -1,11 +1,11 @@
 from django.contrib.auth import login
 from django.contrib.auth.models import User
 from django.core.exceptions import PermissionDenied
-from django.http import HttpResponse, HttpResponseServerError, HttpResponseNotFound
+from django.http import HttpResponse, HttpResponseNotFound, HttpResponseServerError
 from django.shortcuts import render
-from django.views.generic import ListView
-from django.views.decorators.csrf import csrf_exempt
 from django.utils.decorators import method_decorator
+from django.views.decorators.csrf import csrf_exempt
+from django.views.generic import ListView
 
 try:
     from rest_framework.decorators import api_view
@@ -119,4 +119,9 @@ def permission_denied_exc(*args, **kwargs):
 
 
 def csrf_hello_not_exempt(*args, **kwargs):
+    return HttpResponse("ok")
+
+
+@csrf_exempt
+async def async_ok(request):
     return HttpResponse("ok")

--- a/tests/integrations/django/myapp/views.py
+++ b/tests/integrations/django/myapp/views.py
@@ -122,5 +122,10 @@ def csrf_hello_not_exempt(*args, **kwargs):
     return HttpResponse("ok")
 
 
-async def async_ok(request):
-    return HttpResponse("ok")
+try:
+    exec("""async def async_message(request):
+    sentry_sdk.capture_message("hi")
+    return HttpResponse("ok")""")
+
+except SyntaxError:
+    async_message = None

--- a/tests/integrations/django/myapp/views.py
+++ b/tests/integrations/django/myapp/views.py
@@ -123,9 +123,11 @@ def csrf_hello_not_exempt(*args, **kwargs):
 
 
 try:
-    exec("""async def async_message(request):
+    exec(
+        """async def async_message(request):
     sentry_sdk.capture_message("hi")
-    return HttpResponse("ok")""")
+    return HttpResponse("ok")"""
+    )
 
 except SyntaxError:
     async_message = None


### PR DESCRIPTION
Special handling for async views such that the function wrapper is also async. Need to split across files to preserve syntax compatible with Python 2.

Fix #849 