### PR TITLE
Revert `partial` hack, but keep docs

### DIFF
--- a/sentry_sdk/api.py
+++ b/sentry_sdk/api.py
@@ -1,10 +1,9 @@
 import inspect
-from functools import partial
 
 from sentry_sdk._types import TYPE_CHECKING
 from sentry_sdk.hub import Hub
 from sentry_sdk.scope import Scope
-from sentry_sdk.tracing import Transaction
+from sentry_sdk.tracing import NoOpSpan, Transaction
 
 if TYPE_CHECKING:
     from typing import Any
@@ -14,8 +13,16 @@ if TYPE_CHECKING:
     from typing import Callable
     from typing import TypeVar
     from typing import ContextManager
+    from typing import Union
 
-    from sentry_sdk._types import MeasurementUnit
+    from sentry_sdk._types import (
+        Event,
+        Hint,
+        Breadcrumb,
+        BreadcrumbHint,
+        ExcInfo,
+        MeasurementUnit,
+    )
     from sentry_sdk.tracing import Span
 
     T = TypeVar("T")
@@ -70,36 +77,46 @@ def scopemethod(f):
     return f
 
 
-# Alias these functions to have nice auto completion for the arguments without
-# having to specify them here. The `partial(..., None)` hack is needed for Sphinx
-# to generate proper docs for these.
-if TYPE_CHECKING:
-    capture_event = partial(Hub.capture_event, None)
-    capture_message = partial(Hub.capture_message, None)
-    capture_exception = partial(Hub.capture_exception, None)
-    add_breadcrumb = partial(Hub.add_breadcrumb, None)
-    start_span = partial(Hub.start_span, None)
-    start_transaction = partial(Hub.start_transaction, None)
+@hubmethod
+def capture_event(
+    event,  # type: Event
+    hint=None,  # type: Optional[Hint]
+    scope=None,  # type: Optional[Any]
+    **scope_args  # type: Any
+):
+    # type: (...) -> Optional[str]
+    return Hub.current.capture_event(event, hint, scope=scope, **scope_args)
 
-else:
 
-    def capture_event(*args, **kwargs):
-        return Hub.current.capture_event(*args, **kwargs)
+@hubmethod
+def capture_message(
+    message,  # type: str
+    level=None,  # type: Optional[str]
+    scope=None,  # type: Optional[Any]
+    **scope_args  # type: Any
+):
+    # type: (...) -> Optional[str]
+    return Hub.current.capture_message(message, level, scope=scope, **scope_args)
 
-    def capture_message(*args, **kwargs):
-        return Hub.current.capture_message(*args, **kwargs)
 
-    def capture_exception(*args, **kwargs):
-        return Hub.current.capture_exception(*args, **kwargs)
+@hubmethod
+def capture_exception(
+    error=None,  # type: Optional[Union[BaseException, ExcInfo]]
+    scope=None,  # type: Optional[Any]
+    **scope_args  # type: Any
+):
+    # type: (...) -> Optional[str]
+    return Hub.current.capture_exception(error, scope=scope, **scope_args)
 
-    def add_breadcrumb(*args, **kwargs):
-        return Hub.current.add_breadcrumb(*args, **kwargs)
 
-    def start_span(*args, **kwargs):
-        return Hub.current.start_span(*args, **kwargs)
-
-    def start_transaction(*args, **kwargs):
-        return Hub.current.start_transaction(*args, **kwargs)
+@hubmethod
+def add_breadcrumb(
+    crumb=None,  # type: Optional[Breadcrumb]
+    hint=None,  # type: Optional[BreadcrumbHint]
+    **kwargs  # type: Any
+):
+    # type: (...) -> None
+    return Hub.current.add_breadcrumb(crumb, hint, **kwargs)
 
 
 @overload
@@ -189,6 +206,24 @@ def flush(
 def last_event_id():
     # type: () -> Optional[str]
     return Hub.current.last_event_id()
+
+
+@hubmethod
+def start_span(
+    span=None,  # type: Optional[Span]
+    **kwargs  # type: Any
+):
+    # type: (...) -> Span
+    return Hub.current.start_span(span=span, **kwargs)
+
+
+@hubmethod
+def start_transaction(
+    transaction=None,  # type: Optional[Transaction]
+    **kwargs  # type: Any
+):
+    # type: (...) -> Union[Transaction, NoOpSpan]
+    return Hub.current.start_transaction(transaction, **kwargs)
 
 
 def set_measurement(name, value, unit=""):

--- a/sentry_sdk/hub.py
+++ b/sentry_sdk/hub.py
@@ -416,35 +416,15 @@ class Hub(with_metaclass(HubMeta)):  # type: ignore
         """
         logger.error("Internal error in sentry_sdk", exc_info=exc_info)
 
-    def add_breadcrumb(
-        self,
-        crumb=None,  # type: Optional[Breadcrumb]
-        hint=None,  # type: Optional[BreadcrumbHint]
-        timestamp=None,  # type: Optional[datetime]
-        type=None,  # type: Optional[str]
-        data=None,  # type: Optional[Dict[str, Any]]
-        **kwargs  # type: Any
-    ):
-        # type: (...) -> None
+    def add_breadcrumb(self, crumb=None, hint=None, **kwargs):
+        # type: (Optional[Breadcrumb], Optional[BreadcrumbHint], Any) -> None
         """
         Adds a breadcrumb.
 
-        :param crumb: Dictionary with the data as the Sentry v7/v8 protocol expects.
+        :param crumb: Dictionary with the data as the sentry v7/v8 protocol expects.
 
         :param hint: An optional value that can be used by `before_breadcrumb`
             to customize the breadcrumbs that are emitted.
-
-        :param timestamp: The timestamp associated with this breadcrumb. Defaults
-            to now if not provided.
-
-        :param type: The type of the breadcrumb. Will be set to "default" if
-            not provided.
-
-        :param data: Additional custom data to put on the breadcrumb.
-
-        :param kwargs: Adding any further keyword arguments will not result in
-            an error, but the breadcrumb will be dropped before arriving to
-            Sentry.
         """
         client, scope = self._stack[-1]
         if client is None:
@@ -452,12 +432,6 @@ class Hub(with_metaclass(HubMeta)):  # type: ignore
             return
 
         crumb = dict(crumb or ())  # type: Breadcrumb
-        if timestamp is not None:
-            crumb["timestamp"] = timestamp
-        if type is not None:
-            crumb["type"] = type
-        if data is not None:
-            crumb["data"] = data
         crumb.update(kwargs)
         if not crumb:
             return

--- a/sentry_sdk/tracing.py
+++ b/sentry_sdk/tracing.py
@@ -837,7 +837,6 @@ def trace(func=None):
         @sentry_sdk.trace
         async def my_async_function():
             ...
-
     """
     if PY2:
         from sentry_sdk.tracing_utils_py2 import start_child_span_decorator


### PR DESCRIPTION
The `partial` hack enabled us to have nicer sphinx docs, but broke any autocompletion in PyCharm.