### PR TITLE
Auto-retry tests on failure

### DIFF
--- a/.github/workflows/test-common.yml
+++ b/.github/workflows/test-common.yml
@@ -49,16 +49,20 @@ jobs:
           pip install coverage "tox>=3,<4"
 
       - name: Test common
-        timeout-minutes: 45
-        shell: bash
-        run: |
-          set -x # print commands that are executed
-          coverage erase
+        uses: nick-fields/retry@v2
+        with:
+          timeout_minutes: 45
+          max_attempts: 2
+          retry_wait_seconds: 5
+          shell: bash
+          command: |
+            set -x # print commands that are executed
+            coverage erase
 
-          # Run tests
-          ./scripts/runtox.sh "py${{ matrix.python-version }}-common" --cov=tests --cov=sentry_sdk --cov-report= --cov-branch
-          coverage combine .coverage*
-          coverage xml -i
+            # Run tests
+            ./scripts/runtox.sh "py${{ matrix.python-version }}-common" --cov=tests --cov=sentry_sdk --cov-report= --cov-branch
+            coverage combine .coverage*
+            coverage xml -i
 
       - uses: codecov/codecov-action@v3
         with:

--- a/.github/workflows/test-common.yml
+++ b/.github/workflows/test-common.yml
@@ -54,7 +54,7 @@ jobs:
           timeout_minutes: 45
           max_attempts: 2
           retry_wait_seconds: 5
-          shell: bash
+          shell: bash -e
           command: |
             set -x # print commands that are executed
             coverage erase

--- a/.github/workflows/test-common.yml
+++ b/.github/workflows/test-common.yml
@@ -26,7 +26,7 @@ jobs:
   test:
     name: common, python ${{ matrix.python-version }}, ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 45
+    timeout-minutes: 30
 
     strategy:
       fail-fast: false
@@ -51,7 +51,7 @@ jobs:
       - name: Test common
         uses: nick-fields/retry@v2
         with:
-          timeout_minutes: 45
+          timeout_minutes: 15
           max_attempts: 2
           retry_wait_seconds: 5
           shell: bash

--- a/.github/workflows/test-common.yml
+++ b/.github/workflows/test-common.yml
@@ -54,14 +54,14 @@ jobs:
           timeout_minutes: 45
           max_attempts: 2
           retry_wait_seconds: 5
-          shell: bash -e
+          shell: bash
           command: |
             set -x # print commands that are executed
             coverage erase
 
             # Run tests
-            ./scripts/runtox.sh "py${{ matrix.python-version }}-common" --cov=tests --cov=sentry_sdk --cov-report= --cov-branch
-            coverage combine .coverage*
+            ./scripts/runtox.sh "py${{ matrix.python-version }}-common" --cov=tests --cov=sentry_sdk --cov-report= --cov-branch &&
+            coverage combine .coverage* &&
             coverage xml -i
 
       - uses: codecov/codecov-action@v3

--- a/.github/workflows/test-integration-aiohttp.yml
+++ b/.github/workflows/test-integration-aiohttp.yml
@@ -49,16 +49,20 @@ jobs:
           pip install coverage "tox>=3,<4"
 
       - name: Test aiohttp
-        timeout-minutes: 45
-        shell: bash
-        run: |
-          set -x # print commands that are executed
-          coverage erase
+        uses: nick-fields/retry@v2
+        with:
+          timeout_minutes: 45
+          max_attempts: 2
+          retry_wait_seconds: 5
+          shell: bash
+          command: |
+            set -x # print commands that are executed
+            coverage erase
 
-          # Run tests
-          ./scripts/runtox.sh "py${{ matrix.python-version }}-aiohttp" --cov=tests --cov=sentry_sdk --cov-report= --cov-branch
-          coverage combine .coverage*
-          coverage xml -i
+            # Run tests
+            ./scripts/runtox.sh "py${{ matrix.python-version }}-aiohttp" --cov=tests --cov=sentry_sdk --cov-report= --cov-branch &&
+            coverage combine .coverage* &&
+            coverage xml -i
 
       - uses: codecov/codecov-action@v3
         with:

--- a/.github/workflows/test-integration-aiohttp.yml
+++ b/.github/workflows/test-integration-aiohttp.yml
@@ -26,7 +26,7 @@ jobs:
   test:
     name: aiohttp, python ${{ matrix.python-version }}, ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 45
+    timeout-minutes: 30
 
     strategy:
       fail-fast: false
@@ -51,7 +51,7 @@ jobs:
       - name: Test aiohttp
         uses: nick-fields/retry@v2
         with:
-          timeout_minutes: 45
+          timeout_minutes: 15
           max_attempts: 2
           retry_wait_seconds: 5
           shell: bash

--- a/.github/workflows/test-integration-arq.yml
+++ b/.github/workflows/test-integration-arq.yml
@@ -49,16 +49,20 @@ jobs:
           pip install coverage "tox>=3,<4"
 
       - name: Test arq
-        timeout-minutes: 45
-        shell: bash
-        run: |
-          set -x # print commands that are executed
-          coverage erase
+        uses: nick-fields/retry@v2
+        with:
+          timeout_minutes: 45
+          max_attempts: 2
+          retry_wait_seconds: 5
+          shell: bash
+          command: |
+            set -x # print commands that are executed
+            coverage erase
 
-          # Run tests
-          ./scripts/runtox.sh "py${{ matrix.python-version }}-arq" --cov=tests --cov=sentry_sdk --cov-report= --cov-branch
-          coverage combine .coverage*
-          coverage xml -i
+            # Run tests
+            ./scripts/runtox.sh "py${{ matrix.python-version }}-arq" --cov=tests --cov=sentry_sdk --cov-report= --cov-branch &&
+            coverage combine .coverage* &&
+            coverage xml -i
 
       - uses: codecov/codecov-action@v3
         with:

--- a/.github/workflows/test-integration-arq.yml
+++ b/.github/workflows/test-integration-arq.yml
@@ -26,7 +26,7 @@ jobs:
   test:
     name: arq, python ${{ matrix.python-version }}, ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 45
+    timeout-minutes: 30
 
     strategy:
       fail-fast: false
@@ -51,7 +51,7 @@ jobs:
       - name: Test arq
         uses: nick-fields/retry@v2
         with:
-          timeout_minutes: 45
+          timeout_minutes: 15
           max_attempts: 2
           retry_wait_seconds: 5
           shell: bash

--- a/.github/workflows/test-integration-asgi.yml
+++ b/.github/workflows/test-integration-asgi.yml
@@ -49,16 +49,20 @@ jobs:
           pip install coverage "tox>=3,<4"
 
       - name: Test asgi
-        timeout-minutes: 45
-        shell: bash
-        run: |
-          set -x # print commands that are executed
-          coverage erase
+        uses: nick-fields/retry@v2
+        with:
+          timeout_minutes: 45
+          max_attempts: 2
+          retry_wait_seconds: 5
+          shell: bash
+          command: |
+            set -x # print commands that are executed
+            coverage erase
 
-          # Run tests
-          ./scripts/runtox.sh "py${{ matrix.python-version }}-asgi" --cov=tests --cov=sentry_sdk --cov-report= --cov-branch
-          coverage combine .coverage*
-          coverage xml -i
+            # Run tests
+            ./scripts/runtox.sh "py${{ matrix.python-version }}-asgi" --cov=tests --cov=sentry_sdk --cov-report= --cov-branch &&
+            coverage combine .coverage* &&
+            coverage xml -i
 
       - uses: codecov/codecov-action@v3
         with:

--- a/.github/workflows/test-integration-asgi.yml
+++ b/.github/workflows/test-integration-asgi.yml
@@ -26,7 +26,7 @@ jobs:
   test:
     name: asgi, python ${{ matrix.python-version }}, ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 45
+    timeout-minutes: 30
 
     strategy:
       fail-fast: false
@@ -51,7 +51,7 @@ jobs:
       - name: Test asgi
         uses: nick-fields/retry@v2
         with:
-          timeout_minutes: 45
+          timeout_minutes: 15
           max_attempts: 2
           retry_wait_seconds: 5
           shell: bash

--- a/.github/workflows/test-integration-aws_lambda.yml
+++ b/.github/workflows/test-integration-aws_lambda.yml
@@ -49,16 +49,20 @@ jobs:
           pip install coverage "tox>=3,<4"
 
       - name: Test aws_lambda
