### PR TITLE
ref(tracing): Pre-`traces_sampler` documentation additions

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -2,5 +2,5 @@
 DJANGO_SETTINGS_MODULE = tests.integrations.django.myapp.settings
 addopts = --tb=short
 markers =
-    tests_internal_exceptions
+    tests_internal_exceptions: Handle internal exceptions just as the SDK does, to test it. (Otherwise internal exceptions are recorded and reraised.)
     only: A temporary marker, to make pytest only run the tests with the mark, similar to jest's `it.only`. To use, run `pytest -v -m only`.

--- a/sentry_sdk/integrations/flask.py
+++ b/sentry_sdk/integrations/flask.py
@@ -104,7 +104,8 @@ def _request_started(sender, **kwargs):
     with hub.configure_scope() as scope:
         request = _request_ctx_stack.top.request
 
-        # Rely on WSGI middleware to start a trace
+        # Set the transaction name here, but rely on WSGI middleware to actually
+        # start the transaction
         try:
             if integration.transaction_style == "endpoint":
                 scope.transaction = request.url_rule.endpoint

--- a/sentry_sdk/scope.py
+++ b/sentry_sdk/scope.py
@@ -77,6 +77,8 @@ class Scope(object):
         "_level",
         "_name",
         "_fingerprint",
+        # note that for legacy reasons, _transaction is the transaction *name*,
+        # not a Transaction object (the object is stored in _span)
         "_transaction",
         "_user",
         "_tags",

--- a/sentry_sdk/tracing.py
+++ b/sentry_sdk/tracing.py
@@ -166,8 +166,10 @@ class Span(object):
 
     def __repr__(self):
         # type: () -> str
-        return "<%s(trace_id=%r, span_id=%r, parent_span_id=%r, sampled=%r)>" % (
+        return "<%s(op=%r, description:%r, trace_id=%r, span_id=%r, parent_span_id=%r, sampled=%r)>" % (
             self.__class__.__name__,
+            self.op,
+            self.description,
             self.trace_id,
             self.span_id,
             self.parent_span_id,
@@ -459,16 +461,14 @@ class Transaction(Span):
 
     def __repr__(self):
         # type: () -> str
-        return (
-            "<%s(name=%r, trace_id=%r, span_id=%r, parent_span_id=%r, sampled=%r)>"
-            % (
-                self.__class__.__name__,
-                self.name,
-                self.trace_id,
-                self.span_id,
-                self.parent_span_id,
-                self.sampled,
-            )
+        return "<%s(name=%r, op=%r, trace_id=%r, span_id=%r, parent_span_id=%r, sampled=%r)>" % (
+            self.__class__.__name__,
+            self.name,
+            self.op,
+            self.trace_id,
+            self.span_id,
+            self.parent_span_id,
+            self.sampled,
         )
 
     def finish(self, hub=None):

--- a/sentry_sdk/tracing.py
+++ b/sentry_sdk/tracing.py
@@ -111,6 +111,11 @@ class Span(object):
 
     def __new__(cls, **kwargs):
         # type: (**Any) -> Any
+        """
+        Backwards-compatible implementation of Span and Transaction
+        creation.
+        """
+
         # TODO: consider removing this in a future release.
         # This is for backwards compatibility with releases before Transaction
         # existed, to allow for a smoother transition.
@@ -229,6 +234,7 @@ class Span(object):
         environ,  # type: typing.Mapping[str, str]
         **kwargs  # type: Any
     ):
+        # type: (...) -> Transaction
         """
         Create a Transaction with the given params, then add in data pulled from
         the 'sentry-trace' header in the environ (if any) before returning the
@@ -237,7 +243,6 @@ class Span(object):
         If the 'sentry-trace' header is malformed or missing, just create and
         return a Transaction instance with the given params.
         """
-        # type: (...) -> Transaction
         if cls is Span:
             logger.warning(
                 "Deprecated: use Transaction.continue_from_environ "
@@ -251,6 +256,7 @@ class Span(object):
         headers,  # type: typing.Mapping[str, str]
         **kwargs  # type: Any
     ):
+        # type: (...) -> Transaction
         """
         Create a Transaction with the given params, then add in data pulled from
         the 'sentry-trace' header (if any) before returning the Transaction.
@@ -258,7 +264,6 @@ class Span(object):
         If the 'sentry-trace' header is malformed or missing, just create and
         return a Transaction instance with the given params.
         """
-        # type: (...) -> Transaction
         if cls is Span:
             logger.warning(
                 "Deprecated: use Transaction.continue_from_headers "
@@ -282,6 +287,7 @@ class Span(object):
         traceparent,  # type: Optional[str]
         **kwargs  # type: Any
     ):
+        # type: (...) -> Optional[Transaction]
         """
         Create a Transaction with the given params, then add in data pulled from
         the given 'sentry-trace' header value before returning the Transaction.
@@ -289,7 +295,6 @@ class Span(object):
         If the header value is malformed or missing, just create and return a
         Transaction instance with the given params.
         """
-        # type: (...) -> Optional[Transaction]
         if cls is Span:
             logger.warning(
                 "Deprecated: use Transaction.from_traceparent "

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -48,6 +48,8 @@ def internal_exceptions(request, monkeypatch):
 
     @request.addfinalizer
     def _():
+        # rerasise the errors so that this just acts as a pass-through (that
+        # happens to keep track of the errors which pass through it)
         for e in errors:
             reraise(*e)
 

--- a/tests/integrations/stdlib/test_httplib.py
+++ b/tests/integrations/stdlib/test_httplib.py
@@ -4,13 +4,17 @@ import sys
 import pytest
 
 try:
+    # py3
     from urllib.request import urlopen
 except ImportError:
+    # py2
     from urllib import urlopen
 
 try:
+    # py2
     from httplib import HTTPSConnection
 except ImportError:
+    # py3
     from http.client import HTTPSConnection
 
 from sentry_sdk import capture_message

--- a/tests/tracing/test_misc.py
+++ b/tests/tracing/test_misc.py
@@ -14,6 +14,12 @@ def test_span_trimming(sentry_init, capture_events):
                 pass
 
     (event,) = events
+
+    # the transaction is its own first span (which counts for max_spans) but it
+    # doesn't show up in the span list in the event, so this is 1 less than our
+    # max_spans value
+    assert len(event["spans"]) == 2
+
     span1, span2 = event["spans"]
     assert span1["op"] == "foo0"
     assert span2["op"] == "foo1"


### PR DESCRIPTION
A bunch of comments and docstrings which got added while I was working on https://github.com/getsentry/sentry-python/pull/863. Also adds data to both the `Span` and `Transaction` reprs, and changes a handful of variable names to be more accurate. No behavior changes.