### PR TITLE
fix: avoid sending empty Baggage header

### DIFF
--- a/sentry_sdk/tracing.py
+++ b/sentry_sdk/tracing.py
@@ -308,7 +308,9 @@ class Span(object):
             yield "tracestate", tracestate
 
         if self.containing_transaction and self.containing_transaction._baggage:
-            yield "baggage", self.containing_transaction._baggage.serialize()
+            baggage = self.containing_transaction._baggage.serialize()
+            if baggage:
+                yield "baggage", baggage
 
     @classmethod
     def from_traceparent(


### PR DESCRIPTION
According to W3C Working Draft spec, the `Baggage` header must contain at least one value; header with empty value string is invalid.