### PR TITLE
Add more version constraints

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ setup(
     license="BSD",
     install_requires=[
         'urllib3>=1.25.7; python_version<="3.4"',
-        'urllib3>=1.26.9; python_version>="3.5"',
+        'urllib3>=1.26.9; python_version=="3.5"',
         'urllib3>=1.26.11; python_version >="3.6"',
         "certifi",
     ],


### PR DESCRIPTION
For some reason, `poetry` will run the solver at least twice if python version are above 3.6, each with a different constraint for urllib3. This add a significant slowdown on our end in some project.