### PR TITLE
Pin urllib3 to <2.0.0 for python <=3.8 only

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -10,7 +10,8 @@ import sphinx.builders.html
 import sphinx.builders.latex
 import sphinx.builders.texinfo
 import sphinx.builders.text
-import sphinx.ext.autodoc
+import sphinx.ext.autodoc  # noqa: F401
+import urllib3.exceptions  # noqa: F401
 
 typing.TYPE_CHECKING = True
 

--- a/sentry_sdk/integrations/cloud_resource_context.py
+++ b/sentry_sdk/integrations/cloud_resource_context.py
@@ -1,5 +1,5 @@
 import json
-import urllib3  # type: ignore
+import urllib3
 
 from sentry_sdk.integrations import Integration
 from sentry_sdk.api import set_context

--- a/sentry_sdk/integrations/cloud_resource_context.py
+++ b/sentry_sdk/integrations/cloud_resource_context.py
@@ -58,7 +58,7 @@ class CloudResourceContextIntegration(Integration):
 
     cloud_provider = ""
 
-    aws_token = b""
+    aws_token = ""
     http = urllib3.PoolManager()
 
     gcp_metadata = None
@@ -80,7 +80,7 @@ class CloudResourceContextIntegration(Integration):
             if r.status != 200:
                 return False
 
-            cls.aws_token = r.data
+            cls.aws_token = r.data.decode()
             return True
 
         except Exception:

--- a/sentry_sdk/integrations/cloud_resource_context.py
+++ b/sentry_sdk/integrations/cloud_resource_context.py
@@ -58,7 +58,7 @@ class CloudResourceContextIntegration(Integration):
 
     cloud_provider = ""
 
-    aws_token = ""
+    aws_token = b""
     http = urllib3.PoolManager()
 
     gcp_metadata = None

--- a/sentry_sdk/integrations/opentelemetry/span_processor.py
+++ b/sentry_sdk/integrations/opentelemetry/span_processor.py
@@ -26,7 +26,7 @@ from sentry_sdk.tracing import Transaction, Span as SentrySpan
 from sentry_sdk.utils import Dsn
 from sentry_sdk._types import TYPE_CHECKING
 
-from urllib3.util import parse_url as urlparse  # type: ignore
+from urllib3.util import parse_url as urlparse
 
 if TYPE_CHECKING:
     from typing import Any

--- a/sentry_sdk/transport.py
+++ b/sentry_sdk/transport.py
@@ -29,6 +29,11 @@ if TYPE_CHECKING:
     from urllib3.poolmanager import PoolManager
     from urllib3.poolmanager import ProxyManager
 
+    try:
+        from urllib3 import BaseHTTPResponse as Response
+    except ImportError:
+        from urllib3 import HTTPResponse as Response
+
     from sentry_sdk._types import Event, EndpointType
 
     DataCategory = Optional[str]
@@ -186,7 +191,7 @@ class HttpTransport(Transport):
         self._discarded_events[data_category, reason] += quantity
 
     def _update_rate_limits(self, response):
-        # type: (urllib3.HTTPResponse) -> None
+        # type: (Response) -> None
 
         # new sentries with more rate limit insights.  We honor this header
         # no matter of the status code to update our internal rate limits.

--- a/sentry_sdk/transport.py
+++ b/sentry_sdk/transport.py
@@ -1,7 +1,7 @@
 from __future__ import print_function
 
 import io
-import urllib3  # type: ignore
+import urllib3
 import certifi
 import gzip
 import time
@@ -26,7 +26,7 @@ if TYPE_CHECKING:
     from typing import Union
     from typing import DefaultDict
 
-    from urllib3.poolmanager import PoolManager  # type: ignore
+    from urllib3.poolmanager import PoolManager
     from urllib3.poolmanager import ProxyManager
 
     from sentry_sdk._types import Event, EndpointType

