### PR TITLE
Patch eventlet under Sentry SDK

### DIFF
--- a/sentry_sdk/utils.py
+++ b/sentry_sdk/utils.py
@@ -871,13 +871,7 @@ def _get_contextvars():
                 pass
         else:
             # On Python 3.7 contextvars are functional.
-            try:
-                from contextvars import ContextVar
-
-                return True, ContextVar
-            except ImportError:
-                pass
-            # For eventlet
+            # Special check for eventlet
             try:
                 import eventlet  # type: ignore
                 from eventlet.patcher import is_monkey_patched  # type: ignore
@@ -886,6 +880,14 @@ def _get_contextvars():
                     return True, contextvars.ContextVar
             except ImportError:
                 pass
+            
+            try:
+                from contextvars import ContextVar
+
+                return True, ContextVar
+            except ImportError:
+                pass
+
 
     # Fall back to basic thread-local usage.
 

--- a/sentry_sdk/utils.py
+++ b/sentry_sdk/utils.py
@@ -813,9 +813,12 @@ def _is_contextvars_broken():
         pass
 
     try:
+        import greenlet
         from eventlet.patcher import is_monkey_patched  # type: ignore
 
         if is_monkey_patched("thread"):
+        version_tuple = tuple([int(part) for part in greenlet.__version__.split(".")[:2]])
+        if is_monkey_patched("thread") and version_tuple < (0, 5):
             return True
     except ImportError:
         pass
@@ -872,6 +875,15 @@ def _get_contextvars():
                 from contextvars import ContextVar
 
                 return True, ContextVar
+            except ImportError:
+                pass
+            # For eventlet
+            try:
+                import eventlet  # type: ignore
+                from eventlet.patcher import is_monkey_patched  # type: ignore
+                if is_monkey_patched('thread'):
+                    contextvars = eventlet.import_patched('contextvars')
+                    return True, contextvars.ContextVar
             except ImportError:
                 pass
 


### PR DESCRIPTION
This patches the eventlet library to allow it to run without issues under the Sentry SDK when using `gevent>=0.5`. Eventlet doesn't pin the `greenlet` dependency and [greenlet has been supporting contextvars for some time now](https://github.com/eventlet/eventlet/issues/663) (that's why the sdk runs nicely under Gevent for example). So, the eventlet library itself is not a good marker to whatever the contextvars are broken or not.

This should fix #1036