### PR TITLE
Send all events to /envelope endpoint when tracing is enabled

### DIFF
--- a/sentry_sdk/client.py
+++ b/sentry_sdk/client.py
@@ -18,7 +18,7 @@ from sentry_sdk.utils import (
     logger,
 )
 from sentry_sdk.serializer import serialize
-from sentry_sdk.tracing import trace
+from sentry_sdk.tracing import trace, has_tracing_enabled
 from sentry_sdk.transport import make_transport
 from sentry_sdk.consts import (
     DEFAULT_OPTIONS,
@@ -495,24 +495,26 @@ class _Client(object):
         if not is_transaction and not self._should_sample_error(event):
             return None
 
+        tracing_enabled = has_tracing_enabled(self.options)
+        is_checkin = event_opt.get("type") == "check_in"
         attachments = hint.get("attachments")
 
-        dynamic_sampling_context = (
-            event_opt.get("contexts", {})
-            .get("trace", {})
-            .pop("dynamic_sampling_context", {})
+        # If tracing is enabled all events should go to /envelope endpoint.
+        # If no tracing is enabled only transactions, events with attachments, and checkins should go to the /envelope endpoint.
+        should_use_envelope_endpoint = (
+            tracing_enabled or is_transaction or is_checkin or attachments
         )
-
-        is_checkin = event_opt.get("type") == "check_in"
-
-        # Transactions, events with attachments, and checkins should go to the /envelope/
-        # endpoint.
-        if is_transaction or is_checkin or attachments:
-
+        if should_use_envelope_endpoint:
             headers = {
                 "event_id": event_opt["event_id"],
                 "sent_at": format_timestamp(datetime.utcnow()),
             }
+
+            dynamic_sampling_context = (
+                event_opt.get("contexts", {})
+                .get("trace", {})
+                .pop("dynamic_sampling_context", {})
+            )
 
             if dynamic_sampling_context:
                 headers["trace"] = dynamic_sampling_context
@@ -532,9 +534,11 @@ class _Client(object):
                 envelope.add_item(attachment.to_envelope_item())
 
             self.transport.capture_envelope(envelope)
+
         else:
-            # All other events go to the /store/ endpoint.
+            # All other events go to the legacy /store/ endpoint (will be removed in the future).
             self.transport.capture_event(event_opt)
+
         return event_id
 
     def capture_session(

--- a/sentry_sdk/client.py
+++ b/sentry_sdk/client.py
@@ -502,7 +502,7 @@ class _Client(object):
         # If tracing is enabled all events should go to /envelope endpoint.
         # If no tracing is enabled only transactions, events with attachments, and checkins should go to the /envelope endpoint.
         should_use_envelope_endpoint = (
-            tracing_enabled or is_transaction or is_checkin or attachments
+            tracing_enabled or is_transaction or is_checkin or bool(attachments)
         )
         if should_use_envelope_endpoint:
             headers = {

--- a/sentry_sdk/client.py
+++ b/sentry_sdk/client.py
@@ -499,6 +499,12 @@ class _Client(object):
         is_checkin = event_opt.get("type") == "check_in"
         attachments = hint.get("attachments")
 
+        dynamic_sampling_context = (
+            event_opt.get("contexts", {})
+            .get("trace", {})
+            .pop("dynamic_sampling_context", {})
+        )
+
         # If tracing is enabled all events should go to /envelope endpoint.
         # If no tracing is enabled only transactions, events with attachments, and checkins should go to the /envelope endpoint.
         should_use_envelope_endpoint = (
@@ -509,12 +515,6 @@ class _Client(object):
                 "event_id": event_opt["event_id"],
                 "sent_at": format_timestamp(datetime.utcnow()),
             }
-
-            dynamic_sampling_context = (
-                event_opt.get("contexts", {})
-                .get("trace", {})
-                .pop("dynamic_sampling_context", {})
-            )
 
             if dynamic_sampling_context:
                 headers["trace"] = dynamic_sampling_context

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -157,11 +157,15 @@ def monkeypatch_test_transport(monkeypatch, validate_event_schema):
 
     def check_envelope(envelope):
         with capture_internal_exceptions():
-            # Assert error events are sent without envelope to server, for compat.
-            # This does not apply if any item in the envelope is an attachment.
-            if not any(x.type == "attachment" for x in envelope.items):
-                assert not any(item.data_category == "error" for item in envelope.items)
-                assert not any(item.get_event() is not None for item in envelope.items)
+            pass
+            # # Assert error events are sent without envelope to server, for compat.
+            # # This does not apply if any item in the envelope is an attachment.
+            # envelope_contains_attachments = any(x.type == "attachment" for x in envelope.items)
+            # if not envelope_contains_attachments:
+            #     import ipdb
+            #     ipdb.set_trace()
+            #     assert not any(item.data_category == "error" for item in envelope.items)
+            #     assert not any(item.get_event() is not None for item in envelope.items)
 
     def inner(client):
         monkeypatch.setattr(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -157,15 +157,11 @@ def monkeypatch_test_transport(monkeypatch, validate_event_schema):
 
     def check_envelope(envelope):
         with capture_internal_exceptions():
+            # There used to be a check here for errors are not sent in envelopes.
+            # We changed the behaviour to send errors in envelopes when tracing is enabled.
+            # This is checked in test_client.py::test_sending_events_with_tracing
+            # and test_client.py::test_sending_events_with_no_tracing
             pass
-            # # Assert error events are sent without envelope to server, for compat.
-            # # This does not apply if any item in the envelope is an attachment.
-            # envelope_contains_attachments = any(x.type == "attachment" for x in envelope.items)
-            # if not envelope_contains_attachments:
-            #     import ipdb
-            #     ipdb.set_trace()
-            #     assert not any(item.data_category == "error" for item in envelope.items)
-            #     assert not any(item.get_event() is not None for item in envelope.items)
 
     def inner(client):
         monkeypatch.setattr(

--- a/tests/integrations/gcp/test_gcp.py
+++ b/tests/integrations/gcp/test_gcp.py
@@ -94,8 +94,8 @@ def init_sdk(timeout_warning=False, **extra_init_args):
 def run_cloud_function():
     def inner(code, subprocess_kwargs=()):
 
-        event = []
-        envelope = []
+        events = []
+        envelopes = []
         return_value = None
 
         # STEP : Create a zip of cloud function
@@ -133,10 +133,10 @@ def run_cloud_function():
                 print("GCP:", line)
                 if line.startswith("EVENT: "):
                     line = line[len("EVENT: ") :]
-                    event = json.loads(line)
+                    events.append(json.loads(line))
                 elif line.startswith("ENVELOPE: "):
                     line = line[len("ENVELOPE: ") :]
-                    envelope = json.loads(line)
+                    envelopes.append(json.loads(line))
                 elif line.startswith("RETURN VALUE: "):
                     line = line[len("RETURN VALUE: ") :]
                     return_value = json.loads(line)
@@ -145,13 +145,13 @@ def run_cloud_function():
 
             stream.close()
 
-        return envelope, event, return_value
+        return envelopes, events, return_value
 
     return inner
 
 
 def test_handled_exception(run_cloud_function):
-    envelope, event, return_value = run_cloud_function(
+    _, events, return_value = run_cloud_function(
         dedent(
             """
         functionhandler = None
@@ -168,8 +168,8 @@ def test_handled_exception(run_cloud_function):
         """
         )
     )
-    assert event["level"] == "error"
-    (exception,) = event["exception"]["values"]
+    assert events[0]["level"] == "error"
+    (exception,) = events[0]["exception"]["values"]
 
     assert exception["type"] == "Exception"
     assert exception["value"] == "something went wrong"
@@ -177,7 +177,7 @@ def test_handled_exception(run_cloud_function):
 
 
 def test_unhandled_exception(run_cloud_function):
-    envelope, event, return_value = run_cloud_function(
+    _, events, _ = run_cloud_function(
         dedent(
             """
         functionhandler = None
@@ -195,8 +195,8 @@ def test_unhandled_exception(run_cloud_function):
         """
         )
     )
-    assert event["level"] == "error"
-    (exception,) = event["exception"]["values"]
+    assert events[0]["level"] == "error"
+    (exception,) = events[0]["exception"]["values"]
 
     assert exception["type"] == "ZeroDivisionError"
     assert exception["value"] == "division by zero"
@@ -204,7 +204,7 @@ def test_unhandled_exception(run_cloud_function):
 
 
 def test_timeout_error(run_cloud_function):
-    envelope, event, return_value = run_cloud_function(
+    _, events, _ = run_cloud_function(
         dedent(
             """
         functionhandler = None
@@ -222,8 +222,8 @@ def test_timeout_error(run_cloud_function):
         """
         )
     )
-    assert event["level"] == "error"
-    (exception,) = event["exception"]["values"]
+    assert events[0]["level"] == "error"
+    (exception,) = events[0]["exception"]["values"]
 
     assert exception["type"] == "ServerlessTimeoutWarning"
     assert (
@@ -234,7 +234,7 @@ def test_timeout_error(run_cloud_function):
 
 
 def test_performance_no_error(run_cloud_function):
-    envelope, event, return_value = run_cloud_function(
+    envelopes, _, _ = run_cloud_function(
         dedent(
             """
         functionhandler = None
@@ -252,15 +252,15 @@ def test_performance_no_error(run_cloud_function):
         )
     )
 
-    assert envelope["type"] == "transaction"
-    assert envelope["contexts"]["trace"]["op"] == "function.gcp"
-    assert envelope["transaction"].startswith("Google Cloud function")
-    assert envelope["transaction_info"] == {"source": "component"}
-    assert envelope["transaction"] in envelope["request"]["url"]
+    assert envelopes[0]["type"] == "transaction"
+    assert envelopes[0]["contexts"]["trace"]["op"] == "function.gcp"
+    assert envelopes[0]["transaction"].startswith("Google Cloud function")
+    assert envelopes[0]["transaction_info"] == {"source": "component"}
+    assert envelopes[0]["transaction"] in envelopes[0]["request"]["url"]
 
 
 def test_performance_error(run_cloud_function):
-    envelope, event, return_value = run_cloud_function(
+    envelopes, events, _ = run_cloud_function(
         dedent(
             """
         functionhandler = None
@@ -278,16 +278,17 @@ def test_performance_error(run_cloud_function):
         )
     )
 
-    assert envelope["type"] == "transaction"
-    assert envelope["contexts"]["trace"]["op"] == "function.gcp"
-    assert envelope["transaction"].startswith("Google Cloud function")
-    assert envelope["transaction"] in envelope["request"]["url"]
-    assert event["level"] == "error"
-    (exception,) = event["exception"]["values"]
+    assert envelopes[0]["level"] == "error"
+    (exception,) = envelopes[0]["exception"]["values"]
 
     assert exception["type"] == "Exception"
     assert exception["value"] == "something went wrong"
     assert exception["mechanism"] == {"type": "gcp", "handled": False}
+
+    assert envelopes[1]["type"] == "transaction"
+    assert envelopes[1]["contexts"]["trace"]["op"] == "function.gcp"
+    assert envelopes[1]["transaction"].startswith("Google Cloud function")
+    assert envelopes[1]["transaction"] in envelopes[0]["request"]["url"]
 
 
 def test_traces_sampler_gets_correct_values_in_sampling_context(

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -951,43 +951,43 @@ def test_multiple_positional_args(sentry_init):
     assert "Only single positional argument is expected" in str(exinfo.value)
 
 
-def test_sending_event_to_store_endpoint():
-    """
-    If tracing is NOT enabled, the SDK should send error events to the /store endpoint.
-    """
-    mock_transport = mock.MagicMock()
-    mock_transport.capture_event = mock.MagicMock()
-    mock_transport.capture_envelope = mock.MagicMock()
+# def test_sending_event_to_store_endpoint():
+#     """
+#     If tracing is NOT enabled, the SDK should send error events to the /store endpoint.
+#     """
+#     mock_transport = mock.MagicMock()
+#     mock_transport.capture_event = mock.MagicMock()
+#     mock_transport.capture_envelope = mock.MagicMock()
 
-    with mock.patch("sentry_sdk.client.make_transport", return_value=mock_transport):
-        client = Client("http://foobar@127.0.0.1/123", enable_tracing=False)
-        client.capture_event({"type": "event"})
+#     with mock.patch("sentry_sdk.client.make_transport", return_value=mock_transport):
+#         client = Client("http://foobar@127.0.0.1/123", enable_tracing=False)
+#         client.capture_event({"type": "event"})
 
-        try:
-            1 / 0
-        except Exception:
-            capture_exception()
+#         try:
+#             1 / 0
+#         except Exception:
+#             capture_exception()
 
-        mock_transport.capture_event.assert_called_once()
-        mock_transport.capture_envelope.assert_not_called()
+#         mock_transport.capture_event.assert_called_once()
+#         mock_transport.capture_envelope.assert_not_called()
 
 
-def test_sending_event_to_envelope_endpoint():
-    """
-    If tracing is enabled, the SDK should send events to the /envelope endpoint.
-    """
-    mock_transport = mock.MagicMock()
-    mock_transport.capture_event = mock.MagicMock()
-    mock_transport.capture_envelope = mock.MagicMock()
+# def test_sending_event_to_envelope_endpoint():
+#     """
+#     If tracing is enabled, the SDK should send events to the /envelope endpoint.
+#     """
+#     mock_transport = mock.MagicMock()
+#     mock_transport.capture_event = mock.MagicMock()
+#     mock_transport.capture_envelope = mock.MagicMock()
 
-    with mock.patch("sentry_sdk.client.make_transport", return_value=mock_transport):
-        client = Client("http://foobar@127.0.0.1/123", enable_tracing=True)
-        client.capture_event({"type": "event"})
+#     with mock.patch("sentry_sdk.client.make_transport", return_value=mock_transport):
+#         client = Client("http://foobar@127.0.0.1/123", enable_tracing=True)
+#         client.capture_event({"type": "event"})
 
-        try:
-            1 / 0
-        except Exception:
-            capture_exception()
+#         try:
+#             1 / 0
+#         except Exception:
+#             capture_exception()
 
-        mock_transport.capture_event.assert_not_called()
-        mock_transport.capture_envelope.assert_called_once()
+#         mock_transport.capture_event.assert_not_called()
+#         mock_transport.capture_envelope.assert_called_once()

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -949,3 +949,45 @@ def test_multiple_positional_args(sentry_init):
     with pytest.raises(TypeError) as exinfo:
         sentry_init(1, None)
     assert "Only single positional argument is expected" in str(exinfo.value)
+
+
+def test_sending_event_to_store_endpoint():
+    """
+    If tracing is NOT enabled, the SDK should send error events to the /store endpoint.
+    """
+    mock_transport = mock.MagicMock()
+    mock_transport.capture_event = mock.MagicMock()
+    mock_transport.capture_envelope = mock.MagicMock()
+
+    with mock.patch("sentry_sdk.client.make_transport", return_value=mock_transport):
+        client = Client("http://foobar@127.0.0.1/123", enable_tracing=False)
+        client.capture_event({"type": "event"})
+
+        try:
+            1 / 0
+        except Exception:
+            capture_exception()
+
+        mock_transport.capture_event.assert_called_once()
+        mock_transport.capture_envelope.assert_not_called()
+
+
+def test_sending_event_to_envelope_endpoint():
+    """
+    If tracing is enabled, the SDK should send events to the /envelope endpoint.
+    """
+    mock_transport = mock.MagicMock()
+    mock_transport.capture_event = mock.MagicMock()
+    mock_transport.capture_envelope = mock.MagicMock()
+
+    with mock.patch("sentry_sdk.client.make_transport", return_value=mock_transport):
+        client = Client("http://foobar@127.0.0.1/123", enable_tracing=True)
+        client.capture_event({"type": "event"})
+
+        try:
+            1 / 0
+        except Exception:
+            capture_exception()
+
+        mock_transport.capture_event.assert_not_called()
+        mock_transport.capture_envelope.assert_called_once()


### PR DESCRIPTION
When tracing is enabled we can safely send all events to `/envelope`. The dynamic sampling context (DSC) is sent with all envelopes.

The legacy `/store` endpoint will be removed in the future.

Fixes #2008 