### PR TITLE
Backpressure prototype

### DIFF
--- a/sentry_sdk/client.py
+++ b/sentry_sdk/client.py
@@ -212,8 +212,11 @@ class _Client(object):
             self.transport = make_transport(self.options)
 
             self.monitor = None
-            if self.transport and self.options["enable_backpressure_handling"]:
-                self.monitor = Monitor(self.transport)
+            if self.transport:
+                if self.options["_experiments"].get(
+                    "enable_backpressure_handling", False
+                ):
+                    self.monitor = Monitor(self.transport)
 
             self.session_flusher = SessionFlusher(capture_func=_capture_envelope)
 

--- a/sentry_sdk/client.py
+++ b/sentry_sdk/client.py
@@ -32,6 +32,7 @@ from sentry_sdk.sessions import SessionFlusher
 from sentry_sdk.envelope import Envelope
 from sentry_sdk.profiler import has_profiling_enabled, setup_profiler
 from sentry_sdk.scrubber import EventScrubber
+from sentry_sdk.monitor import Monitor
 
 from sentry_sdk._types import TYPE_CHECKING
 
@@ -211,6 +212,7 @@ class _Client(object):
             self.transport = make_transport(self.options)
 
             self.session_flusher = SessionFlusher(capture_func=_capture_envelope)
+            self.monitor = Monitor()
 
             request_bodies = ("always", "never", "small", "medium")
             if self.options["request_bodies"] not in request_bodies:
@@ -571,6 +573,7 @@ class _Client(object):
         if self.transport is not None:
             self.flush(timeout=timeout, callback=callback)
             self.session_flusher.kill()
+            self.monitor.kill()
             self.transport.kill()
             self.transport = None
 

--- a/sentry_sdk/client.py
+++ b/sentry_sdk/client.py
@@ -211,8 +211,11 @@ class _Client(object):
             _client_init_debug.set(self.options["debug"])
             self.transport = make_transport(self.options)
 
+            self.monitor = None
+            if self.transport:
+                self.monitor = Monitor(self.transport)
+
             self.session_flusher = SessionFlusher(capture_func=_capture_envelope)
-            self.monitor = Monitor()
 
             request_bodies = ("always", "never", "small", "medium")
             if self.options["request_bodies"] not in request_bodies:
@@ -573,7 +576,8 @@ class _Client(object):
         if self.transport is not None:
             self.flush(timeout=timeout, callback=callback)
             self.session_flusher.kill()
-            self.monitor.kill()
+            if self.monitor:
+                self.monitor.kill()
             self.transport.kill()
             self.transport = None
 

--- a/sentry_sdk/client.py
+++ b/sentry_sdk/client.py
@@ -212,7 +212,7 @@ class _Client(object):
             self.transport = make_transport(self.options)
 
             self.monitor = None
-            if self.transport:
+            if self.transport and self.options["enable_backpressure_handling"]:
                 self.monitor = Monitor(self.transport)
 
             self.session_flusher = SessionFlusher(capture_func=_capture_envelope)

--- a/sentry_sdk/consts.py
+++ b/sentry_sdk/consts.py
@@ -36,6 +36,7 @@ if TYPE_CHECKING:
             # TODO: Remove these 2 profiling related experiments
             "profiles_sample_rate": Optional[float],
             "profiler_mode": Optional[ProfilerMode],
+            "enable_backpressure_handling": Optional[bool],
         },
         total=False,
     )
@@ -205,7 +206,6 @@ class ClientConstructor(object):
         ],  # type: Optional[Sequence[str]]
         functions_to_trace=[],  # type: Sequence[Dict[str, str]]  # noqa: B006
         event_scrubber=None,  # type: Optional[sentry_sdk.scrubber.EventScrubber]
-        enable_backpressure_handling=True,  # type: bool
     ):
         # type: (...) -> None
         pass

--- a/sentry_sdk/consts.py
+++ b/sentry_sdk/consts.py
@@ -205,6 +205,7 @@ class ClientConstructor(object):
         ],  # type: Optional[Sequence[str]]
         functions_to_trace=[],  # type: Sequence[Dict[str, str]]  # noqa: B006
         event_scrubber=None,  # type: Optional[sentry_sdk.scrubber.EventScrubber]
