### PR TITLE
fix(aws-lambda): Change lambda function handler name to 'x.y'

### DIFF
--- a/scripts/build_awslambda_layer.py
+++ b/scripts/build_awslambda_layer.py
@@ -52,7 +52,7 @@ class PackageBuilder:
         sentry-python-serverless zip
         """
         serverless_sdk_path = (
-            f"{self.packages_dir}/sentry_sdk/" f"integrations/init_serverless_sdk"
+            f"{self.packages_dir}/init_serverless_sdk"
         )
         if not os.path.exists(serverless_sdk_path):
             os.makedirs(serverless_sdk_path)

--- a/tests/integrations/aws_lambda/client.py
+++ b/tests/integrations/aws_lambda/client.py
@@ -51,7 +51,7 @@ def build_no_code_serverless_function_and_layer(
                 }
             },
             Role=os.environ["SENTRY_PYTHON_TEST_AWS_IAM_ROLE"],
-            Handler="sentry_sdk.integrations.init_serverless_sdk.sentry_lambda_handler",
+            Handler="init_serverless_sdk.sentry_lambda_handler",
             Layers=[response["LayerVersionArn"]],
             Code={"ZipFile": zip.read()},
             Description="Created as part of testsuite for getsentry/sentry-python",


### PR DESCRIPTION
This PR provides :
- Fix for AWS Function Handler name to be in the format of `filename.function-name` because
passing paths (what we have now) as function name is giving us import errors from AWS Lambda
- Added the initialisation script for AWS Lambda function handler name to path `init_serverless_sdk.sentry_lambda_handler`

Current Behavior:
Handler name: `sentry_sdk.integrations.init_serverless_sdk.sentry_lambda_handler`

Response from AWS 
```
Response
{
  "errorMessage": "Unable to import module 'sentry_sdk.integrations.init_serverless_sdk': No module named 'init_serverless_sdk'",
  "errorType": "Runtime.ImportModuleError",
  "stackTrace": []
}

```

Note: Unable to replicate in backend tests that actually create real lambda functions and layers. Only able to replicate this behavior on the AWS Console