### PR TITLE
fix(ci): Github action checks failing 

### DIFF
--- a/.github/workflows/test-common.yml
+++ b/.github/workflows/test-common.yml
@@ -24,7 +24,7 @@ jobs:
     continue-on-error: true
     strategy:
       matrix:
-        os: [ubuntu-latest]
+        os: [ubuntu-20.04]
         python-version: ["2.7", "3.5", "3.6", "3.7", "3.8", "3.9", "3.10"]
     services:
       postgres:

--- a/.github/workflows/test-common.yml
+++ b/.github/workflows/test-common.yml
@@ -24,6 +24,10 @@ jobs:
     continue-on-error: true
     strategy:
       matrix:
+        # python3.6 reached EOL and is no longer being supported on
+        # new versions of hosted runners on Github Actions
+        # ubuntu-20.04 is the last version that supported python3.6
+        # see https://github.com/actions/setup-python/issues/544#issuecomment-1332535877
         os: [ubuntu-20.04]
         python-version: ["2.7", "3.5", "3.6", "3.7", "3.8", "3.9", "3.10"]
     services:

--- a/.github/workflows/test-common.yml
+++ b/.github/workflows/test-common.yml
@@ -55,9 +55,6 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Setup Test Env
-        env:
-          PGHOST: localhost
-          PGPASSWORD: sentry
         run: |
           pip install codecov tox
 

--- a/.github/workflows/test-integration-aiohttp.yml
+++ b/.github/workflows/test-integration-aiohttp.yml
@@ -69,6 +69,17 @@ jobs:
     if: always()
     runs-on: ubuntu-20.04
     steps:
+      - name: Print result
+        env:
+          RESULT: ${{ needs.*.result }}
+        run: |
+          echo "$RESULT"
+      - name: Print outcome
+        env:
+          RESULT: ${{ needs.*.outcome }}
+        run: |
+          echo "$RESULT"
+
       - name: Check for failures
         if: contains(needs.*.result, 'ERROR at')
         run: |

--- a/.github/workflows/test-integration-aiohttp.yml
+++ b/.github/workflows/test-integration-aiohttp.yml
@@ -76,11 +76,11 @@ jobs:
           echo "$RESULT"
       - name: Print outcome
         env:
-          RESULT: ${{ needs.*.outcome }}
+          RESULT: ${{ needs.test.outcome }}
         run: |
           echo "$RESULT"
 
       - name: Check for failures
-        if: contains(needs.*.result, 'ERROR at')
+        if: contains(needs.test.result, 'ERROR at')
         run: |
           echo "One of the dependent jobs have failed. You may need to re-run it." && exit 1

--- a/.github/workflows/test-integration-aiohttp.yml
+++ b/.github/workflows/test-integration-aiohttp.yml
@@ -70,6 +70,6 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Check for failures
-        if: contains(needs.*.result, 'failure')
+        if: contains(needs.*.result, 'ERROR at')
         run: |
           echo "One of the dependent jobs have failed. You may need to re-run it." && exit 1

--- a/.github/workflows/test-integration-aiohttp.yml
+++ b/.github/workflows/test-integration-aiohttp.yml
@@ -46,7 +46,7 @@ jobs:
 
       - name: Setup Test Env
         run: |
-          pip install codecov tox
+          pip install codecov "tox>=3,<4"
 
       - name: Test aiohttp
         env:

--- a/.github/workflows/test-integration-aiohttp.yml
+++ b/.github/workflows/test-integration-aiohttp.yml
@@ -29,6 +29,7 @@ jobs:
     timeout-minutes: 45
 
     strategy:
+      fail-fast: false
       matrix:
         python-version: ["3.7","3.8","3.9","3.10"]
         # python3.6 reached EOL and is no longer being supported on
@@ -68,17 +69,6 @@ jobs:
     if: always()
     runs-on: ubuntu-20.04
     steps:
-      - name: Print result
-        env:
-          RESULT: ${{ needs.test.result }}
-        run: |
-          echo "$RESULT"
-      - name: Print outcome
-        env:
-          RESULT: ${{ needs.test.outcome }}
-        run: |
-          echo "$RESULT"
-
       - name: Check for failures
         if: contains(needs.test.result, 'failure')
         run: |

--- a/.github/workflows/test-integration-aiohttp.yml
+++ b/.github/workflows/test-integration-aiohttp.yml
@@ -71,7 +71,7 @@ jobs:
     steps:
       - name: Print result
         env:
-          RESULT: ${{ needs.*.result }}
+          RESULT: ${{ needs.test.result }}
         run: |
           echo "$RESULT"
       - name: Print outcome

--- a/.github/workflows/test-integration-aiohttp.yml
+++ b/.github/workflows/test-integration-aiohttp.yml
@@ -45,9 +45,6 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Setup Test Env
-        env:
-          PGHOST: localhost
-          PGPASSWORD: sentry
         run: |
           pip install codecov tox
 

--- a/.github/workflows/test-integration-aiohttp.yml
+++ b/.github/workflows/test-integration-aiohttp.yml
@@ -32,7 +32,11 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.7","3.8","3.9","3.10"]
-        os: [ubuntu-latest]
+        # python3.6 reached EOL and is no longer being supported on
+        # new versions of hosted runners on Github Actions
+        # ubuntu-20.04 is the last version that supported python3.6
+        # see https://github.com/actions/setup-python/issues/544#issuecomment-1332535877
+        os: [ubuntu-20.04]
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/test-integration-aiohttp.yml
+++ b/.github/workflows/test-integration-aiohttp.yml
@@ -61,3 +61,15 @@ jobs:
           coverage combine .coverage*
           coverage xml -i
           codecov --file coverage.xml
+
+  check_required_tests:
+    name: All aiohttp tests passed or skipped
+    needs: test
+    # Always run this, even if a dependent job failed
+    if: always()
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Check for failures
+        if: contains(needs.*.result, 'failure')
+        run: |
+          echo "One of the dependent jobs have failed. You may need to re-run it." && exit 1

--- a/.github/workflows/test-integration-aiohttp.yml
+++ b/.github/workflows/test-integration-aiohttp.yml
@@ -27,7 +27,6 @@ jobs:
     name: aiohttp, python ${{ matrix.python-version }}, ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     timeout-minutes: 45
-    continue-on-error: true
 
     strategy:
       matrix:
@@ -81,6 +80,6 @@ jobs:
           echo "$RESULT"
 
       - name: Check for failures
-        if: contains(needs.test.result, 'ERROR at')
+        if: contains(needs.test.result, 'failure')
         run: |
           echo "One of the dependent jobs have failed. You may need to re-run it." && exit 1

--- a/.github/workflows/test-integration-asgi.yml
+++ b/.github/workflows/test-integration-asgi.yml
@@ -69,6 +69,17 @@ jobs:
     if: always()
     runs-on: ubuntu-20.04
     steps:
+      - name: Print result
+        env:
+          RESULT: ${{ needs.*.result }}
+        run: |
+          echo "$RESULT"
+      - name: Print outcome
+        env:
+          RESULT: ${{ needs.*.outcome }}
+        run: |
+          echo "$RESULT"
+
       - name: Check for failures
         if: contains(needs.*.result, 'ERROR at')
         run: |

--- a/.github/workflows/test-integration-asgi.yml
+++ b/.github/workflows/test-integration-asgi.yml
@@ -46,7 +46,7 @@ jobs:
 
       - name: Setup Test Env
         run: |
-          pip install codecov tox
+          pip install codecov "tox>=3,<4"
 
       - name: Test asgi
         env:

--- a/.github/workflows/test-integration-asgi.yml
+++ b/.github/workflows/test-integration-asgi.yml
@@ -61,3 +61,15 @@ jobs:
           coverage combine .coverage*
           coverage xml -i
           codecov --file coverage.xml
+
+  check_required_tests:
+    name: All asgi tests passed or skipped
+    needs: test
+    # Always run this, even if a dependent job failed
+    if: always()
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Check for failures
+        if: contains(needs.*.result, 'failure')
+        run: |
+          echo "One of the dependent jobs have failed. You may need to re-run it." && exit 1

--- a/.github/workflows/test-integration-asgi.yml
+++ b/.github/workflows/test-integration-asgi.yml
@@ -76,11 +76,11 @@ jobs:
           echo "$RESULT"
       - name: Print outcome
         env:
-          RESULT: ${{ needs.*.outcome }}
+          RESULT: ${{ needs.test.outcome }}
         run: |
           echo "$RESULT"
 
       - name: Check for failures
-        if: contains(needs.*.result, 'ERROR at')
+        if: contains(needs.test.result, 'ERROR at')
         run: |
           echo "One of the dependent jobs have failed. You may need to re-run it." && exit 1

--- a/.github/workflows/test-integration-asgi.yml
+++ b/.github/workflows/test-integration-asgi.yml
@@ -70,6 +70,6 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Check for failures
-        if: contains(needs.*.result, 'failure')
+        if: contains(needs.*.result, 'ERROR at')
         run: |
           echo "One of the dependent jobs have failed. You may need to re-run it." && exit 1

--- a/.github/workflows/test-integration-asgi.yml
+++ b/.github/workflows/test-integration-asgi.yml
@@ -29,6 +29,7 @@ jobs:
     timeout-minutes: 45
 
     strategy:
+      fail-fast: false
       matrix:
         python-version: ["3.7","3.8","3.9","3.10"]
         # python3.6 reached EOL and is no longer being supported on
@@ -68,17 +69,6 @@ jobs:
     if: always()
     runs-on: ubuntu-20.04
     steps:
-      - name: Print result
-        env:
-          RESULT: ${{ needs.test.result }}
-        run: |
-          echo "$RESULT"
-      - name: Print outcome
-        env:
-          RESULT: ${{ needs.test.outcome }}
-        run: |
-          echo "$RESULT"
-
       - name: Check for failures
         if: contains(needs.test.result, 'failure')
         run: |

--- a/.github/workflows/test-integration-asgi.yml
+++ b/.github/workflows/test-integration-asgi.yml
@@ -27,7 +27,6 @@ jobs:
     name: asgi, python ${{ matrix.python-version }}, ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     timeout-minutes: 45
-    continue-on-error: true
 
     strategy:
       matrix:
@@ -81,6 +80,6 @@ jobs:
           echo "$RESULT"
 
       - name: Check for failures
-        if: contains(needs.test.result, 'ERROR at')
+        if: contains(needs.test.result, 'failure')
         run: |
           echo "One of the dependent jobs have failed. You may need to re-run it." && exit 1

--- a/.github/workflows/test-integration-asgi.yml
+++ b/.github/workflows/test-integration-asgi.yml
@@ -71,7 +71,7 @@ jobs:
     steps:
       - name: Print result
         env:
-          RESULT: ${{ needs.*.result }}
+          RESULT: ${{ needs.test.result }}
         run: |
           echo "$RESULT"
       - name: Print outcome

--- a/.github/workflows/test-integration-asgi.yml
+++ b/.github/workflows/test-integration-asgi.yml
@@ -45,9 +45,6 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Setup Test Env
-        env:
-          PGHOST: localhost
-          PGPASSWORD: sentry
         run: |
           pip install codecov tox
 

--- a/.github/workflows/test-integration-asgi.yml
+++ b/.github/workflows/test-integration-asgi.yml
@@ -32,7 +32,11 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.7","3.8","3.9","3.10"]
-        os: [ubuntu-latest]
+        # python3.6 reached EOL and is no longer being supported on
+        # new versions of hosted runners on Github Actions
+        # ubuntu-20.04 is the last version that supported python3.6
+        # see https://github.com/actions/setup-python/issues/544#issuecomment-1332535877
+        os: [ubuntu-20.04]
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/test-integration-aws_lambda.yml
+++ b/.github/workflows/test-integration-aws_lambda.yml
@@ -27,7 +27,6 @@ jobs:
     name: aws_lambda, python ${{ matrix.python-version }}, ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     timeout-minutes: 45
-    continue-on-error: true
 
     strategy:
       matrix:
@@ -81,6 +80,6 @@ jobs:
           echo "$RESULT"
 
       - name: Check for failures
-        if: contains(needs.test.result, 'ERROR at')
+        if: contains(needs.test.result, 'failure')
         run: |
           echo "One of the dependent jobs have failed. You may need to re-run it." && exit 1

--- a/.github/workflows/test-integration-aws_lambda.yml
+++ b/.github/workflows/test-integration-aws_lambda.yml
@@ -69,6 +69,17 @@ jobs:
     if: always()
     runs-on: ubuntu-20.04
     steps:
+      - name: Print result
+        env:
+          RESULT: ${{ needs.*.result }}
+        run: |
+          echo "$RESULT"
+      - name: Print outcome
+        env:
+          RESULT: ${{ needs.*.outcome }}
+        run: |
+          echo "$RESULT"
+
       - name: Check for failures
         if: contains(needs.*.result, 'ERROR at')
         run: |

--- a/.github/workflows/test-integration-aws_lambda.yml
+++ b/.github/workflows/test-integration-aws_lambda.yml
@@ -76,11 +76,11 @@ jobs:
           echo "$RESULT"
       - name: Print outcome
         env:
-          RESULT: ${{ needs.*.outcome }}
+          RESULT: ${{ needs.test.outcome }}
         run: |
           echo "$RESULT"
 
       - name: Check for failures
-        if: contains(needs.*.result, 'ERROR at')
+        if: contains(needs.test.result, 'ERROR at')
         run: |
           echo "One of the dependent jobs have failed. You may need to re-run it." && exit 1

--- a/.github/workflows/test-integration-aws_lambda.yml
+++ b/.github/workflows/test-integration-aws_lambda.yml
@@ -70,6 +70,6 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Check for failures
-        if: contains(needs.*.result, 'failure')
+        if: contains(needs.*.result, 'ERROR at')
         run: |
           echo "One of the dependent jobs have failed. You may need to re-run it." && exit 1

--- a/.github/workflows/test-integration-aws_lambda.yml
+++ b/.github/workflows/test-integration-aws_lambda.yml
@@ -32,7 +32,11 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.7"]
-        os: [ubuntu-latest]
+        # python3.6 reached EOL and is no longer being supported on
+        # new versions of hosted runners on Github Actions
+        # ubuntu-20.04 is the last version that supported python3.6
+        # see https://github.com/actions/setup-python/issues/544#issuecomment-1332535877
+        os: [ubuntu-20.04]
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/test-integration-aws_lambda.yml
+++ b/.github/workflows/test-integration-aws_lambda.yml
@@ -71,7 +71,7 @@ jobs:
     steps:
       - name: Print result
         env:
-          RESULT: ${{ needs.*.result }}
+          RESULT: ${{ needs.test.result }}
         run: |
           echo "$RESULT"
       - name: Print outcome

--- a/.github/workflows/test-integration-aws_lambda.yml
+++ b/.github/workflows/test-integration-aws_lambda.yml
@@ -45,9 +45,6 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Setup Test Env
-        env:
-          PGHOST: localhost
-          PGPASSWORD: sentry
         run: |
           pip install codecov tox
 

--- a/.github/workflows/test-integration-aws_lambda.yml
+++ b/.github/workflows/test-integration-aws_lambda.yml
@@ -46,7 +46,7 @@ jobs:
 
       - name: Setup Test Env
         run: |
-          pip install codecov tox
+          pip install codecov "tox>=3,<4"
 
       - name: Test aws_lambda
         env:

--- a/.github/workflows/test-integration-aws_lambda.yml
+++ b/.github/workflows/test-integration-aws_lambda.yml
@@ -61,3 +61,15 @@ jobs:
           coverage combine .coverage*
           coverage xml -i
           codecov --file coverage.xml
+
+  check_required_tests:
+    name: All aws_lambda tests passed or skipped
+    needs: test
+    # Always run this, even if a dependent job failed
+    if: always()
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Check for failures
+        if: contains(needs.*.result, 'failure')
+        run: |
+          echo "One of the dependent jobs have failed. You may need to re-run it." && exit 1

--- a/.github/workflows/test-integration-aws_lambda.yml
+++ b/.github/workflows/test-integration-aws_lambda.yml
@@ -29,6 +29,7 @@ jobs:
     timeout-minutes: 45
 
     strategy:
+      fail-fast: false
       matrix:
         python-version: ["3.7"]
         # python3.6 reached EOL and is no longer being supported on
@@ -68,17 +69,6 @@ jobs:
     if: always()
     runs-on: ubuntu-20.04
     steps:
-      - name: Print result
-        env:
-          RESULT: ${{ needs.test.result }}
-        run: |
-          echo "$RESULT"
-      - name: Print outcome
-        env:
-          RESULT: ${{ needs.test.outcome }}
-        run: |
-          echo "$RESULT"
-
       - name: Check for failures
         if: contains(needs.test.result, 'failure')
         run: |

--- a/.github/workflows/test-integration-beam.yml
+++ b/.github/workflows/test-integration-beam.yml
@@ -69,6 +69,17 @@ jobs:
     if: always()
     runs-on: ubuntu-20.04
     steps:
+      - name: Print result
+        env:
+          RESULT: ${{ needs.*.result }}
+        run: |
+          echo "$RESULT"
+      - name: Print outcome
+        env:
+          RESULT: ${{ needs.*.outcome }}
+        run: |
+          echo "$RESULT"
+
       - name: Check for failures
         if: contains(needs.*.result, 'ERROR at')
         run: |

--- a/.github/workflows/test-integration-beam.yml
+++ b/.github/workflows/test-integration-beam.yml
@@ -76,11 +76,11 @@ jobs:
           echo "$RESULT"
       - name: Print outcome
         env:
-          RESULT: ${{ needs.*.outcome }}
+          RESULT: ${{ needs.test.outcome }}
         run: |
           echo "$RESULT"
 
       - name: Check for failures
-        if: contains(needs.*.result, 'ERROR at')
+        if: contains(needs.test.result, 'ERROR at')
         run: |
           echo "One of the dependent jobs have failed. You may need to re-run it." && exit 1

--- a/.github/workflows/test-integration-beam.yml
+++ b/.github/workflows/test-integration-beam.yml
@@ -70,6 +70,6 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Check for failures
-        if: contains(needs.*.result, 'failure')
+        if: contains(needs.*.result, 'ERROR at')
         run: |
           echo "One of the dependent jobs have failed. You may need to re-run it." && exit 1

--- a/.github/workflows/test-integration-beam.yml
+++ b/.github/workflows/test-integration-beam.yml
@@ -32,7 +32,11 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.7"]
-        os: [ubuntu-latest]
+        # python3.6 reached EOL and is no longer being supported on
+        # new versions of hosted runners on Github Actions
+        # ubuntu-20.04 is the last version that supported python3.6
+        # see https://github.com/actions/setup-python/issues/544#issuecomment-1332535877
+        os: [ubuntu-20.04]
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/test-integration-beam.yml
+++ b/.github/workflows/test-integration-beam.yml
@@ -71,7 +71,7 @@ jobs:
     steps:
       - name: Print result
         env:
-          RESULT: ${{ needs.*.result }}
+          RESULT: ${{ needs.test.result }}
         run: |
           echo "$RESULT"
       - name: Print outcome

--- a/.github/workflows/test-integration-beam.yml
+++ b/.github/workflows/test-integration-beam.yml
@@ -27,7 +27,6 @@ jobs:
     name: beam, python ${{ matrix.python-version }}, ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     timeout-minutes: 45
-    continue-on-error: true
 
     strategy:
       matrix:
@@ -81,6 +80,6 @@ jobs:
           echo "$RESULT"
 
       - name: Check for failures
-        if: contains(needs.test.result, 'ERROR at')
+        if: contains(needs.test.result, 'failure')
         run: |
           echo "One of the dependent jobs have failed. You may need to re-run it." && exit 1

--- a/.github/workflows/test-integration-beam.yml
+++ b/.github/workflows/test-integration-beam.yml
@@ -45,9 +45,6 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Setup Test Env
-        env:
-          PGHOST: localhost
-          PGPASSWORD: sentry
         run: |
           pip install codecov tox
 

--- a/.github/workflows/test-integration-beam.yml
+++ b/.github/workflows/test-integration-beam.yml
@@ -46,7 +46,7 @@ jobs:
 
       - name: Setup Test Env
         run: |
-          pip install codecov tox
+          pip install codecov "tox>=3,<4"
 
       - name: Test beam
         env:

--- a/.github/workflows/test-integration-beam.yml
+++ b/.github/workflows/test-integration-beam.yml
@@ -61,3 +61,15 @@ jobs:
           coverage combine .coverage*
           coverage xml -i
           codecov --file coverage.xml
+
+  check_required_tests:
+    name: All beam tests passed or skipped
+    needs: test
+    # Always run this, even if a dependent job failed
+    if: always()
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Check for failures
+        if: contains(needs.*.result, 'failure')
+        run: |
+          echo "One of the dependent jobs have failed. You may need to re-run it." && exit 1

--- a/.github/workflows/test-integration-beam.yml
+++ b/.github/workflows/test-integration-beam.yml
@@ -29,6 +29,7 @@ jobs:
     timeout-minutes: 45
 
     strategy:
+      fail-fast: false
       matrix:
         python-version: ["3.7"]
         # python3.6 reached EOL and is no longer being supported on
@@ -68,17 +69,6 @@ jobs:
     if: always()
     runs-on: ubuntu-20.04
     steps:
-      - name: Print result
-        env:
-          RESULT: ${{ needs.test.result }}
-        run: |
-          echo "$RESULT"
-      - name: Print outcome
-        env:
-          RESULT: ${{ needs.test.outcome }}
-        run: |
-          echo "$RESULT"
-
       - name: Check for failures
         if: contains(needs.test.result, 'failure')
         run: |

--- a/.github/workflows/test-integration-boto3.yml
+++ b/.github/workflows/test-integration-boto3.yml
@@ -46,7 +46,7 @@ jobs:
 
       - name: Setup Test Env
         run: |
-          pip install codecov tox
+          pip install codecov "tox>=3,<4"
 
       - name: Test boto3
         env:

--- a/.github/workflows/test-integration-boto3.yml
+++ b/.github/workflows/test-integration-boto3.yml
@@ -69,6 +69,17 @@ jobs:
     if: always()
     runs-on: ubuntu-20.04
     steps:
+      - name: Print result
+        env:
+          RESULT: ${{ needs.*.result }}
+        run: |
+          echo "$RESULT"
+      - name: Print outcome
+        env:
+          RESULT: ${{ needs.*.outcome }}
+        run: |
+          echo "$RESULT"
+
       - name: Check for failures
         if: contains(needs.*.result, 'ERROR at')
         run: |

