### PR TITLE
Include framework in SDK name

### DIFF
--- a/sentry_sdk/client.py
+++ b/sentry_sdk/client.py
@@ -19,7 +19,7 @@ from sentry_sdk.serializer import serialize
 from sentry_sdk.transport import make_transport
 from sentry_sdk.consts import (
     DEFAULT_OPTIONS,
-    SDK_INFO,
+    VERSION,
     ClientConstructor,
     _get_sdk_name,
 )
@@ -44,6 +44,13 @@ if MYPY:
 
 
 _client_init_debug = ContextVar("client_init_debug")
+
+
+SDK_INFO = {
+    "name": "sentry.python",  # SDK name be overridden after integrations have been loaded with sentry_sdk.integrations.setup_integrations()
+    "version": VERSION,
+    "packages": [{"name": "pypi:sentry-sdk", "version": VERSION}],
+}
 
 
 def _get_options(*args, **kwargs):

--- a/sentry_sdk/client.py
+++ b/sentry_sdk/client.py
@@ -10,6 +10,7 @@ from sentry_sdk.utils import (
     current_stacktrace,
     disable_capture_event,
     format_timestamp,
+    get_sdk_name,
     get_type_name,
     get_default_release,
     handle_in_app,
@@ -35,7 +36,6 @@ if MYPY:
     from typing import Any
     from typing import Callable
     from typing import Dict
-    from typing import List
     from typing import Optional
 
     from sentry_sdk.scope import Scope
@@ -51,40 +51,6 @@ SDK_INFO = {
     "version": VERSION,
     "packages": [{"name": "pypi:sentry-sdk", "version": VERSION}],
 }
-
-
-def _get_sdk_name(installed_integrations):
-    # type: (List[str]) -> str
-    """Return the SDK name including the name of the used web framework."""
-
-    # Note: I can not use for example sentry_sdk.integrations.django.DjangoIntegration.identifier
-    # here because if django is not installed the integration is not accessible.
-    framework_integrations = [
-        "django",
-        "flask",
-        "fastapi",
-        "bottle",
-        "falcon",
-        "quart",
-        "sanic",
-        "starlette",
-        "chalice",
-        "serverless",
-        "pyramid",
-        "tornado",
-        "aiohttp",
-        "aws_lambda",
-        "gcp",
-        "beam",
-        "asgi",
-        "wsgi",
-    ]
-
-    for integration in framework_integrations:
-        if integration in installed_integrations:
-            return "sentry.python.{}".format(integration)
-
-    return "sentry.python"
 
 
 def _get_options(*args, **kwargs):
@@ -175,7 +141,7 @@ class _Client(object):
                 ],
             )
 
-            sdk_name = _get_sdk_name(list(self.integrations.keys()))
+            sdk_name = get_sdk_name(list(self.integrations.keys()))
             SDK_INFO["name"] = sdk_name
             logger.debug("Setting SDK name to '%s'", sdk_name)
 

--- a/sentry_sdk/client.py
+++ b/sentry_sdk/client.py
@@ -17,7 +17,12 @@ from sentry_sdk.utils import (
 )
 from sentry_sdk.serializer import serialize
 from sentry_sdk.transport import make_transport
-from sentry_sdk.consts import DEFAULT_OPTIONS, SDK_INFO, ClientConstructor
+from sentry_sdk.consts import (
+    DEFAULT_OPTIONS,
+    SDK_INFO,
+    ClientConstructor,
+    _get_sdk_name,
+)
 from sentry_sdk.integrations import setup_integrations
 from sentry_sdk.utils import ContextVar
 from sentry_sdk.sessions import SessionFlusher
@@ -128,6 +133,11 @@ class _Client(object):
                     "auto_enabling_integrations"
                 ],
             )
+
+            sdk_name = _get_sdk_name(list(self.integrations.keys()))
+            SDK_INFO["name"] = sdk_name
+            logger.debug("Setting SDK name to '%s'", sdk_name)
+
         finally:
             _client_init_debug.set(old_debug)
 

--- a/sentry_sdk/consts.py
+++ b/sentry_sdk/consts.py
@@ -105,7 +105,7 @@ del _get_default_options
 
 
 def _get_sdk_name(installed_integrations):
-    # type: (list[str]) -> str
+    # type: (List[str]) -> str
     """Return the SDK name including the name of the used web framework."""
 
     # Note: I can not use for example sentry_sdk.integrations.django.DjangoIntegration.identifier

--- a/sentry_sdk/consts.py
+++ b/sentry_sdk/consts.py
@@ -104,38 +104,4 @@ DEFAULT_OPTIONS = _get_default_options()
 del _get_default_options
 
 
