### PR TITLE
Fix trace context in event payload

### DIFF
--- a/sentry_sdk/integrations/django/views.py
+++ b/sentry_sdk/integrations/django/views.py
@@ -26,6 +26,7 @@ def patch_views():
     from django.template.response import SimpleTemplateResponse
     from sentry_sdk.integrations.django import DjangoIntegration
 
+    old_make_view_atomic = BaseHandler.make_view_atomic
     old_render = SimpleTemplateResponse.render
 
     def sentry_patched_render(self):
@@ -35,10 +36,6 @@ def patch_views():
             op=OP.VIEW_RESPONSE_RENDER, description="serialize response"
         ):
             return old_render(self)
-
-    SimpleTemplateResponse.render = sentry_patched_render
-
-    old_make_view_atomic = BaseHandler.make_view_atomic
 
     @_functools.wraps(old_make_view_atomic)
     def sentry_patched_make_view_atomic(self, *args, **kwargs):
@@ -66,6 +63,7 @@ def patch_views():
 
         return sentry_wrapped_callback
 
+    SimpleTemplateResponse.render = sentry_patched_render
     BaseHandler.make_view_atomic = sentry_patched_make_view_atomic
 
 

--- a/sentry_sdk/integrations/django/views.py
+++ b/sentry_sdk/integrations/django/views.py
@@ -18,9 +18,6 @@ try:
 except (ImportError, SyntaxError):
     wrap_async_view = None  # type: ignore
 
-_monkey_patch_index = 0
-_not_set = object()
-
 
 def patch_views():
     # type: () -> None

--- a/sentry_sdk/integrations/django/views.py
+++ b/sentry_sdk/integrations/django/views.py
@@ -30,9 +30,6 @@ def patch_views():
 
     def sentry_patched_render(self):
         # type: (SimpleTemplateResponse) -> Any
-        import ipdb
-
-        ipdb.set_trace()
         hub = Hub.current
         with hub.start_span(
             op=OP.VIEW_RESPONSE_RENDER, description="serialize response"

--- a/sentry_sdk/integrations/django/views.py
+++ b/sentry_sdk/integrations/django/views.py
@@ -26,7 +26,6 @@ def patch_views():
     # type: () -> None
 
     from django.core.handlers.base import BaseHandler
-    from django.http import HttpResponse, HttpResponseBase
     from django.template.response import SimpleTemplateResponse
     from sentry_sdk.integrations.django import DjangoIntegration
 
@@ -74,41 +73,6 @@ def patch_views():
         return sentry_wrapped_callback
 
     BaseHandler.make_view_atomic = sentry_patched_make_view_atomic
-
-    old_http_response = HttpResponse
-
-    def sentry_patched_init(self, *args, **kwargs):
-        try:
-            original_content = args[0]
-            original_content = "xxxx" + original_content
-        except IndexError:
-            pass
-
-        return old_http_response.__init__(self, *args, **kwargs)
-
-    HttpResponse.__init__ = sentry_patched_init
-
-    # def monkey_patch(prop):
-    #     global _monkey_patch_index, _not_set
-    #     special_attr = "$_prop_monkey_patch_{}".format(_monkey_patch_index)
-    #     _monkey_patch_index += 1
-
-    #     def getter(self):
-    #         import ipdb
-
-    #         ipdb.set_trace()
-    #         value = getattr(self, special_attr, _not_set)
-    #         return prop.fget(self) if value is _not_set else value
-
-    #     def setter(self, value):
-    #         import ipdb
-
-    #         ipdb.set_trace()
-    #         setattr(self, special_attr, value)
-
-    #     return property(getter, setter)
-
-    # HttpResponse.content = monkey_patch(HttpResponse.content)
 
 
 def _wrap_sync_view(hub, callback):

--- a/sentry_sdk/scope.py
+++ b/sentry_sdk/scope.py
@@ -608,6 +608,8 @@ class Scope(object):
         if has_tracing_enabled(options):
             if self._span is not None:
                 contexts["trace"] = self._span.get_trace_context()
+            else:
+                contexts["trace"] = self.get_trace_context()
         else:
             contexts["trace"] = self.get_trace_context()
 

--- a/sentry_sdk/tracing.py
+++ b/sentry_sdk/tracing.py
@@ -520,7 +520,7 @@ class Transaction(Span):
         parent_sampled=None,  # type: Optional[bool]
         baggage=None,  # type: Optional[Baggage]
         source=TRANSACTION_SOURCE_CUSTOM,  # type: str
-        **kwargs,  # type: Any
+        **kwargs  # type: Any
     ):
         # type: (...) -> None
         # TODO: consider removing this in a future release.

