### PR TITLE
feat: Support pre-aggregated sessions

### DIFF
--- a/sentry_sdk/client.py
+++ b/sentry_sdk/client.py
@@ -33,7 +33,7 @@ if MYPY:
 
     from sentry_sdk.scope import Scope
     from sentry_sdk._types import Event, Hint
-    from sentry_sdk.sessions import Session
+    from sentry_sdk.session import Session
 
 
 _client_init_debug = ContextVar("client_init_debug")
@@ -98,6 +98,7 @@ class _Client(object):
         old_debug = _client_init_debug.get(False)
 
         def _capture_envelope(envelope):
+            # type: (Envelope) -> None
             if self.transport is not None:
                 self.transport.capture_envelope(envelope)
 

--- a/sentry_sdk/client.py
+++ b/sentry_sdk/client.py
@@ -100,24 +100,14 @@ class _Client(object):
         # type: () -> None
         old_debug = _client_init_debug.get(False)
 
-        def _send_sessions(sessions):
-            # type: (List[Any]) -> None
-            transport = self.transport
-            if not transport or not sessions:
-                return
-            sessions_iter = iter(sessions)
-            while True:
-                envelope = Envelope()
-                for session in islice(sessions_iter, 100):
-                    envelope.add_session(session)
-                if not envelope.items:
-                    break
-                transport.capture_envelope(envelope)
+        def _capture_envelope(envelope):
+            if self.transport is not None:
+                self.transport.capture_envelope(envelope)
 
         try:
             _client_init_debug.set(self.options["debug"])
             self.transport = make_transport(self.options)
-            self.session_flusher = SessionFlusher(flush_func=_send_sessions)
+            self.session_flusher = SessionFlusher(capture_func=_capture_envelope)
 
             request_bodies = ("always", "never", "small", "medium")
             if self.options["request_bodies"] not in request_bodies:

--- a/sentry_sdk/client.py
+++ b/sentry_sdk/client.py
@@ -2,7 +2,6 @@ import os
 import uuid
 import random
 from datetime import datetime
-from itertools import islice
 import socket
 
 from sentry_sdk._compat import string_types, text_type, iteritems
@@ -31,7 +30,6 @@ if MYPY:
     from typing import Any
     from typing import Callable
     from typing import Dict
-    from typing import List
     from typing import Optional
 
     from sentry_sdk.scope import Scope
@@ -107,7 +105,12 @@ class _Client(object):
         try:
             _client_init_debug.set(self.options["debug"])
             self.transport = make_transport(self.options)
-            self.session_flusher = SessionFlusher(capture_func=_capture_envelope)
+            session_mode = self.options["_experiments"].get(
+                "session_mode", "application"
+            )
+            self.session_flusher = SessionFlusher(
+                capture_func=_capture_envelope, session_mode=session_mode
+            )
 
             request_bodies = ("always", "never", "small", "medium")
             if self.options["request_bodies"] not in request_bodies:

--- a/sentry_sdk/envelope.py
+++ b/sentry_sdk/envelope.py
@@ -4,7 +4,7 @@ import mimetypes
 
 from sentry_sdk._compat import text_type
 from sentry_sdk._types import MYPY
-from sentry_sdk.sessions import Session
+from sentry_sdk.session import Session
 from sentry_sdk.utils import json_dumps, capture_internal_exceptions
 
 if MYPY:

--- a/sentry_sdk/envelope.py
+++ b/sentry_sdk/envelope.py
@@ -62,6 +62,12 @@ class Envelope(object):
             session = session.to_json()
         self.add_item(Item(payload=PayloadRef(json=session), type="session"))
 
+    def add_sessions(
+        self, sessions  # type: Any
+    ):
+        # type: (...) -> None
+        self.add_item(Item(payload=PayloadRef(json=sessions), type="sessions"))
+
     def add_item(
         self, item  # type: Item
     ):

--- a/sentry_sdk/hub.py
+++ b/sentry_sdk/hub.py
@@ -8,7 +8,7 @@ from sentry_sdk._compat import with_metaclass
 from sentry_sdk.scope import Scope
 from sentry_sdk.client import Client
 from sentry_sdk.tracing import Span, Transaction
