### PR TITLE
chore: Update logo in readme (again)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,7 @@
 <p align="center">
-    <a href="https://sentry.io/?utm_source=github&utm_medium=logo" target="_blank" align="center">
-        <picture>
-            <source srcset="https://sentry-brand.storage.googleapis.com/sentry-logo-white.png" media="(prefers-color-scheme: dark)" />
-            <source srcset="https://sentry-brand.storage.googleapis.com/sentry-logo-black.png" media="(prefers-color-scheme: light), (prefers-color-scheme: no-preference)" />
-            <img src="https://sentry-brand.storage.googleapis.com/sentry-logo-black.png" alt="Sentry" width="280">
-        </picture>
-    </a>
+  <a href="https://sentry.io/?utm_source=github&utm_medium=logo" target="_blank">
+    <img src="https://sentry-brand.storage.googleapis.com/sentry-wordmark-dark-280x84.png" alt="Sentry" width="280" height="84">
+  </a>
 </p>
 
 _Bad software is everywhere, and we're tired of it. Sentry is on a mission to help developers write better software faster, so we can get back to enjoying technology. If you want to join us [<kbd>**Check out our open positions**</kbd>](https://sentry.io/careers/)_


### PR DESCRIPTION
In #1426, I updated the logo to use white or black based on theme.  While this works well for GitHub, it was pointed out to me that we also render these readme files on package registries, and some (including NPM and also PyPi) do not set their theme correctly.  (See https://github.com/getsentry/sentry-electron/pull/479#issuecomment-1118755203)

Updating to use the purple Sentry logo instead, which renders well on both white and black backgrounds, and will work for both GitHub and PyPi.

Sorry for the friction.

#skip-changelog