### PR TITLE
Import Markup from markupsafe

### DIFF
--- a/sentry_sdk/integrations/flask.py
+++ b/sentry_sdk/integrations/flask.py
@@ -26,7 +26,7 @@ except ImportError:
     flask_login = None
 
 try:
-    from flask import Flask, Markup, Request  # type: ignore
+    from flask import Flask, Request  # type: ignore
     from flask import __version__ as FLASK_VERSION
     from flask import request as flask_request
     from flask.signals import (
@@ -34,6 +34,7 @@ try:
         got_request_exception,
         request_started,
     )
+    from markupsafe import Markup
 except ImportError:
     raise DidNotEnable("Flask is not installed")
 

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ setup(
         "certifi",
     ],
     extras_require={
-        "flask": ["flask>=0.11", "blinker>=1.1"],
+        "flask": ["flask>=0.11", "blinker>=1.1", "markupsafe"],
         "quart": ["quart>=0.16.1", "blinker>=1.1"],
         "bottle": ["bottle>=0.12.13"],
         "falcon": ["falcon>=1.4"],
@@ -69,7 +69,6 @@ setup(
         "pymongo": ["pymongo>=3.1"],
         "opentelemetry": ["opentelemetry-distro>=0.35b0"],
         "grpcio": ["grpcio>=1.21.1"],
-        "markupsafe": ["markupsafe"],
         "loguru": ["loguru>=0.5"],
     },
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -67,7 +67,8 @@ setup(
         "fastapi": ["fastapi>=0.79.0"],
         "pymongo": ["pymongo>=3.1"],
         "opentelemetry": ["opentelemetry-distro>=0.35b0"],
-        "grpcio": ["grpcio>=1.21.1"]
+        "grpcio": ["grpcio>=1.21.1"],
+        "markupsafe": ["markupsafe"],
     },
     classifiers=[
         "Development Status :: 5 - Production/Stable",


### PR DESCRIPTION
Fixes a `DeprecationWarning` when using Flask v2.3.0 or later (actually, it breaks completely with `flask==2.3.0`, but that's down to a mistake in the Flask project. Some tests are failing for me locally, but the same tests are failing on the `master` branch so hopefully that's just something peculiar to my machine.

See [Flask's release notes](https://flask.palletsprojects.com/en/2.3.x/changes/#version-2-3-0) for more context.