### PR TITLE
Adding Power support(ppc64le) with ci and testing to the project for architecture independent

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -57,18 +57,6 @@ jobs:
 
     - python: "3.9"
       arch: ppc64le
-      name: Distribution packages
-      install: []
-      script: make travis-upload-dist
-
-    - python: "3.9"
-      arch: ppc64le
-      name: Build documentation
-      install: []
-      script: make travis-upload-docs
-      
-    - python: "3.8"
-      arch: ppc64le
       dist: bionic
 
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,6 +48,31 @@ jobs:
       install: []
       script: make travis-upload-docs
 
+    - name: Linting
+      arch: ppc64le
+      python: "3.9"
+      install:
+        - pip install tox
+      script: tox -e linters
+
+    - python: "3.9"
+      arch: ppc64le
+      name: Distribution packages
+      install: []
+      script: make travis-upload-dist
+
+    - python: "3.9"
+      arch: ppc64le
+      name: Build documentation
+      install: []
+      script: make travis-upload-docs
+      
+    - python: "3.8"
+      arch: ppc64le
+      dist: bionic
+
+before_install:
+  - sudo apt-get install zip
 before_script:
   - psql -c 'create database travis_ci_test;' -U postgres
   - psql -c 'create database test_travis_ci_test;' -U postgres

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,13 +48,6 @@ jobs:
       install: []
       script: make travis-upload-docs
 
-    - name: Linting
-      arch: ppc64le
-      python: "3.9"
-      install:
-        - pip install tox
-      script: tox -e linters
-
     - python: "3.9"
       arch: ppc64le
       dist: bionic


### PR DESCRIPTION
I am working for IBM to port cpu arch ppc64le for open sources.

This PR adds CI support for the IBM Power Little Endian (ppc64le) architecture. The idea is to ensure that the builds on this architecture are continuously tested along with the Intel builds (amd64) as this is part of the ubuntu distro
on that architecture as well and detecting (and fixing) any issues or failures early would help to ensure that we are always up to date.

This helps us simplify testing later when distributions are re-building and re-releasing,We typically build applications for customers and ISVs, and while we don't use this package directly, we do count on all of the packages in debian/ubuntu to build other packages. So we more likely have this as a second or third level dependency and couldn't tell you explicitly which features we use or our usage model.

Please help to verify and merge.