### PR TITLE
feat(crons): Add CronMonitorIntegration

### DIFF
--- a/sentry_sdk/integrations/__init__.py
+++ b/sentry_sdk/integrations/__init__.py
@@ -67,6 +67,7 @@ _AUTO_ENABLING_INTEGRATIONS = (
     "sentry_sdk.integrations.redis.RedisIntegration",
     "sentry_sdk.integrations.pyramid.PyramidIntegration",
     "sentry_sdk.integrations.boto3.Boto3Integration",
+    "sentry_sdk.integrations.cron_monitor.CronMonitorIntegration",
 )
 
 

--- a/sentry_sdk/integrations/cron_monitor.py
+++ b/sentry_sdk/integrations/cron_monitor.py
@@ -1,0 +1,38 @@
+from __future__ import absolute_import
+
+import os
+
+from sentry_sdk.hub import Hub
+from sentry_sdk.integrations import DidNotEnable, Integration
+from sentry_sdk.scope import add_global_event_processor
+
+from sentry_sdk._types import MYPY
+
+if MYPY:
+    from typing import Optional
+
+    from sentry_sdk._types import Event, Hint
+
+__all__ = ["CronMonitorIntegration"]
+
+
+# The sentry-cli sets the monitor ID in the execution environment
+monitor_id = os.environ.get("SENTRY_MONITOR_ID")
+if monitor_id is None:
+    raise DidNotEnable("SENTRY_MONITOR_ID is not set")
+
+
+class CronMonitorIntegration(Integration):
+    identifier = "cron_monitor"
+
+    @staticmethod
+    def setup_once():
+        # type: () -> None
+        @add_global_event_processor
+        def processor(event, hint):
+            # type: (Event, Optional[Hint]) -> Optional[Event]
+            if Hub.current.get_integration(CronMonitorIntegration) is not None:
+                ctx = event.setdefault("contexts", {}).setdefault("monitor", {})
+                ctx["id"] = monitor_id
+
+            return event

--- a/tests/integrations/cron_monitor/test_cron_monitor.py
+++ b/tests/integrations/cron_monitor/test_cron_monitor.py
@@ -1,0 +1,24 @@
+import uuid
+import os
+
+from sentry_sdk import capture_message
+
+try:
+    from unittest import mock  # python 3.3 and above
+except ImportError:
+    import mock  # python < 3.3
+
+
+def test_basic(sentry_init, capture_events):
+    monitor_id = uuid.uuid4().hex
+    with mock.patch.dict(
+        os.environ, {**os.environ, "SENTRY_MONITOR_ID": monitor_id}, clear=True
+    ):
+        from sentry_sdk.integrations.cron_monitor import CronMonitorIntegration
+
+        sentry_init(integrations=[CronMonitorIntegration()])
+        events = capture_events()
+        capture_message("hi")
+
+    (event,) = events
+    assert event["contexts"]["monitor"] == {"id": monitor_id}


### PR DESCRIPTION
This reads the SENTRY_MONITOR_ID from the environment and puts it into
the monitor context.

This is in support of https://github.com/getsentry/sentry/issues/43647