### PR TITLE
feat(tracing): Add sampling context from AWS and GCP

### DIFF
--- a/sentry_sdk/_compat.py
+++ b/sentry_sdk/_compat.py
@@ -7,7 +7,6 @@ if MYPY:
     from typing import Tuple
     from typing import Any
     from typing import Type
-
     from typing import TypeVar
 
     T = TypeVar("T")

--- a/tests/integrations/aws_lambda/client.py
+++ b/tests/integrations/aws_lambda/client.py
@@ -49,6 +49,13 @@ def run_lambda_function(
             **subprocess_kwargs
         )
 
+        subprocess.check_call(
+            "pip install mock==3.0.0 funcsigs -t .",
+            cwd=tmpdir,
+            shell=True,
+            **subprocess_kwargs
+        )
+
         # https://docs.aws.amazon.com/lambda/latest/dg/lambda-python-how-to-create-deployment-package.html
         subprocess.check_call(
             "pip install ../*.tar.gz -t .", cwd=tmpdir, shell=True, **subprocess_kwargs

--- a/tests/integrations/aws_lambda/test_aws.py
+++ b/tests/integrations/aws_lambda/test_aws.py
@@ -127,7 +127,7 @@ def run_lambda_function(request, lambda_client, lambda_runtime):
 
         # for better debugging
         response["LogResult"] = base64.b64decode(response["LogResult"]).splitlines()
-        response["Payload"] = response["Payload"].read()
+        response["Payload"] = json.loads(response["Payload"].read().decode("utf-8"))
         del response["ResponseMetadata"]
 
         events = []
@@ -567,12 +567,12 @@ def test_traces_sampler_gets_correct_values_in_sampling_context(
                             }
                         )
                     )
-                except AssertionError as e:
-                    # catch the error and print it because the error itself will
+                except AssertionError:
+                    # catch the error and return it because the error itself will
                     # get swallowed by the SDK as an "internal exception"
-                    print("\\nERROR: AssertionError: traces_sampler not called with the specified argument.")
+                    return {"AssertionError raised": True,}
 
-                return "dogs are great"
+                return {"AssertionError raised": False,}
 
 
             traces_sampler = mock.Mock(return_value=True)
@@ -585,4 +585,4 @@ def test_traces_sampler_gets_correct_values_in_sampling_context(
         b'{"httpMethod": "GET", "path": "/sit/stay/rollover", "headers": {"Host": "dogs.are.great", "X-Forwarded-Proto": "http"}}',
     )
 
-    assert "AssertionError" not in str(response["LogResult"])
+    assert response["Payload"]["AssertionError raised"] is False

--- a/tests/integrations/gcp/test_gcp.py
+++ b/tests/integrations/gcp/test_gcp.py
@@ -112,6 +112,8 @@ def run_cloud_function():
             stream = os.popen("python {}/main.py".format(tmpdir))
             stream_data = stream.read()
 
+            stream.close()
+
             for line in stream_data.splitlines():
                 print("GCP:", line)
                 if line.startswith("EVENT: "):

--- a/tests/integrations/gcp/test_gcp.py
+++ b/tests/integrations/gcp/test_gcp.py
@@ -287,6 +287,11 @@ def test_performance_error(run_cloud_function):
 def test_traces_sampler_gets_correct_values_in_sampling_context(
     run_cloud_function, DictionaryContaining  # noqa:N803
 ):
+    # TODO: There are some decent sized hacks below. For more context, see the
+    # long comment in the test of the same name in the AWS integration. The
+    # situations there and here aren't identical, but they're similar enough
+    # that solving one would probably solve both.
+
     import inspect
 
     envelopes, events, return_value = run_cloud_function(


### PR DESCRIPTION
Another follow-up to https://github.com/getsentry/sentry-python/pull/863. This adds sampling context from the AWS and GCP integrations.

In addition, this PR includes two changes to support testing of these changes - fixes to the `DictionaryContaining` and `ObjectDescribedBy` matchers, and closing of resources opened by tests to suppress unnecessary warnings.