### PR TITLE
fix(serialization): Adjust breadcrumb check for new structure

### DIFF
--- a/sentry_sdk/consts.py
+++ b/sentry_sdk/consts.py
@@ -31,6 +31,8 @@ if MYPY:
         total=False,
     )
 
+DEFAULT_MAX_BREADCRUMBS = 100
+
 
 # This type exists to trick mypy and PyCharm into thinking `init` and `Client`
 # take these arguments (even though they take opaque **kwargs)
@@ -39,7 +41,7 @@ class ClientConstructor(object):
         self,
         dsn=None,  # type: Optional[str]
         with_locals=True,  # type: bool
-        max_breadcrumbs=100,  # type: int
+        max_breadcrumbs=DEFAULT_MAX_BREADCRUMBS,  # type: int
         release=None,  # type: Optional[str]
         environment=None,  # type: Optional[str]
         server_name=None,  # type: Optional[str]

--- a/sentry_sdk/serializer.py
+++ b/sentry_sdk/serializer.py
@@ -188,8 +188,8 @@ def serialize(event, smart_transaction_trimming=False, **kwargs):
             if p0 == "request" and path[1] == "data":
                 return True
 
-            if p0 == "breadcrumbs":
-                path[1]
+            if p0 == "breadcrumbs" and path[1] == "values":
+                path[2]
                 return True
 
             if p0 == "extra":


### PR DESCRIPTION
In [this commit](https://github.com/getsentry/sentry-python/commit/16aaed1fdaa08e9ee177d89d6d2938acbdeff8aa#diff-c935006d78056bc518dd6e898d31d972c130c63119df74edf122e2cf4a5733bcL315), the structure of the `"breadcrumbs"` entry of an event was changed such that they were no longer stored at `event["breadcrumbs"]` but instead were stored at `event["breadcrumbs"]["values"]`. The `_is_databag()` helper function wasn't adjusted accordingly, however, resulting in `MAX_DATABAG_BREADTH` being applied to the list of breadcrumbs rather than the data inside each breadcrumb itself. In practice, this meant that no event could have more than 10 breadcrumbs.

This fixes the check in `_is_databag()` to look one level deeper for breadcrumbs. It also adds a more specific assert statement to the max breadth serializer test.


 