### PR TITLE
fix(client-reports): Record lost `sample_rate` events only if tracing is enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ A major release `N` implies the previous release `N-1` will no longer receive up
 ## Unreleased
 
 - Fix django legacy url resolver regex substitution due to upstream CVE-2021-44420 fix #1272
+- Record lost `sample_rate` events only if tracing is enabled
 
 ## 1.5.0
 

--- a/sentry_sdk/tracing_utils.py
+++ b/sentry_sdk/tracing_utils.py
@@ -109,7 +109,7 @@ def has_tracing_enabled(options):
     # type: (Dict[str, Any]) -> bool
     """
     Returns True if either traces_sample_rate or traces_sampler is
-    non-zero/defined, False otherwise.
+    defined, False otherwise.
     """
 
     return bool(

--- a/tests/tracing/test_sampling.py
+++ b/tests/tracing/test_sampling.py
@@ -287,12 +287,12 @@ def test_warns_and_sets_sampled_to_false_on_invalid_traces_sampler_return_value(
 
 
 @pytest.mark.parametrize(
-        "traces_sample_rate,sampled_output,reports_output",
-        [
-            (None, False, []),
-            (0.0, False, [("sample_rate", "transaction")]),
-            (1.0, True, []),
-        ],
+    "traces_sample_rate,sampled_output,reports_output",
+    [
+        (None, False, []),
+        (0.0, False, [("sample_rate", "transaction")]),
+        (1.0, True, []),
+    ],
 )
 def test_records_lost_event_only_if_traces_sample_rate_enabled(
     sentry_init, traces_sample_rate, sampled_output, reports_output, monkeypatch
@@ -316,12 +316,12 @@ def test_records_lost_event_only_if_traces_sample_rate_enabled(
 
 
 @pytest.mark.parametrize(
-        "traces_sampler,sampled_output,reports_output",
-        [
-            (None, False, []),
-            (lambda _x: 0.0, False, [("sample_rate", "transaction")]),
-            (lambda _x: 1.0, True, []),
-        ],
+    "traces_sampler,sampled_output,reports_output",
+    [
+        (None, False, []),
+        (lambda _x: 0.0, False, [("sample_rate", "transaction")]),
+        (lambda _x: 1.0, True, []),
+    ],
 )
 def test_records_lost_event_only_if_traces_sampler_enabled(
     sentry_init, traces_sampler, sampled_output, reports_output, monkeypatch

--- a/tests/tracing/test_sampling.py
+++ b/tests/tracing/test_sampling.py
@@ -309,7 +309,7 @@ def test_records_lost_event_only_if_traces_sample_rate_enabled(
     )
 
     transaction = start_transaction(name="dogpark")
-    assert transaction.sampled == sampled_output
+    assert transaction.sampled is sampled_output
     transaction.finish()
 
     assert reports == reports_output
@@ -338,7 +338,7 @@ def test_records_lost_event_only_if_traces_sampler_enabled(
     )
 
     transaction = start_transaction(name="dogpark")
-    assert transaction.sampled == sampled_output
+    assert transaction.sampled is sampled_output
     transaction.finish()
 
     assert reports == reports_output

--- a/tests/tracing/test_sampling.py
+++ b/tests/tracing/test_sampling.py
@@ -285,8 +285,11 @@ def test_warns_and_sets_sampled_to_false_on_invalid_traces_sampler_return_value(
         logger.warning.assert_any_call(StringContaining("Given sample rate is invalid"))
         assert transaction.sampled is False
 
+
 @pytest.mark.parametrize("traces_sample_rate", [None, 0.0, 1.0])
-def test_records_lost_event_only_if_tracing_enabled(sentry_init, traces_sample_rate, monkeypatch):
+def test_records_lost_event_only_if_tracing_enabled(
+    sentry_init, traces_sample_rate, monkeypatch
+):
     reports = []
     sampled = traces_sample_rate == 1.0
     dropped = traces_sample_rate == 0.0


### PR DESCRIPTION
Spurious client report outcomes were recorded before even if `traces_sample_rate` and `traces_sampler` were both `None` in the config.

Fixes https://getsentry.atlassian.net/browse/WEB-279