### PR TITLE
perf(profiling): Performance tweaks to profile sampler

### DIFF
--- a/sentry_sdk/profiler.py
+++ b/sentry_sdk/profiler.py
@@ -260,9 +260,13 @@ def get_frame_name(frame):
     # if it was a method, we can get the class name by inspecting
     # the f_locals for the `self` argument
     try:
-        # the co_varnames start with the frame's positional arguments
-        # and we expect the first to be `self` if its an instance method
-        if co_varnames and co_varnames[0] == "self":
+        if (
+            # the co_varnames start with the frame's positional arguments
+            # and we expect the first to be `self` if its an instance method
+            co_varnames
+            and co_varnames[0] == "self"
+            and "self" in frame.f_locals
+        ):
             for cls in frame.f_locals["self"].__class__.__mro__:
                 if name in cls.__dict__:
                     return "{}.{}".format(cls.__name__, name)
@@ -272,9 +276,13 @@ def get_frame_name(frame):
     # if it was a class method, (decorated with `@classmethod`)
     # we can get the class name by inspecting the f_locals for the `cls` argument
     try:
-        # the co_varnames start with the frame's positional arguments
-        # and we expect the first to be `cls` if its a class method
-        if co_varnames and co_varnames[0] == "cls":
+        if (
+            # the co_varnames start with the frame's positional arguments
+            # and we expect the first to be `cls` if its a class method
+            co_varnames
+            and co_varnames[0] == "cls"
+            and "cls" in frame.f_locals
+        ):
             for cls in frame.f_locals["cls"].__mro__:
                 if name in cls.__dict__:
                     return "{}.{}".format(cls.__name__, name)

--- a/sentry_sdk/profiler.py
+++ b/sentry_sdk/profiler.py
@@ -356,9 +356,7 @@ class SampleBuffer(object):
     def __init__(self, capacity):
         # type: (int) -> None
 
-        self.buffer = [
-            None
-        ] * capacity  # type: List[Optional[Tuple[int, RawSample]]]
+        self.buffer = [None] * capacity  # type: List[Optional[Tuple[int, RawSample]]]
         self.capacity = capacity  # type: int
         self.idx = 0  # type: int
 

--- a/sentry_sdk/profiler.py
+++ b/sentry_sdk/profiler.py
@@ -239,7 +239,7 @@ def extract_frame(frame, cwd):
         os.path.join(cwd, abs_path),
         module,
         filename_for_module(module, abs_path) or None,
-        get_frame_name(frame) or "<unknown>",
+        get_frame_name(frame),
         frame.f_lineno,
     )
 

--- a/sentry_sdk/profiler.py
+++ b/sentry_sdk/profiler.py
@@ -196,11 +196,10 @@ def extract_stack(
         # Make sure to keep in mind that the stack is ordered from the inner most
         # from to the outer most frame so be careful with the indexing.
         stack = tuple(
-            prev_stack[prev_depth - (depth - i)]
-            if prev_depth >= depth - i
-            and frame is prev_frames[prev_depth - (depth - i)]
+            prev_stack[i]
+            if i >= 0 and frame is prev_frames[i]
             else extract_frame(frame, cwd)
-            for i, frame in enumerate(frames)
+            for i, frame in zip(range(prev_depth - depth, prev_depth), frames)
         )
 
     # Instead of mapping the stack into frame ids and hashing

--- a/tests/test_profiler.py
+++ b/tests/test_profiler.py
@@ -231,7 +231,7 @@ def test_extract_stack_with_max_depth(depth, max_stack_depth, actual_depth):
 
     # increase the max_depth by the `base_stack_depth` to account
     # for the extra frames pytest will add
-    _, stack = extract_stack(
+    _, stack, _ = extract_stack(
         frame, os.getcwd(), max_stack_depth=max_stack_depth + base_stack_depth
     )
     assert len(stack) == base_stack_depth + actual_depth
@@ -242,6 +242,22 @@ def test_extract_stack_with_max_depth(depth, max_stack_depth, actual_depth):
     # index 0 contains the inner most frame on the stack, so the lamdba
     # should be at index `actual_depth`
     assert stack[actual_depth][3] == "<lambda>", actual_depth
+
+
+def test_extract_stack_with_cache():
+    frame = get_frame(depth=1)
+
+    prev_cache = extract_stack(frame, os.getcwd())
+    _, stack1, _ = prev_cache
+    _, stack2, _ = extract_stack(frame, os.getcwd(), prev_cache)
+
+    assert len(stack1) == len(stack2)
+    for i, (frame1, frame2) in enumerate(zip(stack1, stack2)):
+        # DO NOT use `==` for the assertion here since we are
+        # testing for identity, and using `==` would test for
+        # equality which would always pass since we're extract
+        # the same stack.
+        assert frame1 is frame2, i
 
 
 def get_scheduler_threads(scheduler):

--- a/tests/test_profiler.py
+++ b/tests/test_profiler.py
@@ -232,7 +232,7 @@ def test_extract_frame(get_frame, function):
     assert extracted_frame[1] == __name__
 
     # the filename should be the file starting after the cwd
-    assert extracted_frame[2] == __file__[len(cwd) + 1:]
+    assert extracted_frame[2] == __file__[len(cwd) + 1 :]
 
     assert extracted_frame[3] == function
 

--- a/tests/test_profiler.py
+++ b/tests/test_profiler.py
@@ -232,9 +232,7 @@ def test_extract_stack_with_max_depth(depth, max_stack_depth, actual_depth):
     # increase the max_depth by the `base_stack_depth` to account
     # for the extra frames pytest will add
     _, stack = extract_stack(
-        frame,
-        os.getcwd(),
-        max_stack_depth=max_stack_depth + base_stack_depth
+        frame, os.getcwd(), max_stack_depth=max_stack_depth + base_stack_depth
     )
     assert len(stack) == base_stack_depth + actual_depth
 
@@ -280,11 +278,7 @@ def test_thread_scheduler_takes_first_samples(scheduler_class):
                 [
                     (
                         0,
-                        (
-                            (
-                                "/path/to/file.py", "file", "file.py", "name", 1
-                            ),
-                        ),
+                        (("/path/to/file.py", "file", "file.py", "name", 1),),
                     )
                 ],
             )
@@ -320,11 +314,7 @@ def test_thread_scheduler_takes_more_samples(scheduler_class):
                 [
                     (
                         0,
-                        (
-                            (
-                                "/path/to/file.py", "file", "file.py", "name", 1
-                            ),
-                        ),
+                        (("/path/to/file.py", "file", "file.py", "name", 1),),
                     )
                 ],
             )