-        timeout-minutes: 45
-        shell: bash
-        run: |
-          set -x # print commands that are executed
-          coverage erase
+        uses: nick-fields/retry@v2
+        with:
+          timeout_minutes: 45
+          max_attempts: 2
+          retry_wait_seconds: 5
+          shell: bash
+          command: |
+            set -x # print commands that are executed
+            coverage erase
 
-          # Run tests
-          ./scripts/runtox.sh "py${{ matrix.python-version }}-aws_lambda" --cov=tests --cov=sentry_sdk --cov-report= --cov-branch
-          coverage combine .coverage*
-          coverage xml -i
+            # Run tests
+            ./scripts/runtox.sh "py${{ matrix.python-version }}-aws_lambda" --cov=tests --cov=sentry_sdk --cov-report= --cov-branch &&
+            coverage combine .coverage* &&
+            coverage xml -i
 
       - uses: codecov/codecov-action@v3
         with:

--- a/.github/workflows/test-integration-aws_lambda.yml
+++ b/.github/workflows/test-integration-aws_lambda.yml
@@ -26,7 +26,7 @@ jobs:
   test:
     name: aws_lambda, python ${{ matrix.python-version }}, ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 45
+    timeout-minutes: 30
 
     strategy:
       fail-fast: false
@@ -51,7 +51,7 @@ jobs:
       - name: Test aws_lambda
         uses: nick-fields/retry@v2
         with:
-          timeout_minutes: 45
+          timeout_minutes: 15
           max_attempts: 2
           retry_wait_seconds: 5
           shell: bash

--- a/.github/workflows/test-integration-beam.yml
+++ b/.github/workflows/test-integration-beam.yml
@@ -49,16 +49,20 @@ jobs:
           pip install coverage "tox>=3,<4"
 
       - name: Test beam
-        timeout-minutes: 45
-        shell: bash
-        run: |
-          set -x # print commands that are executed
-          coverage erase
+        uses: nick-fields/retry@v2
+        with:
+          timeout_minutes: 45
+          max_attempts: 2
+          retry_wait_seconds: 5
+          shell: bash
+          command: |
+            set -x # print commands that are executed
+            coverage erase
 
-          # Run tests
-          ./scripts/runtox.sh "py${{ matrix.python-version }}-beam" --cov=tests --cov=sentry_sdk --cov-report= --cov-branch
-          coverage combine .coverage*
-          coverage xml -i
+            # Run tests
+            ./scripts/runtox.sh "py${{ matrix.python-version }}-beam" --cov=tests --cov=sentry_sdk --cov-report= --cov-branch &&
+            coverage combine .coverage* &&
+            coverage xml -i
 
       - uses: codecov/codecov-action@v3
         with:

--- a/.github/workflows/test-integration-beam.yml
+++ b/.github/workflows/test-integration-beam.yml
@@ -26,7 +26,7 @@ jobs:
   test:
     name: beam, python ${{ matrix.python-version }}, ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 45
+    timeout-minutes: 30
 
     strategy:
       fail-fast: false
@@ -51,7 +51,7 @@ jobs:
       - name: Test beam
         uses: nick-fields/retry@v2
         with:
-          timeout_minutes: 45
+          timeout_minutes: 15
           max_attempts: 2
           retry_wait_seconds: 5
           shell: bash

--- a/.github/workflows/test-integration-boto3.yml
+++ b/.github/workflows/test-integration-boto3.yml
@@ -49,16 +49,20 @@ jobs:
           pip install coverage "tox>=3,<4"
 
       - name: Test boto3
-        timeout-minutes: 45
-        shell: bash
-        run: |
-          set -x # print commands that are executed
-          coverage erase
+        uses: nick-fields/retry@v2
+        with:
+          timeout_minutes: 45
+          max_attempts: 2
+          retry_wait_seconds: 5
+          shell: bash
+          command: |
+            set -x # print commands that are executed
+            coverage erase
 
-          # Run tests
-          ./scripts/runtox.sh "py${{ matrix.python-version }}-boto3" --cov=tests --cov=sentry_sdk --cov-report= --cov-branch
-          coverage combine .coverage*
-          coverage xml -i
+            # Run tests
+            ./scripts/runtox.sh "py${{ matrix.python-version }}-boto3" --cov=tests --cov=sentry_sdk --cov-report= --cov-branch &&
+            coverage combine .coverage* &&
+            coverage xml -i
 
       - uses: codecov/codecov-action@v3
         with:

--- a/.github/workflows/test-integration-boto3.yml
+++ b/.github/workflows/test-integration-boto3.yml
@@ -26,7 +26,7 @@ jobs:
   test:
     name: boto3, python ${{ matrix.python-version }}, ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 45
+    timeout-minutes: 30
 
     strategy:
       fail-fast: false
@@ -51,7 +51,7 @@ jobs:
       - name: Test boto3
         uses: nick-fields/retry@v2
         with:
-          timeout_minutes: 45
+          timeout_minutes: 15
           max_attempts: 2
           retry_wait_seconds: 5
           shell: bash

--- a/.github/workflows/test-integration-bottle.yml
+++ b/.github/workflows/test-integration-bottle.yml
@@ -26,7 +26,7 @@ jobs:
   test:
     name: bottle, python ${{ matrix.python-version }}, ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 45
+    timeout-minutes: 30
 
     strategy:
       fail-fast: false
@@ -51,7 +51,7 @@ jobs:
       - name: Test bottle
         uses: nick-fields/retry@v2
         with:
-          timeout_minutes: 45
+          timeout_minutes: 15
           max_attempts: 2
           retry_wait_seconds: 5
           shell: bash

--- a/.github/workflows/test-integration-bottle.yml
+++ b/.github/workflows/test-integration-bottle.yml
@@ -49,16 +49,20 @@ jobs:
           pip install coverage "tox>=3,<4"
 
       - name: Test bottle
-        timeout-minutes: 45
-        shell: bash
-        run: |
-          set -x # print commands that are executed
-          coverage erase
+        uses: nick-fields/retry@v2
+        with:
+          timeout_minutes: 45
+          max_attempts: 2
+          retry_wait_seconds: 5
+          shell: bash
+          command: |
+            set -x # print commands that are executed
+            coverage erase
 
-          # Run tests
-          ./scripts/runtox.sh "py${{ matrix.python-version }}-bottle" --cov=tests --cov=sentry_sdk --cov-report= --cov-branch
-          coverage combine .coverage*
-          coverage xml -i
+            # Run tests
+            ./scripts/runtox.sh "py${{ matrix.python-version }}-bottle" --cov=tests --cov=sentry_sdk --cov-report= --cov-branch &&
+            coverage combine .coverage* &&
+            coverage xml -i
 
       - uses: codecov/codecov-action@v3
         with:

--- a/.github/workflows/test-integration-celery.yml
+++ b/.github/workflows/test-integration-celery.yml
@@ -49,16 +49,20 @@ jobs:
           pip install coverage "tox>=3,<4"
 
       - name: Test celery
-        timeout-minutes: 45
-        shell: bash
-        run: |
-          set -x # print commands that are executed
-          coverage erase
+        uses: nick-fields/retry@v2
+        with:
+          timeout_minutes: 45
+          max_attempts: 2
+          retry_wait_seconds: 5
+          shell: bash
+          command: |
+            set -x # print commands that are executed
+            coverage erase
 
-          # Run tests
-          ./scripts/runtox.sh "py${{ matrix.python-version }}-celery" --cov=tests --cov=sentry_sdk --cov-report= --cov-branch
-          coverage combine .coverage*
-          coverage xml -i
+            # Run tests
+            ./scripts/runtox.sh "py${{ matrix.python-version }}-celery" --cov=tests --cov=sentry_sdk --cov-report= --cov-branch &&
+            coverage combine .coverage* &&
+            coverage xml -i
 
       - uses: codecov/codecov-action@v3
         with:

--- a/.github/workflows/test-integration-celery.yml
+++ b/.github/workflows/test-integration-celery.yml
@@ -26,7 +26,7 @@ jobs:
   test:
     name: celery, python ${{ matrix.python-version }}, ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 45
+    timeout-minutes: 30
 
     strategy:
       fail-fast: false
@@ -51,7 +51,7 @@ jobs:
       - name: Test celery
         uses: nick-fields/retry@v2
         with:
