### PR TITLE
Allow (some) autocompletion for top-level API

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -7,3 +7,9 @@ Main API
 .. automodule:: sentry_sdk
     :members:
     :inherited-members:
+
+.. autoclass:: sentry_sdk.tracing.Span
+   :members:
+
+.. autoclass:: sentry_sdk.tracing.Transaction
+   :members:

--- a/sentry_sdk/client.py
+++ b/sentry_sdk/client.py
@@ -469,6 +469,9 @@ class _Client(object):
 
         :param hint: Contains metadata about the event that can be read from `before_send`, such as the original exception object or a HTTP request object.
 
+        :param scope: An optional scope to use for determining whether this event
+            should be captured.
+
         :returns: An event ID. May be `None` if there is no DSN set or of if the SDK decided to discard the event for other reasons. In such situations setting `debug=True` on `init()` may help.
         """
         if disable_capture_event.get(False):

--- a/sentry_sdk/hub.py
+++ b/sentry_sdk/hub.py
@@ -452,8 +452,10 @@ class Hub(with_metaclass(HubMeta)):  # type: ignore
             return
 
         crumb = dict(crumb or ())  # type: Breadcrumb
-        crumb["timestamp"] = timestamp
-        crumb["type"] = type
+        if timestamp is not None:
+            crumb["timestamp"] = timestamp
+        if type is not None:
+            crumb["type"] = type
         if data is not None:
             crumb["data"] = data
         crumb.update(kwargs)

--- a/sentry_sdk/hub.py
+++ b/sentry_sdk/hub.py
@@ -50,6 +50,7 @@ if TYPE_CHECKING:
         Event,
         Hint,
         Breadcrumb,
+        BreadcrumbHint,
         ExcInfo,
     )
     from sentry_sdk.consts import ClientConstructor
@@ -417,12 +418,12 @@ class Hub(with_metaclass(HubMeta)):  # type: ignore
 
     def add_breadcrumb(
         self,
-        crumb=None,  # Optional[Breadcrumb]
-        hint=None,  # Optional[BreadcrumbHint]
-        timestamp=None,  # Optional[datetime.datetime]
-        type=None,  # Optional[str]
-        data=None,  # Optional[Dict[str, Any]]
-        **kwargs  # Any
+        crumb=None,  # type: Optional[Breadcrumb]
+        hint=None,  # type: Optional[BreadcrumbHint]
+        timestamp=None,  # type: Optional[datetime.datetime]
+        type=None,  # type: Optional[str]
+        data=None,  # type: Optional[Dict[str, Any]]
+        **kwargs  # type: Any
     ):
         # type: (...) -> None
         """

--- a/sentry_sdk/hub.py
+++ b/sentry_sdk/hub.py
@@ -484,15 +484,17 @@ class Hub(with_metaclass(HubMeta)):  # type: ignore
     def start_span(self, span=None, instrumenter=INSTRUMENTER.SENTRY, **kwargs):
         # type: (Optional[Span], str, Any) -> Span
         """
-        Create and start timing a new span whose parent is the currently active
-        span or transaction, if any. The return value is a span instance,
+        Start a span whose parent is the currently active span or transaction, if any.
+
+        The return value is a :py:class:`sentry_sdk.tracing.Span` instance,
         typically used as a context manager to start and stop timing in a `with`
         block.
 
         Only spans contained in a transaction are sent to Sentry. Most
         integrations start a transaction at the appropriate time, for example
-        for every incoming HTTP request. Use `start_transaction` to start a new
-        transaction when one is not already in progress.
+        for every incoming HTTP request. Use
+        :py:meth:`sentry_sdk.start_transaction` to start a new transaction when
+        one is not already in progress.
         """
         configuration_instrumenter = self.client and self.client.options["instrumenter"]
 

--- a/sentry_sdk/hub.py
+++ b/sentry_sdk/hub.py
@@ -454,7 +454,7 @@ class Hub(with_metaclass(HubMeta)):  # type: ignore
         crumb = dict(crumb or ())  # type: Breadcrumb
         crumb["timestamp"] = timestamp
         crumb["type"] = type
-        if data:
+        if data is not None:
             crumb["data"] = data
         crumb.update(kwargs)
         if not crumb:

--- a/sentry_sdk/hub.py
+++ b/sentry_sdk/hub.py
@@ -454,7 +454,8 @@ class Hub(with_metaclass(HubMeta)):  # type: ignore
         crumb = dict(crumb or ())  # type: Breadcrumb
         crumb["timestamp"] = timestamp
         crumb["type"] = type
-        crumb["data"] = data
+        if data:
+            crumb["data"] = data
         crumb.update(kwargs)
         if not crumb:
             return

--- a/sentry_sdk/hub.py
+++ b/sentry_sdk/hub.py
@@ -495,6 +495,8 @@ class Hub(with_metaclass(HubMeta)):  # type: ignore
         for every incoming HTTP request. Use
         :py:meth:`sentry_sdk.start_transaction` to start a new transaction when
         one is not already in progress.
