### PR TITLE
Use full git sha as release name

### DIFF
--- a/sentry_sdk/utils.py
+++ b/sentry_sdk/utils.py
@@ -64,7 +64,7 @@ def get_default_release():
         try:
             release = (
                 subprocess.Popen(
-                    ["git", "rev-parse", "--short", "HEAD"],
+                    ["git", "rev-parse", "HEAD"],
                     stdout=subprocess.PIPE,
                     stderr=null,
                     stdin=null,


### PR DESCRIPTION
This was an unintentional behavior. It should in fact use the full git sha as release name.

This fixes #908