### PR TITLE
feat(aws-lambda): Add Python 3.9 support

### DIFF
--- a/.craft.yml
+++ b/.craft.yml
@@ -21,6 +21,7 @@ targets:
           - python3.6
           - python3.7
           - python3.8
+          - python3.9
     license: MIT
 changelog: CHANGELOG.md
 changelogPolicy: simple

--- a/sentry_sdk/integrations/aws_lambda.py
+++ b/sentry_sdk/integrations/aws_lambda.py
@@ -284,11 +284,13 @@ def get_lambda_bootstrap():
     # Python 3.7: If the bootstrap module is *already imported*, it is the
     # one we actually want to use (no idea what's in __main__)
     #
-    # On Python 3.8 bootstrap is also importable, but will be the same file
+    # Python 3.8: bootstrap is also importable, but will be the same file
     # as __main__ imported under a different name:
     #
     #     sys.modules['__main__'].__file__ == sys.modules['bootstrap'].__file__
     #     sys.modules['__main__'] is not sys.modules['bootstrap']
+    #
+    # Python 3.9: bootstrap is in __main__.awslambdaricmain
     #
     # On container builds using the `aws-lambda-python-runtime-interface-client`
     # (awslamdaric) module, bootstrap is located in sys.modules['__main__'].bootstrap
@@ -297,10 +299,18 @@ def get_lambda_bootstrap():
     if "bootstrap" in sys.modules:
         return sys.modules["bootstrap"]
     elif "__main__" in sys.modules:
-        if hasattr(sys.modules["__main__"], "bootstrap"):
+        module = sys.modules["__main__"]
+        # python3.9 runtime
+        if hasattr(module, "awslambdaricmain") and hasattr(
+            module.awslambdaricmain, "bootstrap"  # type: ignore
+        ):
+            return module.awslambdaricmain.bootstrap  # type: ignore
+        elif hasattr(module, "bootstrap"):
             # awslambdaric python module in container builds
-            return sys.modules["__main__"].bootstrap  # type: ignore
-        return sys.modules["__main__"]
+            return module.bootstrap  # type: ignore
+
+        # python3.8 runtime
+        return module
     else:
         return None
 

--- a/tests/integrations/aws_lambda/test_aws.py
+++ b/tests/integrations/aws_lambda/test_aws.py
@@ -105,7 +105,9 @@ def lambda_client():
     return get_boto_client()
 
 
-@pytest.fixture(params=["python3.6", "python3.7", "python3.8", "python2.7"])
+@pytest.fixture(
+    params=["python3.6", "python3.7", "python3.8", "python3.9", "python2.7"]
+)
 def lambda_runtime(request):
     return request.param
 


### PR DESCRIPTION
- Added AWS Lambda Python 3.9 runtime support
- Ignore mypy module check
- Fixed check bug and added python3.9 runtime to tests
- Revert comment
- run black on aws_lambda.py and test
- add python3.9 as compatible runtime in .craft.yml