--- a/.github/workflows/test-integration-boto3.yml
+++ b/.github/workflows/test-integration-boto3.yml
@@ -27,7 +27,6 @@ jobs:
     name: boto3, python ${{ matrix.python-version }}, ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     timeout-minutes: 45
-    continue-on-error: true
 
     strategy:
       matrix:
@@ -81,6 +80,6 @@ jobs:
           echo "$RESULT"
 
       - name: Check for failures
-        if: contains(needs.test.result, 'ERROR at')
+        if: contains(needs.test.result, 'failure')
         run: |
           echo "One of the dependent jobs have failed. You may need to re-run it." && exit 1

--- a/.github/workflows/test-integration-boto3.yml
+++ b/.github/workflows/test-integration-boto3.yml
@@ -29,6 +29,7 @@ jobs:
     timeout-minutes: 45
 
     strategy:
+      fail-fast: false
       matrix:
         python-version: ["2.7","3.6","3.7","3.8"]
         # python3.6 reached EOL and is no longer being supported on
@@ -68,17 +69,6 @@ jobs:
     if: always()
     runs-on: ubuntu-20.04
     steps:
-      - name: Print result
-        env:
-          RESULT: ${{ needs.test.result }}
-        run: |
-          echo "$RESULT"
-      - name: Print outcome
-        env:
-          RESULT: ${{ needs.test.outcome }}
-        run: |
-          echo "$RESULT"
-
       - name: Check for failures
         if: contains(needs.test.result, 'failure')
         run: |

--- a/.github/workflows/test-integration-boto3.yml
+++ b/.github/workflows/test-integration-boto3.yml
@@ -76,11 +76,11 @@ jobs:
           echo "$RESULT"
       - name: Print outcome
         env:
-          RESULT: ${{ needs.*.outcome }}
+          RESULT: ${{ needs.test.outcome }}
         run: |
           echo "$RESULT"
 
       - name: Check for failures
-        if: contains(needs.*.result, 'ERROR at')
+        if: contains(needs.test.result, 'ERROR at')
         run: |
           echo "One of the dependent jobs have failed. You may need to re-run it." && exit 1

--- a/.github/workflows/test-integration-boto3.yml
+++ b/.github/workflows/test-integration-boto3.yml
@@ -70,6 +70,6 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Check for failures
-        if: contains(needs.*.result, 'failure')
+        if: contains(needs.*.result, 'ERROR at')
         run: |
           echo "One of the dependent jobs have failed. You may need to re-run it." && exit 1

--- a/.github/workflows/test-integration-boto3.yml
+++ b/.github/workflows/test-integration-boto3.yml
@@ -61,3 +61,15 @@ jobs:
           coverage combine .coverage*
           coverage xml -i
           codecov --file coverage.xml
+
+  check_required_tests:
+    name: All boto3 tests passed or skipped
+    needs: test
+    # Always run this, even if a dependent job failed
+    if: always()
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Check for failures
+        if: contains(needs.*.result, 'failure')
+        run: |
+          echo "One of the dependent jobs have failed. You may need to re-run it." && exit 1

--- a/.github/workflows/test-integration-boto3.yml
+++ b/.github/workflows/test-integration-boto3.yml
@@ -71,7 +71,7 @@ jobs:
     steps:
       - name: Print result
         env:
-          RESULT: ${{ needs.*.result }}
+          RESULT: ${{ needs.test.result }}
         run: |
           echo "$RESULT"
       - name: Print outcome

--- a/.github/workflows/test-integration-boto3.yml
+++ b/.github/workflows/test-integration-boto3.yml
@@ -45,9 +45,6 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Setup Test Env
-        env:
-          PGHOST: localhost
-          PGPASSWORD: sentry
         run: |
           pip install codecov tox
 

--- a/.github/workflows/test-integration-boto3.yml
+++ b/.github/workflows/test-integration-boto3.yml
@@ -32,7 +32,11 @@ jobs:
     strategy:
       matrix:
         python-version: ["2.7","3.6","3.7","3.8"]
-        os: [ubuntu-latest]
+        # python3.6 reached EOL and is no longer being supported on
+        # new versions of hosted runners on Github Actions
+        # ubuntu-20.04 is the last version that supported python3.6
+        # see https://github.com/actions/setup-python/issues/544#issuecomment-1332535877
+        os: [ubuntu-20.04]
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/test-integration-bottle.yml
+++ b/.github/workflows/test-integration-bottle.yml
@@ -69,6 +69,17 @@ jobs:
     if: always()
     runs-on: ubuntu-20.04
     steps:
+      - name: Print result
+        env:
+          RESULT: ${{ needs.*.result }}
+        run: |
+          echo "$RESULT"
+      - name: Print outcome
+        env:
+          RESULT: ${{ needs.*.outcome }}
+        run: |
+          echo "$RESULT"
+
       - name: Check for failures
         if: contains(needs.*.result, 'ERROR at')
         run: |

--- a/.github/workflows/test-integration-bottle.yml
+++ b/.github/workflows/test-integration-bottle.yml
@@ -76,11 +76,11 @@ jobs:
           echo "$RESULT"
       - name: Print outcome
         env:
-          RESULT: ${{ needs.*.outcome }}
+          RESULT: ${{ needs.test.outcome }}
         run: |
           echo "$RESULT"
 
       - name: Check for failures
-        if: contains(needs.*.result, 'ERROR at')
+        if: contains(needs.test.result, 'ERROR at')
         run: |
           echo "One of the dependent jobs have failed. You may need to re-run it." && exit 1

--- a/.github/workflows/test-integration-bottle.yml
+++ b/.github/workflows/test-integration-bottle.yml
@@ -70,6 +70,6 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Check for failures
-        if: contains(needs.*.result, 'failure')
+        if: contains(needs.*.result, 'ERROR at')
         run: |
           echo "One of the dependent jobs have failed. You may need to re-run it." && exit 1

--- a/.github/workflows/test-integration-bottle.yml
+++ b/.github/workflows/test-integration-bottle.yml
@@ -46,7 +46,7 @@ jobs:
 
       - name: Setup Test Env
         run: |
-          pip install codecov tox
+          pip install codecov "tox>=3,<4"
 
       - name: Test bottle
         env:

--- a/.github/workflows/test-integration-bottle.yml
+++ b/.github/workflows/test-integration-bottle.yml
@@ -27,7 +27,6 @@ jobs:
     name: bottle, python ${{ matrix.python-version }}, ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     timeout-minutes: 45
-    continue-on-error: true
 
     strategy:
       matrix:
@@ -81,6 +80,6 @@ jobs:
           echo "$RESULT"
 
       - name: Check for failures
-        if: contains(needs.test.result, 'ERROR at')
+        if: contains(needs.test.result, 'failure')
         run: |
           echo "One of the dependent jobs have failed. You may need to re-run it." && exit 1

--- a/.github/workflows/test-integration-bottle.yml
+++ b/.github/workflows/test-integration-bottle.yml
@@ -71,7 +71,7 @@ jobs:
     steps:
       - name: Print result
         env:
-          RESULT: ${{ needs.*.result }}
+          RESULT: ${{ needs.test.result }}
         run: |
           echo "$RESULT"
       - name: Print outcome

--- a/.github/workflows/test-integration-bottle.yml
+++ b/.github/workflows/test-integration-bottle.yml
@@ -45,9 +45,6 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Setup Test Env
-        env:
-          PGHOST: localhost
-          PGPASSWORD: sentry
         run: |
           pip install codecov tox
 

--- a/.github/workflows/test-integration-bottle.yml
+++ b/.github/workflows/test-integration-bottle.yml
@@ -32,7 +32,11 @@ jobs:
     strategy:
       matrix:
         python-version: ["2.7","3.5","3.6","3.7","3.8","3.9","3.10"]
-        os: [ubuntu-latest]
+        # python3.6 reached EOL and is no longer being supported on
+        # new versions of hosted runners on Github Actions
+        # ubuntu-20.04 is the last version that supported python3.6
+        # see https://github.com/actions/setup-python/issues/544#issuecomment-1332535877
+        os: [ubuntu-20.04]
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/test-integration-bottle.yml
+++ b/.github/workflows/test-integration-bottle.yml
@@ -61,3 +61,15 @@ jobs:
           coverage combine .coverage*
           coverage xml -i
           codecov --file coverage.xml
+
+  check_required_tests:
+    name: All bottle tests passed or skipped
+    needs: test
+    # Always run this, even if a dependent job failed
+    if: always()
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Check for failures
+        if: contains(needs.*.result, 'failure')
+        run: |
+          echo "One of the dependent jobs have failed. You may need to re-run it." && exit 1

--- a/.github/workflows/test-integration-bottle.yml
+++ b/.github/workflows/test-integration-bottle.yml
@@ -29,6 +29,7 @@ jobs:
     timeout-minutes: 45
 
     strategy:
+      fail-fast: false
       matrix:
         python-version: ["2.7","3.5","3.6","3.7","3.8","3.9","3.10"]
         # python3.6 reached EOL and is no longer being supported on
@@ -68,17 +69,6 @@ jobs:
     if: always()
     runs-on: ubuntu-20.04
     steps:
-      - name: Print result
-        env:
-          RESULT: ${{ needs.test.result }}
-        run: |
-          echo "$RESULT"
-      - name: Print outcome
-        env:
-          RESULT: ${{ needs.test.outcome }}
-        run: |
-          echo "$RESULT"
-
       - name: Check for failures
         if: contains(needs.test.result, 'failure')
         run: |

--- a/.github/workflows/test-integration-celery.yml
+++ b/.github/workflows/test-integration-celery.yml
@@ -69,6 +69,17 @@ jobs:
     if: always()
     runs-on: ubuntu-20.04
     steps:
+      - name: Print result
+        env:
+          RESULT: ${{ needs.*.result }}
+        run: |
+          echo "$RESULT"
+      - name: Print outcome
+        env:
+          RESULT: ${{ needs.*.outcome }}
+        run: |
+          echo "$RESULT"
+
       - name: Check for failures
         if: contains(needs.*.result, 'ERROR at')
         run: |

--- a/.github/workflows/test-integration-celery.yml
+++ b/.github/workflows/test-integration-celery.yml
@@ -27,7 +27,6 @@ jobs:
     name: celery, python ${{ matrix.python-version }}, ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     timeout-minutes: 45
-    continue-on-error: true
 
     strategy:
       matrix:
@@ -81,6 +80,6 @@ jobs:
           echo "$RESULT"
 
       - name: Check for failures
-        if: contains(needs.test.result, 'ERROR at')
+        if: contains(needs.test.result, 'failure')
         run: |
           echo "One of the dependent jobs have failed. You may need to re-run it." && exit 1

--- a/.github/workflows/test-integration-celery.yml
+++ b/.github/workflows/test-integration-celery.yml
@@ -76,11 +76,11 @@ jobs:
           echo "$RESULT"
       - name: Print outcome
         env:
-          RESULT: ${{ needs.*.outcome }}
+          RESULT: ${{ needs.test.outcome }}
         run: |
           echo "$RESULT"
 
       - name: Check for failures
-        if: contains(needs.*.result, 'ERROR at')
+        if: contains(needs.test.result, 'ERROR at')
         run: |
           echo "One of the dependent jobs have failed. You may need to re-run it." && exit 1

--- a/.github/workflows/test-integration-celery.yml
+++ b/.github/workflows/test-integration-celery.yml
@@ -70,6 +70,6 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Check for failures
-        if: contains(needs.*.result, 'failure')
+        if: contains(needs.*.result, 'ERROR at')
         run: |
           echo "One of the dependent jobs have failed. You may need to re-run it." && exit 1

--- a/.github/workflows/test-integration-celery.yml
+++ b/.github/workflows/test-integration-celery.yml
@@ -61,3 +61,15 @@ jobs:
           coverage combine .coverage*
           coverage xml -i
           codecov --file coverage.xml
+
+  check_required_tests:
+    name: All celery tests passed or skipped
+    needs: test
+    # Always run this, even if a dependent job failed
+    if: always()
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Check for failures
+        if: contains(needs.*.result, 'failure')
+        run: |
+          echo "One of the dependent jobs have failed. You may need to re-run it." && exit 1

--- a/.github/workflows/test-integration-celery.yml
+++ b/.github/workflows/test-integration-celery.yml
@@ -71,7 +71,7 @@ jobs:
     steps:
       - name: Print result
         env:
-          RESULT: ${{ needs.*.result }}
+          RESULT: ${{ needs.test.result }}
         run: |
           echo "$RESULT"
       - name: Print outcome

--- a/.github/workflows/test-integration-celery.yml
+++ b/.github/workflows/test-integration-celery.yml
@@ -45,9 +45,6 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Setup Test Env
-        env:
-          PGHOST: localhost
-          PGPASSWORD: sentry
         run: |
           pip install codecov tox
 

--- a/.github/workflows/test-integration-celery.yml
+++ b/.github/workflows/test-integration-celery.yml
@@ -32,7 +32,11 @@ jobs:
     strategy:
       matrix:
         python-version: ["2.7","3.5","3.6","3.7","3.8","3.9","3.10"]
-        os: [ubuntu-latest]
+        # python3.6 reached EOL and is no longer being supported on
+        # new versions of hosted runners on Github Actions
+        # ubuntu-20.04 is the last version that supported python3.6
+        # see https://github.com/actions/setup-python/issues/544#issuecomment-1332535877
+        os: [ubuntu-20.04]
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/test-integration-celery.yml
+++ b/.github/workflows/test-integration-celery.yml
@@ -46,7 +46,7 @@ jobs:
 
       - name: Setup Test Env
         run: |
-          pip install codecov tox
+          pip install codecov "tox>=3,<4"
 
       - name: Test celery
         env:

--- a/.github/workflows/test-integration-celery.yml
+++ b/.github/workflows/test-integration-celery.yml
@@ -29,6 +29,7 @@ jobs:
     timeout-minutes: 45
 
     strategy:
+      fail-fast: false
       matrix:
         python-version: ["2.7","3.5","3.6","3.7","3.8","3.9","3.10"]
         # python3.6 reached EOL and is no longer being supported on
@@ -68,17 +69,6 @@ jobs:
     if: always()
     runs-on: ubuntu-20.04
     steps:
-      - name: Print result
-        env:
-          RESULT: ${{ needs.test.result }}
-        run: |
-          echo "$RESULT"
-      - name: Print outcome
-        env:
-          RESULT: ${{ needs.test.outcome }}
-        run: |
-          echo "$RESULT"
-
       - name: Check for failures
         if: contains(needs.test.result, 'failure')
         run: |

--- a/.github/workflows/test-integration-chalice.yml
+++ b/.github/workflows/test-integration-chalice.yml
@@ -69,6 +69,17 @@ jobs:
     if: always()
     runs-on: ubuntu-20.04
     steps:
+      - name: Print result
+        env:
+          RESULT: ${{ needs.*.result }}
+        run: |
+          echo "$RESULT"
+      - name: Print outcome
+        env:
+          RESULT: ${{ needs.*.outcome }}
+        run: |
+          echo "$RESULT"
+
       - name: Check for failures
         if: contains(needs.*.result, 'ERROR at')
         run: |

--- a/.github/workflows/test-integration-chalice.yml
+++ b/.github/workflows/test-integration-chalice.yml
@@ -46,7 +46,7 @@ jobs:
 
       - name: Setup Test Env
         run: |
-          pip install codecov tox
+          pip install codecov "tox>=3,<4"
 
       - name: Test chalice
         env:

--- a/.github/workflows/test-integration-chalice.yml
+++ b/.github/workflows/test-integration-chalice.yml
@@ -76,11 +76,11 @@ jobs:
           echo "$RESULT"
       - name: Print outcome
         env:
-          RESULT: ${{ needs.*.outcome }}
+          RESULT: ${{ needs.test.outcome }}
         run: |
           echo "$RESULT"
 
       - name: Check for failures
-        if: contains(needs.*.result, 'ERROR at')
+        if: contains(needs.test.result, 'ERROR at')
         run: |
           echo "One of the dependent jobs have failed. You may need to re-run it." && exit 1

--- a/.github/workflows/test-integration-chalice.yml
+++ b/.github/workflows/test-integration-chalice.yml
@@ -32,7 +32,11 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.6","3.7","3.8"]
-        os: [ubuntu-latest]
+        # python3.6 reached EOL and is no longer being supported on
+        # new versions of hosted runners on Github Actions
+        # ubuntu-20.04 is the last version that supported python3.6
+        # see https://github.com/actions/setup-python/issues/544#issuecomment-1332535877
+        os: [ubuntu-20.04]
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/test-integration-chalice.yml
+++ b/.github/workflows/test-integration-chalice.yml
@@ -70,6 +70,6 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Check for failures
-        if: contains(needs.*.result, 'failure')
+        if: contains(needs.*.result, 'ERROR at')
         run: |
           echo "One of the dependent jobs have failed. You may need to re-run it." && exit 1

--- a/.github/workflows/test-integration-chalice.yml
+++ b/.github/workflows/test-integration-chalice.yml
@@ -71,7 +71,7 @@ jobs:
     steps:
       - name: Print result
         env:
-          RESULT: ${{ needs.*.result }}
+          RESULT: ${{ needs.test.result }}
         run: |
           echo "$RESULT"
       - name: Print outcome

--- a/.github/workflows/test-integration-chalice.yml
+++ b/.github/workflows/test-integration-chalice.yml
@@ -45,9 +45,6 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Setup Test Env
-        env:
-          PGHOST: localhost
-          PGPASSWORD: sentry
         run: |
           pip install codecov tox
 

--- a/.github/workflows/test-integration-chalice.yml
+++ b/.github/workflows/test-integration-chalice.yml
@@ -27,7 +27,6 @@ jobs:
     name: chalice, python ${{ matrix.python-version }}, ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     timeout-minutes: 45
-    continue-on-error: true
 
     strategy:
       matrix:
@@ -81,6 +80,6 @@ jobs:
           echo "$RESULT"
 
       - name: Check for failures
-        if: contains(needs.test.result, 'ERROR at')
+        if: contains(needs.test.result, 'failure')
         run: |
           echo "One of the dependent jobs have failed. You may need to re-run it." && exit 1

--- a/.github/workflows/test-integration-chalice.yml
+++ b/.github/workflows/test-integration-chalice.yml
@@ -61,3 +61,15 @@ jobs:
           coverage combine .coverage*
           coverage xml -i
           codecov --file coverage.xml
+
+  check_required_tests:
+    name: All chalice tests passed or skipped
+    needs: test
+    # Always run this, even if a dependent job failed
+    if: always()
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Check for failures
+        if: contains(needs.*.result, 'failure')
+        run: |
+          echo "One of the dependent jobs have failed. You may need to re-run it." && exit 1

--- a/.github/workflows/test-integration-chalice.yml
+++ b/.github/workflows/test-integration-chalice.yml
@@ -29,6 +29,7 @@ jobs:
     timeout-minutes: 45
 
     strategy:
+      fail-fast: false
       matrix:
         python-version: ["3.6","3.7","3.8"]
         # python3.6 reached EOL and is no longer being supported on
@@ -68,17 +69,6 @@ jobs:
     if: always()
     runs-on: ubuntu-20.04
     steps:
-      - name: Print result
-        env:
-          RESULT: ${{ needs.test.result }}
-        run: |
-          echo "$RESULT"
-      - name: Print outcome
-        env:
-          RESULT: ${{ needs.test.outcome }}
-        run: |
-          echo "$RESULT"
-
       - name: Check for failures
         if: contains(needs.test.result, 'failure')
         run: |

--- a/.github/workflows/test-integration-django.yml
+++ b/.github/workflows/test-integration-django.yml
@@ -29,6 +29,7 @@ jobs:
     timeout-minutes: 45
 
     strategy:
+      fail-fast: false
       matrix:
         python-version: ["2.7","3.5","3.6","3.7","3.8","3.9","3.10"]
         # python3.6 reached EOL and is no longer being supported on
@@ -85,17 +86,6 @@ jobs:
     if: always()
     runs-on: ubuntu-20.04
     steps:
-      - name: Print result
-        env:
-          RESULT: ${{ needs.test.result }}
-        run: |
-          echo "$RESULT"
-      - name: Print outcome
-        env:
-          RESULT: ${{ needs.test.outcome }}
-        run: |
-          echo "$RESULT"
-
       - name: Check for failures
         if: contains(needs.test.result, 'failure')
         run: |

--- a/.github/workflows/test-integration-django.yml
+++ b/.github/workflows/test-integration-django.yml
@@ -86,6 +86,17 @@ jobs:
     if: always()
     runs-on: ubuntu-20.04
     steps:
+      - name: Print result
+        env:
+          RESULT: ${{ needs.*.result }}
+        run: |
+          echo "$RESULT"
+      - name: Print outcome
+        env:
+          RESULT: ${{ needs.*.outcome }}
+        run: |
+          echo "$RESULT"
+
       - name: Check for failures
         if: contains(needs.*.result, 'ERROR at')
         run: |

--- a/.github/workflows/test-integration-django.yml
+++ b/.github/workflows/test-integration-django.yml
@@ -78,3 +78,15 @@ jobs:
           coverage combine .coverage*
           coverage xml -i
           codecov --file coverage.xml
+
+  check_required_tests:
+    name: All django tests passed or skipped
+    needs: test
+    # Always run this, even if a dependent job failed
+    if: always()
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Check for failures
+        if: contains(needs.*.result, 'failure')
+        run: |
+          echo "One of the dependent jobs have failed. You may need to re-run it." && exit 1

--- a/.github/workflows/test-integration-django.yml
+++ b/.github/workflows/test-integration-django.yml
@@ -32,7 +32,11 @@ jobs:
     strategy:
       matrix:
         python-version: ["2.7","3.5","3.6","3.7","3.8","3.9","3.10"]
-        os: [ubuntu-latest]
+        # python3.6 reached EOL and is no longer being supported on
+        # new versions of hosted runners on Github Actions
+        # ubuntu-20.04 is the last version that supported python3.6
+        # see https://github.com/actions/setup-python/issues/544#issuecomment-1332535877
+        os: [ubuntu-20.04]
     services:
       postgres:
         image: postgres

--- a/.github/workflows/test-integration-django.yml
+++ b/.github/workflows/test-integration-django.yml
@@ -27,7 +27,6 @@ jobs:
     name: django, python ${{ matrix.python-version }}, ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     timeout-minutes: 45
