### PR TITLE
feat(profiling): Add profiler options to init

### DIFF
--- a/sentry_sdk/_types.py
+++ b/sentry_sdk/_types.py
@@ -85,3 +85,5 @@ if TYPE_CHECKING:
 
     FractionUnit = Literal["ratio", "percent"]
     MeasurementUnit = Union[DurationUnit, InformationUnit, FractionUnit, str]
+
+    ProfilerMode = Literal["sleep", "thread", "gevent", "unknown"]

--- a/sentry_sdk/client.py
+++ b/sentry_sdk/client.py
@@ -28,7 +28,7 @@ from sentry_sdk.integrations import setup_integrations
 from sentry_sdk.utils import ContextVar
 from sentry_sdk.sessions import SessionFlusher
 from sentry_sdk.envelope import Envelope
-from sentry_sdk.profiler import setup_profiler
+from sentry_sdk.profiler import has_profiling_enabled, setup_profiler
 
 from sentry_sdk._types import TYPE_CHECKING
 
@@ -174,8 +174,7 @@ class _Client(object):
         finally:
             _client_init_debug.set(old_debug)
 
-        profiles_sample_rate = self.options["_experiments"].get("profiles_sample_rate")
-        if profiles_sample_rate is not None and profiles_sample_rate > 0:
+        if has_profiling_enabled(self.options):
             try:
                 setup_profiler(self.options)
             except ValueError as e:

--- a/sentry_sdk/consts.py
+++ b/sentry_sdk/consts.py
@@ -19,6 +19,7 @@ if TYPE_CHECKING:
         BreadcrumbProcessor,
         Event,
         EventProcessor,
+        ProfilerMode,
         TracesSampler,
         TransactionProcessor,
     )
@@ -33,8 +34,9 @@ if TYPE_CHECKING:
             "max_spans": Optional[int],
             "record_sql_params": Optional[bool],
             "smart_transaction_trimming": Optional[bool],
+            # TODO: Remvoe these 2 profiling related experiments
             "profiles_sample_rate": Optional[float],
-            "profiler_mode": Optional[str],
+            "profiler_mode": Optional[ProfilerMode],
         },
         total=False,
     )
@@ -115,6 +117,9 @@ class ClientConstructor(object):
         propagate_traces=True,  # type: bool
         traces_sample_rate=None,  # type: Optional[float]
         traces_sampler=None,  # type: Optional[TracesSampler]
+        profiles_sample_rate=None,  # type: Optional[float]
+        profiles_sampler=None,  # type: Optional[TracesSampler]
+        profiler_mode=None,  # type: Optional[ProfilerMode]
         auto_enabling_integrations=True,  # type: bool
         auto_session_tracking=True,  # type: bool
         send_client_reports=True,  # type: bool

--- a/sentry_sdk/profiler.py
+++ b/sentry_sdk/profiler.py
@@ -46,7 +46,7 @@ if TYPE_CHECKING:
     from typing_extensions import TypedDict
 
     import sentry_sdk.tracing
-    from sentry_sdk._types import SamplingContext
+    from sentry_sdk._types import SamplingContext, ProfilerMode
 
     ThreadId = str
 
@@ -148,6 +148,23 @@ DEFAULT_SAMPLING_FREQUENCY = 101
 PROFILE_MINIMUM_SAMPLES = 2
 
 
+def has_profiling_enabled(options):
+    # type: (Dict[str, Any]) -> bool
+    profiles_sampler = options["profiles_sampler"]
+    if profiles_sampler is not None:
+        return True
+
+    profiles_sample_rate = options["profiles_sample_rate"]
+    if profiles_sample_rate is not None and profiles_sample_rate > 0:
+        return True
+
+    profiles_sample_rate = options["_experiments"].get("profiles_sample_rate")
+    if profiles_sample_rate is not None and profiles_sample_rate > 0:
+        return True
+
+    return False
+
+
 def setup_profiler(options):
     # type: (Dict[str, Any]) -> bool
     global _scheduler
