### PR TITLE
fix bootstrap detection for python 3.8 and aws handler in submodule cases

### DIFF
--- a/sentry_sdk/integrations/aws_lambda.py
+++ b/sentry_sdk/integrations/aws_lambda.py
@@ -294,6 +294,9 @@ def get_lambda_bootstrap():
     if "bootstrap" in sys.modules:
         return sys.modules["bootstrap"]
     elif "__main__" in sys.modules:
+        if hasattr(sys.modules["__main__"], "bootstrap"):
+            return sys.modules["__main__"].bootstrap
+
         return sys.modules["__main__"]
     else:
         return None

--- a/sentry_sdk/integrations/aws_lambda.py
+++ b/sentry_sdk/integrations/aws_lambda.py
@@ -101,6 +101,8 @@ def _wrap_handler(handler):
         configured_time = aws_context.get_remaining_time_in_millis()
 
         with hub.push_scope() as scope:
+            timeout_thread = None
+
             with capture_internal_exceptions():
                 scope.clear_breadcrumbs()
                 scope.add_event_processor(
@@ -115,7 +117,6 @@ def _wrap_handler(handler):
                     scope.set_tag("batch_request", True)
                     scope.set_tag("batch_size", batch_size)
 
-                timeout_thread = None
                 # Starting the Timeout thread only if the configured time is greater than Timeout warning
                 # buffer and timeout_warning parameter is set True.
                 if (
@@ -295,7 +296,7 @@ def get_lambda_bootstrap():
         return sys.modules["bootstrap"]
     elif "__main__" in sys.modules:
         if hasattr(sys.modules["__main__"], "bootstrap"):
-            return sys.modules["__main__"].bootstrap
+            return getattr(sys.modules["__main__"], "bootstrap")
 
         return sys.modules["__main__"]
     else:


### PR DESCRIPTION
Fix for: https://github.com/getsentry/sentry-python/issues/972