### PR TITLE
fix(django): Modified test to use settings fixture rather than using django settings

### DIFF
--- a/tests/integrations/django/test_basic.py
+++ b/tests/integrations/django/test_basic.py
@@ -41,14 +41,12 @@ def test_view_exceptions(sentry_init, client, capture_exceptions, capture_events
 
 
 def test_ensures_x_forwarded_header_is_honored_in_sdk_when_enabled_in_django(
-    sentry_init, client, capture_exceptions, capture_events
+    sentry_init, client, capture_exceptions, capture_events, settings
 ):
     """
     Test that ensures if django settings.USE_X_FORWARDED_HOST is set to True
     then the SDK sets the request url to the `HTTP_X_FORWARDED_FOR`
     """
-    from django.conf import settings
-
     settings.USE_X_FORWARDED_HOST = True
 
     sentry_init(integrations=[DjangoIntegration()], send_default_pii=True)
@@ -61,8 +59,6 @@ def test_ensures_x_forwarded_header_is_honored_in_sdk_when_enabled_in_django(
 
     (event,) = events
     assert event["request"]["url"] == "http://example.com/view-exc"
-
-    settings.USE_X_FORWARDED_HOST = False
 
 
 def test_ensures_x_forwarded_header_is_not_honored_when_unenabled_in_django(


### PR DESCRIPTION
This PR modified a test that used to import django settings and manipulate it and now just uses pytest settings fixture