### PR TITLE
ci: Run `dist` job always when CI is run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,8 +14,6 @@ jobs:
     timeout-minutes: 10
     runs-on: ubuntu-16.04
 
-    if: "startsWith(github.ref, 'refs/heads/release/')"
-
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1

--- a/Makefile
+++ b/Makefile
@@ -61,5 +61,7 @@ apidocs-hotfix: apidocs
 .PHONY: apidocs-hotfix
 
 aws-lambda-layer-build: dist
+	$(VENV_PATH)/bin/pip install urllib3
+	$(VENV_PATH)/bin/pip install certifi
 	$(VENV_PATH)/bin/python -m scripts.build-awslambda-layer
 .PHONY: aws-lambda-layer-build


### PR DESCRIPTION
CI runs on master, release branches and PRs; however, the `dist` job only runs on release branches. At the moment there's no other way of building distribution packages (such as the serverless `zip` dist), which may be needed in some cases. This PR removes the `dist` job execution requirement and is run when CI is run.