### PR TITLE
chore: Fix CI failures

### DIFF
--- a/sentry_sdk/integrations/django/__init__.py
+++ b/sentry_sdk/integrations/django/__init__.py
@@ -332,8 +332,9 @@ def _before_get_response(request):
         # Rely on WSGI middleware to start a trace
         try:
             if integration.transaction_style == "function_name":
+                fn = resolve(request.path).func
                 scope.transaction = transaction_from_function(
-                    resolve(request.path).func
+                    getattr(fn, "view_class", fn)
                 )
             elif integration.transaction_style == "url":
                 scope.transaction = LEGACY_RESOLVER.resolve(request.path_info)

--- a/sentry_sdk/integrations/flask.py
+++ b/sentry_sdk/integrations/flask.py
@@ -65,13 +65,17 @@ class FlaskIntegration(Integration):
     @staticmethod
     def setup_once():
         # type: () -> None
+
+        # This version parsing is absolutely naive but the alternative is to
+        # import pkg_resources which slows down the SDK a lot.
         try:
             version = tuple(map(int, FLASK_VERSION.split(".")[:3]))
         except (ValueError, TypeError):
-            raise DidNotEnable("Unparsable Flask version: {}".format(FLASK_VERSION))
-
-        if version < (0, 10):
-            raise DidNotEnable("Flask 0.10 or newer is required.")
+            # It's probably a release candidate, we assume it's fine.
+            pass
+        else:
+            if version < (0, 10):
+                raise DidNotEnable("Flask 0.10 or newer is required.")
 
         request_started.connect(_request_started)
         got_request_exception.connect(_capture_exception)

--- a/tox.ini
+++ b/tox.ini
@@ -76,7 +76,6 @@ envlist =
 
     {py2.7,py3.7,py3.8,py3.9}-sqlalchemy-{1.2,1.3}
 
-    py3.7-spark
 
     {py3.5,py3.6,py3.7,py3.8,py3.9}-pure_eval
 
@@ -215,8 +214,6 @@ deps =
     sqlalchemy-1.2: sqlalchemy>=1.2,<1.3
     sqlalchemy-1.3: sqlalchemy>=1.3,<1.4
 
-    spark: pyspark==2.4.4
-
     linters: -r linter-requirements.txt
 
     py3.8: hypothesis
@@ -260,7 +257,6 @@ setenv =
     rediscluster: TESTPATH=tests/integrations/rediscluster
     asgi: TESTPATH=tests/integrations/asgi
     sqlalchemy: TESTPATH=tests/integrations/sqlalchemy
-    spark: TESTPATH=tests/integrations/spark
     pure_eval: TESTPATH=tests/integrations/pure_eval
     chalice: TESTPATH=tests/integrations/chalice
     boto3: TESTPATH=tests/integrations/boto3


### PR DESCRIPTION
Fix a bunch of issues with CI that prevent me from releasing

* django main branch has changed how classbased views work, slightly, view_func is now some sort of closure
* spark is unmaintained so we can do nothing but remove it from CI for now
* Flask has a RC-version released so it generally feels safer to allow those weird versions to be used with the SDK