### PR TITLE
Fix: Duration in Celery Beat tasks monitoring

### DIFF
--- a/sentry_sdk/integrations/celery.py
+++ b/sentry_sdk/integrations/celery.py
@@ -115,9 +115,11 @@ class CeleryIntegration(Integration):
 
 
 def _now_seconds_since_epoch():
-    # We can not use a perf_counter here, because the start of a Celery
-    # tasks and the finish are recorded in differenct processes
-    # Start happens in the Celery Beat process, the end in the Celery Worker process
+    # We can not use a perf_counter when dealing with durations
+    # of Celery tasks, because the start of a Celery tasks and
+    # the finish are recorded in differenct processes.
+    # Start happens in the Celery Beat process,
+    # the end in the Celery Worker process.
     return time.time()
 
 

--- a/sentry_sdk/integrations/celery.py
+++ b/sentry_sdk/integrations/celery.py
@@ -115,11 +115,11 @@ class CeleryIntegration(Integration):
 
 
 def _now_seconds_since_epoch():
-    # We can not use a perf_counter when dealing with durations
-    # of Celery tasks, because the start of a Celery tasks and
-    # the finish are recorded in differenct processes.
+    # We can not use `time.perf_counter()` when dealing with the duration
+    # of a Celery tasks, because the start of a Celery tasks and
+    # the end are recorded in differenct processes.
     # Start happens in the Celery Beat process,
-    # the end in the Celery Worker process.
+    # the end in a Celery Worker process.
     return time.time()
 
 

--- a/sentry_sdk/integrations/celery.py
+++ b/sentry_sdk/integrations/celery.py
@@ -115,6 +115,7 @@ class CeleryIntegration(Integration):
 
 
 def _now_seconds_since_epoch():
+    # type: () -> float
     # We can not use `time.perf_counter()` when dealing with the duration
     # of a Celery tasks, because the start of a Celery tasks and
     # the end are recorded in differenct processes.

--- a/sentry_sdk/integrations/celery.py
+++ b/sentry_sdk/integrations/celery.py
@@ -116,9 +116,9 @@ class CeleryIntegration(Integration):
 
 def _now_seconds_since_epoch():
     # type: () -> float
-    # We can not use `time.perf_counter()` when dealing with the duration
-    # of a Celery tasks, because the start of a Celery tasks and
-    # the end are recorded in differenct processes.
+    # We cannot use `time.perf_counter()` when dealing with the duration
+    # of a Celery task, because the start of a Celery task and
+    # the end are recorded in different processes.
     # Start happens in the Celery Beat process,
     # the end in a Celery Worker process.
     return time.time()

--- a/tests/integrations/celery/test_celery_beat_crons.py
+++ b/tests/integrations/celery/test_celery_beat_crons.py
@@ -89,7 +89,10 @@ def test_crons_task_success():
     with mock.patch(
         "sentry_sdk.integrations.celery.capture_checkin"
     ) as mock_capture_checkin:
-        with mock.patch("sentry_sdk.integrations.celery.now", return_value=500.5):
+        with mock.patch(
+            "sentry_sdk.integrations.celery._now_seconds_since_epoch",
+            return_value=500.5,
+        ):
             crons_task_success(fake_task)
 
             mock_capture_checkin.assert_called_once_with(
@@ -130,7 +133,10 @@ def test_crons_task_failure():
     with mock.patch(
         "sentry_sdk.integrations.celery.capture_checkin"
     ) as mock_capture_checkin:
-        with mock.patch("sentry_sdk.integrations.celery.now", return_value=500.5):
+        with mock.patch(
+            "sentry_sdk.integrations.celery._now_seconds_since_epoch",
+            return_value=500.5,
+        ):
             crons_task_failure(fake_task)
 
             mock_capture_checkin.assert_called_once_with(
@@ -171,7 +177,10 @@ def test_crons_task_retry():
     with mock.patch(
         "sentry_sdk.integrations.celery.capture_checkin"
     ) as mock_capture_checkin:
-        with mock.patch("sentry_sdk.integrations.celery.now", return_value=500.5):
+        with mock.patch(
+            "sentry_sdk.integrations.celery._now_seconds_since_epoch",
+            return_value=500.5,
+        ):
             crons_task_retry(fake_task)
 
             mock_capture_checkin.assert_called_once_with(


### PR DESCRIPTION
We can not use a `perf_counter` when dealing with duration's of Celery tasks, because the start of a Celery tasks and the finish are recorded in different processes.

Start happens in the Celery Beat process, the end in the Celery Worker process.

Fixes #2078 
