### PR TITLE
record span and breadcrumb when Django opens db connection

### DIFF
--- a/sentry_sdk/integrations/django/__init__.py
+++ b/sentry_sdk/integrations/django/__init__.py
@@ -481,7 +481,12 @@ def install_sql_hook():
     except ImportError:
         from django.db.backends.util import CursorWrapper
 
-    from django.db.backends.base.base import BaseDatabaseWrapper
+    try:
+        # django 1.6 and 1.7 compatability
+        from django.db.backends import BaseDatabaseWrapper
+    except ImportError:
+        # django 1.8 or later
+        from django.db.backends.base.base import BaseDatabaseWrapper
 
     try:
         real_execute = CursorWrapper.execute

--- a/tests/integrations/django/myapp/urls.py
+++ b/tests/integrations/django/myapp/urls.py
@@ -47,6 +47,7 @@ urlpatterns = [
     path("template-exc", views.template_exc, name="template_exc"),
     path("template-test", views.template_test, name="template_test"),
     path("template-test2", views.template_test2, name="template_test2"),
+    path("postgres-select", views.postgres_select, name="postgres_select"),
     path(
         "permission-denied-exc",
         views.permission_denied_exc,

--- a/tests/integrations/django/myapp/views.py
+++ b/tests/integrations/django/myapp/views.py
@@ -128,6 +128,15 @@ def template_test2(request, *args, **kwargs):
 
 
 @csrf_exempt
+def postgres_select(request, *args, **kwargs):
+    from django.db import connections
+
+    cursor = connections["postgres"].cursor()
+    cursor.execute("SELECT 1;")
+    return HttpResponse("ok")
+
+
+@csrf_exempt
 def permission_denied_exc(*args, **kwargs):
     raise PermissionDenied("bye")
 

--- a/tests/integrations/django/test_basic.py
+++ b/tests/integrations/django/test_basic.py
@@ -425,7 +425,7 @@ def test_django_connect_trace(sentry_init, client, capture_events, render_span_t
     events = capture_events()
 
     content, status, headers = client.get(reverse("postgres_select"))
-    assert status == '200 OK'
+    assert status == "200 OK"
 
     assert '- op="db": description="connect"' in render_span_tree(events[0])
 

--- a/tests/integrations/django/test_basic.py
+++ b/tests/integrations/django/test_basic.py
@@ -1,7 +1,5 @@
 from __future__ import absolute_import
 
-from django.shortcuts import render
-
 import pytest
 import pytest_django
 import json

--- a/tests/integrations/django/test_basic.py
+++ b/tests/integrations/django/test_basic.py
@@ -424,8 +424,8 @@ def test_django_connect_trace(sentry_init, client, capture_events, render_span_t
 
     events = capture_events()
 
-    res = client.get(reverse("postgres_select"))
-    assert res.status_code == 200
+    content, status, headers = client.get(reverse("postgres_select"))
+    assert status == '200 OK'
 
     assert '- op="db": description="connect"' in render_span_tree(events[0])
 

--- a/tests/integrations/django/test_basic.py
+++ b/tests/integrations/django/test_basic.py
@@ -402,6 +402,7 @@ def test_sql_psycopg2_placeholders(sentry_init, capture_events):
     ]
 
 
+@pytest.mark.forked
 @pytest_mark_django_db_decorator(transaction=True)
 def test_django_connect_trace(sentry_init, client, capture_events, render_span_tree):
     """
@@ -429,6 +430,7 @@ def test_django_connect_trace(sentry_init, client, capture_events, render_span_t
     assert '- op="db": description="connect"' in render_span_tree(events[0])
 
 
+@pytest.mark.forked
 @pytest_mark_django_db_decorator(transaction=True)
 def test_django_connect_breadcrumbs(
     sentry_init, client, capture_events, render_span_tree


### PR DESCRIPTION
Here's a screenshot of a trace where Django opens a new connection

<img width="400" alt="Screen Shot 2021-11-14 at 9 04 39 PM" src="https://user-images.githubusercontent.com/1929960/141710982-4f9926dc-c386-4a04-9089-aa7b85d142df.png">

fixes #1249