### PR TITLE
fix(profiling): Handle non frame types in profiler

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -175,7 +175,7 @@ deps =
 
     # Arq
     arq: arq>=0.23.0
-    arq: fakeredis>=2.2.0
+    arq: fakeredis>=2.2.0,<2.8
     arq: pytest-asyncio
 
     # Asgi

--- a/tox.ini
+++ b/tox.ini
@@ -175,7 +175,7 @@ deps =
 
     # Arq
     arq: arq>=0.23.0
-    arq: fakeredis>=2.2.0,<2.8
+    arq: fakeredis>=2.2.0
     arq: pytest-asyncio
 
     # Asgi


### PR DESCRIPTION
We've received report that occasionally, there's `AttributeError` on `f_back`. It's unclear what exactly causes this issue because the source of the frame is from a system libray. This avoids the `AttributeError` by wrapping the line in question with a `try ... except ...`. And whenever it does encounter this error, we should continue with what frames we have.

Closes #1958 