### PR TITLE
fix: Rename MYPY to TYPE_CHECKING

### DIFF
--- a/scripts/init_serverless_sdk.py
+++ b/scripts/init_serverless_sdk.py
@@ -10,11 +10,11 @@ import sys
 import re
 
 import sentry_sdk
-from sentry_sdk._types import MYPY
+from sentry_sdk._types import TYPE_CHECKING
 from sentry_sdk.utils import Dsn
 from sentry_sdk.integrations.aws_lambda import AwsLambdaIntegration
 
-if MYPY:
+if TYPE_CHECKING:
     from typing import Any
 
 

--- a/sentry_sdk/_compat.py
+++ b/sentry_sdk/_compat.py
@@ -1,8 +1,8 @@
 import sys
 
-from sentry_sdk._types import MYPY
+from sentry_sdk._types import TYPE_CHECKING
 
-if MYPY:
+if TYPE_CHECKING:
     from typing import Optional
     from typing import Tuple
     from typing import Any

--- a/sentry_sdk/_functools.py
+++ b/sentry_sdk/_functools.py
@@ -5,9 +5,9 @@ we rely upon is that `update_wrapper` handles AttributeError gracefully.
 
 from functools import partial
 
-from sentry_sdk._types import MYPY
+from sentry_sdk._types import TYPE_CHECKING
 
-if MYPY:
+if TYPE_CHECKING:
     from typing import Any
     from typing import Callable
 

--- a/sentry_sdk/_queue.py
+++ b/sentry_sdk/_queue.py
@@ -16,9 +16,9 @@ import threading
 from collections import deque
 from time import time
 
-from sentry_sdk._types import MYPY
+from sentry_sdk._types import TYPE_CHECKING
 
-if MYPY:
+if TYPE_CHECKING:
     from typing import Any
 
 __all__ = ["EmptyError", "FullError", "Queue"]

--- a/sentry_sdk/_types.py
+++ b/sentry_sdk/_types.py
@@ -4,6 +4,10 @@ except ImportError:
     TYPE_CHECKING = False
 
 
+# Re-exported for compat, since code out there in the wild might use this variable.
+MYPY = TYPE_CHECKING
+
+
 if TYPE_CHECKING:
     from types import TracebackType
     from typing import Any

--- a/sentry_sdk/_types.py
+++ b/sentry_sdk/_types.py
@@ -1,10 +1,10 @@
 try:
-    from typing import TYPE_CHECKING as MYPY
+    from typing import TYPE_CHECKING as TYPE_CHECKING
 except ImportError:
-    MYPY = False
+    TYPE_CHECKING = False
 
 
-if MYPY:
+if TYPE_CHECKING:
     from types import TracebackType
     from typing import Any
     from typing import Callable

--- a/sentry_sdk/api.py
+++ b/sentry_sdk/api.py
@@ -3,10 +3,10 @@ import inspect
 from sentry_sdk.hub import Hub
 from sentry_sdk.scope import Scope
 
-from sentry_sdk._types import MYPY
+from sentry_sdk._types import TYPE_CHECKING
 from sentry_sdk.tracing import NoOpSpan
 
-if MYPY:
+if TYPE_CHECKING:
     from typing import Any
     from typing import Dict
     from typing import Optional

--- a/sentry_sdk/attachments.py
+++ b/sentry_sdk/attachments.py
@@ -1,10 +1,10 @@
 import os
 import mimetypes
 
-from sentry_sdk._types import MYPY
+from sentry_sdk._types import TYPE_CHECKING
 from sentry_sdk.envelope import Item, PayloadRef
 
-if MYPY:
+if TYPE_CHECKING:
     from typing import Optional, Union, Callable
 
 

--- a/sentry_sdk/client.py
+++ b/sentry_sdk/client.py
@@ -30,9 +30,9 @@ from sentry_sdk.sessions import SessionFlusher
 from sentry_sdk.envelope import Envelope
 from sentry_sdk.profiler import setup_profiler
 
-from sentry_sdk._types import MYPY
+from sentry_sdk._types import TYPE_CHECKING
 
-if MYPY:
+if TYPE_CHECKING:
     from typing import Any
     from typing import Callable
     from typing import Dict
@@ -512,9 +512,9 @@ class _Client(object):
         self.close()
 
 
-from sentry_sdk._types import MYPY
+from sentry_sdk._types import TYPE_CHECKING
 
-if MYPY:
+if TYPE_CHECKING:
     # Make mypy, PyCharm and other static analyzers think `get_options` is a
     # type to have nicer autocompletion for params.
     #

--- a/sentry_sdk/consts.py
+++ b/sentry_sdk/consts.py
@@ -1,6 +1,6 @@
-from sentry_sdk._types import MYPY
+from sentry_sdk._types import TYPE_CHECKING
 
-if MYPY:
+if TYPE_CHECKING:
     import sentry_sdk
 
     from typing import Optional

--- a/sentry_sdk/envelope.py
+++ b/sentry_sdk/envelope.py
@@ -3,11 +3,11 @@ import json
 import mimetypes
 
 from sentry_sdk._compat import text_type, PY2
-from sentry_sdk._types import MYPY
+from sentry_sdk._types import TYPE_CHECKING
 from sentry_sdk.session import Session
 from sentry_sdk.utils import json_dumps, capture_internal_exceptions
 
-if MYPY:
+if TYPE_CHECKING:
     from typing import Any
     from typing import Optional
     from typing import Union

--- a/sentry_sdk/hub.py
+++ b/sentry_sdk/hub.py
@@ -18,9 +18,9 @@ from sentry_sdk.utils import (
     ContextVar,
 )
 