-          timeout_minutes: 45
+          timeout_minutes: 15
           max_attempts: 2
           retry_wait_seconds: 5
           shell: bash

--- a/.github/workflows/test-integration-chalice.yml
+++ b/.github/workflows/test-integration-chalice.yml
@@ -26,7 +26,7 @@ jobs:
   test:
     name: chalice, python ${{ matrix.python-version }}, ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 45
+    timeout-minutes: 30
 
     strategy:
       fail-fast: false
@@ -51,7 +51,7 @@ jobs:
       - name: Test chalice
         uses: nick-fields/retry@v2
         with:
-          timeout_minutes: 45
+          timeout_minutes: 15
           max_attempts: 2
           retry_wait_seconds: 5
           shell: bash

--- a/.github/workflows/test-integration-chalice.yml
+++ b/.github/workflows/test-integration-chalice.yml
@@ -49,16 +49,20 @@ jobs:
           pip install coverage "tox>=3,<4"
 
       - name: Test chalice
-        timeout-minutes: 45
-        shell: bash
-        run: |
-          set -x # print commands that are executed
-          coverage erase
+        uses: nick-fields/retry@v2
+        with:
+          timeout_minutes: 45
+          max_attempts: 2
+          retry_wait_seconds: 5
+          shell: bash
+          command: |
+            set -x # print commands that are executed
+            coverage erase
 
-          # Run tests
-          ./scripts/runtox.sh "py${{ matrix.python-version }}-chalice" --cov=tests --cov=sentry_sdk --cov-report= --cov-branch
-          coverage combine .coverage*
-          coverage xml -i
+            # Run tests
+            ./scripts/runtox.sh "py${{ matrix.python-version }}-chalice" --cov=tests --cov=sentry_sdk --cov-report= --cov-branch &&
+            coverage combine .coverage* &&
+            coverage xml -i
 
       - uses: codecov/codecov-action@v3
         with:

--- a/.github/workflows/test-integration-cloud_resource_context.yml
+++ b/.github/workflows/test-integration-cloud_resource_context.yml
@@ -49,16 +49,20 @@ jobs:
           pip install coverage "tox>=3,<4"
 
       - name: Test cloud_resource_context
-        timeout-minutes: 45
-        shell: bash
-        run: |
-          set -x # print commands that are executed
-          coverage erase
+        uses: nick-fields/retry@v2
+        with:
+          timeout_minutes: 45
+          max_attempts: 2
+          retry_wait_seconds: 5
+          shell: bash
+          command: |
+            set -x # print commands that are executed
+            coverage erase
 
-          # Run tests
-          ./scripts/runtox.sh "py${{ matrix.python-version }}-cloud_resource_context" --cov=tests --cov=sentry_sdk --cov-report= --cov-branch
-          coverage combine .coverage*
-          coverage xml -i
+            # Run tests
+            ./scripts/runtox.sh "py${{ matrix.python-version }}-cloud_resource_context" --cov=tests --cov=sentry_sdk --cov-report= --cov-branch &&
+            coverage combine .coverage* &&
+            coverage xml -i
 
       - uses: codecov/codecov-action@v3
         with:

--- a/.github/workflows/test-integration-cloud_resource_context.yml
+++ b/.github/workflows/test-integration-cloud_resource_context.yml
@@ -26,7 +26,7 @@ jobs:
   test:
     name: cloud_resource_context, python ${{ matrix.python-version }}, ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 45
+    timeout-minutes: 30
 
     strategy:
       fail-fast: false
@@ -51,7 +51,7 @@ jobs:
       - name: Test cloud_resource_context
         uses: nick-fields/retry@v2
         with:
-          timeout_minutes: 45
+          timeout_minutes: 15
           max_attempts: 2
           retry_wait_seconds: 5
           shell: bash

--- a/.github/workflows/test-integration-django.yml
+++ b/.github/workflows/test-integration-django.yml
@@ -67,16 +67,20 @@ jobs:
           pip install coverage "tox>=3,<4"
 
       - name: Test django
-        timeout-minutes: 45
-        shell: bash
-        run: |
-          set -x # print commands that are executed
-          coverage erase
+        uses: nick-fields/retry@v2
+        with:
+          timeout_minutes: 45
+          max_attempts: 2
+          retry_wait_seconds: 5
+          shell: bash
+          command: |
+            set -x # print commands that are executed
+            coverage erase
 
-          # Run tests
-          ./scripts/runtox.sh "py${{ matrix.python-version }}-django" --cov=tests --cov=sentry_sdk --cov-report= --cov-branch
-          coverage combine .coverage*
-          coverage xml -i
+            # Run tests
+            ./scripts/runtox.sh "py${{ matrix.python-version }}-django" --cov=tests --cov=sentry_sdk --cov-report= --cov-branch &&
+            coverage combine .coverage* &&
+            coverage xml -i
 
       - uses: codecov/codecov-action@v3
         with:

--- a/.github/workflows/test-integration-django.yml
+++ b/.github/workflows/test-integration-django.yml
@@ -26,7 +26,7 @@ jobs:
   test:
     name: django, python ${{ matrix.python-version }}, ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 45
+    timeout-minutes: 30
 
     strategy:
       fail-fast: false
@@ -69,7 +69,7 @@ jobs:
       - name: Test django
         uses: nick-fields/retry@v2
         with:
-          timeout_minutes: 45
+          timeout_minutes: 15
           max_attempts: 2
           retry_wait_seconds: 5
           shell: bash

--- a/.github/workflows/test-integration-falcon.yml
+++ b/.github/workflows/test-integration-falcon.yml
@@ -49,16 +49,20 @@ jobs:
           pip install coverage "tox>=3,<4"
 
       - name: Test falcon
-        timeout-minutes: 45
-        shell: bash
-        run: |
-          set -x # print commands that are executed
-          coverage erase
+        uses: nick-fields/retry@v2
+        with:
+          timeout_minutes: 45
+          max_attempts: 2
+          retry_wait_seconds: 5
+          shell: bash
+          command: |
+            set -x # print commands that are executed
+            coverage erase
 
-          # Run tests
-          ./scripts/runtox.sh "py${{ matrix.python-version }}-falcon" --cov=tests --cov=sentry_sdk --cov-report= --cov-branch
-          coverage combine .coverage*
-          coverage xml -i
+            # Run tests
+            ./scripts/runtox.sh "py${{ matrix.python-version }}-falcon" --cov=tests --cov=sentry_sdk --cov-report= --cov-branch &&
+            coverage combine .coverage* &&
+            coverage xml -i
 
       - uses: codecov/codecov-action@v3
         with:

--- a/.github/workflows/test-integration-falcon.yml
+++ b/.github/workflows/test-integration-falcon.yml
@@ -26,7 +26,7 @@ jobs:
   test:
     name: falcon, python ${{ matrix.python-version }}, ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 45
+    timeout-minutes: 30
 
     strategy:
       fail-fast: false
@@ -51,7 +51,7 @@ jobs:
       - name: Test falcon
         uses: nick-fields/retry@v2
         with:
-          timeout_minutes: 45
+          timeout_minutes: 15
           max_attempts: 2
           retry_wait_seconds: 5
           shell: bash

--- a/.github/workflows/test-integration-fastapi.yml
+++ b/.github/workflows/test-integration-fastapi.yml
@@ -49,16 +49,20 @@ jobs:
           pip install coverage "tox>=3,<4"
 
       - name: Test fastapi
-        timeout-minutes: 45
-        shell: bash
-        run: |
-          set -x # print commands that are executed
-          coverage erase
+        uses: nick-fields/retry@v2
+        with:
+          timeout_minutes: 45
+          max_attempts: 2
+          retry_wait_seconds: 5
+          shell: bash
+          command: |
+            set -x # print commands that are executed
+            coverage erase
 
-          # Run tests
-          ./scripts/runtox.sh "py${{ matrix.python-version }}-fastapi" --cov=tests --cov=sentry_sdk --cov-report= --cov-branch
-          coverage combine .coverage*
-          coverage xml -i
+            # Run tests
+            ./scripts/runtox.sh "py${{ matrix.python-version }}-fastapi" --cov=tests --cov=sentry_sdk --cov-report= --cov-branch &&
+            coverage combine .coverage* &&
+            coverage xml -i
 
       - uses: codecov/codecov-action@v3
         with:

