### PR TITLE
fix(crons): Do not send monitor_config when unset

### DIFF
--- a/sentry_sdk/crons/api.py
+++ b/sentry_sdk/crons/api.py
@@ -22,13 +22,15 @@ def _create_check_in_event(
     check_in = {
         "type": "check_in",
         "monitor_slug": monitor_slug,
-        "monitor_config": monitor_config or {},
         "check_in_id": check_in_id,
         "status": status,
         "duration": duration_s,
         "environment": options.get("environment", None),
         "release": options.get("release", None),
     }
+
+    if monitor_config:
+        check_in["monitor_config"] = monitor_config
 
     return check_in
 


### PR DESCRIPTION
This fixes a regression introduced in 1.18 which caused monitor
check-ins without a `monitor_config` to be rejected by relay.

Fixes https://github.com/getsentry/sentry-python/issues/2052