### PR TITLE
Handle sqlalchemy engine.name being bytes

### DIFF
--- a/sentry_sdk/integrations/sqlalchemy.py
+++ b/sentry_sdk/integrations/sqlalchemy.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import
 
 import re
 
+from sentry_sdk._compat import text_type
 from sentry_sdk._types import TYPE_CHECKING
 from sentry_sdk.consts import SPANDATA
 from sentry_sdk.hub import Hub
@@ -111,6 +112,8 @@ def _handle_error(context, *args):
 # See: https://docs.sqlalchemy.org/en/20/dialects/index.html
 def _get_db_system(name):
     # type: (str) -> Optional[str]
+    name = text_type(name)
+
     if "sqlite" in name:
         return "sqlite"
 

--- a/tests/integrations/sqlalchemy/test_sqlalchemy.py
+++ b/tests/integrations/sqlalchemy/test_sqlalchemy.py
@@ -208,3 +208,15 @@ def test_large_event_not_truncated(sentry_init, capture_events):
     assert event["_meta"]["message"] == {
         "": {"len": 1034, "rem": [["!limit", "x", 1021, 1024]]}
     }
+
+
+def test_engine_name_not_string(sentry_init):
+    sentry_init(
+        integrations=[SqlalchemyIntegration()],
+    )
+
+    engine = create_engine("sqlite:///:memory:")
+    engine.dialect.name = b"sqlite"
+
+    with engine.connect() as con:
+        con.execute("SELECT 0")


### PR DESCRIPTION
There are cases where `engine.name` in sqlalchemy is not a string (see https://github.com/getsentry/sentry-python/issues/2071). 

Fixes https://github.com/getsentry/sentry-python/issues/2071