### PR TITLE
Remove unused node setup from CI.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
       - uses: actions/setup-python@v4
         with:
           python-version: 3.9
@@ -95,7 +94,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
       - uses: actions/setup-python@v4
         with:
           python-version: 3.9


### PR DESCRIPTION
Stumbled upon this when going through the dependabot PRs.