### PR TITLE
chore(profiling): Remove profile context from sdk

### DIFF
--- a/sentry_sdk/profiler.py
+++ b/sentry_sdk/profiler.py
@@ -575,10 +575,6 @@ class Profile(object):
                 )
             )
 
-    def get_profile_context(self):
-        # type: () -> ProfileContext
-        return {"profile_id": self.event_id}
-
     def start(self):
         # type: () -> None
         if not self.sampled or self.active:

--- a/sentry_sdk/tracing.py
+++ b/sentry_sdk/tracing.py
@@ -631,7 +631,6 @@ class Transaction(Span):
 
         if self._profile is not None and self._profile.valid():
             event["profile"] = self._profile
-            contexts.update({"profile": self._profile.get_profile_context()})
             self._profile = None
 
         event["measurements"] = self._measurements

--- a/tests/test_profiler.py
+++ b/tests/test_profiler.py
@@ -232,37 +232,6 @@ def test_profiles_sampler(
     assert len(items["profile"]) == profile_count
 
 
-@mock.patch("sentry_sdk.profiler.PROFILE_MINIMUM_SAMPLES", 0)
-def test_profile_context(
-    sentry_init,
-    capture_envelopes,
-    teardown_profiling,
-):
-    sentry_init(
-        traces_sample_rate=1.0,
-        _experiments={"profiles_sample_rate": 1.0},
-    )
-
-    envelopes = capture_envelopes()
-
-    with start_transaction(name="profiling"):
-        pass
-
-    items = defaultdict(list)
-    for envelope in envelopes:
-        for item in envelope.items:
-            items[item.type].append(item)
-
-    assert len(items["transaction"]) == 1
-    assert len(items["profile"]) == 1
-
-    transaction = items["transaction"][0]
-    profile = items["profile"][0]
-    assert transaction.payload.json["contexts"]["profile"] == {
-        "profile_id": profile.payload.json["event_id"],
-    }
-
-
 def test_minimum_unique_samples_required(
     sentry_init,
     capture_envelopes,


### PR DESCRIPTION
The profile context can be populated by the relay automatically. No need to do this in the SDK. This also means that if the profile has to be dropped by relay due to rate limits or any reason, we won't render a bad link on the transaction to a non-existent profile.