### PR TITLE
Do not overwrite existing baggage on outgoing requests

### DIFF
--- a/sentry_sdk/integrations/celery.py
+++ b/sentry_sdk/integrations/celery.py
@@ -178,8 +178,7 @@ def _wrap_apply_async(f):
                         # Need to setdefault the inner headers too since other
                         # tracing tools (dd-trace-py) also employ this exact
                         # workaround and we don't want to break them.
-                        kwarg_headers.setdefault("headers", {})
-                        kwarg_headers["headers"].update(headers)
+                        kwarg_headers.setdefault("headers", {}).update(headers)
                         if combined_baggage:
                             kwarg_headers["headers"][
                                 BAGGAGE_HEADER_NAME

--- a/sentry_sdk/integrations/celery.py
+++ b/sentry_sdk/integrations/celery.py
@@ -161,13 +161,13 @@ def _wrap_apply_async(f):
 
                         existing_baggage = kwarg_headers.get(BAGGAGE_HEADER_NAME)
                         sentry_baggage = headers.get(BAGGAGE_HEADER_NAME)
+
+                        combined_baggage = sentry_baggage or existing_baggage
                         if sentry_baggage and existing_baggage:
                             combined_baggage = "{},{}".format(
                                 existing_baggage,
                                 sentry_baggage,
                             )
-                        else:
-                            combined_baggage = sentry_baggage or existing_baggage
 
                         kwarg_headers.update(headers)
                         if combined_baggage:

--- a/sentry_sdk/integrations/celery.py
+++ b/sentry_sdk/integrations/celery.py
@@ -160,11 +160,13 @@ def _wrap_apply_async(f):
                         kwarg_headers = kwargs.get("headers") or {}
 
                         existing_baggage = kwarg_headers.get(BAGGAGE_HEADER_NAME)
-                        combined_baggage = existing_baggage
-                        if existing_baggage and headers[BAGGAGE_HEADER_NAME]:
-                            combined_baggage += ",{}".format(
-                                headers[BAGGAGE_HEADER_NAME]
+                        if existing_baggage:
+                            combined_baggage = "{},{}".format(
+                                existing_baggage,
+                                headers[BAGGAGE_HEADER_NAME],
                             )
+                        else:
+                            combined_baggage = headers[BAGGAGE_HEADER_NAME]
 
                         kwarg_headers.update(headers)
                         kwarg_headers[BAGGAGE_HEADER_NAME] = combined_baggage

--- a/sentry_sdk/integrations/celery.py
+++ b/sentry_sdk/integrations/celery.py
@@ -161,7 +161,7 @@ def _wrap_apply_async(f):
 
                         existing_baggage = kwarg_headers.get(BAGGAGE_HEADER_NAME)
                         combined_baggage = existing_baggage
-                        if existing_baggage:
+                        if existing_baggage and headers[BAGGAGE_HEADER_NAME]:
                             combined_baggage += ",{}".format(
                                 headers[BAGGAGE_HEADER_NAME]
                             )

--- a/sentry_sdk/integrations/httpx.py
+++ b/sentry_sdk/integrations/httpx.py
@@ -77,7 +77,9 @@ def _install_httpx_client():
                         BAGGAGE_HEADER_NAME
                     ):
                         # do not overwrite any existing baggage, just append to it
-                        request.headers[key] += "," + value
+                        request.headers[key] = "{},{}".format(
+                            request.headers[key], value
+                        )
                     else:
                         request.headers[key] = value
 

--- a/sentry_sdk/integrations/httpx.py
+++ b/sentry_sdk/integrations/httpx.py
@@ -77,9 +77,7 @@ def _install_httpx_client():
                         BAGGAGE_HEADER_NAME
                     ):
                         # do not overwrite any existing baggage, just append to it
-                        request.headers[key] = "{},{}".format(
-                            request.headers[key], value
-                        )
+                        request.headers[key] += "," + value
                     else:
                         request.headers[key] = value
 

--- a/tests/integrations/celery/test_celery.py
+++ b/tests/integrations/celery/test_celery.py
@@ -359,7 +359,7 @@ def test_retry(celery, capture_events):
 # TODO: This test is hanging when running test with `tox --parallel auto`. Find out why and fix it!
 @pytest.mark.skip
 @pytest.mark.forked
-def test_redis_backend_trace_propagation(init_celery, capture_events_forksafe, tmpdir):
+def test_redis_backend_trace_propagation(init_celery, capture_events_forksafe):
     celery = init_celery(traces_sample_rate=1.0, backend="redis", debug=True)
 
     events = capture_events_forksafe()
@@ -513,7 +513,7 @@ def test_baggage_propagation(init_celery):
     with start_transaction() as transaction:
         result = dummy_task.apply_async(
             args=(1, 0),
-            headers={"baggage": "custom=value", "headers": {"baggage": "custom=value"}},
+            headers={"baggage": "custom=value"},
         ).get()
 
         assert sorted(result["baggage"].split(",")) == sorted(

--- a/tests/integrations/celery/test_celery.py
+++ b/tests/integrations/celery/test_celery.py
@@ -11,7 +11,6 @@ from sentry_sdk._compat import text_type
 
 from celery import Celery, VERSION
 from celery.bin import worker
-from celery.signals import task_success
 
 try:
     from unittest import mock  # python 3.3 and above
@@ -493,17 +492,36 @@ def test_task_headers(celery):
         "sentry-monitor-check-in-id": "123abc",
     }
 
