### PR TITLE
Added top level api to get current span and transaction

### DIFF
--- a/sentry_sdk/__init__.py
+++ b/sentry_sdk/__init__.py
@@ -32,6 +32,9 @@ __all__ = [  # noqa
     "set_user",
     "set_level",
     "set_measurement",
+    "get_current_span",
+    "get_current_transaction",
+    "get_current_span_or_transaction",
 ]
 
 # Initialize the debug support after everything is loaded

--- a/sentry_sdk/__init__.py
+++ b/sentry_sdk/__init__.py
@@ -33,8 +33,6 @@ __all__ = [  # noqa
     "set_level",
     "set_measurement",
     "get_current_span",
-    "get_current_transaction",
-    "get_current_span_or_transaction",
 ]
 
 # Initialize the debug support after everything is loaded

--- a/sentry_sdk/api.py
+++ b/sentry_sdk/api.py
@@ -54,8 +54,6 @@ __all__ = [
     "set_level",
     "set_measurement",
     "get_current_span",
-    "get_current_transaction",
-    "get_current_span_or_transaction",
 ]
 
 
@@ -243,32 +241,3 @@ def get_current_span(hub=None):
 
     current_span = hub.scope.span
     return current_span
-
-
-def get_current_transaction(hub=None):
-    # type: (Optional[Hub]) -> Optional[Transaction]
-    """
-    Returns the currently active transaction if there is one running, otherwise `None`
-    """
-    if hub is None:
-        hub = Hub.current
-
-    transaction = hub.scope.transaction
-    return transaction
-
-
-def get_current_span_or_transaction(hub=None):
-    # type: (Optional[Hub]) -> Optional[Union[Span, Transaction]]
-    """
-    Returns the currently active span if there is one running,
-    otherwise the currently active transaction if there is one running,
-    otherwise `None`
-    """
-    if hub is None:
-        hub = Hub.current
-
-    current_span = get_current_span(hub)
-    if current_span is not None:
-        return current_span
-
-    return get_current_transaction(hub)

--- a/sentry_sdk/api.py
+++ b/sentry_sdk/api.py
@@ -53,6 +53,9 @@ __all__ = [
     "set_user",
     "set_level",
     "set_measurement",
+    "get_current_span",
+    "get_current_transaction",
+    "get_current_span_or_transaction",
 ]
 
 
@@ -228,3 +231,44 @@ def set_measurement(name, value, unit=""):
     transaction = Hub.current.scope.transaction
     if transaction is not None:
         transaction.set_measurement(name, value, unit)
+
+
+def get_current_span(hub=None):
+    # type: (Optional[Hub]) -> Optional[Span]
+    """
+    Returns the currently active span if there is one running, otherwise `None`
+    """
+    if hub is None:
+        hub = Hub.current
+
+    current_span = hub.scope.span
+    return current_span
+
+
+def get_current_transaction(hub=None):
+    # type: (Optional[Hub]) -> Optional[Transaction]
+    """
+    Returns the currently active transaction if there is one running, otherwise `None`
+    """
+    if hub is None:
+        hub = Hub.current
+
+    transaction = hub.scope.transaction
+    return transaction
+
+
+def get_current_span_or_transaction(hub=None):
+    # type: (Optional[Hub]) -> Optional[Union[Span, Transaction]]
+    """
+    Returns the currently active span if there is one running,
+    otherwise the currently active transaction if there is one running,
+    otherwise `None`
+    """
+    if hub is None:
+        hub = Hub.current
+
+    current_span = get_current_span(hub)
+    if current_span is not None:
+        return current_span
+
+    return get_current_transaction(hub)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -2,9 +2,7 @@ import mock
 
 from sentry_sdk import (
     configure_scope,
-    get_current_span_or_transaction,
     get_current_span,
-    get_current_transaction,
     start_transaction,
 )
 
@@ -32,53 +30,10 @@ def test_get_current_span_default_hub(sentry_init):
         assert get_current_span() == fake_span
 
 
-def test_get_current_transaction():
-    fake_hub = mock.MagicMock()
-    fake_hub.scope = mock.MagicMock()
-
-    fake_hub.scope.transaction = mock.MagicMock()
-    assert get_current_transaction(fake_hub) == fake_hub.scope.transaction
-
-    fake_hub.scope.transaction = None
-    assert get_current_transaction(fake_hub) is None
-
-
-def test_get_current_transaction_default_hub(sentry_init):
+def test_get_current_span_default_hub_with_transaction(sentry_init):
     sentry_init()
 
-    assert get_current_transaction() is None
+    assert get_current_span() is None
 
     with start_transaction() as new_transaction:
-        assert get_current_transaction() == new_transaction
-
-
-def test_get_current_span_or_transaction():
-    fake_hub = mock.MagicMock()
-    fake_hub.scope = mock.MagicMock()
-
-    fake_hub.scope.span = mock.MagicMock()
-    fake_hub.scope.transaction = None
-    assert get_current_span_or_transaction(fake_hub) == fake_hub.scope.span
-
-    fake_hub.scope.span = None
-    fake_hub.scope.transaction = mock.MagicMock()
-    assert get_current_span_or_transaction(fake_hub) == fake_hub.scope.transaction
-
-    fake_hub.scope.span = None
-    fake_hub.scope.transaction = None
-    assert get_current_span_or_transaction(fake_hub) is None
-
-
-def test_get_current_span_or_transaction_default_hub(sentry_init):
-    sentry_init()
-
-    assert get_current_span_or_transaction() is None
-
-    with start_transaction() as new_transaction:
-        assert get_current_span_or_transaction() == new_transaction
-
-        with configure_scope() as scope:
-            fake_span = mock.MagicMock()
-            scope.span = fake_span
-
-            assert get_current_span_or_transaction() == fake_span
+        assert get_current_span() == new_transaction

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,46 @@
+import mock
+
+from sentry_sdk import (
+    get_current_span_or_transaction,
+    get_current_span,
+    get_current_transaction,
+)
+
+
+def test_get_current_span():
+    fake_hub = mock.MagicMock()
+    fake_hub.scope = mock.MagicMock()
+
+    fake_hub.scope.span = mock.MagicMock()
+    assert get_current_span(fake_hub) == fake_hub.scope.span
+
+    fake_hub.scope.span = None
+    assert get_current_span(fake_hub) is None
+
+
+def test_get_current_transaction():
+    fake_hub = mock.MagicMock()
+    fake_hub.scope = mock.MagicMock()
+
+    fake_hub.scope.transaction = mock.MagicMock()
+    assert get_current_transaction(fake_hub) == fake_hub.scope.transaction
+
+    fake_hub.scope.transaction = None
+    assert get_current_transaction(fake_hub) is None
+
+
+def test_get_current_span_or_transaction():
+    fake_hub = mock.MagicMock()
+    fake_hub.scope = mock.MagicMock()
+
+    fake_hub.scope.span = mock.MagicMock()
+    fake_hub.scope.transaction = None
+    assert get_current_span_or_transaction(fake_hub) == fake_hub.scope.span
+
+    fake_hub.scope.span = None
+    fake_hub.scope.transaction = mock.MagicMock()
+    assert get_current_span_or_transaction(fake_hub) == fake_hub.scope.transaction
+
+    fake_hub.scope.span = None
+    fake_hub.scope.transaction = None
+    assert get_current_span_or_transaction(fake_hub) is None

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,9 +1,11 @@
 import mock
 
 from sentry_sdk import (
+    configure_scope,
     get_current_span_or_transaction,
     get_current_span,
     get_current_transaction,
+    start_transaction,
 )
 
 
@@ -18,6 +20,18 @@ def test_get_current_span():
     assert get_current_span(fake_hub) is None
 
 
+def test_get_current_span_default_hub(sentry_init):
+    sentry_init()
+
+    assert get_current_span() is None
+
+    with configure_scope() as scope:
+        fake_span = mock.MagicMock()
+        scope.span = fake_span
+
+        assert get_current_span() == fake_span
+
+
 def test_get_current_transaction():
     fake_hub = mock.MagicMock()
     fake_hub.scope = mock.MagicMock()
@@ -27,6 +41,15 @@ def test_get_current_transaction():
 
     fake_hub.scope.transaction = None
     assert get_current_transaction(fake_hub) is None
+
+
+def test_get_current_transaction_default_hub(sentry_init):
+    sentry_init()
+
+    assert get_current_transaction() is None
+
+    with start_transaction() as new_transaction:
+        assert get_current_transaction() == new_transaction
 
 
 def test_get_current_span_or_transaction():
@@ -44,3 +67,18 @@ def test_get_current_span_or_transaction():
     fake_hub.scope.span = None
     fake_hub.scope.transaction = None
     assert get_current_span_or_transaction(fake_hub) is None
+
+
+def test_get_current_span_or_transaction_default_hub(sentry_init):
+    sentry_init()
+
+    assert get_current_span_or_transaction() is None
+
+    with start_transaction() as new_transaction:
+        assert get_current_span_or_transaction() == new_transaction
+
+        with configure_scope() as scope:
+            fake_span = mock.MagicMock()
+            scope.span = fake_span
+
+            assert get_current_span_or_transaction() == fake_span


### PR DESCRIPTION
Idea originated in this comment of a code review: https://github.com/getsentry/sentry-python/pull/1089#discussion_r1133985202