-from sentry_sdk.sessions import Session
+from sentry_sdk.session import Session
 from sentry_sdk.utils import (
     exc_info_from_error,
     event_from_exception,

--- a/sentry_sdk/hub.py
+++ b/sentry_sdk/hub.py
@@ -639,11 +639,12 @@ class Hub(with_metaclass(HubMeta)):  # type: ignore
         """Ends the current session if there is one."""
         client, scope = self._stack[-1]
         session = scope._session
+        self.scope._session = None
+        
         if session is not None:
             session.close()
             if client is not None:
                 client.capture_session(session)
-        self.scope._session = None
 
     def stop_auto_session_tracking(self):
         # type: (...) -> None

--- a/sentry_sdk/hub.py
+++ b/sentry_sdk/hub.py
@@ -640,7 +640,7 @@ class Hub(with_metaclass(HubMeta)):  # type: ignore
         client, scope = self._stack[-1]
         session = scope._session
         self.scope._session = None
-        
+
         if session is not None:
             session.close()
             if client is not None:

--- a/sentry_sdk/scope.py
+++ b/sentry_sdk/scope.py
@@ -28,7 +28,7 @@ if MYPY:
     )
 
     from sentry_sdk.tracing import Span
-    from sentry_sdk.sessions import Session
+    from sentry_sdk.session import Session
 
     F = TypeVar("F", bound=Callable[..., Any])
     T = TypeVar("T")

--- a/sentry_sdk/session.py
+++ b/sentry_sdk/session.py
@@ -1,0 +1,172 @@
+import uuid
+from datetime import datetime
+
+from sentry_sdk._types import MYPY
+from sentry_sdk.utils import format_timestamp
+
+if MYPY:
+    from typing import Optional
+    from typing import Union
+    from typing import Any
+    from typing import Dict
+
+    from sentry_sdk._types import SessionStatus
+
+
+def _minute_trunc(ts):
+    # type: (datetime) -> datetime
+    return ts.replace(second=0, microsecond=0)
+
+
+def _make_uuid(
+    val,  # type: Union[str, uuid.UUID]
+):
+    # type: (...) -> uuid.UUID
+    if isinstance(val, uuid.UUID):
+        return val
+    return uuid.UUID(val)
+
+
+class Session(object):
+    def __init__(
+        self,
+        sid=None,  # type: Optional[Union[str, uuid.UUID]]
+        did=None,  # type: Optional[str]
+        timestamp=None,  # type: Optional[datetime]
+        started=None,  # type: Optional[datetime]
+        duration=None,  # type: Optional[float]
+        status=None,  # type: Optional[SessionStatus]
+        release=None,  # type: Optional[str]
+        environment=None,  # type: Optional[str]
+        user_agent=None,  # type: Optional[str]
+        ip_address=None,  # type: Optional[str]
+        errors=None,  # type: Optional[int]
+        user=None,  # type: Optional[Any]
+    ):
+        # type: (...) -> None
+        if sid is None:
+            sid = uuid.uuid4()
+        if started is None:
+            started = datetime.utcnow()
+        if status is None:
+            status = "ok"
+        self.status = status
+        self.did = None  # type: Optional[str]
+        self.started = started
+        self.release = None  # type: Optional[str]
+        self.environment = None  # type: Optional[str]
+        self.duration = None  # type: Optional[float]
+        self.user_agent = None  # type: Optional[str]
+        self.ip_address = None  # type: Optional[str]
+        self.errors = 0
+
+        self.update(
+            sid=sid,
+            did=did,
+            timestamp=timestamp,
+            duration=duration,
+            release=release,
+            environment=environment,
+            user_agent=user_agent,
+            ip_address=ip_address,
+            errors=errors,
+            user=user,
+        )
+
+    @property
+    def truncated_started(self):
+        # type: (...) -> datetime
+        return _minute_trunc(self.started)
+
+    def update(
+        self,
+        sid=None,  # type: Optional[Union[str, uuid.UUID]]
+        did=None,  # type: Optional[str]
+        timestamp=None,  # type: Optional[datetime]
+        started=None,  # type: Optional[datetime]
+        duration=None,  # type: Optional[float]
+        status=None,  # type: Optional[SessionStatus]
+        release=None,  # type: Optional[str]
+        environment=None,  # type: Optional[str]
+        user_agent=None,  # type: Optional[str]
+        ip_address=None,  # type: Optional[str]
+        errors=None,  # type: Optional[int]
+        user=None,  # type: Optional[Any]
+    ):
+        # type: (...) -> None
+        # If a user is supplied we pull some data form it
+        if user:
+            if ip_address is None:
+                ip_address = user.get("ip_address")
+            if did is None:
+                did = user.get("id") or user.get("email") or user.get("username")
+
+        if sid is not None:
+            self.sid = _make_uuid(sid)
+        if did is not None:
+            self.did = str(did)
+        if timestamp is None:
+            timestamp = datetime.utcnow()
+        self.timestamp = timestamp
+        if started is not None:
+            self.started = started
+        if duration is not None:
+            self.duration = duration
+        if release is not None:
+            self.release = release
+        if environment is not None:
+            self.environment = environment
+        if ip_address is not None:
+            self.ip_address = ip_address
+        if user_agent is not None:
+            self.user_agent = user_agent
+        if errors is not None:
+            self.errors = errors
+
+        if status is not None:
+            self.status = status
+
+    def close(
+        self, status=None  # type: Optional[SessionStatus]
+    ):
+        # type: (...) -> Any
+        if status is None and self.status == "ok":
+            status = "exited"
+        if status is not None:
+            self.update(status=status)
+
+    def get_json_attrs(
+        self, with_user_info=True  # type: Optional[bool]
+    ):
+        # type: (...) -> Any
+        attrs = {}
+        if self.release is not None:
+            attrs["release"] = self.release
+        if self.environment is not None:
+            attrs["environment"] = self.environment
+        if with_user_info:
+            if self.ip_address is not None:
+                attrs["ip_address"] = self.ip_address
+            if self.user_agent is not None:
+                attrs["user_agent"] = self.user_agent
+        return attrs
+
+    def to_json(self):
+        # type: (...) -> Any
+        rv = {
+            "sid": str(self.sid),
+            "init": True,
+            "started": format_timestamp(self.started),
+            "timestamp": format_timestamp(self.timestamp),
+            "status": self.status,
+        }  # type: Dict[str, Any]
+        if self.errors:
+            rv["errors"] = self.errors
+        if self.did is not None:
+            rv["did"] = self.did
+        if self.duration is not None:
+            rv["duration"] = self.duration
+        attrs = self.get_json_attrs()
+        if attrs:
+            rv["attrs"] = attrs
+        return rv

