### PR TITLE
Add function to extract sentry trace info from traceparent string.

### DIFF
--- a/sentry_sdk/tracing.py
+++ b/sentry_sdk/tracing.py
@@ -372,6 +372,13 @@ class Span(object):
             sampled = "0"
         return "%s-%s-%s" % (self.trace_id, self.span_id, sampled)
 
+    @classmethod
+    def extract_sentry_trace(cls, sentry_trace):
+        # type: (str) -> Tuple[str, str, bool]
+        trace_id, parent_span_id, parent_sampled = sentry_trace.split("-")
+        parent_sampled = True if parent_sampled == "1" else False
+        return (trace_id, parent_span_id, parent_sampled)
+
     def to_tracestate(self):
         # type: () -> Optional[str]
         """

--- a/tests/tracing/test_misc.py
+++ b/tests/tracing/test_misc.py
@@ -274,3 +274,21 @@ def test_set_meaurement(sentry_init, capture_events):
     assert event["measurements"]["metric.bar"] == {"value": 456, "unit": "second"}
     assert event["measurements"]["metric.baz"] == {"value": 420.69, "unit": "custom"}
     assert event["measurements"]["metric.foobar"] == {"value": 17.99, "unit": "percent"}
+
+
+def test_extract_sentry_trace():
+    # type: () -> None
+
+    trace_id, parent_span_id, parent_sampled = Transaction.extract_sentry_trace(
+        "4c79f60c11214eb38604f4ae0781bfb2-fa90fdead5f74052-1"
+    )
+    assert trace_id == "4c79f60c11214eb38604f4ae0781bfb2"
+    assert parent_span_id == "fa90fdead5f74052"
+    assert parent_sampled
+
+    trace_id, parent_span_id, parent_sampled = Transaction.extract_sentry_trace(
+        "5e79f60c11214eb38604f4ae0781bfb2-0390fdead5f74052-0"
+    )
+    assert trace_id == "5e79f60c11214eb38604f4ae0781bfb2"
+    assert parent_span_id == "0390fdead5f74052"
+    assert not parent_sampled


### PR DESCRIPTION
This is basically the opposite of `to_traceparent()`.