-from sentry_sdk._types import MYPY
+from sentry_sdk._types import TYPE_CHECKING
 
-if MYPY:
+if TYPE_CHECKING:
     from typing import Union
     from typing import Any
     from typing import Optional
@@ -125,9 +125,9 @@ def _init(*args, **kwargs):
     return rv
 
 
-from sentry_sdk._types import MYPY
+from sentry_sdk._types import TYPE_CHECKING
 
-if MYPY:
+if TYPE_CHECKING:
     # Make mypy, PyCharm and other static analyzers think `init` is a type to
     # have nicer autocompletion for params.
     #
@@ -223,7 +223,7 @@ class Hub(with_metaclass(HubMeta)):  # type: ignore
 
     # Mypy doesn't pick up on the metaclass.
 
-    if MYPY:
+    if TYPE_CHECKING:
         current = None  # type: Hub
         main = None  # type: Hub
 

--- a/sentry_sdk/integrations/__init__.py
+++ b/sentry_sdk/integrations/__init__.py
@@ -6,9 +6,9 @@ from threading import Lock
 from sentry_sdk._compat import iteritems
 from sentry_sdk.utils import logger
 
-from sentry_sdk._types import MYPY
+from sentry_sdk._types import TYPE_CHECKING
 
-if MYPY:
+if TYPE_CHECKING:
     from typing import Callable
     from typing import Dict
     from typing import Iterator

--- a/sentry_sdk/integrations/_wsgi_common.py
+++ b/sentry_sdk/integrations/_wsgi_common.py
@@ -4,9 +4,9 @@ from sentry_sdk.hub import Hub, _should_send_default_pii
 from sentry_sdk.utils import AnnotatedValue
 from sentry_sdk._compat import text_type, iteritems
 
-from sentry_sdk._types import MYPY
+from sentry_sdk._types import TYPE_CHECKING
 
-if MYPY:
+if TYPE_CHECKING:
     import sentry_sdk
 
     from typing import Any

--- a/sentry_sdk/integrations/aiohttp.py
+++ b/sentry_sdk/integrations/aiohttp.py
@@ -29,9 +29,9 @@ try:
 except ImportError:
     raise DidNotEnable("AIOHTTP not installed")
 
-from sentry_sdk._types import MYPY
+from sentry_sdk._types import TYPE_CHECKING
 
-if MYPY:
+if TYPE_CHECKING:
     from aiohttp.web_request import Request
     from aiohttp.abc import AbstractMatchInfo
     from typing import Any

--- a/sentry_sdk/integrations/argv.py
+++ b/sentry_sdk/integrations/argv.py
@@ -6,9 +6,9 @@ from sentry_sdk.hub import Hub
 from sentry_sdk.integrations import Integration
 from sentry_sdk.scope import add_global_event_processor
 
-from sentry_sdk._types import MYPY
+from sentry_sdk._types import TYPE_CHECKING
 
-if MYPY:
+if TYPE_CHECKING:
     from typing import Optional
 
     from sentry_sdk._types import Event, Hint

--- a/sentry_sdk/integrations/arq.py
+++ b/sentry_sdk/integrations/arq.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import
 import sys
 
 from sentry_sdk._compat import reraise
-from sentry_sdk._types import MYPY
+from sentry_sdk._types import TYPE_CHECKING
 from sentry_sdk import Hub
 from sentry_sdk.consts import OP
 from sentry_sdk.hub import _should_send_default_pii
@@ -24,7 +24,7 @@ try:
 except ImportError:
     raise DidNotEnable("Arq is not installed")
 
-if MYPY:
+if TYPE_CHECKING:
     from typing import Any, Dict, Optional
 
     from sentry_sdk._types import EventProcessor, Event, ExcInfo, Hint

--- a/sentry_sdk/integrations/asgi.py
+++ b/sentry_sdk/integrations/asgi.py
@@ -9,7 +9,7 @@ import inspect
 import urllib
 
 from sentry_sdk._functools import partial
-from sentry_sdk._types import MYPY
+from sentry_sdk._types import TYPE_CHECKING
 from sentry_sdk.consts import OP
 from sentry_sdk.hub import Hub, _should_send_default_pii
 from sentry_sdk.integrations._wsgi_common import _filter_headers
@@ -29,7 +29,7 @@ from sentry_sdk.utils import (
 )
 from sentry_sdk.tracing import Transaction
 
-if MYPY:
+if TYPE_CHECKING:
     from typing import Dict
     from typing import Any
     from typing import Optional

--- a/sentry_sdk/integrations/asyncio.py
+++ b/sentry_sdk/integrations/asyncio.py
@@ -5,7 +5,7 @@ from sentry_sdk._compat import reraise
 from sentry_sdk.consts import OP
 from sentry_sdk.hub import Hub
 from sentry_sdk.integrations import Integration, DidNotEnable
-from sentry_sdk._types import MYPY
+from sentry_sdk._types import TYPE_CHECKING
 from sentry_sdk.utils import event_from_exception
 
 try:
@@ -15,7 +15,7 @@ except ImportError:
     raise DidNotEnable("asyncio not available")
 
 
-if MYPY:
+if TYPE_CHECKING:
     from typing import Any
 
     from sentry_sdk._types import ExcInfo

--- a/sentry_sdk/integrations/atexit.py
+++ b/sentry_sdk/integrations/atexit.py
@@ -8,9 +8,9 @@ from sentry_sdk.hub import Hub
 from sentry_sdk.utils import logger
 from sentry_sdk.integrations import Integration
 
