### PR TITLE
[Hackweek] Added feature flags to SDK

### DIFF
--- a/sentry_sdk/_types.py
+++ b/sentry_sdk/_types.py
@@ -47,7 +47,7 @@ if MYPY:
         "internal",
     ]
     SessionStatus = Literal["ok", "exited", "crashed", "abnormal"]
-    EndpointType = Literal["store", "envelope"]
+    EndpointType = Literal["store", "envelope", "feature-flags"]
 
     DurationUnit = Literal[
         "nanosecond",

--- a/sentry_sdk/api.py
+++ b/sentry_sdk/api.py
@@ -44,6 +44,7 @@ __all__ = [
     "set_extra",
     "set_user",
     "set_level",
+    "is_feature_flag_enabled",
 ]
 
 
@@ -212,3 +213,14 @@ def start_transaction(
 ):
     # type: (...) -> Transaction
     return Hub.current.start_transaction(transaction, **kwargs)
+
+
+@hubmethod
+def is_feature_flag_enabled(
+    name,
+    scope=None,
+    context=None,
+    default=False,
+):
+    # type: (...) -> bool
+    return Hub.current.is_feature_flag_enabled(name, scope, context, default)

--- a/sentry_sdk/api.py
+++ b/sentry_sdk/api.py
@@ -17,6 +17,7 @@ if MYPY:
 
     from sentry_sdk._types import Event, Hint, Breadcrumb, BreadcrumbHint, ExcInfo
     from sentry_sdk.tracing import Span, Transaction
+    from sentry_sdk.feature_flags import FeatureFlagInfo
 
     T = TypeVar("T")
     F = TypeVar("F", bound=Callable[..., Any])
@@ -45,6 +46,7 @@ __all__ = [
     "set_user",
     "set_level",
     "is_feature_flag_enabled",
+    "get_feature_flag_info",
 ]
 
 
@@ -224,3 +226,13 @@ def is_feature_flag_enabled(
 ):
     # type: (...) -> bool
     return Hub.current.is_feature_flag_enabled(name, scope, context, default)
+
+
+@hubmethod
+def get_feature_flag_info(
+    name,
+    scope=None,
+    context=None,
+):
+    # type: (...) -> Optional[FeatureFlagInfo]
+    return Hub.current.get_feature_flag_info(name, scope, context)

--- a/sentry_sdk/api.py
+++ b/sentry_sdk/api.py
@@ -47,6 +47,7 @@ __all__ = [
     "set_level",
     "is_feature_flag_enabled",
     "get_feature_flag_info",
+    "wait_until_ready",
 ]
 
 
@@ -236,3 +237,11 @@ def get_feature_flag_info(
 ):
     # type: (...) -> Optional[FeatureFlagInfo]
     return Hub.current.get_feature_flag_info(name, scope, context)
+
+
+@hubmethod
+def wait_until_ready(
+    timeout=None,  # type: Optional[float]
+):
+    # type: (...) -> bool
+    return Hub.current.wait_until_ready(timeout)

--- a/sentry_sdk/api.py
+++ b/sentry_sdk/api.py
@@ -219,10 +219,10 @@ def start_transaction(
 
 @hubmethod
 def is_feature_flag_enabled(
-    name,
-    scope=None,
-    context=None,
-    default=False,
+    name,  # type: str
+    scope=None,  # type: Optional[Scope]
+    context=None,  # type: Optional[Dict[str, Any]]
+    default=False,  # type: bool
 ):
     # type: (...) -> bool
     return Hub.current.is_feature_flag_enabled(name, scope, context, default)
@@ -230,9 +230,9 @@ def is_feature_flag_enabled(
 
 @hubmethod
 def get_feature_flag_info(
-    name,
-    scope=None,
-    context=None,
+    name,  # type: str
+    scope=None,  # type: Optional[Scope]
+    context=None,  # type: Optional[Dict[str, Any]]
 ):
     # type: (...) -> Optional[FeatureFlagInfo]
     return Hub.current.get_feature_flag_info(name, scope, context)

--- a/sentry_sdk/consts.py
+++ b/sentry_sdk/consts.py
@@ -35,6 +35,8 @@ if MYPY:
             "propagate_tracestate": Optional[bool],
             "custom_measurements": Optional[bool],
             "enable_profiling": Optional[bool],
+            "feature_flags_refresh": Optional[float],
+            "feature_flags_enabled": Optional[bool],
         },
         total=False,
     )

--- a/sentry_sdk/feature_flags.py
+++ b/sentry_sdk/feature_flags.py
@@ -53,10 +53,9 @@ class XorShift(object):
 
 
 class FeatureFlagsManager(object):
-    def __init__(self, request_func, apply_func=None, refresh=None, is_enabled=None):
-        # type: (Any, Any, Optional[float], Optional[bool]) -> None
+    def __init__(self, request_func, refresh=None, is_enabled=None):
+        # type: (Any, Optional[float], Optional[bool]) -> None
         self._request_func = request_func
-        self._apply_func = apply_func
         self._fetched_flags = {}  # type: Dict[str, Any]
         self._last_fetch = None  # type: Optional[float]
         self._dead = False  # type: bool
@@ -97,8 +96,6 @@ class FeatureFlagsManager(object):
         def callback(response):
             # type: (Any) -> None
             self._fetched_flags = response
-            if self._apply_func is not None:
-                self._apply_func()
             self._load_event.set()
 
         self._request_func(callback)

--- a/sentry_sdk/feature_flags.py
+++ b/sentry_sdk/feature_flags.py
@@ -53,9 +53,10 @@ class XorShift(object):
 
 
 class FeatureFlagsManager(object):
-    def __init__(self, request_func=None, refresh=None, is_enabled=None):
-        # type: (Any, Optional[float], Optional[bool]) -> None
+    def __init__(self, request_func, apply_func=None, refresh=None, is_enabled=None):
+        # type: (Any, Any, Optional[float], Optional[bool]) -> None
         self._request_func = request_func
+        self._apply_func = apply_func
         self._fetched_flags = {}  # type: Dict[str, Any]
         self._last_fetch = None  # type: Optional[float]
         self._dead = False  # type: bool
@@ -96,6 +97,8 @@ class FeatureFlagsManager(object):
         def callback(response):
             # type: (Any) -> None
             self._fetched_flags = response
+            if self._apply_func is not None:
+                self._apply_func()
             self._load_event.set()
 
         self._request_func(callback)

--- a/sentry_sdk/feature_flags.py
+++ b/sentry_sdk/feature_flags.py
@@ -136,7 +136,7 @@ def roll_random_number(group, context):
     # type: (str, Dict[str, Any]) -> float
     sticky_id = str(context.get("stickyId") or context.get("userId") or FALLBACK_ID)
     seed = "%s|%s" % (group, sticky_id)
-    return XorShift(seed=sticky_id).next_float()
+    return XorShift(seed=seed).next_float()
 
 
 def matches_tags(tags, context):

--- a/sentry_sdk/feature_flags.py
+++ b/sentry_sdk/feature_flags.py
@@ -132,6 +132,10 @@ def roll_random_number(context):
 def matches_tags(tags, context):
     # type: (Dict[str, str], Dict[str, Any]) -> bool
     for key, value in tags.items():
-        if context.get(key) != str(value):
+        context_value = context.get(key)
+        if isinstance(context_value, list):
+            if str(value) not in context_value:
+                return False
+        elif context_value != str(value):
             return False
     return True

--- a/sentry_sdk/feature_flags.py
+++ b/sentry_sdk/feature_flags.py
@@ -1,0 +1,136 @@
+import threading
+import time
+import hashlib
+import struct
+import uuid
+
+from sentry_sdk._types import MYPY
+
+if MYPY:
+    from typing import Dict
+    from typing import Optional
+    from typing import Any
+
+
+MASK = 0xFFFFFFFF
+FALLBACK_ID = uuid.uuid4()
+
+
+class XorShift(object):
+    def __init__(self, seed=None):
+        # type: (Optional[Any]) -> None
+        self.state = [0] * 4
+        if seed is not None:
+            self.seed(seed)
+
+    def seed(self, seed):
+        # type: (Any) -> None
+        bytes = hashlib.sha1(seed.encode("utf-8")).digest()
+        # 4 big endian integers, eg:
+        #   (x[0] << 24) | (x[1] << 16) | (x[2] << 8) | (x[3])
+        self.state[:] = struct.unpack(">IIII", bytes[:16])
+
+    def next_u32(self):
+        # type: () -> int
+        t = self.state[3]
+        s = self.state[0]
+
+        self.state[3] = self.state[2]
+        self.state[2] = self.state[1]
+        self.state[1] = s
+
+        t = (t << 11) & MASK
+        t ^= t >> 8
+        self.state[0] = (t ^ s ^ (s >> 19)) & MASK
+
+        return self.state[0]
+
+    def next(self):
+        # type: () -> float
+        return self.next_u32() / MASK
+
+
+class FeatureFlagsManager(object):
+    def __init__(self, request_func=None, refresh=None, is_enabled=None):
+        # type: (Any, Optional[float], Optional[bool]) -> None
+        self._request_func = request_func
+        self._fetched_flags = {}
+        self._last_fetch = None
+        self._dead = False
+        self._refresh = refresh or 60.0
+        self.is_enabled = is_enabled or False
+
+        if self.is_enabled:
+
+            def refresh():
+                while self._dead:
+                    if (
+                        self._last_fetch is None
+                        or self._last_fetch + self._refresh < time.time()
+                    ):
+                        self.refresh()
+                    time.sleep(1.0)
+
+            self._thread = threading.Thread(target=refresh)
+            self._thread.daemon = True
+            self._thread.start()
+
+        self.refresh()
+
+    def refresh(self):
+        # type: () -> None
+        if not self.is_enabled:
+            return
+
+        def callback(response):
+            self._fetched_flags = response
+
+        self._request_func(callback)
+        self._last_fetch = time.time()
+
+    def evaluate_feature_flag(self, name, context):
+        # type: (str, Dict[str, Any]) -> Optional[FeatureFlagInfo]
+        config = self._fetched_flags.get(name)
+        if config is None:
+            return None
+
+        for eval_config in config["evaluation"]:
+            tags = eval_config.get("tags") or {}
+            if not matches_tags(tags, context):
+                continue
+            if eval_config["type"] == "match" or (
+                eval_config["type"] == "rollout"
+                and roll_random_number(context) < eval_config["percentage"]
+            ):
+                return FeatureFlagInfo(
+                    result=eval_config["result"],
+                    payload=eval_config.get("payload") or {},
+                    tags=tags,
+                )
+
+        return None
+
+    def close(self):
+        self._dead = True
+
+
+class FeatureFlagInfo(object):
+    def __init__(self, result, payload, tags):
+        # type: (Any, Dict[str, Any], Dict[str, str]) -> None
+        self.result = result
+        self.payload = payload
+        self.tags = tags
+
+
+def roll_random_number(context):
+    # type: (Dict[str, Any]) -> float
+    sticky_id = context.get("stickyId") or context.get("userId") or FALLBACK_ID.hex
+    return XorShift(seed=sticky_id).next()
+
+
+def matches_tags(tags, context):
+    # type: (Dict[str, str], Dict[str, Any]) -> None
+    for key, value in tags.items():
+        if context.get(key) != str(value):
+            return False
+    return True

--- a/sentry_sdk/feature_flags.py
+++ b/sentry_sdk/feature_flags.py
@@ -113,7 +113,8 @@ class FeatureFlagsManager(object):
                 continue
             if eval_config["type"] == "match" or (
                 eval_config["type"] == "rollout"
-                and roll_random_number(context) < eval_config["percentage"]
+                and roll_random_number(config.get("group") or name, context)
+                < eval_config["percentage"]
             ):
                 return FeatureFlagInfo(
                     result=eval_config["result"],
@@ -131,9 +132,10 @@ class FeatureFlagsManager(object):
 FeatureFlagInfo = namedtuple("FeatureFlagInfo", ["result", "payload", "tags"])
 
 
-def roll_random_number(context):
-    # type: (Dict[str, Any]) -> float
+def roll_random_number(group, context):
+    # type: (str, Dict[str, Any]) -> float
     sticky_id = str(context.get("stickyId") or context.get("userId") or FALLBACK_ID)
+    seed = "%s|%s" % (group, sticky_id)
     return XorShift(seed=sticky_id).next_float()
 
 

--- a/sentry_sdk/hub.py
+++ b/sentry_sdk/hub.py
@@ -262,6 +262,21 @@ class Hub(with_metaclass(HubMeta)):  # type: ignore
         old = self._old_hubs.pop()
         _local.set(old)
 
+    def wait_until_ready(self, timeout=None):
+        """
+        The SDK can perform some on-startup functionality that
+        you might want to await.  In that case method returns `True`
+        if it managed to complete the activity upon calling within
+        the given timeout.
+        """
+        # type: (...) -> bool
+        if timeout is None:
+            timeout = 2.0
+        client = self.client
+        if client is not None:
+            return client.feature_flags_manager.wait(timeout)
+        return True
+
     def run(
         self, callback  # type: Callable[[], T]
     ):

--- a/sentry_sdk/hub.py
+++ b/sentry_sdk/hub.py
@@ -750,14 +750,7 @@ class Hub(with_metaclass(HubMeta)):  # type: ignore
             context = {}
         else:
             context = dict(context)
-        for tag, value in scope._tags.items():
-            context[tag] = str(value)
-        context["transaction"] = scope.transaction
-        if scope._user:
-            user_id = scope._user.get("id")
-            if user_id is not None:
-                context["userId"] = user_id
-        return client._get_feature_flag_info(name, context)
+        return client._get_feature_flag_info(name, scope, context)
 
     def is_feature_flag_enabled(self, name, scope=None, context=None, default=False):
         # type: (str, Optional[Scope], Optional[Dict[str, Any]], bool) -> bool

--- a/sentry_sdk/hub.py
+++ b/sentry_sdk/hub.py
@@ -727,7 +727,7 @@ class Hub(with_metaclass(HubMeta)):  # type: ignore
         """
         client, top_scope = self._stack[-1]
         if client is None:
-            return
+            return None
         scope = _update_scope(top_scope, scope, {})
         if context is None:
             context = {}
@@ -735,17 +735,17 @@ class Hub(with_metaclass(HubMeta)):  # type: ignore
             context = dict(context)
         for tag, value in scope._tags.items():
             context[tag] = str(value)
-        context["release"] = self.client.options["release"]
-        context["environment"] = self.client.options["environment"]
+        context["release"] = client.options["release"]
+        context["environment"] = client.options["environment"]
         context["transaction"] = scope.transaction
         if scope._user:
             user_id = scope._user.get("id")
             if user_id is not None:
                 context["userId"] = user_id
-        return self.client.feature_flags_manager.evaluate_feature_flag(name, context)
+        return client.feature_flags_manager.evaluate_feature_flag(name, context)
 
     def is_feature_flag_enabled(self, name, scope=None, context=None, default=False):
-        # type: (str, Optional[Scope], Optional[Dict[str, Any]], Optional[bool]) -> bool
+        # type: (str, Optional[Scope], Optional[Dict[str, Any]], bool) -> bool
         """
         Given the name of a feature flag, optional scope and context
         evaluates the feature flag and returns the result as bool.

--- a/sentry_sdk/hub.py
+++ b/sentry_sdk/hub.py
@@ -262,14 +262,16 @@ class Hub(with_metaclass(HubMeta)):  # type: ignore
         old = self._old_hubs.pop()
         _local.set(old)
 
-    def wait_until_ready(self, timeout=None):
+    def wait_until_ready(
+        self, timeout=None  # type: Optional[float]
+    ):
+        # type: (...) -> bool
         """
         The SDK can perform some on-startup functionality that
         you might want to await.  In that case method returns `True`
         if it managed to complete the activity upon calling within
         the given timeout.
         """
-        # type: (...) -> bool
         if timeout is None:
             timeout = 2.0
         client = self.client
@@ -750,14 +752,12 @@ class Hub(with_metaclass(HubMeta)):  # type: ignore
             context = dict(context)
         for tag, value in scope._tags.items():
             context[tag] = str(value)
-        context["release"] = client.options["release"]
-        context["environment"] = client.options["environment"]
         context["transaction"] = scope.transaction
         if scope._user:
             user_id = scope._user.get("id")
             if user_id is not None:
                 context["userId"] = user_id
-        return client.feature_flags_manager.evaluate_feature_flag(name, context)
+        return client._get_feature_flag_info(name, context)
 
     def is_feature_flag_enabled(self, name, scope=None, context=None, default=False):
         # type: (str, Optional[Scope], Optional[Dict[str, Any]], bool) -> bool

--- a/sentry_sdk/profiler.py
+++ b/sentry_sdk/profiler.py
@@ -198,8 +198,14 @@ def has_profiling_enabled(hub=None):
     if hub is None:
         hub = sentry_sdk.Hub.current
 
-    options = hub.client and hub.client.options
-    return bool(options and options["_experiments"].get("enable_profiling"))
+    if hub.client:
+        options = hub.client.options
+        profiling_enabled = bool(options and options["_experiments"].get("enable_profiling"))
+        dynamic_profiling_enabled = hub.client._get_feature_flag_info("@@profilingEnabled")
+        if dynamic_profiling_enabled is not None:
+            profiling_enabled = dynamic_profiling_enabled
+        return profiling_enabled
+    return False
 
 
 @contextmanager

--- a/sentry_sdk/profiler.py
+++ b/sentry_sdk/profiler.py
@@ -202,7 +202,9 @@ def has_profiling_enabled(hub=None):
 
     if client:
         options = client.options
-        profiling_enabled = bool(options and options["_experiments"].get("enable_profiling"))
+        profiling_enabled = bool(
+            options and options["_experiments"].get("enable_profiling")
+        )
         dynamic_profiling_enabled = client._get_feature_flag_info("@@profilingEnabled")
         if dynamic_profiling_enabled is not None:
             profiling_enabled = dynamic_profiling_enabled.result

--- a/sentry_sdk/profiler.py
+++ b/sentry_sdk/profiler.py
@@ -198,12 +198,14 @@ def has_profiling_enabled(hub=None):
     if hub is None:
         hub = sentry_sdk.Hub.current
 
-    if hub.client:
-        options = hub.client.options
+    client = hub.client
+
+    if client:
+        options = client.options
         profiling_enabled = bool(options and options["_experiments"].get("enable_profiling"))
-        dynamic_profiling_enabled = hub.client._get_feature_flag_info("@@profilingEnabled")
+        dynamic_profiling_enabled = client._get_feature_flag_info("@@profilingEnabled")
         if dynamic_profiling_enabled is not None:
-            profiling_enabled = dynamic_profiling_enabled
+            profiling_enabled = dynamic_profiling_enabled.result
         return profiling_enabled
     return False
 

--- a/sentry_sdk/tracing.py
+++ b/sentry_sdk/tracing.py
@@ -761,6 +761,16 @@ class Transaction(Span):
             )
         )
 