-    continue-on-error: true
 
     strategy:
       matrix:
@@ -98,6 +97,6 @@ jobs:
           echo "$RESULT"
 
       - name: Check for failures
-        if: contains(needs.test.result, 'ERROR at')
+        if: contains(needs.test.result, 'failure')
         run: |
           echo "One of the dependent jobs have failed. You may need to re-run it." && exit 1

--- a/.github/workflows/test-integration-django.yml
+++ b/.github/workflows/test-integration-django.yml
@@ -93,11 +93,11 @@ jobs:
           echo "$RESULT"
       - name: Print outcome
         env:
-          RESULT: ${{ needs.*.outcome }}
+          RESULT: ${{ needs.test.outcome }}
         run: |
           echo "$RESULT"
 
       - name: Check for failures
-        if: contains(needs.*.result, 'ERROR at')
+        if: contains(needs.test.result, 'ERROR at')
         run: |
           echo "One of the dependent jobs have failed. You may need to re-run it." && exit 1

--- a/.github/workflows/test-integration-django.yml
+++ b/.github/workflows/test-integration-django.yml
@@ -87,6 +87,6 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Check for failures
-        if: contains(needs.*.result, 'failure')
+        if: contains(needs.*.result, 'ERROR at')
         run: |
           echo "One of the dependent jobs have failed. You may need to re-run it." && exit 1

--- a/.github/workflows/test-integration-django.yml
+++ b/.github/workflows/test-integration-django.yml
@@ -88,7 +88,7 @@ jobs:
     steps:
       - name: Print result
         env:
-          RESULT: ${{ needs.*.result }}
+          RESULT: ${{ needs.test.result }}
         run: |
           echo "$RESULT"
       - name: Print outcome

--- a/.github/workflows/test-integration-django.yml
+++ b/.github/workflows/test-integration-django.yml
@@ -62,9 +62,6 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Setup Test Env
-        env:
-          PGHOST: localhost
-          PGPASSWORD: sentry
         run: |
           pip install codecov tox
 

--- a/.github/workflows/test-integration-django.yml
+++ b/.github/workflows/test-integration-django.yml
@@ -63,7 +63,7 @@ jobs:
 
       - name: Setup Test Env
         run: |
-          pip install codecov tox
+          pip install codecov "tox>=3,<4"
 
       - name: Test django
         env:

--- a/.github/workflows/test-integration-falcon.yml
+++ b/.github/workflows/test-integration-falcon.yml
@@ -69,6 +69,17 @@ jobs:
     if: always()
     runs-on: ubuntu-20.04
     steps:
+      - name: Print result
+        env:
+          RESULT: ${{ needs.*.result }}
+        run: |
+          echo "$RESULT"
+      - name: Print outcome
+        env:
+          RESULT: ${{ needs.*.outcome }}
+        run: |
+          echo "$RESULT"
+
       - name: Check for failures
         if: contains(needs.*.result, 'ERROR at')
         run: |

--- a/.github/workflows/test-integration-falcon.yml
+++ b/.github/workflows/test-integration-falcon.yml
@@ -76,11 +76,11 @@ jobs:
           echo "$RESULT"
       - name: Print outcome
         env:
-          RESULT: ${{ needs.*.outcome }}
+          RESULT: ${{ needs.test.outcome }}
         run: |
           echo "$RESULT"
 
       - name: Check for failures
-        if: contains(needs.*.result, 'ERROR at')
+        if: contains(needs.test.result, 'ERROR at')
         run: |
           echo "One of the dependent jobs have failed. You may need to re-run it." && exit 1

--- a/.github/workflows/test-integration-falcon.yml
+++ b/.github/workflows/test-integration-falcon.yml
@@ -46,7 +46,7 @@ jobs:
 
       - name: Setup Test Env
         run: |
-          pip install codecov tox
+          pip install codecov "tox>=3,<4"
 
       - name: Test falcon
         env:

--- a/.github/workflows/test-integration-falcon.yml
+++ b/.github/workflows/test-integration-falcon.yml
@@ -70,6 +70,6 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Check for failures
-        if: contains(needs.*.result, 'failure')
+        if: contains(needs.*.result, 'ERROR at')
         run: |
           echo "One of the dependent jobs have failed. You may need to re-run it." && exit 1

--- a/.github/workflows/test-integration-falcon.yml
+++ b/.github/workflows/test-integration-falcon.yml
@@ -61,3 +61,15 @@ jobs:
           coverage combine .coverage*
           coverage xml -i
           codecov --file coverage.xml
+
+  check_required_tests:
+    name: All falcon tests passed or skipped
+    needs: test
+    # Always run this, even if a dependent job failed
+    if: always()
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Check for failures
+        if: contains(needs.*.result, 'failure')
+        run: |
+          echo "One of the dependent jobs have failed. You may need to re-run it." && exit 1

--- a/.github/workflows/test-integration-falcon.yml
+++ b/.github/workflows/test-integration-falcon.yml
@@ -71,7 +71,7 @@ jobs:
     steps:
       - name: Print result
         env:
-          RESULT: ${{ needs.*.result }}
+          RESULT: ${{ needs.test.result }}
         run: |
           echo "$RESULT"
       - name: Print outcome

--- a/.github/workflows/test-integration-falcon.yml
+++ b/.github/workflows/test-integration-falcon.yml
@@ -45,9 +45,6 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Setup Test Env
-        env:
-          PGHOST: localhost
-          PGPASSWORD: sentry
         run: |
           pip install codecov tox
 

--- a/.github/workflows/test-integration-falcon.yml
+++ b/.github/workflows/test-integration-falcon.yml
@@ -32,7 +32,11 @@ jobs:
     strategy:
       matrix:
         python-version: ["2.7","3.5","3.6","3.7","3.8","3.9","3.10"]
-        os: [ubuntu-latest]
+        # python3.6 reached EOL and is no longer being supported on
+        # new versions of hosted runners on Github Actions
+        # ubuntu-20.04 is the last version that supported python3.6
+        # see https://github.com/actions/setup-python/issues/544#issuecomment-1332535877
+        os: [ubuntu-20.04]
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/test-integration-falcon.yml
+++ b/.github/workflows/test-integration-falcon.yml
@@ -27,7 +27,6 @@ jobs:
     name: falcon, python ${{ matrix.python-version }}, ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     timeout-minutes: 45
-    continue-on-error: true
 
     strategy:
       matrix:
@@ -81,6 +80,6 @@ jobs:
           echo "$RESULT"
 
       - name: Check for failures
-        if: contains(needs.test.result, 'ERROR at')
+        if: contains(needs.test.result, 'failure')
         run: |
           echo "One of the dependent jobs have failed. You may need to re-run it." && exit 1

--- a/.github/workflows/test-integration-falcon.yml
+++ b/.github/workflows/test-integration-falcon.yml
@@ -29,6 +29,7 @@ jobs:
     timeout-minutes: 45
 
     strategy:
+      fail-fast: false
       matrix:
         python-version: ["2.7","3.5","3.6","3.7","3.8","3.9","3.10"]
         # python3.6 reached EOL and is no longer being supported on
@@ -68,17 +69,6 @@ jobs:
     if: always()
     runs-on: ubuntu-20.04
     steps:
-      - name: Print result
-        env:
-          RESULT: ${{ needs.test.result }}
-        run: |
-          echo "$RESULT"
-      - name: Print outcome
-        env:
-          RESULT: ${{ needs.test.outcome }}
-        run: |
-          echo "$RESULT"
-
       - name: Check for failures
         if: contains(needs.test.result, 'failure')
         run: |

--- a/.github/workflows/test-integration-fastapi.yml
+++ b/.github/workflows/test-integration-fastapi.yml
@@ -69,6 +69,17 @@ jobs:
     if: always()
     runs-on: ubuntu-20.04
     steps:
+      - name: Print result
+        env:
+          RESULT: ${{ needs.*.result }}
+        run: |
+          echo "$RESULT"
+      - name: Print outcome
+        env:
+          RESULT: ${{ needs.*.outcome }}
+        run: |
+          echo "$RESULT"
+
       - name: Check for failures
         if: contains(needs.*.result, 'ERROR at')
         run: |

--- a/.github/workflows/test-integration-fastapi.yml
+++ b/.github/workflows/test-integration-fastapi.yml
@@ -27,7 +27,6 @@ jobs:
     name: fastapi, python ${{ matrix.python-version }}, ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     timeout-minutes: 45
-    continue-on-error: true
 
     strategy:
       matrix:
@@ -81,6 +80,6 @@ jobs:
           echo "$RESULT"
 
       - name: Check for failures
-        if: contains(needs.test.result, 'ERROR at')
+        if: contains(needs.test.result, 'failure')
         run: |
           echo "One of the dependent jobs have failed. You may need to re-run it." && exit 1

--- a/.github/workflows/test-integration-fastapi.yml
+++ b/.github/workflows/test-integration-fastapi.yml
@@ -76,11 +76,11 @@ jobs:
           echo "$RESULT"
       - name: Print outcome
         env:
-          RESULT: ${{ needs.*.outcome }}
+          RESULT: ${{ needs.test.outcome }}
         run: |
           echo "$RESULT"
 
       - name: Check for failures
-        if: contains(needs.*.result, 'ERROR at')
+        if: contains(needs.test.result, 'ERROR at')
         run: |
           echo "One of the dependent jobs have failed. You may need to re-run it." && exit 1

--- a/.github/workflows/test-integration-fastapi.yml
+++ b/.github/workflows/test-integration-fastapi.yml
@@ -70,6 +70,6 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Check for failures
-        if: contains(needs.*.result, 'failure')
+        if: contains(needs.*.result, 'ERROR at')
         run: |
           echo "One of the dependent jobs have failed. You may need to re-run it." && exit 1

--- a/.github/workflows/test-integration-fastapi.yml
+++ b/.github/workflows/test-integration-fastapi.yml
@@ -29,6 +29,7 @@ jobs:
     timeout-minutes: 45
 
     strategy:
+      fail-fast: false
       matrix:
         python-version: ["3.7","3.8","3.9","3.10"]
         # python3.6 reached EOL and is no longer being supported on
@@ -68,17 +69,6 @@ jobs:
     if: always()
     runs-on: ubuntu-20.04
     steps:
-      - name: Print result
-        env:
-          RESULT: ${{ needs.test.result }}
-        run: |
-          echo "$RESULT"
-      - name: Print outcome
-        env:
-          RESULT: ${{ needs.test.outcome }}
-        run: |
-          echo "$RESULT"
-
       - name: Check for failures
         if: contains(needs.test.result, 'failure')
         run: |

--- a/.github/workflows/test-integration-fastapi.yml
+++ b/.github/workflows/test-integration-fastapi.yml
@@ -71,7 +71,7 @@ jobs:
     steps:
       - name: Print result
         env:
-          RESULT: ${{ needs.*.result }}
+          RESULT: ${{ needs.test.result }}
         run: |
           echo "$RESULT"
       - name: Print outcome

--- a/.github/workflows/test-integration-fastapi.yml
+++ b/.github/workflows/test-integration-fastapi.yml
@@ -45,9 +45,6 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Setup Test Env
-        env:
-          PGHOST: localhost
-          PGPASSWORD: sentry
         run: |
           pip install codecov tox
 

--- a/.github/workflows/test-integration-fastapi.yml
+++ b/.github/workflows/test-integration-fastapi.yml
@@ -32,7 +32,11 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.7","3.8","3.9","3.10"]
-        os: [ubuntu-latest]
+        # python3.6 reached EOL and is no longer being supported on
+        # new versions of hosted runners on Github Actions
+        # ubuntu-20.04 is the last version that supported python3.6
+        # see https://github.com/actions/setup-python/issues/544#issuecomment-1332535877
+        os: [ubuntu-20.04]
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/test-integration-fastapi.yml
+++ b/.github/workflows/test-integration-fastapi.yml
@@ -61,3 +61,15 @@ jobs:
           coverage combine .coverage*
           coverage xml -i
           codecov --file coverage.xml
+
+  check_required_tests:
+    name: All fastapi tests passed or skipped
+    needs: test
+    # Always run this, even if a dependent job failed
+    if: always()
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Check for failures
+        if: contains(needs.*.result, 'failure')
+        run: |
+          echo "One of the dependent jobs have failed. You may need to re-run it." && exit 1

--- a/.github/workflows/test-integration-fastapi.yml
+++ b/.github/workflows/test-integration-fastapi.yml
@@ -46,7 +46,7 @@ jobs:
 
       - name: Setup Test Env
         run: |
-          pip install codecov tox
+          pip install codecov "tox>=3,<4"
 
       - name: Test fastapi
         env:

--- a/.github/workflows/test-integration-flask.yml
+++ b/.github/workflows/test-integration-flask.yml
@@ -69,6 +69,17 @@ jobs:
     if: always()
     runs-on: ubuntu-20.04
     steps:
+      - name: Print result
+        env:
+          RESULT: ${{ needs.*.result }}
+        run: |
+          echo "$RESULT"
+      - name: Print outcome
+        env:
+          RESULT: ${{ needs.*.outcome }}
+        run: |
+          echo "$RESULT"
+
       - name: Check for failures
         if: contains(needs.*.result, 'ERROR at')
         run: |

--- a/.github/workflows/test-integration-flask.yml
+++ b/.github/workflows/test-integration-flask.yml
@@ -76,11 +76,11 @@ jobs:
           echo "$RESULT"
       - name: Print outcome
         env:
-          RESULT: ${{ needs.*.outcome }}
+          RESULT: ${{ needs.test.outcome }}
         run: |
           echo "$RESULT"
 
       - name: Check for failures
-        if: contains(needs.*.result, 'ERROR at')
+        if: contains(needs.test.result, 'ERROR at')
         run: |
           echo "One of the dependent jobs have failed. You may need to re-run it." && exit 1

--- a/.github/workflows/test-integration-flask.yml
+++ b/.github/workflows/test-integration-flask.yml
@@ -46,7 +46,7 @@ jobs:
 
       - name: Setup Test Env
         run: |
-          pip install codecov tox
+          pip install codecov "tox>=3,<4"
 
       - name: Test flask
         env:

--- a/.github/workflows/test-integration-flask.yml
+++ b/.github/workflows/test-integration-flask.yml
@@ -70,6 +70,6 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Check for failures
-        if: contains(needs.*.result, 'failure')
+        if: contains(needs.*.result, 'ERROR at')
         run: |
           echo "One of the dependent jobs have failed. You may need to re-run it." && exit 1

--- a/.github/workflows/test-integration-flask.yml
+++ b/.github/workflows/test-integration-flask.yml
@@ -61,3 +61,15 @@ jobs:
           coverage combine .coverage*
           coverage xml -i
           codecov --file coverage.xml
+
+  check_required_tests:
+    name: All flask tests passed or skipped
+    needs: test
+    # Always run this, even if a dependent job failed
+    if: always()
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Check for failures
+        if: contains(needs.*.result, 'failure')
+        run: |
+          echo "One of the dependent jobs have failed. You may need to re-run it." && exit 1

--- a/.github/workflows/test-integration-flask.yml
+++ b/.github/workflows/test-integration-flask.yml
@@ -71,7 +71,7 @@ jobs:
     steps:
       - name: Print result
         env:
-          RESULT: ${{ needs.*.result }}
+          RESULT: ${{ needs.test.result }}
         run: |
           echo "$RESULT"
       - name: Print outcome

--- a/.github/workflows/test-integration-flask.yml
+++ b/.github/workflows/test-integration-flask.yml
@@ -45,9 +45,6 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Setup Test Env
-        env:
-          PGHOST: localhost
-          PGPASSWORD: sentry
         run: |
           pip install codecov tox
 

--- a/.github/workflows/test-integration-flask.yml
+++ b/.github/workflows/test-integration-flask.yml
@@ -32,7 +32,11 @@ jobs:
     strategy:
       matrix:
         python-version: ["2.7","3.5","3.6","3.7","3.8","3.9","3.10"]
-        os: [ubuntu-latest]
+        # python3.6 reached EOL and is no longer being supported on
+        # new versions of hosted runners on Github Actions
+        # ubuntu-20.04 is the last version that supported python3.6
+        # see https://github.com/actions/setup-python/issues/544#issuecomment-1332535877
+        os: [ubuntu-20.04]
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/test-integration-flask.yml
+++ b/.github/workflows/test-integration-flask.yml
@@ -27,7 +27,6 @@ jobs:
     name: flask, python ${{ matrix.python-version }}, ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     timeout-minutes: 45
-    continue-on-error: true
 
     strategy:
       matrix:
@@ -81,6 +80,6 @@ jobs:
           echo "$RESULT"
 
       - name: Check for failures
-        if: contains(needs.test.result, 'ERROR at')
+        if: contains(needs.test.result, 'failure')
         run: |
           echo "One of the dependent jobs have failed. You may need to re-run it." && exit 1

--- a/.github/workflows/test-integration-flask.yml
+++ b/.github/workflows/test-integration-flask.yml
@@ -29,6 +29,7 @@ jobs:
     timeout-minutes: 45
 
     strategy:
+      fail-fast: false
       matrix:
         python-version: ["2.7","3.5","3.6","3.7","3.8","3.9","3.10"]
         # python3.6 reached EOL and is no longer being supported on
@@ -68,17 +69,6 @@ jobs:
     if: always()
     runs-on: ubuntu-20.04
     steps:
-      - name: Print result
-        env:
-          RESULT: ${{ needs.test.result }}
-        run: |
-          echo "$RESULT"
-      - name: Print outcome
-        env:
-          RESULT: ${{ needs.test.outcome }}
-        run: |
-          echo "$RESULT"
-
       - name: Check for failures
         if: contains(needs.test.result, 'failure')
         run: |

--- a/.github/workflows/test-integration-gcp.yml
+++ b/.github/workflows/test-integration-gcp.yml
@@ -69,6 +69,17 @@ jobs:
     if: always()
     runs-on: ubuntu-20.04
     steps:
+      - name: Print result
+        env:
+          RESULT: ${{ needs.*.result }}
+        run: |
+          echo "$RESULT"
+      - name: Print outcome
+        env:
+          RESULT: ${{ needs.*.outcome }}
+        run: |
+          echo "$RESULT"
+
       - name: Check for failures
         if: contains(needs.*.result, 'ERROR at')
         run: |

--- a/.github/workflows/test-integration-gcp.yml
+++ b/.github/workflows/test-integration-gcp.yml
@@ -46,7 +46,7 @@ jobs:
 
       - name: Setup Test Env
         run: |
-          pip install codecov tox
+          pip install codecov "tox>=3,<4"
 
       - name: Test gcp
         env:

--- a/.github/workflows/test-integration-gcp.yml
+++ b/.github/workflows/test-integration-gcp.yml
@@ -76,11 +76,11 @@ jobs:
           echo "$RESULT"
       - name: Print outcome
         env:
-          RESULT: ${{ needs.*.outcome }}
+          RESULT: ${{ needs.test.outcome }}
         run: |
           echo "$RESULT"
 
       - name: Check for failures
-        if: contains(needs.*.result, 'ERROR at')
+        if: contains(needs.test.result, 'ERROR at')
         run: |
           echo "One of the dependent jobs have failed. You may need to re-run it." && exit 1

--- a/.github/workflows/test-integration-gcp.yml
+++ b/.github/workflows/test-integration-gcp.yml
@@ -70,6 +70,6 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Check for failures
-        if: contains(needs.*.result, 'failure')
+        if: contains(needs.*.result, 'ERROR at')
         run: |
           echo "One of the dependent jobs have failed. You may need to re-run it." && exit 1

--- a/.github/workflows/test-integration-gcp.yml
+++ b/.github/workflows/test-integration-gcp.yml
@@ -61,3 +61,15 @@ jobs:
           coverage combine .coverage*
           coverage xml -i
           codecov --file coverage.xml
+
+  check_required_tests:
+    name: All gcp tests passed or skipped
+    needs: test
+    # Always run this, even if a dependent job failed
+    if: always()
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Check for failures
+        if: contains(needs.*.result, 'failure')
+        run: |
+          echo "One of the dependent jobs have failed. You may need to re-run it." && exit 1

--- a/.github/workflows/test-integration-gcp.yml
+++ b/.github/workflows/test-integration-gcp.yml
@@ -32,7 +32,11 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.7"]
-        os: [ubuntu-latest]
+        # python3.6 reached EOL and is no longer being supported on
+        # new versions of hosted runners on Github Actions
+        # ubuntu-20.04 is the last version that supported python3.6
+        # see https://github.com/actions/setup-python/issues/544#issuecomment-1332535877
+        os: [ubuntu-20.04]
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/test-integration-gcp.yml
+++ b/.github/workflows/test-integration-gcp.yml
@@ -71,7 +71,7 @@ jobs:
     steps:
       - name: Print result
         env:
-          RESULT: ${{ needs.*.result }}
+          RESULT: ${{ needs.test.result }}
         run: |
           echo "$RESULT"
       - name: Print outcome

--- a/.github/workflows/test-integration-gcp.yml
+++ b/.github/workflows/test-integration-gcp.yml
@@ -45,9 +45,6 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Setup Test Env
-        env:
-          PGHOST: localhost
-          PGPASSWORD: sentry
         run: |
           pip install codecov tox
 

--- a/.github/workflows/test-integration-gcp.yml
+++ b/.github/workflows/test-integration-gcp.yml
@@ -27,7 +27,6 @@ jobs:
     name: gcp, python ${{ matrix.python-version }}, ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     timeout-minutes: 45
-    continue-on-error: true
 
     strategy:
       matrix:
@@ -81,6 +80,6 @@ jobs:
           echo "$RESULT"
 
       - name: Check for failures
-        if: contains(needs.test.result, 'ERROR at')
+        if: contains(needs.test.result, 'failure')
         run: |
           echo "One of the dependent jobs have failed. You may need to re-run it." && exit 1

--- a/.github/workflows/test-integration-gcp.yml
+++ b/.github/workflows/test-integration-gcp.yml
@@ -29,6 +29,7 @@ jobs:
     timeout-minutes: 45
 
     strategy:
+      fail-fast: false
       matrix:
         python-version: ["3.7"]
         # python3.6 reached EOL and is no longer being supported on
@@ -68,17 +69,6 @@ jobs:
     if: always()
     runs-on: ubuntu-20.04
     steps:
