### PR TITLE
Refactor Sanic integration for v21.9 support

### DIFF
--- a/sentry_sdk/integrations/sanic.py
+++ b/sentry_sdk/integrations/sanic.py
@@ -125,10 +125,10 @@ class SanicIntegration(Integration):
 
         old_error_handler_lookup = ErrorHandler.lookup
 
-        def sentry_error_handler_lookup(self, exception):
+        def sentry_error_handler_lookup(self, exception, *args, **kwargs):
             # type: (Any, Exception) -> Optional[object]
             _capture_exception(exception)
-            old_error_handler = old_error_handler_lookup(self, exception)
+            old_error_handler = old_error_handler_lookup(self, exception, *args, **kwargs)
 
             if old_error_handler is None:
                 return None

--- a/sentry_sdk/integrations/sanic.py
+++ b/sentry_sdk/integrations/sanic.py
@@ -42,6 +42,7 @@ old_handle_request = Sanic.handle_request
 old_router_get = Router.get
 old_startup = Sanic._startup
 
+
 class SanicIntegration(Integration):
     identifier = "sanic"
 
@@ -83,6 +84,7 @@ class SanicIntegration(Integration):
 
         _setup_sanic()
 
+
 class SanicRequestExtractor(RequestExtractor):
     def content_length(self):
         # type: () -> int
@@ -118,14 +120,17 @@ class SanicRequestExtractor(RequestExtractor):
         # type: (Any) -> int
         return len(file.body or ())
 
+
 def _setup_sanic():
     Sanic._startup = _startup
     ErrorHandler.lookup = _sentry_error_handler_lookup
+
 
 def _setup_legacy_sanic():
     Sanic.handle_request = _legacy_handle_request
     Router.get = _legacy_router_get
     ErrorHandler.lookup = _sentry_error_handler_lookup
+
 
 async def _startup(self):
     # This happens about as early in the lifecycle as possible, just after the
@@ -147,7 +152,9 @@ async def _startup(self):
 
 async def _hub_enter(request):
     hub = Hub.current
-    request.ctx._sentry_do_integration = hub.get_integration(SanicIntegration) is not None
+    request.ctx._sentry_do_integration = (
+        hub.get_integration(SanicIntegration) is not None
+    )
 
     if not request.ctx._sentry_do_integration:
         return
@@ -172,6 +179,7 @@ async def _set_transaction(request, route, **kwargs):
             with hub.configure_scope() as scope:
                 route_name = route.name.replace(request.app.name, "").strip(".")
                 scope.transaction = route_name
+
 
 def _sentry_error_handler_lookup(self, exception, *args, **kwargs):
     # type: (Any, Exception, *Any, **Any) -> Optional[object]
@@ -206,6 +214,7 @@ def _sentry_error_handler_lookup(self, exception, *args, **kwargs):
 
     return sentry_wrapped_error_handler
 
+
 async def _legacy_handle_request(self, request, *args, **kwargs):
     # type: (Any, Request, *Any, **Any) -> Any
     hub = Hub.current
@@ -224,6 +233,7 @@ async def _legacy_handle_request(self, request, *args, **kwargs):
             response = await response
 
         return response
+
 
 def _legacy_router_get(self, *args):
     # type: (Any, Union[Any, Request]) -> Any

--- a/sentry_sdk/integrations/sanic.py
+++ b/sentry_sdk/integrations/sanic.py
@@ -46,7 +46,7 @@ try:
     # This method was introduced in Sanic v21.9
     old_startup = Sanic._startup
 except AttributeError:
-    ...
+    pass
 
 
 class SanicIntegration(Integration):

--- a/sentry_sdk/integrations/sanic.py
+++ b/sentry_sdk/integrations/sanic.py
@@ -50,7 +50,7 @@ except AttributeError:
 
 class SanicIntegration(Integration):
     identifier = "sanic"
-    version: Tuple[int, ...] = (0, 0)
+    version = (0, 0)  # type: Tuple[int, ...]
 
     @staticmethod
     def setup_once():

--- a/tests/integrations/sanic/test_sanic.py
+++ b/tests/integrations/sanic/test_sanic.py
@@ -6,7 +6,7 @@ import asyncio
 import pytest
 
 from sentry_sdk import capture_message, configure_scope
-from sentry_sdk.integrations.sanic import SanicIntegration, _hub_enter
+from sentry_sdk.integrations.sanic import SanicIntegration
 
 from sanic import Sanic, request, response, __version__ as SANIC_VERSION_RAW
 from sanic.response import HTTPResponse
@@ -200,7 +200,9 @@ def test_concurrency(sentry_init, app):
 
             if SANIC_VERSION >= (21, 9):
                 await app.dispatch(
-                    "http.lifecycle.request", context={"request": patched_request}, inline=True,
+                    "http.lifecycle.request",
+                    context={"request": patched_request},
+                    inline=True,
                 )
 
             await app.handle_request(

--- a/tests/integrations/sanic/test_sanic.py
+++ b/tests/integrations/sanic/test_sanic.py
@@ -173,6 +173,7 @@ def test_concurrency(sentry_init, app):
             kwargs["app"] = app
 
         if SANIC_VERSION >= (21, 3):
+
             class MockAsyncStreamer:
                 def __init__(self, request_body):
                     self.request_body = request_body
@@ -198,7 +199,9 @@ def test_concurrency(sentry_init, app):
             patched_request.stream = MockAsyncStreamer([b"hello", b"foo"])
 
             if SANIC_VERSION >= (21, 9):
-                await app.dispatch("http.lifecycle.request", context={"request": patched_request})
+                await app.dispatch(
+                    "http.lifecycle.request", context={"request": patched_request}
+                )
 
             await app.handle_request(
                 patched_request,

--- a/tests/integrations/sanic/test_sanic.py
+++ b/tests/integrations/sanic/test_sanic.py
@@ -200,7 +200,7 @@ def test_concurrency(sentry_init, app):
 
             if SANIC_VERSION >= (21, 9):
                 await app.dispatch(
-                    "http.lifecycle.request", context={"request": patched_request}
+                    "http.lifecycle.request", context={"request": patched_request}, inline=True,
                 )
 
             await app.handle_request(
@@ -226,7 +226,7 @@ def test_concurrency(sentry_init, app):
                     app.router.finalize()
                 except AttributeError:
                     ...
-        await asyncio.gather(*(task(i) for i in range(10)))
+        await asyncio.gather(*(task(i) for i in range(1000)))
 
     if sys.version_info < (3, 7):
         loop = asyncio.new_event_loop()


### PR DESCRIPTION
This PR allows for Sanic v21.9 style error handlers to operate and provide full access to handling Blueprint specific error handlers.

---

> The ErrorHandler.lookup now requires two positional arguments:

[Source](https://sanicframework.org/en/guide/release-notes/v21.9.html#what-to-know)

See also: https://github.com/sanic-org/sanic/pull/2259

---

_UPDATE_: 
Fixes https://github.com/getsentry/sentry-python/issues/1240
Fixes https://github.com/sanic-org/sanic/issues/2250