### PR TITLE
Prevent adding `sentry-trace` header multiple times

### DIFF
--- a/sentry_sdk/hub.py
+++ b/sentry_sdk/hub.py
@@ -795,7 +795,11 @@ class Hub(with_metaclass(HubMeta)):  # type: ignore
         span on the scope if not.
         """
         client = self._stack[-1][0]
-        propagate_traces = client and client.options["propagate_traces"]
+        propagate_traces = (
+            client
+            and client.options["propagate_traces"]
+            and client.options["instrumenter"] == INSTRUMENTER.SENTRY
+        )
         if not propagate_traces:
             return
 

--- a/sentry_sdk/hub.py
+++ b/sentry_sdk/hub.py
@@ -795,11 +795,7 @@ class Hub(with_metaclass(HubMeta)):  # type: ignore
         span on the scope if not.
         """
         client = self._stack[-1][0]
-        propagate_traces = (
-            client
-            and client.options["propagate_traces"]
-            and client.options["instrumenter"] == INSTRUMENTER.SENTRY
-        )
+        propagate_traces = client and client.options["propagate_traces"]
         if not propagate_traces:
             return
 

--- a/sentry_sdk/tracing.py
+++ b/sentry_sdk/tracing.py
@@ -815,7 +815,7 @@ class NoOpSpan(Span):
         pass
 
     def iter_headers(self):
-        # type: (int) -> None
+        # type: () -> Iterator[Tuple[str, str]]
         yield from ()
 
     def finish(self, hub=None, end_timestamp=None):

--- a/sentry_sdk/tracing.py
+++ b/sentry_sdk/tracing.py
@@ -814,6 +814,10 @@ class NoOpSpan(Span):
         # type: (int) -> None
         pass
 
+    def iter_headers(self):
+        # type: (int) -> None
+        yield from ()
+
     def finish(self, hub=None, end_timestamp=None):
         # type: (Optional[sentry_sdk.Hub], Optional[datetime]) -> Optional[str]
         pass

--- a/sentry_sdk/tracing.py
+++ b/sentry_sdk/tracing.py
@@ -796,14 +796,6 @@ class NoOpSpan(Span):
         # type: () -> str
         return self.__class__.__name__
 
-    def __enter__(self):
-        # type: () -> Span
-        return self
-
-    def __exit__(self, ty, value, tb):
-        # type: (Optional[Any], Optional[Any], Optional[Any]) -> None
-        pass
-
     def start_child(self, instrumenter=INSTRUMENTER.SENTRY, **kwargs):
         # type: (str, **Any) -> NoOpSpan
         return NoOpSpan()

--- a/sentry_sdk/tracing.py
+++ b/sentry_sdk/tracing.py
@@ -800,7 +800,7 @@ class NoOpSpan(Span):
 
     @property
     def containing_transaction(self):
-        # type: () -> Optional[Transaction]
+        # type: () -> Any
         return None
 
     def start_child(self, instrumenter=INSTRUMENTER.SENTRY, **kwargs):
@@ -817,7 +817,7 @@ class NoOpSpan(Span):
         environ,  # type: typing.Mapping[str, str]
         **kwargs  # type: Any
     ):
-        # type: (...) -> Transaction
+        # type: (...) -> Any
         return NoOpSpan()
 
     @classmethod
@@ -826,7 +826,7 @@ class NoOpSpan(Span):
         headers,  # type: typing.Mapping[str, str]
         **kwargs  # type: Any
     ):
-        # type: (...) -> Transaction
+        # type: (...) -> Any
         return NoOpSpan()
 
     @classmethod
@@ -835,7 +835,7 @@ class NoOpSpan(Span):
         traceparent,  # type: Optional[str]
         **kwargs  # type: Any
     ):
-        # type: (...) -> Optional[Transaction]
+        # type: (...) -> Any
         return None
 
     def to_traceparent(self):

--- a/sentry_sdk/tracing.py
+++ b/sentry_sdk/tracing.py
@@ -854,7 +854,7 @@ class NoOpSpan(Span):
 
     def iter_headers(self):
         # type: () -> Iterator[Tuple[str, str]]
-        yield from ()
+        return iter(())
 
     def set_tag(self, key, value):
         # type: (str, Any) -> None

