### PR TITLE
Fix Celery tests

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -56,7 +56,8 @@ envlist =
     {py2.7}-celery-3
     {py2.7,py3.5,py3.6}-celery-{4.1,4.2}
     {py2.7,py3.5,py3.6,py3.7,py3.8}-celery-{4.3,4.4}
-    {py3.6,py3.7,py3.8,py3.9,py3.10}-celery-5.0
+    {py3.6,py3.7,py3.8}-celery-{5.0}
+    {py3.7,py3.8,py3.9,py3.10}-celery-{5.1,5.2}
 
     py3.7-beam-{2.12,2.13,2.32,2.33}
 
@@ -193,8 +194,11 @@ deps =
     # https://github.com/celery/celery/issues/6153
     celery-4.4: Celery>=4.4,<4.5,!=4.4.4
     celery-5.0: Celery>=5.0,<5.1
+    celery-5.1: Celery>=5.1,<5.2
+    celery-5.2: Celery>=5.2,<5.3
 
     py3.5-celery: newrelic<6.0.0
+    {py3.7}-celery: importlib-metadata<5.0
     {py2.7,py3.6,py3.7,py3.8,py3.9,py3.10}-celery: newrelic
 
     requests: requests>=2.0


### PR DESCRIPTION
New versions of dependencies of Celery have been released that break our test suite. #1656 