### PR TITLE
fix(ci): unpin pytest, stop testing eventlet

### DIFF
--- a/sentry_sdk/integrations/flask.py
+++ b/sentry_sdk/integrations/flask.py
@@ -14,7 +14,6 @@ if MYPY:
     from sentry_sdk.integrations.wsgi import _ScopedResponse
     from typing import Any
     from typing import Dict
-    from werkzeug.datastructures import ImmutableTypeConversionDict
     from werkzeug.datastructures import ImmutableMultiDict
     from werkzeug.datastructures import FileStorage
     from typing import Union
@@ -127,7 +126,7 @@ class FlaskRequestExtractor(RequestExtractor):
         return self.request.environ
 
     def cookies(self):
-        # type: () -> ImmutableTypeConversionDict[Any, Any]
+        # type: () -> Dict[Any, Any]
         return {
             k: v[0] if isinstance(v, list) and len(v) == 1 else v
             for k, v in self.request.cookies.items()

--- a/sentry_sdk/integrations/flask.py
+++ b/sentry_sdk/integrations/flask.py
@@ -128,7 +128,10 @@ class FlaskRequestExtractor(RequestExtractor):
 
     def cookies(self):
         # type: () -> ImmutableTypeConversionDict[Any, Any]
-        return {k: v[0] if isinstance(v, list) and len(v) == 1 else v for k, v in self.request.cookies.items()}
+        return {
+            k: v[0] if isinstance(v, list) and len(v) == 1 else v
+            for k, v in self.request.cookies.items()
+        }
 
     def raw_data(self):
         # type: () -> bytes

--- a/sentry_sdk/integrations/flask.py
+++ b/sentry_sdk/integrations/flask.py
@@ -128,7 +128,7 @@ class FlaskRequestExtractor(RequestExtractor):
 
     def cookies(self):
         # type: () -> ImmutableTypeConversionDict[Any, Any]
-        return self.request.cookies
+        return {k: v[0] if isinstance(v, list) and len(v) == 1 else v for k, v in self.request.cookies.items()}
 
     def raw_data(self):
         # type: () -> bytes

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,7 +1,7 @@
 pytest
 pytest-forked==1.1.3
 tox==3.7.0
-Werkzeug==0.15.5
+Werkzeug
 pytest-localserver==0.5.0
 pytest-cov==2.8.1
 jsonschema==3.2.0

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,4 +1,4 @@
-pytest==3.7.3
+pytest
 pytest-forked==1.1.3
 tox==3.7.0
 Werkzeug==0.15.5
@@ -9,7 +9,6 @@ pyrsistent==0.16.0 # TODO(py3): 0.17.0 requires python3, see https://github.com/
 mock # for testing under python < 3.3
 
 gevent
-eventlet
 
 newrelic
 executing

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,8 +4,15 @@ import json
 import pytest
 import jsonschema
 
-import gevent
-import eventlet
+try:
+    import gevent
+except ImportError:
+    gevent = None
+
+try:
+    import eventlet
+except ImportError:
+    eventlet = None
 
 import sentry_sdk
 from sentry_sdk._compat import reraise, string_types, iteritems
@@ -284,6 +291,9 @@ class EventStreamReader(object):
 )
 def maybe_monkeypatched_threading(request):
     if request.param == "eventlet":
+        if eventlet is None:
+            pytest.skip("no eventlet installed")
+
         try:
             eventlet.monkey_patch()
         except AttributeError as e:
@@ -293,6 +303,8 @@ def maybe_monkeypatched_threading(request):
             else:
                 raise
     elif request.param == "gevent":
+        if gevent is None:
+            pytest.skip("no gevent installed")
         try:
             gevent.monkey.patch_all()
         except Exception as e:

--- a/tests/integrations/django/myapp/routing.py
+++ b/tests/integrations/django/myapp/routing.py
@@ -1,4 +1,11 @@
+import channels
+
 from channels.http import AsgiHandler
 from channels.routing import ProtocolTypeRouter
 
-application = ProtocolTypeRouter({"http": AsgiHandler()})
+if channels.__version__ < "4.0.0":
+    channels_handler = AsgiHandler
+else:
+    channels_handler = AsgiHandler()
+
+application = ProtocolTypeRouter({"http": channels_handler})

--- a/tests/integrations/django/myapp/routing.py
+++ b/tests/integrations/django/myapp/routing.py
@@ -3,7 +3,7 @@ import channels
 from channels.http import AsgiHandler
 from channels.routing import ProtocolTypeRouter
 
