### PR TITLE
feat(aiohttp): add instrumentation of client requests

### DIFF
--- a/sentry_sdk/integrations/aiohttp.py
+++ b/sentry_sdk/integrations/aiohttp.py
@@ -55,12 +55,10 @@ if TYPE_CHECKING:
 TRANSACTION_STYLE_VALUES = ("handler_name", "method_and_path_pattern")
 
 
-def create_trace_config() -> TraceConfig:
-    async def on_request_start(
-        session: ClientSession,
-        trace_config_ctx: "SimpleNamespace",
-        params: "TraceRequestStartParams",
-    ):
+def create_trace_config():
+    # type: () -> TraceConfig
+    async def on_request_start(session, trace_config_ctx, params):
+        # type: (ClientSession, SimpleNamespace, TraceRequestStartParams) -> None
         hub = Hub.current
         if hub.get_integration(AioHttpIntegration) is None:
             return
@@ -84,11 +82,8 @@ def create_trace_config() -> TraceConfig:
 
         trace_config_ctx.span = span
 
-    async def on_request_end(
-        session: ClientSession,
-        trace_config_ctx: "SimpleNamespace",
-        params: "TraceRequestEndParams",
-    ):
+    async def on_request_end(session, trace_config_ctx, params):
+        # type: (ClientSession, SimpleNamespace, TraceRequestEndParams) -> None
         if trace_config_ctx.span is None:
             return
 
@@ -223,6 +218,7 @@ class AioHttpIntegration(Integration):
         old_client_session_init = ClientSession.__init__
 
         def init(*args, **kwargs):
+            # type: (Any, Any) -> ClientSession
             hub = Hub.current
             if hub.get_integration(AioHttpIntegration) is None:
                 return old_client_session_init(*args, **kwargs)

--- a/sentry_sdk/integrations/aiohttp.py
+++ b/sentry_sdk/integrations/aiohttp.py
@@ -23,6 +23,7 @@ from sentry_sdk.utils import (
     transaction_from_function,
     HAS_REAL_CONTEXTVARS,
     CONTEXTVARS_ERROR_MESSAGE,
+    SENSITIVE_DATA_SUBSTITUTE,
     AnnotatedValue,
 )
 
@@ -203,14 +204,16 @@ def create_trace_config():
             parsed_url = parse_url(str(params.url), sanitize=False)
 
         span = hub.start_span(
-            op=OP.HTTP_CLIENT, description="%s %s" % (method, parsed_url)
+            op=OP.HTTP_CLIENT,
+            description="%s %s"
+            % (method, parsed_url.url if parsed_url else SENSITIVE_DATA_SUBSTITUTE),
         )
         span.set_data(SPANDATA.HTTP_METHOD, method)
         span.set_data("url", parsed_url.url)
         span.set_data(SPANDATA.HTTP_QUERY, parsed_url.query)
         span.set_data(SPANDATA.HTTP_FRAGMENT, parsed_url.fragment)
 
-        if should_propagate_trace(hub, parsed_url.url):
+        if should_propagate_trace(hub, str(params.url)):
             for key, value in hub.iter_trace_propagation_headers(span):
                 logger.debug(
                     "[Tracing] Adding `{key}` header {value} to outgoing request to {url}.".format(

--- a/sentry_sdk/integrations/aiohttp.py
+++ b/sentry_sdk/integrations/aiohttp.py
@@ -206,11 +206,11 @@ def create_trace_config():
             op=OP.HTTP_CLIENT, description="%s %s" % (method, parsed_url)
         )
         span.set_data(SPANDATA.HTTP_METHOD, method)
-        span.set_data("url", parsed_url)
+        span.set_data("url", parsed_url.url)
         span.set_data(SPANDATA.HTTP_QUERY, parsed_url.query)
         span.set_data(SPANDATA.HTTP_FRAGMENT, parsed_url.fragment)
 
-        if should_propagate_trace(hub, parsed_url):
+        if should_propagate_trace(hub, parsed_url.url):
             for key, value in hub.iter_trace_propagation_headers(span):
                 logger.debug(
                     "[Tracing] Adding `{key}` header {value} to outgoing request to {url}.".format(

--- a/tests/integrations/aiohttp/test_aiohttp.py
+++ b/tests/integrations/aiohttp/test_aiohttp.py
@@ -430,6 +430,7 @@ async def test_trace_from_headers_if_performance_disabled(
     assert error_event["contexts"]["trace"]["trace_id"] == trace_id
 
 
+@pytest.mark.asyncio
 async def test_crumb_capture(
     sentry_init, aiohttp_raw_server, aiohttp_client, loop, capture_events
 ):
@@ -461,13 +462,16 @@ async def test_crumb_capture(
         assert crumb["category"] == "httplib"
         assert crumb["data"] == {
             "url": "http://127.0.0.1:{}/".format(raw_server.port),
-            "method": "GET",
-            "status_code": 200,
+            "http.fragment": "",
+            "http.method": "GET",
+            "http.query": "",
+            "http.response.status_code": 200,
             "reason": "OK",
             "extra": "foo",
         }
 
 
+@pytest.mark.asyncio
 async def test_outgoing_trace_headers(sentry_init, aiohttp_raw_server, aiohttp_client):
     sentry_init(
         integrations=[AioHttpIntegration()],


### PR DESCRIPTION
Adds instrumentation of client requests for aiohttp. See https://docs.aiohttp.org/en/stable/client_advanced.html#client-tracing for aiohttp documentation on tracing hooks for client requests.

This change could arguably go in a separate AioHttpClientIntegration but will leave that for discussion.