### PR TITLE
feat(redis): Add instrumentation for redis pipeline

### DIFF
--- a/sentry_sdk/integrations/redis.py
+++ b/sentry_sdk/integrations/redis.py
@@ -28,7 +28,11 @@ def patch_redis_pipeline(pipeline_cls, parse_command_fn):
 
         with hub.start_span(op="redis", description="redis.pipeline.execute") as span:
             with capture_internal_exceptions():
-                print(self.command_stack)
+                transaction = (
+                    self.transaction if pipeline_cls.__name__ == "Pipeline" else False
+                )
+                span.set_tag("transaction", transaction)
+
                 commands = [parse_command_fn(c) for c in self.command_stack[:10]]
                 if len(self.command_stack) > 10:
                     commands.append("...")

--- a/sentry_sdk/integrations/redis.py
+++ b/sentry_sdk/integrations/redis.py
@@ -109,6 +109,9 @@ class RedisIntegration(Integration):
 
         patch_redis_client(redis.StrictRedis, is_cluster=False)
         patch_redis_pipeline(redis.client.Pipeline, False, _get_redis_command_args)
+        patch_redis_pipeline(
+            redis.client.StrictPipeline, False, _get_redis_command_args
+        )
 
         try:
             import rb.clients  # type: ignore

--- a/sentry_sdk/integrations/redis.py
+++ b/sentry_sdk/integrations/redis.py
@@ -66,6 +66,14 @@ def _parse_rediscluster_command(command):
     return command.args
 
 
+def _get_pipeline_cls(rediscluster):
+    # type: (Any) -> Any
+    try:
+        return rediscluster.ClusterPipeline
+    except AttributeError:
+        return rediscluster.StrictClusterPipeline
+
+
 def _patch_rediscluster():
     # type: () -> None
     try:
@@ -75,7 +83,7 @@ def _patch_rediscluster():
 
     patch_redis_client(rediscluster.RedisCluster, is_cluster=True)
     patch_redis_pipeline(
-        rediscluster.ClusterPipeline, True, _parse_rediscluster_command
+        _get_pipeline_cls(rediscluster), True, _parse_rediscluster_command
     )
 
     # up to v1.3.6, __version__ attribute is a tuple

--- a/tests/integrations/redis/test_redis.py
+++ b/tests/integrations/redis/test_redis.py
@@ -20,7 +20,11 @@ def test_basic(sentry_init, capture_events):
     assert crumb == {
         "category": "redis",
         "message": "GET 'foobar'",
-        "data": {"redis.key": "foobar", "redis.command": "GET"},
+        "data": {
+            "redis.key": "foobar",
+            "redis.command": "GET",
+            "redis.is_cluster": False,
+        },
         "timestamp": crumb["timestamp"],
         "type": "redis",
     }
@@ -40,7 +44,6 @@ def test_redis_pipeline(sentry_init, capture_events, is_transaction):
         pipeline.execute()
 
     (event,) = events
-    print(event)
     (span,) = event["spans"]
     assert span["op"] == "redis"
     assert span["description"] == "redis.pipeline.execute"
@@ -52,4 +55,5 @@ def test_redis_pipeline(sentry_init, capture_events, is_transaction):
     }
     assert span["tags"] == {
         "redis.transaction": is_transaction,
+        "redis.is_cluster": False,
     }

--- a/tests/integrations/redis/test_redis.py
+++ b/tests/integrations/redis/test_redis.py
@@ -45,8 +45,11 @@ def test_redis_pipeline(sentry_init, capture_events, is_transaction):
     assert span["op"] == "redis"
     assert span["description"] == "redis.pipeline.execute"
     assert span["data"] == {
-        "commands": {"count": 3, "first_ten": ["GET foo", "SET bar 1", "SET baz 2"]}
+        "redis.commands": {
+            "count": 3,
+            "first_ten": ["GET 'foo'", "SET 'bar' 1", "SET 'baz' 2"],
+        }
     }
     assert span["tags"] == {
-        "transaction": is_transaction,
+        "redis.transaction": is_transaction,
     }

