### PR TITLE
Strip sensitive data from URLs.

### DIFF
--- a/sentry_sdk/integrations/httpx.py
+++ b/sentry_sdk/integrations/httpx.py
@@ -1,7 +1,7 @@
 from sentry_sdk import Hub
 from sentry_sdk.consts import OP
 from sentry_sdk.integrations import Integration, DidNotEnable
-from sentry_sdk.utils import logger, parameterize_url
+from sentry_sdk.utils import logger, sanitize_url
 
 from sentry_sdk._types import MYPY
 
@@ -43,7 +43,7 @@ def _install_httpx_client():
 
         with hub.start_span(
             op=OP.HTTP_CLIENT,
-            description="%s %s" % (request.method, parameterize_url(request.url)),
+            description="%s %s" % (request.method, sanitize_url(request.url)),
         ) as span:
             span.set_data("method", request.method)
             span.set_data("url", str(request.url))
@@ -76,7 +76,7 @@ def _install_httpx_async_client():
 
         with hub.start_span(
             op=OP.HTTP_CLIENT,
-            description="%s %s" % (request.method, parameterize_url(request.url)),
+            description="%s %s" % (request.method, sanitize_url(request.url)),
         ) as span:
             span.set_data("method", request.method)
             span.set_data("url", str(request.url))

--- a/sentry_sdk/integrations/httpx.py
+++ b/sentry_sdk/integrations/httpx.py
@@ -1,7 +1,7 @@
 from sentry_sdk import Hub
 from sentry_sdk.consts import OP
 from sentry_sdk.integrations import Integration, DidNotEnable
-from sentry_sdk.utils import logger
+from sentry_sdk.utils import logger, parameterize_url
 
 from sentry_sdk._types import MYPY
 
@@ -42,7 +42,8 @@ def _install_httpx_client():
             return real_send(self, request, **kwargs)
 
         with hub.start_span(
-            op=OP.HTTP_CLIENT, description="%s %s" % (request.method, request.url)
+            op=OP.HTTP_CLIENT,
+            description="%s %s" % (request.method, parameterize_url(request.url)),
         ) as span:
             span.set_data("method", request.method)
             span.set_data("url", str(request.url))
@@ -74,7 +75,8 @@ def _install_httpx_async_client():
             return await real_send(self, request, **kwargs)
 
         with hub.start_span(
-            op=OP.HTTP_CLIENT, description="%s %s" % (request.method, request.url)
+            op=OP.HTTP_CLIENT,
+            description="%s %s" % (request.method, parameterize_url(request.url)),
         ) as span:
             span.set_data("method", request.method)
             span.set_data("url", str(request.url))

--- a/sentry_sdk/integrations/httpx.py
+++ b/sentry_sdk/integrations/httpx.py
@@ -1,5 +1,6 @@
 from sentry_sdk import Hub
 from sentry_sdk.consts import OP
+from sentry_sdk.hub import _should_send_default_pii
 from sentry_sdk.integrations import Integration, DidNotEnable
 from sentry_sdk.utils import logger, sanitize_url
 
@@ -43,7 +44,13 @@ def _install_httpx_client():
 
         with hub.start_span(
             op=OP.HTTP_CLIENT,
-            description="%s %s" % (request.method, sanitize_url(request.url)),
+            description="%s %s"
+            % (
+                request.method,
+                request.url
+                if _should_send_default_pii()
+                else sanitize_url(request.url),
+            ),
         ) as span:
             span.set_data("method", request.method)
             span.set_data("url", str(request.url))
@@ -76,7 +83,13 @@ def _install_httpx_async_client():
 
         with hub.start_span(
             op=OP.HTTP_CLIENT,
-            description="%s %s" % (request.method, sanitize_url(request.url)),
+            description="%s %s"
+            % (
+                request.method,
+                request.url
+                if _should_send_default_pii()
+                else sanitize_url(request.url),
+            ),
         ) as span:
             span.set_data("method", request.method)
             span.set_data("url", str(request.url))

--- a/sentry_sdk/integrations/stdlib.py
+++ b/sentry_sdk/integrations/stdlib.py
@@ -8,7 +8,12 @@ from sentry_sdk.hub import Hub
 from sentry_sdk.integrations import Integration
 from sentry_sdk.scope import add_global_event_processor
 from sentry_sdk.tracing_utils import EnvironHeaders
