### PR TITLE
feat(transport): Client Report Support

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,4 @@
 {
-    "python.pythonPath": ".venv/bin/python"
+    "python.pythonPath": ".venv/bin/python",
+    "python.formatting.provider": "black"
 }

--- a/scripts/init_serverless_sdk.py
+++ b/scripts/init_serverless_sdk.py
@@ -51,16 +51,23 @@ class AWSLambdaModuleLoader:
             # Supported python versions are 2.7, 3.6, 3.7, 3.8
             if py_version >= (3, 5):
                 import importlib.util
-                spec = importlib.util.spec_from_file_location(module_name, module_file_path)
+
+                spec = importlib.util.spec_from_file_location(
+                    module_name, module_file_path
+                )
                 self.lambda_function_module = importlib.util.module_from_spec(spec)
                 spec.loader.exec_module(self.lambda_function_module)
             elif py_version[0] < 3:
                 import imp
-                self.lambda_function_module = imp.load_source(module_name, module_file_path)
+
+                self.lambda_function_module = imp.load_source(
+                    module_name, module_file_path
+                )
             else:
                 raise ValueError("Python version %s is not supported." % py_version)
         else:
             import importlib
+
             self.lambda_function_module = importlib.import_module(module_path)
 
     def get_lambda_handler(self):

--- a/sentry_sdk/_types.py
+++ b/sentry_sdk/_types.py
@@ -37,7 +37,14 @@ if MYPY:
     NotImplementedType = Any
 
     EventDataCategory = Literal[
-        "default", "error", "crash", "transaction", "security", "attachment", "session"
+        "default",
+        "error",
+        "crash",
+        "transaction",
+        "security",
+        "attachment",
+        "session",
+        "internal",
     ]
     SessionStatus = Literal["ok", "exited", "crashed", "abnormal"]
     EndpointType = Literal["store", "envelope"]

--- a/sentry_sdk/client.py
+++ b/sentry_sdk/client.py
@@ -200,6 +200,7 @@ class _Client(object):
                 new_event = before_send(event, hint or {})
             if new_event is None:
                 logger.info("before send dropped event (%s)", event)
+                self.tansport.record_lost_event("before_send")
             event = new_event  # type: ignore
 
         return event

--- a/sentry_sdk/client.py
+++ b/sentry_sdk/client.py
@@ -200,7 +200,7 @@ class _Client(object):
                 new_event = before_send(event, hint or {})
             if new_event is None:
                 logger.info("before send dropped event (%s)", event)
-                self.tansport.record_lost_event("before_send")
+                self.transport.record_lost_event("before_send")
             event = new_event  # type: ignore
 
         return event

--- a/sentry_sdk/client.py
+++ b/sentry_sdk/client.py
@@ -244,7 +244,8 @@ class _Client(object):
             and random.random() >= self.options["sample_rate"]
         ):
             # record a lost event if we did not sample this.
-            self.transport.record_lost_event("sample_rate", "error")
+            if self.transport:
+                self.transport.record_lost_event("sample_rate", "error")
             return False
 
         if self._is_ignored_error(event, hint):

--- a/sentry_sdk/client.py
+++ b/sentry_sdk/client.py
@@ -245,7 +245,7 @@ class _Client(object):
         ):
             # record a lost event if we did not sample this.
             if self.transport:
-                self.transport.record_lost_event("sample_rate", "error")
+                self.transport.record_lost_event("sample_rate", data_category="error")
             return False
 
         if self._is_ignored_error(event, hint):

--- a/sentry_sdk/client.py
+++ b/sentry_sdk/client.py
@@ -200,7 +200,6 @@ class _Client(object):
                 new_event = before_send(event, hint or {})
             if new_event is None:
                 logger.info("before send dropped event (%s)", event)
-                self.transport.record_lost_event("before_send")
             event = new_event  # type: ignore
 
         return event
@@ -244,6 +243,8 @@ class _Client(object):
             self.options["sample_rate"] < 1.0
             and random.random() >= self.options["sample_rate"]
         ):
+            # record a lost event if we did not sample this.
+            self.transport.record_lost_event("sample_rate", "error")
             return False
 
         if self._is_ignored_error(event, hint):

--- a/sentry_sdk/consts.py
+++ b/sentry_sdk/consts.py
@@ -75,6 +75,7 @@ class ClientConstructor(object):
         traces_sampler=None,  # type: Optional[TracesSampler]
         auto_enabling_integrations=True,  # type: bool
         auto_session_tracking=True,  # type: bool
