### PR TITLE
Add documentation and changelog links on PyPI

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,10 @@ setup(
     author="Sentry Team and Contributors",
     author_email="hello@sentry.io",
     url="https://github.com/getsentry/sentry-python",
+    project_urls={
+        "Documentation": "https://docs.sentry.io/platforms/python/",
+        "Changelog": "https://github.com/getsentry/sentry-python/blob/master/CHANGES.md",
+    },
     description="Python client for Sentry (https://sentry.io)",
     long_description=__doc__,
     packages=find_packages(exclude=("tests", "tests.*")),


### PR DESCRIPTION
These appear on the sidebar and provide neat, somewhat standard shortcuts to useful places. cf. [scout-apm](https://pypi.org/project/scout-apm/) , as defined in https://github.com/scoutapp/scout_apm_python/blob/631f2432f643d256ad5ab7ff6b8f7b95b14231f5/setup.py#L44