-from sentry_sdk.utils import capture_internal_exceptions, logger, safe_repr
+from sentry_sdk.utils import (
+    capture_internal_exceptions,
+    logger,
+    parameterize_url,
+    safe_repr,
+)
 
 from sentry_sdk._types import MYPY
 
@@ -80,7 +85,8 @@ def _install_httplib():
             )
 
         span = hub.start_span(
-            op=OP.HTTP_CLIENT, description="%s %s" % (method, real_url)
+            op=OP.HTTP_CLIENT,
+            description="%s %s" % (method, parameterize_url(real_url)),
         )
 
         span.set_data("method", method)

--- a/sentry_sdk/integrations/stdlib.py
+++ b/sentry_sdk/integrations/stdlib.py
@@ -11,7 +11,7 @@ from sentry_sdk.tracing_utils import EnvironHeaders
 from sentry_sdk.utils import (
     capture_internal_exceptions,
     logger,
-    parameterize_url,
+    sanitize_url,
     safe_repr,
 )
 
@@ -86,7 +86,7 @@ def _install_httplib():
 
         span = hub.start_span(
             op=OP.HTTP_CLIENT,
-            description="%s %s" % (method, parameterize_url(real_url)),
+            description="%s %s" % (method, sanitize_url(real_url)),
         )
 
         span.set_data("method", method)

--- a/sentry_sdk/integrations/stdlib.py
+++ b/sentry_sdk/integrations/stdlib.py
@@ -4,7 +4,7 @@ import sys
 import platform
 from sentry_sdk.consts import OP
 
-from sentry_sdk.hub import Hub
+from sentry_sdk.hub import Hub, _should_send_default_pii
 from sentry_sdk.integrations import Integration
 from sentry_sdk.scope import add_global_event_processor
 from sentry_sdk.tracing_utils import EnvironHeaders
@@ -86,7 +86,11 @@ def _install_httplib():
 
         span = hub.start_span(
             op=OP.HTTP_CLIENT,
-            description="%s %s" % (method, sanitize_url(real_url)),
+            description="%s %s"
+            % (
+                method,
+                real_url if _should_send_default_pii() else sanitize_url(real_url),
+            ),
         )
 
         span.set_data("method", method)

--- a/sentry_sdk/utils.py
+++ b/sentry_sdk/utils.py
@@ -9,7 +9,23 @@ import subprocess
 import re
 import time
 from collections import namedtuple
-from urllib import parse
+
+try:
+    # Python 3
+    from urllib.parse import parse_qs
+    from urllib.parse import unquote
+    from urllib.parse import urlencode
+    from urllib.parse import urlsplit
+    from urllib.parse import urlunsplit
+
+except ImportError:
+    # Python 2
+    from cgi import parse_qs
+    from urllib import unquote
+    from urllib import urlencode
+    from urlparse import urlsplit
+    from urlparse import urlunsplit
+
 
 from datetime import datetime
 
@@ -1098,8 +1114,8 @@ def sanitize_url(url):
     """
     Removes all query parameter values and username:password from a given URL.
     """
-    parsed_url = parse.urlsplit(url)
-    query_params = parse.parse_qs(parsed_url.query, keep_blank_values=True)
+    parsed_url = urlsplit(url)
+    query_params = parse_qs(parsed_url.query, keep_blank_values=True)
 
     # strip username:password (netloc can be usr:pwd@example.com)
     netloc_parts = parsed_url.netloc.split("@")
@@ -1109,9 +1125,9 @@ def sanitize_url(url):
         netloc = parsed_url.netloc
 
     # strip values from query string
-    query_string = parse.unquote(parse.urlencode({key: "%s" for key in query_params}))
+    query_string = unquote(urlencode({key: "%s" for key in query_params}))
 
