### PR TITLE
Dynamic Sampling Context / Baggage continuation

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -25,9 +25,9 @@ sys.path.insert(0, os.path.abspath(".."))
 
 # -- Project information -----------------------------------------------------
 
-project = u"sentry-python"
-copyright = u"2019, Sentry Team and Contributors"
-author = u"Sentry Team and Contributors"
+project = "sentry-python"
+copyright = "2019, Sentry Team and Contributors"
+author = "Sentry Team and Contributors"
 
 release = "1.6.0"
 version = ".".join(release.split(".")[:2])  # The short X.Y version.
@@ -72,7 +72,7 @@ language = None
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 # This pattern also affects html_static_path and html_extra_path.
-exclude_patterns = [u"_build", "Thumbs.db", ".DS_Store"]
+exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
 
 # The name of the Pygments (syntax highlighting) style to use.
 pygments_style = None
@@ -140,8 +140,8 @@ latex_documents = [
     (
         master_doc,
         "sentry-python.tex",
-        u"sentry-python Documentation",
-        u"Sentry Team and Contributors",
+        "sentry-python Documentation",
+        "Sentry Team and Contributors",
         "manual",
     )
 ]
@@ -151,7 +151,7 @@ latex_documents = [
 
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
-man_pages = [(master_doc, "sentry-python", u"sentry-python Documentation", [author], 1)]
+man_pages = [(master_doc, "sentry-python", "sentry-python Documentation", [author], 1)]
 
 
 # -- Options for Texinfo output ----------------------------------------------
@@ -163,7 +163,7 @@ texinfo_documents = [
     (
         master_doc,
         "sentry-python",
-        u"sentry-python Documentation",
+        "sentry-python Documentation",
         author,
         "sentry-python",
         "One line description of project.",

--- a/sentry_sdk/client.py
+++ b/sentry_sdk/client.py
@@ -373,7 +373,11 @@ class _Client(object):
             event_opt.get("contexts", {}).get("trace", {}).pop("tracestate", "")
         )
 
-        baggage = event_opt.get("contexts", {}).get("trace", {}).pop("baggage", None)
+        dynamic_sampling_context = (
+            event_opt.get("contexts", {})
+            .get("trace", {})
+            .pop("dynamic_sampling_context", {})
+        )
 
         # Transactions or events with attachments should go to the /envelope/
         # endpoint.
@@ -391,8 +395,8 @@ class _Client(object):
 
                 if tracestate_data:
                     headers["trace"] = tracestate_data
-            elif baggage is not None:
-                headers["trace"] = baggage.trace_envelope_header()
+            elif dynamic_sampling_context:
+                headers["trace"] = dynamic_sampling_context
 
             envelope = Envelope(headers=headers)
 

--- a/sentry_sdk/scope.py
+++ b/sentry_sdk/scope.py
@@ -375,10 +375,10 @@ class Scope(object):
         if self._contexts:
             event.setdefault("contexts", {}).update(self._contexts)
 
-        if self.transaction is not None:
+        if self._span is not None:
             contexts = event.setdefault("contexts", {})
             if not contexts.get("trace"):
-                contexts["trace"] = self.transaction.get_trace_context()
+                contexts["trace"] = self._span.get_trace_context()
 
         exc_info = hint.get("exc_info")
         if exc_info is not None:

--- a/sentry_sdk/scope.py
+++ b/sentry_sdk/scope.py
@@ -375,10 +375,10 @@ class Scope(object):
         if self._contexts:
             event.setdefault("contexts", {}).update(self._contexts)
 
-        if self._span is not None:
+        if self.transaction is not None:
             contexts = event.setdefault("contexts", {})
             if not contexts.get("trace"):
-                contexts["trace"] = self._span.get_trace_context()
+                contexts["trace"] = self.transaction.get_trace_context()
 
         exc_info = hint.get("exc_info")
         if exc_info is not None:

--- a/sentry_sdk/tracing.py
+++ b/sentry_sdk/tracing.py
@@ -132,14 +132,17 @@ class Span(object):
 
     def __repr__(self):
         # type: () -> str
-        return "<%s(op=%r, description:%r, trace_id=%r, span_id=%r, parent_span_id=%r, sampled=%r)>" % (
-            self.__class__.__name__,
-            self.op,
-            self.description,
-            self.trace_id,
-            self.span_id,
-            self.parent_span_id,
-            self.sampled,
+        return (
+            "<%s(op=%r, description:%r, trace_id=%r, span_id=%r, parent_span_id=%r, sampled=%r)>"
+            % (
+                self.__class__.__name__,
+                self.op,
+                self.description,
+                self.trace_id,
+                self.span_id,
+                self.parent_span_id,
+                self.sampled,
+            )
         )
 
     def __enter__(self):
@@ -539,14 +542,17 @@ class Transaction(Span):
 
     def __repr__(self):
         # type: () -> str
-        return "<%s(name=%r, op=%r, trace_id=%r, span_id=%r, parent_span_id=%r, sampled=%r)>" % (
-            self.__class__.__name__,
-            self.name,
-            self.op,
-            self.trace_id,
-            self.span_id,
-            self.parent_span_id,
-            self.sampled,
+        return (
+            "<%s(name=%r, op=%r, trace_id=%r, span_id=%r, parent_span_id=%r, sampled=%r)>"
+            % (
+                self.__class__.__name__,
+                self.name,
+                self.op,
+                self.trace_id,
+                self.span_id,
+                self.parent_span_id,
+                self.sampled,
+            )
         )
 
     @property

--- a/sentry_sdk/tracing.py
+++ b/sentry_sdk/tracing.py
@@ -132,17 +132,14 @@ class Span(object):
 
     def __repr__(self):
         # type: () -> str
-        return (
-            "<%s(op=%r, description:%r, trace_id=%r, span_id=%r, parent_span_id=%r, sampled=%r)>"
-            % (
-                self.__class__.__name__,
-                self.op,
-                self.description,
-                self.trace_id,
-                self.span_id,
-                self.parent_span_id,
-                self.sampled,
-            )
+        return "<%s(op=%r, description:%r, trace_id=%r, span_id=%r, parent_span_id=%r, sampled=%r)>" % (
+            self.__class__.__name__,
+            self.op,
+            self.description,
+            self.trace_id,
+            self.span_id,
+            self.parent_span_id,
+            self.sampled,
         )
 
     def __enter__(self):
@@ -249,10 +246,10 @@ class Span(object):
 
         # TODO-neel move away from this kwargs stuff, it's confusing and opaque
         # make more explicit
-        sentrytrace_kwargs = extract_sentrytrace_data(headers.get("sentry-trace"))
-
         baggage = Baggage.from_incoming_header(headers.get("baggage"))
         kwargs.update({"baggage": baggage})
+
+        sentrytrace_kwargs = extract_sentrytrace_data(headers.get("sentry-trace"))
 
         if sentrytrace_kwargs is not None:
             kwargs.update(sentrytrace_kwargs)
@@ -268,7 +265,7 @@ class Span(object):
     def iter_headers(self):
         # type: () -> Iterator[Tuple[str, str]]
         """
-        Creates a generator which returns the span's `sentry-trace` and
+        Creates a generator which returns the span's `sentry-trace`, `baggage` and
         `tracestate` headers.
 
         If the span's containing transaction doesn't yet have a
@@ -542,17 +539,14 @@ class Transaction(Span):
 
     def __repr__(self):
         # type: () -> str
-        return (
-            "<%s(name=%r, op=%r, trace_id=%r, span_id=%r, parent_span_id=%r, sampled=%r)>"
-            % (
-                self.__class__.__name__,
-                self.name,
-                self.op,
-                self.trace_id,
-                self.span_id,
-                self.parent_span_id,
-                self.sampled,
-            )
+        return "<%s(name=%r, op=%r, trace_id=%r, span_id=%r, parent_span_id=%r, sampled=%r)>" % (
+            self.__class__.__name__,
+            self.name,
+            self.op,
+            self.trace_id,
+            self.span_id,
+            self.parent_span_id,
+            self.sampled,
         )
 
     @property

--- a/sentry_sdk/tracing.py
+++ b/sentry_sdk/tracing.py
@@ -285,6 +285,9 @@ class Span(object):
         if tracestate:
             yield "tracestate", tracestate
 
+        if self.containing_transaction and self.containing_transaction._baggage:
+            yield "baggage", self.containing_transaction._baggage.serialize()
+
     @classmethod
     def from_traceparent(
         cls,

--- a/sentry_sdk/tracing.py
+++ b/sentry_sdk/tracing.py
@@ -466,6 +466,33 @@ class Span(object):
 
         return rv
 
+    def get_trace_context(self):
+        # type: () -> Any
+        rv = {
+            "trace_id": self.trace_id,
+            "span_id": self.span_id,
+            "parent_span_id": self.parent_span_id,
+            "op": self.op,
+            "description": self.description,
+        }
+        if self.status:
+            rv["status"] = self.status
+
+        # if the transaction didn't inherit a tracestate value, and no outgoing
+        # requests - whose need for headers would have caused a tracestate value
+        # to be created - were made as part of the transaction, the transaction
+        # still won't have a tracestate value, so compute one now
+        sentry_tracestate = self.get_or_set_sentry_tracestate()
+
+        if sentry_tracestate:
+            rv["tracestate"] = sentry_tracestate
+
+        # TODO-neel populate fresh if head SDK
+        if self.containing_transaction and self.containing_transaction._baggage:
+            rv["bagage"] = self.containing_transaction._baggage
+
+        return rv
+
 
 class Transaction(Span):
     __slots__ = (
@@ -621,33 +648,6 @@ class Transaction(Span):
 
         rv["name"] = self.name
         rv["sampled"] = self.sampled
-
-        return rv
-
-    def get_trace_context(self):
-        # type: () -> Any
-        rv = {
-            "trace_id": self.trace_id,
-            "span_id": self.span_id,
-            "parent_span_id": self.parent_span_id,
-            "op": self.op,
-            "description": self.description,
-        }
-        if self.status:
-            rv["status"] = self.status
-
-        # if the transaction didn't inherit a tracestate value, and no outgoing
-        # requests - whose need for headers would have caused a tracestate value
-        # to be created - were made as part of the transaction, the transaction
-        # still won't have a tracestate value, so compute one now
-        sentry_tracestate = self.get_or_set_sentry_tracestate()
-
-        if sentry_tracestate:
-            rv["tracestate"] = sentry_tracestate
-
-        # TODO-neel populate fresh if head SDK
-        if self._baggage:
-            rv["bagage"] = self._baggage
 
         return rv
 

--- a/sentry_sdk/tracing.py
+++ b/sentry_sdk/tracing.py
@@ -463,29 +463,6 @@ class Span(object):
 
         return rv
 
-    def get_trace_context(self):
-        # type: () -> Any
-        rv = {
-            "trace_id": self.trace_id,
-            "span_id": self.span_id,
-            "parent_span_id": self.parent_span_id,
-            "op": self.op,
-            "description": self.description,
-        }
-        if self.status:
-            rv["status"] = self.status
-
-        # if the transaction didn't inherit a tracestate value, and no outgoing
-        # requests - whose need for headers would have caused a tracestate value
-        # to be created - were made as part of the transaction, the transaction
-        # still won't have a tracestate value, so compute one now
-        sentry_tracestate = self.get_or_set_sentry_tracestate()
-
-        if sentry_tracestate:
-            rv["tracestate"] = sentry_tracestate
-
-        return rv
-
 
 class Transaction(Span):
     __slots__ = (
@@ -641,6 +618,33 @@ class Transaction(Span):
 
         rv["name"] = self.name
         rv["sampled"] = self.sampled
+
+        return rv
+
+    def get_trace_context(self):
+        # type: () -> Any
+        rv = {
+            "trace_id": self.trace_id,
+            "span_id": self.span_id,
+            "parent_span_id": self.parent_span_id,
+            "op": self.op,
+            "description": self.description,
+        }
+        if self.status:
+            rv["status"] = self.status
+
+        # if the transaction didn't inherit a tracestate value, and no outgoing
+        # requests - whose need for headers would have caused a tracestate value
+        # to be created - were made as part of the transaction, the transaction
+        # still won't have a tracestate value, so compute one now
+        sentry_tracestate = self.get_or_set_sentry_tracestate()
+
+        if sentry_tracestate:
+            rv["tracestate"] = sentry_tracestate
+
+        # TODO-neel populate fresh if head SDK
+        if self._baggage:
+            rv["bagage"] = self._baggage
 
         return rv
 

--- a/sentry_sdk/tracing.py
+++ b/sentry_sdk/tracing.py
@@ -474,7 +474,7 @@ class Span(object):
             "parent_span_id": self.parent_span_id,
             "op": self.op,
             "description": self.description,
-        }
+        }  # type: Dict[str, Any]
         if self.status:
             rv["status"] = self.status
 
@@ -489,7 +489,9 @@ class Span(object):
 
         # TODO-neel populate fresh if head SDK
         if self.containing_transaction and self.containing_transaction._baggage:
-            rv["bagage"] = self.containing_transaction._baggage
+            rv[
+                "dynamic_sampling_context"
+            ] = self.containing_transaction._baggage.dynamic_sampling_context()
 
         return rv
 

--- a/sentry_sdk/tracing.py
+++ b/sentry_sdk/tracing.py
@@ -215,7 +215,7 @@ class Span(object):
         # type: (...) -> Transaction
         """
         Create a Transaction with the given params, then add in data pulled from
-        the 'sentry-trace' and 'tracestate' headers from the environ (if any)
+        the 'sentry-trace', 'baggage' and 'tracestate' headers from the environ (if any)
         before returning the Transaction.
 
         This is different from `continue_from_headers` in that it assumes header
@@ -227,6 +227,7 @@ class Span(object):
                 "Deprecated: use Transaction.continue_from_environ "
                 "instead of Span.continue_from_environ."
             )
+        # TODO-neel not sure if baggage has HTTP_ prefix
         return Transaction.continue_from_headers(EnvironHeaders(environ), **kwargs)
 
     @classmethod
@@ -238,7 +239,7 @@ class Span(object):
         # type: (...) -> Transaction
         """
         Create a transaction with the given params (including any data pulled from
-        the 'sentry-trace' and 'tracestate' headers).
+        the 'sentry-trace', 'baggage' and 'tracestate' headers).
         """
         # TODO move this to the Transaction class
         if cls is Span:
@@ -247,7 +248,17 @@ class Span(object):
                 "instead of Span.continue_from_headers."
             )
 
-        kwargs.update(extract_sentrytrace_data(headers.get("sentry-trace")))
+        # TODO-neel move away from this kwargs stuff, it's confusing and opaque
+        # make more explicit
+        sentrytrace_kwargs = extract_sentrytrace_data(headers.get("sentry-trace"))
+
+        baggage = Baggage.from_incoming_header(headers.get("baggage"))
+        kwargs.update({"baggage": baggage})
+
+        if sentrytrace_kwargs is not None:
+            kwargs.update(sentrytrace_kwargs)
+            baggage.freeze
+
         kwargs.update(extract_tracestate_data(headers.get("tracestate")))
 
         transaction = Transaction(**kwargs)
@@ -488,6 +499,7 @@ class Transaction(Span):
         # tracestate data from other vendors, of the form `dogs=yes,cats=maybe`
         "_third_party_tracestate",
         "_measurements",
+        "_baggage",
     )
 
     def __init__(
@@ -496,6 +508,7 @@ class Transaction(Span):
         parent_sampled=None,  # type: Optional[bool]
         sentry_tracestate=None,  # type: Optional[str]
         third_party_tracestate=None,  # type: Optional[str]
+        baggage=None,  # type: Optional[Baggage]
         **kwargs  # type: Any
     ):
         # type: (...) -> None
@@ -517,6 +530,7 @@ class Transaction(Span):
         self._sentry_tracestate = sentry_tracestate
         self._third_party_tracestate = third_party_tracestate
         self._measurements = {}  # type: Dict[str, Any]
+        self._baggage = baggage
 
     def __repr__(self):
         # type: () -> str
@@ -734,6 +748,7 @@ class Transaction(Span):
 # Circular imports
 
 from sentry_sdk.tracing_utils import (
+    Baggage,
     EnvironHeaders,
     compute_tracestate_entry,
     extract_sentrytrace_data,

--- a/sentry_sdk/tracing.py
+++ b/sentry_sdk/tracing.py
@@ -227,7 +227,6 @@ class Span(object):
                 "Deprecated: use Transaction.continue_from_environ "
                 "instead of Span.continue_from_environ."
             )
-        # TODO-neel not sure if baggage has HTTP_ prefix
         return Transaction.continue_from_headers(EnvironHeaders(environ), **kwargs)
 
     @classmethod

--- a/sentry_sdk/tracing_utils.py
+++ b/sentry_sdk/tracing_utils.py
@@ -424,6 +424,18 @@ class Baggage(object):
     SENTRY_PREFIX = "sentry-"
     SENTRY_PREFIX_REGEX = re.compile("^sentry-")
 
+    # DynamicSamplingContext
+    DSC_KEYS = [
+        "trace_id",
+        "public_key",
+        "sample_rate",
+        "release",
+        "environment",
+        "transaction",
+        "user_id",
+        "user_segment",
+    ]
+
     def __init__(
         self,
         sentry_items={},  # type: Dict[str, str]
@@ -458,6 +470,18 @@ class Baggage(object):
 
     def freeze(self):
         self.mutable = False
+
+    def trace_envelope_header(self):
+        header = {}
+
+        for key in Baggage.DSC_KEYS:
+            if self.sentry_items[key] is not None:
+                header[key] = self.sentry_items[key]
+
+        return header
+
+    def serialize(self):
+        pass
 
 
 # Circular imports

--- a/sentry_sdk/tracing_utils.py
+++ b/sentry_sdk/tracing_utils.py
@@ -220,8 +220,6 @@ def extract_sentrytrace_data(header):
     if not header:
         return None
 
-    trace_id = parent_span_id = parent_sampled = None
-
     if header.startswith("00-") and header.endswith("-00"):
         header = header[3:-3]
 
@@ -230,6 +228,7 @@ def extract_sentrytrace_data(header):
         return None
 
     trace_id, parent_span_id, sampled_str = match.groups()
+    parent_sampled = None
 
     if trace_id:
         trace_id = "{:032x}".format(int(trace_id, 16))

--- a/sentry_sdk/tracing_utils.py
+++ b/sentry_sdk/tracing_utils.py
@@ -480,8 +480,18 @@ class Baggage(object):
 
         return header
 
-    def serialize(self):
-        pass
+    def serialize(self, include_third_party=False):
+        # type: (bool) -> str
+        items = []
+
+        for key, val in self.sentry_items:
+            item = Baggage.SENTRY_PREFIX + quote(key) + "=" + quote(val)
+            items.append(item)
+
+        if include_third_party:
+            items.append(self.third_party_items)
+
+        return ",".join(items)
 
 
 # Circular imports

--- a/sentry_sdk/tracing_utils.py
+++ b/sentry_sdk/tracing_utils.py
@@ -211,27 +211,30 @@ def maybe_create_breadcrumbs_from_span(hub, span):
 
 
 def extract_sentrytrace_data(header):
-    # type: (Optional[str]) -> typing.Mapping[str, Union[str, bool, None]]
+    # type: (Optional[str]) -> Optional[typing.Mapping[str, Union[str, bool, None]]]
     """
     Given a `sentry-trace` header string, return a dictionary of data.
     """
+    if not header:
+        return None
+
     trace_id = parent_span_id = parent_sampled = None
 
-    if header:
-        if header.startswith("00-") and header.endswith("-00"):
-            header = header[3:-3]
+    if header.startswith("00-") and header.endswith("-00"):
+        header = header[3:-3]
 
-        match = SENTRY_TRACE_REGEX.match(header)
+    match = SENTRY_TRACE_REGEX.match(header)
+    if not match:
+        return None
 
-        if match:
-            trace_id, parent_span_id, sampled_str = match.groups()
+    trace_id, parent_span_id, sampled_str = match.groups()
 
-            if trace_id:
-                trace_id = "{:032x}".format(int(trace_id, 16))
-            if parent_span_id:
-                parent_span_id = "{:016x}".format(int(parent_span_id, 16))
-            if sampled_str:
-                parent_sampled = sampled_str != "0"
+    if trace_id:
+        trace_id = "{:032x}".format(int(trace_id, 16))
+    if parent_span_id:
+        parent_span_id = "{:016x}".format(int(parent_span_id, 16))
+    if sampled_str:
+        parent_sampled = sampled_str != "0"
 
     return {
         "trace_id": trace_id,
@@ -411,6 +414,47 @@ def has_custom_measurements_enabled():
     client = sentry_sdk.Hub.current.client
     options = client and client.options
     return bool(options and options["_experiments"].get("custom_measurements"))
+
+
+class Baggage(object):
+    __slots__ = ("sentry_items", "third_party_items", "mutable")
+
+    SENTRY_PREFIX = "sentry-"
+    SENTRY_PREFIX_REGEX = re.compile("^sentry-")
+
+    def __init__(
+        self,
+        sentry_items={},  # type: Dict[str, str]
+        third_party_items={},  # type: Dict[str, str]
+        mutable=True,  # type: bool
+    ):
+        self.sentry_items = sentry_items
+        self.third_party_items = third_party_items
+        self.mutable = mutable
+
+    @classmethod
+    def from_incoming_header(cls, header):
+        """
+        freeze if incoming header already has sentry baggage
+        """
+        sentry_items = {}
+        third_party_items = {}
+        mutable = True
+
+        if header is not None:
+            for item in header.split(","):
+                key, val = item.strip().split("=")
+                if Baggage.SENTRY_PREFIX_REGEX.match(key):
+                    # TODO-neel decodeURI?
+                    sentry_items[key] = val
+                    mutable = False
+                else:
+                    third_party_items[key] = val
+
+        return Baggage(sentry_items, third_party_items, mutable)
+
+    def freeze(self):
+        self.mutable = False
 
 
 # Circular imports

--- a/sentry_sdk/tracing_utils.py
+++ b/sentry_sdk/tracing_utils.py
@@ -16,7 +16,7 @@ from sentry_sdk.utils import (
     to_string,
     from_base64,
 )
-from sentry_sdk._compat import PY2
+from sentry_sdk._compat import PY2, iteritems
 from sentry_sdk._types import MYPY
 
 if PY2:
@@ -438,7 +438,7 @@ class Baggage(object):
 
     def __init__(
         self,
-        sentry_items={},  # type: Dict[str, str]
+        sentry_items,  # type: Dict[str, str]
         third_party_items="",  # type: str
         mutable=True,  # type: bool
     ):
@@ -448,6 +448,7 @@ class Baggage(object):
 
     @classmethod
     def from_incoming_header(cls, header):
+        # type: (Optional[str]) -> Baggage
         """
         freeze if incoming header already has sentry baggage
         """
@@ -469,9 +470,11 @@ class Baggage(object):
         return Baggage(sentry_items, third_party_items, mutable)
 
     def freeze(self):
+        # type: () -> None
         self.mutable = False
 
-    def trace_envelope_header(self):
+    def dynamic_sampling_context(self):
+        # type: () -> Dict[str, str]
         header = {}
 
         for key in Baggage.DSC_KEYS:
@@ -484,7 +487,7 @@ class Baggage(object):
         # type: (bool) -> str
         items = []
 
-        for key, val in self.sentry_items:
+        for key, val in iteritems(self.sentry_items):
             item = Baggage.SENTRY_PREFIX + quote(key) + "=" + quote(val)
             items.append(item)
 

--- a/sentry_sdk/tracing_utils.py
+++ b/sentry_sdk/tracing_utils.py
@@ -464,7 +464,7 @@ class Baggage(object):
                     sentry_items[baggage_key] = unquote(val)
                     mutable = False
                 else:
-                    third_party_items += val
+                    third_party_items += ("," if third_party_items else "") + item
 
         return Baggage(sentry_items, third_party_items, mutable)
 

--- a/sentry_sdk/tracing_utils.py
+++ b/sentry_sdk/tracing_utils.py
@@ -477,8 +477,9 @@ class Baggage(object):
         header = {}
 
         for key in Baggage.DSC_KEYS:
-            if self.sentry_items.get(key):
-                header[key] = self.sentry_items[key]
+            item = self.sentry_items.get(key)
+            if item:
+                header[key] = item
 
         return header
 

--- a/sentry_sdk/tracing_utils.py
+++ b/sentry_sdk/tracing_utils.py
@@ -456,7 +456,7 @@ class Baggage(object):
         third_party_items = ""
         mutable = True
 
-        if header is not None:
+        if header:
             for item in header.split(","):
                 item = item.strip()
                 key, val = item.split("=")
@@ -478,7 +478,7 @@ class Baggage(object):
         header = {}
 
         for key in Baggage.DSC_KEYS:
-            if self.sentry_items[key] is not None:
+            if self.sentry_items.get(key):
                 header[key] = self.sentry_items[key]
 
         return header

--- a/tests/integrations/stdlib/test_httplib.py
+++ b/tests/integrations/stdlib/test_httplib.py
@@ -151,7 +151,7 @@ def test_outgoing_trace_headers(
 
         HTTPSConnection("www.squirrelchasers.com").request("GET", "/top-chasers")
 
-        (request_str,) = mock_send.call_args.args
+        (request_str,) = mock_send.call_args[0]
         request_headers = {}
         for line in request_str.decode("utf-8").split("\r\n")[1:]:
             if line:

--- a/tests/integrations/stdlib/test_httplib.py
+++ b/tests/integrations/stdlib/test_httplib.py
@@ -23,6 +23,7 @@ except ImportError:
     import mock  # python < 3.3
 
 from sentry_sdk import capture_message, start_transaction
+from sentry_sdk.tracing import Transaction
 from sentry_sdk.integrations.stdlib import StdlibIntegration
 
 
@@ -132,7 +133,17 @@ def test_outgoing_trace_headers(
 
     sentry_init(traces_sample_rate=1.0)
 
+    headers = {}
+    headers["baggage"] = (
+        "other-vendor-value-1=foo;bar;baz, sentry-trace_id=771a43a4192642f0b136d5159a501700, "
+        "sentry-public_key=49d0f7386ad645858ae85020e393bef3, sentry-sample_rate=0.01337, "
+        "sentry-user_id=Am%C3%A9lie, other-vendor-value-2=foo;bar;"
+    )
+
+    transaction = Transaction.continue_from_headers(headers)
+
     with start_transaction(
+        transaction=transaction,
         name="/interactions/other-dogs/new-dog",
         op="greeting.sniff",
         trace_id="12312012123120121231201212312012",
@@ -140,14 +151,28 @@ def test_outgoing_trace_headers(
 
         HTTPSConnection("www.squirrelchasers.com").request("GET", "/top-chasers")
 
+        (request_str,) = mock_send.call_args.args
+        request_headers = {}
+        for line in request_str.decode("utf-8").split("\r\n")[1:]:
+            if line:
+                key, val = line.split(": ")
+                request_headers[key] = val
+
         request_span = transaction._span_recorder.spans[-1]
-
-        expected_sentry_trace = (
-            "sentry-trace: {trace_id}-{parent_span_id}-{sampled}".format(
-                trace_id=transaction.trace_id,
-                parent_span_id=request_span.span_id,
-                sampled=1,
-            )
+        expected_sentry_trace = "{trace_id}-{parent_span_id}-{sampled}".format(
+            trace_id=transaction.trace_id,
+            parent_span_id=request_span.span_id,
+            sampled=1,
         )
+        assert request_headers["sentry-trace"] == expected_sentry_trace
 
-        mock_send.assert_called_with(StringContaining(expected_sentry_trace))
+        expected_outgoing_baggage_items = [
+            "sentry-trace_id=771a43a4192642f0b136d5159a501700",
+            "sentry-public_key=49d0f7386ad645858ae85020e393bef3",
+            "sentry-sample_rate=0.01337",
+            "sentry-user_id=Am%C3%A9lie",
+        ]
+
+        assert sorted(request_headers["baggage"].split(",")) == sorted(
+            expected_outgoing_baggage_items
+        )

--- a/tests/tracing/test_baggage.py
+++ b/tests/tracing/test_baggage.py
@@ -8,16 +8,14 @@ def test_third_party_baggage():
 
     assert baggage.mutable
     assert baggage.sentry_items == {}
-    assert (
-        sorted(baggage.third_party_items.split(","))
-        == sorted("other-vendor-value-1=foo;bar;baz,other-vendor-value-2=foo;bar;".split(","))
+    assert sorted(baggage.third_party_items.split(",")) == sorted(
+        "other-vendor-value-1=foo;bar;baz,other-vendor-value-2=foo;bar;".split(",")
     )
 
     assert baggage.dynamic_sampling_context() == {}
     assert baggage.serialize() == ""
-    assert (
-        sorted(baggage.serialize(include_third_party=True).split(","))
-        == sorted("other-vendor-value-1=foo;bar;baz,other-vendor-value-2=foo;bar;".split(","))
+    assert sorted(baggage.serialize(include_third_party=True).split(",")) == sorted(
+        "other-vendor-value-1=foo;bar;baz,other-vendor-value-2=foo;bar;".split(",")
     )
 
 
@@ -51,15 +49,19 @@ def test_mixed_baggage():
         "sample_rate": "0.01337",
     }
 
-    assert sorted(baggage.serialize().split(",")) == sorted((
-        "sentry-trace_id=771a43a4192642f0b136d5159a501700,"
-        "sentry-public_key=49d0f7386ad645858ae85020e393bef3,"
-        "sentry-sample_rate=0.01337,sentry-user_id=Am%C3%A9lie"
-    ).split(","))
+    assert sorted(baggage.serialize().split(",")) == sorted(
+        (
+            "sentry-trace_id=771a43a4192642f0b136d5159a501700,"
+            "sentry-public_key=49d0f7386ad645858ae85020e393bef3,"
+            "sentry-sample_rate=0.01337,sentry-user_id=Am%C3%A9lie"
+        ).split(",")
+    )
 
-    assert sorted(baggage.serialize(include_third_party=True).split(",")) == sorted((
-        "sentry-trace_id=771a43a4192642f0b136d5159a501700,"
-        "sentry-public_key=49d0f7386ad645858ae85020e393bef3,"
-        "sentry-sample_rate=0.01337,sentry-user_id=Am%C3%A9lie,"
-        "other-vendor-value-1=foo;bar;baz,other-vendor-value-2=foo;bar;"
-    ).split(","))
+    assert sorted(baggage.serialize(include_third_party=True).split(",")) == sorted(
+        (
+            "sentry-trace_id=771a43a4192642f0b136d5159a501700,"
+            "sentry-public_key=49d0f7386ad645858ae85020e393bef3,"
+            "sentry-sample_rate=0.01337,sentry-user_id=Am%C3%A9lie,"
+            "other-vendor-value-1=foo;bar;baz,other-vendor-value-2=foo;bar;"
+        ).split(",")
+    )

--- a/tests/tracing/test_baggage.py
+++ b/tests/tracing/test_baggage.py
@@ -1,0 +1,65 @@
+import pytest
+from sentry_sdk.tracing_utils import Baggage
+
+
+def test_third_party_baggage():
+    header = "other-vendor-value-1=foo;bar;baz, other-vendor-value-2=foo;bar;"
+    baggage = Baggage.from_incoming_header(header)
+
+    assert baggage.mutable
+    assert baggage.sentry_items == {}
+    assert (
+        baggage.third_party_items
+        == "other-vendor-value-1=foo;bar;baz,other-vendor-value-2=foo;bar;"
+    )
+
+    assert baggage.dynamic_sampling_context() == {}
+    assert baggage.serialize() == ""
+    assert (
+        baggage.serialize(include_third_party=True)
+        == "other-vendor-value-1=foo;bar;baz,other-vendor-value-2=foo;bar;"
+    )
+
+
+def test_mixed_baggage():
+    header = (
+        "other-vendor-value-1=foo;bar;baz, sentry-trace_id=771a43a4192642f0b136d5159a501700, "
+        "sentry-public_key=49d0f7386ad645858ae85020e393bef3, sentry-sample_rate=0.01337, "
+        "sentry-user_id=Am%C3%A9lie, other-vendor-value-2=foo;bar;"
+    )
+
+    baggage = Baggage.from_incoming_header(header)
+
+    assert not baggage.mutable
+
+    assert baggage.sentry_items == {
+        "public_key": "49d0f7386ad645858ae85020e393bef3",
+        "trace_id": "771a43a4192642f0b136d5159a501700",
+        "user_id": "Amélie",
+        "sample_rate": "0.01337",
+    }
+
+    assert (
+        baggage.third_party_items
+        == "other-vendor-value-1=foo;bar;baz,other-vendor-value-2=foo;bar;"
+    )
+
+    assert baggage.dynamic_sampling_context() == {
+        "public_key": "49d0f7386ad645858ae85020e393bef3",
+        "trace_id": "771a43a4192642f0b136d5159a501700",
+        "user_id": "Amélie",
+        "sample_rate": "0.01337",
+    }
+
+    assert baggage.serialize() == (
+        "sentry-trace_id=771a43a4192642f0b136d5159a501700,"
+        "sentry-public_key=49d0f7386ad645858ae85020e393bef3,"
+        "sentry-sample_rate=0.01337,sentry-user_id=Am%C3%A9lie"
+    )
+
+    assert baggage.serialize(include_third_party=True) == (
+        "sentry-trace_id=771a43a4192642f0b136d5159a501700,"
+        "sentry-public_key=49d0f7386ad645858ae85020e393bef3,"
+        "sentry-sample_rate=0.01337,sentry-user_id=Am%C3%A9lie,"
+        "other-vendor-value-1=foo;bar;baz,other-vendor-value-2=foo;bar;"
+    )

--- a/tests/tracing/test_baggage.py
+++ b/tests/tracing/test_baggage.py
@@ -1,3 +1,4 @@
+# coding: utf-8
 from sentry_sdk.tracing_utils import Baggage
 
 
@@ -8,15 +9,15 @@ def test_third_party_baggage():
     assert baggage.mutable
     assert baggage.sentry_items == {}
     assert (
-        baggage.third_party_items
-        == "other-vendor-value-1=foo;bar;baz,other-vendor-value-2=foo;bar;"
+        sorted(baggage.third_party_items.split(","))
+        == sorted("other-vendor-value-1=foo;bar;baz,other-vendor-value-2=foo;bar;".split(","))
     )
 
     assert baggage.dynamic_sampling_context() == {}
     assert baggage.serialize() == ""
     assert (
-        baggage.serialize(include_third_party=True)
-        == "other-vendor-value-1=foo;bar;baz,other-vendor-value-2=foo;bar;"
+        sorted(baggage.serialize(include_third_party=True).split(","))
+        == sorted("other-vendor-value-1=foo;bar;baz,other-vendor-value-2=foo;bar;".split(","))
     )
 
 
@@ -50,15 +51,15 @@ def test_mixed_baggage():
         "sample_rate": "0.01337",
     }
 
-    assert baggage.serialize() == (
+    assert sorted(baggage.serialize().split(",")) == sorted((
         "sentry-trace_id=771a43a4192642f0b136d5159a501700,"
         "sentry-public_key=49d0f7386ad645858ae85020e393bef3,"
         "sentry-sample_rate=0.01337,sentry-user_id=Am%C3%A9lie"
-    )
+    ).split(","))
 
-    assert baggage.serialize(include_third_party=True) == (
+    assert sorted(baggage.serialize(include_third_party=True).split(",")) == sorted((
         "sentry-trace_id=771a43a4192642f0b136d5159a501700,"
         "sentry-public_key=49d0f7386ad645858ae85020e393bef3,"
         "sentry-sample_rate=0.01337,sentry-user_id=Am%C3%A9lie,"
         "other-vendor-value-1=foo;bar;baz,other-vendor-value-2=foo;bar;"
-    )
+    ).split(","))

--- a/tests/tracing/test_baggage.py
+++ b/tests/tracing/test_baggage.py
@@ -1,4 +1,3 @@
-import pytest
 from sentry_sdk.tracing_utils import Baggage
 
 

--- a/tests/tracing/test_integration_tests.py
+++ b/tests/tracing/test_integration_tests.py
@@ -49,13 +49,13 @@ def test_basic(sentry_init, capture_events, sample_rate):
 
 @pytest.mark.parametrize("sampled", [True, False, None])
 @pytest.mark.parametrize("sample_rate", [0.0, 1.0])
-def test_continue_from_headers(sentry_init, capture_events, sampled, sample_rate):
+def test_continue_from_headers(sentry_init, capture_envelopes, sampled, sample_rate):
     """
     Ensure data is actually passed along via headers, and that they are read
     correctly.
     """
     sentry_init(traces_sample_rate=sample_rate)
-    events = capture_events()
+    envelopes = capture_envelopes()
 
     # make a parent transaction (normally this would be in a different service)
     with start_transaction(
@@ -63,8 +63,16 @@ def test_continue_from_headers(sentry_init, capture_events, sampled, sample_rate
     ) as parent_transaction:
         with start_span() as old_span:
             old_span.sampled = sampled
-            headers = dict(Hub.current.iter_trace_propagation_headers(old_span))
             tracestate = parent_transaction._sentry_tracestate
+
+            headers = dict(Hub.current.iter_trace_propagation_headers(old_span))
+            headers["baggage"] = (
+                "other-vendor-value-1=foo;bar;baz, "
+                "sentry-trace_id=771a43a4192642f0b136d5159a501700, "
+                "sentry-public_key=49d0f7386ad645858ae85020e393bef3, "
+                "sentry-sample_rate=0.01337, sentry-user_id=Am%C3%A9lie, "
+                "other-vendor-value-2=foo;bar;"
+            )
 
     # child transaction, to prove that we can read 'sentry-trace' and
     # `tracestate` header data correctly
@@ -76,6 +84,16 @@ def test_continue_from_headers(sentry_init, capture_events, sampled, sample_rate
     assert child_transaction.parent_span_id == old_span.span_id
     assert child_transaction.span_id != old_span.span_id
     assert child_transaction._sentry_tracestate == tracestate
+
+    baggage = child_transaction._baggage
+    assert baggage
+    assert not baggage.mutable
+    assert baggage.sentry_items == {
+        "public_key": "49d0f7386ad645858ae85020e393bef3",
+        "trace_id": "771a43a4192642f0b136d5159a501700",
+        "user_id": "Amélie",
+        "sample_rate": "0.01337",
+    }
 
     # add child transaction to the scope, to show that the captured message will
     # be tagged with the trace id (since it happens while the transaction is
@@ -89,23 +107,36 @@ def test_continue_from_headers(sentry_init, capture_events, sampled, sample_rate
 
     # in this case the child transaction won't be captured
     if sampled is False or (sample_rate == 0 and sampled is None):
-        trace1, message = events
+        trace1, message = envelopes
+        message_payload = message.get_event()
+        trace1_payload = trace1.get_transaction_event()
 
-        assert trace1["transaction"] == "hi"
+        assert trace1_payload["transaction"] == "hi"
     else:
-        trace1, message, trace2 = events
+        trace1, message, trace2 = envelopes
+        trace1_payload = trace1.get_transaction_event()
+        message_payload = message.get_event()
+        trace2_payload = trace2.get_transaction_event()
 
-        assert trace1["transaction"] == "hi"
-        assert trace2["transaction"] == "ho"
+        assert trace1_payload["transaction"] == "hi"
+        assert trace2_payload["transaction"] == "ho"
 
         assert (
-            trace1["contexts"]["trace"]["trace_id"]
-            == trace2["contexts"]["trace"]["trace_id"]
+            trace1_payload["contexts"]["trace"]["trace_id"]
+            == trace2_payload["contexts"]["trace"]["trace_id"]
             == child_transaction.trace_id
-            == message["contexts"]["trace"]["trace_id"]
+            == message_payload["contexts"]["trace"]["trace_id"]
         )
 
-    assert message["message"] == "hello"
+        assert trace2.headers["trace"] == baggage.dynamic_sampling_context()
+        assert trace2.headers["trace"] == {
+            "public_key": "49d0f7386ad645858ae85020e393bef3",
+            "trace_id": "771a43a4192642f0b136d5159a501700",
+            "user_id": "Amélie",
+            "sample_rate": "0.01337",
+        }
+
+    assert message_payload["message"] == "hello"
 
 
 @pytest.mark.parametrize(

--- a/tests/tracing/test_integration_tests.py
+++ b/tests/tracing/test_integration_tests.py
@@ -1,6 +1,6 @@
+# coding: utf-8
 import weakref
 import gc
-
 import pytest
 
 from sentry_sdk import (
@@ -70,7 +70,7 @@ def test_continue_from_headers(sentry_init, capture_envelopes, sampled, sample_r
                 "other-vendor-value-1=foo;bar;baz, "
                 "sentry-trace_id=771a43a4192642f0b136d5159a501700, "
                 "sentry-public_key=49d0f7386ad645858ae85020e393bef3, "
-                "sentry-sample_rate=0.01337, sentry-user_id=Am%C3%A9lie, "
+                "sentry-sample_rate=0.01337, sentry-user_id=Amelie, "
                 "other-vendor-value-2=foo;bar;"
             )
 
@@ -91,7 +91,7 @@ def test_continue_from_headers(sentry_init, capture_envelopes, sampled, sample_r
     assert baggage.sentry_items == {
         "public_key": "49d0f7386ad645858ae85020e393bef3",
         "trace_id": "771a43a4192642f0b136d5159a501700",
-        "user_id": "Amélie",
+        "user_id": "Amelie",
         "sample_rate": "0.01337",
     }
 
@@ -132,7 +132,7 @@ def test_continue_from_headers(sentry_init, capture_envelopes, sampled, sample_r
         assert trace2.headers["trace"] == {
             "public_key": "49d0f7386ad645858ae85020e393bef3",
             "trace_id": "771a43a4192642f0b136d5159a501700",
-            "user_id": "Amélie",
+            "user_id": "Amelie",
             "sample_rate": "0.01337",
         }
 


### PR DESCRIPTION
* `Baggage` class implementing sentry/third party/mutable logic with parsing from header and serialization
* Parse incoming `baggage` header while starting transaction and store it on the transaction
* Extract `dynamic_sampling_context` fields and add to the `trace` field in the envelope header while sending the transaction
* Propagate the `baggage` header (only sentry fields / no third party as per spec)

[DSC Spec](https://develop.sentry.dev/sdk/performance/dynamic-sampling-context/)
fixes #1476 