### PR TITLE
feat(integration): Add support for Sanic >=21.3

### DIFF
--- a/sentry_sdk/integrations/sanic.py
+++ b/sentry_sdk/integrations/sanic.py
@@ -108,7 +108,9 @@ class SanicIntegration(Integration):
                             # route name, and so we need to remove it from Route name so the
                             # transaction name is consistent across all versions
                             sanic_app_name = self.ctx.app.name
-                            scope.transaction = rv[0].name.split("%s." % sanic_app_name)[1]
+                            scope.transaction = rv[0].name.split(
+                                "%s." % sanic_app_name
+                            )[1]
                         else:
                             scope.transaction = rv[0].__name__
             return rv

--- a/sentry_sdk/integrations/sanic.py
+++ b/sentry_sdk/integrations/sanic.py
@@ -108,9 +108,15 @@ class SanicIntegration(Integration):
                             # route name, and so we need to remove it from Route name so the
                             # transaction name is consistent across all versions
                             sanic_app_name = self.ctx.app.name
-                            scope.transaction = rv[0].name.split(
-                                "%s." % sanic_app_name
-                            )[1]
+                            sanic_route = rv[0].name
+
+                            if sanic_route.startswith("%s." % sanic_app_name):
+                                # We add a 1 to the len of the sanic_app_name because there is a dot
+                                # that joins app name and the route name
+                                # Format: app_name.route_name
+                                sanic_route = sanic_route[len(sanic_app_name) + 1 :]
+
+                            scope.transaction = sanic_route
                         else:
                             scope.transaction = rv[0].__name__
             return rv

--- a/sentry_sdk/integrations/sanic.py
+++ b/sentry_sdk/integrations/sanic.py
@@ -104,7 +104,11 @@ class SanicIntegration(Integration):
                 with capture_internal_exceptions():
                     with hub.configure_scope() as scope:
                         if version >= (21, 3):
-                            scope.transaction = rv[0].name
+                            # Sanic versions above and including 21.3 append the app name to the
+                            # route name, and so we need to remove it from Route name so the
+                            # transaction name is consistent across all versions
+                            sanic_app_name = self.ctx.app.name
+                            scope.transaction = rv[0].name.split("%s." % sanic_app_name)[1]
                         else:
                             scope.transaction = rv[0].__name__
             return rv

--- a/sentry_sdk/integrations/sanic.py
+++ b/sentry_sdk/integrations/sanic.py
@@ -98,11 +98,7 @@ class SanicIntegration(Integration):
 
         def sentry_router_get(self, *args):
             # type: (Any, Union[Any, Request]) -> Any
-            if version >= (21, 3):
-                rv = old_router_get(self, *args)
-            else:
-                request = args[0]
-                rv = old_router_get(self, request)
+            rv = old_router_get(self, *args)
             hub = Hub.current
             if hub.get_integration(SanicIntegration) is not None:
                 with capture_internal_exceptions():

--- a/tests/integrations/sanic/test_sanic.py
+++ b/tests/integrations/sanic/test_sanic.py
@@ -9,6 +9,7 @@ from sentry_sdk import capture_message, configure_scope
 from sentry_sdk.integrations.sanic import SanicIntegration
 
 from sanic import Sanic, request, response, __version__ as SANIC_VERSION_RAW
+from sanic.response import HTTPResponse
 from sanic.exceptions import abort
 
 SANIC_VERSION = tuple(map(int, SANIC_VERSION_RAW.split(".")))
@@ -16,7 +17,12 @@ SANIC_VERSION = tuple(map(int, SANIC_VERSION_RAW.split(".")))
 
 @pytest.fixture
 def app():
-    app = Sanic(__name__)
+    if SANIC_VERSION >= (20, 12):
+        # Build (20.12.0) adds a feature where the instance is stored in an internal class
+        # registry for later retrieval, and so add register=False to disable that
+        app = Sanic(__name__, register=False)
+    else:
+        app = Sanic(__name__)
 
     @app.route("/message")
     def hi(request):
@@ -34,7 +40,11 @@ def test_request_data(sentry_init, app, capture_events):
     assert response.status == 200
 
     (event,) = events