-def _get_sdk_name(installed_integrations):
-    # type: (List[str]) -> str
-    """Return the SDK name including the name of the used web framework."""
-
-    # Note: I can not use for example sentry_sdk.integrations.django.DjangoIntegration.identifier
-    # here because if django is not installed the integration is not accessible.
-    framework_integrations = [
-        "django",
-        "flask",
-        "fastapi",
-        "bottle",
-        "falcon",
-        "quart",
-        "sanic",
-        "starlette",
-        "chalice",
-        "serverless",
-        "pyramid",
-        "tornado",
-        "aiohttp",
-        "aws_lambda",
-        "gcp",
-        "beam",
-        "asgi",
-        "wsgi",
-    ]
-
-    for integration in framework_integrations:
-        if integration in installed_integrations:
-            return "sentry.python.{}".format(integration)
-
-    return "sentry.python"
-
-
 VERSION = "1.9.10"

--- a/sentry_sdk/consts.py
+++ b/sentry_sdk/consts.py
@@ -104,9 +104,17 @@ DEFAULT_OPTIONS = _get_default_options()
 del _get_default_options
 
 
+def _get_sdk_name():
+    return "sentry.python"
+
+
+SDK_NAME = _get_sdk_name()
+del _get_sdk_name
+
+
 VERSION = "1.9.10"
 SDK_INFO = {
-    "name": "sentry.python",
+    "name": SDK_NAME,
     "version": VERSION,
     "packages": [{"name": "pypi:sentry-sdk", "version": VERSION}],
 }

--- a/sentry_sdk/consts.py
+++ b/sentry_sdk/consts.py
@@ -139,8 +139,3 @@ def _get_sdk_name(installed_integrations):
 
 
 VERSION = "1.9.10"
-SDK_INFO = {
-    "name": "sentry.python",  # SDK name be overridden after integrations have been loaded with sentry_sdk.integrations.setup_integrations()
-    "version": VERSION,
-    "packages": [{"name": "pypi:sentry-sdk", "version": VERSION}],
-}

--- a/sentry_sdk/consts.py
+++ b/sentry_sdk/consts.py
@@ -104,17 +104,43 @@ DEFAULT_OPTIONS = _get_default_options()
 del _get_default_options
 
 
-def _get_sdk_name():
+def _get_sdk_name(installed_integrations):
+    # type: (list[str]) -> str
+    """Return the SDK name including the name of the used web framework."""
+
+    # Note: I can not use for example sentry_sdk.integrations.django.DjangoIntegration.identifier
+    # here because if django is not installed the integration is not accessible.
+    framework_integrations = [
+        "django",
+        "flask",
+        "fastapi",
+        "bottle",
+        "falcon",
+        "quart",
+        "sanic",
+        "starlette",
+        "chalice",
+        "serverless",
+        "pyramid",
+        "tornado",
+        "aiohttp",
+        "aws_lambda",
+        "gcp",
+        "beam",
+        "asgi",
+        "wsgi",
+    ]
+
+    for integration in framework_integrations:
+        if integration in installed_integrations:
+            return "sentry.python.{}".format(integration)
+
     return "sentry.python"
-
-
-SDK_NAME = _get_sdk_name()
-del _get_sdk_name
 
 
 VERSION = "1.9.10"
 SDK_INFO = {
-    "name": SDK_NAME,
+    "name": "sentry.python",  # SDK name be overridden after integrations have been loaded with sentry_sdk.integrations.setup_integrations()
     "version": VERSION,
     "packages": [{"name": "pypi:sentry-sdk", "version": VERSION}],
 }

--- a/sentry_sdk/utils.py
+++ b/sentry_sdk/utils.py
@@ -95,6 +95,40 @@ def get_default_release():
     return None
 
 
+def get_sdk_name(installed_integrations):
+    # type: (List[str]) -> str
+    """Return the SDK name including the name of the used web framework."""
+
+    # Note: I can not use for example sentry_sdk.integrations.django.DjangoIntegration.identifier
+    # here because if django is not installed the integration is not accessible.
+    framework_integrations = [
+        "django",
+        "flask",
+        "fastapi",
+        "bottle",
+        "falcon",
+        "quart",
+        "sanic",
+        "starlette",
+        "chalice",
+        "serverless",
+        "pyramid",
+        "tornado",
+        "aiohttp",
+        "aws_lambda",
+        "gcp",
+        "beam",
+        "asgi",
+        "wsgi",
+    ]
+
+    for integration in framework_integrations:
+        if integration in installed_integrations:
+            return "sentry.python.{}".format(integration)
+
+    return "sentry.python"
+
+
 class CaptureInternalException(object):
     __slots__ = ()
 

--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -18,7 +18,7 @@ from sentry_sdk import (
 )
 
 from sentry_sdk._compat import reraise
-from sentry_sdk.consts import _get_sdk_name
+from sentry_sdk.client import _get_sdk_name
 from sentry_sdk.integrations import _AUTO_ENABLING_INTEGRATIONS
 from sentry_sdk.integrations.logging import LoggingIntegration
 from sentry_sdk.scope import (  # noqa: F401

--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -18,13 +18,13 @@ from sentry_sdk import (
 )
 
 from sentry_sdk._compat import reraise
-from sentry_sdk.client import _get_sdk_name
 from sentry_sdk.integrations import _AUTO_ENABLING_INTEGRATIONS
 from sentry_sdk.integrations.logging import LoggingIntegration
 from sentry_sdk.scope import (  # noqa: F401
     add_global_event_processor,
     global_event_processors,
 )
+from sentry_sdk.utils import get_sdk_name
 
 
 def test_processors(sentry_init, capture_events):
@@ -503,4 +503,4 @@ def test_event_processor_drop_records_client_report(
     ],
 )
 def test_get_sdk_name(installed_integrations, expected_name):
