### PR TITLE
Skip malformed baggage items

### DIFF
--- a/sentry_sdk/tracing_utils.py
+++ b/sentry_sdk/tracing_utils.py
@@ -457,6 +457,8 @@ class Baggage(object):
 
         if header:
             for item in header.split(","):
+                if "=" not in item:
+                    continue
                 item = item.strip()
                 key, val = item.split("=")
                 if Baggage.SENTRY_PREFIX_REGEX.match(key):

--- a/tests/tracing/test_baggage.py
+++ b/tests/tracing/test_baggage.py
@@ -65,3 +65,13 @@ def test_mixed_baggage():
             "other-vendor-value-1=foo;bar;baz,other-vendor-value-2=foo;bar;"
         ).split(",")
     )
+
+
+def test_malformed_baggage():
+    header = ","
+
+    baggage = Baggage.from_incoming_header(header)
+
+    assert baggage.sentry_items == {}
+    assert baggage.third_party_items == ""
+    assert baggage.mutable


### PR DESCRIPTION
We are seeing baggage headers coming in with a single comma. This is obviously invalid but Sentry should error out.