### PR TITLE
feat(profiling): Use co_qualname in python 3.11

### DIFF
--- a/sentry_sdk/_compat.py
+++ b/sentry_sdk/_compat.py
@@ -16,6 +16,7 @@ PY2 = sys.version_info[0] == 2
 PY33 = sys.version_info[0] == 3 and sys.version_info[1] >= 3
 PY37 = sys.version_info[0] == 3 and sys.version_info[1] >= 7
 PY310 = sys.version_info[0] == 3 and sys.version_info[1] >= 10
+PY311 = sys.version_info[0] == 3 and sys.version_info[1] >= 11
 
 if PY2:
     import urlparse

--- a/sentry_sdk/profiler.py
+++ b/sentry_sdk/profiler.py
@@ -24,7 +24,7 @@ from collections import deque
 from contextlib import contextmanager
 
 import sentry_sdk
-from sentry_sdk._compat import PY33
+from sentry_sdk._compat import PY33, PY311
 from sentry_sdk._types import MYPY
 from sentry_sdk.utils import (
     filename_for_module,
@@ -241,55 +241,60 @@ def extract_frame(frame, cwd):
     )
 
 
-def get_frame_name(frame):
-    # type: (FrameType) -> str
+if PY311:
 
-    # in 3.11+, there is a frame.f_code.co_qualname that
-    # we should consider using instead where possible
+    def get_frame_name(frame):
+        # type: (FrameType) -> str
+        return frame.f_code.co_qualname  # type: ignore
 
-    f_code = frame.f_code
-    co_varnames = f_code.co_varnames
+else:
 
-    # co_name only contains the frame name.  If the frame was a method,
-    # the class name will NOT be included.
-    name = f_code.co_name
+    def get_frame_name(frame):
+        # type: (FrameType) -> str
 
-    # if it was a method, we can get the class name by inspecting
-    # the f_locals for the `self` argument
-    try:
-        if (
-            # the co_varnames start with the frame's positional arguments
-            # and we expect the first to be `self` if its an instance method
-            co_varnames
-            and co_varnames[0] == "self"
-            and "self" in frame.f_locals
-        ):
-            for cls in frame.f_locals["self"].__class__.__mro__:
-                if name in cls.__dict__:
-                    return "{}.{}".format(cls.__name__, name)
-    except AttributeError:
-        pass
+        f_code = frame.f_code
+        co_varnames = f_code.co_varnames
 
-    # if it was a class method, (decorated with `@classmethod`)
-    # we can get the class name by inspecting the f_locals for the `cls` argument
-    try:
-        if (
-            # the co_varnames start with the frame's positional arguments
-            # and we expect the first to be `cls` if its a class method
-            co_varnames
-            and co_varnames[0] == "cls"
-            and "cls" in frame.f_locals
-        ):
-            for cls in frame.f_locals["cls"].__mro__:
-                if name in cls.__dict__:
-                    return "{}.{}".format(cls.__name__, name)
-    except AttributeError:
-        pass
+        # co_name only contains the frame name.  If the frame was a method,
+        # the class name will NOT be included.
+        name = f_code.co_name
 
-    # nothing we can do if it is a staticmethod (decorated with @staticmethod)
+        # if it was a method, we can get the class name by inspecting
+        # the f_locals for the `self` argument
+        try:
+            if (
+                # the co_varnames start with the frame's positional arguments
+                # and we expect the first to be `self` if its an instance method
+                co_varnames
+                and co_varnames[0] == "self"
+                and "self" in frame.f_locals
+            ):
+                for cls in frame.f_locals["self"].__class__.__mro__:
+                    if name in cls.__dict__:
+                        return "{}.{}".format(cls.__name__, name)
+        except AttributeError:
+            pass
 
-    # we've done all we can, time to give up and return what we have
-    return name
+        # if it was a class method, (decorated with `@classmethod`)
+        # we can get the class name by inspecting the f_locals for the `cls` argument
+        try:
+            if (
+                # the co_varnames start with the frame's positional arguments
+                # and we expect the first to be `cls` if its a class method
+                co_varnames
+                and co_varnames[0] == "cls"
+                and "cls" in frame.f_locals
+            ):
+                for cls in frame.f_locals["cls"].__mro__:
+                    if name in cls.__dict__:
+                        return "{}.{}".format(cls.__name__, name)
+        except AttributeError:
+            pass
+
+        # nothing we can do if it is a staticmethod (decorated with @staticmethod)
+
+        # we've done all we can, time to give up and return what we have
+        return name
 
 
 MAX_PROFILE_DURATION_NS = int(3e10)  # 30 seconds

--- a/tests/test_profiler.py
+++ b/tests/test_profiler.py
@@ -27,6 +27,7 @@ def requires_python_version(major, minor, reason=None):
         reason = "Requires Python {}.{}".format(major, minor)
     return pytest.mark.skipif(sys.version_info < (major, minor), reason=reason)
 
+
 requires_gevent = pytest.mark.skipif(gevent is None, reason="gevent not enabled")
 
 


### PR DESCRIPTION
The `get_frame_name` implementation works well for <3.11 but 3.11 introduced a `co_qualname` that works like our implementation of `get_frame_name` and handles some cases better.