### PR TITLE
Remove deprecated `tracestate`

### DIFF
--- a/sentry_sdk/consts.py
+++ b/sentry_sdk/consts.py
@@ -33,7 +33,6 @@ if MYPY:
             "max_spans": Optional[int],
             "record_sql_params": Optional[bool],
             "smart_transaction_trimming": Optional[bool],
-            "propagate_tracestate": Optional[bool],
             "custom_measurements": Optional[bool],
             "profiles_sample_rate": Optional[float],
             "profiler_mode": Optional[str],

--- a/sentry_sdk/tracing_utils.py
+++ b/sentry_sdk/tracing_utils.py
@@ -1,6 +1,5 @@
 import re
 import contextlib
-import json
 import math
 
 from numbers import Real
@@ -13,10 +12,7 @@ from sentry_sdk.utils import (
     capture_internal_exceptions,
     Dsn,
     logger,
-    safe_str,
-    to_base64,
     to_string,
-    from_base64,
 )
 from sentry_sdk._compat import PY2, iteritems
 from sentry_sdk._types import MYPY
@@ -55,27 +51,6 @@ base64_stripped = (
     # https://en.wikipedia.org/wiki/Base64#Decoding_Base64_without_padding for
     # why there's never only 1 extra character)
     "([a-zA-Z0-9+/]{2,3})?"
-)
-
-# comma-delimited list of entries of the form `xxx=yyy`
-tracestate_entry = "[^=]+=[^=]+"
-TRACESTATE_ENTRIES_REGEX = re.compile(
-    # one or more xxxxx=yyyy entries
-    "^({te})+"
-    # each entry except the last must be followed by a comma
-    "(,|$)".format(te=tracestate_entry)
-)
-
-# this doesn't check that the value is valid, just that there's something there
-# of the form `sentry=xxxx`
-SENTRY_TRACESTATE_ENTRY_REGEX = re.compile(
-    # either sentry is the first entry or there's stuff immediately before it,
-    # ending in a comma (this prevents matching something like `coolsentry=xxx`)
-    "(?:^|.+,)"
-    # sentry's part, not including the potential comma
-    "(sentry=[^,]*)"
-    # either there's a comma and another vendor's entry or we end
-    "(?:,.+|$)"
 )
 
 
@@ -246,143 +221,6 @@ def extract_sentrytrace_data(header):
     }
 
 
-def extract_tracestate_data(header):
-    # type: (Optional[str]) -> typing.Mapping[str, Optional[str]]
-    """
-    Extracts the sentry tracestate value and any third-party data from the given
-    tracestate header, returning a dictionary of data.
-    """
-    sentry_entry = third_party_entry = None
-    before = after = ""
-
-    if header:
-        # find sentry's entry, if any
-        sentry_match = SENTRY_TRACESTATE_ENTRY_REGEX.search(header)
-
-        if sentry_match:
-            sentry_entry = sentry_match.group(1)
-
-            # remove the commas after the split so we don't end up with
-            # `xxx=yyy,,zzz=qqq` (double commas) when we put them back together
-            before, after = map(lambda s: s.strip(","), header.split(sentry_entry))
-
-            # extract sentry's value from its entry and test to make sure it's
-            # valid; if it isn't, discard the entire entry so that a new one
-            # will be created
-            sentry_value = sentry_entry.replace("sentry=", "")
-            if not re.search("^{b64}$".format(b64=base64_stripped), sentry_value):
-                sentry_entry = None
-        else:
-            after = header
-
-        # if either part is invalid or empty, remove it before gluing them together
-        third_party_entry = (
-            ",".join(filter(TRACESTATE_ENTRIES_REGEX.search, [before, after])) or None
-        )
-
-    return {
-        "sentry_tracestate": sentry_entry,
-        "third_party_tracestate": third_party_entry,
-    }
-
-
-def compute_tracestate_value(data):
-    # type: (typing.Mapping[str, str]) -> str
-    """
-    Computes a new tracestate value using the given data.
-
-    Note: Returns just the base64-encoded data, NOT the full `sentry=...`
-    tracestate entry.
-    """
-
-    tracestate_json = json.dumps(data, default=safe_str)
-
-    # Base64-encoded strings always come out with a length which is a multiple
-    # of 4. In order to achieve this, the end is padded with one or more `=`
-    # signs. Because the tracestate standard calls for using `=` signs between
-    # vendor name and value (`sentry=xxx,dogsaregreat=yyy`), to avoid confusion
-    # we strip the `=`
-    return (to_base64(tracestate_json) or "").rstrip("=")
-
-
-def compute_tracestate_entry(span):
-    # type: (Span) -> Optional[str]
-    """
-    Computes a new sentry tracestate for the span. Includes the `sentry=`.
-
-    Will return `None` if there's no client and/or no DSN.
-    """
-    data = {}
-
-    hub = span.hub or sentry_sdk.Hub.current
-
-    client = hub.client
-    scope = hub.scope
-
-    if client and client.options.get("dsn"):
-        options = client.options
-        user = scope._user
-
-        data = {
-            "trace_id": span.trace_id,
-            "environment": options["environment"],
-            "release": options.get("release"),
-            "public_key": Dsn(options["dsn"]).public_key,
-        }
-
-        if user and (user.get("id") or user.get("segment")):
-            user_data = {}
-
-            if user.get("id"):
-                user_data["id"] = user["id"]
-
-            if user.get("segment"):
-                user_data["segment"] = user["segment"]
-
-            data["user"] = user_data
-
-        if span.containing_transaction:
-            data["transaction"] = span.containing_transaction.name
-
-        return "sentry=" + compute_tracestate_value(data)
-
-    return None
-
-
-def reinflate_tracestate(encoded_tracestate):
-    # type: (str) -> typing.Optional[Mapping[str, str]]
-    """
-    Given a sentry tracestate value in its encoded form, translate it back into
-    a dictionary of data.
-    """
-    inflated_tracestate = None
-
-    if encoded_tracestate:
-        # Base64-encoded strings always come out with a length which is a
-        # multiple of 4. In order to achieve this, the end is padded with one or
-        # more `=` signs. Because the tracestate standard calls for using `=`
-        # signs between vendor name and value (`sentry=xxx,dogsaregreat=yyy`),
-        # to avoid confusion we strip the `=` when the data is initially
-        # encoded. Python's decoding function requires they be put back.
-        # Fortunately, it doesn't complain if there are too many, so we just
-        # attach two `=` on spec (there will never be more than 2, see
-        # https://en.wikipedia.org/wiki/Base64#Decoding_Base64_without_padding).
-        tracestate_json = from_base64(encoded_tracestate + "==")
-
-        try:
-            assert tracestate_json is not None
-            inflated_tracestate = json.loads(tracestate_json)
-        except Exception as err:
-            logger.warning(
-                (
-                    "Unable to attach tracestate data to envelope header: {err}"
-                    + "\nTracestate value is {encoded_tracestate}"
-                ).format(err=err, encoded_tracestate=encoded_tracestate),
-            )
-
-    return inflated_tracestate
-
-
 def _format_sql(cursor, sql):
     # type: (Any, str) -> Optional[str]
 
