### PR TITLE
Make sure we're importing `redis` the library

### DIFF
--- a/sentry_sdk/integrations/redis.py
+++ b/sentry_sdk/integrations/redis.py
@@ -115,14 +115,14 @@ class RedisIntegration(Integration):
     def setup_once():
         # type: () -> None
         try:
-            import redis
+            from redis import StrictRedis, client
         except ImportError:
             raise DidNotEnable("Redis client not installed")
 
-        patch_redis_client(redis.StrictRedis, is_cluster=False)
-        patch_redis_pipeline(redis.client.Pipeline, False, _get_redis_command_args)
+        patch_redis_client(StrictRedis, is_cluster=False)
+        patch_redis_pipeline(client.Pipeline, False, _get_redis_command_args)
         try:
-            strict_pipeline = redis.client.StrictPipeline  # type: ignore
+            strict_pipeline = client.StrictPipeline  # type: ignore
         except AttributeError:
             pass
         else:


### PR DESCRIPTION
...not the module, if there is one present.

https://github.com/getsentry/sentry-python/issues/1402