### PR TITLE
Fix CI tests

### DIFF
--- a/scripts/runtox.sh
+++ b/scripts/runtox.sh
@@ -27,4 +27,4 @@ elif [ -n "$AZURE_PYTHON_VERSION" ]; then
 fi
 
 export TOX_PARALLEL_NO_SPINNER=1
-exec $TOXPATH --parallel auto -e $($TOXPATH -l | grep "$searchstring" | tr $'\n' ',') -- "${@:2}"
+exec $TOXPATH -p auto -e $($TOXPATH -l | grep "$searchstring" | tr $'\n' ',') -- "${@:2}"

--- a/tests/integrations/sanic/test_sanic.py
+++ b/tests/integrations/sanic/test_sanic.py
@@ -32,8 +32,8 @@ def app():
 
         Sanic.test_client = property(new_test_client)
 
-    if SANIC_VERSION >= (20, 12):
-        # Build (20.12.0) adds a feature where the instance is stored in an internal class
+    if SANIC_VERSION >= (20, 12) and SANIC_VERSION < (22, 6):
+        # Some builds (20.12.0 intruduced and 22.6.0 removed again) have a feature where the instance is stored in an internal class
         # registry for later retrieval, and so add register=False to disable that
         app = Sanic("Test", register=False)
     else:
@@ -229,7 +229,6 @@ def test_concurrency(sentry_init, app):
                 def respond(self, response):
                     responses.append(response)
                     patched_response = HTTPResponse()
-                    patched_response.send = lambda end_stream: asyncio.sleep(0.001)
                     return patched_response
 
                 def __aiter__(self):

--- a/tox.ini
+++ b/tox.ini
@@ -51,6 +51,7 @@ envlist =
     {py3.6,py3.7}-sanic-19
     {py3.6,py3.7,py3.8}-sanic-20
     {py3.7,py3.8,py3.9,py3.10}-sanic-21
+    {py3.7,py3.8,py3.9,py3.10}-sanic-22
 
     {py2.7}-celery-3
     {py2.7,py3.5,py3.6}-celery-{4.1,4.2}
@@ -160,9 +161,12 @@ deps =
     sanic-19: sanic>=19.0,<20.0
     sanic-20: sanic>=20.0,<21.0
     sanic-21: sanic>=21.0,<22.0
-    {py3.7,py3.8,py3.9,py3.10}-sanic-21: sanic_testing
-    {py3.5,py3.6}-sanic: aiocontextvars==0.2.1
+    sanic-22: sanic>=22.0,<22.9.0
+
     sanic: aiohttp
+    sanic-21: sanic_testing<22
+    sanic-22: sanic_testing<22.9.0
+    {py3.5,py3.6}-sanic: aiocontextvars==0.2.1
     py3.5-sanic: ujson<4
 
     beam-2.12: apache-beam>=2.12.0, <2.13.0


### PR DESCRIPTION
The new version of Sanic that was released a couple of hours ago has some breaking changes and thus break our test suite. So I have now excluded the latest Sanic version from our test suite.