### PR TITLE
WIP: try to remove Flask version contraint

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ setup(
     license="BSD",
     install_requires=["urllib3>=1.10.0", "certifi"],
     extras_require={
-        "flask": ["flask>=0.11,<2.1.0", "blinker>=1.1"],
+        "flask": ["flask>=0.11", "blinker>=1.1"],
         "quart": ["quart>=0.16.1", "blinker>=1.1"],
         "bottle": ["bottle>=0.12.13"],
         "falcon": ["falcon>=1.4"],

--- a/tox.ini
+++ b/tox.ini
@@ -25,7 +25,7 @@ envlist =
     {py3.5,py3.6,py3.7}-django-{2.0,2.1}
     {py3.7,py3.8,py3.9,py3.10}-django-{2.2,3.0,3.1,3.2}
 
-    {pypy,py2.7,py3.4,py3.5,py3.6,py3.7,py3.8,py3.9}-flask-{0.10,0.11,0.12,1.0}
+    {pypy,py2.7,py3.4,py3.5,py3.6,py3.7,py3.8,py3.9}-flask-{0.11,0.12,1.0}
     {pypy,py2.7,py3.5,py3.6,py3.7,py3.8,py3.9,py3.10}-flask-1.1
     {py3.6,py3.8,py3.9,py3.10}-flask-2.0
 
@@ -118,7 +118,6 @@ deps =
     django-3.2: Django>=3.2,<3.3
 
     flask: flask-login
-    flask-0.10: Flask>=0.10,<0.11
     flask-0.11: Flask>=0.11,<0.12
     flask-0.12: Flask>=0.12,<0.13
     flask-1.0: Flask>=1.0,<1.1
@@ -307,14 +306,14 @@ basepython =
 
 commands =
     ; https://github.com/pytest-dev/pytest/issues/5532
-    {py3.5,py3.6,py3.7,py3.8,py3.9}-flask-{0.10,0.11,0.12}: pip install pytest<5
+    {py3.5,py3.6,py3.7,py3.8,py3.9}-flask-{0.11,0.12}: pip install pytest<5
     {py3.6,py3.7,py3.8,py3.9}-flask-{0.11}: pip install Werkzeug<2
 
     ; https://github.com/pallets/flask/issues/4455
     {py3.7,py3.8,py3.9,py3.10}-flask-{0.11,0.12,1.0,1.1}: pip install "itsdangerous>=0.24,<2.0" "markupsafe<2.0.0" "jinja2<3.1.1"
 
     ; https://github.com/more-itertools/more-itertools/issues/578
-    py3.5-flask-{0.10,0.11,0.12}: pip install more-itertools<8.11.0
+    py3.5-flask-{0.11,0.12}: pip install more-itertools<8.11.0
 
     ; use old pytest for old Python versions:
     {py2.7,py3.4,py3.5}: pip install pytest-forked==1.1.3


### PR DESCRIPTION
There is a problem with the newly introduced version constraint for Flask:
https://github.com/getsentry/sentry-python/issues/1391

In this PR we try to fix this.