### PR TITLE
Feature/add scope to sampling context asgi integration

### DIFF
--- a/sentry_sdk/integrations/asgi.py
+++ b/sentry_sdk/integrations/asgi.py
@@ -139,7 +139,10 @@ class SentryAsgiMiddleware:
                 transaction.name = _DEFAULT_TRANSACTION_NAME
                 transaction.set_tag("asgi.type", ty)
 
-                with hub.start_transaction(transaction):
+                with hub.start_transaction(
+                    transaction,
+                    custom_sampling_context={"scope": scope}
+                ):
                     # XXX: Would be cool to have correct span status, but we
                     # would have to wrap send(). That is a bit hard to do with
                     # the current abstraction over ASGI 2/3.

--- a/sentry_sdk/integrations/asgi.py
+++ b/sentry_sdk/integrations/asgi.py
@@ -140,8 +140,7 @@ class SentryAsgiMiddleware:
                 transaction.set_tag("asgi.type", ty)
 
                 with hub.start_transaction(
-                    transaction,
-                    custom_sampling_context={"scope": scope}
+                    transaction, custom_sampling_context={"scope": scope}
                 ):
                     # XXX: Would be cool to have correct span status, but we
                     # would have to wrap send(). That is a bit hard to do with

--- a/tests/integrations/asgi/test_asgi.py
+++ b/tests/integrations/asgi/test_asgi.py
@@ -13,6 +13,7 @@ try:
 except ImportError:
     import mock  # python < 3.3
 
+
 @pytest.fixture
 def app():
     app = Starlette()
@@ -207,20 +208,18 @@ def test_starlette_last_event_id(app, sentry_init, capture_events, request):
     assert exception["type"] == "ValueError"
     assert exception["value"] == "oh no"
 
+
 async def test_traces_sampler_gets_scope_object_in_sampling_context(
-        sentry_init,
-        app,
-        capture_events,
-        DictionaryContaining,
-        ObjectDescribedBy
+    sentry_init,
+    app,
+    capture_events,
+    DictionaryContaining,  # noqa:N803
+    ObjectDescribedBy,  # noqa:N803
 ):
     test_url = "/sync-message"
 
     traces_sampler = mock.Mock()
-    sentry_init(
-        send_default_pii=True,
-        traces_sampler=traces_sampler
-    )
+    sentry_init(send_default_pii=True, traces_sampler=traces_sampler)
 
     events = capture_events()
 
@@ -231,17 +230,18 @@ async def test_traces_sampler_gets_scope_object_in_sampling_context(
 
     traces_sampler.assert_any_call(
         DictionaryContaining(
-           {
-              "scope": ObjectDescribedBy(
-                 type=dict, attrs={
-                    'type': 'http',
-                    'http_version': '1.1',
-                    'method': 'GET',
-                    'path': test_url,
-                    'root_path': '',
-                    'scheme': 'http'
-                 }
-              )
-           }
+            {
+                "scope": ObjectDescribedBy(
+                    type=dict,
+                    attrs={
+                        "type": "http",
+                        "http_version": "1.1",
+                        "method": "GET",
+                        "path": test_url,
+                        "root_path": "",
+                        "scheme": "http",
+                    },
+                )
+            }
         )
     )


### PR DESCRIPTION
Inside of the `traces_sampler` method, I need an access to the `path`, as well as to the `method`. These are stored inside of the `scope`.
It helps me to filter out URLs, that I don't want to include in the performance report.