### PR TITLE
fix(profiling): Race condition spawning multiple profiling threads

### DIFF
--- a/tests/test_profiler.py
+++ b/tests/test_profiler.py
@@ -1,0 +1,48 @@
+import threading
+import time
+
+from sentry_sdk.profiler import SleepScheduler
+
+
+def test_sleep_scheduler_single_background_thread():
+    def sampler():
+        pass
+
+    scheduler = SleepScheduler(sampler=sampler, frequency=100)
+
+    assert scheduler.start_profiling()
+
+    # the scheduler thread does not immediately exit
+    # but it should exit after the next time it samples
+    assert scheduler.stop_profiling()
+
+    assert scheduler.start_profiling()
+
+    # because the scheduler thread does not immediately exit
+    # after stop_profiling is called, we have to wait a little
+    # otherwise, we'll see an extra scheduler thread in the
+    # following assertion
+    time.sleep(0.1)
+
+    # there should be 1 scheduler thread now because the first
+    # one should be stopped and a new one started
+    assert len([
+        thread
+        for thread in threading.enumerate()
+        if thread.name == scheduler.name
+    ]) == 1
+
+    assert scheduler.stop_profiling()
+
+    # because the scheduler thread does not immediately exit
+    # after stop_profiling is called, we have to wait a little
+    # otherwise, we'll see an extra scheduler thread in the
+    # following assertion
+    time.sleep(0.1)
+
+    # there should be 0 scheduler threads now because they stopped
+    assert len([
+        thread
+        for thread in threading.enumerate()
+        if thread.name == scheduler.name
+    ]) == 0


### PR DESCRIPTION
There is a race condition where multiple profiling threads may be spawned. Specifically, if `start_profiling` is called immediately after `stop_profiling`. This happens because `stop_profiling` does not immediately terminate the thread, instead the thread will check that the event was set and exit at the end of the current iteration. If `start_profiling` is called during the iteration, the event gets set again and the old thread will continue running. To fix this, a new event is created when a profiling thread starts so they can be terminated independently.