### PR TITLE
Fix multiple **kwargs type hints

### DIFF
--- a/sentry_sdk/api.py
+++ b/sentry_sdk/api.py
@@ -70,7 +70,7 @@ def capture_event(
     event,  # type: Event
     hint=None,  # type: Optional[Hint]
     scope=None,  # type: Optional[Any]
-    **scope_args  # type: Dict[str, Any]
+    **scope_args  # type: Any
 ):
     # type: (...) -> Optional[str]
     return Hub.current.capture_event(event, hint, scope=scope, **scope_args)
@@ -81,7 +81,7 @@ def capture_message(
     message,  # type: str
     level=None,  # type: Optional[str]
     scope=None,  # type: Optional[Any]
-    **scope_args  # type: Dict[str, Any]
+    **scope_args  # type: Any
 ):
     # type: (...) -> Optional[str]
     return Hub.current.capture_message(message, level, scope=scope, **scope_args)
@@ -91,7 +91,7 @@ def capture_message(
 def capture_exception(
     error=None,  # type: Optional[Union[BaseException, ExcInfo]]
     scope=None,  # type: Optional[Any]
-    **scope_args  # type: Dict[str, Any]
+    **scope_args  # type: Any
 ):
     # type: (...) -> Optional[str]
     return Hub.current.capture_exception(error, scope=scope, **scope_args)

--- a/sentry_sdk/hub.py
+++ b/sentry_sdk/hub.py
@@ -311,7 +311,7 @@ class Hub(with_metaclass(HubMeta)):  # type: ignore
         event,  # type: Event
         hint=None,  # type: Optional[Hint]
         scope=None,  # type: Optional[Any]
-        **scope_args  # type: Dict[str, Any]
+        **scope_args  # type: Any
     ):
         # type: (...) -> Optional[str]
         """Captures an event. Alias of :py:meth:`sentry_sdk.Client.capture_event`."""
@@ -329,7 +329,7 @@ class Hub(with_metaclass(HubMeta)):  # type: ignore
         message,  # type: str
         level=None,  # type: Optional[str]
         scope=None,  # type: Optional[Any]
-        **scope_args  # type: Dict[str, Any]
+        **scope_args  # type: Any
     ):
         # type: (...) -> Optional[str]
         """Captures a message.  The message is just a string.  If no level
@@ -349,7 +349,7 @@ class Hub(with_metaclass(HubMeta)):  # type: ignore
         self,
         error=None,  # type: Optional[Union[BaseException, ExcInfo]]
         scope=None,  # type: Optional[Any]
-        **scope_args  # type: Dict[str, Any]
+        **scope_args  # type: Any
     ):
         # type: (...) -> Optional[str]
         """Captures an exception.

--- a/sentry_sdk/integrations/chalice.py
+++ b/sentry_sdk/integrations/chalice.py
@@ -17,6 +17,7 @@ from chalice.app import EventSourceHandler as ChaliceEventSourceHandler  # type:
 
 if MYPY:
     from typing import Any
+    from typing import Dict
     from typing import TypeVar
     from typing import Callable
 
@@ -110,7 +111,7 @@ class ChaliceIntegration(Integration):
             )
 
         def sentry_event_response(app, view_function, function_args):
-            # type: (Any, F, **Any) -> Any
+            # type: (Any, F, Dict[str, Any]) -> Any
             wrapped_view_function = _get_view_function_response(
                 app, view_function, function_args
             )


### PR DESCRIPTION
A **kwargs argument should be hinted as `T`, instead of `Dict[str, T]`.
The dict wrapping is already implied by the type system.

See: https://mypy.readthedocs.io/en/stable/getting_started.html?highlight=kwargs#more-function-signatures