+
+        For supported `**kwargs` see :py:class:`sentry_sdk.tracing.Span`.
         """
         configuration_instrumenter = self.client and self.client.options["instrumenter"]
 
@@ -553,6 +555,8 @@ class Hub(with_metaclass(HubMeta)):  # type: ignore
 
         When the transaction is finished, it will be sent to Sentry with all its
         finished child spans.
+
+        For supported `**kwargs` see :py:class:`sentry_sdk.tracing.Transaction`.
         """
         configuration_instrumenter = self.client and self.client.options["instrumenter"]
 

--- a/sentry_sdk/hub.py
+++ b/sentry_sdk/hub.py
@@ -420,7 +420,7 @@ class Hub(with_metaclass(HubMeta)):  # type: ignore
         self,
         crumb=None,  # type: Optional[Breadcrumb]
         hint=None,  # type: Optional[BreadcrumbHint]
-        timestamp=None,  # type: Optional[datetime.datetime]
+        timestamp=None,  # type: Optional[datetime]
         type=None,  # type: Optional[str]
         data=None,  # type: Optional[Dict[str, Any]]
         **kwargs  # type: Any

--- a/sentry_sdk/integrations/logging.py
+++ b/sentry_sdk/integrations/logging.py
@@ -269,8 +269,7 @@ class BreadcrumbHandler(_BaseHandler):
             return
 
         Hub.current.add_breadcrumb(
-            hint={"log_record": record},
-            **self._breadcrumb_from_record(record),
+            hint={"log_record": record}, **self._breadcrumb_from_record(record)
         )
 
     def _breadcrumb_from_record(self, record):

--- a/sentry_sdk/integrations/logging.py
+++ b/sentry_sdk/integrations/logging.py
@@ -269,7 +269,8 @@ class BreadcrumbHandler(_BaseHandler):
             return
 
         Hub.current.add_breadcrumb(
-            self._breadcrumb_from_record(record), hint={"log_record": record}
+            hint={"log_record": record},
+            **self._breadcrumb_from_record(record),
         )
 
     def _breadcrumb_from_record(self, record):

--- a/sentry_sdk/integrations/logging.py
+++ b/sentry_sdk/integrations/logging.py
@@ -269,7 +269,7 @@ class BreadcrumbHandler(_BaseHandler):
             return
 
         Hub.current.add_breadcrumb(
-            hint={"log_record": record}, **self._breadcrumb_from_record(record)
+            self._breadcrumb_from_record(record), hint={"log_record": record}
         )
 
     def _breadcrumb_from_record(self, record):

--- a/sentry_sdk/tracing.py
+++ b/sentry_sdk/tracing.py
@@ -241,7 +241,7 @@ class Span(object):
 
     def new_span(self, **kwargs):
         # type: (**Any) -> Span
-        """Deprecated: use start_child instead."""
+        """Deprecated: use :py:meth:`sentry_sdk.tracing.Span.start_child` instead."""
         logger.warning("Deprecated: use Span.start_child instead of Span.new_span.")
         return self.start_child(**kwargs)
 
@@ -330,11 +330,10 @@ class Span(object):
     ):
         # type: (...) -> Optional[Transaction]
         """
-        DEPRECATED: Use Transaction.continue_from_headers(headers, **kwargs)
+        DEPRECATED: Use :py:meth:`sentry_sdk.tracing.Transaction.continue_from_headers`.
 
-        Create a Transaction with the given params, then add in data pulled from
-        the given 'sentry-trace' header value before returning the Transaction.
-
+        Create a `Transaction` with the given params, then add in data pulled from
+        the given 'sentry-trace' header value before returning the `Transaction`.
         """
         logger.warning(
             "Deprecated: Use Transaction.continue_from_headers(headers, **kwargs) "
@@ -826,7 +825,9 @@ def trace(func=None):
     Decorator to start a child span under the existing current transaction.
     If there is no current transaction, then nothing will be traced.
 
-    Usage:
+    .. code-block::
+        :caption: Usage
+
         import sentry_sdk
 
         @sentry_sdk.trace
@@ -836,6 +837,7 @@ def trace(func=None):
         @sentry_sdk.trace
         async def my_async_function():
             ...
+
     """
     if PY2:
         from sentry_sdk.tracing_utils_py2 import start_child_span_decorator


### PR DESCRIPTION
- Support autocompletion for the most commonly used args/kwargs of the top level API and remove some arg duplication. Couldn't get this done for everything and for all args/kwargs, but it should be an improvement compared to now. Step by step.
- Also added `Span` and `Transaction` to the docs. (For some reason, autodocumenting the `tracing.py` module doesn't do anything so had to add the classes explicitly.)
- Expanded some docstrings, too.

Fixes https://github.com/getsentry/sentry-python/issues/2199
Fixes https://github.com/getsentry/sentry-python/issues/2196