--- a/tests/integrations/redis/test_redis.py
+++ b/tests/integrations/redis/test_redis.py
@@ -2,6 +2,7 @@ from sentry_sdk import capture_message, start_transaction
 from sentry_sdk.integrations.redis import RedisIntegration
 
 from fakeredis import FakeStrictRedis
+import pytest
 
 
 def test_basic(sentry_init, capture_events):
@@ -25,22 +26,27 @@ def test_basic(sentry_init, capture_events):
     }
 
 
-def test_redis_pipeline(sentry_init, capture_events):
+@pytest.mark.parametrize("is_transaction", [False, True])
+def test_redis_pipeline(sentry_init, capture_events, is_transaction):
     sentry_init(integrations=[RedisIntegration()], traces_sample_rate=1.0)
     events = capture_events()
 
     connection = FakeStrictRedis()
     with start_transaction():
-        pipeline = connection.pipeline()
+        pipeline = connection.pipeline(transaction=is_transaction)
         pipeline.get("foo")
         pipeline.set("bar", 1)
         pipeline.set("baz", 2)
         pipeline.execute()
 
     (event,) = events
+    print(event)
     (span,) = event["spans"]
     assert span["op"] == "redis"
     assert span["description"] == "redis.pipeline.execute"
     assert span["data"] == {
         "commands": {"count": 3, "first_ten": ["GET foo", "SET bar 1", "SET baz 2"]}
+    }
+    assert span["tags"] == {
+        "transaction": is_transaction,
     }

--- a/tests/integrations/redis/test_redis.py
+++ b/tests/integrations/redis/test_redis.py
@@ -1,4 +1,4 @@
-from sentry_sdk import capture_message
+from sentry_sdk import capture_message, start_transaction
 from sentry_sdk.integrations.redis import RedisIntegration
 
 from fakeredis import FakeStrictRedis
@@ -22,4 +22,25 @@ def test_basic(sentry_init, capture_events):
         "data": {"redis.key": "foobar", "redis.command": "GET"},
         "timestamp": crumb["timestamp"],
         "type": "redis",
+    }
+
+
+def test_redis_pipeline(sentry_init, capture_events):
+    sentry_init(integrations=[RedisIntegration()], traces_sample_rate=1.0)
+    events = capture_events()
+
+    connection = FakeStrictRedis()
+    with start_transaction():
+        pipeline = connection.pipeline()
+        pipeline.get("foo")
+        pipeline.set("bar", 1)
+        pipeline.set("baz", 2)
+        pipeline.execute()
+
+    (event,) = events
+    (span,) = event["spans"]
+    assert span["op"] == "redis"
+    assert span["description"] == "redis.pipeline.execute"
+    assert span["data"] == {
+        "commands": {"count": 3, "first_ten": ["GET foo", "SET bar 1", "SET baz 2"]}
     }

--- a/tests/integrations/redis/test_redis.py
+++ b/tests/integrations/redis/test_redis.py
@@ -37,6 +37,7 @@ def test_redis_pipeline(sentry_init, capture_events, is_transaction):
 
     connection = FakeStrictRedis()
     with start_transaction():
+
         pipeline = connection.pipeline(transaction=is_transaction)
         pipeline.get("foo")
         pipeline.set("bar", 1)

--- a/tests/integrations/rediscluster/test_rediscluster.py
+++ b/tests/integrations/rediscluster/test_rediscluster.py
@@ -48,7 +48,7 @@ def test_rediscluster_basic(rediscluster_cls, sentry_init, capture_events):
 
 
 def test_rediscluster_pipeline(sentry_init, capture_events):
-    sentry_init(integrations=[RedisIntegration()], traces_sample_rate=1.0)
+    sentry_init(integrations=[RedisIntegration()], traces_sample_rate=1.0, debug=True)
     events = capture_events()
 
     rc = rediscluster.RedisCluster(connection_pool=True)

