### PR TITLE
fix(profiler): Add function name to profiler frame cache

### DIFF
--- a/tests/test_profiler.py
+++ b/tests/test_profiler.py
@@ -15,6 +15,7 @@ from sentry_sdk.profiler import (
     ThreadScheduler,
     extract_frame,
     extract_stack,
+    frame_id,
     get_current_thread_id,
     get_frame_name,
     setup_profiler,
@@ -444,7 +445,7 @@ def test_get_frame_name(frame, frame_name):
 def test_extract_frame(get_frame, function):
     cwd = os.getcwd()
     frame = get_frame()
-    extracted_frame = extract_frame(frame, cwd)
+    extracted_frame = extract_frame(frame_id(frame), frame, cwd)
 
     # the abs_path should be equal toe the normalized path of the co_filename
     assert extracted_frame["abs_path"] == os.path.normpath(frame.f_code.co_filename)


### PR DESCRIPTION
Wrapper functions can take on the same name as the wrapped function. This means that if a decorator is used to wrap different functions, even though the filename and line number will be the same for all instances of the frame, the function name can vary. Add the function name to the cache to avoid these cache collisions.