### PR TITLE
Tracing without performance

### DIFF
--- a/scripts/runtox.sh
+++ b/scripts/runtox.sh
@@ -16,5 +16,4 @@ fi
 searchstring="$1"
 
 export TOX_PARALLEL_NO_SPINNER=1
-exec $TOXPATH -vvv -e "$($TOXPATH -l | grep "$searchstring" | tr $'\n' ',')" -- "${@:2}"
-# exec $TOXPATH -vv -p auto -e "$($TOXPATH -l | grep "$searchstring" | tr $'\n' ',')" -- "${@:2}"
+exec $TOXPATH -vv -p auto -e "$($TOXPATH -l | grep "$searchstring" | tr $'\n' ',')" -- "${@:2}"

--- a/scripts/runtox.sh
+++ b/scripts/runtox.sh
@@ -16,5 +16,4 @@ fi
 searchstring="$1"
 
 export TOX_PARALLEL_NO_SPINNER=1
-printenv | sort
 exec $TOXPATH -vvv -e "$($TOXPATH -l | grep "$searchstring" | tr $'\n' ',')" -- "${@:2}"

--- a/scripts/runtox.sh
+++ b/scripts/runtox.sh
@@ -16,4 +16,4 @@ fi
 searchstring="$1"
 
 export TOX_PARALLEL_NO_SPINNER=1
-exec $TOXPATH -vv -p auto -e "$($TOXPATH -l | grep "$searchstring" | tr $'\n' ',')" -- "${@:2}"
+exec $TOXPATH -vvv -e "$($TOXPATH -l | grep "$searchstring" | tr $'\n' ',')" -- "${@:2}"

--- a/scripts/runtox.sh
+++ b/scripts/runtox.sh
@@ -17,4 +17,4 @@ searchstring="$1"
 
 export TOX_PARALLEL_NO_SPINNER=1
 printenv | sort
-exec $TOXPATH -vv -p auto -e "$($TOXPATH -l | grep "$searchstring" | tr $'\n' ',')" -- "${@:2}"
+exec $TOXPATH -vvv -e "$($TOXPATH -l | grep "$searchstring" | tr $'\n' ',')" -- "${@:2}"

--- a/scripts/runtox.sh
+++ b/scripts/runtox.sh
@@ -16,4 +16,5 @@ fi
 searchstring="$1"
 
 export TOX_PARALLEL_NO_SPINNER=1
+printenv | sort
 exec $TOXPATH -vv -p auto -e "$($TOXPATH -l | grep "$searchstring" | tr $'\n' ',')" -- "${@:2}"

--- a/scripts/runtox.sh
+++ b/scripts/runtox.sh
@@ -16,4 +16,4 @@ fi
 searchstring="$1"
 
 export TOX_PARALLEL_NO_SPINNER=1
-exec $TOXPATH -vvv -e "$($TOXPATH -l | grep "$searchstring" | tr $'\n' ',')" -- "${@:2}"
+exec $TOXPATH -vv -p auto -e "$($TOXPATH -l | grep "$searchstring" | tr $'\n' ',')" -- "${@:2}"

--- a/sentry_sdk/__init__.py
+++ b/sentry_sdk/__init__.py
@@ -36,8 +36,8 @@ __all__ = [  # noqa
     "set_level",
     "set_measurement",
     "get_current_span",
-    "traceparent",
-    "baggage",
+    "get_traceparent",
+    "get_baggage",
     "continue_trace",
 ]
 

--- a/sentry_sdk/__init__.py
+++ b/sentry_sdk/__init__.py
@@ -36,6 +36,9 @@ __all__ = [  # noqa
     "set_level",
     "set_measurement",
     "get_current_span",
+    "traceparent",
+    "baggage",
+    "continue_trace",
 ]
 
 # Initialize the debug support after everything is loaded

--- a/sentry_sdk/api.py
+++ b/sentry_sdk/api.py
@@ -278,7 +278,7 @@ def baggage():
 
 
 def continue_trace(environ_or_headers, op=None, name=None, source=None):
-    # type: (Dict[str, Any], Optional[str], Optional[str], Optional[str]) -> Optional[Transaction]
+    # type: (Dict[str, Any], Optional[str], Optional[str], Optional[str]) -> Transaction
     """
     Sets the propagation context from environment or headers and returns a transaction.
     """

--- a/sentry_sdk/api.py
+++ b/sentry_sdk/api.py
@@ -1,10 +1,13 @@
 import inspect
 
+from sentry_sdk._types import TYPE_CHECKING
 from sentry_sdk.hub import Hub
 from sentry_sdk.scope import Scope
-
-from sentry_sdk._types import TYPE_CHECKING
-from sentry_sdk.tracing import NoOpSpan
+from sentry_sdk.tracing import NoOpSpan, Transaction
+from sentry_sdk.tracing_utils import (
+    has_tracing_enabled,
+    normalize_incoming_data,
+)
 
 if TYPE_CHECKING:
     from typing import Any
@@ -24,7 +27,8 @@ if TYPE_CHECKING:
         ExcInfo,
         MeasurementUnit,
     )
-    from sentry_sdk.tracing import Span, Transaction
+    from sentry_sdk.tracing import Span
+    from sentry_sdk.tracing_utils import Baggage
 
     T = TypeVar("T")
     F = TypeVar("F", bound=Callable[..., Any])
@@ -54,6 +58,9 @@ __all__ = [
     "set_level",
     "set_measurement",
     "get_current_span",
+    "traceparent",
+    "baggage",
+    "continue_trace",
 ]
 
 
@@ -241,3 +248,47 @@ def get_current_span(hub=None):
 
     current_span = hub.scope.span
     return current_span
+
+
+def traceparent():
+    # type: () -> Optional[str]
+    """
+    Returns the traceparent either from the active span or from the scope.
+    """
+    hub = Hub.current
+    if hub.client is not None:
+        if has_tracing_enabled(hub.client.options) and hub.scope.span is not None:
+            return hub.scope.span.to_traceparent()
+
+    return hub.scope.get_traceparent()
+
+
+def baggage():
+    # type: () -> Optional[Baggage]
+    """
+    Returns Baggage either from the active span or from the scope.
+    """
+    # XXX: should this return the serialized baggage?
+    hub = Hub.current
+    if hub.client is not None:
+        if has_tracing_enabled(hub.client.options) and hub.scope.span is not None:
+            return hub.scope.span.to_baggage()
+
+    return hub.scope.get_baggage()
+
+
+def continue_trace(environ_or_headers, op=None, name=None, source=None):
+    # type: (Dict[str, Any], Optional[str], Optional[str], Optional[str]) -> Optional[Transaction]
+    """
+    Sets the propagation context from environment or headers and returns a transaction.
+    """
+    with Hub.current.configure_scope() as scope:
+        scope.generate_propagation_context(environ_or_headers)
+
+    transaction = Transaction.continue_from_headers(
+        normalize_incoming_data(environ_or_headers),
+        op=op,
+        name=name,
+        source=source,
+    )
+    return transaction

--- a/sentry_sdk/client.py
+++ b/sentry_sdk/client.py
@@ -510,11 +510,8 @@ class _Client(object):
         is_checkin = event_opt.get("type") == "check_in"
         attachments = hint.get("attachments")
 
-        dynamic_sampling_context = (
-            event_opt.get("contexts", {})
-            .get("trace", {})
-            .pop("dynamic_sampling_context", {})
-        )
+        trace_context = event_opt.get("contexts", {}).get("trace") or {}
+        dynamic_sampling_context = trace_context.pop("dynamic_sampling_context", {})
 
         # If tracing is enabled all events should go to /envelope endpoint.
         # If no tracing is enabled only transactions, events with attachments, and checkins should go to the /envelope endpoint.

--- a/sentry_sdk/hub.py
+++ b/sentry_sdk/hub.py
@@ -715,13 +715,17 @@ class Hub(with_metaclass(HubMeta)):  # type: ignore
 
         if client and has_tracing_enabled(client.options) and span is not None:
             logger.warning(
-                f"TwP: iter_trace_propagation_headers: yield trace propagation headers from span: {dict(span.iter_headers())}"
+                "TwP: iter_trace_propagation_headers: yield trace propagation headers from span: {}".format(
+                    dict(span.iter_headers())
+                )
             )
             for header in span.iter_headers():
                 yield header
         else:
             logger.warning(
-                f"TwP: iter_trace_propagation_headers: yield trace propagation headers from scope: {dict(self.scope.iter_headers())}"
+                "TwP: iter_trace_propagation_headers: yield trace propagation headers from scope: {}".format(
+                    dict(self.scope.iter_headers())
+                )
             )
             for header in self.scope.iter_headers():
                 yield header

--- a/sentry_sdk/hub.py
+++ b/sentry_sdk/hub.py
@@ -323,14 +323,8 @@ class Hub(with_metaclass(HubMeta)):  # type: ignore
         top = self._stack[-1]
         self._stack[-1] = (new, top[1])
 
-    def capture_event(
-        self,
-        event,  # type: Event
-        hint=None,  # type: Optional[Hint]
-        scope=None,  # type: Optional[Any]
-        **scope_args,  # type: Any
-    ):
-        # type: (...) -> Optional[str]
+    def capture_event(self, event, hint=None, scope=None, **scope_args):
+        # type: (Event, Optional[Hint], Optional[Scope], Any) -> Optional[str]
         """Captures an event. Alias of :py:meth:`sentry_sdk.Client.capture_event`."""
         client, top_scope = self._stack[-1]
         scope = _update_scope(top_scope, scope, scope_args)
@@ -342,14 +336,8 @@ class Hub(with_metaclass(HubMeta)):  # type: ignore
             return rv
         return None
 
-    def capture_message(
-        self,
-        message,  # type: str
-        level=None,  # type: Optional[str]
-        scope=None,  # type: Optional[Any]
-        **scope_args,  # type: Any
-    ):
-        # type: (...) -> Optional[str]
+    def capture_message(self, message, level=None, scope=None, **scope_args):
+        # type: (str, Optional[str], Optional[Scope], Any) -> Optional[str]
         """Captures a message.  The message is just a string.  If no level
         is provided the default level is `info`.
 
@@ -363,13 +351,8 @@ class Hub(with_metaclass(HubMeta)):  # type: ignore
             {"message": message, "level": level}, scope=scope, **scope_args
         )
 
-    def capture_exception(
-        self,
-        error=None,  # type: Optional[Union[BaseException, ExcInfo]]
-        scope=None,  # type: Optional[Any]
-        **scope_args,  # type: Any
-    ):
-        # type: (...) -> Optional[str]
+    def capture_exception(self, error=None, scope=None, **scope_args):
+        # type: (Optional[Union[BaseException, ExcInfo]], Optional[Scope], Any) -> Optional[str]
         """Captures an exception.
 
         :param error: An exception to catch. If `None`, `sys.exc_info()` will be used.
@@ -404,13 +387,8 @@ class Hub(with_metaclass(HubMeta)):  # type: ignore
         """
         logger.error("Internal error in sentry_sdk", exc_info=exc_info)
 
-    def add_breadcrumb(
-        self,
-        crumb=None,  # type: Optional[Breadcrumb]
-        hint=None,  # type: Optional[BreadcrumbHint]
-        **kwargs,  # type: Any
-    ):
-        # type: (...) -> None
+    def add_breadcrumb(self, crumb=None, hint=None, **kwargs):
+        # type: (Optional[Breadcrumb], Optional[BreadcrumbHint], Any) -> None
         """
         Adds a breadcrumb.
 
@@ -450,13 +428,8 @@ class Hub(with_metaclass(HubMeta)):  # type: ignore
         while len(scope._breadcrumbs) > max_breadcrumbs:
             scope._breadcrumbs.popleft()
 
-    def start_span(
-        self,
-        span=None,  # type: Optional[Span]
-        instrumenter=INSTRUMENTER.SENTRY,  # type: str
-        **kwargs,  # type: Any
-    ):
-        # type: (...) -> Span
+    def start_span(self, span=None, instrumenter=INSTRUMENTER.SENTRY, **kwargs):
+        # type: (Optional[Span], str, Any) -> Span
         """
         Create and start timing a new span whose parent is the currently active
         span or transaction, if any. The return value is a span instance,
@@ -501,12 +474,9 @@ class Hub(with_metaclass(HubMeta)):  # type: ignore
         return Span(**kwargs)
 
     def start_transaction(
-        self,
-        transaction=None,  # type: Optional[Transaction]
-        instrumenter=INSTRUMENTER.SENTRY,  # type: str
-        **kwargs,  # type: Any
+        self, transaction=None, instrumenter=INSTRUMENTER.SENTRY, **kwargs
     ):
-        # type: (...) -> Union[Transaction, NoOpSpan]
+        # type: (Optional[Transaction], str, Any) -> Union[Transaction, NoOpSpan]
         """
         Start and return a transaction.
 

