### PR TITLE
CHANGELOG: update requirements example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,8 @@ We recommend to pin your version requirements against `1.x.*` or `1.x.y`.
 Either one of the following is fine:
 
 ```
-sentry-sdk>=0.10.0,<0.11.0
-sentry-sdk==0.10.1
+sentry-sdk>=1.0.0,<2.0.0
+sentry-sdk==1.5.0
 ```
 
 A major release `N` implies the previous release `N-1` will no longer receive updates. We generally do not backport bugfixes to older versions unless they are security relevant. However, feel free to ask for backports of specific commits on the bugtracker.


### PR DESCRIPTION
To match at least a > 1.0.0 world as the description