### PR TITLE
Use logging levelno instead of levelname.  Levelnames can be overridden

### DIFF
--- a/sentry_sdk/integrations/logging.py
+++ b/sentry_sdk/integrations/logging.py
@@ -130,7 +130,9 @@ def _breadcrumb_from_record(record):
 
 def _logging_to_event_level(record):
     # type: (LogRecord) -> str
-    return LOGGING_TO_EVENT_LEVEL.get(record.levelno, record.levelname.lower())
+    return LOGGING_TO_EVENT_LEVEL.get(
+        record.levelno, record.levelname.lower() if record.levelname else ""
+    )
 
 
 COMMON_RECORD_ATTRS = frozenset(

--- a/sentry_sdk/integrations/logging.py
+++ b/sentry_sdk/integrations/logging.py
@@ -120,7 +120,7 @@ def _breadcrumb_from_record(record):
 
 def _logging_to_event_level(record):
     # type: (LogRecord) -> str
-    return {
+    to_event_level = {
         logging.NOTSET: "notset",
         logging.DEBUG: "debug",
         logging.INFO: "info",
@@ -129,7 +129,13 @@ def _logging_to_event_level(record):
         logging.ERROR: "error",
         logging.FATAL: "fatal",
         logging.CRITICAL: "fatal",  # CRITICAL is same as FATAL
-    }.get(record.levelno, DEFAULT_EVENT_LEVEL)
+    }
+
+    event_level = to_event_level.get(record.levelno) or to_event_level.get(
+        DEFAULT_EVENT_LEVEL
+    )
+
+    return event_level
 
 
 COMMON_RECORD_ATTRS = frozenset(

--- a/sentry_sdk/integrations/logging.py
+++ b/sentry_sdk/integrations/logging.py
@@ -120,17 +120,16 @@ def _breadcrumb_from_record(record):
 
 def _logging_to_event_level(record):
     # type: (LogRecord) -> str
-    default = 'error'
     return {
-        logging.NOTSET: 'notset',
-        logging.DEBUG: 'debug',
-        logging.INFO: 'info',
-        logging.WARN: 'warning',  # WARN is same a WARNING
-        logging.WARNING: 'warning',
-        logging.ERROR: 'error',
-        logging.FATAL: 'fatal',
-        logging.CRITICAL: 'fatal',  # CRITICAL is same as FATAL
-    }.get(record.levelno, default)
+        logging.NOTSET: "notset",
+        logging.DEBUG: "debug",
+        logging.INFO: "info",
+        logging.WARN: "warning",  # WARN is same a WARNING
+        logging.WARNING: "warning",
+        logging.ERROR: "error",
+        logging.FATAL: "fatal",
+        logging.CRITICAL: "fatal",  # CRITICAL is same as FATAL
+    }.get(record.levelno, DEFAULT_EVENT_LEVEL)
 
 
 COMMON_RECORD_ATTRS = frozenset(

--- a/sentry_sdk/integrations/logging.py
+++ b/sentry_sdk/integrations/logging.py
@@ -24,6 +24,16 @@ if MYPY:
 
 DEFAULT_LEVEL = logging.INFO
 DEFAULT_EVENT_LEVEL = logging.ERROR
+LOGGING_TO_EVENT_LEVEL = {
+    logging.NOTSET: "notset",
+    logging.DEBUG: "debug",
+    logging.INFO: "info",
+    logging.WARN: "warning",  # WARN is same a WARNING
+    logging.WARNING: "warning",
+    logging.ERROR: "error",
+    logging.FATAL: "fatal",
+    logging.CRITICAL: "fatal",  # CRITICAL is same as FATAL
+}
 
 # Capturing events from those loggers causes recursion errors. We cannot allow
 # the user to unconditionally create events from those loggers under any
@@ -120,22 +130,7 @@ def _breadcrumb_from_record(record):
 
 def _logging_to_event_level(record):
     # type: (LogRecord) -> str
-    to_event_level = {
-        logging.NOTSET: "notset",
-        logging.DEBUG: "debug",
-        logging.INFO: "info",
-        logging.WARN: "warning",  # WARN is same a WARNING
-        logging.WARNING: "warning",
-        logging.ERROR: "error",
-        logging.FATAL: "fatal",
-        logging.CRITICAL: "fatal",  # CRITICAL is same as FATAL
-    }
-
-    event_level = to_event_level.get(record.levelno) or to_event_level.get(
-        DEFAULT_EVENT_LEVEL
-    )
-
-    return event_level
+    return LOGGING_TO_EVENT_LEVEL.get(record.levelno, record.levelname.lower())
 
 
 COMMON_RECORD_ATTRS = frozenset(

--- a/tests/integrations/logging/test_logging.py
+++ b/tests/integrations/logging/test_logging.py
@@ -127,7 +127,9 @@ def test_custom_log_level_names(sentry_init, capture_events):
     }
 
     # set custom log level names
-    logging.addLevelName(logging.DEBUG, "custom level debüg: ")
+    # fmt: off
+    logging.addLevelName(logging.DEBUG, u"custom level debüg: ")
+    # fmt: on
     logging.addLevelName(logging.INFO, "")
     logging.addLevelName(logging.WARN, "custom level warn: ")
     logging.addLevelName(logging.WARNING, "custom level warning: ")

--- a/tests/integrations/logging/test_logging.py
+++ b/tests/integrations/logging/test_logging.py
@@ -1,3 +1,4 @@
+# coding: utf-8
 import sys
 
 import pytest

--- a/tests/integrations/logging/test_logging.py
+++ b/tests/integrations/logging/test_logging.py
@@ -115,31 +115,39 @@ def test_logging_level(sentry_init, capture_events):
     assert not events
 
 
-def test_all_logging_levels(sentry_init, capture_events):
-
+def test_custom_log_level_names(sentry_init, capture_events):
     levels = {
-        # logging.NOTSET: 'notset',
-        logging.DEBUG: 'debug',
-        logging.INFO: 'info',
-        logging.WARN: 'warning',
-        logging.WARNING: 'warning',
-        logging.ERROR: 'error',
-        logging.CRITICAL: 'fatal',
-        logging.FATAL: 'fatal',
-        }
+        logging.DEBUG: "debug",
+        logging.INFO: "info",
+        logging.WARN: "warning",
+        logging.WARNING: "warning",
+        logging.ERROR: "error",
+        logging.CRITICAL: "fatal",
+        logging.FATAL: "fatal",
+    }
+
+    # set custom log level names
+    logging.addLevelName(logging.DEBUG, "custom level debüg: ")
+    logging.addLevelName(logging.INFO, "")
+    logging.addLevelName(logging.WARN, "custom level warn: ")
+    logging.addLevelName(logging.WARNING, "custom level warning: ")
+    logging.addLevelName(logging.ERROR, None)
+    logging.addLevelName(logging.CRITICAL, "custom level critical: ")
+    logging.addLevelName(logging.FATAL, "custom level 🔥: ")
 
     for logging_level, sentry_level in levels.items():
-
         logger.setLevel(logging_level)
-        sentry_init(integrations=[LoggingIntegration(event_level=logging_level)],
-                    default_integrations=False)
+        sentry_init(
+            integrations=[LoggingIntegration(event_level=logging_level)],
+            default_integrations=False,
+        )
         events = capture_events()
 
         logger.log(logging_level, "Trying level %s", logging_level)
         assert events
-        assert events[0]['level'] == sentry_level
-        assert events[0]['logentry']['message'] == "Trying level %s"
-        assert events[0]['logentry']['params'] == [logging_level]
+        assert events[0]["level"] == sentry_level
+        assert events[0]["logentry"]["message"] == "Trying level %s"
+        assert events[0]["logentry"]["params"] == [logging_level]
 
         del events[:]
 

--- a/tests/integrations/logging/test_logging.py
+++ b/tests/integrations/logging/test_logging.py
@@ -115,6 +115,35 @@ def test_logging_level(sentry_init, capture_events):
     assert not events
 
 
+def test_all_logging_levels(sentry_init, capture_events):
+
+    levels = {
+        # logging.NOTSET: 'notset',
+        logging.DEBUG: 'debug',
+        logging.INFO: 'info',
+        logging.WARN: 'warning',
+        logging.WARNING: 'warning',
+        logging.ERROR: 'error',
+        logging.CRITICAL: 'fatal',
+        logging.FATAL: 'fatal',
+        }
+
+    for logging_level, sentry_level in levels.items():
+
+        logger.setLevel(logging_level)
+        sentry_init(integrations=[LoggingIntegration(event_level=logging_level)],
+                    default_integrations=False)
+        events = capture_events()
+
+        logger.log(logging_level, "Trying level %s", logging_level)
+        assert events
+        assert events[0]['level'] == sentry_level
+        assert events[0]['logentry']['message'] == "Trying level %s"
+        assert events[0]['logentry']['params'] == [logging_level]
+
+        del events[:]
+
+
 def test_logging_filters(sentry_init, capture_events):
     sentry_init(integrations=[LoggingIntegration()], default_integrations=False)
     events = capture_events()


### PR DESCRIPTION
See https://github.com/getsentry/sentry-python/issues/1443