--- a/tests/test_envelope.py
+++ b/tests/test_envelope.py
@@ -1,5 +1,5 @@
 from sentry_sdk.envelope import Envelope
-from sentry_sdk.sessions import Session
+from sentry_sdk.session import Session
 
 
 def generate_transaction_item():

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -1,5 +1,12 @@
-from sentry_sdk import Hub
+import sentry_sdk
 
+from sentry_sdk import Hub
+from sentry_sdk.sessions import auto_session_tracking
+
+def sorted_aggregates(item):
+    aggregates = item["aggregates"]
+    aggregates.sort(key=lambda item: (item["started"], item.get("did", "")))
+    return aggregates
 
 def test_basic(sentry_init, capture_envelopes):
     sentry_init(release="fun-release", environment="not-fun-env")
@@ -24,11 +31,57 @@ def test_basic(sentry_init, capture_envelopes):
     assert len(sess.items) == 1
     sess_event = sess.items[0].payload.json
 
-    assert sess_event["did"] == "42"
-    assert sess_event["init"]
-    assert sess_event["status"] == "exited"
-    assert sess_event["errors"] == 1
     assert sess_event["attrs"] == {
         "release": "fun-release",
         "environment": "not-fun-env",
     }
+    # TODO: The SDK needs a setting to explicitly choose between application-mode
+    # or request-mode sessions.
+    # assert sess_event["did"] == "42"
+    # assert sess_event["init"]
+    # assert sess_event["status"] == "exited"
+    # assert sess_event["errors"] == 1
+
+
+def test_aggregates(sentry_init, capture_envelopes):
+    sentry_init(release="fun-release", environment="not-fun-env",
+        _experiments=dict(
+            auto_session_tracking=True,
+        ),)
+    envelopes = capture_envelopes()
+
+    hub = Hub.current
+
+    with auto_session_tracking():
+        with sentry_sdk.push_scope():
+            try:
+                with sentry_sdk.configure_scope() as scope:
+                    scope.set_user({"id": "42"})
+                    raise Exception("all is wrong")
+            except Exception:
+                sentry_sdk.capture_exception()
+    
+    with auto_session_tracking():
+        pass
+    
+    hub.start_session()
+    hub.end_session()
+
+    sentry_sdk.flush()
+
+    assert len(envelopes) == 2
+    assert envelopes[0].get_event() is not None
+
+    sess = envelopes[1]
+    assert len(sess.items) == 1
+    sess_event = sess.items[0].payload.json
+    assert sess_event["attrs"] == {
+        "release": "fun-release",
+        "environment": "not-fun-env",
+    }
+
+    aggregates = sorted_aggregates(sess_event)
+    assert len(aggregates) == 2
+    assert aggregates[0]["exited"] == 2
+    assert aggregates[1]["did"] == "42"
+    assert aggregates[1]["errored"] == 1

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -3,10 +3,12 @@ import sentry_sdk
 from sentry_sdk import Hub
 from sentry_sdk.sessions import auto_session_tracking
 
