### PR TITLE
ref: Use constants for http.query and http.fragment

### DIFF
--- a/sentry_sdk/consts.py
+++ b/sentry_sdk/consts.py
@@ -58,6 +58,21 @@ class SPANDATA:
     An identifier for the database management system (DBMS) product being used.
     See: https://github.com/open-telemetry/opentelemetry-python/blob/e00306206ea25cf8549eca289e39e0b6ba2fa560/opentelemetry-semantic-conventions/src/opentelemetry/semconv/trace/__init__.py#L58
     """
+    HTTP_QUERY = "http.query"
+    """
+    The Query string present in the URL.
+    Example: ?foo=bar&bar=baz
+    """
+    HTTP_FRAGMENT = "http.fragment"
+    """
+    The Fragments present in the URL.
+    Example: #foo=bar
+    """
+    HTTP_METHOD = "http.method"
+    """
+    The HTTP method used.
+    Example: GET
+    """
 
 
 class OP:

--- a/sentry_sdk/integrations/boto3.py
+++ b/sentry_sdk/integrations/boto3.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import
 
 from sentry_sdk import Hub
-from sentry_sdk.consts import OP
+from sentry_sdk.consts import OP, SPANDATA
 from sentry_sdk.integrations import Integration, DidNotEnable
 from sentry_sdk.tracing import Span
 
@@ -73,8 +73,8 @@ def _sentry_request_created(service_id, request, operation_name, **kwargs):
     span.set_tag("aws.service_id", service_id)
     span.set_tag("aws.operation_name", operation_name)
     span.set_data("aws.request.url", parsed_url.url)
-    span.set_data("http.query", parsed_url.query)
-    span.set_data("http.fragment", parsed_url.fragment)
+    span.set_data(SPANDATA.HTTP_QUERY, parsed_url.query)
+    span.set_data(SPANDATA.HTTP_FRAGMENT, parsed_url.fragment)
 
     # We do it in order for subsequent http calls/retries be
     # attached to this span.

--- a/sentry_sdk/integrations/httpx.py
+++ b/sentry_sdk/integrations/httpx.py
@@ -1,5 +1,5 @@
 from sentry_sdk import Hub
-from sentry_sdk.consts import OP
+from sentry_sdk.consts import OP, SPANDATA
 from sentry_sdk.integrations import Integration, DidNotEnable
 from sentry_sdk.tracing_utils import should_propagate_trace
 from sentry_sdk.utils import logger, parse_url
@@ -50,8 +50,8 @@ def _install_httpx_client():
         ) as span:
             span.set_data("method", request.method)
             span.set_data("url", parsed_url.url)
-            span.set_data("http.query", parsed_url.query)
-            span.set_data("http.fragment", parsed_url.fragment)
+            span.set_data(SPANDATA.HTTP_QUERY, parsed_url.query)
+            span.set_data(SPANDATA.HTTP_FRAGMENT, parsed_url.fragment)
 
             if should_propagate_trace(hub, str(request.url)):
                 for key, value in hub.iter_trace_propagation_headers():
@@ -91,8 +91,8 @@ def _install_httpx_async_client():
         ) as span:
             span.set_data("method", request.method)
             span.set_data("url", parsed_url.url)
-            span.set_data("http.query", parsed_url.query)
-            span.set_data("http.fragment", parsed_url.fragment)
+            span.set_data(SPANDATA.HTTP_QUERY, parsed_url.query)
+            span.set_data(SPANDATA.HTTP_FRAGMENT, parsed_url.fragment)
 
             if should_propagate_trace(hub, str(request.url)):
                 for key, value in hub.iter_trace_propagation_headers():

--- a/sentry_sdk/integrations/stdlib.py
+++ b/sentry_sdk/integrations/stdlib.py
@@ -2,7 +2,7 @@ import os
 import subprocess
 import sys
 import platform
-from sentry_sdk.consts import OP
+from sentry_sdk.consts import OP, SPANDATA
 
 from sentry_sdk.hub import Hub
 from sentry_sdk.integrations import Integration
@@ -93,8 +93,8 @@ def _install_httplib():
 
         span.set_data("method", method)
         span.set_data("url", parsed_url.url)
-        span.set_data("http.query", parsed_url.query)
-        span.set_data("http.fragment", parsed_url.fragment)
+        span.set_data(SPANDATA.HTTP_QUERY, parsed_url.query)
+        span.set_data(SPANDATA.HTTP_FRAGMENT, parsed_url.fragment)
 
         rv = real_putrequest(self, method, url, *args, **kwargs)
 

--- a/tests/integrations/httpx/test_httpx.py
+++ b/tests/integrations/httpx/test_httpx.py
@@ -5,7 +5,7 @@ import httpx
 import responses
 
 from sentry_sdk import capture_message, start_transaction
-from sentry_sdk.consts import MATCH_ALL
+from sentry_sdk.consts import MATCH_ALL, SPANDATA
 from sentry_sdk.integrations.httpx import HttpxIntegration
 
 
@@ -44,8 +44,8 @@ def test_crumb_capture_and_hint(sentry_init, capture_events, httpx_client):
         assert crumb["data"] == {
             "url": url,
             "method": "GET",
-            "http.fragment": "",
-            "http.query": "",
+            SPANDATA.HTTP_FRAGMENT: "",
+            SPANDATA.HTTP_QUERY: "",
             "status_code": 200,
             "reason": "OK",
             "extra": "foo",

--- a/tests/integrations/requests/test_requests.py
+++ b/tests/integrations/requests/test_requests.py
@@ -4,6 +4,7 @@ import responses
 requests = pytest.importorskip("requests")
 
 from sentry_sdk import capture_message
+from sentry_sdk.consts import SPANDATA
 from sentry_sdk.integrations.stdlib import StdlibIntegration
 
 
@@ -25,8 +26,8 @@ def test_crumb_capture(sentry_init, capture_events):
     assert crumb["data"] == {
         "url": url,
         "method": "GET",
-        "http.fragment": "",
-        "http.query": "",
+        SPANDATA.HTTP_FRAGMENT: "",
+        SPANDATA.HTTP_QUERY: "",
         "status_code": response.status_code,
         "reason": response.reason,
     }

--- a/tests/integrations/stdlib/test_httplib.py
+++ b/tests/integrations/stdlib/test_httplib.py
@@ -23,7 +23,7 @@ except ImportError:
 
 
 from sentry_sdk import capture_message, start_transaction
-from sentry_sdk.consts import MATCH_ALL
+from sentry_sdk.consts import MATCH_ALL, SPANDATA
 from sentry_sdk.tracing import Transaction
 from sentry_sdk.integrations.stdlib import StdlibIntegration
 
@@ -51,8 +51,8 @@ def test_crumb_capture(sentry_init, capture_events):
         "method": "GET",
         "status_code": 200,
         "reason": "OK",
-        "http.fragment": "",
-        "http.query": "",
+        SPANDATA.HTTP_FRAGMENT: "",
+        SPANDATA.HTTP_QUERY: "",
     }
 
 
@@ -79,8 +79,8 @@ def test_crumb_capture_hint(sentry_init, capture_events):
         "status_code": 200,
         "reason": "OK",
         "extra": "foo",
-        "http.fragment": "",
-        "http.query": "",
+        SPANDATA.HTTP_FRAGMENT: "",
+        SPANDATA.HTTP_QUERY: "",
     }
 
 
@@ -136,8 +136,8 @@ def test_httplib_misuse(sentry_init, capture_events, request):
         "method": "GET",
         "status_code": 200,
         "reason": "OK",
-        "http.fragment": "",
-        "http.query": "",
+        SPANDATA.HTTP_FRAGMENT: "",
+        SPANDATA.HTTP_QUERY: "",
     }
 
 


### PR DESCRIPTION
#skip-changelog

while working toward https://github.com/getsentry/team-webplatform-meta/issues/60, this is a small refactor to clean up our http related span data (documented in https://develop.sentry.dev/sdk/performance/span-data-conventions/) by making sure they all use the same central constant (and adding docstrings as appropriate). 

In a follow up PR, I'm going to update the spans to start setting `http.method` instead of `method`, because this is the schema we want to use moving forward. 