### PR TITLE
build(craft): Remove Python 2.7 support for AWS Lambda layers

### DIFF
--- a/.craft.yml
+++ b/.craft.yml
@@ -18,7 +18,6 @@ targets:
         # On the other hand, AWS Lambda does not support every Python runtime.
         # The supported runtimes are available in the following link:
         # https://docs.aws.amazon.com/lambda/latest/dg/lambda-python.html
-          - python2.7
           - python3.6
           - python3.7
           - python3.8


### PR DESCRIPTION
From [AWS docs](https://docs.aws.amazon.com/lambda/latest/dg/lambda-python.html):

> End of support for the Python 2.7 runtime started on July 15, 2021.

Since Python 2.7 is no longer supported, there's no point in having it as a compatible runtime for the created layers. Removing this version means new layers created by Craft on releases won't have it as a compatible runtime; so it doesn't affect existing layers.