@@ -428,11 +418,7 @@ thread_metadata = {
                     [
                         (
                             "1",
-                            (
-                                (
-                                    "/path/to/file.py", "file", "file.py", "name", 1
-                                ),
-                            ),
+                            (("/path/to/file.py", "file", "file.py", "name", 1),),
                         )
                     ],
                 )
@@ -455,11 +441,7 @@ thread_metadata = {
                     [
                         (
                             "1",
-                            (
-                                (
-                                    "/path/to/file.py", "file", "file.py", "name", 1
-                                ),
-                            ),
+                            (("/path/to/file.py", "file", "file.py", "name", 1),),
                         )
                     ],
                 )
@@ -496,11 +478,7 @@ thread_metadata = {
                     [
                         (
                             "1",
-                            (
-                                (
-                                    "/path/to/file.py", "file", "file.py", "name", 1
-                                ),
-                            ),
+                            (("/path/to/file.py", "file", "file.py", "name", 1),),
                         )
                     ],
                 ),
@@ -509,11 +487,7 @@ thread_metadata = {
                     [
                         (
                             "1",
-                            (
-                                (
-                                    "/path/to/file.py", "file", "file.py", "name", 1
-                                ),
-                            ),
+                            (("/path/to/file.py", "file", "file.py", "name", 1),),
                         )
                     ],
                 ),
@@ -555,11 +529,7 @@ thread_metadata = {
                     [
                         (
                             "1",
-                            (
-                                (
-                                    "/path/to/file.py", "file", "file.py", "name1", 1
-                                ),
-                            ),
+                            (("/path/to/file.py", "file", "file.py", "name1", 1),),
                         )
                     ],
                 ),
@@ -569,12 +539,8 @@ thread_metadata = {
                         (
                             "1",
                             (
-                                (
-                                    "/path/to/file.py", "file", "file.py", "name1", 1
-                                ),
-                                (
-                                    "/path/to/file.py", "file", "file.py", "name2", 2
-                                ),
+                                ("/path/to/file.py", "file", "file.py", "name1", 1),
+                                ("/path/to/file.py", "file", "file.py", "name2", 2),
                             ),
                         )
                     ],
@@ -625,11 +591,14 @@ thread_metadata = {
                         (
                             "1",
                             (
+                                ("/path/to/file.py", "file", "file.py", "name1", 1),
                                 (
-                                    "/path/to/file.py", "file", "file.py", "name1", 1
-                                ),
-                                (
-                                    "/path/to/file.py", "file", "file.py", "name2", 2, "file"
+                                    "/path/to/file.py",
+                                    "file",
+                                    "file.py",
+                                    "name2",
+                                    2,
+                                    "file",
                                 ),
                             ),
                         )
@@ -642,10 +611,20 @@ thread_metadata = {
                             "1",
                             (
                                 (
-                                    "/path/to/file.py", "file", "file.py", "name3", 3, "file"
+                                    "/path/to/file.py",
+                                    "file",
+                                    "file.py",
+                                    "name3",
+                                    3,
+                                    "file",
                                 ),
                                 (
-                                    "/path/to/file.py", "file", "file.py", "name4", 4, "file"
+                                    "/path/to/file.py",
+                                    "file",
+                                    "file.py",
+                                    "name4",
+                                    4,
+                                    "file",
                                 ),
                             ),
                         )
@@ -710,11 +689,7 @@ thread_metadata = {
                     [
                         (
                             "1",
-                            (
-                                (
-                                    "/path/to/file.py", "file", "file.py", "name1", 1
-                                ),
-                            ),
+                            (("/path/to/file.py", "file", "file.py", "name1", 1),),
                         )
                     ],
                 ),
@@ -724,12 +699,8 @@ thread_metadata = {
                         (
                             "1",
                             (
-                                (
-                                    "/path/to/file.py", "file", "file.py", "name2", 2
-                                ),
-                                (
-                                    "/path/to/file.py", "file", "file.py", "name3", 3
-                                ),
+                                ("/path/to/file.py", "file", "file.py", "name2", 2),
+                                ("/path/to/file.py", "file", "file.py", "name3", 3),
                             ),
                         )
                     ],


### PR DESCRIPTION
This contains some small tweaks to speed up the profiler.
- changed from a namedtuple to a regular tuple as namedtuples were much slower but the tradeoff here is that it's more legible
- moved away from `os.path.abspath` as it was doing some extra operations that were unnecessary for our use case
- use the previous sample as a cache while sampling