### PR TITLE
feat: disable client reports by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ A major release `N` implies the previous release `N-1` will no longer receive up
 ## Unreleased
 
 - No longer set the last event id for transactions #1186
-- Added support for client reports #1181
+- Added support for client reports (disabled by default for now) #1181
 
 ## 1.3.1
 

--- a/sentry_sdk/consts.py
+++ b/sentry_sdk/consts.py
@@ -76,7 +76,7 @@ class ClientConstructor(object):
         traces_sampler=None,  # type: Optional[TracesSampler]
         auto_enabling_integrations=True,  # type: bool
         auto_session_tracking=True,  # type: bool
-        send_client_reports=True,  # type: bool
+        send_client_reports=False,  # type: bool
         _experiments={},  # type: Experiments  # noqa: B006
     ):
         # type: (...) -> None


### PR DESCRIPTION
Since we don't do beta releases in this SDK turn this of for one release so we can test this before enabling it by default.