### PR TITLE
feat(measurements): Add experimental set_measurement api on transaction

### DIFF
--- a/sentry_sdk/_types.py
+++ b/sentry_sdk/_types.py
@@ -48,3 +48,4 @@ if MYPY:
     ]
     SessionStatus = Literal["ok", "exited", "crashed", "abnormal"]
     EndpointType = Literal["store", "envelope"]
+    MeasurementUnit = Literal["ns", "ms", "s"]

--- a/sentry_sdk/_types.py
+++ b/sentry_sdk/_types.py
@@ -48,4 +48,34 @@ if MYPY:
     ]
     SessionStatus = Literal["ok", "exited", "crashed", "abnormal"]
     EndpointType = Literal["store", "envelope"]
-    MeasurementUnit = Literal["ns", "ms", "s"]
+
+    DurationUnit = Literal[
+        "nanosecond",
+        "microsecond",
+        "millisecond",
+        "second",
+        "minute",
+        "hour",
+        "day",
+        "week",
+    ]
+
+    InformationUnit = Literal[
+        "bit",
+        "byte",
+        "kilobyte",
+        "kibibyte",
+        "megabyte",
+        "mebibyte",
+        "gigabyte",
+        "gibibyte",
+        "terabyte",
+        "tebibyte",
+        "petabyte",
+        "pebibyte",
+        "exabyte",
+        "exbibyte",
+    ]
+
+    FractionUnit = Literal["ratio", "percent"]
+    MeasurementUnit = Union[DurationUnit, InformationUnit, FractionUnit, str]

--- a/sentry_sdk/consts.py
+++ b/sentry_sdk/consts.py
@@ -33,6 +33,7 @@ if MYPY:
             "record_sql_params": Optional[bool],
             "smart_transaction_trimming": Optional[bool],
             "propagate_tracestate": Optional[bool],
+            "custom_measurements": Optional[bool],
         },
         total=False,
     )

--- a/sentry_sdk/tracing.py
+++ b/sentry_sdk/tracing.py
@@ -132,17 +132,14 @@ class Span(object):
 
     def __repr__(self):
         # type: () -> str
