### PR TITLE
fix(serializer): Add support for `bytearray` and `memoryview` types

### DIFF
--- a/sentry_sdk/_compat.py
+++ b/sentry_sdk/_compat.py
@@ -26,6 +26,7 @@ if PY2:
     number_types = (int, long, float)  # noqa
     int_types = (int, long)  # noqa
     iteritems = lambda x: x.iteritems()  # noqa: B301
+    binary_sequence_types = (bytearray, memoryview)
 
     def implements_str(cls):
         # type: (T) -> T
@@ -44,6 +45,7 @@ else:
     number_types = (int, float)  # type: Tuple[type, type]
     int_types = (int,)
     iteritems = lambda x: x.items()
+    binary_sequence_types = (bytes, bytearray, memoryview)
 
     def implements_str(x):
         # type: (T) -> T

--- a/sentry_sdk/serializer.py
+++ b/sentry_sdk/serializer.py
@@ -15,7 +15,14 @@ from sentry_sdk.utils import (
 
 import sentry_sdk.utils
 
-from sentry_sdk._compat import text_type, PY2, string_types, number_types, iteritems
+from sentry_sdk._compat import (
+    text_type,
+    PY2,
+    string_types,
+    number_types,
+    iteritems,
+    binary_sequence_types,
+)
 
 from sentry_sdk._types import MYPY
 
@@ -47,7 +54,7 @@ if PY2:
     # https://github.com/python/cpython/blob/master/Lib/collections/__init__.py#L49
     from collections import Mapping, Sequence, Set
 
-    serializable_str_types = string_types
+    serializable_str_types = string_types + binary_sequence_types
 
 else:
     # New in 3.3
@@ -55,7 +62,7 @@ else:
     from collections.abc import Mapping, Sequence, Set
 
     # Bytes are technically not strings in Python 3, but we can serialize them
-    serializable_str_types = (str, bytes)
+    serializable_str_types = string_types + binary_sequence_types
 
 
 # Maximum length of JSON-serialized event payloads that can be safely sent
@@ -350,7 +357,7 @@ def serialize(event, smart_transaction_trimming=False, **kwargs):
         if should_repr_strings:
             obj = safe_repr(obj)
         else:
-            if isinstance(obj, bytes):
+            if isinstance(obj, bytes) or isinstance(obj, bytearray):
                 obj = obj.decode("utf-8", "replace")
 
             if not isinstance(obj, string_types):

--- a/tests/test_serializer.py
+++ b/tests/test_serializer.py
@@ -1,3 +1,4 @@
+import re
 import sys
 import pytest
 
@@ -60,6 +61,25 @@ def test_bytes_serialization_repr(message_normalizer):
     binary = b"abc123\x80\xf0\x9f\x8d\x95"
     result = message_normalizer(binary, should_repr_strings=True)
     assert result == r"b'abc123\x80\xf0\x9f\x8d\x95'"
+
+
+def test_bytearray_serialization_decode(message_normalizer):
+    binary = bytearray(b"abc123\x80\xf0\x9f\x8d\x95")
+    result = message_normalizer(binary, should_repr_strings=False)
+    assert result == "abc123\ufffd\U0001f355"
+
+
+@pytest.mark.xfail(sys.version_info < (3,), reason="Known safe_repr bugs in Py2.7")
+def test_bytearray_serialization_repr(message_normalizer):
+    binary = bytearray(b"abc123\x80\xf0\x9f\x8d\x95")
+    result = message_normalizer(binary, should_repr_strings=True)
+    assert result == r"bytearray(b'abc123\x80\xf0\x9f\x8d\x95')"
+
+
+def test_memoryview_serialization_repr(message_normalizer):
+    binary = memoryview(b"abc123\x80\xf0\x9f\x8d\x95")
+    result = message_normalizer(binary, should_repr_strings=False)
+    assert re.match(r"^<memory at 0x\w+>$", result)
 
 
 def test_serialize_sets(extra_normalizer):


### PR DESCRIPTION
Both `bytearray` and `memoryview` built-in types weren't explicitly mentioned in the serializer logic, and as they are subtyping Sequence, this led their instances to be enumerated upon, and to be output as a list of bytes, byte per byte.

In the case of `memoryview`, this could also lead to a segmentation fault if the memory referenced was already freed and unavailable to the process by then.

By explicitly adding them as seralizable types, bytearray will be decoded as a string just like bytes, and memoryview will use its __repr__ method instead.

Close GH-1829

-----

I noticed Python 2.7 was still supported, so I also attempted to add the fix for this version.

However `bytearray` and `memoryview` were introduced by Python 2.7, so this PR introduces code that is not supported by Python 2.6 (which reached its end of life in 2013).

I don't know if this is a concern or not?