### PR TITLE
test(integrations): Add pytest_asyncio to test-requirements file

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -5,6 +5,7 @@ pytest-cov==2.8.1
 pytest-forked<=1.4.0
 pytest-localserver==0.5.0
 pytest-watch==4.2.0
+pytest-asyncio==0.20.1
 tox==3.7.0
 Werkzeug<2.1.0
 jsonschema==3.2.0


### PR DESCRIPTION
Fixes GH-1712

Hello!

When I was testing my first issue to the sentry-python repo I found this error when I tried to run the tests.

Hopefully this was the problem!

Thank you!