### PR TITLE
Surface `include_source_context` as a client option

### DIFF
--- a/sentry_sdk/consts.py
+++ b/sentry_sdk/consts.py
@@ -185,6 +185,7 @@ class ClientConstructor(object):
         project_root=None,  # type: Optional[str]
         enable_tracing=None,  # type: Optional[bool]
         include_local_variables=True,  # type: Optional[bool]
+        include_source_context=True,  # type: Optional[bool]
         trace_propagation_targets=[  # noqa: B006
             MATCH_ALL
         ],  # type: Optional[Sequence[str]]

--- a/sentry_sdk/utils.py
+++ b/sentry_sdk/utils.py
@@ -632,8 +632,8 @@ def serialize_frame(
     return rv
 
 
-def current_stacktrace(include_local_variables=True):
-    # type: (bool) -> Any
+def current_stacktrace(include_local_variables=True, include_source_context=True):
+    # type: (bool, bool) -> Any
     __tracebackhide__ = True
     frames = []
 
@@ -641,7 +641,11 @@ def current_stacktrace(include_local_variables=True):
     while f is not None:
         if not should_hide_frame(f):
             frames.append(
-                serialize_frame(f, include_local_variables=include_local_variables)
+                serialize_frame(
+                    f,
+                    include_local_variables=include_local_variables,
+                    include_source_context=include_source_context,
+                )
             )
         f = f.f_back
 
@@ -677,14 +681,17 @@ def single_exception_from_error_tuple(
 
     if client_options is None:
         include_local_variables = True
+        include_source_context = True
     else:
         include_local_variables = client_options["include_local_variables"]
+        include_source_context = client_options["include_source_context"]
 
     frames = [
         serialize_frame(
             tb.tb_frame,
             tb_lineno=tb.tb_lineno,
             include_local_variables=include_local_variables,
+            include_source_context=include_source_context,
         )
         for tb in iter_stacks(tb)
     ]

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -365,6 +365,38 @@ def test_include_local_variables_disabled(sentry_init, capture_events):
     )
 
 
+def test_include_source_context_enabled(sentry_init, capture_events):
+    sentry_init(include_source_context=True)
+    events = capture_events()
+    try:
+        1 / 0
+    except Exception:
+        capture_exception()
+
+    (event,) = events
+
+    frame = event["exception"]["values"][0]["stacktrace"]["frames"][0]
+    assert "post_context" in frame
+    assert "pre_context" in frame
+    assert "context_line" in frame
+
+
+def test_include_source_context_disabled(sentry_init, capture_events):
+    sentry_init(include_source_context=False)
+    events = capture_events()
+    try:
+        1 / 0
+    except Exception:
+        capture_exception()
+
+    (event,) = events
+
+    frame = event["exception"]["values"][0]["stacktrace"]["frames"][0]
+    assert "post_context" not in frame
+    assert "pre_context" not in frame
+    assert "context_line" not in frame
+
+
 @pytest.mark.parametrize("integrations", [[], [ExecutingIntegration()]])
 def test_function_names(sentry_init, capture_events, integrations):
     sentry_init(integrations=integrations)


### PR DESCRIPTION
The possibility to omit source context was added in https://github.com/getsentry/sentry-python/pull/2020, this PR surfaces it as a client option.

https://github.com/getsentry/sentry-python/issues/2017