### PR TITLE
Add build scripts for building and publishing AWS Lambda layers.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,3 +73,49 @@ travis-upload-dist: dist install-zeus-cli
 	zeus upload -t "application/zip+wheel" dist/* \
 		|| [[ ! "$(TRAVIS_BRANCH)" =~ ^release/ ]]
 .PHONY: travis-upload-dist
+
+awslambda-layer-build-pre: dist
+	@$(VENV_PATH)/bin/pip install .
+.PHONY: awslambda-layer-build-pre
+
+awslambda-layer-build-py27: awslambda-layer-build-pre
+	$(VENV_PATH)/bin/python scripts/build-awslambda-layer.py --python 2.7
+.PHONY: awslambda-layer-build-py27
+
+awslambda-layer-build-py36: awslambda-layer-build-pre
+	$(VENV_PATH)/bin/python scripts/build-awslambda-layer.py --python 3.6
+.PHONY: awslambda-layer-build-py36
+
+awslambda-layer-build-py37: awslambda-layer-build-pre
+	$(VENV_PATH)/bin/python scripts/build-awslambda-layer.py --python 3.7
+.PHONY: awslambda-layer-build-py37
+
+awslambda-layer-build-py38: awslambda-layer-build-pre
+	$(VENV_PATH)/bin/python scripts/build-awslambda-layer.py --python 3.8
+.PHONY: awslambda-layer-build-py38
+
+awslambda-layer-build: awslambda-layer-build-py27 awslambda-layer-build-py36 awslambda-layer-build-py37 awslambda-layer-build-py38
+.PHONY: awslambda-layer-build
+
+awslambda-layer-publish-pre:
+	@$(VENV_PATH)/bin/pip install boto3
+.PHONY: awslambda-layer-pre
+
+awslambda-layer-publish-py27: awslambda-layer-build-py27 awslambda-layer-publish-pre
+	$(VENV_PATH)/bin/python scripts/publish-awslambda-layer.py --python 2.7
+.PHONY: awslambda-layer-publish-py27
+
+awslambda-layer-publish-py36: awslambda-layer-build-py36 awslambda-layer-publish-pre
+	$(VENV_PATH)/bin/python scripts/publish-awslambda-layer.py --python 3.6
+.PHONY: awslambda-layer-publish-py36
+
+awslambda-layer-publish-py37: awslambda-layer-build-py37 awslambda-layer-publish-pre
+	$(VENV_PATH)/bin/python scripts/publish-awslambda-layer.py --python 3.7
+.PHONY: awslambda-layer-publish-py37
+
+awslambda-layer-publish-py38: awslambda-layer-build-py38 awslambda-layer-publish-pre
+	$(VENV_PATH)/bin/python scripts/publish-awslambda-layer.py --python 3.8
+.PHONY: awslambda-layer-publish-py38
+
+awslambda-layer-publish: awslambda-layer-publish-py27 awslambda-layer-publish-py36 awslambda-layer-publish-py37 awslambda-layer-publish-py38
+.PHONY: awslambda-layer-publish

--- a/scripts/build-awslambda-layer.py
+++ b/scripts/build-awslambda-layer.py
@@ -1,0 +1,77 @@
+import argparse
+import os
+import os.path
+import shutil
+import subprocess
+import tempfile
+
+from sentry_sdk import VERSION as SENTRY_SDK_VERSION
+
+# This script builds dist/sentry-python-awslambda-layer-A.B.C-pyX.Y.zip layer
+# that could to be uploaded as AWS Lambda layer.
+#
+# To run this script, dist/sentry_sdk-A.B.C-py2.py3-none-any.whl must exist.
+# You can build a wheel file using `make dist` command.
+
+work_dir = os.path.realpath(os.path.join(os.path.dirname(__file__), ".."))
+
+arg_parser = argparse.ArgumentParser()
+arg_parser.add_argument(
+    "--python", "-p", action="store", choices=["2.7", "3.6", "3.7", "3.8"]
+)
+args = arg_parser.parse_args()
+
+if args.python == "2.7":
+    zip_file_name = "sentry-python-awslambda-layer-{}-py2.7.zip"
+    site_dir = "python2.7"
+elif args.python == "3.6":
+    zip_file_name = "sentry-python-awslambda-layer-{}-py3.6.zip"
+    site_dir = "python3.6"
+elif args.python == "3.7":
+    zip_file_name = "sentry-python-awslambda-layer-{}-py3.7.zip"
+    site_dir = "python3.7"
+elif args.python == "3.8":
+    zip_file_name = "sentry-python-awslambda-layer-{}-py3.8.zip"
+    site_dir = "python3.8"
+
+zip_file_name = zip_file_name.format(SENTRY_SDK_VERSION)
+
+print(
+    "Building a layer for SDK version {} and Python {}\n".format(
+        SENTRY_SDK_VERSION, args.python
+    )
+)
+
+with tempfile.TemporaryDirectory() as tmpdir:
+    target_rel_path = os.path.join("python", "lib", site_dir, "site-packages")
+    target_path = os.path.join(tmpdir, target_rel_path)
+    os.makedirs(target_path)
+    subprocess.run(
+        [
+            "pip",
+            "install",
+            "--no-cache-dir",
+            "-q",
+            os.path.join(
+                "dist", "sentry_sdk-{}-py2.py3-none-any.whl".format(SENTRY_SDK_VERSION)
+            ),
+            "-t",
+            target_path,
+        ],
+        check=True,
+    )
+    subprocess.run(
+        [
+            "zip",
+            "-q",
+            "-x",
+            "**/__pycache__/*",
+            "-r",
+            zip_file_name,
+            target_rel_path,
+        ],
+        cwd=tmpdir,
+        check=True,
+    )
+    dist_path = os.path.join(work_dir, "dist")
+    shutil.copy(os.path.join(tmpdir, zip_file_name), dist_path)

--- a/scripts/publish-awslambda-layer.py
+++ b/scripts/publish-awslambda-layer.py
@@ -1,0 +1,97 @@
+import argparse
+import os
+
+import boto3
+from botocore.config import Config
+
+from sentry_sdk import VERSION as SENTRY_SDK_VERSION
+
+# This scripts publishes current lambda layer zip bundle to AWS and sets layer permission to public.
+# To run you'll probably need to set AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY environment variables.
+#
+# The file dist/sentry-python-awslambda-layer-A.B.C-pyX.Y.zip MUST exist before publishing.
+# You could get it using `python scripts/build-awslambda-layer.py` or just `make awslambda-layer-build`.
+
+all_regions = [
+    "us-east-1",
+    "us-east-2",
+    "us-west-1",
+    "us-west-2",
+    "ap-south-1",
+    "ap-southeast-1",
+    "ap-southeast-2",
+    "ap-northeast-1",
+    "ap-northeast-2",
+    "ca-central-1",
+    "eu-central-1",
+    "eu-west-1",
+    "eu-west-2",
+    "eu-west-3",
+    "sa-east-1",
+]
+
+arg_parser = argparse.ArgumentParser()
+arg_parser.add_argument(
+    "--regions",
+    "-r",
+    nargs="+",
+    action="extend",
+    help="If not specified, layer will be published to all supported regions",
+)
+arg_parser.add_argument(
+    "--python", "-p", action="store", choices=["2.7", "3.6", "3.7", "3.8"]
+)
+args = arg_parser.parse_args()
+
+if args.python == "2.7":
+    layer_name = "SentryPythonSDK27"
+    zip_file_name = "sentry-python-awslambda-layer-{}-py2.7.zip"
+    compatible_runtime = "python2.7"
+elif args.python == "3.6":
+    layer_name = "SentryPythonSDK36"
+    zip_file_name = "sentry-python-awslambda-layer-{}-py3.6.zip"
+    compatible_runtime = "python3.6"
+elif args.python == "3.7":
+    layer_name = "SentryPythonSDK37"
+    zip_file_name = "sentry-python-awslambda-layer-{}-py3.7.zip"
+    compatible_runtime = "python3.7"
+elif args.python == "3.8":
+    layer_name = "SentryPythonSDK38"
+    zip_file_name = "sentry-python-awslambda-layer-{}-py3.8.zip"
+    compatible_runtime = "python3.8"
+
+zip_file_name = zip_file_name.format(SENTRY_SDK_VERSION)
+
+work_dir = os.path.realpath(os.path.join(os.path.dirname(__file__), ".."))
+
+with open(os.path.join(work_dir, "dist", zip_file_name), "rb") as fd:
+    layer_contents = fd.read()
+
+print(
+    "Publishing a layer for SDK version {} and Python {}\n".format(
+        SENTRY_SDK_VERSION, args.python
+    )
+)
+
+regions = args.regions
+if regions is None:
+    regions = all_regions
+
+for region in regions:
+    awslambda = boto3.client("lambda", config=Config(region_name=region))
+    response = awslambda.publish_layer_version(
+        LayerName=layer_name,
+        Content={
+            "ZipFile": layer_contents,
+        },
+        CompatibleRuntimes=[compatible_runtime],
+        LicenseInfo="BSD",
+    )
+    awslambda.add_layer_version_permission(
+        LayerName=layer_name,
+        VersionNumber=response["Version"],
+        StatementId="public",
+        Action="lambda:GetLayerVersion",
+        Principal="*",
+    )
+    print(response["LayerVersionArn"])


### PR DESCRIPTION
These are my scripts that I wrote to package a Sentry SDK for AWS Lambda.

Lambda layers are being uploaded as zip archives, then being extracted to `/opt` directory in Lambda runtime.
And if you put your package to somewhere like `/opt/python/lib/python3.8/site-packages` then it will be available to import from lambda function code.

Having such layers that users can attach to their lambda function is nice because it's easier to integrate, especially in cases when lambda function does not have any required packages except Sentry SDK.

So i wrote a couple of scripts.

One that builds the zip bundle with a specific file structure for each Python version, e.g. `python/lib/python3.8/site-packages/sentry_sdk/`, 
`python/lib/python3.7/site-packages/sentry_sdk` and so on.

And the one that publishes a layer to a set of AWS regions. It's important to publish layer to every region the user might want because layer region and lambda function region must match.

To run the publish script, it's required to set `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` environment variables that `boto3` library understands.

For each Python version, publish-script prints a list of obtained ARNs. Having an ARN for the region, user could just paste it in the settings and the package will be available to the runtime.

So it's necessary to put the list with latest ARNs somewhere in documentation.