### PR TITLE
fix(dev): Pin `eventlet` version

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -9,7 +9,8 @@ pyrsistent==0.16.0 # TODO(py3): 0.17.0 requires python3, see https://github.com/
 mock # for testing under python < 3.3
 
 gevent
-eventlet
+# https://github.com/eventlet/eventlet/issues/660
+eventlet==0.28.0
 # https://github.com/eventlet/eventlet/issues/619
 dnspython<2.0
 


### PR DESCRIPTION
See https://github.com/eventlet/eventlet/issues/660.

Until that gets addressed, this pins us at a version we know doesn't break py2.7 tests.