### PR TITLE
fix(python): Capture only 5xx HTTP errors in Falcon Integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ sentry-sdk==1.5.0
 
 A major release `N` implies the previous release `N-1` will no longer receive updates. We generally do not backport bugfixes to older versions unless they are security relevant. However, feel free to ask for backports of specific commits on the bugtracker.
 
+## 1.5.3
+
+- Pick up custom urlconf set by Django middlewares from request if any (#1308)
+
 ## 1.5.2
 
 - Record event_processor client reports #1281

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -29,7 +29,7 @@ project = u"sentry-python"
 copyright = u"2019, Sentry Team and Contributors"
 author = u"Sentry Team and Contributors"
 
-release = "1.5.2"
+release = "1.5.3"
 version = ".".join(release.split(".")[:2])  # The short X.Y version.
 
 

--- a/sentry_sdk/consts.py
+++ b/sentry_sdk/consts.py
@@ -101,7 +101,7 @@ DEFAULT_OPTIONS = _get_default_options()
 del _get_default_options
 
 
-VERSION = "1.5.2"
+VERSION = "1.5.3"
 SDK_INFO = {
     "name": "sentry.python",
     "version": VERSION,

--- a/sentry_sdk/integrations/falcon.py
+++ b/sentry_sdk/integrations/falcon.py
@@ -188,8 +188,12 @@ def _patch_prepare_middleware():
 
 def _exception_leads_to_http_5xx(ex):
     # type: (BaseException) -> bool
-    server_error = isinstance(ex, falcon.HTTPError) and (ex.status or '').startswith('5')
-    unhandled_error = not isinstance(ex, (falcon.HTTPError, falcon.http_status.HTTPStatus))
+    server_error = isinstance(ex, falcon.HTTPError) and (ex.status or "").startswith(
+        "5"
+    )
+    unhandled_error = not isinstance(
+        ex, (falcon.HTTPError, falcon.http_status.HTTPStatus)
+    )
     return server_error or unhandled_error
 
 

--- a/sentry_sdk/integrations/falcon.py
+++ b/sentry_sdk/integrations/falcon.py
@@ -188,7 +188,6 @@ def _patch_prepare_middleware():
 
 def _exception_leads_to_http_5xx(ex):
     # type: (BaseException) -> bool
-
     server_error = isinstance(ex, falcon.HTTPError) and (ex.status or '').startswith('5')
     unhandled_error = not isinstance(ex, (falcon.HTTPError, falcon.http_status.HTTPStatus))
     return server_error or unhandled_error

--- a/sentry_sdk/integrations/falcon.py
+++ b/sentry_sdk/integrations/falcon.py
@@ -153,7 +153,7 @@ def _patch_handle_exception():
         hub = Hub.current
         integration = hub.get_integration(FalconIntegration)
 
-        if integration is not None and not _is_falcon_http_error(ex):
+        if integration is not None and _exception_leads_to_http_5xx(ex):
             # If an integration is there, a client has to be there.
             client = hub.client  # type: Any
 
@@ -186,9 +186,12 @@ def _patch_prepare_middleware():
     falcon.api_helpers.prepare_middleware = sentry_patched_prepare_middleware
 
 
-def _is_falcon_http_error(ex):
+def _exception_leads_to_http_5xx(ex):
     # type: (BaseException) -> bool
-    return isinstance(ex, (falcon.HTTPError, falcon.http_status.HTTPStatus))
+
+    server_error = isinstance(ex, falcon.HTTPError) and (ex.status or '').startswith('5')
+    unhandled_error = not isinstance(ex, (falcon.HTTPError, falcon.http_status.HTTPStatus))
+    return server_error or unhandled_error
 
 
 def _make_request_event_processor(req, integration):

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ def get_file_text(file_name):
 
 setup(
     name="sentry-sdk",
-    version="1.5.2",
+    version="1.5.3",
     author="Sentry Team and Contributors",
     author_email="hello@sentry.io",
     url="https://github.com/getsentry/sentry-python",

--- a/tests/integrations/django/myapp/custom_urls.py
+++ b/tests/integrations/django/myapp/custom_urls.py
@@ -1,0 +1,31 @@
+"""myapp URL Configuration
+
+The `urlpatterns` list routes URLs to views. For more information please see:
+    https://docs.djangoproject.com/en/2.0/topics/http/urls/
+Examples:
+Function views
+    1. Add an import:  from my_app import views
+    2. Add a URL to urlpatterns:  path('', views.home, name='home')
+Class-based views
+    1. Add an import:  from other_app.views import Home
+    2. Add a URL to urlpatterns:  path('', Home.as_view(), name='home')
+Including another URLconf
+    1. Import the include() function: from django.urls import include, path
+    2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
+"""
+from __future__ import absolute_import
+
+try:
+    from django.urls import path
+except ImportError:
+    from django.conf.urls import url
+
+    def path(path, *args, **kwargs):
+        return url("^{}$".format(path), *args, **kwargs)
+
+
+from . import views
+
+urlpatterns = [
+    path("custom/ok", views.custom_ok, name="custom_ok"),
+]

--- a/tests/integrations/django/myapp/middleware.py
+++ b/tests/integrations/django/myapp/middleware.py
@@ -1,19 +1,30 @@
-import asyncio
-from django.utils.decorators import sync_and_async_middleware
+import django
+
+if django.VERSION >= (3, 1):
+    import asyncio
+    from django.utils.decorators import sync_and_async_middleware
+
+    @sync_and_async_middleware
+    def simple_middleware(get_response):
+        if asyncio.iscoroutinefunction(get_response):
+
+            async def middleware(request):
+                response = await get_response(request)
+                return response
+
+        else:
+
+            def middleware(request):
+                response = get_response(request)
+                return response
+
+        return middleware
 
 
-@sync_and_async_middleware
-def simple_middleware(get_response):
-    if asyncio.iscoroutinefunction(get_response):
-
-        async def middleware(request):
-            response = await get_response(request)
-            return response
-
-    else:
-
-        def middleware(request):
-            response = get_response(request)
-            return response
+def custom_urlconf_middleware(get_response):
+    def middleware(request):
+        request.urlconf = "tests.integrations.django.myapp.custom_urls"
+        response = get_response(request)
+        return response
 
     return middleware

--- a/tests/integrations/django/myapp/views.py
+++ b/tests/integrations/django/myapp/views.py
@@ -121,6 +121,11 @@ def template_test(request, *args, **kwargs):
 
 
 @csrf_exempt
+def custom_ok(request, *args, **kwargs):
+    return HttpResponse("custom ok")
+
+
+@csrf_exempt
 def template_test2(request, *args, **kwargs):
     return TemplateResponse(
         request, ("user_name.html", "another_template.html"), {"user_age": 25}

--- a/tests/integrations/falcon/test_falcon.py
+++ b/tests/integrations/falcon/test_falcon.py
@@ -96,7 +96,7 @@ def test_unhandled_errors(sentry_init, capture_exceptions, capture_events):
 
     (event,) = events
     assert event["exception"]["values"][0]["mechanism"]["type"] == "falcon"
-    assert event["exception"]["values"][0]['value'] == 'division by zero'
+    assert " by zero" in event["exception"]["values"][0]['value']
 
 
 def test_raised_5xx_errors(sentry_init, capture_exceptions, capture_events):
@@ -120,9 +120,9 @@ def test_raised_5xx_errors(sentry_init, capture_exceptions, capture_events):
 
     (event,) = events
     assert event["exception"]["values"][0]["mechanism"]["type"] == "falcon"
-    assert event["exception"]["values"][0]['value'] == '502 Bad Gateway'
-
-
+    assert event["exception"]["values"][0]["type"] == "HTTPError"
+    
+    
 def test_raised_4xx_errors(sentry_init, capture_exceptions, capture_events):
     sentry_init(integrations=[FalconIntegration()], debug=True)
 

--- a/tests/integrations/falcon/test_falcon.py
+++ b/tests/integrations/falcon/test_falcon.py
@@ -71,15 +71,15 @@ def test_transaction_style(
     assert event["transaction"] == expected_transaction
 
 
-def test_errors(sentry_init, capture_exceptions, capture_events):
+def test_unhandled_errors(sentry_init, capture_exceptions, capture_events):
     sentry_init(integrations=[FalconIntegration()], debug=True)
 
-    class ZeroDivisionErrorResource:
+    class Resource:
         def on_get(self, req, resp):
             1 / 0
 
     app = falcon.API()
-    app.add_route("/", ZeroDivisionErrorResource())
+    app.add_route("/", Resource())
 
     exceptions = capture_exceptions()
     events = capture_events()
@@ -96,6 +96,75 @@ def test_errors(sentry_init, capture_exceptions, capture_events):
 
     (event,) = events
     assert event["exception"]["values"][0]["mechanism"]["type"] == "falcon"
+    assert event["exception"]["values"][0]['value'] == 'division by zero'
+
+
+def test_raised_5xx_errors(sentry_init, capture_exceptions, capture_events):
+    sentry_init(integrations=[FalconIntegration()], debug=True)
+
+    class Resource:
+        def on_get(self, req, resp):
+            raise falcon.HTTPError(falcon.HTTP_502)
+
+    app = falcon.API()
+    app.add_route("/", Resource())
+
+    exceptions = capture_exceptions()
+    events = capture_events()
+
+    client = falcon.testing.TestClient(app)
+    client.simulate_get("/")
+
+    (exc,) = exceptions
+    assert isinstance(exc, falcon.HTTPError)
+
+    (event,) = events
+    assert event["exception"]["values"][0]["mechanism"]["type"] == "falcon"
+    assert event["exception"]["values"][0]['value'] == '502 Bad Gateway'
+
+
+def test_raised_4xx_errors(sentry_init, capture_exceptions, capture_events):
+    sentry_init(integrations=[FalconIntegration()], debug=True)
+
+    class Resource:
+        def on_get(self, req, resp):
+            raise falcon.HTTPError(falcon.HTTP_400)
+
+    app = falcon.API()
+    app.add_route("/", Resource())
+
+    exceptions = capture_exceptions()
+    events = capture_events()
+
+    client = falcon.testing.TestClient(app)
+    client.simulate_get("/")
+
+    assert len(exceptions) == 0
+    assert len(events) == 0
+
+
+def test_http_status(sentry_init, capture_exceptions, capture_events):
+    """
+    This just demonstrates, that if Falcon raises a HTTPStatus with code 500
+    (instead of a HTTPError with code 500) Sentry will not capture it.
+    """
+    sentry_init(integrations=[FalconIntegration()], debug=True)
+
+    class Resource:
+        def on_get(self, req, resp):
+            raise falcon.http_status.HTTPStatus(falcon.HTTP_508)
+
+    app = falcon.API()
+    app.add_route("/", Resource())
+
+    exceptions = capture_exceptions()
+    events = capture_events()
+
+    client = falcon.testing.TestClient(app)
+    client.simulate_get("/")
+
+    assert len(exceptions) == 0
+    assert len(events) == 0
 
 
 def test_falcon_large_json_request(sentry_init, capture_events):

--- a/tests/integrations/falcon/test_falcon.py
+++ b/tests/integrations/falcon/test_falcon.py
@@ -96,7 +96,7 @@ def test_unhandled_errors(sentry_init, capture_exceptions, capture_events):
 
     (event,) = events
     assert event["exception"]["values"][0]["mechanism"]["type"] == "falcon"
-    assert " by zero" in event["exception"]["values"][0]['value']
+    assert " by zero" in event["exception"]["values"][0]["value"]
 
 
 def test_raised_5xx_errors(sentry_init, capture_exceptions, capture_events):

--- a/tests/integrations/falcon/test_falcon.py
+++ b/tests/integrations/falcon/test_falcon.py
@@ -121,8 +121,8 @@ def test_raised_5xx_errors(sentry_init, capture_exceptions, capture_events):
     (event,) = events
     assert event["exception"]["values"][0]["mechanism"]["type"] == "falcon"
     assert event["exception"]["values"][0]["type"] == "HTTPError"
-    
-    
+
+
 def test_raised_4xx_errors(sentry_init, capture_exceptions, capture_events):
     sentry_init(integrations=[FalconIntegration()], debug=True)
 


### PR DESCRIPTION
fixes #753 