+        enable_backpressure_handling=True,  # type: bool
     ):
         # type: (...) -> None
         pass

--- a/sentry_sdk/monitor.py
+++ b/sentry_sdk/monitor.py
@@ -105,6 +105,7 @@ class Monitor(object):
         self._ensure_running()
         return self._healthy
 
+    @property
     def downsample_factor(self):
         # type: () -> int
         self._ensure_running()

--- a/sentry_sdk/monitor.py
+++ b/sentry_sdk/monitor.py
@@ -59,21 +59,9 @@ class Monitor(object):
     def run(self):
         # type: () -> None
         self.check_health()
-        self._set_downsample_factor()
+        self.set_downsample_factor()
 
-    def _is_transport_rate_limited(self):
-        # type: () -> bool
-        if self.transport and hasattr(self.transport, "is_rate_limited"):
-            return self.transport.is_rate_limited()
-        return False
-
-    def _is_transport_worker_full(self):
-        # type: () -> bool
-        if self.transport and hasattr(self.transport, "is_worker_full"):
-            return self.transport.is_worker_full()
-        return False
-
-    def _set_downsample_factor(self):
+    def set_downsample_factor(self):
         # type: () -> None
         if self._healthy:
             if self._downsample_factor > 1:
@@ -95,10 +83,7 @@ class Monitor(object):
         currently only checks if the transport is rate-limited.
         TODO: augment in the future with more checks.
         """
-        if self._is_transport_worker_full() or self._is_transport_rate_limited():
-            self._healthy = False
-        else:
-            self._healthy = True
+        self._healthy = self.transport.is_healthy()
 
     def is_healthy(self):
         # type: () -> bool

--- a/sentry_sdk/monitor.py
+++ b/sentry_sdk/monitor.py
@@ -70,7 +70,10 @@ class Monitor(object):
             self._downsample_factor = 1
         else:
             self._downsample_factor *= 2
-            logger.debug("monitor health check negative, downsampling with a factor of %d", self._downsample_factor)
+            logger.debug(
+                "monitor health check negative, downsampling with a factor of %d",
+                self._downsample_factor,
+            )
 
     def check_health(self):
         # type: () -> None

--- a/sentry_sdk/monitor.py
+++ b/sentry_sdk/monitor.py
@@ -20,9 +20,9 @@ class Monitor(object):
     name = "sentry.monitor"
 
     def __init__(self, transport, interval=10):
-        # type: (sentry_sdk.transport.Transport, int) -> None
+        # type: (sentry_sdk.transport.Transport, float) -> None
         self.transport = transport  # type: sentry_sdk.transport.Transport
-        self.interval = interval  # type: int
+        self.interval = interval  # type: float
 
         self._healthy = True
         self._downsample_factor = 1  # type: int

--- a/sentry_sdk/monitor.py
+++ b/sentry_sdk/monitor.py
@@ -1,0 +1,83 @@
+import os
+import time
+from threading import Thread, Lock
+
+import sentry_sdk
+from sentry_sdk._types import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from typing import Optional
+
+
+class Monitor(object):
+    """
+    Performs health checks in a separate thread once every interval seconds
+    and updates the internal state. Other parts of the SDK only read this state
+    and act accordingly.
+    """
+
+    name = "sentry.monitor"
+
+    def __init__(self, interval=60):
+        # type: (int) -> None
+        self.interval = interval  # type: int
+        self._healthy = True
+        self._thread = None  # type: Optional[Thread]
+        self._thread_lock = Lock()
+        self._thread_for_pid = None  # type: Optional[int]
+        self._running = True
+
+    def _ensure_running(self):
+        # type: () -> None
+        if self._thread_for_pid == os.getpid() and self._thread is not None:
+            return None
+
+        with self._thread_lock:
+            if self._thread_for_pid == os.getpid() and self._thread is not None:
+                return None
+
+            def _thread():
+                # type: (...) -> None
+                while self._running:
+                    time.sleep(self.interval)
+                    if self._running:
+                        self.check_health()
+
+            thread = Thread(name=self.name, target=_thread)
+            thread.daemon = True
+            thread.start()
+            self._thread = thread
+            self._thread_for_pid = os.getpid()
+
+        return None
+
+    def _is_transport_rate_limited(self):
+        # type: () -> bool
+        transport = (
+            sentry_sdk.Hub.current.client and sentry_sdk.Hub.current.client.transport
+        )
+        if transport and hasattr(transport, "_is_rate_limited"):
+            return transport._is_rate_limited()
+        return False
+
+    def check_health(self):
+        # type: () -> None
+        """
+        Perform the actual health checks,
+        currently only checks if the transport is rate-limited.
+        TODO: augment in the future with more checks.
+        """
+        if self._is_transport_rate_limited():
+            self._healthy = False
+
+    def is_healthy(self):
+        # type: () -> bool
+        return self._healthy
+
+    def kill(self):
+        # type: () -> None
+        self._running = False
+
+    def __del__(self):
+        # type: () -> None
+        self.kill()

--- a/sentry_sdk/monitor.py
+++ b/sentry_sdk/monitor.py
@@ -19,7 +19,7 @@ class Monitor(object):
 
     name = "sentry.monitor"
 
-    def __init__(self, transport, interval=60):
+    def __init__(self, transport, interval=10):
         # type: (sentry_sdk.transport.Transport, int) -> None
         self.transport = transport  # type: sentry_sdk.transport.Transport
         self.interval = interval  # type: int

--- a/sentry_sdk/monitor.py
+++ b/sentry_sdk/monitor.py
@@ -72,11 +72,15 @@ class Monitor(object):
     def _set_downsample_factor(self):
         # type: () -> None
         if self._healthy:
+            if self._downsample_factor > 1:
+                logger.debug(
+                    "[Monitor] health check positive, reverting to normal sampling"
+                )
             self._downsample_factor = 1
         else:
             self._downsample_factor *= 2
             logger.debug(
-                "monitor health check negative, downsampling with a factor of %d",
+                "[Monitor] health check negative, downsampling with a factor of %d",
                 self._downsample_factor,
             )
 
@@ -87,17 +91,19 @@ class Monitor(object):
         currently only checks if the transport is rate-limited.
         TODO: augment in the future with more checks.
         """