-      - name: Print result
-        env:
-          RESULT: ${{ needs.test.result }}
-        run: |
-          echo "$RESULT"
-      - name: Print outcome
-        env:
-          RESULT: ${{ needs.test.outcome }}
-        run: |
-          echo "$RESULT"
-
       - name: Check for failures
         if: contains(needs.test.result, 'failure')
         run: |

--- a/.github/workflows/test-integration-httpx.yml
+++ b/.github/workflows/test-integration-httpx.yml
@@ -69,6 +69,17 @@ jobs:
     if: always()
     runs-on: ubuntu-20.04
     steps:
+      - name: Print result
+        env:
+          RESULT: ${{ needs.*.result }}
+        run: |
+          echo "$RESULT"
+      - name: Print outcome
+        env:
+          RESULT: ${{ needs.*.outcome }}
+        run: |
+          echo "$RESULT"
+
       - name: Check for failures
         if: contains(needs.*.result, 'ERROR at')
         run: |

--- a/.github/workflows/test-integration-httpx.yml
+++ b/.github/workflows/test-integration-httpx.yml
@@ -29,6 +29,7 @@ jobs:
     timeout-minutes: 45
 
     strategy:
+      fail-fast: false
       matrix:
         python-version: ["3.6","3.7","3.8","3.9","3.10"]
         # python3.6 reached EOL and is no longer being supported on
@@ -68,17 +69,6 @@ jobs:
     if: always()
     runs-on: ubuntu-20.04
     steps:
-      - name: Print result
-        env:
-          RESULT: ${{ needs.test.result }}
-        run: |
-          echo "$RESULT"
-      - name: Print outcome
-        env:
-          RESULT: ${{ needs.test.outcome }}
-        run: |
-          echo "$RESULT"
-
       - name: Check for failures
         if: contains(needs.test.result, 'failure')
         run: |

--- a/.github/workflows/test-integration-httpx.yml
+++ b/.github/workflows/test-integration-httpx.yml
@@ -76,11 +76,11 @@ jobs:
           echo "$RESULT"
       - name: Print outcome
         env:
-          RESULT: ${{ needs.*.outcome }}
+          RESULT: ${{ needs.test.outcome }}
         run: |
           echo "$RESULT"
 
       - name: Check for failures
-        if: contains(needs.*.result, 'ERROR at')
+        if: contains(needs.test.result, 'ERROR at')
         run: |
           echo "One of the dependent jobs have failed. You may need to re-run it." && exit 1

--- a/.github/workflows/test-integration-httpx.yml
+++ b/.github/workflows/test-integration-httpx.yml
@@ -70,6 +70,6 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Check for failures
-        if: contains(needs.*.result, 'failure')
+        if: contains(needs.*.result, 'ERROR at')
         run: |
           echo "One of the dependent jobs have failed. You may need to re-run it." && exit 1

--- a/.github/workflows/test-integration-httpx.yml
+++ b/.github/workflows/test-integration-httpx.yml
@@ -32,7 +32,11 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.6","3.7","3.8","3.9","3.10"]
-        os: [ubuntu-latest]
+        # python3.6 reached EOL and is no longer being supported on
+        # new versions of hosted runners on Github Actions
+        # ubuntu-20.04 is the last version that supported python3.6
+        # see https://github.com/actions/setup-python/issues/544#issuecomment-1332535877
+        os: [ubuntu-20.04]
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/test-integration-httpx.yml
+++ b/.github/workflows/test-integration-httpx.yml
@@ -46,7 +46,7 @@ jobs:
 
       - name: Setup Test Env
         run: |
-          pip install codecov tox
+          pip install codecov "tox>=3,<4"
 
       - name: Test httpx
         env:

--- a/.github/workflows/test-integration-httpx.yml
+++ b/.github/workflows/test-integration-httpx.yml
@@ -71,7 +71,7 @@ jobs:
     steps:
       - name: Print result
         env:
-          RESULT: ${{ needs.*.result }}
+          RESULT: ${{ needs.test.result }}
         run: |
           echo "$RESULT"
       - name: Print outcome

--- a/.github/workflows/test-integration-httpx.yml
+++ b/.github/workflows/test-integration-httpx.yml
@@ -45,9 +45,6 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Setup Test Env
-        env:
-          PGHOST: localhost
-          PGPASSWORD: sentry
         run: |
           pip install codecov tox
 

--- a/.github/workflows/test-integration-httpx.yml
+++ b/.github/workflows/test-integration-httpx.yml
@@ -27,7 +27,6 @@ jobs:
     name: httpx, python ${{ matrix.python-version }}, ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     timeout-minutes: 45
-    continue-on-error: true
 
     strategy:
       matrix:
@@ -81,6 +80,6 @@ jobs:
           echo "$RESULT"
 
       - name: Check for failures
-        if: contains(needs.test.result, 'ERROR at')
+        if: contains(needs.test.result, 'failure')
         run: |
           echo "One of the dependent jobs have failed. You may need to re-run it." && exit 1

--- a/.github/workflows/test-integration-httpx.yml
+++ b/.github/workflows/test-integration-httpx.yml
@@ -61,3 +61,15 @@ jobs:
           coverage combine .coverage*
           coverage xml -i
           codecov --file coverage.xml
+
+  check_required_tests:
+    name: All httpx tests passed or skipped
+    needs: test
+    # Always run this, even if a dependent job failed
+    if: always()
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Check for failures
+        if: contains(needs.*.result, 'failure')
+        run: |
+          echo "One of the dependent jobs have failed. You may need to re-run it." && exit 1

--- a/.github/workflows/test-integration-pure_eval.yml
+++ b/.github/workflows/test-integration-pure_eval.yml
@@ -69,6 +69,17 @@ jobs:
     if: always()
     runs-on: ubuntu-20.04
     steps:
+      - name: Print result
+        env:
+          RESULT: ${{ needs.*.result }}
+        run: |
+          echo "$RESULT"
+      - name: Print outcome
+        env:
+          RESULT: ${{ needs.*.outcome }}
+        run: |
+          echo "$RESULT"
+
       - name: Check for failures
         if: contains(needs.*.result, 'ERROR at')
         run: |

--- a/.github/workflows/test-integration-pure_eval.yml
+++ b/.github/workflows/test-integration-pure_eval.yml
@@ -76,11 +76,11 @@ jobs:
           echo "$RESULT"
       - name: Print outcome
         env:
-          RESULT: ${{ needs.*.outcome }}
+          RESULT: ${{ needs.test.outcome }}
         run: |
           echo "$RESULT"
 
       - name: Check for failures
-        if: contains(needs.*.result, 'ERROR at')
+        if: contains(needs.test.result, 'ERROR at')
         run: |
           echo "One of the dependent jobs have failed. You may need to re-run it." && exit 1

--- a/.github/workflows/test-integration-pure_eval.yml
+++ b/.github/workflows/test-integration-pure_eval.yml
@@ -32,7 +32,11 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.5","3.6","3.7","3.8","3.9","3.10"]
-        os: [ubuntu-latest]
+        # python3.6 reached EOL and is no longer being supported on
+        # new versions of hosted runners on Github Actions
+        # ubuntu-20.04 is the last version that supported python3.6
+        # see https://github.com/actions/setup-python/issues/544#issuecomment-1332535877
+        os: [ubuntu-20.04]
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/test-integration-pure_eval.yml
+++ b/.github/workflows/test-integration-pure_eval.yml
@@ -61,3 +61,15 @@ jobs:
           coverage combine .coverage*
           coverage xml -i
           codecov --file coverage.xml
+
+  check_required_tests:
+    name: All pure_eval tests passed or skipped
+    needs: test
+    # Always run this, even if a dependent job failed
+    if: always()
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Check for failures
+        if: contains(needs.*.result, 'failure')
+        run: |
+          echo "One of the dependent jobs have failed. You may need to re-run it." && exit 1

--- a/.github/workflows/test-integration-pure_eval.yml
+++ b/.github/workflows/test-integration-pure_eval.yml
@@ -70,6 +70,6 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Check for failures
-        if: contains(needs.*.result, 'failure')
+        if: contains(needs.*.result, 'ERROR at')
         run: |
           echo "One of the dependent jobs have failed. You may need to re-run it." && exit 1

--- a/.github/workflows/test-integration-pure_eval.yml
+++ b/.github/workflows/test-integration-pure_eval.yml
@@ -29,6 +29,7 @@ jobs:
     timeout-minutes: 45
 
     strategy:
+      fail-fast: false
       matrix:
         python-version: ["3.5","3.6","3.7","3.8","3.9","3.10"]
         # python3.6 reached EOL and is no longer being supported on
@@ -68,17 +69,6 @@ jobs:
     if: always()
     runs-on: ubuntu-20.04
     steps:
-      - name: Print result
-        env:
-          RESULT: ${{ needs.test.result }}
-        run: |
-          echo "$RESULT"
-      - name: Print outcome
-        env:
-          RESULT: ${{ needs.test.outcome }}
-        run: |
-          echo "$RESULT"
-
       - name: Check for failures
         if: contains(needs.test.result, 'failure')
         run: |

--- a/.github/workflows/test-integration-pure_eval.yml
+++ b/.github/workflows/test-integration-pure_eval.yml
@@ -27,7 +27,6 @@ jobs:
     name: pure_eval, python ${{ matrix.python-version }}, ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     timeout-minutes: 45
-    continue-on-error: true
 
     strategy:
       matrix:
@@ -81,6 +80,6 @@ jobs:
           echo "$RESULT"
 
       - name: Check for failures
-        if: contains(needs.test.result, 'ERROR at')
+        if: contains(needs.test.result, 'failure')
         run: |
           echo "One of the dependent jobs have failed. You may need to re-run it." && exit 1

--- a/.github/workflows/test-integration-pure_eval.yml
+++ b/.github/workflows/test-integration-pure_eval.yml
@@ -71,7 +71,7 @@ jobs:
     steps:
       - name: Print result
         env:
-          RESULT: ${{ needs.*.result }}
+          RESULT: ${{ needs.test.result }}
         run: |
           echo "$RESULT"
       - name: Print outcome

--- a/.github/workflows/test-integration-pure_eval.yml
+++ b/.github/workflows/test-integration-pure_eval.yml
@@ -45,9 +45,6 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Setup Test Env
-        env:
-          PGHOST: localhost
-          PGPASSWORD: sentry
         run: |
           pip install codecov tox
 

--- a/.github/workflows/test-integration-pure_eval.yml
+++ b/.github/workflows/test-integration-pure_eval.yml
@@ -46,7 +46,7 @@ jobs:
 
       - name: Setup Test Env
         run: |
-          pip install codecov tox
+          pip install codecov "tox>=3,<4"
 
       - name: Test pure_eval
         env:

--- a/.github/workflows/test-integration-pymongo.yml
+++ b/.github/workflows/test-integration-pymongo.yml
@@ -69,6 +69,17 @@ jobs:
     if: always()
     runs-on: ubuntu-20.04
     steps:
+      - name: Print result
+        env:
+          RESULT: ${{ needs.*.result }}
+        run: |
+          echo "$RESULT"
+      - name: Print outcome
+        env:
+          RESULT: ${{ needs.*.outcome }}
+        run: |
+          echo "$RESULT"
+
       - name: Check for failures
         if: contains(needs.*.result, 'ERROR at')
         run: |

--- a/.github/workflows/test-integration-pymongo.yml
+++ b/.github/workflows/test-integration-pymongo.yml
@@ -76,11 +76,11 @@ jobs:
           echo "$RESULT"
       - name: Print outcome
         env:
-          RESULT: ${{ needs.*.outcome }}
+          RESULT: ${{ needs.test.outcome }}
         run: |
           echo "$RESULT"
 
       - name: Check for failures
-        if: contains(needs.*.result, 'ERROR at')
+        if: contains(needs.test.result, 'ERROR at')
         run: |
           echo "One of the dependent jobs have failed. You may need to re-run it." && exit 1

--- a/.github/workflows/test-integration-pymongo.yml
+++ b/.github/workflows/test-integration-pymongo.yml
@@ -70,6 +70,6 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Check for failures
-        if: contains(needs.*.result, 'failure')
+        if: contains(needs.*.result, 'ERROR at')
         run: |
           echo "One of the dependent jobs have failed. You may need to re-run it." && exit 1

--- a/.github/workflows/test-integration-pymongo.yml
+++ b/.github/workflows/test-integration-pymongo.yml
@@ -61,3 +61,15 @@ jobs:
           coverage combine .coverage*
           coverage xml -i
           codecov --file coverage.xml
+
+  check_required_tests:
+    name: All pymongo tests passed or skipped
+    needs: test
+    # Always run this, even if a dependent job failed
+    if: always()
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Check for failures
+        if: contains(needs.*.result, 'failure')
+        run: |
+          echo "One of the dependent jobs have failed. You may need to re-run it." && exit 1

--- a/.github/workflows/test-integration-pymongo.yml
+++ b/.github/workflows/test-integration-pymongo.yml
@@ -71,7 +71,7 @@ jobs:
     steps:
       - name: Print result
         env:
-          RESULT: ${{ needs.*.result }}
+          RESULT: ${{ needs.test.result }}
         run: |
           echo "$RESULT"
       - name: Print outcome

--- a/.github/workflows/test-integration-pymongo.yml
+++ b/.github/workflows/test-integration-pymongo.yml
@@ -45,9 +45,6 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Setup Test Env
-        env:
-          PGHOST: localhost
-          PGPASSWORD: sentry
         run: |
           pip install codecov tox
 

--- a/.github/workflows/test-integration-pymongo.yml
+++ b/.github/workflows/test-integration-pymongo.yml
@@ -32,7 +32,11 @@ jobs:
     strategy:
       matrix:
         python-version: ["2.7","3.6","3.7","3.8","3.9","3.10"]
-        os: [ubuntu-latest]
+        # python3.6 reached EOL and is no longer being supported on
+        # new versions of hosted runners on Github Actions
+        # ubuntu-20.04 is the last version that supported python3.6
+        # see https://github.com/actions/setup-python/issues/544#issuecomment-1332535877
+        os: [ubuntu-20.04]
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/test-integration-pymongo.yml
+++ b/.github/workflows/test-integration-pymongo.yml
@@ -27,7 +27,6 @@ jobs:
     name: pymongo, python ${{ matrix.python-version }}, ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     timeout-minutes: 45
-    continue-on-error: true
 
     strategy:
       matrix:
@@ -81,6 +80,6 @@ jobs:
           echo "$RESULT"
 
       - name: Check for failures
-        if: contains(needs.test.result, 'ERROR at')
+        if: contains(needs.test.result, 'failure')
         run: |
           echo "One of the dependent jobs have failed. You may need to re-run it." && exit 1

--- a/.github/workflows/test-integration-pymongo.yml
+++ b/.github/workflows/test-integration-pymongo.yml
@@ -46,7 +46,7 @@ jobs:
 
       - name: Setup Test Env
         run: |
-          pip install codecov tox
+          pip install codecov "tox>=3,<4"
 
       - name: Test pymongo
         env:

--- a/.github/workflows/test-integration-pymongo.yml
+++ b/.github/workflows/test-integration-pymongo.yml
@@ -29,6 +29,7 @@ jobs:
     timeout-minutes: 45
 
     strategy:
+      fail-fast: false
       matrix:
         python-version: ["2.7","3.6","3.7","3.8","3.9","3.10"]
         # python3.6 reached EOL and is no longer being supported on
@@ -68,17 +69,6 @@ jobs:
     if: always()
     runs-on: ubuntu-20.04
     steps:
-      - name: Print result
-        env:
-          RESULT: ${{ needs.test.result }}
-        run: |
-          echo "$RESULT"
-      - name: Print outcome
-        env:
-          RESULT: ${{ needs.test.outcome }}
-        run: |
-          echo "$RESULT"
-
       - name: Check for failures
         if: contains(needs.test.result, 'failure')
         run: |

--- a/.github/workflows/test-integration-pyramid.yml
+++ b/.github/workflows/test-integration-pyramid.yml
@@ -69,6 +69,17 @@ jobs:
     if: always()
     runs-on: ubuntu-20.04
     steps:
+      - name: Print result
+        env:
+          RESULT: ${{ needs.*.result }}
+        run: |
+          echo "$RESULT"
+      - name: Print outcome
+        env:
+          RESULT: ${{ needs.*.outcome }}
+        run: |
+          echo "$RESULT"
+
       - name: Check for failures
         if: contains(needs.*.result, 'ERROR at')
         run: |

--- a/.github/workflows/test-integration-pyramid.yml
+++ b/.github/workflows/test-integration-pyramid.yml
@@ -76,11 +76,11 @@ jobs:
           echo "$RESULT"
       - name: Print outcome
         env:
-          RESULT: ${{ needs.*.outcome }}
+          RESULT: ${{ needs.test.outcome }}
         run: |
           echo "$RESULT"
 
       - name: Check for failures
-        if: contains(needs.*.result, 'ERROR at')
+        if: contains(needs.test.result, 'ERROR at')
         run: |
           echo "One of the dependent jobs have failed. You may need to re-run it." && exit 1

--- a/.github/workflows/test-integration-pyramid.yml
+++ b/.github/workflows/test-integration-pyramid.yml
@@ -27,7 +27,6 @@ jobs:
     name: pyramid, python ${{ matrix.python-version }}, ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     timeout-minutes: 45
-    continue-on-error: true
 
     strategy:
       matrix:
@@ -81,6 +80,6 @@ jobs:
           echo "$RESULT"
 
       - name: Check for failures
-        if: contains(needs.test.result, 'ERROR at')
+        if: contains(needs.test.result, 'failure')
         run: |
           echo "One of the dependent jobs have failed. You may need to re-run it." && exit 1

--- a/.github/workflows/test-integration-pyramid.yml
+++ b/.github/workflows/test-integration-pyramid.yml
@@ -70,6 +70,6 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Check for failures
-        if: contains(needs.*.result, 'failure')
+        if: contains(needs.*.result, 'ERROR at')
         run: |
           echo "One of the dependent jobs have failed. You may need to re-run it." && exit 1

--- a/.github/workflows/test-integration-pyramid.yml
+++ b/.github/workflows/test-integration-pyramid.yml
@@ -61,3 +61,15 @@ jobs:
           coverage combine .coverage*
           coverage xml -i
           codecov --file coverage.xml
+
+  check_required_tests:
+    name: All pyramid tests passed or skipped
+    needs: test
+    # Always run this, even if a dependent job failed
+    if: always()
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Check for failures
+        if: contains(needs.*.result, 'failure')
+        run: |
+          echo "One of the dependent jobs have failed. You may need to re-run it." && exit 1

--- a/.github/workflows/test-integration-pyramid.yml
+++ b/.github/workflows/test-integration-pyramid.yml
@@ -71,7 +71,7 @@ jobs:
     steps:
       - name: Print result
         env:
-          RESULT: ${{ needs.*.result }}
+          RESULT: ${{ needs.test.result }}
         run: |
           echo "$RESULT"
       - name: Print outcome

--- a/.github/workflows/test-integration-pyramid.yml
+++ b/.github/workflows/test-integration-pyramid.yml
@@ -45,9 +45,6 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Setup Test Env
-        env:
-          PGHOST: localhost
-          PGPASSWORD: sentry
         run: |
           pip install codecov tox
 

--- a/.github/workflows/test-integration-pyramid.yml
+++ b/.github/workflows/test-integration-pyramid.yml
@@ -32,7 +32,11 @@ jobs:
     strategy:
       matrix:
         python-version: ["2.7","3.5","3.6","3.7","3.8","3.9","3.10"]
-        os: [ubuntu-latest]
+        # python3.6 reached EOL and is no longer being supported on
+        # new versions of hosted runners on Github Actions
+        # ubuntu-20.04 is the last version that supported python3.6
+        # see https://github.com/actions/setup-python/issues/544#issuecomment-1332535877
+        os: [ubuntu-20.04]
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/test-integration-pyramid.yml
+++ b/.github/workflows/test-integration-pyramid.yml
@@ -29,6 +29,7 @@ jobs:
     timeout-minutes: 45
 
     strategy:
+      fail-fast: false
       matrix:
         python-version: ["2.7","3.5","3.6","3.7","3.8","3.9","3.10"]
         # python3.6 reached EOL and is no longer being supported on
@@ -68,17 +69,6 @@ jobs:
     if: always()
     runs-on: ubuntu-20.04
     steps:
-      - name: Print result
-        env:
-          RESULT: ${{ needs.test.result }}
-        run: |
-          echo "$RESULT"
-      - name: Print outcome
-        env:
-          RESULT: ${{ needs.test.outcome }}
-        run: |
-          echo "$RESULT"
-
       - name: Check for failures
         if: contains(needs.test.result, 'failure')
         run: |

--- a/.github/workflows/test-integration-pyramid.yml
+++ b/.github/workflows/test-integration-pyramid.yml
@@ -46,7 +46,7 @@ jobs:
 
       - name: Setup Test Env
         run: |
-          pip install codecov tox
+          pip install codecov "tox>=3,<4"
 
       - name: Test pyramid
         env:

--- a/.github/workflows/test-integration-quart.yml
+++ b/.github/workflows/test-integration-quart.yml
@@ -69,6 +69,17 @@ jobs:
     if: always()
     runs-on: ubuntu-20.04
     steps:
+      - name: Print result
+        env:
+          RESULT: ${{ needs.*.result }}
+        run: |
+          echo "$RESULT"
+      - name: Print outcome
+        env:
+          RESULT: ${{ needs.*.outcome }}
+        run: |
+          echo "$RESULT"
+
       - name: Check for failures
         if: contains(needs.*.result, 'ERROR at')
         run: |

--- a/.github/workflows/test-integration-quart.yml
+++ b/.github/workflows/test-integration-quart.yml
@@ -76,11 +76,11 @@ jobs:
           echo "$RESULT"
       - name: Print outcome
         env:
-          RESULT: ${{ needs.*.outcome }}
+          RESULT: ${{ needs.test.outcome }}
         run: |
           echo "$RESULT"
 
       - name: Check for failures
-        if: contains(needs.*.result, 'ERROR at')
+        if: contains(needs.test.result, 'ERROR at')
         run: |
           echo "One of the dependent jobs have failed. You may need to re-run it." && exit 1

--- a/.github/workflows/test-integration-quart.yml
+++ b/.github/workflows/test-integration-quart.yml
@@ -70,6 +70,6 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Check for failures
-        if: contains(needs.*.result, 'failure')
+        if: contains(needs.*.result, 'ERROR at')
         run: |
           echo "One of the dependent jobs have failed. You may need to re-run it." && exit 1

