### PR TITLE
Fix (Sanic 21.3): TypeError: sentry_router_get() takes 2 positional arguments but 4 were given

### DIFF
--- a/sentry_sdk/integrations/sanic.py
+++ b/sentry_sdk/integrations/sanic.py
@@ -99,7 +99,7 @@ class SanicIntegration(Integration):
         def sentry_router_get(self, request, *args):
             # type: (Any, Request, Any) -> Any
             if version >= (21, 3):
-                rv = old_router_get(self, request, args[0], args[1])
+                rv = old_router_get(self, request, *args)
             else:
                 rv = old_router_get(self, request)
             hub = Hub.current

--- a/sentry_sdk/integrations/sanic.py
+++ b/sentry_sdk/integrations/sanic.py
@@ -98,7 +98,7 @@ class SanicIntegration(Integration):
 
         def sentry_router_get(self, request, *args):
             # type: (Any, Request, Any) -> Any
-            if version < (21, 3):
+            if version >= (21, 3):
                 rv = old_router_get(self, request, args[0], args[1])
             else:
                 rv = old_router_get(self, request)

--- a/sentry_sdk/integrations/sanic.py
+++ b/sentry_sdk/integrations/sanic.py
@@ -96,9 +96,12 @@ class SanicIntegration(Integration):
 
         old_router_get = Router.get
 
-        def sentry_router_get(self, request):
-            # type: (Any, Request) -> Any
-            rv = old_router_get(self, request)
+        def sentry_router_get(self, request, *args):
+            # type: (Any, Request, Any) -> Any
+            if version < (21, 3):
+                rv = old_router_get(self, request, args[0], args[1])
+            else:
+                rv = old_router_get(self, request)
             hub = Hub.current
             if hub.get_integration(SanicIntegration) is not None:
                 with capture_internal_exceptions():


### PR DESCRIPTION
Fixed an issue with processing requests in 21.3.