+        send_client_reports=True,  # type: bool
         _experiments={},  # type: Experiments  # noqa: B006
     ):
         # type: (...) -> None

--- a/sentry_sdk/envelope.py
+++ b/sentry_sdk/envelope.py
@@ -236,6 +236,8 @@ class Item(object):
             return "transaction"
         elif ty == "event":
             return "error"
+        elif ty == "sdk_outcomes":
+            return "sdk_outcomes"
         else:
             return "default"
 

--- a/sentry_sdk/envelope.py
+++ b/sentry_sdk/envelope.py
@@ -236,7 +236,7 @@ class Item(object):
             return "transaction"
         elif ty == "event":
             return "error"
-        elif ty == "sdk_outcomes":
+        elif ty == "client_report":
             return "internal"
         else:
             return "default"

--- a/sentry_sdk/envelope.py
+++ b/sentry_sdk/envelope.py
@@ -237,7 +237,7 @@ class Item(object):
         elif ty == "event":
             return "error"
         elif ty == "sdk_outcomes":
-            return "sdk_outcomes"
+            return "internal"
         else:
             return "default"
 

--- a/sentry_sdk/envelope.py
+++ b/sentry_sdk/envelope.py
@@ -19,6 +19,7 @@ if MYPY:
 
 
 def parse_json(data):
+    # type: (Union[bytes, text_type]) -> Any
     # on some python 3 versions this needs to be bytes
     if not PY2 and isinstance(data, bytes):
         data = data.decode("utf-8", "replace")

--- a/sentry_sdk/tracing.py
+++ b/sentry_sdk/tracing.py
@@ -517,7 +517,7 @@ class Transaction(Span):
             # This is not entirely accurate because discards here are not
             # exclusively based on sample rate but also traces sampler, but
             # we handle this the same here.
-            if client:
+            if client and client.transport:
                 client.transport.record_lost_event("sample_rate", "transaction")
 
             return None

--- a/sentry_sdk/tracing.py
+++ b/sentry_sdk/tracing.py
@@ -518,7 +518,9 @@ class Transaction(Span):
             # exclusively based on sample rate but also traces sampler, but
             # we handle this the same here.
             if client and client.transport:
-                client.transport.record_lost_event("sample_rate", "transaction")
+                client.transport.record_lost_event(
+                    "sample_rate", data_category="transaction"
+                )
 
             return None
 

--- a/sentry_sdk/tracing.py
+++ b/sentry_sdk/tracing.py
@@ -507,13 +507,20 @@ class Transaction(Span):
             # This transaction is already finished, ignore.
             return None
 
+        hub = hub or self.hub or sentry_sdk.Hub.current
+        client = hub.client
+
         # This is a de facto proxy for checking if sampled = False
         if self._span_recorder is None:
             logger.debug("Discarding transaction because sampled = False")
-            return None
 
-        hub = hub or self.hub or sentry_sdk.Hub.current
-        client = hub.client
+            # This is not entirely accurate because discards here are not
+            # exclusively based on sample rate but also traces sampler, but
+            # we handle this the same here.
+            if client:
+                client.transport.record_lost_event("sample_rate", "transaction")
+
+            return None
 
         if client is None:
             # We have no client and therefore nowhere to send this transaction.

