### PR TITLE
fix(profiling): Default in_app decision to None

### DIFF
--- a/sentry_sdk/profiler.py
+++ b/sentry_sdk/profiler.py
@@ -439,7 +439,10 @@ class Profile(object):
         profile = self.process()
 
         handle_in_app_impl(
-            profile["frames"], options["in_app_exclude"], options["in_app_include"]
+            profile["frames"],
+            options["in_app_exclude"],
+            options["in_app_include"],
+            default_in_app=False,  # Do not default a frame to `in_app: True`
         )
 
         return {

--- a/sentry_sdk/utils.py
+++ b/sentry_sdk/utils.py
@@ -755,8 +755,8 @@ def handle_in_app(event, in_app_exclude=None, in_app_include=None):
     return event
 
 
-def handle_in_app_impl(frames, in_app_exclude, in_app_include):
-    # type: (Any, Optional[List[str]], Optional[List[str]]) -> Optional[Any]
+def handle_in_app_impl(frames, in_app_exclude, in_app_include, default_in_app=True):
+    # type: (Any, Optional[List[str]], Optional[List[str]], bool) -> Optional[Any]
     if not frames:
         return None
 
@@ -777,7 +777,7 @@ def handle_in_app_impl(frames, in_app_exclude, in_app_include):
         elif _module_in_set(module, in_app_exclude):
             frame["in_app"] = False
 
-    if not any_in_app:
+    if default_in_app and not any_in_app:
         for frame in frames:
             if frame.get("in_app") is None:
                 frame["in_app"] = True

--- a/tests/utils/test_general.py
+++ b/tests/utils/test_general.py
@@ -154,6 +154,22 @@ def test_in_app(empty):
     ) == [{"module": "foo", "in_app": False}, {"module": "bar", "in_app": True}]
 
 
+def test_default_in_app():
+    assert handle_in_app_impl(
+        [{"module": "foo"}, {"module": "bar"}], in_app_include=None, in_app_exclude=None
+    ) == [
+        {"module": "foo", "in_app": True},
+        {"module": "bar", "in_app": True},
+    ]
+
+    assert handle_in_app_impl(
+        [{"module": "foo"}, {"module": "bar"}],
+        in_app_include=None,
+        in_app_exclude=None,
+        default_in_app=False,
+    ) == [{"module": "foo"}, {"module": "bar"}]
+
+
 def test_iter_stacktraces():
     assert set(
         iter_event_stacktraces(


### PR DESCRIPTION
Currently, the SDK marks all frames as in_app when it can't find any in_app frames. As we try to move some of this detection server side, we still want to allow the end user to overwrite the decision client side. So we'll leave in_app as `None` to indicate the server should decide of the frame is in_app.