### PR TITLE
fix(tests): Pin more-itertools in tests for Python 3.5 compat

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -302,6 +302,9 @@ commands =
     {py3.5,py3.6,py3.7,py3.8,py3.9}-flask-{0.10,0.11,0.12}: pip install pytest<5
     {py3.6,py3.7,py3.8,py3.9}-flask-{0.11}: pip install Werkzeug<2
 
+    ; https://github.com/more-itertools/more-itertools/issues/578
+    py3.5-flask-{0.10,0.11,0.12}: pip install more-itertools<8.11.0
+
     py.test {env:TESTPATH} {posargs}
 
 [testenv:linters]


### PR DESCRIPTION
Version 8.11.0 of more-itertools drops Python 3.5 support. This pins
the library to <8.11.0 so that we still run tests.