### PR TITLE
feat: Add `db.system` indicators to redis, sqlalchemy, and django

### DIFF
--- a/sentry_sdk/consts.py
+++ b/sentry_sdk/consts.py
@@ -88,6 +88,15 @@ class OP:
     SOCKET_DNS = "socket.dns"
 
 
+# See: https://develop.sentry.dev/sdk/performance/span-data-conventions/
+class SPAN_DATA:
+    DB_SYSTEM = "db.system"
+    """
+    An identifier for the database management system (DBMS) product being used.
+    See: https://github.com/open-telemetry/opentelemetry-python/blob/e00306206ea25cf8549eca289e39e0b6ba2fa560/opentelemetry-semantic-conventions/src/opentelemetry/semconv/trace/__init__.py#L58
+    """
+
+
 # This type exists to trick mypy and PyCharm into thinking `init` and `Client`
 # take these arguments (even though they take opaque **kwargs)
 class ClientConstructor(object):

--- a/sentry_sdk/consts.py
+++ b/sentry_sdk/consts.py
@@ -89,7 +89,7 @@ class OP:
 
 
 # See: https://develop.sentry.dev/sdk/performance/span-data-conventions/
-class SPAN_DATA:
+class SPANDATA:
     DB_SYSTEM = "db.system"
     """
     An identifier for the database management system (DBMS) product being used.

--- a/sentry_sdk/integrations/django/__init__.py
+++ b/sentry_sdk/integrations/django/__init__.py
@@ -6,7 +6,7 @@ import threading
 import weakref
 
 from sentry_sdk._types import TYPE_CHECKING
-from sentry_sdk.consts import OP, SPAN_DATA
+from sentry_sdk.consts import OP, SPANDATA
 from sentry_sdk.hub import Hub, _should_send_default_pii
 from sentry_sdk.scope import add_global_event_processor
 from sentry_sdk.serializer import add_global_repr_processor
@@ -586,7 +586,7 @@ def install_sql_hook():
             hub, self.cursor, sql, params, paramstyle="format", executemany=False
         ) as span:
             if db_system:
-                span.set_data(SPAN_DATA.DB_SYSTEM, db_system)
+                span.set_data(SPANDATA.DB_SYSTEM, db_system)
             return real_execute(self, sql, params)
 
     def executemany(self, sql, param_list):
@@ -603,7 +603,7 @@ def install_sql_hook():
             hub, self.cursor, sql, param_list, paramstyle="format", executemany=True
         ) as span:
             if db_system:
-                span.set_data(SPAN_DATA.DB_SYSTEM, db_system)
+                span.set_data(SPANDATA.DB_SYSTEM, db_system)
             return real_executemany(self, sql, param_list)
 
     def connect(self):
@@ -621,7 +621,7 @@ def install_sql_hook():
 
         with hub.start_span(op=OP.DB, description="connect") as span:
             if db_system:
-                span.set_data(SPAN_DATA.DB_SYSTEM, db_system)
+                span.set_data(SPANDATA.DB_SYSTEM, db_system)
 
             return real_connect(self)
 

--- a/sentry_sdk/integrations/redis.py
+++ b/sentry_sdk/integrations/redis.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import
 
 from sentry_sdk import Hub
-from sentry_sdk.consts import OP
+from sentry_sdk.consts import OP, SPAN_DATA
 from sentry_sdk.hub import _should_send_default_pii
 from sentry_sdk.utils import (
     SENSITIVE_DATA_SUBSTITUTE,
@@ -63,6 +63,7 @@ def patch_redis_pipeline(pipeline_cls, is_cluster, get_command_args_fn):
                     "redis.commands",
                     {"count": len(self.command_stack), "first_ten": commands},
                 )
+                span.set_data(SPAN_DATA.DB_SYSTEM, "redis")
 
             return old_execute(self, *args, **kwargs)
 

--- a/sentry_sdk/integrations/redis.py
+++ b/sentry_sdk/integrations/redis.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import
 
 from sentry_sdk import Hub
-from sentry_sdk.consts import OP, SPAN_DATA
+from sentry_sdk.consts import OP, SPANDATA
 from sentry_sdk.hub import _should_send_default_pii
 from sentry_sdk.utils import (
     SENSITIVE_DATA_SUBSTITUTE,
@@ -63,7 +63,7 @@ def patch_redis_pipeline(pipeline_cls, is_cluster, get_command_args_fn):
                     "redis.commands",
                     {"count": len(self.command_stack), "first_ten": commands},
                 )
-                span.set_data(SPAN_DATA.DB_SYSTEM, "redis")
+                span.set_data(SPANDATA.DB_SYSTEM, "redis")
 
             return old_execute(self, *args, **kwargs)
 

--- a/sentry_sdk/integrations/sqlalchemy.py
+++ b/sentry_sdk/integrations/sqlalchemy.py
@@ -3,9 +3,10 @@ from __future__ import absolute_import
 import re
 
 from sentry_sdk._types import TYPE_CHECKING
+from sentry_sdk.consts import SPAN_DATA
 from sentry_sdk.hub import Hub
 from sentry_sdk.integrations import Integration, DidNotEnable
-from sentry_sdk.tracing_utils import record_sql_queries
+from sentry_sdk.tracing_utils import record_sql_queries, get_db_system
 
 try:
     from sqlalchemy.engine import Engine  # type: ignore
@@ -67,6 +68,9 @@ def _before_cursor_execute(
     span = ctx_mgr.__enter__()
 
     if span is not None:
+        db_system = get_db_system(conn.engine.name)
+        if db_system is not None:
+            span.set_data(SPAN_DATA.DB_SYSTEM, db_system)
         context._sentry_sql_span = span
 
 

--- a/sentry_sdk/integrations/sqlalchemy.py
+++ b/sentry_sdk/integrations/sqlalchemy.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import
 import re
 
 from sentry_sdk._types import TYPE_CHECKING
-from sentry_sdk.consts import SPAN_DATA
+from sentry_sdk.consts import SPANDATA
 from sentry_sdk.hub import Hub
 from sentry_sdk.integrations import Integration, DidNotEnable
 from sentry_sdk.tracing_utils import record_sql_queries, get_db_system
@@ -70,7 +70,7 @@ def _before_cursor_execute(
     if span is not None:
         db_system = get_db_system(conn.engine.name)
         if db_system is not None:
-            span.set_data(SPAN_DATA.DB_SYSTEM, db_system)
+            span.set_data(SPANDATA.DB_SYSTEM, db_system)
         context._sentry_sql_span = span
 
 

--- a/sentry_sdk/tracing_utils.py
+++ b/sentry_sdk/tracing_utils.py
@@ -135,7 +135,19 @@ def record_sql_queries(
     with hub.start_span(op=OP.DB, description=query) as span:
         for k, v in data.items():
             span.set_data(k, v)
+
         yield span
+
+
+def get_db_system(name):
+    # type: (str) -> Optional[str]
+    if "sqlite" in name:
+        return "sqlite"
+
+    if "postgres" in name:
+        return "postgresql"
+
+    return None
 
 
 def maybe_create_breadcrumbs_from_span(hub, span):

--- a/sentry_sdk/tracing_utils.py
+++ b/sentry_sdk/tracing_utils.py
@@ -139,17 +139,6 @@ def record_sql_queries(
         yield span
 
 
-def get_db_system(name):
-    # type: (str) -> Optional[str]
-    if "sqlite" in name:
-        return "sqlite"
-
-    if "postgres" in name:
-        return "postgresql"
-
-    return None
-
-
 def maybe_create_breadcrumbs_from_span(hub, span):
     # type: (sentry_sdk.Hub, Span) -> None
     if span.op == OP.DB_REDIS:

--- a/tests/integrations/redis/test_redis.py
+++ b/tests/integrations/redis/test_redis.py
@@ -1,5 +1,6 @@
 import mock
 
+from sentry_sdk.consts import SPAN_DATA
 from sentry_sdk import capture_message, start_transaction
 from sentry_sdk.integrations.redis import RedisIntegration
 
@@ -53,7 +54,8 @@ def test_redis_pipeline(sentry_init, capture_events, is_transaction):
         "redis.commands": {
             "count": 3,
             "first_ten": ["GET 'foo'", "SET 'bar' 1", "SET 'baz' 2"],
-        }
+        },
+        [SPAN_DATA.DB_SYSTEM]: "redis",
     }
     assert span["tags"] == {
         "redis.transaction": is_transaction,

--- a/tests/integrations/redis/test_redis.py
+++ b/tests/integrations/redis/test_redis.py
@@ -1,6 +1,6 @@
 import mock
 
-from sentry_sdk.consts import SPAN_DATA
+from sentry_sdk.consts import SPANDATA
 from sentry_sdk import capture_message, start_transaction
 from sentry_sdk.integrations.redis import RedisIntegration
 
@@ -55,7 +55,7 @@ def test_redis_pipeline(sentry_init, capture_events, is_transaction):
             "count": 3,
             "first_ten": ["GET 'foo'", "SET 'bar' 1", "SET 'baz' 2"],
         },
-        [SPAN_DATA.DB_SYSTEM]: "redis",
+        [SPANDATA.DB_SYSTEM]: "redis",
     }
     assert span["tags"] == {
         "redis.transaction": is_transaction,

--- a/tests/integrations/redis/test_redis.py
+++ b/tests/integrations/redis/test_redis.py
@@ -55,7 +55,7 @@ def test_redis_pipeline(sentry_init, capture_events, is_transaction):
             "count": 3,
             "first_ten": ["GET 'foo'", "SET 'bar' 1", "SET 'baz' 2"],
         },
-        [SPANDATA.DB_SYSTEM]: "redis",
+        SPANDATA.DB_SYSTEM: "redis",
     }
     assert span["tags"] == {
         "redis.transaction": is_transaction,

--- a/tests/integrations/rediscluster/test_rediscluster.py
+++ b/tests/integrations/rediscluster/test_rediscluster.py
@@ -73,7 +73,7 @@ def test_rediscluster_pipeline(sentry_init, capture_events):
             "count": 3,
             "first_ten": ["GET 'foo'", "SET 'bar' 1", "SET 'baz' 2"],
         },
-        [SPANDATA.DB_SYSTEM]: "redis",
+        SPANDATA.DB_SYSTEM: "redis",
     }
     assert span["tags"] == {
         "redis.transaction": False,  # For Cluster, this is always False

--- a/tests/integrations/rediscluster/test_rediscluster.py
+++ b/tests/integrations/rediscluster/test_rediscluster.py
@@ -1,5 +1,6 @@
 import pytest
 from sentry_sdk import capture_message
+from sentry_sdk.consts import SPANDATA
 from sentry_sdk.api import start_transaction
 from sentry_sdk.integrations.redis import RedisIntegration
 
@@ -71,7 +72,8 @@ def test_rediscluster_pipeline(sentry_init, capture_events):
         "redis.commands": {
             "count": 3,
             "first_ten": ["GET 'foo'", "SET 'bar' 1", "SET 'baz' 2"],
-        }
+        },
+        [SPANDATA.DB_SYSTEM]: "redis",
     }
     assert span["tags"] == {
         "redis.transaction": False,  # For Cluster, this is always False

--- a/tests/integrations/sqlalchemy/test_sqlalchemy.py
+++ b/tests/integrations/sqlalchemy/test_sqlalchemy.py
@@ -6,7 +6,7 @@ from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import relationship, sessionmaker
 
-from sentry_sdk.consts import SPAN_DATA
+from sentry_sdk.consts import SPANDATA
 from sentry_sdk import capture_message, start_transaction, configure_scope
 from sentry_sdk.integrations.sqlalchemy import SqlalchemyIntegration
 from sentry_sdk.serializer import MAX_EVENT_BYTES
@@ -120,7 +120,7 @@ def test_transactions(sentry_init, capture_events, render_span_tree):
 
     (event,) = events
 
-    assert event["spans"][0]["data"][SPAN_DATA.DB_SYSTEM] == "sqlite"
+    assert event["spans"][0]["data"][SPANDATA.DB_SYSTEM] == "sqlite"
 
     assert (
         render_span_tree(event)

--- a/tests/integrations/sqlalchemy/test_sqlalchemy.py
+++ b/tests/integrations/sqlalchemy/test_sqlalchemy.py
@@ -6,6 +6,7 @@ from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import relationship, sessionmaker
 
+from sentry_sdk.consts import SPAN_DATA
 from sentry_sdk import capture_message, start_transaction, configure_scope
 from sentry_sdk.integrations.sqlalchemy import SqlalchemyIntegration
 from sentry_sdk.serializer import MAX_EVENT_BYTES
@@ -118,6 +119,8 @@ def test_transactions(sentry_init, capture_events, render_span_tree):
             session.query(Person).first()
 
     (event,) = events
+
+    assert event["spans"][0]["data"][SPAN_DATA.DB_SYSTEM] == "sqlite"
 
     assert (
         render_span_tree(event)


### PR DESCRIPTION
ref https://github.com/getsentry/team-webplatform-meta/issues/60

dependent on https://github.com/getsentry/develop/pull/917

Add this information to span data field as db.system, matching [OpenTelemetry's well known conventions](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/database.md#notes-and-well-known-identifiers-for-dbsystem).

For example, db.system of postgresql would indicate that it's a postgres database.