--- a/.github/workflows/test-integration-quart.yml
+++ b/.github/workflows/test-integration-quart.yml
@@ -29,6 +29,7 @@ jobs:
     timeout-minutes: 45
 
     strategy:
+      fail-fast: false
       matrix:
         python-version: ["3.7","3.8","3.9","3.10"]
         # python3.6 reached EOL and is no longer being supported on
@@ -68,17 +69,6 @@ jobs:
     if: always()
     runs-on: ubuntu-20.04
     steps:
-      - name: Print result
-        env:
-          RESULT: ${{ needs.test.result }}
-        run: |
-          echo "$RESULT"
-      - name: Print outcome
-        env:
-          RESULT: ${{ needs.test.outcome }}
-        run: |
-          echo "$RESULT"
-
       - name: Check for failures
         if: contains(needs.test.result, 'failure')
         run: |

--- a/.github/workflows/test-integration-quart.yml
+++ b/.github/workflows/test-integration-quart.yml
@@ -61,3 +61,15 @@ jobs:
           coverage combine .coverage*
           coverage xml -i
           codecov --file coverage.xml
+
+  check_required_tests:
+    name: All quart tests passed or skipped
+    needs: test
+    # Always run this, even if a dependent job failed
+    if: always()
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Check for failures
+        if: contains(needs.*.result, 'failure')
+        run: |
+          echo "One of the dependent jobs have failed. You may need to re-run it." && exit 1

--- a/.github/workflows/test-integration-quart.yml
+++ b/.github/workflows/test-integration-quart.yml
@@ -71,7 +71,7 @@ jobs:
     steps:
       - name: Print result
         env:
-          RESULT: ${{ needs.*.result }}
+          RESULT: ${{ needs.test.result }}
         run: |
           echo "$RESULT"
       - name: Print outcome

--- a/.github/workflows/test-integration-quart.yml
+++ b/.github/workflows/test-integration-quart.yml
@@ -45,9 +45,6 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Setup Test Env
-        env:
-          PGHOST: localhost
-          PGPASSWORD: sentry
         run: |
           pip install codecov tox
 

--- a/.github/workflows/test-integration-quart.yml
+++ b/.github/workflows/test-integration-quart.yml
@@ -32,7 +32,11 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.7","3.8","3.9","3.10"]
-        os: [ubuntu-latest]
+        # python3.6 reached EOL and is no longer being supported on
+        # new versions of hosted runners on Github Actions
+        # ubuntu-20.04 is the last version that supported python3.6
+        # see https://github.com/actions/setup-python/issues/544#issuecomment-1332535877
+        os: [ubuntu-20.04]
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/test-integration-quart.yml
+++ b/.github/workflows/test-integration-quart.yml
@@ -46,7 +46,7 @@ jobs:
 
       - name: Setup Test Env
         run: |
-          pip install codecov tox
+          pip install codecov "tox>=3,<4"
 
       - name: Test quart
         env:

--- a/.github/workflows/test-integration-quart.yml
+++ b/.github/workflows/test-integration-quart.yml
@@ -27,7 +27,6 @@ jobs:
     name: quart, python ${{ matrix.python-version }}, ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     timeout-minutes: 45
-    continue-on-error: true
 
     strategy:
       matrix:
@@ -81,6 +80,6 @@ jobs:
           echo "$RESULT"
 
       - name: Check for failures
-        if: contains(needs.test.result, 'ERROR at')
+        if: contains(needs.test.result, 'failure')
         run: |
           echo "One of the dependent jobs have failed. You may need to re-run it." && exit 1

--- a/.github/workflows/test-integration-redis.yml
+++ b/.github/workflows/test-integration-redis.yml
@@ -32,7 +32,11 @@ jobs:
     strategy:
       matrix:
         python-version: ["2.7","3.7","3.8","3.9"]
-        os: [ubuntu-latest]
+        # python3.6 reached EOL and is no longer being supported on
+        # new versions of hosted runners on Github Actions
+        # ubuntu-20.04 is the last version that supported python3.6
+        # see https://github.com/actions/setup-python/issues/544#issuecomment-1332535877
+        os: [ubuntu-20.04]
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/test-integration-redis.yml
+++ b/.github/workflows/test-integration-redis.yml
@@ -69,6 +69,17 @@ jobs:
     if: always()
     runs-on: ubuntu-20.04
     steps:
+      - name: Print result
+        env:
+          RESULT: ${{ needs.*.result }}
+        run: |
+          echo "$RESULT"
+      - name: Print outcome
+        env:
+          RESULT: ${{ needs.*.outcome }}
+        run: |
+          echo "$RESULT"
+
       - name: Check for failures
         if: contains(needs.*.result, 'ERROR at')
         run: |

--- a/.github/workflows/test-integration-redis.yml
+++ b/.github/workflows/test-integration-redis.yml
@@ -61,3 +61,15 @@ jobs:
           coverage combine .coverage*
           coverage xml -i
           codecov --file coverage.xml
+
+  check_required_tests:
+    name: All redis tests passed or skipped
+    needs: test
+    # Always run this, even if a dependent job failed
+    if: always()
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Check for failures
+        if: contains(needs.*.result, 'failure')
+        run: |
+          echo "One of the dependent jobs have failed. You may need to re-run it." && exit 1

--- a/.github/workflows/test-integration-redis.yml
+++ b/.github/workflows/test-integration-redis.yml
@@ -76,11 +76,11 @@ jobs:
           echo "$RESULT"
       - name: Print outcome
         env:
-          RESULT: ${{ needs.*.outcome }}
+          RESULT: ${{ needs.test.outcome }}
         run: |
           echo "$RESULT"
 
       - name: Check for failures
-        if: contains(needs.*.result, 'ERROR at')
+        if: contains(needs.test.result, 'ERROR at')
         run: |
           echo "One of the dependent jobs have failed. You may need to re-run it." && exit 1

--- a/.github/workflows/test-integration-redis.yml
+++ b/.github/workflows/test-integration-redis.yml
@@ -70,6 +70,6 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Check for failures
-        if: contains(needs.*.result, 'failure')
+        if: contains(needs.*.result, 'ERROR at')
         run: |
           echo "One of the dependent jobs have failed. You may need to re-run it." && exit 1

--- a/.github/workflows/test-integration-redis.yml
+++ b/.github/workflows/test-integration-redis.yml
@@ -29,6 +29,7 @@ jobs:
     timeout-minutes: 45
 
     strategy:
+      fail-fast: false
       matrix:
         python-version: ["2.7","3.7","3.8","3.9"]
         # python3.6 reached EOL and is no longer being supported on
@@ -68,17 +69,6 @@ jobs:
     if: always()
     runs-on: ubuntu-20.04
     steps:
-      - name: Print result
-        env:
-          RESULT: ${{ needs.test.result }}
-        run: |
-          echo "$RESULT"
-      - name: Print outcome
-        env:
-          RESULT: ${{ needs.test.outcome }}
-        run: |
-          echo "$RESULT"
-
       - name: Check for failures
         if: contains(needs.test.result, 'failure')
         run: |

--- a/.github/workflows/test-integration-redis.yml
+++ b/.github/workflows/test-integration-redis.yml
@@ -71,7 +71,7 @@ jobs:
     steps:
       - name: Print result
         env:
-          RESULT: ${{ needs.*.result }}
+          RESULT: ${{ needs.test.result }}
         run: |
           echo "$RESULT"
       - name: Print outcome

--- a/.github/workflows/test-integration-redis.yml
+++ b/.github/workflows/test-integration-redis.yml
@@ -45,9 +45,6 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Setup Test Env
-        env:
-          PGHOST: localhost
-          PGPASSWORD: sentry
         run: |
           pip install codecov tox
 

--- a/.github/workflows/test-integration-redis.yml
+++ b/.github/workflows/test-integration-redis.yml
@@ -46,7 +46,7 @@ jobs:
 
       - name: Setup Test Env
         run: |
-          pip install codecov tox
+          pip install codecov "tox>=3,<4"
 
       - name: Test redis
         env:

--- a/.github/workflows/test-integration-redis.yml
+++ b/.github/workflows/test-integration-redis.yml
@@ -27,7 +27,6 @@ jobs:
     name: redis, python ${{ matrix.python-version }}, ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     timeout-minutes: 45
-    continue-on-error: true
 
     strategy:
       matrix:
@@ -81,6 +80,6 @@ jobs:
           echo "$RESULT"
 
       - name: Check for failures
-        if: contains(needs.test.result, 'ERROR at')
+        if: contains(needs.test.result, 'failure')
         run: |
           echo "One of the dependent jobs have failed. You may need to re-run it." && exit 1

--- a/.github/workflows/test-integration-rediscluster.yml
+++ b/.github/workflows/test-integration-rediscluster.yml
@@ -32,7 +32,11 @@ jobs:
     strategy:
       matrix:
         python-version: ["2.7","3.7","3.8","3.9"]
-        os: [ubuntu-latest]
+        # python3.6 reached EOL and is no longer being supported on
+        # new versions of hosted runners on Github Actions
+        # ubuntu-20.04 is the last version that supported python3.6
+        # see https://github.com/actions/setup-python/issues/544#issuecomment-1332535877
+        os: [ubuntu-20.04]
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/test-integration-rediscluster.yml
+++ b/.github/workflows/test-integration-rediscluster.yml
@@ -69,6 +69,17 @@ jobs:
     if: always()
     runs-on: ubuntu-20.04
     steps:
+      - name: Print result
+        env:
+          RESULT: ${{ needs.*.result }}
+        run: |
+          echo "$RESULT"
+      - name: Print outcome
+        env:
+          RESULT: ${{ needs.*.outcome }}
+        run: |
+          echo "$RESULT"
+
       - name: Check for failures
         if: contains(needs.*.result, 'ERROR at')
         run: |

--- a/.github/workflows/test-integration-rediscluster.yml
+++ b/.github/workflows/test-integration-rediscluster.yml
@@ -46,7 +46,7 @@ jobs:
 
       - name: Setup Test Env
         run: |
-          pip install codecov tox
+          pip install codecov "tox>=3,<4"
 
       - name: Test rediscluster
         env:

--- a/.github/workflows/test-integration-rediscluster.yml
+++ b/.github/workflows/test-integration-rediscluster.yml
@@ -76,11 +76,11 @@ jobs:
           echo "$RESULT"
       - name: Print outcome
         env:
-          RESULT: ${{ needs.*.outcome }}
+          RESULT: ${{ needs.test.outcome }}
         run: |
           echo "$RESULT"
 
       - name: Check for failures
-        if: contains(needs.*.result, 'ERROR at')
+        if: contains(needs.test.result, 'ERROR at')
         run: |
           echo "One of the dependent jobs have failed. You may need to re-run it." && exit 1

--- a/.github/workflows/test-integration-rediscluster.yml
+++ b/.github/workflows/test-integration-rediscluster.yml
@@ -70,6 +70,6 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Check for failures
-        if: contains(needs.*.result, 'failure')
+        if: contains(needs.*.result, 'ERROR at')
         run: |
           echo "One of the dependent jobs have failed. You may need to re-run it." && exit 1

--- a/.github/workflows/test-integration-rediscluster.yml
+++ b/.github/workflows/test-integration-rediscluster.yml
@@ -29,6 +29,7 @@ jobs:
     timeout-minutes: 45
 
     strategy:
+      fail-fast: false
       matrix:
         python-version: ["2.7","3.7","3.8","3.9"]
         # python3.6 reached EOL and is no longer being supported on
@@ -68,17 +69,6 @@ jobs:
     if: always()
     runs-on: ubuntu-20.04
     steps:
-      - name: Print result
-        env:
-          RESULT: ${{ needs.test.result }}
-        run: |
-          echo "$RESULT"
-      - name: Print outcome
-        env:
-          RESULT: ${{ needs.test.outcome }}
-        run: |
-          echo "$RESULT"
-
       - name: Check for failures
         if: contains(needs.test.result, 'failure')
         run: |

--- a/.github/workflows/test-integration-rediscluster.yml
+++ b/.github/workflows/test-integration-rediscluster.yml
@@ -27,7 +27,6 @@ jobs:
     name: rediscluster, python ${{ matrix.python-version }}, ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     timeout-minutes: 45
-    continue-on-error: true
 
     strategy:
       matrix:
@@ -81,6 +80,6 @@ jobs:
           echo "$RESULT"
 
       - name: Check for failures
-        if: contains(needs.test.result, 'ERROR at')
+        if: contains(needs.test.result, 'failure')
         run: |
           echo "One of the dependent jobs have failed. You may need to re-run it." && exit 1

--- a/.github/workflows/test-integration-rediscluster.yml
+++ b/.github/workflows/test-integration-rediscluster.yml
@@ -61,3 +61,15 @@ jobs:
           coverage combine .coverage*
           coverage xml -i
           codecov --file coverage.xml
+
+  check_required_tests:
+    name: All rediscluster tests passed or skipped
+    needs: test
+    # Always run this, even if a dependent job failed
+    if: always()
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Check for failures
+        if: contains(needs.*.result, 'failure')
+        run: |
+          echo "One of the dependent jobs have failed. You may need to re-run it." && exit 1

--- a/.github/workflows/test-integration-rediscluster.yml
+++ b/.github/workflows/test-integration-rediscluster.yml
@@ -71,7 +71,7 @@ jobs:
     steps:
       - name: Print result
         env:
-          RESULT: ${{ needs.*.result }}
+          RESULT: ${{ needs.test.result }}
         run: |
           echo "$RESULT"
       - name: Print outcome

--- a/.github/workflows/test-integration-rediscluster.yml
+++ b/.github/workflows/test-integration-rediscluster.yml
@@ -45,9 +45,6 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Setup Test Env
-        env:
-          PGHOST: localhost
-          PGPASSWORD: sentry
         run: |
           pip install codecov tox
 

--- a/.github/workflows/test-integration-requests.yml
+++ b/.github/workflows/test-integration-requests.yml
@@ -69,6 +69,17 @@ jobs:
     if: always()
     runs-on: ubuntu-20.04
     steps:
+      - name: Print result
+        env:
+          RESULT: ${{ needs.*.result }}
+        run: |
+          echo "$RESULT"
+      - name: Print outcome
+        env:
+          RESULT: ${{ needs.*.outcome }}
+        run: |
+          echo "$RESULT"
+
       - name: Check for failures
         if: contains(needs.*.result, 'ERROR at')
         run: |

--- a/.github/workflows/test-integration-requests.yml
+++ b/.github/workflows/test-integration-requests.yml
@@ -27,7 +27,6 @@ jobs:
     name: requests, python ${{ matrix.python-version }}, ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     timeout-minutes: 45
-    continue-on-error: true
 
     strategy:
       matrix:
@@ -81,6 +80,6 @@ jobs:
           echo "$RESULT"
 
       - name: Check for failures
-        if: contains(needs.test.result, 'ERROR at')
+        if: contains(needs.test.result, 'failure')
         run: |
           echo "One of the dependent jobs have failed. You may need to re-run it." && exit 1

--- a/.github/workflows/test-integration-requests.yml
+++ b/.github/workflows/test-integration-requests.yml
@@ -76,11 +76,11 @@ jobs:
           echo "$RESULT"
       - name: Print outcome
         env:
-          RESULT: ${{ needs.*.outcome }}
+          RESULT: ${{ needs.test.outcome }}
         run: |
           echo "$RESULT"
 
       - name: Check for failures
-        if: contains(needs.*.result, 'ERROR at')
+        if: contains(needs.test.result, 'ERROR at')
         run: |
           echo "One of the dependent jobs have failed. You may need to re-run it." && exit 1

--- a/.github/workflows/test-integration-requests.yml
+++ b/.github/workflows/test-integration-requests.yml
@@ -70,6 +70,6 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Check for failures
-        if: contains(needs.*.result, 'failure')
+        if: contains(needs.*.result, 'ERROR at')
         run: |
           echo "One of the dependent jobs have failed. You may need to re-run it." && exit 1

--- a/.github/workflows/test-integration-requests.yml
+++ b/.github/workflows/test-integration-requests.yml
@@ -32,7 +32,11 @@ jobs:
     strategy:
       matrix:
         python-version: ["2.7","3.8","3.9"]
-        os: [ubuntu-latest]
+        # python3.6 reached EOL and is no longer being supported on
+        # new versions of hosted runners on Github Actions
+        # ubuntu-20.04 is the last version that supported python3.6
+        # see https://github.com/actions/setup-python/issues/544#issuecomment-1332535877
+        os: [ubuntu-20.04]
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/test-integration-requests.yml
+++ b/.github/workflows/test-integration-requests.yml
@@ -29,6 +29,7 @@ jobs:
     timeout-minutes: 45
 
     strategy:
+      fail-fast: false
       matrix:
         python-version: ["2.7","3.8","3.9"]
         # python3.6 reached EOL and is no longer being supported on
@@ -68,17 +69,6 @@ jobs:
     if: always()
     runs-on: ubuntu-20.04
     steps:
-      - name: Print result
-        env:
-          RESULT: ${{ needs.test.result }}
-        run: |
-          echo "$RESULT"
-      - name: Print outcome
-        env:
-          RESULT: ${{ needs.test.outcome }}
-        run: |
-          echo "$RESULT"
-
       - name: Check for failures
         if: contains(needs.test.result, 'failure')
         run: |

--- a/.github/workflows/test-integration-requests.yml
+++ b/.github/workflows/test-integration-requests.yml
@@ -71,7 +71,7 @@ jobs:
     steps:
       - name: Print result
         env:
-          RESULT: ${{ needs.*.result }}
+          RESULT: ${{ needs.test.result }}
         run: |
           echo "$RESULT"
       - name: Print outcome

--- a/.github/workflows/test-integration-requests.yml
+++ b/.github/workflows/test-integration-requests.yml
@@ -61,3 +61,15 @@ jobs:
           coverage combine .coverage*
           coverage xml -i
           codecov --file coverage.xml
+
+  check_required_tests:
+    name: All requests tests passed or skipped
+    needs: test
+    # Always run this, even if a dependent job failed
+    if: always()
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Check for failures
+        if: contains(needs.*.result, 'failure')
+        run: |
+          echo "One of the dependent jobs have failed. You may need to re-run it." && exit 1

--- a/.github/workflows/test-integration-requests.yml
+++ b/.github/workflows/test-integration-requests.yml
@@ -45,9 +45,6 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Setup Test Env
-        env:
-          PGHOST: localhost
-          PGPASSWORD: sentry
         run: |
           pip install codecov tox
 

--- a/.github/workflows/test-integration-requests.yml
+++ b/.github/workflows/test-integration-requests.yml
@@ -46,7 +46,7 @@ jobs:
 
       - name: Setup Test Env
         run: |
-          pip install codecov tox
+          pip install codecov "tox>=3,<4"
 
       - name: Test requests
         env:

--- a/.github/workflows/test-integration-rq.yml
+++ b/.github/workflows/test-integration-rq.yml
@@ -69,6 +69,17 @@ jobs:
     if: always()
     runs-on: ubuntu-20.04
     steps:
+      - name: Print result
+        env:
+          RESULT: ${{ needs.*.result }}
+        run: |
+          echo "$RESULT"
+      - name: Print outcome
+        env:
+          RESULT: ${{ needs.*.outcome }}
+        run: |
+          echo "$RESULT"
+
       - name: Check for failures
         if: contains(needs.*.result, 'ERROR at')
         run: |

--- a/.github/workflows/test-integration-rq.yml
+++ b/.github/workflows/test-integration-rq.yml
@@ -76,11 +76,11 @@ jobs:
           echo "$RESULT"
       - name: Print outcome
         env:
-          RESULT: ${{ needs.*.outcome }}
+          RESULT: ${{ needs.test.outcome }}
         run: |
           echo "$RESULT"
 
       - name: Check for failures
-        if: contains(needs.*.result, 'ERROR at')
+        if: contains(needs.test.result, 'ERROR at')
         run: |
           echo "One of the dependent jobs have failed. You may need to re-run it." && exit 1

--- a/.github/workflows/test-integration-rq.yml
+++ b/.github/workflows/test-integration-rq.yml
@@ -27,7 +27,6 @@ jobs:
     name: rq, python ${{ matrix.python-version }}, ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     timeout-minutes: 45
-    continue-on-error: true
 
     strategy:
       matrix:
@@ -81,6 +80,6 @@ jobs:
           echo "$RESULT"
 
       - name: Check for failures
-        if: contains(needs.test.result, 'ERROR at')
+        if: contains(needs.test.result, 'failure')
         run: |
           echo "One of the dependent jobs have failed. You may need to re-run it." && exit 1

--- a/.github/workflows/test-integration-rq.yml
+++ b/.github/workflows/test-integration-rq.yml
@@ -70,6 +70,6 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Check for failures
-        if: contains(needs.*.result, 'failure')
+        if: contains(needs.*.result, 'ERROR at')
         run: |
           echo "One of the dependent jobs have failed. You may need to re-run it." && exit 1

--- a/.github/workflows/test-integration-rq.yml
+++ b/.github/workflows/test-integration-rq.yml
@@ -46,7 +46,7 @@ jobs:
 
       - name: Setup Test Env
         run: |
-          pip install codecov tox
+          pip install codecov "tox>=3,<4"
 
       - name: Test rq
         env:

--- a/.github/workflows/test-integration-rq.yml
+++ b/.github/workflows/test-integration-rq.yml
@@ -71,7 +71,7 @@ jobs:
     steps:
       - name: Print result
         env:
-          RESULT: ${{ needs.*.result }}
+          RESULT: ${{ needs.test.result }}
         run: |
           echo "$RESULT"
       - name: Print outcome

--- a/.github/workflows/test-integration-rq.yml
+++ b/.github/workflows/test-integration-rq.yml
@@ -45,9 +45,6 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Setup Test Env
-        env:
-          PGHOST: localhost
-          PGPASSWORD: sentry
         run: |
           pip install codecov tox
 

--- a/.github/workflows/test-integration-rq.yml
+++ b/.github/workflows/test-integration-rq.yml
@@ -61,3 +61,15 @@ jobs:
           coverage combine .coverage*
           coverage xml -i
           codecov --file coverage.xml
+
+  check_required_tests:
+    name: All rq tests passed or skipped
+    needs: test
+    # Always run this, even if a dependent job failed
+    if: always()
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Check for failures
+        if: contains(needs.*.result, 'failure')
+        run: |
+          echo "One of the dependent jobs have failed. You may need to re-run it." && exit 1

