### PR TITLE
Fix __qualname__ missing attribute in asyncio integration

### DIFF
--- a/sentry_sdk/integrations/asyncio.py
+++ b/sentry_sdk/integrations/asyncio.py
@@ -21,6 +21,15 @@ if TYPE_CHECKING:
     from sentry_sdk._types import ExcInfo
 
 
+def get_name(coro):
+    # type: (Any) -> str
+    return (
+        getattr(coro, "__qualname__", None)
+        or getattr(coro, "__name__", None)
+        or "coroutine without __name__"
+    )
+
+
 def patch_asyncio():
     # type: () -> None
     orig_task_factory = None
@@ -37,7 +46,7 @@ def patch_asyncio():
                 result = None
 
                 with hub:
-                    with hub.start_span(op=OP.FUNCTION, description=coro.__qualname__):
+                    with hub.start_span(op=OP.FUNCTION, description=get_name(coro)):
                         try:
                             result = await coro
                         except Exception:


### PR DESCRIPTION
fixes #2093 

I'll add a test case if the user comes up with a sample task that fails for him