### PR TITLE
Fix unbound local crash on handling aws lambda exception

### DIFF
--- a/sentry_sdk/integrations/aws_lambda.py
+++ b/sentry_sdk/integrations/aws_lambda.py
@@ -101,6 +101,7 @@ def _wrap_handler(handler):
         configured_time = aws_context.get_remaining_time_in_millis()
 
         with hub.push_scope() as scope:
+            timeout_thread = None
             with capture_internal_exceptions():
                 scope.clear_breadcrumbs()
                 scope.add_event_processor(
@@ -115,7 +116,6 @@ def _wrap_handler(handler):
                     scope.set_tag("batch_request", True)
                     scope.set_tag("batch_size", batch_size)
 
-                timeout_thread = None
                 # Starting the Timeout thread only if the configured time is greater than Timeout warning
                 # buffer and timeout_warning parameter is set True.
                 if (


### PR DESCRIPTION
Fix for https://github.com/getsentry/sentry-python/issues/974