--- a/.github/workflows/test-integration-rq.yml
+++ b/.github/workflows/test-integration-rq.yml
@@ -32,7 +32,11 @@ jobs:
     strategy:
       matrix:
         python-version: ["2.7","3.5","3.6","3.7","3.8","3.9","3.10"]
-        os: [ubuntu-latest]
+        # python3.6 reached EOL and is no longer being supported on
+        # new versions of hosted runners on Github Actions
+        # ubuntu-20.04 is the last version that supported python3.6
+        # see https://github.com/actions/setup-python/issues/544#issuecomment-1332535877
+        os: [ubuntu-20.04]
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/test-integration-rq.yml
+++ b/.github/workflows/test-integration-rq.yml
@@ -29,6 +29,7 @@ jobs:
     timeout-minutes: 45
 
     strategy:
+      fail-fast: false
       matrix:
         python-version: ["2.7","3.5","3.6","3.7","3.8","3.9","3.10"]
         # python3.6 reached EOL and is no longer being supported on
@@ -68,17 +69,6 @@ jobs:
     if: always()
     runs-on: ubuntu-20.04
     steps:
-      - name: Print result
-        env:
-          RESULT: ${{ needs.test.result }}
-        run: |
-          echo "$RESULT"
-      - name: Print outcome
-        env:
-          RESULT: ${{ needs.test.outcome }}
-        run: |
-          echo "$RESULT"
-
       - name: Check for failures
         if: contains(needs.test.result, 'failure')
         run: |

--- a/.github/workflows/test-integration-sanic.yml
+++ b/.github/workflows/test-integration-sanic.yml
@@ -69,6 +69,17 @@ jobs:
     if: always()
     runs-on: ubuntu-20.04
     steps:
+      - name: Print result
+        env:
+          RESULT: ${{ needs.*.result }}
+        run: |
+          echo "$RESULT"
+      - name: Print outcome
+        env:
+          RESULT: ${{ needs.*.outcome }}
+        run: |
+          echo "$RESULT"
+
       - name: Check for failures
         if: contains(needs.*.result, 'ERROR at')
         run: |

--- a/.github/workflows/test-integration-sanic.yml
+++ b/.github/workflows/test-integration-sanic.yml
@@ -46,7 +46,7 @@ jobs:
 
       - name: Setup Test Env
         run: |
-          pip install codecov tox
+          pip install codecov "tox>=3,<4"
 
       - name: Test sanic
         env:

--- a/.github/workflows/test-integration-sanic.yml
+++ b/.github/workflows/test-integration-sanic.yml
@@ -76,11 +76,11 @@ jobs:
           echo "$RESULT"
       - name: Print outcome
         env:
-          RESULT: ${{ needs.*.outcome }}
+          RESULT: ${{ needs.test.outcome }}
         run: |
           echo "$RESULT"
 
       - name: Check for failures
-        if: contains(needs.*.result, 'ERROR at')
+        if: contains(needs.test.result, 'ERROR at')
         run: |
           echo "One of the dependent jobs have failed. You may need to re-run it." && exit 1

--- a/.github/workflows/test-integration-sanic.yml
+++ b/.github/workflows/test-integration-sanic.yml
@@ -32,7 +32,11 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.5","3.6","3.7","3.8","3.9","3.10"]
-        os: [ubuntu-latest]
+        # python3.6 reached EOL and is no longer being supported on
+        # new versions of hosted runners on Github Actions
+        # ubuntu-20.04 is the last version that supported python3.6
+        # see https://github.com/actions/setup-python/issues/544#issuecomment-1332535877
+        os: [ubuntu-20.04]
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/test-integration-sanic.yml
+++ b/.github/workflows/test-integration-sanic.yml
@@ -70,6 +70,6 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Check for failures
-        if: contains(needs.*.result, 'failure')
+        if: contains(needs.*.result, 'ERROR at')
         run: |
           echo "One of the dependent jobs have failed. You may need to re-run it." && exit 1

--- a/.github/workflows/test-integration-sanic.yml
+++ b/.github/workflows/test-integration-sanic.yml
@@ -29,6 +29,7 @@ jobs:
     timeout-minutes: 45
 
     strategy:
+      fail-fast: false
       matrix:
         python-version: ["3.5","3.6","3.7","3.8","3.9","3.10"]
         # python3.6 reached EOL and is no longer being supported on
@@ -68,17 +69,6 @@ jobs:
     if: always()
     runs-on: ubuntu-20.04
     steps:
-      - name: Print result
-        env:
-          RESULT: ${{ needs.test.result }}
-        run: |
-          echo "$RESULT"
-      - name: Print outcome
-        env:
-          RESULT: ${{ needs.test.outcome }}
-        run: |
-          echo "$RESULT"
-
       - name: Check for failures
         if: contains(needs.test.result, 'failure')
         run: |

--- a/.github/workflows/test-integration-sanic.yml
+++ b/.github/workflows/test-integration-sanic.yml
@@ -71,7 +71,7 @@ jobs:
     steps:
       - name: Print result
         env:
-          RESULT: ${{ needs.*.result }}
+          RESULT: ${{ needs.test.result }}
         run: |
           echo "$RESULT"
       - name: Print outcome

--- a/.github/workflows/test-integration-sanic.yml
+++ b/.github/workflows/test-integration-sanic.yml
@@ -45,9 +45,6 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Setup Test Env
-        env:
-          PGHOST: localhost
-          PGPASSWORD: sentry
         run: |
           pip install codecov tox
 

--- a/.github/workflows/test-integration-sanic.yml
+++ b/.github/workflows/test-integration-sanic.yml
@@ -27,7 +27,6 @@ jobs:
     name: sanic, python ${{ matrix.python-version }}, ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     timeout-minutes: 45
-    continue-on-error: true
 
     strategy:
       matrix:
@@ -81,6 +80,6 @@ jobs:
           echo "$RESULT"
 
       - name: Check for failures
-        if: contains(needs.test.result, 'ERROR at')
+        if: contains(needs.test.result, 'failure')
         run: |
           echo "One of the dependent jobs have failed. You may need to re-run it." && exit 1

--- a/.github/workflows/test-integration-sanic.yml
+++ b/.github/workflows/test-integration-sanic.yml
@@ -61,3 +61,15 @@ jobs:
           coverage combine .coverage*
           coverage xml -i
           codecov --file coverage.xml
+
+  check_required_tests:
+    name: All sanic tests passed or skipped
+    needs: test
+    # Always run this, even if a dependent job failed
+    if: always()
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Check for failures
+        if: contains(needs.*.result, 'failure')
+        run: |
+          echo "One of the dependent jobs have failed. You may need to re-run it." && exit 1

--- a/.github/workflows/test-integration-sqlalchemy.yml
+++ b/.github/workflows/test-integration-sqlalchemy.yml
@@ -69,6 +69,17 @@ jobs:
     if: always()
     runs-on: ubuntu-20.04
     steps:
+      - name: Print result
+        env:
+          RESULT: ${{ needs.*.result }}
+        run: |
+          echo "$RESULT"
+      - name: Print outcome
+        env:
+          RESULT: ${{ needs.*.outcome }}
+        run: |
+          echo "$RESULT"
+
       - name: Check for failures
         if: contains(needs.*.result, 'ERROR at')
         run: |

--- a/.github/workflows/test-integration-sqlalchemy.yml
+++ b/.github/workflows/test-integration-sqlalchemy.yml
@@ -76,11 +76,11 @@ jobs:
           echo "$RESULT"
       - name: Print outcome
         env:
-          RESULT: ${{ needs.*.outcome }}
+          RESULT: ${{ needs.test.outcome }}
         run: |
           echo "$RESULT"
 
       - name: Check for failures
-        if: contains(needs.*.result, 'ERROR at')
+        if: contains(needs.test.result, 'ERROR at')
         run: |
           echo "One of the dependent jobs have failed. You may need to re-run it." && exit 1

--- a/.github/workflows/test-integration-sqlalchemy.yml
+++ b/.github/workflows/test-integration-sqlalchemy.yml
@@ -70,6 +70,6 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Check for failures
-        if: contains(needs.*.result, 'failure')
+        if: contains(needs.*.result, 'ERROR at')
         run: |
           echo "One of the dependent jobs have failed. You may need to re-run it." && exit 1

--- a/.github/workflows/test-integration-sqlalchemy.yml
+++ b/.github/workflows/test-integration-sqlalchemy.yml
@@ -61,3 +61,15 @@ jobs:
           coverage combine .coverage*
           coverage xml -i
           codecov --file coverage.xml
+
+  check_required_tests:
+    name: All sqlalchemy tests passed or skipped
+    needs: test
+    # Always run this, even if a dependent job failed
+    if: always()
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Check for failures
+        if: contains(needs.*.result, 'failure')
+        run: |
+          echo "One of the dependent jobs have failed. You may need to re-run it." && exit 1

--- a/.github/workflows/test-integration-sqlalchemy.yml
+++ b/.github/workflows/test-integration-sqlalchemy.yml
@@ -29,6 +29,7 @@ jobs:
     timeout-minutes: 45
 
     strategy:
+      fail-fast: false
       matrix:
         python-version: ["2.7","3.7","3.8","3.9","3.10"]
         # python3.6 reached EOL and is no longer being supported on
@@ -68,17 +69,6 @@ jobs:
     if: always()
     runs-on: ubuntu-20.04
     steps:
-      - name: Print result
-        env:
-          RESULT: ${{ needs.test.result }}
-        run: |
-          echo "$RESULT"
-      - name: Print outcome
-        env:
-          RESULT: ${{ needs.test.outcome }}
-        run: |
-          echo "$RESULT"
-
       - name: Check for failures
         if: contains(needs.test.result, 'failure')
         run: |

--- a/.github/workflows/test-integration-sqlalchemy.yml
+++ b/.github/workflows/test-integration-sqlalchemy.yml
@@ -46,7 +46,7 @@ jobs:
 
       - name: Setup Test Env
         run: |
-          pip install codecov tox
+          pip install codecov "tox>=3,<4"
 
       - name: Test sqlalchemy
         env:

--- a/.github/workflows/test-integration-sqlalchemy.yml
+++ b/.github/workflows/test-integration-sqlalchemy.yml
@@ -71,7 +71,7 @@ jobs:
     steps:
       - name: Print result
         env:
-          RESULT: ${{ needs.*.result }}
+          RESULT: ${{ needs.test.result }}
         run: |
           echo "$RESULT"
       - name: Print outcome

--- a/.github/workflows/test-integration-sqlalchemy.yml
+++ b/.github/workflows/test-integration-sqlalchemy.yml
@@ -45,9 +45,6 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Setup Test Env
-        env:
-          PGHOST: localhost
-          PGPASSWORD: sentry
         run: |
           pip install codecov tox
 

--- a/.github/workflows/test-integration-sqlalchemy.yml
+++ b/.github/workflows/test-integration-sqlalchemy.yml
@@ -32,7 +32,11 @@ jobs:
     strategy:
       matrix:
         python-version: ["2.7","3.7","3.8","3.9","3.10"]
-        os: [ubuntu-latest]
+        # python3.6 reached EOL and is no longer being supported on
+        # new versions of hosted runners on Github Actions
+        # ubuntu-20.04 is the last version that supported python3.6
+        # see https://github.com/actions/setup-python/issues/544#issuecomment-1332535877
+        os: [ubuntu-20.04]
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/test-integration-sqlalchemy.yml
+++ b/.github/workflows/test-integration-sqlalchemy.yml
@@ -27,7 +27,6 @@ jobs:
     name: sqlalchemy, python ${{ matrix.python-version }}, ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     timeout-minutes: 45
-    continue-on-error: true
 
     strategy:
       matrix:
@@ -81,6 +80,6 @@ jobs:
           echo "$RESULT"
 
       - name: Check for failures
-        if: contains(needs.test.result, 'ERROR at')
+        if: contains(needs.test.result, 'failure')
         run: |
           echo "One of the dependent jobs have failed. You may need to re-run it." && exit 1

--- a/.github/workflows/test-integration-starlette.yml
+++ b/.github/workflows/test-integration-starlette.yml
@@ -69,6 +69,17 @@ jobs:
     if: always()
     runs-on: ubuntu-20.04
     steps:
+      - name: Print result
+        env:
+          RESULT: ${{ needs.*.result }}
+        run: |
+          echo "$RESULT"
+      - name: Print outcome
+        env:
+          RESULT: ${{ needs.*.outcome }}
+        run: |
+          echo "$RESULT"
+
       - name: Check for failures
         if: contains(needs.*.result, 'ERROR at')
         run: |

--- a/.github/workflows/test-integration-starlette.yml
+++ b/.github/workflows/test-integration-starlette.yml
@@ -76,11 +76,11 @@ jobs:
           echo "$RESULT"
       - name: Print outcome
         env:
-          RESULT: ${{ needs.*.outcome }}
+          RESULT: ${{ needs.test.outcome }}
         run: |
           echo "$RESULT"
 
       - name: Check for failures
-        if: contains(needs.*.result, 'ERROR at')
+        if: contains(needs.test.result, 'ERROR at')
         run: |
           echo "One of the dependent jobs have failed. You may need to re-run it." && exit 1

--- a/.github/workflows/test-integration-starlette.yml
+++ b/.github/workflows/test-integration-starlette.yml
@@ -27,7 +27,6 @@ jobs:
     name: starlette, python ${{ matrix.python-version }}, ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     timeout-minutes: 45
-    continue-on-error: true
 
     strategy:
       matrix:
@@ -81,6 +80,6 @@ jobs:
           echo "$RESULT"
 
       - name: Check for failures
-        if: contains(needs.test.result, 'ERROR at')
+        if: contains(needs.test.result, 'failure')
         run: |
           echo "One of the dependent jobs have failed. You may need to re-run it." && exit 1

--- a/.github/workflows/test-integration-starlette.yml
+++ b/.github/workflows/test-integration-starlette.yml
@@ -70,6 +70,6 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Check for failures
-        if: contains(needs.*.result, 'failure')
+        if: contains(needs.*.result, 'ERROR at')
         run: |
           echo "One of the dependent jobs have failed. You may need to re-run it." && exit 1

--- a/.github/workflows/test-integration-starlette.yml
+++ b/.github/workflows/test-integration-starlette.yml
@@ -29,6 +29,7 @@ jobs:
     timeout-minutes: 45
 
     strategy:
+      fail-fast: false
       matrix:
         python-version: ["3.7","3.8","3.9","3.10"]
         # python3.6 reached EOL and is no longer being supported on
@@ -68,17 +69,6 @@ jobs:
     if: always()
     runs-on: ubuntu-20.04
     steps:
-      - name: Print result
-        env:
-          RESULT: ${{ needs.test.result }}
-        run: |
-          echo "$RESULT"
-      - name: Print outcome
-        env:
-          RESULT: ${{ needs.test.outcome }}
-        run: |
-          echo "$RESULT"
-
       - name: Check for failures
         if: contains(needs.test.result, 'failure')
         run: |

--- a/.github/workflows/test-integration-starlette.yml
+++ b/.github/workflows/test-integration-starlette.yml
@@ -46,7 +46,7 @@ jobs:
 
       - name: Setup Test Env
         run: |
-          pip install codecov tox
+          pip install codecov "tox>=3,<4"
 
       - name: Test starlette
         env:

--- a/.github/workflows/test-integration-starlette.yml
+++ b/.github/workflows/test-integration-starlette.yml
@@ -71,7 +71,7 @@ jobs:
     steps:
       - name: Print result
         env:
-          RESULT: ${{ needs.*.result }}
+          RESULT: ${{ needs.test.result }}
         run: |
           echo "$RESULT"
       - name: Print outcome

--- a/.github/workflows/test-integration-starlette.yml
+++ b/.github/workflows/test-integration-starlette.yml
@@ -45,9 +45,6 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Setup Test Env
-        env:
-          PGHOST: localhost
-          PGPASSWORD: sentry
         run: |
           pip install codecov tox
 

--- a/.github/workflows/test-integration-starlette.yml
+++ b/.github/workflows/test-integration-starlette.yml
@@ -32,7 +32,11 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.7","3.8","3.9","3.10"]
-        os: [ubuntu-latest]
+        # python3.6 reached EOL and is no longer being supported on
+        # new versions of hosted runners on Github Actions
+        # ubuntu-20.04 is the last version that supported python3.6
+        # see https://github.com/actions/setup-python/issues/544#issuecomment-1332535877
+        os: [ubuntu-20.04]
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/test-integration-starlette.yml
+++ b/.github/workflows/test-integration-starlette.yml
@@ -61,3 +61,15 @@ jobs:
           coverage combine .coverage*
           coverage xml -i
           codecov --file coverage.xml
+
+  check_required_tests:
+    name: All starlette tests passed or skipped
+    needs: test
+    # Always run this, even if a dependent job failed
+    if: always()
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Check for failures
+        if: contains(needs.*.result, 'failure')
+        run: |
+          echo "One of the dependent jobs have failed. You may need to re-run it." && exit 1

--- a/.github/workflows/test-integration-tornado.yml
+++ b/.github/workflows/test-integration-tornado.yml
@@ -61,3 +61,15 @@ jobs:
           coverage combine .coverage*
           coverage xml -i
           codecov --file coverage.xml
+
+  check_required_tests:
+    name: All tornado tests passed or skipped
+    needs: test
+    # Always run this, even if a dependent job failed
+    if: always()
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Check for failures
+        if: contains(needs.*.result, 'failure')
+        run: |
+          echo "One of the dependent jobs have failed. You may need to re-run it." && exit 1

--- a/.github/workflows/test-integration-tornado.yml
+++ b/.github/workflows/test-integration-tornado.yml
@@ -69,6 +69,17 @@ jobs:
     if: always()
     runs-on: ubuntu-20.04
     steps:
+      - name: Print result
+        env:
+          RESULT: ${{ needs.*.result }}
+        run: |
+          echo "$RESULT"
+      - name: Print outcome
+        env:
+          RESULT: ${{ needs.*.outcome }}
+        run: |
+          echo "$RESULT"
+
       - name: Check for failures
         if: contains(needs.*.result, 'ERROR at')
         run: |

--- a/.github/workflows/test-integration-tornado.yml
+++ b/.github/workflows/test-integration-tornado.yml
@@ -46,7 +46,7 @@ jobs:
 
       - name: Setup Test Env
         run: |
-          pip install codecov tox
+          pip install codecov "tox>=3,<4"
 
       - name: Test tornado
         env:

--- a/.github/workflows/test-integration-tornado.yml
+++ b/.github/workflows/test-integration-tornado.yml
@@ -76,11 +76,11 @@ jobs:
           echo "$RESULT"
       - name: Print outcome
         env:
-          RESULT: ${{ needs.*.outcome }}
+          RESULT: ${{ needs.test.outcome }}
         run: |
           echo "$RESULT"
 
       - name: Check for failures
-        if: contains(needs.*.result, 'ERROR at')
+        if: contains(needs.test.result, 'ERROR at')
         run: |
           echo "One of the dependent jobs have failed. You may need to re-run it." && exit 1

--- a/.github/workflows/test-integration-tornado.yml
+++ b/.github/workflows/test-integration-tornado.yml
@@ -70,6 +70,6 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Check for failures
-        if: contains(needs.*.result, 'failure')
+        if: contains(needs.*.result, 'ERROR at')
         run: |
           echo "One of the dependent jobs have failed. You may need to re-run it." && exit 1

--- a/.github/workflows/test-integration-tornado.yml
+++ b/.github/workflows/test-integration-tornado.yml
@@ -29,6 +29,7 @@ jobs:
     timeout-minutes: 45
 
     strategy:
+      fail-fast: false
       matrix:
         python-version: ["3.7","3.8","3.9","3.10"]
         # python3.6 reached EOL and is no longer being supported on
@@ -68,17 +69,6 @@ jobs:
     if: always()
     runs-on: ubuntu-20.04
     steps:
-      - name: Print result
-        env:
-          RESULT: ${{ needs.test.result }}
-        run: |
-          echo "$RESULT"
-      - name: Print outcome
-        env:
-          RESULT: ${{ needs.test.outcome }}
-        run: |
-          echo "$RESULT"
-
       - name: Check for failures
         if: contains(needs.test.result, 'failure')
         run: |

--- a/.github/workflows/test-integration-tornado.yml
+++ b/.github/workflows/test-integration-tornado.yml
@@ -71,7 +71,7 @@ jobs:
     steps:
       - name: Print result
         env:
-          RESULT: ${{ needs.*.result }}
+          RESULT: ${{ needs.test.result }}
         run: |
           echo "$RESULT"
       - name: Print outcome

--- a/.github/workflows/test-integration-tornado.yml
+++ b/.github/workflows/test-integration-tornado.yml
@@ -45,9 +45,6 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Setup Test Env
-        env:
-          PGHOST: localhost
-          PGPASSWORD: sentry
         run: |
           pip install codecov tox
 

--- a/.github/workflows/test-integration-tornado.yml
+++ b/.github/workflows/test-integration-tornado.yml
@@ -32,7 +32,11 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.7","3.8","3.9","3.10"]
-        os: [ubuntu-latest]
+        # python3.6 reached EOL and is no longer being supported on
+        # new versions of hosted runners on Github Actions
+        # ubuntu-20.04 is the last version that supported python3.6
+        # see https://github.com/actions/setup-python/issues/544#issuecomment-1332535877
+        os: [ubuntu-20.04]
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/test-integration-tornado.yml
+++ b/.github/workflows/test-integration-tornado.yml
@@ -27,7 +27,6 @@ jobs:
     name: tornado, python ${{ matrix.python-version }}, ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     timeout-minutes: 45
-    continue-on-error: true
 
     strategy:
       matrix:
@@ -81,6 +80,6 @@ jobs:
           echo "$RESULT"
 
       - name: Check for failures
-        if: contains(needs.test.result, 'ERROR at')
+        if: contains(needs.test.result, 'failure')
         run: |
           echo "One of the dependent jobs have failed. You may need to re-run it." && exit 1

--- a/.github/workflows/test-integration-trytond.yml
+++ b/.github/workflows/test-integration-trytond.yml
@@ -69,6 +69,17 @@ jobs:
     if: always()
     runs-on: ubuntu-20.04
     steps:
+      - name: Print result
+        env:
+          RESULT: ${{ needs.*.result }}
+        run: |
+          echo "$RESULT"
+      - name: Print outcome
+        env:
+          RESULT: ${{ needs.*.outcome }}
+        run: |
+          echo "$RESULT"
+
       - name: Check for failures
         if: contains(needs.*.result, 'ERROR at')
         run: |