--- a/.github/workflows/test-integration-fastapi.yml
+++ b/.github/workflows/test-integration-fastapi.yml
@@ -26,7 +26,7 @@ jobs:
   test:
     name: fastapi, python ${{ matrix.python-version }}, ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 45
+    timeout-minutes: 30
 
     strategy:
       fail-fast: false
@@ -51,7 +51,7 @@ jobs:
       - name: Test fastapi
         uses: nick-fields/retry@v2
         with:
-          timeout_minutes: 45
+          timeout_minutes: 15
           max_attempts: 2
           retry_wait_seconds: 5
           shell: bash

--- a/.github/workflows/test-integration-flask.yml
+++ b/.github/workflows/test-integration-flask.yml
@@ -26,7 +26,7 @@ jobs:
   test:
     name: flask, python ${{ matrix.python-version }}, ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 45
+    timeout-minutes: 30
 
     strategy:
       fail-fast: false
@@ -51,7 +51,7 @@ jobs:
       - name: Test flask
         uses: nick-fields/retry@v2
         with:
-          timeout_minutes: 45
+          timeout_minutes: 15
           max_attempts: 2
           retry_wait_seconds: 5
           shell: bash

--- a/.github/workflows/test-integration-flask.yml
+++ b/.github/workflows/test-integration-flask.yml
@@ -49,16 +49,20 @@ jobs:
           pip install coverage "tox>=3,<4"
 
       - name: Test flask
-        timeout-minutes: 45
-        shell: bash
-        run: |
-          set -x # print commands that are executed
-          coverage erase
+        uses: nick-fields/retry@v2
+        with:
+          timeout_minutes: 45
+          max_attempts: 2
+          retry_wait_seconds: 5
+          shell: bash
+          command: |
+            set -x # print commands that are executed
+            coverage erase
 
-          # Run tests
-          ./scripts/runtox.sh "py${{ matrix.python-version }}-flask" --cov=tests --cov=sentry_sdk --cov-report= --cov-branch
-          coverage combine .coverage*
-          coverage xml -i
+            # Run tests
+            ./scripts/runtox.sh "py${{ matrix.python-version }}-flask" --cov=tests --cov=sentry_sdk --cov-report= --cov-branch &&
+            coverage combine .coverage* &&
+            coverage xml -i
 
       - uses: codecov/codecov-action@v3
         with:

--- a/.github/workflows/test-integration-gcp.yml
+++ b/.github/workflows/test-integration-gcp.yml
@@ -49,16 +49,20 @@ jobs:
           pip install coverage "tox>=3,<4"
 
       - name: Test gcp
-        timeout-minutes: 45
-        shell: bash
-        run: |
-          set -x # print commands that are executed
-          coverage erase
+        uses: nick-fields/retry@v2
+        with:
+          timeout_minutes: 45
+          max_attempts: 2
+          retry_wait_seconds: 5
+          shell: bash
+          command: |
+            set -x # print commands that are executed
+            coverage erase
 
-          # Run tests
-          ./scripts/runtox.sh "py${{ matrix.python-version }}-gcp" --cov=tests --cov=sentry_sdk --cov-report= --cov-branch
-          coverage combine .coverage*
-          coverage xml -i
+            # Run tests
+            ./scripts/runtox.sh "py${{ matrix.python-version }}-gcp" --cov=tests --cov=sentry_sdk --cov-report= --cov-branch &&
+            coverage combine .coverage* &&
+            coverage xml -i
 
       - uses: codecov/codecov-action@v3
         with:

--- a/.github/workflows/test-integration-gcp.yml
+++ b/.github/workflows/test-integration-gcp.yml
@@ -26,7 +26,7 @@ jobs:
   test:
     name: gcp, python ${{ matrix.python-version }}, ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 45
+    timeout-minutes: 30
 
     strategy:
       fail-fast: false
@@ -51,7 +51,7 @@ jobs:
       - name: Test gcp
         uses: nick-fields/retry@v2
         with:
-          timeout_minutes: 45
+          timeout_minutes: 15
           max_attempts: 2
           retry_wait_seconds: 5
           shell: bash

--- a/.github/workflows/test-integration-gevent.yml
+++ b/.github/workflows/test-integration-gevent.yml
@@ -49,16 +49,20 @@ jobs:
           pip install coverage "tox>=3,<4"
 
       - name: Test gevent
-        timeout-minutes: 45
-        shell: bash
-        run: |
-          set -x # print commands that are executed
-          coverage erase
+        uses: nick-fields/retry@v2
+        with:
+          timeout_minutes: 45
+          max_attempts: 2
+          retry_wait_seconds: 5
+          shell: bash
+          command: |
+            set -x # print commands that are executed
+            coverage erase
 
-          # Run tests
-          ./scripts/runtox.sh "py${{ matrix.python-version }}-gevent" --cov=tests --cov=sentry_sdk --cov-report= --cov-branch
-          coverage combine .coverage*
-          coverage xml -i
+            # Run tests
+            ./scripts/runtox.sh "py${{ matrix.python-version }}-gevent" --cov=tests --cov=sentry_sdk --cov-report= --cov-branch &&
+            coverage combine .coverage* &&
+            coverage xml -i
 
       - uses: codecov/codecov-action@v3
         with:

--- a/.github/workflows/test-integration-gevent.yml
+++ b/.github/workflows/test-integration-gevent.yml
@@ -26,7 +26,7 @@ jobs:
   test:
     name: gevent, python ${{ matrix.python-version }}, ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 45
+    timeout-minutes: 30
 
     strategy:
       fail-fast: false
@@ -51,7 +51,7 @@ jobs:
       - name: Test gevent
         uses: nick-fields/retry@v2
         with:
-          timeout_minutes: 45
+          timeout_minutes: 15
           max_attempts: 2
           retry_wait_seconds: 5
           shell: bash

--- a/.github/workflows/test-integration-grpc.yml
+++ b/.github/workflows/test-integration-grpc.yml
@@ -49,16 +49,20 @@ jobs:
           pip install coverage "tox>=3,<4"
 
       - name: Test grpc
-        timeout-minutes: 45
-        shell: bash
-        run: |
-          set -x # print commands that are executed
-          coverage erase
+        uses: nick-fields/retry@v2
+        with:
+          timeout_minutes: 45
+          max_attempts: 2
+          retry_wait_seconds: 5
+          shell: bash
+          command: |
+            set -x # print commands that are executed
+            coverage erase
 
-          # Run tests
-          ./scripts/runtox.sh "py${{ matrix.python-version }}-grpc" --cov=tests --cov=sentry_sdk --cov-report= --cov-branch
-          coverage combine .coverage*
-          coverage xml -i
+            # Run tests
+            ./scripts/runtox.sh "py${{ matrix.python-version }}-grpc" --cov=tests --cov=sentry_sdk --cov-report= --cov-branch &&
+            coverage combine .coverage* &&
+            coverage xml -i
 
       - uses: codecov/codecov-action@v3
         with:

--- a/.github/workflows/test-integration-grpc.yml
+++ b/.github/workflows/test-integration-grpc.yml
@@ -26,7 +26,7 @@ jobs:
   test:
     name: grpc, python ${{ matrix.python-version }}, ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 45
+    timeout-minutes: 30
 
     strategy:
       fail-fast: false
@@ -51,7 +51,7 @@ jobs:
       - name: Test grpc
         uses: nick-fields/retry@v2
         with:
-          timeout_minutes: 45
+          timeout_minutes: 15
           max_attempts: 2
           retry_wait_seconds: 5
           shell: bash

--- a/.github/workflows/test-integration-httpx.yml
+++ b/.github/workflows/test-integration-httpx.yml
@@ -49,16 +49,20 @@ jobs:
           pip install coverage "tox>=3,<4"
 
       - name: Test httpx
-        timeout-minutes: 45
-        shell: bash
-        run: |
-          set -x # print commands that are executed
-          coverage erase
+        uses: nick-fields/retry@v2
+        with:
+          timeout_minutes: 45
+          max_attempts: 2
+          retry_wait_seconds: 5
+          shell: bash
+          command: |
+            set -x # print commands that are executed
+            coverage erase
 
