### PR TITLE
Support Celery abstract tasks

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -59,3 +59,5 @@ ignore_missing_imports = True
 [mypy-sentry_sdk._queue]
 ignore_missing_imports = True
 disallow_untyped_defs = False
+[mypy-celery.app.trace]
+ignore_missing_imports = True

--- a/sentry_sdk/integrations/celery.py
+++ b/sentry_sdk/integrations/celery.py
@@ -30,6 +30,7 @@ try:
         Ignore,
         Reject,
     )
+    from celery.app.trace import task_has_custom
 except ImportError:
     raise DidNotEnable("Celery not installed")
 
@@ -57,10 +58,12 @@ class CeleryIntegration(Integration):
         def sentry_build_tracer(name, task, *args, **kwargs):
             # type: (Any, Any, *Any, **Any) -> Any
             if not getattr(task, "_sentry_is_patched", False):
-                # Need to patch both methods because older celery sometimes
-                # short-circuits to task.run if it thinks it's safe.
-                task.__call__ = _wrap_task_call(task, task.__call__)
-                task.run = _wrap_task_call(task, task.run)
+                # determine whether Celery will use __call__ or run and patch
+                # accordingly
+                if task_has_custom(task, "__call__"):
+                    type(task).__call__ = _wrap_task_call(task, type(task).__call__)
+                else:
+                    task.run = _wrap_task_call(task, task.run)
 
                 # `build_tracer` is apparently called for every task
                 # invocation. Can't wrap every celery task for every invocation

--- a/tests/integrations/celery/test_celery.py
+++ b/tests/integrations/celery/test_celery.py
@@ -425,7 +425,7 @@ def test_abstract_task(capture_events, celery, celery_invocation):
     def dummy_task(x, y):
         return x / y
 
-    with start_transaction() as transaction:
+    with start_transaction():
         celery_invocation(dummy_task, 1, 0)
 
     assert not events


### PR DESCRIPTION
I have a use case for Celery [abstract
tasks](https://docs.celeryproject.org/en/latest/userguide/application.html#abstract-tasks)
to handle exceptions for an entire Celery app in a common way. Handled
exceptions should be swallowed in the abstract task and never make it to
Sentry.

Prior to this change, the Celery integration always instruments
`task.run` and incorrectly instruments `task.__call__` (`task(...)` is
equivalent to `type(task).__call__(...)`, not `task.__call__(...)`).
After this change, we'll use the same logic as Celery to decide whether
to instrument `task.__call__` or `task.run`. That change allows abstract
tasks to catch/raise exceptions before the Sentry wrapper.