### PR TITLE
Add DSC to error events

### DIFF
--- a/sentry_sdk/client.py
+++ b/sentry_sdk/client.py
@@ -510,7 +510,7 @@ class _Client(object):
         dynamic_sampling_context = (
             event_opt.get("contexts", {})
             .get("trace", {})
-            .pop("dynamic_sampling_context", {})
+            .get("dynamic_sampling_context", {})
         )
 
         # If tracing is enabled all events should go to /envelope endpoint.


### PR DESCRIPTION
At this point in time only for error events that happened in the context of a transaction.

The difficulty here is that, conceptually speaking, there can actually be no exceptions happening in a transaction. If an unhandled exception occurs inside of a context manager, the context manager is first `__exit__`ed before propagating the exception higher up. For the SDK this results in the scope losing the reference to the transaction (since we exited it) and only then raising the error.

In other words, at the point in time when the exception actually bubbles all the way up, the scope has no information about the transaction anymore. This PR adds a separate mechanism for recording the transaction for later if it is exited with an exception.