### PR TITLE
fix(worker): Log data-dropping events with error

### DIFF
--- a/sentry_sdk/worker.py
+++ b/sentry_sdk/worker.py
@@ -99,11 +99,15 @@ class BackgroundWorker(object):
         # type: (float, Optional[Any]) -> None
         initial_timeout = min(0.1, timeout)
         if not self._timed_queue_join(initial_timeout):
-            pending = self._queue.qsize()
+            pending = self._queue.qsize() + 1
             logger.debug("%d event(s) pending on flush", pending)
             if callback is not None:
                 callback(pending, timeout)
-            self._timed_queue_join(timeout - initial_timeout)
+
+            if not self._timed_queue_join(timeout - initial_timeout):
+                pending = self._queue.qsize() + 1
+                logger.error("flush timed out, dropped %s events", pending)
+
 
     def submit(self, callback):
         # type: (Callable[[], None]) -> None
@@ -115,7 +119,7 @@ class BackgroundWorker(object):
 
     def on_full_queue(self, callback):
         # type: (Optional[Any]) -> None
-        logger.debug("background worker queue full, dropping event")
+        logger.error("background worker queue full, dropping event")
 
     def _target(self):
         # type: () -> None

--- a/sentry_sdk/worker.py
+++ b/sentry_sdk/worker.py
@@ -108,7 +108,6 @@ class BackgroundWorker(object):
                 pending = self._queue.qsize() + 1
                 logger.error("flush timed out, dropped %s events", pending)
 
-
     def submit(self, callback):
         # type: (Callable[[], None]) -> None
         self._ensure_thread()


### PR DESCRIPTION
When we fail to flush all events, or when the queue overflows, this
should be an error event.

I have some concerns about when the user uses things like logly, which
are known for sending out blocking HTTP requests from within their log
handler. However I believe they don't register that handler for all
loggers.