### PR TITLE
Update session also for non sampled events and change filter order

### DIFF
--- a/sentry_sdk/client.py
+++ b/sentry_sdk/client.py
@@ -260,6 +260,12 @@ class _Client(object):
         if ignored_by_config_option:
             return False
 
+        return True
+    
+    def _should_sample(
+        self,
+        event,  # type: Event
+    ):
         not_in_sample_rate = (
             self.options["sample_rate"] < 1.0
             and random.random() >= self.options["sample_rate"]
@@ -270,7 +276,7 @@ class _Client(object):
                 self.transport.record_lost_event("sample_rate", data_category="error")
 
             return False
-
+        
         return True
 
     def _update_session_from_event(
@@ -348,6 +354,9 @@ class _Client(object):
         session = scope._session if scope else None
         if session:
             self._update_session_from_event(session, event)
+        
+        if not self._should_sample(event):
+            return None
 
         attachments = hint.get("attachments")
         is_transaction = event_opt.get("type") == "transaction"


### PR DESCRIPTION
We have already merged https://github.com/getsentry/sentry-python/pull/1390 where we moved `ignore_errors` before sampling.

Background for the order change:
We want to update the session for dropped events in case the event is dropped by sampling. Events dropped by other mechanisms should not update the session. See https://github.com/getsentry/develop/pull/551

Now we would like to discuss if we can simply move sampling after `before_send` and `event_processor` then update the session right before sampling.

What are implications of changing this?
* How does this affect session count and session crash rate?
* Will this have a negative effect on performance as `before_send` and `event_processor` will now be executed for every event instead of only being executed for sampled events? Developers may have fine tuned their sample rate for a good performance tradeoff and now we change how this behaves. Also developers can supply their own implementations for both `before_send` and `event_processor` on some SDKs so we have no way of predicting performance I'm afraid.
* We are uncertain why a developer chose to drop an event in `before_send` and `event_processor`:
    * Was it because they want to ignore the event - then it shouldn't update the session
    * Or was it to save quota - then it should update the session

Please feel free to optimize the code this is just to start the discussion.