### PR TITLE
Work with a copy of request, vars in the event

### DIFF
--- a/sentry_sdk/integrations/_wsgi_common.py
+++ b/sentry_sdk/integrations/_wsgi_common.py
@@ -1,4 +1,5 @@
 import json
+from copy import deepcopy
 
 from sentry_sdk.hub import Hub, _should_send_default_pii
 from sentry_sdk.utils import AnnotatedValue
@@ -77,7 +78,7 @@ class RequestExtractor(object):
         if data is not None:
             request_info["data"] = data
 
-        event["request"] = request_info
+        event["request"] = deepcopy(request_info)
 
     def content_length(self):
         # type: () -> int

--- a/sentry_sdk/integrations/asgi.py
+++ b/sentry_sdk/integrations/asgi.py
@@ -7,6 +7,7 @@ Based on Tom Christie's `sentry-asgi <https://github.com/encode/sentry-asgi>`.
 import asyncio
 import inspect
 import urllib
+from copy import deepcopy
 
 from sentry_sdk._functools import partial
 from sentry_sdk._types import TYPE_CHECKING
@@ -211,7 +212,7 @@ class SentryAsgiMiddleware:
 
         self._set_transaction_name_and_source(event, self.transaction_style, asgi_scope)
 
-        event["request"] = request_info
+        event["request"] = deepcopy(request_info)
 
         return event
 

--- a/sentry_sdk/integrations/aws_lambda.py
+++ b/sentry_sdk/integrations/aws_lambda.py
@@ -1,8 +1,9 @@
+import sys
+from copy import deepcopy
 from datetime import datetime, timedelta
 from os import environ
-import sys
-from sentry_sdk.consts import OP
 
+from sentry_sdk.consts import OP
 from sentry_sdk.hub import Hub, _should_send_default_pii
 from sentry_sdk.tracing import TRANSACTION_SOURCE_COMPONENT, Transaction
 from sentry_sdk._compat import reraise
@@ -380,7 +381,7 @@ def _make_request_event_processor(aws_event, aws_context, configured_timeout):
                 # event. Meaning every body is unstructured to us.
                 request["data"] = AnnotatedValue.removed_because_raw_data()
 
-        sentry_event["request"] = request
+        sentry_event["request"] = deepcopy(request)
 
         return sentry_event
 

--- a/sentry_sdk/integrations/fastapi.py
+++ b/sentry_sdk/integrations/fastapi.py
@@ -1,4 +1,5 @@
 import asyncio
+from copy import deepcopy
 
 from sentry_sdk._types import TYPE_CHECKING
 from sentry_sdk.hub import Hub, _should_send_default_pii
@@ -116,7 +117,7 @@ def patch_get_request_handler():
                                 request_info["cookies"] = info["cookies"]
                             if "data" in info:
                                 request_info["data"] = info["data"]
-                        event["request"] = request_info
+                        event["request"] = deepcopy(request_info)
 
                         return event
 

--- a/sentry_sdk/integrations/gcp.py
+++ b/sentry_sdk/integrations/gcp.py
@@ -1,8 +1,9 @@
+import sys
+from copy import deepcopy
 from datetime import datetime, timedelta
 from os import environ
-import sys
-from sentry_sdk.consts import OP
 
+from sentry_sdk.consts import OP
 from sentry_sdk.hub import Hub, _should_send_default_pii
 from sentry_sdk.tracing import TRANSACTION_SOURCE_COMPONENT, Transaction
 from sentry_sdk._compat import reraise
@@ -193,7 +194,7 @@ def _make_request_event_processor(gcp_event, configured_timeout, initial_time):
                 # event. Meaning every body is unstructured to us.
                 request["data"] = AnnotatedValue.removed_because_raw_data()
 
-        event["request"] = request
+        event["request"] = deepcopy(request)
 
         return event
 

--- a/sentry_sdk/integrations/starlette.py
+++ b/sentry_sdk/integrations/starlette.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import
 
 import asyncio
 import functools
+from copy import deepcopy
 
 from sentry_sdk._compat import iteritems
 from sentry_sdk._types import TYPE_CHECKING
@@ -389,7 +390,7 @@ def patch_request_response():
                                     request_info["cookies"] = info["cookies"]
                                 if "data" in info:
                                     request_info["data"] = info["data"]
-                            event["request"] = request_info
+                            event["request"] = deepcopy(request_info)
 
                             return event
 
@@ -435,7 +436,7 @@ def patch_request_response():
                             if cookies:
                                 request_info["cookies"] = cookies
 
-                            event["request"] = request_info
+                            event["request"] = deepcopy(request_info)
 
                             return event
 

--- a/sentry_sdk/utils.py
+++ b/sentry_sdk/utils.py
@@ -10,6 +10,7 @@ import sys
 import threading
 import time
 from collections import namedtuple
+from copy import copy
 from decimal import Decimal
 from numbers import Real
 
