### PR TITLE
ref: Change serverless dist destination path to `/dist-serverless`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,9 @@ jobs:
       - uses: actions/upload-artifact@v2
         with:
           name: ${{ github.sha }}
-          path: dist/*
+          path: |
+            dist/*
+            dist-serverless/*
 
   docs:
     timeout-minutes: 10

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ pip-log.txt
 *.egg-info
 /build
 /dist
+/dist-serverless
 .cache
 .idea
 .eggs

--- a/scripts/build-awslambda-layer.py
+++ b/scripts/build-awslambda-layer.py
@@ -6,7 +6,10 @@ from sentry_sdk.consts import VERSION as SDK_VERSION
 
 
 DIST_DIRNAME = "dist"
-DIST_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", DIST_DIRNAME))
+DEST_REL_PATH = "dist-serverless"
+DEST_ABS_PATH = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), "..", DEST_REL_PATH)
+)
 DEST_ZIP_FILENAME = f"sentry-python-serverless-{SDK_VERSION}.zip"
 WHEELS_FILEPATH = os.path.join(
     DIST_DIRNAME, f"sentry_sdk-{SDK_VERSION}-py2.py3-none-any.whl"
@@ -65,7 +68,9 @@ def build_packaged_zip():
         package_builder.make_directories()
         package_builder.install_python_binaries()
         package_builder.zip(DEST_ZIP_FILENAME)
-        shutil.copy(package_builder.get_relative_path_of(DEST_ZIP_FILENAME), DIST_DIR)
+        shutil.copy(
+            package_builder.get_relative_path_of(DEST_ZIP_FILENAME), DEST_ABS_PATH
+        )
 
 
 build_packaged_zip()


### PR DESCRIPTION
`/dist` is used by twine, so the serverless dist package shouldn't be in the same directory. This PR fixes the issue where `twine` tries to upload the serverless package.