### PR TITLE
Fix incorrect timeout warnings in AWS Lambda and GCP integrations

### DIFF
--- a/sentry_sdk/integrations/aws_lambda.py
+++ b/sentry_sdk/integrations/aws_lambda.py
@@ -116,6 +116,13 @@ def _wrap_handler(handler):
                     )
                     hub.capture_event(event, hint=hint)
                     reraise(*exc_info)
+                finally:
+                    if (
+                        integration.timeout_warning
+                        and configured_time > TIMEOUT_WARNING_BUFFER
+                    ):
+                        timeout_thread.stop_thread = True
+                        timeout_thread.join()
 
     return sentry_handler  # type: ignore
 

--- a/sentry_sdk/integrations/aws_lambda.py
+++ b/sentry_sdk/integrations/aws_lambda.py
@@ -83,6 +83,8 @@ def _wrap_handler(handler):
                     _make_request_event_processor(event, context, configured_time)
                 )
                 scope.set_tag("aws_region", context.invoked_function_arn.split(":")[3])
+
+                timeout_thread = None
                 # Starting the Timeout thread only if the configured time is greater than Timeout warning
                 # buffer and timeout_warning parameter is set True.
                 if (
@@ -94,7 +96,8 @@ def _wrap_handler(handler):
                     ) / MILLIS_TO_SECONDS
 
                     timeout_thread = TimeoutThread(
-                        waiting_time, configured_time / MILLIS_TO_SECONDS
+                        waiting_time,
+                        configured_time / MILLIS_TO_SECONDS,
                     )
 
                     # Starting the thread to raise timeout warning exception
@@ -117,12 +120,8 @@ def _wrap_handler(handler):
                     hub.capture_event(event, hint=hint)
                     reraise(*exc_info)
                 finally:
-                    if (
-                        integration.timeout_warning
-                        and configured_time > TIMEOUT_WARNING_BUFFER
-                    ):
-                        timeout_thread.stop_thread = True
-                        timeout_thread.join()
+                    if timeout_thread:
+                        timeout_thread.stop()
 
     return sentry_handler  # type: ignore
 

--- a/sentry_sdk/integrations/gcp.py
+++ b/sentry_sdk/integrations/gcp.py
@@ -63,6 +63,7 @@ def _wrap_func(func):
                     _make_request_event_processor(event, configured_time, initial_time)
                 )
                 scope.set_tag("gcp_region", environ.get("FUNCTION_REGION"))
