### PR TITLE
feat(profiling): Set active thread id for ASGI frameworks

### DIFF
--- a/sentry_sdk/integrations/asgi.py
+++ b/sentry_sdk/integrations/asgi.py
@@ -14,6 +14,7 @@ from sentry_sdk.consts import OP
 from sentry_sdk.hub import Hub, _should_send_default_pii
 from sentry_sdk.integrations._wsgi_common import _filter_headers
 from sentry_sdk.integrations.modules import _get_installed_modules
+from sentry_sdk.profiler import start_profiling
 from sentry_sdk.sessions import auto_session_tracking
 from sentry_sdk.tracing import (
     SOURCE_FOR_STYLE,
@@ -175,7 +176,7 @@ class SentryAsgiMiddleware:
 
                     with hub.start_transaction(
                         transaction, custom_sampling_context={"asgi_scope": scope}
-                    ):
+                    ), start_profiling(transaction, hub):
                         # XXX: Would be cool to have correct span status, but we
                         # would have to wrap send(). That is a bit hard to do with
                         # the current abstraction over ASGI 2/3.

--- a/sentry_sdk/integrations/django/asgi.py
+++ b/sentry_sdk/integrations/django/asgi.py
@@ -7,6 +7,7 @@ Since this file contains `async def` it is conditionally imported in
 """
 
 import asyncio
+import threading
 
 from sentry_sdk import Hub, _functools
 from sentry_sdk._types import MYPY
@@ -89,10 +90,15 @@ def wrap_async_view(hub, callback):
     async def sentry_wrapped_callback(request, *args, **kwargs):
         # type: (Any, *Any, **Any) -> Any
 
-        with hub.start_span(
-            op=OP.VIEW_RENDER, description=request.resolver_match.view_name
-        ):
-            return await callback(request, *args, **kwargs)
+        with hub.configure_scope() as sentry_scope:
+            # set the active thread id to the handler thread for sync views
+            # this isn't necessary for async views since that runs on main
+            sentry_scope.set_active_thread_id(threading.current_thread().ident)
+
+            with hub.start_span(
+                op=OP.VIEW_RENDER, description=request.resolver_match.view_name
+            ):
+                return await callback(request, *args, **kwargs)
 
     return sentry_wrapped_callback
 

--- a/sentry_sdk/integrations/django/views.py
+++ b/sentry_sdk/integrations/django/views.py
@@ -1,3 +1,5 @@
+import threading
+
 from sentry_sdk.consts import OP
 from sentry_sdk.hub import Hub
 from sentry_sdk._types import MYPY
@@ -62,9 +64,14 @@ def _wrap_sync_view(hub, callback):
     @_functools.wraps(callback)
     def sentry_wrapped_callback(request, *args, **kwargs):
         # type: (Any, *Any, **Any) -> Any
-        with hub.start_span(
-            op=OP.VIEW_RENDER, description=request.resolver_match.view_name
-        ):
-            return callback(request, *args, **kwargs)
+        with hub.configure_scope() as sentry_scope:
+            # set the active thread id to the handler thread for sync views
+            # this isn't necessary for async views since that runs on main
+            sentry_scope.set_active_thread_id(threading.current_thread().ident)
+
+            with hub.start_span(
+                op=OP.VIEW_RENDER, description=request.resolver_match.view_name
+            ):
+                return callback(request, *args, **kwargs)
 
     return sentry_wrapped_callback

--- a/sentry_sdk/integrations/fastapi.py
+++ b/sentry_sdk/integrations/fastapi.py
@@ -1,3 +1,5 @@
+import threading
+
 from sentry_sdk._types import MYPY
 from sentry_sdk.hub import Hub, _should_send_default_pii
 from sentry_sdk.integrations import DidNotEnable
@@ -62,6 +64,21 @@ def patch_get_request_handler():
 
     def _sentry_get_request_handler(*args, **kwargs):
         # type: (*Any, **Any) -> Any
+        dependant = kwargs.get("dependant")
+        if dependant:
+            old_call = dependant.call
+
+            def _sentry_call(*args, **kwargs):
+                # type: (*Any, **Any) -> Any
+                hub = Hub.current
+                with hub.configure_scope() as sentry_scope:
+                    # set the active thread id to the handler thread for sync views
+                    # this isn't necessary for async views since that runs on main
+                    sentry_scope.set_active_thread_id(threading.current_thread().ident)
+                    return old_call(*args, **kwargs)
+
+            dependant.call = _sentry_call
+
         old_app = old_get_request_handler(*args, **kwargs)
 
         async def _sentry_app(*args, **kwargs):

--- a/sentry_sdk/integrations/fastapi.py
+++ b/sentry_sdk/integrations/fastapi.py
@@ -1,3 +1,4 @@
+import asyncio
 import threading
 
 from sentry_sdk._types import MYPY
@@ -65,7 +66,7 @@ def patch_get_request_handler():
     def _sentry_get_request_handler(*args, **kwargs):
         # type: (*Any, **Any) -> Any
         dependant = kwargs.get("dependant")
-        if dependant:
+        if dependant and not asyncio.iscoroutinefunction(dependant.call):
             old_call = dependant.call
 
             def _sentry_call(*args, **kwargs):

--- a/sentry_sdk/integrations/quart.py
+++ b/sentry_sdk/integrations/quart.py
@@ -109,6 +109,7 @@ def patch_scaffold_route():
             # type: (Any) -> Any
 
             if inspect.isfunction(old_func) and not is_coroutine_function(old_func):
+
                 @wraps(old_func)
                 def _sentry_func(*args, **kwargs):
                     # type: (*Any, **Any) -> Any
@@ -120,7 +121,9 @@ def patch_scaffold_route():
                     with hub.configure_scope() as sentry_scope:
                         # set the active thread id to the handler thread for sync views
                         # this isn't necessary for async views since that runs on main
-                        sentry_scope.set_active_thread_id(threading.current_thread().ident)
+                        sentry_scope.set_active_thread_id(
+                            threading.current_thread().ident
+                        )
 
                         return old_func(*args, **kwargs)
 

--- a/sentry_sdk/integrations/starlette.py
+++ b/sentry_sdk/integrations/starlette.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import
 
 import asyncio
 import functools
+import threading
 
 from sentry_sdk._compat import iteritems
 from sentry_sdk._types import MYPY
@@ -403,6 +404,10 @@ def patch_request_response():
                     return old_func(*args, **kwargs)
 
                 with hub.configure_scope() as sentry_scope:
+                    # set the active thread id to the handler thread for sync views
+                    # this isn't necessary for async views since that runs on main
+                    sentry_scope.set_active_thread_id(threading.current_thread().ident)
+
                     request = args[0]
 
                     _set_transaction_name_and_source(

--- a/tests/integrations/django/myapp/urls.py
+++ b/tests/integrations/django/myapp/urls.py
@@ -69,7 +69,9 @@ if views.my_async_view is not None:
     urlpatterns.append(path("my_async_view", views.my_async_view, name="my_async_view"))
 
 if views.thread_ids_async is not None:
-    urlpatterns.append(path("async/thread_ids", views.thread_ids_async, name="thread_ids_async"))
+    urlpatterns.append(
+        path("async/thread_ids", views.thread_ids_async, name="thread_ids_async")
+    )
 
 # rest framework
 try:

--- a/tests/integrations/django/myapp/urls.py
+++ b/tests/integrations/django/myapp/urls.py
@@ -58,6 +58,7 @@ urlpatterns = [
         views.csrf_hello_not_exempt,
         name="csrf_hello_not_exempt",
     ),
+    path("sync/thread_ids", views.thread_ids_sync, name="thread_ids_sync"),
 ]
 
 # async views
@@ -66,6 +67,9 @@ if views.async_message is not None:
 
 if views.my_async_view is not None:
     urlpatterns.append(path("my_async_view", views.my_async_view, name="my_async_view"))
+
+if views.thread_ids_async is not None:
+    urlpatterns.append(path("async/thread_ids", views.thread_ids_async, name="thread_ids_async"))
 
 # rest framework
 try:

--- a/tests/integrations/django/myapp/views.py
+++ b/tests/integrations/django/myapp/views.py
@@ -1,3 +1,6 @@
+import json
+import threading
+
 from django import VERSION
 from django.contrib.auth import login
 from django.contrib.auth.models import User
@@ -159,6 +162,14 @@ def csrf_hello_not_exempt(*args, **kwargs):
     return HttpResponse("ok")
 
 
+def thread_ids_sync(*args, **kwargs):
+    response = json.dumps({
+        "main": threading.main_thread().ident,
+        "active": threading.current_thread().ident,
+    })
+    return HttpResponse(response)
+
+
 if VERSION >= (3, 1):
     # Use exec to produce valid Python 2
     exec(
@@ -173,6 +184,16 @@ if VERSION >= (3, 1):
     await asyncio.sleep(1)
     return HttpResponse('Hello World')"""
     )