+
 def sorted_aggregates(item):
     aggregates = item["aggregates"]
     aggregates.sort(key=lambda item: (item["started"], item.get("did", "")))
     return aggregates
+
 
 def test_basic(sentry_init, capture_envelopes):
     sentry_init(release="fun-release", environment="not-fun-env")
@@ -44,10 +46,13 @@ def test_basic(sentry_init, capture_envelopes):
 
 
 def test_aggregates(sentry_init, capture_envelopes):
-    sentry_init(release="fun-release", environment="not-fun-env",
+    sentry_init(
+        release="fun-release",
+        environment="not-fun-env",
         _experiments=dict(
             auto_session_tracking=True,
-        ),)
+        ),
+    )
     envelopes = capture_envelopes()
 
     hub = Hub.current
@@ -60,10 +65,10 @@ def test_aggregates(sentry_init, capture_envelopes):
                     raise Exception("all is wrong")
             except Exception:
                 sentry_sdk.capture_exception()
-    
+
     with auto_session_tracking():
         pass
-    
+
     hub.start_session()
     hub.end_session()
 

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -37,21 +37,17 @@ def test_basic(sentry_init, capture_envelopes):
         "release": "fun-release",
         "environment": "not-fun-env",
     }
-    # TODO: The SDK needs a setting to explicitly choose between application-mode
-    # or request-mode sessions.
-    # assert sess_event["did"] == "42"
-    # assert sess_event["init"]
-    # assert sess_event["status"] == "exited"
-    # assert sess_event["errors"] == 1
+    assert sess_event["did"] == "42"
+    assert sess_event["init"]
+    assert sess_event["status"] == "exited"
+    assert sess_event["errors"] == 1
 
 
 def test_aggregates(sentry_init, capture_envelopes):
     sentry_init(
         release="fun-release",
         environment="not-fun-env",
-        _experiments=dict(
-            auto_session_tracking=True,
-        ),
+        _experiments={"auto_session_tracking": True, "session_mode": "request"},
     )
     envelopes = capture_envelopes()
 
@@ -86,7 +82,6 @@ def test_aggregates(sentry_init, capture_envelopes):
     }
 
     aggregates = sorted_aggregates(sess_event)
-    assert len(aggregates) == 2
+    assert len(aggregates) == 1
     assert aggregates[0]["exited"] == 2
-    assert aggregates[1]["did"] == "42"
-    assert aggregates[1]["errored"] == 1
+    assert aggregates[0]["errored"] == 1


### PR DESCRIPTION
This changes the SessionFlusher to pre-aggregate sessions according to https://develop.sentry.dev/sdk/sessions/#session-aggregates-payload instead of sending individual session updates.

The current implementation will *always* aggregate sessions, as the SDK currently lacks the possibility to chose between application-mode or request-mode sessions.