### PR TITLE
feat: Support wildcards in ignore_logger

### DIFF
--- a/scripts/build_awslambda_layer.py
+++ b/scripts/build_awslambda_layer.py
@@ -51,12 +51,14 @@ class PackageBuilder:
         Method that creates the init_serverless_sdk pkg in the
         sentry-python-serverless zip
         """
-        serverless_sdk_path = f'{self.packages_dir}/sentry_sdk/' \
-                              f'integrations/init_serverless_sdk'
+        serverless_sdk_path = (
+            f"{self.packages_dir}/sentry_sdk/" f"integrations/init_serverless_sdk"
+        )
         if not os.path.exists(serverless_sdk_path):
             os.makedirs(serverless_sdk_path)
-        shutil.copy('scripts/init_serverless_sdk.py',
-                    f'{serverless_sdk_path}/__init__.py')
+        shutil.copy(
+            "scripts/init_serverless_sdk.py", f"{serverless_sdk_path}/__init__.py"
+        )
 
     def zip(
         self, filename  # type: str

--- a/scripts/init_serverless_sdk.py
+++ b/scripts/init_serverless_sdk.py
@@ -19,7 +19,7 @@ if MYPY:
 sentry_sdk.init(
     dsn=os.environ["SENTRY_DSN"],
     integrations=[AwsLambdaIntegration(timeout_warning=True)],
-    traces_sample_rate=float(os.environ["SENTRY_TRACES_SAMPLE_RATE"])
+    traces_sample_rate=float(os.environ["SENTRY_TRACES_SAMPLE_RATE"]),
 )
 
 

--- a/sentry_sdk/integrations/logging.py
+++ b/sentry_sdk/integrations/logging.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import
 
 import logging
 import datetime
+from fnmatch import fnmatch
 
 from sentry_sdk.hub import Hub
 from sentry_sdk.utils import (
@@ -97,8 +98,12 @@ class LoggingIntegration(Integration):
 
 
 def _can_record(record):
+    """Prevents ignored loggers from recording"""
     # type: (LogRecord) -> bool
-    return record.name not in _IGNORED_LOGGERS
+    for logger in _IGNORED_LOGGERS:
+        if fnmatch(record.name, logger):
+            return False
+    return True
 
 
 def _breadcrumb_from_record(record):

--- a/sentry_sdk/integrations/logging.py
+++ b/sentry_sdk/integrations/logging.py
@@ -98,8 +98,8 @@ class LoggingIntegration(Integration):
 
 
 def _can_record(record):
-    """Prevents ignored loggers from recording"""
     # type: (LogRecord) -> bool
+    """Prevents ignored loggers from recording"""
     for logger in _IGNORED_LOGGERS:
         if fnmatch(record.name, logger):
             return False

--- a/tests/integrations/logging/test_logging.py
+++ b/tests/integrations/logging/test_logging.py
@@ -3,7 +3,11 @@ import sys
 import pytest
 import logging
 
-from sentry_sdk.integrations.logging import LoggingIntegration, ignore_logger, _IGNORED_LOGGERS
+from sentry_sdk.integrations.logging import (
+    LoggingIntegration,
+    ignore_logger,
+    _IGNORED_LOGGERS,
+)
 
 other_logger = logging.getLogger("testfoo")
 logger = logging.getLogger(__name__)

--- a/tests/integrations/logging/test_logging.py
+++ b/tests/integrations/logging/test_logging.py
@@ -3,11 +3,7 @@ import sys
 import pytest
 import logging
 
-from sentry_sdk.integrations.logging import (
-    LoggingIntegration,
-    ignore_logger,
-    _IGNORED_LOGGERS,
-)
+from sentry_sdk.integrations.logging import LoggingIntegration, ignore_logger
 
 other_logger = logging.getLogger("testfoo")
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
Fixes #511 

This implementation uses [fnmatch](https://docs.python.org/3/library/fnmatch.html) since the `glob` module only matches existing files.

`fnmatch` also works on python 2.7 and later, so this should work with all python versions supported by the SDK.