### PR TITLE
Minor tweak of recommended version to pin in changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ This project follows [semver](https://semver.org/), with three additions:
 
 - Certain features (e.g. integrations) may be explicitly called out as "experimental" or "unstable" in the documentation. They come with their own versioning policy described in the documentation.
 
-We recommend to pin your version requirements against `0.x.*` or `0.x.y`.
+We recommend to pin your version requirements against `1.x.*` or `1.x.y`.
 Either one of the following is fine:
 
 ```


### PR DESCRIPTION
Since we're on major version 1, I think the docs should recommend that version.