### PR TITLE
Wrap `parse_url` calls in `capture_internal_exceptions`

### DIFF
--- a/sentry_sdk/integrations/boto3.py
+++ b/sentry_sdk/integrations/boto3.py
@@ -7,7 +7,7 @@ from sentry_sdk.tracing import Span
 
 from sentry_sdk._functools import partial
 from sentry_sdk._types import TYPE_CHECKING
-from sentry_sdk.utils import parse_url, parse_version
+from sentry_sdk.utils import capture_internal_exceptions, parse_url, parse_version
 
 if TYPE_CHECKING:
     from typing import Any
@@ -71,13 +71,14 @@ def _sentry_request_created(service_id, request, operation_name, **kwargs):
         description=description,
     )
 
-    parsed_url = parse_url(request.url, sanitize=False)
+    with capture_internal_exceptions():
+        parsed_url = parse_url(request.url, sanitize=False)
+        span.set_data("aws.request.url", parsed_url.url)
+        span.set_data(SPANDATA.HTTP_QUERY, parsed_url.query)
+        span.set_data(SPANDATA.HTTP_FRAGMENT, parsed_url.fragment)
 
     span.set_tag("aws.service_id", service_id)
     span.set_tag("aws.operation_name", operation_name)
-    span.set_data("aws.request.url", parsed_url.url)
-    span.set_data(SPANDATA.HTTP_QUERY, parsed_url.query)
-    span.set_data(SPANDATA.HTTP_FRAGMENT, parsed_url.fragment)
     span.set_data(SPANDATA.HTTP_METHOD, request.method)
 
     # We do it in order for subsequent http calls/retries be

--- a/sentry_sdk/integrations/httpx.py
+++ b/sentry_sdk/integrations/httpx.py
@@ -2,7 +2,12 @@ from sentry_sdk import Hub
 from sentry_sdk.consts import OP, SPANDATA
 from sentry_sdk.integrations import Integration, DidNotEnable
 from sentry_sdk.tracing_utils import should_propagate_trace
-from sentry_sdk.utils import capture_internal_exceptions, logger, parse_url
+from sentry_sdk.utils import (
+    SENSITIVE_DATA_SUBSTITUTE,
+    capture_internal_exceptions,
+    logger,
+    parse_url,
+)
 
 from sentry_sdk._types import TYPE_CHECKING
 
@@ -49,7 +54,10 @@ def _install_httpx_client():
         with hub.start_span(
             op=OP.HTTP_CLIENT,
             description="%s %s"
-            % (request.method, parsed_url.url if parsed_url else "<url>"),
+            % (
+                request.method,
+                parsed_url.url if parsed_url else SENSITIVE_DATA_SUBSTITUTE,
+            ),
         ) as span:
             span.set_data(SPANDATA.HTTP_METHOD, request.method)
             if parsed_url is not None:
@@ -93,7 +101,10 @@ def _install_httpx_async_client():
         with hub.start_span(
             op=OP.HTTP_CLIENT,
             description="%s %s"
-            % (request.method, parsed_url.url if parsed_url else "<url>"),
+            % (
+                request.method,
+                parsed_url.url if parsed_url else SENSITIVE_DATA_SUBSTITUTE,
+            ),
         ) as span:
             span.set_data(SPANDATA.HTTP_METHOD, request.method)
             if parsed_url is not None:

--- a/sentry_sdk/integrations/httpx.py
+++ b/sentry_sdk/integrations/httpx.py
@@ -48,10 +48,11 @@ def _install_httpx_client():
 
         with hub.start_span(
             op=OP.HTTP_CLIENT,
-            description="%s %s" % (request.method, parsed_url.url),
+            description="%s %s"
+            % (request.method, parsed_url.url if parsed_url else "<url>"),
         ) as span:
+            span.set_data(SPANDATA.HTTP_METHOD, request.method)
             if parsed_url is not None:
-                span.set_data(SPANDATA.HTTP_METHOD, request.method)
                 span.set_data("url", parsed_url.url)
                 span.set_data(SPANDATA.HTTP_QUERY, parsed_url.query)
                 span.set_data(SPANDATA.HTTP_FRAGMENT, parsed_url.fragment)
@@ -91,10 +92,11 @@ def _install_httpx_async_client():
 
         with hub.start_span(
             op=OP.HTTP_CLIENT,
-            description="%s %s" % (request.method, parsed_url.url),
+            description="%s %s"
+            % (request.method, parsed_url.url if parsed_url else "<url>"),
         ) as span:
+            span.set_data(SPANDATA.HTTP_METHOD, request.method)
             if parsed_url is not None:
-                span.set_data(SPANDATA.HTTP_METHOD, request.method)
                 span.set_data("url", parsed_url.url)
                 span.set_data(SPANDATA.HTTP_QUERY, parsed_url.query)
                 span.set_data(SPANDATA.HTTP_FRAGMENT, parsed_url.fragment)

--- a/sentry_sdk/integrations/httpx.py
+++ b/sentry_sdk/integrations/httpx.py
@@ -93,7 +93,7 @@ def _install_httpx_async_client():
             op=OP.HTTP_CLIENT,
             description="%s %s" % (request.method, parsed_url.url),
         ) as span:
-            if parsed_url is None:
+            if parsed_url is not None:
                 span.set_data(SPANDATA.HTTP_METHOD, request.method)
                 span.set_data("url", parsed_url.url)
                 span.set_data(SPANDATA.HTTP_QUERY, parsed_url.query)

--- a/sentry_sdk/integrations/httpx.py
+++ b/sentry_sdk/integrations/httpx.py
@@ -2,7 +2,7 @@ from sentry_sdk import Hub
 from sentry_sdk.consts import OP, SPANDATA
 from sentry_sdk.integrations import Integration, DidNotEnable
 from sentry_sdk.tracing_utils import should_propagate_trace
-from sentry_sdk.utils import logger, parse_url
+from sentry_sdk.utils import capture_internal_exceptions, logger, parse_url
 
 from sentry_sdk._types import TYPE_CHECKING
 
@@ -42,16 +42,19 @@ def _install_httpx_client():
         if hub.get_integration(HttpxIntegration) is None:
             return real_send(self, request, **kwargs)
 
-        parsed_url = parse_url(str(request.url), sanitize=False)
+        parsed_url = None
+        with capture_internal_exceptions():
+            parsed_url = parse_url(str(request.url), sanitize=False)
 
         with hub.start_span(
             op=OP.HTTP_CLIENT,
             description="%s %s" % (request.method, parsed_url.url),
         ) as span:
-            span.set_data(SPANDATA.HTTP_METHOD, request.method)
-            span.set_data("url", parsed_url.url)
-            span.set_data(SPANDATA.HTTP_QUERY, parsed_url.query)
-            span.set_data(SPANDATA.HTTP_FRAGMENT, parsed_url.fragment)
+            if parsed_url is not None:
+                span.set_data(SPANDATA.HTTP_METHOD, request.method)
+                span.set_data("url", parsed_url.url)
+                span.set_data(SPANDATA.HTTP_QUERY, parsed_url.query)
+                span.set_data(SPANDATA.HTTP_FRAGMENT, parsed_url.fragment)
 
             if should_propagate_trace(hub, str(request.url)):
                 for key, value in hub.iter_trace_propagation_headers():
@@ -82,16 +85,19 @@ def _install_httpx_async_client():
         if hub.get_integration(HttpxIntegration) is None:
             return await real_send(self, request, **kwargs)
 
-        parsed_url = parse_url(str(request.url), sanitize=False)
+        parsed_url = None
+        with capture_internal_exceptions():
+            parsed_url = parse_url(str(request.url), sanitize=False)
 
         with hub.start_span(
             op=OP.HTTP_CLIENT,
             description="%s %s" % (request.method, parsed_url.url),
         ) as span:
-            span.set_data(SPANDATA.HTTP_METHOD, request.method)
-            span.set_data("url", parsed_url.url)
-            span.set_data(SPANDATA.HTTP_QUERY, parsed_url.query)
-            span.set_data(SPANDATA.HTTP_FRAGMENT, parsed_url.fragment)
+            if parsed_url is None:
+                span.set_data(SPANDATA.HTTP_METHOD, request.method)
+                span.set_data("url", parsed_url.url)
+                span.set_data(SPANDATA.HTTP_QUERY, parsed_url.query)
+                span.set_data(SPANDATA.HTTP_FRAGMENT, parsed_url.fragment)
 
             if should_propagate_trace(hub, str(request.url)):
                 for key, value in hub.iter_trace_propagation_headers():

--- a/sentry_sdk/integrations/stdlib.py
+++ b/sentry_sdk/integrations/stdlib.py
@@ -9,6 +9,7 @@ from sentry_sdk.integrations import Integration
 from sentry_sdk.scope import add_global_event_processor
 from sentry_sdk.tracing_utils import EnvironHeaders, should_propagate_trace
 from sentry_sdk.utils import (
+    SENSITIVE_DATA_SUBSTITUTE,
     capture_internal_exceptions,
     logger,
     safe_repr,
@@ -90,7 +91,8 @@ def _install_httplib():
 
         span = hub.start_span(
             op=OP.HTTP_CLIENT,
-            description="%s %s" % (method, parsed_url.url if parsed_url else "<url>"),
+            description="%s %s"
+            % (method, parsed_url.url if parsed_url else SENSITIVE_DATA_SUBSTITUTE),
         )
 
         span.set_data(SPANDATA.HTTP_METHOD, method)

--- a/sentry_sdk/integrations/stdlib.py
+++ b/sentry_sdk/integrations/stdlib.py
@@ -84,7 +84,9 @@ def _install_httplib():
                 url,
             )
 
