### PR TITLE
Pin urllib3 to <2.0.0 for now

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -41,6 +41,7 @@ setup(
         'urllib3>=1.25.7; python_version<="3.4"',
         'urllib3>=1.26.9; python_version=="3.5"',
         'urllib3>=1.26.11; python_version >="3.6"',
+        'urllib3<2.0.0',
         "certifi",
     ],
     extras_require={


### PR DESCRIPTION
urllib3 released a major which breaks with openssl on some AWS runtimes and some other setups (#2051)
Pin for now and we can investigate changes needed separately.


fixes #2051 
(for now)
