### PR TITLE
Fix(serverless): Add "SENTRY_" prefix to env variables in serverless init script + added traces_sample_rate

### DIFF
--- a/scripts/init_serverless_sdk.py
+++ b/scripts/init_serverless_sdk.py
@@ -1,7 +1,7 @@
 """
 For manual instrumentation,
 The Handler function string of an aws lambda function should be added as an
-environment variable with a key of 'INITIAL_HANDLER' along with the 'DSN'
+environment variable with a key of 'SENTRY_INITIAL_HANDLER' along with the 'DSN'
 Then the Handler function sstring should be replaced with
 'sentry_sdk.integrations.init_serverless_sdk.sentry_lambda_handler'
 """
@@ -17,8 +17,9 @@ if MYPY:
 
 # Configure Sentry SDK
 sentry_sdk.init(
-    dsn=os.environ["DSN"],
+    dsn=os.environ["SENTRY_DSN"],
     integrations=[AwsLambdaIntegration(timeout_warning=True)],
+    traces_sample_rate=float(os.environ["SENTRY_TRACES_SAMPLE_RATE"])
 )
 
 
@@ -26,10 +27,10 @@ def sentry_lambda_handler(event, context):
     # type: (Any, Any) -> None
     """
     Handler function that invokes a lambda handler which path is defined in
-    environment vairables as "INITIAL_HANDLER"
+    environment vairables as "SENTRY_INITIAL_HANDLER"
     """
     try:
-        module_name, handler_name = os.environ["INITIAL_HANDLER"].rsplit(".", 1)
+        module_name, handler_name = os.environ["SENTRY_INITIAL_HANDLER"].rsplit(".", 1)
     except ValueError:
         raise ValueError("Incorrect AWS Handler path (Not a path)")
     lambda_function = __import__(module_name)

--- a/tests/integrations/aws_lambda/client.py
+++ b/tests/integrations/aws_lambda/client.py
@@ -45,8 +45,9 @@ def build_no_code_serverless_function_and_layer(
             Timeout=timeout,
             Environment={
                 "Variables": {
-                    "INITIAL_HANDLER": "test_lambda.test_handler",
-                    "DSN": "https://123abc@example.com/123",
+                    "SENTRY_INITIAL_HANDLER": "test_lambda.test_handler",
+                    "SENTRY_DSN": "https://123abc@example.com/123",
+                    "SENTRY_TRACES_SAMPLE_RATE": "1.0"
                 }
             },
             Role=os.environ["SENTRY_PYTHON_TEST_AWS_IAM_ROLE"],

--- a/tests/integrations/aws_lambda/client.py
+++ b/tests/integrations/aws_lambda/client.py
@@ -47,7 +47,7 @@ def build_no_code_serverless_function_and_layer(
                 "Variables": {
                     "SENTRY_INITIAL_HANDLER": "test_lambda.test_handler",
                     "SENTRY_DSN": "https://123abc@example.com/123",
-                    "SENTRY_TRACES_SAMPLE_RATE": "1.0"
+                    "SENTRY_TRACES_SAMPLE_RATE": "1.0",
                 }
             },
             Role=os.environ["SENTRY_PYTHON_TEST_AWS_IAM_ROLE"],


### PR DESCRIPTION
This PR is a minor fix to the environment variables names in the `scripts/init_serverless_sdk.py`
- Added `SENTRY_` prefix to all environment variables
- Added `SENTRY_TRACES_SAMPLE_RATE` environment variable to initialization of sentry_sdk