### PR TITLE
Change API doc theme

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,7 +84,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v4
         with:
-          python-version: 3.9
+          python-version: 3.11
 
       - run: |
           pip install virtualenv

--- a/docs-requirements.txt
+++ b/docs-requirements.txt
@@ -1,3 +1,4 @@
 shibuya
 sphinx==7.0.1
+sphinx-autodoc-typehints[type_comments]>=1.8.0
 typing-extensions

--- a/docs-requirements.txt
+++ b/docs-requirements.txt
@@ -1,4 +1,3 @@
+shibuya
 sphinx==7.0.1
-sphinx-rtd-theme
-sphinx-autodoc-typehints[type_comments]>=1.8.0
 typing-extensions

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -2,16 +2,16 @@
 
 import os
 import sys
-
 import typing
+from datetime import datetime
 
 # prevent circular imports
 import sphinx.builders.html
 import sphinx.builders.latex
 import sphinx.builders.texinfo
 import sphinx.builders.text
-import sphinx.ext.autodoc
-import urllib3.exceptions
+import sphinx.ext.autodoc  # noqa: F401
+import urllib3.exceptions  # noqa: F401
 
 typing.TYPE_CHECKING = True
 
@@ -27,7 +27,7 @@ sys.path.insert(0, os.path.abspath(".."))
 # -- Project information -----------------------------------------------------
 
 project = "sentry-python"
-copyright = "2019, Sentry Team and Contributors"
+copyright = "2019-{}, Sentry Team and Contributors".format(datetime.now().year)
 author = "Sentry Team and Contributors"
 
 release = "1.26.0"
@@ -87,13 +87,15 @@ pygments_style = None
 
 on_rtd = os.environ.get("READTHEDOCS", None) == "True"
 
-html_theme = "alabaster"
+html_theme = "shibuya"
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further. For a list of options available for each theme, see the
 # documentation.
 #
-# html_theme_options = {}
+html_theme_options = {
+    "github_url": "https://github.com/getsentry/sentry-python",
+}
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
@@ -167,7 +169,7 @@ texinfo_documents = [
         "sentry-python Documentation",
         author,
         "sentry-python",
-        "One line description of project.",
+        "The official Sentry SDK for Python.",
         "Miscellaneous",
     )
 ]


### PR DESCRIPTION
This should be a quick fix to address some visual overlapping issues that we currently have (see screenshot https://github.com/getsentry/sentry-python/issues/2196).

![Screenshot 2023-06-28 at 10 05 19](https://github.com/getsentry/sentry-python/assets/131587164/c2ac57f8-a65d-4c67-88d1-ca6a46afa71d)
