### PR TITLE
fix: functions_to_trace typing

### DIFF
--- a/sentry_sdk/consts.py
+++ b/sentry_sdk/consts.py
@@ -189,7 +189,7 @@ class ClientConstructor(object):
         trace_propagation_targets=[  # noqa: B006
             MATCH_ALL
         ],  # type: Optional[Sequence[str]]
-        functions_to_trace=[],  # type: Sequence[str]  # noqa: B006
+        functions_to_trace=[],  # type: Sequence[Dict[str, str]]  # noqa: B006
         event_scrubber=None,  # type: Optional[sentry_sdk.scrubber.EventScrubber]
     ):
         # type: (...) -> None


### PR DESCRIPTION
# Problem

This updates the type of the `functions_to_trace` param to match the latest changes.

The expected format introduced [here](https://github.com/getsentry/sentry-python/pull/1960) is:
```
functions_to_trace = [
    {"qualified_name": "tests.test_basics._hello_world_counter"},
    {"qualified_name": "time.sleep"},
    {"qualified_name": "collections.Counter.most_common"},
]
```

But the current type is `List[str]`
