### PR TITLE
Skip distributions with incomplete metadata

### DIFF
--- a/sentry_sdk/integrations/modules.py
+++ b/sentry_sdk/integrations/modules.py
@@ -26,12 +26,18 @@ def _normalize_module_name(name):
 def _generate_installed_modules():
     # type: () -> Iterator[Tuple[str, str]]
     try:
-        from importlib.metadata import distributions, version
+        from importlib import metadata
 
-        for dist in distributions():
-            yield _normalize_module_name(dist.metadata["Name"]), version(
-                dist.metadata["Name"]
-            )
+        for dist in metadata.distributions():
+            name = dist.metadata["Name"]
+            # `metadata` values may be `None`, see:
+            # https://github.com/python/cpython/issues/91216
+            # and
+            # https://github.com/python/importlib_metadata/issues/371
+            if name is not None:
+                version = metadata.version(name)
+                if version is not None:
+                    yield _normalize_module_name(name), version
 
     except ImportError:
         # < py3.8

--- a/tests/integrations/modules/test_modules.py
+++ b/tests/integrations/modules/test_modules.py
@@ -1,3 +1,4 @@
+import pytest
 import re
 import sentry_sdk
 
@@ -55,12 +56,16 @@ def test_installed_modules():
                 dist.metadata["Name"]
             )
             for dist in distributions()
+            if dist.metadata["Name"] is not None
+            and version(dist.metadata["Name"]) is not None
         }
         assert installed_distributions == importlib_distributions
 
-    if pkg_resources_available:
+    elif pkg_resources_available:
         pkg_resources_distributions = {
             _normalize_distribution_name(dist.key): dist.version
             for dist in pkg_resources.working_set
         }
         assert installed_distributions == pkg_resources_distributions
+    else:
+        pytest.fail("Neither importlib nor pkg_resources is available")


### PR DESCRIPTION
In rare cases, `importlib.metadata` values may contain `None`, see
https://github.com/python/cpython/issues/91216
and
https://github.com/python/importlib_metadata/issues/371

The fix skips all distributions with incomplete metadata.
