### PR TITLE
ref(tracing): Various tweaks to tracestate header handling

### DIFF
--- a/sentry_sdk/client.py
+++ b/sentry_sdk/client.py
@@ -346,7 +346,7 @@ class _Client(object):
                 "sent_at": format_timestamp(datetime.utcnow()),
             }
 
-            tracestate_data = reinflate_tracestate(
+            tracestate_data = raw_tracestate and reinflate_tracestate(
                 raw_tracestate.replace("sentry=", "")
             )
             if tracestate_data:

--- a/sentry_sdk/scope.py
+++ b/sentry_sdk/scope.py
@@ -150,19 +150,13 @@ class Scope(object):
         if self._span is None:
             return None
 
-        # the span on the scope is itself a transaction
-        if isinstance(self._span, Transaction):
-            return self._span
+        # there is an orphan span on the scope
+        if self._span.containing_transaction is None:
+            return None
 
-        # the span on the scope isn't a transaction but belongs to one
-        if self._span._containing_transaction:
-            return self._span._containing_transaction
-
-        # there's a span (not a transaction) on the scope, but it was started on
-        # its own, not as the descendant of a transaction (this is deprecated
-        # behavior, but as long as the start_span function exists, it can still
-        # happen)
-        return None
+        # there is either a transaction (which is its own containing
+        # transaction) or a non-orphan span on the scope
+        return self._span.containing_transaction
 
     @transaction.setter
     def transaction(self, value):

--- a/sentry_sdk/tracing.py
+++ b/sentry_sdk/tracing.py
@@ -321,6 +321,9 @@ class Span(object):
             sentry_tracestate = compute_tracestate_entry(self)
             third_party_tracestate = None
 
+        if not sentry_tracestate:
+            return None
+
         header_value = sentry_tracestate
 
         if third_party_tracestate:

--- a/sentry_sdk/tracing_utils.py
+++ b/sentry_sdk/tracing_utils.py
@@ -301,7 +301,7 @@ def compute_tracestate_value(data):
 
 
 def compute_tracestate_entry(span):
-    # type: (Span) -> str
+    # type: (Span) -> Optional[str]
     """
     Computes a new sentry tracestate for the span. Includes the `sentry=`.
 
@@ -311,8 +311,6 @@ def compute_tracestate_entry(span):
 
     client = (span.hub or sentry_sdk.Hub.current).client
 
-    # if there's no client and/or no DSN, we're not sending anything anywhere,
-    # so it's fine to not have any tracestate data
     if client and client.options.get("dsn"):
         options = client.options
         data = {
@@ -322,7 +320,9 @@ def compute_tracestate_entry(span):
             "public_key": Dsn(options["dsn"]).public_key,
         }
 
-    return "sentry=" + compute_tracestate_value(data)
+        return "sentry=" + compute_tracestate_value(data)
+
+    return None
 
 
 def reinflate_tracestate(encoded_tracestate):

--- a/tests/tracing/test_http_headers.py
+++ b/tests/tracing/test_http_headers.py
@@ -2,6 +2,7 @@ import json
 
 import pytest
 
+import sentry_sdk
 from sentry_sdk.tracing import Transaction, Span
 from sentry_sdk.tracing_utils import (
     compute_tracestate_value,
@@ -48,8 +49,7 @@ def test_tracestate_computation(sentry_init):
     }
 
 
-@pytest.mark.xfail()  # TODO kmclb
-def test_adds_new_tracestate_to_transaction_when_none_given(sentry_init):
+def test_doesnt_add_new_tracestate_to_transaction_when_none_given(sentry_init):
     sentry_init(
         dsn="https://dogsarebadatkeepingsecrets@squirrelchasers.ingest.sentry.io/12312012",
         environment="dogpark",
@@ -62,7 +62,90 @@ def test_adds_new_tracestate_to_transaction_when_none_given(sentry_init):
         # sentry_tracestate=< value would be passed here >
     )
 
+    assert transaction._sentry_tracestate is None
+
+
+def test_adds_tracestate_to_transaction_when_to_traceparent_called(sentry_init):
+    sentry_init(
+        dsn="https://dogsarebadatkeepingsecrets@squirrelchasers.ingest.sentry.io/12312012",
+        environment="dogpark",
+        release="off.leash.park",
+    )
+
+    transaction = Transaction(
+        name="/interactions/other-dogs/new-dog",
+        op="greeting.sniff",
+    )
+
+    # no inherited tracestate, and none created in Transaction constructor
+    assert transaction._sentry_tracestate is None
+
+    transaction.to_tracestate()
+
     assert transaction._sentry_tracestate is not None
+
+
+def test_adds_tracestate_to_transaction_when_getting_trace_context(sentry_init):
+    sentry_init(
+        dsn="https://dogsarebadatkeepingsecrets@squirrelchasers.ingest.sentry.io/12312012",
+        environment="dogpark",
+        release="off.leash.park",
+    )
+
+    transaction = Transaction(
+        name="/interactions/other-dogs/new-dog",
+        op="greeting.sniff",
+    )
+
+    # no inherited tracestate, and none created in Transaction constructor
+    assert transaction._sentry_tracestate is None
+
+    transaction.get_trace_context()
+
+    assert transaction._sentry_tracestate is not None
+
+
+@pytest.mark.parametrize(
+    "set_by", ["inheritance", "to_tracestate", "get_trace_context"]
+)
+def test_tracestate_is_immutable_once_set(sentry_init, monkeypatch, set_by):
+    monkeypatch.setattr(
+        sentry_sdk.tracing,
+        "compute_tracestate_entry",
+        mock.Mock(return_value="sentry=doGsaREgReaT"),
+    )
+
+    sentry_init(
+        dsn="https://dogsarebadatkeepingsecrets@squirrelchasers.ingest.sentry.io/12312012",
+        environment="dogpark",
+        release="off.leash.park",
+    )
+
+    # for each scenario, get to the point where tracestate has been set
+    if set_by == "inheritance":
+        transaction = Transaction(
+            name="/interactions/other-dogs/new-dog",
+            op="greeting.sniff",
+            sentry_tracestate=("sentry=doGsaREgReaT"),
+        )
+    else:
+        transaction = Transaction(
+            name="/interactions/other-dogs/new-dog",
+            op="greeting.sniff",
+        )
+
+        if set_by == "to_tracestate":
+            transaction.to_tracestate()
+        if set_by == "get_trace_context":
+            transaction.get_trace_context()
+
+    assert transaction._sentry_tracestate == "sentry=doGsaREgReaT"
+
+    # user data would be included in tracestate if it were recomputed at this point
+    sentry_sdk.set_user({"id": 12312013, "segment": "bigs"})
+
+    # value hasn't changed
+    assert transaction._sentry_tracestate == "sentry=doGsaREgReaT"
 
 
 @pytest.mark.parametrize("sampled", [True, False, None])

--- a/tests/tracing/test_http_headers.py
+++ b/tests/tracing/test_http_headers.py
@@ -31,6 +31,9 @@ def test_tracestate_computation(sentry_init):
         trace_id="12312012123120121231201212312012",
     )
 
+    # force lazy computation to create a value
+    transaction.to_tracestate()
+
     computed_value = transaction._sentry_tracestate.replace("sentry=", "")
     # we have to decode and reinflate the data because we can guarantee that the
     # order of the entries in the jsonified dict will be the same here as when
@@ -45,6 +48,7 @@ def test_tracestate_computation(sentry_init):
     }
 
 
+@pytest.mark.xfail()  # TODO kmclb
 def test_adds_new_tracestate_to_transaction_when_none_given(sentry_init):
     sentry_init(
         dsn="https://dogsarebadatkeepingsecrets@squirrelchasers.ingest.sentry.io/12312012",


### PR DESCRIPTION
Three small changes here, mostly unrelated. Probably easiest to look at this commit by commit.

- Correct return type of `compute_tracestate_entry` to correctly return `None` when we're missing a client or DSN.

- Let transactions (effectively) point to themselves as the "containing transaction." In order to avoid a circular reference, this is handled through a new property on both spans and transactions. As a result of this change, we can eliminate a good deal of type-checking that we've been doing up until now.

- Switch `tracestate` creation to be lazy. Rather than always creating a value in the transaction constructor, we now wait until we need it - either for an outgoing HTTP header or for the envelope header when sending the transaction event. 