### PR TITLE
feat(django): Pick custom urlconf up from request if any

### DIFF
--- a/sentry_sdk/integrations/django/__init__.py
+++ b/sentry_sdk/integrations/django/__init__.py
@@ -338,8 +338,7 @@ def _before_get_response(request):
                 )
             elif integration.transaction_style == "url":
                 scope.transaction = LEGACY_RESOLVER.resolve(
-                    request.path_info,
-                    getattr(request, 'urlconf', None)
+                    request.path_info, getattr(request, "urlconf", None)
                 )
         except Exception:
             pass

--- a/sentry_sdk/integrations/django/__init__.py
+++ b/sentry_sdk/integrations/django/__init__.py
@@ -338,7 +338,8 @@ def _before_get_response(request):
                 )
             elif integration.transaction_style == "url":
                 scope.transaction = LEGACY_RESOLVER.resolve(
-                    request.path_info, getattr(request, "urlconf", None)
+                    request.path_info,
+                    urlconf=getattr(request, "urlconf", None),
                 )
         except Exception:
             pass

--- a/sentry_sdk/integrations/django/__init__.py
+++ b/sentry_sdk/integrations/django/__init__.py
@@ -337,7 +337,10 @@ def _before_get_response(request):
                     getattr(fn, "view_class", fn)
                 )
             elif integration.transaction_style == "url":
-                scope.transaction = LEGACY_RESOLVER.resolve(request.path_info)
+                scope.transaction = LEGACY_RESOLVER.resolve(
+                    request.path_info,
+                    getattr(request, 'urlconf', None)
+                )
         except Exception:
             pass
 

--- a/sentry_sdk/integrations/django/__init__.py
+++ b/sentry_sdk/integrations/django/__init__.py
@@ -337,10 +337,7 @@ def _before_get_response(request):
                     getattr(fn, "view_class", fn)
                 )
             elif integration.transaction_style == "url":
-                scope.transaction = LEGACY_RESOLVER.resolve(
-                    request.path_info,
-                    urlconf=getattr(request, "urlconf", None),
-                )
+                scope.transaction = LEGACY_RESOLVER.resolve(request.path_info)
         except Exception:
             pass
 

--- a/sentry_sdk/integrations/django/middleware.py
+++ b/sentry_sdk/integrations/django/middleware.py
@@ -179,8 +179,7 @@ def _wrap_middleware(middleware, middleware_name):
                 request = args[0]
                 if isinstance(request, WSGIRequest) and hasattr(request, "urlconf"):
                     span.containing_transaction.name = LEGACY_RESOLVER.resolve(
-                        request.path_info,
-                        request.urlconf
+                        request.path_info, request.urlconf
                     )
 
                 return rv

--- a/tests/integrations/django/myapp/custom_urls.py
+++ b/tests/integrations/django/myapp/custom_urls.py
@@ -1,0 +1,31 @@
+"""myapp URL Configuration
+
+The `urlpatterns` list routes URLs to views. For more information please see:
+    https://docs.djangoproject.com/en/2.0/topics/http/urls/
+Examples:
+Function views
+    1. Add an import:  from my_app import views
+    2. Add a URL to urlpatterns:  path('', views.home, name='home')
+Class-based views
+    1. Add an import:  from other_app.views import Home
+    2. Add a URL to urlpatterns:  path('', Home.as_view(), name='home')
+Including another URLconf
+    1. Import the include() function: from django.urls import include, path
+    2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
+"""
+from __future__ import absolute_import
+
+try:
+    from django.urls import path
+except ImportError:
+    from django.conf.urls import url
+
+    def path(path, *args, **kwargs):
+        return url("^{}$".format(path), *args, **kwargs)
+
+
+from . import views
+
+urlpatterns = [
+    path("custom/ok", views.custom_ok, name="custom_ok"),
+]

--- a/tests/integrations/django/myapp/middleware.py
+++ b/tests/integrations/django/myapp/middleware.py
@@ -1,19 +1,31 @@
-import asyncio
-from django.utils.decorators import sync_and_async_middleware
+import django
+
+if django.VERSION >= (3, 0):
+    import asyncio
+    from django.utils.decorators import sync_and_async_middleware
 
 
-@sync_and_async_middleware
-def simple_middleware(get_response):
-    if asyncio.iscoroutinefunction(get_response):
+    @sync_and_async_middleware
+    def simple_middleware(get_response):
+        if asyncio.iscoroutinefunction(get_response):
 
-        async def middleware(request):
-            response = await get_response(request)
-            return response
+            async def middleware(request):
+                response = await get_response(request)
+                return response
 
-    else:
+        else:
 
-        def middleware(request):
-            response = get_response(request)
-            return response
+            def middleware(request):
+                response = get_response(request)
+                return response
+
+        return middleware
+
+
+def custom_urlconf_middleware(get_response):
+    def middleware(request):
+        request.urlconf = "tests.integrations.django.myapp.custom_urls"
+        response = get_response(request)
+        return response
 
     return middleware

--- a/tests/integrations/django/myapp/middleware.py
+++ b/tests/integrations/django/myapp/middleware.py
@@ -1,6 +1,6 @@
 import django
 
-if django.VERSION >= (3, 0):
+if django.VERSION >= (3, 1):
     import asyncio
     from django.utils.decorators import sync_and_async_middleware
 

