### PR TITLE
feat(flask): Add `sentry_trace()` template helper

### DIFF
--- a/examples/tracing/templates/index.html
+++ b/examples/tracing/templates/index.html
@@ -1,6 +1,6 @@
 <meta name="sentry-trace" content="{{ sentry_trace }}" />
 <script src="https://browser.sentry-cdn.com/6.17.7/bundle.js" crossorigin="anonymous"></script>
-{{ sentry_trace() }}
+{{ sentry_trace }}
 <!-- TODO: Replace with real tracing integration once it's fixed -->
 <script src="/static/tracing.js" crossorigin="anonymous"></script>
 

--- a/examples/tracing/templates/index.html
+++ b/examples/tracing/templates/index.html
@@ -1,4 +1,6 @@
-<script src="https://browser.sentry-cdn.com/5.4.1/bundle.js" crossorigin="anonymous"></script>
+<meta name="sentry-trace" content="{{ sentry_trace }}" />
+<script src="https://browser.sentry-cdn.com/6.17.7/bundle.js" crossorigin="anonymous"></script>
+{{ sentry_trace() }}
 <!-- TODO: Replace with real tracing integration once it's fixed -->
 <script src="/static/tracing.js" crossorigin="anonymous"></script>
 
@@ -12,14 +14,6 @@ Sentry.init({
         new Sentry.Integrations.Tracing({ tracingOrigins: ['']})
     ],
     debug: true
-});
-
-window.setTimeout(function() {
-    const scope = Sentry.getCurrentHub().getScope();
-    // TODO: Wait for Daniel's traceparent API
-    scope.setSpan(scope.getSpan().constructor.fromTraceparent(
-        "00-{{ traceparent['sentry-trace'].strip("-") }}-00"
-    ));
 });
 
 async function compute() {

--- a/sentry_sdk/integrations/flask.py
+++ b/sentry_sdk/integrations/flask.py
@@ -100,7 +100,7 @@ class FlaskIntegration(Integration):
                 environ, start_response
             )
 
-            patched_app.jinja_env.globals['sentry_trace'] = self._get_sentry_trace
+            patched_app.add_template_global(self._get_sentry_trace, 'sentry_trace')
 
             return patched_app
 

--- a/sentry_sdk/integrations/flask.py
+++ b/sentry_sdk/integrations/flask.py
@@ -67,9 +67,12 @@ class FlaskIntegration(Integration):
     def _get_sentry_trace():
         sentry_span = Hub.current.scope.span
         if sentry_span:
-            return Markup('<meta name="sentry-trace" content="%s" />' % (sentry_span.to_traceparent(),))
+            return Markup(
+                '<meta name="sentry-trace" content="%s" />'
+                % (sentry_span.to_traceparent(),)
+            )
 
-        return ''
+        return ""
 
     @staticmethod
     def setup_once():
@@ -96,11 +99,11 @@ class FlaskIntegration(Integration):
             if Hub.current.get_integration(FlaskIntegration) is None:
                 return old_app(self, environ, start_response)
 
-            patched_app = SentryWsgiMiddleware(lambda *a, **kw: old_app(self, *a, **kw))(
-                environ, start_response
-            )
+            patched_app = SentryWsgiMiddleware(
+                lambda *a, **kw: old_app(self, *a, **kw)
+            )(environ, start_response)
 
-            patched_app.add_template_global(self._get_sentry_trace, 'sentry_trace')
+            patched_app.add_template_global(self._get_sentry_trace, "sentry_trace")
 
             return patched_app
 

--- a/sentry_sdk/integrations/flask.py
+++ b/sentry_sdk/integrations/flask.py
@@ -101,10 +101,10 @@ class FlaskIntegration(Integration):
             if Hub.current.get_integration(FlaskIntegration) is None:
                 return old_app(self, environ, start_response)
 
-            def app_factory(*a, **kw):
+            def app_factory(_environ, _start_response):
                 # type: (Dict[str, str], Callable[..., Any]) -> Any
 
-                patched_app = old_app(self, *a, **kw)
+                patched_app = old_app(self, _environ, _start_response)
                 patched_app.add_template_global(
                     FlaskIntegration._get_sentry_trace, "sentry_trace"
                 )

--- a/sentry_sdk/integrations/flask.py
+++ b/sentry_sdk/integrations/flask.py
@@ -68,7 +68,7 @@ class FlaskIntegration(Integration):
         sentry_span = Hub.current.scope.span
         if sentry_span:
             return Markup(f'<meta name="sentry-trace" content="{ sentry_span.to_traceparent() }" />')
-    
+
         return ''
 
     @staticmethod

--- a/sentry_sdk/integrations/flask.py
+++ b/sentry_sdk/integrations/flask.py
@@ -98,7 +98,7 @@ class FlaskIntegration(Integration):
 
 
 def _add_sentry_trace(sender, template, context, **extra):
-    # type: (Flask, Any, Dict[str, any], ...) -> None
+    # type: (Flask, Any, Dict[str, any], **Any) -> None
 
     if "sentry_trace" in context:
         return