--- a/sentry_sdk/tracing.py
+++ b/sentry_sdk/tracing.py
@@ -790,6 +790,19 @@ class NoOpSpan(Span):
         # type: () -> str
         return self.__class__.__name__
 
+    def __enter__(self):
+        # type: () -> Span
+        return self
+
+    def __exit__(self, ty, value, tb):
+        # type: (Optional[Any], Optional[Any], Optional[Any]) -> None
+        pass
+
+    @property
+    def containing_transaction(self):
+        # type: () -> Optional[Transaction]
+        return None
+
     def start_child(self, instrumenter=INSTRUMENTER.SENTRY, **kwargs):
         # type: (str, **Any) -> NoOpSpan
         return NoOpSpan()
@@ -797,6 +810,45 @@ class NoOpSpan(Span):
     def new_span(self, **kwargs):
         # type: (**Any) -> NoOpSpan
         return self.start_child(**kwargs)
+
+    @classmethod
+    def continue_from_environ(
+        cls,
+        environ,  # type: typing.Mapping[str, str]
+        **kwargs  # type: Any
+    ):
+        # type: (...) -> Transaction
+        return NoOpSpan()
+
+    @classmethod
+    def continue_from_headers(
+        cls,
+        headers,  # type: typing.Mapping[str, str]
+        **kwargs  # type: Any
+    ):
+        # type: (...) -> Transaction
+        return NoOpSpan()
+
+    @classmethod
+    def from_traceparent(
+        cls,
+        traceparent,  # type: Optional[str]
+        **kwargs  # type: Any
+    ):
+        # type: (...) -> Optional[Transaction]
+        return None
+
+    def to_traceparent(self):
+        # type: () -> str
+        return ""
+
+    def to_baggage(self):
+        # type: () -> Optional[Baggage]
+        return None
+
+    def iter_headers(self):
+        # type: () -> Iterator[Tuple[str, str]]
+        yield from ()
 
     def set_tag(self, key, value):
         # type: (str, Any) -> None
@@ -814,9 +866,17 @@ class NoOpSpan(Span):
         # type: (int) -> None
         pass
 
-    def iter_headers(self):
-        # type: () -> Iterator[Tuple[str, str]]
-        yield from ()
+    def is_success(self):
+        # type: () -> bool
+        return True
+
+    def to_json(self):
+        # type: () -> Dict[str, Any]
+        return {}
+
+    def get_trace_context(self):
+        # type: () -> Any
+        return {}
 
     def finish(self, hub=None, end_timestamp=None):
         # type: (Optional[sentry_sdk.Hub], Optional[datetime]) -> Optional[str]

--- a/sentry_sdk/tracing.py
+++ b/sentry_sdk/tracing.py
@@ -804,11 +804,6 @@ class NoOpSpan(Span):
         # type: (Optional[Any], Optional[Any], Optional[Any]) -> None
         pass
 
-    @property
-    def containing_transaction(self):
-        # type: () -> Any
-        return None
-
     def start_child(self, instrumenter=INSTRUMENTER.SENTRY, **kwargs):
         # type: (str, **Any) -> NoOpSpan
         return NoOpSpan()
@@ -816,33 +811,6 @@ class NoOpSpan(Span):
     def new_span(self, **kwargs):
         # type: (**Any) -> NoOpSpan
         return self.start_child(**kwargs)
-
-    @classmethod
-    def continue_from_environ(
-        cls,
-        environ,  # type: typing.Mapping[str, str]
-        **kwargs  # type: Any
-    ):
-        # type: (...) -> Any
-        return NoOpSpan()
-
-    @classmethod
-    def continue_from_headers(
-        cls,
-        headers,  # type: typing.Mapping[str, str]
-        **kwargs  # type: Any
-    ):
-        # type: (...) -> Any
-        return NoOpSpan()
-
-    @classmethod
-    def from_traceparent(
-        cls,
-        traceparent,  # type: Optional[str]
-        **kwargs  # type: Any
-    ):
-        # type: (...) -> Any
-        return None
 
     def to_traceparent(self):
         # type: () -> str


### PR DESCRIPTION
If OpenTelementry is enabled, the `sentry-trace` headers should not be applied by Sentry intregration, but only by the OTel propagator.

Fixes #1940 