### PR TITLE
bug(flask): Transactions missing body

### DIFF
--- a/sentry_sdk/integrations/flask.py
+++ b/sentry_sdk/integrations/flask.py
@@ -111,9 +111,7 @@ def _request_started(sender, **kwargs):
         except Exception:
             pass
 
-        evt_processor = _make_request_event_processor(
-            app, request, integration  # type: ignore
-        )
+        evt_processor = _make_request_event_processor(app, request, integration)
         scope.add_event_processor(evt_processor)
 
 

--- a/sentry_sdk/integrations/flask.py
+++ b/sentry_sdk/integrations/flask.py
@@ -1,7 +1,5 @@
 from __future__ import absolute_import
 
-import weakref
-
 from sentry_sdk.hub import Hub, _should_send_default_pii
 from sentry_sdk.utils import capture_internal_exceptions, event_from_exception
 from sentry_sdk.integrations import Integration, DidNotEnable
@@ -113,9 +111,8 @@ def _request_started(sender, **kwargs):
         except Exception:
             pass
 
-        weak_request = weakref.ref(request)
         evt_processor = _make_request_event_processor(
-            app, weak_request, integration  # type: ignore
+            app, request, integration  # type: ignore
         )
         scope.add_event_processor(evt_processor)
 
@@ -157,11 +154,11 @@ class FlaskRequestExtractor(RequestExtractor):
         return file.content_length
 
 
-def _make_request_event_processor(app, weak_request, integration):
+def _make_request_event_processor(app, request, integration):
     # type: (Flask, Callable[[], Request], FlaskIntegration) -> EventProcessor
+
     def inner(event, hint):
         # type: (Dict[str, Any], Dict[str, Any]) -> Dict[str, Any]
-        request = weak_request()
 
         # if the request is gone we are fine not logging the data from
         # it.  This might happen if the processor is pushed away to

--- a/tests/integrations/flask/test_flask.py
+++ b/tests/integrations/flask/test_flask.py
@@ -332,14 +332,15 @@ def test_flask_medium_formdata_request(sentry_init, capture_events, app):
     assert len(event["request"]["data"]["foo"]) == 512
 
 
-def test_flask_formdata_request_appear_transaction_body(sentry_init, capture_events, app):
+def test_flask_formdata_request_appear_transaction_body(
+    sentry_init, capture_events, app
+):
     """
     Test that ensures that transaction request data contains body, even if no exception was raised
     """
     sentry_init(integrations=[flask_sentry.FlaskIntegration()], traces_sample_rate=1.0)
 
-    data = {"username": "sentry-user",
-            "age": "26"}
+    data = {"username": "sentry-user", "age": "26"}
 
     @app.route("/", methods=["POST"])
     def index():

--- a/tests/integrations/flask/test_flask.py
+++ b/tests/integrations/flask/test_flask.py
@@ -332,6 +332,38 @@ def test_flask_medium_formdata_request(sentry_init, capture_events, app):
     assert len(event["request"]["data"]["foo"]) == 512
 
 
+def test_flask_formdata_request_appear_transaction_body(sentry_init, capture_events, app):
+    """
+    Test that ensures that transaction request data contains body, even if no exception was raised
+    """
+    sentry_init(integrations=[flask_sentry.FlaskIntegration()], traces_sample_rate=1.0)
+
+    data = {"username": "sentry-user",
+            "age": "26"}
+
+    @app.route("/", methods=["POST"])
+    def index():
+        assert request.form["username"] == data["username"]
+        assert request.form["age"] == data["age"]
+        assert not request.get_data()
+        assert not request.get_json()
+        set_tag("view", "yes")
+        capture_message("hi")
+        return "ok"
+
+    events = capture_events()
+
+    client = app.test_client()
+    response = client.post("/", data=data)
+    assert response.status_code == 200
+
+    event, transaction_event = events
+
+    assert "request" in transaction_event
+    assert "data" in transaction_event["request"]
+    assert transaction_event["request"]["data"] == data
+
+
 @pytest.mark.parametrize("input_char", [u"a", b"a"])
 def test_flask_too_large_raw_request(sentry_init, input_char, capture_events, app):
     sentry_init(integrations=[flask_sentry.FlaskIntegration()], request_bodies="small")


### PR DESCRIPTION
This PR fixes the bug that transactions were missing data/body because weakref to the request object was garbage collected before the request object made into the event_processor
- Removed weakref to request object when passed to the event_processor_factory

Ref: https://app.asana.com/0/1142928854421177/1199663160066590