### PR TITLE
Do not overwrite default for username with email address in Flask-Login integration

### DIFF
--- a/sentry_sdk/integrations/flask.py
+++ b/sentry_sdk/integrations/flask.py
@@ -261,6 +261,5 @@ def _add_user_to_event(event):
 
         try:
             user_info.setdefault("username", user.username)
-            user_info.setdefault("username", user.email)
         except Exception:
             pass


### PR DESCRIPTION
This line seems like a copy/paste error, introduced in 41120009fa7d6cb88d9219cb20874c9dd705639d.

The email address is already set a few lines above for "email".

Unless I'm missing some very clever fallback magic, considering the `try/catch` around this, I think this is a mistake and the email address should not be used as username.