-          # Run tests
-          ./scripts/runtox.sh "py${{ matrix.python-version }}-httpx" --cov=tests --cov=sentry_sdk --cov-report= --cov-branch
-          coverage combine .coverage*
-          coverage xml -i
+            # Run tests
+            ./scripts/runtox.sh "py${{ matrix.python-version }}-httpx" --cov=tests --cov=sentry_sdk --cov-report= --cov-branch &&
+            coverage combine .coverage* &&
+            coverage xml -i
 
       - uses: codecov/codecov-action@v3
         with:

--- a/.github/workflows/test-integration-httpx.yml
+++ b/.github/workflows/test-integration-httpx.yml
@@ -26,7 +26,7 @@ jobs:
   test:
     name: httpx, python ${{ matrix.python-version }}, ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 45
+    timeout-minutes: 30
 
     strategy:
       fail-fast: false
@@ -51,7 +51,7 @@ jobs:
       - name: Test httpx
         uses: nick-fields/retry@v2
         with:
-          timeout_minutes: 45
+          timeout_minutes: 15
           max_attempts: 2
           retry_wait_seconds: 5
           shell: bash

--- a/.github/workflows/test-integration-huey.yml
+++ b/.github/workflows/test-integration-huey.yml
@@ -49,16 +49,20 @@ jobs:
           pip install coverage "tox>=3,<4"
 
       - name: Test huey
-        timeout-minutes: 45
-        shell: bash
-        run: |
-          set -x # print commands that are executed
-          coverage erase
+        uses: nick-fields/retry@v2
+        with:
+          timeout_minutes: 45
+          max_attempts: 2
+          retry_wait_seconds: 5
+          shell: bash
+          command: |
+            set -x # print commands that are executed
+            coverage erase
 
-          # Run tests
-          ./scripts/runtox.sh "py${{ matrix.python-version }}-huey" --cov=tests --cov=sentry_sdk --cov-report= --cov-branch
-          coverage combine .coverage*
-          coverage xml -i
+            # Run tests
+            ./scripts/runtox.sh "py${{ matrix.python-version }}-huey" --cov=tests --cov=sentry_sdk --cov-report= --cov-branch &&
+            coverage combine .coverage* &&
+            coverage xml -i
 
       - uses: codecov/codecov-action@v3
         with:

--- a/.github/workflows/test-integration-huey.yml
+++ b/.github/workflows/test-integration-huey.yml
@@ -26,7 +26,7 @@ jobs:
   test:
     name: huey, python ${{ matrix.python-version }}, ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 45
+    timeout-minutes: 30
 
     strategy:
       fail-fast: false
@@ -51,7 +51,7 @@ jobs:
       - name: Test huey
         uses: nick-fields/retry@v2
         with:
-          timeout_minutes: 45
+          timeout_minutes: 15
           max_attempts: 2
           retry_wait_seconds: 5
           shell: bash

--- a/.github/workflows/test-integration-loguru.yml
+++ b/.github/workflows/test-integration-loguru.yml
@@ -49,16 +49,20 @@ jobs:
           pip install coverage "tox>=3,<4"
 
       - name: Test loguru
-        timeout-minutes: 45
-        shell: bash
-        run: |
-          set -x # print commands that are executed
-          coverage erase
+        uses: nick-fields/retry@v2
+        with:
+          timeout_minutes: 45
+          max_attempts: 2
+          retry_wait_seconds: 5
+          shell: bash
+          command: |
+            set -x # print commands that are executed
+            coverage erase
 
-          # Run tests
-          ./scripts/runtox.sh "py${{ matrix.python-version }}-loguru" --cov=tests --cov=sentry_sdk --cov-report= --cov-branch
-          coverage combine .coverage*
-          coverage xml -i
+            # Run tests
+            ./scripts/runtox.sh "py${{ matrix.python-version }}-loguru" --cov=tests --cov=sentry_sdk --cov-report= --cov-branch &&
+            coverage combine .coverage* &&
+            coverage xml -i
 
       - uses: codecov/codecov-action@v3
         with:

--- a/.github/workflows/test-integration-loguru.yml
+++ b/.github/workflows/test-integration-loguru.yml
@@ -26,7 +26,7 @@ jobs:
   test:
     name: loguru, python ${{ matrix.python-version }}, ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 45
+    timeout-minutes: 30
 
     strategy:
       fail-fast: false
@@ -51,7 +51,7 @@ jobs:
       - name: Test loguru
         uses: nick-fields/retry@v2
         with:
-          timeout_minutes: 45
+          timeout_minutes: 15
           max_attempts: 2
           retry_wait_seconds: 5
           shell: bash

--- a/.github/workflows/test-integration-opentelemetry.yml
+++ b/.github/workflows/test-integration-opentelemetry.yml
@@ -26,7 +26,7 @@ jobs:
   test:
     name: opentelemetry, python ${{ matrix.python-version }}, ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 45
+    timeout-minutes: 30
 
     strategy:
       fail-fast: false
@@ -51,7 +51,7 @@ jobs:
       - name: Test opentelemetry
         uses: nick-fields/retry@v2
         with:
-          timeout_minutes: 45
+          timeout_minutes: 15
           max_attempts: 2
           retry_wait_seconds: 5
           shell: bash

--- a/.github/workflows/test-integration-opentelemetry.yml
+++ b/.github/workflows/test-integration-opentelemetry.yml
@@ -49,16 +49,20 @@ jobs:
           pip install coverage "tox>=3,<4"
 
       - name: Test opentelemetry
-        timeout-minutes: 45
-        shell: bash
-        run: |
-          set -x # print commands that are executed
-          coverage erase
+        uses: nick-fields/retry@v2
+        with:
+          timeout_minutes: 45
+          max_attempts: 2
+          retry_wait_seconds: 5
+          shell: bash
+          command: |
+            set -x # print commands that are executed
+            coverage erase
 
-          # Run tests
-          ./scripts/runtox.sh "py${{ matrix.python-version }}-opentelemetry" --cov=tests --cov=sentry_sdk --cov-report= --cov-branch
-          coverage combine .coverage*
-          coverage xml -i
+            # Run tests
+            ./scripts/runtox.sh "py${{ matrix.python-version }}-opentelemetry" --cov=tests --cov=sentry_sdk --cov-report= --cov-branch &&
+            coverage combine .coverage* &&
+            coverage xml -i
 
       - uses: codecov/codecov-action@v3
         with:

--- a/.github/workflows/test-integration-pure_eval.yml
+++ b/.github/workflows/test-integration-pure_eval.yml
@@ -49,16 +49,20 @@ jobs:
           pip install coverage "tox>=3,<4"
 
       - name: Test pure_eval
-        timeout-minutes: 45
-        shell: bash
-        run: |
-          set -x # print commands that are executed
-          coverage erase
+        uses: nick-fields/retry@v2
+        with:
+          timeout_minutes: 45
+          max_attempts: 2
+          retry_wait_seconds: 5
+          shell: bash
+          command: |
+            set -x # print commands that are executed
+            coverage erase
 
-          # Run tests
-          ./scripts/runtox.sh "py${{ matrix.python-version }}-pure_eval" --cov=tests --cov=sentry_sdk --cov-report= --cov-branch
-          coverage combine .coverage*
-          coverage xml -i
+            # Run tests
+            ./scripts/runtox.sh "py${{ matrix.python-version }}-pure_eval" --cov=tests --cov=sentry_sdk --cov-report= --cov-branch &&
+            coverage combine .coverage* &&
+            coverage xml -i
 
       - uses: codecov/codecov-action@v3
         with:

--- a/.github/workflows/test-integration-pure_eval.yml
+++ b/.github/workflows/test-integration-pure_eval.yml
@@ -26,7 +26,7 @@ jobs:
   test:
     name: pure_eval, python ${{ matrix.python-version }}, ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 45
+    timeout-minutes: 30
 
     strategy:
       fail-fast: false
@@ -51,7 +51,7 @@ jobs:
       - name: Test pure_eval
         uses: nick-fields/retry@v2
         with:
-          timeout_minutes: 45
+          timeout_minutes: 15
           max_attempts: 2
           retry_wait_seconds: 5
           shell: bash

--- a/.github/workflows/test-integration-pymongo.yml
+++ b/.github/workflows/test-integration-pymongo.yml
@@ -26,7 +26,7 @@ jobs:
   test:
     name: pymongo, python ${{ matrix.python-version }}, ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 45
+    timeout-minutes: 30
 
     strategy:
       fail-fast: false
