### PR TITLE
feat: Build dist ZIP for AWS Lambda layers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
 
       - run: |
           pip install virtualenv
-          make dist
+          make aws-lambda-layer-build
 
       - uses: actions/upload-artifact@v2
         with:

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,7 @@ help:
 	@echo "make test: Run basic tests (not testing most integrations)"
 	@echo "make test-all: Run ALL tests (slow, closest to CI)"
 	@echo "make format: Run code formatters (destructive)"
+	@echo "make aws-lambda-layer-build: Build serverless ZIP dist package"
 	@echo
 	@echo "Also make sure to read ./CONTRIBUTING.md"
 	@false
@@ -58,3 +59,7 @@ apidocs-hotfix: apidocs
 	@$(VENV_PATH)/bin/pip install ghp-import
 	@$(VENV_PATH)/bin/ghp-import -pf docs/_build
 .PHONY: apidocs-hotfix
+
+aws-lambda-layer-build: dist
+	$(VENV_PATH)/bin/python -m scripts.build-awslambda-layer
+.PHONY: aws-lambda-layer-build

--- a/scripts/build-awslambda-layer.py
+++ b/scripts/build-awslambda-layer.py
@@ -56,7 +56,7 @@ class PackageBuilder:
 
 
 def build_packaged_zip():
-    packages_dir = os.path.join("python", "lib", "pythonX.Y", "site-packages")
+    packages_dir = os.path.join("python", "lib", "python", "site-packages")
     with tempfile.TemporaryDirectory() as tmp_dir:
         package_builder = PackageBuilder(tmp_dir, packages_dir)
         package_builder.make_directories()

--- a/scripts/build-awslambda-layer.py
+++ b/scripts/build-awslambda-layer.py
@@ -8,6 +8,9 @@ from sentry_sdk.consts import VERSION as SDK_VERSION
 DIST_DIRNAME = "dist"
 DIST_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", DIST_DIRNAME))
 DEST_ZIP_FILENAME = f"sentry-python-serverless-{SDK_VERSION}.zip"
+WHEELS_FILEPATH = os.path.join(
+    DIST_DIRNAME, f"sentry_sdk-{SDK_VERSION}-py2.py3-none-any.whl"
+)
 
 
 class PackageBuilder:
@@ -20,16 +23,13 @@ class PackageBuilder:
         os.makedirs(self.packages_inner_dir)
 
     def install_python_binaries(self):
-        wheels_filepath = os.path.join(
-            DIST_DIRNAME, f"sentry_sdk-{SDK_VERSION}-py2.py3-none-any.whl"
-        )
         subprocess.run(
             [
                 "pip",
                 "install",
                 "--no-cache-dir",  # Disables the cache -> always accesses PyPI
                 "-q",  # Quiet
-                wheels_filepath,  # Copied to the target directory before installation
+                WHEELS_FILEPATH,  # Copied to the target directory before installation
                 "-t",  # Target directory flag
                 self.packages_inner_dir,
             ],

--- a/scripts/build-awslambda-layer.py
+++ b/scripts/build-awslambda-layer.py
@@ -1,0 +1,95 @@
+import argparse
+import os
+import subprocess
+import tempfile
+import shutil
+
+
+SDK_VERSION = "0.19.5"
+DIST_DIRNAME = "dist"
+DIST_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", DIST_DIRNAME))
+
+
+def add_arguments(arg_parser):
+    arg_parser.add_argument(
+        "python",
+        action="store",
+        nargs=1,  # Default behaviour: will make a list of 1 item
+        choices=["2.7", "3.6", "3.7", "3.8"],
+        help="Selects the Python runtime version to build the ZIP file for.",
+        metavar="python-version",
+    )
+    return arg_parser
+
+
+class PackageBuilder:
+    def __init__(self, base_dir, packages_dir) -> None:
+        self.base_dir = base_dir
+        self.packages_dir = packages_dir
+        self.packages_inner_dir = os.path.join(self.base_dir, self.packages_dir)
+        self.binaries_installation_path = os.path.join(base_dir, packages_dir)
+
+    def make_directories(self):
+        os.makedirs(self.packages_inner_dir)
+
+    def install_python_binaries(self):
+        wheels_filepath = os.path.join(
+            DIST_DIRNAME, f"sentry_sdk-{SDK_VERSION}-py2.py3-none-any.whl"
+        )
+        subprocess.run(
+            [
+                "pip",
+                "install",
+                "--no-cache-dir",  # Disables the cache -> always accesses PyPI
+                "-q",  # Quiet
+                wheels_filepath,  # Copied to the target directory before installation
+                "-t",  # Target directory flag
+                self.packages_inner_dir,
+            ],
+            check=True,
+        )
+
+    def zip(self, filename):
+        subprocess.run(
+            [
+                "zip",
+                "-q",  # Quiet
+                "-x",  # Exclude files
+                "**/__pycache__/*",  # Files to be excluded
+                "-r",  # Recurse paths
+                filename,  # Output filename
+                self.packages_dir,  # Files to be zipped
+            ],
+            cwd=self.base_dir,
+            check=True,  # Raises CalledProcessError if exit status is non-zero
+        )
+
+    def get_relative_path_of(self, subfile):
+        return os.path.join(self.base_dir, subfile)
+
+
+def build_packaged_zip_for_runtime(runtime, dst_filename):
+    print(f"Zipping files for SDK v{SDK_VERSION} with {runtime}")
+
+    packages_dir = os.path.join("python", "lib", runtime, "site-packages")
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        package_builder = PackageBuilder(tmp_dir, packages_dir)
+        package_builder.make_directories()
+        package_builder.install_python_binaries()
+        package_builder.zip(dst_filename)
+        shutil.copy(package_builder.get_relative_path_of(dst_filename), DIST_DIR)
+
+
+def main():
+    arg_parser = argparse.ArgumentParser()
+    add_arguments(arg_parser)
+    python_version = arg_parser.parse_args().python[0]
+
+    runtime = f"python{python_version}"
+    dest_zip_filename = (
+        f"sentry-python-awslambda-layer-{SDK_VERSION}-py{python_version}.zip"
+    )
+    build_packaged_zip_for_runtime(runtime, dest_zip_filename)
+
+
+main()


### PR DESCRIPTION
In order to get the Python SDK on an AWS Lambda function, a layer where Python is installed must be added to that function. The layer requires a ZIP file to be uploaded, containing the Python binaries installed (i.e. the Python SDK and the required additional modules installed). The `scripts/build-awslambda-layer.py` generates that ZIP file. The script is also run in the CI, so it will be available as an artifact.