### PR TITLE
Handle event being None before before_send_(transaction)

### DIFF
--- a/sentry_sdk/client.py
+++ b/sentry_sdk/client.py
@@ -323,7 +323,11 @@ class _Client(object):
             event = serialize(event)
 
         before_send = self.options["before_send"]
-        if before_send is not None and event.get("type") != "transaction":
+        if (
+            before_send is not None
+            and event is not None
+            and event.get("type") != "transaction"
+        ):
             new_event = None
             with capture_internal_exceptions():
                 new_event = before_send(event, hint or {})
@@ -336,7 +340,11 @@ class _Client(object):
             event = new_event  # type: ignore
 
         before_send_transaction = self.options["before_send_transaction"]
-        if before_send_transaction is not None and event.get("type") == "transaction":
+        if (
+            before_send_transaction is not None
+            and event is not None
+            and event.get("type") == "transaction"
+        ):
             new_event = None
             with capture_internal_exceptions():
                 new_event = before_send_transaction(event, hint or {})


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry-python/issues/1979