--- a/.github/workflows/test-integration-trytond.yml
+++ b/.github/workflows/test-integration-trytond.yml
@@ -76,11 +76,11 @@ jobs:
           echo "$RESULT"
       - name: Print outcome
         env:
-          RESULT: ${{ needs.*.outcome }}
+          RESULT: ${{ needs.test.outcome }}
         run: |
           echo "$RESULT"
 
       - name: Check for failures
-        if: contains(needs.*.result, 'ERROR at')
+        if: contains(needs.test.result, 'ERROR at')
         run: |
           echo "One of the dependent jobs have failed. You may need to re-run it." && exit 1

--- a/.github/workflows/test-integration-trytond.yml
+++ b/.github/workflows/test-integration-trytond.yml
@@ -32,7 +32,11 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.5","3.6","3.7","3.8","3.9","3.10"]
-        os: [ubuntu-latest]
+        # python3.6 reached EOL and is no longer being supported on
+        # new versions of hosted runners on Github Actions
+        # ubuntu-20.04 is the last version that supported python3.6
+        # see https://github.com/actions/setup-python/issues/544#issuecomment-1332535877
+        os: [ubuntu-20.04]
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/test-integration-trytond.yml
+++ b/.github/workflows/test-integration-trytond.yml
@@ -70,6 +70,6 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Check for failures
-        if: contains(needs.*.result, 'failure')
+        if: contains(needs.*.result, 'ERROR at')
         run: |
           echo "One of the dependent jobs have failed. You may need to re-run it." && exit 1

--- a/.github/workflows/test-integration-trytond.yml
+++ b/.github/workflows/test-integration-trytond.yml
@@ -29,6 +29,7 @@ jobs:
     timeout-minutes: 45
 
     strategy:
+      fail-fast: false
       matrix:
         python-version: ["3.5","3.6","3.7","3.8","3.9","3.10"]
         # python3.6 reached EOL and is no longer being supported on
@@ -68,17 +69,6 @@ jobs:
     if: always()
     runs-on: ubuntu-20.04
     steps:
-      - name: Print result
-        env:
-          RESULT: ${{ needs.test.result }}
-        run: |
-          echo "$RESULT"
-      - name: Print outcome
-        env:
-          RESULT: ${{ needs.test.outcome }}
-        run: |
-          echo "$RESULT"
-
       - name: Check for failures
         if: contains(needs.test.result, 'failure')
         run: |

--- a/.github/workflows/test-integration-trytond.yml
+++ b/.github/workflows/test-integration-trytond.yml
@@ -71,7 +71,7 @@ jobs:
     steps:
       - name: Print result
         env:
-          RESULT: ${{ needs.*.result }}
+          RESULT: ${{ needs.test.result }}
         run: |
           echo "$RESULT"
       - name: Print outcome

--- a/.github/workflows/test-integration-trytond.yml
+++ b/.github/workflows/test-integration-trytond.yml
@@ -45,9 +45,6 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Setup Test Env
-        env:
-          PGHOST: localhost
-          PGPASSWORD: sentry
         run: |
           pip install codecov tox
 

--- a/.github/workflows/test-integration-trytond.yml
+++ b/.github/workflows/test-integration-trytond.yml
@@ -27,7 +27,6 @@ jobs:
     name: trytond, python ${{ matrix.python-version }}, ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     timeout-minutes: 45
-    continue-on-error: true
 
     strategy:
       matrix:
@@ -81,6 +80,6 @@ jobs:
           echo "$RESULT"
 
       - name: Check for failures
-        if: contains(needs.test.result, 'ERROR at')
+        if: contains(needs.test.result, 'failure')
         run: |
           echo "One of the dependent jobs have failed. You may need to re-run it." && exit 1

--- a/.github/workflows/test-integration-trytond.yml
+++ b/.github/workflows/test-integration-trytond.yml
@@ -61,3 +61,15 @@ jobs:
           coverage combine .coverage*
           coverage xml -i
           codecov --file coverage.xml
+
+  check_required_tests:
+    name: All trytond tests passed or skipped
+    needs: test
+    # Always run this, even if a dependent job failed
+    if: always()
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Check for failures
+        if: contains(needs.*.result, 'failure')
+        run: |
+          echo "One of the dependent jobs have failed. You may need to re-run it." && exit 1

--- a/.github/workflows/test-integration-trytond.yml
+++ b/.github/workflows/test-integration-trytond.yml
@@ -46,7 +46,7 @@ jobs:
 
       - name: Setup Test Env
         run: |
-          pip install codecov tox
+          pip install codecov "tox>=3,<4"
 
       - name: Test trytond
         env:

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,6 +1,6 @@
 [pytest]
 DJANGO_SETTINGS_MODULE = tests.integrations.django.myapp.settings
-addopts = --tb=short --reuse-db --create-db
+addopts = --tb=short
 markers =
     tests_internal_exceptions: Handle internal exceptions just as the SDK does, to test it. (Otherwise internal exceptions are recorded and reraised.)
     only: A temporary marker, to make pytest only run the tests with the mark, similar to jests `it.only`. To use, run `pytest -v -m only`.

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,6 +1,6 @@
 [pytest]
 DJANGO_SETTINGS_MODULE = tests.integrations.django.myapp.settings
-addopts = --tb=short
+addopts = --tb=short --reuse-db --create-db
 markers =
     tests_internal_exceptions: Handle internal exceptions just as the SDK does, to test it. (Otherwise internal exceptions are recorded and reraised.)
     only: A temporary marker, to make pytest only run the tests with the mark, similar to jests `it.only`. To use, run `pytest -v -m only`.

--- a/scripts/split-tox-gh-actions/ci-yaml.txt
+++ b/scripts/split-tox-gh-actions/ci-yaml.txt
@@ -64,7 +64,7 @@ jobs:
     steps:
       - name: Print result
         env:
-          RESULT: ${{ needs.*.result }}
+          RESULT: ${{ needs.test.result }}
         run: |
           echo "$RESULT"
       - name: Print outcome

--- a/scripts/split-tox-gh-actions/ci-yaml.txt
+++ b/scripts/split-tox-gh-actions/ci-yaml.txt
@@ -54,3 +54,15 @@ jobs:
           coverage combine .coverage*
           coverage xml -i
           codecov --file coverage.xml
+
+  check_required_tests:
+    name: All required tests passed or skipped
+    needs: test
+    # Always run this, even if a dependent job failed
+    if: always()
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Check for failures
+        if: contains(needs.*.result, 'failure')
+        run: |
+          echo "One of the dependent jobs have failed. You may need to re-run it." && exit 1

--- a/scripts/split-tox-gh-actions/ci-yaml.txt
+++ b/scripts/split-tox-gh-actions/ci-yaml.txt
@@ -38,9 +38,6 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Setup Test Env
-        env:
-          PGHOST: localhost
-          PGPASSWORD: sentry
         run: |
           pip install codecov tox
 

--- a/scripts/split-tox-gh-actions/ci-yaml.txt
+++ b/scripts/split-tox-gh-actions/ci-yaml.txt
@@ -56,7 +56,7 @@ jobs:
           codecov --file coverage.xml
 
   check_required_tests:
-    name: All required tests passed or skipped
+    name: All {{ framework }} tests passed or skipped
     needs: test
     # Always run this, even if a dependent job failed
     if: always()

--- a/scripts/split-tox-gh-actions/ci-yaml.txt
+++ b/scripts/split-tox-gh-actions/ci-yaml.txt
@@ -69,11 +69,11 @@ jobs:
           echo "$RESULT"
       - name: Print outcome
         env:
-          RESULT: ${{ needs.*.outcome }}
+          RESULT: ${{ needs.test.outcome }}
         run: |
           echo "$RESULT"
 
       - name: Check for failures
-        if: contains(needs.*.result, 'ERROR at')
+        if: contains(needs.test.result, 'ERROR at')
         run: |
           echo "One of the dependent jobs have failed. You may need to re-run it." && exit 1

--- a/scripts/split-tox-gh-actions/ci-yaml.txt
+++ b/scripts/split-tox-gh-actions/ci-yaml.txt
@@ -62,6 +62,17 @@ jobs:
     if: always()
     runs-on: ubuntu-20.04
     steps:
+      - name: Print result
+        env:
+          RESULT: ${{ needs.*.result }}
+        run: |
+          echo "$RESULT"
+      - name: Print outcome
+        env:
+          RESULT: ${{ needs.*.outcome }}
+        run: |
+          echo "$RESULT"
+
       - name: Check for failures
         if: contains(needs.*.result, 'ERROR at')
         run: |

--- a/scripts/split-tox-gh-actions/ci-yaml.txt
+++ b/scripts/split-tox-gh-actions/ci-yaml.txt
@@ -38,7 +38,7 @@ jobs:
 
       - name: Setup Test Env
         run: |
-          pip install codecov tox
+          pip install codecov "tox>=3,<4"
 
       - name: Test {{ framework }}
         env:

--- a/scripts/split-tox-gh-actions/ci-yaml.txt
+++ b/scripts/split-tox-gh-actions/ci-yaml.txt
@@ -45,7 +45,6 @@ jobs:
           CI_PYTHON_VERSION: ${{ matrix.python-version }}
         timeout-minutes: 45
         shell: bash
-        continue-on-error: true
         run: |
           set -x # print commands that are executed
           coverage erase
@@ -74,6 +73,6 @@ jobs:
           echo "$RESULT"
 
       - name: Check for failures
-        if: contains(needs.test.result, 'ERROR at')
+        if: contains(needs.test.result, 'failure')
         run: |
           echo "One of the dependent jobs have failed. You may need to re-run it." && exit 1

--- a/scripts/split-tox-gh-actions/ci-yaml.txt
+++ b/scripts/split-tox-gh-actions/ci-yaml.txt
@@ -63,6 +63,6 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Check for failures
-        if: contains(needs.*.result, 'failure')
+        if: contains(needs.*.result, 'ERROR at')
         run: |
           echo "One of the dependent jobs have failed. You may need to re-run it." && exit 1

--- a/scripts/split-tox-gh-actions/ci-yaml.txt
+++ b/scripts/split-tox-gh-actions/ci-yaml.txt
@@ -61,17 +61,6 @@ jobs:
     if: always()
     runs-on: ubuntu-20.04
     steps:
-      - name: Print result
-        env:
-          RESULT: ${{ needs.test.result }}
-        run: |
-          echo "$RESULT"
-      - name: Print outcome
-        env:
-          RESULT: ${{ needs.test.outcome }}
-        run: |
-          echo "$RESULT"
-
       - name: Check for failures
         if: contains(needs.test.result, 'failure')
         run: |

--- a/scripts/split-tox-gh-actions/ci-yaml.txt
+++ b/scripts/split-tox-gh-actions/ci-yaml.txt
@@ -27,7 +27,6 @@ jobs:
     name: {{ framework }}, python ${{ matrix.python-version }}, ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     timeout-minutes: 45
-    continue-on-error: true
 {{ strategy_matrix }}
 {{ services }}
 
@@ -46,6 +45,7 @@ jobs:
           CI_PYTHON_VERSION: ${{ matrix.python-version }}
         timeout-minutes: 45
         shell: bash
+        continue-on-error: true
         run: |
           set -x # print commands that are executed
           coverage erase

--- a/scripts/split-tox-gh-actions/split-tox-gh-actions.py
+++ b/scripts/split-tox-gh-actions/split-tox-gh-actions.py
@@ -32,6 +32,7 @@ FRAMEWORKS_NEEDING_POSTGRES = ["django"]
 
 MATRIX_DEFINITION = """
     strategy:
+      fail-fast: false
       matrix:
         python-version: [{{ python-version }}]
         # python3.6 reached EOL and is no longer being supported on
@@ -81,7 +82,7 @@ def get_yaml_files_hash():
     """Calculate a hash of all the yaml configuration files"""
 
     hasher = hashlib.md5()
-    path_pattern = (OUT_DIR / f"test-integration-*.yml").as_posix()
+    path_pattern = (OUT_DIR / "test-integration-*.yml").as_posix()
     for file in glob(path_pattern):
         with open(file, "rb") as f:
             buf = f.read()
@@ -131,7 +132,7 @@ def main(fail_on_changes):
                 if python_version not in python_versions[framework]:
                     python_versions[framework].append(python_version)
 
-        except ValueError as err:
+        except ValueError:
             print(f"ERROR reading line {line}")
 
     for framework in python_versions:

--- a/scripts/split-tox-gh-actions/split-tox-gh-actions.py
+++ b/scripts/split-tox-gh-actions/split-tox-gh-actions.py
@@ -34,7 +34,11 @@ MATRIX_DEFINITION = """
     strategy:
       matrix:
         python-version: [{{ python-version }}]
-        os: [ubuntu-latest]
+        # python3.6 reached EOL and is no longer being supported on
+        # new versions of hosted runners on Github Actions
+        # ubuntu-20.04 is the last version that supported python3.6
+        # see https://github.com/actions/setup-python/issues/544#issuecomment-1332535877
+        os: [ubuntu-20.04]
 """
 
 

--- a/tests/integrations/django/test_basic.py
+++ b/tests/integrations/django/test_basic.py
@@ -404,7 +404,7 @@ def test_sql_psycopg2_placeholders(sentry_init, capture_events):
 
 
 @pytest.mark.forked
-@pytest_mark_django_db_decorator()
+@pytest_mark_django_db_decorator(transaction=True)
 def test_django_connect_trace(sentry_init, client, capture_events, render_span_tree):
     """
     Verify we record a span when opening a new database.
