### PR TITLE
fix: no longer set the last event id for transactions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ sentry-sdk==0.10.1
 
 A major release `N` implies the previous release `N-1` will no longer receive updates. We generally do not backport bugfixes to older versions unless they are security relevant. However, feel free to ask for backports of specific commits on the bugtracker.
 
+## Unreleased
+
+- No longer set the last event id for transactions #1186
+
 ## 1.3.1
 
 - Fix detection of contextvars compatibility with Gevent versions >=20.9.0 #1157

--- a/sentry_sdk/hub.py
+++ b/sentry_sdk/hub.py
@@ -318,8 +318,9 @@ class Hub(with_metaclass(HubMeta)):  # type: ignore
         client, top_scope = self._stack[-1]
         scope = _update_scope(top_scope, scope, scope_args)
         if client is not None:
+            is_transaction = event.get("type") == "transaction"
             rv = client.capture_event(event, hint, scope)
-            if rv is not None:
+            if rv is not None and not is_transaction:
                 self._last_event_id = rv
             return rv
         return None

--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -71,6 +71,11 @@ def test_event_id(sentry_init, capture_events):
     assert last_event_id() == event_id
     assert Hub.current.last_event_id() == event_id
 
+    new_event_id = Hub.current.capture_event({"type": "transaction"})
+    assert new_event_id is not None
+    assert new_event_id != event_id
+    assert Hub.current.last_event_id() == event_id
+
 
 def test_option_callback(sentry_init, capture_events):
     drop_events = False


### PR DESCRIPTION
This fixes the logic to not set the last event id for transactions which was not intended.