### PR TITLE
New ASGIMiddleware tests

### DIFF
--- a/tests/integrations/asgi/__init__.py
+++ b/tests/integrations/asgi/__init__.py
@@ -1,0 +1,4 @@
+import pytest
+
+asyncio = pytest.importorskip("asyncio")
+pytest_asyncio = pytest.importorskip("pytest_asyncio")

--- a/tests/integrations/asgi/test_asgi.py
+++ b/tests/integrations/asgi/test_asgi.py
@@ -19,7 +19,11 @@ minimum_python_36 = pytest.mark.skipif(
 @pytest.fixture
 def asgi3_app():
     async def app(scope, receive, send):
-        if scope["type"] == "http" and scope["route"] == "/trigger/error":
+        if (
+            scope["type"] == "http"
+            and "route" in scope
+            and scope["route"] == "/trigger/error"
+        ):
             division_by_zero = 1 / 0  # noqa
 
         await send(

--- a/tests/integrations/asgi/test_asgi.py
+++ b/tests/integrations/asgi/test_asgi.py
@@ -1,6 +1,9 @@
 import sys
 
+from collections import Counter
+
 import pytest
+import sentry_sdk
 from sentry_sdk.integrations.asgi import SentryAsgiMiddleware, _looks_like_asgi3
 
 async_asgi_testclient = pytest.importorskip("async_asgi_testclient")
@@ -15,6 +18,9 @@ minimum_python_36 = pytest.mark.skipif(
 @pytest.fixture
 def asgi3_app():
     async def app(scope, receive, send):
+        if scope["type"] == "http" and scope["route"] == "/trigger/error":
+            division_by_zero = 1 / 0  # noqa
+
         await send(
             {
                 "type": "http.response.start",
@@ -137,6 +143,59 @@ async def test_capture_transaction_with_error(
 
 
 @minimum_python_36
+@pytest.mark.asyncio
+async def test_websocket(
+    sentry_init,
+    asgi3_app_with_error,
+    capture_events,
+    DictionaryContaining,  # noqa: N803
+):
+    sentry_init(send_default_pii=True, traces_sample_rate=1.0)
+    app = SentryAsgiMiddleware(asgi3_app_with_error)
+    print(app)
+    # TODO: implement
+
+
+@minimum_python_36
+@pytest.mark.asyncio
+async def test_auto_session_tracking_with_aggregates(
+    sentry_init, asgi3_app, capture_envelopes
+):
+    sentry_init(send_default_pii=True, traces_sample_rate=1.0)
+    app = SentryAsgiMiddleware(asgi3_app)
+
+    scope = {
+        "endpoint": asgi3_app,
+        "client": ("127.0.0.1", 60457),
+    }
+    with pytest.raises(ZeroDivisionError):
+        envelopes = capture_envelopes()
+        async with TestClient(app, scope=scope) as client:
+            scope["route"] = "/some/fine/url"
+            await client.get("/some/fine/url")
+            scope["route"] = "/some/fine/url"
+            await client.get("/some/fine/url")
+            scope["route"] = "/trigger/error"
+            await client.get("/trigger/error")
+
+    sentry_sdk.flush()
+
+    count_item_types = Counter()
+    for envelope in envelopes:
+        count_item_types[envelope.items[0].type] += 1
+
+    assert count_item_types["transaction"] == 4
+    assert count_item_types["event"] == 1
+    assert count_item_types["sessions"] == 1
+    assert len(envelopes) == 6
+
+    session_aggregates = envelopes[-1].items[0].payload.json["aggregates"]
+    assert session_aggregates[0]["exited"] == 3
+    assert session_aggregates[0]["crashed"] == 1
+    assert len(session_aggregates) == 1
+
+
+@minimum_python_36
 @pytest.mark.parametrize(
     "url,transaction_style,expected_transaction,expected_source",
     [
@@ -218,3 +277,127 @@ def test_looks_like_asgi3(asgi3_app):
     assert _looks_like_asgi3(asgi3)
     asgi2 = MockAsgi2App()
     assert not _looks_like_asgi3(asgi2)
+
+
+@minimum_python_36
+def test_get_ip_x_forwarded_for():
+    headers = [
+        (b"x-forwarded-for", b"8.8.8.8"),
+    ]
+    scope = {
+        "client": ("127.0.0.1", 60457),
+        "headers": headers,
+    }
+    middleware = SentryAsgiMiddleware({})
+    ip = middleware._get_ip(scope)
+    assert ip == "8.8.8.8"
+
+    # x-forwarded-for overrides x-real-ip
+    headers = [
+        (b"x-forwarded-for", b"8.8.8.8"),
+        (b"x-real-ip", b"10.10.10.10"),
+    ]
+    scope = {
+        "client": ("127.0.0.1", 60457),
+        "headers": headers,
+    }
+    middleware = SentryAsgiMiddleware({})
+    ip = middleware._get_ip(scope)
+    assert ip == "8.8.8.8"
+
+    # when multiple x-forwarded-for headers are, the first is taken
+    headers = [
+        (b"x-forwarded-for", b"5.5.5.5"),
+        (b"x-forwarded-for", b"6.6.6.6"),
+        (b"x-forwarded-for", b"7.7.7.7"),
+    ]
+    scope = {
+        "client": ("127.0.0.1", 60457),
+        "headers": headers,
+    }
+    middleware = SentryAsgiMiddleware({})
+    ip = middleware._get_ip(scope)
+    assert ip == "5.5.5.5"
+
+
+@minimum_python_36
+def test_get_ip_x_real_ip():
+    headers = [
+        (b"x-real-ip", b"10.10.10.10"),
+    ]
+    scope = {
+        "client": ("127.0.0.1", 60457),
+        "headers": headers,
+    }
+    middleware = SentryAsgiMiddleware({})
+    ip = middleware._get_ip(scope)
+    assert ip == "10.10.10.10"
+
+    # x-forwarded-for overrides x-real-ip
+    headers = [
+        (b"x-forwarded-for", b"8.8.8.8"),
+        (b"x-real-ip", b"10.10.10.10"),
+    ]
+    scope = {
+        "client": ("127.0.0.1", 60457),
+        "headers": headers,
+    }
+    middleware = SentryAsgiMiddleware({})
+    ip = middleware._get_ip(scope)
+    assert ip == "8.8.8.8"
+
+
+@minimum_python_36
+def test_get_ip():
+    # if now headers are provided the ip is taken from the client.
+    headers = []
+    scope = {
+        "client": ("127.0.0.1", 60457),
+        "headers": headers,
+    }
+    middleware = SentryAsgiMiddleware({})
+    ip = middleware._get_ip(scope)
+    assert ip == "127.0.0.1"
+
+    # x-forwarded-for header overides the ip from client
+    headers = [
+        (b"x-forwarded-for", b"8.8.8.8"),
+    ]
+    scope = {
+        "client": ("127.0.0.1", 60457),
+        "headers": headers,
+    }
+    middleware = SentryAsgiMiddleware({})
+    ip = middleware._get_ip(scope)
+    assert ip == "8.8.8.8"
+
+    # x-real-for header overides the ip from client
+    headers = [
+        (b"x-real-ip", b"10.10.10.10"),
+    ]
+    scope = {
+        "client": ("127.0.0.1", 60457),
+        "headers": headers,
+    }
+    middleware = SentryAsgiMiddleware({})
+    ip = middleware._get_ip(scope)
+    assert ip == "10.10.10.10"
+
+
+@minimum_python_36
+def test_get_headers():
+    headers = [
+        (b"x-real-ip", b"10.10.10.10"),
+        (b"some_header", b"123"),
+        (b"some_header", b"abc"),
+    ]
+    scope = {
+        "client": ("127.0.0.1", 60457),
+        "headers": headers,
+    }
+    middleware = SentryAsgiMiddleware({})
+    headers = middleware._get_headers(scope)
+    assert headers == {
+        "x-real-ip": "10.10.10.10",
+        "some_header": "123, abc",
+    }

--- a/tests/integrations/asgi/test_asgi.py
+++ b/tests/integrations/asgi/test_asgi.py
@@ -63,7 +63,9 @@ def test_invalid_transaction_style(asgi3_app):
 
 @pytest.mark.asyncio
 async def test_capture_transaction(
-    sentry_init, asgi3_app, capture_events, DictionaryContaining
+    sentry_init,
+    asgi3_app,
+    capture_events,
 ):
     sentry_init(send_default_pii=True, traces_sample_rate=1.0)
     app = SentryAsgiMiddleware(asgi3_app)
@@ -91,7 +93,10 @@ async def test_capture_transaction(
 
 @pytest.mark.asyncio
 async def test_capture_transaction_with_error(
-    sentry_init, asgi3_app_with_error, capture_events, DictionaryContaining
+    sentry_init,
+    asgi3_app_with_error,
+    capture_events,
+    DictionaryContaining,  # noqa: N803
 ):
     sentry_init(send_default_pii=True, traces_sample_rate=1.0)
     app = SentryAsgiMiddleware(asgi3_app_with_error)

--- a/tests/integrations/asgi/test_asgi.py
+++ b/tests/integrations/asgi/test_asgi.py
@@ -1,6 +1,15 @@
+import sys
+
 import pytest
-from async_asgi_testclient import TestClient
 from sentry_sdk.integrations.asgi import SentryAsgiMiddleware, _looks_like_asgi3
+
+async_asgi_testclient = pytest.importorskip("async_asgi_testclient")
+from async_asgi_testclient import TestClient
+
+
+minimum_python_36 = pytest.mark.skipif(
+    sys.version_info < (3, 6), reason="ASGI is only supported in Python >= 3.6"
+)
 
 
 @pytest.fixture
@@ -51,6 +60,7 @@ def asgi3_app_with_error():
     return app
 
 
+@minimum_python_36
 def test_invalid_transaction_style(asgi3_app):
     with pytest.raises(ValueError) as exp:
         SentryAsgiMiddleware(asgi3_app, transaction_style="URL")
@@ -61,6 +71,7 @@ def test_invalid_transaction_style(asgi3_app):
     )
 
 
+@minimum_python_36
 @pytest.mark.asyncio
 async def test_capture_transaction(
     sentry_init,
@@ -91,6 +102,7 @@ async def test_capture_transaction(
     }
 
 
+@minimum_python_36
 @pytest.mark.asyncio
 async def test_capture_transaction_with_error(
     sentry_init,
@@ -124,6 +136,7 @@ async def test_capture_transaction_with_error(
     assert transaction_event["request"] == error_event["request"]
 
 
+@minimum_python_36
 @pytest.mark.parametrize(
     "url,transaction_style,expected_transaction,expected_source",
     [
@@ -190,6 +203,7 @@ class MockAsgi3App(MockAsgi2App):
         pass
 
 
+@minimum_python_36
 def test_looks_like_asgi3(asgi3_app):
     # branch: inspect.isclass(app)
     assert _looks_like_asgi3(MockAsgi3App)

--- a/tests/integrations/asgi/test_asgi.py
+++ b/tests/integrations/asgi/test_asgi.py
@@ -1,7 +1,192 @@
-#
-# TODO: Implement tests similar to test_wsgi using async-asgi-testclient
-#
+import pytest
+from async_asgi_testclient import TestClient
+from sentry_sdk.integrations.asgi import SentryAsgiMiddleware
+
+# from unittest import mock
 
 
-def test_noop():
-    pass
+@pytest.fixture
+def asgi3_app():
+    async def app(scope, receive, send):
+        await send(
+            {
+                "type": "http.response.start",
+                "status": 200,
+                "headers": [
+                    [b"content-type", b"text/plain"],
+                ],
+            }
+        )
+
+        await send(
+            {
+                "type": "http.response.body",
+                "body": b"Hello, world!",
+            }
+        )
+
+    return app
+
+
+@pytest.fixture
+def asgi3_app_with_error():
+    async def app(scope, receive, send):
+        await send(
+            {
+                "type": "http.response.start",
+                "status": 200,
+                "headers": [
+                    [b"content-type", b"text/plain"],
+                ],
+            }
+        )
+
+        division_by_zero = 1 / 0  # noqa
+
+        await send(
+            {
+                "type": "http.response.body",
+                "body": b"Hello, world!",
+            }
+        )
+
+    return app
+
+
+def test_warning_if_manual_setup_and_starlette():
+    assert False
+
+
+def test_run_asgi2():
+    assert False
+
+
+@pytest.mark.asyncio
+# @mock.patch("sentry_sdk.integrations.asgi.SentryAsgiMiddleware._run_asgi3")
+async def test_run_asgi3(asgi3_app):
+    assert False
+
+
+def test_invalid_transaction_style(asgi3_app):
+    with pytest.raises(ValueError) as exp:
+        SentryAsgiMiddleware(asgi3_app, transaction_style="URL")
+
+    assert (
+        str(exp.value)
+        == "Invalid value for transaction_style: URL (must be in ('endpoint', 'url'))"
+    )
+
+
+@pytest.mark.asyncio
+async def test_capture_transaction(
+    sentry_init, asgi3_app, capture_events, DictionaryContaining
+):
+    sentry_init(send_default_pii=True, traces_sample_rate=1.0)
+    app = SentryAsgiMiddleware(asgi3_app)
+
+    async with TestClient(app) as client:
+        events = capture_events()
+        await client.get("/?somevalue=123")
+
+    (transaction_event,) = events
+
+    assert transaction_event["type"] == "transaction"
+    assert transaction_event["transaction"] == "generic ASGI request"
+    assert transaction_event["contexts"]["trace"]["op"] == "http.server"
+    assert transaction_event["request"] == {
+        "headers": {
+            "host": "localhost",
+            "remote-addr": "127.0.0.1",
+            "user-agent": "ASGI-Test-Client",
+        },
+        "method": "GET",
+        "query_string": "somevalue=123",
+        "url": "http://localhost/",
+    }
+
+
+@pytest.mark.asyncio
+async def test_capture_transaction_with_error(
+    sentry_init, asgi3_app_with_error, capture_events, DictionaryContaining
+):
+    sentry_init(send_default_pii=True, traces_sample_rate=1.0)
+    app = SentryAsgiMiddleware(asgi3_app_with_error)
+
+    with pytest.raises(ZeroDivisionError):
+        async with TestClient(app) as client:
+            events = capture_events()
+            await client.get("/")
+
+    (error_event, transaction_event) = events
+
+    assert error_event["transaction"] == "generic ASGI request"
+    assert error_event["contexts"]["trace"]["op"] == "http.server"
+    assert error_event["exception"]["values"][0]["type"] == "ZeroDivisionError"
+    assert error_event["exception"]["values"][0]["value"] == "division by zero"
+
+    assert transaction_event["type"] == "transaction"
+    assert transaction_event["contexts"]["trace"] == DictionaryContaining(
+        error_event["contexts"]["trace"]
+    )
+    assert transaction_event["contexts"]["trace"]["status"] == "internal_error"
+    assert transaction_event["transaction"] == error_event["transaction"]
+    assert transaction_event["request"] == error_event["request"]
+
+
+@pytest.mark.parametrize(
+    "url,transaction_style,expected_transaction,expected_source",
+    [
+        (
+            "/message",
+            "url",
+            "/message",
+            "route",
+        ),
+        (
+            "/message",
+            "endpoint",
+            "tests.integrations.starlette.test_starlette.starlette_app_factory.<locals>._message",
+            "component",
+        ),
+        (
+            "/message/123456",
+            "url",
+            "/message/{message_id}",
+            "route",
+        ),
+        (
+            "/message/123456",
+            "endpoint",
+            "tests.integrations.starlette.test_starlette.starlette_app_factory.<locals>._message_with_id",
+            "component",
+        ),
+    ],
+)
+def test_transaction_style(
+    sentry_init,
+    capture_events,
+    url,
+    transaction_style,
+    expected_transaction,
+    expected_source,
+):
+    # sentry_init(
+    #     integrations=[StarletteIntegration(transaction_style=transaction_style)],
+    # )
+    assert False
+
+
+def test_get_url():
+    assert False
+
+
+def test_get_query():
+    assert False
+
+
+def test_get_ip():
+    assert False
+
+
+def test_get_headers():
+    assert False

--- a/tests/integrations/starlette/test_starlette.py
+++ b/tests/integrations/starlette/test_starlette.py
@@ -5,6 +5,7 @@ import os
 
 import pytest
 
+from sentry_sdk import last_event_id
 from sentry_sdk.integrations.asgi import SentryAsgiMiddleware
 
 try:
@@ -82,7 +83,7 @@ SCOPE = {
 }
 
 
-def starlette_app_factory(middleware=None):
+def starlette_app_factory(middleware=None, debug=True):
     async def _homepage(request):
         1 / 0
         return starlette.responses.JSONResponse({"status": "ok"})
@@ -99,7 +100,7 @@ def starlette_app_factory(middleware=None):
         return starlette.responses.JSONResponse({"status": "ok"})
 
     app = starlette.applications.Starlette(
-        debug=True,
+        debug=debug,
         routes=[
             starlette.routing.Route("/some_url", _homepage),
             starlette.routing.Route("/custom_error", _custom_error),
@@ -541,6 +542,29 @@ def test_middleware_spans(sentry_init, capture_events):
             assert span["description"] == expected[idx]
             assert span["tags"]["starlette.middleware_name"] == expected[idx]
             idx += 1
+
+
+def test_last_event_id(sentry_init, capture_events):
+    sentry_init(
+        integrations=[StarletteIntegration()],
+    )
+    events = capture_events()
+
+    def handler(*args, **kwargs):
+        return starlette.responses.PlainTextResponse(last_event_id(), status_code=500)
+
+    app = starlette_app_factory(debug=False)
+    app.add_exception_handler(500, handler)
+
+    client = TestClient(SentryAsgiMiddleware(app), raise_server_exceptions=False)
+    response = client.get("/custom_error")
+    assert response.status_code == 500
+
+    (event,) = events
+    assert response.content.strip().decode("ascii") == event["event_id"]
+    (exception,) = event["exception"]["values"]
+    assert exception["type"] == "ValueError"
+    assert exception["value"] == "oh no"
 
 
 def test_legacy_setup(

--- a/tox.ini
+++ b/tox.ini
@@ -127,6 +127,8 @@ deps =
     flask-1.1: Flask>=1.1,<1.2
     flask-2.0: Flask>=2.0,<2.1
 
+    asgi: async-asgi-testclient
+
     quart: quart>=0.16.1
     quart: quart-auth
     quart: pytest-asyncio

--- a/tox.ini
+++ b/tox.ini
@@ -127,6 +127,7 @@ deps =
     flask-1.1: Flask>=1.1,<1.2
     flask-2.0: Flask>=2.0,<2.1
 
+    asgi: pytest-asyncio
     asgi: async-asgi-testclient
 
     quart: quart>=0.16.1


### PR DESCRIPTION
Rewrote tests to not use Starlette (or any other framework) for testing the `SentryAsgiMiddleware`.