### PR TITLE
Performance optimizations

### DIFF
--- a/sentry_sdk/_compat.py
+++ b/sentry_sdk/_compat.py
@@ -15,6 +15,7 @@ if MYPY:
 PY2 = sys.version_info[0] == 2
 PY33 = sys.version_info[0] == 3 and sys.version_info[1] >= 3
 PY37 = sys.version_info[0] == 3 and sys.version_info[1] >= 7
+PY310 = sys.version_info[0] == 3 and sys.version_info[1] >= 10
 
 if PY2:
     import urlparse

--- a/sentry_sdk/integrations/django/signals_handlers.py
+++ b/sentry_sdk/integrations/django/signals_handlers.py
@@ -25,7 +25,7 @@ def _get_receiver_name(receiver):
     elif hasattr(
         receiver, "func"
     ):  # certain functions (like partials) dont have a name
-        name = "functools.partial(<function " + receiver.func.__name__ + ">)"
+        name = "functools.partial(<function " + receiver.func.__name__ + ">)"  # type: ignore
 
     if (
         name == ""

--- a/sentry_sdk/integrations/django/signals_handlers.py
+++ b/sentry_sdk/integrations/django/signals_handlers.py
@@ -25,7 +25,7 @@ def _get_receiver_name(receiver):
     elif hasattr(
         receiver, "func"
     ):  # certain functions (like partials) dont have a name
-        name = "functools.partial(<function " + receiver.func.__name__ + ">)"  # type: ignore
+        name = "partial(<function " + receiver.func.__name__ + ">)"  # type: ignore
 
     if (
         name == ""

--- a/sentry_sdk/integrations/django/signals_handlers.py
+++ b/sentry_sdk/integrations/django/signals_handlers.py
@@ -19,13 +19,17 @@ def _get_receiver_name(receiver):
     name = ""
 
     if hasattr(receiver, "__qualname__"):
-        name += receiver.__qualname__
+        name = receiver.__qualname__
     elif hasattr(receiver, "__name__"):  # Python 2.7 has no __qualname__
-        name += receiver.__name__
+        name = receiver.__name__
+    elif hasattr(
+        receiver, "func"
+    ):  # certain functions (like partials) dont have a name
+        name = "functools.partial(<function " + receiver.func.__name__ + ">)"
 
     if (
         name == ""
-    ):  # certain functions (like partials) dont have a name so return the string representation
+    ):  # In case nothing was found, return the string representation (this is the slowest case)
         return str(receiver)
 
     if hasattr(receiver, "__module__"):  # prepend with module, if there is one

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -11,3 +11,4 @@ jsonschema==3.2.0
 pyrsistent==0.16.0 # TODO(py3): 0.17.0 requires python3, see https://github.com/tobgu/pyrsistent/issues/205
 executing
 asttokens
+ipdb

--- a/tests/integrations/django/test_basic.py
+++ b/tests/integrations/django/test_basic.py
@@ -834,4 +834,4 @@ def test_get_receiver_name():
 
     a_partial = partial(dummy)
     name = _get_receiver_name(a_partial)
-    assert name == str(a_partial)
+    assert name == "functools.partial(<function " + a_partial.func.__name__ + ">)"

--- a/tests/integrations/django/test_basic.py
+++ b/tests/integrations/django/test_basic.py
@@ -16,7 +16,7 @@ try:
 except ImportError:
     from django.core.urlresolvers import reverse
 
-from sentry_sdk._compat import PY2
+from sentry_sdk._compat import PY2, PY310
 from sentry_sdk import capture_message, capture_exception, configure_scope
 from sentry_sdk.integrations.django import DjangoIntegration
 from sentry_sdk.integrations.django.signals_handlers import _get_receiver_name
@@ -834,4 +834,7 @@ def test_get_receiver_name():
 
     a_partial = partial(dummy)
     name = _get_receiver_name(a_partial)
-    assert name == "functools.partial(<function " + a_partial.func.__name__ + ">)"
+    if PY310:
+        assert name == "functools.partial(<function " + a_partial.func.__name__ + ">)"
+    else:
+        assert name == "partial(<function " + a_partial.func.__name__ + ">)"


### PR DESCRIPTION
Our Django signals integrations added a lot of overhead in some cases. 
See: https://github.com/getsentry/sentry-python/issues/1721

This code runs now over an order of magnitude faster for getting the name of a partials.