### PR TITLE
feat(profiling): Introduce different profiler schedulers

### DIFF
--- a/sentry_sdk/client.py
+++ b/sentry_sdk/client.py
@@ -134,9 +134,9 @@ class _Client(object):
         profiles_sample_rate = self.options["_experiments"].get("profiles_sample_rate")
         if profiles_sample_rate is not None and profiles_sample_rate > 0:
             try:
-                setup_profiler()
-            except ValueError:
-                logger.debug("Profiling can only be enabled from the main thread.")
+                setup_profiler(self.options)
+            except ValueError as e:
+                logger.debug(str(e))
 
     @property
     def dsn(self):

--- a/sentry_sdk/profiler.py
+++ b/sentry_sdk/profiler.py
@@ -437,7 +437,9 @@ class _SignalScheduler(_Scheduler):
         try:
             signal.signal(self.signal_num, _sample_stack)
         except ValueError:
-            raise ValueError("Signal based profiling can only be enabled from the main thread.")
+            raise ValueError(
+                "Signal based profiling can only be enabled from the main thread."
+            )
 
         # Ensures that system calls interrupted by signals are restarted
         # automatically. Otherwise, we may see some strage behaviours

--- a/sentry_sdk/profiler.py
+++ b/sentry_sdk/profiler.py
@@ -100,7 +100,7 @@ def teardown_profiler():
 
 
 def _sample_stack(*args, **kwargs):
-    # type: () -> None
+    # type: (*Any, **Any) -> None
     """
     Take a sample of the stack on all the threads in the process.
     This should be called at a regular interval to collect samples.


### PR DESCRIPTION
Previously, the only scheduling mechanism was via `signals.SIGPROF`. This was limited to UNIX platforms and was not always consistent. This PR introduces more ways to schedule the sampling. They are the following:

- `_SigprofScheduler` uses `signals.SIGPROF` to schedule
- `_SigalrmScheduler` uses `signals.SIGALRM` to schedule
- `_SleepScheduler` uses threads and `time.sleep` to schedule
- `_EventScheduler` uses threads and `threading.Event().wait` to schedule