--- a/tests/integrations/rediscluster/test_rediscluster.py
+++ b/tests/integrations/rediscluster/test_rediscluster.py
@@ -60,12 +60,8 @@ def test_rediscluster_pipeline(sentry_init, capture_events):
     assert span["op"] == "redis"
     assert span["description"] == "redis.pipeline.execute"
     assert span["data"] == {
-        "commands": {
-            "count": 3,
-            "first_ten": [
-                [["GET", "foo"], {}],
-                [["SET", "bar", 1], {}],
-                [["SET", "baz", 2], {}],
-            ],
-        }
+        "commands": {"count": 3, "first_ten": ["GET foo", "SET bar 1", "SET baz 2"]}
+    }
+    assert span["tags"] == {
+        "transaction": False,  # For Cluster, this is always False
     }

--- a/tests/integrations/rediscluster/test_rediscluster.py
+++ b/tests/integrations/rediscluster/test_rediscluster.py
@@ -1,7 +1,7 @@
 import pytest
 from sentry_sdk import capture_message
 from sentry_sdk.api import start_transaction
-from sentry_sdk.integrations.redis import RedisIntegration
+from sentry_sdk.integrations.redis import RedisIntegration, _get_pipeline_cls
 
 import rediscluster
 
@@ -13,10 +13,7 @@ if hasattr(rediscluster, "StrictRedisCluster"):
 
 @pytest.fixture(scope="module", autouse=True)
 def monkeypatch_rediscluster_classes():
-    try:
-        pipeline_cls = rediscluster.ClusterPipeline
-    except AttributeError:
-        pipeline_cls = rediscluster.StrictClusterPipeline
+    pipeline_cls = _get_pipeline_cls(rediscluster)
     rediscluster.RedisCluster.pipeline = lambda *_, **__: pipeline_cls(
         connection_pool=True
     )

--- a/tests/integrations/rediscluster/test_rediscluster.py
+++ b/tests/integrations/rediscluster/test_rediscluster.py
@@ -36,7 +36,11 @@ def test_rediscluster_basic(rediscluster_cls, sentry_init, capture_events):
     assert crumb == {
         "category": "redis",
         "message": "GET 'foobar'",
-        "data": {"redis.key": "foobar", "redis.command": "GET"},
+        "data": {
+            "redis.key": "foobar",
+            "redis.command": "GET",
+            "redis.is_cluster": True,
+        },
         "timestamp": crumb["timestamp"],
         "type": "redis",
     }
@@ -66,4 +70,5 @@ def test_rediscluster_pipeline(sentry_init, capture_events):
     }
     assert span["tags"] == {
         "redis.transaction": False,  # For Cluster, this is always False
+        "redis.is_cluster": True,
     }

--- a/tests/integrations/rediscluster/test_rediscluster.py
+++ b/tests/integrations/rediscluster/test_rediscluster.py
@@ -13,7 +13,6 @@ if hasattr(rediscluster, "StrictRedisCluster"):
 
 @pytest.fixture(scope="module", autouse=True)
 def monkeypatch_rediscluster_classes():
-    # FIXME: patch StrictRedisCluster
     rediscluster.RedisCluster.pipeline = lambda *_, **__: rediscluster.ClusterPipeline(
         connection_pool=True
     )
@@ -60,8 +59,11 @@ def test_rediscluster_pipeline(sentry_init, capture_events):
     assert span["op"] == "redis"
     assert span["description"] == "redis.pipeline.execute"
     assert span["data"] == {
-        "commands": {"count": 3, "first_ten": ["GET foo", "SET bar 1", "SET baz 2"]}
+        "redis.commands": {
+            "count": 3,
+            "first_ten": ["GET 'foo'", "SET 'bar' 1", "SET 'baz' 2"],
+        }
     }
     assert span["tags"] == {
-        "transaction": False,  # For Cluster, this is always False
+        "redis.transaction": False,  # For Cluster, this is always False
     }

