### PR TITLE
Sanic v21.12 support

### DIFF
--- a/sentry_sdk/integrations/sanic.py
+++ b/sentry_sdk/integrations/sanic.py
@@ -222,7 +222,7 @@ def _sentry_error_handler_lookup(self, exception, *args, **kwargs):
         finally:
             # As mentioned in previous comment in _startup, this can be removed
             # after https://github.com/sanic-org/sanic/issues/2297 is resolved
-            if SanicIntegration.version >= (21, 9):
+            if SanicIntegration.version == (21, 9):
                 await _hub_exit(request)
 
     return sentry_wrapped_error_handler

--- a/tests/integrations/sanic/test_sanic.py
+++ b/tests/integrations/sanic/test_sanic.py
@@ -91,7 +91,7 @@ def test_bad_request_not_captured(sentry_init, app, capture_events):
 
     @app.route("/")
     def index(request):
-        raise SanicException(status_code=400)
+        raise SanicException("...", status_code=400)
 
     request, response = app.test_client.get("/")
     assert response.status == 400


### PR DESCRIPTION
The previous version of the SDK had a workaround for v21.9. That is no longer needed in v21.12 and should not be triggered. By doing so, it calls the `__exit__` method of the `Hub` twice causing the error in #1290.

Ref https://github.com/sanic-org/sanic/issues/2297
Closes #1290 