### PR TITLE
fix(tests): Bad arq dependency in tests

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -175,7 +175,7 @@ deps =
 
     # Arq
     arq: arq>=0.23.0
-    arq: fakeredis>=2.2.0
+    arq: fakeredis>=2.2.0,<2.8
     arq: pytest-asyncio
 
     # Asgi


### PR DESCRIPTION
The newer versions of fakeredis does not install `async-timeout` which it needs.