--- a/sentry_sdk/tracing.py
+++ b/sentry_sdk/tracing.py
@@ -508,7 +508,7 @@ class Transaction(Span):
         parent_sampled=None,  # type: Optional[bool]
         baggage=None,  # type: Optional[Baggage]
         source=TRANSACTION_SOURCE_CUSTOM,  # type: str
-        **kwargs  # type: Any
+        **kwargs,  # type: Any
     ):
         # type: (...) -> None
         # TODO: consider removing this in a future release.

--- a/sentry_sdk/tracing.py
+++ b/sentry_sdk/tracing.py
@@ -508,7 +508,7 @@ class Transaction(Span):
         parent_sampled=None,  # type: Optional[bool]
         baggage=None,  # type: Optional[Baggage]
         source=TRANSACTION_SOURCE_CUSTOM,  # type: str
-        **kwargs,  # type: Any
+        **kwargs  # type: Any
     ):
         # type: (...) -> None
         # TODO: consider removing this in a future release.

--- a/sentry_sdk/tracing.py
+++ b/sentry_sdk/tracing.py
@@ -239,7 +239,7 @@ class Span(object):
             trace_id=self.trace_id,
             parent_span_id=self.span_id,
             containing_transaction=self.containing_transaction,
-            **kwargs,
+            **kwargs
         )
 
         span_recorder = (
@@ -256,8 +256,12 @@ class Span(object):
         return self.start_child(**kwargs)
 
     @classmethod
-    def continue_from_environ(cls, environ, **kwargs):
-        # type: (Span, typing.Mapping[str, str], Any) -> Transaction
+    def continue_from_environ(
+        cls,
+        environ,  # type: typing.Mapping[str, str]
+        **kwargs  # type: Any
+    ):
+        # type: (...) -> Transaction
         """
         Create a Transaction with the given params, then add in data pulled from
         the 'sentry-trace' and 'baggage' headers from the environ (if any)
@@ -275,8 +279,12 @@ class Span(object):
         return Transaction.continue_from_headers(EnvironHeaders(environ), **kwargs)
 
     @classmethod
-    def continue_from_headers(cls, headers, **kwargs):
-        # type: (Span, typing.Mapping[str, str], Any) -> Transaction
+    def continue_from_headers(
+        cls,
+        headers,  # type: typing.Mapping[str, str]
+        **kwargs  # type: Any
+    ):
+        # type: (...) -> Transaction
         """
         Create a transaction with the given params (including any data pulled from
         the 'sentry-trace' and 'baggage' headers).
@@ -325,8 +333,12 @@ class Span(object):
                 yield BAGGAGE_HEADER_NAME, baggage
 
     @classmethod
-    def from_traceparent(cls, traceparent, **kwargs):
-        # type: (Span, Optional[str], Any) -> Optional[Transaction]
+    def from_traceparent(
+        cls,
+        traceparent,  # type: Optional[str]
+        **kwargs  # type: Any
+    ):
+        # type: (...) -> Optional[Transaction]
         """
         DEPRECATED: Use Transaction.continue_from_headers(headers, **kwargs)
 


### PR DESCRIPTION
- Make sure that always a `trace` context is added to the event payload. 
- Make sure that the trace information is always taken from propagation context. (was not the case if you create a span without a transaction)