### PR TITLE
fix(utils): strip_string() checks text length counting bytes not chars

### DIFF
--- a/sentry_sdk/utils.py
+++ b/sentry_sdk/utils.py
@@ -841,7 +841,7 @@ def strip_string(value, max_length=None):
         # This is intentionally not just the default such that one can patch `MAX_STRING_LENGTH` and affect `strip_string`.
         max_length = MAX_STRING_LENGTH
 
-    length = len(value)
+    length = len(value.encode("utf-8"))
 
     if length > max_length:
         return AnnotatedValue(


### PR DESCRIPTION
The truncation and indexes in the AnnotatedValues it's done by number of bytes and not number of characters.

Fixes GH-1691