@@ -171,7 +188,10 @@ def setup_profiler(options):
     else:
         default_profiler_mode = ThreadScheduler.mode
 
-    profiler_mode = options["_experiments"].get("profiler_mode", default_profiler_mode)
+    if options.get("profiler_mode") is not None:
+        profiler_mode = options["profiler_mode"]
+    else:
+        profiler_mode = options.get("_experiments", {}).get("profiler_mode") or default_profiler_mode
 
     if (
         profiler_mode == ThreadScheduler.mode
@@ -491,7 +511,13 @@ class Profile(object):
             return
 
         options = client.options
-        sample_rate = options["_experiments"].get("profiles_sample_rate")
+
+        if callable(options.get("profiles_sampler")):
+            sample_rate = options["profiles_sampler"](sampling_context)
+        elif options["profiles_sample_rate"] is not None:
+            sample_rate = options["profiles_sample_rate"]
+        else:
+            sample_rate = options["_experiments"].get("profiles_sample_rate")
 
         # The profiles_sample_rate option was not set, so profiling
         # was never enabled.
@@ -695,7 +721,7 @@ class Profile(object):
 
 
 class Scheduler(object):
-    mode = "unknown"
+    mode = "unknown"  # type: ProfilerMode
 
     def __init__(self, frequency):
         # type: (int) -> None
@@ -824,7 +850,7 @@ class ThreadScheduler(Scheduler):
     the sampler at a regular interval.
     """
 
-    mode = "thread"
+    mode = "thread"  # type: ProfilerMode
     name = "sentry.profiler.ThreadScheduler"
 
     def __init__(self, frequency):
@@ -905,7 +931,7 @@ class GeventScheduler(Scheduler):
        results in a sample containing only the sampler's code.
     """
 
-    mode = "gevent"
+    mode = "gevent"  # type: ProfilerMode
     name = "sentry.profiler.GeventScheduler"
 
     def __init__(self, frequency):

--- a/tests/test_profiler.py
+++ b/tests/test_profiler.py
@@ -46,6 +46,14 @@ def process_test_sample(sample):
     return [(tid, (stack, stack)) for tid, stack in sample]
 
 
+def non_experimental_options(mode=None, sample_rate=None):
+    return {"profiler_mode": mode, "profiles_sample_rate": sample_rate}
+
+
+def experimental_options(mode=None, sample_rate=None):
+    return {"_experiments": {"profiler_mode": mode, "profiles_sample_rate": sample_rate}}
+
+
 @requires_python_version(3, 3)
 @pytest.mark.parametrize(
     "mode",
@@ -57,9 +65,16 @@ def process_test_sample(sample):
         ),
     ],
 )
-def test_profiler_invalid_mode(mode, teardown_profiling):
+@pytest.mark.parametrize(
+    "make_options",
+    [
+        pytest.param(experimental_options, id="experiment"),
+        pytest.param(non_experimental_options, id="non experimental"),
+    ],
+)
+def test_profiler_invalid_mode(mode, make_options, teardown_profiling):
     with pytest.raises(ValueError):
-        setup_profiler({"_experiments": {"profiler_mode": mode}})
+        setup_profiler(make_options(mode))
 
 
 @pytest.mark.parametrize(
@@ -70,17 +85,31 @@ def test_profiler_invalid_mode(mode, teardown_profiling):
         pytest.param("gevent", marks=requires_gevent),
     ],
 )
-def test_profiler_valid_mode(mode, teardown_profiling):
+@pytest.mark.parametrize(
+    "make_options",
+    [
+        pytest.param(experimental_options, id="experiment"),
+        pytest.param(non_experimental_options, id="non experimental"),
+    ],
+)
+def test_profiler_valid_mode(mode, make_options, teardown_profiling):
     # should not raise any exceptions
-    setup_profiler({"_experiments": {"profiler_mode": mode}})
+    setup_profiler(make_options(mode))
 
 
 @requires_python_version(3, 3)
