### PR TITLE
fix(dev): Pin `pytest-django` version

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -91,7 +91,18 @@ deps =
     {py2.7,py3.7,py3.8,py3.9}-django-{1.11,2.2,3.0,3.1,dev}: psycopg2-binary
 
     django-{1.6,1.7,1.8}: pytest-django<3.0
-    django-{1.9,1.10,1.11,2.0,2.1,2.2,3.0,3.1}: pytest-django>=3.0
+
+    ; TODO: once we upgrade pytest to at least 5.4, we can split it like this:
+    ; django-{1.9,1.10,1.11,2.0,2.1}: pytest-django<4.0
+    ; django-{2.2,3.0,3.1}: pytest-django>=4.0
+
+    ; (note that py3.9, on which we recently began testing, only got official
+    ; support in pytest-django >=4.0, so we probablly want to upgrade the whole
+    ; kit and kaboodle at some point soon)
+
+    ; see https://pytest-django.readthedocs.io/en/latest/changelog.html#v4-0-0-2020-10-16
+    django-{1.9,1.10,1.11,2.0,2.1,2.2,3.0,3.1}: pytest-django<4.0
+
     django-dev: git+https://github.com/pytest-dev/pytest-django#egg=pytest-django
 
     django-1.6: Django>=1.6,<1.7


### PR DESCRIPTION
The newest `pytest-django` drops support for older versions of `python`, `django`, and `pytest`. This should hopefully fix CI until we can think about upgrading.