-from sentry_sdk._types import MYPY
+from sentry_sdk._types import TYPE_CHECKING
 
-if MYPY:
+if TYPE_CHECKING:
 
     from typing import Any
     from typing import Optional

--- a/sentry_sdk/integrations/aws_lambda.py
+++ b/sentry_sdk/integrations/aws_lambda.py
@@ -16,9 +16,9 @@ from sentry_sdk.utils import (
 from sentry_sdk.integrations import Integration
 from sentry_sdk.integrations._wsgi_common import _filter_headers
 
-from sentry_sdk._types import MYPY
+from sentry_sdk._types import TYPE_CHECKING
 
-if MYPY:
+if TYPE_CHECKING:
     from typing import Any
     from typing import TypeVar
     from typing import Callable

--- a/sentry_sdk/integrations/beam.py
+++ b/sentry_sdk/integrations/beam.py
@@ -9,9 +9,9 @@ from sentry_sdk._compat import reraise
 from sentry_sdk.utils import capture_internal_exceptions, event_from_exception
 from sentry_sdk.integrations import Integration
 from sentry_sdk.integrations.logging import ignore_logger
-from sentry_sdk._types import MYPY
+from sentry_sdk._types import TYPE_CHECKING
 
-if MYPY:
+if TYPE_CHECKING:
     from typing import Any
     from typing import Iterator
     from typing import TypeVar

--- a/sentry_sdk/integrations/boto3.py
+++ b/sentry_sdk/integrations/boto3.py
@@ -6,10 +6,10 @@ from sentry_sdk.integrations import Integration, DidNotEnable
 from sentry_sdk.tracing import Span
 
 from sentry_sdk._functools import partial
-from sentry_sdk._types import MYPY
+from sentry_sdk._types import TYPE_CHECKING
 from sentry_sdk.utils import parse_url
 
-if MYPY:
+if TYPE_CHECKING:
     from typing import Any
     from typing import Dict
     from typing import Optional

--- a/sentry_sdk/integrations/bottle.py
+++ b/sentry_sdk/integrations/bottle.py
@@ -11,9 +11,9 @@ from sentry_sdk.integrations import Integration, DidNotEnable
 from sentry_sdk.integrations.wsgi import SentryWsgiMiddleware
 from sentry_sdk.integrations._wsgi_common import RequestExtractor
 
-from sentry_sdk._types import MYPY
+from sentry_sdk._types import TYPE_CHECKING
 
-if MYPY:
+if TYPE_CHECKING:
     from sentry_sdk.integrations.wsgi import _ScopedResponse
     from typing import Any
     from typing import Dict

--- a/sentry_sdk/integrations/celery.py
+++ b/sentry_sdk/integrations/celery.py
@@ -13,10 +13,10 @@ from sentry_sdk.tracing import Transaction
 from sentry_sdk._compat import reraise
 from sentry_sdk.integrations import Integration, DidNotEnable
 from sentry_sdk.integrations.logging import ignore_logger
-from sentry_sdk._types import MYPY
+from sentry_sdk._types import TYPE_CHECKING
 from sentry_sdk._functools import wraps
 
-if MYPY:
+if TYPE_CHECKING:
     from typing import Any
     from typing import TypeVar
     from typing import Callable

--- a/sentry_sdk/integrations/chalice.py
+++ b/sentry_sdk/integrations/chalice.py
@@ -9,14 +9,14 @@ from sentry_sdk.utils import (
     capture_internal_exceptions,
     event_from_exception,
 )
-from sentry_sdk._types import MYPY
+from sentry_sdk._types import TYPE_CHECKING
 from sentry_sdk._functools import wraps
 
 import chalice  # type: ignore
 from chalice import Chalice, ChaliceViewError
 from chalice.app import EventSourceHandler as ChaliceEventSourceHandler  # type: ignore
 
-if MYPY:
+if TYPE_CHECKING:
     from typing import Any
     from typing import Dict
     from typing import TypeVar

--- a/sentry_sdk/integrations/cloud_resource_context.py
+++ b/sentry_sdk/integrations/cloud_resource_context.py
@@ -5,9 +5,9 @@ from sentry_sdk.integrations import Integration
 from sentry_sdk.api import set_context
 from sentry_sdk.utils import logger
 
-from sentry_sdk._types import MYPY
+from sentry_sdk._types import TYPE_CHECKING
 
-if MYPY:
+if TYPE_CHECKING:
     from typing import Dict
 
 

--- a/sentry_sdk/integrations/dedupe.py
+++ b/sentry_sdk/integrations/dedupe.py
@@ -3,9 +3,9 @@ from sentry_sdk.utils import ContextVar
 from sentry_sdk.integrations import Integration
 from sentry_sdk.scope import add_global_event_processor
 
-from sentry_sdk._types import MYPY
+from sentry_sdk._types import TYPE_CHECKING
 
-if MYPY:
+if TYPE_CHECKING:
     from typing import Optional
 
     from sentry_sdk._types import Event, Hint

--- a/sentry_sdk/integrations/django/__init__.py
+++ b/sentry_sdk/integrations/django/__init__.py
@@ -5,7 +5,7 @@ import sys
 import threading
 import weakref
 
-from sentry_sdk._types import MYPY
+from sentry_sdk._types import TYPE_CHECKING
 from sentry_sdk.consts import OP
 from sentry_sdk.hub import Hub, _should_send_default_pii
 from sentry_sdk.scope import add_global_event_processor
@@ -51,7 +51,7 @@ from sentry_sdk.integrations.django.signals_handlers import patch_signals
 from sentry_sdk.integrations.django.views import patch_views
 
 
-if MYPY:
+if TYPE_CHECKING:
     from typing import Any
     from typing import Callable
     from typing import Dict

--- a/sentry_sdk/integrations/django/asgi.py
+++ b/sentry_sdk/integrations/django/asgi.py
@@ -9,12 +9,12 @@ Since this file contains `async def` it is conditionally imported in
 import asyncio
 
 from sentry_sdk import Hub, _functools
-from sentry_sdk._types import MYPY
+from sentry_sdk._types import TYPE_CHECKING
 from sentry_sdk.consts import OP
 
 from sentry_sdk.integrations.asgi import SentryAsgiMiddleware
 
-if MYPY:
+if TYPE_CHECKING:
     from typing import Any
     from typing import Union
     from typing import Callable
@@ -109,7 +109,7 @@ def _asgi_middleware_mixin_factory(_check_middleware_span):
     """
 
     class SentryASGIMixin:
-        if MYPY:
+        if TYPE_CHECKING:
             _inner = None
 
         def __init__(self, get_response):

--- a/sentry_sdk/integrations/django/middleware.py
+++ b/sentry_sdk/integrations/django/middleware.py
@@ -6,7 +6,7 @@ from django import VERSION as DJANGO_VERSION
 
 from sentry_sdk import Hub
 from sentry_sdk._functools import wraps
-from sentry_sdk._types import MYPY
+from sentry_sdk._types import TYPE_CHECKING
 from sentry_sdk.consts import OP
 from sentry_sdk.utils import (
     ContextVar,
@@ -14,7 +14,7 @@ from sentry_sdk.utils import (
     capture_internal_exceptions,
 )
 
-if MYPY:
+if TYPE_CHECKING:
     from typing import Any
     from typing import Callable
     from typing import Optional

--- a/sentry_sdk/integrations/django/signals_handlers.py
+++ b/sentry_sdk/integrations/django/signals_handlers.py
@@ -5,11 +5,11 @@ from django.dispatch import Signal
 
 from sentry_sdk import Hub
 from sentry_sdk._functools import wraps
-from sentry_sdk._types import MYPY
+from sentry_sdk._types import TYPE_CHECKING
 from sentry_sdk.consts import OP
 
 
-if MYPY:
+if TYPE_CHECKING:
     from typing import Any
     from typing import Callable
     from typing import List

--- a/sentry_sdk/integrations/django/templates.py
+++ b/sentry_sdk/integrations/django/templates.py
@@ -2,10 +2,10 @@ from django.template import TemplateSyntaxError
 from django import VERSION as DJANGO_VERSION
 
 from sentry_sdk import _functools, Hub
-from sentry_sdk._types import MYPY
+from sentry_sdk._types import TYPE_CHECKING
 from sentry_sdk.consts import OP
 
-if MYPY:
+if TYPE_CHECKING:
     from typing import Any
     from typing import Dict
     from typing import Optional

--- a/sentry_sdk/integrations/django/transactions.py
+++ b/sentry_sdk/integrations/django/transactions.py
@@ -7,9 +7,9 @@ from __future__ import absolute_import
 
 import re
 
-from sentry_sdk._types import MYPY
+from sentry_sdk._types import TYPE_CHECKING
 
-if MYPY:
+if TYPE_CHECKING:
     from django.urls.resolvers import URLResolver
     from typing import Dict
     from typing import List

--- a/sentry_sdk/integrations/django/views.py
+++ b/sentry_sdk/integrations/django/views.py
@@ -1,9 +1,9 @@
 from sentry_sdk.consts import OP
 from sentry_sdk.hub import Hub
-from sentry_sdk._types import MYPY
+from sentry_sdk._types import TYPE_CHECKING
 from sentry_sdk import _functools
 
-if MYPY:
+if TYPE_CHECKING:
     from typing import Any
 
 

--- a/sentry_sdk/integrations/excepthook.py
+++ b/sentry_sdk/integrations/excepthook.py
@@ -4,9 +4,9 @@ from sentry_sdk.hub import Hub
 from sentry_sdk.utils import capture_internal_exceptions, event_from_exception
 from sentry_sdk.integrations import Integration
 
-from sentry_sdk._types import MYPY
+from sentry_sdk._types import TYPE_CHECKING
 
-if MYPY:
+if TYPE_CHECKING:
     from typing import Callable
     from typing import Any
     from typing import Type

--- a/sentry_sdk/integrations/executing.py
+++ b/sentry_sdk/integrations/executing.py
@@ -1,12 +1,12 @@
 from __future__ import absolute_import
 
 from sentry_sdk import Hub
-from sentry_sdk._types import MYPY
+from sentry_sdk._types import TYPE_CHECKING
 from sentry_sdk.integrations import Integration, DidNotEnable
 from sentry_sdk.scope import add_global_event_processor
 from sentry_sdk.utils import walk_exception_chain, iter_stacks
 
-if MYPY:
+if TYPE_CHECKING:
     from typing import Optional
 
     from sentry_sdk._types import Event, Hint

--- a/sentry_sdk/integrations/falcon.py
+++ b/sentry_sdk/integrations/falcon.py
@@ -10,9 +10,9 @@ from sentry_sdk.utils import (
     event_from_exception,
 )
 
-from sentry_sdk._types import MYPY
+from sentry_sdk._types import TYPE_CHECKING
 
-if MYPY:
+if TYPE_CHECKING:
     from typing import Any
     from typing import Dict
     from typing import Optional

--- a/sentry_sdk/integrations/fastapi.py
+++ b/sentry_sdk/integrations/fastapi.py
@@ -1,12 +1,12 @@
 import asyncio
 
-from sentry_sdk._types import MYPY
+from sentry_sdk._types import TYPE_CHECKING
 from sentry_sdk.hub import Hub, _should_send_default_pii
 from sentry_sdk.integrations import DidNotEnable
 from sentry_sdk.tracing import SOURCE_FOR_STYLE, TRANSACTION_SOURCE_ROUTE
 from sentry_sdk.utils import transaction_from_function
 
-if MYPY:
+if TYPE_CHECKING:
     from typing import Any, Callable, Dict
     from sentry_sdk.scope import Scope
 

--- a/sentry_sdk/integrations/flask.py
+++ b/sentry_sdk/integrations/flask.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 
-from sentry_sdk._types import MYPY
+from sentry_sdk._types import TYPE_CHECKING
 from sentry_sdk.hub import Hub, _should_send_default_pii
 from sentry_sdk.integrations import DidNotEnable, Integration
 from sentry_sdk.integrations._wsgi_common import RequestExtractor
@@ -12,7 +12,7 @@ from sentry_sdk.utils import (
     event_from_exception,
 )
 
-if MYPY:
+if TYPE_CHECKING:
     from typing import Any, Callable, Dict, Union
 
     from sentry_sdk._types import EventProcessor

--- a/sentry_sdk/integrations/gcp.py
+++ b/sentry_sdk/integrations/gcp.py
@@ -16,13 +16,13 @@ from sentry_sdk.utils import (
 from sentry_sdk.integrations import Integration
 from sentry_sdk.integrations._wsgi_common import _filter_headers
 
-from sentry_sdk._types import MYPY
+from sentry_sdk._types import TYPE_CHECKING
 
 # Constants
 TIMEOUT_WARNING_BUFFER = 1.5  # Buffer time required to send timeout warning to Sentry
 MILLIS_TO_SECONDS = 1000.0
 
-if MYPY:
+if TYPE_CHECKING:
     from typing import Any
     from typing import TypeVar
     from typing import Callable

--- a/sentry_sdk/integrations/gnu_backtrace.py
+++ b/sentry_sdk/integrations/gnu_backtrace.py
@@ -5,9 +5,9 @@ from sentry_sdk.integrations import Integration
 from sentry_sdk.scope import add_global_event_processor
 from sentry_sdk.utils import capture_internal_exceptions
 
-from sentry_sdk._types import MYPY
+from sentry_sdk._types import TYPE_CHECKING
 
-if MYPY:
+if TYPE_CHECKING:
     from typing import Any
     from typing import Dict
 

--- a/sentry_sdk/integrations/httpx.py
+++ b/sentry_sdk/integrations/httpx.py
@@ -4,9 +4,9 @@ from sentry_sdk.integrations import Integration, DidNotEnable
 from sentry_sdk.tracing_utils import should_propagate_trace
 from sentry_sdk.utils import logger, parse_url
 
-from sentry_sdk._types import MYPY
+from sentry_sdk._types import TYPE_CHECKING
 
-if MYPY:
+if TYPE_CHECKING:
     from typing import Any
 
 

--- a/sentry_sdk/integrations/huey.py
+++ b/sentry_sdk/integrations/huey.py
@@ -4,7 +4,7 @@ import sys
 from datetime import datetime
 
 from sentry_sdk._compat import reraise
-from sentry_sdk._types import MYPY
+from sentry_sdk._types import TYPE_CHECKING
 from sentry_sdk import Hub
 from sentry_sdk.consts import OP
 from sentry_sdk.hub import _should_send_default_pii
@@ -16,7 +16,7 @@ from sentry_sdk.utils import (
     SENSITIVE_DATA_SUBSTITUTE,
 )
 
-if MYPY:
+if TYPE_CHECKING:
     from typing import Any, Callable, Optional, Union, TypeVar
 
     from sentry_sdk._types import EventProcessor, Event, Hint

--- a/sentry_sdk/integrations/logging.py
+++ b/sentry_sdk/integrations/logging.py
@@ -14,9 +14,9 @@ from sentry_sdk.utils import (
 from sentry_sdk.integrations import Integration
 from sentry_sdk._compat import iteritems
 
-from sentry_sdk._types import MYPY
+from sentry_sdk._types import TYPE_CHECKING
 
-if MYPY:
+if TYPE_CHECKING:
     from logging import LogRecord
     from typing import Any
     from typing import Dict

--- a/sentry_sdk/integrations/modules.py
+++ b/sentry_sdk/integrations/modules.py
@@ -4,9 +4,9 @@ from sentry_sdk.hub import Hub
 from sentry_sdk.integrations import Integration
 from sentry_sdk.scope import add_global_event_processor
 
-from sentry_sdk._types import MYPY
+from sentry_sdk._types import TYPE_CHECKING
 
-if MYPY:
+if TYPE_CHECKING:
     from typing import Any
     from typing import Dict
     from typing import Tuple

--- a/sentry_sdk/integrations/opentelemetry/propagator.py
+++ b/sentry_sdk/integrations/opentelemetry/propagator.py
@@ -30,9 +30,9 @@ from sentry_sdk.tracing import (
     SENTRY_TRACE_HEADER_NAME,
 )
 from sentry_sdk.tracing_utils import Baggage, extract_sentrytrace_data
-from sentry_sdk._types import MYPY
+from sentry_sdk._types import TYPE_CHECKING
 
-if MYPY:
+if TYPE_CHECKING:
     from typing import Optional
     from typing import Set
 

--- a/sentry_sdk/integrations/opentelemetry/span_processor.py
+++ b/sentry_sdk/integrations/opentelemetry/span_processor.py
@@ -24,11 +24,11 @@ from sentry_sdk.integrations.opentelemetry.consts import (
 from sentry_sdk.scope import add_global_event_processor
 from sentry_sdk.tracing import Transaction, Span as SentrySpan
 from sentry_sdk.utils import Dsn
-from sentry_sdk._types import MYPY
+from sentry_sdk._types import TYPE_CHECKING
 
 from urllib3.util import parse_url as urlparse  # type: ignore
 
-if MYPY:
+if TYPE_CHECKING:
     from typing import Any
     from typing import Dict
     from typing import Union

--- a/sentry_sdk/integrations/pure_eval.py
+++ b/sentry_sdk/integrations/pure_eval.py
@@ -3,12 +3,12 @@ from __future__ import absolute_import
 import ast
 
 from sentry_sdk import Hub, serializer
-from sentry_sdk._types import MYPY
+from sentry_sdk._types import TYPE_CHECKING
 from sentry_sdk.integrations import Integration, DidNotEnable
 from sentry_sdk.scope import add_global_event_processor
 from sentry_sdk.utils import walk_exception_chain, iter_stacks
 
-if MYPY:
+if TYPE_CHECKING:
     from typing import Optional, Dict, Any, Tuple, List
     from types import FrameType
 

--- a/sentry_sdk/integrations/pymongo.py
+++ b/sentry_sdk/integrations/pymongo.py
@@ -7,14 +7,14 @@ from sentry_sdk.integrations import DidNotEnable, Integration
 from sentry_sdk.tracing import Span
 from sentry_sdk.utils import capture_internal_exceptions
 
-from sentry_sdk._types import MYPY
+from sentry_sdk._types import TYPE_CHECKING
 
 try:
     from pymongo import monitoring
 except ImportError:
     raise DidNotEnable("Pymongo not installed")
 
-if MYPY:
+if TYPE_CHECKING:
     from typing import Any, Dict, Union
 
     from pymongo.monitoring import (

--- a/sentry_sdk/integrations/pyramid.py
+++ b/sentry_sdk/integrations/pyramid.py
@@ -23,9 +23,9 @@ try:
 except ImportError:
     raise DidNotEnable("Pyramid not installed")
 
-from sentry_sdk._types import MYPY
+from sentry_sdk._types import TYPE_CHECKING
 
-if MYPY:
+if TYPE_CHECKING:
     from pyramid.response import Response
     from typing import Any
     from sentry_sdk.integrations.wsgi import _ScopedResponse

--- a/sentry_sdk/integrations/quart.py
+++ b/sentry_sdk/integrations/quart.py
@@ -11,9 +11,9 @@ from sentry_sdk.utils import (
     event_from_exception,
 )
 
-from sentry_sdk._types import MYPY
+from sentry_sdk._types import TYPE_CHECKING
 
-if MYPY:
+if TYPE_CHECKING:
     from typing import Any
     from typing import Dict
     from typing import Union

--- a/sentry_sdk/integrations/redis.py
+++ b/sentry_sdk/integrations/redis.py
@@ -5,9 +5,9 @@ from sentry_sdk.consts import OP
 from sentry_sdk.utils import capture_internal_exceptions, logger
 from sentry_sdk.integrations import Integration, DidNotEnable
 
-from sentry_sdk._types import MYPY
+from sentry_sdk._types import TYPE_CHECKING
 
-if MYPY:
+if TYPE_CHECKING:
     from typing import Any, Sequence
 
 _SINGLE_KEY_COMMANDS = frozenset(

--- a/sentry_sdk/integrations/rq.py
+++ b/sentry_sdk/integrations/rq.py
@@ -21,9 +21,9 @@ try:
 except ImportError:
     raise DidNotEnable("RQ not installed")
 
-from sentry_sdk._types import MYPY
+from sentry_sdk._types import TYPE_CHECKING
 
-if MYPY:
+if TYPE_CHECKING:
     from typing import Any, Callable, Dict
 
     from sentry_sdk._types import EventProcessor

--- a/sentry_sdk/integrations/sanic.py
+++ b/sentry_sdk/integrations/sanic.py
@@ -15,9 +15,9 @@ from sentry_sdk.integrations import Integration, DidNotEnable
 from sentry_sdk.integrations._wsgi_common import RequestExtractor, _filter_headers
 from sentry_sdk.integrations.logging import ignore_logger
 
-from sentry_sdk._types import MYPY
+from sentry_sdk._types import TYPE_CHECKING
 
-if MYPY:
+if TYPE_CHECKING:
     from typing import Any
     from typing import Callable
     from typing import Optional

--- a/sentry_sdk/integrations/serverless.py
+++ b/sentry_sdk/integrations/serverless.py
@@ -6,9 +6,9 @@ from sentry_sdk._compat import reraise
 from sentry_sdk._functools import wraps
 
 
-from sentry_sdk._types import MYPY
+from sentry_sdk._types import TYPE_CHECKING
 
-if MYPY:
+if TYPE_CHECKING:
     from typing import Any
     from typing import Callable
     from typing import TypeVar

--- a/sentry_sdk/integrations/spark/spark_driver.py
+++ b/sentry_sdk/integrations/spark/spark_driver.py
@@ -3,9 +3,9 @@ from sentry_sdk.hub import Hub
 from sentry_sdk.integrations import Integration
 from sentry_sdk.utils import capture_internal_exceptions
 
-from sentry_sdk._types import MYPY
+from sentry_sdk._types import TYPE_CHECKING
 
-if MYPY:
+if TYPE_CHECKING:
     from typing import Any
     from typing import Optional
 

--- a/sentry_sdk/integrations/spark/spark_worker.py
+++ b/sentry_sdk/integrations/spark/spark_worker.py
@@ -13,9 +13,9 @@ from sentry_sdk.utils import (
     event_hint_with_exc_info,
 )
 
-from sentry_sdk._types import MYPY
+from sentry_sdk._types import TYPE_CHECKING
 
-if MYPY:
+if TYPE_CHECKING:
     from typing import Any
     from typing import Optional
 

--- a/sentry_sdk/integrations/sqlalchemy.py
+++ b/sentry_sdk/integrations/sqlalchemy.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import
 
 import re
 
-from sentry_sdk._types import MYPY
+from sentry_sdk._types import TYPE_CHECKING
 from sentry_sdk.hub import Hub
 from sentry_sdk.integrations import Integration, DidNotEnable
 from sentry_sdk.tracing_utils import record_sql_queries
@@ -14,7 +14,7 @@ try:
 except ImportError:
     raise DidNotEnable("SQLAlchemy not installed.")
 
-if MYPY:
+if TYPE_CHECKING:
     from typing import Any
     from typing import ContextManager
     from typing import Optional

--- a/sentry_sdk/integrations/starlette.py
+++ b/sentry_sdk/integrations/starlette.py
@@ -4,7 +4,7 @@ import asyncio
 import functools
 
 from sentry_sdk._compat import iteritems
-from sentry_sdk._types import MYPY
+from sentry_sdk._types import TYPE_CHECKING
 from sentry_sdk.consts import OP
 from sentry_sdk.hub import Hub, _should_send_default_pii
 from sentry_sdk.integrations import DidNotEnable, Integration
@@ -21,7 +21,7 @@ from sentry_sdk.utils import (
     transaction_from_function,
 )
 
-if MYPY:
+if TYPE_CHECKING:
     from typing import Any, Awaitable, Callable, Dict, Optional
 
     from sentry_sdk.scope import Scope as SentryScope

--- a/sentry_sdk/integrations/stdlib.py
+++ b/sentry_sdk/integrations/stdlib.py
@@ -15,9 +15,9 @@ from sentry_sdk.utils import (
     parse_url,
 )
 
-from sentry_sdk._types import MYPY
+from sentry_sdk._types import TYPE_CHECKING
 
-if MYPY:
+if TYPE_CHECKING:
     from typing import Any
     from typing import Callable
     from typing import Dict

--- a/sentry_sdk/integrations/threading.py
+++ b/sentry_sdk/integrations/threading.py
@@ -5,11 +5,11 @@ from threading import Thread, current_thread
 
 from sentry_sdk import Hub
 from sentry_sdk._compat import reraise
-from sentry_sdk._types import MYPY
+from sentry_sdk._types import TYPE_CHECKING
 from sentry_sdk.integrations import Integration
 from sentry_sdk.utils import event_from_exception, capture_internal_exceptions
 
-if MYPY:
+if TYPE_CHECKING:
     from typing import Any
     from typing import TypeVar
     from typing import Callable

--- a/sentry_sdk/integrations/tornado.py
+++ b/sentry_sdk/integrations/tornado.py
@@ -32,9 +32,9 @@ try:
 except ImportError:
     raise DidNotEnable("Tornado not installed")
 
-from sentry_sdk._types import MYPY
+from sentry_sdk._types import TYPE_CHECKING
 
-if MYPY:
+if TYPE_CHECKING:
     from typing import Any
     from typing import Optional
     from typing import Dict

--- a/sentry_sdk/integrations/trytond.py
+++ b/sentry_sdk/integrations/trytond.py
@@ -2,12 +2,12 @@ import sentry_sdk.hub
 import sentry_sdk.utils
 import sentry_sdk.integrations
 import sentry_sdk.integrations.wsgi
-from sentry_sdk._types import MYPY
+from sentry_sdk._types import TYPE_CHECKING
 
 from trytond.exceptions import TrytonException  # type: ignore
 from trytond.wsgi import app  # type: ignore
 
-if MYPY:
+if TYPE_CHECKING:
     from typing import Any
 
 

--- a/sentry_sdk/integrations/wsgi.py
+++ b/sentry_sdk/integrations/wsgi.py
@@ -13,9 +13,9 @@ from sentry_sdk.tracing import Transaction, TRANSACTION_SOURCE_ROUTE
 from sentry_sdk.sessions import auto_session_tracking
 from sentry_sdk.integrations._wsgi_common import _filter_headers
 
-from sentry_sdk._types import MYPY
+from sentry_sdk._types import TYPE_CHECKING
 
-if MYPY:
+if TYPE_CHECKING:
     from typing import Callable
     from typing import Dict
     from typing import Iterator

--- a/sentry_sdk/profiler.py
+++ b/sentry_sdk/profiler.py
@@ -24,7 +24,7 @@ from collections import deque
 
 import sentry_sdk
 from sentry_sdk._compat import PY33, PY311
-from sentry_sdk._types import MYPY
+from sentry_sdk._types import TYPE_CHECKING
 from sentry_sdk.utils import (
     filename_for_module,
     logger,
@@ -32,7 +32,7 @@ from sentry_sdk.utils import (
     set_in_app_in_frames,
 )
 
-if MYPY:
+if TYPE_CHECKING:
     from types import FrameType
     from typing import Any
     from typing import Callable

--- a/sentry_sdk/scope.py
+++ b/sentry_sdk/scope.py
@@ -3,12 +3,12 @@ from collections import deque
 from itertools import chain
 
 from sentry_sdk._functools import wraps
-from sentry_sdk._types import MYPY
+from sentry_sdk._types import TYPE_CHECKING
 from sentry_sdk.utils import logger, capture_internal_exceptions
 from sentry_sdk.tracing import Transaction
 from sentry_sdk.attachments import Attachment
 
-if MYPY:
+if TYPE_CHECKING:
     from typing import Any
     from typing import Dict
     from typing import Optional

--- a/sentry_sdk/serializer.py
+++ b/sentry_sdk/serializer.py
@@ -24,9 +24,9 @@ from sentry_sdk._compat import (
     binary_sequence_types,
 )
 
-from sentry_sdk._types import MYPY
+from sentry_sdk._types import TYPE_CHECKING
 
-if MYPY:
+if TYPE_CHECKING:
     from datetime import timedelta
 
     from types import TracebackType

--- a/sentry_sdk/session.py
+++ b/sentry_sdk/session.py
@@ -1,10 +1,10 @@
 import uuid
 from datetime import datetime
 
-from sentry_sdk._types import MYPY
+from sentry_sdk._types import TYPE_CHECKING
 from sentry_sdk.utils import format_timestamp
 
-if MYPY:
+if TYPE_CHECKING:
     from typing import Optional
     from typing import Union
     from typing import Any

--- a/sentry_sdk/sessions.py
+++ b/sentry_sdk/sessions.py
@@ -6,10 +6,10 @@ from contextlib import contextmanager
 import sentry_sdk
 from sentry_sdk.envelope import Envelope
 from sentry_sdk.session import Session
-from sentry_sdk._types import MYPY
+from sentry_sdk._types import TYPE_CHECKING
 from sentry_sdk.utils import format_timestamp
 
-if MYPY:
+if TYPE_CHECKING:
     from typing import Any
     from typing import Callable
     from typing import Dict

--- a/sentry_sdk/tracing.py
+++ b/sentry_sdk/tracing.py
@@ -6,10 +6,10 @@ from datetime import datetime, timedelta
 import sentry_sdk
 from sentry_sdk.consts import INSTRUMENTER
 from sentry_sdk.utils import logger, nanosecond_time
-from sentry_sdk._types import MYPY
+from sentry_sdk._types import TYPE_CHECKING
 
 
-if MYPY:
+if TYPE_CHECKING:
     import typing
 
     from typing import Optional

--- a/sentry_sdk/tracing_utils.py
+++ b/sentry_sdk/tracing_utils.py
@@ -15,7 +15,7 @@ from sentry_sdk.utils import (
     to_string,
 )
 from sentry_sdk._compat import PY2, iteritems
-from sentry_sdk._types import MYPY
+from sentry_sdk._types import TYPE_CHECKING
 
 if PY2:
     from collections import Mapping
@@ -24,7 +24,7 @@ else:
     from collections.abc import Mapping
     from urllib.parse import quote, unquote
 
-if MYPY:
+if TYPE_CHECKING:
     import typing
 
     from typing import Any
@@ -398,5 +398,5 @@ def should_propagate_trace(hub, url):
 # Circular imports
 from sentry_sdk.tracing import LOW_QUALITY_TRANSACTION_SOURCES
 
-if MYPY:
+if TYPE_CHECKING:
     from sentry_sdk.tracing import Span, Transaction

--- a/sentry_sdk/transport.py
+++ b/sentry_sdk/transport.py
@@ -13,9 +13,9 @@ from sentry_sdk.utils import Dsn, logger, capture_internal_exceptions, json_dump
 from sentry_sdk.worker import BackgroundWorker
 from sentry_sdk.envelope import Envelope, Item, PayloadRef
 
-from sentry_sdk._types import MYPY
+from sentry_sdk._types import TYPE_CHECKING
 
-if MYPY:
+if TYPE_CHECKING:
     from typing import Any
     from typing import Callable
     from typing import Dict

--- a/sentry_sdk/utils.py
+++ b/sentry_sdk/utils.py
@@ -39,9 +39,9 @@ except ImportError:
 
 import sentry_sdk
 from sentry_sdk._compat import PY2, PY33, PY37, implements_str, text_type, urlparse
-from sentry_sdk._types import MYPY
+from sentry_sdk._types import TYPE_CHECKING
 
-if MYPY:
+if TYPE_CHECKING:
     from types import FrameType, TracebackType
     from typing import (
         Any,
@@ -407,7 +407,7 @@ class AnnotatedValue(object):
         )
 
 
-if MYPY:
+if TYPE_CHECKING:
     from typing import TypeVar
 
     T = TypeVar("T")

--- a/sentry_sdk/worker.py
+++ b/sentry_sdk/worker.py
@@ -7,9 +7,9 @@ from sentry_sdk._queue import Queue, FullError
 from sentry_sdk.utils import logger
 from sentry_sdk.consts import DEFAULT_QUEUE_SIZE
 
-from sentry_sdk._types import MYPY
+from sentry_sdk._types import TYPE_CHECKING
 
-if MYPY:
+if TYPE_CHECKING:
     from typing import Any
     from typing import Optional
     from typing import Callable


### PR DESCRIPTION
we have a lot of conditionals in our codebase that are supposed to
separate the code that mypy is supposed to see from the code that we
actually want to execute.

In the specific case of sentry_sdk.configure_scope, this means that
pyright does not handle with the overloads correctly because it only
recognizes TYPE_CHECKING as a special variable name, not MYPY.

Rename MYPY to TYPE_CHECKING so pyright typechecks configure_scope
correctly.