@@ -51,7 +51,7 @@ jobs:
       - name: Test pymongo
         uses: nick-fields/retry@v2
         with:
-          timeout_minutes: 45
+          timeout_minutes: 15
           max_attempts: 2
           retry_wait_seconds: 5
           shell: bash

--- a/.github/workflows/test-integration-pymongo.yml
+++ b/.github/workflows/test-integration-pymongo.yml
@@ -49,16 +49,20 @@ jobs:
           pip install coverage "tox>=3,<4"
 
       - name: Test pymongo
-        timeout-minutes: 45
-        shell: bash
-        run: |
-          set -x # print commands that are executed
-          coverage erase
+        uses: nick-fields/retry@v2
+        with:
+          timeout_minutes: 45
+          max_attempts: 2
+          retry_wait_seconds: 5
+          shell: bash
+          command: |
+            set -x # print commands that are executed
+            coverage erase
 
-          # Run tests
-          ./scripts/runtox.sh "py${{ matrix.python-version }}-pymongo" --cov=tests --cov=sentry_sdk --cov-report= --cov-branch
-          coverage combine .coverage*
-          coverage xml -i
+            # Run tests
+            ./scripts/runtox.sh "py${{ matrix.python-version }}-pymongo" --cov=tests --cov=sentry_sdk --cov-report= --cov-branch &&
+            coverage combine .coverage* &&
+            coverage xml -i
 
       - uses: codecov/codecov-action@v3
         with:

--- a/.github/workflows/test-integration-pyramid.yml
+++ b/.github/workflows/test-integration-pyramid.yml
@@ -26,7 +26,7 @@ jobs:
   test:
     name: pyramid, python ${{ matrix.python-version }}, ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 45
+    timeout-minutes: 30
 
     strategy:
       fail-fast: false
@@ -51,7 +51,7 @@ jobs:
       - name: Test pyramid
         uses: nick-fields/retry@v2
         with:
-          timeout_minutes: 45
+          timeout_minutes: 15
           max_attempts: 2
           retry_wait_seconds: 5
           shell: bash

--- a/.github/workflows/test-integration-pyramid.yml
+++ b/.github/workflows/test-integration-pyramid.yml
@@ -49,16 +49,20 @@ jobs:
           pip install coverage "tox>=3,<4"
 
       - name: Test pyramid
-        timeout-minutes: 45
-        shell: bash
-        run: |
-          set -x # print commands that are executed
-          coverage erase
+        uses: nick-fields/retry@v2
+        with:
+          timeout_minutes: 45
+          max_attempts: 2
+          retry_wait_seconds: 5
+          shell: bash
+          command: |
+            set -x # print commands that are executed
+            coverage erase
 
-          # Run tests
-          ./scripts/runtox.sh "py${{ matrix.python-version }}-pyramid" --cov=tests --cov=sentry_sdk --cov-report= --cov-branch
-          coverage combine .coverage*
-          coverage xml -i
+            # Run tests
+            ./scripts/runtox.sh "py${{ matrix.python-version }}-pyramid" --cov=tests --cov=sentry_sdk --cov-report= --cov-branch &&
+            coverage combine .coverage* &&
+            coverage xml -i
 
       - uses: codecov/codecov-action@v3
         with:

--- a/.github/workflows/test-integration-quart.yml
+++ b/.github/workflows/test-integration-quart.yml
@@ -49,16 +49,20 @@ jobs:
           pip install coverage "tox>=3,<4"
 
       - name: Test quart
-        timeout-minutes: 45
-        shell: bash
-        run: |
-          set -x # print commands that are executed
-          coverage erase
+        uses: nick-fields/retry@v2
+        with:
+          timeout_minutes: 45
+          max_attempts: 2
+          retry_wait_seconds: 5
+          shell: bash
+          command: |
+            set -x # print commands that are executed
+            coverage erase
 
-          # Run tests
-          ./scripts/runtox.sh "py${{ matrix.python-version }}-quart" --cov=tests --cov=sentry_sdk --cov-report= --cov-branch
-          coverage combine .coverage*
-          coverage xml -i
+            # Run tests
+            ./scripts/runtox.sh "py${{ matrix.python-version }}-quart" --cov=tests --cov=sentry_sdk --cov-report= --cov-branch &&
+            coverage combine .coverage* &&
+            coverage xml -i
 
       - uses: codecov/codecov-action@v3
         with:

--- a/.github/workflows/test-integration-quart.yml
+++ b/.github/workflows/test-integration-quart.yml
@@ -26,7 +26,7 @@ jobs:
   test:
     name: quart, python ${{ matrix.python-version }}, ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 45
+    timeout-minutes: 30
 
     strategy:
       fail-fast: false
@@ -51,7 +51,7 @@ jobs:
       - name: Test quart
         uses: nick-fields/retry@v2
         with:
-          timeout_minutes: 45
+          timeout_minutes: 15
           max_attempts: 2
           retry_wait_seconds: 5
           shell: bash

--- a/.github/workflows/test-integration-redis.yml
+++ b/.github/workflows/test-integration-redis.yml
@@ -49,16 +49,20 @@ jobs:
           pip install coverage "tox>=3,<4"
 
       - name: Test redis
-        timeout-minutes: 45
-        shell: bash
-        run: |
-          set -x # print commands that are executed
-          coverage erase
+        uses: nick-fields/retry@v2
+        with:
+          timeout_minutes: 45
+          max_attempts: 2
+          retry_wait_seconds: 5
+          shell: bash
+          command: |
+            set -x # print commands that are executed
+            coverage erase
 
-          # Run tests
-          ./scripts/runtox.sh "py${{ matrix.python-version }}-redis" --cov=tests --cov=sentry_sdk --cov-report= --cov-branch
-          coverage combine .coverage*
-          coverage xml -i
+            # Run tests
+            ./scripts/runtox.sh "py${{ matrix.python-version }}-redis" --cov=tests --cov=sentry_sdk --cov-report= --cov-branch &&
+            coverage combine .coverage* &&
+            coverage xml -i
 
       - uses: codecov/codecov-action@v3
         with:

--- a/.github/workflows/test-integration-redis.yml
+++ b/.github/workflows/test-integration-redis.yml
@@ -26,7 +26,7 @@ jobs:
   test:
     name: redis, python ${{ matrix.python-version }}, ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 45
+    timeout-minutes: 30
 
     strategy:
       fail-fast: false
@@ -51,7 +51,7 @@ jobs:
       - name: Test redis
         uses: nick-fields/retry@v2
         with:
-          timeout_minutes: 45
+          timeout_minutes: 15
           max_attempts: 2
           retry_wait_seconds: 5
           shell: bash

--- a/.github/workflows/test-integration-rediscluster.yml
+++ b/.github/workflows/test-integration-rediscluster.yml
@@ -26,7 +26,7 @@ jobs:
   test:
     name: rediscluster, python ${{ matrix.python-version }}, ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 45
+    timeout-minutes: 30
 
     strategy:
       fail-fast: false
@@ -51,7 +51,7 @@ jobs:
       - name: Test rediscluster
         uses: nick-fields/retry@v2
         with:
-          timeout_minutes: 45
+          timeout_minutes: 15
           max_attempts: 2
           retry_wait_seconds: 5
           shell: bash

--- a/.github/workflows/test-integration-rediscluster.yml
+++ b/.github/workflows/test-integration-rediscluster.yml
@@ -49,16 +49,20 @@ jobs:
           pip install coverage "tox>=3,<4"
 
       - name: Test rediscluster
-        timeout-minutes: 45
-        shell: bash
-        run: |
-          set -x # print commands that are executed
-          coverage erase
+        uses: nick-fields/retry@v2
+        with:
+          timeout_minutes: 45
+          max_attempts: 2
+          retry_wait_seconds: 5
+          shell: bash
+          command: |
+            set -x # print commands that are executed
+            coverage erase
 
-          # Run tests
-          ./scripts/runtox.sh "py${{ matrix.python-version }}-rediscluster" --cov=tests --cov=sentry_sdk --cov-report= --cov-branch
-          coverage combine .coverage*
-          coverage xml -i
+            # Run tests
+            ./scripts/runtox.sh "py${{ matrix.python-version }}-rediscluster" --cov=tests --cov=sentry_sdk --cov-report= --cov-branch &&
+            coverage combine .coverage* &&
+            coverage xml -i
 
       - uses: codecov/codecov-action@v3
         with:

--- a/.github/workflows/test-integration-requests.yml
+++ b/.github/workflows/test-integration-requests.yml
@@ -49,16 +49,20 @@ jobs:
           pip install coverage "tox>=3,<4"
 
       - name: Test requests
-        timeout-minutes: 45
-        shell: bash
-        run: |
-          set -x # print commands that are executed
-          coverage erase
+        uses: nick-fields/retry@v2
+        with:
+          timeout_minutes: 45
+          max_attempts: 2
+          retry_wait_seconds: 5
+          shell: bash
+          command: |
+            set -x # print commands that are executed
+            coverage erase
 
-          # Run tests
-          ./scripts/runtox.sh "py${{ matrix.python-version }}-requests" --cov=tests --cov=sentry_sdk --cov-report= --cov-branch
-          coverage combine .coverage*
-          coverage xml -i
+            # Run tests
+            ./scripts/runtox.sh "py${{ matrix.python-version }}-requests" --cov=tests --cov=sentry_sdk --cov-report= --cov-branch &&
+            coverage combine .coverage* &&
+            coverage xml -i
 
       - uses: codecov/codecov-action@v3
         with:

--- a/.github/workflows/test-integration-requests.yml
+++ b/.github/workflows/test-integration-requests.yml
@@ -26,7 +26,7 @@ jobs:
   test:
     name: requests, python ${{ matrix.python-version }}, ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 45
+    timeout-minutes: 30
 
     strategy:
       fail-fast: false
@@ -51,7 +51,7 @@ jobs:
       - name: Test requests
         uses: nick-fields/retry@v2
         with:
-          timeout_minutes: 45
+          timeout_minutes: 15
           max_attempts: 2
           retry_wait_seconds: 5
           shell: bash

--- a/.github/workflows/test-integration-rq.yml
+++ b/.github/workflows/test-integration-rq.yml
@@ -49,16 +49,20 @@ jobs:
           pip install coverage "tox>=3,<4"
 
       - name: Test rq
-        timeout-minutes: 45
-        shell: bash
-        run: |
-          set -x # print commands that are executed
-          coverage erase
+        uses: nick-fields/retry@v2
+        with:
+          timeout_minutes: 45
+          max_attempts: 2
+          retry_wait_seconds: 5
+          shell: bash
+          command: |
+            set -x # print commands that are executed
+            coverage erase
 
-          # Run tests
-          ./scripts/runtox.sh "py${{ matrix.python-version }}-rq" --cov=tests --cov=sentry_sdk --cov-report= --cov-branch
-          coverage combine .coverage*
-          coverage xml -i
+            # Run tests
+            ./scripts/runtox.sh "py${{ matrix.python-version }}-rq" --cov=tests --cov=sentry_sdk --cov-report= --cov-branch &&
+            coverage combine .coverage* &&
+            coverage xml -i
 
       - uses: codecov/codecov-action@v3
         with:

--- a/.github/workflows/test-integration-rq.yml
+++ b/.github/workflows/test-integration-rq.yml
@@ -26,7 +26,7 @@ jobs:
   test:
     name: rq, python ${{ matrix.python-version }}, ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 45
+    timeout-minutes: 30
 
     strategy:
       fail-fast: false
@@ -51,7 +51,7 @@ jobs:
       - name: Test rq
         uses: nick-fields/retry@v2
         with:
-          timeout_minutes: 45
+          timeout_minutes: 15
           max_attempts: 2
           retry_wait_seconds: 5
           shell: bash

--- a/.github/workflows/test-integration-sanic.yml
+++ b/.github/workflows/test-integration-sanic.yml
@@ -49,16 +49,20 @@ jobs:
           pip install coverage "tox>=3,<4"
 
       - name: Test sanic
-        timeout-minutes: 45
-        shell: bash
-        run: |
-          set -x # print commands that are executed
-          coverage erase
+        uses: nick-fields/retry@v2
+        with:
+          timeout_minutes: 45
+          max_attempts: 2
+          retry_wait_seconds: 5
+          shell: bash
+          command: |
+            set -x # print commands that are executed
+            coverage erase
 
-          # Run tests
-          ./scripts/runtox.sh "py${{ matrix.python-version }}-sanic" --cov=tests --cov=sentry_sdk --cov-report= --cov-branch
-          coverage combine .coverage*
-          coverage xml -i
+            # Run tests
+            ./scripts/runtox.sh "py${{ matrix.python-version }}-sanic" --cov=tests --cov=sentry_sdk --cov-report= --cov-branch &&
+            coverage combine .coverage* &&
+            coverage xml -i
 
       - uses: codecov/codecov-action@v3
         with:

--- a/.github/workflows/test-integration-sanic.yml
+++ b/.github/workflows/test-integration-sanic.yml
@@ -26,7 +26,7 @@ jobs:
   test:
     name: sanic, python ${{ matrix.python-version }}, ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 45
+    timeout-minutes: 30
 
     strategy:
       fail-fast: false
@@ -51,7 +51,7 @@ jobs:
       - name: Test sanic
         uses: nick-fields/retry@v2
         with:
-          timeout_minutes: 45
+          timeout_minutes: 15
           max_attempts: 2
           retry_wait_seconds: 5
           shell: bash

--- a/.github/workflows/test-integration-sqlalchemy.yml
+++ b/.github/workflows/test-integration-sqlalchemy.yml
@@ -26,7 +26,7 @@ jobs:
   test:
     name: sqlalchemy, python ${{ matrix.python-version }}, ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 45
+    timeout-minutes: 30
 
     strategy:
       fail-fast: false
@@ -51,7 +51,7 @@ jobs:
       - name: Test sqlalchemy
         uses: nick-fields/retry@v2
         with:
-          timeout_minutes: 45
+          timeout_minutes: 15
           max_attempts: 2
           retry_wait_seconds: 5
           shell: bash

--- a/.github/workflows/test-integration-sqlalchemy.yml
+++ b/.github/workflows/test-integration-sqlalchemy.yml
@@ -49,16 +49,20 @@ jobs:
           pip install coverage "tox>=3,<4"
 
       - name: Test sqlalchemy
-        timeout-minutes: 45
-        shell: bash
-        run: |
-          set -x # print commands that are executed
-          coverage erase
+        uses: nick-fields/retry@v2
+        with:
+          timeout_minutes: 45
+          max_attempts: 2
+          retry_wait_seconds: 5
+          shell: bash
+          command: |
+            set -x # print commands that are executed
+            coverage erase
 
-          # Run tests
-          ./scripts/runtox.sh "py${{ matrix.python-version }}-sqlalchemy" --cov=tests --cov=sentry_sdk --cov-report= --cov-branch
-          coverage combine .coverage*
-          coverage xml -i
+            # Run tests
+            ./scripts/runtox.sh "py${{ matrix.python-version }}-sqlalchemy" --cov=tests --cov=sentry_sdk --cov-report= --cov-branch &&
+            coverage combine .coverage* &&
+            coverage xml -i
 
       - uses: codecov/codecov-action@v3
         with:

--- a/.github/workflows/test-integration-starlette.yml
+++ b/.github/workflows/test-integration-starlette.yml
@@ -49,16 +49,20 @@ jobs:
           pip install coverage "tox>=3,<4"
 
       - name: Test starlette
-        timeout-minutes: 45
-        shell: bash
-        run: |
-          set -x # print commands that are executed
-          coverage erase
+        uses: nick-fields/retry@v2
+        with:
+          timeout_minutes: 45
+          max_attempts: 2
+          retry_wait_seconds: 5
+          shell: bash
+          command: |
+            set -x # print commands that are executed
+            coverage erase
 
-          # Run tests
-          ./scripts/runtox.sh "py${{ matrix.python-version }}-starlette" --cov=tests --cov=sentry_sdk --cov-report= --cov-branch
-          coverage combine .coverage*
-          coverage xml -i
+            # Run tests
+            ./scripts/runtox.sh "py${{ matrix.python-version }}-starlette" --cov=tests --cov=sentry_sdk --cov-report= --cov-branch &&
+            coverage combine .coverage* &&
+            coverage xml -i
 
       - uses: codecov/codecov-action@v3
         with:

--- a/.github/workflows/test-integration-starlette.yml
+++ b/.github/workflows/test-integration-starlette.yml
@@ -26,7 +26,7 @@ jobs:
   test:
     name: starlette, python ${{ matrix.python-version }}, ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 45
