### PR TITLE
chore: remove quotes

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setup(
     install_requires=[
         'urllib3>=1.25.7; python_version<="3.4"',
         'urllib3>=1.26.9; python_version>="3.5"',
-        'urllib3>=1.26.11"; python_version >="3.6"',
+        'urllib3>=1.26.11; python_version >="3.6"',
         "certifi",
     ],
     extras_require={


### PR DESCRIPTION
Fixes #1544

In [one of our previous commits](https://github.com/getsentry/sentry-python/commit/b7c0dc412a1505fff382732f567952c8a9572b60#diff-60f61ab7a8d1910d86d9fda2261620314edcae5894d5aaa236b821c7256badd7R43) we mistakenly added a quote that was confusing conda.