### PR TITLE
Keeping compatibility with celery 4.x.x BaseTask subclass like PeriodicTask

### DIFF
--- a/sentry_sdk/integrations/celery.py
+++ b/sentry_sdk/integrations/celery.py
@@ -70,10 +70,13 @@ class CeleryIntegration(Integration):
             return _wrap_tracer(task, old_build_tracer(name, task, *args, **kwargs))
 
         trace.build_tracer = sentry_build_tracer
+        if CELERY_VERSION < (5,):
+            # Keeping compatibility with celery 4.x.x BaseTask subclass like PeriodicTasks
+            from celery.task.base import BaseTask  # type: ignore
+        else:
+            from celery.app.task import BaseTask # type: ignore
 
-        from celery.app.task import Task  # type: ignore
-
-        Task.apply_async = _wrap_apply_async(Task.apply_async)
+        BaseTask.apply_async = _wrap_apply_async(BaseTask.apply_async)
 
         _patch_worker_exit()
 


### PR DESCRIPTION
fix #844

I'm using sentry_sdk 1.3.0 on python 2.7 with celery 4.4.6 and I'm having an issue with apply_async from PeriodicTask task instances. Following the @ahmedetefy leads I decided to open this PullRequest I'm not sure if it is the best way to fix that.

```
[2021-07-16 18:15:01,512: ERROR/Beat] Message Error: Couldn't apply scheduled task cron_jobs.periodic_jobs.schedule_report: unbound method apply_async() must be called with Task instance as first argument (got TaskType instance instead)
Traceback (most recent call last):
  File "/usr/local/pythonenv/myproject/local/lib/python2.7/site-packages/redbeat/schedulers.py", line 437, in maybe_due
    result = self.apply_async(entry, **kwargs)
  File "/usr/local/pythonenv/myproject/local/lib/python2.7/site-packages/celery/beat.py", line 400, in apply_async
    entry, exc=exc)), sys.exc_info()[2])
  File "/usr/local/pythonenv/myproject/local/lib/python2.7/site-packages/celery/beat.py", line 392, in apply_async
    **entry.options)
  File "/usr/local/pythonenv/myproject/local/lib/python2.7/site-packages/sentry_sdk/integrations/celery.py", line 117, in apply_async
    return f(*args, **kwargs)
SchedulingError: Couldn't apply scheduled task cron_jobs.periodic_jobs.schedule_report: unbound method apply_async() must be called with Task instance as first argument (got TaskType instance instead)```