-    assert event["transaction"] == "hi"
+    # Sanic versions above and including 21.3 append the app name to the route name
+    if SANIC_VERSION >= (21, 3):
+        assert event["transaction"] == "%s.hi" % __name__
+    else:
+        assert event["transaction"] == "hi"
     assert event["request"]["env"] == {"REMOTE_ADDR": ""}
     assert set(event["request"]["headers"]) >= {
         "accept",
@@ -67,7 +77,12 @@ def test_errors(sentry_init, app, capture_events):
     assert response.status == 500
 
     (event,) = events
-    assert event["transaction"] == "myerror"
+    # Sanic versions above and including 21.3 append the app name to the route name
+    if SANIC_VERSION >= (21, 3):
+        assert event["transaction"] == "%s.myerror" % __name__
+    else:
+        assert event["transaction"] == "myerror"
+
     (exception,) = event["exception"]["values"]
 
     assert exception["type"] == "ValueError"
@@ -166,11 +181,50 @@ def test_concurrency(sentry_init, app):
         if SANIC_VERSION >= (19,):
             kwargs["app"] = app
 
-        await app.handle_request(
-            request.Request(**kwargs),
-            write_callback=responses.append,
-            stream_callback=responses.append,
-        )
+        if SANIC_VERSION >= (21, 3):
+            try:
+                app.router.reset()
+                app.router.finalize()
+            except AttributeError:
+                ...
+
+            class MockAsyncStreamer:
+                def __init__(self, request_body):
+                    self.request_body = request_body.encode("ASCII")
+                    self.iter = iter(request_body)
+                    self.response = b"success"
+
+                def respond(self, response):
+                    responses.append(response)
+
+                    def send_patched(*args, **kwargs):
+                        return lambda end_stream: asyncio.sleep(0.001)
+
+                    patched_response = HTTPResponse()
+                    patched_response.send = send_patched()
+                    return patched_response
+
+                def __aiter__(self):
+                    return self
+
+                async def __anext__(self):
+                    try:
+                        return next(self.iter)
+                    except StopIteration:
+                        raise StopAsyncIteration
+
+            patched_request = request.Request(**kwargs)
+            patched_request.stream = MockAsyncStreamer("hellowold")
+
+            await app.handle_request(
+                patched_request,
+            )
+        else:
+            await app.handle_request(
+                request.Request(**kwargs),
+                write_callback=responses.append,
+                stream_callback=responses.append,
+            )
 
         (r,) = responses
         assert r.status == 200

--- a/tests/integrations/sanic/test_sanic.py
+++ b/tests/integrations/sanic/test_sanic.py
@@ -40,7 +40,6 @@ def test_request_data(sentry_init, app, capture_events):
     assert response.status == 200
 
     (event,) = events
-
     assert event["transaction"] == "hi"
     assert event["request"]["env"] == {"REMOTE_ADDR": ""}
     assert set(event["request"]["headers"]) >= {
@@ -75,7 +74,6 @@ def test_errors(sentry_init, app, capture_events):
 
     (event,) = events
     assert event["transaction"] == "myerror"
-
     (exception,) = event["exception"]["values"]
 
     assert exception["type"] == "ValueError"
@@ -189,12 +187,8 @@ def test_concurrency(sentry_init, app):
 
                 def respond(self, response):
                     responses.append(response)
-
-                    def send_patched(*args, **kwargs):
-                        return lambda end_stream: asyncio.sleep(0.001)
-
                     patched_response = HTTPResponse()
-                    patched_response.send = send_patched()
+                    patched_response.send = lambda end_stream: asyncio.sleep(0.001)
                     return patched_response
 
                 def __aiter__(self):

--- a/tox.ini
+++ b/tox.ini
@@ -39,6 +39,8 @@ envlist =
 
     {py3.5,py3.6,py3.7}-sanic-{0.8,18}
     {py3.6,py3.7}-sanic-19
+    {py3.6,py3.7,py3.8,py3.9}-sanic-20
+    {py3.7,py3.8,py3.9}-sanic-21
 
     # TODO: Add py3.9
     {pypy,py2.7}-celery-3
@@ -140,7 +142,7 @@ deps =
     sanic-18: sanic>=18.0,<19.0
     sanic-19: sanic>=19.0,<20.0
     sanic-20: sanic>=20.0,<21.0
-    {py3.7,py3.8,py3.9}-sanic-21: sanic>=21.0
+    sanic-21: sanic>=21.0
     {py3.7,py3.8,py3.9}-sanic-21: sanic_testing
     {py3.5,py3.6}-sanic: aiocontextvars==0.2.1
     sanic: aiohttp

--- a/tox.ini
+++ b/tox.ini
@@ -39,7 +39,7 @@ envlist =
 
     {py3.5,py3.6,py3.7}-sanic-{0.8,18}
     {py3.6,py3.7}-sanic-19
-    {py3.6,py3.7,py3.8,py3.9}-sanic-20
+    {py3.6,py3.7,py3.8}-sanic-20
     {py3.7,py3.8,py3.9}-sanic-21
 
     # TODO: Add py3.9

--- a/tox.ini
+++ b/tox.ini
@@ -142,7 +142,7 @@ deps =
     sanic-18: sanic>=18.0,<19.0
     sanic-19: sanic>=19.0,<20.0
     sanic-20: sanic>=20.0,<21.0
-    sanic-21: sanic>=21.0
+    sanic-21: sanic>=21.0,<22.0
     {py3.7,py3.8,py3.9}-sanic-21: sanic_testing
     {py3.5,py3.6}-sanic: aiocontextvars==0.2.1
     sanic: aiohttp

--- a/tox.ini
+++ b/tox.ini
@@ -139,6 +139,9 @@ deps =
     sanic-0.8: sanic>=0.8,<0.9
     sanic-18: sanic>=18.0,<19.0
     sanic-19: sanic>=19.0,<20.0
+    sanic-20: sanic>=20.0,<21.0
+    {py3.7,py3.8,py3.9}-sanic-21: sanic>=21.0
+    {py3.7,py3.8,py3.9}-sanic-21: sanic_testing
     {py3.5,py3.6}-sanic: aiocontextvars==0.2.1
     sanic: aiohttp
     py3.5-sanic: ujson<4


### PR DESCRIPTION
This PR:
- Adds support for latest Sanic versions >= 21.3 because it was initially broken due to breaking changes after LTS of 20.12

Note/Todo:
- There **MIGHT** be missing support for new added functionality in version 21.3 that should be integrated in future work
- This PR is merely there to not break support for what we already have

Fixes: #1066, #1128 