### PR TITLE
Fix middleware being patched multiple times when using FastAPI

### DIFF
--- a/sentry_sdk/integrations/starlette.py
+++ b/sentry_sdk/integrations/starlette.py
@@ -167,44 +167,47 @@ def patch_exception_middleware(middleware_class):
     """
     old_middleware_init = middleware_class.__init__
 
-    def _sentry_middleware_init(self, *args, **kwargs):
-        # type: (Any, Any, Any) -> None
-        old_middleware_init(self, *args, **kwargs)
+    not_yet_patched = "_sentry_middleware_init" not in str(old_middleware_init)
 
-        # Patch existing exception handlers
-        old_handlers = self._exception_handlers.copy()
-
-        async def _sentry_patched_exception_handler(self, *args, **kwargs):
+    if not_yet_patched:
+        def _sentry_middleware_init(self, *args, **kwargs):
             # type: (Any, Any, Any) -> None
-            exp = args[0]
+            old_middleware_init(self, *args, **kwargs)
 
-            is_http_server_error = (
-                hasattr(exp, "status_code") and exp.status_code >= 500
-            )
-            if is_http_server_error:
-                _capture_exception(exp, handled=True)
+            # Patch existing exception handlers
+            old_handlers = self._exception_handlers.copy()
 
-            # Find a matching handler
-            old_handler = None
-            for cls in type(exp).__mro__:
-                if cls in old_handlers:
-                    old_handler = old_handlers[cls]
-                    break
+            async def _sentry_patched_exception_handler(self, *args, **kwargs):
+                # type: (Any, Any, Any) -> None
+                exp = args[0]
 
-            if old_handler is None:
-                return
+                is_http_server_error = (
+                    hasattr(exp, "status_code") and exp.status_code >= 500
+                )
+                if is_http_server_error:
+                    _capture_exception(exp, handled=True)
 
-            if _is_async_callable(old_handler):
-                return await old_handler(self, *args, **kwargs)
-            else:
-                return old_handler(self, *args, **kwargs)
+                # Find a matching handler
+                old_handler = None
+                for cls in type(exp).__mro__:
+                    if cls in old_handlers:
+                        old_handler = old_handlers[cls]
+                        break
 
-        for key in self._exception_handlers.keys():
-            self._exception_handlers[key] = _sentry_patched_exception_handler
+                if old_handler is None:
+                    return
 
-    middleware_class.__init__ = _sentry_middleware_init
+                if _is_async_callable(old_handler):
+                    return await old_handler(self, *args, **kwargs)
+                else:
+                    return old_handler(self, *args, **kwargs)
 
-    old_call = middleware_class.__call__
+            for key in self._exception_handlers.keys():
+                self._exception_handlers[key] = _sentry_patched_exception_handler
+
+        middleware_class.__init__ = _sentry_middleware_init
+
+        old_call = middleware_class.__call__
 
     async def _sentry_exceptionmiddleware_call(self, scope, receive, send):
         # type: (Dict[str, Any], Dict[str, Any], Callable[[], Awaitable[Dict[str, Any]]], Callable[[Dict[str, Any]], Awaitable[None]]) -> None
@@ -267,12 +270,16 @@ def patch_authentication_middleware(middleware_class):
     """
     old_call = middleware_class.__call__
 
-    async def _sentry_authenticationmiddleware_call(self, scope, receive, send):
-        # type: (Dict[str, Any], Dict[str, Any], Callable[[], Awaitable[Dict[str, Any]]], Callable[[Dict[str, Any]], Awaitable[None]]) -> None
-        await old_call(self, scope, receive, send)
-        _add_user_to_sentry_scope(scope)
+    not_yet_patched = "_sentry_authenticationmiddleware_call" not in str(old_call)
 
-    middleware_class.__call__ = _sentry_authenticationmiddleware_call
+    if not_yet_patched:
+
+        async def _sentry_authenticationmiddleware_call(self, scope, receive, send):
+            # type: (Dict[str, Any], Dict[str, Any], Callable[[], Awaitable[Dict[str, Any]]], Callable[[Dict[str, Any]], Awaitable[None]]) -> None
+            await old_call(self, scope, receive, send)
+            _add_user_to_sentry_scope(scope)
+
+        middleware_class.__call__ = _sentry_authenticationmiddleware_call
 
 
 def patch_middlewares():

