### PR TITLE
This disables Django Cache spans by default.

### DIFF
--- a/sentry_sdk/integrations/django/__init__.py
+++ b/sentry_sdk/integrations/django/__init__.py
@@ -103,7 +103,7 @@ class DjangoIntegration(Integration):
         transaction_style="url",
         middleware_spans=True,
         signals_spans=True,
-        cache_spans=True,
+        cache_spans=False,
     ):
         # type: (str, bool, bool, bool) -> None
         if transaction_style not in TRANSACTION_STYLE_VALUES:

--- a/tests/integrations/django/test_basic.py
+++ b/tests/integrations/django/test_basic.py
@@ -1017,8 +1017,6 @@ def test_cache_spans_middleware(
     use_django_caching_with_middlewares,
     settings,
 ):
-    client.application.load_middleware()
-
     sentry_init(
         integrations=[
             DjangoIntegration(
@@ -1029,6 +1027,8 @@ def test_cache_spans_middleware(
         ],
         traces_sample_rate=1.0,
     )
+
+    client.application.load_middleware()
     events = capture_events()
 
     client.get(reverse("not_cached_view"))


### PR DESCRIPTION
Users were telling us that the cache spans are adding to much overhead onto their servers, so we are disabling cache spans by default and make them opt-in.