### PR TITLE
Use Django internal ASGI handling from Channels version 4.0.0.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ format: .venv
 .PHONY: format
 
 test: .venv
-	@$(VENV_PATH)/bin/tox -e py3.7
+	@$(VENV_PATH)/bin/tox -e py2.7,py3.7
 .PHONY: test
 
 test-all: .venv

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ format: .venv
 .PHONY: format
 
 test: .venv
-	@$(VENV_PATH)/bin/tox -e py2.7,py3.7
+	@$(VENV_PATH)/bin/tox -e py3.7
 .PHONY: test
 
 test-all: .venv

--- a/tests/integrations/django/myapp/routing.py
+++ b/tests/integrations/django/myapp/routing.py
@@ -1,11 +1,18 @@
 import channels
-
-from channels.http import AsgiHandler
 from channels.routing import ProtocolTypeRouter
 
-if channels.__version__ < "3.0.0":
-    channels_handler = AsgiHandler
-else:
-    channels_handler = AsgiHandler()
+try:
+    from channels.http import AsgiHandler
 
-application = ProtocolTypeRouter({"http": channels_handler})
+    if channels.__version__ < "3.0.0":
+        django_asgi_app = AsgiHandler
+    else:
+        django_asgi_app = AsgiHandler()
+
+except ModuleNotFoundError:
+    # Since channels 4.0 ASGI handling is done by Django itself
+    from django.core.asgi import get_asgi_application
+
+    django_asgi_app = get_asgi_application()
+
+application = ProtocolTypeRouter({"http": django_asgi_app})

--- a/tox.ini
+++ b/tox.ini
@@ -108,7 +108,7 @@ deps =
 
     django-{1.11,2.0,2.1,2.2,3.0,3.1,3.2}: djangorestframework>=3.0.0,<4.0.0
 
-    {py3.7,py3.8,py3.9,py3.10}-django-{1.11,2.0,2.1,2.2,3.0,3.1,3.2}: channels>2
+    {py3.7,py3.8,py3.9,py3.10}-django-{1.11,2.0,2.1,2.2,3.0,3.1,3.2}: channels[daphne]>2
     {py3.7,py3.8,py3.9,py3.10}-django-{1.11,2.0,2.1,2.2,3.0,3.1,3.2}: pytest-asyncio
     {py2.7,py3.7,py3.8,py3.9,py3.10}-django-{1.11,2.2,3.0,3.1,3.2}: psycopg2-binary
 


### PR DESCRIPTION
From Channels 4.0.0 on it has no ASGI handling included but utilizes Django's own  ASGI handling.