--- a/sentry_sdk/integrations/starlette.py
+++ b/sentry_sdk/integrations/starlette.py
@@ -32,14 +32,12 @@ try:
     from starlette.applications import Starlette  # type: ignore
     from starlette.datastructures import UploadFile  # type: ignore
     from starlette.middleware import Middleware  # type: ignore
-    from starlette.middleware.authentication import (
+    from starlette.middleware.authentication import (  # type: ignore
         AuthenticationMiddleware,
-    )  # type: ignore
+    )
     from starlette.requests import Request  # type: ignore
     from starlette.routing import Match  # type: ignore
-    from starlette.types import ASGIApp, Receive
-    from starlette.types import Scope as StarletteScope  # type: ignore
-    from starlette.types import Send
+    from starlette.types import ASGIApp, Receive, Scope as StarletteScope, Send  # type: ignore
 except ImportError:
     raise DidNotEnable("Starlette is not installed")
 

--- a/sentry_sdk/integrations/starlette.py
+++ b/sentry_sdk/integrations/starlette.py
@@ -9,12 +9,18 @@ from sentry_sdk._types import MYPY
 from sentry_sdk.consts import OP
 from sentry_sdk.hub import Hub, _should_send_default_pii
 from sentry_sdk.integrations import DidNotEnable, Integration
-from sentry_sdk.integrations._wsgi_common import (_is_json_content_type,
-                                                  request_body_within_bounds)
+from sentry_sdk.integrations._wsgi_common import (
+    _is_json_content_type,
+    request_body_within_bounds,
+)
 from sentry_sdk.integrations.asgi import SentryAsgiMiddleware
 from sentry_sdk.tracing import SOURCE_FOR_STYLE, TRANSACTION_SOURCE_ROUTE
-from sentry_sdk.utils import (AnnotatedValue, capture_internal_exceptions,
-                              event_from_exception, transaction_from_function)
+from sentry_sdk.utils import (
+    AnnotatedValue,
+    capture_internal_exceptions,
+    event_from_exception,
+    transaction_from_function,
+)
 
 if MYPY:
     from typing import Any, Awaitable, Callable, Dict, Optional
@@ -26,8 +32,9 @@ try:
     from starlette.applications import Starlette  # type: ignore
     from starlette.datastructures import UploadFile  # type: ignore
     from starlette.middleware import Middleware  # type: ignore
-    from starlette.middleware.authentication import \
-        AuthenticationMiddleware  # type: ignore
+    from starlette.middleware.authentication import (
+        AuthenticationMiddleware,
+    )  # type: ignore
     from starlette.requests import Request  # type: ignore
     from starlette.routing import Match  # type: ignore
     from starlette.types import ASGIApp, Receive
@@ -38,8 +45,7 @@ except ImportError:
 
 try:
     # Starlette 0.20
-    from starlette.middleware.exceptions import \
-        ExceptionMiddleware  # type: ignore
+    from starlette.middleware.exceptions import ExceptionMiddleware  # type: ignore
 except ImportError:
     # Startlette 0.19.1
     from starlette.exceptions import ExceptionMiddleware  # type: ignore
@@ -167,6 +173,7 @@ def patch_exception_middleware(middleware_class):
     not_yet_patched = "_sentry_middleware_init" not in str(old_middleware_init)
 
     if not_yet_patched:
+
         def _sentry_middleware_init(self, *args, **kwargs):
             # type: (Any, Any, Any) -> None
             old_middleware_init(self, *args, **kwargs)


### PR DESCRIPTION
When the `StarletteIntegration` is used in a FastAPI app, as instructed in [the docs](https://docs.sentry.io/platforms/python/guides/fastapi/), the `AuthenticationMiddleware` and `ExceptionMiddleware` get patched every time `add_middleware` or `add_exception_handler` is called, since these methods call `build_middleware_stack`, where patched `Middleware` instances are repatched without checking if they were already patched.

If these functions are called enough times, Python registers this as infinite recursion (as we've discovered).

The changes look broad, but amount to the addition of two `if not_yet_patched` checks and indentation.