### PR TITLE
fix: Remove Python3.7 from Django

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -24,7 +24,8 @@ envlist =
     {pypy,py2.7,py3.5}-django-{1.8,1.9,1.10}
     {pypy,py2.7}-django-{1.8,1.9,1.10,1.11}
     {py3.5,py3.6,py3.7}-django-{2.0,2.1}
-    {py3.7,py3.8,py3.9}-django-{2.2,3.0,3.1,dev}
+    {py3.7,py3.8,py3.9}-django-{2.2,3.0,3.1}
+    {py3.8,py3.9}-django-dev
 
     {pypy,py2.7,py3.4,py3.5,py3.6,py3.7,py3.8,py3.9}-flask-{0.10,0.11,0.12,1.0}
     {pypy,py2.7,py3.5,py3.6,py3.7,py3.8,py3.9}-flask-1.1
@@ -92,9 +93,12 @@ deps =
 
     django-{1.11,2.0,2.1,2.2,3.0,3.1,dev}: djangorestframework>=3.0.0,<4.0.0
 
-    {py3.7,py3.8,py3.9}-django-{1.11,2.0,2.1,2.2,3.0,3.1,dev}: channels>2
-    {py3.7,py3.8,py3.9}-django-{1.11,2.0,2.1,2.2,3.0,3.1,dev}: pytest-asyncio
-    {py2.7,py3.7,py3.8,py3.9}-django-{1.11,2.2,3.0,3.1,dev}: psycopg2-binary
+    {py3.7,py3.8,py3.9}-django-{1.11,2.0,2.1,2.2,3.0,3.1}: channels>2
+    {py3.8,py3.9}-django-dev: channels>2
+    {py3.7,py3.8,py3.9}-django-{1.11,2.0,2.1,2.2,3.0,3.1}: pytest-asyncio
+    {py3.8,py3.9}-django-dev: pytest-asyncio
+    {py2.7,py3.7,py3.8,py3.9}-django-{1.11,2.2,3.0,3.1}: psycopg2-binary
+    {py2.7,py3.8,py3.9}-django-dev: psycopg2-binary
 
     django-{1.6,1.7}: pytest-django<3.0
     django-{1.8,1.9,1.10,1.11,2.0,2.1}: pytest-django<4.0


### PR DESCRIPTION
Django dropped support for `Python3.7`. This PR removes `Python3.7` from `django-dev`. Fixes master.