### PR TITLE
fix: properly freeze Baggage object

### DIFF
--- a/sentry_sdk/tracing.py
+++ b/sentry_sdk/tracing.py
@@ -279,7 +279,7 @@ class Span(object):
 
         if sentrytrace_kwargs is not None:
             kwargs.update(sentrytrace_kwargs)
-            baggage.freeze
+            baggage.freeze()
 
         kwargs.update(extract_tracestate_data(headers.get("tracestate")))
 


### PR DESCRIPTION
Clearly the intent was to call the function, but previously the `freeze` method was dead code.

I have not verified that this actually works correctly, however.
