### PR TITLE
fix(aws-lambda): Fix bug for initial handler path

### DIFF
--- a/tests/integrations/aws_lambda/client.py
+++ b/tests/integrations/aws_lambda/client.py
@@ -78,7 +78,7 @@ def run_lambda_function(
             # `test_lambda.test_handler`, then create another dir level so that our path is
             # test_dir.test_lambda.test_handler
             test_dir_path = os.path.join(tmpdir, "test_dir")
-            python_init_file = os.path.join(test_dir_path, '__init__.py')
+            python_init_file = os.path.join(test_dir_path, "__init__.py")
             os.makedirs(test_dir_path)
             with open(python_init_file, "w"):
                 # Create __init__ file to make it a python package

--- a/tests/integrations/aws_lambda/test_aws.py
+++ b/tests/integrations/aws_lambda/test_aws.py
@@ -634,16 +634,16 @@ def test_serverless_no_code_instrumentation(run_lambda_function):
             dedent(
                 """
             import sentry_sdk
-    
+
             def test_handler(event, context):
                 current_client = sentry_sdk.Hub.current.client
-    
+
                 assert current_client is not None
-    
+
                 assert len(current_client.options['integrations']) == 1
                 assert isinstance(current_client.options['integrations'][0],
                                   sentry_sdk.integrations.aws_lambda.AwsLambdaIntegration)
-    
+
                 raise Exception("something went wrong")
             """
             ),

--- a/tests/integrations/aws_lambda/test_aws.py
+++ b/tests/integrations/aws_lambda/test_aws.py
@@ -112,7 +112,7 @@ def lambda_runtime(request):
 
 @pytest.fixture
 def run_lambda_function(request, lambda_client, lambda_runtime):
-    def inner(code, payload, timeout=30, syntax_check=True, layer=None):
+    def inner(code, payload, timeout=30, syntax_check=True, layer=None, initial_handler=None):
         from tests.integrations.aws_lambda.client import run_lambda_function
 
         response = run_lambda_function(
@@ -124,6 +124,7 @@ def run_lambda_function(request, lambda_client, lambda_runtime):
             timeout=timeout,
             syntax_check=syntax_check,
             layer=layer,
+            initial_handler=initial_handler
         )
 
         # for better debugging
@@ -621,32 +622,37 @@ def test_serverless_no_code_instrumentation(run_lambda_function):
     python sdk, with no code changes sentry is able to capture errors
     """
 
-    _, _, response = run_lambda_function(
-        dedent(
+    for initial_handler in [None,
+                            "test_dir/test_lambda.test_handler",
+                            "test_dir.test_lambda.test_handler"]:
+        print("Testing Initial Handler ", initial_handler)
+        _, _, response = run_lambda_function(
+            dedent(
+                """
+            import sentry_sdk
+    
+            def test_handler(event, context):
+                current_client = sentry_sdk.Hub.current.client
+    
+                assert current_client is not None
+    
+                assert len(current_client.options['integrations']) == 1
+                assert isinstance(current_client.options['integrations'][0],
+                                  sentry_sdk.integrations.aws_lambda.AwsLambdaIntegration)
+    
+                raise Exception("something went wrong")
             """
-        import sentry_sdk
+            ),
+            b'{"foo": "bar"}',
+            layer=True,
+            initial_handler=initial_handler
+        )
+        assert response["FunctionError"] == "Unhandled"
+        assert response["StatusCode"] == 200
 
-        def test_handler(event, context):
-            current_client = sentry_sdk.Hub.current.client
+        assert response["Payload"]["errorType"] != "AssertionError"
 
-            assert current_client is not None
+        assert response["Payload"]["errorType"] == "Exception"
+        assert response["Payload"]["errorMessage"] == "something went wrong"
 
-            assert len(current_client.options['integrations']) == 1
-            assert isinstance(current_client.options['integrations'][0],
-                              sentry_sdk.integrations.aws_lambda.AwsLambdaIntegration)
-
-            raise Exception("something went wrong")
-        """
-        ),
-        b'{"foo": "bar"}',
-        layer=True,
-    )
-    assert response["FunctionError"] == "Unhandled"
-    assert response["StatusCode"] == 200
-
-    assert response["Payload"]["errorType"] != "AssertionError"
-
-    assert response["Payload"]["errorType"] == "Exception"
-    assert response["Payload"]["errorMessage"] == "something went wrong"
-
-    assert "sentry_handler" in response["LogResult"][3].decode("utf-8")
+        assert "sentry_handler" in response["LogResult"][3].decode("utf-8")

--- a/tests/integrations/aws_lambda/test_aws.py
+++ b/tests/integrations/aws_lambda/test_aws.py
@@ -112,7 +112,9 @@ def lambda_runtime(request):
 
 @pytest.fixture
 def run_lambda_function(request, lambda_client, lambda_runtime):
-    def inner(code, payload, timeout=30, syntax_check=True, layer=None, initial_handler=None):
+    def inner(
+        code, payload, timeout=30, syntax_check=True, layer=None, initial_handler=None
+    ):
         from tests.integrations.aws_lambda.client import run_lambda_function
 
         response = run_lambda_function(
@@ -124,7 +126,7 @@ def run_lambda_function(request, lambda_client, lambda_runtime):
             timeout=timeout,
             syntax_check=syntax_check,
             layer=layer,
-            initial_handler=initial_handler
+            initial_handler=initial_handler,
         )
 
         # for better debugging
@@ -622,9 +624,11 @@ def test_serverless_no_code_instrumentation(run_lambda_function):
     python sdk, with no code changes sentry is able to capture errors
     """
 
-    for initial_handler in [None,
-                            "test_dir/test_lambda.test_handler",
-                            "test_dir.test_lambda.test_handler"]:
+    for initial_handler in [
+        None,
+        "test_dir/test_lambda.test_handler",
+        "test_dir.test_lambda.test_handler",
+    ]:
         print("Testing Initial Handler ", initial_handler)
         _, _, response = run_lambda_function(
             dedent(
@@ -645,7 +649,7 @@ def test_serverless_no_code_instrumentation(run_lambda_function):
             ),
             b'{"foo": "bar"}',
             layer=True,
-            initial_handler=initial_handler
+            initial_handler=initial_handler,
         )
         assert response["FunctionError"] == "Unhandled"
         assert response["StatusCode"] == 200

--- a/tests/integrations/django/myapp/settings.py
+++ b/tests/integrations/django/myapp/settings.py
@@ -157,7 +157,7 @@ USE_I18N = True
 
 USE_L10N = True
 
-USE_TZ = True
+USE_TZ = False
 
 TEMPLATE_DEBUG = True
 


### PR DESCRIPTION
This PR:-
- Fixes bug that would technically fail if the initial handler for a lambda function by adding support for  `x.y.z` rather than just `x.y`
- Adds support for initial handler dir paths in the format of `x/y.z`

Ref: https://sentry.zendesk.com/agent/tickets/49603