### PR TITLE
docs: fix simple typo, collecter -> collector

### DIFF
--- a/tests/tracing/test_misc.py
+++ b/tests/tracing/test_misc.py
@@ -173,7 +173,7 @@ def test_circular_references(monkeypatch, sentry_init, request):
     #     request.addfinalizer(lambda: gc.set_debug(~gc.DEBUG_LEAK))
     #
     # immediately after the initial collection below, so we can see what new
-    # objects the garbage collecter has to clean up once `transaction.finish` is
+    # objects the garbage collector has to clean up once `transaction.finish` is
     # called and the serializer runs.)
     monkeypatch.setattr(
         sentry_sdk.client,


### PR DESCRIPTION
There is a small typo in tests/tracing/test_misc.py.

Should read `collector` rather than `collecter`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md