### PR TITLE
Make pytest run instruction clear in contribution guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,7 +21,8 @@ for you. Run `make` or `make help` to list commands.
 Of course you can always run the underlying commands yourself, which is
 particularly useful when wanting to provide arguments to `pytest` to run
 specific tests. If you want to do that, we expect you to know your way around
-Python development, and you can run the following to get started with `pytest`:
+Python development, to get started clone sentry-python sdk and cd into the sdk
+directory and then you can run the following to get started with `pytest`:
 
     # This is "advanced mode". Use `make help` if you have no clue what's
     # happening here!

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,8 +21,8 @@ for you. Run `make` or `make help` to list commands.
 Of course you can always run the underlying commands yourself, which is
 particularly useful when wanting to provide arguments to `pytest` to run
 specific tests. If you want to do that, we expect you to know your way around
-Python development, to get started clone sentry-python sdk and cd into the sdk
-directory and then you can run the following to get started with `pytest`:
+Python development. To get started, clone the SDK repository, cd into it, set
+up a virtualenv and run:
 
     # This is "advanced mode". Use `make help` if you have no clue what's
     # happening here!


### PR DESCRIPTION
This commit adds more instructions on how to install the sdk from source. It will be more clear to someone who is new to python.