### PR TITLE
conf.py: removed double-spaces after period

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -89,7 +89,7 @@ on_rtd = os.environ.get("READTHEDOCS", None) == "True"
 html_theme = "alabaster"
 
 # Theme options are theme-specific and customize the look and feel of a theme
-# further.  For a list of options available for each theme, see the
+# further. For a list of options available for each theme, see the
 # documentation.
 #
 # html_theme_options = {}
@@ -103,7 +103,7 @@ html_static_path = ["_static"]
 # to template names.
 #
 # The default sidebars (for documents that don't match any pattern) are
-# defined by theme itself.  Builtin themes are using these templates by
+# defined by theme itself. Builtin themes are using these templates by
 # default: ``['localtoc.html', 'relations.html', 'sourcelink.html',
 # 'searchbox.html']``.
 #


### PR DESCRIPTION
Noticed while reading the documentation. Of course, with monospaced typewriters two space made sense, but it's 2022.




<!-- Describe your PR here. -->



<!--

  The following applies to third-party contributors.
  Sentry employees and contractors can delete or ignore.

-->

----

By submitting this pull request, I confirm that Sentry can use, modify, copy, and redistribute this contribution, under Sentry's choice of terms.
