### PR TITLE
Prefer importlib.metadata over pkg_resources if available

### DIFF
--- a/sentry_sdk/integrations/modules.py
+++ b/sentry_sdk/integrations/modules.py
@@ -24,7 +24,9 @@ def _generate_installed_modules():
         from importlib.metadata import distributions, version
 
         for dist in distributions():
-            yield dist.metadata["Name"].lower(), version(dist.metadata["Name"])
+            yield dist.metadata["Name"].lower().replace("-", "_"), version(
+                dist.metadata["Name"]
+            )
 
     except ImportError:
         # < py3.8

--- a/sentry_sdk/integrations/modules.py
+++ b/sentry_sdk/integrations/modules.py
@@ -20,7 +20,7 @@ _installed_modules = None
 
 def _normalize_module_name(name):
     # type: (str) -> str
-    return name.lower().replace("-", "_")
+    return name.lower()
 
 
 def _generate_installed_modules():

--- a/sentry_sdk/integrations/modules.py
+++ b/sentry_sdk/integrations/modules.py
@@ -18,13 +18,17 @@ if TYPE_CHECKING:
 _installed_modules = None
 
 
+def _normalize_module_name(name):
+    return name.lower().replace("-", "_")
+
+
 def _generate_installed_modules():
     # type: () -> Iterator[Tuple[str, str]]
     try:
         from importlib.metadata import distributions, version
 
         for dist in distributions():
-            yield dist.metadata["Name"].lower().replace("-", "_"), version(
+            yield _normalize_module_name(dist.metadata["Name"]), version(
                 dist.metadata["Name"]
             )
 
@@ -36,7 +40,7 @@ def _generate_installed_modules():
             return
 
         for info in pkg_resources.working_set:
-            yield info.key, info.version
+            yield _normalize_module_name(info.key), info.version
 
 
 def _get_installed_modules():

--- a/sentry_sdk/integrations/modules.py
+++ b/sentry_sdk/integrations/modules.py
@@ -19,6 +19,7 @@ _installed_modules = None
 
 
 def _normalize_module_name(name):
+    # type: (str) -> str
     return name.lower().replace("-", "_")
 
 

--- a/sentry_sdk/integrations/modules.py
+++ b/sentry_sdk/integrations/modules.py
@@ -24,7 +24,7 @@ def _generate_installed_modules():
         from importlib.metadata import distributions, version
 
         for dist in distributions():
-            yield dist.metadata["Name"], version(dist.metadata["Name"])
+            yield dist.metadata["Name"].lower(), version(dist.metadata["Name"])
 
     except ImportError:
         # < py3.8

--- a/sentry_sdk/integrations/modules.py
+++ b/sentry_sdk/integrations/modules.py
@@ -21,12 +21,20 @@ _installed_modules = None
 def _generate_installed_modules():
     # type: () -> Iterator[Tuple[str, str]]
     try:
-        import pkg_resources
-    except ImportError:
-        return
+        from importlib.metadata import distributions, version
 
-    for info in pkg_resources.working_set:
-        yield info.key, info.version
+        for dist in distributions():
+            yield dist.metadata["Name"], version(dist.metadata["Name"])
+
+    except ImportError:
+        # < py3.8
+        try:
+            import pkg_resources
+        except ImportError:
+            return
+
+        for info in pkg_resources.working_set:
+            yield info.key, info.version
 
 
 def _get_installed_modules():

--- a/tests/integrations/modules/test_modules.py
+++ b/tests/integrations/modules/test_modules.py
@@ -32,7 +32,9 @@ def test_installed_modules():
     installed_modules = _get_installed_modules()
     if importlib_available:
         assert installed_modules == {
-            dist.metadata["Name"].lower(): version(dist.metadata["Name"])
+            dist.metadata["Name"]
+            .lower()
+            .replace("-", "_"): version(dist.metadata["Name"])
             for dist in distributions()
         }
     if pkg_resources_available:

--- a/tests/integrations/modules/test_modules.py
+++ b/tests/integrations/modules/test_modules.py
@@ -14,7 +14,7 @@ def test_basic(sentry_init, capture_events):
     sentry_sdk.capture_exception(ValueError())
 
     (event,) = events
-    assert "sentry-sdk" in event["modules"]
+    assert "sentry_sdk" in event["modules"]
     assert "pytest" in event["modules"]
 
 

--- a/tests/integrations/modules/test_modules.py
+++ b/tests/integrations/modules/test_modules.py
@@ -1,6 +1,10 @@
 import sentry_sdk
 
-from sentry_sdk.integrations.modules import ModulesIntegration, _get_installed_modules
+from sentry_sdk.integrations.modules import (
+    ModulesIntegration,
+    _get_installed_modules,
+    _normalize_module_name,
+)
 
 
 def test_basic(sentry_init, capture_events):
@@ -32,12 +36,13 @@ def test_installed_modules():
     installed_modules = _get_installed_modules()
     if importlib_available:
         assert installed_modules == {
-            dist.metadata["Name"]
-            .lower()
-            .replace("-", "_"): version(dist.metadata["Name"])
+            _normalize_module_name(dist.metadata["Name"]): version(
+                dist.metadata["Name"]
+            )
             for dist in distributions()
         }
     if pkg_resources_available:
         assert installed_modules == {
-            dist.key: dist.version for dist in pkg_resources.working_set
+            _normalize_module_name(dist.key): dist.version
+            for dist in pkg_resources.working_set
         }

--- a/tests/integrations/modules/test_modules.py
+++ b/tests/integrations/modules/test_modules.py
@@ -48,7 +48,7 @@ def test_installed_modules():
             )
             for dist in distributions()
         }
