### PR TITLE
chore: add bug issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -6,10 +6,10 @@ body:
     attributes:
       label: Type
       description: How do you use Sentry?
+      value: "Sentry Saas (sentry.io)"
       options:
         - Sentry Saas (sentry.io)
         - Self-hosted/on-premise
-      value: Sentry Saas (sentry.io)
     validations:
       required: true
   - type: input

--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -9,6 +9,7 @@ body:
       options:
         - Sentry Saas (sentry.io)
         - Self-hosted/on-premise
+      value: Sentry Saas (sentry.io)
     validations:
       required: true
   - type: input

--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,51 @@
+name: 🐞 Bug Report
+description: Tell us about something that's not working the way we (probably) intend.
+body:
+  - type: dropdown
+    id: type
+    attributes:
+      label: Type
+      description: How do you use Sentry?
+      options:
+        - Sentry Saas (sentry.io)
+        - Self-hosted/on-premise
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: Version
+      description: Which SDK version?
+      placeholder: ex. 1.5.2
+    validations:
+      required: true
+  - type: textarea
+    id: repro
+    attributes:
+      label: Steps to Reproduce
+      description: How can we see what you're seeing? Specific is terrific.
+      placeholder: |-
+        1. What
+        2. you
+        3. did.
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected Result
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual Result
+      description: Logs? Screenshots? Yes, please.
+    validations:
+      required: true
+  - type: markdown
+    attributes:
+      value: |-
+        ## Thanks 🙏
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -4,10 +4,9 @@ body:
   - type: dropdown
     id: type
     attributes:
-      label: Type
-      description: How do you use Sentry?
+      label: How do you use Sentry?
       options:
-        - Sentry Saas - sentry.io (Default)
+        - Sentry Saas (sentry.io)
         - Self-hosted/on-premise
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -6,9 +6,8 @@ body:
     attributes:
       label: Type
       description: How do you use Sentry?
-      value: "Sentry Saas (sentry.io)"
       options:
-        - Sentry Saas (sentry.io)
+        - Sentry Saas - sentry.io (Default)
         - Self-hosted/on-premise
     validations:
       required: true


### PR DESCRIPTION
Adding Github [issue form](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-issue-forms) for bugs.

**Preview**: 
https://github.com/getsentry/sentry-python/blob/217d337a41feeb516893626be6c4abbc32cbc48e/.github/ISSUE_TEMPLATE/bug.yml