### PR TITLE
ci(release): Update release to use v1.1 of action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,31 +15,14 @@ jobs:
     runs-on: ubuntu-latest
     name: "Release a new version"
     steps:
-      - name: Prepare release
-        uses: getsentry/action-prepare-release@33507ed
-        with:
-          version: ${{ github.event.inputs.version }}
-          force: ${{ github.event.inputs.force }}
-
       - uses: actions/checkout@v2
         with:
           token: ${{ secrets.GH_RELEASE_PAT }}
           fetch-depth: 0
-
-      - name: Craft Prepare
-        run: npx @sentry/craft prepare --no-input "${{ env.RELEASE_VERSION }}"
+      - name: Prepare release
+        uses: getsentry/action-prepare-release@v1.1
         env:
-          GITHUB_API_TOKEN: ${{ github.token }}
-
-      - name: Request publish
-        if: success()
-        uses: actions/github-script@v3
+          GITHUB_TOKEN: ${{ secrets.GH_RELEASE_PAT }}
         with:
-          github-token: ${{ secrets.GH_RELEASE_PAT }}
-          script: |
-            const repoInfo = context.repo;
-            await github.issues.create({
-              owner: repoInfo.owner,
-              repo: 'publish',
-              title: `publish: ${repoInfo.repo}@${process.env.RELEASE_VERSION}`,
-            });
+          version: ${{ github.event.inputs.version }}
+          force: ${{ github.event.inputs.force }}


### PR DESCRIPTION
Addresses @HazAT's comment here: https://sentry.slack.com/archives/C01C205FUAE/p1613045701031000