### PR TITLE
feat(test): Add `only` pytest marker

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,6 @@
 [pytest]
 DJANGO_SETTINGS_MODULE = tests.integrations.django.myapp.settings
 addopts = --tb=short
-markers = tests_internal_exceptions
+markers =
+    tests_internal_exceptions
+    only: A temporary marker, to make pytest only run the tests with the mark, similar to jest's `it.only`. To use, run `pytest -v -m only`.


### PR DESCRIPTION
This adds a pytest marker similar to `it.only` in jest.