### PR TITLE
fix(docs): Add sphinx imports to docs conf to prevent circular deps

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -5,6 +5,13 @@ import sys
 
 import typing
 
+# prevent circular imports
+import sphinx.builders.html
+import sphinx.builders.latex
+import sphinx.builders.texinfo
+import sphinx.builders.text
+import sphinx.ext.autodoc
+
 typing.TYPE_CHECKING = True
 
 #


### PR DESCRIPTION
This PR adds explicit imports for sphinx packages due to circular dependency bug introduced in sphinx 4.x

Ref: https://github.com/sphinx-doc/sphinx/issues/9243