### PR TITLE
Revert "Pin urllib3 to <2.0.0 for now"

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -11,6 +11,7 @@ import sphinx.builders.latex
 import sphinx.builders.texinfo
 import sphinx.builders.text
 import sphinx.ext.autodoc
+import urllib3.exceptions
 
 typing.TYPE_CHECKING = True
 

--- a/sentry_sdk/integrations/cloud_resource_context.py
+++ b/sentry_sdk/integrations/cloud_resource_context.py
@@ -1,5 +1,5 @@
 import json
-import urllib3  # type: ignore
+import urllib3
 
 from sentry_sdk.integrations import Integration
 from sentry_sdk.api import set_context
@@ -80,7 +80,7 @@ class CloudResourceContextIntegration(Integration):
             if r.status != 200:
                 return False
 
-            cls.aws_token = r.data
+            cls.aws_token = r.data.decode()
             return True
 
         except Exception:

--- a/sentry_sdk/integrations/opentelemetry/span_processor.py
+++ b/sentry_sdk/integrations/opentelemetry/span_processor.py
@@ -26,7 +26,7 @@ from sentry_sdk.tracing import Transaction, Span as SentrySpan
 from sentry_sdk.utils import Dsn
 from sentry_sdk._types import TYPE_CHECKING
 
-from urllib3.util import parse_url as urlparse  # type: ignore
+from urllib3.util import parse_url as urlparse
 
 if TYPE_CHECKING:
     from typing import Any

--- a/sentry_sdk/transport.py
+++ b/sentry_sdk/transport.py
@@ -1,7 +1,7 @@
 from __future__ import print_function
 
 import io
-import urllib3  # type: ignore
+import urllib3
 import certifi
 import gzip
 import time
@@ -26,7 +26,7 @@ if TYPE_CHECKING:
     from typing import Union
     from typing import DefaultDict
 
-    from urllib3.poolmanager import PoolManager  # type: ignore
+    from urllib3.poolmanager import PoolManager
     from urllib3.poolmanager import ProxyManager
 
     from sentry_sdk._types import Event, EndpointType
@@ -186,7 +186,7 @@ class HttpTransport(Transport):
         self._discarded_events[data_category, reason] += quantity
 
     def _update_rate_limits(self, response):
-        # type: (urllib3.HTTPResponse) -> None
+        # type: (urllib3.BaseHTTPResponse) -> None
 
         # new sentries with more rate limit insights.  We honor this header
         # no matter of the status code to update our internal rate limits.

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,6 @@ setup(
         'urllib3>=1.25.7; python_version<="3.4"',
         'urllib3>=1.26.9; python_version=="3.5"',
         'urllib3>=1.26.11; python_version >="3.6"',
-        'urllib3<2.0.0',
         "certifi",
     ],
     extras_require={

--- a/tests/integrations/cloud_resource_context/test_cloud_resource_context.py
+++ b/tests/integrations/cloud_resource_context/test_cloud_resource_context.py
@@ -136,7 +136,7 @@ def test_is_aws_ok():
     CloudResourceContextIntegration.http.request = MagicMock(return_value=response)
 
     assert CloudResourceContextIntegration._is_aws() is True
-    assert CloudResourceContextIntegration.aws_token == b"something"
+    assert CloudResourceContextIntegration.aws_token == "something"
 
     CloudResourceContextIntegration.http.request = MagicMock(
         side_effect=Exception("Test")


### PR DESCRIPTION
Reverts getsentry/sentry-python#2069

Resolves #2070

this shouldn't have been pinned in the first place.  the actual failure was unrelated to sentry.  _they_ should have pinned in their app -- a library should not make this decision for its users