--- a/sentry_sdk/transport.py
+++ b/sentry_sdk/transport.py
@@ -274,9 +274,9 @@ class HttpTransport(Transport):
                 json={
                     "timestamp": time.time(),
                     "discarded_events": [
-                        (data_category, reason, quantity)
+                        {"reason": reason, "category": category, "quantity": quantity}
                         for (
-                            (data_category, reason),
+                            (category, reason),
                             quantity,
                         ) in discarded_events.items()
                     ],

--- a/sentry_sdk/transport.py
+++ b/sentry_sdk/transport.py
@@ -140,7 +140,7 @@ class HttpTransport(Transport):
 
         Transport.__init__(self, options)
         assert self.parsed_dsn is not None
-        self.options = options
+        self.options = options  # type: Dict[str, Any]
         self._worker = BackgroundWorker(queue_size=options["transport_queue_size"])
         self._auth = self.parsed_dsn.to_auth("sentry.python/%s" % VERSION)
         self._disabled_until = {}  # type: Dict[DataCategory, datetime]

--- a/sentry_sdk/transport.py
+++ b/sentry_sdk/transport.py
@@ -220,19 +220,31 @@ class HttpTransport(Transport):
         self.record_lost_event(reason)
 
     def _flush_stats(self, force=False):
-        if not (force or self._last_event_loss_sent is None or \
-            self._last_event_loss_sent < time.time() - 60):
+        if not (
+            force
+            or self._last_event_loss_sent is None
+            or self._last_event_loss_sent < time.time() - 60
+        ):
             return
         outcomes = self._event_loss_counters
         self._event_loss_counters = {}
 
         if outcomes:
-            self.capture_envelope(Envelope(
-                items=[Item(PayloadRef(json={
-                    "timestamp": time.time(),
-                    "outcomes": outcomes,
-                }), type="sdk_outomes")],
-            ))
+            self.capture_envelope(
+                Envelope(
+                    items=[
+                        Item(
+                            PayloadRef(
+                                json={
+                                    "timestamp": time.time(),
+                                    "outcomes": outcomes,
+                                }
+                            ),
+                            type="sdk_outomes",
+                        )
+                    ],
+                )
+            )
 
         self._last_event_loss_sent = time.time()
 

--- a/sentry_sdk/transport.py
+++ b/sentry_sdk/transport.py
@@ -176,7 +176,9 @@ class HttpTransport(Transport):
         if item is not None:
             data_category = item.data_category
             if data_category == "attachment":
-                quantity = len(item.get_bytes())
+                # quantity of 0 is actually 1 as we do not want to count
+                # empty attachments as actually empty.
+                quantity = len(item.get_bytes()) or 1
         elif data_category is None:
             raise TypeError("data category not provided")
 

--- a/sentry_sdk/transport.py
+++ b/sentry_sdk/transport.py
@@ -255,10 +255,9 @@ class HttpTransport(Transport):
 
         if not (
             force
-            or not discarded_events
             or self._last_event_loss_sent is None
             or self._last_event_loss_sent < time.time() - 60
-        ):
+        ) or not discarded_events:
             return
 
         self._discarded_events = defaultdict(int)

--- a/sentry_sdk/transport.py
+++ b/sentry_sdk/transport.py
@@ -253,11 +253,14 @@ class HttpTransport(Transport):
         # type: (bool) -> None
         discarded_events = self._discarded_events
 
-        if not (
-            force
-            or self._last_event_loss_sent is None
-            or self._last_event_loss_sent < time.time() - 60
-        ) or not discarded_events:
+        if (
+            not (
+                force
+                or self._last_event_loss_sent is None
+                or self._last_event_loss_sent < time.time() - 60
+            )
+            or not discarded_events
+        ):
             return
 
         self._discarded_events = defaultdict(int)

--- a/sentry_sdk/transport.py
+++ b/sentry_sdk/transport.py
@@ -262,12 +262,12 @@ class HttpTransport(Transport):
         # type: (str) -> None
         return None
 
-    def _fetch_pending_client_report(self, force=False):
-        # type: (bool) -> Optional[Item]
+    def _fetch_pending_client_report(self, force=False, interval=60):
+        # type: (bool, int) -> Optional[Item]
         if not self.options["send_client_reports"]:
             return None
 
-        if not (force or self._last_client_report_sent < time.time() - 60):
+        if not (force or self._last_client_report_sent < time.time() - interval):
             return None
 
         discarded_events = self._discarded_events
@@ -295,7 +295,7 @@ class HttpTransport(Transport):
 
     def _flush_client_reports(self, force=False):
         # type: (bool) -> None
-        client_report = self._fetch_pending_client_report(force=force)
+        client_report = self._fetch_pending_client_report(force=force, interval=60)
         if client_report is not None:
             self.capture_envelope(Envelope(items=[client_report]))
 
@@ -363,7 +363,7 @@ class HttpTransport(Transport):
         # can attach it to this enveloped scheduled for sending.  This will
         # currently typically attach the client report to the most recent
         # session update.
-        client_report_item = self._fetch_pending_client_report()
+        client_report_item = self._fetch_pending_client_report(interval=30)
         if client_report_item is not None:
             envelope.items.append(client_report_item)
 