-        if self._is_transport_rate_limited() or self._is_transport_worker_full():
+        if self._is_transport_worker_full() or self._is_transport_rate_limited():
             self._healthy = False
         else:
             self._healthy = True
 
     def is_healthy(self):
         # type: () -> bool
+        self._ensure_running()
         return self._healthy
 
     def downsample_factor(self):
         # type: () -> int
+        self._ensure_running()
         return self._downsample_factor
 
     def kill(self):

--- a/sentry_sdk/monitor.py
+++ b/sentry_sdk/monitor.py
@@ -46,8 +46,7 @@ class Monitor(object):
                 while self._running:
                     time.sleep(self.interval)
                     if self._running:
-                        self.check_health()
-                        self._set_downsample_factor()
+                        self.run()
 
             thread = Thread(name=self.name, target=_thread)
             thread.daemon = True
@@ -56,6 +55,11 @@ class Monitor(object):
             self._thread_for_pid = os.getpid()
 
         return None
+
+    def run(self):
+        # type: () -> None
+        self.check_health()
+        self._set_downsample_factor()
 
     def _is_transport_rate_limited(self):
         # type: () -> bool

--- a/sentry_sdk/tracing.py
+++ b/sentry_sdk/tracing.py
@@ -595,7 +595,7 @@ class Transaction(Span):
             # exclusively based on sample rate but also traces sampler, but
             # we handle this the same here.
             if client.transport and has_tracing_enabled(client.options):
-                if client.monitor and client.monitor.downsample_factor() > 1:
+                if client.monitor and client.monitor.downsample_factor > 1:
                     reason = "backpressure"
                 else:
                     reason = "sample_rate"
@@ -753,7 +753,7 @@ class Transaction(Span):
         self.sample_rate = float(sample_rate)
 
         if client.monitor:
-            self.sample_rate /= client.monitor.downsample_factor()
+            self.sample_rate /= client.monitor.downsample_factor
 
         # if the function returned 0 (or false), or if `traces_sample_rate` is
         # 0, it's a sign the transaction should be dropped

--- a/sentry_sdk/transport.py
+++ b/sentry_sdk/transport.py
@@ -311,9 +311,13 @@ class HttpTransport(Transport):
 
         return _disabled(category) or _disabled(None)
 
-    def _is_rate_limited(self):
+    def is_rate_limited(self):
         # type: () -> bool
         return any(ts > datetime.utcnow() for ts in self._disabled_until.values())
+
+    def is_worker_full(self):
+        # type: () -> bool
+        return self._worker.full()
 
     def _send_event(
         self, event  # type: Event

--- a/sentry_sdk/transport.py
+++ b/sentry_sdk/transport.py
@@ -107,6 +107,10 @@ class Transport(object):
         """
         return None
 
+    def is_healthy(self):
+        # type: () -> bool
+        return True
+
     def __del__(self):
         # type: () -> None
         try:
@@ -311,13 +315,17 @@ class HttpTransport(Transport):
 
         return _disabled(category) or _disabled(None)
 
-    def is_rate_limited(self):
+    def _is_rate_limited(self):
         # type: () -> bool
         return any(ts > datetime.utcnow() for ts in self._disabled_until.values())
 
-    def is_worker_full(self):
+    def _is_worker_full(self):
         # type: () -> bool
         return self._worker.full()
+
+    def is_healthy(self):
+        # type: () -> bool
+        return not (self._is_worker_full() or self._is_rate_limited())
 
     def _send_event(
         self, event  # type: Event

--- a/sentry_sdk/transport.py
+++ b/sentry_sdk/transport.py
@@ -311,6 +311,10 @@ class HttpTransport(Transport):
 
         return _disabled(category) or _disabled(None)
 
+    def _is_rate_limited(self):
+        # type: () -> bool
+        return any(ts > datetime.utcnow() for ts in self._disabled_until.values())
+
     def _send_event(
         self, event  # type: Event
     ):

--- a/sentry_sdk/worker.py
+++ b/sentry_sdk/worker.py
@@ -95,6 +95,10 @@ class BackgroundWorker(object):
                 self._wait_flush(timeout, callback)
         logger.debug("background worker flushed")
 
+    def full(self):
+        # type: () -> bool
+        return self._queue.full()
+
     def _wait_flush(self, timeout, callback):
         # type: (float, Optional[Any]) -> None
         initial_timeout = min(0.1, timeout)

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -11,13 +11,13 @@ class HealthyTestTransport(Transport):
     def _send_envelope(self, envelope):
         pass
 
-    def is_worker_full(self):
-        return False
+    def is_healthy(self):
+        return True
 
 
 class UnhealthyTestTransport(HealthyTestTransport):
-    def is_worker_full(self):
-        return True
+    def is_healthy(self):
+        return False
 
 
 def test_no_monitor_if_disabled(sentry_init):

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -1,5 +1,4 @@
 import random
-from time import sleep
 
 from sentry_sdk import Hub, start_transaction
 from sentry_sdk.transport import Transport
@@ -52,10 +51,10 @@ def test_monitor_unhealthy(sentry_init):
     monitor.interval = 0.1
 
     assert monitor.is_healthy() is True
-    sleep(0.1)  # wait for monitor to run
+    monitor.run()
     assert monitor.is_healthy() is False
     assert monitor.downsample_factor() == 2
-    sleep(0.1)  # wait for monitor to run
+    monitor.run()
     assert monitor.downsample_factor() == 4
 
 
@@ -77,7 +76,7 @@ def test_transaction_uses_downsampled_rate(
     monkeypatch.setattr(random, "random", lambda: 0.9)
 
     assert monitor.is_healthy() is True
-    sleep(0.1)  # wait for monitor to run
+    monitor.run()
     assert monitor.is_healthy() is False
     assert monitor.downsample_factor() == 2
 

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -36,7 +36,7 @@ def test_monitor_if_enabled(sentry_init):
     assert monitor._thread is None
 
     assert monitor.is_healthy() is True
-    assert monitor.downsample_factor() == 1
+    assert monitor.downsample_factor == 1
     assert monitor._thread is not None
     assert monitor._thread.name == "sentry.monitor"
 
@@ -53,9 +53,9 @@ def test_monitor_unhealthy(sentry_init):
     assert monitor.is_healthy() is True
     monitor.run()
     assert monitor.is_healthy() is False
-    assert monitor.downsample_factor() == 2
+    assert monitor.downsample_factor == 2
     monitor.run()
-    assert monitor.downsample_factor() == 4
+    assert monitor.downsample_factor == 4
 
 
 def test_transaction_uses_downsampled_rate(
@@ -78,7 +78,7 @@ def test_transaction_uses_downsampled_rate(
     assert monitor.is_healthy() is True
     monitor.run()
     assert monitor.is_healthy() is False
-    assert monitor.downsample_factor() == 2
+    assert monitor.downsample_factor == 2
 
     with start_transaction(name="foobar") as transaction:
         assert transaction.sampled is False

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -1,0 +1,88 @@
+import random
+from time import sleep
+
+from sentry_sdk import Hub, start_transaction
+from sentry_sdk.transport import Transport
+
+
+class HealthyTestTransport(Transport):
+    def _send_event(self, event):
+        pass
+
+    def _send_envelope(self, envelope):
+        pass
+
+    def is_worker_full(self):
+        return False
+
+
+class UnhealthyTestTransport(HealthyTestTransport):
+    def is_worker_full(self):
+        return True
+
+
+def test_no_monitor_if_disabled(sentry_init):
+    sentry_init(transport=HealthyTestTransport())
+    assert Hub.current.client.monitor is None
+
+
+def test_monitor_if_enabled(sentry_init):
+    sentry_init(
+        transport=HealthyTestTransport(),
+        _experiments={"enable_backpressure_handling": True},
+    )
+
+    monitor = Hub.current.client.monitor
+    assert monitor is not None
+    assert monitor._thread is None
+
+    assert monitor.is_healthy() is True
+    assert monitor.downsample_factor() == 1
+    assert monitor._thread is not None
+    assert monitor._thread.name == "sentry.monitor"
+
+
+def test_monitor_unhealthy(sentry_init):
+    sentry_init(
+        transport=UnhealthyTestTransport(),
+        _experiments={"enable_backpressure_handling": True},
+    )
+
+    monitor = Hub.current.client.monitor
+    monitor.interval = 0.1
+
+    assert monitor.is_healthy() is True
+    sleep(0.1)  # wait for monitor to run
+    assert monitor.is_healthy() is False
+    assert monitor.downsample_factor() == 2
+    sleep(0.1)  # wait for monitor to run
+    assert monitor.downsample_factor() == 4
+
+
+def test_transaction_uses_downsampled_rate(
+    sentry_init, capture_client_reports, monkeypatch
+):
+    sentry_init(
+        traces_sample_rate=1.0,
+        transport=UnhealthyTestTransport(),
+        _experiments={"enable_backpressure_handling": True},
+    )
+
+    reports = capture_client_reports()
+
+    monitor = Hub.current.client.monitor
+    monitor.interval = 0.1
+
+    # make sure rng doesn't sample
+    monkeypatch.setattr(random, "random", lambda: 0.9)
+
+    assert monitor.is_healthy() is True
+    sleep(0.1)  # wait for monitor to run
+    assert monitor.is_healthy() is False
+    assert monitor.downsample_factor() == 2
+
+    with start_transaction(name="foobar") as transaction:
+        assert transaction.sampled is False
+        assert transaction.sample_rate == 0.5
+
+    assert reports == [("backpressure", "transaction")]


### PR DESCRIPTION
* Monitor class performs health checks in a thread every 10s
* if not healthy, we downsample / halve in steps till healthy again
* exposed as experimental `enable_backpressure_handling`

related to #2095 and https://github.com/getsentry/team-webplatform-meta/issues/50