-    safe_url = parse.urlunsplit(
+    safe_url = urlunsplit(
         Components(  # type: ignore
             scheme=parsed_url.scheme,
             netloc=netloc,

--- a/sentry_sdk/utils.py
+++ b/sentry_sdk/utils.py
@@ -1093,7 +1093,7 @@ def from_base64(base64_string):
     return utf8_string
 
 
-def parameterize_url(url):
+def sanitize_url(url):
     # type: (str) -> str
     """
     Removes all query parameter values and username:password from a given URL.

--- a/sentry_sdk/utils.py
+++ b/sentry_sdk/utils.py
@@ -39,7 +39,7 @@ if MYPY:
 epoch = datetime(1970, 1, 1)
 
 
-Components = namedtuple(
+Components = namedtuple(  # type: ignore
     typename="Components", field_names=["scheme", "netloc", "path", "query", "fragment"]
 )
 
@@ -1112,7 +1112,7 @@ def sanitize_url(url):
     query_string = parse.unquote(parse.urlencode({key: "%s" for key in query_params}))
 
     safe_url = parse.urlunsplit(
-        Components(
+        Components(  # type: ignore
             scheme=parsed_url.scheme,
             netloc=netloc,
             query=query_string,

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,53 @@
+import pytest
+
+from sentry_sdk.utils import parameterize_url
+
+
+@pytest.mark.parametrize(
+    ("url", "expected_result"),
+    [
+        ("http://localhost:8000", "http://localhost:8000"),
+        ("http://example.com", "http://example.com"),
+        ("https://example.com", "https://example.com"),
+        (
+            "example.com?token=abc&sessionid=123&save=true",
+            "example.com?token=%s&sessionid=%s&save=%s",
+        ),
+        (
+            "http://example.com?token=abc&sessionid=123&save=true",
+            "http://example.com?token=%s&sessionid=%s&save=%s",
+        ),
+        (
+            "https://example.com?token=abc&sessionid=123&save=true",
+            "https://example.com?token=%s&sessionid=%s&save=%s",
+        ),
+        (
+            "http://localhost:8000/?token=abc&sessionid=123&save=true",
+            "http://localhost:8000/?token=%s&sessionid=%s&save=%s",
+        ),
+        (
+            "ftp://username:password@ftp.example.com:9876/bla/blub#foo",
+            "ftp://%s:%s@ftp.example.com:9876/bla/blub#foo",
+        ),
+        (
+            "https://username:password@example.com/bla/blub?token=abc&sessionid=123&save=true#fragment",
+            "https://%s:%s@example.com/bla/blub?token=%s&sessionid=%s&save=%s#fragment",
+        ),
+        (
+            "http://example.com/bla?üsername=ada&pwd=häöüß",
+            "http://example.com/bla?üsername=%s&pwd=%s",
+        ),
+        ("bla/blub/foo", "bla/blub/foo"),
+        ("/bla/blub/foo/", "/bla/blub/foo/"),
+        (
+            "bla/blub/foo?token=abc&sessionid=123&save=true",
+            "bla/blub/foo?token=%s&sessionid=%s&save=%s",
+        ),
+        (
+            "/bla/blub/foo/?token=abc&sessionid=123&save=true",
+            "/bla/blub/foo/?token=%s&sessionid=%s&save=%s",
+        ),
+    ],
+)
+def test_parameterize_url(url, expected_result):
+    assert parameterize_url(url) == expected_result

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,6 +1,6 @@
 import pytest
 
-from sentry_sdk.utils import parameterize_url
+from sentry_sdk.utils import sanitize_url
 
 
 @pytest.mark.parametrize(
@@ -49,5 +49,5 @@ from sentry_sdk.utils import parameterize_url
         ),
     ],
 )
-def test_parameterize_url(url, expected_result):
-    assert parameterize_url(url) == expected_result
+def test_sanitize_url(url, expected_result):
+    assert sanitize_url(url) == expected_result


### PR DESCRIPTION
When we do HTTP requests to third party services we create a breadcrumb with the URL and also create a span that has the URL as a description.

If the config option send_default_pii/sendDefaultPII is set to False the sensitive information should be redacted from the URL.

The username/password that can be included in URLs should be removed and also should the values of all query string parameters be removed. The keys of the query string parameters should be left untouched.

A URL like this:
https://username:password@example.com/bla/blub?token=abc&sessionid=123&save=true#fragment

Should become this:
https://%s:%s@example.com/bla/blub?token=%s&sessionid=%s&save=%s#fragment

Ref #1742