+        # Override sample rate with what comes from the feature flag system.
+        dynamic_sample_rate = hub.get_feature_flag_info(
+            "@@tracesSampleRate",
+            context={
+                "transaction": self.name,
+            },
+        )
+        if dynamic_sample_rate is not None:
+            sample_rate = dynamic_sample_rate.result
+
         # Since this is coming from the user (or from a function provided by the
         # user), who knows what we might get. (The only valid values are
         # booleans or numbers between 0 and 1.)

--- a/sentry_sdk/transport.py
+++ b/sentry_sdk/transport.py
@@ -218,7 +218,7 @@ class HttpTransport(Transport):
         headers,  # type: Dict[str, str]
         endpoint_type="store",  # type: EndpointType
         envelope=None,  # type: Optional[Envelope]
-        callback=None,  # type: Callable[[urllib3.HTTPResponse], None]
+        callback=None,  # type: Optional[Callable[[urllib3.HTTPResponse], None]]
     ):
         # type: (...) -> None
 
@@ -280,7 +280,9 @@ class HttpTransport(Transport):
     def request_feature_flags(
         self, callback  # type: Callable[[Any], None]
     ):
+        # type: (...) -> None
         def on_response(response):
+            # type: (Any) -> None
             if response.status == 200:
                 rv = json.loads(response.data)
                 callback(rv["feature_flags"])


### PR DESCRIPTION
This adds basic support for the hackweek feature flag API.

Example:

```python
import sentry_sdk

sentry_sdk.init(_experiments={"feature_flags_enabled": True})
sentry_sdk.wait_until_ready()

with sentry_sdk.configure_scope() as scope:
    scope.set_tag("isSentryDev", "true")

profiling_enabled = sentry_sdk.is_feature_flag_enabled("@@profilingEnabled")
access_to_profiling = sentry_sdk.is_feature_flag_enabled("@@accessToProfiling")
sample_rate = None

if access_to_profiling:
    info = sentry_sdk.get_feature_flag_info("@@tracesSampleRate")
    if info is not None:
        sample_rate = info.result

print(f"{profiling_enabled=}")
print(f"{access_to_profiling=}")
print(f"{sample_rate=}")
```