### PR TITLE
Add `traces_sampler` option

### DIFF
--- a/sentry_sdk/api.py
+++ b/sentry_sdk/api.py
@@ -207,8 +207,7 @@ def start_span(
 @hubmethod
 def start_transaction(
     transaction=None,  # type: Optional[Transaction]
-    custom_sampling_context=None,  # type: Optional[Dict[str, Any]]
     **kwargs  # type: Any
 ):
     # type: (...) -> Transaction
-    return Hub.current.start_transaction(transaction, custom_sampling_context, **kwargs)
+    return Hub.current.start_transaction(transaction, **kwargs)

--- a/sentry_sdk/api.py
+++ b/sentry_sdk/api.py
@@ -207,7 +207,8 @@ def start_span(
 @hubmethod
 def start_transaction(
     transaction=None,  # type: Optional[Transaction]
+    custom_sampling_context=None,  # type: Optional[Dict[str, Any]]
     **kwargs  # type: Any
 ):
     # type: (...) -> Transaction
-    return Hub.current.start_transaction(transaction, **kwargs)
+    return Hub.current.start_transaction(transaction, custom_sampling_context, **kwargs)

--- a/sentry_sdk/consts.py
+++ b/sentry_sdk/consts.py
@@ -69,7 +69,7 @@ class ClientConstructor(object):
         attach_stacktrace=False,  # type: bool
         ca_certs=None,  # type: Optional[str]
         propagate_traces=True,  # type: bool
-        traces_sample_rate=0.0,  # type: float
+        traces_sample_rate=None,  # type: Optional[float]
         traces_sampler=None,  # type: Optional[TracesSampler]
         auto_enabling_integrations=True,  # type: bool
         _experiments={},  # type: Experiments  # noqa: B006

--- a/sentry_sdk/hub.py
+++ b/sentry_sdk/hub.py
@@ -479,7 +479,6 @@ class Hub(with_metaclass(HubMeta)):  # type: ignore
     def start_transaction(
         self,
         transaction=None,  # type: Optional[Transaction]
-        custom_sampling_context=None,  # type: Optional[Dict[str, Any]]
         **kwargs  # type: Any
     ):
         # type: (...) -> Transaction
@@ -505,6 +504,8 @@ class Hub(with_metaclass(HubMeta)):  # type: ignore
         When the transaction is finished, it will be sent to Sentry with all its
         finished child spans.
         """
+        custom_sampling_context = kwargs.pop("custom_sampling_context", {})
+
         # if we haven't been given a transaction, make one
         if transaction is None:
             kwargs.setdefault("hub", self)
@@ -516,7 +517,7 @@ class Hub(with_metaclass(HubMeta)):  # type: ignore
             "transaction_context": transaction.to_json(),
             "parent_sampled": transaction.parent_sampled,
         }
-        sampling_context.update(custom_sampling_context or {})
+        sampling_context.update(custom_sampling_context)
         transaction._set_initial_sampling_decision(sampling_context=sampling_context)
 
         # we don't bother to keep spans if we already know we're not going to

--- a/sentry_sdk/hub.py
+++ b/sentry_sdk/hub.py
@@ -479,6 +479,7 @@ class Hub(with_metaclass(HubMeta)):  # type: ignore
     def start_transaction(
         self,
         transaction=None,  # type: Optional[Transaction]
+        custom_sampling_context=None,  # type: Optional[Dict[str, Any]]
         **kwargs  # type: Any
     ):
         # type: (...) -> Transaction
@@ -511,9 +512,12 @@ class Hub(with_metaclass(HubMeta)):  # type: ignore
 
         # use traces_sample_rate, traces_sampler, and/or inheritance to make a
         # sampling decision
-        transaction._set_initial_sampling_decision(
-            sampling_context=transaction.to_json()
-        )
+        sampling_context = {
+            "transaction_context": transaction.to_json(),
+            "parent_sampled": transaction.parent_sampled,
+        }
+        sampling_context.update(custom_sampling_context or {})
+        transaction._set_initial_sampling_decision(sampling_context=sampling_context)
 
         # we don't bother to keep spans if we already know we're not going to
         # send the transaction

--- a/sentry_sdk/tracing.py
+++ b/sentry_sdk/tracing.py
@@ -631,7 +631,7 @@ class Transaction(Span):
         # 0, it's a sign the transaction should be dropped
         if not sample_rate:
             logger.debug(
-                "[Tracing] Discarding {transaction_description} because ${reason}".format(
+                "[Tracing] Discarding {transaction_description} because {reason}".format(
                     transaction_description=transaction_description,
                     reason=(
                         "traces_sampler returned 0 or False"

--- a/sentry_sdk/tracing.py
+++ b/sentry_sdk/tracing.py
@@ -337,7 +337,7 @@ class Span(object):
         return Transaction(
             trace_id=trace_id,
             parent_span_id=parent_span_id,
-            sampled=parent_sampled,
+            parent_sampled=parent_sampled,
             **kwargs
         )
 

--- a/sentry_sdk/tracing.py
+++ b/sentry_sdk/tracing.py
@@ -2,14 +2,21 @@ import re
 import uuid
 import contextlib
 import math
+import random
 import time
 
 from datetime import datetime, timedelta
+from inspect import isfunction
 from numbers import Real
 
 import sentry_sdk
 
-from sentry_sdk.utils import capture_internal_exceptions, logger, to_string
+from sentry_sdk.utils import (
+    capture_internal_exceptions,
+    has_tracing_enabled,
+    logger,
+    to_string,
+)
 from sentry_sdk._compat import PY2
 from sentry_sdk._types import MYPY
 
@@ -27,6 +34,9 @@ if MYPY:
     from typing import Dict
     from typing import List
     from typing import Tuple
+    from typing import Union
+
+    from sentry_sdk._types import SamplingContext
 
 _traceparent_header_format_re = re.compile(
     "^[ \t]*"  # whitespace
@@ -554,6 +564,112 @@ class Transaction(Span):
         rv["parent_sampled"] = self.parent_sampled
 
         return rv
+
+    def _set_initial_sampling_decision(self, sampling_context):
+        # type: (SamplingContext) -> None
+        """
+        Sets the transaction's sampling decision, according to the following
+        precedence rules:
+
+        1. If a sampling decision is passed to `start_transaction`
+        (`start_transaction(name: "my transaction", sampled: True)`), that
+        decision will be used, regardlesss of anything else
+
+        2. If `traces_sampler` is defined, its decision will be used. It can
+        choose to keep or ignore any parent sampling decision, or use the
+        sampling context data to make its own decision or to choose a sample
+        rate for the transaction.
+
+        3. If `traces_sampler` is not defined, but there's a parent sampling
+        decision, the parent sampling decision will be used.
+
+        4. If `traces_sampler` is not defined and there's no parent sampling
+        decision, `traces_sample_rate` will be used.
+        """
+
+        def _inherit_or_use_static_rate(parent_sampled, traces_sample_rate):
+            # type: (bool, float) -> Union[bool, float]
+            """
+            Implements the default inheritance behavior, to be used when
+            traces_sampler is not defined.
+            """
+
+            return parent_sampled if parent_sampled is not None else traces_sample_rate
+
+        hub = self.hub or sentry_sdk.Hub.current
+        client = hub.client
+        options = (client and client.options) or {}
+        transaction_description = "{op}transaction <{name}>".format(
+            op=("<" + self.op + "> " if self.op else ""), name=self.name
+        )
+
+        # nothing to do if there's no client or if tracing is disabled
+        if not client or not has_tracing_enabled(options):
+            self.sampled = False
+            return
+
+        # if the user has forced a sampling decision by passing a `sampled`
+        # value when starting the transaction, go with that
+        if self.sampled is not None:
+            return
+
+        # we would have bailed already if neither `traces_sampler` nor
+        # `traces_sample_rate` were defined, so one of these should work; prefer
+        # the hook if so
+        sample_rate = (
+            options["traces_sampler"](sampling_context)
+            if isfunction(options.get("traces_sampler"))
+            else _inherit_or_use_static_rate(
+                sampling_context["parent_sampled"], options["traces_sample_rate"]
+            )
+        )
+
+        # Since this is coming from the user (or from a function provided by the
+        # user), who knows what we might get. (The only valid values are
+        # booleans or numbers between 0 and 1.)
+        if not _is_valid_sample_rate(sample_rate):
+            logger.warning(
+                "[Tracing] Discarding {transaction_description} because of invalid sample rate.".format(
+                    transaction_description=transaction_description,
+                )
+            )
+            self.sampled = False
+            return
+
+        # if the function returned 0 (or false), or if `traces_sample_rate` is
+        # 0, it's a sign the transaction should be dropped
+        if not sample_rate:
+            logger.debug(
+                "[Tracing] Discarding {transaction_description} because ${reason}".format(
+                    transaction_description=transaction_description,
+                    reason=(
+                        "traces_sampler returned 0 or False"
+                        if isfunction(options.get("traces_sampler"))
+                        else "traces_sample_rate is set to 0"
+                    ),
+                )
+            )
+            self.sampled = False
+            return
+
+        # Now we roll the dice. random.random is inclusive of 0, but not of 1,
+        # so strict < is safe here. In case sample_rate is a boolean, cast it
+        # to a float (True becomes 1.0 and False becomes 0.0)
+        self.sampled = random.random() < float(sample_rate)
+
+        if self.sampled:
+            logger.debug(
+                "[Tracing] Starting {transaction_description}".format(
+                    transaction_description=transaction_description,
+                )
+            )
+        else:
+            logger.debug(
+                "[Tracing] Discarding {transaction_description} because it's not included in the random sample (sampling rate = {sample_rate})".format(
+                    transaction_description=transaction_description,
+                    sample_rate=float(sample_rate),
+                )
+            )
 
 
 def _is_valid_sample_rate(rate):

--- a/sentry_sdk/tracing.py
+++ b/sentry_sdk/tracing.py
@@ -13,7 +13,6 @@ import sentry_sdk
 
 from sentry_sdk.utils import (
     capture_internal_exceptions,
-    has_tracing_enabled,
     logger,
     to_string,
 )
@@ -663,6 +662,16 @@ class Transaction(Span):
                     sample_rate=float(sample_rate),
                 )
             )
+
+
+def has_tracing_enabled(options):
+    # type: (Dict[str, Any]) -> bool
+    """
+    Returns True if either traces_sample_rate or traces_sampler is
+    non-zero/defined, False otherwise.
+    """
+
+    return bool(options.get("traces_sample_rate") or options.get("traces_sampler"))
 
 
 def _is_valid_sample_rate(rate):

--- a/sentry_sdk/tracing.py
+++ b/sentry_sdk/tracing.py
@@ -6,7 +6,6 @@ import random
 import time
 
 from datetime import datetime, timedelta
-from inspect import isfunction
 from numbers import Real
 
 import sentry_sdk
@@ -636,7 +635,7 @@ class Transaction(Span):
                     transaction_description=transaction_description,
                     reason=(
                         "traces_sampler returned 0 or False"
-                        if isfunction(options.get("traces_sampler"))
+                        if callable(options.get("traces_sampler"))
                         else "traces_sample_rate is set to 0"
                     ),
                 )

--- a/sentry_sdk/utils.py
+++ b/sentry_sdk/utils.py
@@ -968,13 +968,3 @@ class TimeoutThread(threading.Thread):
                 integer_configured_timeout
             )
         )
-
-
-def has_tracing_enabled(options):
-    # type: (Dict[str, Any]) -> bool
-    """
-    Returns True if either traces_sample_rate or traces_sampler is
-    non-zero/defined, False otherwise.
-    """
-
-    return bool(options.get("traces_sample_rate") or options.get("traces_sampler"))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,5 @@
 import os
 import json
-from types import FunctionType
 
 import pytest
 import jsonschema
@@ -36,11 +35,6 @@ except ImportError:
 
 else:
     del pytest_benchmark
-
-try:
-    from unittest import mock  # python 3.3 and above
-except ImportError:
-    import mock  # python < 3.3
 
 
 @pytest.fixture(autouse=True)
@@ -400,18 +394,3 @@ def dictionary_containing_matcher():
             return all(test_dict.get(key) == self.subdict[key] for key in self.subdict)
 
     return DictionaryContaining
-
-
-@pytest.fixture(name="FunctionMock")
-def function_mock():
-    """
-    Just like a mock.Mock object, but one which always passes an isfunction
-    test.
-    """
-
-    class FunctionMock(mock.Mock):
-        def __init__(self, *args, **kwargs):
-            super(FunctionMock, self).__init__(*args, **kwargs)
-            self.__class__ = FunctionType
-
-    return FunctionMock

--- a/tests/integrations/sqlalchemy/test_sqlalchemy.py
+++ b/tests/integrations/sqlalchemy/test_sqlalchemy.py
@@ -76,7 +76,9 @@ def test_orm_queries(sentry_init, capture_events):
 def test_transactions(sentry_init, capture_events, render_span_tree):
 
     sentry_init(
-        integrations=[SqlalchemyIntegration()], _experiments={"record_sql_params": True}
+        integrations=[SqlalchemyIntegration()],
+        _experiments={"record_sql_params": True},
+        traces_sample_rate=1.0,
     )
     events = capture_events()
 

--- a/tests/tracing/test_integration_tests.py
+++ b/tests/tracing/test_integration_tests.py
@@ -70,7 +70,7 @@ def test_continue_from_headers(sentry_init, capture_events, sampled):
     # correctly
     transaction = Transaction.continue_from_headers(headers, name="WRONG")
     assert transaction is not None
-    assert transaction.sampled == sampled
+    assert transaction.parent_sampled == sampled
     assert transaction.trace_id == old_span.trace_id
     assert transaction.same_process_as_parent is False
     assert transaction.parent_span_id == old_span.span_id

--- a/tests/tracing/test_sampling.py
+++ b/tests/tracing/test_sampling.py
@@ -119,11 +119,10 @@ def test_uses_traces_sample_rate_correctly(
 )
 def test_uses_traces_sampler_return_value_correctly(
     sentry_init,
-    FunctionMock,  # noqa: N803
     traces_sampler_return_value,
     expected_decision,
 ):
-    sentry_init(traces_sampler=FunctionMock(return_value=traces_sampler_return_value))
+    sentry_init(traces_sampler=mock.Mock(return_value=traces_sampler_return_value))
 
     with mock.patch.object(random, "random", return_value=0.5):
 
@@ -133,9 +132,9 @@ def test_uses_traces_sampler_return_value_correctly(
 
 @pytest.mark.parametrize("traces_sampler_return_value", [True, False])
 def test_tolerates_traces_sampler_returning_a_boolean(
-    sentry_init, FunctionMock, traces_sampler_return_value  # noqa: N803
+    sentry_init, traces_sampler_return_value
 ):
-    sentry_init(traces_sampler=FunctionMock(return_value=traces_sampler_return_value))
+    sentry_init(traces_sampler=mock.Mock(return_value=traces_sampler_return_value))
 
     transaction = start_transaction(name="dogpark")
     assert transaction.sampled is traces_sampler_return_value
@@ -143,9 +142,9 @@ def test_tolerates_traces_sampler_returning_a_boolean(
 
 @pytest.mark.parametrize("sampling_decision", [True, False])
 def test_only_captures_transaction_when_sampled_is_true(
-    sentry_init, FunctionMock, sampling_decision, capture_events  # noqa: N803
+    sentry_init, sampling_decision, capture_events
 ):
-    sentry_init(traces_sampler=FunctionMock(return_value=sampling_decision))
+    sentry_init(traces_sampler=mock.Mock(return_value=sampling_decision))
     events = capture_events()
 
     transaction = start_transaction(name="dogpark")
@@ -159,13 +158,12 @@ def test_only_captures_transaction_when_sampled_is_true(
 )
 def test_prefers_traces_sampler_to_traces_sample_rate(
     sentry_init,
-    FunctionMock,  # noqa: N803
     traces_sample_rate,
     traces_sampler_return_value,
 ):
     # make traces_sample_rate imply the opposite of traces_sampler, to prove
     # that traces_sampler takes precedence
-    traces_sampler = FunctionMock(return_value=traces_sampler_return_value)
+    traces_sampler = mock.Mock(return_value=traces_sampler_return_value)
     sentry_init(
         traces_sample_rate=traces_sample_rate,
         traces_sampler=traces_sampler,
@@ -246,9 +244,9 @@ def test_passes_parent_sampling_decision_in_sampling_context(
 
 
 def test_passes_custom_samling_context_from_start_transaction_to_traces_sampler(
-    FunctionMock, sentry_init, DictionaryContaining  # noqa: N803
+    sentry_init, DictionaryContaining  # noqa: N803
 ):
-    traces_sampler = FunctionMock()
+    traces_sampler = mock.Mock()
     sentry_init(traces_sampler=traces_sampler)
 
     start_transaction(custom_sampling_context={"dogs": "yes", "cats": "maybe"})

--- a/tests/tracing/test_sampling.py
+++ b/tests/tracing/test_sampling.py
@@ -1,7 +1,9 @@
+import random
+
 import pytest
 
 from sentry_sdk import Hub, start_span, start_transaction
-from sentry_sdk.tracing import _is_valid_sample_rate
+from sentry_sdk.tracing import Transaction, _is_valid_sample_rate
 from sentry_sdk.utils import logger
 
 try:
@@ -23,12 +25,17 @@ def test_sampling_decided_only_for_transactions(sentry_init, capture_events):
         assert span.sampled is None
 
 
-def test_nested_transaction_sampling_override():
-    with start_transaction(name="outer", sampled=True) as outer_transaction:
-        assert outer_transaction.sampled is True
-        with start_transaction(name="inner", sampled=False) as inner_transaction:
-            assert inner_transaction.sampled is False
-        assert outer_transaction.sampled is True
+@pytest.mark.parametrize("sampled", [True, False])
+def test_nested_transaction_sampling_override(sentry_init, sampled):
+    sentry_init(traces_sample_rate=1.0)
+
+    with start_transaction(name="outer", sampled=sampled) as outer_transaction:
+        assert outer_transaction.sampled is sampled
+        with start_transaction(
+            name="inner", sampled=(not sampled)
+        ) as inner_transaction:
+            assert inner_transaction.sampled is not sampled
+        assert outer_transaction.sampled is sampled
 
 
 def test_no_double_sampling(sentry_init, capture_events):
@@ -87,3 +94,190 @@ def test_get_transaction_and_span_from_scope_regardless_of_sampling_decision(
                 scope = Hub.current.scope
                 assert scope.span.op == "child-child-span"
                 assert scope.transaction.name == "/"
+
+
+@pytest.mark.parametrize(
+    "traces_sample_rate,expected_decision",
+    [(0.0, False), (0.25, False), (0.75, True), (1.00, True)],
+)
+def test_uses_traces_sample_rate_correctly(
+    sentry_init,
+    traces_sample_rate,
+    expected_decision,
+):
+    sentry_init(traces_sample_rate=traces_sample_rate)
+
+    with mock.patch.object(random, "random", return_value=0.5):
+
+        transaction = start_transaction(name="dogpark")
+        assert transaction.sampled is expected_decision
+
+
+@pytest.mark.parametrize(
+    "traces_sampler_return_value,expected_decision",
+    [(0.0, False), (0.25, False), (0.75, True), (1.00, True)],
+)
+def test_uses_traces_sampler_return_value_correctly(
+    sentry_init,
+    FunctionMock,  # noqa: N803
+    traces_sampler_return_value,
+    expected_decision,
+):
+    sentry_init(traces_sampler=FunctionMock(return_value=traces_sampler_return_value))
+
+    with mock.patch.object(random, "random", return_value=0.5):
+
+        transaction = start_transaction(name="dogpark")
+        assert transaction.sampled is expected_decision
+
+
+@pytest.mark.parametrize("traces_sampler_return_value", [True, False])
+def test_tolerates_traces_sampler_returning_a_boolean(
+    sentry_init, FunctionMock, traces_sampler_return_value  # noqa: N803
+):
+    sentry_init(traces_sampler=FunctionMock(return_value=traces_sampler_return_value))
+
+    transaction = start_transaction(name="dogpark")
+    assert transaction.sampled is traces_sampler_return_value
+
+
+@pytest.mark.parametrize("sampling_decision", [True, False])
+def test_only_captures_transaction_when_sampled_is_true(
+    sentry_init, FunctionMock, sampling_decision, capture_events  # noqa: N803
+):
+    sentry_init(traces_sampler=FunctionMock(return_value=sampling_decision))
+    events = capture_events()
+
+    transaction = start_transaction(name="dogpark")
+    transaction.finish()
+
+    assert len(events) == (1 if sampling_decision else 0)
+
+
+@pytest.mark.parametrize(
+    "traces_sample_rate,traces_sampler_return_value", [(0, True), (1, False)]
+)
+def test_prefers_traces_sampler_to_traces_sample_rate(
+    sentry_init,
+    FunctionMock,  # noqa: N803
+    traces_sample_rate,
+    traces_sampler_return_value,
+):
+    # make traces_sample_rate imply the opposite of traces_sampler, to prove
+    # that traces_sampler takes precedence
+    traces_sampler = FunctionMock(return_value=traces_sampler_return_value)
+    sentry_init(
+        traces_sample_rate=traces_sample_rate,
+        traces_sampler=traces_sampler,
+    )
+
+    transaction = start_transaction(name="dogpark")
+    assert traces_sampler.called is True
+    assert transaction.sampled is traces_sampler_return_value
+
+
+@pytest.mark.parametrize("parent_sampling_decision", [True, False])
+def test_ignores_inherited_sample_decision_when_traces_sampler_defined(
+    sentry_init, parent_sampling_decision
+):
+    # make traces_sampler pick the opposite of the inherited decision, to prove
+    # that traces_sampler takes precedence
+    sentry_init(traces_sampler=lambda _: not parent_sampling_decision)
+
+    transaction = start_transaction(
+        name="dogpark", parent_sampled=parent_sampling_decision
+    )
+    assert transaction.sampled is not parent_sampling_decision
+
+
+@pytest.mark.parametrize("explicit_decision", [True, False])
+def test_traces_sampler_doesnt_overwrite_explicitly_passed_sampling_decision(
+    sentry_init, explicit_decision
+):
+    # make traces_sampler pick the opposite of the explicit decision, to prove
+    # that the explicit decision takes precedence
+    sentry_init(traces_sampler=lambda _: not explicit_decision)
+
+    transaction = start_transaction(name="dogpark", sampled=explicit_decision)
+    assert transaction.sampled is explicit_decision
+
+
+@pytest.mark.parametrize("parent_sampling_decision", [True, False])
+def test_inherits_parent_sampling_decision_when_traces_sampler_undefined(
+    sentry_init, parent_sampling_decision
+):
+    # make sure the parent sampling decision is the opposite of what
+    # traces_sample_rate would produce, to prove the inheritance takes
+    # precedence
+    sentry_init(traces_sample_rate=0.5)
+    mock_random_value = 0.25 if parent_sampling_decision is False else 0.75
+
+    with mock.patch.object(random, "random", return_value=mock_random_value):
+        transaction = start_transaction(
+            name="dogpark", parent_sampled=parent_sampling_decision
+        )
+        assert transaction.sampled is parent_sampling_decision
+
+
+@pytest.mark.parametrize("parent_sampling_decision", [True, False])
+def test_passes_parent_sampling_decision_in_sampling_context(
+    sentry_init, parent_sampling_decision
+):
+    sentry_init(traces_sample_rate=1.0)
+
+    sentry_trace_header = (
+        "12312012123120121231201212312012-1121201211212012-{sampled}".format(
+            sampled=int(parent_sampling_decision)
+        )
+    )
+
+    transaction = Transaction.from_traceparent(sentry_trace_header, name="dogpark")
+    spy = mock.Mock(wraps=transaction)
+    start_transaction(transaction=spy)
+
+    # there's only one call (so index at 0) and kwargs are always last in a call
+    # tuple (so index at -1)
+    sampling_context = spy._set_initial_sampling_decision.mock_calls[0][-1][
+        "sampling_context"
+    ]
+    assert "parent_sampled" in sampling_context
+    # because we passed in a spy, attribute access requires unwrapping
+    assert sampling_context["parent_sampled"]._mock_wraps is parent_sampling_decision
+
+
+def test_passes_custom_samling_context_from_start_transaction_to_traces_sampler(
+    FunctionMock, sentry_init, DictionaryContaining  # noqa: N803
+):
+    traces_sampler = FunctionMock()
+    sentry_init(traces_sampler=traces_sampler)
+
+    start_transaction(custom_sampling_context={"dogs": "yes", "cats": "maybe"})
+
+    traces_sampler.assert_any_call(
+        DictionaryContaining({"dogs": "yes", "cats": "maybe"})
+    )
+
+
+@pytest.mark.parametrize(
+    "traces_sampler_return_value",
+    [
+        "dogs are great",  # wrong type
+        (0, 1),  # wrong type
+        {"Maisey": "Charllie"},  # wrong type
+        [True, True],  # wrong type
+        {0.2012},  # wrong type
+        float("NaN"),  # wrong type
+        None,  # wrong type
+        -1.121,  # wrong value
+        1.231,  # wrong value
+    ],
+)
+def test_warns_and_sets_sampled_to_false_on_invalid_traces_sampler_return_value(
+    sentry_init, traces_sampler_return_value, StringContaining  # noqa: N803
+):
+    sentry_init(traces_sampler=mock.Mock(return_value=traces_sampler_return_value))
+
+    with mock.patch.object(logger, "warning", mock.Mock()):
+        transaction = start_transaction(name="dogpark")
+        logger.warning.assert_any_call(StringContaining("Given sample rate is invalid"))
+        assert transaction.sampled is False

--- a/tests/tracing/test_sampling.py
+++ b/tests/tracing/test_sampling.py
@@ -180,7 +180,8 @@ def test_ignores_inherited_sample_decision_when_traces_sampler_defined(
 ):
     # make traces_sampler pick the opposite of the inherited decision, to prove
     # that traces_sampler takes precedence
-    sentry_init(traces_sampler=lambda _: not parent_sampling_decision)
+    traces_sampler = mock.Mock(return_value=not parent_sampling_decision)
+    sentry_init(traces_sampler=traces_sampler)
 
     transaction = start_transaction(
         name="dogpark", parent_sampled=parent_sampling_decision
@@ -194,7 +195,8 @@ def test_traces_sampler_doesnt_overwrite_explicitly_passed_sampling_decision(
 ):
     # make traces_sampler pick the opposite of the explicit decision, to prove
     # that the explicit decision takes precedence
-    sentry_init(traces_sampler=lambda _: not explicit_decision)
+    traces_sampler = mock.Mock(return_value=not explicit_decision)
+    sentry_init(traces_sampler=traces_sampler)
 
     transaction = start_transaction(name="dogpark", sampled=explicit_decision)
     assert transaction.sampled is explicit_decision


### PR DESCRIPTION
This adds a `traces_sampler` option to the SDK, allowing dynamic sampling and filtering of transactions, as outlined [here](https://develop.sentry.dev/sdk/unified-api/tracing).

The one piece of that spec that this doesn't yet implement is pulling in default sampling context values from various frameworks/integrations, which will happen in subsequent PRs.