### PR TITLE
unpin eventlet and dnspython

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -9,10 +9,7 @@ pyrsistent==0.16.0 # TODO(py3): 0.17.0 requires python3, see https://github.com/
 mock # for testing under python < 3.3
 
 gevent
-# https://github.com/eventlet/eventlet/issues/660
-eventlet==0.28.0
-# https://github.com/eventlet/eventlet/issues/619
-dnspython<2.0
+eventlet
 
 newrelic
 executing


### PR DESCRIPTION
eventlet recursion on py2.7 fixed in 0.29.1 https://github.com/eventlet/eventlet/issues/660
dnspython was pinned in eventlet since 0.26.1