### PR TITLE
AWS Lambda integration fails to detect the aws-lambda-ric 1.0 bootstrap

### DIFF
--- a/sentry_sdk/integrations/aws_lambda.py
+++ b/sentry_sdk/integrations/aws_lambda.py
@@ -294,6 +294,8 @@ def get_lambda_bootstrap():
     if "bootstrap" in sys.modules:
         return sys.modules["bootstrap"]
     elif "__main__" in sys.modules:
+        if hasattr(sys.modules["__main__"], "bootstrap"):
+            return sys.modules["__main__"].bootstrap  # type: ignore
         return sys.modules["__main__"]
     else:
         return None

--- a/sentry_sdk/integrations/aws_lambda.py
+++ b/sentry_sdk/integrations/aws_lambda.py
@@ -290,11 +290,15 @@ def get_lambda_bootstrap():
     #     sys.modules['__main__'].__file__ == sys.modules['bootstrap'].__file__
     #     sys.modules['__main__'] is not sys.modules['bootstrap']
     #
+    # On container builds using the `aws-lambda-python-runtime-interface-client`
+    # (awslamdaric) module, bootstrap is located in sys.modules['__main__'].bootstrap
+    #
     # Such a setup would then make all monkeypatches useless.
     if "bootstrap" in sys.modules:
         return sys.modules["bootstrap"]
     elif "__main__" in sys.modules:
         if hasattr(sys.modules["__main__"], "bootstrap"):
+            # awslambdaric python module in container builds
             return sys.modules["__main__"].bootstrap  # type: ignore
         return sys.modules["__main__"]
     else:


### PR DESCRIPTION
Fix for https://github.com/getsentry/sentry-python/issues/972