### PR TITLE
fix(ci): Fix `py3.5-celery` and `*-django-dev`

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -10,6 +10,5 @@ mock # for testing under python < 3.3
 
 gevent
 
-newrelic
 executing
 asttokens

--- a/tests/integrations/django/test_transactions.py
+++ b/tests/integrations/django/test_transactions.py
@@ -3,19 +3,21 @@ from __future__ import absolute_import
 import pytest
 import django
 
-try:
+if django.VERSION >= (2, 0):
+    # TODO: once we stop supporting django < 2, use the real name of this
+    # function (re_path)
+    from django.urls import re_path as url
+    from django.conf.urls import include
+else:
     from django.conf.urls import url, include
-except ImportError:
-    # for Django version less than 1.4
-    from django.conf.urls.defaults import url, include  # NOQA
-
-from sentry_sdk.integrations.django.transactions import RavenResolver
-
 
 if django.VERSION < (1, 9):
     included_url_conf = (url(r"^foo/bar/(?P<param>[\w]+)", lambda x: ""),), "", ""
 else:
     included_url_conf = ((url(r"^foo/bar/(?P<param>[\w]+)", lambda x: ""),), "")
+
+from sentry_sdk.integrations.django.transactions import RavenResolver
+
 
 example_url_conf = (
     url(r"^api/(?P<project_id>[\w_-]+)/store/$", lambda x: ""),

--- a/tox.ini
+++ b/tox.ini
@@ -152,6 +152,9 @@ deps =
     celery-4.4: Celery>=4.4,<4.5,!=4.4.4
     celery-5.0: Celery>=5.0,<5.1
 
+    py3.5-celery: newrelic<6.0.0
+    {pypy,py2.7,py3.6,py3.7,py3.8,py3.9}-celery: newrelic
+
     requests: requests>=2.0
 
     aws_lambda: boto3


### PR DESCRIPTION
Two fixes to CI, both caused by dependencies dropping support for specific things we use.

1. Our celery tests depend on the `newrelic` package, which just hit v6, [dropping support for py3.5 in the process](https://docs.newrelic.com/docs/release-notes/agent-release-notes/python-release-notes/python-agent-600154). Fortunately, since the celery tests are the only thing which uses the package, it was possible to move it out of the general test requirements and into celery-specific requirements in tox, allowing py3.5 to use a different veresion of `newrelic` than other Python versions.

2. Since version 2.0 (4 years ago), Django's `url` function has really [just been an alias](https://github.com/django/django/commit/df41b5a05d4e00e80e73afe629072e37873e767a#diff-318c25772a3e40b833969d2d1c3e1a6f9b2cd23c165bb155e5895c69deca83b6R12) for a new function, `re_path`. They then deprecated `url`, and in preparation for 4.0 they [just removed it](https://github.com/django/django/commit/98ae3925e57c3f054814b847971194f7cd8d98d1). This PR therefore adjusts our import statements to use `re_path` for Django 2+. It also removes the condition for Django < 1.4, since the earliest Django against which we test is 1.6.