### PR TITLE
Fix side effects for parallel tests

### DIFF
--- a/sentry_sdk/integrations/redis.py
+++ b/sentry_sdk/integrations/redis.py
@@ -131,7 +131,6 @@ def patch_redis_client(cls, is_cluster):
     This function can be used to instrument custom redis client classes or
     subclasses.
     """
-
     old_execute_command = cls.execute_command
 
     def sentry_patched_execute_command(self, name, *args, **kwargs):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,6 +19,7 @@ from sentry_sdk._compat import reraise, string_types, iteritems
 from sentry_sdk.transport import Transport
 from sentry_sdk.envelope import Envelope
 from sentry_sdk.utils import capture_internal_exceptions
+from sentry_sdk.integrations import _installed_integrations  # noqa: F401
 
 from tests import _warning_recorder, _warning_recorder_mgr
 
@@ -163,6 +164,17 @@ def validate_event_schema(tmpdir):
             jsonschema.validate(instance=event, schema=SENTRY_EVENT_SCHEMA)
 
     return inner
+
+
+@pytest.fixture
+def reset_integrations():
+    """
+    Use with caution, sometimes we really need to start
+    with a clean slate to ensure monkeypatching works well,
+    but this also means some other stuff will be monkeypatched twice.
+    """
+    global _installed_integrations
+    _installed_integrations.clear()
 
 
 @pytest.fixture

--- a/tests/integrations/rediscluster/test_rediscluster.py
+++ b/tests/integrations/rediscluster/test_rediscluster.py
@@ -11,8 +11,8 @@ if hasattr(rediscluster, "StrictRedisCluster"):
     rediscluster_classes.append(rediscluster.StrictRedisCluster)
 
 
-@pytest.fixture(scope="module", autouse=True)
-def monkeypatch_rediscluster_classes():
+@pytest.fixture(autouse=True)
+def monkeypatch_rediscluster_classes(reset_integrations):
 
     try:
         pipeline_cls = rediscluster.ClusterPipeline


### PR DESCRIPTION
fixes #1553

#1504 added parallelization for tox but we have some tests that have global side effects and thus will flake when run concurrently.

* Fixed Sanic tests starting on the same fixed port for older versions 0.8.x and 18.x
* Fixed `rediscluster` test side-effect by resetting integrations list to ensure our monkeypatching happens after the test fixture monkeypatching