### PR TITLE
fix(dev): Pin `channels` for django tests

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -91,7 +91,10 @@ deps =
     -r test-requirements.txt
 
     django-{1.11,2.0,2.1,2.2,3.0,3.1,dev}: djangorestframework>=3.0.0,<4.0.0
-    {py3.7,py3.8,py3.9}-django-{1.11,2.0,2.1,2.2,3.0,3.1,dev}: channels>2
+
+    ; TODO: right now channels 3 is crashing tests/integrations/django/asgi/test_asgi.py
+    ; see https://github.com/django/channels/issues/1549
+    {py3.7,py3.8,py3.9}-django-{1.11,2.0,2.1,2.2,3.0,3.1,dev}: channels>2,<3
     {py3.7,py3.8,py3.9}-django-{1.11,2.0,2.1,2.2,3.0,3.1,dev}: pytest-asyncio==0.10.0
     {py2.7,py3.7,py3.8,py3.9}-django-{1.11,2.2,3.0,3.1,dev}: psycopg2-binary
 


### PR DESCRIPTION
This may end up being a bug on our end, in that the way that we're using `channels`/`asgiref` no longer matches their API, but as a temporary measure, this pins `channels` to a version which lets CI pass. 

See https://github.com/django/channels/issues/1549.