--- a/tests/test_transport.py
+++ b/tests/test_transport.py
@@ -287,7 +287,7 @@ def test_data_category_limits_reporting(
     assert envelope.items[0].type == "event"
     assert envelope.items[1].type == "client_report"
     report = parse_json(envelope.items[1].get_bytes())
-    assert report["discarded_events"] == [
+    assert sorted(report["discarded_events"], key=lambda x: x["quantity"]) == [
         {"category": "transaction", "reason": "ratelimit_backoff", "quantity": 2},
         {"category": "attachment", "reason": "ratelimit_backoff", "quantity": 11},
     ]

--- a/tests/test_transport.py
+++ b/tests/test_transport.py
@@ -45,7 +45,7 @@ class CapturingServer(WSGIServer):
         request = Request(environ)
         event = envelope = None
         if request.mimetype == "application/json":
-            event = json.load(gzip.GzipFile(fileobj=io.BytesIO(request.data)))
+            event = json.loads(gzip.GzipFile(fileobj=io.BytesIO(request.data)).read())
         else:
             envelope = Envelope.deserialize_from(
                 gzip.GzipFile(fileobj=io.BytesIO(request.data))

--- a/tests/test_transport.py
+++ b/tests/test_transport.py
@@ -9,6 +9,7 @@ import io
 from datetime import datetime, timedelta
 
 import pytest
+from collections import namedtuple
 from werkzeug.wrappers import Request, Response
 
 from pytest_localserver.http import WSGIServer
@@ -19,11 +20,7 @@ from sentry_sdk.envelope import Envelope
 from sentry_sdk.integrations.logging import LoggingIntegration
 
 
-class CapturedData(object):
-    def __init__(self, path, event=None, envelope=None):
-        self.path = path
-        self.event = event
-        self.envelope = envelope
+CapturedData = namedtuple("CapturedData", ["path", "event", "envelope"])
 
 
 class CapturingServer(WSGIServer):

--- a/tests/test_transport.py
+++ b/tests/test_transport.py
@@ -2,7 +2,6 @@
 import time
 import logging
 import pickle
-import json
 import gzip
 import io
 

--- a/tests/test_transport.py
+++ b/tests/test_transport.py
@@ -16,7 +16,7 @@ from pytest_localserver.http import WSGIServer
 
 from sentry_sdk import Hub, Client, add_breadcrumb, capture_message, Scope
 from sentry_sdk.transport import _parse_rate_limits
-from sentry_sdk.envelope import Envelope
+from sentry_sdk.envelope import Envelope, parse_json
 from sentry_sdk.integrations.logging import LoggingIntegration
 
 
@@ -45,7 +45,7 @@ class CapturingServer(WSGIServer):
         request = Request(environ)
         event = envelope = None
         if request.mimetype == "application/json":
-            event = json.loads(gzip.GzipFile(fileobj=io.BytesIO(request.data)).read())
+            event = parse_json(gzip.GzipFile(fileobj=io.BytesIO(request.data)).read())
         else:
             envelope = Envelope.deserialize_from(
                 gzip.GzipFile(fileobj=io.BytesIO(request.data))

--- a/tests/test_transport.py
+++ b/tests/test_transport.py
@@ -276,7 +276,7 @@ def test_data_category_limits_reporting(
     envelope = capturing_server.captured[0].envelope
     assert envelope.items[0].type == "event"
     assert envelope.items[1].type == "client_report"
-    report = json.loads(envelope.items[1].get_bytes())
+    report = parse_json(envelope.items[1].get_bytes())
     assert report["discarded_events"] == [
         {"category": "transaction", "reason": "ratelimit_backoff", "quantity": 2},
         {"category": "attachment", "reason": "ratelimit_backoff", "quantity": 11},
@@ -296,7 +296,7 @@ def test_data_category_limits_reporting(
 
     envelope = capturing_server.captured[1].envelope
     assert envelope.items[0].type == "client_report"
-    report = json.loads(envelope.items[0].get_bytes())
+    report = parse_json(envelope.items[0].get_bytes())
     assert report["discarded_events"] == [
         {"category": "transaction", "reason": "ratelimit_backoff", "quantity": 1},
     ]

--- a/tests/test_transport.py
+++ b/tests/test_transport.py
@@ -136,9 +136,13 @@ def test_data_category_limits(
     client = make_client(send_client_reports=False)
 
     captured_outcomes = []
-    monkeypatch.setattr(
-        client.transport, "record_lost_event", lambda *x: captured_outcomes.append(x)
-    )
+
+    def record_lost_event(reason, data_category=None, item=None):
+        if data_category is None:
+            data_category = item.data_category
+        return captured_outcomes.append((reason, data_category))
+
+    monkeypatch.setattr(client.transport, "record_lost_event", record_lost_event)
 
     httpserver.serve_content(
         "hm",


### PR DESCRIPTION
This adds support for client reports to the python SDK. This will cause the SDK to send a report once every 30 seconds or once a minute. After 30 seconds it will attempt to attach the report to a scheduled envelope if there is one, after 60 seconds it will send it as a separate envelope. Attempts of sending are only made as a byproduct of attempted event / envelope sending or an explicit flush.

The feature can be turned off via the `send_client_reports` option which is on by default.

Refs: https://github.com/getsentry/relay/pull/1074