### PR TITLE
feat(tracing): Add user data/transaction name to tracestate value

### DIFF
--- a/sentry_sdk/tracing_utils.py
+++ b/sentry_sdk/tracing_utils.py
@@ -320,6 +320,9 @@ def compute_tracestate_entry(span):
             "public_key": Dsn(options["dsn"]).public_key,
         }
 
+        if span.containing_transaction:
+            data["transaction"] = span.containing_transaction.name
+
         return "sentry=" + compute_tracestate_value(data)
 
     return None

--- a/tests/tracing/test_http_headers.py
+++ b/tests/tracing/test_http_headers.py
@@ -46,6 +46,7 @@ def test_tracestate_computation(sentry_init):
         "environment": "dogpark",
         "release": "off.leash.park",
         "public_key": "dogsarebadatkeepingsecrets",
+        "transaction": "/interactions/other-dogs/new-dog",
     }
 
 

--- a/tests/tracing/test_http_headers.py
+++ b/tests/tracing/test_http_headers.py
@@ -26,6 +26,8 @@ def test_tracestate_computation(sentry_init):
         release="off.leash.park",
     )
 
+    sentry_sdk.set_user({"id": 12312013, "segment": "bigs"})
+
     transaction = Transaction(
         name="/interactions/other-dogs/new-dog",
         op="greeting.sniff",
@@ -46,6 +48,7 @@ def test_tracestate_computation(sentry_init):
         "environment": "dogpark",
         "release": "off.leash.park",
         "public_key": "dogsarebadatkeepingsecrets",
+        "user": {"id": 12312013, "segment": "bigs"},
         "transaction": "/interactions/other-dogs/new-dog",
     }
 


### PR DESCRIPTION
This adds user data (specifically `id` and `segment`) and transaction name to the `tracetate` value. 

Doing this has two known limitations, which, though we've discussed them, I'm adding here for posterity:

1) Adding this data puts us over the character limit for tracestate values [listed in the W3C spec](https://www.w3.org/TR/trace-context/#value) (256 characters). For reference:

    Tracestate data:

    ```
    {
        "trace_id": "12312012123120121231201212312012",
        "environment": "dogpark",
        "release": "off.leash.park",
        "public_key": "dogsarebadatkeepingsecrets",
        "user": {"id": 12312013, "segment": "bigs"},
        "transaction": "/interactions/other-dogs/new-dog/"
    }
    ```

    `tracestate`  with without either: 196 characters
    `tracestate` with user data: 256 characters
    `tracestate` with transaction name: 264 characters
    `tracestate` with both: 324 characters

2) This data may change and/or get added to the scope after the tracestate value has been calculated, making it impossible to sample based on those attributes. This is especially a problem for transaction name, which in some frameworks isn't set to its final value until the transaction ends. This poses the added problem that the transaction name in its raw, un-finalized form may contain PII, because it is often the raw URL as opposed to the parameterized one (so, `/users/maisey/tricks/` rather than `/users/:username/tricks/`). More work needs to be done to investigate whether the final transaction name can be set earlier in any/all of the frameworks where this poses a problem. (For instance, it is a known problem in our Express integration, but not yet clear if it is a problem in any Python frameworks.)