### PR TITLE
feat(dev): Add `type_name` option for `ObjectDescribedBy` test matcher

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -413,8 +413,10 @@ def object_described_by_matcher():
     """
     An object which matches any other object with the given properties.
 
-    Available properties currently are "type" (a type object) and "attrs" (a
-    dictionary).
+    Available properties currently are "type" (a type object), "type_name" (a
+    string), and "attrs" (a dictionary). Note that while "type" allows for
+    subclasses to match, "type_name" must be an exact match to the object being
+    tested.
 
     Useful for assert_called_with, assert_any_call, etc.
 
@@ -429,17 +431,23 @@ def object_described_by_matcher():
     >>> f = mock.Mock()
     >>> f(maisey)
     >>> f.assert_any_call(ObjectDescribedBy(type=Dog)) # no AssertionError
+    >>> f.assert_any_call(ObjectDescribedBy(type_name="Dog")) # no AssertionError
     >>> f.assert_any_call(ObjectDescribedBy(attrs={"name": "Maisey"})) # no AssertionError
     """
 
     class ObjectDescribedBy(object):
-        def __init__(self, type=None, attrs=None):
+        def __init__(self, type=None, type_name=None, attrs=None):
             self.type = type
+            self.type_name = type_name
             self.attrs = attrs
 
         def __eq__(self, test_obj):
             if self.type:
                 if not isinstance(test_obj, self.type):
+                    return False
+
+            if self.type_name:
+                if self.type_name != type(test_obj).__name__:
                     return False
 
             # all checks here done with getattr rather than comparing to

--- a/tests/test_conftest.py
+++ b/tests/test_conftest.py
@@ -71,24 +71,24 @@ class Cat(Animal):
 
 
 @pytest.mark.parametrize(
-    "test_obj, type_and_attrs_result, type_only_result, attrs_only_result",
+    "test_obj, type_and_attrs_result, type_only_result, attrs_only_result, type_name_only_result",
     [
         # type matches
-        (Dog("Maisey", 7, "silly"), True, True, True),  # full attr containment
-        (Dog("Maisey", 7), True, True, True),  # type and attr equality
-        (Dog(), False, True, False),  # reverse attr containment
-        (Dog("Maisey"), False, True, False),  # reverse attr containment
-        (Dog("Charlie", 7, "goofy"), False, True, False),  # partial attr overlap
-        (Dog("Bodhi", 6, "floppy"), False, True, False),  # no attr overlap
+        (Dog("Maisey", 7, "silly"), True, True, True, True),  # full attr containment
+        (Dog("Maisey", 7), True, True, True, True),  # type and attr equality
+        (Dog(), False, True, False, True),  # reverse attr containment
+        (Dog("Maisey"), False, True, False, True),  # reverse attr containment
+        (Dog("Charlie", 7, "goofy"), False, True, False, True),  # partial attr overlap
+        (Dog("Bodhi", 6, "floppy"), False, True, False, True),  # no attr overlap
         # type mismatches
-        (Cat("Maisey", 7), False, False, True),  # attr equality
-        (Cat("Piper", 1, "doglike"), False, False, False),
-        ("Good girl, Maisey", False, False, False),
-        ({"name": "Maisey", "age": 7}, False, False, False),
-        (1231, False, False, False),
-        (11.21, False, False, False),
-        ([], False, False, False),
-        (True, False, False, False),
+        (Cat("Maisey", 7), False, False, True, False),  # attr equality
+        (Cat("Piper", 1, "doglike"), False, False, False, False),
+        ("Good girl, Maisey", False, False, False, False),
+        ({"name": "Maisey", "age": 7}, False, False, False, False),
+        (1231, False, False, False, False),
+        (11.21, False, False, False, False),
+        ([], False, False, False, False),
+        (True, False, False, False, False),
     ],
 )
 def test_object_described_by(
@@ -96,6 +96,7 @@ def test_object_described_by(
     type_and_attrs_result,
     type_only_result,
     attrs_only_result,
+    type_name_only_result,
     ObjectDescribedBy,  # noqa: N803
 ):
 
@@ -108,3 +109,5 @@ def test_object_described_by(
     assert (
         test_obj == ObjectDescribedBy(attrs={"name": "Maisey", "age": 7})
     ) is attrs_only_result
+
+    assert (test_obj == ObjectDescribedBy(type_name="Dog")) is type_name_only_result


### PR DESCRIPTION
Sometimes, it's easier to pass the name of the type you're checking against, rather than the type/class object itself, so this lets you do that. Using this option has the disadvantage of not being able to match on subclasses, so I added it rather than replacing the `type` check.