### PR TITLE
Upgraded linting tooling 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: 3.9
+          python-version: 3.11
 
       - run: |
           pip install tox

--- a/linter-requirements.txt
+++ b/linter-requirements.txt
@@ -1,4 +1,4 @@
-mypy==0.971
+mypy==1.2.0
 black==22.12.0
 flake8==5.0.4
 types-certifi

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,5 +1,5 @@
 [mypy]
-python_version = 3.7
+python_version = 3.11
 allow_redefinition = True
 check_untyped_defs = True
 ; disallow_any_decorated = True

--- a/sentry_sdk/integrations/asyncio.py
+++ b/sentry_sdk/integrations/asyncio.py
@@ -47,7 +47,7 @@ def patch_asyncio():
 
             # Trying to use user set task factory (if there is one)
             if orig_task_factory:
-                return orig_task_factory(loop, _coro_creating_hub_and_span())  # type: ignore
+                return orig_task_factory(loop, _coro_creating_hub_and_span())
 
             # The default task factory in `asyncio` does not have its own function
             # but is just a couple of lines in `asyncio.base_events.create_task()`

--- a/sentry_sdk/integrations/celery.py
+++ b/sentry_sdk/integrations/celery.py
@@ -33,7 +33,7 @@ if TYPE_CHECKING:
 
 
 try:
-    from celery import VERSION as CELERY_VERSION
+    from celery import VERSION as CELERY_VERSION  # type: ignore
     from celery import Task, Celery
     from celery.app.trace import task_has_custom
     from celery.beat import Scheduler  # type: ignore

--- a/sentry_sdk/integrations/django/signals_handlers.py
+++ b/sentry_sdk/integrations/django/signals_handlers.py
@@ -26,8 +26,8 @@ def _get_receiver_name(receiver):
     elif hasattr(
         receiver, "func"
     ):  # certain functions (like partials) dont have a name
-        if hasattr(receiver, "func") and hasattr(receiver.func, "__name__"):  # type: ignore
-            name = "partial(<function " + receiver.func.__name__ + ">)"  # type: ignore
+        if hasattr(receiver, "func") and hasattr(receiver.func, "__name__"):
+            name = "partial(<function " + receiver.func.__name__ + ">)"
 
     if (
         name == ""

--- a/sentry_sdk/integrations/socket.py
+++ b/sentry_sdk/integrations/socket.py
@@ -65,7 +65,7 @@ def _patch_create_connection():
                 address=address, timeout=timeout, source_address=source_address
             )
 
-    socket.create_connection = create_connection
+    socket.create_connection = create_connection  # type: ignore
 
 
 def _patch_getaddrinfo():
@@ -86,4 +86,4 @@ def _patch_getaddrinfo():
 
             return real_getaddrinfo(host, port, family, type, proto, flags)
 
-    socket.getaddrinfo = getaddrinfo
+    socket.getaddrinfo = getaddrinfo  # type: ignore

--- a/sentry_sdk/integrations/tornado.py
+++ b/sentry_sdk/integrations/tornado.py
@@ -78,7 +78,7 @@ class TornadoIntegration(Integration):
         else:
 
             @coroutine  # type: ignore
-            def sentry_execute_request_handler(self, *args, **kwargs):  # type: ignore
+            def sentry_execute_request_handler(self, *args, **kwargs):
                 # type: (RequestHandler, *Any, **Any) -> Any
                 with _handle_request_impl(self):
                     result = yield from old_execute(self, *args, **kwargs)

--- a/sentry_sdk/integrations/wsgi.py
+++ b/sentry_sdk/integrations/wsgi.py
@@ -34,7 +34,7 @@ if TYPE_CHECKING:
     WsgiExcInfo = TypeVar("WsgiExcInfo")
 
     class StartResponse(Protocol):
-        def __call__(self, status, response_headers, exc_info=None):
+        def __call__(self, status, response_headers, exc_info=None):  # type: ignore
             # type: (str, WsgiResponseHeaders, Optional[WsgiExcInfo]) -> WsgiResponseIter
             pass
 
@@ -119,7 +119,7 @@ class SentryWsgiMiddleware(object):
         return _ScopedResponse(hub, rv)
 
 
-def _sentry_start_response(
+def _sentry_start_response(  # type: ignore
     old_start_response,  # type: StartResponse
     transaction,  # type: Transaction
     status,  # type: str

--- a/sentry_sdk/profiler.py
+++ b/sentry_sdk/profiler.py
@@ -346,7 +346,7 @@ if PY311:
 
     def get_frame_name(frame):
         # type: (FrameType) -> str
-        return frame.f_code.co_qualname  # type: ignore
+        return frame.f_code.co_qualname
 
 else:
 

--- a/sentry_sdk/tracing.py
+++ b/sentry_sdk/tracing.py
@@ -781,7 +781,7 @@ class NoOpSpan(Span):
 
     def new_span(self, **kwargs):
         # type: (**Any) -> NoOpSpan
-        pass
+        return self.start_child(**kwargs)
 
     def set_tag(self, key, value):
         # type: (str, Any) -> None

--- a/sentry_sdk/utils.py
+++ b/sentry_sdk/utils.py
@@ -1077,10 +1077,10 @@ def qualname_from_function(func):
     if (
         _PARTIALMETHOD_AVAILABLE
         and hasattr(func, "_partialmethod")
-        and isinstance(func._partialmethod, partialmethod)  # type: ignore
+        and isinstance(func._partialmethod, partialmethod)
     ):
         prefix, suffix = "partialmethod(<function ", ">)"
-        func = func._partialmethod.func  # type: ignore
+        func = func._partialmethod.func
     elif isinstance(func, partial) and hasattr(func.func, "__name__"):
         prefix, suffix = "partial(<function ", ">)"
         func = func.func

--- a/tox.ini
+++ b/tox.ini
@@ -500,7 +500,7 @@ basepython =
     # some random Python 3 binary, but then you get guaranteed mismatches with
     # CI. Other tools such as mypy and black have options that pin the Python
     # version.
-    linters: python3.9
+    linters: python3.11
 
 commands =
     ; https://github.com/pytest-dev/pytest/issues/5532


### PR DESCRIPTION
I had to remove and/or add some `# type:ignore` type hints because `mypy` does different things in Python 3.9 (the version we run it in earlier) and Python 3.11 (the version we run it in now)