### PR TITLE
fix(perf): Fix transaction setter on scope to use containing_transaction

### DIFF
--- a/sentry_sdk/scope.py
+++ b/sentry_sdk/scope.py
@@ -173,9 +173,8 @@ class Scope(object):
         # transaction name or transaction (self._span) depending on the type of
         # the value argument.
         self._transaction = value
-        span = self._span
-        if span and isinstance(span, Transaction):
-            span.name = value
+        if self._span and self._span.containing_transaction:
+            self._span.containing_transaction.name = value
 
     @_attr_setter
     def user(self, value):


### PR DESCRIPTION
fixes #1155, not sure why we have this discrepancy between getter and setter behaviour in the first place