### PR TITLE
feat(profiling): Introduce active thread id on scope

### DIFF
--- a/sentry_sdk/client.py
+++ b/sentry_sdk/client.py
@@ -429,7 +429,7 @@ class _Client(object):
 
             if is_transaction:
                 if profile is not None:
-                    envelope.add_profile(profile.to_json(event_opt, self.options))
+                    envelope.add_profile(profile.to_json(event_opt, self.options, scope))
                 envelope.add_transaction(event_opt)
             else:
                 envelope.add_event(event_opt)

--- a/sentry_sdk/client.py
+++ b/sentry_sdk/client.py
@@ -429,7 +429,9 @@ class _Client(object):
 
             if is_transaction:
                 if profile is not None:
-                    envelope.add_profile(profile.to_json(event_opt, self.options, scope))
+                    envelope.add_profile(
+                        profile.to_json(event_opt, self.options, scope)
+                    )
                 envelope.add_transaction(event_opt)
             else:
                 envelope.add_event(event_opt)

--- a/sentry_sdk/profiler.py
+++ b/sentry_sdk/profiler.py
@@ -315,8 +315,8 @@ class Profile(object):
                     "trace_id": self.transaction.trace_id,
                     "active_thread_id": str(
                         self.transaction._active_thread_id
-                        if active_thread_id is None else
-                        active_thread_id
+                        if active_thread_id is None
+                        else active_thread_id
                     ),
                 }
             ],

--- a/sentry_sdk/scope.py
+++ b/sentry_sdk/scope.py
@@ -223,17 +223,6 @@ class Scope(object):
         """Get/set current tracing span or transaction."""
         return self._span
 
-    @property
-    def active_thread_id(self):
-        # type: () -> Optional[int]
-        """Get/set the current active thread id."""
-        return self._active_thread_id
-
-    def set_active_thread_id(self, active_thread_id):
-        # type: (Optional[int]) -> None
-        """Set the current active thread id."""
-        self._active_thread_id = active_thread_id
-
     @span.setter
     def span(self, span):
         # type: (Optional[Span]) -> None
@@ -244,6 +233,17 @@ class Scope(object):
             transaction = span
             if transaction.name:
                 self._transaction = transaction.name
+
+    @property
+    def active_thread_id(self):
+        # type: () -> Optional[int]
+        """Get/set the current active thread id."""
+        return self._active_thread_id
+
+    def set_active_thread_id(self, active_thread_id):
+        # type: (Optional[int]) -> None
+        """Set the current active thread id."""
+        self._active_thread_id = active_thread_id
 
     def set_tag(
         self,

--- a/sentry_sdk/scope.py
+++ b/sentry_sdk/scope.py
@@ -94,6 +94,11 @@ class Scope(object):
         "_session",
         "_attachments",
         "_force_auto_session_tracking",
+
+        # The thread that is handling the bulk of the work. This can just
+        # be the main thread, but that's not always true. For web frameworks,
+        # this would be the thread handling the request.
+        "_active_thread_id",
     )
 
     def __init__(self):
@@ -124,6 +129,8 @@ class Scope(object):
         self._span = None  # type: Optional[Span]
         self._session = None  # type: Optional[Session]
         self._force_auto_session_tracking = None  # type: Optional[bool]
+
+        self._active_thread_id = None  # type: Optional[int]
 
     @_attr_setter
     def level(self, value):
@@ -216,6 +223,17 @@ class Scope(object):
         # type: () -> Optional[Span]
         """Get/set current tracing span or transaction."""
         return self._span
+
+    @property
+    def active_thread_id(self):
+        # type: () -> Optional[int]
+        """Get/set the current active thread id."""
+        return self._active_thread_id
+
+    def set_active_thread_id(self, active_thread_id):
+        # type: (Optional[int]) -> None
+        """Set the current active thread id."""
+        self._active_thread_id = active_thread_id
 
     @span.setter
     def span(self, span):
@@ -447,6 +465,8 @@ class Scope(object):
             self._span = scope._span
         if scope._attachments:
             self._attachments.extend(scope._attachments)
+        if scope._active_thread_id is not None:
+            self._active_thread_id = scope._active_thread_id
 
     def update_from_kwargs(
         self,
@@ -495,6 +515,8 @@ class Scope(object):
         rv._session = self._session
         rv._force_auto_session_tracking = self._force_auto_session_tracking
         rv._attachments = list(self._attachments)
+
+        rv._active_thread_id = self._active_thread_id
 
         return rv
 

--- a/sentry_sdk/scope.py
+++ b/sentry_sdk/scope.py
@@ -94,7 +94,6 @@ class Scope(object):
         "_session",
         "_attachments",
         "_force_auto_session_tracking",
-
         # The thread that is handling the bulk of the work. This can just
         # be the main thread, but that's not always true. For web frameworks,
         # this would be the thread handling the request.


### PR DESCRIPTION
Upto this point, simply taking the current thread when the transaction/profile was started was good enough. When using ASGI apps with non async handlers, the request is received on the main thread. This is also where the transaction or profile was started. However, the request is handled on another thread using a thread pool. To support this use case, we want to be able to set the active thread id on the scope where we can read it when we need it to allow the active thread id to be set elsewhere.