-        del importlib_modules["typing-extensions"]
+        importlib_modules.pop("typing-extensions", None)
         assert installed_modules == importlib_modules
 
     if pkg_resources_available:
@@ -56,5 +56,5 @@ def test_installed_modules():
             _normalize_module_name(dist.key): dist.version
             for dist in pkg_resources.working_set
         }
-        del pkg_resources_modules["typing-extensions"]
+        pkg_resources_modules.pop("typing-extensions", None)
         assert installed_modules == pkg_resources_modules

--- a/tests/integrations/modules/test_modules.py
+++ b/tests/integrations/modules/test_modules.py
@@ -14,7 +14,7 @@ def test_basic(sentry_init, capture_events):
     sentry_sdk.capture_exception(ValueError())
 
     (event,) = events
-    assert "sentry_sdk" in event["modules"]
+    assert "sentry-sdk" in event["modules"]
     assert "pytest" in event["modules"]
 
 
@@ -34,15 +34,27 @@ def test_installed_modules():
         pkg_resources_available = False
 
     installed_modules = _get_installed_modules()
+
+    # This one package is reported differently by importlib
+    # and pkg_resources, but we don't really care, so let's
+    # just ignore it
+    installed_modules.pop("typing-extensions", None)
+    installed_modules.pop("typing_extensions", None)
+
     if importlib_available:
-        assert installed_modules == {
+        importlib_modules = {
             _normalize_module_name(dist.metadata["Name"]): version(
                 dist.metadata["Name"]
             )
             for dist in distributions()
         }
+        del importlib_modules["typing-extensions"]
+        assert installed_modules == importlib_modules
+
     if pkg_resources_available:
-        assert installed_modules == {
+        pkg_resources_modules = {
             _normalize_module_name(dist.key): dist.version
             for dist in pkg_resources.working_set
         }
+        del pkg_resources_modules["typing-extensions"]
+        assert installed_modules == pkg_resources_modules

--- a/tests/integrations/modules/test_modules.py
+++ b/tests/integrations/modules/test_modules.py
@@ -1,6 +1,6 @@
 import sentry_sdk
 
-from sentry_sdk.integrations.modules import ModulesIntegration
+from sentry_sdk.integrations.modules import ModulesIntegration, _get_installed_modules
 
 
 def test_basic(sentry_init, capture_events):
@@ -12,3 +12,30 @@ def test_basic(sentry_init, capture_events):
     (event,) = events
     assert "sentry-sdk" in event["modules"]
     assert "pytest" in event["modules"]
+
+
+def test_installed_modules():
+    try:
+        from importlib import distributions, version
+
+        importlib_available = True
+    except ImportError:
+        importlib_available = False
+
+    try:
+        import pkg_resources
+
+        pkg_resources_available = True
+    except ImportError:
+        pkg_resources_available = False
+
+    installed_modules = _get_installed_modules()
+    if importlib_available:
+        assert installed_modules == [
+            (dist.metadata["Name"].lower(), version(dist.metadata["Name"]))
+            for dist in distributions()
+        ]
+    if pkg_resources_available:
+        assert installed_modules == [
+            (dist.key, dist.version) for dist in pkg_resources.working_set
+        ]

--- a/tests/integrations/modules/test_modules.py
+++ b/tests/integrations/modules/test_modules.py
@@ -31,11 +31,11 @@ def test_installed_modules():
 
     installed_modules = _get_installed_modules()
     if importlib_available:
-        assert installed_modules == [
-            (dist.metadata["Name"].lower(), version(dist.metadata["Name"]))
+        assert installed_modules == {
+            dist.metadata["Name"].lower(): version(dist.metadata["Name"])
             for dist in distributions()
-        ]
+        }
     if pkg_resources_available:
-        assert installed_modules == [
-            (dist.key, dist.version) for dist in pkg_resources.working_set
-        ]
+        assert installed_modules == {
+            dist.key: dist.version for dist in pkg_resources.working_set
+        }

--- a/tests/integrations/pyramid/test_pyramid.py
+++ b/tests/integrations/pyramid/test_pyramid.py
@@ -1,8 +1,6 @@
 import json
 import logging
-import pkg_resources
 import pytest
-
 from io import BytesIO
 
 import pyramid.testing
@@ -17,9 +15,18 @@ from sentry_sdk.serializer import MAX_DATABAG_BREADTH
 from werkzeug.test import Client
 
 
-PYRAMID_VERSION = tuple(
-    map(int, pkg_resources.get_distribution("pyramid").version.split("."))
-)
+try:
+    from importlib.metadata import version
+
+    PYRAMID_VERSION = tuple(map(int, version("pyramid").split(".")))
+
+except ImportError:
+    # < py3.8
+    import pkg_resources
+
+    PYRAMID_VERSION = tuple(
+        map(int, pkg_resources.get_distribution("pyramid").version.split("."))
+    )
 
 
 def hi(request):


### PR DESCRIPTION
Let's not use `pkg_resources` and avoid a `DeprecationWarning` if `importlib.metadata` is available.

Fixes https://github.com/getsentry/sentry-python/issues/2048