### PR TITLE
misc(test): Dont run tests on -dev branches and add latest versions of Django and Flask

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ A major release `N` implies the previous release `N-1` will no longer receive up
 - No longer set the last event id for transactions #1186
 - Added support for client reports (disabled by default for now) #1181
 - Added `tracestate` header handling #1179
+- Added real ip detection to asgi integration #1199
 
 ## 1.3.1
 

--- a/tox.ini
+++ b/tox.ini
@@ -24,13 +24,11 @@ envlist =
     {pypy,py2.7,py3.5}-django-{1.8,1.9,1.10}
     {pypy,py2.7}-django-{1.8,1.9,1.10,1.11}
     {py3.5,py3.6,py3.7}-django-{2.0,2.1}
-    {py3.7,py3.8,py3.9}-django-{2.2,3.0,3.1}
-    {py3.8,py3.9}-django-dev
+    {py3.7,py3.8,py3.9}-django-{2.2,3.0,3.1,3.2}
 
     {pypy,py2.7,py3.4,py3.5,py3.6,py3.7,py3.8,py3.9}-flask-{0.10,0.11,0.12,1.0}
     {pypy,py2.7,py3.5,py3.6,py3.7,py3.8,py3.9}-flask-1.1
-
-    {py3.7,py3.8,py3.9}-flask-dev
+    {py3.6,py3.8,py3.9}-flask-2.0
 
     {pypy,py2.7,py3.5,py3.6,py3.7,py3.8,py3.9}-bottle-0.12
 
@@ -48,7 +46,7 @@ envlist =
     {pypy,py2.7,py3.5,py3.6,py3.7,py3.8}-celery-{4.3,4.4}
     {py3.6,py3.7,py3.8}-celery-5.0
 
-    {py2.7,py3.7}-beam-{2.12,2.13}
+    py3.7-beam-{2.12,2.13}
 
     # The aws_lambda tests deploy to the real AWS and have their own matrix of Python versions.
     py3.7-aws_lambda
@@ -94,20 +92,16 @@ deps =
     # with the -r flag
     -r test-requirements.txt
 
-    django-{1.11,2.0,2.1,2.2,3.0,3.1,dev}: djangorestframework>=3.0.0,<4.0.0
+    django-{1.11,2.0,2.1,2.2,3.0,3.1,3.2}: djangorestframework>=3.0.0,<4.0.0
 
-    {py3.7,py3.8,py3.9}-django-{1.11,2.0,2.1,2.2,3.0,3.1}: channels>2
-    {py3.8,py3.9}-django-dev: channels>2
-    {py3.7,py3.8,py3.9}-django-{1.11,2.0,2.1,2.2,3.0,3.1}: pytest-asyncio
-    {py3.8,py3.9}-django-dev: pytest-asyncio
-    {py2.7,py3.7,py3.8,py3.9}-django-{1.11,2.2,3.0,3.1}: psycopg2-binary
-    {py2.7,py3.8,py3.9}-django-dev: psycopg2-binary
+    {py3.7,py3.8,py3.9}-django-{1.11,2.0,2.1,2.2,3.0,3.1,3.2}: channels>2
+    {py3.7,py3.8,py3.9}-django-{1.11,2.0,2.1,2.2,3.0,3.1,3.2}: pytest-asyncio
+    {py2.7,py3.7,py3.8,py3.9}-django-{1.11,2.2,3.0,3.1,3.2}: psycopg2-binary
 
     django-{1.6,1.7}: pytest-django<3.0
     django-{1.8,1.9,1.10,1.11,2.0,2.1}: pytest-django<4.0
-    django-{2.2,3.0,3.1}: pytest-django>=4.0
-    django-{2.2,3.0,3.1}: Werkzeug<2.0
-    django-dev: git+https://github.com/pytest-dev/pytest-django#egg=pytest-django
+    django-{2.2,3.0,3.1,3.2}: pytest-django>=4.0
+    django-{2.2,3.0,3.1,3.2}: Werkzeug<2.0
 
     django-1.6: Django>=1.6,<1.7
     django-1.7: Django>=1.7,<1.8
@@ -120,7 +114,6 @@ deps =
     django-2.2: Django>=2.2,<2.3
     django-3.0: Django>=3.0,<3.1
     django-3.1: Django>=3.1,<3.2
-    django-dev: git+https://github.com/django/django.git#egg=Django
 
     flask: flask-login
     flask-0.10: Flask>=0.10,<0.11
@@ -128,12 +121,9 @@ deps =
     flask-0.12: Flask>=0.12,<0.13
     flask-1.0: Flask>=1.0,<1.1
     flask-1.1: Flask>=1.1,<1.2
-
-    flask-dev: git+https://github.com/pallets/flask.git#egg=flask
-    flask-dev: git+https://github.com/pallets/werkzeug.git#egg=werkzeug
+    flask-2.0: Flask>=2.0,<2.1
 
     bottle-0.12: bottle>=0.12,<0.13
-    bottle-dev: git+https://github.com/bottlepy/bottle#egg=bottle
 
     falcon-1.4: falcon>=1.4,<1.5
     falcon-2.0: falcon>=2.0.0rc3,<3.0
@@ -148,7 +138,6 @@ deps =
     sanic: aiohttp
     py3.5-sanic: ujson<4
 
-    py2.7-beam: rsa<=4.0
     beam-2.12: apache-beam>=2.12.0, <2.13.0
     beam-2.13: apache-beam>=2.13.0, <2.14.0
     beam-master: git+https://github.com/apache/beam#egg=apache-beam&subdirectory=sdks/python


### PR DESCRIPTION
I'm not fully convinced that we should run everything on the latest branches.
It can be noisy and block our release process, while providing is with nothing else than a warning that upstream might be broken.