@@ -627,7 +628,7 @@ def serialize_frame(
         )
 
     if include_local_variables:
-        rv["vars"] = frame.f_locals
+        rv["vars"] = copy(frame.f_locals)
 
     return rv
 

--- a/tests/integrations/fastapi/test_fastapi.py
+++ b/tests/integrations/fastapi/test_fastapi.py
@@ -202,13 +202,9 @@ async def test_original_request_not_scrubbed(sentry_init, capture_events):
 
     @app.post("/error")
     async def _error(request: Request):
-        headers = request.headers
-        body = await request.json()
-
         logging.critical("Oh no!")
-
-        assert headers["Authorization"] == "Bearer ohno"
-        assert body == {"password": "secret"}
+        assert request.headers["Authorization"] == "Bearer ohno"
+        assert await request.json() == {"password": "secret"}
 
         return {"error": "Oh no!"}
 

--- a/tests/integrations/starlette/test_starlette.py
+++ b/tests/integrations/starlette/test_starlette.py
@@ -2,6 +2,7 @@ import asyncio
 import base64
 import functools
 import json
+import logging
 import os
 import threading
 
@@ -873,3 +874,37 @@ def test_active_thread_id(sentry_init, capture_envelopes, teardown_profiling, en
         transactions = profile.payload.json["transactions"]
         assert len(transactions) == 1
         assert str(data["active"]) == transactions[0]["active_thread_id"]
+
+
+def test_original_request_not_scrubbed(sentry_init, capture_events):
+    sentry_init(
+        integrations=[StarletteIntegration()],
+    )
+
+    async def _error(request):
+        logging.critical("Oh no!")
+        assert request.headers["Authorization"] == "Bearer ohno"
+        assert request.get_json() == {"password": "ohno"}
+        return starlette.responses.JSONResponse({"status": "Oh no!"})
+
+    app = starlette.applications.Starlette(
+        routes=[
+            starlette.routing.Route("/error", _error),
+        ],
+    )
+
+    events = capture_events()
+
+    client = TestClient(app)
+    try:
+        client.get(
+            "/error",
+            json={"password": "ohno"},
+            headers={"Authorization": "Bearer ohno"},
+        )
+    except Exception:
+        pass
+
+    event = events[0]
+    assert event["request"]["data"] == {"password": "[Filtered]"}
+    assert event["request"]["headers"]["authorization"] == "[Filtered]"

--- a/tests/integrations/starlette/test_starlette.py
+++ b/tests/integrations/starlette/test_starlette.py
@@ -884,7 +884,7 @@ def test_original_request_not_scrubbed(sentry_init, capture_events):
     async def _error(request):
         logging.critical("Oh no!")
         assert request.headers["Authorization"] == "Bearer ohno"
-        assert request.get_json() == {"password": "ohno"}
+        assert await request.json() == {"password": "ohno"}
         return starlette.responses.JSONResponse({"status": "Oh no!"})
 
     app = starlette.applications.Starlette(
@@ -896,14 +896,11 @@ def test_original_request_not_scrubbed(sentry_init, capture_events):
     events = capture_events()
 
     client = TestClient(app)
-    try:
-        client.get(
-            "/error",
-            json={"password": "ohno"},
-            headers={"Authorization": "Bearer ohno"},
-        )
-    except Exception:
-        pass
+    client.get(
+        "/error",
+        json={"password": "ohno"},
+        headers={"Authorization": "Bearer ohno"},
+    )
 
     event = events[0]
     assert event["request"]["data"] == {"password": "[Filtered]"}

--- a/tests/integrations/starlette/test_starlette.py
+++ b/tests/integrations/starlette/test_starlette.py
@@ -877,9 +877,9 @@ def test_active_thread_id(sentry_init, capture_envelopes, teardown_profiling, en
 
 
 def test_original_request_not_scrubbed(sentry_init, capture_events):
-    sentry_init(
-        integrations=[StarletteIntegration()],
-    )
+    sentry_init(integrations=[StarletteIntegration()])
+
+    events = capture_events()
 
     async def _error(request):
         logging.critical("Oh no!")
@@ -889,14 +889,12 @@ def test_original_request_not_scrubbed(sentry_init, capture_events):
 
     app = starlette.applications.Starlette(
         routes=[
-            starlette.routing.Route("/error", _error),
+            starlette.routing.Route("/error", _error, methods=["POST"]),
         ],
     )
 
-    events = capture_events()
-
     client = TestClient(app)
-    client.get(
+    client.post(
         "/error",
         json={"password": "ohno"},
         headers={"Authorization": "Bearer ohno"},


### PR DESCRIPTION
In some cases we were attaching parts of the original request to the event with live references on them and ending up modifying the underlying headers or request data when we scrubbed the event. Now we make sure to only attach a copy of the request to the event. We also do the same for frame vars.

See:
- https://github.com/getsentry/sentry-python/issues/2109
- https://github.com/getsentry/sentry-python/issues/2114