### PR TITLE
fix(profiling): Always use builtin time.sleep

### DIFF
--- a/sentry_sdk/profiler.py
+++ b/sentry_sdk/profiler.py
@@ -118,6 +118,13 @@ except ImportError:
         return False
 
 
+try:
+    from gevent.monkey import get_original
+    thread_sleep = get_original("time", "sleep")
+except ImportError:
+    thread_sleep = time.sleep
+
+
 _scheduler = None  # type: Optional[Scheduler]
 
 
@@ -658,7 +665,7 @@ class ThreadScheduler(Scheduler):
             # not sleep for too long
             elapsed = time.perf_counter() - last
             if elapsed < self.interval:
-                time.sleep(self.interval - elapsed)
+                thread_sleep(self.interval - elapsed)
 
             # after sleeping, make sure to take the current
             # timestamp so we can use it next iteration
@@ -720,7 +727,7 @@ class GeventScheduler(Scheduler):
             # not sleep for too long
             elapsed = time.perf_counter() - last
             if elapsed < self.interval:
-                time.sleep(self.interval - elapsed)
+                thread_sleep(self.interval - elapsed)
 
             # after sleeping, make sure to take the current
             # timestamp so we can use it next iteration

--- a/sentry_sdk/profiler.py
+++ b/sentry_sdk/profiler.py
@@ -120,6 +120,7 @@ except ImportError:
 
 try:
     from gevent.monkey import get_original
+
     thread_sleep = get_original("time", "sleep")
 except ImportError:
     thread_sleep = time.sleep


### PR DESCRIPTION
As pointed out in https://github.com/getsentry/sentry-python/issues/1813#issuecomment-1406636598, gevent patches the `time` module and `time.sleep` will only release the GIL if there no other greenlets ready to run. This ensures that we always use the builtin `time.sleep` and not the patched version provided by `gevent`.