### PR TITLE
Support China domain in lambda cloudwatch logs url

### DIFF
--- a/sentry_sdk/integrations/aws_lambda.py
+++ b/sentry_sdk/integrations/aws_lambda.py
@@ -400,7 +400,7 @@ def _get_cloudwatch_logs_url(aws_context, start_time):
         str -- AWS Console URL to logs.
     """
     formatstring = "%Y-%m-%dT%H:%M:%SZ"
-    region = environ.get("AWS_REGION")
+    region = environ.get("AWS_REGION", "")
 
     url = (
         "https://console.{domain}/cloudwatch/home?region={region}"

--- a/sentry_sdk/integrations/aws_lambda.py
+++ b/sentry_sdk/integrations/aws_lambda.py
@@ -400,13 +400,15 @@ def _get_cloudwatch_logs_url(aws_context, start_time):
         str -- AWS Console URL to logs.
     """
     formatstring = "%Y-%m-%dT%H:%M:%SZ"
+    region = environ.get("AWS_REGION")
 
     url = (
-        "https://console.aws.amazon.com/cloudwatch/home?region={region}"
+        "https://console.{domain}/cloudwatch/home?region={region}"
         "#logEventViewer:group={log_group};stream={log_stream}"
         ";start={start_time};end={end_time}"
     ).format(
-        region=environ.get("AWS_REGION"),
+        domain="amazonaws.cn" if region.startswith("cn-") else "aws.amazon.com",
+        region=region,
         log_group=aws_context.log_group_name,
         log_stream=aws_context.log_stream_name,
         start_time=(start_time - timedelta(seconds=1)).strftime(formatstring),


### PR DESCRIPTION
The AWSLambdaIntegration adds the cloudwatch URL in the context but the domain is hardcoded and doesn't work for China regions.