--- a/tests/integrations/django/myapp/middleware.py
+++ b/tests/integrations/django/myapp/middleware.py
@@ -4,7 +4,6 @@ if django.VERSION >= (3, 0):
     import asyncio
     from django.utils.decorators import sync_and_async_middleware
 
-
     @sync_and_async_middleware
     def simple_middleware(get_response):
         if asyncio.iscoroutinefunction(get_response):

--- a/tests/integrations/django/myapp/views.py
+++ b/tests/integrations/django/myapp/views.py
@@ -121,6 +121,11 @@ def template_test(request, *args, **kwargs):
 
 
 @csrf_exempt
+def custom_ok(request, *args, **kwargs):
+    return HttpResponse("custom ok")
+
+
+@csrf_exempt
 def template_test2(request, *args, **kwargs):
     return TemplateResponse(
         request, ("user_name.html", "another_template.html"), {"user_age": 25}

--- a/tests/integrations/django/test_basic.py
+++ b/tests/integrations/django/test_basic.py
@@ -757,6 +757,7 @@ def test_csrf(sentry_init, client):
     assert b"".join(content) == b"ok"
 
 
+@pytest.mark.skipif(DJANGO_VERSION < (2, 0), reason="Requires Django > 2.0")
 def test_custom_urlconf_middleware(
     settings, sentry_init, client, capture_events, render_span_tree
 ):

--- a/tests/integrations/django/test_basic.py
+++ b/tests/integrations/django/test_basic.py
@@ -778,4 +778,4 @@ def test_custom_urlconf_middleware(
 
     (event,) = events
     assert event["transaction"] == "/custom/ok"
-    assert "custom_urlconf_middleware" in render_span_tree(events[0])
+    assert "custom_urlconf_middleware" in render_span_tree(event)

--- a/tests/integrations/django/test_basic.py
+++ b/tests/integrations/django/test_basic.py
@@ -780,3 +780,5 @@ def test_custom_urlconf_middleware(
     (event,) = events
     assert event["transaction"] == "/custom/ok"
     assert "custom_urlconf_middleware" in render_span_tree(event)
+
+    settings.MIDDLEWARE.pop(0)

--- a/tests/integrations/django/test_basic.py
+++ b/tests/integrations/django/test_basic.py
@@ -755,3 +755,27 @@ def test_csrf(sentry_init, client):
     content, status, _headers = client.post(reverse("message"))
     assert status.lower() == "200 ok"
     assert b"".join(content) == b"ok"
+
+
+def test_custom_urlconf_middleware(
+    settings, sentry_init, client, capture_events, render_span_tree
+):
+    """
+    Some middlewares (for instance in django-tenants) overwrite request.urlconf.
+    Test that the resolver picks up the correct urlconf for transaction naming.
+    """
+    urlconf = "tests.integrations.django.myapp.middleware.custom_urlconf_middleware"
+    settings.ROOT_URLCONF = ""
+    settings.MIDDLEWARE.insert(0, urlconf)
+    client.application.load_middleware()
+
+    sentry_init(integrations=[DjangoIntegration()], traces_sample_rate=1.0)
+    events = capture_events()
+
+    content, status, _headers = client.get("/custom/ok")
+    assert status.lower() == "200 ok"
+    assert b"".join(content) == b"custom ok"
+
+    (event,) = events
+    assert event["transaction"] == "/custom/ok"
+    assert "custom_urlconf_middleware" in render_span_tree(events[0])


### PR DESCRIPTION
## Premise
Django middlewares sometimes [can override `request.urlconf`](https://github.com/django-tenants/django-tenants/blob/eee77af68004745ed104b63ed69995789e3a6b32/django_tenants/middleware/main.py#L73) for the current request which it has a [contract](https://github.com/django/django/blob/main/django/core/handlers/base.py#L283-L288) for using subsequently as the source of truth for url related operations.

As a result, we also need to respect the overwritten `urlconf` in our transaction name resolving.

## Solution

I finally went with an `_after_get_response` solution. The resolution is repeated code but runs only if `urlconf` is overwritten. I wanted to touch as little of existing logic as possible.

For reference, I went back and forth several times between doing it in a couple of other places.
* [`_before_get_response`](https://github.com/getsentry/sentry-python/blob/f92e9707ea73765eb9fdcf6482dc46aed4221a7a/sentry_sdk/integrations/django/__init__.py#L340) - this doesn't work because it runs before all the django middlewares
* [middleware wrapping](https://github.com/getsentry/sentry-python/blob/f92e9707ea73765eb9fdcf6482dc46aed4221a7a/sentry_sdk/integrations/django/middleware.py#L172) - this feels clunky since the new code block would run on every middleware invocation


## Problem
One of our customers have a `django-tenants` [multi-tenant setup](https://django-tenants.readthedocs.io/en/latest/use.html#multi-types-tenants). They have a dynamically resolved `urlconf` and set `ROOT_URLCONF` to an empty string which [breaks this `get_resolver`](https://github.com/django/django/blob/main/django/urls/resolvers.py#L83) in Django.

This results in a silent exception when we try to [update the transaction name](https://github.com/getsentry/sentry-python/blob/2e18af218996cf9214c124457bc384976ed02921/sentry_sdk/integrations/django/__init__.py#L347) and hence they see `Generic WSGI request` for all their requests.

## References

* https://docs.djangoproject.com/en/4.0/topics/http/urls/#how-django-processes-a-request
* https://docs.djangoproject.com/en/4.0/topics/http/middleware/
* https://getsentry.atlassian.net/browse/WEB-530