### PR TITLE
fix: Ensure that an envelope is cloned before it's modified

### DIFF
--- a/sentry_sdk/transport.py
+++ b/sentry_sdk/transport.py
@@ -356,7 +356,10 @@ class HttpTransport(Transport):
             else:
                 new_items.append(item)
 
-        envelope.items[:] = new_items
+        # Since we're modifying the envelope here make a copy so that others
+        # that hold references do not see their envelope modified.
+        envelope = Envelope(headers=envelope.headers, items=new_items)
+
         if not envelope.items:
             return None
 


### PR DESCRIPTION
Previously the envelope was modified in place which meant that an envelope could not be easily sent to multiple transports. Now the http transport makes a copy of the envelope before modifying it.