### PR TITLE
Django caching span fixes

### DIFF
--- a/sentry_sdk/consts.py
+++ b/sentry_sdk/consts.py
@@ -96,7 +96,7 @@ class SPANDATA:
 
 
 class OP:
-    CACHE = "cache"
+    CACHE_GET_ITEM = "cache.get_item"
     DB = "db"
     DB_REDIS = "db.redis"
     EVENT_DJANGO = "event.django"

--- a/sentry_sdk/integrations/django/caching.py
+++ b/sentry_sdk/integrations/django/caching.py
@@ -27,7 +27,7 @@ def _get_span_description(method_name, args, kwargs):
     if args is not None and len(args) >= 1:
         description += text_type(args[0])
     elif kwargs is not None and "key" in kwargs:
-        description += kwargs["key"]
+        description += text_type(kwargs["key"])
 
     return description
 

--- a/sentry_sdk/integrations/django/caching.py
+++ b/sentry_sdk/integrations/django/caching.py
@@ -20,6 +20,18 @@ METHODS_TO_INSTRUMENT = [
 ]
 
 
+def _get_span_description(method_name, args, kwargs):
+    # type: (str, Any, Any) -> str
+    description = "{} ".format(method_name)
+
+    if args is not None and len(args) >= 1:
+        description += text_type(args[0])
+    elif kwargs is not None and "key" in kwargs:
+        description += kwargs["key"]
+
+    return description
+
+
 def _patch_cache_method(cache, method_name):
     # type: (CacheHandler, str) -> None
     from sentry_sdk.integrations.django import DjangoIntegration
@@ -31,7 +43,7 @@ def _patch_cache_method(cache, method_name):
         if integration is None or not integration.cache_spans:
             return original_method(*args, **kwargs)
 
-        description = "{} {}".format(method_name, args[0])
+        description = _get_span_description(method_name, args, kwargs)
 
         with hub.start_span(op=OP.CACHE_GET_ITEM, description=description) as span:
             value = original_method(*args, **kwargs)

--- a/sentry_sdk/integrations/django/caching.py
+++ b/sentry_sdk/integrations/django/caching.py
@@ -33,7 +33,7 @@ def _patch_cache_method(cache, method_name):
 
         description = "{} {}".format(method_name, args[0])
 
-        with hub.start_span(op=OP.CACHE, description=description) as span:
+        with hub.start_span(op=OP.CACHE_GET_ITEM, description=description) as span:
             value = original_method(*args, **kwargs)
 
             if value:

--- a/tests/integrations/django/test_basic.py
+++ b/tests/integrations/django/test_basic.py
@@ -1036,20 +1036,20 @@ def test_cache_spans_middleware(
 
     (first_event, second_event) = events
     assert len(first_event["spans"]) == 1
-    assert first_event["spans"][0]["op"] == "cache"
+    assert first_event["spans"][0]["op"] == "cache.get_item"
     assert first_event["spans"][0]["description"].startswith(
         "get views.decorators.cache.cache_header."
     )
     assert first_event["spans"][0]["data"] == {"cache.hit": False}
 
     assert len(second_event["spans"]) == 2
-    assert second_event["spans"][0]["op"] == "cache"
+    assert second_event["spans"][0]["op"] == "cache.get_item"
     assert second_event["spans"][0]["description"].startswith(
         "get views.decorators.cache.cache_header."
     )
     assert second_event["spans"][0]["data"] == {"cache.hit": False}
 
-    assert second_event["spans"][1]["op"] == "cache"
+    assert second_event["spans"][1]["op"] == "cache.get_item"
     assert second_event["spans"][1]["description"].startswith(
         "get views.decorators.cache.cache_page."
     )
@@ -1078,20 +1078,20 @@ def test_cache_spans_decorator(sentry_init, client, capture_events, use_django_c
 
     (first_event, second_event) = events
     assert len(first_event["spans"]) == 1
-    assert first_event["spans"][0]["op"] == "cache"
+    assert first_event["spans"][0]["op"] == "cache.get_item"
     assert first_event["spans"][0]["description"].startswith(
         "get views.decorators.cache.cache_header."
     )
     assert first_event["spans"][0]["data"] == {"cache.hit": False}
 
     assert len(second_event["spans"]) == 2
-    assert second_event["spans"][0]["op"] == "cache"
+    assert second_event["spans"][0]["op"] == "cache.get_item"
     assert second_event["spans"][0]["description"].startswith(
         "get views.decorators.cache.cache_header."
     )
     assert second_event["spans"][0]["data"] == {"cache.hit": False}
 
-    assert second_event["spans"][1]["op"] == "cache"
+    assert second_event["spans"][1]["op"] == "cache.get_item"
     assert second_event["spans"][1]["description"].startswith(
         "get views.decorators.cache.cache_page."
     )
@@ -1122,14 +1122,14 @@ def test_cache_spans_templatetag(
 
     (first_event, second_event) = events
     assert len(first_event["spans"]) == 1
-    assert first_event["spans"][0]["op"] == "cache"
+    assert first_event["spans"][0]["op"] == "cache.get_item"
     assert first_event["spans"][0]["description"].startswith(
         "get template.cache.some_identifier."
     )
     assert first_event["spans"][0]["data"] == {"cache.hit": False}
 
     assert len(second_event["spans"]) == 1
-    assert second_event["spans"][0]["op"] == "cache"
+    assert second_event["spans"][0]["op"] == "cache.get_item"
     assert second_event["spans"][0]["description"].startswith(
         "get template.cache.some_identifier."
     )


### PR DESCRIPTION
- Fix problem when the cache key is given with kwargs (instead of positional args)
- Using the more specific `cache.get_item` span `op` because we only patch the getting cache functions.

Fixes #2085 