### PR TITLE
fix(docs): Correct docstring on `has_tracing_enabled`

### DIFF
--- a/sentry_sdk/tracing.py
+++ b/sentry_sdk/tracing.py
@@ -666,7 +666,7 @@ def has_tracing_enabled(options):
     # type: (Dict[str, Any]) -> bool
     """
     Returns True if either traces_sample_rate or traces_sampler is
-    non-zero/defined, False otherwise.
+    defined, False otherwise.
     """
 
     return bool(


### PR DESCRIPTION
Zero is a valid sample rate, which will turn on tracing.