--- a/sentry_sdk/integrations/aiohttp.py
+++ b/sentry_sdk/integrations/aiohttp.py
@@ -1,6 +1,7 @@
 import sys
 import weakref
 
+from sentry_sdk.api import continue_trace
 from sentry_sdk._compat import reraise
 from sentry_sdk.consts import OP
 from sentry_sdk.hub import Hub
@@ -11,7 +12,7 @@ from sentry_sdk.integrations._wsgi_common import (
     _filter_headers,
     request_body_within_bounds,
 )
-from sentry_sdk.tracing import SOURCE_FOR_STYLE, Transaction, TRANSACTION_SOURCE_ROUTE
+from sentry_sdk.tracing import SOURCE_FOR_STYLE, TRANSACTION_SOURCE_ROUTE
 from sentry_sdk.utils import (
     capture_internal_exceptions,
     event_from_exception,
@@ -98,11 +99,10 @@ class AioHttpIntegration(Integration):
                     # Scope data will not leak between requests because aiohttp
                     # create a task to wrap each request.
                     with hub.configure_scope() as scope:
-                        scope.generate_propagation_context(request.headers)
                         scope.clear_breadcrumbs()
                         scope.add_event_processor(_make_request_processor(weak_request))
 
-                    transaction = Transaction.continue_from_headers(
+                    transaction = continue_trace(
                         request.headers,
                         op=OP.HTTP_SERVER,
                         # If this transaction name makes it to the UI, AIOHTTP's

--- a/sentry_sdk/integrations/asgi.py
+++ b/sentry_sdk/integrations/asgi.py
@@ -11,6 +11,7 @@ from copy import deepcopy
 
 from sentry_sdk._functools import partial
 from sentry_sdk._types import TYPE_CHECKING
+from sentry_sdk.api import continue_trace
 from sentry_sdk.consts import OP
 from sentry_sdk.hub import Hub, _should_send_default_pii
 from sentry_sdk.integrations._wsgi_common import _filter_headers
@@ -160,18 +161,15 @@ class SentryAsgiMiddleware:
                         processor = partial(self.event_processor, asgi_scope=scope)
                         sentry_scope.add_event_processor(processor)
 
-                        ty = scope["type"]
+                    ty = scope["type"]
 
-                        if ty in ("http", "websocket"):
-                            headers = self._get_headers(scope)
-
-                            sentry_scope.generate_propagation_context(headers)
-                            transaction = Transaction.continue_from_headers(
-                                headers,
-                                op="{}.server".format(ty),
-                            )
-                        else:
-                            transaction = Transaction(op=OP.HTTP_SERVER)
+                    if ty in ("http", "websocket"):
+                        transaction = continue_trace(
+                            self._get_headers(scope),
+                            op="{}.server".format(ty),
+                        )
+                    else:
+                        transaction = Transaction(op=OP.HTTP_SERVER)
 
                     transaction.name = _DEFAULT_TRANSACTION_NAME
                     transaction.source = TRANSACTION_SOURCE_ROUTE

--- a/sentry_sdk/integrations/asgi.py
+++ b/sentry_sdk/integrations/asgi.py
@@ -160,20 +160,18 @@ class SentryAsgiMiddleware:
                         processor = partial(self.event_processor, asgi_scope=scope)
                         sentry_scope.add_event_processor(processor)
 
-                    ty = scope["type"]
+                        ty = scope["type"]
 
-                    if ty in ("http", "websocket"):
-                        headers = self._get_headers(scope)
+                        if ty in ("http", "websocket"):
+                            headers = self._get_headers(scope)
 
-                        with hub.configure_scope() as sentry_scope:
                             sentry_scope.generate_propagation_context(headers)
-
-                        transaction = Transaction.continue_from_headers(
-                            headers,
-                            op="{}.server".format(ty),
-                        )
-                    else:
-                        transaction = Transaction(op=OP.HTTP_SERVER)
+                            transaction = Transaction.continue_from_headers(
+                                headers,
+                                op="{}.server".format(ty),
+                            )
+                        else:
+                            transaction = Transaction(op=OP.HTTP_SERVER)
 
                     transaction.name = _DEFAULT_TRANSACTION_NAME
                     transaction.source = TRANSACTION_SOURCE_ROUTE

--- a/sentry_sdk/integrations/aws_lambda.py
+++ b/sentry_sdk/integrations/aws_lambda.py
@@ -3,10 +3,10 @@ from copy import deepcopy
 from datetime import datetime, timedelta
 from os import environ
 
+from sentry_sdk.api import continue_trace
 from sentry_sdk.consts import OP
 from sentry_sdk.hub import Hub, _should_send_default_pii
-from sentry_sdk.tracing import TRANSACTION_SOURCE_COMPONENT, Transaction
-from sentry_sdk._compat import reraise
+from sentry_sdk.tracing import TRANSACTION_SOURCE_COMPONENT
 from sentry_sdk.utils import (
     AnnotatedValue,
     capture_internal_exceptions,
@@ -16,7 +16,7 @@ from sentry_sdk.utils import (
 )
 from sentry_sdk.integrations import Integration
 from sentry_sdk.integrations._wsgi_common import _filter_headers
-
+from sentry_sdk._compat import reraise
 from sentry_sdk._types import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -141,9 +141,7 @@ def _wrap_handler(handler):
             if headers is None:
                 headers = {}
 
-            scope.generate_propagation_context(headers)
-
-            transaction = Transaction.continue_from_headers(
+            transaction = continue_trace(
                 headers,
                 op=OP.FUNCTION_AWS,
                 name=aws_context.function_name,

--- a/sentry_sdk/integrations/gcp.py
+++ b/sentry_sdk/integrations/gcp.py
@@ -3,9 +3,10 @@ from copy import deepcopy
 from datetime import datetime, timedelta
 from os import environ
 
+from sentry_sdk.api import continue_trace
 from sentry_sdk.consts import OP
 from sentry_sdk.hub import Hub, _should_send_default_pii
-from sentry_sdk.tracing import TRANSACTION_SOURCE_COMPONENT, Transaction
+from sentry_sdk.tracing import TRANSACTION_SOURCE_COMPONENT
 from sentry_sdk._compat import reraise
 from sentry_sdk.utils import (
     AnnotatedValue,
@@ -83,8 +84,7 @@ def _wrap_func(func):
             if hasattr(gcp_event, "headers"):
                 headers = gcp_event.headers
 
-            scope.generate_propagation_context(headers)
-            transaction = Transaction.continue_from_headers(
+            transaction = continue_trace(
                 headers,
                 op=OP.FUNCTION_GCP,
                 name=environ.get("FUNCTION_NAME", ""),

--- a/sentry_sdk/integrations/rq.py
+++ b/sentry_sdk/integrations/rq.py
@@ -109,9 +109,10 @@ class RqIntegration(Integration):
             # type: (Queue, Any, **Any) -> Any
             hub = Hub.current
             if hub.get_integration(RqIntegration) is not None:
-                job.meta["_sentry_trace_headers"] = dict(
-                    hub.iter_trace_propagation_headers()
-                )
+                if hub.scope.span is not None:
+                    job.meta["_sentry_trace_headers"] = dict(
+                        hub.iter_trace_propagation_headers()
+                    )
 
             return old_enqueue_job(self, job, **kwargs)
 

--- a/sentry_sdk/integrations/tornado.py
+++ b/sentry_sdk/integrations/tornado.py
@@ -1,13 +1,13 @@
 import weakref
 import contextlib
 from inspect import iscoroutinefunction
-from sentry_sdk.consts import OP
 
+from sentry_sdk.api import continue_trace
+from sentry_sdk.consts import OP
 from sentry_sdk.hub import Hub, _should_send_default_pii
 from sentry_sdk.tracing import (
     TRANSACTION_SOURCE_COMPONENT,
     TRANSACTION_SOURCE_ROUTE,
-    Transaction,
 )
 from sentry_sdk.utils import (
     HAS_REAL_CONTEXTVARS,
@@ -111,12 +111,11 @@ def _handle_request_impl(self):
         headers = self.request.headers
 
         with hub.configure_scope() as scope:
-            scope.generate_propagation_context(headers)
             scope.clear_breadcrumbs()
             processor = _make_event_processor(weak_handler)
             scope.add_event_processor(processor)
 
-        transaction = Transaction.continue_from_headers(
+        transaction = continue_trace(
             headers,
             op=OP.HTTP_SERVER,
             # Like with all other integrations, this is our

--- a/sentry_sdk/integrations/tornado.py
+++ b/sentry_sdk/integrations/tornado.py
@@ -108,14 +108,16 @@ def _handle_request_impl(self):
     weak_handler = weakref.ref(self)
 
     with Hub(hub) as hub:
+        headers = self.request.headers
+
         with hub.configure_scope() as scope:
-            scope.generate_propagation_context(self.request.headers)
+            scope.generate_propagation_context(headers)
             scope.clear_breadcrumbs()
             processor = _make_event_processor(weak_handler)
             scope.add_event_processor(processor)
 
         transaction = Transaction.continue_from_headers(
-            self.request.headers,
+            headers,
             op=OP.HTTP_SERVER,
             # Like with all other integrations, this is our
             # fallback transaction in case there is no route.

--- a/sentry_sdk/integrations/wsgi.py
+++ b/sentry_sdk/integrations/wsgi.py
@@ -1,7 +1,10 @@
 import sys
 
+from sentry_sdk._compat import PY2, reraise
 from sentry_sdk._functools import partial
+from sentry_sdk._types import TYPE_CHECKING
 from sentry_sdk._werkzeug import get_host, _get_headers
+from sentry_sdk.api import continue_trace
 from sentry_sdk.consts import OP
 from sentry_sdk.hub import Hub, _should_send_default_pii
 from sentry_sdk.utils import (
@@ -9,12 +12,9 @@ from sentry_sdk.utils import (
     capture_internal_exceptions,
     event_from_exception,
 )
-from sentry_sdk._compat import PY2, reraise
 from sentry_sdk.tracing import Transaction, TRANSACTION_SOURCE_ROUTE
 from sentry_sdk.sessions import auto_session_tracking
 from sentry_sdk.integrations._wsgi_common import _filter_headers
-
-from sentry_sdk._types import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from typing import Callable
@@ -86,7 +86,6 @@ class SentryWsgiMiddleware(object):
                 with hub:
                     with capture_internal_exceptions():
                         with hub.configure_scope() as scope:
-                            scope.generate_propagation_context(environ)
                             scope.clear_breadcrumbs()
                             scope._name = "wsgi"
                             scope.add_event_processor(
@@ -95,7 +94,7 @@ class SentryWsgiMiddleware(object):
                                 )
                             )
 
-                    transaction = Transaction.continue_from_environ(
+                    transaction = continue_trace(
                         environ,
                         op=OP.HTTP_SERVER,
                         name="generic WSGI request",

--- a/sentry_sdk/scope.py
+++ b/sentry_sdk/scope.py
@@ -139,7 +139,7 @@ class Scope(object):
         self.clear()
         self.generate_propagation_context()
 
-    def extract_propagation_context(data):
+    def _extract_propagation_context(data):
         # type: (Dict[str, Any]) -> Optional[Dict[str, Any]]
         context = {}  # type: Dict[str, Any]
         normalized_data = _normalize_incoming_data(data)
@@ -164,7 +164,7 @@ class Scope(object):
 
         return None
 
-    def new_propagation_context():
+    def _create_new_propagation_context():
         # type: () -> Dict[str, Any]
         return {
             "trace_id": uuid.uuid4().hex,
@@ -175,16 +175,16 @@ class Scope(object):
     def generate_propagation_context(self, incoming_data=None):
         # type: (Optional[Dict[str, str]]) -> None
         """
-        Populates `_propagation_context` with a new Propagation Context.
+        Populates `_propagation_context`. Either from `incoming_data` or with a new propagation context.
         """
         if incoming_data:
-            context = self.extract_propagation_context(incoming_data)
+            context = self._extract_propagation_context(incoming_data)
 
             if context is not None:
                 self._propagation_context = context
 
         if self._propagation_context is None:
-            self._propagation_context = self.new_propagation_context()
+            self._propagation_context = self._create_new_propagation_context()
 
     def get_dynamic_sampling_context(self):
         # type: () -> Optional[Dict[str, str]]

--- a/sentry_sdk/scope.py
+++ b/sentry_sdk/scope.py
@@ -178,6 +178,9 @@ class Scope(object):
         Returns the Dynamic Sampling Context from the Propagation Context.
         If not existing, creates a new one.
         """
+        if self._propagation_context is None:
+            return None
+
         baggage = self.get_baggage()
         if baggage is not None:
             self._propagation_context[

--- a/sentry_sdk/scope.py
+++ b/sentry_sdk/scope.py
@@ -1,31 +1,33 @@
 from copy import copy
 from collections import deque
 from itertools import chain
-from typing import Iterator, Tuple
 import uuid
 
+from sentry_sdk.attachments import Attachment
 from sentry_sdk._functools import wraps
-from sentry_sdk._types import TYPE_CHECKING
 from sentry_sdk.tracing_utils import (
     Baggage,
     extract_sentrytrace_data,
     has_tracing_enabled,
 )
-from sentry_sdk.utils import logger, capture_internal_exceptions
 from sentry_sdk.tracing import (
     BAGGAGE_HEADER_NAME,
     SENTRY_TRACE_HEADER_NAME,
     Transaction,
 )
-from sentry_sdk.attachments import Attachment
+from sentry_sdk._types import TYPE_CHECKING
+from sentry_sdk.utils import logger, capture_internal_exceptions
+
 
 if TYPE_CHECKING:
     from typing import Any
     from typing import Dict
+    from typing import Iterator
     from typing import Optional
     from typing import Deque
     from typing import List
     from typing import Callable
+    from typing import Tuple
     from typing import TypeVar
 
     from sentry_sdk._types import (

--- a/sentry_sdk/scope.py
+++ b/sentry_sdk/scope.py
@@ -145,7 +145,7 @@ class Scope(object):
         Populates `_propagation_context` with a new Propagation Context.
         """
         logger.warning(
-            f"TwP: generate_propagation_context: incoming_data: {incoming_data}"
+            "TwP: generate_propagation_context: incoming_data: {}".format(incoming_data)
         )
 
         if incoming_data:
@@ -172,12 +172,16 @@ class Scope(object):
                 self._propagation_context = context
 
                 logger.warning(
-                    f"TwP: generate_propagation_context: (incoming data) Initializing propagation context in Scope: {self._propagation_context}"
+                    "TwP: generate_propagation_context: (incoming data) Initializing propagation context in Scope: {}".format(
+                        self._propagation_context
+                    )
                 )
 
         if self._propagation_context is None:
             logger.warning(
-                f"TwP: generate_propagation_context: Initializing propagation context in Scope: {self._propagation_context}"
+                "TwP: generate_propagation_context: Initializing propagation context in Scope: {}".format(
+                    self._propagation_context
+                )
             )
 
             self._propagation_context = {
@@ -569,12 +573,16 @@ class Scope(object):
         if has_tracing_enabled(options):
             if self._span is not None:
                 logger.warning(
-                    f"TwP: apply_to_event: Setting trace from self._span: {self._span.get_trace_context()}"
+                    "TwP: apply_to_event: Setting trace from self._span: {}".format(
+                        self._span.get_trace_context()
+                    )
                 )
                 contexts["trace"] = self._span.get_trace_context()
         else:
             logger.warning(
-                f"TwP: apply_to_event: Setting trace context from Scope: {self.get_trace_context()}"
+                "TwP: apply_to_event: Setting trace context from Scope: {}".format(
+                    self.get_trace_context()
+                )
             )
             contexts["trace"] = self.get_trace_context()
 

--- a/sentry_sdk/scope.py
+++ b/sentry_sdk/scope.py
@@ -213,12 +213,9 @@ class Scope(object):
         if self._propagation_context is None:
             return None
 
-        sampled = 0
-
-        traceparent = "%s-%s-%s" % (
+        traceparent = "%s-%s" % (
             self._propagation_context["trace_id"],
             self._propagation_context["span_id"],
-            sampled,
         )
         return traceparent
 

--- a/sentry_sdk/scope.py
+++ b/sentry_sdk/scope.py
@@ -170,11 +170,9 @@ class Scope(object):
             incoming_data = _normalize_incoming_data(incoming_data)
 
             if incoming_data.get(BAGGAGE_HEADER_NAME):
-                baggage = Baggage.from_incoming_header(
+                context["dynamic_sampling_context"] = Baggage.from_incoming_header(
                     incoming_data.get(BAGGAGE_HEADER_NAME)
-                )
-                dynamic_sampling_context = baggage.dynamic_sampling_context()
-                context["dynamic_sampling_context"] = dynamic_sampling_context
+                ).dynamic_sampling_context()
 
             if incoming_data.get(SENTRY_TRACE_HEADER_NAME):
                 sentrytrace_data = extract_sentrytrace_data(

--- a/sentry_sdk/scope.py
+++ b/sentry_sdk/scope.py
@@ -168,9 +168,17 @@ class Scope(object):
 
             if context is not None:
                 self._propagation_context = context
+                logger.debug(
+                    "[Tracing] Extracted propagation context from incoming data: %s",
+                    self._propagation_context,
+                )
 
         if self._propagation_context is None:
             self._propagation_context = self._create_new_propagation_context()
+            logger.debug(
+                "[Tracing] Create new propagation context: %s",
+                self._propagation_context,
+            )
 
     def get_dynamic_sampling_context(self):
         # type: () -> Optional[Dict[str, str]]
@@ -224,6 +232,7 @@ class Scope(object):
         trace_context = {
             "trace_id": self._propagation_context["trace_id"],
             "span_id": self._propagation_context["span_id"],
+            "parent_span_id": self._propagation_context["parent_span_id"],
             "dynamic_sampling_context": self.get_dynamic_sampling_context(),
         }  # type: Dict[str, Any]
 

--- a/sentry_sdk/scope.py
+++ b/sentry_sdk/scope.py
@@ -194,7 +194,7 @@ class Scope(object):
         if self._propagation_context is None:
             return None
 
-        if self._propagation_context["dynamic_sampling_context"] is None:
+        if self._propagation_context.get("dynamic_sampling_context") is None:
             baggage = Baggage.from_options(self)
             if baggage is not None:
                 self._propagation_context[

--- a/sentry_sdk/scope.py
+++ b/sentry_sdk/scope.py
@@ -280,7 +280,7 @@ class Scope(object):
 
         self._profile = None  # type: Optional[Profile]
 
-        self._propagation_context = None  # type: Optional[Dict[str, Any]]
+        self._propagation_context = None
 
     @_attr_setter
     def level(self, value):

--- a/sentry_sdk/tracing.py
+++ b/sentry_sdk/tracing.py
@@ -350,12 +350,24 @@ class Span(object):
 
     def to_traceparent(self):
         # type: () -> str
-        sampled = ""
         if self.sampled is True:
             sampled = "1"
-        if self.sampled is False:
+        elif self.sampled is False:
             sampled = "0"
-        return "%s-%s-%s" % (self.trace_id, self.span_id, sampled)
+        else:
+            sampled = None
+
+        traceparent = "%s-%s" % (self.trace_id, self.span_id)
+        if sampled is not None:
+            traceparent += "-%s" % (sampled,)
+
+        return traceparent
+
+    def to_baggage(self):
+        # type: () -> Optional[Baggage]
+        if self.containing_transaction:
+            return self.containing_transaction.get_baggage()
+        return None
 
     def set_tag(self, key, value):
         # type: (str, Any) -> None

--- a/sentry_sdk/tracing_utils.py
+++ b/sentry_sdk/tracing_utils.py
@@ -255,7 +255,7 @@ class Baggage(object):
 
     @classmethod
     def from_options(cls, scope):
-        # type: (Any) -> Optional[Baggage]
+        # type: (Scope) -> Optional[Baggage]
         sentry_items = {}  # type: Dict[str, str]
         third_party_items = ""
         mutable = False
@@ -381,3 +381,4 @@ from sentry_sdk.tracing import LOW_QUALITY_TRANSACTION_SOURCES
 
 if TYPE_CHECKING:
     from sentry_sdk.tracing import Span, Transaction
+    from sentry_sdk.scope import Scope

--- a/sentry_sdk/tracing_utils.py
+++ b/sentry_sdk/tracing_utils.py
@@ -107,7 +107,7 @@ def record_sql_queries(
     paramstyle,  # type: Optional[str]
     executemany,  # type: bool
 ):
-    # type: (...) -> Generator[Span, None, None]
+    # type: (...) -> Generator[sentry_sdk.tracing.Span, None, None]
 
     # TODO: Bring back capturing of params by default
     if hub.client and hub.client.options["_experiments"].get(
@@ -142,7 +142,7 @@ def record_sql_queries(
 
 
 def maybe_create_breadcrumbs_from_span(hub, span):
-    # type: (sentry_sdk.Hub, Span) -> None
+    # type: (sentry_sdk.Hub, sentry_sdk.tracing.Span) -> None
     if span.op == OP.DB_REDIS:
         hub.add_breadcrumb(
             message=span.description, type="redis", category="redis", data=span._tags
@@ -255,7 +255,8 @@ class Baggage(object):
 
     @classmethod
     def from_options(cls, scope):
-        # type: (Scope) -> Optional[Baggage]
+        # type: (sentry_sdk.scope.Scope) -> Optional[Baggage]
+
         sentry_items = {}  # type: Dict[str, str]
         third_party_items = ""
         mutable = False
@@ -291,7 +292,7 @@ class Baggage(object):
 
     @classmethod
     def populate_from_transaction(cls, transaction):
-        # type: (Transaction) -> Baggage
+        # type: (sentry_sdk.tracing.Transaction) -> Baggage
         """
         Populate fresh baggage entry with sentry_items and make it immutable
         if this is the head SDK which originates traces.
@@ -378,7 +379,3 @@ def should_propagate_trace(hub, url):
 
 # Circular imports
 from sentry_sdk.tracing import LOW_QUALITY_TRANSACTION_SOURCES
-
-if TYPE_CHECKING:
-    from sentry_sdk.tracing import Span, Transaction
-    from sentry_sdk.scope import Scope

--- a/sentry_sdk/tracing_utils.py
+++ b/sentry_sdk/tracing_utils.py
@@ -255,7 +255,8 @@ class Baggage(object):
 
     @classmethod
     def from_options(cls, scope):
-        # XXX fix type here, Scope can't be imported due to a circular ref: type: (Optional[Scope]) -> Optional[Baggage]
+        # XXX fix type here, Scope can't be imported due to a circular ref
+        # should be type: (Scope) -> Optional[Baggage]
         # type: (Any) -> Optional[Baggage]
         sentry_items = {}  # type: Dict[str, str]
         third_party_items = ""

--- a/sentry_sdk/tracing_utils.py
+++ b/sentry_sdk/tracing_utils.py
@@ -383,14 +383,12 @@ def normalize_incoming_data(incoming_data):
     Normalizes incoming data so the keys are all lowercase with dashes instead of underscores and stripped from known prefixes.
     """
     data = {}
-    for k, v in incoming_data.items():
-        if k.startswith("HTTP_"):
-            k = k[5:]
+    for key, value in incoming_data.items():
+        if key.startswith("HTTP_"):
+            key = key[5:]
 
-        # TODO: when loading from environment like described in RFC-0071 also trim `SENTRY_TRACING_` prefix.
-
-        k = k.replace("_", "-").lower()
-        data[k] = v
+        key = key.replace("_", "-").lower()
+        data[key] = value
 
     return data
 

--- a/sentry_sdk/tracing_utils.py
+++ b/sentry_sdk/tracing_utils.py
@@ -377,5 +377,23 @@ def should_propagate_trace(hub, url):
     return match_regex_list(url, trace_propagation_targets, substring_matching=True)
 
 
+def normalize_incoming_data(incoming_data):
+    # type: (Dict[str, Any]) -> Dict[str, Any]
+    """
+    Normalizes incoming data so the keys are all lowercase with dashes instead of underscores and stripped from known prefixes.
+    """
+    data = {}
+    for k, v in incoming_data.items():
+        if k.startswith("HTTP_"):
+            k = k[5:]
+
+        # TODO: when loading from environment like described in RFC-0071 also trim `SENTRY_TRACING_` prefix.
+
+        k = k.replace("_", "-").lower()
+        data[k] = v
+
+    return data
+
+
 # Circular imports
 from sentry_sdk.tracing import LOW_QUALITY_TRANSACTION_SOURCES

--- a/sentry_sdk/tracing_utils.py
+++ b/sentry_sdk/tracing_utils.py
@@ -255,8 +255,6 @@ class Baggage(object):
 
     @classmethod
     def from_options(cls, scope):
-        # XXX fix type here, Scope can't be imported due to a circular ref
-        # should be type: (Scope) -> Optional[Baggage]
         # type: (Any) -> Optional[Baggage]
         sentry_items = {}  # type: Dict[str, str]
         third_party_items = ""
@@ -264,7 +262,7 @@ class Baggage(object):
 
         client = sentry_sdk.Hub.current.client
 
-        if client is None or scope is None or scope._propagation_context is None:
+        if client is None or scope._propagation_context is None:
             return Baggage(sentry_items)
 
         options = client.options

--- a/tests/integrations/asgi/test_asgi.py
+++ b/tests/integrations/asgi/test_asgi.py
@@ -24,7 +24,7 @@ def asgi3_app():
             and "route" in scope
             and scope["route"] == "/trigger/error"
         ):
-            division_by_zero = 1 / 0  # noqa
+            1 / 0
 
         await send(
             {
@@ -59,7 +59,7 @@ def asgi3_app_with_error():
             }
         )
 
-        division_by_zero = 1 / 0  # noqa
+        1 / 0
 
         await send(
             {
@@ -85,7 +85,7 @@ def asgi3_app_with_error_and_msg():
         )
 
         capture_message("Let's try dividing by 0")
-        division_by_zero = 1 / 0  # noqa
+        1 / 0
 
         await send(
             {

--- a/tests/integrations/aws_lambda/client.py
+++ b/tests/integrations/aws_lambda/client.py
@@ -104,14 +104,14 @@ def run_lambda_function(
 
             subprocess.check_call(
                 [sys.executable, "setup.py", "sdist", "-d", os.path.join(tmpdir, "..")],
-                **subprocess_kwargs
+                **subprocess_kwargs,
             )
 
             subprocess.check_call(
                 "pip install mock==3.0.0 funcsigs -t .",
                 cwd=tmpdir,
                 shell=True,
-                **subprocess_kwargs
+                **subprocess_kwargs,
             )
 
             # https://docs.aws.amazon.com/lambda/latest/dg/lambda-python-how-to-create-deployment-package.html
@@ -119,10 +119,14 @@ def run_lambda_function(
                 "pip install ../*.tar.gz -t .",
                 cwd=tmpdir,
                 shell=True,
-                **subprocess_kwargs
+                **subprocess_kwargs,
             )
 
             shutil.make_archive(os.path.join(tmpdir, "ball"), "zip", tmpdir)
+
+            print(
+                f"Creating {runtime} Lambda function '{fn_name}' in role {os.environ['SENTRY_PYTHON_TEST_AWS_IAM_ROLE']}"
+            )
 
             with open(os.path.join(tmpdir, "ball.zip"), "rb") as zip:
                 client.create_function(

--- a/tests/integrations/aws_lambda/client.py
+++ b/tests/integrations/aws_lambda/client.py
@@ -104,14 +104,14 @@ def run_lambda_function(
 
             subprocess.check_call(
                 [sys.executable, "setup.py", "sdist", "-d", os.path.join(tmpdir, "..")],
-                **subprocess_kwargs,
+                **subprocess_kwargs
             )
 
             subprocess.check_call(
                 "pip install mock==3.0.0 funcsigs -t .",
                 cwd=tmpdir,
                 shell=True,
-                **subprocess_kwargs,
+                **subprocess_kwargs
             )
 
             # https://docs.aws.amazon.com/lambda/latest/dg/lambda-python-how-to-create-deployment-package.html
@@ -119,14 +119,10 @@ def run_lambda_function(
                 "pip install ../*.tar.gz -t .",
                 cwd=tmpdir,
                 shell=True,
-                **subprocess_kwargs,
+                **subprocess_kwargs
             )
 
             shutil.make_archive(os.path.join(tmpdir, "ball"), "zip", tmpdir)
-
-            print(
-                f"Creating {runtime} Lambda function '{fn_name}' in role {os.environ['SENTRY_PYTHON_TEST_AWS_IAM_ROLE']}"
-            )
 
             with open(os.path.join(tmpdir, "ball.zip"), "rb") as zip:
                 client.create_function(

--- a/tests/integrations/aws_lambda/test_aws.py
+++ b/tests/integrations/aws_lambda/test_aws.py
@@ -25,8 +25,6 @@ import pytest
 boto3 = pytest.importorskip("boto3")
 
 LAMBDA_PRELUDE = """
-from __future__ import print_function
-
 from sentry_sdk.integrations.aws_lambda import AwsLambdaIntegration, get_lambda_bootstrap
 import sentry_sdk
 import json
@@ -107,10 +105,10 @@ def lambda_client():
 
 @pytest.fixture(
     params=[
-        "python3.7",
+        # "python3.7",
         "python3.8",
-        "python3.9",
-        "python3.10",
+        # "python3.9",
+        # "python3.10",
     ]
 )
 def lambda_runtime(request):
@@ -671,32 +669,136 @@ def test_serverless_no_code_instrumentation(run_lambda_function):
 
 
 def test_error_has_new_trace_context_performance_enabled(run_lambda_function):
-    envelopes, events, response = run_lambda_function(
+    envelopes, _, _ = run_lambda_function(
         LAMBDA_PRELUDE
         + dedent(
             """
         init_sdk(traces_sample_rate=1.0)
 
         def test_handler(event, context):
+            sentry_sdk.capture_message("hi")
             raise Exception("something went wrong")
         """
         ),
-        b'{"foo": "bar"}',
+        payload=b'{"foo": "bar"}',
     )
 
-    (event,) = events
-    assert event["level"] == "error"
-    assert "trace" in event["contexts"]
-    assert "trace_id" in event["contexts"]["trace"]
+    (msg_event, error_event, transaction_event) = envelopes
+
+    assert "trace" in msg_event["contexts"]
+    assert "trace_id" in msg_event["contexts"]["trace"]
+
+    assert "trace" in error_event["contexts"]
+    assert "trace_id" in error_event["contexts"]["trace"]
+
+    assert "trace" in transaction_event["contexts"]
+    assert "trace_id" in transaction_event["contexts"]["trace"]
+
+    assert (
+        msg_event["contexts"]["trace"]["trace_id"]
+        == error_event["contexts"]["trace"]["trace_id"]
+        == transaction_event["contexts"]["trace"]["trace_id"]
+    )
 
 
 def test_error_has_new_trace_context_performance_disabled(run_lambda_function):
-    ...
+    _, events, _ = run_lambda_function(
+        LAMBDA_PRELUDE
+        + dedent(
+            """
+        init_sdk(traces_sample_rate=None) # this is the default, just added for clarity
+
+        def test_handler(event, context):
+            sentry_sdk.capture_message("hi")
+            raise Exception("something went wrong")
+        """
+        ),
+        payload=b'{"foo": "bar"}',
+    )
+
+    (msg_event, error_event) = events
+
+    assert "trace" in msg_event["contexts"]
+    assert "trace_id" in msg_event["contexts"]["trace"]
+
+    assert "trace" in error_event["contexts"]
+    assert "trace_id" in error_event["contexts"]["trace"]
+
+    assert (
+        msg_event["contexts"]["trace"]["trace_id"]
+        == error_event["contexts"]["trace"]["trace_id"]
+    )
 
 
 def test_error_has_existing_trace_context_performance_enabled(run_lambda_function):
-    ...
+    trace_id = "471a43a4192642f0b136d5159a501701"
+    parent_span_id = "6e8f22c393e68f19"
+    parent_sampled = 1
+    sentry_trace_header = "{}-{}-{}".format(trace_id, parent_span_id, parent_sampled)
+
+    envelopes, _, _ = run_lambda_function(
+        LAMBDA_PRELUDE
+        + dedent(
+            """
+        init_sdk(traces_sample_rate=1.0)
+
+        def test_handler(event, context):
+            sentry_sdk.capture_message("hi")
+            raise Exception("something went wrong")
+        """
+        ),
+        payload=b'{"sentry_trace": "%s"}' % sentry_trace_header.encode(),
+    )
+
+    (msg_event, error_event, transaction_event) = envelopes
+
+    assert "trace" in msg_event["contexts"]
+    assert "trace_id" in msg_event["contexts"]["trace"]
+
+    assert "trace" in error_event["contexts"]
+    assert "trace_id" in error_event["contexts"]["trace"]
+
+    assert "trace" in transaction_event["contexts"]
+    assert "trace_id" in transaction_event["contexts"]["trace"]
+
+    assert (
+        msg_event["contexts"]["trace"]["trace_id"]
+        == error_event["contexts"]["trace"]["trace_id"]
+        == transaction_event["contexts"]["trace"]["trace_id"]
+        == "471a43a4192642f0b136d5159a501701"
+    )
 
 
 def test_error_has_existing_trace_context_performance_disabled(run_lambda_function):
-    ...
+    trace_id = "471a43a4192642f0b136d5159a501701"
+    parent_span_id = "6e8f22c393e68f19"
+    parent_sampled = 1
+    sentry_trace_header = "{}-{}-{}".format(trace_id, parent_span_id, parent_sampled)
+
+    _, events, _ = run_lambda_function(
+        LAMBDA_PRELUDE
+        + dedent(
+            """
+        init_sdk(traces_sample_rate=None)  # this is the default, just added for clarity
+
+        def test_handler(event, context):
+            sentry_sdk.capture_message("hi")
+            raise Exception("something went wrong")
+        """
+        ),
+        payload=b'{"sentry_trace": "%s"}' % sentry_trace_header.encode(),
+    )
+
+    (msg_event, error_event) = events
+
+    assert "trace" in msg_event["contexts"]
+    assert "trace_id" in msg_event["contexts"]["trace"]
+
+    assert "trace" in error_event["contexts"]
+    assert "trace_id" in error_event["contexts"]["trace"]
+
+    assert (
+        msg_event["contexts"]["trace"]["trace_id"]
+        == error_event["contexts"]["trace"]["trace_id"]
+        == "471a43a4192642f0b136d5159a501701"
+    )

--- a/tests/integrations/aws_lambda/test_aws.py
+++ b/tests/integrations/aws_lambda/test_aws.py
@@ -666,3 +666,35 @@ def test_serverless_no_code_instrumentation(run_lambda_function):
         assert response["Payload"]["errorMessage"] == "something went wrong"
 
         assert "sentry_handler" in response["LogResult"][3].decode("utf-8")
+
+
+def test_error_has_new_trace_context_performance_enabled(run_lambda_function):
+    envelopes, events, response = run_lambda_function(
+        LAMBDA_PRELUDE
+        + dedent(
+            """
+        init_sdk(traces_sample_rate=1.0)
+
+        def test_handler(event, context):
+            raise Exception("something went wrong")
+        """
+        ),
+        b'{"foo": "bar"}',
+    )
+
+    (event,) = events
+    assert event["level"] == "error"
+    assert "trace" in event["contexts"]
+    assert "trace_id" in event["contexts"]["trace"]
+
+
+def test_error_has_new_trace_context_performance_disabled(run_lambda_function):
+    ...
+
+
+def test_error_has_existing_trace_context_performance_enabled(run_lambda_function):
+    ...
+
+
+def test_error_has_existing_trace_context_performance_disabled(run_lambda_function):
+    ...

--- a/tests/integrations/aws_lambda/test_aws.py
+++ b/tests/integrations/aws_lambda/test_aws.py
@@ -105,10 +105,9 @@ def lambda_client():
 
 @pytest.fixture(
     params=[
-        # "python3.7",
+        "python3.7",
         "python3.8",
-        # "python3.9",
-        # "python3.10",
+        "python3.9",
     ]
 )
 def lambda_runtime(request):

--- a/tests/integrations/aws_lambda/test_aws.py
+++ b/tests/integrations/aws_lambda/test_aws.py
@@ -106,7 +106,12 @@ def lambda_client():
 
 
 @pytest.fixture(
-    params=["python3.6", "python3.7", "python3.8", "python3.9", "python2.7"]
+    params=[
+        "python3.7",
+        "python3.8",
+        "python3.9",
+        "python3.10",
+    ]
 )
 def lambda_runtime(request):
     return request.param
@@ -284,9 +289,6 @@ def test_request_data(run_lambda_function):
 
 
 def test_init_error(run_lambda_function, lambda_runtime):
-    if lambda_runtime == "python2.7":
-        pytest.skip("initialization error not supported on Python 2.7")
-
     envelopes, events, response = run_lambda_function(
         LAMBDA_PRELUDE
         + (

--- a/tests/integrations/django/asgi/test_asgi.py
+++ b/tests/integrations/django/asgi/test_asgi.py
@@ -83,9 +83,7 @@ async def test_async_views(sentry_init, capture_events, application):
 @pytest.mark.skipif(
     django.VERSION < (3, 1), reason="async views have been introduced in Django 3.1"
 )
-async def test_active_thread_id(
-    sentry_init, capture_envelopes, teardown_profiling, endpoint, application
-):
+async def test_active_thread_id(sentry_init, capture_envelopes, endpoint, application):
     with mock.patch("sentry_sdk.profiler.PROFILE_MINIMUM_SAMPLES", 0):
         sentry_init(
             integrations=[DjangoIntegration()],
@@ -119,7 +117,7 @@ async def test_active_thread_id(
 @pytest.mark.skipif(
     django.VERSION < (3, 1), reason="async views have been introduced in Django 3.1"
 )
-async def test_async_views_concurrent_execution(sentry_init, capture_events, settings):
+async def test_async_views_concurrent_execution(sentry_init, settings):
     import asyncio
     import time
 
@@ -153,7 +151,7 @@ async def test_async_views_concurrent_execution(sentry_init, capture_events, set
     django.VERSION < (3, 1), reason="async views have been introduced in Django 3.1"
 )
 async def test_async_middleware_that_is_function_concurrent_execution(
-    sentry_init, capture_events, settings
+    sentry_init, settings
 ):
     import asyncio
     import time

--- a/tests/integrations/django/asgi/test_asgi.py
+++ b/tests/integrations/django/asgi/test_asgi.py
@@ -233,6 +233,9 @@ async def test_async_middleware_spans(
 
 
 @pytest.mark.asyncio
+@pytest.mark.skipif(
+    django.VERSION < (3, 1), reason="async views have been introduced in Django 3.1"
+)
 async def test_has_trace_if_performance_enabled(sentry_init, capture_events):
     sentry_init(integrations=[DjangoIntegration()], traces_sample_rate=1.0)
 
@@ -259,6 +262,9 @@ async def test_has_trace_if_performance_enabled(sentry_init, capture_events):
 
 
 @pytest.mark.asyncio
+@pytest.mark.skipif(
+    django.VERSION < (3, 1), reason="async views have been introduced in Django 3.1"
+)
 async def test_has_trace_if_performance_disabled(sentry_init, capture_events):
     sentry_init(integrations=[DjangoIntegration()])
 
@@ -282,6 +288,9 @@ async def test_has_trace_if_performance_disabled(sentry_init, capture_events):
 
 
 @pytest.mark.asyncio
+@pytest.mark.skipif(
+    django.VERSION < (3, 1), reason="async views have been introduced in Django 3.1"
+)
 async def test_trace_from_headers_if_performance_enabled(sentry_init, capture_events):
     sentry_init(integrations=[DjangoIntegration()], traces_sample_rate=1.0)
 
@@ -314,6 +323,9 @@ async def test_trace_from_headers_if_performance_enabled(sentry_init, capture_ev
 
 
 @pytest.mark.asyncio
+@pytest.mark.skipif(
+    django.VERSION < (3, 1), reason="async views have been introduced in Django 3.1"
+)
 async def test_trace_from_headers_if_performance_disabled(sentry_init, capture_events):
     sentry_init(integrations=[DjangoIntegration()])
 

--- a/tests/integrations/django/asgi/test_asgi.py
+++ b/tests/integrations/django/asgi/test_asgi.py
@@ -242,7 +242,9 @@ async def test_has_trace_if_performance_enabled(sentry_init, capture_events):
     response = await comm.get_response()
     assert response["status"] == 500
 
-    (msg_event, error_event, transaction_event) = events
+    # ASGI Django does not create transactions per default,
+    # so we do not have a transaction_event here.
+    (msg_event, error_event) = events
 
     assert msg_event["contexts"]["trace"]
     assert "trace_id" in msg_event["contexts"]["trace"]
@@ -250,13 +252,9 @@ async def test_has_trace_if_performance_enabled(sentry_init, capture_events):
     assert error_event["contexts"]["trace"]
     assert "trace_id" in error_event["contexts"]["trace"]
 
-    assert transaction_event["contexts"]["trace"]
-    assert "trace_id" in transaction_event["contexts"]["trace"]
-
     assert (
         msg_event["contexts"]["trace"]["trace_id"]
         == error_event["contexts"]["trace"]["trace_id"]
-        == transaction_event["contexts"]["trace"]["trace_id"]
     )
 
 
@@ -301,7 +299,9 @@ async def test_trace_from_headers_if_performance_enabled(sentry_init, capture_ev
     response = await comm.get_response()
     assert response["status"] == 500
 
-    (msg_event, error_event, transaction_event) = events
+    # ASGI Django does not create transactions per default,
+    # so we do not have a transaction_event here.
+    (msg_event, error_event) = events
 
     assert msg_event["contexts"]["trace"]
     assert "trace_id" in msg_event["contexts"]["trace"]
@@ -309,12 +309,8 @@ async def test_trace_from_headers_if_performance_enabled(sentry_init, capture_ev
     assert error_event["contexts"]["trace"]
     assert "trace_id" in error_event["contexts"]["trace"]
 
-    assert transaction_event["contexts"]["trace"]
-    assert "trace_id" in transaction_event["contexts"]["trace"]
-
     assert msg_event["contexts"]["trace"]["trace_id"] == trace_id
     assert error_event["contexts"]["trace"]["trace_id"] == trace_id
-    assert transaction_event["contexts"]["trace"]["trace_id"] == trace_id
 
 
 @pytest.mark.asyncio

--- a/tests/integrations/django/myapp/urls.py
+++ b/tests/integrations/django/myapp/urls.py
@@ -28,6 +28,7 @@ from . import views
 
 urlpatterns = [
     path("view-exc", views.view_exc, name="view_exc"),
+    path("view-exc-with-msg", views.view_exc_with_msg, name="view_exc_with_msg"),
     path("cached-view", views.cached_view, name="cached_view"),
     path("not-cached-view", views.not_cached_view, name="not_cached_view"),
     path(

--- a/tests/integrations/django/myapp/views.py
+++ b/tests/integrations/django/myapp/views.py
@@ -14,7 +14,6 @@ from django.views.decorators.cache import cache_page
 from django.views.decorators.csrf import csrf_exempt
 from django.views.generic import ListView
 
-
 try:
     from rest_framework.decorators import api_view
     from rest_framework.response import Response
@@ -45,10 +44,17 @@ except ImportError:
 
 
 import sentry_sdk
+from sentry_sdk import capture_message
 
 
 @csrf_exempt
 def view_exc(request):
+    1 / 0
+
+
+@csrf_exempt
+def view_exc_with_msg(request):
+    capture_message("oops")
     1 / 0
 
 

--- a/tests/integrations/django/test_basic.py
+++ b/tests/integrations/django/test_basic.py
@@ -162,6 +162,112 @@ def test_transaction_with_class_view(sentry_init, client, capture_events):
     assert event["message"] == "hi"
 
 
+def test_has_trace_if_performance_enabled(sentry_init, client, capture_events):
+    sentry_init(
+        integrations=[DjangoIntegration()],
+        traces_sample_rate=1.0,
+    )
+    events = capture_events()
+    client.head(reverse("view_exc_with_msg"))
+
+    (msg_event, error_event, transaction_event) = events
+
+    assert msg_event["contexts"]["trace"]
+    assert "trace_id" in msg_event["contexts"]["trace"]
+
+    assert error_event["contexts"]["trace"]
+    assert "trace_id" in error_event["contexts"]["trace"]
+
+    assert transaction_event["contexts"]["trace"]
+    assert "trace_id" in transaction_event["contexts"]["trace"]
+
+    assert (
+        msg_event["contexts"]["trace"]["trace_id"]
+        == error_event["contexts"]["trace"]["trace_id"]
+        == transaction_event["contexts"]["trace"]["trace_id"]
+    )
+
+
+def test_has_trace_if_performance_disabled(sentry_init, client, capture_events):
+    sentry_init(
+        integrations=[DjangoIntegration()],
+    )
+    events = capture_events()
+    client.head(reverse("view_exc_with_msg"))
+
+    (msg_event, error_event) = events
+
+    assert msg_event["contexts"]["trace"]
+    assert "trace_id" in msg_event["contexts"]["trace"]
+
+    assert error_event["contexts"]["trace"]
+    assert "trace_id" in error_event["contexts"]["trace"]
+
+    assert (
+        msg_event["contexts"]["trace"]["trace_id"]
+        == error_event["contexts"]["trace"]["trace_id"]
+    )
+
+
+def test_trace_from_headers_if_performance_enabled(sentry_init, client, capture_events):
+    sentry_init(
+        integrations=[DjangoIntegration()],
+        traces_sample_rate=1.0,
+    )
+
+    events = capture_events()
+
+    trace_id = "582b43a4192642f0b136d5159a501701"
+    sentry_trace_header = "{}-{}-{}".format(trace_id, "6e8f22c393e68f19", 1)
+
+    client.head(
+        reverse("view_exc_with_msg"), headers={"sentry-trace": sentry_trace_header}
+    )
+
+    (msg_event, error_event, transaction_event) = events
+
+    assert msg_event["contexts"]["trace"]
+    assert "trace_id" in msg_event["contexts"]["trace"]
+
+    assert error_event["contexts"]["trace"]
+    assert "trace_id" in error_event["contexts"]["trace"]
+
+    assert transaction_event["contexts"]["trace"]
+    assert "trace_id" in transaction_event["contexts"]["trace"]
+
+    assert msg_event["contexts"]["trace"]["trace_id"] == trace_id
+    assert error_event["contexts"]["trace"]["trace_id"] == trace_id
+    assert transaction_event["contexts"]["trace"]["trace_id"] == trace_id
+
+
+def test_trace_from_headers_if_performance_disabled(
+    sentry_init, client, capture_events
+):
+    sentry_init(
+        integrations=[DjangoIntegration()],
+    )
+
+    events = capture_events()
+
+    trace_id = "582b43a4192642f0b136d5159a501701"
+    sentry_trace_header = "{}-{}-{}".format(trace_id, "6e8f22c393e68f19", 1)
+
+    client.head(
+        reverse("view_exc_with_msg"), headers={"sentry-trace": sentry_trace_header}
+    )
+
+    (msg_event, error_event) = events
+
+    assert msg_event["contexts"]["trace"]
+    assert "trace_id" in msg_event["contexts"]["trace"]
+
+    assert error_event["contexts"]["trace"]
+    assert "trace_id" in error_event["contexts"]["trace"]
+
+    assert msg_event["contexts"]["trace"]["trace_id"] == trace_id
+    assert error_event["contexts"]["trace"]["trace_id"] == trace_id
+
+
 @pytest.mark.forked
 @pytest.mark.django_db
 def test_user_captured(sentry_init, client, capture_events):

--- a/tests/integrations/gcp/test_gcp.py
+++ b/tests/integrations/gcp/test_gcp.py
@@ -540,10 +540,7 @@ def test_error_has_existing_trace_context_performance_disabled(run_cloud_functio
         """
         )
     )
-    (
-        msg_event,
-        error_event,
-    ) = events
+    (msg_event, error_event) = events
 
     assert "trace" in msg_event["contexts"]
     assert "trace_id" in msg_event["contexts"]["trace"]

--- a/tests/integrations/gcp/test_gcp.py
+++ b/tests/integrations/gcp/test_gcp.py
@@ -372,3 +372,187 @@ def test_traces_sampler_gets_correct_values_in_sampling_context(
     )
 
     assert return_value["AssertionError raised"] is False
+
+
+def test_error_has_new_trace_context_performance_enabled(run_cloud_function):
+    """
+    Check if an 'trace' context is added to errros and transactions when performance monitoring is enabled.
+    """
+    envelopes, _, _ = run_cloud_function(
+        dedent(
+            """
+        functionhandler = None
+        event = {}
+        def cloud_function(functionhandler, event):
+            sentry_sdk.capture_message("hi")
+            x = 3/0
+            return "3"
+        """
+        )
+        + FUNCTIONS_PRELUDE
+        + dedent(
+            """
+        init_sdk(traces_sample_rate=1.0)
+        gcp_functions.worker_v1.FunctionHandler.invoke_user_function(functionhandler, event)
+        """
+        )
+    )
+    (msg_event, error_event, transaction_event) = envelopes
+
+    assert "trace" in msg_event["contexts"]
+    assert "trace_id" in msg_event["contexts"]["trace"]
+
+    assert "trace" in error_event["contexts"]
+    assert "trace_id" in error_event["contexts"]["trace"]
+
+    assert "trace" in transaction_event["contexts"]
+    assert "trace_id" in transaction_event["contexts"]["trace"]
+
+    assert (
+        msg_event["contexts"]["trace"]["trace_id"]
+        == error_event["contexts"]["trace"]["trace_id"]
+        == transaction_event["contexts"]["trace"]["trace_id"]
+    )
+
+
+def test_error_has_new_trace_context_performance_disabled(run_cloud_function):
+    """
+    Check if an 'trace' context is added to errros and transactions when performance monitoring is disabled.
+    """
+    _, events, _ = run_cloud_function(
+        dedent(
+            """
+        functionhandler = None
+        event = {}
+        def cloud_function(functionhandler, event):
+            sentry_sdk.capture_message("hi")
+            x = 3/0
+            return "3"
+        """
+        )
+        + FUNCTIONS_PRELUDE
+        + dedent(
+            """
+        init_sdk(traces_sample_rate=None),  # this is the default, just added for clarity
+        gcp_functions.worker_v1.FunctionHandler.invoke_user_function(functionhandler, event)
+        """
+        )
+    )
+
+    (msg_event, error_event) = events
+
+    assert "trace" in msg_event["contexts"]
+    assert "trace_id" in msg_event["contexts"]["trace"]
+
+    assert "trace" in error_event["contexts"]
+    assert "trace_id" in error_event["contexts"]["trace"]
+
+    assert (
+        msg_event["contexts"]["trace"]["trace_id"]
+        == error_event["contexts"]["trace"]["trace_id"]
+    )
+
+
+def test_error_has_existing_trace_context_performance_enabled(run_cloud_function):
+    """
+    Check if an 'trace' context is added to errros and transactions
+    from the incoming 'sentry-trace' header when performance monitoring is enabled.
+    """
+    trace_id = "471a43a4192642f0b136d5159a501701"
+    parent_span_id = "6e8f22c393e68f19"
+    parent_sampled = 1
+    sentry_trace_header = "{}-{}-{}".format(trace_id, parent_span_id, parent_sampled)
+
+    envelopes, _, _ = run_cloud_function(
+        dedent(
+            """
+        functionhandler = None
+
+        from collections import namedtuple
+        GCPEvent = namedtuple("GCPEvent", ["headers"])
+        event = GCPEvent(headers={"sentry-trace": "%s"})
+
+        def cloud_function(functionhandler, event):
+            sentry_sdk.capture_message("hi")
+            x = 3/0
+            return "3"
+        """
+            % sentry_trace_header
+        )
+        + FUNCTIONS_PRELUDE
+        + dedent(
+            """
+        init_sdk(traces_sample_rate=1.0)
+        gcp_functions.worker_v1.FunctionHandler.invoke_user_function(functionhandler, event)
+        """
+        )
+    )
+    (msg_event, error_event, transaction_event) = envelopes
+
+    assert "trace" in msg_event["contexts"]
+    assert "trace_id" in msg_event["contexts"]["trace"]
+
+    assert "trace" in error_event["contexts"]
+    assert "trace_id" in error_event["contexts"]["trace"]
+
+    assert "trace" in transaction_event["contexts"]
+    assert "trace_id" in transaction_event["contexts"]["trace"]
+
+    assert (
+        msg_event["contexts"]["trace"]["trace_id"]
+        == error_event["contexts"]["trace"]["trace_id"]
+        == transaction_event["contexts"]["trace"]["trace_id"]
+        == "471a43a4192642f0b136d5159a501701"
+    )
+
+
+def test_error_has_existing_trace_context_performance_disabled(run_cloud_function):
+    """
+    Check if an 'trace' context is added to errros and transactions
+    from the incoming 'sentry-trace' header when performance monitoring is disabled.
+    """
+    trace_id = "471a43a4192642f0b136d5159a501701"
+    parent_span_id = "6e8f22c393e68f19"
+    parent_sampled = 1
+    sentry_trace_header = "{}-{}-{}".format(trace_id, parent_span_id, parent_sampled)
+
+    _, events, _ = run_cloud_function(
+        dedent(
+            """
+        functionhandler = None
+
+        from collections import namedtuple
+        GCPEvent = namedtuple("GCPEvent", ["headers"])
+        event = GCPEvent(headers={"sentry-trace": "%s"})
+
+        def cloud_function(functionhandler, event):
+            sentry_sdk.capture_message("hi")
+            x = 3/0
+            return "3"
+        """
+            % sentry_trace_header
+        )
+        + FUNCTIONS_PRELUDE
+        + dedent(
+            """
+        init_sdk(traces_sample_rate=None),  # this is the default, just added for clarity
+        gcp_functions.worker_v1.FunctionHandler.invoke_user_function(functionhandler, event)
+        """
+        )
+    )
+    (
+        msg_event,
+        error_event,
+    ) = events
+
+    assert "trace" in msg_event["contexts"]
+    assert "trace_id" in msg_event["contexts"]["trace"]
+
+    assert "trace" in error_event["contexts"]
+    assert "trace_id" in error_event["contexts"]["trace"]
+
+    assert (
+        msg_event["contexts"]["trace"]["trace_id"]
+        == error_event["contexts"]["trace"]["trace_id"]
+        == "471a43a4192642f0b136d5159a501701"
+    )

--- a/tests/integrations/rq/test_rq.py
+++ b/tests/integrations/rq/test_rq.py
@@ -1,5 +1,6 @@
 import pytest
 from fakeredis import FakeStrictRedis
+from sentry_sdk import configure_scope, start_transaction
 from sentry_sdk.integrations.rq import RqIntegration
 
 import rq
@@ -93,7 +94,6 @@ def test_transport_shutdown(sentry_init, capture_events_forksafe):
 def test_transaction_with_error(
     sentry_init, capture_events, DictionaryContaining  # noqa:N803
 ):
-
     sentry_init(integrations=[RqIntegration()], traces_sample_rate=1.0)
     events = capture_events()
 
@@ -124,6 +124,71 @@ def test_transaction_with_error(
             "description": "tests.integrations.rq.test_rq.chew_up_shoes('Charlie', 'Katie', shoes='flip-flops')",
         }
     )
+
+
+def test_error_has_trace_context_if_tracing_disabled(
+    sentry_init,
+    capture_events,
+):
+    sentry_init(integrations=[RqIntegration()])
+    events = capture_events()
+
+    queue = rq.Queue(connection=FakeStrictRedis())
+    worker = rq.SimpleWorker([queue], connection=queue.connection)
+
+    queue.enqueue(crashing_job, foo=None)
+    worker.work(burst=True)
+
+    (error_event,) = events
+
+    assert error_event["contexts"]["trace"]
+
+
+def test_performance_enabled(
+    sentry_init,
+    capture_events,
+):
+    sentry_init(integrations=[RqIntegration()], traces_sample_rate=1.0)
+    events = capture_events()
+
+    queue = rq.Queue(connection=FakeStrictRedis())
+    worker = rq.SimpleWorker([queue], connection=queue.connection)
+
+    with start_transaction(op="rq transaction") as transaction:
+        queue.enqueue(crashing_job, foo=None)
+        worker.work(burst=True)
+
+    error_event, envelope, _ = events
+
+    assert error_event["transaction"] == "tests.integrations.rq.test_rq.crashing_job"
+    assert error_event["contexts"]["trace"]["trace_id"] == transaction.trace_id
+
+    assert envelope["contexts"]["trace"] == error_event["contexts"]["trace"]
+
+
+def test_performance_disabled(
+    sentry_init,
+    capture_events,
+):
+    sentry_init(integrations=[RqIntegration()])
+    events = capture_events()
+
+    queue = rq.Queue(connection=FakeStrictRedis())
+    worker = rq.SimpleWorker([queue], connection=queue.connection)
+
+    with configure_scope() as scope:
+        queue.enqueue(crashing_job, foo=None)
+        worker.work(burst=True)
+
+        (error_event,) = events
+
+        assert (
+            error_event["transaction"] == "tests.integrations.rq.test_rq.crashing_job"
+        )
+        assert (
+            error_event["contexts"]["trace"]["trace_id"]
+            == scope._propagation_context["trace_id"]
+        )
 
 
 def test_transaction_no_error(

--- a/tests/integrations/tornado/test_tornado.py
+++ b/tests/integrations/tornado/test_tornado.py
@@ -356,6 +356,11 @@ def test_error_has_new_trace_context_performance_disabled(
     assert "trace" in error_event["contexts"]
     assert "trace_id" in error_event["contexts"]["trace"]
 
+    assert (
+        msg_event["contexts"]["trace"]["trace_id"]
+        == error_event["contexts"]["trace"]["trace_id"]
+    )
+
 
 def test_error_has_existing_trace_context_performance_enabled(
     tornado_testcase, sentry_init, capture_events

--- a/tests/integrations/tornado/test_tornado.py
+++ b/tests/integrations/tornado/test_tornado.py
@@ -348,10 +348,7 @@ def test_error_has_new_trace_context_performance_disabled(
     client = tornado_testcase(Application([(r"/hi", CrashingWithMessageHandler)]))
     client.fetch("/hi")
 
-    (
-        msg_event,
-        error_event,
-    ) = events
+    (msg_event, error_event) = events
 
     assert "trace" in msg_event["contexts"]
     assert "trace_id" in msg_event["contexts"]["trace"]
@@ -425,10 +422,7 @@ def test_error_has_existing_trace_context_performance_disabled(
     client = tornado_testcase(Application([(r"/hi", CrashingWithMessageHandler)]))
     client.fetch("/hi", headers=headers)
 
-    (
-        msg_event,
-        error_event,
-    ) = events
+    (msg_event, error_event) = events
 
     assert "trace" in msg_event["contexts"]
     assert "trace_id" in msg_event["contexts"]["trace"]

--- a/tests/integrations/wsgi/test_wsgi.py
+++ b/tests/integrations/wsgi/test_wsgi.py
@@ -211,9 +211,9 @@ def test_has_trace_if_performance_enabled(
     assert "trace_id" in transaction_event["contexts"]["trace"]
 
     assert (
-        error_event["contexts"]["trace"]["trace_id"]
+        msg_event["contexts"]["trace"]["trace_id"]
+        == error_event["contexts"]["trace"]["trace_id"]
         == transaction_event["contexts"]["trace"]["trace_id"]
-        == msg_event["contexts"]["trace"]["trace_id"]
     )
 
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,8 +1,12 @@
 from sentry_sdk import (
+    baggage,
     configure_scope,
+    continue_trace,
     get_current_span,
     start_transaction,
+    traceparent,
 )
+from sentry_sdk.hub import Hub
 
 try:
     from unittest import mock  # python 3.3 and above
@@ -40,3 +44,77 @@ def test_get_current_span_default_hub_with_transaction(sentry_init):
 
     with start_transaction() as new_transaction:
         assert get_current_span() == new_transaction
+
+
+def test_traceparent_with_tracing(sentry_init):
+    sentry_init(traces_sample_rate=1.0)
+
+    with start_transaction() as transaction:
+        expected_traceparent = "%s-%s-1" % (
+            transaction.trace_id,
+            transaction.span_id,
+        )
+        assert traceparent() == expected_traceparent
+
+
+def test_traceparent_without_tracing(sentry_init):
+    sentry_init()
+
+    propagation_context = Hub.current.scope._propagation_context
+    expected_traceparent = "%s-%s" % (
+        propagation_context["trace_id"],
+        propagation_context["span_id"],
+    )
+    assert traceparent() == expected_traceparent
+
+
+def test_baggage_without_tracing(sentry_init):
+    sentry_init(release="1.0.0", environment="dev")
+    bag = baggage()
+    propagation_context = Hub.current.scope._propagation_context
+    assert bag.sentry_items == {
+        "trace_id": propagation_context["trace_id"],
+        "release": "1.0.0",
+        "environment": "dev",
+    }
+    assert bag.third_party_items == ""
+    assert not bag.mutable
+
+
+def test_baggage_with_tracing(sentry_init):
+    sentry_init(traces_sample_rate=1.0, release="1.0.0", environment="dev")
+    with start_transaction() as transaction:
+        bag = baggage()
+        assert bag.sentry_items == {
+            "trace_id": transaction.trace_id,
+            "release": "1.0.0",
+            "sample_rate": "1.0",
+            "environment": "dev",
+        }
+        assert bag.third_party_items == ""
+        assert not bag.mutable
+
+
+def test_continue_trace(sentry_init):
+    sentry_init()
+
+    trace_id = "471a43a4192642f0b136d5159a501701"
+    parent_span_id = "6e8f22c393e68f19"
+    parent_sampled = 1
+    transaction = continue_trace(
+        {
+            "sentry-trace": "{}-{}-{}".format(trace_id, parent_span_id, parent_sampled),
+            "baggage": "sentry-trace_id=566e3688a61d4bc888951642d6f14a19",
+        },
+        name="some name",
+    )
+    with start_transaction(transaction):
+        assert transaction.name == "some name"
+
+        propagation_context = Hub.current.scope._propagation_context
+        assert propagation_context["trace_id"] == transaction.trace_id == trace_id
+        assert propagation_context["parent_span_id"] == parent_span_id
+        assert propagation_context["parent_sampled"] == parent_sampled
+        assert propagation_context["dynamic_sampling_context"] == {
+            "trace_id": "566e3688a61d4bc888951642d6f14a19"
+        }

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -46,7 +46,7 @@ def test_get_current_span_default_hub_with_transaction(sentry_init):
         assert get_current_span() == new_transaction
 
 
-def test_traceparent_with_tracing(sentry_init):
+def test_traceparent_with_tracing_enabled(sentry_init):
     sentry_init(traces_sample_rate=1.0)
 
     with start_transaction() as transaction:
@@ -57,7 +57,7 @@ def test_traceparent_with_tracing(sentry_init):
         assert get_traceparent() == expected_traceparent
 
 
-def test_traceparent_without_tracing(sentry_init):
+def test_traceparent_with_tracing_disabled(sentry_init):
     sentry_init()
 
     propagation_context = Hub.current.scope._propagation_context
@@ -68,7 +68,7 @@ def test_traceparent_without_tracing(sentry_init):
     assert get_traceparent() == expected_traceparent
 
 
-def test_baggage_without_tracing(sentry_init):
+def test_baggage_with_tracing_disabled(sentry_init):
     sentry_init(release="1.0.0", environment="dev")
     propagation_context = Hub.current.scope._propagation_context
     expected_baggage = (
@@ -80,7 +80,7 @@ def test_baggage_without_tracing(sentry_init):
     assert sorted(get_baggage().split(",")) == sorted(expected_baggage.split(","))
 
 
-def test_baggage_with_tracing(sentry_init):
+def test_baggage_with_tracing_enabled(sentry_init):
     sentry_init(traces_sample_rate=1.0, release="1.0.0", environment="dev")
     with start_transaction() as transaction:
         expected_baggage = "sentry-trace_id={},sentry-environment=dev,sentry-release=1.0.0,sentry-sample_rate=1.0".format(

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -76,7 +76,8 @@ def test_baggage_without_tracing(sentry_init):
             propagation_context["trace_id"]
         )
     )
-    assert get_baggage() == expected_baggage
+    # order not guaranteed in older python versions
+    assert sorted(get_baggage().split(",")) == sorted(expected_baggage.split(","))
 
 
 def test_baggage_with_tracing(sentry_init):
@@ -85,7 +86,8 @@ def test_baggage_with_tracing(sentry_init):
         expected_baggage = "sentry-trace_id={},sentry-environment=dev,sentry-release=1.0.0,sentry-sample_rate=1.0".format(
             transaction.trace_id
         )
-        assert get_baggage() == expected_baggage
+        # order not guaranteed in older python versions
+        assert sorted(get_baggage().split(",")) == sorted(expected_baggage.split(","))
 
 
 def test_continue_trace(sentry_init):

--- a/tests/test_envelope.py
+++ b/tests/test_envelope.py
@@ -88,6 +88,7 @@ def test_envelope_headers(sentry_init, capture_envelopes, monkeypatch):
 
     sentry_init(
         dsn="https://dogsarebadatkeepingsecrets@squirrelchasers.ingest.sentry.io/12312012",
+        traces_sample_rate=1.0,
     )
     envelopes = capture_envelopes()
 

--- a/tests/tracing/test_http_headers.py
+++ b/tests/tracing/test_http_headers.py
@@ -22,7 +22,7 @@ def test_to_traceparent(sampled):
     traceparent = transaction.to_traceparent()
 
     parts = traceparent.split("-")
-    assert parts[0] == "12312012123120121231201212312012"  # trace id
+    assert parts[0] == "12312012123120121231201212312012"  # trace_id
     assert parts[1] == transaction.span_id  # parent_span_id
     if sampled is None:
         assert len(parts) == 2

--- a/tests/tracing/test_http_headers.py
+++ b/tests/tracing/test_http_headers.py
@@ -11,7 +11,7 @@ except ImportError:
 
 
 @pytest.mark.parametrize("sampled", [True, False, None])
-def test_to_traceparent(sentry_init, sampled):
+def test_to_traceparent(sampled):
     transaction = Transaction(
         name="/interactions/other-dogs/new-dog",
         op="greeting.sniff",
@@ -21,12 +21,13 @@ def test_to_traceparent(sentry_init, sampled):
 
     traceparent = transaction.to_traceparent()
 
-    trace_id, parent_span_id, parent_sampled = traceparent.split("-")
-    assert trace_id == "12312012123120121231201212312012"
-    assert parent_span_id == transaction.span_id
-    assert parent_sampled == (
-        "1" if sampled is True else "0" if sampled is False else ""
-    )
+    parts = traceparent.split("-")
+    assert parts[0] == "12312012123120121231201212312012"  # trace id
+    assert parts[1] == transaction.span_id  # parent_span_id
+    if sampled is None:
+        assert len(parts) == 2
+    else:
+        assert parts[2] == "1" if sampled is True else "0"  # sampled
 
 
 @pytest.mark.parametrize("sampling_decision", [True, False])
@@ -41,7 +42,7 @@ def test_sentrytrace_extraction(sampling_decision):
     }
 
 
-def test_iter_headers(sentry_init, monkeypatch):
+def test_iter_headers(monkeypatch):
     monkeypatch.setattr(
         Transaction,
         "to_traceparent",

--- a/tox.ini
+++ b/tox.ini
@@ -6,156 +6,156 @@
 [tox]
 envlist =
     # === Common ===
-    {py2.7,py3.5,py3.6,python37,py3.8,py3.9,py3.10,py3.11}-common
+    {py2.7,py3.5,py3.6,py3.7,py3.8,py3.9,py3.10,py3.11}-common
 
     # === Integrations ===
     # General format is {pythonversion}-{integrationname}-v{frameworkversion}
     # 1 blank line between different integrations
     # Each framework version should only be mentioned once. I.e:
-    #   {python37,py3.10}-django-v{3.2}
+    #   {py3.7,py3.10}-django-v{3.2}
     #   {py3.10}-django-v{4.0}
     # instead of:
-    #   {python37}-django-v{3.2}
-    #   {python37,py3.10}-django-v{3.2,4.0}
+    #   {py3.7}-django-v{3.2}
+    #   {py3.7,py3.10}-django-v{3.2,4.0}
 
     # AIOHTTP
-    {python37}-aiohttp-v{3.5}
-    {python37,py3.8,py3.9,py3.10,py3.11}-aiohttp-v{3.6}
+    {py3.7}-aiohttp-v{3.5}
+    {py3.7,py3.8,py3.9,py3.10,py3.11}-aiohttp-v{3.6}
 
     # Arq
-    {python37,py3.8,py3.9,py3.10,py3.11}-arq
+    {py3.7,py3.8,py3.9,py3.10,py3.11}-arq
 
     # Asgi
-    {python37,py3.8,py3.9,py3.10,py3.11}-asgi
+    {py3.7,py3.8,py3.9,py3.10,py3.11}-asgi
 
     # AWS Lambda
     # The aws_lambda tests deploy to the real AWS and have their own matrix of Python versions.
-    {python37}-aws_lambda
+    {py3.7}-aws_lambda
 
     # Beam
-    {python37}-beam-v{2.12,2.13,2.32,2.33}
+    {py3.7}-beam-v{2.12,2.13,2.32,2.33}
 
     # Boto3
-    {py2.7,py3.6,python37,py3.8}-boto3-v{1.9,1.10,1.11,1.12,1.13,1.14,1.15,1.16}
+    {py2.7,py3.6,py3.7,py3.8}-boto3-v{1.9,1.10,1.11,1.12,1.13,1.14,1.15,1.16}
 
     # Bottle
-    {py2.7,py3.5,py3.6,python37,py3.8,py3.9,py3.10,py3.11}-bottle-v{0.12}
+    {py2.7,py3.5,py3.6,py3.7,py3.8,py3.9,py3.10,py3.11}-bottle-v{0.12}
 
     # Celery
     {py2.7}-celery-v{3}
     {py2.7,py3.5,py3.6}-celery-v{4.1,4.2}
-    {py2.7,py3.5,py3.6,python37,py3.8}-celery-v{4.3,4.4}
-    {py3.6,python37,py3.8}-celery-v{5.0}
-    {python37,py3.8,py3.9,py3.10}-celery-v{5.1,5.2}
-    # TODO: enable when celery is ready {python37,py3.8,py3.9,py3.10,py3.11}-celery-v{5.3}
+    {py2.7,py3.5,py3.6,py3.7,py3.8}-celery-v{4.3,4.4}
+    {py3.6,py3.7,py3.8}-celery-v{5.0}
+    {py3.7,py3.8,py3.9,py3.10}-celery-v{5.1,5.2}
+    # TODO: enable when celery is ready {py3.7,py3.8,py3.9,py3.10,py3.11}-celery-v{5.3}
 
     # Chalice
-    {py3.6,python37,py3.8}-chalice-v{1.16,1.17,1.18,1.19,1.20}
+    {py3.6,py3.7,py3.8}-chalice-v{1.16,1.17,1.18,1.19,1.20}
 
     # Cloud Resource Context
-    {py3.6,python37,py3.8,py3.9,py3.10,py3.11}-cloud_resource_context
+    {py3.6,py3.7,py3.8,py3.9,py3.10,py3.11}-cloud_resource_context
 
     # Django
     # - Django 1.x
     {py2.7,py3.5}-django-v{1.8,1.9,1.10}
-    {py2.7,py3.5,py3.6,python37}-django-v{1.11}
+    {py2.7,py3.5,py3.6,py3.7}-django-v{1.11}
     # - Django 2.x
-    {py3.5,py3.6,python37}-django-v{2.0,2.1}
-    {py3.5,py3.6,python37,py3.8,py3.9}-django-v{2.2}
+    {py3.5,py3.6,py3.7}-django-v{2.0,2.1}
+    {py3.5,py3.6,py3.7,py3.8,py3.9}-django-v{2.2}
     # - Django 3.x
-    {py3.6,python37,py3.8,py3.9}-django-v{3.0,3.1}
-    {py3.6,python37,py3.8,py3.9,py3.10,py3.11}-django-v{3.2}
+    {py3.6,py3.7,py3.8,py3.9}-django-v{3.0,3.1}
+    {py3.6,py3.7,py3.8,py3.9,py3.10,py3.11}-django-v{3.2}
     # - Django 4.x
     {py3.8,py3.9,py3.10,py3.11}-django-v{4.0,4.1}
 
     # Falcon
-    {py2.7,py3.5,py3.6,python37}-falcon-v{1.4}
-    {py2.7,py3.5,py3.6,python37}-falcon-v{2.0}
-    {py3.5,py3.6,python37,py3.8,py3.9}-falcon-v{3.0}
+    {py2.7,py3.5,py3.6,py3.7}-falcon-v{1.4}
+    {py2.7,py3.5,py3.6,py3.7}-falcon-v{2.0}
+    {py3.5,py3.6,py3.7,py3.8,py3.9}-falcon-v{3.0}
 
     # FastAPI
-    {python37,py3.8,py3.9,py3.10,py3.11}-fastapi
+    {py3.7,py3.8,py3.9,py3.10,py3.11}-fastapi
 
     # Flask
-    {py2.7,py3.5,py3.6,python37,py3.8,py3.9}-flask-v{0.11,0.12,1.0}
-    {py2.7,py3.5,py3.6,python37,py3.8,py3.9,py3.10,py3.11}-flask-v{1.1}
+    {py2.7,py3.5,py3.6,py3.7,py3.8,py3.9}-flask-v{0.11,0.12,1.0}
+    {py2.7,py3.5,py3.6,py3.7,py3.8,py3.9,py3.10,py3.11}-flask-v{1.1}
     {py3.6,py3.8,py3.9,py3.10,py3.11}-flask-v{2.0}
 
     # Gevent
-    {py2.7,py3.6,python37,py3.8,py3.9,py3.10,py3.11}-gevent
+    {py2.7,py3.6,py3.7,py3.8,py3.9,py3.10,py3.11}-gevent
 
     # GCP
-    {python37}-gcp
+    {py3.7}-gcp
 
     # Grpc
-    {python37,py3.8,py3.9,py3.10,py3.11}-grpc-v{1.21.1,1.22.1,1.23.1,1.24.1,1.25.0,1.26.0,1.27.1,1.28.1,1.29.0,1.30.0,1.31.0,1.32.0,1.33.1,1.34.0,1.36.0,1.37.0,1.38.0,1.39.0,1.40.0,1.41.1,1.43.0,1.44.0,1.46.1,1.48.1,1.51.3,1.53.0}
+    {py3.7,py3.8,py3.9,py3.10,py3.11}-grpc-v{1.21.1,1.22.1,1.23.1,1.24.1,1.25.0,1.26.0,1.27.1,1.28.1,1.29.0,1.30.0,1.31.0,1.32.0,1.33.1,1.34.0,1.36.0,1.37.0,1.38.0,1.39.0,1.40.0,1.41.1,1.43.0,1.44.0,1.46.1,1.48.1,1.51.3,1.53.0}
 
     # HTTPX
-    {py3.6,python37,py3.8,py3.9}-httpx-v{0.16,0.17,0.18}
-    {py3.6,python37,py3.8,py3.9,py3.10}-httpx-v{0.19,0.20,0.21,0.22}
-    {python37,py3.8,py3.9,py3.10,py3.11}-httpx-v{0.23}
+    {py3.6,py3.7,py3.8,py3.9}-httpx-v{0.16,0.17,0.18}
+    {py3.6,py3.7,py3.8,py3.9,py3.10}-httpx-v{0.19,0.20,0.21,0.22}
+    {py3.7,py3.8,py3.9,py3.10,py3.11}-httpx-v{0.23}
 
     # Huey
-    {py2.7,py3.5,py3.6,python37,py3.8,py3.9,py3.10,py3.11}-huey-2
+    {py2.7,py3.5,py3.6,py3.7,py3.8,py3.9,py3.10,py3.11}-huey-2
 
     # Loguru
-    {py3.5,py3.6,python37,py3.8,py3.9,py3.10,py3.11}-loguru-v{0.5,0.6,0.7}
+    {py3.5,py3.6,py3.7,py3.8,py3.9,py3.10,py3.11}-loguru-v{0.5,0.6,0.7}
 
     # OpenTelemetry (OTel)
-    {python37,py3.8,py3.9,py3.10,py3.11}-opentelemetry
+    {py3.7,py3.8,py3.9,py3.10,py3.11}-opentelemetry
 
     # pure_eval
-    {py3.5,py3.6,python37,py3.8,py3.9,py3.10,py3.11}-pure_eval
+    {py3.5,py3.6,py3.7,py3.8,py3.9,py3.10,py3.11}-pure_eval
 
     # PyMongo (Mongo DB)
     {py2.7,py3.6}-pymongo-v{3.1}
-    {py2.7,py3.6,python37,py3.8,py3.9}-pymongo-v{3.12}
-    {py3.6,python37,py3.8,py3.9,py3.10,py3.11}-pymongo-v{4.0}
-    {python37,py3.8,py3.9,py3.10,py3.11}-pymongo-v{4.1,4.2}
+    {py2.7,py3.6,py3.7,py3.8,py3.9}-pymongo-v{3.12}
+    {py3.6,py3.7,py3.8,py3.9,py3.10,py3.11}-pymongo-v{4.0}
+    {py3.7,py3.8,py3.9,py3.10,py3.11}-pymongo-v{4.1,4.2}
 
     # Pyramid
-    {py2.7,py3.5,py3.6,python37,py3.8,py3.9,py3.10,py3.11}-pyramid-v{1.6,1.7,1.8,1.9,1.10}
+    {py2.7,py3.5,py3.6,py3.7,py3.8,py3.9,py3.10,py3.11}-pyramid-v{1.6,1.7,1.8,1.9,1.10}
 
     # Quart
-    {python37,py3.8,py3.9,py3.10,py3.11}-quart-v{0.16,0.17,0.18}
+    {py3.7,py3.8,py3.9,py3.10,py3.11}-quart-v{0.16,0.17,0.18}
 
     # Redis
-    {py2.7,python37,py3.8,py3.9}-redis
+    {py2.7,py3.7,py3.8,py3.9}-redis
 
     # Redis Cluster
-    {py2.7,python37,py3.8,py3.9}-rediscluster-v{1,2.1.0,2}
+    {py2.7,py3.7,py3.8,py3.9}-rediscluster-v{1,2.1.0,2}
 
     # Requests
     {py2.7,py3.8,py3.9}-requests
 
     # RQ (Redis Queue)
     {py2.7,py3.5,py3.6}-rq-v{0.6,0.7,0.8,0.9,0.10,0.11}
-    {py2.7,py3.5,py3.6,python37,py3.8,py3.9}-rq-v{0.12,0.13,1.0,1.1,1.2,1.3}
-    {py3.5,py3.6,python37,py3.8,py3.9,py3.10,py3.11}-rq-v{1.4,1.5}
+    {py2.7,py3.5,py3.6,py3.7,py3.8,py3.9}-rq-v{0.12,0.13,1.0,1.1,1.2,1.3}
+    {py3.5,py3.6,py3.7,py3.8,py3.9,py3.10,py3.11}-rq-v{1.4,1.5}
 
     # Sanic
-    {py3.5,py3.6,python37}-sanic-v{0.8,18}
-    {py3.6,python37}-sanic-v{19}
-    {py3.6,python37,py3.8}-sanic-v{20}
-    {python37,py3.8,py3.9,py3.10,py3.11}-sanic-v{21}
-    {python37,py3.8,py3.9,py3.10,py3.11}-sanic-v{22}
+    {py3.5,py3.6,py3.7}-sanic-v{0.8,18}
+    {py3.6,py3.7}-sanic-v{19}
+    {py3.6,py3.7,py3.8}-sanic-v{20}
+    {py3.7,py3.8,py3.9,py3.10,py3.11}-sanic-v{21}
+    {py3.7,py3.8,py3.9,py3.10,py3.11}-sanic-v{22}
 
     # Starlette
-    {python37,py3.8,py3.9,py3.10,py3.11}-starlette-v{0.19.1,0.20,0.21}
+    {py3.7,py3.8,py3.9,py3.10,py3.11}-starlette-v{0.19.1,0.20,0.21}
 
     # Starlite
     {py3.8,py3.9,py3.10,py3.11}-starlite
 
     # SQL Alchemy
-    {py2.7,python37,py3.8,py3.9,py3.10,py3.11}-sqlalchemy-v{1.2,1.3}
+    {py2.7,py3.7,py3.8,py3.9,py3.10,py3.11}-sqlalchemy-v{1.2,1.3}
 
     # Tornado
-    {python37,py3.8,py3.9}-tornado-v{5}
-    {python37,py3.8,py3.9,py3.10,py3.11}-tornado-v{6}
+    {py3.7,py3.8,py3.9}-tornado-v{5}
+    {py3.7,py3.8,py3.9,py3.10,py3.11}-tornado-v{6}
 
     # Trytond
-    {py3.5,py3.6,python37,py3.8,py3.9}-trytond-v{4.6,5.0,5.2}
-    {py3.6,python37,py3.8,py3.9,py3.10,py3.11}-trytond-v{5.4}
+    {py3.5,py3.6,py3.7,py3.8,py3.9}-trytond-v{4.6,5.0,5.2}
+    {py3.6,py3.7,py3.8,py3.9,py3.10,py3.11}-trytond-v{5.4}
 
 [testenv]
 deps =
@@ -172,7 +172,7 @@ deps =
     linters: werkzeug<2.3.0
 
     # Common
-    {py3.6,python37,py3.8,py3.9,py3.10,py3.11}-common: pytest-asyncio
+    {py3.6,py3.7,py3.8,py3.9,py3.10,py3.11}-common: pytest-asyncio
 
     # AIOHTTP
     aiohttp-v3.4: aiohttp>=3.4.0,<3.5.0
@@ -228,8 +228,8 @@ deps =
     celery-v5.2: Celery>=5.2,<5.3
 
     {py3.5}-celery: newrelic<6.0.0
-    {python37}-celery: importlib-metadata<5.0
-    {py2.7,py3.6,python37,py3.8,py3.9,py3.10,py3.11}-celery: newrelic
+    {py3.7}-celery: importlib-metadata<5.0
+    {py2.7,py3.6,py3.7,py3.8,py3.9,py3.10,py3.11}-celery: newrelic
 
     # Chalice
     chalice-v1.16: chalice>=1.16.0,<1.17.0
@@ -243,9 +243,9 @@ deps =
     django: Werkzeug<2.1.0
     django-v{1.11,2.0,2.1,2.2,3.0,3.1,3.2}: djangorestframework>=3.0.0,<4.0.0
 
-    {python37,py3.8,py3.9,py3.10,py3.11}-django-v{1.11,2.0,2.1,2.2,3.0,3.1,3.2}: channels[daphne]>2
-    {python37,py3.8,py3.9,py3.10,py3.11}-django-v{1.11,2.0,2.1,2.2,3.0,3.1,3.2}: pytest-asyncio
-    {py2.7,python37,py3.8,py3.9,py3.10,py3.11}-django-v{1.11,2.2,3.0,3.1,3.2}: psycopg2-binary
+    {py3.7,py3.8,py3.9,py3.10,py3.11}-django-v{1.11,2.0,2.1,2.2,3.0,3.1,3.2}: channels[daphne]>2
+    {py3.7,py3.8,py3.9,py3.10,py3.11}-django-v{1.11,2.0,2.1,2.2,3.0,3.1,3.2}: pytest-asyncio
+    {py2.7,py3.7,py3.8,py3.9,py3.10,py3.11}-django-v{1.11,2.2,3.0,3.1,3.2}: psycopg2-binary
 
     django-v{1.8,1.9,1.10,1.11,2.0,2.1}: pytest-django<4.0
     django-v{2.2,3.0,3.1,3.2}: pytest-django>=4.0
@@ -299,7 +299,7 @@ deps =
     # See https://stackoverflow.com/questions/51496550/runtime-warning-greenlet-greenlet-size-changed
     # for justification why greenlet is pinned here
     py3.5-gevent: greenlet==0.4.17
-    {py2.7,py3.6,python37,py3.8,py3.9,py3.10,py3.11}-gevent: gevent>=22.10.0, <22.11.0
+    {py2.7,py3.6,py3.7,py3.8,py3.9,py3.10,py3.11}-gevent: gevent>=22.10.0, <22.11.0
 
     # Grpc
     grpc: grpcio-tools
@@ -500,7 +500,7 @@ basepython =
     py3.4: python3.4
     py3.5: python3.5
     py3.6: python3.6
-    python37: python3.7
+    py3.7: python3.7
     py3.8: python3.8
     py3.9: python3.9
     py3.10: python3.10
@@ -514,13 +514,13 @@ basepython =
     linters: python3.11
 
 commands =
-    {python37,py3.8}-boto3: pip install urllib3<2.0.0
+    {py3.7,py3.8}-boto3: pip install urllib3<2.0.0
 
     ; https://github.com/pytest-dev/pytest/issues/5532
-    {py3.5,py3.6,python37,py3.8,py3.9}-flask-v{0.11,0.12}: pip install pytest<5
-    {py3.6,python37,py3.8,py3.9}-flask-v{0.11}: pip install Werkzeug<2
+    {py3.5,py3.6,py3.7,py3.8,py3.9}-flask-v{0.11,0.12}: pip install pytest<5
+    {py3.6,py3.7,py3.8,py3.9}-flask-v{0.11}: pip install Werkzeug<2
     ; https://github.com/pallets/flask/issues/4455
-    {python37,py3.8,py3.9,py3.10,py3.11}-flask-v{0.11,0.12,1.0,1.1}: pip install "itsdangerous>=0.24,<2.0" "markupsafe<2.0.0" "jinja2<3.1.1"
+    {py3.7,py3.8,py3.9,py3.10,py3.11}-flask-v{0.11,0.12,1.0,1.1}: pip install "itsdangerous>=0.24,<2.0" "markupsafe<2.0.0" "jinja2<3.1.1"
     ; https://github.com/more-itertools/more-itertools/issues/578
     py3.5-flask-v{0.11,0.12}: pip install more-itertools<8.11.0
 
@@ -532,7 +532,7 @@ commands =
     ; load the settings from the test module.
 
     {py2.7}: python -m pytest --ignore-glob='*py3.py' -rsx -s --durations=5 -vvv {env:TESTPATH} {posargs}
-    {py3.5,py3.6,python37,py3.8,py3.9,py3.10,py3.11}: python -m pytest -rsx -s --durations=5 -vvv {env:TESTPATH} {posargs}
+    {py3.5,py3.6,py3.7,py3.8,py3.9,py3.10,py3.11}: python -m pytest -rsx -s --durations=5 -vvv {env:TESTPATH} {posargs}
 
 [testenv:linters]
 commands =


### PR DESCRIPTION
It should be possible that tracing information (`sentry-trace` and `baggage` headers) is propagated from/to incoming/outgoing HTTP requests even if performance is disabled and thus no transactions/spans are available.

Fixes #2128 