@@ -432,7 +432,7 @@ def test_django_connect_trace(sentry_init, client, capture_events, render_span_t
 
 
 @pytest.mark.forked
-@pytest_mark_django_db_decorator()
+@pytest_mark_django_db_decorator(transaction=True)
 def test_django_connect_breadcrumbs(
     sentry_init, client, capture_events, render_span_tree
 ):

--- a/tests/integrations/django/test_basic.py
+++ b/tests/integrations/django/test_basic.py
@@ -404,7 +404,7 @@ def test_sql_psycopg2_placeholders(sentry_init, capture_events):
 
 
 @pytest.mark.forked
-@pytest_mark_django_db_decorator(transaction=True)
+@pytest_mark_django_db_decorator()
 def test_django_connect_trace(sentry_init, client, capture_events, render_span_tree):
     """
     Verify we record a span when opening a new database.
@@ -432,7 +432,7 @@ def test_django_connect_trace(sentry_init, client, capture_events, render_span_t
 
 
 @pytest.mark.forked
-@pytest_mark_django_db_decorator(transaction=True)
+@pytest_mark_django_db_decorator()
 def test_django_connect_breadcrumbs(
     sentry_init, client, capture_events, render_span_tree
 ):

--- a/tox.ini
+++ b/tox.ini
@@ -9,97 +9,97 @@ envlist =
     py{2.7,3.4,3.5,3.6,3.7,3.8,3.9,3.10}
 
     # === Integrations ===
-    # General format is {pythonversion}-{integrationname}-{frameworkversion}
+    # General format is {pythonversion}-{integrationname}-v{frameworkversion}
     # 1 blank line between different integrations
     # Each framework version should only be mentioned once. I.e:
-    #   {py3.7,py3.10}-django-{3.2}
-    #   {py3.10}-django-{4.0}
+    #   {py3.7,py3.10}-django-v{3.2}
+    #   {py3.10}-django-v{4.0}
     # instead of:
-    #   {py3.7}-django-{3.2}
-    #   {py3.7,py3.10}-django-{3.2,4.0}
+    #   {py3.7}-django-v{3.2}
+    #   {py3.7,py3.10}-django-v{3.2,4.0}
 
     # Django 1.x
-    {py2.7,py3.5}-django-{1.8,1.9,1.10}
-    {py2.7,py3.5,py3.6,py3.7}-django-{1.11}
+    {py2.7,py3.5}-django-v{1.8,1.9,1.10}
+    {py2.7,py3.5,py3.6,py3.7}-django-v{1.11}
     # Django 2.x
-    {py3.5,py3.6,py3.7}-django-{2.0,2.1}
-    {py3.5,py3.6,py3.7,py3.8,py3.9}-django-{2.2}
+    {py3.5,py3.6,py3.7}-django-v{2.0,2.1}
+    {py3.5,py3.6,py3.7,py3.8,py3.9}-django-v{2.2}
     # Django 3.x
-    {py3.6,py3.7,py3.8,py3.9}-django-{3.0,3.1}
-    {py3.6,py3.7,py3.8,py3.9,py3.10}-django-{3.2}
+    {py3.6,py3.7,py3.8,py3.9}-django-v{3.0,3.1}
+    {py3.6,py3.7,py3.8,py3.9,py3.10}-django-v{3.2}
     # Django 4.x
-    {py3.8,py3.9,py3.10}-django-{4.0,4.1}
+    {py3.8,py3.9,py3.10}-django-v{4.0,4.1}
 
-    {py2.7,py3.5,py3.6,py3.7,py3.8,py3.9}-flask-{0.11,0.12,1.0}
-    {py2.7,py3.5,py3.6,py3.7,py3.8,py3.9,py3.10}-flask-1.1
-    {py3.6,py3.8,py3.9,py3.10}-flask-2.0
+    {py2.7,py3.5,py3.6,py3.7,py3.8,py3.9}-flask-v{0.11,0.12,1.0}
+    {py2.7,py3.5,py3.6,py3.7,py3.8,py3.9,py3.10}-flask-v1.1
+    {py3.6,py3.8,py3.9,py3.10}-flask-v2.0
 
     {py3.7,py3.8,py3.9,py3.10}-asgi
 
-    {py3.7,py3.8,py3.9,py3.10}-starlette-{0.19.1,0.20,0.21}
+    {py3.7,py3.8,py3.9,py3.10}-starlette-v{0.19.1,0.20,0.21}
 
     {py3.7,py3.8,py3.9,py3.10}-fastapi
 
     {py3.7,py3.8,py3.9,py3.10}-quart
 
-    {py2.7,py3.5,py3.6,py3.7,py3.8,py3.9,py3.10}-bottle-0.12
+    {py2.7,py3.5,py3.6,py3.7,py3.8,py3.9,py3.10}-bottle-v0.12
 
-    {py2.7,py3.5,py3.6,py3.7}-falcon-1.4
-    {py2.7,py3.5,py3.6,py3.7,py3.8,py3.9,py3.10}-falcon-2.0
+    {py2.7,py3.5,py3.6,py3.7}-falcon-v1.4
+    {py2.7,py3.5,py3.6,py3.7,py3.8,py3.9,py3.10}-falcon-v2.0
 
-    {py3.5,py3.6,py3.7}-sanic-{0.8,18}
-    {py3.6,py3.7}-sanic-19
-    {py3.6,py3.7,py3.8}-sanic-20
-    {py3.7,py3.8,py3.9,py3.10}-sanic-21
-    {py3.7,py3.8,py3.9,py3.10}-sanic-22
+    {py3.5,py3.6,py3.7}-sanic-v{0.8,18}
+    {py3.6,py3.7}-sanic-v19
+    {py3.6,py3.7,py3.8}-sanic-v20
+    {py3.7,py3.8,py3.9,py3.10}-sanic-v21
+    {py3.7,py3.8,py3.9,py3.10}-sanic-v22
 
-    {py2.7}-celery-3
-    {py2.7,py3.5,py3.6}-celery-{4.1,4.2}
-    {py2.7,py3.5,py3.6,py3.7,py3.8}-celery-{4.3,4.4}
-    {py3.6,py3.7,py3.8}-celery-{5.0}
-    {py3.7,py3.8,py3.9,py3.10}-celery-{5.1,5.2}
+    {py2.7}-celery-v3
+    {py2.7,py3.5,py3.6}-celery-v{4.1,4.2}
+    {py2.7,py3.5,py3.6,py3.7,py3.8}-celery-v{4.3,4.4}
+    {py3.6,py3.7,py3.8}-celery-v{5.0}
+    {py3.7,py3.8,py3.9,py3.10}-celery-v{5.1,5.2}
 
-    py3.7-beam-{2.12,2.13,2.32,2.33}
+    py3.7-beam-v{2.12,2.13,2.32,2.33}
 
     # The aws_lambda tests deploy to the real AWS and have their own matrix of Python versions.
     py3.7-aws_lambda
 
     py3.7-gcp
 
-    {py2.7,py3.5,py3.6,py3.7,py3.8,py3.9,py3.10}-pyramid-{1.6,1.7,1.8,1.9,1.10}
+    {py2.7,py3.5,py3.6,py3.7,py3.8,py3.9,py3.10}-pyramid-v{1.6,1.7,1.8,1.9,1.10}
 
-    {py2.7,py3.5,py3.6}-rq-{0.6,0.7,0.8,0.9,0.10,0.11}
-    {py2.7,py3.5,py3.6,py3.7,py3.8,py3.9}-rq-{0.12,0.13,1.0,1.1,1.2,1.3}
-    {py3.5,py3.6,py3.7,py3.8,py3.9,py3.10}-rq-{1.4,1.5}
+    {py2.7,py3.5,py3.6}-rq-v{0.6,0.7,0.8,0.9,0.10,0.11}
+    {py2.7,py3.5,py3.6,py3.7,py3.8,py3.9}-rq-v{0.12,0.13,1.0,1.1,1.2,1.3}
+    {py3.5,py3.6,py3.7,py3.8,py3.9,py3.10}-rq-v{1.4,1.5}
 
-    py3.7-aiohttp-3.5
-    {py3.7,py3.8,py3.9,py3.10}-aiohttp-3.6
+    py3.7-aiohttp-v3.5
+    {py3.7,py3.8,py3.9,py3.10}-aiohttp-v3.6
 
-    {py3.7,py3.8,py3.9}-tornado-{5}
-    {py3.7,py3.8,py3.9,py3.10}-tornado-{6}
+    {py3.7,py3.8,py3.9}-tornado-v{5}
+    {py3.7,py3.8,py3.9,py3.10}-tornado-v{6}
 
-    {py3.5,py3.6,py3.7,py3.8,py3.9}-trytond-{4.6,5.0,5.2}
-    {py3.6,py3.7,py3.8,py3.9,py3.10}-trytond-{5.4}
+    {py3.5,py3.6,py3.7,py3.8,py3.9}-trytond-v{4.6,5.0,5.2}
+    {py3.6,py3.7,py3.8,py3.9,py3.10}-trytond-v{5.4}
 
     {py2.7,py3.8,py3.9}-requests
 
     {py2.7,py3.7,py3.8,py3.9}-redis
-    {py2.7,py3.7,py3.8,py3.9}-rediscluster-{1,2.1.0,2}
+    {py2.7,py3.7,py3.8,py3.9}-rediscluster-v{1,2.1.0,2}
 
-    {py2.7,py3.7,py3.8,py3.9,py3.10}-sqlalchemy-{1.2,1.3}
+    {py2.7,py3.7,py3.8,py3.9,py3.10}-sqlalchemy-v{1.2,1.3}
 
     {py3.5,py3.6,py3.7,py3.8,py3.9,py3.10}-pure_eval
 
-    {py3.6,py3.7,py3.8}-chalice-{1.16,1.17,1.18,1.19,1.20}
+    {py3.6,py3.7,py3.8}-chalice-v{1.16,1.17,1.18,1.19,1.20}
 
-    {py2.7,py3.6,py3.7,py3.8}-boto3-{1.9,1.10,1.11,1.12,1.13,1.14,1.15,1.16}
+    {py2.7,py3.6,py3.7,py3.8}-boto3-v{1.9,1.10,1.11,1.12,1.13,1.14,1.15,1.16}
 
-    {py3.6,py3.7,py3.8,py3.9,py3.10}-httpx-{0.16,0.17}
+    {py3.6,py3.7,py3.8,py3.9,py3.10}-httpx-v{0.16,0.17}
 
-    {py2.7,py3.6}-pymongo-{3.1}
-    {py2.7,py3.6,py3.7,py3.8,py3.9}-pymongo-{3.12}
-    {py3.6,py3.7,py3.8,py3.9,py3.10}-pymongo-{4.0}
-    {py3.7,py3.8,py3.9,py3.10}-pymongo-{4.1,4.2}
+    {py2.7,py3.6}-pymongo-v{3.1}
+    {py2.7,py3.6,py3.7,py3.8,py3.9}-pymongo-v{3.12}
+    {py3.6,py3.7,py3.8,py3.9,py3.10}-pymongo-v{4.0}
+    {py3.7,py3.8,py3.9,py3.10}-pymongo-v{4.1,4.2}
 
 [testenv]
 deps =
@@ -111,41 +111,41 @@ deps =
     py3.4: colorama==0.4.1
     py3.4: watchdog==0.10.7
 
-    django-{1.11,2.0,2.1,2.2,3.0,3.1,3.2}: djangorestframework>=3.0.0,<4.0.0
+    django-v{1.11,2.0,2.1,2.2,3.0,3.1,3.2}: djangorestframework>=3.0.0,<4.0.0
 
-    {py3.7,py3.8,py3.9,py3.10}-django-{1.11,2.0,2.1,2.2,3.0,3.1,3.2}: channels[daphne]>2
-    {py3.7,py3.8,py3.9,py3.10}-django-{1.11,2.0,2.1,2.2,3.0,3.1,3.2}: pytest-asyncio
-    {py2.7,py3.7,py3.8,py3.9,py3.10}-django-{1.11,2.2,3.0,3.1,3.2}: psycopg2-binary
+    {py3.7,py3.8,py3.9,py3.10}-django-v{1.11,2.0,2.1,2.2,3.0,3.1,3.2}: channels[daphne]>2
+    {py3.7,py3.8,py3.9,py3.10}-django-v{1.11,2.0,2.1,2.2,3.0,3.1,3.2}: pytest-asyncio
+    {py2.7,py3.7,py3.8,py3.9,py3.10}-django-v{1.11,2.2,3.0,3.1,3.2}: psycopg2-binary
 
-    django-{1.8,1.9,1.10,1.11,2.0,2.1}: pytest-django<4.0
-    django-{2.2,3.0,3.1,3.2}: pytest-django>=4.0
-    django-{2.2,3.0,3.1,3.2}: Werkzeug<2.0
+    django-v{1.8,1.9,1.10,1.11,2.0,2.1}: pytest-django<4.0
+    django-v{2.2,3.0,3.1,3.2}: pytest-django>=4.0
+    django-v{2.2,3.0,3.1,3.2}: Werkzeug<2.0
 
-    django-{4.0,4.1}: djangorestframework
-    django-{4.0,4.1}: pytest-asyncio
-    django-{4.0,4.1}: psycopg2-binary
-    django-{4.0,4.1}: pytest-django
-    django-{4.0,4.1}: Werkzeug
+    django-v{4.0,4.1}: djangorestframework
+    django-v{4.0,4.1}: pytest-asyncio
+    django-v{4.0,4.1}: psycopg2-binary
+    django-v{4.0,4.1}: pytest-django
+    django-v{4.0,4.1}: Werkzeug
 
-    django-1.8: Django>=1.8,<1.9
-    django-1.9: Django>=1.9,<1.10
-    django-1.10: Django>=1.10,<1.11
-    django-1.11: Django>=1.11,<1.12
-    django-2.0: Django>=2.0,<2.1
-    django-2.1: Django>=2.1,<2.2
-    django-2.2: Django>=2.2,<2.3
-    django-3.0: Django>=3.0,<3.1
-    django-3.1: Django>=3.1,<3.2
-    django-3.2: Django>=3.2,<3.3
-    django-4.0: Django>=4.0,<4.1
-    django-4.1: Django>=4.1,<4.2
+    django-v1.8: Django>=1.8,<1.9
+    django-v1.9: Django>=1.9,<1.10
+    django-v1.10: Django>=1.10,<1.11
+    django-v1.11: Django>=1.11,<1.12
+    django-v2.0: Django>=2.0,<2.1
+    django-v2.1: Django>=2.1,<2.2
+    django-v2.2: Django>=2.2,<2.3
+    django-v3.0: Django>=3.0,<3.1
+    django-v3.1: Django>=3.1,<3.2
+    django-v3.2: Django>=3.2,<3.3
+    django-v4.0: Django>=4.0,<4.1
+    django-v4.1: Django>=4.1,<4.2
 
     flask: flask-login
-    flask-0.11: Flask>=0.11,<0.12
-    flask-0.12: Flask>=0.12,<0.13
-    flask-1.0: Flask>=1.0,<1.1
-    flask-1.1: Flask>=1.1,<1.2
-    flask-2.0: Flask>=2.0,<2.1
+    flask-v0.11: Flask>=0.11,<0.12
+    flask-v0.12: Flask>=0.12,<0.13
+    flask-v1.0: Flask>=1.0,<1.1
+    flask-v1.1: Flask>=1.1,<1.2
+    flask-v2.0: Flask>=2.0,<2.1
 
     asgi: pytest-asyncio
     asgi: async-asgi-testclient
@@ -157,10 +157,10 @@ deps =
     starlette: pytest-asyncio
     starlette: python-multipart
     starlette: requests
-    starlette-0.21: httpx
-    starlette-0.19.1: starlette==0.19.1
-    starlette-0.20: starlette>=0.20.0,<0.21.0
-    starlette-0.21: starlette>=0.21.0,<0.22.0
+    starlette-v0.21: httpx
+    starlette-v0.19.1: starlette==0.19.1
+    starlette-v0.20: starlette>=0.20.0,<0.21.0
+    starlette-v0.21: starlette>=0.21.0,<0.22.0
 
     fastapi: fastapi
     fastapi: httpx
@@ -168,42 +168,42 @@ deps =
     fastapi: python-multipart
     fastapi: requests
 
-    bottle-0.12: bottle>=0.12,<0.13
+    bottle-v0.12: bottle>=0.12,<0.13
 
-    falcon-1.4: falcon>=1.4,<1.5
-    falcon-2.0: falcon>=2.0.0rc3,<3.0
+    falcon-v1.4: falcon>=1.4,<1.5
+    falcon-v2.0: falcon>=2.0.0rc3,<3.0
 
-    sanic-0.8: sanic>=0.8,<0.9
-    sanic-18: sanic>=18.0,<19.0
-    sanic-19: sanic>=19.0,<20.0
-    sanic-20: sanic>=20.0,<21.0
-    sanic-21: sanic>=21.0,<22.0
-    sanic-22: sanic>=22.0,<22.9.0
+    sanic-v0.8: sanic>=0.8,<0.9
+    sanic-v18: sanic>=18.0,<19.0
+    sanic-v19: sanic>=19.0,<20.0
+    sanic-v20: sanic>=20.0,<21.0
+    sanic-v21: sanic>=21.0,<22.0
+    sanic-v22: sanic>=22.0,<22.9.0
 
     sanic: aiohttp
-    sanic-21: sanic_testing<22
-    sanic-22: sanic_testing<22.9.0
+    sanic-v21: sanic_testing<22
+    sanic-v22: sanic_testing<22.9.0
     {py3.5,py3.6}-sanic: aiocontextvars==0.2.1
     py3.5-sanic: ujson<4
 
-    beam-2.12: apache-beam>=2.12.0, <2.13.0
-    beam-2.13: apache-beam>=2.13.0, <2.14.0
-    beam-2.32: apache-beam>=2.32.0, <2.33.0
-    beam-2.33: apache-beam>=2.33.0, <2.34.0
+    beam-v2.12: apache-beam>=2.12.0, <2.13.0
+    beam-v2.13: apache-beam>=2.13.0, <2.14.0
+    beam-v2.32: apache-beam>=2.32.0, <2.33.0
+    beam-v2.33: apache-beam>=2.33.0, <2.34.0
     beam-master: git+https://github.com/apache/beam#egg=apache-beam&subdirectory=sdks/python
 
     celery: redis
-    celery-3: Celery>=3.1,<4.0
-    celery-4.1: Celery>=4.1,<4.2
-    celery-4.2: Celery>=4.2,<4.3
-    celery-4.3: Celery>=4.3,<4.4
+    celery-v3: Celery>=3.1,<4.0
+    celery-v4.1: Celery>=4.1,<4.2
+    celery-v4.2: Celery>=4.2,<4.3
+    celery-v4.3: Celery>=4.3,<4.4
     # https://github.com/celery/vine/pull/29#issuecomment-689498382
     celery-4.3: vine<5.0.0
     # https://github.com/celery/celery/issues/6153
-    celery-4.4: Celery>=4.4,<4.5,!=4.4.4
-    celery-5.0: Celery>=5.0,<5.1
-    celery-5.1: Celery>=5.1,<5.2
-    celery-5.2: Celery>=5.2,<5.3
+    celery-v4.4: Celery>=4.4,<4.5,!=4.4.4
+    celery-v5.0: Celery>=5.0,<5.1
+    celery-v5.1: Celery>=5.1,<5.2
+    celery-v5.2: Celery>=5.2,<5.3
 
     py3.5-celery: newrelic<6.0.0
     {py3.7}-celery: importlib-metadata<5.0
@@ -213,85 +213,85 @@ deps =
 
     aws_lambda: boto3
 
-    pyramid-1.6: pyramid>=1.6,<1.7
-    pyramid-1.7: pyramid>=1.7,<1.8
-    pyramid-1.8: pyramid>=1.8,<1.9
-    pyramid-1.9: pyramid>=1.9,<1.10
-    pyramid-1.10: pyramid>=1.10,<1.11
+    pyramid-v1.6: pyramid>=1.6,<1.7
+    pyramid-v1.7: pyramid>=1.7,<1.8
+    pyramid-v1.8: pyramid>=1.8,<1.9
+    pyramid-v1.9: pyramid>=1.9,<1.10
+    pyramid-v1.10: pyramid>=1.10,<1.11
 
     # https://github.com/jamesls/fakeredis/issues/245
-    rq-{0.6,0.7,0.8,0.9,0.10,0.11,0.12}: fakeredis<1.0
-    rq-{0.6,0.7,0.8,0.9,0.10,0.11,0.12}: redis<3.2.2
-    rq-{0.13,1.0,1.1,1.2,1.3,1.4,1.5}: fakeredis>=1.0,<1.7.4
+    rq-v{0.6,0.7,0.8,0.9,0.10,0.11,0.12}: fakeredis<1.0
+    rq-v{0.6,0.7,0.8,0.9,0.10,0.11,0.12}: redis<3.2.2
+    rq-v{0.13,1.0,1.1,1.2,1.3,1.4,1.5}: fakeredis>=1.0,<1.7.4
 
-    rq-0.6: rq>=0.6,<0.7
-    rq-0.7: rq>=0.7,<0.8
-    rq-0.8: rq>=0.8,<0.9
-    rq-0.9: rq>=0.9,<0.10
-    rq-0.10: rq>=0.10,<0.11
-    rq-0.11: rq>=0.11,<0.12
-    rq-0.12: rq>=0.12,<0.13
-    rq-0.13: rq>=0.13,<0.14
-    rq-1.0: rq>=1.0,<1.1
-    rq-1.1: rq>=1.1,<1.2
-    rq-1.2: rq>=1.2,<1.3
-    rq-1.3: rq>=1.3,<1.4
-    rq-1.4: rq>=1.4,<1.5
-    rq-1.5: rq>=1.5,<1.6
+    rq-v0.6: rq>=0.6,<0.7
+    rq-v0.7: rq>=0.7,<0.8
+    rq-v0.8: rq>=0.8,<0.9
+    rq-v0.9: rq>=0.9,<0.10
+    rq-v0.10: rq>=0.10,<0.11
+    rq-v0.11: rq>=0.11,<0.12
+    rq-v0.12: rq>=0.12,<0.13
+    rq-v0.13: rq>=0.13,<0.14
+    rq-v1.0: rq>=1.0,<1.1
+    rq-v1.1: rq>=1.1,<1.2
+    rq-v1.2: rq>=1.2,<1.3
+    rq-v1.3: rq>=1.3,<1.4
+    rq-v1.4: rq>=1.4,<1.5
+    rq-v1.5: rq>=1.5,<1.6
 
-    aiohttp-3.4: aiohttp>=3.4.0,<3.5.0
-    aiohttp-3.5: aiohttp>=3.5.0,<3.6.0
+    aiohttp-v3.4: aiohttp>=3.4.0,<3.5.0
+    aiohttp-v3.5: aiohttp>=3.5.0,<3.6.0
     aiohttp: pytest-aiohttp
 
-    tornado-5: tornado>=5,<6
-    tornado-6: tornado>=6.0a1
+    tornado-v5: tornado>=5,<6
+    tornado-v6: tornado>=6.0a1
 
-    trytond-5.4: trytond>=5.4,<5.5
-    trytond-5.2: trytond>=5.2,<5.3
-    trytond-5.0: trytond>=5.0,<5.1
-    trytond-4.6: trytond>=4.6,<4.7
+    trytond-v5.4: trytond>=5.4,<5.5
+    trytond-v5.2: trytond>=5.2,<5.3
+    trytond-v5.0: trytond>=5.0,<5.1
+    trytond-v4.6: trytond>=4.6,<4.7
 
-    trytond-{4.6,4.8,5.0,5.2,5.4}: werkzeug<2.0
+    trytond-v{4.6,4.8,5.0,5.2,5.4}: werkzeug<2.0
 
     redis: fakeredis<1.7.4
 
-    rediscluster-1: redis-py-cluster>=1.0.0,<2.0.0
-    rediscluster-2.1.0: redis-py-cluster>=2.0.0,<2.1.1
-    rediscluster-2: redis-py-cluster>=2.1.1,<3.0.0
+    rediscluster-v1: redis-py-cluster>=1.0.0,<2.0.0
+    rediscluster-v2.1.0: redis-py-cluster>=2.0.0,<2.1.1
+    rediscluster-v2: redis-py-cluster>=2.1.1,<3.0.0
 
-    sqlalchemy-1.2: sqlalchemy>=1.2,<1.3
-    sqlalchemy-1.3: sqlalchemy>=1.3,<1.4
+    sqlalchemy-v1.2: sqlalchemy>=1.2,<1.3
+    sqlalchemy-v1.3: sqlalchemy>=1.3,<1.4
 
     linters: -r linter-requirements.txt
 
     py3.8: hypothesis
 
     pure_eval: pure_eval
-    chalice-1.16: chalice>=1.16.0,<1.17.0
-    chalice-1.17: chalice>=1.17.0,<1.18.0
-    chalice-1.18: chalice>=1.18.0,<1.19.0
-    chalice-1.19: chalice>=1.19.0,<1.20.0
-    chalice-1.20: chalice>=1.20.0,<1.21.0
+    chalice-v1.16: chalice>=1.16.0,<1.17.0
+    chalice-v1.17: chalice>=1.17.0,<1.18.0
+    chalice-v1.18: chalice>=1.18.0,<1.19.0
+    chalice-v1.19: chalice>=1.19.0,<1.20.0
+    chalice-v1.20: chalice>=1.20.0,<1.21.0
     chalice: pytest-chalice==0.0.5
 
-    boto3-1.9: boto3>=1.9,<1.10
-    boto3-1.10: boto3>=1.10,<1.11
-    boto3-1.11: boto3>=1.11,<1.12
-    boto3-1.12: boto3>=1.12,<1.13
-    boto3-1.13: boto3>=1.13,<1.14
-    boto3-1.14: boto3>=1.14,<1.15
-    boto3-1.15: boto3>=1.15,<1.16
-    boto3-1.16: boto3>=1.16,<1.17
+    boto3-v1.9: boto3>=1.9,<1.10
+    boto3-v1.10: boto3>=1.10,<1.11
+    boto3-v1.11: boto3>=1.11,<1.12
+    boto3-v1.12: boto3>=1.12,<1.13
+    boto3-v1.13: boto3>=1.13,<1.14
+    boto3-v1.14: boto3>=1.14,<1.15
+    boto3-v1.15: boto3>=1.15,<1.16
+    boto3-v1.16: boto3>=1.16,<1.17
 
-    httpx-0.16: httpx>=0.16,<0.17
-    httpx-0.17: httpx>=0.17,<0.18
+    httpx-v0.16: httpx>=0.16,<0.17
+    httpx-v0.17: httpx>=0.17,<0.18
 
     pymongo: mockupdb
-    pymongo-3.1: pymongo>=3.1,<3.2
-    pymongo-3.12: pymongo>=3.12,<4.0
-    pymongo-4.0: pymongo>=4.0,<4.1
-    pymongo-4.1: pymongo>=4.1,<4.2
-    pymongo-4.2: pymongo>=4.2,<4.3
+    pymongo-v3.1: pymongo>=3.1,<3.2
+    pymongo-v3.12: pymongo>=3.12,<4.0
+    pymongo-v4.0: pymongo>=4.0,<4.1
+    pymongo-v4.1: pymongo>=4.1,<4.2
+    pymongo-v4.2: pymongo>=4.2,<4.3
 
 setenv =
     PYTHONDONTWRITEBYTECODE=1
@@ -359,14 +359,14 @@ basepython =
 
 commands =
     ; https://github.com/pytest-dev/pytest/issues/5532
-    {py3.5,py3.6,py3.7,py3.8,py3.9}-flask-{0.11,0.12}: pip install pytest<5
-    {py3.6,py3.7,py3.8,py3.9}-flask-{0.11}: pip install Werkzeug<2
+    {py3.5,py3.6,py3.7,py3.8,py3.9}-flask-v{0.11,0.12}: pip install pytest<5
+    {py3.6,py3.7,py3.8,py3.9}-flask-v{0.11}: pip install Werkzeug<2
 
     ; https://github.com/pallets/flask/issues/4455
-    {py3.7,py3.8,py3.9,py3.10}-flask-{0.11,0.12,1.0,1.1}: pip install "itsdangerous>=0.24,<2.0" "markupsafe<2.0.0" "jinja2<3.1.1"
+    {py3.7,py3.8,py3.9,py3.10}-flask-v{0.11,0.12,1.0,1.1}: pip install "itsdangerous>=0.24,<2.0" "markupsafe<2.0.0" "jinja2<3.1.1"
 
     ; https://github.com/more-itertools/more-itertools/issues/578
-    py3.5-flask-{0.11,0.12}: pip install more-itertools<8.11.0
+    py3.5-flask-v{0.11,0.12}: pip install more-itertools<8.11.0
 
     ; use old pytest for old Python versions:
     {py2.7,py3.4,py3.5}: pip install pytest-forked==1.1.3

--- a/tox.ini
+++ b/tox.ini
@@ -374,7 +374,7 @@ commands =
     ; Running `py.test` as an executable suffers from an import error
     ; when loading tests in scenarios. In particular, django fails to
     ; load the settings from the test module.
-    python -m pytest --durations=5 {env:TESTPATH} {posargs}
+    python -m pytest --durations=5 -vvv {env:TESTPATH} {posargs}
 
 [testenv:linters]
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -374,7 +374,7 @@ commands =
     ; Running `py.test` as an executable suffers from an import error
     ; when loading tests in scenarios. In particular, django fails to
     ; load the settings from the test module.
-    python -m pytest --durations=5 {env:TESTPATH} {posargs}
+    python -m pytest --reuse-db --durations=5 {env:TESTPATH} {posargs}
 
 [testenv:linters]
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -371,6 +371,9 @@ commands =
     ; use old pytest for old Python versions:
     {py2.7,py3.4,py3.5}: pip install pytest-forked==1.1.3
 
+    ; Running `py.test` as an executable suffers from an import error
+    ; when loading tests in scenarios. In particular, django fails to
+    ; load the settings from the test module.
     python -m pytest --durations=5 {env:TESTPATH} {posargs}
 
 [testenv:linters]

--- a/tox.ini
+++ b/tox.ini
@@ -374,7 +374,7 @@ commands =
     ; Running `py.test` as an executable suffers from an import error
     ; when loading tests in scenarios. In particular, django fails to
     ; load the settings from the test module.
-    python -m pytest --reuse-db --durations=5 {env:TESTPATH} {posargs}
+    python -m pytest --durations=5 {env:TESTPATH} {posargs}
 
 [testenv:linters]
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -371,7 +371,7 @@ commands =
     ; use old pytest for old Python versions:
     {py2.7,py3.4,py3.5}: pip install pytest-forked==1.1.3
 
-    py.test --durations=5 {env:TESTPATH} {posargs}
+    python -m pytest --durations=5 {env:TESTPATH} {posargs}
 
 [testenv:linters]
 commands =


### PR DESCRIPTION
The checks are failing for 2 reasons

1. Github actions dropped python3.6 support on the latest hosted runners.
   https://github.com/actions/setup-python/issues/544#issuecomment-1332535877
2. New release of tox was validation the python version in the environment name
   and the trailing framework version being used in the environment name was
   being treated as a python version and validated causing an issue.