### PR TITLE
feat(profiling): Enable profiling for all transactions

### DIFF
--- a/sentry_sdk/hub.py
+++ b/sentry_sdk/hub.py
@@ -547,6 +547,7 @@ class Hub(with_metaclass(HubMeta)):  # type: ignore
         }
         sampling_context.update(custom_sampling_context)
         transaction._set_initial_sampling_decision(sampling_context=sampling_context)
+        transaction._set_profiling_decision()
 
         # we don't bother to keep spans if we already know we're not going to
         # send the transaction

--- a/sentry_sdk/integrations/wsgi.py
+++ b/sentry_sdk/integrations/wsgi.py
@@ -12,7 +12,6 @@ from sentry_sdk._compat import PY2, reraise, iteritems
 from sentry_sdk.tracing import Transaction, TRANSACTION_SOURCE_ROUTE
 from sentry_sdk.sessions import auto_session_tracking
 from sentry_sdk.integrations._wsgi_common import _filter_headers
-from sentry_sdk.profiler import start_profiling
 
 from sentry_sdk._types import MYPY
 
@@ -132,7 +131,7 @@ class SentryWsgiMiddleware(object):
 
                     with hub.start_transaction(
                         transaction, custom_sampling_context={"wsgi_environ": environ}
-                    ), start_profiling(transaction, hub):
+                    ):
                         try:
                             rv = self.app(
                                 environ,

--- a/sentry_sdk/profiler.py
+++ b/sentry_sdk/profiler.py
@@ -554,9 +554,6 @@ class SleepScheduler(ThreadScheduler):
 
     def run(self):
         # type: () -> None
-        if self.active_profiles:
-            self.sampler()
-
         last = time.perf_counter()
 
         while True:
@@ -589,9 +586,6 @@ class EventScheduler(ThreadScheduler):
 
     def run(self):
         # type: () -> None
-        if self.active_profiles:
-            self.sampler()
-
         while True:
             self.event.wait(timeout=self._interval)
 

--- a/sentry_sdk/tracing.py
+++ b/sentry_sdk/tracing.py
@@ -7,7 +7,7 @@ from datetime import datetime, timedelta
 
 import sentry_sdk
 from sentry_sdk.consts import INSTRUMENTER
-from sentry_sdk.profiler import Profile, should_profile
+from sentry_sdk.profiler import Profile
 from sentry_sdk.utils import logger
 from sentry_sdk._types import MYPY
 


### PR DESCRIPTION
Up to now, we've only been profiling WSGI transactions. This change will enable profiling for all transactions.

#1778 is required for the active thread id to be set correctly for ASGI transactions