### PR TITLE
Better setting of in-app in stack frames

### DIFF
--- a/sentry_sdk/client.py
+++ b/sentry_sdk/client.py
@@ -103,6 +103,15 @@ class _Client(object):
     def __init__(self, *args, **kwargs):
         # type: (*Any, **Any) -> None
         self.options = get_options(*args, **kwargs)  # type: Dict[str, Any]
+
+        try:
+            project_root = os.getcwd()
+        except Exception:
+            project_root = None
+
+        self.configuration = {
+            "project_root": project_root,
+        }
         self._init_impl()
 
     def __getstate__(self):
@@ -222,7 +231,10 @@ class _Client(object):
             event["platform"] = "python"
 
         event = handle_in_app(
-            event, self.options["in_app_exclude"], self.options["in_app_include"]
+            event,
+            self.options["in_app_exclude"],
+            self.options["in_app_include"],
+            self.configuration["project_root"],
         )
 
         # Postprocess the event here so that annotated types do
@@ -446,7 +458,9 @@ class _Client(object):
 
             if is_transaction:
                 if profile is not None:
-                    envelope.add_profile(profile.to_json(event_opt, self.options))
+                    envelope.add_profile(
+                        profile.to_json(event_opt, self.options, self.configuration)
+                    )
                 envelope.add_transaction(event_opt)
             else:
                 envelope.add_event(event_opt)

--- a/sentry_sdk/client.py
+++ b/sentry_sdk/client.py
@@ -90,12 +90,13 @@ def _get_options(*args, **kwargs):
     if rv["instrumenter"] is None:
         rv["instrumenter"] = INSTRUMENTER.SENTRY
 
-    try:
-        project_root = os.getcwd()
-    except Exception:
-        project_root = None
+    if rv["project_root"] is None:
+        try:
+            project_root = os.getcwd()
+        except Exception:
+            project_root = None
 
-    rv["project_root"] = project_root
+        rv["project_root"] = project_root
 
     return rv
 

--- a/sentry_sdk/client.py
+++ b/sentry_sdk/client.py
@@ -90,6 +90,13 @@ def _get_options(*args, **kwargs):
     if rv["instrumenter"] is None:
         rv["instrumenter"] = INSTRUMENTER.SENTRY
 
+    try:
+        project_root = os.getcwd()
+    except Exception:
+        project_root = None
+
+    rv["project_root"] = project_root
+
     return rv
 
 
@@ -104,14 +111,6 @@ class _Client(object):
         # type: (*Any, **Any) -> None
         self.options = get_options(*args, **kwargs)  # type: Dict[str, Any]
 
-        try:
-            project_root = os.getcwd()
-        except Exception:
-            project_root = None
-
-        self.configuration = {
-            "project_root": project_root,
-        }
         self._init_impl()
 
     def __getstate__(self):
@@ -234,7 +233,7 @@ class _Client(object):
             event,
             self.options["in_app_exclude"],
             self.options["in_app_include"],
-            self.configuration["project_root"],
+            self.options["project_root"],
         )
 
         # Postprocess the event here so that annotated types do
@@ -458,9 +457,7 @@ class _Client(object):
 
             if is_transaction:
                 if profile is not None:
-                    envelope.add_profile(
-                        profile.to_json(event_opt, self.options, self.configuration)
-                    )
+                    envelope.add_profile(profile.to_json(event_opt, self.options))
                 envelope.add_transaction(event_opt)
             else:
                 envelope.add_event(event_opt)

--- a/sentry_sdk/consts.py
+++ b/sentry_sdk/consts.py
@@ -123,6 +123,7 @@ class ClientConstructor(object):
         proxy_headers=None,  # type: Optional[Dict[str, str]]
         instrumenter=INSTRUMENTER.SENTRY,  # type: Optional[str]
         before_send_transaction=None,  # type: Optional[TransactionProcessor]
+        project_root=None,  # type: Optional[str]
     ):
         # type: (...) -> None
         pass

--- a/sentry_sdk/profiler.py
+++ b/sentry_sdk/profiler.py
@@ -598,14 +598,15 @@ class Profile(object):
             "thread_metadata": thread_metadata,
         }
 
