### PR TITLE
feat(client-reports): Record event_processor client reports

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -39,7 +39,6 @@ except ImportError:
     def benchmark():
         return lambda x: x()
 
-
 else:
     del pytest_benchmark
 
@@ -239,6 +238,26 @@ def capture_envelopes(monkeypatch):
         monkeypatch.setattr(test_client.transport, "capture_event", append_event)
         monkeypatch.setattr(test_client.transport, "capture_envelope", append_envelope)
         return envelopes
+
+    return inner
+
+
+@pytest.fixture
+def capture_client_reports(monkeypatch):
+    def inner():
+        reports = []
+        test_client = sentry_sdk.Hub.current.client
+        old_record_lost_event = test_client.transport.record_lost_event
+
+        def record_lost_event(reason, data_category=None, item=None):
+            if data_category is None:
+                data_category = item.data_category
+            return reports.append((reason, data_category))
+
+        monkeypatch.setattr(
+            test_client.transport, "record_lost_event", record_lost_event
+        )
+        return reports
 
     return inner
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -39,6 +39,7 @@ except ImportError:
     def benchmark():
         return lambda x: x()
 
+
 else:
     del pytest_benchmark
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -248,7 +248,6 @@ def capture_client_reports(monkeypatch):
     def inner():
         reports = []
         test_client = sentry_sdk.Hub.current.client
-        old_record_lost_event = test_client.transport.record_lost_event
 
         def record_lost_event(reason, data_category=None, item=None):
             if data_category is None:

--- a/tests/integrations/gcp/test_gcp.py
+++ b/tests/integrations/gcp/test_gcp.py
@@ -81,6 +81,9 @@ def init_sdk(timeout_warning=False, **extra_init_args):
         transport=TestTransport,
         integrations=[GcpIntegration(timeout_warning=timeout_warning)],
         shutdown_timeout=10,
+        # excepthook -> dedupe -> event_processor client report gets added
+        # which we don't really care about for these tests
+        send_client_reports=False,
         **extra_init_args
     )
 

--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -20,7 +20,10 @@ from sentry_sdk import (
 from sentry_sdk._compat import reraise
 from sentry_sdk.integrations import _AUTO_ENABLING_INTEGRATIONS
 from sentry_sdk.integrations.logging import LoggingIntegration
-from sentry_sdk.scope import add_global_event_processor, global_event_processors # noqa: F401
+from sentry_sdk.scope import (
+    add_global_event_processor,
+    global_event_processors,
+)  # noqa: F401
 
 
 def test_processors(sentry_init, capture_events):

--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -1,6 +1,5 @@
 import os
 import sys
-import copy
 import logging
 
 import pytest
@@ -21,7 +20,7 @@ from sentry_sdk import (
 from sentry_sdk._compat import reraise
 from sentry_sdk.integrations import _AUTO_ENABLING_INTEGRATIONS
 from sentry_sdk.integrations.logging import LoggingIntegration
-from sentry_sdk.scope import add_global_event_processor, global_event_processors
+from sentry_sdk.scope import add_global_event_processor, global_event_processors # noqa: F401
 
 
 def test_processors(sentry_init, capture_events):
@@ -396,7 +395,7 @@ def test_dedupe_event_processor_drop_records_client_report(
         try:
             capture_exception()
             reraise(*sys.exc_info())
-        except:
+        except Exception:
             capture_exception()
 
     (event,) = events
@@ -422,7 +421,7 @@ def test_event_processor_drop_records_client_report(
 
     capture_message("dropped")
 
-    with start_transaction(name="dropped") as transaction:
+    with start_transaction(name="dropped") as _transaction:
         pass
 
     assert len(events) == 0

--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -20,10 +20,10 @@ from sentry_sdk import (
 from sentry_sdk._compat import reraise
 from sentry_sdk.integrations import _AUTO_ENABLING_INTEGRATIONS
 from sentry_sdk.integrations.logging import LoggingIntegration
-from sentry_sdk.scope import (
+from sentry_sdk.scope import (  # noqa: F401
     add_global_event_processor,
     global_event_processors,
-)  # noqa: F401
+)
 
 
 def test_processors(sentry_init, capture_events):
@@ -424,7 +424,7 @@ def test_event_processor_drop_records_client_report(
 
     capture_message("dropped")
 
-    with start_transaction(name="dropped") as _transaction:
+    with start_transaction(name="dropped"):
         pass
 
     assert len(events) == 0

--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -1,5 +1,6 @@
 import os
 import sys
+import copy
 import logging
 
 import pytest
@@ -18,9 +19,9 @@ from sentry_sdk import (
 )
 
 from sentry_sdk._compat import reraise
-from sentry_sdk.scope import add_global_event_processor
 from sentry_sdk.integrations import _AUTO_ENABLING_INTEGRATIONS
 from sentry_sdk.integrations.logging import LoggingIntegration
+from sentry_sdk.scope import add_global_event_processor, global_event_processors
 
 
 def test_processors(sentry_init, capture_events):
@@ -413,6 +414,8 @@ def test_event_processor_drop_records_client_report(
     events = capture_events()
     reports = capture_client_reports()
 
+    global global_event_processors
+
     @add_global_event_processor
     def foo(event, hint):
         return None
@@ -424,3 +427,5 @@ def test_event_processor_drop_records_client_report(
 
     assert len(events) == 0
     assert reports == [("event_processor", "error"), ("event_processor", "transaction")]
+
+    global_event_processors.pop()


### PR DESCRIPTION
Record client reports of `event_processor` type when dropped.

Closes https://github.com/getsentry/sentry-python/issues/1210
and https://getsentry.atlassian.net/browse/WEB-341
