### PR TITLE
fix(tracing): Get HTTP headers from span rather than transaction if possible

### DIFF
--- a/sentry_sdk/hub.py
+++ b/sentry_sdk/hub.py
@@ -682,14 +682,14 @@ class Hub(with_metaclass(HubMeta)):  # type: ignore
         if client is not None:
             return client.flush(timeout=timeout, callback=callback)
 
-    def iter_trace_propagation_headers(self):
-        # type: () -> Generator[Tuple[str, str], None, None]
+    def iter_trace_propagation_headers(self, span=None):
+        # type: (Optional[Span]) -> Generator[Tuple[str, str], None, None]
         # TODO: Document
-        client, scope = self._stack[-1]
-        span = scope.span
-
-        if span is None:
+        span = span or self.scope.span
+        if not span:
             return
+
+        client = self._stack[-1][0]
 
         propagate_traces = client and client.options["propagate_traces"]
         if not propagate_traces:

--- a/sentry_sdk/hub.py
+++ b/sentry_sdk/hub.py
@@ -684,7 +684,11 @@ class Hub(with_metaclass(HubMeta)):  # type: ignore
 
     def iter_trace_propagation_headers(self, span=None):
         # type: (Optional[Span]) -> Generator[Tuple[str, str], None, None]
-        # TODO: Document
+        """
+        Return HTTP headers which allow propagation of trace data. Data taken
+        from the span representing the request, if available, or the current
+        span on the scope if not.
+        """
         span = span or self.scope.span
         if not span:
             return

--- a/sentry_sdk/integrations/celery.py
+++ b/sentry_sdk/integrations/celery.py
@@ -96,9 +96,9 @@ def _wrap_apply_async(f):
         hub = Hub.current
         integration = hub.get_integration(CeleryIntegration)
         if integration is not None and integration.propagate_traces:
-            with hub.start_span(op="celery.submit", description=args[0].name):
+            with hub.start_span(op="celery.submit", description=args[0].name) as span:
                 with capture_internal_exceptions():
-                    headers = dict(hub.iter_trace_propagation_headers())
+                    headers = dict(hub.iter_trace_propagation_headers(span))
 
                     if headers:
                         # Note: kwargs can contain headers=None, so no setdefault!

--- a/sentry_sdk/integrations/stdlib.py
+++ b/sentry_sdk/integrations/stdlib.py
@@ -85,7 +85,7 @@ def _install_httplib():
 
         rv = real_putrequest(self, method, url, *args, **kwargs)
 
-        for key, value in hub.iter_trace_propagation_headers():
+        for key, value in hub.iter_trace_propagation_headers(span):
             self.putheader(key, value)
 
         self._sentrysdk_span = span
@@ -178,12 +178,15 @@ def _install_subprocess():
 
         env = None
 
-        for k, v in hub.iter_trace_propagation_headers():
-            if env is None:
-                env = _init_argument(a, kw, "env", 10, lambda x: dict(x or os.environ))
-            env["SUBPROCESS_" + k.upper().replace("-", "_")] = v
-
         with hub.start_span(op="subprocess", description=description) as span:
+
+            for k, v in hub.iter_trace_propagation_headers(span):
+                if env is None:
+                    env = _init_argument(
+                        a, kw, "env", 10, lambda x: dict(x or os.environ)
+                    )
+                env["SUBPROCESS_" + k.upper().replace("-", "_")] = v
+
             if cwd:
                 span.set_data("subprocess.cwd", cwd)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -368,14 +368,20 @@ def string_containing_matcher():
             self.substring = substring
 
             try:
-                # unicode only exists in python 2
+                # the `unicode` type only exists in python 2, so if this blows up,
+                # we must be in py3 and have the `bytes` type
                 self.valid_types = (str, unicode)  # noqa
             except NameError:
-                self.valid_types = (str,)
+                self.valid_types = (str, bytes)
 
         def __eq__(self, test_string):
             if not isinstance(test_string, self.valid_types):
                 return False
+
+            # this is safe even in py2 because as of 2.6, `bytes` exists in py2
+            # as an alias for `str`
+            if isinstance(test_string, bytes):
+                test_string = test_string.decode()
 
             if len(self.substring) > len(test_string):
                 return False

--- a/tests/integrations/stdlib/test_subprocess.py
+++ b/tests/integrations/stdlib/test_subprocess.py
@@ -183,9 +183,6 @@ def test_subprocess_invalid_args(sentry_init):
     sentry_init(integrations=[StdlibIntegration()])
 
     with pytest.raises(TypeError) as excinfo:
-        subprocess.Popen()
+        subprocess.Popen(1)
 
-    if PY2:
-        assert "__init__() takes at least 2 arguments (1 given)" in str(excinfo.value)
-    else:
-        assert "missing 1 required positional argument: 'args" in str(excinfo.value)
+    assert "'int' object is not iterable" in str(excinfo.value)

--- a/tests/tracing/test_integration_tests.py
+++ b/tests/tracing/test_integration_tests.py
@@ -58,7 +58,7 @@ def test_continue_from_headers(sentry_init, capture_events, sampled, sample_rate
     with start_transaction(name="hi", sampled=True if sample_rate == 0 else None):
         with start_span() as old_span:
             old_span.sampled = sampled
-            headers = dict(Hub.current.iter_trace_propagation_headers())
+            headers = dict(Hub.current.iter_trace_propagation_headers(old_span))
 
     # test that the sampling decision is getting encoded in the header correctly
     header = headers["sentry-trace"]


### PR DESCRIPTION
Currently, there are situations in which a trace ends up looking not like this (as it should):

![image](https://user-images.githubusercontent.com/14812505/109337780-347ca980-781a-11eb-8251-03a076258b1c.png)

but instead looks like this:

![image](https://user-images.githubusercontent.com/14812505/109337859-49f1d380-781a-11eb-9e59-a4669444bf47.png)

This happens because we currently create the outgoing tracing headers based not on the span representing the outgoing request but on whatever span is on the scope, which is most often the transaction itself. There are situations in which this is necessary (if there is no child span to tie to*), but in situations where it's not, we should be correctly associating child transactions with their parent spans, not their ancestor transactions.

\*It's a separate question whether, in the one place there isn't a span ([here](https://github.com/getsentry/sentry-python/blob/1279eeca6763e119d97da5da8318f48a04d3adef/sentry_sdk/integrations/rq.py#L99-L107), the `rq` integration), there should be.