### PR TITLE
fix(django): Attempt custom urlconf resolve in got_request_exception as well

### DIFF
--- a/sentry_sdk/integrations/django/__init__.py
+++ b/sentry_sdk/integrations/django/__init__.py
@@ -58,6 +58,7 @@ if MYPY:
     from django.http.request import QueryDict
     from django.utils.datastructures import MultiValueDict
 
+    from sentry_sdk.scope import Scope
     from sentry_sdk.integrations.wsgi import _ScopedResponse
     from sentry_sdk._types import Event, Hint, EventProcessor, NotImplementedType
 

--- a/sentry_sdk/integrations/django/__init__.py
+++ b/sentry_sdk/integrations/django/__init__.py
@@ -346,8 +346,8 @@ def _before_get_response(request):
         )
 
 
-def _after_get_response(request):
-    # type: (WSGIRequest) -> None
+def _attempt_resolve_again(request, scope):
+    # type: (WSGIRequest, Scope) -> None
     """
     Some django middlewares overwrite request.urlconf
     so we need to respect that contract,
@@ -356,19 +356,24 @@ def _after_get_response(request):
     if not hasattr(request, "urlconf"):
         return
 
+    try:
+        scope.transaction = LEGACY_RESOLVER.resolve(
+            request.path_info,
+            urlconf=request.urlconf,
+        )
+    except Exception:
+        pass
+
+
+def _after_get_response(request):
+    # type: (WSGIRequest) -> None
     hub = Hub.current
     integration = hub.get_integration(DjangoIntegration)
     if integration is None or integration.transaction_style != "url":
         return
 
     with hub.configure_scope() as scope:
-        try:
-            scope.transaction = LEGACY_RESOLVER.resolve(
-                request.path_info,
-                urlconf=request.urlconf,
-            )
-        except Exception:
-            pass
+        _attempt_resolve_again(request, scope)
 
 
 def _patch_get_response():
@@ -430,6 +435,10 @@ def _got_request_exception(request=None, **kwargs):
     hub = Hub.current
     integration = hub.get_integration(DjangoIntegration)
     if integration is not None:
+
+        if request is not None and integration.transaction_style == "url":
+            with hub.configure_scope() as scope:
+                _attempt_resolve_again(request, scope)
 
         # If an integration is there, a client has to be there.
         client = hub.client  # type: Any

--- a/tests/integrations/django/myapp/custom_urls.py
+++ b/tests/integrations/django/myapp/custom_urls.py
@@ -28,4 +28,5 @@ from . import views
 
 urlpatterns = [
     path("custom/ok", views.custom_ok, name="custom_ok"),
+    path("custom/exc", views.custom_exc, name="custom_exc"),
 ]

--- a/tests/integrations/django/myapp/views.py
+++ b/tests/integrations/django/myapp/views.py
@@ -126,6 +126,11 @@ def custom_ok(request, *args, **kwargs):
 
 
 @csrf_exempt
+def custom_exc(request, *args, **kwargs):
+    1 / 0
+
+
+@csrf_exempt
 def template_test2(request, *args, **kwargs):
     return TemplateResponse(
         request, ("user_name.html", "another_template.html"), {"user_age": 25}


### PR DESCRIPTION
The fix in https://github.com/getsentry/sentry-python/pull/1308 only worked for transactions and not for exceptions since exceptions will nope out before `_after_get_reponse` runs in most cases. This generalizes the solution to also run in `_got_request_exception`.

https://getsentry.atlassian.net/browse/WEB-530