### PR TITLE
API Changes for Otel integration

### DIFF
--- a/tests/tracing/test_misc.py
+++ b/tests/tracing/test_misc.py
@@ -274,3 +274,21 @@ def test_set_meaurement(sentry_init, capture_events):
     assert event["measurements"]["metric.bar"] == {"value": 456, "unit": "second"}
     assert event["measurements"]["metric.baz"] == {"value": 420.69, "unit": "custom"}
     assert event["measurements"]["metric.foobar"] == {"value": 17.99, "unit": "percent"}
+
+
+def test_extract_sentry_trace():
+    # type: () -> None
+
+    trace_id, parent_span_id, parent_sampled = Transaction.extract_sentry_trace(
+        "4c79f60c11214eb38604f4ae0781bfb2-fa90fdead5f74052-1"
+    )
+    assert trace_id == "4c79f60c11214eb38604f4ae0781bfb2"
+    assert parent_span_id == "fa90fdead5f74052"
+    assert parent_sampled
+
+    trace_id, parent_span_id, parent_sampled = Transaction.extract_sentry_trace(
+        "5e79f60c11214eb38604f4ae0781bfb2-0390fdead5f74052-0"
+    )
+    assert trace_id == "5e79f60c11214eb38604f4ae0781bfb2"
+    assert parent_span_id == "0390fdead5f74052"
+    assert not parent_sampled


### PR DESCRIPTION
Allowing:
* set contexts in spans
* start/end times for spans 
* extract sentry trace information