### PR TITLE
adds basic validation to environment name

### DIFF
--- a/sentry_sdk/transport.py
+++ b/sentry_sdk/transport.py
@@ -56,7 +56,9 @@ class Transport(object):
             self.parsed_dsn = Dsn(options["dsn"])
         else:
             self.parsed_dsn = None
-        assert isinstance(options.get("environment"), (str,type(None))), "Environment name should be a string"
+        assert isinstance(
+            options.get("environment"), (str, type(None))
+        ), "Environment name should be a string"
 
     def capture_event(
         self, event  # type: Event

--- a/sentry_sdk/transport.py
+++ b/sentry_sdk/transport.py
@@ -56,6 +56,7 @@ class Transport(object):
             self.parsed_dsn = Dsn(options["dsn"])
         else:
             self.parsed_dsn = None
+        assert isinstance(options.get("environment"), (str,type(None))), "Environment name should be a string"
 
     def capture_event(
         self, event  # type: Event


### PR DESCRIPTION
Made a typo while initialising sentry sdk in one of the code changes. Instead of setting environment to `environment=value`, we accidentally set it to `environment={value}`. Which resulted in environment's value being a set. This caused downtime for us when the code was deployed 😅

So added a basic validation for environment name in this PR so that the module will give error during initialization if a string is not passed. 

```py
sentry_patched_wsgi_handler
    return SentryWsgiMiddleware(bound_old_app, use_x_forwarded_for)(
  File "/home/ubuntu/backend/venv/lib/python3.9/site-packages/sentry_sdk/integrations/wsgi.py", line 140, in __call__
    reraise(*_capture_exception(hub))
  File "/usr/lib/python3.9/contextlib.py", line 124, in __exit__
    next(self.gen)
  File "/home/ubuntu/backend/venv/lib/python3.9/site-packages/sentry_sdk/sessions.py", line 46, in auto_session_tracking
    hub.end_session()
  File "/home/ubuntu/backend/venv/lib/python3.9/site-packages/sentry_sdk/hub.py", line 651, in end_session
    client.capture_session(session)
  File "/home/ubuntu/backend/venv/lib/python3.9/site-packages/sentry_sdk/client.py", line 384, in capture_session
    self.session_flusher.add_session(session)
  File "/home/ubuntu/backend/venv/lib/python3.9/site-packages/sentry_sdk/sessions.py", line 160, in add_session
    self.add_aggregate_session(session)
  File "/home/ubuntu/backend/venv/lib/python3.9/site-packages/sentry_sdk/sessions.py", line 139, in add_aggregate_session
    states = self.pending_aggregates.setdefault(primary_key, {})
TypeError: unhashable type: 'set'
```