### PR TITLE
fix: Fix header extraction for AWS Lambda/ApiGateway

### DIFF
--- a/sentry_sdk/integrations/aws_lambda.py
+++ b/sentry_sdk/integrations/aws_lambda.py
@@ -134,7 +134,7 @@ def _wrap_handler(handler):
                     # Starting the thread to raise timeout warning exception
                     timeout_thread.start()
 
-            headers = request_data.get("headers", None)
+            headers = request_data.get("headers")
             # AWS Service may set an explicit `{headers: None}`, we can't rely on `.get()`'s default.
             if headers is None:
                 headers = {}

--- a/sentry_sdk/integrations/aws_lambda.py
+++ b/sentry_sdk/integrations/aws_lambda.py
@@ -339,12 +339,16 @@ def _make_request_event_processor(aws_event, aws_context, configured_timeout):
 
         if _should_send_default_pii():
             user_info = sentry_event.setdefault("user", {})
-
-            id = aws_event.get("identity", {}).get("userArn")
+            
+            identity = aws_event.get("identity")
+            if identity is None:
+                identity = {}
+            
+            id = identity.get("userArn")
             if id is not None:
                 user_info.setdefault("id", id)
 
-            ip = aws_event.get("identity", {}).get("sourceIp")
+            ip = identity.get("sourceIp")
             if ip is not None:
                 user_info.setdefault("ip_address", ip)
 
@@ -366,7 +370,11 @@ def _make_request_event_processor(aws_event, aws_context, configured_timeout):
 def _get_url(aws_event, aws_context):
     # type: (Any, Any) -> str
     path = aws_event.get("path", None)
-    headers = aws_event.get("headers", {})
+    
+    headers = aws_event.get("headers")
+    if headers is None:
+        headers = {}
+        
     host = headers.get("Host", None)
     proto = headers.get("X-Forwarded-Proto", None)
     if proto and host and path:

--- a/sentry_sdk/integrations/aws_lambda.py
+++ b/sentry_sdk/integrations/aws_lambda.py
@@ -134,7 +134,10 @@ def _wrap_handler(handler):
                     # Starting the thread to raise timeout warning exception
                     timeout_thread.start()
 
-            headers = request_data.get("headers", {})
+            headers = request_data.get("headers", None)
+            # AWS Service may set an explicit `{header: None}`, we can't rely on `.get()`'s default.
+            if headers is None:
+                header = {}
             transaction = Transaction.continue_from_headers(
                 headers, op="serverless.function", name=aws_context.function_name
             )

--- a/sentry_sdk/integrations/aws_lambda.py
+++ b/sentry_sdk/integrations/aws_lambda.py
@@ -135,7 +135,7 @@ def _wrap_handler(handler):
                     timeout_thread.start()
 
             headers = request_data.get("headers", None)
-            # AWS Service may set an explicit `{header: None}`, we can't rely on `.get()`'s default.
+            # AWS Service may set an explicit `{headers: None}`, we can't rely on `.get()`'s default.
             if headers is None:
                 headers = {}
             transaction = Transaction.continue_from_headers(

--- a/sentry_sdk/integrations/aws_lambda.py
+++ b/sentry_sdk/integrations/aws_lambda.py
@@ -137,7 +137,7 @@ def _wrap_handler(handler):
             headers = request_data.get("headers", None)
             # AWS Service may set an explicit `{header: None}`, we can't rely on `.get()`'s default.
             if headers is None:
-                header = {}
+                headers = {}
             transaction = Transaction.continue_from_headers(
                 headers, op="serverless.function", name=aws_context.function_name
             )

--- a/sentry_sdk/integrations/aws_lambda.py
+++ b/sentry_sdk/integrations/aws_lambda.py
@@ -339,11 +339,11 @@ def _make_request_event_processor(aws_event, aws_context, configured_timeout):
 
         if _should_send_default_pii():
             user_info = sentry_event.setdefault("user", {})
-            
+
             identity = aws_event.get("identity")
             if identity is None:
                 identity = {}
-            
+
             id = identity.get("userArn")
             if id is not None:
                 user_info.setdefault("id", id)
@@ -370,11 +370,11 @@ def _make_request_event_processor(aws_event, aws_context, configured_timeout):
 def _get_url(aws_event, aws_context):
     # type: (Any, Any) -> str
     path = aws_event.get("path", None)
-    
+
     headers = aws_event.get("headers")
     if headers is None:
         headers = {}
-        
+
     host = headers.get("Host", None)
     proto = headers.get("X-Forwarded-Proto", None)
     if proto and host and path:

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ def get_file_text(file_name):
     with open(os.path.join(here, file_name)) as in_file:
         return in_file.read()
 
-    
+
 setup(
     name="sentry-sdk",
     version="0.19.4",
@@ -31,7 +31,7 @@ setup(
     },
     description="Python client for Sentry (https://sentry.io)",
     long_description=get_file_text("README.md"),
-    long_description_content_type='text/markdown',
+    long_description_content_type="text/markdown",
     packages=find_packages(exclude=("tests", "tests.*")),
     # PEP 561
     package_data={"sentry_sdk": ["py.typed"]},


### PR DESCRIPTION
Fixes #944 

Since the `headers` property is present and set to `None`, the `.get` default value is ignored.
We need an explicit check on `None` for this one.

~I would advise checking other places in `sentry_sdk/integrations/aws_lambda.py` where the default value is expected to be an empty dictionary. This kind of error is frequent when working with Lambda/ApiGateway.~ Fixed.