### PR TITLE
ref(profiling): Use the transaction timestamps to anchor the profile

### DIFF
--- a/sentry_sdk/profiler.py
+++ b/sentry_sdk/profiler.py
@@ -428,11 +428,7 @@ class Profile(object):
 
         self.start_ns = 0  # type: int
         try:
-            start_timestamp_monotonic, unit = transaction._start_timestamp_monotonic
-            if unit == "s":
-                self.start_ns = int(start_timestamp_monotonic * 1e9)
-            elif unit == "ns":
-                self.start_ns = int(start_timestamp_monotonic)
+            self.start_ns = transaction._start_timestamp_monotonic.total_nanoseconds()
         except AttributeError:
             pass
 

--- a/sentry_sdk/profiler.py
+++ b/sentry_sdk/profiler.py
@@ -428,7 +428,7 @@ class Profile(object):
 
         self.start_ns = 0  # type: int
         try:
-            self.start_ns = transaction._start_timestamp_monotonic.total_nanoseconds()
+            self.start_ns = transaction._start_timestamp_monotonic
         except AttributeError:
             pass
 

--- a/sentry_sdk/profiler.py
+++ b/sentry_sdk/profiler.py
@@ -428,7 +428,7 @@ class Profile(object):
 
         self.start_ns = 0  # type: int
         try:
-            self.start_ns = transaction._start_timestamp_monotonic
+            self.start_ns = transaction._start_timestamp_monotonic_ns
         except AttributeError:
             pass
 

--- a/sentry_sdk/profiler.py
+++ b/sentry_sdk/profiler.py
@@ -150,11 +150,11 @@ def setup_profiler(options):
     global _scheduler
 
     if _scheduler is not None:
-        logger.debug("profiling is already setup")
+        logger.debug("[Profiling] Profiler is already setup")
         return False
 
     if not PY33:
-        logger.warn("profiling is only supported on Python >= 3.3")
+        logger.warn("[Profiling] Profiler requires Python >= 3.3")
         return False
 
     frequency = DEFAULT_SAMPLING_FREQUENCY
@@ -184,6 +184,9 @@ def setup_profiler(options):
     else:
         raise ValueError("Unknown profiler mode: {}".format(profiler_mode))
 
+    logger.debug(
+        "[Profiling] Setting up profiler in {mode} mode".format(mode=_scheduler.mode)
+    )
     _scheduler.setup()
 
     atexit.register(teardown_profiler)
@@ -440,6 +443,11 @@ class Profile(object):
     def update_active_thread_id(self):
         # type: () -> None
         self.active_thread_id = get_current_thread_id()
+        logger.debug(
+            "[Profiling] updating active thread id to {tid}".format(
+                tid=self.active_thread_id
+            )
+        )
 
     def _set_initial_sampling_decision(self, sampling_context):
         # type: (SamplingContext) -> None
@@ -456,11 +464,17 @@ class Profile(object):
         # The corresponding transaction was not sampled,
         # so don't generate a profile for it.
         if not self.sampled:
+            logger.debug(
+                "[Profiling] Discarding profile because transaction is discarded."
+            )
             self.sampled = False
             return
 
         # The profiler hasn't been properly initialized.
         if self.scheduler is None:
+            logger.debug(
+                "[Profiling] Discarding profile because profiler was not started."
+            )
             self.sampled = False
             return
 
@@ -478,6 +492,9 @@ class Profile(object):
         # The profiles_sample_rate option was not set, so profiling
         # was never enabled.
         if sample_rate is None:
+            logger.debug(
+                "[Profiling] Discarding profile because profiling was not enabled."
+            )
             self.sampled = False
             return
 
@@ -485,6 +502,15 @@ class Profile(object):
         # so strict < is safe here. In case sample_rate is a boolean, cast it
         # to a float (True becomes 1.0 and False becomes 0.0)
         self.sampled = random.random() < float(sample_rate)
