### PR TITLE
Fix signals problem on sentry.io

### DIFF
--- a/sentry_sdk/integrations/django/signals_handlers.py
+++ b/sentry_sdk/integrations/django/signals_handlers.py
@@ -25,7 +25,8 @@ def _get_receiver_name(receiver):
     elif hasattr(
         receiver, "func"
     ):  # certain functions (like partials) dont have a name
-        name = "partial(<function " + receiver.func.__name__ + ">)"  # type: ignore
+        if hasattr(receiver, "func") and hasattr(receiver.func, "__name__"):
+            name = "partial(<function " + receiver.func.__name__ + ">)"  # type: ignore
 
     if (
         name == ""

--- a/sentry_sdk/integrations/django/signals_handlers.py
+++ b/sentry_sdk/integrations/django/signals_handlers.py
@@ -25,7 +25,7 @@ def _get_receiver_name(receiver):
     elif hasattr(
         receiver, "func"
     ):  # certain functions (like partials) dont have a name
-        if hasattr(receiver, "func") and hasattr(receiver.func, "__name__"):
+        if hasattr(receiver, "func") and hasattr(receiver.func, "__name__"):  # type: ignore
             name = "partial(<function " + receiver.func.__name__ + ">)"  # type: ignore
 
     if (


### PR DESCRIPTION
When using the newest version of the Python SDK on the sentry backend we get the following error:

```
tests/getsentry/billing/test_staged.py:838: in test_apply_inplace_trigger_post_save
    subscription = self.create_subscription(
    ...
/usr/local/lib/python3.8/site-packages/sentry_sdk/integrations/django/signals_handlers.py:56: in wrapper
    signal_name = _get_receiver_name(receiver)
/usr/local/lib/python3.8/site-packages/sentry_sdk/integrations/django/signals_handlers.py:28: in _get_receiver_name
    name = "partial(<function " + receiver.func.__name__ + ">)"  # type: ignore
/usr/local/lib/python3.8/unittest/mock.py:639: in __getattr__
    raise AttributeError(name)
E   AttributeError: __name__
```

This change gets the `__name__` attribute in a very defensive way, to not raise any errors what so ever.