### PR TITLE
feat(serializer): Allow classes to short circuit serializer with `sentry_repr`

### DIFF
--- a/sentry_sdk/serializer.py
+++ b/sentry_sdk/serializer.py
@@ -281,6 +281,9 @@ def serialize(event, smart_transaction_trimming=False, **kwargs):
             else:
                 return obj
 
+        elif callable(getattr(obj, "sentry_repr", None)):
+            return obj.sentry_repr()
+
         elif isinstance(obj, datetime):
             return (
                 text_type(format_timestamp(obj))

--- a/tests/test_serializer.py
+++ b/tests/test_serializer.py
@@ -64,3 +64,12 @@ def test_bytes_serialization_repr(message_normalizer):
 def test_serialize_sets(extra_normalizer):
     result = extra_normalizer({1, 2, 3})
     assert result == [1, 2, 3]
+
+
+def test_serialize_custom_mapping(extra_normalizer):
+    class CustomReprDict(dict):
+        def sentry_repr(self):
+            return "custom!"
+
+    result = extra_normalizer(CustomReprDict(one=1, two=2))
+    assert result == "custom!"


### PR DESCRIPTION
Based on the discussion in https://github.com/getsentry/sentry-python/pull/1300 and https://github.com/getsentry/sentry-python/issues/1296.

We do a lot of truncation magic in our serializer to not send huge payloads.
In the process, we ignore if a user/framework sets a custom `__repr__` on a class.
This PR lets users add a `sentry_repr` that will short circuit our truncation logic and pick the user defined repr.
We cannot just go with checking if `__repr__` is overridden because we still want to preserve the truncation behavior for classes out there in the wild like [`QueryDict`](https://docs.djangoproject.com/en/2.2/ref/request-response/#django.http.QueryDict).

Some notes from the TSC:
* for now this is python only because python is the only SDK with an elaborate serializer
* and in general, this only makes sense for dynamic languages