+
+        if self.sampled:
+            logger.debug("[Profiling] Initializing profile")
+        else:
+            logger.debug(
+                "[Profiling] Discarding profile because it's not included in the random sample (sample rate = {sample_rate})".format(
+                    sample_rate=float(sample_rate)
+                )
+            )
 
     def get_profile_context(self):
         # type: () -> ProfileContext
@@ -496,6 +522,7 @@ class Profile(object):
             return
 
         assert self.scheduler, "No scheduler specified"
+        logger.debug("[Profiling] Starting profile")
         self.active = True
         self.start_ns = nanosecond_time()
         self.scheduler.start_profiling(self)
@@ -506,6 +533,7 @@ class Profile(object):
             return
 
         assert self.scheduler, "No scheduler specified"
+        logger.debug("[Profiling] Stopping profile")
         self.active = False
         self.scheduler.stop_profiling(self)
         self.stop_ns = nanosecond_time()
@@ -651,11 +679,14 @@ class Profile(object):
 
     def valid(self):
         # type: () -> bool
-        return (
-            self.sampled is not None
-            and self.sampled
-            and self.unique_samples >= PROFILE_MINIMUM_SAMPLES
-        )
+        if self.sampled is None or not self.sampled:
+            return False
+
+        if self.unique_samples < PROFILE_MINIMUM_SAMPLES:
+            logger.debug("[Profiling] Discarding profile because insufficient samples.")
+            return False
+
+        return True
 
 
 class Scheduler(object):

--- a/sentry_sdk/profiler.py
+++ b/sentry_sdk/profiler.py
@@ -426,11 +426,10 @@ class Profile(object):
         self._default_active_thread_id = get_current_thread_id() or 0  # type: int
         self.active_thread_id = None  # type: Optional[int]
 
-        self.start_ns = 0  # type: int
         try:
-            self.start_ns = transaction._start_timestamp_monotonic_ns
+            self.start_ns = transaction._start_timestamp_monotonic_ns  # type: int
         except AttributeError:
-            pass
+            self.start_ns = 0
 
         self.stop_ns = 0  # type: int
         self.active = False  # type: bool

--- a/sentry_sdk/tracing.py
+++ b/sentry_sdk/tracing.py
@@ -479,7 +479,9 @@ class Span(object):
                 self.timestamp = end_timestamp
             else:
                 elapsed = nanosecond_time() - self._start_timestamp_monotonic
-                self.timestamp = self.start_timestamp + timedelta(microseconds=elapsed / 1000)
+                self.timestamp = self.start_timestamp + timedelta(
+                    microseconds=elapsed / 1000
+                )
         except (AttributeError, ValueError):
             self.timestamp = datetime.utcnow()
 

--- a/sentry_sdk/tracing.py
+++ b/sentry_sdk/tracing.py
@@ -478,23 +478,8 @@ class Span(object):
             if end_timestamp:
                 self.timestamp = end_timestamp
             else:
-                end_timestamp_monotonic, unit = perf_counter()
-
-                if unit == "s":
-                    elapsed_seconds = (
-                        end_timestamp_monotonic - self._start_timestamp_monotonic[0]
-                    )
-                    duration = timedelta(seconds=elapsed_seconds)
-                elif unit == "ns":
-                    elapsed_nanoseconds = (
-                        end_timestamp_monotonic - self._start_timestamp_monotonic[0]
-                    )
-                    duration = timedelta(microseconds=elapsed_nanoseconds / 1000)
-                else:
-                    # An unexpected unit was encountered, use the fallback
-                    raise ValueError
-
-                self.timestamp = self.start_timestamp + duration
+                elapsed = perf_counter() - self._start_timestamp_monotonic
+                self.timestamp = self.start_timestamp + elapsed.as_timedelta()
         except (AttributeError, ValueError):
             self.timestamp = datetime.utcnow()
 

--- a/sentry_sdk/tracing.py
+++ b/sentry_sdk/tracing.py
@@ -1,7 +1,7 @@
 import uuid
 import random
 
