### PR TITLE
Make Django signals tracing optional

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,6 +2,5 @@
     "python.pythonPath": ".venv/bin/python",
     "python.formatting.provider": "black",
     "python.testing.unittestEnabled": false,
-    "python.testing.pytestEnabled": true,
-    "esbonio.sphinx.confDir": ""
+    "python.testing.pytestEnabled": true
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,5 +2,6 @@
     "python.pythonPath": ".venv/bin/python",
     "python.formatting.provider": "black",
     "python.testing.unittestEnabled": false,
-    "python.testing.pytestEnabled": true
+    "python.testing.pytestEnabled": true,
+    "esbonio.sphinx.confDir": ""
 }

--- a/sentry_sdk/integrations/django/__init__.py
+++ b/sentry_sdk/integrations/django/__init__.py
@@ -93,7 +93,7 @@ class DjangoIntegration(Integration):
     signals_spans = None
 
     def __init__(
-        self, transaction_style="url", middleware_spans=True, signals_spans=False
+        self, transaction_style="url", middleware_spans=True, signals_spans=True
     ):
         # type: (str, bool, bool) -> None
         if transaction_style not in TRANSACTION_STYLE_VALUES:

--- a/sentry_sdk/integrations/django/__init__.py
+++ b/sentry_sdk/integrations/django/__init__.py
@@ -90,9 +90,12 @@ class DjangoIntegration(Integration):
 
     transaction_style = ""
     middleware_spans = None
+    signals_spans = None
 
-    def __init__(self, transaction_style="url", middleware_spans=True):
-        # type: (str, bool) -> None
+    def __init__(
+        self, transaction_style="url", middleware_spans=True, signals_spans=False
+    ):
+        # type: (str, bool, bool) -> None
         if transaction_style not in TRANSACTION_STYLE_VALUES:
             raise ValueError(
                 "Invalid value for transaction_style: %s (must be in %s)"
@@ -100,6 +103,7 @@ class DjangoIntegration(Integration):
             )
         self.transaction_style = transaction_style
         self.middleware_spans = middleware_spans
+        self.signals_spans = signals_spans
 
     @staticmethod
     def setup_once():

--- a/sentry_sdk/integrations/django/signals_handlers.py
+++ b/sentry_sdk/integrations/django/signals_handlers.py
@@ -67,12 +67,11 @@ def patch_signals():
 
             return wrapper
 
-        for idx, receiver in enumerate(receivers):
-            receivers[idx] = sentry_receiver_wrapper(receiver)
+        integration = hub.get_integration(DjangoIntegration)
+        if integration and integration.signals_spans:
+            for idx, receiver in enumerate(receivers):
+                receivers[idx] = sentry_receiver_wrapper(receiver)
 
         return receivers
 
-    hub = Hub.current
-    integration = hub.get_integration(DjangoIntegration)
-    if integration and integration.signals_spans:
-        Signal._live_receivers = _sentry_live_receivers
+    Signal._live_receivers = _sentry_live_receivers

--- a/sentry_sdk/integrations/django/signals_handlers.py
+++ b/sentry_sdk/integrations/django/signals_handlers.py
@@ -43,6 +43,7 @@ def _get_receiver_name(receiver):
 def patch_signals():
     # type: () -> None
     """Patch django signal receivers to create a span"""
+    from sentry_sdk.integrations.django import DjangoIntegration
 
     old_live_receivers = Signal._live_receivers
 
@@ -71,4 +72,7 @@ def patch_signals():
 
         return receivers
 
-    Signal._live_receivers = _sentry_live_receivers
+    hub = Hub.current
+    integration = hub.get_integration(DjangoIntegration)
+    if integration and integration.signals_spans:
+        Signal._live_receivers = _sentry_live_receivers

--- a/tests/integrations/django/test_basic.py
+++ b/tests/integrations/django/test_basic.py
@@ -670,7 +670,7 @@ def test_does_not_capture_403(sentry_init, client, capture_events, endpoint):
     sentry_init(integrations=[DjangoIntegration()])
     events = capture_events()
 
-    _content, status, _headers = client.get(reverse(endpoint))
+    _, status, _ = client.get(reverse(endpoint))
     assert status.lower() == "403 forbidden"
 
     assert not events
@@ -697,32 +697,14 @@ def test_render_spans(sentry_init, client, capture_events, render_span_tree):
 
     for url, expected_line in views_tests:
         events = capture_events()
-        _content, status, _headers = client.get(url)
+        client.get(url)
         transaction = events[0]
         assert expected_line in render_span_tree(transaction)
 
 
