### PR TITLE
fix(rq): Only capture exception if RQ job has failed (ignore retries)

### DIFF
--- a/sentry_sdk/integrations/rq.py
+++ b/sentry_sdk/integrations/rq.py
@@ -108,7 +108,6 @@ class RqIntegration(Integration):
 
         Queue.enqueue_job = sentry_patched_enqueue_job
 
-
         ignore_logger("rq.worker")
 
 

--- a/sentry_sdk/integrations/rq.py
+++ b/sentry_sdk/integrations/rq.py
@@ -89,7 +89,10 @@ class RqIntegration(Integration):
 
         def sentry_patched_handle_exception(self, job, *exc_info, **kwargs):
             # type: (Worker, Any, *Any, **Any) -> Any
-            _capture_exception(exc_info)  # type: ignore
+
+            if job.is_failed:
+                _capture_exception(exc_info)  # type: ignore
+
             return old_handle_exception(self, job, *exc_info, **kwargs)
 
         Worker.handle_exception = sentry_patched_handle_exception

--- a/sentry_sdk/integrations/rq.py
+++ b/sentry_sdk/integrations/rq.py
@@ -3,30 +3,28 @@ from __future__ import absolute_import
 import weakref
 
 from sentry_sdk.hub import Hub
-from sentry_sdk.integrations import Integration, DidNotEnable
+from sentry_sdk.integrations import DidNotEnable, Integration
+from sentry_sdk.integrations.logging import ignore_logger
 from sentry_sdk.tracing import Transaction
 from sentry_sdk.utils import capture_internal_exceptions, event_from_exception
 
-
 try:
-    from rq.version import VERSION as RQ_VERSION
-    from rq.timeouts import JobTimeoutException
-    from rq.worker import Worker
     from rq.queue import Queue
+    from rq.timeouts import JobTimeoutException
+    from rq.version import VERSION as RQ_VERSION
+    from rq.worker import Worker
 except ImportError:
     raise DidNotEnable("RQ not installed")
 
 from sentry_sdk._types import MYPY
 
 if MYPY:
-    from typing import Any
-    from typing import Dict
-    from typing import Callable
+    from typing import Any, Callable, Dict
+
+    from sentry_sdk._types import EventProcessor
+    from sentry_sdk.utils import ExcInfo
 
     from rq.job import Job
-
-    from sentry_sdk.utils import ExcInfo
-    from sentry_sdk._types import EventProcessor
 
 
 class RqIntegration(Integration):
@@ -89,7 +87,6 @@ class RqIntegration(Integration):
 
         def sentry_patched_handle_exception(self, job, *exc_info, **kwargs):
             # type: (Worker, Any, *Any, **Any) -> Any
-
             if job.is_failed:
                 _capture_exception(exc_info)  # type: ignore
 
@@ -110,6 +107,9 @@ class RqIntegration(Integration):
             return old_enqueue_job(self, job, **kwargs)
 
         Queue.enqueue_job = sentry_patched_enqueue_job
+
+
+        ignore_logger("rq.worker")
 
 
 def _make_event_processor(weak_job):

--- a/tests/integrations/rq/test_rq.py
+++ b/tests/integrations/rq/test_rq.py
@@ -177,6 +177,7 @@ def test_traces_sampler_gets_correct_values_in_sampling_context(
         )
     )
 
+
 @pytest.mark.skipif(
     rq.__version__.split(".") < ["1", "5"], reason="At least rq-1.5 required"
 )

--- a/tests/integrations/rq/test_rq.py
+++ b/tests/integrations/rq/test_rq.py
@@ -177,7 +177,9 @@ def test_traces_sampler_gets_correct_values_in_sampling_context(
         )
     )
 
-
+@pytest.mark.skipif(
+    rq.__version__.split(".") < ["1", "5"], reason="At least rq-1.5 required"
+)
 def test_job_with_retries(sentry_init, capture_events):
     sentry_init(integrations=[RqIntegration()])
     events = capture_events()

--- a/tests/integrations/rq/test_rq.py
+++ b/tests/integrations/rq/test_rq.py
@@ -177,6 +177,7 @@ def test_traces_sampler_gets_correct_values_in_sampling_context(
         )
     )
 
+
 def test_job_with_retries(sentry_init, capture_events):
     sentry_init(integrations=[RqIntegration()])
     events = capture_events()
@@ -188,4 +189,3 @@ def test_job_with_retries(sentry_init, capture_events):
     worker.work(burst=True)
 
     assert len(events) == 1
-

--- a/tests/integrations/rq/test_rq.py
+++ b/tests/integrations/rq/test_rq.py
@@ -1,8 +1,7 @@
+import pytest
+from fakeredis import FakeStrictRedis
 from sentry_sdk.integrations.rq import RqIntegration
 
-import pytest
-
-from fakeredis import FakeStrictRedis
 import rq
 
 try:
@@ -177,3 +176,16 @@ def test_traces_sampler_gets_correct_values_in_sampling_context(
             }
         )
     )
+
+def test_job_with_retries(sentry_init, capture_events):
+    sentry_init(integrations=[RqIntegration()])
+    events = capture_events()
+
+    queue = rq.Queue(connection=FakeStrictRedis())
+    worker = rq.SimpleWorker([queue], connection=queue.connection)
+
+    queue.enqueue(crashing_job, foo=42, retry=rq.Retry(max=1))
+    worker.work(burst=True)
+
+    assert len(events) == 1
+


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry-python/issues/1074

Sentry reports all errors from RQ even if it is still retrying the job. 

This changes checks to ensure that retries have been exhausted, ie. the job has failed and will be moved to the failed jobs queue, before capturing the exception. 

Changes:

integrations/rq.py
 - only call _capture exception if job.is_failed is true, indicating it is moving to the failed jobs registry
 - add ignore_logger('rq.worker') so the exception does not get captured via the logging integration 
 
tests/integrations/rq/test_rq.py
 - Add a failing test case for redis version 1.5 and above (where Retry was introduced) to ensure only one exception is captured in the event of a retry