### PR TITLE
fix(redis): import redis pipeline using full path

### DIFF
--- a/sentry_sdk/integrations/redis.py
+++ b/sentry_sdk/integrations/redis.py
@@ -82,10 +82,10 @@ def _patch_rediscluster():
     # StrictRedisCluster was introduced in v0.2.0 and removed in v2.0.0
     # https://github.com/Grokzen/redis-py-cluster/blob/master/docs/release-notes.rst
     if (0, 2, 0) < version < (2, 0, 0):
-        pipeline_cls = rediscluster.StrictClusterPipeline
+        pipeline_cls = rediscluster.pipeline.StrictClusterPipeline
         patch_redis_client(rediscluster.StrictRedisCluster, is_cluster=True)
     else:
-        pipeline_cls = rediscluster.ClusterPipeline
+        pipeline_cls = rediscluster.pipeline.ClusterPipeline
 
     patch_redis_pipeline(pipeline_cls, True, _parse_rediscluster_command)
 

--- a/tests/integrations/rediscluster/test_rediscluster.py
+++ b/tests/integrations/rediscluster/test_rediscluster.py
@@ -15,7 +15,7 @@ if hasattr(rediscluster, "StrictRedisCluster"):
 def monkeypatch_rediscluster_classes(reset_integrations):
 
     try:
-        pipeline_cls = rediscluster.ClusterPipeline
+        pipeline_cls = rediscluster.pipeline.ClusterPipeline
     except AttributeError:
         pipeline_cls = rediscluster.StrictClusterPipeline
     rediscluster.RedisCluster.pipeline = lambda *_, **__: pipeline_cls(

--- a/tox.ini
+++ b/tox.ini
@@ -77,7 +77,7 @@ envlist =
     {py2.7,py3.8,py3.9}-requests
 
     {py2.7,py3.7,py3.8,py3.9}-redis
-    {py2.7,py3.7,py3.8,py3.9}-rediscluster-{1,2}
+    {py2.7,py3.7,py3.8,py3.9}-rediscluster-{1,2.1.0,2}
 
     {py2.7,py3.7,py3.8,py3.9,py3.10}-sqlalchemy-{1.2,1.3}
 
@@ -227,7 +227,8 @@ deps =
     redis: fakeredis<1.7.4
 
     rediscluster-1: redis-py-cluster>=1.0.0,<2.0.0
-    rediscluster-2: redis-py-cluster>=2.0.0,<3.0.0
+    rediscluster-2.1.0: redis-py-cluster>=2.0.0,<2.1.1
+    rediscluster-2: redis-py-cluster>=2.1.1,<3.0.0
 
     sqlalchemy-1.2: sqlalchemy>=1.2,<1.3
     sqlalchemy-1.3: sqlalchemy>=1.3,<1.4


### PR DESCRIPTION
Currently  Sentry uses [`redis-py-cluster==2.1.0`](https://github.com/getsentry/sentry/blob/fd84edc46ad29083c7fe69ff48a159f1ae8ea85a/requirements-frozen.txt#L91) which does not expose the `ClusterPipeline` as a top level object. The fix was introduced in version `2.1.1` and another fix in `2.1.2` see https://github.com/Grokzen/redis-py-cluster/blob/master/docs/release-notes.rst

And getting following error 
```python
09:05:04 [INFO] sentry.plugins.github: apps-not-configured
Traceback (most recent call last):
  File "/Users/olksdr/dev/sentry/.venv/lib/python3.8/site-packages/sentry_sdk/integrations/redis.py", line 123, in setup_once
    _patch_rediscluster()
  File "/Users/olksdr/dev/sentry/.venv/lib/python3.8/site-packages/sentry_sdk/integrations/redis.py", line 88, in _patch_rediscluster
    pipeline_cls = rediscluster.ClusterPipeline
AttributeError: module 'rediscluster' has no attribute 'ClusterPipeline'
```

This PR makes sure to use the full path to import `rediscluster.pipeline.ClusterPipeline` which always available in any version now. 

See errors in integration tests on https://github.com/getsentry/relay/pull/1413 and https://github.com/getsentry/relay/pull/1414 where the sentry `master` branch is used to run those tests with newly updated python sentry-sdk dependency. 

Related changes which "broke" the sdk for redis-py-cluster==2.1.0 were introduced in https://github.com/getsentry/sentry-python/pull/1543