### PR TITLE
fix(integration): fix FlaskIntegration for Werkzeug > 2.1.0

### DIFF
--- a/sentry_sdk/integrations/flask.py
+++ b/sentry_sdk/integrations/flask.py
@@ -173,7 +173,7 @@ class FlaskRequestExtractor(RequestExtractor):
 
     def json(self):
         # type: () -> Any
-        return self.request.get_json()
+        return self.request.get_json(silent=True)
 
     def size_of_file(self, file):
         # type: (FileStorage) -> int


### PR DESCRIPTION
As explained in [this bug report](https://github.com/getsentry/sentry-python/issues/1936), recent versions of werkzeug [introduced](https://github.com/pallets/werkzeug/pull/2355) the behaviour to `get_json` where it will throw an error when content_type isn't set. 