--- a/setup.py
+++ b/setup.py
@@ -38,10 +38,10 @@ setup(
     zip_safe=False,
     license="MIT",
     install_requires=[
-        'urllib3>=1.25.7; python_version<="3.4"',
-        'urllib3>=1.26.9; python_version=="3.5"',
         'urllib3>=1.26.11,<2.0.0; python_version<="3.8"',
+        'urllib3>=1.25.7; python_version<="3.4"',
         'urllib3>=1.26.11; python_version>="3.9"',
+        'urllib3>=1.26.9; python_version=="3.5"',
         "certifi",
     ],
     extras_require={

--- a/setup.py
+++ b/setup.py
@@ -38,10 +38,10 @@ setup(
     zip_safe=False,
     license="MIT",
     install_requires=[
-        'urllib3>=1.26.11,<2.0.0; python_version<="3.8"',
         'urllib3>=1.25.7; python_version<="3.4"',
+        'urllib3>=1.26.9; python_version>="3.5" and python_version<"3.6"',
+        'urllib3>=1.26.11,<2.0.0; python_version>="3.6" and python_version<="3.8"',
         'urllib3>=1.26.11; python_version>="3.9"',
-        'urllib3>=1.26.9; python_version=="3.5"',
         "certifi",
     ],
     extras_require={

--- a/setup.py
+++ b/setup.py
@@ -38,10 +38,10 @@ setup(
     zip_safe=False,
     license="MIT",
     install_requires=[
-        'urllib3>=1.25.7; python_version<="3.4"',
-        'urllib3>=1.26.9; python_version>="3.5" and python_version<"3.6"',
-        'urllib3>=1.26.11,<2.0.0; python_version>="3.6" and python_version<="3.8"',
         'urllib3>=1.26.11; python_version>="3.9"',
+        'urllib3>=1.26.11,<2; python_version>="3.6"',
+        'urllib3>=1.26.9,<2; python_version=="3.5"',
+        'urllib3>=1.25.7,<2; python_version<="3.4"',
         "certifi",
     ],
     extras_require={

--- a/setup.py
+++ b/setup.py
@@ -40,8 +40,8 @@ setup(
     install_requires=[
         'urllib3>=1.25.7; python_version<="3.4"',
         'urllib3>=1.26.9; python_version=="3.5"',
-        'urllib3>=1.26.11; python_version >="3.6"',
-        'urllib3<2.0.0',
+        'urllib3>=1.26.11,<2.0.0; python_version<="3.8"',
+        'urllib3>=1.26.11; python_version>="3.9"',
         "certifi",
     ],
     extras_require={

--- a/setup.py
+++ b/setup.py
@@ -38,10 +38,10 @@ setup(
     zip_safe=False,
     license="MIT",
     install_requires=[
-        'urllib3>=1.26.11; python_version>="3.9"',
-        'urllib3>=1.26.11,<2; python_version>="3.6"',
-        'urllib3>=1.26.9,<2; python_version=="3.5"',
         'urllib3>=1.25.7,<2; python_version<="3.4"',
+        'urllib3>=1.26.9,<2; python_version=="3.5"',
+        'urllib3>=1.26.11,<2; python_version>="3.6"; python_version<"3.9"',
+        "urllib3>=1.26.11",
         "certifi",
     ],
     extras_require={

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setup(
     install_requires=[
         'urllib3>=1.25.7,<2; python_version<="3.4"',
         'urllib3>=1.26.9,<2; python_version=="3.5"',
-        'urllib3>=1.26.11,<2; python_version>="3.6"; python_version<"3.9"',
+        'urllib3>=1.26.11,<2; python_version>="3.6" and python_version<"3.9"',
         "urllib3>=1.26.11",
         "certifi",
     ],

--- a/tests/integrations/cloud_resource_context/test_cloud_resource_context.py
+++ b/tests/integrations/cloud_resource_context/test_cloud_resource_context.py
@@ -136,7 +136,7 @@ def test_is_aws_ok():
     CloudResourceContextIntegration.http.request = MagicMock(return_value=response)
 
     assert CloudResourceContextIntegration._is_aws() is True
-    assert CloudResourceContextIntegration.aws_token == b"something"
+    assert CloudResourceContextIntegration.aws_token == "something"
 
     CloudResourceContextIntegration.http.request = MagicMock(
         side_effect=Exception("Test")


### PR DESCRIPTION
Following the suggestion here https://github.com/getsentry/sentry-python/issues/2070#issuecomment-1550502825 this PR pins `urllib3` to `<2.0.0` only for older Python versions (`<=3.8`).

TODOs:
- [x] go through the [changelog](https://github.com/urllib3/urllib3/blob/main/CHANGES.rst) to see what might potentially affect us
- [x] run the tests looking for `DeprecationWarning`s (see https://urllib3.readthedocs.io/en/latest/v2-migration-guide.html#migrating-as-a-package-maintainer)
- [x] look at actual code changes in the implementation of the things we're using (e.g. `PoolManager`, `ProxyManager`)
- [x] play around with the SDK manually

https://github.com/getsentry/sentry-python/issues/2070