### PR TITLE
Add db.system to redis spans

### DIFF
--- a/sentry_sdk/integrations/redis.py
+++ b/sentry_sdk/integrations/redis.py
@@ -191,6 +191,8 @@ def patch_redis_client(cls, is_cluster):
             description = description[: integration.max_data_size - len("...")] + "..."
 
         with hub.start_span(op=OP.DB_REDIS, description=description) as span:
+            span.set_data("db.system", "redis")
+
             span.set_tag("redis.is_cluster", is_cluster)
 
             if name:


### PR DESCRIPTION
Add information to span data field as `db.system`, matching [OpenTelemetry's well known conventions](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/database.md#notes-and-well-known-identifiers-for-dbsystem).

See: https://github.com/getsentry/team-webplatform-meta/issues/60