-    def to_json(self, event_opt, options):
-        # type: (Any, Dict[str, Any]) -> Dict[str, Any]
+    def to_json(self, event_opt, options, configuration):
+        # type: (Any, Dict[str, Any], Dict[str, Any]) -> Dict[str, Any]
         profile = self.process()
 
         handle_in_app_impl(
             profile["frames"],
             options["in_app_exclude"],
             options["in_app_include"],
+            configuration["project_root"],
         )
 
         return {

--- a/sentry_sdk/profiler.py
+++ b/sentry_sdk/profiler.py
@@ -606,7 +606,6 @@ class Profile(object):
             profile["frames"],
             options["in_app_exclude"],
             options["in_app_include"],
-            default_in_app=False,  # Do not default a frame to `in_app: True`
         )
 
         return {

--- a/sentry_sdk/profiler.py
+++ b/sentry_sdk/profiler.py
@@ -626,7 +626,7 @@ class Profile(object):
             "thread_metadata": thread_metadata,
         }
 
-    def to_json(self, event_opt, options, configuration):
+    def to_json(self, event_opt, options):
         # type: (Any, Dict[str, Any], Dict[str, Any]) -> Dict[str, Any]
         profile = self.process()
 
@@ -634,7 +634,7 @@ class Profile(object):
             profile["frames"],
             options["in_app_exclude"],
             options["in_app_include"],
