### PR TITLE
feat(tracing): Add tracestate feature flag

### DIFF
--- a/sentry_sdk/client.py
+++ b/sentry_sdk/client.py
@@ -22,7 +22,7 @@ from sentry_sdk.integrations import setup_integrations
 from sentry_sdk.utils import ContextVar
 from sentry_sdk.sessions import SessionFlusher
 from sentry_sdk.envelope import Envelope
-from sentry_sdk.tracing_utils import reinflate_tracestate
+from sentry_sdk.tracing_utils import has_tracestate_enabled, reinflate_tracestate
 
 from sentry_sdk._types import MYPY
 
@@ -349,7 +349,7 @@ class _Client(object):
             tracestate_data = raw_tracestate and reinflate_tracestate(
                 raw_tracestate.replace("sentry=", "")
             )
-            if tracestate_data:
+            if tracestate_data and has_tracestate_enabled():
                 headers["trace"] = tracestate_data
 
             envelope = Envelope(headers=headers)

--- a/sentry_sdk/consts.py
+++ b/sentry_sdk/consts.py
@@ -32,6 +32,7 @@ if MYPY:
             "max_spans": Optional[int],
             "record_sql_params": Optional[bool],
             "smart_transaction_trimming": Optional[bool],
+            "propagate_tracestate": Optional[bool],
         },
         total=False,
     )

--- a/sentry_sdk/tracing.py
+++ b/sentry_sdk/tracing.py
@@ -12,6 +12,7 @@ from sentry_sdk.tracing_utils import (
     compute_tracestate_entry,
     extract_sentrytrace_data,
     extract_tracestate_data,
+    has_tracestate_enabled,
     has_tracing_enabled,
     is_valid_sample_rate,
     maybe_create_breadcrumbs_from_span,
@@ -270,8 +271,10 @@ class Span(object):
         """
         yield "sentry-trace", self.to_traceparent()
 
-        tracestate = self.to_tracestate()
+        tracestate = self.to_tracestate() if has_tracestate_enabled(self) else None
         # `tracestate` will only be `None` if there's no client or no DSN
+        # TODO (kmclb) the above will be true once the feature is no longer
+        # behind a flag
         if tracestate:
             yield "tracestate", tracestate
 

--- a/sentry_sdk/tracing_utils.py
+++ b/sentry_sdk/tracing_utils.py
@@ -396,3 +396,12 @@ def _format_sql(cursor, sql):
         real_sql = None
 
     return real_sql or to_string(sql)
+
+
+def has_tracestate_enabled(span=None):
+    # type: (Optional[Span]) -> bool
+
+    client = ((span and span.hub) or sentry_sdk.Hub.current).client
+    options = client and client.options
+
+    return bool(options and options["_experiments"].get("propagate_tracestate"))

--- a/tests/tracing/test_misc.py
+++ b/tests/tracing/test_misc.py
@@ -2,6 +2,7 @@ import pytest
 
 from sentry_sdk import Hub, start_span, start_transaction
 from sentry_sdk.tracing import Span, Transaction
+from sentry_sdk.tracing_utils import has_tracestate_enabled
 
 
 def test_span_trimming(sentry_init, capture_events):
@@ -149,3 +150,19 @@ def test_finds_non_orphan_span_on_scope(sentry_init):
     assert scope._span is not None
     assert isinstance(scope._span, Span)
     assert scope._span.op == "sniffing"
+
+
+# TODO (kmclb) remove this test once tracestate is a real feature
+@pytest.mark.parametrize("tracestate_enabled", [True, False, None])
+def test_has_tracestate_enabled(sentry_init, tracestate_enabled):
+    experiments = (
+        {"propagate_tracestate": tracestate_enabled}
+        if tracestate_enabled is not None
+        else {}
+    )
+    sentry_init(_experiments=experiments)
+
+    if tracestate_enabled is True:
+        assert has_tracestate_enabled() is True
+    else:
+        assert has_tracestate_enabled() is False


### PR DESCRIPTION
This PR adds a feature flag, `"propagate_tracestate"`, to `_experiments`, which enables the tracestate header handling behavior. In particular, if the flag is `False` or missing:

- `tracestate` headers won't be attached to outgoing HTTP requests, and
- `trace` data will not be added to envelope headers.