### PR TITLE
fix(django): Fix django legacy url resolver regex substitution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ A major release `N` implies the previous release `N-1` will no longer receive up
 
 ## Unreleased
 
+- Fix django legacy url resolver regex substitution due to upstream CVE-2021-44420 fix #1272
+
 ## 1.5.0
 
 - Also record client outcomes for before send #1211

--- a/sentry_sdk/integrations/django/transactions.py
+++ b/sentry_sdk/integrations/django/transactions.py
@@ -76,6 +76,8 @@ class RavenResolver(object):
             result.replace("^", "")
             .replace("$", "")
             .replace("?", "")
+            .replace("\\A", "")
+            .replace("\\Z", "")
             .replace("//", "/")
             .replace("\\", "")
         )

--- a/tox.ini
+++ b/tox.ini
@@ -114,6 +114,7 @@ deps =
     django-2.2: Django>=2.2,<2.3
     django-3.0: Django>=3.0,<3.1
     django-3.1: Django>=3.1,<3.2
+    django-3.2: Django>=3.1,<3.3
 
     flask: flask-login
     flask-0.10: Flask>=0.10,<0.11


### PR DESCRIPTION
Upstream django [CVE fix](https://github.com/django/django/compare/2.2.24...2.2.25#diff-ecd72d5e5c6a5496735ace4b936d519f89699baff8d932b908de0b598c58f662L233) caused master tests to fail.
This patches our url resolver regex substition to account for \A and \Z metacharacters.
