### PR TITLE
fix(integration): Discard `-dev` when parsing required versions for bottle

### DIFF
--- a/sentry_sdk/integrations/bottle.py
+++ b/sentry_sdk/integrations/bottle.py
@@ -57,7 +57,7 @@ class BottleIntegration(Integration):
         # type: () -> None
 
         try:
-            version = tuple(map(int, BOTTLE_VERSION.split(".")))
+            version = tuple(map(int, BOTTLE_VERSION.replace("-dev", "").split(".")))
         except (TypeError, ValueError):
             raise DidNotEnable("Unparsable Bottle version: {}".format(version))
 


### PR DESCRIPTION
This PR bring support dev branch integration.
Simply strip -dev suffix.

https://github.com/bottlepy/bottle/blob/master/bottle.py#L20

`>>> tuple(map(int, "0.13-dev".split(".")))
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ValueError: invalid literal for int() with base 10: '13-dev'
`