### PR TITLE
fix: fix propagation of OTEL NonRecordingSpan

### DIFF
--- a/sentry_sdk/integrations/opentelemetry/propagator.py
+++ b/sentry_sdk/integrations/opentelemetry/propagator.py
@@ -13,9 +13,9 @@ from opentelemetry.propagators.textmap import (  # type: ignore
     default_setter,
 )
 from opentelemetry.trace import (  # type: ignore
-    TraceFlags,
     NonRecordingSpan,
     SpanContext,
+    TraceFlags,
 )
 from sentry_sdk.integrations.opentelemetry.consts import (
     SENTRY_BAGGAGE_KEY,
@@ -90,11 +90,12 @@ class SentryPropagator(TextMapPropagator):  # type: ignore
             context = get_current()
 
         current_span = trace.get_current_span(context)
+        current_span_context = current_span.get_span_context()
 
-        if not current_span.context.is_valid:
+        if not current_span_context.is_valid:
             return
 
-        span_id = trace.format_span_id(current_span.context.span_id)
+        span_id = trace.format_span_id(current_span_context.span_id)
 
         span_map = SentrySpanProcessor().otel_span_map
         sentry_span = span_map.get(span_id, None)

--- a/sentry_sdk/integrations/opentelemetry/propagator.py
+++ b/sentry_sdk/integrations/opentelemetry/propagator.py
@@ -104,9 +104,10 @@ class SentryPropagator(TextMapPropagator):  # type: ignore
 
         setter.set(carrier, SENTRY_TRACE_HEADER_NAME, sentry_span.to_traceparent())
 
-        baggage = sentry_span.containing_transaction.get_baggage()
-        if baggage:
-            setter.set(carrier, BAGGAGE_HEADER_NAME, baggage.serialize())
+        if sentry_span.containing_transaction:
+            baggage = sentry_span.containing_transaction.get_baggage()
+            if baggage:
+                setter.set(carrier, BAGGAGE_HEADER_NAME, baggage.serialize())
 
     @property
     def fields(self):

--- a/tests/integrations/opentelemetry/test_propagator.py
+++ b/tests/integrations/opentelemetry/test_propagator.py
@@ -139,7 +139,7 @@ def test_inject_empty_otel_span_map():
         is_remote=True,
     )
     span = MagicMock()
-    span.context = span_context
+    span.get_span_context.return_value = span_context
 
     with mock.patch(
         "sentry_sdk.integrations.opentelemetry.propagator.trace.get_current_span",
@@ -170,7 +170,7 @@ def test_inject_sentry_span_no_baggage():
         is_remote=True,
     )
     span = MagicMock()
-    span.context = span_context
+    span.get_span_context.return_value = span_context
 
     sentry_span = MagicMock()
     sentry_span.to_traceparent = mock.Mock(
@@ -214,7 +214,7 @@ def test_inject_sentry_span_baggage():
         is_remote=True,
     )
     span = MagicMock()
