### PR TITLE
fix(tracing): Break `transaction` / `span` circular references before garbage collection

### DIFF
--- a/sentry_sdk/tracing.py
+++ b/sentry_sdk/tracing.py
@@ -133,11 +133,12 @@ class Span(object):
 
         self._span_recorder = None  # type: Optional[_SpanRecorder]
 
+    # TODO this should really live on the Transaction class rather than the Span
+    # class
     def init_span_recorder(self, maxlen):
         # type: (int) -> None
         if self._span_recorder is None:
             self._span_recorder = _SpanRecorder(maxlen)
-        self._span_recorder.add(self)
 
     def __repr__(self):
         # type: () -> str
@@ -577,7 +578,7 @@ class Transaction(Span):
         finished_spans = [
             span.to_json()
             for span in self._span_recorder.spans
-            if span is not self and span.timestamp is not None
+            if span.timestamp is not None
         ]
 
         return hub.capture_event(

--- a/sentry_sdk/tracing.py
+++ b/sentry_sdk/tracing.py
@@ -200,9 +200,11 @@ class Span(object):
             **kwargs
         )
 
-        child._span_recorder = recorder = self._span_recorder
-        if recorder:
-            recorder.add(child)
+        span_recorder = (
+            self.containing_transaction and self.containing_transaction._span_recorder
+        )
+        if span_recorder:
+            span_recorder.add(child)
         return child
 
     def new_span(self, **kwargs):

--- a/sentry_sdk/tracing.py
+++ b/sentry_sdk/tracing.py
@@ -583,6 +583,12 @@ class Transaction(Span):
             if span.timestamp is not None
         ]
 
