### PR TITLE
ref(tracing): Restore ability to have tracing disabled

### DIFF
--- a/sentry_sdk/consts.py
+++ b/sentry_sdk/consts.py
@@ -72,7 +72,7 @@ class ClientConstructor(object):
         attach_stacktrace=False,  # type: bool
         ca_certs=None,  # type: Optional[str]
         propagate_traces=True,  # type: bool
-        traces_sample_rate=0.0,  # type: float
+        traces_sample_rate=None,  # type: Optional[float]
         traces_sampler=None,  # type: Optional[TracesSampler]
         auto_enabling_integrations=True,  # type: bool
         _experiments={},  # type: Experiments  # noqa: B006

--- a/sentry_sdk/tracing.py
+++ b/sentry_sdk/tracing.py
@@ -583,23 +583,22 @@ class Transaction(Span):
         decision, `traces_sample_rate` will be used.
         """
 
-        # if the user has forced a sampling decision by passing a `sampled`
-        # value when starting the transaction, go with that
-        if self.sampled is not None:
-            return
-
         hub = self.hub or sentry_sdk.Hub.current
         client = hub.client
+        options = (client and client.options) or {}
         transaction_description = "{op}transaction <{name}>".format(
             op=("<" + self.op + "> " if self.op else ""), name=self.name
         )
 
-        # nothing to do if there's no client
-        if not client:
+        # nothing to do if there's no client or if tracing is disabled
+        if not client or not has_tracing_enabled(options):
             self.sampled = False
             return
 
-        options = client.options
+        # if the user has forced a sampling decision by passing a `sampled`
+        # value when starting the transaction, go with that
+        if self.sampled is not None:
+            return
 
         # we would have bailed already if neither `traces_sampler` nor
         # `traces_sample_rate` were defined, so one of these should work; prefer
@@ -661,6 +660,19 @@ class Transaction(Span):
                     sample_rate=float(sample_rate),
                 )
             )
+
+
+def has_tracing_enabled(options):
+    # type: (Dict[str, Any]) -> bool
+    """
+    Returns True if either traces_sample_rate or traces_sampler is
+    non-zero/defined, False otherwise.
+    """
+
+    return bool(
+        options.get("traces_sample_rate") is not None
+        or options.get("traces_sampler") is not None
+    )
 
 
 def _is_valid_sample_rate(rate):


### PR DESCRIPTION
This PR partially reverts https://github.com/getsentry/sentry-python/pull/948 and https://github.com/getsentry/sentry-python/commit/6fc2287c6f5280e5adf76bb7a66f05f7c8d18882, to restore the ability to disable tracing, which allows it to truly be opt-in [as per the spec](https://develop.sentry.dev/sdk/performance/#sdk-configuration).

Note that this does not change the behavior that PR was made to reinstate - the model wherein the front end makes sampling decisions, the backend has `traces_sample_rate` set to `0`, and the result is that the backend samples according to the front end decision when there is one, but otherwise does not send transactions. (That PR modified a test to test for that exact scenario, and it still passes.)