### PR TITLE
Handle no release when uploading profiles

### DIFF
--- a/sentry_sdk/client.py
+++ b/sentry_sdk/client.py
@@ -403,10 +403,7 @@ class _Client(object):
             if is_transaction:
                 if "profile" in event_opt:
                     event_opt["profile"]["transaction_id"] = event_opt["event_id"]
-                    try:
-                        event_opt["profile"]["version_name"] = event_opt["release"]
-                    except KeyError:
-                        event_opt["profile"]["version_name"] = ""
+                    event_opt["profile"]["version_name"] = event_opt.get("release", "")
                     envelope.add_profile(event_opt.pop("profile"))
                 envelope.add_transaction(event_opt)
             else:

--- a/sentry_sdk/client.py
+++ b/sentry_sdk/client.py
@@ -403,7 +403,10 @@ class _Client(object):
             if is_transaction:
                 if "profile" in event_opt:
                     event_opt["profile"]["transaction_id"] = event_opt["event_id"]
-                    event_opt["profile"]["version_name"] = event_opt["release"]
+                    try:
+                        event_opt["profile"]["version_name"] = event_opt["release"]
+                    except KeyError:
+                        event_opt["profile"]["version_name"] = ""
                     envelope.add_profile(event_opt.pop("profile"))
                 envelope.add_transaction(event_opt)
             else:


### PR DESCRIPTION
We noticed that an error occurs when a profile is being uploaded and there is no release set (the error can only occur when profiling is enabled). This PR stops the error from occurring. 