### PR TITLE
fix(python): Capture only 5xx HTTP errors in Falcon Integration

### DIFF
--- a/sentry_sdk/integrations/falcon.py
+++ b/sentry_sdk/integrations/falcon.py
@@ -187,8 +187,13 @@ def _patch_prepare_middleware():
 
 
 def _exception_leads_to_http_5xx(ex):
-    # type: (BaseException) -> bool
-    status = ex.status or ""
+    # type: (Exception) -> bool
+    status = ""
+    try:
+        status = ex.status
+    except:
+        pass
+
     is_server_error = isinstance(ex, falcon.HTTPError) and status.startswith('5')
     is_unhandled_error = not isinstance(ex, (falcon.HTTPError, falcon.http_status.HTTPStatus))
     return is_server_error or is_unhandled_error

--- a/sentry_sdk/integrations/falcon.py
+++ b/sentry_sdk/integrations/falcon.py
@@ -187,7 +187,6 @@ def _patch_prepare_middleware():
 
 
 def _exception_leads_to_http_5xx(ex):
-<<<<<<< HEAD
     # type: (Exception) -> bool
     status = ""
     try:
@@ -196,15 +195,9 @@ def _exception_leads_to_http_5xx(ex):
         pass
 
     is_server_error = isinstance(ex, falcon.HTTPError) and status.startswith('5')
-    is_unhandled_error = not isinstance(ex, (falcon.HTTPError, falcon.http_status.HTTPStatus))
-=======
-    # type: (BaseException) -> bool
-    status = ex.status or ""
-    is_server_error = isinstance(ex, falcon.HTTPError) and status.startswith("5")
     is_unhandled_error = not isinstance(
         ex, (falcon.HTTPError, falcon.http_status.HTTPStatus)
     )
->>>>>>> 1bfb78c9d19c3913f66a0aa957a5bdbfe2b41179
     return is_server_error or is_unhandled_error
 
 

--- a/sentry_sdk/integrations/falcon.py
+++ b/sentry_sdk/integrations/falcon.py
@@ -194,7 +194,7 @@ def _exception_leads_to_http_5xx(ex):
     except:
         pass
 
-    is_server_error = isinstance(ex, falcon.HTTPError) and status.startswith('5')
+    is_server_error = isinstance(ex, falcon.HTTPError) and status.startswith("5")
     is_unhandled_error = not isinstance(
         ex, (falcon.HTTPError, falcon.http_status.HTTPStatus)
     )

--- a/sentry_sdk/integrations/falcon.py
+++ b/sentry_sdk/integrations/falcon.py
@@ -188,7 +188,7 @@ def _patch_prepare_middleware():
 
 
 def _exception_leads_to_http_5xx(ex):
-    # type: (Union[Exception, falcon.HTTPError, falcon.http_status.HTTPStatus]) -> bool
+    # type: (Exception) -> bool
     is_server_error = isinstance(ex, falcon.HTTPError) and (ex.status or "").startswith(
         "5"
     )

--- a/sentry_sdk/integrations/falcon.py
+++ b/sentry_sdk/integrations/falcon.py
@@ -12,7 +12,6 @@ if MYPY:
     from typing import Any
     from typing import Dict
     from typing import Optional
-    from typing import Union
 
     from sentry_sdk._types import EventProcessor
 

--- a/sentry_sdk/integrations/falcon.py
+++ b/sentry_sdk/integrations/falcon.py
@@ -153,7 +153,7 @@ def _patch_handle_exception():
         hub = Hub.current
         integration = hub.get_integration(FalconIntegration)
 
-        if integration is not None and not _is_falcon_http_error(ex):
+        if integration is not None and _exception_leads_to_http_5xx(ex):
             # If an integration is there, a client has to be there.
             client = hub.client  # type: Any
 
@@ -186,9 +186,12 @@ def _patch_prepare_middleware():
     falcon.api_helpers.prepare_middleware = sentry_patched_prepare_middleware
 
 
-def _is_falcon_http_error(ex):
+def _exception_leads_to_http_5xx(ex):
     # type: (BaseException) -> bool
-    return isinstance(ex, (falcon.HTTPError, falcon.http_status.HTTPStatus))
+    status = ex.status or ""
+    is_server_error = isinstance(ex, falcon.HTTPError) and status.startswith('5')
+    is_unhandled_error = not isinstance(ex, (falcon.HTTPError, falcon.http_status.HTTPStatus))
+    return is_server_error or is_unhandled_error
 
 
 def _make_request_event_processor(req, integration):

--- a/sentry_sdk/integrations/falcon.py
+++ b/sentry_sdk/integrations/falcon.py
@@ -12,6 +12,7 @@ if MYPY:
     from typing import Any
     from typing import Dict
     from typing import Optional