+        # we do this to break the circular reference of transaction -> span
+        # recorder -> span -> containing transaction (which is where we started)
+        # before either the spans or the transaction goes out of scope and has
+        # to be garbage collected
+        del self._span_recorder
+
         return hub.capture_event(
             {
                 "type": "transaction",

--- a/tests/integrations/sqlalchemy/test_sqlalchemy.py
+++ b/tests/integrations/sqlalchemy/test_sqlalchemy.py
@@ -189,7 +189,7 @@ def test_too_large_event_truncated(sentry_init, capture_events):
     assert len(json_dumps(event)) < max_bytes
 
     # Some spans are discarded.
-    assert len(event["spans"]) == 999
+    assert len(event["spans"]) == 1000
 
     # Some spans have their descriptions truncated. Because the test always
     # generates the same amount of descriptions and truncation is deterministic,
@@ -197,7 +197,7 @@ def test_too_large_event_truncated(sentry_init, capture_events):
     #
     # Which exact span descriptions are truncated depends on the span durations
     # of each SQL query and is non-deterministic.
-    assert len(event["_meta"]["spans"]) == 536
+    assert len(event["_meta"]["spans"]) == 537
 
     for i, span in enumerate(event["spans"]):
         description = span["description"]

--- a/tests/tracing/test_misc.py
+++ b/tests/tracing/test_misc.py
@@ -16,14 +16,12 @@ def test_span_trimming(sentry_init, capture_events):
 
     (event,) = events
 
-    # the transaction is its own first span (which counts for max_spans) but it
-    # doesn't show up in the span list in the event, so this is 1 less than our
-    # max_spans value
-    assert len(event["spans"]) == 2
+    assert len(event["spans"]) == 3
 
-    span1, span2 = event["spans"]
+    span1, span2, span3 = event["spans"]
     assert span1["op"] == "foo0"
     assert span2["op"] == "foo1"
+    assert span3["op"] == "foo2"
 
 
 def test_transaction_naming(sentry_init, capture_events):

--- a/tests/tracing/test_misc.py
+++ b/tests/tracing/test_misc.py
@@ -1,8 +1,15 @@
 import pytest
+import gc
 
+import sentry_sdk
 from sentry_sdk import Hub, start_span, start_transaction
 from sentry_sdk.tracing import Span, Transaction
 from sentry_sdk.tracing_utils import has_tracestate_enabled
+
+try:
+    from unittest import mock  # python 3.3 and above
+except ImportError:
+    import mock  # python < 3.3
 
 
 def test_span_trimming(sentry_init, capture_events):
@@ -148,6 +155,65 @@ def test_finds_non_orphan_span_on_scope(sentry_init):
     assert scope._span is not None
     assert isinstance(scope._span, Span)
     assert scope._span.op == "sniffing"
+
+
+def test_circular_references(monkeypatch, sentry_init, request):
+    # TODO: We discovered while writing this test about transaction/span
+    # reference cycles that there's actually also a circular reference in
+    # `serializer.py`, between the functions `_serialize_node` and
+    # `_serialize_node_impl`, both of which are defined inside of the main
+    # `serialize` function, and each of which calls the other one. For now, in
+    # order to avoid having those ref cycles give us a false positive here, we
+    # can mock out `serialize`. In the long run, though, we should probably fix
+    # that. (Whenever we do work on fixing it, it may be useful to add
+    #
+    #     gc.set_debug(gc.DEBUG_LEAK)
+    #     request.addfinalizer(lambda: gc.set_debug(~gc.DEBUG_LEAK))
+    #
+    # immediately after the initial collection below, so we can see what new
+    # objects the garbage collecter has to clean up once `transaction.finish` is
+    # called and the serializer runs.)
+    monkeypatch.setattr(
+        sentry_sdk.client,
+        "serialize",
+        mock.Mock(
+            return_value=None,
+        ),
+    )
+
+    gc.disable()
+    request.addfinalizer(gc.enable)
+
+    sentry_init(traces_sample_rate=1.0)
+
+    # Make sure that we're starting with a clean slate before we start creating
+    # transaction/span reference cycles
+    gc.collect()
+
+    dogpark_transaction = start_transaction(name="dogpark")
+    sniffing_span = dogpark_transaction.start_child(op="sniffing")
+    wagging_span = dogpark_transaction.start_child(op="wagging")
+
+    # At some point, you have to stop sniffing - there are balls to chase! - so finish
+    # this span while the dogpark transaction is still open
+    sniffing_span.finish()
+
+    # The wagging, however, continues long past the dogpark, so that span will
+    # NOT finish before the transaction ends. (Doing it in this order proves
+    # that both finished and unfinished spans get their cycles broken.)
+    dogpark_transaction.finish()
+
+    # Eventually you gotta sleep...
+    wagging_span.finish()
+
+    # assuming there are no cycles by this point, these should all be able to go
+    # out of scope and get their memory deallocated without the garbage
+    # collector having anything to do
+    del sniffing_span
+    del wagging_span
+    del dogpark_transaction
+
+    assert gc.collect() == 0
 
 
 # TODO (kmclb) remove this test once tracestate is a real feature


### PR DESCRIPTION
_Background for anyone not familiar with Python's internal workings (skip ahead if you that's not you):_

_Python handles memory deallocation through a combination of reference counting and cyclic garbage collection, the former taking way fewer resources than the latter. Having circular references forces the cyclic garbage collector to run, since anything involved in a reference cycle will never have a refcount of 0, even once everything _outside_ of the cycle is done with all of its members. The `gc` module used in the test mentioned below is a window specifically into the cyclic garbage collector part of the memory deallocation system, and its `collect` method returns the number of objects it was forced to deal with. See https://devguide.python.org/garbage_collector/ and https://docs.python.org/3/library/gc.html?highlight=gc#module-gc for more info._

-------

There are currently a few places in the SDK where we have circular references:

1) Transaction -> span recorder -> spans including transaction itself
2) Child span -> span recorder -> spans including child span itself
3) Transaction -> span recorder -> spans -> containing transaction
4) In `serializer.py`, `_serialize_node()` -> `_serialize_node_impl()` -> `_serialize_node()`, making each a closure for the other.

This PR addresses points 1-3*, by making the following changes:

1) Transaction -> span recorder -> spans ~including transaction itself~
    Transactions are no longer added to their own span recorders. (The SDK doesn't ever use the fact that they're there, and they're stripped out before the event is sent to Sentry.)

2) ~Child span ->~ span recorder -> spans including child span itself
    Child spans no longer have their own span recorder pointer, and instead access the recorder through their containing transaction.

3) Transaction ~-> span recorder -> spans -> containing transaction~
    When a transaction ends, after it harvests any completed spans, it now jettisons its link to its span recorder before it (the transaction) goes out of scope.

It also adds to/modifies tests covering all three scenarios

\*Point 4, which we only discovered in the process of fixing 1-3, concerns a different system than the rest, and therefore will need to be fixed in a separate PR. (h/t @untitaker for tracking this down to the serializer)