--- a/tests/integrations/rediscluster/test_rediscluster.py
+++ b/tests/integrations/rediscluster/test_rediscluster.py
@@ -13,10 +13,14 @@ if hasattr(rediscluster, "StrictRedisCluster"):
 
 @pytest.fixture(scope="module", autouse=True)
 def monkeypatch_rediscluster_classes():
-    rediscluster.RedisCluster.pipeline = lambda *_, **__: rediscluster.ClusterPipeline(
+    try:
+        pipeline_cls = rediscluster.ClusterPipeline
+    except AttributeError:
+        pipeline_cls = rediscluster.StrictClusterPipeline
+    rediscluster.RedisCluster.pipeline = lambda *_, **__: pipeline_cls(
         connection_pool=True
     )
-    rediscluster.ClusterPipeline.execute = lambda *_, **__: None
+    pipeline_cls.execute = lambda *_, **__: None
     for cls in rediscluster_classes:
         cls.execute_command = lambda *_, **__: None
 

--- a/tests/integrations/rediscluster/test_rediscluster.py
+++ b/tests/integrations/rediscluster/test_rediscluster.py
@@ -1,7 +1,7 @@
 import pytest
 from sentry_sdk import capture_message
 from sentry_sdk.api import start_transaction
-from sentry_sdk.integrations.redis import RedisIntegration, _get_pipeline_cls
+from sentry_sdk.integrations.redis import RedisIntegration, _get_cluster_pipeline_cls
 
 import rediscluster
 
@@ -13,7 +13,7 @@ if hasattr(rediscluster, "StrictRedisCluster"):
 
 @pytest.fixture(scope="module", autouse=True)
 def monkeypatch_rediscluster_classes():
-    pipeline_cls = _get_pipeline_cls(rediscluster)
+    pipeline_cls = _get_cluster_pipeline_cls(rediscluster)
     rediscluster.RedisCluster.pipeline = lambda *_, **__: pipeline_cls(
         connection_pool=True
     )
@@ -48,7 +48,7 @@ def test_rediscluster_basic(rediscluster_cls, sentry_init, capture_events):
 
 
 def test_rediscluster_pipeline(sentry_init, capture_events):
-    sentry_init(integrations=[RedisIntegration()], traces_sample_rate=1.0, debug=True)
+    sentry_init(integrations=[RedisIntegration()], traces_sample_rate=1.0)
     events = capture_events()
 
     rc = rediscluster.RedisCluster(connection_pool=True)

--- a/tests/integrations/rediscluster/test_rediscluster.py
+++ b/tests/integrations/rediscluster/test_rediscluster.py
@@ -1,7 +1,7 @@
 import pytest
 from sentry_sdk import capture_message
 from sentry_sdk.api import start_transaction
-from sentry_sdk.integrations.redis import RedisIntegration, _get_cluster_pipeline_cls
+from sentry_sdk.integrations.redis import RedisIntegration
 
 import rediscluster
 
@@ -13,7 +13,11 @@ if hasattr(rediscluster, "StrictRedisCluster"):
 
 @pytest.fixture(scope="module", autouse=True)
 def monkeypatch_rediscluster_classes():
-    pipeline_cls = _get_cluster_pipeline_cls(rediscluster)
+
+    try:
+        pipeline_cls = rediscluster.ClusterPipeline
+    except AttributeError:
+        pipeline_cls = rediscluster.StrictClusterPipeline
     rediscluster.RedisCluster.pipeline = lambda *_, **__: pipeline_cls(
         connection_pool=True
     )


### PR DESCRIPTION
Add automatic instrumentation of [redis pipelining](https://redis.io/docs/manual/pipelining/) for both `redis` and `rediscluster`. 

Note: This does not add instrumentation for [`StrictRedisCluster`](https://github.com/Grokzen/redis-py-cluster/blob/master/docs/release-notes.rst#200-aug-12-2019).