### PR TITLE
Centralized way to configure custom instrumentation

### DIFF
--- a/sentry_sdk/client.py
+++ b/sentry_sdk/client.py
@@ -168,6 +168,7 @@ class _Client(object):
                 module_obj = import_module(module_name)
                 function_obj = getattr(module_obj, function_name)
                 setattr(module_obj, function_name, trace(function_obj))
+                logger.debug("Enabled tracing for %s", function_qualname)
 
             except module_not_found_error:
                 try:
@@ -180,6 +181,7 @@ class _Client(object):
                     function_obj = getattr(class_obj, function_name)
                     setattr(class_obj, function_name, trace(function_obj))
                     setattr(module_obj, class_name, class_obj)
+                    logger.debug("Enabled tracing for %s", function_qualname)
 
                 except Exception as e:
                     logger.warning(

--- a/sentry_sdk/client.py
+++ b/sentry_sdk/client.py
@@ -117,6 +117,14 @@ def _get_options(*args, **kwargs):
     return rv
 
 
+try:
+    # Python 3.6+
+    module_not_found_error = ModuleNotFoundError
+except Exception:
+    # Older Python versions
+    module_not_found_error = ImportError
+
+
 class _Client(object):
     """The client is internally responsible for capturing the events and
     forwarding them to sentry through the configured transport.  It takes
@@ -157,7 +165,7 @@ class _Client(object):
                 function_obj = getattr(module_obj, function_name)
                 setattr(module_obj, function_name, trace(function_obj))
 
-            except ModuleNotFoundError:
+            except module_not_found_error:
                 try:
                     # Try to import a class
                     # ex: "mymodule.submodule.MyClassName.member_function"

--- a/sentry_sdk/client.py
+++ b/sentry_sdk/client.py
@@ -169,16 +169,18 @@ class _Client(object):
                     setattr(class_obj, function_name, trace(function_obj))
                     setattr(module_obj, class_name, class_obj)
 
-                except Exception:
+                except Exception as e:
                     logger.warning(
-                        "Can not enable tracing for '%s'. Please check your `functions_to_trace` parameter.",
+                        "Can not enable tracing for '%s'. (%s) Please check your `functions_to_trace` parameter.",
                         function_qualname,
+                        e,
                     )
 
-            except Exception:
+            except Exception as e:
                 logger.warning(
-                    "Can not enable tracing for '%s'. Please check your `functions_to_trace` parameter.",
+                    "Can not enable tracing for '%s'. (%s) Please check your `functions_to_trace` parameter.",
                     function_qualname,
+                    e,
                 )
 
     def _init_impl(self):

--- a/sentry_sdk/client.py
+++ b/sentry_sdk/client.py
@@ -122,7 +122,7 @@ try:
     module_not_found_error = ModuleNotFoundError
 except Exception:
     # Older Python versions
-    module_not_found_error = ImportError
+    module_not_found_error = ImportError  # type: ignore
 
 
 class _Client(object):

--- a/sentry_sdk/client.py
+++ b/sentry_sdk/client.py
@@ -1,3 +1,4 @@
+from importlib import import_module
 import os
 import uuid
 import random
@@ -37,6 +38,7 @@ if TYPE_CHECKING:
     from typing import Callable
     from typing import Dict
     from typing import Optional
+    from typing import Sequence
 
     from sentry_sdk.scope import Scope
     from sentry_sdk._types import Event, Hint
@@ -136,6 +138,16 @@ class _Client(object):
         self.options = state["options"]
         self._init_impl()
 
+    def _trace_functions(self, functions_to_trace):
+        # type: (Sequence[str]) -> None
+        import ipdb
+
+        ipdb.set_trace()
+        for function in functions_to_trace:
+            module, cls = function.rsplit(".", 1)
+            func_obj = getattr(import_module(module), cls)
+            print(func_obj)
+
     def _init_impl(self):
         # type: () -> None
         old_debug = _client_init_debug.get(False)
@@ -180,6 +192,8 @@ class _Client(object):
                 setup_profiler(self.options)
             except ValueError as e:
                 logger.debug(str(e))
+
+        self._trace_functions(self.options.get("functions_to_trace", []))
 
     @property
     def dsn(self):

--- a/sentry_sdk/consts.py
+++ b/sentry_sdk/consts.py
@@ -128,6 +128,7 @@ class ClientConstructor(object):
         trace_propagation_targets=[  # noqa: B006
             MATCH_ALL
         ],  # type: Optional[Sequence[str]]
+        functions_to_trace=[],  # type: Sequence[str]  # noqa: B006
     ):
         # type: (...) -> None
         pass

--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -652,3 +652,37 @@ def test_functions_to_trace(sentry_init, capture_events):
     assert event["spans"][0]["description"] == "time.sleep"
     assert event["spans"][1]["description"] == "tests.test_basics._hello_world"
     assert event["spans"][2]["description"] == "tests.test_basics._hello_world"
+
+
+class WorldGreeter:
+    def __init__(self, word):
+        self.word = word
+
+    def greet(self, new_word=None):
+        return "Hello, {}".format(new_word if new_word else self.word)
+
+
+def test_functions_to_trace_with_class(sentry_init, capture_events):
+    functions_to_trace = [
+        {"qualified_name": "tests.test_basics.WorldGreeter.greet"},
+    ]
+
+    sentry_init(
+        traces_sample_rate=1.0,
+        functions_to_trace=functions_to_trace,
+    )
+
+    events = capture_events()
+
+    with start_transaction(name="something"):
+        wg = WorldGreeter("World")
+        wg.greet()
+        wg.greet("You")
+
+    assert len(events) == 1
+
+    (event,) = events
+
+    assert len(event["spans"]) == 2
+    assert event["spans"][0]["description"] == "tests.test_basics.WorldGreeter.greet"
+    assert event["spans"][1]["description"] == "tests.test_basics.WorldGreeter.greet"

--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -621,16 +621,14 @@ def test_get_sdk_name(installed_integrations, expected_name):
     assert get_sdk_name(installed_integrations) == expected_name
 
 
-def _hello_world_counter(word, counter):
-    counter[word] = +1
+def _hello_world(word):
     return "Hello, {}".format(word)
 
 
 def test_functions_to_trace(sentry_init, capture_events):
     functions_to_trace = [
-        {"qualified_name": "tests.test_basics._hello_world_counter"},
+        {"qualified_name": "tests.test_basics._hello_world"},
         {"qualified_name": "time.sleep"},
-        {"qualified_name": "collections.Counter.most_common"},
     ]
 
     sentry_init(
@@ -643,21 +641,14 @@ def test_functions_to_trace(sentry_init, capture_events):
     with start_transaction(name="something"):
         time.sleep(0)
 
-        from collections import Counter
-
-        c = Counter()
-
         for word in ["World", "You"]:
-            _hello_world_counter(word, c)
-
-        print(c.most_common())
+            _hello_world(word)
 
     assert len(events) == 1
 
     (event,) = events
 
-    assert len(event["spans"]) == 4
+    assert len(event["spans"]) == 3
     assert event["spans"][0]["description"] == "time.sleep"
-    assert event["spans"][1]["description"] == "tests.test_basics._hello_world_counter"
-    assert event["spans"][2]["description"] == "tests.test_basics._hello_world_counter"
-    assert event["spans"][3]["description"] == "collections.Counter.most_common"
+    assert event["spans"][1]["description"] == "tests.test_basics._hello_world"
+    assert event["spans"][2]["description"] == "tests.test_basics._hello_world"

--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -618,3 +618,23 @@ def test_event_processor_drop_records_client_report(
 )
 def test_get_sdk_name(installed_integrations, expected_name):
     assert get_sdk_name(installed_integrations) == expected_name
+
+
+def test_functions_to_trace(sentry_init):
+    functions_to_trace = [
+        "time.sleep",
+        "django.contrib.admin.something",
+        "myproject.somemodule.deprecated_function",
+    ]
+
+    # OR:
+    functions_to_trace = [
+        {"name": "time.sleep"},
+        {"name": "django.contrib.admin.something"},
+        {"name": "myproject.somemodule.deprecated_function", "op": "deprecated"},
+    ]
+
+    sentry_init(
+        traces_sample_rate=1.0,
+        functions_to_trace=functions_to_trace,
+    )

--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -621,16 +621,16 @@ def test_get_sdk_name(installed_integrations, expected_name):
     assert get_sdk_name(installed_integrations) == expected_name
 
 
-def _trace_me_baby_one_more_time(word, counter):
+def _hello_world_counter(word, counter):
     counter[word] = +1
-    return "My loneliness is killing me {}".format(word)
+    return "Hello, {}".format(word)
 
 
 def test_functions_to_trace(sentry_init, capture_events):
     functions_to_trace = [
-        {"name": "tests.test_basics._trace_me_baby_one_more_time"},
-        {"name": "time.sleep"},
-        {"name": "collections.Counter.most_common"},
+        {"qualified_name": "tests.test_basics._hello_world_counter"},
+        {"qualified_name": "time.sleep"},
+        {"qualified_name": "collections.Counter.most_common"},
     ]
 
     sentry_init(
@@ -647,8 +647,8 @@ def test_functions_to_trace(sentry_init, capture_events):
 
         c = Counter()
 
-        for word in ["one", "two"]:
-            _trace_me_baby_one_more_time(word, c)
+        for word in ["World", "You"]:
+            _hello_world_counter(word, c)
 
         print(c.most_common())
 
@@ -658,12 +658,6 @@ def test_functions_to_trace(sentry_init, capture_events):
 
     assert len(event["spans"]) == 4
     assert event["spans"][0]["description"] == "time.sleep"
-    assert (
-        event["spans"][1]["description"]
-        == "tests.test_basics._trace_me_baby_one_more_time"
-    )
-    assert (
-        event["spans"][2]["description"]
-        == "tests.test_basics._trace_me_baby_one_more_time"
-    )
+    assert event["spans"][1]["description"] == "tests.test_basics._hello_world_counter"
+    assert event["spans"][2]["description"] == "tests.test_basics._hello_world_counter"
     assert event["spans"][3]["description"] == "collections.Counter.most_common"

--- a/tox.ini
+++ b/tox.ini
@@ -177,6 +177,7 @@ deps =
     arq: arq>=0.23.0
     arq: fakeredis>=2.2.0
     arq: pytest-asyncio
+    arq: async-timeout
 
     # Asgi
     asgi: pytest-asyncio


### PR DESCRIPTION
Have a list of functions that can be passed to "sentry_sdk.init()". When the SDK starts it goes through the list and instruments all the functions in the list. 

```python
functions_to_trace = [
    {"qualified_name": "tests.test_basics._hello_world_counter"},
    {"qualified_name": "time.sleep"},
    {"qualified_name": "collections.Counter.most_common"},
]

sentry_sdk.init(
    dsn="...",
    traces_sample_rate=1.0,
    functions_to_trace=functions_to_trace,
)
```

Fixes #1963 
Docs: https://github.com/getsentry/sentry-docs/pull/6520
Fixes https://github.com/getsentry/team-webplatform-meta/issues/19