### PR TITLE
Fix: Handle a list of keys (not just a single key) in Django cache spans

### DIFF
--- a/sentry_sdk/integrations/django/caching.py
+++ b/sentry_sdk/integrations/django/caching.py
@@ -31,7 +31,7 @@ def _patch_cache_method(cache, method_name):
         if integration is None or not integration.cache_spans:
             return original_method(*args, **kwargs)
 
-        description = "{} {}".format(method_name, args)
+        description = "{} {}".format(method_name, args[0])
 
         with hub.start_span(op=OP.CACHE, description=description) as span:
             value = original_method(*args, **kwargs)

--- a/sentry_sdk/integrations/django/caching.py
+++ b/sentry_sdk/integrations/django/caching.py
@@ -31,7 +31,7 @@ def _patch_cache_method(cache, method_name):
         if integration is None or not integration.cache_spans:
             return original_method(*args, **kwargs)
 
-        description = "{} {}".format(method_name, " ".join(args))
+        description = "{} {}".format(method_name, args)
 
         with hub.start_span(op=OP.CACHE, description=description) as span:
             value = original_method(*args, **kwargs)


### PR DESCRIPTION
Dogfooding (or at least trying to) in our own project already found a problem: 
https://github.com/getsentry/sentry/actions/runs/4893658363/jobs/8736882698?pr=48624#step:5:345

This fixes it that args can also be a list of lists.