### PR TITLE
Add Django template tag for adding sentry tracing information

### DIFF
--- a/scripts/runtox.sh
+++ b/scripts/runtox.sh
@@ -23,5 +23,5 @@ ENV="$($TOXPATH -l | grep "$searchstring" | tr $'\n' ',')"
 if [ "$ENV" = py2.7-common, ] || [ "$ENV" = py2.7-gevent, ]; then
     exec $TOXPATH -vv -e "$ENV" -- "${@:2}"
 else
-    exec $TOXPATH -vv -p auto -e "$ENV" -- "${@:2}"
+    exec $TOXPATH -vv -e "$ENV" -- "${@:2}"
 fi

--- a/scripts/runtox.sh
+++ b/scripts/runtox.sh
@@ -23,5 +23,5 @@ ENV="$($TOXPATH -l | grep "$searchstring" | tr $'\n' ',')"
 if [ "$ENV" = py2.7-common, ] || [ "$ENV" = py2.7-gevent, ]; then
     exec $TOXPATH -vv -e "$ENV" -- "${@:2}"
 else
-    exec $TOXPATH -vv -e "$ENV" -- "${@:2}"
+    exec $TOXPATH -vv -p auto -e "$ENV" -- "${@:2}"
 fi

--- a/sentry_sdk/integrations/django/templates.py
+++ b/sentry_sdk/integrations/django/templates.py
@@ -91,7 +91,8 @@ def patch_templates():
 
         # Inject trace meta tags into template context
         context = context or {}
-        context["sentry_trace_meta"] = mark_safe(hub.trace_propagation_meta())
+        if "sentry_trace_meta" not in context:
+            context["sentry_trace_meta"] = mark_safe(hub.trace_propagation_meta())
 
         with hub.start_span(
             op=OP.TEMPLATE_RENDER,

--- a/tests/integrations/django/myapp/templates/trace_meta.html
+++ b/tests/integrations/django/myapp/templates/trace_meta.html
@@ -1,0 +1,1 @@
+{{ sentry_trace_meta }}

--- a/tests/integrations/django/myapp/urls.py
+++ b/tests/integrations/django/myapp/urls.py
@@ -55,6 +55,7 @@ urlpatterns = [
     path("template-exc", views.template_exc, name="template_exc"),
     path("template-test", views.template_test, name="template_test"),
     path("template-test2", views.template_test2, name="template_test2"),
+    path("template-test3", views.template_test3, name="template_test3"),
     path("postgres-select", views.postgres_select, name="postgres_select"),
     path(
         "permission-denied-exc",

--- a/tests/integrations/django/myapp/views.py
+++ b/tests/integrations/django/myapp/views.py
@@ -176,6 +176,11 @@ def template_test2(request, *args, **kwargs):
 
 
 @csrf_exempt
+def template_test3(request, *args, **kwargs):
+    return render(request, "trace_meta.html", {})
+
+
+@csrf_exempt
 def postgres_select(request, *args, **kwargs):
     from django.db import connections
 

--- a/tests/integrations/django/myapp/views.py
+++ b/tests/integrations/django/myapp/views.py
@@ -177,6 +177,10 @@ def template_test2(request, *args, **kwargs):
 
 @csrf_exempt
 def template_test3(request, *args, **kwargs):
+    from sentry_sdk import Hub
+
+    hub = Hub.current
+    capture_message(hub.get_traceparent() + "\n" + hub.get_baggage())
     return render(request, "trace_meta.html", {})
 
 

--- a/tests/integrations/django/test_basic.py
+++ b/tests/integrations/django/test_basic.py
@@ -713,7 +713,7 @@ def test_template_tracing_meta(sentry_init, client, capture_exceptions, capture_
 
     content = b"".join(content).decode("utf-8")
     pattern = r'^<meta name="sentry-trace" content="[^\"]*"><meta name="baggage" content="[^\"]*">\n$'
-    assert re.fullmatch(pattern, content) is not None
+    assert re.match(pattern, content) is not None
 
 
 @pytest.mark.parametrize("with_executing_integration", [[], [ExecutingIntegration()]])

--- a/tests/integrations/django/test_basic.py
+++ b/tests/integrations/django/test_basic.py
@@ -716,7 +716,7 @@ def test_template_tracing_meta(sentry_init, client, capture_events):
 
     traceparent, baggage = events[0]["message"].split("\n")
     expected_meta = (
-        '<meta name="sentry-trace" content="%s"><meta name="baggage" content="%s">'
+        '<meta name="sentry-trace" content="%s"><meta name="baggage" content="%s">\n'
         % (
             traceparent,
             baggage,

--- a/tests/integrations/django/test_basic.py
+++ b/tests/integrations/django/test_basic.py
@@ -707,7 +707,7 @@ def test_read_request(sentry_init, client, capture_events):
 
 
 def test_template_tracing_meta(sentry_init, client, capture_events):
-    sentry_init(integrations=[DjangoIntegration()], send_default_pii=True)
+    sentry_init(integrations=[DjangoIntegration()], traces_sample_rate=1.0)
     events = capture_events()
 
     # The view will capture_message the sentry-trace and baggage information


### PR DESCRIPTION
Adding `sentry_trace_meta` to template context so meta tags including Sentry trace information can be rendered using `{{ sentry_trace_meta }}` in the Django templates