### PR TITLE
feat(tracing): Add types for `traces_sampler` implementation

### DIFF
--- a/sentry_sdk/_types.py
+++ b/sentry_sdk/_types.py
@@ -5,6 +5,7 @@ except ImportError:
 
 
 if MYPY:
+    from numbers import Real
     from types import TracebackType
     from typing import Any
     from typing import Callable
@@ -12,6 +13,7 @@ if MYPY:
     from typing import Optional
     from typing import Tuple
     from typing import Type
+    from typing import Union
     from typing_extensions import Literal
 
     ExcInfo = Tuple[
@@ -24,9 +26,13 @@ if MYPY:
     Breadcrumb = Dict[str, Any]
     BreadcrumbHint = Dict[str, Any]
 
+    SamplingContext = Dict[str, Any]
+
     EventProcessor = Callable[[Event, Hint], Optional[Event]]
     ErrorProcessor = Callable[[Event, ExcInfo], Optional[Event]]
     BreadcrumbProcessor = Callable[[Breadcrumb, BreadcrumbHint], Optional[Breadcrumb]]
+
+    TracesSampler = Callable[[SamplingContext], Union[Real, bool]]
 
     # https://github.com/python/mypy/issues/5710
     NotImplementedType = Any

--- a/sentry_sdk/consts.py
+++ b/sentry_sdk/consts.py
@@ -14,7 +14,12 @@ if MYPY:
     from sentry_sdk.transport import Transport
     from sentry_sdk.integrations import Integration
 
-    from sentry_sdk._types import Event, EventProcessor, BreadcrumbProcessor
+    from sentry_sdk._types import (
+        BreadcrumbProcessor,
+        Event,
+        EventProcessor,
+        TracesSampler,
+    )
 
     # Experiments are feature flags to enable and disable certain unstable SDK
     # functionality. Changing them from the defaults (`None`) in production
@@ -63,6 +68,7 @@ class ClientConstructor(object):
         ca_certs=None,  # type: Optional[str]
         propagate_traces=True,  # type: bool
         traces_sample_rate=0.0,  # type: float
+        traces_sampler=None,  # type: Optional[TracesSampler]
         auto_enabling_integrations=True,  # type: bool
         _experiments={},  # type: Experiments  # noqa: B006
     ):

--- a/sentry_sdk/tracing.py
+++ b/sentry_sdk/tracing.py
@@ -449,11 +449,12 @@ class Span(object):
 
 
 class Transaction(Span):
-    __slots__ = ("name",)
+    __slots__ = ("name", "parent_sampled")
 
     def __init__(
         self,
         name="",  # type: str
+        parent_sampled=None,  # type: Optional[bool]
         **kwargs  # type: Any
     ):
         # type: (...) -> None
@@ -468,6 +469,7 @@ class Transaction(Span):
             name = kwargs.pop("transaction")
         Span.__init__(self, **kwargs)
         self.name = name
+        self.parent_sampled = parent_sampled
 
     def __repr__(self):
         # type: () -> str


### PR DESCRIPTION
This adds (but doesn't yet use) the types and attributes necessary for adding the `traces_sampler` option which is specced [here](https://develop.sentry.dev/sdk/unified-api/tracing). Extracted from the larger PR on that topic, https://github.com/getsentry/sentry-python/pull/863.

- Types for the `traces_sampler` itself (the function and its input)
- A new attribute on the `Transaction` class tracking the parent sampling decision separately from the sampling decision of the transaction itself, since part of the `traces_sampler` spec is that there needs to be a difference between an inherited decision and an explicitly set decision.