### PR TITLE
Fix for partial signals in old Django and old Python versions.

### DIFF
--- a/sentry_sdk/integrations/django/signals_handlers.py
+++ b/sentry_sdk/integrations/django/signals_handlers.py
@@ -15,11 +15,17 @@ if MYPY:
 
 def _get_receiver_name(receiver):
     # type: (Callable[..., Any]) -> str
-    if hasattr(receiver, "__qualname__"):
-        return receiver.__qualname__
+    name = ""
+    if hasattr(receiver, "__module__"):
+        name += receiver.__module__ + "."
 
-    return str(receiver)
+    if hasattr(receiver, "__name__"):
+        name += receiver.__name__
 
+    if name == "":
+        return str(receiver)
+
+    return name
 
 def patch_signals():
     # type: () -> None

--- a/sentry_sdk/integrations/django/signals_handlers.py
+++ b/sentry_sdk/integrations/django/signals_handlers.py
@@ -19,16 +19,19 @@ def _get_receiver_name(receiver):
 
     if hasattr(receiver, "__qualname__"):
         name += receiver.__qualname__
-    elif hasattr(receiver, "__name__"): # Python 2.7 has no __qualname__
+    elif hasattr(receiver, "__name__"):  # Python 2.7 has no __qualname__
         name += receiver.__name__
 
-    if name == "":  # certain functions (like partials) dont have a name so return the string representation
+    if (
+        name == ""
+    ):  # certain functions (like partials) dont have a name so return the string representation
         return str(receiver)
 
     if hasattr(receiver, "__module__"):  # prepend with module, if there is one
         name = receiver.__module__ + "." + name
 
     return name
+
 
 def patch_signals():
     # type: () -> None

--- a/sentry_sdk/integrations/django/signals_handlers.py
+++ b/sentry_sdk/integrations/django/signals_handlers.py
@@ -16,14 +16,17 @@ if MYPY:
 def _get_receiver_name(receiver):
     # type: (Callable[..., Any]) -> str
     name = ""
-    if hasattr(receiver, "__module__"):
-        name += receiver.__module__ + "."
 
     if hasattr(receiver, "__qualname__"):
         name += receiver.__qualname__
+    elif hasattr(receiver, "__name__"): # Python 2.7 has no __qualname__
+        name += receiver.__name__
 
-    if name == "":
+    if name == "":  # certain functions (like partials) dont have a name so return the string representation
         return str(receiver)
+
+    if hasattr(receiver, "__module__"):  # prepend with module, if there is one
+        name = receiver.__module__ + "." + name
 
     return name
 

--- a/sentry_sdk/integrations/django/signals_handlers.py
+++ b/sentry_sdk/integrations/django/signals_handlers.py
@@ -19,8 +19,8 @@ def _get_receiver_name(receiver):
     if hasattr(receiver, "__module__"):
         name += receiver.__module__ + "."
 
-    if hasattr(receiver, "__name__"):
-        name += receiver.__name__
+    if hasattr(receiver, "__qualname__"):
+        name += receiver.__qualname__
 
     if name == "":
         return str(receiver)

--- a/sentry_sdk/integrations/django/signals_handlers.py
+++ b/sentry_sdk/integrations/django/signals_handlers.py
@@ -21,7 +21,7 @@ def patch_signals():
 
     def _get_receiver_name(receiver):
         # type: (Callable[..., Any]) -> str
-        name = receiver.__module__ + "." if hasattr(receiver, "__name__") else ""
+        name = receiver.__module__ + "." if hasattr(receiver, "__module__") else ""
 
         if hasattr(receiver, "__name__"):
             return name + receiver.__name__

--- a/sentry_sdk/integrations/django/signals_handlers.py
+++ b/sentry_sdk/integrations/django/signals_handlers.py
@@ -21,7 +21,10 @@ def patch_signals():
 
     def _get_receiver_name(receiver):
         # type: (Callable[..., Any]) -> str
-        name = receiver.__module__ + "." if hasattr(receiver, "__module__") else ""
+        if hasattr(receiver, "__module__"):
+            name = receiver.__module__ + "."
+        else:
+            name = ""
 
         if hasattr(receiver, "__name__"):
             return name + receiver.__name__

--- a/sentry_sdk/integrations/django/signals_handlers.py
+++ b/sentry_sdk/integrations/django/signals_handlers.py
@@ -13,23 +13,19 @@ if MYPY:
     from typing import List
 
 
+def _get_receiver_name(receiver):
+    # type: (Callable[..., Any]) -> str
+    if hasattr(receiver, "__qualname__"):
+        return receiver.__qualname__
+
+    return str(receiver)
+
+
 def patch_signals():
     # type: () -> None
     """Patch django signal receivers to create a span"""
 
     old_live_receivers = Signal._live_receivers
-
-    def _get_receiver_name(receiver):
-        # type: (Callable[..., Any]) -> str
-        if hasattr(receiver, "__module__"):
-            name = receiver.__module__ + "."
-        else:
-            name = ""
-
-        if hasattr(receiver, "__name__"):
-            return name + receiver.__name__
-
-        return name + str(receiver)
 
     def _sentry_live_receivers(self, sender):
         # type: (Signal, Any) -> List[Callable[..., Any]]

--- a/tests/integrations/django/test_basic.py
+++ b/tests/integrations/django/test_basic.py
@@ -823,7 +823,7 @@ def test_get_receiver_name():
         return a+b
 
     name = _get_receiver_name(dummy)
-    assert name == 'tests.integrations.django.test_basic.dummy'
+    assert name == 'tests.integrations.django.test_basic.test_get_receiver_name.<locals>.dummy'
 
     a_partial = partial(dummy)
     name = _get_receiver_name(a_partial)

--- a/tests/integrations/django/test_basic.py
+++ b/tests/integrations/django/test_basic.py
@@ -823,7 +823,7 @@ def test_get_receiver_name():
         return a+b
 
     name = _get_receiver_name(dummy)
-    assert name == 'test_get_receiver_name.<locals>.dummy'
+    assert name == 'tests.integrations.django.test_basic.dummy'
 
     a_partial = partial(dummy)
     name = _get_receiver_name(a_partial)

--- a/tests/integrations/django/test_basic.py
+++ b/tests/integrations/django/test_basic.py
@@ -16,6 +16,7 @@ try:
 except ImportError:
     from django.core.urlresolvers import reverse
 
+from sentry_sdk._compat import PY2
 from sentry_sdk import capture_message, capture_exception, configure_scope
 from sentry_sdk.integrations.django import DjangoIntegration
 from sentry_sdk.integrations.django.signals_handlers import _get_receiver_name
@@ -820,10 +821,17 @@ def test_custom_urlconf_middleware(
 
 def test_get_receiver_name():
     def dummy(a, b):
-        return a+b
+        return a + b
 
     name = _get_receiver_name(dummy)
-    assert name == 'tests.integrations.django.test_basic.test_get_receiver_name.<locals>.dummy'
+
+    if PY2:
+        assert name == "tests.integrations.django.test_basic.dummy"
+    else:
+        assert (
+            name
+            == "tests.integrations.django.test_basic.test_get_receiver_name.<locals>.dummy"
+        )
 
     a_partial = partial(dummy)
     name = _get_receiver_name(a_partial)


### PR DESCRIPTION
Making sure signal name can also be set when partials are used as signal in  old Django versions in old Python versions.

Fixes #1640