-    @celery.task(name="dummy_task")
-    def dummy_task(x, y):
-        return x + y
-
-    def crons_task_success(sender, **kwargs):
-        headers = _get_headers(sender)
-        assert headers == sentry_crons_setup
-
-    task_success.connect(crons_task_success)
+    @celery.task(name="dummy_task", bind=True)
+    def dummy_task(self, x, y):
+        return _get_headers(self)
 
     # This is how the Celery Beat auto-instrumentation starts a task
     # in the monkey patched version of `apply_async`
     # in `sentry_sdk/integrations/celery.py::_wrap_apply_async()`
-    dummy_task.apply_async(args=(1, 0), headers=sentry_crons_setup)
+    result = dummy_task.apply_async(args=(1, 0), headers=sentry_crons_setup)
+    assert result.get() == sentry_crons_setup
+
+
+def test_baggage_propagation(init_celery):
+    celery = init_celery(traces_sample_rate=1.0, release="abcdef")
+
+    @celery.task(name="dummy_task", bind=True)
+    def dummy_task(self, x, y):
+        return _get_headers(self)
+
+    with start_transaction() as transaction:
+        result = dummy_task.apply_async(
+            args=(1, 0),
+            headers={"baggage": "custom=value", "headers": {"baggage": "custom=value"}},
+        ).get()
+
+        assert sorted(result["baggage"].split(",")) == sorted(
+            [
+                "sentry-release=abcdef",
+                "sentry-trace_id={}".format(transaction.trace_id),
+                "sentry-environment=production",
+                "sentry-sample_rate=1.0",
+                "custom=value",
+            ]
+        )

--- a/tests/integrations/httpx/test_httpx.py
+++ b/tests/integrations/httpx/test_httpx.py
@@ -90,6 +90,46 @@ def test_outgoing_trace_headers(sentry_init, httpx_client):
 
 
 @pytest.mark.parametrize(
+    "httpx_client",
+    (httpx.Client(), httpx.AsyncClient()),
+)
+def test_outgoing_trace_headers_append_to_baggage(sentry_init, httpx_client):
+    sentry_init(
+        traces_sample_rate=1.0,
+        integrations=[HttpxIntegration()],
+        release="d08ebdb9309e1b004c6f52202de58a09c2268e42",
+    )
+
+    url = "http://example.com/"
+    responses.add(responses.GET, url, status=200)
+
+    with start_transaction(
+        name="/interactions/other-dogs/new-dog",
+        op="greeting.sniff",
+        trace_id="01234567890123456789012345678901",
+    ) as transaction:
+        if asyncio.iscoroutinefunction(httpx_client.get):
+            response = asyncio.get_event_loop().run_until_complete(
+                httpx_client.get(url, headers={"baGGage": "custom-data"})
+            )
+        else:
+            response = httpx_client.get(url, headers={"baGGage": "custom-data"})
+
+        request_span = transaction._span_recorder.spans[-1]
+        assert response.request.headers[
+            "sentry-trace"
+        ] == "{trace_id}-{parent_span_id}-{sampled}".format(
+            trace_id=transaction.trace_id,
+            parent_span_id=request_span.span_id,
+            sampled=1,
+        )
+        assert (
+            response.request.headers["baggage"]
+            == "custom-data,sentry-trace_id=01234567890123456789012345678901,sentry-environment=production,sentry-release=d08ebdb9309e1b004c6f52202de58a09c2268e42,sentry-transaction=/interactions/other-dogs/new-dog,sentry-sample_rate=1.0"
+        )
+
+
+@pytest.mark.parametrize(
     "httpx_client,trace_propagation_targets,url,trace_propagated",
     [
         [

--- a/tests/integrations/httpx/test_httpx.py
+++ b/tests/integrations/httpx/test_httpx.py
@@ -110,10 +110,10 @@ def test_outgoing_trace_headers_append_to_baggage(sentry_init, httpx_client):
     ) as transaction:
         if asyncio.iscoroutinefunction(httpx_client.get):
             response = asyncio.get_event_loop().run_until_complete(
-                httpx_client.get(url, headers={"baGGage": "custom-data"})
+                httpx_client.get(url, headers={"baGGage": "custom=data"})
             )
         else:
-            response = httpx_client.get(url, headers={"baGGage": "custom-data"})
+            response = httpx_client.get(url, headers={"baGGage": "custom=data"})
 
         request_span = transaction._span_recorder.spans[-1]
         assert response.request.headers[
@@ -125,7 +125,7 @@ def test_outgoing_trace_headers_append_to_baggage(sentry_init, httpx_client):
         )
         assert (
             response.request.headers["baggage"]
-            == "custom-data,sentry-trace_id=01234567890123456789012345678901,sentry-environment=production,sentry-release=d08ebdb9309e1b004c6f52202de58a09c2268e42,sentry-transaction=/interactions/other-dogs/new-dog,sentry-sample_rate=1.0"
+            == "custom=data,sentry-trace_id=01234567890123456789012345678901,sentry-environment=production,sentry-release=d08ebdb9309e1b004c6f52202de58a09c2268e42,sentry-transaction=/interactions/other-dogs/new-dog,sentry-sample_rate=1.0"
         )
 
 


### PR DESCRIPTION
If there's custom data in the `baggage` header of an outgoing request, we should preserve it when adding our custom sentry tracing baggage items.

Closes https://github.com/getsentry/sentry-python/issues/2190