### PR TITLE
fix: Pin newrelic

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -11,6 +11,6 @@ mock # for testing under python < 3.3
 gevent
 eventlet
 
-newrelic
+newrelic==5.24.0.153
 executing
 asttokens

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -11,6 +11,6 @@ mock # for testing under python < 3.3
 gevent
 eventlet
 
-newrelic==5.24.0.153
+newrelic==5.24.0.153 ; python_version >= "3.5"
 executing
 asttokens


### PR DESCRIPTION
Dependabot should be able to bump this, but pip has... issues resolving
newrelic to the latest version, apparently.