### PR TITLE
feat(tooling): Enabled local linting

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,24 @@
+# See https://pre-commit.com for more information
+# See https://pre-commit.com/hooks.html for more hooks
+repos:
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v3.2.0
+    hooks:
+    -   id: trailing-whitespace
+    -   id: end-of-file-fixer
+
+-   repo: https://github.com/psf/black
+    rev: stable
+    hooks:
+    -   id: black
+
+-   repo: https://gitlab.com/pycqa/flake8
+    rev: 4.0.1
+    hooks:
+    -   id: flake8
+
+# Disabled for now, because it lists a lot of problems.
+#-   repo: https://github.com/pre-commit/mirrors-mypy
+#    rev: 'v0.931'
+#    hooks:
+#    -   id: mypy

--- a/linter-requirements.txt
+++ b/linter-requirements.txt
@@ -4,3 +4,4 @@ flake8-import-order==0.18.1
 mypy==0.782
 flake8-bugbear==21.4.3
 pep8-naming==0.11.1
+pre-commit # local linting

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -8,6 +8,8 @@ jsonschema==3.2.0
 pyrsistent==0.16.0 # TODO(py3): 0.17.0 requires python3, see https://github.com/tobgu/pyrsistent/issues/205
 mock # for testing under python < 3.3
 
+pre-commit # local linting
+
 gevent
 
 executing

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -8,8 +8,6 @@ jsonschema==3.2.0
 pyrsistent==0.16.0 # TODO(py3): 0.17.0 requires python3, see https://github.com/tobgu/pyrsistent/issues/205
 mock # for testing under python < 3.3
 
-pre-commit # local linting
-
 gevent
 
 executing


### PR DESCRIPTION
To speed up development and prevent a lot of front and back with the CI linter, I added a pre-commit hook, so before one can commit something the linting (black, flake8 and mypy) will run locally to format and lint the changed files. 