### PR TITLE
fix(serverless): Return value from original handler

### DIFF
--- a/scripts/init_serverless_sdk.py
+++ b/scripts/init_serverless_sdk.py
@@ -35,4 +35,4 @@ def sentry_lambda_handler(event, context):
         raise ValueError("Incorrect AWS Handler path (Not a path)")
     lambda_function = __import__(module_name)
     lambda_handler = getattr(lambda_function, handler_name)
-    lambda_handler(event, context)
+    return lambda_handler(event, context)


### PR DESCRIPTION
I think this is the culprit of broken AWS API Gateway <-> AWS Lambda when the Sentry Lambda Layer is enabled.

(Have not tested myself)