### PR TITLE
Revert "fix(aws-lambda): Change lambda function handler name to 'x.y'"

### DIFF
--- a/scripts/build_awslambda_layer.py
+++ b/scripts/build_awslambda_layer.py
@@ -52,7 +52,7 @@ class PackageBuilder:
         sentry-python-serverless zip
         """
         serverless_sdk_path = (
-            f"{self.packages_dir}/init_serverless_sdk"
+            f"{self.packages_dir}/sentry_sdk/" f"integrations/init_serverless_sdk"
         )
         if not os.path.exists(serverless_sdk_path):
             os.makedirs(serverless_sdk_path)

--- a/tests/integrations/aws_lambda/client.py
+++ b/tests/integrations/aws_lambda/client.py
@@ -51,7 +51,7 @@ def build_no_code_serverless_function_and_layer(
                 }
             },
             Role=os.environ["SENTRY_PYTHON_TEST_AWS_IAM_ROLE"],
-            Handler="init_serverless_sdk.sentry_lambda_handler",
+            Handler="sentry_sdk.integrations.init_serverless_sdk.sentry_lambda_handler",
             Layers=[response["LayerVersionArn"]],
             Code={"ZipFile": zip.read()},
             Description="Created as part of testsuite for getsentry/sentry-python",


### PR DESCRIPTION
Reverts getsentry/sentry-python#1107