+    timeout-minutes: 30
 
     strategy:
       fail-fast: false
@@ -51,7 +51,7 @@ jobs:
       - name: Test starlette
         uses: nick-fields/retry@v2
         with:
-          timeout_minutes: 45
+          timeout_minutes: 15
           max_attempts: 2
           retry_wait_seconds: 5
           shell: bash

--- a/.github/workflows/test-integration-starlite.yml
+++ b/.github/workflows/test-integration-starlite.yml
@@ -26,7 +26,7 @@ jobs:
   test:
     name: starlite, python ${{ matrix.python-version }}, ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 45
+    timeout-minutes: 30
 
     strategy:
       fail-fast: false
@@ -51,7 +51,7 @@ jobs:
       - name: Test starlite
         uses: nick-fields/retry@v2
         with:
-          timeout_minutes: 45
+          timeout_minutes: 15
           max_attempts: 2
           retry_wait_seconds: 5
           shell: bash

--- a/.github/workflows/test-integration-starlite.yml
+++ b/.github/workflows/test-integration-starlite.yml
@@ -49,16 +49,20 @@ jobs:
           pip install coverage "tox>=3,<4"
 
       - name: Test starlite
-        timeout-minutes: 45
-        shell: bash
-        run: |
-          set -x # print commands that are executed
-          coverage erase
+        uses: nick-fields/retry@v2
+        with:
+          timeout_minutes: 45
+          max_attempts: 2
+          retry_wait_seconds: 5
+          shell: bash
+          command: |
+            set -x # print commands that are executed
+            coverage erase
 
-          # Run tests
-          ./scripts/runtox.sh "py${{ matrix.python-version }}-starlite" --cov=tests --cov=sentry_sdk --cov-report= --cov-branch
-          coverage combine .coverage*
-          coverage xml -i
+            # Run tests
+            ./scripts/runtox.sh "py${{ matrix.python-version }}-starlite" --cov=tests --cov=sentry_sdk --cov-report= --cov-branch &&
+            coverage combine .coverage* &&
+            coverage xml -i
 
       - uses: codecov/codecov-action@v3
         with:

--- a/.github/workflows/test-integration-tornado.yml
+++ b/.github/workflows/test-integration-tornado.yml
@@ -26,7 +26,7 @@ jobs:
   test:
     name: tornado, python ${{ matrix.python-version }}, ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 45
+    timeout-minutes: 30
 
     strategy:
       fail-fast: false
@@ -51,7 +51,7 @@ jobs:
       - name: Test tornado
         uses: nick-fields/retry@v2
         with:
-          timeout_minutes: 45
+          timeout_minutes: 15
           max_attempts: 2
           retry_wait_seconds: 5
           shell: bash

--- a/.github/workflows/test-integration-tornado.yml
+++ b/.github/workflows/test-integration-tornado.yml
@@ -49,16 +49,20 @@ jobs:
           pip install coverage "tox>=3,<4"
 
       - name: Test tornado
-        timeout-minutes: 45
-        shell: bash
-        run: |
-          set -x # print commands that are executed
-          coverage erase
+        uses: nick-fields/retry@v2
+        with:
+          timeout_minutes: 45
+          max_attempts: 2
+          retry_wait_seconds: 5
+          shell: bash
+          command: |
+            set -x # print commands that are executed
+            coverage erase
 
-          # Run tests
-          ./scripts/runtox.sh "py${{ matrix.python-version }}-tornado" --cov=tests --cov=sentry_sdk --cov-report= --cov-branch
-          coverage combine .coverage*
-          coverage xml -i
+            # Run tests
+            ./scripts/runtox.sh "py${{ matrix.python-version }}-tornado" --cov=tests --cov=sentry_sdk --cov-report= --cov-branch &&
+            coverage combine .coverage* &&
+            coverage xml -i
 
       - uses: codecov/codecov-action@v3
         with:

--- a/.github/workflows/test-integration-trytond.yml
+++ b/.github/workflows/test-integration-trytond.yml
@@ -49,16 +49,20 @@ jobs:
           pip install coverage "tox>=3,<4"
 
       - name: Test trytond
-        timeout-minutes: 45
-        shell: bash
-        run: |
-          set -x # print commands that are executed
-          coverage erase
+        uses: nick-fields/retry@v2
+        with:
+          timeout_minutes: 45
+          max_attempts: 2
+          retry_wait_seconds: 5
+          shell: bash
+          command: |
+            set -x # print commands that are executed
+            coverage erase
 
-          # Run tests
-          ./scripts/runtox.sh "py${{ matrix.python-version }}-trytond" --cov=tests --cov=sentry_sdk --cov-report= --cov-branch
-          coverage combine .coverage*
-          coverage xml -i
+            # Run tests
+            ./scripts/runtox.sh "py${{ matrix.python-version }}-trytond" --cov=tests --cov=sentry_sdk --cov-report= --cov-branch &&
+            coverage combine .coverage* &&
+            coverage xml -i
 
       - uses: codecov/codecov-action@v3
         with:

--- a/.github/workflows/test-integration-trytond.yml
+++ b/.github/workflows/test-integration-trytond.yml
@@ -26,7 +26,7 @@ jobs:
   test:
     name: trytond, python ${{ matrix.python-version }}, ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 45
+    timeout-minutes: 30
 
     strategy:
       fail-fast: false
@@ -51,7 +51,7 @@ jobs:
       - name: Test trytond
         uses: nick-fields/retry@v2
         with:
-          timeout_minutes: 45
+          timeout_minutes: 15
           max_attempts: 2
           retry_wait_seconds: 5
           shell: bash

--- a/scripts/split-tox-gh-actions/ci-yaml.txt
+++ b/scripts/split-tox-gh-actions/ci-yaml.txt
@@ -41,16 +41,20 @@ jobs:
           pip install coverage "tox>=3,<4"
 
       - name: Test {{ framework }}
-        timeout-minutes: 45
-        shell: bash
-        run: |
-          set -x # print commands that are executed
-          coverage erase
+        uses: nick-fields/retry@v2
+        with:
+          timeout_minutes: 45
+          max_attempts: 2
+          retry_wait_seconds: 5
+          shell: bash
+          command: |
+            set -x # print commands that are executed
+            coverage erase
 
-          # Run tests
-          ./scripts/runtox.sh "py${{ matrix.python-version }}-{{ framework }}" --cov=tests --cov=sentry_sdk --cov-report= --cov-branch
-          coverage combine .coverage*
-          coverage xml -i
+            # Run tests
+            ./scripts/runtox.sh "py${{ matrix.python-version }}-{{ framework }}" --cov=tests --cov=sentry_sdk --cov-report= --cov-branch &&
+            coverage combine .coverage* &&
+            coverage xml -i
 
       - uses: codecov/codecov-action@v3
         with:

--- a/scripts/split-tox-gh-actions/ci-yaml.txt
+++ b/scripts/split-tox-gh-actions/ci-yaml.txt
@@ -26,7 +26,7 @@ jobs:
   test:
     name: {{ framework }}, python ${{ matrix.python-version }}, ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 45
+    timeout-minutes: 30
 {{ strategy_matrix }}
 {{ services }}
 
@@ -43,7 +43,7 @@ jobs:
       - name: Test {{ framework }}
         uses: nick-fields/retry@v2
         with:
-          timeout_minutes: 45
+          timeout_minutes: 15
           max_attempts: 2
           retry_wait_seconds: 5
           shell: bash

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -17,8 +17,6 @@ def test_get_current_span():
     fake_hub.scope.span = None
     assert get_current_span(fake_hub) is None
 
-    assert False  # XXX just for testing the github action
-
 
 def test_get_current_span_default_hub(sentry_init):
     sentry_init()

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -17,6 +17,8 @@ def test_get_current_span():
     fake_hub.scope.span = None
     assert get_current_span(fake_hub) is None
 
+    assert False  # XXX just for testing the github action
+
 
 def test_get_current_span_default_hub(sentry_init):
     sentry_init()


### PR DESCRIPTION
Our tests are sometimes flaky and require rerunning manually. There's a [GitHub action](https://github.com/marketplace/actions/retry-step) that auto-retries a step on failure. Incorporating this would save us quite some time spent babysitting tests.