-def test_middleware_spans(sentry_init, client, capture_events, render_span_tree):
-    sentry_init(
-        integrations=[DjangoIntegration()],
-        traces_sample_rate=1.0,
-        _experiments={"record_sql_params": True},
-    )
-    events = capture_events()
-
-    _content, status, _headers = client.get(reverse("message"))
-
-    message, transaction = events
-
-    assert message["message"] == "hi"
-
-    if DJANGO_VERSION >= (1, 10):
-        assert (
-            render_span_tree(transaction)
-            == """\
+if DJANGO_VERSION >= (1, 10):
+    EXPECTED_MIDDLEWARE_SPANS = """\
 - op="http.server": description=null
-  - op="event.django": description="django.db.reset_queries"
-  - op="event.django": description="django.db.close_old_connections"
   - op="middleware.django": description="django.contrib.sessions.middleware.SessionMiddleware.__call__"
     - op="middleware.django": description="django.contrib.auth.middleware.AuthenticationMiddleware.__call__"
       - op="middleware.django": description="django.middleware.csrf.CsrfViewMiddleware.__call__"
@@ -731,15 +713,9 @@ def test_middleware_spans(sentry_init, client, capture_events, render_span_tree)
             - op="middleware.django": description="django.middleware.csrf.CsrfViewMiddleware.process_view"
             - op="view.render": description="message"\
 """
-        )
-
-    else:
-        assert (
-            render_span_tree(transaction)
-            == """\
+else:
+    EXPECTED_MIDDLEWARE_SPANS = """\
 - op="http.server": description=null
-  - op="event.django": description="django.db.reset_queries"
-  - op="event.django": description="django.db.close_old_connections"
   - op="middleware.django": description="django.contrib.sessions.middleware.SessionMiddleware.process_request"
   - op="middleware.django": description="django.contrib.auth.middleware.AuthenticationMiddleware.process_request"
   - op="middleware.django": description="tests.integrations.django.myapp.settings.TestMiddleware.process_request"
@@ -749,65 +725,71 @@ def test_middleware_spans(sentry_init, client, capture_events, render_span_tree)
   - op="middleware.django": description="django.middleware.csrf.CsrfViewMiddleware.process_response"
   - op="middleware.django": description="django.contrib.sessions.middleware.SessionMiddleware.process_response"\
 """
-        )
 
 
-def test_middleware_spans_disabled(sentry_init, client, capture_events):
+def test_middleware_spans(sentry_init, client, capture_events, render_span_tree):
     sentry_init(
-        integrations=[DjangoIntegration(middleware_spans=False)], traces_sample_rate=1.0
-    )
-    events = capture_events()
-
-    _content, status, _headers = client.get(reverse("message"))
-
-    message, transaction = events
-
-    assert message["message"] == "hi"
-
-    assert len(transaction["spans"]) == 2
-
-    assert transaction["spans"][0]["op"] == "event.django"
-    assert transaction["spans"][0]["description"] == "django.db.reset_queries"
-
-    assert transaction["spans"][1]["op"] == "event.django"
-    assert transaction["spans"][1]["description"] == "django.db.close_old_connections"
-
-
-def test_signals_spans(sentry_init, client, capture_events, render_span_tree):
-    sentry_init(
-        integrations=[DjangoIntegration(middleware_spans=False)],
+        integrations=[
+            DjangoIntegration(signals_spans=False),
+        ],
         traces_sample_rate=1.0,
     )
     events = capture_events()
 
-    _content, status, _headers = client.get(reverse("message"))
+    client.get(reverse("message"))
 
     message, transaction = events
 
     assert message["message"] == "hi"
+    assert render_span_tree(transaction) == EXPECTED_MIDDLEWARE_SPANS
 
-    if DJANGO_VERSION >= (1, 10):
-        import ipdb
 
-        ipdb.set_trace()
-        assert (
-            render_span_tree(transaction)
-            == """\
+def test_middleware_spans_disabled(sentry_init, client, capture_events):
+    sentry_init(
+        integrations=[
+            DjangoIntegration(middleware_spans=False, signals_spans=False),
+        ],
+        traces_sample_rate=1.0,
+    )
+    events = capture_events()
+
+    client.get(reverse("message"))
+
+    message, transaction = events
+
+    assert message["message"] == "hi"
+    assert not len(transaction["spans"])
+
+
+if DJANGO_VERSION >= (1, 10):
+    EXPECTED_SIGNALS_SPANS = """\
 - op="http.server": description=null
   - op="event.django": description="django.db.reset_queries"
   - op="event.django": description="django.db.close_old_connections"\
 """
-        )
-
-    else:
-        assert (
-            render_span_tree(transaction)
-            == """\
+else:
+    EXPECTED_SIGNALS_SPANS = """\
 - op="http.server": description=null
   - op="event.django": description="django.db.reset_queries"
   - op="event.django": description="django.db.close_old_connections"\
 """
-        )
+
+
+def test_signals_spans(sentry_init, client, capture_events, render_span_tree):
+    sentry_init(
+        integrations=[
+            DjangoIntegration(middleware_spans=False),
+        ],
+        traces_sample_rate=1.0,
+    )
+    events = capture_events()
+
+    client.get(reverse("message"))
+
+    message, transaction = events
+
+    assert message["message"] == "hi"
+    assert render_span_tree(transaction) == EXPECTED_SIGNALS_SPANS
 
     assert transaction["spans"][0]["op"] == "event.django"
     assert transaction["spans"][0]["description"] == "django.db.reset_queries"
@@ -818,17 +800,18 @@ def test_signals_spans(sentry_init, client, capture_events, render_span_tree):
 
 def test_signals_spans_disabled(sentry_init, client, capture_events):
     sentry_init(
-        integrations=[DjangoIntegration(middleware_spans=False, signals_spans=False)],
+        integrations=[
+            DjangoIntegration(middleware_spans=False, signals_spans=False),
+        ],
         traces_sample_rate=1.0,
     )
     events = capture_events()
 
-    _content, status, _headers = client.get(reverse("message"))
+    client.get(reverse("message"))
 
     message, transaction = events
 
     assert message["message"] == "hi"
-
     assert not transaction["spans"]
 
 


### PR DESCRIPTION
Adds an option `signals_spans` to the DjangoIntegrations that works the same as `middleware_spans` so the tracing of Django signals can be turned of.

Also I cleaned up the tests a bit.

Fixes #1893  