### PR TITLE
Bug fixes for FastAPI and Sentry SDK 1.10.0

### DIFF
--- a/sentry_sdk/integrations/starlette.py
+++ b/sentry_sdk/integrations/starlette.py
@@ -103,7 +103,7 @@ def _enable_span_for_middleware(middleware_class):
                     hub = Hub.current
                     with hub.start_span(
                         op=OP.MIDDLEWARE_STARLETTE_RECEIVE,
-                        description=receive.__qualname__,
+                        description=getattr(receive, "__qualname__", str(receive)),
                     ) as span:
                         span.set_tag("starlette.middleware_name", middleware_name)
                         return await receive(*args, **kwargs)
@@ -117,7 +117,8 @@ def _enable_span_for_middleware(middleware_class):
                     # type: (*Any, **Any) -> Any
                     hub = Hub.current
                     with hub.start_span(
-                        op=OP.MIDDLEWARE_STARLETTE_SEND, description=send.__qualname__
+                        op=OP.MIDDLEWARE_STARLETTE_SEND,
+                        description=getattr(send, "__qualname__", str(send)),
                     ) as span:
                         span.set_tag("starlette.middleware_name", middleware_name)
                         return await send(*args, **kwargs)

--- a/sentry_sdk/integrations/starlette.py
+++ b/sentry_sdk/integrations/starlette.py
@@ -108,7 +108,8 @@ def _enable_span_for_middleware(middleware_class):
                         span.set_tag("starlette.middleware_name", middleware_name)
                         await receive(*args, **kwargs)
 
-                receive_patched = receive.__name__ == "_sentry_receive"
+                receive_name = getattr(receive, "__name__", str(receive))
+                receive_patched = receive_name == "_sentry_receive"
                 new_receive = _sentry_receive if not receive_patched else receive
 
                 # Creating spans for the "send" callback
@@ -121,7 +122,8 @@ def _enable_span_for_middleware(middleware_class):
                         span.set_tag("starlette.middleware_name", middleware_name)
                         await send(*args, **kwargs)
 
-                send_patched = send.__name__ == "_sentry_send"
+                send_name = getattr(send, "__name__", str(send))
+                send_patched = send_name == "_sentry_send"
                 new_send = _sentry_send if not send_patched else send
 
                 await old_call(app, scope, new_receive, new_send, **kwargs)

--- a/tests/integrations/starlette/test_starlette.py
+++ b/tests/integrations/starlette/test_starlette.py
@@ -733,7 +733,9 @@ def test_middleware_partial_receive_send(sentry_init, capture_events):
         },
         {
             "op": "middleware.starlette.receive",
-            "description": "_ASGIAdapter.send.<locals>.receive",
+            "description": "_ASGIAdapter.send.<locals>.receive"
+            if STARLETTE_VERSION < (0, 21)
+            else "_TestClientTransport.handle_request.<locals>.receive",
             "tags": {"starlette.middleware_name": "ServerErrorMiddleware"},
         },
         {
@@ -743,7 +745,9 @@ def test_middleware_partial_receive_send(sentry_init, capture_events):
         },
         {
             "op": "middleware.starlette.send",
-            "description": "_ASGIAdapter.send.<locals>.send",
+            "description": "_ASGIAdapter.send.<locals>.send"
+            if STARLETTE_VERSION < (0, 21)
+            else "_TestClientTransport.handle_request.<locals>.send",
             "tags": {"starlette.middleware_name": "ServerErrorMiddleware"},
         },
         {


### PR DESCRIPTION
Make sure receive/send callbacks can also be `functools.partial` objects (or other objects that are not having a `__name__`)

Refs #1697