### PR TITLE
Provide default argument to json.dumps in compute_tracestate_value

### DIFF
--- a/sentry_sdk/tracing_utils.py
+++ b/sentry_sdk/tracing_utils.py
@@ -11,6 +11,7 @@ from sentry_sdk.utils import (
     capture_internal_exceptions,
     Dsn,
     logger,
+    safe_str,
     to_base64,
     to_string,
     from_base64,
@@ -288,7 +289,7 @@ def compute_tracestate_value(data):
     tracestate entry.
     """
 
-    tracestate_json = json.dumps(data)
+    tracestate_json = json.dumps(data, default=safe_str)
 
     # Base64-encoded strings always come out with a length which is a multiple
     # of 4. In order to achieve this, the end is padded with one or more `=`


### PR DESCRIPTION
Granted, this is a bit of an edge-case, but I'll explain the rationale.

In our Django application, we define `MERCURIAL_TAG` in our settings. To compute this we subprocess out to `hg`. As you can imagine, this is quite expensive and has a significant impact on application startup time. So we've wrapped this in `django.utils.functional.lazy()` so that it's only evaluated when it's needed, not every time the app starts or every time a uwsgi worker is recycled.

The issue is, we primarily use this setting by passing it to `sentry_sdk.init()`. When the Sentry SDK goes to report an error, `compute_tracestate_value()` calls `json.dumps()` which blows up with a whole stack of `TypeError: Object of type __proxy__ is not JSON serializable` as the `_got_request_exception` signal fires over and over.

![image](https://user-images.githubusercontent.com/193906/150870192-3ff59955-10f6-4ebf-ab6c-0eb66df917d0.png)

I've added a `default=safe_str` to `json.dumps()` to make sure that whatever weird thing some random idiot (read: me) passes to to `sentry_sdk.init()` is properly converted to a string.

I've left the type hint intact as `(typing.Mapping[str, str]) -> str` as it's probably worth maintaining the expectation that this is the case.