### PR TITLE
fix #1163

### DIFF
--- a/sentry_sdk/utils.py
+++ b/sentry_sdk/utils.py
@@ -792,7 +792,7 @@ def _is_contextvars_broken():
         from gevent.monkey import is_object_patched  # type: ignore
 
         # Get the MAJOR and MINOR version numbers of Gevent
-        version_tuple = tuple([int(part) for part in gevent.__version__.split(".")[:2]])
+        version_tuple = tuple([int(part) for part in re.split(r"a|b|rc|\.", gevent.__version__)[:2]])
         if is_object_patched("threading", "local"):
             # Gevent 20.9.0 depends on Greenlet 0.4.17 which natively handles switching
             # context vars when greenlets are switched, so, Gevent 20.9.0+ is all fine.


### PR DESCRIPTION
Fix #1163.  It parse correctly versions like "20.1a2"  