### PR TITLE
🐛 Fix detection of contextvars compatibility with Gevent 20.9.0+

### DIFF
--- a/sentry_sdk/utils.py
+++ b/sentry_sdk/utils.py
@@ -785,7 +785,7 @@ def _is_contextvars_broken():
     Returns whether gevent/eventlet have patched the stdlib in a way where thread locals are now more "correct" than contextvars.
     """
     try:
-        import gevent
+        import gevent  # type: ignore
         from gevent.monkey import is_object_patched  # type: ignore
 
         # Get the MAJOR and MINOR version numbers of Gevent

--- a/sentry_sdk/utils.py
+++ b/sentry_sdk/utils.py
@@ -5,6 +5,7 @@ import os
 import sys
 import threading
 import subprocess
+import sys
 
 from datetime import datetime
 
@@ -787,8 +788,9 @@ def _is_contextvars_broken():
     try:
         import gevent
         from gevent.monkey import is_object_patched  # type: ignore
+
         # Get the MAJOR and MINOR version numbers of Gevent
-        gevent_version_parts = [int(part) for part in gevent.__version__.split(".")[:2]]
+        version_tuple = tuple([int(part) for part in gevent.__version__.split(".")[:2]])
         if is_object_patched("threading", "local"):
             # Gevent 20.9.0 depends on Greenlet 0.4.17 which natively handles switching
             # context vars when greenlets are switched, so, Gevent 20.9.0+ is all fine.
@@ -797,14 +799,10 @@ def _is_contextvars_broken():
             # for contextvars, is able to patch both thread locals and contextvars, in
             # that case, check if contextvars are effectively patched.
             if (
-                # Gevent > 20
-                (gevent_version_parts[0] > 20)
                 # Gevent 20.9.0+
-                or (gevent_version_parts[0] == 20 and gevent_version_parts[1] >= 9)
-                # Gevent 20.5.0+
-                or (
-                    is_object_patched("contextvars", "ContextVar")
-                )
+                (sys.version_info >= (3, 7) and version_tuple >= (20, 9))
+                # Gevent 20.5.0+ or Python < 3.7
+                or (is_object_patched("contextvars", "ContextVar"))
             ):
                 return False
 

--- a/sentry_sdk/utils.py
+++ b/sentry_sdk/utils.py
@@ -5,7 +5,6 @@ import os
 import sys
 import threading
 import subprocess
-import sys
 
 from datetime import datetime
 


### PR DESCRIPTION
🐛 Fix detection of contextvars compatibility with Gevent 20.9.0+

This is described in https://github.com/getsentry/sentry-python/issues/1063, and this PR would fix it (it should at least).

## Description

The current implementation checks if Gevent patched contextvars, but:

> Gevent 20.9.0 depends on Greenlet 0.4.17 which natively handles switching context vars when greenlets are switched.
> Older versions of Python [older than 3.7] that have the backport installed will still be patched.

Ref: https://github.com/gevent/gevent/blob/83c9e2ae5b0834b8f84233760aabe82c3ba065b4/src/gevent/monkey.py#L604-L609

This PR updates the implementation to check the version of Gevent and Python to account for that.

## Use Case

I'm migrating a code base with a couple of apps from Flask to FastAPI. During the migration both Flask and FastAPI are available at the same time, sharing a lot of the code and tests.

The Flask app is currently deployed with Gevent, so the tests use Gevent's monkey patching.

The FastAPI app uses the `SentryAsgiMiddleware`, which internally uses `contextvars` to store and handle all the Sentry stuff per request. And that in turn uses this utility function to check if the current environment has working contextvars available.

So, with Python 3.7+ and a recent installation of Gevent monkey patching stuff, Sentry errors out complaining about broken contextvars, but it seems it's actually just a false positive.