### PR TITLE
Set daemon attribute instead of using setDaemon method that was deprecated in Python 3.10

### DIFF
--- a/sentry_sdk/worker.py
+++ b/sentry_sdk/worker.py
@@ -66,7 +66,7 @@ class BackgroundWorker(object):
                 self._thread = threading.Thread(
                     target=self._target, name="raven-sentry.BackgroundWorker"
                 )
-                self._thread.setDaemon(True)
+                self._thread.daemon = True
                 self._thread.start()
                 self._thread_for_pid = os.getpid()
 


### PR DESCRIPTION
Fixes #1092 