### PR TITLE
Celery beat exclude option

### DIFF
--- a/sentry_sdk/crons/api.py
+++ b/sentry_sdk/crons/api.py
@@ -32,6 +32,7 @@ def _create_check_in_event(
     if monitor_config:
         check_in["monitor_config"] = monitor_config
 
+    print(f"check_in: {check_in}")
     return check_in
 
 

--- a/sentry_sdk/crons/api.py
+++ b/sentry_sdk/crons/api.py
@@ -32,7 +32,6 @@ def _create_check_in_event(
     if monitor_config:
         check_in["monitor_config"] = monitor_config
 
-    print(f"check_in: {check_in}")
     return check_in
 
 

--- a/sentry_sdk/tracing_utils.py
+++ b/sentry_sdk/tracing_utils.py
@@ -7,6 +7,7 @@ from sentry_sdk.consts import OP
 from sentry_sdk.utils import (
     capture_internal_exceptions,
     Dsn,
+    match_regex_list,
     to_string,
 )
 from sentry_sdk._compat import PY2, iteritems
@@ -334,15 +335,7 @@ def should_propagate_trace(hub, url):
     client = hub.client  # type: Any
     trace_propagation_targets = client.options["trace_propagation_targets"]
 
-    if trace_propagation_targets is None:
-        return False
-
-    for target in trace_propagation_targets:
-        matched = re.search(target, url)
-        if matched:
-            return True
-
-    return False
+    return match_regex_list(url, trace_propagation_targets)
 
 
 # Circular imports

--- a/sentry_sdk/tracing_utils.py
+++ b/sentry_sdk/tracing_utils.py
@@ -335,7 +335,7 @@ def should_propagate_trace(hub, url):
     client = hub.client  # type: Any
     trace_propagation_targets = client.options["trace_propagation_targets"]
 
-    return match_regex_list(url, trace_propagation_targets)
+    return match_regex_list(url, trace_propagation_targets, substring_matching=True)
 
 
 # Circular imports

--- a/sentry_sdk/utils.py
+++ b/sentry_sdk/utils.py
@@ -1303,12 +1303,15 @@ def is_valid_sample_rate(rate, source):
     return True
 
 
-def match_regex_list(item, regex_list=None):
-    # type: (str, Optional[List[str]]) -> bool
+def match_regex_list(item, regex_list=None, substring_matching=False):
+    # type: (str, Optional[List[str]], bool) -> bool
     if regex_list is None:
         return False
 
     for item_matcher in regex_list:
+        if not substring_matching and item_matcher[-1] != "$":
+            item_matcher += "$"
+
         matched = re.search(item_matcher, item)
         if matched:
             return True

--- a/sentry_sdk/utils.py
+++ b/sentry_sdk/utils.py
@@ -1303,6 +1303,19 @@ def is_valid_sample_rate(rate, source):
     return True
 
 
+def match_regex_list(item, regex_list=None):
+    # type: (str, Optional[List[str]]) -> bool
+    if regex_list is None:
+        return False
+
+    for item_matcher in regex_list:
+        matched = re.search(item_matcher, item)
+        if matched:
+            return True
+
+    return False
+
+
 if PY37:
 
     def nanosecond_time():

--- a/tests/integrations/celery/test_celery_beat_crons.py
+++ b/tests/integrations/celery/test_celery_beat_crons.py
@@ -274,7 +274,7 @@ def test_exclude_beat_tasks_option(
 
     with mock.patch(
         "sentry_sdk.integrations.celery.Scheduler", fake_scheduler
-    ) as Scheduler:
+    ) as Scheduler:  # noqa: N806
         with mock.patch(
             "sentry_sdk.integrations.celery.Hub.current.get_integration",
             return_value=fake_integration,

--- a/tests/integrations/celery/test_celery_beat_crons.py
+++ b/tests/integrations/celery/test_celery_beat_crons.py
@@ -8,6 +8,7 @@ from sentry_sdk.integrations.celery import (
     _get_headers,
     _get_humanized_interval,
     _get_monitor_config,
+    _patch_beat_apply_entry,
     crons_task_success,
     crons_task_failure,
     crons_task_retry,
@@ -243,3 +244,56 @@ def test_get_monitor_config_default_timezone():
     monitor_config = _get_monitor_config(celery_schedule, app)
 
     assert monitor_config["timezone"] == "UTC"
+
+
+@pytest.mark.parametrize(
+    "task_name,exclude_beat_tasks,task_in_excluded_beat_tasks",
+    [
+        ["some_task_name", ["xxx", "some_task.*"], True],
+        ["some_task_name", ["xxx", "some_other_task.*"], False],
+    ],
+)
+def test_exclude_beat_tasks_option(
+    task_name, exclude_beat_tasks, task_in_excluded_beat_tasks
+):
+    """
+    Test excluding Celery Beat tasks from automatic instrumentation.
+    """
+    fake_apply_entry = mock.MagicMock()
+
+    fake_scheduler = mock.MagicMock()
+    fake_scheduler.apply_entry = fake_apply_entry
+
+    fake_integration = mock.MagicMock()
+    fake_integration.exclude_beat_tasks = exclude_beat_tasks
+
+    fake_schedule_entry = mock.MagicMock()
+    fake_schedule_entry.name = task_name
+
+    fake_get_monitor_config = mock.MagicMock()
+
+    with mock.patch(
+        "sentry_sdk.integrations.celery.Scheduler", fake_scheduler
+    ) as Scheduler:
+        with mock.patch(
+            "sentry_sdk.integrations.celery.Hub.current.get_integration",
+            return_value=fake_integration,
+        ):
+            with mock.patch(
+                "sentry_sdk.integrations.celery._get_monitor_config",
+                fake_get_monitor_config,
+            ) as _get_monitor_config:
+                # Mimic CeleryIntegration patching of Scheduler.apply_entry()
+                _patch_beat_apply_entry()
+                # Mimic Celery Beat calling a task from the Beat schedule
+                Scheduler.apply_entry(fake_scheduler, fake_schedule_entry)
+
+                if task_in_excluded_beat_tasks:
+                    # Only the original Scheduler.apply_entry() is called, _get_monitor_config is NOT called.
+                    fake_apply_entry.assert_called_once()
+                    _get_monitor_config.assert_not_called()
+
+                else:
+                    # The original Scheduler.apply_entry() is called, AND _get_monitor_config is called.
+                    fake_apply_entry.assert_called_once()
+                    _get_monitor_config.assert_called_once()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -254,13 +254,9 @@ def test_include_source_context_when_serializing_frame(include_source_context):
         ["some-string", [], False],
         ["some-string", None, False],
         ["some-string", ["some-string"], True],
-        [
-            "some-string",
-            ["some"],
-            True,
-        ],  # String do not need to fully match, a substring match is enough
-        ["some-string", ["some.*"], True],  # same as the one above
-        ["some-string", ["some$"], False],
+        ["some-string", ["some"], False],
+        ["some-string", ["some$"], False],  # same as above
+        ["some-string", ["some.*"], True],
         ["some-string", ["Some"], False],  # we do case sensitive matching
         ["some-string", [".*string$"], True],
     ],

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -5,6 +5,7 @@ import sys
 from sentry_sdk.utils import (
     is_valid_sample_rate,
     logger,
+    match_regex_list,
     parse_url,
     sanitize_url,
     serialize_frame,
@@ -241,3 +242,28 @@ def test_include_source_context_when_serializing_frame(include_source_context):
     assert include_source_context ^ ("pre_context" in result) ^ True
     assert include_source_context ^ ("context_line" in result) ^ True
     assert include_source_context ^ ("post_context" in result) ^ True
+
+
+@pytest.mark.parametrize(
+    "item,regex_list,expected_result",
+    [
+        ["", [], False],
+        [None, [], False],
+        ["", None, False],
+        [None, None, False],
+        ["some-string", [], False],
+        ["some-string", None, False],
+        ["some-string", ["some-string"], True],
+        [
+            "some-string",
+            ["some"],
+            True,
+        ],  # String do not need to fully match, a substring match is enough
+        ["some-string", ["some.*"], True],  # same as the one above
+        ["some-string", ["some$"], False],
+        ["some-string", ["Some"], False],  # we do case sensitive matching
+        ["some-string", [".*string$"], True],
+    ],
+)
+def test_match_regex_list(item, regex_list, expected_result):
+    assert match_regex_list(item, regex_list) == expected_result


### PR DESCRIPTION
Adds a `exclude_beat_tasks` option to `CeleryIntegration` where users can exclude Celery Beat tasks from being auto-instrumented.

Fixes #2119 