-if channels.__version__ < "4.0.0":
+if channels.__version__ < "3.0.0":
     channels_handler = AsgiHandler
 else:
     channels_handler = AsgiHandler()

--- a/tests/integrations/django/myapp/routing.py
+++ b/tests/integrations/django/myapp/routing.py
@@ -1,4 +1,4 @@
 from channels.http import AsgiHandler
 from channels.routing import ProtocolTypeRouter
 
-application = ProtocolTypeRouter({"http": AsgiHandler})
+application = ProtocolTypeRouter({"http": AsgiHandler()})

--- a/tests/utils/test_general.py
+++ b/tests/utils/test_general.py
@@ -76,7 +76,6 @@ def test_filename():
     assert x("bogus", "bogus") == "bogus"
 
     assert x("os", os.__file__) == "os.py"
-    assert x("pytest", pytest.__file__) == "pytest.py"
 
     import sentry_sdk.utils
 

--- a/tox.ini
+++ b/tox.ini
@@ -128,7 +128,7 @@ deps =
     ; flask-dev: git+https://github.com/pallets/werkzeug.git#egg=werkzeug
 
     # https://github.com/pytest-dev/pytest/issues/5532
-    flask-{0.10,0.11,0.12}: pytest<5
+    {py3.7,py3.8,py3.9}-flask-{0.10,0.11,0.12}: pytest<5
 
     bottle-0.12: bottle>=0.12,<0.13
     bottle-dev: git+https://github.com/bottlepy/bottle#egg=bottle

--- a/tox.ini
+++ b/tox.ini
@@ -29,8 +29,7 @@ envlist =
     {pypy,py2.7,py3.4,py3.5,py3.6,py3.7,py3.8,py3.9}-flask-{0.10,0.11,0.12,1.0}
     {pypy,py2.7,py3.5,py3.6,py3.7,py3.8,py3.9}-flask-1.1
 
-    # TODO: see note in [testenv:flask-dev] below
-    ; {py3.6,py3.7,py3.8,py3.9}-flask-dev
+    {py3.6,py3.7,py3.8,py3.9}-flask-dev
 
     {pypy,py2.7,py3.5,py3.6,py3.7,py3.8,py3.9}-bottle-0.12
 
@@ -123,9 +122,8 @@ deps =
     flask-1.0: Flask>=1.0,<1.1
     flask-1.1: Flask>=1.1,<1.2
 
-    # TODO: see note in [testenv:flask-dev] below
-    ; flask-dev: git+https://github.com/pallets/flask.git#egg=flask
-    ; flask-dev: git+https://github.com/pallets/werkzeug.git#egg=werkzeug
+    flask-dev: git+https://github.com/pallets/flask.git#egg=flask
+    flask-dev: git+https://github.com/pallets/werkzeug.git#egg=werkzeug
 
     # https://github.com/pytest-dev/pytest/issues/5532
     {py3.7,py3.8,py3.9}-flask-{0.10,0.11,0.12}: pytest<5
@@ -294,39 +292,6 @@ basepython =
 
 commands =
     py.test {env:TESTPATH} {posargs}
-
-
-# TODO: This is broken out as a separate env so as to be able to override the
-# werkzeug version. (You can't do it just by letting one version be specifed in
-# a requirements file and specifying a different version in one testenv, see
-# https://github.com/tox-dev/tox/issues/1390.) The issue is that as of 11/11/20,
-# flask-dev has made a change which werkzeug then had to compensate for in
-# https://github.com/pallets/werkzeug/pull/1960. Since we've got werkzeug
-# pinned at 0.15.5 in test-requirements.txt, we don't get this fix.
-
-# At some point, we probably want to revisit this, since the list copied from
-# test-requirements.txt could easily get stale.
-[testenv:flask-dev]
-deps =
-    git+https://github.com/pallets/flask.git#egg=flask
-    git+https://github.com/pallets/werkzeug.git#egg=werkzeug
-
-    # everything below this point is from test-requirements.txt (minus, of
-    # course, werkzeug)
-    pytest==3.7.3
-    pytest-forked==1.1.3
-    tox==3.7.0
-    pytest-localserver==0.5.0
-    pytest-cov==2.8.1
-    jsonschema==3.2.0
-    pyrsistent==0.16.0 # TODO(py3): 0.17.0 requires python3, see https://github.com/tobgu/pyrsistent/issues/205
-    mock # for testing under python < 3.3
-
-    gevent
-
-    newrelic
-    executing
-    asttokens
 
 [testenv:linters]
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -63,8 +63,7 @@ envlist =
 
     {py3.7,py3.8,py3.9}-tornado-{5,6}
 
