### PR TITLE
fix(environment): Remove release condition on default

### DIFF
--- a/sentry_sdk/client.py
+++ b/sentry_sdk/client.py
@@ -13,7 +13,6 @@ from sentry_sdk.utils import (
     format_timestamp,
     get_type_name,
     get_default_release,
-    get_default_environment,
     handle_in_app,
     logger,
 )
@@ -67,7 +66,7 @@ def _get_options(*args, **kwargs):
         rv["release"] = get_default_release()
 
     if rv["environment"] is None:
-        rv["environment"] = get_default_environment(rv["release"])
+        rv["environment"] = os.environ.get("SENTRY_ENVIRONMENT") or "production"
 
     if rv["server_name"] is None and hasattr(socket, "gethostname"):
         rv["server_name"] = socket.gethostname()

--- a/sentry_sdk/utils.py
+++ b/sentry_sdk/utils.py
@@ -92,18 +92,6 @@ def get_default_release():
     return None
 
 
-def get_default_environment(
-    release=None,  # type: Optional[str]
-):
-    # type: (...) -> Optional[str]
-    rv = os.environ.get("SENTRY_ENVIRONMENT")
-    if rv:
-        return rv
-    if release is not None:
-        return "production"
-    return None
-
-
 class CaptureInternalException(object):
     __slots__ = ()
 


### PR DESCRIPTION
The SDK spec ([here](https://develop.sentry.dev/sdk/overview/)) doesn't list a release condition on the default environment value.

Specifically:

> The following items are expected of production-ready SDKs:
> [...]
> Additionally, the following features are highly encouraged:
> - [...]
> - Send an `environment` on each event. If none was detected or set by the user, `production` should be used.