### PR TITLE
Fix check for Starlette in FastAPI integration

### DIFF
--- a/sentry_sdk/integrations/fastapi.py
+++ b/sentry_sdk/integrations/fastapi.py
@@ -4,17 +4,20 @@ import threading
 from sentry_sdk._types import MYPY
 from sentry_sdk.hub import Hub, _should_send_default_pii
 from sentry_sdk.integrations import DidNotEnable
-from sentry_sdk.integrations.starlette import (
-    StarletteIntegration,
-    StarletteRequestExtractor,
-)
 from sentry_sdk.tracing import SOURCE_FOR_STYLE, TRANSACTION_SOURCE_ROUTE
 from sentry_sdk.utils import transaction_from_function
 
 if MYPY:
     from typing import Any, Callable, Dict
-
     from sentry_sdk.scope import Scope
+
+try:
+    from sentry_sdk.integrations.starlette import (
+        StarletteIntegration,
+        StarletteRequestExtractor,
+    )
+except DidNotEnable:
+    raise DidNotEnable("Starlette is not installed")
 
 try:
     import fastapi  # type: ignore


### PR DESCRIPTION
When loading FastAPI integration also check if `StarletteIntegration` can actually be loaded. (Because Starlette is a requirement for FastAPI)

Fixes #1603 
 