@@ -401,15 +239,6 @@ def _format_sql(cursor, sql):
         real_sql = None
 
     return real_sql or to_string(sql)
-
-
-def has_tracestate_enabled(span=None):
-    # type: (Optional[Span]) -> bool
-
-    client = ((span and span.hub) or sentry_sdk.Hub.current).client
-    options = client and client.options
-
-    return bool(options and options["_experiments"].get("propagate_tracestate"))
 
 
 def has_custom_measurements_enabled():

--- a/tests/test_envelope.py
+++ b/tests/test_envelope.py
@@ -1,15 +1,7 @@
 from sentry_sdk.envelope import Envelope
 from sentry_sdk.session import Session
 from sentry_sdk import capture_event
-from sentry_sdk.tracing_utils import compute_tracestate_value
 import sentry_sdk.client
-
-import pytest
-
-try:
-    from unittest import mock  # python 3.3 and above
-except ImportError:
-    import mock  # python < 3.3
 
 
 def generate_transaction_item():
@@ -26,16 +18,15 @@ def generate_transaction_item():
                 "parent_span_id": None,
                 "description": "<OrganizationContext>",
                 "op": "greeting.sniff",
-                "tracestate": compute_tracestate_value(
-                    {
-                        "trace_id": "12312012123120121231201212312012",
-                        "environment": "dogpark",
-                        "release": "off.leash.park",
-                        "public_key": "dogsarebadatkeepingsecrets",
-                        "user": {"id": 12312013, "segment": "bigs"},
-                        "transaction": "/interactions/other-dogs/new-dog",
-                    }
-                ),
+                "dynamic_sampling_context": {
+                    "trace_id": "12312012123120121231201212312012",
+                    "sample_rate": "1.0",
+                    "environment": "dogpark",
+                    "release": "off.leash.park",
+                    "public_key": "dogsarebadatkeepingsecrets",
+                    "user_segment": "bigs",
+                    "transaction": "/interactions/other-dogs/new-dog",
+                },
             }
         },
         "spans": [
@@ -88,21 +79,11 @@ def test_add_and_get_session():
             assert item.payload.json == expected.to_json()
 
 
-# TODO (kmclb) remove this parameterization once tracestate is a real feature
-@pytest.mark.parametrize("tracestate_enabled", [True, False])
-def test_envelope_headers(
-    sentry_init, capture_envelopes, monkeypatch, tracestate_enabled
-):
+def test_envelope_headers(sentry_init, capture_envelopes, monkeypatch):
     monkeypatch.setattr(
         sentry_sdk.client,
         "format_timestamp",
         lambda x: "2012-11-21T12:31:12.415908Z",
-    )
-
-    monkeypatch.setattr(
-        sentry_sdk.client,
-        "has_tracestate_enabled",
-        mock.Mock(return_value=tracestate_enabled),
     )
 
     sentry_init(
@@ -114,24 +95,10 @@ def test_envelope_headers(
 
     assert len(envelopes) == 1
 
-    if tracestate_enabled:
-        assert envelopes[0].headers == {
-            "event_id": "15210411201320122115110420122013",
-            "sent_at": "2012-11-21T12:31:12.415908Z",
-            "trace": {
-                "trace_id": "12312012123120121231201212312012",
-                "environment": "dogpark",
-                "release": "off.leash.park",
-                "public_key": "dogsarebadatkeepingsecrets",
-                "user": {"id": 12312013, "segment": "bigs"},
-                "transaction": "/interactions/other-dogs/new-dog",
-            },
-        }
-    else:
-        assert envelopes[0].headers == {
-            "event_id": "15210411201320122115110420122013",
-            "sent_at": "2012-11-21T12:31:12.415908Z",
-        }
+    assert envelopes[0].headers == {
+        "event_id": "15210411201320122115110420122013",
+        "sent_at": "2012-11-21T12:31:12.415908Z",
+    }
 
 
 def test_envelope_with_sized_items():


### PR DESCRIPTION
Sentry is using `baggage` for trace propagation to the implementation of `tracestate` was deprecated for a while now and will not be removed.