-    assert _get_sdk_name(installed_integrations) == expected_name
+    assert get_sdk_name(installed_integrations) == expected_name

--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -18,6 +18,7 @@ from sentry_sdk import (
 )
 
 from sentry_sdk._compat import reraise
+from sentry_sdk.consts import _get_sdk_name
 from sentry_sdk.integrations import _AUTO_ENABLING_INTEGRATIONS
 from sentry_sdk.integrations.logging import LoggingIntegration
 from sentry_sdk.scope import (  # noqa: F401
@@ -437,3 +438,69 @@ def test_event_processor_drop_records_client_report(
     assert reports == [("event_processor", "error"), ("event_processor", "transaction")]
 
     global_event_processors.pop()
+
+
+@pytest.mark.parametrize(
+    "installed_integrations, expected_name",
+    [
+        # integrations with own name
+        (["django"], "sentry.python.django"),
+        (["flask"], "sentry.python.flask"),
+        (["fastapi"], "sentry.python.fastapi"),
+        (["bottle"], "sentry.python.bottle"),
+        (["falcon"], "sentry.python.falcon"),
+        (["quart"], "sentry.python.quart"),
+        (["sanic"], "sentry.python.sanic"),
+        (["starlette"], "sentry.python.starlette"),
+        (["chalice"], "sentry.python.chalice"),
+        (["serverless"], "sentry.python.serverless"),
+        (["pyramid"], "sentry.python.pyramid"),
+        (["tornado"], "sentry.python.tornado"),
+        (["aiohttp"], "sentry.python.aiohttp"),
+        (["aws_lambda"], "sentry.python.aws_lambda"),
+        (["gcp"], "sentry.python.gcp"),
+        (["beam"], "sentry.python.beam"),
+        (["asgi"], "sentry.python.asgi"),
+        (["wsgi"], "sentry.python.wsgi"),
+        # integrations without name
+        (["argv"], "sentry.python"),
+        (["atexit"], "sentry.python"),
+        (["boto3"], "sentry.python"),
+        (["celery"], "sentry.python"),
+        (["dedupe"], "sentry.python"),
+        (["excepthook"], "sentry.python"),
+        (["executing"], "sentry.python"),
+        (["modules"], "sentry.python"),
+        (["pure_eval"], "sentry.python"),
+        (["redis"], "sentry.python"),
+        (["rq"], "sentry.python"),
+        (["sqlalchemy"], "sentry.python"),
+        (["stdlib"], "sentry.python"),
+        (["threading"], "sentry.python"),
+        (["trytond"], "sentry.python"),
+        (["logging"], "sentry.python"),
+        (["gnu_backtrace"], "sentry.python"),
+        (["httpx"], "sentry.python"),
+        # precedence of frameworks
+        (["flask", "django", "celery"], "sentry.python.django"),
+        (["fastapi", "flask", "redis"], "sentry.python.flask"),
+        (["bottle", "fastapi", "httpx"], "sentry.python.fastapi"),
+        (["falcon", "bottle", "logging"], "sentry.python.bottle"),
+        (["quart", "falcon", "gnu_backtrace"], "sentry.python.falcon"),
+        (["sanic", "quart", "sqlalchemy"], "sentry.python.quart"),
+        (["starlette", "sanic", "rq"], "sentry.python.sanic"),
+        (["chalice", "starlette", "modules"], "sentry.python.starlette"),
+        (["serverless", "chalice", "pure_eval"], "sentry.python.chalice"),
+        (["pyramid", "serverless", "modules"], "sentry.python.serverless"),
+        (["tornado", "pyramid", "executing"], "sentry.python.pyramid"),
+        (["aiohttp", "tornado", "dedupe"], "sentry.python.tornado"),
+        (["aws_lambda", "aiohttp", "boto3"], "sentry.python.aiohttp"),
+        (["gcp", "aws_lambda", "atexit"], "sentry.python.aws_lambda"),
+        (["beam", "gcp", "argv"], "sentry.python.gcp"),
+        (["asgi", "beam", "stdtlib"], "sentry.python.beam"),
+        (["wsgi", "asgi", "boto3"], "sentry.python.asgi"),
+        (["wsgi", "celery", "redis"], "sentry.python.wsgi"),
+    ],
+)
+def test_get_sdk_name(installed_integrations, expected_name):
+    assert _get_sdk_name(installed_integrations) == expected_name


### PR DESCRIPTION
Currently the Python sdk reports always the name `sentry.python` as its name. For consistent sdk naming and better data analysis of events we want to have also include the framework in the SDK name. Like `sentry.python.django`.

Fixes #1497