### PR TITLE
fix(ci): Fix failing CI dependencies due to Werkzeug and pytest_django

### DIFF
--- a/tests/integrations/django/test_basic.py
+++ b/tests/integrations/django/test_basic.py
@@ -245,7 +245,7 @@ def test_sql_queries(sentry_init, capture_events, with_integration):
 
 
 @pytest.mark.forked
-@pytest.mark.django_db
+@pytest.mark.django_db(databases="__all__")
 def test_sql_dict_query_params(sentry_init, capture_events):
     sentry_init(
         integrations=[DjangoIntegration()],
@@ -257,8 +257,6 @@ def test_sql_dict_query_params(sentry_init, capture_events):
 
     if "postgres" not in connections:
         pytest.skip("postgres tests disabled")
-
-    pytest.mark.django_db.databases.append("postgres")
 
     sql = connections["postgres"].cursor()
 
@@ -292,7 +290,7 @@ def test_sql_dict_query_params(sentry_init, capture_events):
     ],
 )
 @pytest.mark.forked
-@pytest.mark.django_db
+@pytest.mark.django_db(databases="__all__")
 def test_sql_psycopg2_string_composition(sentry_init, capture_events, query):
     sentry_init(
         integrations=[DjangoIntegration()],
@@ -305,7 +303,6 @@ def test_sql_psycopg2_string_composition(sentry_init, capture_events, query):
         pytest.skip("postgres tests disabled")
 
     import psycopg2.sql
-    pytest.mark.django_db.databases.append("postgres")
 
     sql = connections["postgres"].cursor()
 
@@ -326,7 +323,7 @@ def test_sql_psycopg2_string_composition(sentry_init, capture_events, query):
 
 
 @pytest.mark.forked
-@pytest.mark.django_db
+@pytest.mark.django_db(databases="__all__")
 def test_sql_psycopg2_placeholders(sentry_init, capture_events):
     sentry_init(
         integrations=[DjangoIntegration()],
@@ -339,7 +336,6 @@ def test_sql_psycopg2_placeholders(sentry_init, capture_events):
         pytest.skip("postgres tests disabled")
 
     import psycopg2.sql
-    pytest.mark.django_db.databases.append("postgres")
 
     sql = connections["postgres"].cursor()
 

--- a/tests/integrations/django/test_basic.py
+++ b/tests/integrations/django/test_basic.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import
 
 import pytest
+import pytest_django
 import json
 
 from werkzeug.test import Client
@@ -20,6 +21,15 @@ from sentry_sdk import capture_message, capture_exception, configure_scope
 from sentry_sdk.integrations.django import DjangoIntegration
 
 from tests.integrations.django.myapp.wsgi import application
+
+# Hack to prevent from experimental feature introduced in version `4.3.0` in `pytest-django` that
+# requires explicit database allow from failing the test
+pytest_mark_django_db_decorator = pytest.mark.django_db
+try:
+    if pytest_django.__version__ > (4, 2, 0):
+        pytest_mark_django_db_decorator = pytest.mark.django_db(database="__all__")
+except AttributeError:
+    pass
 
 
 @pytest.fixture
@@ -245,7 +255,7 @@ def test_sql_queries(sentry_init, capture_events, with_integration):
 
 
 @pytest.mark.forked
-@pytest.mark.django_db(databases="__all__")
+@pytest_mark_django_db_decorator
 def test_sql_dict_query_params(sentry_init, capture_events):
     sentry_init(
         integrations=[DjangoIntegration()],
@@ -290,7 +300,7 @@ def test_sql_dict_query_params(sentry_init, capture_events):
     ],
 )
 @pytest.mark.forked
-@pytest.mark.django_db(databases="__all__")
+@pytest_mark_django_db_decorator
 def test_sql_psycopg2_string_composition(sentry_init, capture_events, query):
     sentry_init(
         integrations=[DjangoIntegration()],
@@ -323,7 +333,7 @@ def test_sql_psycopg2_string_composition(sentry_init, capture_events, query):
 
 
 @pytest.mark.forked
-@pytest.mark.django_db(databases="__all__")
+@pytest_mark_django_db_decorator
 def test_sql_psycopg2_placeholders(sentry_init, capture_events):
     sentry_init(
         integrations=[DjangoIntegration()],

--- a/tests/integrations/django/test_basic.py
+++ b/tests/integrations/django/test_basic.py
@@ -258,6 +258,8 @@ def test_sql_dict_query_params(sentry_init, capture_events):
     if "postgres" not in connections:
         pytest.skip("postgres tests disabled")
 
+    pytest.mark.django_db.databases.append("postgres")
+
     sql = connections["postgres"].cursor()
 
     events = capture_events()
@@ -303,6 +305,7 @@ def test_sql_psycopg2_string_composition(sentry_init, capture_events, query):
         pytest.skip("postgres tests disabled")
 
     import psycopg2.sql
+    pytest.mark.django_db.databases.append("postgres")
 
     sql = connections["postgres"].cursor()
 
@@ -336,6 +339,7 @@ def test_sql_psycopg2_placeholders(sentry_init, capture_events):
         pytest.skip("postgres tests disabled")
 
     import psycopg2.sql
+    pytest.mark.django_db.databases.append("postgres")
 
     sql = connections["postgres"].cursor()
 

--- a/tests/integrations/django/test_basic.py
+++ b/tests/integrations/django/test_basic.py
@@ -26,8 +26,9 @@ from tests.integrations.django.myapp.wsgi import application
 # requires explicit database allow from failing the test
 pytest_mark_django_db_decorator = pytest.mark.django_db
 try:
-    if pytest_django.__version__ > (4, 2, 0):
-        pytest_mark_django_db_decorator = pytest.mark.django_db(database="__all__")
+    pytest_version = tuple(map(int, pytest_django.__version__.split('.')))
+    if pytest_version > (4, 2, 0):
+        pytest_mark_django_db_decorator = pytest.mark.django_db(databases="__all__")
 except AttributeError:
     pass
 

--- a/tests/integrations/django/test_basic.py
+++ b/tests/integrations/django/test_basic.py
@@ -29,6 +29,9 @@ try:
     pytest_version = tuple(map(int, pytest_django.__version__.split('.')))
     if pytest_version > (4, 2, 0):
         pytest_mark_django_db_decorator = pytest.mark.django_db(databases="__all__")
+except ValueError:
+    if "dev" in pytest_django:
+        pytest_mark_django_db_decorator = pytest.mark.django_db(databases="__all__")
 except AttributeError:
     pass
 

--- a/tox.ini
+++ b/tox.ini
@@ -201,7 +201,7 @@ deps =
     trytond-5.0: trytond>=5.0,<5.1
     trytond-4.6: trytond>=4.6,<4.7
 
-    trytond-4.8: werkzeug<1.0
+    trytond-{4.6,4.8,5.0,5.2,5.4}: werkzeug<2.0
 
     redis: fakeredis
 
@@ -297,9 +297,6 @@ commands =
 
     ; https://github.com/pytest-dev/pytest/issues/5532
     {py3.5,py3.6,py3.7,py3.8,py3.9}-flask-{0.10,0.11,0.12}: pip install pytest<5
-
-    ; trytond tries to import werkzeug.contrib
-    trytond-5.0: pip install werkzeug<1.0
 
     py.test {env:TESTPATH} {posargs}
 

--- a/tox.ini
+++ b/tox.ini
@@ -101,7 +101,7 @@ deps =
 
     django-{1.6,1.7}: pytest-django<3.0
     django-{1.8,1.9,1.10,1.11,2.0,2.1}: pytest-django<4.0
-    django-{2.2,3.0,3.1}: pytest-django>=4.0
+    django-{2.2,3.0,3.1}: pytest-django>=4.0,<4.3
     django-dev: git+https://github.com/pytest-dev/pytest-django#egg=pytest-django
 
     django-1.6: Django>=1.6,<1.7

--- a/tox.ini
+++ b/tox.ini
@@ -101,7 +101,8 @@ deps =
 
     django-{1.6,1.7}: pytest-django<3.0
     django-{1.8,1.9,1.10,1.11,2.0,2.1}: pytest-django<4.0
-    django-{2.2,3.0,3.1}: pytest-django>=4.0,<4.3
+    django-{2.2,3.0,3.1}: pytest-django>=4.0
+    django-{2.2,3.0,3.1}: Werkzeug<2.0
     django-dev: git+https://github.com/pytest-dev/pytest-django#egg=pytest-django
 
     django-1.6: Django>=1.6,<1.7

--- a/tox.ini
+++ b/tox.ini
@@ -297,6 +297,7 @@ commands =
 
     ; https://github.com/pytest-dev/pytest/issues/5532
     {py3.5,py3.6,py3.7,py3.8,py3.9}-flask-{0.10,0.11,0.12}: pip install pytest<5
+    {py3.6,py3.7,py3.8,py3.9}-flask-{0.11}: pip install Werkzeug<2
 
     py.test {env:TESTPATH} {posargs}
 


### PR DESCRIPTION
This PR fixes failing CI due to : 
- `trytond` failing dependency because it uses deprecated methods in Wekzeug and so pinning `werkzeug` to version `<2.0`
- Introduction of explicit database access requirement due to an experimental feature in `pytest-django` version `4.3`