### PR TITLE
fix(mypy): Use correct typings for set_user

### DIFF
--- a/sentry_sdk/api.py
+++ b/sentry_sdk/api.py
@@ -171,7 +171,7 @@ def set_extra(key, value):
 
 @scopemethod  # noqa
 def set_user(value):
-    # type: (Dict[str, Any]) -> None
+    # type: (Optional[Dict[str, Any]]) -> None
     return Hub.current.scope.set_user(value)
 
 

--- a/sentry_sdk/scope.py
+++ b/sentry_sdk/scope.py
@@ -185,12 +185,12 @@ class Scope(object):
 
     @_attr_setter
     def user(self, value):
-        # type: (Dict[str, Any]) -> None
+        # type: (Optional[Dict[str, Any]]) -> None
         """When set a specific user is bound to the scope. Deprecated in favor of set_user."""
         self.set_user(value)
 
     def set_user(self, value):
-        # type: (Dict[str, Any]) -> None
+        # type: (Optional[Dict[str, Any]]) -> None
         """Sets a user for the scope."""
         self._user = value
         if self._session is not None:


### PR DESCRIPTION
Switch from using (Dict[str, Any]) -> None to
(Optional[Dict[str, Any]]) -> None for the `set_user` function's type
hints.

Fixes https://github.com/getsentry/sentry-python/issues/1164