### PR TITLE
Add `db.system` constant

### DIFF
--- a/sentry_sdk/consts.py
+++ b/sentry_sdk/consts.py
@@ -51,6 +51,15 @@ class INSTRUMENTER:
     OTEL = "otel"
 
 
+# See: https://develop.sentry.dev/sdk/performance/span-data-conventions/
+class SPANDATA:
+    DB_SYSTEM = "db.system"
+    """
+    An identifier for the database management system (DBMS) product being used.
+    See: https://github.com/open-telemetry/opentelemetry-python/blob/e00306206ea25cf8549eca289e39e0b6ba2fa560/opentelemetry-semantic-conventions/src/opentelemetry/semconv/trace/__init__.py#L58
+    """
+
+
 class OP:
     DB = "db"
     DB_REDIS = "db.redis"


### PR DESCRIPTION
ref https://github.com/getsentry/team-webplatform-meta/issues/60 and https://github.com/getsentry/sentry-python/pull/2035

dependent on https://github.com/getsentry/develop/pull/917

Add this information to span data field as db.system, matching [OpenTelemetry's well known conventions](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/database.md#notes-and-well-known-identifiers-for-dbsystem).

