### PR TITLE
Serialize local vars early on

### DIFF
--- a/sentry_sdk/client.py
+++ b/sentry_sdk/client.py
@@ -320,7 +320,11 @@ class _Client(object):
         # Postprocess the event here so that annotated types do
         # generally not surface in before_send
         if event is not None:
-            event = serialize(event, request_bodies=self.options.get("request_bodies"))
+            event = serialize(
+                event,
+                request_bodies=self.options.get("request_bodies"),
+                ignore_local_vars=True,
+            )
 
         before_send = self.options["before_send"]
         if (

--- a/sentry_sdk/serializer.py
+++ b/sentry_sdk/serializer.py
@@ -121,6 +121,7 @@ def serialize(event, **kwargs):
     meta_stack = []  # type: List[Dict[str, Any]]
 
     keep_request_bodies = kwargs.pop("request_bodies", None) == "always"  # type: bool
+    ignore_local_vars = kwargs.pop("ignore_local_vars", False)
 
     def _annotate(**meta):
         # type: (**Any) -> None
@@ -380,7 +381,8 @@ def serialize(event, **kwargs):
             return rv_list
 
         if should_repr_strings:
-            obj = safe_repr(obj)
+            if not ignore_local_vars:
+                obj = safe_repr(obj)
         else:
             if isinstance(obj, bytes) or isinstance(obj, bytearray):
                 obj = obj.decode("utf-8", "replace")

--- a/sentry_sdk/utils.py
+++ b/sentry_sdk/utils.py
@@ -627,7 +627,11 @@ def serialize_frame(
         )
 
     if include_local_variables:
-        rv["vars"] = frame.f_locals
+        # repr local vars here already to avoid changing stuff
+        # by reference later (e.g. when scrubbing PII)
+        from sentry_sdk.serializer import serialize
+
+        rv["vars"] = serialize(frame.f_locals, should_repr_strings=True)
 
     return rv
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -241,3 +241,11 @@ def test_include_source_context_when_serializing_frame(include_source_context):
     assert include_source_context ^ ("pre_context" in result) ^ True
     assert include_source_context ^ ("context_line" in result) ^ True
     assert include_source_context ^ ("post_context" in result) ^ True
+
+
+def test_local_vars_serialized_when_serializing_frame():
+    local_var = lambda: "cats"  # noqa: F841
+    frame = sys._getframe()
+    result = serialize_frame(frame)
+
+    assert all(isinstance(val, str) for val in result["vars"].values())


### PR DESCRIPTION
No need to have actual references floating around. This also helps us avoid tampering with the underlying objects by mistake later on.

The "proper" way to do this would be to somehow yank var serialization out of the serializer to be able to use it standalone, but this would be a huge undertaking and possible source of bugs due to how complicated the serializer is. Which is doubly problematic given how integral it is. So what I opted for instead is a minimally invasive approach.

WIP: still getting this right and will probably add another test.