### PR TITLE
fix(django):  Added SDK logic that honors the `X-Forwarded-For` header

### DIFF
--- a/sentry_sdk/integrations/django/__init__.py
+++ b/sentry_sdk/integrations/django/__init__.py
@@ -121,10 +121,12 @@ class DjangoIntegration(Integration):
             bound_old_app = old_app.__get__(self, WSGIHandler)
 
             from django.conf import settings
-            use_x_forwarded_for = settings.get('USE_X_FORWARDED_HOST', False)
 
-            return SentryWsgiMiddleware(
-                bound_old_app, use_x_forwarded_for)(environ, start_response)
+            use_x_forwarded_for = settings.get("USE_X_FORWARDED_HOST", False)
+
+            return SentryWsgiMiddleware(bound_old_app, use_x_forwarded_for)(
+                environ, start_response
+            )
 
         WSGIHandler.__call__ = sentry_patched_wsgi_handler
 

--- a/sentry_sdk/integrations/django/__init__.py
+++ b/sentry_sdk/integrations/django/__init__.py
@@ -120,7 +120,11 @@ class DjangoIntegration(Integration):
 
             bound_old_app = old_app.__get__(self, WSGIHandler)
 
-            return SentryWsgiMiddleware(bound_old_app)(environ, start_response)
+            from django.conf import settings
+            use_x_forwarded_for = settings.get('USE_X_FORWARDED_HOST', False)
+
+            return SentryWsgiMiddleware(
+                bound_old_app, use_x_forwarded_for)(environ, start_response)
 
         WSGIHandler.__call__ = sentry_patched_wsgi_handler
 

--- a/sentry_sdk/integrations/django/__init__.py
+++ b/sentry_sdk/integrations/django/__init__.py
@@ -122,7 +122,7 @@ class DjangoIntegration(Integration):
 
             from django.conf import settings
 
-            use_x_forwarded_for = settings.get("USE_X_FORWARDED_HOST", False)
+            use_x_forwarded_for = settings.USE_X_FORWARDED_HOST
 
             return SentryWsgiMiddleware(bound_old_app, use_x_forwarded_for)(
                 environ, start_response

--- a/tests/integrations/django/test_basic.py
+++ b/tests/integrations/django/test_basic.py
@@ -41,31 +41,33 @@ def test_view_exceptions(sentry_init, client, capture_exceptions, capture_events
 
 
 def test_ensures_x_forwarded_header_is_honored_in_sdk_when_enabled_in_django(
-        sentry_init, client, capture_exceptions, capture_events):
+    sentry_init, client, capture_exceptions, capture_events
+):
     """
     Test that ensures if django settings.USE_X_FORWARDED_HOST is set to True
     then the SDK sets the request url to the `HTTP_X_FORWARDED_FOR`
     """
     from django.conf import settings
+
     settings.USE_X_FORWARDED_HOST = True
 
     sentry_init(integrations=[DjangoIntegration()], send_default_pii=True)
     exceptions = capture_exceptions()
     events = capture_events()
-    client.get(reverse("view_exc"),
-               headers={"X_FORWARDED_HOST": 'example.com'})
+    client.get(reverse("view_exc"), headers={"X_FORWARDED_HOST": "example.com"})
 
     (error,) = exceptions
     assert isinstance(error, ZeroDivisionError)
 
     (event,) = events
-    assert event["request"]["url"] == 'http://example.com/view-exc'
+    assert event["request"]["url"] == "http://example.com/view-exc"
 
     settings.USE_X_FORWARDED_HOST = False
 
 
 def test_ensures_x_forwarded_header_is_not_honored_when_unenabled_in_django(
-        sentry_init, client, capture_exceptions, capture_events):
+    sentry_init, client, capture_exceptions, capture_events
+):
     """
     Test that ensures if django settings.USE_X_FORWARDED_HOST is set to False
     then the SDK sets the request url to the `HTTP_POST`
@@ -73,14 +75,13 @@ def test_ensures_x_forwarded_header_is_not_honored_when_unenabled_in_django(
     sentry_init(integrations=[DjangoIntegration()], send_default_pii=True)
     exceptions = capture_exceptions()
     events = capture_events()
-    client.get(reverse("view_exc"),
-               headers={"X_FORWARDED_HOST": 'example.com'})
+    client.get(reverse("view_exc"), headers={"X_FORWARDED_HOST": "example.com"})
 
     (error,) = exceptions
     assert isinstance(error, ZeroDivisionError)
 
     (event,) = events
-    assert event["request"]["url"] == 'http://localhost/view-exc'
+    assert event["request"]["url"] == "http://localhost/view-exc"
 
 
 def test_middleware_exceptions(sentry_init, client, capture_exceptions):


### PR DESCRIPTION
This PR, 
- Changes the `SentryWsgiMiddleware` to accept a `use_x_forwarded_for` arg that defaults to False. It acts as a flag that if enabled  allows for checking if the `HTTP_X_FORWARDED_HOST` and if it is present in the `environ`, it is used to generate the request URL rather than using the `HTTP_HOST` for it
- Modified the Django integration's initialization of `SentryWsgiMiddleware` to pass the value of `settings.USE_X_FORWARDED_HOST`