### PR TITLE
ci(release): Use the latest version of publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
           token: ${{ secrets.GH_RELEASE_PAT }}
           fetch-depth: 0
       - name: Prepare release
-        uses: getsentry/action-prepare-release@v1.1
+        uses: getsentry/action-prepare-release@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GH_RELEASE_PAT }}
         with:


### PR DESCRIPTION
Upgrade to latest version of `getsentry/action-prepare-release` (from 1.1 to 1.3+)

Noticed getsentry/publish#556 is using the old version of our release action so bumping it here.