-from datetime import datetime, timedelta
+from datetime import datetime
 
 import sentry_sdk
 from sentry_sdk.consts import INSTRUMENTER

--- a/sentry_sdk/tracing.py
+++ b/sentry_sdk/tracing.py
@@ -1,11 +1,11 @@
 import uuid
 import random
 
-from datetime import datetime
+from datetime import datetime, timedelta
 
 import sentry_sdk
 from sentry_sdk.consts import INSTRUMENTER
-from sentry_sdk.utils import logger, perf_counter
+from sentry_sdk.utils import logger, nanosecond_time
 from sentry_sdk._types import MYPY
 
 
@@ -141,7 +141,7 @@ class Span(object):
         self._containing_transaction = containing_transaction
         self.start_timestamp = start_timestamp or datetime.utcnow()
         try:
-            self._start_timestamp_monotonic = perf_counter()
+            self._start_timestamp_monotonic = nanosecond_time()
         except AttributeError:
             pass
 
@@ -478,8 +478,8 @@ class Span(object):
             if end_timestamp:
                 self.timestamp = end_timestamp
             else:
-                elapsed = perf_counter() - self._start_timestamp_monotonic
-                self.timestamp = self.start_timestamp + elapsed.as_timedelta()
+                elapsed = nanosecond_time() - self._start_timestamp_monotonic
+                self.timestamp = self.start_timestamp + timedelta(microseconds=elapsed / 1000)
         except (AttributeError, ValueError):
             self.timestamp = datetime.utcnow()
 

--- a/sentry_sdk/tracing.py
+++ b/sentry_sdk/tracing.py
@@ -1,6 +1,5 @@
 import uuid
 import random
-import time
 
 from datetime import datetime, timedelta
 
@@ -482,10 +481,14 @@ class Span(object):
                 end_timestamp_monotonic, unit = perf_counter()
 
                 if unit == "s":
-                    elapsed_seconds = end_timestamp_monotonic - self._start_timestamp_monotonic[0]
+                    elapsed_seconds = (
+                        end_timestamp_monotonic - self._start_timestamp_monotonic[0]
+                    )
                     duration = timedelta(seconds=elapsed_seconds)
                 elif unit == "ns":
-                    elapsed_nanoseconds = end_timestamp_monotonic - self._start_timestamp_monotonic[0]
+                    elapsed_nanoseconds = (
+                        end_timestamp_monotonic - self._start_timestamp_monotonic[0]
+                    )
                     duration = timedelta(microseconds=elapsed_nanoseconds / 1000)
                 else:
                     # An unexpected unit was encountered, use the fallback

--- a/sentry_sdk/utils.py
+++ b/sentry_sdk/utils.py
@@ -37,8 +37,11 @@ if MYPY:
         Type,
         Union,
     )
+    from typing_extensions import Literal
 
     from sentry_sdk._types import EndpointType, ExcInfo
+
+    TimeUnit = Literal["s", "ns"]
 
 
 epoch = datetime(1970, 1, 1)
@@ -1132,16 +1135,26 @@ if PY37:
         # type: () -> int
         return time.perf_counter_ns()
 
+    def perf_counter():
+        # type: () -> Tuple[float, TimeUnit]
+        return time.perf_counter_ns(), 'ns'
+
 elif PY33:
 
     def nanosecond_time():
         # type: () -> int
-
         return int(time.perf_counter() * 1e9)
+
+    def perf_counter():
+        # type: () -> Tuple[float, TimeUnit]
+        return time.perf_counter(), 's'
 
 else:
 
     def nanosecond_time():
         # type: () -> int
+        raise AttributeError
 
+    def perf_counter():
+        # type: () -> Tuple[float, TimeUnit]
         raise AttributeError

--- a/sentry_sdk/utils.py
+++ b/sentry_sdk/utils.py
@@ -1137,7 +1137,7 @@ if PY37:
 
     def perf_counter():
         # type: () -> Tuple[float, TimeUnit]