+
+    exec(
+            """async def thread_ids_async(request):
+    response = json.dumps({
+        "main": threading.main_thread().ident,
+        "active": threading.current_thread().ident,
+    })
+    return HttpResponse(response)"""
+    )
 else:
     async_message = None
     my_async_view = None
+    thread_ids_async = None

--- a/tests/integrations/django/myapp/views.py
+++ b/tests/integrations/django/myapp/views.py
@@ -163,10 +163,12 @@ def csrf_hello_not_exempt(*args, **kwargs):
 
 
 def thread_ids_sync(*args, **kwargs):
-    response = json.dumps({
-        "main": threading.main_thread().ident,
-        "active": threading.current_thread().ident,
-    })
+    response = json.dumps(
+        {
+            "main": threading.main_thread().ident,
+            "active": threading.current_thread().ident,
+        }
+    )
     return HttpResponse(response)
 
 
@@ -186,7 +188,7 @@ if VERSION >= (3, 1):
     )
 
     exec(
-            """async def thread_ids_async(request):
+        """async def thread_ids_async(request):
     response = json.dumps({
         "main": threading.main_thread().ident,
         "active": threading.current_thread().ident,

--- a/tests/integrations/fastapi/test_fastapi.py
+++ b/tests/integrations/fastapi/test_fastapi.py
@@ -1,3 +1,6 @@
+import json
+import threading
+
 import pytest
 from sentry_sdk.integrations.fastapi import FastApiIntegration
 
@@ -22,6 +25,20 @@ def fastapi_app_factory():
     async def _message_with_id(message_id):
         capture_message("Hi")
         return {"message": "Hi"}
+
+    @app.get("/sync/thread_ids")
+    def _thread_ids_sync():
+        return {
+            "main": str(threading.main_thread().ident),
+            "active": str(threading.current_thread().ident),
+        }
+
+    @app.get("/async/thread_ids")
+    async def _thread_ids_async():
+        return {
+            "main": str(threading.main_thread().ident),
+            "active": str(threading.current_thread().ident),
+        }
 
     return app
 
@@ -135,3 +152,32 @@ def test_legacy_setup(
 
     (event,) = events
     assert event["transaction"] == "/message/{message_id}"
+
+
+@pytest.mark.parametrize("endpoint", ["/sync/thread_ids", "/async/thread_ids"])
+def test_active_thread_id(sentry_init, capture_envelopes, endpoint):
+    sentry_init(
+        traces_sample_rate=1.0,
+        _experiments={"profiles_sample_rate": 1.0},
+    )
+    app = fastapi_app_factory()
+    asgi_app = SentryAsgiMiddleware(app)
+
+    envelopes = capture_envelopes()
+
+    client = TestClient(asgi_app)
+    response = client.get(endpoint)
+    assert response.status_code == 200
+
+    data = json.loads(response.content)
+
+    envelopes = [envelope for envelope in envelopes]
+    assert len(envelopes) == 1
+
+    profiles = [item for item in envelopes[0].items if item.type == "profile"]
+    assert len(profiles) == 1
+
+    for profile in profiles:
+        transactions = profile.payload.json["transactions"]
+        assert len(transactions) == 1
+        assert str(data["active"]) == transactions[0]["active_thread_id"]

--- a/tests/integrations/starlette/test_starlette.py
+++ b/tests/integrations/starlette/test_starlette.py
@@ -110,16 +110,20 @@ def starlette_app_factory(middleware=None, debug=True):
         return starlette.responses.JSONResponse({"status": "ok"})
 
     def _thread_ids_sync(request):
-        return starlette.responses.JSONResponse({
-            "main": threading.main_thread().ident,
-            "active": threading.current_thread().ident,
-        })
+        return starlette.responses.JSONResponse(
+            {
+                "main": threading.main_thread().ident,
+                "active": threading.current_thread().ident,
+            }
+        )
 
     async def _thread_ids_async(request):
-        return starlette.responses.JSONResponse({
-            "main": threading.main_thread().ident,
-            "active": threading.current_thread().ident,
-        })
+        return starlette.responses.JSONResponse(
+            {
+                "main": threading.main_thread().ident,
+                "active": threading.current_thread().ident,
+            }
+        )
 
     app = starlette.applications.Starlette(
         debug=debug,

--- a/tests/integrations/starlette/test_starlette.py
+++ b/tests/integrations/starlette/test_starlette.py
@@ -3,6 +3,7 @@ import base64
 import functools
 import json
 import os
+import threading
 
 import pytest
 
@@ -108,6 +109,18 @@ def starlette_app_factory(middleware=None, debug=True):
         capture_message("hi")
         return starlette.responses.JSONResponse({"status": "ok"})
 
+    def _thread_ids_sync(request):
+        return starlette.responses.JSONResponse({
+            "main": threading.main_thread().ident,
+            "active": threading.current_thread().ident,
+        })
+
+    async def _thread_ids_async(request):
+        return starlette.responses.JSONResponse({
+            "main": threading.main_thread().ident,
+            "active": threading.current_thread().ident,
+        })
+
     app = starlette.applications.Starlette(
         debug=debug,
         routes=[
@@ -115,6 +128,8 @@ def starlette_app_factory(middleware=None, debug=True):
             starlette.routing.Route("/custom_error", _custom_error),
             starlette.routing.Route("/message", _message),
             starlette.routing.Route("/message/{message_id}", _message_with_id),
+            starlette.routing.Route("/sync/thread_ids", _thread_ids_sync),
+            starlette.routing.Route("/async/thread_ids", _thread_ids_async),
         ],
         middleware=middleware,
     )
@@ -824,3 +839,32 @@ def test_legacy_setup(
 
     (event,) = events
     assert event["transaction"] == "/message/{message_id}"
+
+
+@pytest.mark.parametrize("endpoint", ["/sync/thread_ids", "/async/thread_ids"])
+def test_active_thread_id(sentry_init, capture_envelopes, endpoint):
+    sentry_init(
+        traces_sample_rate=1.0,
+        _experiments={"profiles_sample_rate": 1.0},
+    )
+    app = starlette_app_factory()
+    asgi_app = SentryAsgiMiddleware(app)
+
+    envelopes = capture_envelopes()
+
+    client = TestClient(asgi_app)
+    response = client.get(endpoint)
+    assert response.status_code == 200
+
+    data = json.loads(response.content)
+
+    envelopes = [envelope for envelope in envelopes]
+    assert len(envelopes) == 1
+
+    profiles = [item for item in envelopes[0].items if item.type == "profile"]
+    assert len(profiles) == 1
+
+    for profile in profiles:
+        transactions = profile.payload.json["transactions"]
+        assert len(transactions) == 1
+        assert str(data["active"]) == transactions[0]["active_thread_id"]

--- a/tests/integrations/wsgi/test_wsgi.py
+++ b/tests/integrations/wsgi/test_wsgi.py
@@ -297,8 +297,8 @@ def test_auto_session_tracking_with_aggregates(sentry_init, capture_envelopes):
     ],
 )
 def test_profile_sent(
-    capture_envelopes,
     sentry_init,
+    capture_envelopes,
     teardown_profiling,
     profiles_sample_rate,
     profile_count,


### PR DESCRIPTION
When running in ASGI sync views, the transaction gets started in the main thread then the request is dispatched to a handler thread. We want to set the handler thread as the active thread id to ensure that profiles will show it on first render.