### PR TITLE
Pinning test requirements versions

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,5 +1,5 @@
-pytest
-pytest-forked
+pytest<7
+pytest-forked<=1.4.0
 tox==3.7.0
 Werkzeug
 pytest-localserver==0.5.0


### PR DESCRIPTION
`pytest` version 7.0.0 was released on last friday and it does not work with our test suite. So I pinned the pytest version in our test suite to use the "old" one until pytest fixes the problems with 7.0.0 release.