-        return time.perf_counter_ns(), 'ns'
+        return time.perf_counter_ns(), "ns"
 
 elif PY33:
 
@@ -1147,7 +1147,7 @@ elif PY33:
 
     def perf_counter():
         # type: () -> Tuple[float, TimeUnit]
-        return time.perf_counter(), 's'
+        return time.perf_counter(), "s"
 
 else:
 

--- a/sentry_sdk/utils.py
+++ b/sentry_sdk/utils.py
@@ -8,7 +8,7 @@ import subprocess
 import sys
 import threading
 import time
-from datetime import datetime, timedelta
+from datetime import datetime
 from functools import partial
 
 try:
@@ -37,11 +37,8 @@ if MYPY:
         Type,
         Union,
     )
-    from typing_extensions import Literal
 
     from sentry_sdk._types import EndpointType, ExcInfo
-
-    TimeUnit = Literal["s", "ns"]
 
 
 epoch = datetime(1970, 1, 1)
@@ -1129,63 +1126,11 @@ def from_base64(base64_string):
     return utf8_string
 
 
-class PerfCounter(object):
-    __slots__ = ("value", "unit")
-
-    def __init__(self, value, unit):
-        # type: (float, Literal["s", "ns"]) -> None
-        self.value = value
-        self.unit = unit
-
-    @staticmethod
-    def from_second(value):
-        # type: (float) -> PerfCounter
-        return PerfCounter(value, unit="s")
-
-    @staticmethod
-    def from_nanosecond(value):
-        # type: (float) -> PerfCounter
-        return PerfCounter(value, unit="ns")
-
-    def __sub__(self, other):
-        # type: (PerfCounter) -> PerfCounter
-        if self.unit == other.unit:
-            return PerfCounter(value=self.value - other.value, unit=self.unit)
-
-        raise ValueError("Mismatched units in PerfCounter")
-
-    def as_timedelta(self):
-        # type: () -> timedelta
-
-        if self.unit == "ns":
-            return timedelta(microseconds=self.value / 1000)
-
-        elif self.unit == "s":
-            return timedelta(seconds=self.value)
-
-        raise ValueError("Unknown unit: {}".format(self.unit))
-
-    def total_nanoseconds(self):
-        # type: () -> int
-
-        if self.unit == "ns":
-            return int(self.value)
-
-        elif self.unit == "s":
-            return int(self.value * 1e9)
-
-        raise ValueError("Unknown unit: {}".format(self.unit))
-
-
 if PY37:
 
     def nanosecond_time():
         # type: () -> int
         return time.perf_counter_ns()
-
-    def perf_counter():
-        # type: () -> PerfCounter
-        return PerfCounter.from_nanosecond(time.perf_counter_ns())
 
 elif PY33:
 
@@ -1193,16 +1138,9 @@ elif PY33:
         # type: () -> int
         return int(time.perf_counter() * 1e9)
 
-    def perf_counter():
-        # type: () -> PerfCounter
-        return PerfCounter.from_second(time.perf_counter())
 
 else:
 
     def nanosecond_time():
         # type: () -> int
-        raise AttributeError
-
-    def perf_counter():
-        # type: () -> PerfCounter
         raise AttributeError

--- a/sentry_sdk/utils.py
+++ b/sentry_sdk/utils.py
@@ -1138,7 +1138,6 @@ elif PY33:
         # type: () -> int
         return int(time.perf_counter() * 1e9)
 
-
 else:
 
     def nanosecond_time():


### PR DESCRIPTION
We want the profile to be as closely aligned with the transaction's timestamps as possible to make aligning the two visualizations as accurate as possible. Here we change the transaction's internal `_start_timestamp_monotonic` to be in nanoseconds derived from each of the possible clocks we use in the various python versions. This allows us to use the `start_timestamp` of the transaction as the timestamp of the profile, and we can use the `_start_timestamp_monontonic` as the anchor for all the relative timestamps in the profile.