+                timeout_thread = None
                 if (
                     integration.timeout_warning
                     and configured_time > TIMEOUT_WARNING_BUFFER
@@ -93,12 +94,8 @@ def _wrap_func(func):
                     hub.capture_event(event, hint=hint)
                     reraise(*exc_info)
                 finally:
-                    if (
-                        integration.timeout_warning
-                        and configured_time > TIMEOUT_WARNING_BUFFER
-                    ):
-                        timeout_thread.stop_thread = True
-                        timeout_thread.join()
+                    if timeout_thread:
+                        timeout_thread.stop()
                     # Flush out the event queue
                     hub.flush()
 

--- a/sentry_sdk/integrations/gcp.py
+++ b/sentry_sdk/integrations/gcp.py
@@ -93,6 +93,12 @@ def _wrap_func(func):
                     hub.capture_event(event, hint=hint)
                     reraise(*exc_info)
                 finally:
+                    if (
+                        integration.timeout_warning
+                        and configured_time > TIMEOUT_WARNING_BUFFER
+                    ):
+                        timeout_thread.stop_thread = True
+                        timeout_thread.join()
                     # Flush out the event queue
                     hub.flush()
 

--- a/sentry_sdk/utils.py
+++ b/sentry_sdk/utils.py
@@ -903,7 +903,7 @@ class TimeoutThread(threading.Thread):
 
         if self._stop_event.is_set():
             return
-        
+
         integer_configured_timeout = int(self.configured_timeout)
 
         # Setting up the exact integer value of configured time(in seconds)

--- a/sentry_sdk/utils.py
+++ b/sentry_sdk/utils.py
@@ -891,27 +891,22 @@ class TimeoutThread(threading.Thread):
         threading.Thread.__init__(self)
         self.waiting_time = waiting_time
         self.configured_timeout = configured_timeout
-        self.stop_thread = False
+        self._stop_event = threading.Event()
+
+    def stop(self):
+        # type: () -> None
+        self._stop_event.set()
+
+    def stopped(self):
+        # type: () -> Any
+        return self._stop_event.is_set()
 
     def run(self):
         # type: () -> None
 
-        raise_exception = True
-        threading_is_running = True
-        start_time = time.time()
+        time.sleep(self.waiting_time)
 
-        while threading_is_running:
-            if self.stop_thread:
-                raise_exception = False
-                threading_is_running = False
-            current_time = time.time()
-            elapsed_time = current_time - start_time
-            if elapsed_time >= self.waiting_time:
-                threading_is_running = False
-
-        if raise_exception:
-            time.sleep(self.waiting_time)
-
+        if not self.stopped():
             integer_configured_timeout = int(self.configured_timeout)
 
             # Setting up the exact integer value of configured time(in seconds)

--- a/sentry_sdk/utils.py
+++ b/sentry_sdk/utils.py
@@ -891,21 +891,32 @@ class TimeoutThread(threading.Thread):
         threading.Thread.__init__(self)
         self.waiting_time = waiting_time
         self.configured_timeout = configured_timeout
+        self.stop_thread = False
 
     def run(self):
         # type: () -> None
 
-        time.sleep(self.waiting_time)
+        raise_exception = True
+        threading_is_running = True
+        while threading_is_running and self.waiting_time > 1:
+            time.sleep(1)
+            self.waiting_time = self.waiting_time - 1
+            if self.stop_thread:
+                raise_exception = False
+                threading_is_running = False
 
-        integer_configured_timeout = int(self.configured_timeout)
+        if raise_exception:
+            time.sleep(self.waiting_time)
 
-        # Setting up the exact integer value of configured time(in seconds)
-        if integer_configured_timeout < self.configured_timeout:
-            integer_configured_timeout = integer_configured_timeout + 1
+            integer_configured_timeout = int(self.configured_timeout)
 
-        # Raising Exception after timeout duration is reached
-        raise ServerlessTimeoutWarning(
-            "WARNING : Function is expected to get timed out. Configured timeout duration = {} seconds.".format(
-                integer_configured_timeout
+            # Setting up the exact integer value of configured time(in seconds)
+            if integer_configured_timeout < self.configured_timeout:
+                integer_configured_timeout = integer_configured_timeout + 1
+
+            # Raising Exception after timeout duration is reached
+            raise ServerlessTimeoutWarning(
+                "WARNING : Function is expected to get timed out. Configured timeout duration = {} seconds.".format(
+                    integer_configured_timeout
+                )
             )
-        )

--- a/sentry_sdk/utils.py
+++ b/sentry_sdk/utils.py
@@ -3,7 +3,6 @@ import linecache
 import logging
 import os
 import sys
-import time
 import threading
 
 from datetime import datetime
@@ -897,16 +896,12 @@ class TimeoutThread(threading.Thread):
         # type: () -> None
         self._stop_event.set()
 
-    def stopped(self):
-        # type: () -> Any
-        return self._stop_event.is_set()
-
     def run(self):
         # type: () -> None
 
-        time.sleep(self.waiting_time)
+        self._stop_event.wait(self.waiting_time)
 
-        if not self.stopped():
+        if not self._stop_event.is_set():
             integer_configured_timeout = int(self.configured_timeout)
 
             # Setting up the exact integer value of configured time(in seconds)

--- a/sentry_sdk/utils.py
+++ b/sentry_sdk/utils.py
@@ -901,16 +901,18 @@ class TimeoutThread(threading.Thread):
 
         self._stop_event.wait(self.waiting_time)
 
-        if not self._stop_event.is_set():
-            integer_configured_timeout = int(self.configured_timeout)
+        if self._stop_event.is_set():
+            return
+        
+        integer_configured_timeout = int(self.configured_timeout)
 
-            # Setting up the exact integer value of configured time(in seconds)
-            if integer_configured_timeout < self.configured_timeout:
-                integer_configured_timeout = integer_configured_timeout + 1
+        # Setting up the exact integer value of configured time(in seconds)
+        if integer_configured_timeout < self.configured_timeout:
+            integer_configured_timeout = integer_configured_timeout + 1
 
-            # Raising Exception after timeout duration is reached
-            raise ServerlessTimeoutWarning(
-                "WARNING : Function is expected to get timed out. Configured timeout duration = {} seconds.".format(
-                    integer_configured_timeout
-                )
+        # Raising Exception after timeout duration is reached
+        raise ServerlessTimeoutWarning(
+            "WARNING : Function is expected to get timed out. Configured timeout duration = {} seconds.".format(
+                integer_configured_timeout
             )
+        )

--- a/sentry_sdk/utils.py
+++ b/sentry_sdk/utils.py
@@ -898,11 +898,15 @@ class TimeoutThread(threading.Thread):
 
         raise_exception = True
         threading_is_running = True
-        while threading_is_running and self.waiting_time > 1:
-            time.sleep(1)
-            self.waiting_time = self.waiting_time - 1
+        start_time = time.time()
+
+        while threading_is_running:
             if self.stop_thread:
                 raise_exception = False
+                threading_is_running = False
+            current_time = time.time()
+            elapsed_time = current_time - start_time
+            if elapsed_time >= self.waiting_time:
                 threading_is_running = False
 
         if raise_exception:


### PR DESCRIPTION
1) Added code to stop thread in aws_lambda.py & gcp.py.
2) Modified logic of run() function of class TimeoutThread to stop the thread and raise ServerlessTimeoutWarning exception, conditionally.

Fixes #846.