### PR TITLE
Change the Quart signal receivers to coroutine functions

### DIFF
--- a/sentry_sdk/integrations/quart.py
+++ b/sentry_sdk/integrations/quart.py
@@ -151,7 +151,7 @@ def _set_transaction_name_and_source(scope, transaction_style, request):
         pass
 
 
-def _request_websocket_started(app, **kwargs):
+async def _request_websocket_started(app, **kwargs):
     # type: (Quart, **Any) -> None
     hub = Hub.current
     integration = hub.get_integration(QuartIntegration)
@@ -205,7 +205,7 @@ def _make_request_event_processor(app, request, integration):
     return inner
 
 
-def _capture_exception(sender, exception, **kwargs):
+async def _capture_exception(sender, exception, **kwargs):
     # type: (Quart, Union[ValueError, BaseException], **Any) -> None
     hub = Hub.current
     if hub.get_integration(QuartIntegration) is None:


### PR DESCRIPTION
This will ensure that the integration works best with Quart 0.19 (not yet released) and pre 0.19 versions. As the latter would have implicitly converted the signal receivers to coroutine functions anyway. There is sadly no way to support Quart <= 0.18 and Blinker >= 1.6.

@antonpirker something to consider.