-    {py3.4,py3.5,py3.6,py3.7,py3.8,py3.9}-trytond-{4.6,4.8,5.0}
-    {py3.5,py3.6,py3.7,py3.8,py3.9}-trytond-{5.2}
+    {py3.5,py3.6,py3.7,py3.8,py3.9}-trytond-{4.6,4.8,5.0,5.2}
     {py3.6,py3.7,py3.8,py3.9}-trytond-{5.4}
 
     {py2.7,py3.8,py3.9}-requests

--- a/tox.ini
+++ b/tox.ini
@@ -291,6 +291,12 @@ basepython =
     pypy: pypy
 
 commands =
+    ; Note this sort of post-install hackery should only be necessary on Python
+    ; 2. On Python 3 the new dependency resolver by pip allows you to declare a
+    ; dependency multiple times as long as the versions don't directly
+    ; conflict.
+    django-{1.6,1.7}: pip install pytest<4
+
     py.test {env:TESTPATH} {posargs}
 
 [testenv:linters]

--- a/tox.ini
+++ b/tox.ini
@@ -98,6 +98,7 @@ deps =
     {py3.7,py3.8,py3.9}-django-{1.11,2.0,2.1,2.2,3.0,3.1,dev}: pytest-asyncio
     {py2.7,py3.7,py3.8,py3.9}-django-{1.11,2.2,3.0,3.1,dev}: psycopg2-binary
 
+    django-{1.6,1.7,1.8}: pytest-django<3.0
     django-{1.9,1.10,1.11,2.0,2.1}: pytest-django<4.0
     django-{2.2,3.0,3.1}: pytest-django>=4.0
     django-dev: git+https://github.com/pytest-dev/pytest-django#egg=pytest-django

--- a/tox.ini
+++ b/tox.ini
@@ -127,6 +127,9 @@ deps =
     ; flask-dev: git+https://github.com/pallets/flask.git#egg=flask
     ; flask-dev: git+https://github.com/pallets/werkzeug.git#egg=werkzeug
 
+    # https://github.com/pytest-dev/pytest/issues/5532
+    flask-{0.10,0.11,0.12}: pytest<5
+
     bottle-0.12: bottle>=0.12,<0.13
     bottle-dev: git+https://github.com/bottlepy/bottle#egg=bottle
 

--- a/tox.ini
+++ b/tox.ini
@@ -199,6 +199,8 @@ deps =
     trytond-4.8: trytond>=4.8,<4.9
     trytond-4.6: trytond>=4.6,<4.7
 
+    trytond-4.8: werkzeug<1.0
+
     redis: fakeredis
 
     rediscluster-1: redis-py-cluster>=1.0.0,<2.0.0

--- a/tox.ini
+++ b/tox.ini
@@ -94,25 +94,12 @@ deps =
 
     django-{1.11,2.0,2.1,2.2,3.0,3.1,dev}: djangorestframework>=3.0.0,<4.0.0
 
-    ; TODO: right now channels 3 is crashing tests/integrations/django/asgi/test_asgi.py
-    ; see https://github.com/django/channels/issues/1549
-    {py3.7,py3.8,py3.9}-django-{1.11,2.0,2.1,2.2,3.0,3.1,dev}: channels>2,<3
-    {py3.7,py3.8,py3.9}-django-{1.11,2.0,2.1,2.2,3.0,3.1,dev}: pytest-asyncio==0.10.0
+    {py3.7,py3.8,py3.9}-django-{1.11,2.0,2.1,2.2,3.0,3.1,dev}: channels>2
+    {py3.7,py3.8,py3.9}-django-{1.11,2.0,2.1,2.2,3.0,3.1,dev}: pytest-asyncio
     {py2.7,py3.7,py3.8,py3.9}-django-{1.11,2.2,3.0,3.1,dev}: psycopg2-binary
 
-    django-{1.6,1.7,1.8}: pytest-django<3.0
-
-    ; TODO: once we upgrade pytest to at least 5.4, we can split it like this:
-    ; django-{1.9,1.10,1.11,2.0,2.1}: pytest-django<4.0
-    ; django-{2.2,3.0,3.1}: pytest-django>=4.0
-
-    ; (note that py3.9, on which we recently began testing, only got official
-    ; support in pytest-django >=4.0, so we probablly want to upgrade the whole
-    ; kit and kaboodle at some point soon)
-
-    ; see https://pytest-django.readthedocs.io/en/latest/changelog.html#v4-0-0-2020-10-16
-    django-{1.9,1.10,1.11,2.0,2.1,2.2,3.0,3.1}: pytest-django<4.0
-
+    django-{1.9,1.10,1.11,2.0,2.1}: pytest-django<4.0
+    django-{2.2,3.0,3.1}: pytest-django>=4.0
     django-dev: git+https://github.com/pytest-dev/pytest-django#egg=pytest-django
 
     django-1.6: Django>=1.6,<1.7
