### PR TITLE
feat(tracing): Add more sampling context for asgi, celery, rq, and wsgi

### DIFF
--- a/sentry_sdk/integrations/asgi.py
+++ b/sentry_sdk/integrations/asgi.py
@@ -139,7 +139,9 @@ class SentryAsgiMiddleware:
                 transaction.name = _DEFAULT_TRANSACTION_NAME
                 transaction.set_tag("asgi.type", ty)
 
-                with hub.start_transaction(transaction):
+                with hub.start_transaction(
+                    transaction, custom_sampling_context={"asgi_scope": scope}
+                ):
                     # XXX: Would be cool to have correct span status, but we
                     # would have to wrap send(). That is a bit hard to do with
                     # the current abstraction over ASGI 2/3.

--- a/sentry_sdk/integrations/celery.py
+++ b/sentry_sdk/integrations/celery.py
@@ -159,7 +159,18 @@ def _wrap_tracer(task, f):
             if transaction is None:
                 return f(*args, **kwargs)
 
-            with hub.start_transaction(transaction):
+            with hub.start_transaction(
+                transaction,
+                custom_sampling_context={
+                    "celery_job": {
+                        "task": task.name,
+                        # for some reason, args[1] is a list if non-empty but a
+                        # tuple if empty
+                        "args": list(args[1]),
+                        "kwargs": args[2],
+                    }
+                },
+            ):
                 return f(*args, **kwargs)
 
     return _inner  # type: ignore

--- a/sentry_sdk/integrations/rq.py
+++ b/sentry_sdk/integrations/rq.py
@@ -70,7 +70,9 @@ class RqIntegration(Integration):
                 with capture_internal_exceptions():
                     transaction.name = job.func_name
 
-                with hub.start_transaction(transaction):
+                with hub.start_transaction(
+                    transaction, custom_sampling_context={"rq_job": job}
+                ):
                     rv = old_perform_job(self, job, *args, **kwargs)
 
             if self.is_horse:

--- a/sentry_sdk/integrations/wsgi.py
+++ b/sentry_sdk/integrations/wsgi.py
@@ -117,7 +117,9 @@ class SentryWsgiMiddleware(object):
                         environ, op="http.server", name="generic WSGI request"
                     )
 
