### PR TITLE
fix(serializer): Implement abstract base class for customizing serialization

### DIFF
--- a/sentry_sdk/serializer.py
+++ b/sentry_sdk/serializer.py
@@ -85,6 +85,7 @@ def add_global_repr_processor(processor):
 class SentryReprMixin(ABC):
     @abstractmethod
     def sentry_repr(self):
+        # type: () -> str
         pass
 
 

--- a/sentry_sdk/serializer.py
+++ b/sentry_sdk/serializer.py
@@ -67,7 +67,7 @@ else:
 # Can be overwritten if wanting to send more bytes, e.g. with a custom server.
 # When changing this, keep in mind that events may be a little bit larger than
 # this value due to attached metadata, so keep the number conservative.
-MAX_EVENT_BYTES = 10**6
+MAX_EVENT_BYTES = 10 ** 6
 
 MAX_DATABAG_DEPTH = 5
 MAX_DATABAG_BREADTH = 10

--- a/tests/test_serializer.py
+++ b/tests/test_serializer.py
@@ -2,7 +2,7 @@ import sys
 
 import pytest
 
-from sentry_sdk.serializer import serialize
+from sentry_sdk.serializer import serialize, SentryReprMixin
 
 try:
     from hypothesis import given
@@ -51,7 +51,7 @@ def extra_normalizer(validate_event_schema):
 def test_bytes_serialization_decode(message_normalizer):
     binary = b"abc123\x80\xf0\x9f\x8d\x95"
     result = message_normalizer(binary, should_repr_strings=False)
-    assert result == u"abc123\ufffd\U0001f355"
+    assert result == "abc123\ufffd\U0001f355"
 
 
 @pytest.mark.xfail(sys.version_info < (3,), reason="Known safe_repr bugs in Py2.7")
@@ -67,7 +67,7 @@ def test_serialize_sets(extra_normalizer):
 
 
 def test_serialize_custom_mapping(extra_normalizer):
-    class CustomReprDict(dict):
+    class CustomReprDict(dict, SentryReprMixin):
         def sentry_repr(self):
             return "custom!"
 


### PR DESCRIPTION
The addition of `sentry_repr` in #1322 breaks `MagicMock` since it creates attrs on the fly.
This adds a new ABC mixin class called `SentryReprMixin` which the user has to inherit and implement the `sentry_repr` method to customize serialization instead of directly implementing it on their class.