### PR TITLE
fix(serializer): Make sentry_repr dunder method to avoid mock problems

### DIFF
--- a/sentry_sdk/serializer.py
+++ b/sentry_sdk/serializer.py
@@ -274,8 +274,6 @@ def serialize(event, smart_transaction_trimming=False, **kwargs):
                     return _flatten_annotated(result)
 
         sentry_repr = getattr(type(obj), "__sentry_repr__", None)
-        if callable(sentry_repr):
-            return sentry_repr(obj)
 
         if obj is None or isinstance(obj, (bool, number_types)):
             if should_repr_strings or (
@@ -284,6 +282,9 @@ def serialize(event, smart_transaction_trimming=False, **kwargs):
                 return safe_repr(obj)
             else:
                 return obj
+
+        elif callable(sentry_repr):
+            return sentry_repr(obj)
 
         elif isinstance(obj, datetime):
             return (

--- a/sentry_sdk/serializer.py
+++ b/sentry_sdk/serializer.py
@@ -273,6 +273,10 @@ def serialize(event, smart_transaction_trimming=False, **kwargs):
                 if result is not NotImplemented:
                     return _flatten_annotated(result)
 
+        sentry_repr = getattr(type(obj), "__sentry_repr__", None)
+        if callable(sentry_repr):
+            return sentry_repr(obj)
+
         if obj is None or isinstance(obj, (bool, number_types)):
             if should_repr_strings or (
                 isinstance(obj, float) and (math.isinf(obj) or math.isnan(obj))
@@ -280,9 +284,6 @@ def serialize(event, smart_transaction_trimming=False, **kwargs):
                 return safe_repr(obj)
             else:
                 return obj
-
-        elif callable(getattr(obj, "sentry_repr", None)):
-            return obj.sentry_repr()
 
         elif isinstance(obj, datetime):
             return (

--- a/tests/test_serializer.py
+++ b/tests/test_serializer.py
@@ -1,7 +1,5 @@
 import sys
-
 import pytest
-from unittest import mock
 
 from sentry_sdk.serializer import serialize
 
@@ -76,12 +74,18 @@ def test_serialize_custom_mapping(extra_normalizer):
     assert result == "custom!"
 
 
-def test_custom_mapping_doesnt_mess_with_mock(extra_normalizer):
-    """
-    Adding the __sentry_repr__ magic method check in the serializer
-    shouldn't mess with how mock works. This broke some stuff when we added
-    sentry_repr without the dunders.
-    """
-    m = mock.Mock()
-    extra_normalizer(m)
-    assert len(m.mock_calls) == 0
+try:
+    from unittest import mock
+except ImportError:
+    pass
+else:
+
+    def test_custom_mapping_doesnt_mess_with_mock(extra_normalizer):
+        """
+        Adding the __sentry_repr__ magic method check in the serializer
+        shouldn't mess with how mock works. This broke some stuff when we added
+        sentry_repr without the dunders.
+        """
+        m = mock.Mock()
+        extra_normalizer(m)
+        assert len(m.mock_calls) == 0

--- a/tests/test_serializer.py
+++ b/tests/test_serializer.py
@@ -74,18 +74,13 @@ def test_serialize_custom_mapping(extra_normalizer):
     assert result == "custom!"
 
 
-try:
-    from unittest import mock
-except ImportError:
-    pass
-else:
-
-    def test_custom_mapping_doesnt_mess_with_mock(extra_normalizer):
-        """
-        Adding the __sentry_repr__ magic method check in the serializer
-        shouldn't mess with how mock works. This broke some stuff when we added
-        sentry_repr without the dunders.
-        """
-        m = mock.Mock()
-        extra_normalizer(m)
-        assert len(m.mock_calls) == 0
+def test_custom_mapping_doesnt_mess_with_mock(extra_normalizer):
+    """
+    Adding the __sentry_repr__ magic method check in the serializer
+    shouldn't mess with how mock works. This broke some stuff when we added
+    sentry_repr without the dunders.
+    """
+    mock = pytest.importorskip("unittest.mock")
+    m = mock.Mock()
+    extra_normalizer(m)
+    assert len(m.mock_calls) == 0

--- a/tests/test_serializer.py
+++ b/tests/test_serializer.py
@@ -83,5 +83,5 @@ def test_custom_mapping_doesnt_mess_with_mock(extra_normalizer):
     sentry_repr without the dunders.
     """
     m = mock.Mock()
-    result = extra_normalizer(m)
+    extra_normalizer(m)
     assert len(m.mock_calls) == 0


### PR DESCRIPTION
The addition of `sentry_repr` in #1322 breaks `MagicMock` since it creates attrs on the fly.
This converts it to a dunder magic method `__sentry_repr__`.

See [here](https://github.com/python/cpython/blob/main/Lib/unittest/mock.py#L639-L640) that mock doesn't mess with custom magics and the following test code:

```bash
In [22]: from unittest import mock

In [23]: m = mock.Mock()

In [24]: m
Out[24]: <Mock id='140712474488560'>

In [25]: type(m)
Out[25]: unittest.mock.Mock

In [26]: getattr(m, "foo")
Out[26]: <Mock name='mock.foo' id='140712490825808'>

In [27]: getattr(m, "__foo__")
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
Input In [27], in <module>
----> 1 getattr(m, "__foo__")

File /usr/lib/python3.10/unittest/mock.py:636, in NonCallableMock.__getattr__(self, name)
    634         raise AttributeError("Mock object has no attribute %r" % name)
    635 elif _is_magic(name):
--> 636     raise AttributeError(name)
    637 if not self._mock_unsafe:
    638     if name.startswith(('assert', 'assret', 'asert', 'aseert', 'assrt')):

AttributeError: __foo__
```