-        parsed_url = parse_url(real_url, sanitize=False)
+        parsed_url = None
+        with capture_internal_exceptions():
+            parsed_url = parse_url(real_url, sanitize=False)
 
         span = hub.start_span(
             op=OP.HTTP_CLIENT,
@@ -92,9 +94,11 @@ def _install_httplib():
         )
 
         span.set_data(SPANDATA.HTTP_METHOD, method)
-        span.set_data("url", parsed_url.url)
-        span.set_data(SPANDATA.HTTP_QUERY, parsed_url.query)
-        span.set_data(SPANDATA.HTTP_FRAGMENT, parsed_url.fragment)
+
+        if parsed_url is not None:
+            span.set_data("url", parsed_url.url)
+            span.set_data(SPANDATA.HTTP_QUERY, parsed_url.query)
+            span.set_data(SPANDATA.HTTP_FRAGMENT, parsed_url.fragment)
 
         rv = real_putrequest(self, method, url, *args, **kwargs)
 

--- a/sentry_sdk/integrations/stdlib.py
+++ b/sentry_sdk/integrations/stdlib.py
@@ -90,11 +90,10 @@ def _install_httplib():
 
         span = hub.start_span(
             op=OP.HTTP_CLIENT,
-            description="%s %s" % (method, parsed_url.url),
+            description="%s %s" % (method, parsed_url.url if parsed_url else "<url>"),
         )
 
         span.set_data(SPANDATA.HTTP_METHOD, method)
-
         if parsed_url is not None:
             span.set_data("url", parsed_url.url)
             span.set_data(SPANDATA.HTTP_QUERY, parsed_url.query)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -69,7 +69,7 @@ def internal_exceptions(request, monkeypatch):
 
     @request.addfinalizer
     def _():
-        # rerasise the errors so that this just acts as a pass-through (that
+        # reraise the errors so that this just acts as a pass-through (that
         # happens to keep track of the errors which pass through it)
         for e in errors:
             reraise(*e)

--- a/tests/integrations/boto3/test_s3.py
+++ b/tests/integrations/boto3/test_s3.py
@@ -69,7 +69,6 @@ def test_streaming(sentry_init, capture_events):
         "http.method": "GET",
         "aws.request.url": "https://bucket.s3.amazonaws.com/foo.pdf",
         "http.fragment": "",
-        "http.method": "GET",
         "http.query": "",
     }
 

--- a/tests/integrations/boto3/test_s3.py
+++ b/tests/integrations/boto3/test_s3.py
@@ -61,9 +61,18 @@ def test_streaming(sentry_init, capture_events):
     (event,) = events
     assert event["type"] == "transaction"
     assert len(event["spans"]) == 2
+
     span1 = event["spans"][0]
     assert span1["op"] == "http.client"
     assert span1["description"] == "aws.s3.GetObject"
+    assert span1["data"] == {
+        "http.method": "GET",
+        "aws.request.url": "https://bucket.s3.amazonaws.com/foo.pdf",
+        "http.fragment": "",
+        "http.method": "GET",
+        "http.query": "",
+    }
+
     span2 = event["spans"][1]
     assert span2["op"] == "http.client.stream"
     assert span2["description"] == "aws.s3.GetObject"
@@ -91,32 +100,6 @@ def test_streaming_close(sentry_init, capture_events):
     assert span1["op"] == "http.client"
     span2 = event["spans"][1]
     assert span2["op"] == "http.client.stream"
-
-
-def test_url_data(sentry_init, capture_events):
-    sentry_init(traces_sample_rate=1.0, integrations=[Boto3Integration()])
-    events = capture_events()
-
-    s3 = session.resource("s3")
-
-    with Hub.current.start_transaction() as transaction, MockResponse(
-        s3.meta.client, 200, {}, read_fixture("s3_list.xml")
-    ):
-        bucket = s3.Bucket("bucket")
-        items = [obj for obj in bucket.objects.all()]
-        assert len(items) == 2
-        assert items[0].key == "foo.txt"
-        assert items[1].key == "bar.txt"
-        transaction.finish()
-
-    (event,) = events
-    assert event["spans"][0]["data"] == {
-        "http.method": "GET",
-        "aws.request.url": "https://bucket.s3.amazonaws.com/",
-        "http.fragment": "",
-        "http.method": "GET",
-        "http.query": "encoding-type=url",
-    }
 
 
 @pytest.mark.tests_internal_exceptions

