### PR TITLE
Replace Travis CI badge with GitHub Actions badge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,8 +95,6 @@ jobs:
           PGHOST: localhost
           PGPASSWORD: sentry
         run: |
-          psql -c 'create database travis_ci_test;' -U postgres
-          psql -c 'create database test_travis_ci_test;' -U postgres
           pip install codecov tox
 
       - name: Run Tests

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ _Bad software is everywhere, and we're tired of it. Sentry is on a mission to he
 
 # Official Sentry SDK for Python
 
-[![Build Status](https://travis-ci.com/getsentry/sentry-python.svg?branch=master)](https://travis-ci.com/getsentry/sentry-python)
+[![Build Status](https://github.com/getsentry/sentry-python/actions/workflows/ci.yml/badge.svg)](https://github.com/getsentry/sentry-python/actions/workflows/ci.yml)
 [![PyPi page link -- version](https://img.shields.io/pypi/v/sentry-sdk.svg)](https://pypi.python.org/pypi/sentry-sdk)
 [![Discord](https://img.shields.io/discord/621778831602221064)](https://discord.gg/cWnMQeA)
 


### PR DESCRIPTION
Travis CI is no longer being used and has been replaced by GitHub Actions.
The ci.yml workflow contains the main tests, so show that status in the README.