--- a/sentry_sdk/integrations/flask.py
+++ b/sentry_sdk/integrations/flask.py
@@ -98,7 +98,7 @@ class FlaskIntegration(Integration):
 
 
 def _add_sentry_trace(sender, template, context, **extra):
-    # type: (Flask, Any, Dict[str, any], **Any) -> None
+    # type: (Flask, Any, Dict[str, Any], **Any) -> None
 
     if "sentry_trace" in context:
         return

--- a/sentry_sdk/integrations/flask.py
+++ b/sentry_sdk/integrations/flask.py
@@ -101,8 +101,8 @@ class FlaskIntegration(Integration):
             if Hub.current.get_integration(FlaskIntegration) is None:
                 return old_app(self, environ, start_response)
 
-            def app_factory(self, *a, **kw):
-                # type: (Flask, Dict[str, str], (...) -> Any) -> Flask
+            def app_factory(*a, **kw):
+                # type: (Dict[str, str], (...) -> Any) -> Flask
 
                 patched_app = old_app(self, *a, **kw)
                 patched_app.add_template_global(

--- a/sentry_sdk/integrations/flask.py
+++ b/sentry_sdk/integrations/flask.py
@@ -103,7 +103,9 @@ class FlaskIntegration(Integration):
                 lambda *a, **kw: old_app(self, *a, **kw)
             )(environ, start_response)
 
-            patched_app.add_template_global(self._get_sentry_trace, "sentry_trace")
+            patched_app.add_template_global(
+                FlaskIntegration._get_sentry_trace, "sentry_trace"
+            )
 
             return patched_app
 

--- a/sentry_sdk/integrations/flask.py
+++ b/sentry_sdk/integrations/flask.py
@@ -79,7 +79,7 @@ class FlaskIntegration(Integration):
             if version < (0, 10):
                 raise DidNotEnable("Flask 0.10 or newer is required.")
 
-        before_render_template(_add_sentry_trace)
+        before_render_template.connect(_add_sentry_trace)
         request_started.connect(_request_started)
         got_request_exception.connect(_capture_exception)
 

--- a/sentry_sdk/integrations/flask.py
+++ b/sentry_sdk/integrations/flask.py
@@ -102,7 +102,7 @@ class FlaskIntegration(Integration):
                 return old_app(self, environ, start_response)
 
             def app_factory(*a, **kw):
