### PR TITLE
chore(ci): Update GHA jobs to run on `ubuntu-latest`

### DIFF
--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -4,12 +4,12 @@ on: push
 
 jobs:
   format:
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
-          python-version: '3.x'
+          python-version: "3.x"
 
       - name: Install Black
         run: pip install -r linter-requirements.txt

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
   dist:
     name: distribution packages
     timeout-minutes: 10
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v2
@@ -35,7 +35,7 @@ jobs:
   docs:
     timeout-minutes: 10
     name: build documentation
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-latest
 
     if: "startsWith(github.ref, 'refs/heads/release/')"
 
@@ -58,7 +58,7 @@ jobs:
 
   lint:
     timeout-minutes: 10
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v2
@@ -73,11 +73,10 @@ jobs:
   test:
     continue-on-error: true
     timeout-minutes: 45
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version:
-          ["2.7", "3.4", "3.5", "3.6", "3.7", "3.8", "3.9"]
+        python-version: ["2.7", "3.4", "3.5", "3.6", "3.7", "3.8", "3.9"]
 
     services:
       # Label used to access the service container

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,10 +73,18 @@ jobs:
   test:
     continue-on-error: true
     timeout-minutes: 45
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.linux-version }}
     strategy:
       matrix:
-        python-version: ["2.7", "3.4", "3.5", "3.6", "3.7", "3.8", "3.9"]
+        linux-version: [ubuntu-latest]
+        python-version: ["2.7", "3.5", "3.6", "3.7", "3.8", "3.9"]
+        include:
+          # GHA doesn't host the combo of python 3.4 and ubuntu-latest (which is
+          # currently 20.04), so run just that one under 18.04. (See
+          # https://raw.githubusercontent.com/actions/python-versions/main/versions-manifest.json
+          # for a listing of supported python/os combos.)
+          - linux-version: ubuntu-18.04
+            python-version: "3.4"
 
     services:
       # Label used to access the service container


### PR DESCRIPTION
GitHub is retiring `ubuntu-16.04` as a platform for GitHub Actions later this month.

![image](https://user-images.githubusercontent.com/14812505/131726210-38990cfa-3741-4f9e-9506-b0a7663e721d.png)

This moves all but our Python 3.4 tests to `ubuntu-latest` (which is currently `20.04`). GitHub doesn't host a `py3.4` binary on `latest`, so those tests are now run on `18.04`.