### PR TITLE
add span for response rendering

### DIFF
--- a/sentry_sdk/consts.py
+++ b/sentry_sdk/consts.py
@@ -71,6 +71,7 @@ class OP:
     SUBPROCESS_COMMUNICATE = "subprocess.communicate"
     TEMPLATE_RENDER = "template.render"
     VIEW_RENDER = "view.render"
+    VIEW_RESPONSE_RENDER = "view.response.render"
     WEBSOCKET_SERVER = "websocket.server"
 
 

--- a/sentry_sdk/integrations/django/views.py
+++ b/sentry_sdk/integrations/django/views.py
@@ -32,7 +32,9 @@ def patch_views():
     def sentry_patched_render(self):
         # type: (SimpleTemplateResponse) -> Any
         hub = Hub.current
-        with hub.start_span(op=OP.VIEW_RESPONSE_RENDER, description="serialize response"):
+        with hub.start_span(
+            op=OP.VIEW_RESPONSE_RENDER, description="serialize response"
+        ):
             return old_render(self)
 
     @_functools.wraps(old_make_view_atomic)

--- a/sentry_sdk/integrations/django/views.py
+++ b/sentry_sdk/integrations/django/views.py
@@ -23,9 +23,17 @@ def patch_views():
     # type: () -> None
 
     from django.core.handlers.base import BaseHandler
+    from django.template.response import SimpleTemplateResponse
     from sentry_sdk.integrations.django import DjangoIntegration
 
     old_make_view_atomic = BaseHandler.make_view_atomic
+    original_render = SimpleTemplateResponse.render
+
+    def wrapped_render(self):
+        # type: (SimpleTemplateResponse) -> Any
+        hub = Hub.current
+        with hub.start_span(op="django.response", description="render"):
+            return original_render(self)
 
     @_functools.wraps(old_make_view_atomic)
     def sentry_patched_make_view_atomic(self, *args, **kwargs):
@@ -54,6 +62,7 @@ def patch_views():
 
         return sentry_wrapped_callback
 
+    SimpleTemplateResponse.render = wrapped_render
     BaseHandler.make_view_atomic = sentry_patched_make_view_atomic
 
 

--- a/tests/integrations/django/myapp/urls.py
+++ b/tests/integrations/django/myapp/urls.py
@@ -81,6 +81,9 @@ try:
     )
     urlpatterns.append(path("rest-hello", views.rest_hello, name="rest_hello"))
     urlpatterns.append(
+        path("rest-json-response", views.rest_json_response, name="rest_json_response")
+    )
+    urlpatterns.append(
         path(
             "rest-permission-denied-exc",
             views.rest_permission_denied_exc,

--- a/tests/integrations/django/myapp/views.py
+++ b/tests/integrations/django/myapp/views.py
@@ -11,6 +11,7 @@ from django.views.generic import ListView
 
 try:
     from rest_framework.decorators import api_view
+    from rest_framework.response import Response
 
     @api_view(["POST"])
     def rest_framework_exc(request):
@@ -28,6 +29,11 @@ try:
     @api_view(["GET"])
     def rest_permission_denied_exc(request):
         raise PermissionDenied("bye")
+
+    @api_view(["GET"])
+    def rest_json_response(request):
+        return Response(dict(ok=True))
+
 
 except ImportError:
     pass

--- a/tests/integrations/django/myapp/views.py
+++ b/tests/integrations/django/myapp/views.py
@@ -34,7 +34,6 @@ try:
     def rest_json_response(request):
         return Response(dict(ok=True))
 
-
 except ImportError:
     pass
 

--- a/tests/integrations/django/test_basic.py
+++ b/tests/integrations/django/test_basic.py
@@ -313,8 +313,9 @@ def test_response_trace(sentry_init, client, capture_events, render_span_tree):
     content, status, headers = client.get(reverse("rest_json_response"))
     assert status == "200 OK"
 
-    assert '- op="view.response.render": description="serialize response"' in render_span_tree(
-        events[0]
+    assert (
+        '- op="view.response.render": description="serialize response"'
+        in render_span_tree(events[0])
     )
 
 

--- a/tests/integrations/django/test_basic.py
+++ b/tests/integrations/django/test_basic.py
@@ -313,7 +313,9 @@ def test_response_trace(sentry_init, client, capture_events, render_span_tree):
     content, status, headers = client.get(reverse("rest_json_response"))
     assert status == "200 OK"
 
-    assert '- op="django.response": description="render"' in render_span_tree(events[0])
+    assert '- op="view.response.render": description="serialize response"' in render_span_tree(
+        events[0]
+    )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Response rendering can be a source of slow performance in Django, especially with Django rest framework and serializers. This change adds a span to track this.

<img width="983" alt="Screenshot 2023-01-02 at 4 30 46 PM" src="https://user-images.githubusercontent.com/1929960/210279251-b127e508-3597-4568-a1a6-29090dea4076.png">


related: #1250