### PR TITLE
feat(profiling): Extract qualified name for each frame

### DIFF
--- a/sentry_sdk/profiler.py
+++ b/sentry_sdk/profiler.py
@@ -135,7 +135,7 @@ def _extract_stack(frame):
     only the first `MAX_STACK_DEPTH` frames will be returned.
     """
 
-    stack = deque(maxlen=MAX_STACK_DEPTH)  # type: Deque[FrameData]
+    stack = deque(maxlen=MAX_STACK_DEPTH)  # type: Deque[FrameType]
 
     while frame is not None:
         stack.append(frame)

--- a/sentry_sdk/profiler.py
+++ b/sentry_sdk/profiler.py
@@ -138,16 +138,17 @@ def _extract_stack(frame):
     stack = deque(maxlen=MAX_STACK_DEPTH)  # type: Deque[FrameData]
 
     while frame is not None:
-        stack.append(
-            FrameData(
-                name=get_frame_name(frame),
-                file=frame.f_code.co_filename,
-                line=frame.f_lineno,
-            )
-        )
+        stack.append(frame)
         frame = frame.f_back
 
-    return stack
+    return [
+        FrameData(
+            name=get_frame_name(frame),
+            file=frame.f_code.co_filename,
+            line=frame.f_lineno,
+        )
+        for frame in stack
+    ]
 
 
 def get_frame_name(frame):

--- a/sentry_sdk/profiler.py
+++ b/sentry_sdk/profiler.py
@@ -113,7 +113,7 @@ def _sample_stack(*args, **kwargs):
         (
             nanosecond_time(),
             [
-                (tid, _extract_stack(frame))
+                (tid, extract_stack(frame))
                 for tid, frame in sys._current_frames().items()
             ],
         )
@@ -124,7 +124,7 @@ def _sample_stack(*args, **kwargs):
 MAX_STACK_DEPTH = 128
 
 
-def _extract_stack(frame):
+def extract_stack(frame, max_stack_depth=MAX_STACK_DEPTH):
     # type: (Optional[FrameType]) -> Sequence[FrameData]
     """
     Extracts the stack starting the specified frame. The extracted stack
@@ -135,7 +135,7 @@ def _extract_stack(frame):
     only the first `MAX_STACK_DEPTH` frames will be returned.
     """
 
-    stack = deque(maxlen=MAX_STACK_DEPTH)  # type: Deque[FrameType]
+    stack = deque(maxlen=max_stack_depth)  # type: Deque[FrameType]
 
     while frame is not None:
         stack.append(frame)

--- a/sentry_sdk/profiler.py
+++ b/sentry_sdk/profiler.py
@@ -125,7 +125,7 @@ MAX_STACK_DEPTH = 128
 
 
 def extract_stack(frame, max_stack_depth=MAX_STACK_DEPTH):
-    # type: (Optional[FrameType]) -> Sequence[FrameData]
+    # type: (Optional[FrameType], int) -> Sequence[FrameData]
     """
     Extracts the stack starting the specified frame. The extracted stack
     assumes the specified frame is the top of the stack, and works back

--- a/tests/test_profiler.py
+++ b/tests/test_profiler.py
@@ -1,0 +1,95 @@
+import inspect
+
+import pytest
+
+from sentry_sdk.profiler import extract_stack, get_frame_name
+
+
+def get_frame(depth=1):
+    """
+    This function is not exactly true to its name. Depending on
+    how it is called, the true depth of the stack can be deeper
+    than the argument implies.
+    """
+    if depth <= 0:
+        raise ValueError("only positive integers allowed")
+    if depth > 1:
+        return get_frame(depth=depth - 1)
+    return inspect.currentframe()
+
+
+class GetFrame:
+    def instance_method(self):
+        return inspect.currentframe()
+
+    @classmethod
+    def class_method(cls):
+        return inspect.currentframe()
+
+    @staticmethod
+    def static_method():
+        return inspect.currentframe()
+
+
+@pytest.mark.parametrize(
+    ("frame", "frame_name"),
+    [
+        pytest.param(
+            get_frame(),
+            "get_frame",
+            id="function",
+        ),
+        pytest.param(
+            (lambda: inspect.currentframe())(),
+            "<lambda>",
+            id="lambda",
+        ),
+        pytest.param(
+            GetFrame().instance_method(),
+            "GetFrame.instance_method",
+            id="instance_method",
+        ),
+        pytest.param(
+            GetFrame().class_method(),
+            "GetFrame.class_method",
+            id="class_method",
+        ),
+        pytest.param(
+            GetFrame().static_method(),
+            "GetFrame.static_method",
+            id="static_method",
+            marks=pytest.mark.skip(reason="unsupported"),
+        ),
+    ],
+)
+def test_get_frame_name(frame, frame_name):
+    assert get_frame_name(frame) == frame_name
+
+
+@pytest.mark.parametrize(
+    ("depth", "max_stack_depth", "actual_depth"),
+    [
+        pytest.param(1, 128, 1, id="less than"),
+        pytest.param(256, 128, 128, id="greater than"),
+        pytest.param(128, 128, 128, id="equals"),
+    ],
+)
+def test_extract_stack_with_max_depth(depth, max_stack_depth, actual_depth):
+    # introduce a lambda that we'll be looking for in the stack
+    frame = (lambda: get_frame(depth=depth))()
+
+    # plus 1 because we introduced a lambda intentionally that we'll
+    # look for in the final stack to make sure its in the right position
+    base_stack_depth = len(inspect.stack()) + 1
+
+    # increase the max_depth by the `base_stack_depth` to account
+    # for the extra frames pytest will add
+    stack = extract_stack(frame, max_stack_depth + base_stack_depth)
+    assert len(stack) == base_stack_depth + actual_depth
+
+    for i in range(actual_depth):
+        assert stack[i].name == "get_frame", i
+
+    # index 0 contains the inner most frame on the stack, so the lamdba
+    # should be at index `actual_depth`
+    assert stack[actual_depth].name == "<lambda>", actual_depth

