### PR TITLE
Support newest starlette versions

### DIFF
--- a/tests/integrations/starlette/test_starlette.py
+++ b/tests/integrations/starlette/test_starlette.py
@@ -62,7 +62,6 @@ PARSED_FORM = starlette.datastructures.FormData(
             starlette.datastructures.UploadFile(
                 filename="photo.jpg",
                 file=open(PICTURE, "rb"),
-                content_type="image/jpeg",
             ),
         ),
     ]

--- a/tox.ini
+++ b/tox.ini
@@ -141,7 +141,7 @@ envlist =
     {py3.7,py3.8,py3.9,py3.10,py3.11}-sanic-v{22}
 
     # Starlette
-    {py3.7,py3.8,py3.9,py3.10,py3.11}-starlette-v{0.19.1,0.20,0.21}
+    {py3.7,py3.8,py3.9,py3.10,py3.11}-starlette-v{0.19.1,0.20,0.21,0.22,0.23,0.24,0.25,0.26,0.27,0.28}
 
     # Starlite
     {py3.8,py3.9,py3.10,py3.11}-starlite
@@ -415,6 +415,13 @@ deps =
     starlette-v0.19.1: starlette==0.19.1
     starlette-v0.20: starlette>=0.20.0,<0.21.0
     starlette-v0.21: starlette>=0.21.0,<0.22.0
+    starlette-v0.22: starlette>=0.22.0,<0.23.0
+    starlette-v0.23: starlette>=0.23.0,<0.24.0
+    starlette-v0.24: starlette>=0.24.0,<0.25.0
+    starlette-v0.25: starlette>=0.25.0,<0.26.0
+    starlette-v0.26: starlette>=0.26.0,<0.27.0
+    starlette-v0.27: starlette>=0.27.0,<0.28.0
+    starlette-v0.28: starlette>=0.28.0,<0.29.0
 
     # Starlite
     starlite: pytest-asyncio

--- a/tox.ini
+++ b/tox.ini
@@ -141,7 +141,7 @@ envlist =
     {py3.7,py3.8,py3.9,py3.10,py3.11}-sanic-v{22}
 
     # Starlette
-    {py3.7,py3.8,py3.9,py3.10,py3.11}-starlette-v{0.19.1,0.20,0.21,0.22,0.23,0.24,0.25,0.26,0.27,0.28}
+    {py3.7,py3.8,py3.9,py3.10,py3.11}-starlette-v{0.20,0.22,0.24,0.26,0.28}
 
     # Starlite
     {py3.8,py3.9,py3.10,py3.11}-starlite
@@ -411,16 +411,11 @@ deps =
     starlette: pytest-asyncio
     starlette: python-multipart
     starlette: requests
-    starlette-v0.21: httpx
-    starlette-v0.19.1: starlette==0.19.1
+    starlette: httpx
     starlette-v0.20: starlette>=0.20.0,<0.21.0
-    starlette-v0.21: starlette>=0.21.0,<0.22.0
     starlette-v0.22: starlette>=0.22.0,<0.23.0
-    starlette-v0.23: starlette>=0.23.0,<0.24.0
     starlette-v0.24: starlette>=0.24.0,<0.25.0
-    starlette-v0.25: starlette>=0.25.0,<0.26.0
     starlette-v0.26: starlette>=0.26.0,<0.27.0
-    starlette-v0.27: starlette>=0.27.0,<0.28.0
     starlette-v0.28: starlette>=0.28.0,<0.29.0
 
     # Starlite


### PR DESCRIPTION
Update our test matrix to support current Starlette versions. (only testing every other version, because otherwise it would be too much versions to test)