+    from typing import Union
 
     from sentry_sdk._types import EventProcessor
 
@@ -187,14 +188,8 @@ def _patch_prepare_middleware():
 
 
 def _exception_leads_to_http_5xx(ex):
-    # type: (BaseException) -> bool
-    status = ""
-    try:
-        status = ex.status
-    except BaseException:
-        pass
-
-    is_server_error = isinstance(ex, falcon.HTTPError) and status.startswith("5")
+    # type: (Union[Exception, falcon.HTTPError, falcon.http_status.HTTPStatus]) -> bool
+    is_server_error = isinstance(ex, falcon.HTTPError) and (ex.status or "").startswith("5")
     is_unhandled_error = not isinstance(
         ex, (falcon.HTTPError, falcon.http_status.HTTPStatus)
     )

--- a/sentry_sdk/integrations/falcon.py
+++ b/sentry_sdk/integrations/falcon.py
@@ -187,11 +187,11 @@ def _patch_prepare_middleware():
 
 
 def _exception_leads_to_http_5xx(ex):
-    # type: (Exception) -> bool
+    # type: (BaseException) -> bool
     status = ""
     try:
         status = ex.status
-    except:
+    except BaseException:
         pass
 
     is_server_error = isinstance(ex, falcon.HTTPError) and status.startswith("5")

--- a/tests/integrations/falcon/test_falcon.py
+++ b/tests/integrations/falcon/test_falcon.py
@@ -71,15 +71,15 @@ def test_transaction_style(
     assert event["transaction"] == expected_transaction
 
 
-def test_errors(sentry_init, capture_exceptions, capture_events):
+def test_unhandled_errors(sentry_init, capture_exceptions, capture_events):
     sentry_init(integrations=[FalconIntegration()], debug=True)
 
-    class ZeroDivisionErrorResource:
+    class Resource:
         def on_get(self, req, resp):
             1 / 0
 
     app = falcon.API()
-    app.add_route("/", ZeroDivisionErrorResource())
+    app.add_route("/", Resource())
 
     exceptions = capture_exceptions()
     events = capture_events()
@@ -96,6 +96,75 @@ def test_errors(sentry_init, capture_exceptions, capture_events):
 
     (event,) = events
     assert event["exception"]["values"][0]["mechanism"]["type"] == "falcon"
+    assert " by zero" in event["exception"]["values"][0]['value']
+
+
+def test_raised_5xx_errors(sentry_init, capture_exceptions, capture_events):
+    sentry_init(integrations=[FalconIntegration()], debug=True)
+
+    class Resource:
+        def on_get(self, req, resp):
+            raise falcon.HTTPError(falcon.HTTP_502)
+
+    app = falcon.API()
+    app.add_route("/", Resource())
+
+    exceptions = capture_exceptions()
+    events = capture_events()
+
+    client = falcon.testing.TestClient(app)
+    client.simulate_get("/")
+
+    (exc,) = exceptions
+    assert isinstance(exc, falcon.HTTPError)
+
+    (event,) = events
+    assert event["exception"]["values"][0]["mechanism"]["type"] == "falcon"
+    assert event["exception"]["values"][0]["type"] == "HTTPError"
+
+
+def test_raised_4xx_errors(sentry_init, capture_exceptions, capture_events):
+    sentry_init(integrations=[FalconIntegration()], debug=True)
+
+    class Resource:
+        def on_get(self, req, resp):
+            raise falcon.HTTPError(falcon.HTTP_400)
+
+    app = falcon.API()
+    app.add_route("/", Resource())
+
+    exceptions = capture_exceptions()
+    events = capture_events()
+
+    client = falcon.testing.TestClient(app)
+    client.simulate_get("/")
+
+    assert len(exceptions) == 0
+    assert len(events) == 0
+
+
+def test_http_status(sentry_init, capture_exceptions, capture_events):
+    """
+    This just demonstrates, that if Falcon raises a HTTPStatus with code 500
+    (instead of a HTTPError with code 500) Sentry will not capture it.
+    """
+    sentry_init(integrations=[FalconIntegration()], debug=True)
+
+    class Resource:
+        def on_get(self, req, resp):
+            raise falcon.http_status.HTTPStatus(falcon.HTTP_508)
+
+    app = falcon.API()
+    app.add_route("/", Resource())
+
+    exceptions = capture_exceptions()
+    events = capture_events()
+
+    client = falcon.testing.TestClient(app)
+    client.simulate_get("/")
+
+    assert len(exceptions) == 0
+    assert len(events) == 0
 
 
 def test_falcon_large_json_request(sentry_init, capture_events):


### PR DESCRIPTION
fixes #753