### PR TITLE
Avoid import of pkg_resource with Starlette integration

### DIFF
--- a/sentry_sdk/integrations/asgi.py
+++ b/sentry_sdk/integrations/asgi.py
@@ -108,7 +108,7 @@ class SentryAsgiMiddleware:
             )
 
         asgi_middleware_while_using_starlette_or_fastapi = (
-            "starlette" in _get_installed_modules() and mechanism_type == "asgi"
+            mechanism_type == "asgi" and "starlette" in _get_installed_modules()
         )
         if asgi_middleware_while_using_starlette_or_fastapi:
             logger.warning(


### PR DESCRIPTION
By changing the order in the condition, we can avoid the call to `_get_installed_modules` at import time (which imports `pkg_resources`) when the `mechanism_type` is set to `"starlette"`.

I have validated the change using `PYTHONPROFILEIMPORTTIME=1`.

Tell me if such a change requires a link to an issue or some testing.