-                    with hub.start_transaction(transaction):
+                    with hub.start_transaction(
+                        transaction, custom_sampling_context={"wsgi_environ": environ}
+                    ):
                         try:
                             rv = self.app(
                                 environ,

--- a/tests/integrations/celery/test_celery.py
+++ b/tests/integrations/celery/test_celery.py
@@ -405,5 +405,5 @@ def test_traces_sampler_gets_task_info_in_sampling_context(
     traces_sampler.assert_any_call(
         # depending on the iteration of celery_invocation, the data might be
         # passed as args or as kwargs, so make this generic
-        DictionaryContaining({"celery_job": {"task": "dog_walk", **args_kwargs}})
+        DictionaryContaining({"celery_job": dict(task="dog_walk", **args_kwargs)})
     )

--- a/tests/integrations/celery/test_celery.py
+++ b/tests/integrations/celery/test_celery.py
@@ -11,6 +11,11 @@ from sentry_sdk._compat import text_type
 from celery import Celery, VERSION
 from celery.bin import worker
 
+try:
+    from unittest import mock  # python 3.3 and above
+except ImportError:
+    import mock  # python < 3.3
+
 
 @pytest.fixture
 def connect_signal(request):
@@ -379,3 +384,26 @@ def test_newrelic_interference(init_celery, newrelic_order, celery_invocation):
 
     assert dummy_task.apply(kwargs={"x": 1, "y": 1}).wait() == 1
     assert celery_invocation(dummy_task, 1, 1)[0].wait() == 1
+
+
+def test_traces_sampler_gets_task_info_in_sampling_context(
+    init_celery, celery_invocation, DictionaryContaining  # noqa:N803
+):
+    traces_sampler = mock.Mock()
+    celery = init_celery(traces_sampler=traces_sampler)
+
+    @celery.task(name="dog_walk")
+    def walk_dogs(x, y):
+        dogs, route = x
+        num_loops = y
+        return dogs, route, num_loops
+
+    _, args_kwargs = celery_invocation(
+        walk_dogs, [["Maisey", "Charlie", "Bodhi", "Cory"], "Dog park round trip"], 1
+    )
+
+    traces_sampler.assert_any_call(
+        # depending on the iteration of celery_invocation, the data might be
+        # passed as args or as kwargs, so make this generic
+        DictionaryContaining({"celery_job": {"task": "dog_walk", **args_kwargs}})
+    )

--- a/tests/integrations/rq/test_rq.py
+++ b/tests/integrations/rq/test_rq.py
@@ -5,6 +5,11 @@ import pytest
 from fakeredis import FakeStrictRedis
 import rq
 
+try:
+    from unittest import mock  # python 3.3 and above
+except ImportError:
+    import mock  # python < 3.3
+
 
 @pytest.fixture(autouse=True)
 def _patch_rq_get_server_version(monkeypatch):
@@ -26,6 +31,14 @@ def _patch_rq_get_server_version(monkeypatch):
 
 def crashing_job(foo):
     1 / 0
+
+
+def chew_up_shoes(dog, human, shoes):
+    raise Exception("{}!! Why did you eat {}'s {}??".format(dog, human, shoes))
+
+
+def do_trick(dog, trick):
+    return "{}, can you {}? Good dog!".format(dog, trick)
 
 
 def test_basic(sentry_init, capture_events):
@@ -71,3 +84,96 @@ def test_transport_shutdown(sentry_init, capture_events_forksafe):
 
     (exception,) = event["exception"]["values"]
     assert exception["type"] == "ZeroDivisionError"
+
+
+def test_transaction_with_error(
+    sentry_init, capture_events, DictionaryContaining  # noqa:N803
+):
+
+    sentry_init(integrations=[RqIntegration()], traces_sample_rate=1.0)
+    events = capture_events()
+
+    queue = rq.Queue(connection=FakeStrictRedis())
+    worker = rq.SimpleWorker([queue], connection=queue.connection)
+
+    queue.enqueue(chew_up_shoes, "Charlie", "Katie", shoes="flip-flops")
+    worker.work(burst=True)
+
+    error_event, envelope = events
+
+    assert error_event["transaction"] == "tests.integrations.rq.test_rq.chew_up_shoes"
+    assert error_event["contexts"]["trace"]["op"] == "rq.task"
+    assert error_event["exception"]["values"][0]["type"] == "Exception"
+    assert (
+        error_event["exception"]["values"][0]["value"]
+        == "Charlie!! Why did you eat Katie's flip-flops??"
+    )
+
+    assert envelope["type"] == "transaction"
+    assert envelope["contexts"]["trace"] == error_event["contexts"]["trace"]
+    assert envelope["transaction"] == error_event["transaction"]
+    assert envelope["extra"]["rq-job"] == DictionaryContaining(
+        {
+            "args": ["Charlie", "Katie"],
+            "kwargs": {"shoes": "flip-flops"},
+            "func": "tests.integrations.rq.test_rq.chew_up_shoes",
+            "description": "tests.integrations.rq.test_rq.chew_up_shoes('Charlie', 'Katie', shoes='flip-flops')",
+        }
+    )
+
+
+def test_transaction_no_error(
+    sentry_init, capture_events, DictionaryContaining  # noqa:N803
+):
+    sentry_init(integrations=[RqIntegration()], traces_sample_rate=1.0)
+    events = capture_events()
+
+    queue = rq.Queue(connection=FakeStrictRedis())
+    worker = rq.SimpleWorker([queue], connection=queue.connection)
+
+    queue.enqueue(do_trick, "Maisey", trick="kangaroo")
+    worker.work(burst=True)
+
+    envelope = events[0]
+
+    assert envelope["type"] == "transaction"
+    assert envelope["contexts"]["trace"]["op"] == "rq.task"
+    assert envelope["transaction"] == "tests.integrations.rq.test_rq.do_trick"
+    assert envelope["extra"]["rq-job"] == DictionaryContaining(
+        {
+            "args": ["Maisey"],
+            "kwargs": {"trick": "kangaroo"},
+            "func": "tests.integrations.rq.test_rq.do_trick",
+            "description": "tests.integrations.rq.test_rq.do_trick('Maisey', trick='kangaroo')",
+        }
+    )
+
+
+def test_traces_sampler_gets_correct_values_in_sampling_context(
+    sentry_init, DictionaryContaining, ObjectDescribedBy  # noqa:N803
+):
+    traces_sampler = mock.Mock(return_value=True)
+    sentry_init(integrations=[RqIntegration()], traces_sampler=traces_sampler)
+
+    queue = rq.Queue(connection=FakeStrictRedis())
+    worker = rq.SimpleWorker([queue], connection=queue.connection)
+
+    queue.enqueue(do_trick, "Bodhi", trick="roll over")
+    worker.work(burst=True)
+
+    traces_sampler.assert_any_call(
+        DictionaryContaining(
+            {
+                "rq_job": ObjectDescribedBy(
+                    type=rq.job.Job,
+                    attrs={
+                        "description": "tests.integrations.rq.test_rq.do_trick('Bodhi', trick='roll over')",
+                        "result": "Bodhi, can you roll over? Good dog!",
+                        "func_name": "tests.integrations.rq.test_rq.do_trick",
+                        "args": ("Bodhi",),
+                        "kwargs": {"trick": "roll over"},
+                    },
+                ),
+            }
+        )
+    )


### PR DESCRIPTION
Following up on https://github.com/getsentry/sentry-python/pull/863, this adds useful information to the data automatically passed to `traces_sampler` when using the asgi, celery, rq, and wsgi integrations.