### PR TITLE
Fix mypy hinting of toplevel sentry_sdk module

### DIFF
--- a/sentry_sdk/__init__.py
+++ b/sentry_sdk/__init__.py
@@ -4,11 +4,10 @@ from sentry_sdk.transport import Transport, HttpTransport
 from sentry_sdk.client import Client
 
 from sentry_sdk.api import *  # noqa
-from sentry_sdk.api import __all__ as api_all
 
 from sentry_sdk.consts import VERSION  # noqa
 
-__all__ = api_all + [  # noqa
+__all__ = [  # noqa
     "Hub",
     "Scope",
     "Client",
@@ -16,6 +15,22 @@ __all__ = api_all + [  # noqa
     "HttpTransport",
     "init",
     "integrations",
+    # From sentry_sdk.api
+    "capture_event",
+    "capture_message",
+    "capture_exception",
+    "add_breadcrumb",
+    "configure_scope",
+    "push_scope",
+    "flush",
+    "last_event_id",
+    "start_span",
+    "start_transaction",
+    "set_tag",
+    "set_context",
+    "set_extra",
+    "set_user",
+    "set_level",
 ]
 
 # Initialize the debug support after everything is loaded

--- a/sentry_sdk/api.py
+++ b/sentry_sdk/api.py
@@ -27,6 +27,7 @@ else:
         return x
 
 
+# When changing this, update __all__ in __init__.py too
 __all__ = [
     "capture_event",
     "capture_message",


### PR DESCRIPTION
Mypy does not support runtime-calculated `__all__`, so duplicate symbols
from `sentry_sdk.api.__all__` to top-level `__init__.py`.

Fixes #375.

Tested with mypy 0.790.