-def test_profiler_setup_twice(teardown_profiling):
+@pytest.mark.parametrize(
+    "options",
+    [
+        pytest.param(experimental_options(), id="experiment"),
+        pytest.param(non_experimental_options(), id="non experimental"),
+    ],
+)
+def test_profiler_setup_twice(options, teardown_profiling):
     # setting up the first time should return True to indicate success
-    assert setup_profiler({"_experiments": {}})
+    assert setup_profiler(options)
     # setting up the second time should return False to indicate no-op
-    assert not setup_profiler({"_experiments": {}})
+    assert not setup_profiler(options)
 
 
 @pytest.mark.parametrize(
@@ -100,21 +129,82 @@ def test_profiler_setup_twice(teardown_profiling):
         pytest.param(None, 0, id="profiler not enabled"),
     ],
 )
+@pytest.mark.parametrize(
+    "make_options",
+    [
+        pytest.param(experimental_options, id="experiment"),
+        pytest.param(non_experimental_options, id="non experimental"),
+    ],
+)
 @mock.patch("sentry_sdk.profiler.PROFILE_MINIMUM_SAMPLES", 0)
-def test_profiled_transaction(
+def test_profiles_sample_rate(
     sentry_init,
     capture_envelopes,
     teardown_profiling,
     profiles_sample_rate,
     profile_count,
+    make_options,
     mode,
 ):
     sentry_init(
         traces_sample_rate=1.0,
-        _experiments={
-            "profiles_sample_rate": profiles_sample_rate,
-            "profiler_mode": mode,
-        },
+        **make_options(mode=mode, sample_rate=profiles_sample_rate),
+    )
+
+    envelopes = capture_envelopes()
+
+    with mock.patch("sentry_sdk.profiler.random.random", return_value=0.5):
+        with start_transaction(name="profiling"):
+            pass
+
+    items = defaultdict(list)
+    for envelope in envelopes:
+        for item in envelope.items:
+            items[item.type].append(item)
+
+    assert len(items["transaction"]) == 1
+    assert len(items["profile"]) == profile_count
+
+
+@pytest.mark.parametrize(
+    "mode",
+    [
+        pytest.param("thread"),
+        pytest.param("gevent", marks=requires_gevent),
+    ],
+)
+@pytest.mark.parametrize(
+    ("profiles_sampler", "profile_count"),
+    [
+        pytest.param(lambda _: 1.00, 1, id="profiler sampled at 1.00"),
+        pytest.param(lambda _: 0.75, 1, id="profiler sampled at 0.75"),
+        pytest.param(lambda _: 0.25, 0, id="profiler sampled at 0.25"),
+        pytest.param(lambda _: 0.00, 0, id="profiler sampled at 0.00"),
+        pytest.param(lambda _: None, 0, id="profiler not enabled"),
+        pytest.param(
+            lambda ctx: 1 if ctx["transaction_context"]["name"] == "profiling" else 0,
+            1,
+            id="profiler sampled for transaction name"
+        ),
+        pytest.param(
+            lambda ctx: 0 if ctx["transaction_context"]["name"] == "profiling" else 1,
+            0,
+            id="profiler not sampled for transaction name"
+        ),
+    ],
+)
+@mock.patch("sentry_sdk.profiler.PROFILE_MINIMUM_SAMPLES", 0)
+def test_profiles_sampler(
+    sentry_init,
+    capture_envelopes,
+    teardown_profiling,
+    profiles_sampler,
+    profile_count,
+    mode,
+):
+    sentry_init(
+        traces_sample_rate=1.0,
+        profiles_sampler=profiles_sampler,
     )
 
     envelopes = capture_envelopes()


### PR DESCRIPTION
This adds the `profiles_sample_rate`, `profiles_sampler` and `profiler_mode` options to the top level of the init call. The `_experiment` options will still be available temporarily but is deprecated and will be removed in the future.