-        return (
-            "<%s(op=%r, description:%r, trace_id=%r, span_id=%r, parent_span_id=%r, sampled=%r)>"
-            % (
-                self.__class__.__name__,
-                self.op,
-                self.description,
-                self.trace_id,
-                self.span_id,
-                self.parent_span_id,
-                self.sampled,
-            )
+        return "<%s(op=%r, description:%r, trace_id=%r, span_id=%r, parent_span_id=%r, sampled=%r)>" % (
+            self.__class__.__name__,
+            self.op,
+            self.description,
+            self.trace_id,
+            self.span_id,
+            self.parent_span_id,
+            self.sampled,
         )
 
     def __enter__(self):
@@ -520,17 +517,14 @@ class Transaction(Span):
 
     def __repr__(self):
         # type: () -> str
-        return (
-            "<%s(name=%r, op=%r, trace_id=%r, span_id=%r, parent_span_id=%r, sampled=%r)>"
-            % (
-                self.__class__.__name__,
-                self.name,
-                self.op,
-                self.trace_id,
-                self.span_id,
-                self.parent_span_id,
-                self.sampled,
-            )
+        return "<%s(name=%r, op=%r, trace_id=%r, span_id=%r, parent_span_id=%r, sampled=%r)>" % (
+            self.__class__.__name__,
+            self.name,
+            self.op,
+            self.trace_id,
+            self.span_id,
+            self.parent_span_id,
+            self.sampled,
         )
 
     @property

--- a/sentry_sdk/tracing.py
+++ b/sentry_sdk/tracing.py
@@ -607,25 +607,24 @@ class Transaction(Span):
             "spans": finished_spans,
         }
 
-
         if has_custom_measurements_enabled():
             event["measurements"] = self._measurements
 
         return hub.capture_event(event)
 
-
     def set_measurement(self, name, value, unit="ms"):
         # type: (str, float, MeasurementUnit) -> None
         if not has_custom_measurements_enabled():
-            logger.debug("[Tracing] Experimental custom_measurements feature is disabled")
+            logger.debug(
+                "[Tracing] Experimental custom_measurements feature is disabled"
+            )
             return
 
         if unit not in ("ns", "ms", "s"):
             logger.debug("[Tracing] Discarding measurement due to invalid unit")
             return
 
-        self._measurements[name] = { "value": value, "unit": unit }
-
+        self._measurements[name] = {"value": value, "unit": unit}
 
     def to_json(self):
         # type: () -> Dict[str, Any]

--- a/sentry_sdk/tracing.py
+++ b/sentry_sdk/tracing.py
@@ -517,7 +517,7 @@ class Transaction(Span):
         # first time an event needs it for inclusion in the captured data
         self._sentry_tracestate = sentry_tracestate
         self._third_party_tracestate = third_party_tracestate
-        self._measurements = {}
+        self._measurements = {} # type: Dict[str, Any]
 
     def __repr__(self):
         # type: () -> str

--- a/sentry_sdk/tracing.py
+++ b/sentry_sdk/tracing.py
@@ -8,7 +8,6 @@ import sentry_sdk
 
 from sentry_sdk.utils import logger
 from sentry_sdk._types import MYPY
-from sentry_sdk.tracing_utils import has_custom_measurements_enabled
 
 
 if MYPY:
@@ -747,4 +746,5 @@ from sentry_sdk.tracing_utils import (
     has_tracing_enabled,
     is_valid_sample_rate,
     maybe_create_breadcrumbs_from_span,
+    has_custom_measurements_enabled,
 )

--- a/sentry_sdk/tracing.py
+++ b/sentry_sdk/tracing.py
@@ -132,14 +132,17 @@ class Span(object):
 
     def __repr__(self):
         # type: () -> str
-        return "<%s(op=%r, description:%r, trace_id=%r, span_id=%r, parent_span_id=%r, sampled=%r)>" % (
-            self.__class__.__name__,
-            self.op,
-            self.description,
-            self.trace_id,
-            self.span_id,
-            self.parent_span_id,
-            self.sampled,
+        return (
+            "<%s(op=%r, description:%r, trace_id=%r, span_id=%r, parent_span_id=%r, sampled=%r)>"
+            % (
+                self.__class__.__name__,
+                self.op,
+                self.description,
+                self.trace_id,
+                self.span_id,
+                self.parent_span_id,
+                self.sampled,
+            )
         )
 
     def __enter__(self):
@@ -517,14 +520,17 @@ class Transaction(Span):
 
     def __repr__(self):
         # type: () -> str
-        return "<%s(name=%r, op=%r, trace_id=%r, span_id=%r, parent_span_id=%r, sampled=%r)>" % (
-            self.__class__.__name__,
-            self.name,
-            self.op,
-            self.trace_id,
-            self.span_id,
-            self.parent_span_id,
-            self.sampled,
+        return (
+            "<%s(name=%r, op=%r, trace_id=%r, span_id=%r, parent_span_id=%r, sampled=%r)>"
+            % (
+                self.__class__.__name__,
+                self.name,
+                self.op,
+                self.trace_id,
+                self.span_id,
+                self.parent_span_id,
+                self.sampled,
+            )
         )
 
     @property

--- a/sentry_sdk/tracing.py
+++ b/sentry_sdk/tracing.py
@@ -8,6 +8,7 @@ import sentry_sdk
 
 from sentry_sdk.utils import logger
 from sentry_sdk._types import MYPY
+from sentry_sdk.tracing_utils import has_custom_measurements_enabled
 
 
 if MYPY:
@@ -20,7 +21,7 @@ if MYPY:
     from typing import Tuple
     from typing import Iterator
 
-    from sentry_sdk._types import SamplingContext
+    from sentry_sdk._types import SamplingContext, MeasurementUnit
 
 
 class _SpanRecorder(object):
@@ -487,6 +488,7 @@ class Transaction(Span):
         "_sentry_tracestate",
         # tracestate data from other vendors, of the form `dogs=yes,cats=maybe`
         "_third_party_tracestate",
+        "_measurements",
     )
 
     def __init__(
@@ -515,6 +517,7 @@ class Transaction(Span):
         # first time an event needs it for inclusion in the captured data
         self._sentry_tracestate = sentry_tracestate
         self._third_party_tracestate = third_party_tracestate
+        self._measurements = {}
 
     def __repr__(self):
         # type: () -> str
@@ -594,17 +597,35 @@ class Transaction(Span):
         # to be garbage collected
         self._span_recorder = None
 
-        return hub.capture_event(
-            {
-                "type": "transaction",
-                "transaction": self.name,
-                "contexts": {"trace": self.get_trace_context()},
-                "tags": self._tags,
-                "timestamp": self.timestamp,
-                "start_timestamp": self.start_timestamp,
-                "spans": finished_spans,
-            }
-        )
+        event = {
+            "type": "transaction",
+            "transaction": self.name,
+            "contexts": {"trace": self.get_trace_context()},
+            "tags": self._tags,
+            "timestamp": self.timestamp,
+            "start_timestamp": self.start_timestamp,
+            "spans": finished_spans,
+        }
+
+
+        if has_custom_measurements_enabled():
+            event["measurements"] = self._measurements
+
+        return hub.capture_event(event)
+
+
+    def set_measurement(self, name, value, unit="ms"):
+        # type: (str, float, MeasurementUnit) -> None
+        if not has_custom_measurements_enabled():
+            logger.debug("[Tracing] Experimental custom_measurements feature is disabled")
+            return
+
+        if unit not in ("ns", "ms", "s"):
+            logger.debug("[Tracing] Discarding measurement due to invalid unit")
+            return
+
+        self._measurements[name] = { "value": value, "unit": unit }
+
 
     def to_json(self):
         # type: () -> Dict[str, Any]

--- a/sentry_sdk/tracing.py
+++ b/sentry_sdk/tracing.py
@@ -517,7 +517,7 @@ class Transaction(Span):
         # first time an event needs it for inclusion in the captured data
         self._sentry_tracestate = sentry_tracestate
         self._third_party_tracestate = third_party_tracestate
-        self._measurements = {} # type: Dict[str, Any]
+        self._measurements = {}  # type: Dict[str, Any]
 
     def __repr__(self):
         # type: () -> str

--- a/sentry_sdk/tracing.py
+++ b/sentry_sdk/tracing.py
@@ -605,16 +605,12 @@ class Transaction(Span):
 
         return hub.capture_event(event)
 
-    def set_measurement(self, name, value, unit="ms"):
+    def set_measurement(self, name, value, unit=""):
         # type: (str, float, MeasurementUnit) -> None
         if not has_custom_measurements_enabled():
             logger.debug(
                 "[Tracing] Experimental custom_measurements feature is disabled"
             )
-            return
-
-        if unit not in ("ns", "ms", "s"):
-            logger.debug("[Tracing] Discarding measurement due to invalid unit")
             return
 
         self._measurements[name] = {"value": value, "unit": unit}

--- a/sentry_sdk/tracing_utils.py
+++ b/sentry_sdk/tracing_utils.py
@@ -406,6 +406,13 @@ def has_tracestate_enabled(span=None):
     return bool(options and options["_experiments"].get("propagate_tracestate"))
 
 
+def has_custom_measurements_enabled():
+    # type: () -> bool
+    client = sentry_sdk.Hub.current.client
+    options = client and client.options
+    return bool(options and options["_experiments"].get("custom_measurements"))
+
+
 # Circular imports
 
 if MYPY:

--- a/tests/tracing/test_misc.py
+++ b/tests/tracing/test_misc.py
@@ -259,5 +259,5 @@ def test_set_meaurement(sentry_init, capture_events):
     transaction.finish()
 
     (event,) = events
-    assert event["measurements"]["metric.foo"] == { "value": 123, "unit": "ms" }
-    assert event["measurements"]["metric.bar"] == { "value": 456, "unit": "s" }
+    assert event["measurements"]["metric.foo"] == {"value": 123, "unit": "ms"}
+    assert event["measurements"]["metric.bar"] == {"value": 456, "unit": "s"}

--- a/tests/tracing/test_misc.py
+++ b/tests/tracing/test_misc.py
@@ -254,12 +254,23 @@ def test_set_meaurement(sentry_init, capture_events):
     events = capture_events()
 
     transaction = start_transaction(name="measuring stuff")
+
+    with pytest.raises(TypeError):
+        transaction.set_measurement()
+
+    with pytest.raises(TypeError):
+        transaction.set_measurement("metric.foo")
+
     transaction.set_measurement("metric.foo", 123)
     transaction.set_measurement("metric.bar", 456, unit="second")
     transaction.set_measurement("metric.baz", 420.69, unit="custom")
+    transaction.set_measurement("metric.foobar", 12, unit="percent")
+    transaction.set_measurement("metric.foobar", 17.99, unit="percent")
+
     transaction.finish()
 
     (event,) = events
     assert event["measurements"]["metric.foo"] == {"value": 123, "unit": ""}
     assert event["measurements"]["metric.bar"] == {"value": 456, "unit": "second"}
     assert event["measurements"]["metric.baz"] == {"value": 420.69, "unit": "custom"}
+    assert event["measurements"]["metric.foobar"] == {"value": 17.99, "unit": "percent"}

--- a/tests/tracing/test_misc.py
+++ b/tests/tracing/test_misc.py
@@ -255,9 +255,11 @@ def test_set_meaurement(sentry_init, capture_events):
 
     transaction = start_transaction(name="measuring stuff")
     transaction.set_measurement("metric.foo", 123)
-    transaction.set_measurement("metric.bar", 456, unit="s")
+    transaction.set_measurement("metric.bar", 456, unit="second")
+    transaction.set_measurement("metric.baz", 420.69, unit="custom")
     transaction.finish()
 
     (event,) = events
-    assert event["measurements"]["metric.foo"] == {"value": 123, "unit": "ms"}
-    assert event["measurements"]["metric.bar"] == {"value": 456, "unit": "s"}
+    assert event["measurements"]["metric.foo"] == {"value": 123, "unit": ""}
+    assert event["measurements"]["metric.bar"] == {"value": 456, "unit": "second"}
+    assert event["measurements"]["metric.baz"] == {"value": 420.69, "unit": "custom"}


### PR DESCRIPTION
I went with  `set_measurement(name, value, unit)` (singular) instead of `set_measurements` as in JS since I think this is more convenient for the end user. Otherwise they need to build the  name -> unit/value dict themselves.

This should be merged once [develop](https://github.com/getsentry/develop/pull/515#discussion_r819587128) is synced and the changes in relay have been made to support units for `measurements`.