### PR TITLE
feat: Use `http.method` instead of `method`

### DIFF
--- a/sentry_sdk/integrations/boto3.py
+++ b/sentry_sdk/integrations/boto3.py
@@ -75,6 +75,7 @@ def _sentry_request_created(service_id, request, operation_name, **kwargs):
     span.set_data("aws.request.url", parsed_url.url)
     span.set_data(SPANDATA.HTTP_QUERY, parsed_url.query)
     span.set_data(SPANDATA.HTTP_FRAGMENT, parsed_url.fragment)
+    span.set_data(SPANDATA.HTTP_METHOD, request.method)
 
     # We do it in order for subsequent http calls/retries be
     # attached to this span.

--- a/sentry_sdk/integrations/httpx.py
+++ b/sentry_sdk/integrations/httpx.py
@@ -48,7 +48,7 @@ def _install_httpx_client():
             op=OP.HTTP_CLIENT,
             description="%s %s" % (request.method, parsed_url.url),
         ) as span:
-            span.set_data("method", request.method)
+            span.set_data(SPANDATA.HTTP_METHOD, request.method)
             span.set_data("url", parsed_url.url)
             span.set_data(SPANDATA.HTTP_QUERY, parsed_url.query)
             span.set_data(SPANDATA.HTTP_FRAGMENT, parsed_url.fragment)
@@ -89,7 +89,7 @@ def _install_httpx_async_client():
             op=OP.HTTP_CLIENT,
             description="%s %s" % (request.method, parsed_url.url),
         ) as span:
-            span.set_data("method", request.method)
+            span.set_data(SPANDATA.HTTP_METHOD, request.method)
             span.set_data("url", parsed_url.url)
             span.set_data(SPANDATA.HTTP_QUERY, parsed_url.query)
             span.set_data(SPANDATA.HTTP_FRAGMENT, parsed_url.fragment)

--- a/sentry_sdk/integrations/stdlib.py
+++ b/sentry_sdk/integrations/stdlib.py
@@ -91,7 +91,7 @@ def _install_httplib():
             description="%s %s" % (method, parsed_url.url),
         )
 
-        span.set_data("method", method)
+        span.set_data(SPANDATA.HTTP_METHOD, method)
         span.set_data("url", parsed_url.url)
         span.set_data(SPANDATA.HTTP_QUERY, parsed_url.query)
         span.set_data(SPANDATA.HTTP_FRAGMENT, parsed_url.fragment)

--- a/tests/integrations/httpx/test_httpx.py
+++ b/tests/integrations/httpx/test_httpx.py
@@ -43,7 +43,7 @@ def test_crumb_capture_and_hint(sentry_init, capture_events, httpx_client):
         assert crumb["category"] == "httplib"
         assert crumb["data"] == {
             "url": url,
-            "method": "GET",
+            SPANDATA.HTTP_METHOD: "GET",
             SPANDATA.HTTP_FRAGMENT: "",
             SPANDATA.HTTP_QUERY: "",
             "status_code": 200,

--- a/tests/integrations/requests/test_requests.py
+++ b/tests/integrations/requests/test_requests.py
@@ -25,7 +25,7 @@ def test_crumb_capture(sentry_init, capture_events):
     assert crumb["category"] == "httplib"
     assert crumb["data"] == {
         "url": url,
-        "method": "GET",
+        SPANDATA.HTTP_METHOD: "GET",
         SPANDATA.HTTP_FRAGMENT: "",
         SPANDATA.HTTP_QUERY: "",
         "status_code": response.status_code,

--- a/tests/integrations/stdlib/test_httplib.py
+++ b/tests/integrations/stdlib/test_httplib.py
@@ -48,7 +48,7 @@ def test_crumb_capture(sentry_init, capture_events):
     assert crumb["category"] == "httplib"
     assert crumb["data"] == {
         "url": url,
-        "method": "GET",
+        SPANDATA.HTTP_METHOD: "GET",
         "status_code": 200,
         "reason": "OK",
         SPANDATA.HTTP_FRAGMENT: "",
@@ -75,7 +75,7 @@ def test_crumb_capture_hint(sentry_init, capture_events):
     assert crumb["category"] == "httplib"
     assert crumb["data"] == {
         "url": url,
-        "method": "GET",
+        SPANDATA.HTTP_METHOD: "GET",
         "status_code": 200,
         "reason": "OK",
         "extra": "foo",
@@ -133,7 +133,7 @@ def test_httplib_misuse(sentry_init, capture_events, request):
     assert crumb["category"] == "httplib"
     assert crumb["data"] == {
         "url": "http://localhost:{}/200".format(PORT),
-        "method": "GET",
+        SPANDATA.HTTP_METHOD: "GET",
         "status_code": 200,
         "reason": "OK",
         SPANDATA.HTTP_FRAGMENT: "",


### PR DESCRIPTION
~Blocked on https://github.com/getsentry/sentry-python/pull/2053 merging, so draft for now.~

As per https://develop.sentry.dev/sdk/performance/span-data-conventions/, we want to rename `method` being set on spans to `http.method`. This better aligns with otel, and also removes ambiguity when operating in Relay.