--- a/tests/test_profiler.py
+++ b/tests/test_profiler.py
@@ -21,7 +21,6 @@ unix_only = pytest.mark.skipif(
 def test_profiler_invalid_mode(teardown_profiling):
     with pytest.raises(ValueError):
         setup_profiler({"_experiments": {"profiler_mode": "magic"}})
-    # make sure to clean up at the end of the test
 
 
 @unix_only
@@ -53,9 +52,8 @@ def test_profiler_signal_mode_none_main_thread(mode, teardown_profiling):
         thread.start()
         thread.join()
 
-    # make sure to clean up at the end of the test
 
-
+@unix_only
 @pytest.mark.parametrize("mode", ["sleep", "event", "sigprof", "sigalrm"])
 def test_profiler_valid_mode(mode, teardown_profiling):
     # should not raise any exceptions

--- a/tests/test_profiler.py
+++ b/tests/test_profiler.py
@@ -17,35 +17,6 @@ unix_only = pytest.mark.skipif(
 )
 
 
-@pytest.mark.parametrize(
-    ("depth", "max_stack_depth", "actual_depth"),
-    [
-        pytest.param(1, 128, 1, id="less than"),
-        pytest.param(256, 128, 128, id="greater than"),
-        pytest.param(128, 128, 128, id="equals"),
-    ],
-)
-def test_extract_stack_with_max_depth(depth, max_stack_depth, actual_depth):
-    # introduce a lambda that we'll be looking for in the stack
-    frame = (lambda: get_frame(depth=depth))()
-
-    # plus 1 because we introduced a lambda intentionally that we'll
-    # look for in the final stack to make sure its in the right position
-    base_stack_depth = len(inspect.stack()) + 1
-
-    # increase the max_depth by the `base_stack_depth` to account
-    # for the extra frames pytest will add
-    stack = extract_stack(frame, max_stack_depth + base_stack_depth)
-    assert len(stack) == base_stack_depth + actual_depth
-
-    for i in range(actual_depth):
-        assert stack[i].name == "get_frame", i
-
-    # index 0 contains the inner most frame on the stack, so the lamdba
-    # should be at index `actual_depth`
-    assert stack[actual_depth].name == "<lambda>", actual_depth
-
-
 @minimum_python_33
 def test_profiler_invalid_mode(teardown_profiling):
     with pytest.raises(ValueError):
@@ -150,3 +121,32 @@ class GetFrame:
 )
 def test_get_frame_name(frame, frame_name):
     assert get_frame_name(frame) == frame_name
+
+
+@pytest.mark.parametrize(
+    ("depth", "max_stack_depth", "actual_depth"),
+    [
+        pytest.param(1, 128, 1, id="less than"),
+        pytest.param(256, 128, 128, id="greater than"),
+        pytest.param(128, 128, 128, id="equals"),
+    ],
+)
+def test_extract_stack_with_max_depth(depth, max_stack_depth, actual_depth):
+    # introduce a lambda that we'll be looking for in the stack
+    frame = (lambda: get_frame(depth=depth))()
+
+    # plus 1 because we introduced a lambda intentionally that we'll
+    # look for in the final stack to make sure its in the right position
+    base_stack_depth = len(inspect.stack()) + 1
+
+    # increase the max_depth by the `base_stack_depth` to account
+    # for the extra frames pytest will add
+    stack = extract_stack(frame, max_stack_depth + base_stack_depth)
+    assert len(stack) == base_stack_depth + actual_depth
+
+    for i in range(actual_depth):
+        assert stack[i].name == "get_frame", i
+
+    # index 0 contains the inner most frame on the stack, so the lamdba
+    # should be at index `actual_depth`
+    assert stack[actual_depth].name == "<lambda>", actual_depth


### PR DESCRIPTION
Currently, we use `code.co_name` for the frame name. This does not include the name of the class if it was a method. This tries to extract the qualified name for each frame where possible.

- methods: *typically* have `self` as a positional argument and we can inspect it to extract the class name
- class methods: *typically* have `cls` as a positional argument and we can inspect it to extract the class name
- static methods: no obvious way of extract the class name