### PR TITLE
fix(crons): Fix KeyError in capture_checkin if SDK is not initialized

### DIFF
--- a/sentry_sdk/crons.py
+++ b/sentry_sdk/crons.py
@@ -38,8 +38,8 @@ def _create_checkin_event(
         "check_in_id": check_in_id,
         "status": status,
         "duration": duration,
-        "environment": options["environment"],
-        "release": options["release"],
+        "environment": options.get("environment"),
+        "release": options.get("release"),
     }
 
     return checkin

--- a/tests/test_crons.py
+++ b/tests/test_crons.py
@@ -86,3 +86,15 @@ def test_capture_checkin_new_id(sentry_init):
         )
 
         assert check_in_id == "a8098c1af86e11dabd1a00112444be1e"
+
+
+def test_capture_checkin_sdk_not_initialized():
+    # Tests that the capture_checkin does not raise an error when Sentry SDK is not initialized.
+    # sentry_init() is intentionally omitted.
+    check_in_id = capture_checkin(
+        monitor_slug="abc123",
+        check_in_id="112233",
+        status=None,
+        duration=None,
+    )
+    assert check_in_id == "112233"


### PR DESCRIPTION
When Sentry SDK was not initialized, any calls to `capture_checkin()` raised a `KeyError`. This made all calls to functions decorated with `@sentry_sdk.monitor()` fail, because `capture_checkin()` is always called within the decorator.

This caused trouble especially in local dev environments, which usually does not have Sentry integration enabled.