-    span.context = span_context
+    span.get_span_context.return_value = span_context
 
     sentry_span = MagicMock()
     sentry_span.to_traceparent = mock.Mock(

--- a/tests/integrations/opentelemetry/test_span_processor.py
+++ b/tests/integrations/opentelemetry/test_span_processor.py
@@ -62,9 +62,12 @@ def test_get_otel_context():
 
 def test_get_trace_data_with_span_and_trace():
     otel_span = MagicMock()
-    otel_span.context = MagicMock()
-    otel_span.context.trace_id = int("1234567890abcdef1234567890abcdef", 16)
-    otel_span.context.span_id = int("1234567890abcdef", 16)
+    span_context = SpanContext(
+        trace_id=int("1234567890abcdef1234567890abcdef", 16),
+        span_id=int("1234567890abcdef", 16),
+        is_remote=True,
+    )
+    otel_span.get_span_context.return_value = span_context
     otel_span.parent = None
 
     parent_context = {}
@@ -80,9 +83,12 @@ def test_get_trace_data_with_span_and_trace():
 
 def test_get_trace_data_with_span_and_trace_and_parent():
     otel_span = MagicMock()
-    otel_span.context = MagicMock()
-    otel_span.context.trace_id = int("1234567890abcdef1234567890abcdef", 16)
-    otel_span.context.span_id = int("1234567890abcdef", 16)
+    span_context = SpanContext(
+        trace_id=int("1234567890abcdef1234567890abcdef", 16),
+        span_id=int("1234567890abcdef", 16),
+        is_remote=True,
+    )
+    otel_span.get_span_context.return_value = span_context
     otel_span.parent = MagicMock()
     otel_span.parent.span_id = int("abcdef1234567890", 16)
 
@@ -99,9 +105,12 @@ def test_get_trace_data_with_span_and_trace_and_parent():
 
 def test_get_trace_data_with_sentry_trace():
     otel_span = MagicMock()
-    otel_span.context = MagicMock()
-    otel_span.context.trace_id = int("1234567890abcdef1234567890abcdef", 16)
-    otel_span.context.span_id = int("1234567890abcdef", 16)
+    span_context = SpanContext(
+        trace_id=int("1234567890abcdef1234567890abcdef", 16),
+        span_id=int("1234567890abcdef", 16),
+        is_remote=True,
+    )
+    otel_span.get_span_context.return_value = span_context
     otel_span.parent = MagicMock()
     otel_span.parent.span_id = int("abcdef1234567890", 16)
 
@@ -144,9 +153,12 @@ def test_get_trace_data_with_sentry_trace():
 
 def test_get_trace_data_with_sentry_trace_and_baggage():
     otel_span = MagicMock()
-    otel_span.context = MagicMock()
-    otel_span.context.trace_id = int("1234567890abcdef1234567890abcdef", 16)
-    otel_span.context.span_id = int("1234567890abcdef", 16)
+    span_context = SpanContext(
+        trace_id=int("1234567890abcdef1234567890abcdef", 16),
+        span_id=int("1234567890abcdef", 16),
+        is_remote=True,
+    )
+    otel_span.get_span_context.return_value = span_context
     otel_span.parent = MagicMock()
     otel_span.parent.span_id = int("abcdef1234567890", 16)
 
@@ -263,9 +275,12 @@ def test_on_start_transaction():
     otel_span = MagicMock()
     otel_span.name = "Sample OTel Span"
     otel_span.start_time = time.time_ns()
-    otel_span.context = MagicMock()
-    otel_span.context.trace_id = int("1234567890abcdef1234567890abcdef", 16)
-    otel_span.context.span_id = int("1234567890abcdef", 16)
+    span_context = SpanContext(
+        trace_id=int("1234567890abcdef1234567890abcdef", 16),
+        span_id=int("1234567890abcdef", 16),
+        is_remote=True,
+    )
+    otel_span.get_span_context.return_value = span_context
     otel_span.parent = MagicMock()
     otel_span.parent.span_id = int("abcdef1234567890", 16)
 
@@ -305,9 +320,12 @@ def test_on_start_child():
     otel_span = MagicMock()
     otel_span.name = "Sample OTel Span"
     otel_span.start_time = time.time_ns()
-    otel_span.context = MagicMock()
-    otel_span.context.trace_id = int("1234567890abcdef1234567890abcdef", 16)
-    otel_span.context.span_id = int("1234567890abcdef", 16)
+    span_context = SpanContext(
+        trace_id=int("1234567890abcdef1234567890abcdef", 16),
+        span_id=int("1234567890abcdef", 16),
+        is_remote=True,
+    )
+    otel_span.get_span_context.return_value = span_context
     otel_span.parent = MagicMock()
     otel_span.parent.span_id = int("abcdef1234567890", 16)
 
@@ -351,8 +369,12 @@ def test_on_end_no_sentry_span():
     otel_span = MagicMock()
     otel_span.name = "Sample OTel Span"
     otel_span.end_time = time.time_ns()
-    otel_span.context = MagicMock()
-    otel_span.context.span_id = int("1234567890abcdef", 16)
+    span_context = SpanContext(
+        trace_id=int("1234567890abcdef1234567890abcdef", 16),
+        span_id=int("1234567890abcdef", 16),
+        is_remote=True,
+    )
+    otel_span.get_span_context.return_value = span_context
 
     span_processor = SentrySpanProcessor()
     span_processor.otel_span_map = {}
@@ -372,8 +394,12 @@ def test_on_end_sentry_transaction():
     otel_span = MagicMock()
     otel_span.name = "Sample OTel Span"
     otel_span.end_time = time.time_ns()
-    otel_span.context = MagicMock()
-    otel_span.context.span_id = int("1234567890abcdef", 16)
+    span_context = SpanContext(
+        trace_id=int("1234567890abcdef1234567890abcdef", 16),
+        span_id=int("1234567890abcdef", 16),
+        is_remote=True,
+    )
+    otel_span.get_span_context.return_value = span_context
 
     fake_sentry_span = MagicMock(spec=Transaction)
     fake_sentry_span.set_context = MagicMock()
@@ -398,8 +424,12 @@ def test_on_end_sentry_span():
     otel_span = MagicMock()
     otel_span.name = "Sample OTel Span"
     otel_span.end_time = time.time_ns()
-    otel_span.context = MagicMock()
-    otel_span.context.span_id = int("1234567890abcdef", 16)
+    span_context = SpanContext(
+        trace_id=int("1234567890abcdef1234567890abcdef", 16),
+        span_id=int("1234567890abcdef", 16),
+        is_remote=True,
+    )
+    otel_span.get_span_context.return_value = span_context
 
     fake_sentry_span = MagicMock(spec=Span)
     fake_sentry_span.set_context = MagicMock()
@@ -425,7 +455,6 @@ def test_link_trace_context_to_error_event():
     """
     fake_client = MagicMock()
     fake_client.options = {"instrumenter": "otel"}
-    fake_client
 
     current_hub = MagicMock()
     current_hub.client = fake_client


### PR DESCRIPTION
This builds on top of #1995, while also applying the same fix to `SentrySpanProcessor`.