-            configuration["project_root"],
+            options["project_root"],
         )
 
         return {

--- a/sentry_sdk/profiler.py
+++ b/sentry_sdk/profiler.py
@@ -27,9 +27,9 @@ from sentry_sdk._compat import PY33, PY311
 from sentry_sdk._types import MYPY
 from sentry_sdk.utils import (
     filename_for_module,
-    handle_in_app_impl,
     logger,
     nanosecond_time,
+    set_in_app_in_frames,
 )
 
 if MYPY:
@@ -630,7 +630,7 @@ class Profile(object):
         # type: (Any, Dict[str, Any], Dict[str, Any]) -> Dict[str, Any]
         profile = self.process()
 
-        handle_in_app_impl(
+        set_in_app_in_frames(
             profile["frames"],
             options["in_app_exclude"],
             options["in_app_include"],

--- a/sentry_sdk/utils.py
+++ b/sentry_sdk/utils.py
@@ -873,6 +873,7 @@ def _module_in_list(name, items):
 
 
 def _is_external_source(abs_path):
+    # type: (str) -> bool
     # check if frame is in 'site-packages' or 'dist-packages'
     external_source = (
         re.search(r"[\\/](?:dist|site)-packages[\\/]", abs_path) is not None
@@ -881,6 +882,7 @@ def _is_external_source(abs_path):
 
 
 def _is_in_project_root(abs_path, project_root):
+    # type: (str, Optional[str]) -> bool
     if project_root is None:
         return False
 

--- a/sentry_sdk/utils.py
+++ b/sentry_sdk/utils.py
@@ -764,7 +764,7 @@ def iter_event_frames(event):
 def handle_in_app(event, in_app_exclude=None, in_app_include=None, project_root=None):
     # type: (Dict[str, Any], Optional[List[str]], Optional[List[str]], Optional[str]) -> Dict[str, Any]
     for stacktrace in iter_event_stacktraces(event):
-        handle_in_app_impl(
+        set_in_app_in_frames(
             stacktrace.get("frames"),
             in_app_exclude=in_app_exclude,
             in_app_include=in_app_include,
@@ -774,7 +774,7 @@ def handle_in_app(event, in_app_exclude=None, in_app_include=None, project_root=
     return event
 
 
-def handle_in_app_impl(frames, in_app_exclude, in_app_include, project_root=None):
+def set_in_app_in_frames(frames, in_app_exclude, in_app_include, project_root=None):
     # type: (Any, Optional[List[str]], Optional[List[str]], Optional[str]) -> Optional[Any]
     if not frames:
         return None

--- a/sentry_sdk/utils.py
+++ b/sentry_sdk/utils.py
@@ -800,7 +800,8 @@ def handle_in_app_impl(frames, in_app_exclude, in_app_include):
                 re.search(r"[\\/](?:dist|site)-packages[\\/]", frame["abs_path"])
                 is not None
             )
-            frame["in_app"] = not external_source
+            if external_source:
+                frame["in_app"] = False
 
     return frames
 

--- a/sentry_sdk/utils.py
+++ b/sentry_sdk/utils.py
@@ -792,6 +792,10 @@ def handle_in_app_impl(frames, in_app_exclude, in_app_include):
             frame["in_app"] = False
 
         else:
+            abs_path = frame.get("abs_path")
+            if abs_path is None:
+                continue
+
             external_source = (
                 re.search(r"[\\/](?:dist|site)-packages[\\/]", frame["abs_path"])
                 is not None

--- a/tests/integrations/django/test_basic.py
+++ b/tests/integrations/django/test_basic.py
@@ -595,20 +595,12 @@ def test_template_exception(
         if not f["filename"].startswith("django/")
     ]
     view_frame, template_frame = frames[-2:]
-    import logging
-
-    logger = logging.getLogger("xxx")
-    logger.error("view_frame")
-    logger.error(view_frame)
-    logger.error("template_frame")
-    logger.error(template_frame)
 
     assert template_frame["context_line"] == "{% invalid template tag %}\n"
     assert template_frame["pre_context"] == ["5\n", "6\n", "7\n", "8\n", "9\n"]
 
     assert template_frame["post_context"] == ["11\n", "12\n", "13\n", "14\n", "15\n"]
     assert template_frame["lineno"] == 10
-    assert template_frame["in_app"]
     assert template_frame["filename"].endswith("error.html")
 
     filenames = [

--- a/tests/integrations/django/test_basic.py
+++ b/tests/integrations/django/test_basic.py
@@ -595,6 +595,13 @@ def test_template_exception(
         if not f["filename"].startswith("django/")
     ]
     view_frame, template_frame = frames[-2:]
+    import logging
+
+    logger = logging.getLogger("xxx")
+    logger.error("view_frame")
+    logger.error(view_frame)
+    logger.error("template_frame")
+    logger.error(template_frame)
 
     assert template_frame["context_line"] == "{% invalid template tag %}\n"
     assert template_frame["pre_context"] == ["5\n", "6\n", "7\n", "8\n", "9\n"]

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -401,7 +401,6 @@ def test_attach_stacktrace_in_app(sentry_init, capture_events):
     pytest_frames = [f for f in frames if f["module"].startswith("_pytest")]
     assert pytest_frames
     assert all(f["in_app"] is False for f in pytest_frames)
-    assert any(f["in_app"] for f in frames)
 
 
 def test_attach_stacktrace_disabled(sentry_init, capture_events):

--- a/tests/utils/test_general.py
+++ b/tests/utils/test_general.py
@@ -154,22 +154,6 @@ def test_in_app(empty):
     ) == [{"module": "foo", "in_app": False}, {"module": "bar", "in_app": True}]
 
 
-def test_default_in_app():
-    assert handle_in_app_impl(
-        [{"module": "foo"}, {"module": "bar"}], in_app_include=None, in_app_exclude=None
-    ) == [
-        {"module": "foo", "in_app": True},
-        {"module": "bar", "in_app": True},
-    ]
-
-    assert handle_in_app_impl(
-        [{"module": "foo"}, {"module": "bar"}],
-        in_app_include=None,
-        in_app_exclude=None,
-        default_in_app=False,
-    ) == [{"module": "foo"}, {"module": "bar"}]
-
-
 def test_iter_stacktraces():
     assert set(
         iter_event_stacktraces(

--- a/tests/utils/test_general.py
+++ b/tests/utils/test_general.py
@@ -396,6 +396,38 @@ def test_parse_invalid_dsn(dsn):
                 "in_app": False,
             },
         ],
+        [
+            {
+                "module": "fastapi.routing",
+            },
+            None,
+            None,
+            {
+                "module": "fastapi.routing",
+            },
+        ],
+        [
+            {
+                "module": "fastapi.routing",
+            },
+            ["fastapi"],
+            None,
+            {
+                "module": "fastapi.routing",
+                "in_app": True,
+            },
+        ],
+        [
+            {
+                "module": "fastapi.routing",
+            },
+            None,
+            ["fastapi"],
+            {
+                "module": "fastapi.routing",
+                "in_app": False,
+            },
+        ],
     ],
 )
 def test_handle_in_app_impl(frame, in_app_include, in_app_exclude, resulting_frame):

--- a/tests/utils/test_general.py
+++ b/tests/utils/test_general.py
@@ -133,25 +133,277 @@ def test_parse_invalid_dsn(dsn):
         dsn = Dsn(dsn)
 
 
-@pytest.mark.parametrize("empty", [None, []])
-def test_in_app(empty):
-    assert handle_in_app_impl(
-        [{"module": "foo"}, {"module": "bar"}],
-        in_app_include=["foo"],
-        in_app_exclude=empty,
-    ) == [{"module": "foo", "in_app": True}, {"module": "bar"}]
+@pytest.mark.parametrize(
+    "frame,in_app_include,in_app_exclude,resulting_frame",
+    [
+        [
+            {
+                "abs_path": "/home/ubuntu/fastapi/.venv/lib/python3.10/site-packages/fastapi/routing.py",
+            },
+            None,
+            None,
+            {
+                "abs_path": "/home/ubuntu/fastapi/.venv/lib/python3.10/site-packages/fastapi/routing.py",
+                "in_app": False,
+            },
+        ],
+        [
+            {
+                "module": "fastapi.routing",
+                "abs_path": "/home/ubuntu/fastapi/.venv/lib/python3.10/site-packages/fastapi/routing.py",
+            },
+            None,
+            None,
+            {
+                "module": "fastapi.routing",
+                "abs_path": "/home/ubuntu/fastapi/.venv/lib/python3.10/site-packages/fastapi/routing.py",
+                "in_app": False,
+            },
+        ],
+        [
+            {
+                "module": "fastapi.routing",
+                "abs_path": "/home/ubuntu/fastapi/.venv/lib/python3.10/site-packages/fastapi/routing.py",
+                "in_app": True,
+            },
+            None,
+            None,
+            {
+                "module": "fastapi.routing",
+                "abs_path": "/home/ubuntu/fastapi/.venv/lib/python3.10/site-packages/fastapi/routing.py",
+                "in_app": True,
+            },
+        ],
+        [
+            {
+                "abs_path": "C:\\Users\\winuser\\AppData\\Roaming\\Python\\Python35\\site-packages\\fastapi\\routing.py",
+            },
+            None,
+            None,
+            {
+                "abs_path": "C:\\Users\\winuser\\AppData\\Roaming\\Python\\Python35\\site-packages\\fastapi\\routing.py",
+                "in_app": False,
+            },
+        ],
+        [
+            {
+                "module": "fastapi.routing",
+                "abs_path": "/usr/lib/python2.7/dist-packages/fastapi/routing.py",
+            },
+            None,
+            None,
+            {
+                "module": "fastapi.routing",
+                "abs_path": "/usr/lib/python2.7/dist-packages/fastapi/routing.py",
+                "in_app": False,
+            },
+        ],
+        [
+            {
+                "abs_path": "/home/ubuntu/fastapi/main.py",
+            },
+            None,
+            None,
+            {
+                "abs_path": "/home/ubuntu/fastapi/main.py",
+                "in_app": True,
+            },
+        ],
+        [
+            {
+                "module": "main",
+                "abs_path": "/home/ubuntu/fastapi/main.py",
+            },
+            None,
+            None,
+            {
+                "module": "main",
+                "abs_path": "/home/ubuntu/fastapi/main.py",
+                "in_app": True,
+            },
+        ],
+        # include
+        [
+            {
+                "abs_path": "/home/ubuntu/fastapi/.venv/lib/python3.10/site-packages/fastapi/routing.py",
+            },
+            ["fastapi"],
+            None,
+            {
+                "abs_path": "/home/ubuntu/fastapi/.venv/lib/python3.10/site-packages/fastapi/routing.py",
+                "in_app": False,  # because there is no module set
+            },
+        ],
+        [
+            {
+                "module": "fastapi.routing",
+                "abs_path": "/home/ubuntu/fastapi/.venv/lib/python3.10/site-packages/fastapi/routing.py",
+            },
+            ["fastapi"],
+            None,
+            {
+                "module": "fastapi.routing",
+                "abs_path": "/home/ubuntu/fastapi/.venv/lib/python3.10/site-packages/fastapi/routing.py",
+                "in_app": True,
+            },
+        ],
+        [
+            {
+                "module": "fastapi.routing",
+                "abs_path": "/home/ubuntu/fastapi/.venv/lib/python3.10/site-packages/fastapi/routing.py",
+                "in_app": False,
+            },
+            ["fastapi"],
+            None,
+            {
+                "module": "fastapi.routing",
+                "abs_path": "/home/ubuntu/fastapi/.venv/lib/python3.10/site-packages/fastapi/routing.py",
+                "in_app": False,
+            },
+        ],
+        [
+            {
+                "abs_path": "C:\\Users\\winuser\\AppData\\Roaming\\Python\\Python35\\site-packages\\fastapi\\routing.py",
+            },
+            ["fastapi"],
+            None,
+            {
+                "abs_path": "C:\\Users\\winuser\\AppData\\Roaming\\Python\\Python35\\site-packages\\fastapi\\routing.py",
+                "in_app": False,  # because there is no module set
+            },
+        ],
+        [
+            {
+                "module": "fastapi.routing",
+                "abs_path": "/usr/lib/python2.7/dist-packages/fastapi/routing.py",
+            },
+            ["fastapi"],
+            None,
+            {
+                "module": "fastapi.routing",
+                "abs_path": "/usr/lib/python2.7/dist-packages/fastapi/routing.py",
+                "in_app": True,
+            },
+        ],
+        [
+            {
+                "abs_path": "/home/ubuntu/fastapi/main.py",
+            },
+            ["fastapi"],
+            None,
+            {
+                "abs_path": "/home/ubuntu/fastapi/main.py",
+                "in_app": True,
+            },
+        ],
+        [
+            {
+                "module": "main",
+                "abs_path": "/home/ubuntu/fastapi/main.py",
+            },
+            ["fastapi"],
+            None,
+            {
+                "module": "main",
+                "abs_path": "/home/ubuntu/fastapi/main.py",
+                "in_app": True,
+            },
+        ],
+        # exclude
+        [
+            {
+                "abs_path": "/home/ubuntu/fastapi/.venv/lib/python3.10/site-packages/fastapi/routing.py",
+            },
+            None,
+            ["main"],
+            {
+                "abs_path": "/home/ubuntu/fastapi/.venv/lib/python3.10/site-packages/fastapi/routing.py",
+                "in_app": False,
+            },
+        ],
+        [
+            {
+                "module": "fastapi.routing",
+                "abs_path": "/home/ubuntu/fastapi/.venv/lib/python3.10/site-packages/fastapi/routing.py",
+            },
+            None,
+            ["main"],
+            {
+                "module": "fastapi.routing",
+                "abs_path": "/home/ubuntu/fastapi/.venv/lib/python3.10/site-packages/fastapi/routing.py",
+                "in_app": False,
+            },
+        ],
+        [
+            {
+                "module": "fastapi.routing",
+                "abs_path": "/home/ubuntu/fastapi/.venv/lib/python3.10/site-packages/fastapi/routing.py",
+                "in_app": True,
+            },
+            None,
+            ["main"],
+            {
+                "module": "fastapi.routing",
+                "abs_path": "/home/ubuntu/fastapi/.venv/lib/python3.10/site-packages/fastapi/routing.py",
+                "in_app": True,
+            },
+        ],
+        [
+            {
+                "abs_path": "C:\\Users\\winuser\\AppData\\Roaming\\Python\\Python35\\site-packages\\fastapi\\routing.py",
+            },
+            None,
+            ["main"],
+            {
+                "abs_path": "C:\\Users\\winuser\\AppData\\Roaming\\Python\\Python35\\site-packages\\fastapi\\routing.py",
+                "in_app": False,
+            },
+        ],
+        [
+            {
+                "module": "fastapi.routing",
+                "abs_path": "/usr/lib/python2.7/dist-packages/fastapi/routing.py",
+            },
+            None,
+            ["main"],
+            {
+                "module": "fastapi.routing",
+                "abs_path": "/usr/lib/python2.7/dist-packages/fastapi/routing.py",
+                "in_app": False,
+            },
+        ],
+        [
+            {
+                "abs_path": "/home/ubuntu/fastapi/main.py",
+            },
+            None,
+            ["main"],
+            {
+                "abs_path": "/home/ubuntu/fastapi/main.py",
+                "in_app": True,  # because there is no module set
+            },
+        ],
+        [
+            {
+                "module": "main",
+                "abs_path": "/home/ubuntu/fastapi/main.py",
+            },
+            None,
+            ["main"],
+            {
+                "module": "main",
+                "abs_path": "/home/ubuntu/fastapi/main.py",
+                "in_app": False,
+            },
+        ],
+    ],
+)
+def test_handle_in_app_impl(frame, in_app_include, in_app_exclude, resulting_frame):
+    new_frames = handle_in_app_impl(
+        [frame], in_app_include=in_app_include, in_app_exclude=in_app_exclude
+    )
 
-    assert handle_in_app_impl(
-        [{"module": "foo"}, {"module": "bar"}],
-        in_app_include=["foo"],
-        in_app_exclude=["foo"],
-    ) == [{"module": "foo", "in_app": True}, {"module": "bar"}]
-
-    assert handle_in_app_impl(
-        [{"module": "foo"}, {"module": "bar"}],
-        in_app_include=empty,
-        in_app_exclude=["foo"],
-    ) == [{"module": "foo", "in_app": False}, {"module": "bar", "in_app": True}]
+    assert new_frames[0] == resulting_frame
 
 
 def test_iter_stacktraces():

--- a/tests/utils/test_general.py
+++ b/tests/utils/test_general.py
@@ -134,12 +134,13 @@ def test_parse_invalid_dsn(dsn):
 
 
 @pytest.mark.parametrize(
-    "frame,in_app_include,in_app_exclude,resulting_frame",
+    "frame,in_app_include,in_app_exclude,project_root,resulting_frame",
     [
         [
             {
                 "abs_path": "/home/ubuntu/fastapi/.venv/lib/python3.10/site-packages/fastapi/routing.py",
             },
+            None,
             None,
             None,
             {
@@ -152,6 +153,7 @@ def test_parse_invalid_dsn(dsn):
                 "module": "fastapi.routing",
                 "abs_path": "/home/ubuntu/fastapi/.venv/lib/python3.10/site-packages/fastapi/routing.py",
             },
+            None,
             None,
             None,
             {
@@ -166,6 +168,7 @@ def test_parse_invalid_dsn(dsn):
                 "abs_path": "/home/ubuntu/fastapi/.venv/lib/python3.10/site-packages/fastapi/routing.py",
                 "in_app": True,
             },
+            None,
             None,
             None,
             {
@@ -178,6 +181,7 @@ def test_parse_invalid_dsn(dsn):
             {
                 "abs_path": "C:\\Users\\winuser\\AppData\\Roaming\\Python\\Python35\\site-packages\\fastapi\\routing.py",
             },
+            None,
             None,
             None,
             {
@@ -190,6 +194,7 @@ def test_parse_invalid_dsn(dsn):
                 "module": "fastapi.routing",
                 "abs_path": "/usr/lib/python2.7/dist-packages/fastapi/routing.py",
             },
+            None,
             None,
             None,
             {
@@ -202,6 +207,7 @@ def test_parse_invalid_dsn(dsn):
             {
                 "abs_path": "/home/ubuntu/fastapi/main.py",
             },
+            None,
             None,
             None,
             {
@@ -213,6 +219,7 @@ def test_parse_invalid_dsn(dsn):
                 "module": "main",
                 "abs_path": "/home/ubuntu/fastapi/main.py",
             },
+            None,
             None,
             None,
             {
@@ -227,6 +234,7 @@ def test_parse_invalid_dsn(dsn):
             },
             ["fastapi"],
             None,
+            None,
             {
                 "abs_path": "/home/ubuntu/fastapi/.venv/lib/python3.10/site-packages/fastapi/routing.py",
                 "in_app": False,  # because there is no module set
@@ -238,6 +246,7 @@ def test_parse_invalid_dsn(dsn):
                 "abs_path": "/home/ubuntu/fastapi/.venv/lib/python3.10/site-packages/fastapi/routing.py",
             },
             ["fastapi"],
+            None,
             None,
             {
                 "module": "fastapi.routing",
@@ -253,6 +262,7 @@ def test_parse_invalid_dsn(dsn):
             },
             ["fastapi"],
             None,
+            None,
             {
                 "module": "fastapi.routing",
                 "abs_path": "/home/ubuntu/fastapi/.venv/lib/python3.10/site-packages/fastapi/routing.py",
@@ -265,6 +275,7 @@ def test_parse_invalid_dsn(dsn):
             },
             ["fastapi"],
             None,
+            None,
             {
                 "abs_path": "C:\\Users\\winuser\\AppData\\Roaming\\Python\\Python35\\site-packages\\fastapi\\routing.py",
                 "in_app": False,  # because there is no module set
@@ -276,6 +287,7 @@ def test_parse_invalid_dsn(dsn):
                 "abs_path": "/usr/lib/python2.7/dist-packages/fastapi/routing.py",
             },
             ["fastapi"],
+            None,
             None,
             {
                 "module": "fastapi.routing",
@@ -288,6 +300,7 @@ def test_parse_invalid_dsn(dsn):
                 "abs_path": "/home/ubuntu/fastapi/main.py",
             },
             ["fastapi"],
+            None,
             None,
             {
                 "abs_path": "/home/ubuntu/fastapi/main.py",
@@ -299,6 +312,7 @@ def test_parse_invalid_dsn(dsn):
                 "abs_path": "/home/ubuntu/fastapi/main.py",
             },
             ["fastapi"],
+            None,
             None,
             {
                 "module": "main",
@@ -312,6 +326,7 @@ def test_parse_invalid_dsn(dsn):
             },
             None,
             ["main"],
+            None,
             {
                 "abs_path": "/home/ubuntu/fastapi/.venv/lib/python3.10/site-packages/fastapi/routing.py",
                 "in_app": False,
@@ -324,6 +339,7 @@ def test_parse_invalid_dsn(dsn):
             },
             None,
             ["main"],
+            None,
             {
                 "module": "fastapi.routing",
                 "abs_path": "/home/ubuntu/fastapi/.venv/lib/python3.10/site-packages/fastapi/routing.py",
@@ -338,6 +354,7 @@ def test_parse_invalid_dsn(dsn):
             },
             None,
             ["main"],
+            None,
             {
                 "module": "fastapi.routing",
                 "abs_path": "/home/ubuntu/fastapi/.venv/lib/python3.10/site-packages/fastapi/routing.py",
@@ -350,6 +367,7 @@ def test_parse_invalid_dsn(dsn):
             },
             None,
             ["main"],
+            None,
             {
                 "abs_path": "C:\\Users\\winuser\\AppData\\Roaming\\Python\\Python35\\site-packages\\fastapi\\routing.py",
                 "in_app": False,
@@ -362,6 +380,7 @@ def test_parse_invalid_dsn(dsn):
             },
             None,
             ["main"],
+            None,
             {
                 "module": "fastapi.routing",
                 "abs_path": "/usr/lib/python2.7/dist-packages/fastapi/routing.py",
@@ -374,6 +393,7 @@ def test_parse_invalid_dsn(dsn):
             },
             None,
             ["main"],
+            None,
             {
                 "abs_path": "/home/ubuntu/fastapi/main.py",
             },
@@ -385,6 +405,7 @@ def test_parse_invalid_dsn(dsn):
             },
             None,
             ["main"],
+            None,
             {
                 "module": "main",
                 "abs_path": "/home/ubuntu/fastapi/main.py",
@@ -397,6 +418,7 @@ def test_parse_invalid_dsn(dsn):
             },
             None,
             None,
+            None,
             {
                 "module": "fastapi.routing",
             },
@@ -406,6 +428,7 @@ def test_parse_invalid_dsn(dsn):
                 "module": "fastapi.routing",
             },
             ["fastapi"],
+            None,
             None,
             {
                 "module": "fastapi.routing",
@@ -418,16 +441,65 @@ def test_parse_invalid_dsn(dsn):
             },
             None,
             ["fastapi"],
+            None,
             {
                 "module": "fastapi.routing",
+                "in_app": False,
+            },
+        ],
+        # with project_root set
+        [
+            {
+                "module": "main",
+                "abs_path": "/home/ubuntu/fastapi/main.py",
+            },
+            None,
+            None,
+            "/home/ubuntu/fastapi",
+            {
+                "module": "main",
+                "abs_path": "/home/ubuntu/fastapi/main.py",
+                "in_app": True,
+            },
+        ],
+        [
+            {
+                "module": "main",
+                "abs_path": "/home/ubuntu/fastapi/main.py",
+            },
+            ["main"],
+            None,
+            "/home/ubuntu/fastapi",
+            {
+                "module": "main",
+                "abs_path": "/home/ubuntu/fastapi/main.py",
+                "in_app": True,
+            },
+        ],
+        [
+            {
+                "module": "main",
+                "abs_path": "/home/ubuntu/fastapi/main.py",
+            },
+            None,
+            ["main"],
+            "/home/ubuntu/fastapi",
+            {
+                "module": "main",
+                "abs_path": "/home/ubuntu/fastapi/main.py",
                 "in_app": False,
             },
         ],
     ],
 )
-def test_handle_in_app_impl(frame, in_app_include, in_app_exclude, resulting_frame):
+def test_handle_in_app_impl(
+    frame, in_app_include, in_app_exclude, project_root, resulting_frame
+):
     new_frames = handle_in_app_impl(
-        [frame], in_app_include=in_app_include, in_app_exclude=in_app_exclude
+        [frame],
+        in_app_include=in_app_include,
+        in_app_exclude=in_app_exclude,
+        project_root=project_root,
     )
 
     assert new_frames[0] == resulting_frame

--- a/tests/utils/test_general.py
+++ b/tests/utils/test_general.py
@@ -206,7 +206,6 @@ def test_parse_invalid_dsn(dsn):
             None,
             {
                 "abs_path": "/home/ubuntu/fastapi/main.py",
-                "in_app": True,
             },
         ],
         [
@@ -219,7 +218,6 @@ def test_parse_invalid_dsn(dsn):
             {
                 "module": "main",
                 "abs_path": "/home/ubuntu/fastapi/main.py",
-                "in_app": True,
             },
         ],
         # include
@@ -293,7 +291,6 @@ def test_parse_invalid_dsn(dsn):
             None,
             {
                 "abs_path": "/home/ubuntu/fastapi/main.py",
-                "in_app": True,
             },
         ],
         [
@@ -306,7 +303,6 @@ def test_parse_invalid_dsn(dsn):
             {
                 "module": "main",
                 "abs_path": "/home/ubuntu/fastapi/main.py",
-                "in_app": True,
             },
         ],
         # exclude
@@ -380,7 +376,6 @@ def test_parse_invalid_dsn(dsn):
             ["main"],
             {
                 "abs_path": "/home/ubuntu/fastapi/main.py",
-                "in_app": True,  # because there is no module set
             },
         ],
         [

--- a/tests/utils/test_general.py
+++ b/tests/utils/test_general.py
@@ -11,10 +11,10 @@ from sentry_sdk.utils import (
     safe_repr,
     exceptions_from_error_tuple,
     filename_for_module,
-    handle_in_app_impl,
     iter_event_stacktraces,
     to_base64,
     from_base64,
+    set_in_app_in_frames,
     strip_string,
     AnnotatedValue,
 )
@@ -492,10 +492,10 @@ def test_parse_invalid_dsn(dsn):
         ],
     ],
 )
-def test_handle_in_app_impl(
+def test_set_in_app_in_frames(
     frame, in_app_include, in_app_exclude, project_root, resulting_frame
 ):
-    new_frames = handle_in_app_impl(
+    new_frames = set_in_app_in_frames(
         [frame],
         in_app_include=in_app_include,
         in_app_exclude=in_app_exclude,


### PR DESCRIPTION
How the `in_app` flag is set in stack trace frames (in `set_in_app_in_frames()`):
- If there is already `in_app` set, it is left untouched.
- If there is a `module` in the frame and it is in the `in_app_includes` -> `in_app=True`
- If there is a `module` in the frame and it is in the `in_app_excludes` -> `in_app=False`
- If there is an `abs_path` in the frame and the path is in `/side-packages/` or `/dist-packages/` -> `in_app=False`
- If there is an `abs_path` in the frame and it starts with the current working directory of the process -> `in_app=True`
- If nothing of the above is true, there will be no `in_app` set.

Fixes #1754 
Fixes #320 