### PR TITLE
fix(tracing): Fix race condition between finish and start_child

### DIFF
--- a/sentry_sdk/tracing.py
+++ b/sentry_sdk/tracing.py
@@ -586,7 +586,7 @@ class Transaction(Span):
         # recorder -> span -> containing transaction (which is where we started)
         # before either the spans or the transaction goes out of scope and has
         # to be garbage collected
-        del self._span_recorder
+        self._span_recorder = None
 
         return hub.capture_event(
             {


### PR DESCRIPTION
In `__exit__` method, we call `self.finish` first, and then we restore the previous span to the scope. Because of that, in some circumstances, it can happen, that `start_child` will be called on the Transaction which `_span_recorder` has been already deleted from the instance, making the call below blow up without a proper check.

In our case, we performed db calls through our options cache inside the custom transport - https://github.com/getsentry/sentry/blob/14dc81c124e4ab4d86967c14e44a7bb8af8ca742/src/sentry/utils/sdk.py#L278-L280