### PR TITLE
feat(redis): Add `db.system` to redis db spans

### DIFF
--- a/sentry_sdk/integrations/redis.py
+++ b/sentry_sdk/integrations/redis.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import
 
 from sentry_sdk import Hub
-from sentry_sdk.consts import OP
+from sentry_sdk.consts import OP, SPANDATA
 from sentry_sdk.hub import _should_send_default_pii
 from sentry_sdk.utils import (
     SENSITIVE_DATA_SUBSTITUTE,
@@ -63,6 +63,7 @@ def patch_redis_pipeline(pipeline_cls, is_cluster, get_command_args_fn):
                     "redis.commands",
                     {"count": len(self.command_stack), "first_ten": commands},
                 )
+                span.set_data(SPANDATA.DB_SYSTEM, "redis")
 
             return old_execute(self, *args, **kwargs)
 

--- a/tests/integrations/redis/test_redis.py
+++ b/tests/integrations/redis/test_redis.py
@@ -1,6 +1,7 @@
 import mock
 
 from sentry_sdk import capture_message, start_transaction
+from sentry_sdk.consts import SPANDATA
 from sentry_sdk.integrations.redis import RedisIntegration
 
 from fakeredis import FakeStrictRedis
@@ -53,7 +54,8 @@ def test_redis_pipeline(sentry_init, capture_events, is_transaction):
         "redis.commands": {
             "count": 3,
             "first_ten": ["GET 'foo'", "SET 'bar' 1", "SET 'baz' 2"],
-        }
+        },
+        SPANDATA.DB_SYSTEM: "redis",
     }
     assert span["tags"] == {
         "redis.transaction": is_transaction,

--- a/tests/integrations/rediscluster/test_rediscluster.py
+++ b/tests/integrations/rediscluster/test_rediscluster.py
@@ -1,5 +1,6 @@
 import pytest
 from sentry_sdk import capture_message
+from sentry_sdk.consts import SPANDATA
 from sentry_sdk.api import start_transaction
 from sentry_sdk.integrations.redis import RedisIntegration
 
@@ -71,7 +72,8 @@ def test_rediscluster_pipeline(sentry_init, capture_events):
         "redis.commands": {
             "count": 3,
             "first_ten": ["GET 'foo'", "SET 'bar' 1", "SET 'baz' 2"],
-        }
+        },
+        SPANDATA.DB_SYSTEM: "redis",
     }
     assert span["tags"] == {
         "redis.transaction": False,  # For Cluster, this is always False


### PR DESCRIPTION
Dependent on https://github.com/getsentry/sentry-python/pull/2037

Extracted from https://github.com/getsentry/sentry-python/pull/2035