--- a/tests/integrations/boto3/test_s3.py
+++ b/tests/integrations/boto3/test_s3.py
@@ -1,9 +1,17 @@
+import pytest
+
+import boto3
+
 from sentry_sdk import Hub
 from sentry_sdk.integrations.boto3 import Boto3Integration
 from tests.integrations.boto3.aws_mock import MockResponse
 from tests.integrations.boto3 import read_fixture
 
-import boto3
+try:
+    from unittest import mock  # python 3.3 and above
+except ImportError:
+    import mock  # python < 3.3
+
 
 session = boto3.Session(
     aws_access_key_id="-",
@@ -83,3 +91,57 @@ def test_streaming_close(sentry_init, capture_events):
     assert span1["op"] == "http.client"
     span2 = event["spans"][1]
     assert span2["op"] == "http.client.stream"
+
+
+def test_url_data(sentry_init, capture_events):
+    sentry_init(traces_sample_rate=1.0, integrations=[Boto3Integration()])
+    events = capture_events()
+
+    s3 = session.resource("s3")
+
+    with Hub.current.start_transaction() as transaction, MockResponse(
+        s3.meta.client, 200, {}, read_fixture("s3_list.xml")
+    ):
+        bucket = s3.Bucket("bucket")
+        items = [obj for obj in bucket.objects.all()]
+        assert len(items) == 2
+        assert items[0].key == "foo.txt"
+        assert items[1].key == "bar.txt"
+        transaction.finish()
+
+    (event,) = events
+    assert event["spans"][0]["data"] == {
+        "http.method": "GET",
+        "aws.request.url": "https://bucket.s3.amazonaws.com/",
+        "http.fragment": "",
+        "http.method": "GET",
+        "http.query": "encoding-type=url",
+    }
+
+
+@pytest.mark.tests_internal_exceptions
+def test_omit_url_data_if_parsing_fails(sentry_init, capture_events):
+    sentry_init(traces_sample_rate=1.0, integrations=[Boto3Integration()])
+    events = capture_events()
+
+    s3 = session.resource("s3")
+
+    with mock.patch(
+        "sentry_sdk.integrations.boto3.parse_url",
+        side_effect=ValueError,
+    ):
+        with Hub.current.start_transaction() as transaction, MockResponse(
+            s3.meta.client, 200, {}, read_fixture("s3_list.xml")
+        ):
+            bucket = s3.Bucket("bucket")
+            items = [obj for obj in bucket.objects.all()]
+            assert len(items) == 2
+            assert items[0].key == "foo.txt"
+            assert items[1].key == "bar.txt"
+            transaction.finish()
+
+    (event,) = events
+    assert event["spans"][0]["data"] == {
+        "http.method": "GET",
+        # no url data
+    }

--- a/tests/integrations/requests/test_requests.py
+++ b/tests/integrations/requests/test_requests.py
@@ -7,6 +7,11 @@ from sentry_sdk import capture_message
 from sentry_sdk.consts import SPANDATA
 from sentry_sdk.integrations.stdlib import StdlibIntegration
 
+try:
+    from unittest import mock  # python 3.3 and above
+except ImportError:
+    import mock  # python < 3.3
+
 
 def test_crumb_capture(sentry_init, capture_events):
     sentry_init(integrations=[StdlibIntegration()])
@@ -30,4 +35,30 @@ def test_crumb_capture(sentry_init, capture_events):
         SPANDATA.HTTP_QUERY: "",
         SPANDATA.HTTP_STATUS_CODE: response.status_code,
         "reason": response.reason,
+    }
+
+
+@pytest.mark.tests_internal_exceptions
+def test_omit_url_data_if_parsing_fails(sentry_init, capture_events):
+    sentry_init(integrations=[StdlibIntegration()])
+
+    url = "https://example.com"
+    responses.add(responses.GET, url, status=200)
+
+    events = capture_events()
+
+    with mock.patch(
+        "sentry_sdk.integrations.stdlib.parse_url",
+        side_effect=ValueError,
+    ):
+        response = requests.get(url)
+
+    capture_message("Testing!")
+
+    (event,) = events
+    assert event["breadcrumbs"]["values"][0]["data"] == {
+        SPANDATA.HTTP_METHOD: "GET",
+        SPANDATA.HTTP_STATUS_CODE: response.status_code,
+        "reason": response.reason,
+        # no url related data
     }


### PR DESCRIPTION
Follow up to https://github.com/getsentry/sentry-python/issues/2160

Our URL parsing and sanitizing can fail. If it does, the error must never break the user's application.

This PR:

- wraps all calls to `parse_url` in `capture_internal_exceptions` and skips setting any parsed URL related data on the span (affects the `stdlib`, `boto3`, `httpx` integrations)
- adds more test cases for the `sanitize_url` function with `split=True`