### PR TITLE
fix(otel): NoOpSpan updates scope

### DIFF
--- a/sentry_sdk/tracing.py
+++ b/sentry_sdk/tracing.py
@@ -859,14 +859,6 @@ class NoOpSpan(Span):
         # type: () -> str
         return self.__class__.__name__
 
-    def __enter__(self):
-        # type: () -> NoOpSpan
-        return self
-
-    def __exit__(self, ty, value, tb):
-        # type: (Optional[Any], Optional[Any], Optional[Any]) -> None
-        pass
-
     def start_child(self, instrumenter=INSTRUMENTER.SENTRY, **kwargs):
         # type: (str, **Any) -> NoOpSpan
         return NoOpSpan()

--- a/tests/tracing/test_noop_span.py
+++ b/tests/tracing/test_noop_span.py
@@ -11,7 +11,9 @@ from sentry_sdk.tracing import NoOpSpan
 def test_noop_start_transaction(sentry_init):
     sentry_init(instrumenter="otel", debug=True)
 
-    with sentry_sdk.start_transaction(op="task", name="test_transaction_name") as transaction:
+    with sentry_sdk.start_transaction(
+        op="task", name="test_transaction_name"
+    ) as transaction:
         assert isinstance(transaction, NoOpSpan)
         assert sentry_sdk.Hub.current.scope.span is transaction
 

--- a/tests/tracing/test_noop_span.py
+++ b/tests/tracing/test_noop_span.py
@@ -11,10 +11,11 @@ from sentry_sdk.tracing import NoOpSpan
 def test_noop_start_transaction(sentry_init):
     sentry_init(instrumenter="otel", debug=True)
 
-    transaction = sentry_sdk.start_transaction(op="task", name="test_transaction_name")
-    assert isinstance(transaction, NoOpSpan)
+    with sentry_sdk.start_transaction(op="task", name="test_transaction_name") as transaction:
+        assert isinstance(transaction, NoOpSpan)
+        assert sentry_sdk.Hub.current.scope.span is transaction
 
-    transaction.name = "new name"
+        transaction.name = "new name"
 
 
 def test_noop_start_span(sentry_init):
@@ -22,6 +23,7 @@ def test_noop_start_span(sentry_init):
 
     with sentry_sdk.start_span(op="http", description="GET /") as span:
         assert isinstance(span, NoOpSpan)
+        assert sentry_sdk.Hub.current.scope.span is span
 
         span.set_tag("http.status_code", "418")
         span.set_data("http.entity_type", "teapot")
@@ -35,6 +37,7 @@ def test_noop_transaction_start_child(sentry_init):
 
     with transaction.start_child(op="child_task") as child:
         assert isinstance(child, NoOpSpan)
+        assert sentry_sdk.Hub.current.scope.span is child
 
 
 def test_noop_span_start_child(sentry_init):
@@ -44,3 +47,4 @@ def test_noop_span_start_child(sentry_init):
 
     with span.start_child(op="child_task") as child:
         assert isinstance(child, NoOpSpan)
+        assert sentry_sdk.Hub.current.scope.span is child


### PR DESCRIPTION
When using otel as the instrumentor, the NoOpSpan needs to update the scope when it's used as a context manager. If it does not, then this differs from the usual behaviour of a span and the end user may start seeing an unexpected `None` on the scope.