-                # type: (Dict[str, str], (...) -> Any) -> Flask
+                # type: (Dict[str, str], Callable[..., Any]) -> Flask
 
                 patched_app = old_app(self, *a, **kw)
                 patched_app.add_template_global(

--- a/sentry_sdk/integrations/flask.py
+++ b/sentry_sdk/integrations/flask.py
@@ -102,6 +102,8 @@ class FlaskIntegration(Integration):
                 return old_app(self, environ, start_response)
 
             def app_factory(self, *a, **kw):
+                # type: (Flask, *Any, **Any) -> Flask
+
                 patched_app = old_app(self, *a, **kw)
                 patched_app.add_template_global(
                     FlaskIntegration._get_sentry_trace, "sentry_trace"

--- a/sentry_sdk/integrations/flask.py
+++ b/sentry_sdk/integrations/flask.py
@@ -102,7 +102,7 @@ class FlaskIntegration(Integration):
                 return old_app(self, environ, start_response)
 
             def app_factory(self, *a, **kw):
-                # type: (Flask, *Any, **Any) -> Flask
+                # type: (Flask, Dict[str, str], (...) -> Any) -> Flask
 
                 patched_app = old_app(self, *a, **kw)
                 patched_app.add_template_global(

--- a/sentry_sdk/integrations/flask.py
+++ b/sentry_sdk/integrations/flask.py
@@ -102,7 +102,7 @@ class FlaskIntegration(Integration):
                 return old_app(self, environ, start_response)
 
             def app_factory(*a, **kw):
-                # type: (Dict[str, str], Callable[..., Any]) -> Flask
+                # type: (Dict[str, str], Callable[..., Any]) -> Any
 
                 patched_app = old_app(self, *a, **kw)
                 patched_app.add_template_global(

--- a/sentry_sdk/integrations/flask.py
+++ b/sentry_sdk/integrations/flask.py
@@ -67,7 +67,7 @@ class FlaskIntegration(Integration):
     def _get_sentry_trace():
         sentry_span = Hub.current.scope.span
         if sentry_span:
-            return Markup(f'<meta name="sentry-trace" content="{ sentry_span.to_traceparent() }" />')
+            return Markup('<meta name="sentry-trace" content="%s" />' % (sentry_span.to_traceparent(),))
 
         return ''
 

--- a/tests/integrations/flask/test_flask.py
+++ b/tests/integrations/flask/test_flask.py
@@ -759,7 +759,7 @@ def test_sentry_trace_context(sentry_init, app, capture_events):
     with app.test_client() as client:
         response = client.get("/")
         assert response.status_code == 200
-        assert response.text == '<meta name="sentry-trace" content="%s" />' % (
+        assert response.data == '<meta name="sentry-trace" content="%s" />' % (
             events[0]["message"],
         )
 
@@ -774,4 +774,4 @@ def test_dont_override_sentry_trace_context(sentry_init, app):
     with app.test_client() as client:
         response = client.get("/")
         assert response.status_code == 200
-        assert response.text == "hi"
+        assert response.data == "hi"

--- a/tests/integrations/flask/test_flask.py
+++ b/tests/integrations/flask/test_flask.py
@@ -759,9 +759,9 @@ def test_sentry_trace_context(sentry_init, app, capture_events):
     with app.test_client() as client:
         response = client.get("/")
         assert response.status_code == 200
-        assert response.data == '<meta name="sentry-trace" content="%s" />' % (
-            events[0]["message"],
-        )
+        assert response.data.decode(
+            "utf-8"
+        ) == '<meta name="sentry-trace" content="%s" />' % (events[0]["message"],)
 
 
 def test_dont_override_sentry_trace_context(sentry_init, app):
@@ -774,4 +774,4 @@ def test_dont_override_sentry_trace_context(sentry_init, app):
     with app.test_client() as client:
         response = client.get("/")
         assert response.status_code == 200
-        assert response.data == "hi"
+        assert response.data == b"hi"

--- a/tests/integrations/flask/test_flask.py
+++ b/tests/integrations/flask/test_flask.py
@@ -769,7 +769,7 @@ def test_dont_override_sentry_trace_context(sentry_init, app):
 
     @app.route("/")
     def index():
-        return render_template_string("{{ sentry_trace }}", dict(sentry_trace="hi"))
+        return render_template_string("{{ sentry_trace }}", sentry_trace="hi")
 
     with app.test_client() as client:
         response = client.get("/")

--- a/tests/integrations/flask/test_flask.py
+++ b/tests/integrations/flask/test_flask.py
@@ -6,7 +6,14 @@ from io import BytesIO
 
 flask = pytest.importorskip("flask")
 
-from flask import Flask, Response, request, abort, stream_with_context
+from flask import (
+    Flask,
+    Response,
+    request,
+    abort,
+    stream_with_context,
+    render_template_string,
+)
 from flask.views import View
 
 from flask_login import LoginManager, login_user
@@ -747,7 +754,7 @@ def test_sentry_trace_context(sentry_init, app, capture_events):
     def index():
         sentry_span = Hub.current.scope.span
         capture_message(sentry_span.to_traceparent())
-        return app.render_template_string("{{ sentry_trace }}")
+        return render_template_string("{{ sentry_trace }}")
 
     with app.test_client() as client:
         response = client.get("/")
@@ -762,7 +769,7 @@ def test_dont_override_sentry_trace_context(sentry_init, app):
 
     @app.route("/")
     def index():
-        return app.render_template_string("{{ sentry_trace }}", dict(sentry_trace="hi"))
+        return render_template_string("{{ sentry_trace }}", dict(sentry_trace="hi"))
 
     with app.test_client() as client:
         response = client.get("/")

--- a/tests/integrations/flask/test_flask.py
+++ b/tests/integrations/flask/test_flask.py
@@ -365,7 +365,7 @@ def test_flask_formdata_request_appear_transaction_body(
     assert transaction_event["request"]["data"] == data
 
 
-@pytest.mark.parametrize("input_char", [u"a", b"a"])
+@pytest.mark.parametrize("input_char", ["a", b"a"])
 def test_flask_too_large_raw_request(sentry_init, input_char, capture_events, app):
     sentry_init(integrations=[flask_sentry.FlaskIntegration()], request_bodies="small")
 
@@ -737,3 +737,34 @@ def test_class_based_views(sentry_init, app, capture_events):
 
     assert event["message"] == "hi"
     assert event["transaction"] == "hello_class"
+
+
+def test_sentry_trace_context(sentry_init, app, capture_events):
+    sentry_init(integrations=[flask_sentry.FlaskIntegration()])
+    events = capture_events()
+
+    @app.route("/")
+    def index():
+        sentry_span = Hub.current.scope.span
+        capture_message(sentry_span.to_traceparent())
+        return app.render_template_string("{{ sentry_trace }}")
+
+    with app.test_client() as client:
+        response = client.get("/")
+        assert response.status_code == 200
+        assert response.text == '<meta name="sentry-trace" content="%s" />' % (
+            events[0]["message"],
+        )
+
+
+def test_dont_override_sentry_trace_context(sentry_init, app):
+    sentry_init(integrations=[flask_sentry.FlaskIntegration()])
+
+    @app.route("/")
+    def index():
+        return app.render_template_string("{{ sentry_trace }}", dict(sentry_trace="hi"))
+
+    with app.test_client() as client:
+        response = client.get("/")
+        assert response.status_code == 200
+        assert response.text == "hi"


### PR DESCRIPTION
To setup distributed tracing links between a Flask app and a front-end app, one needs to figure out how to get the current hub, safely get the traceparent and then properly pass it into a template and then finally use that properly in a `meta` tag. [The guide](https://docs.sentry.io/platforms/javascript/performance/connect-services/) is woefully inadequate and error-prone so this PR adds a built-in helper `sentry_trace()` to the Flask integration to simplify this linking.

I'll follow up with documentation updates once the approach here is approved.