@@ -332,7 +319,6 @@ deps =
     mock # for testing under python < 3.3
 
     gevent
-    eventlet
 
     newrelic
     executing

--- a/tox.ini
+++ b/tox.ini
@@ -29,7 +29,7 @@ envlist =
     {pypy,py2.7,py3.4,py3.5,py3.6,py3.7,py3.8,py3.9}-flask-{0.10,0.11,0.12,1.0}
     {pypy,py2.7,py3.5,py3.6,py3.7,py3.8,py3.9}-flask-1.1
 
-    {py3.6,py3.7,py3.8,py3.9}-flask-dev
+    {py3.7,py3.8,py3.9}-flask-dev
 
     {pypy,py2.7,py3.5,py3.6,py3.7,py3.8,py3.9}-bottle-0.12
 

--- a/tox.ini
+++ b/tox.ini
@@ -63,7 +63,7 @@ envlist =
 
     {py3.7,py3.8,py3.9}-tornado-{5,6}
 
-    {py3.5,py3.6,py3.7,py3.8,py3.9}-trytond-{4.6,4.8,5.0,5.2}
+    {py3.5,py3.6,py3.7,py3.8,py3.9}-trytond-{4.6,5.0,5.2}
     {py3.6,py3.7,py3.8,py3.9}-trytond-{5.4}
 
     {py2.7,py3.8,py3.9}-requests
@@ -96,8 +96,8 @@ deps =
     {py3.7,py3.8,py3.9}-django-{1.11,2.0,2.1,2.2,3.0,3.1,dev}: pytest-asyncio
     {py2.7,py3.7,py3.8,py3.9}-django-{1.11,2.2,3.0,3.1,dev}: psycopg2-binary
 
-    django-{1.6,1.7,1.8}: pytest-django<3.0
-    django-{1.9,1.10,1.11,2.0,2.1}: pytest-django<4.0
+    django-{1.6,1.7}: pytest-django<3.0
+    django-{1.8,1.9,1.10,1.11,2.0,2.1}: pytest-django<4.0
     django-{2.2,3.0,3.1}: pytest-django>=4.0
     django-dev: git+https://github.com/pytest-dev/pytest-django#egg=pytest-django
 
@@ -123,9 +123,6 @@ deps =
 
     flask-dev: git+https://github.com/pallets/flask.git#egg=flask
     flask-dev: git+https://github.com/pallets/werkzeug.git#egg=werkzeug
-
-    # https://github.com/pytest-dev/pytest/issues/5532
-    {py3.7,py3.8,py3.9}-flask-{0.10,0.11,0.12}: pytest<5
 
     bottle-0.12: bottle>=0.12,<0.13
     bottle-dev: git+https://github.com/bottlepy/bottle#egg=bottle
@@ -195,7 +192,6 @@ deps =
     trytond-5.4: trytond>=5.4,<5.5
     trytond-5.2: trytond>=5.2,<5.3
     trytond-5.0: trytond>=5.0,<5.1
-    trytond-4.8: trytond>=4.8,<4.9
     trytond-4.6: trytond>=4.6,<4.7
 
     trytond-4.8: werkzeug<1.0
@@ -292,11 +288,13 @@ basepython =
     pypy: pypy
 
 commands =
-    ; Note this sort of post-install hackery should only be necessary on Python
-    ; 2. On Python 3 the new dependency resolver by pip allows you to declare a
-    ; dependency multiple times as long as the versions don't directly
-    ; conflict.
     django-{1.6,1.7}: pip install pytest<4
+
+    ; https://github.com/pytest-dev/pytest/issues/5532
+    {py3.5,py3.6,py3.7,py3.8,py3.9}-flask-{0.10,0.11,0.12}: pip install pytest<5
+
+    ; trytond tries to import werkzeug.contrib
+    trytond-5.0: pip install werkzeug<1.0
 
     py.test {env:TESTPATH} {posargs}
 


### PR DESCRIPTION
* eventlet is broken all the time in newer Python versions
* Channels 3.0 needs some adjustments.
* unpin pytest to satisfy conflicts between Python 3.9 and Python 2.7 environments