### PR TITLE
Capture GraphQL client errors

### DIFF
--- a/sentry_sdk/integrations/aiohttp.py
+++ b/sentry_sdk/integrations/aiohttp.py
@@ -254,6 +254,7 @@ def create_trace_config():
     async def on_request_chunk_sent(session, trace_config_ctx, params):
         # type: (ClientSession, SimpleNamespace, TraceRequestChunkSentParams) -> None
         if not hasattr(params, "url") or not hasattr(params, "method"):
+            # these are missing from params in earlier aiohttp versions
             return
 
         if params.url.path == "/graphql" and params.method == "POST":

--- a/sentry_sdk/integrations/aiohttp.py
+++ b/sentry_sdk/integrations/aiohttp.py
@@ -1,7 +1,11 @@
 import json
 import sys
 import weakref
-from urllib.parse import parse_qsl
+
+try:
+    from urllib.parse import parse_qsl
+except ImportError:
+    from urlparse import parse_qsl
 
 from sentry_sdk.api import continue_trace
 from sentry_sdk._compat import reraise

--- a/sentry_sdk/integrations/aiohttp.py
+++ b/sentry_sdk/integrations/aiohttp.py
@@ -307,7 +307,8 @@ def create_trace_config():
                             )
                             hub.capture_event(event, hint=hint)
 
-        span.finish()
+        if trace_config_ctx.span is not None:
+            span.finish()
 
     trace_config = TraceConfig()
 

--- a/sentry_sdk/integrations/aiohttp.py
+++ b/sentry_sdk/integrations/aiohttp.py
@@ -244,6 +244,9 @@ def create_trace_config():
             trace_config_ctx.request_headers = params.headers
 
     async def on_request_chunk_sent(session, trace_config_ctx, params):
+        if not hasattr(params, "url") or not hasattr(params, "method"):
+            return
+
         if params.url.path == "/graphql" and params.method == "POST":
             with capture_internal_exceptions():
                 trace_config_ctx.request_body = json.loads(params.chunk)

--- a/sentry_sdk/integrations/aiohttp.py
+++ b/sentry_sdk/integrations/aiohttp.py
@@ -50,7 +50,11 @@ from sentry_sdk._types import TYPE_CHECKING
 if TYPE_CHECKING:
     from aiohttp.web_request import Request
     from aiohttp.abc import AbstractMatchInfo
-    from aiohttp import TraceRequestStartParams, TraceRequestEndParams
+    from aiohttp import (
+        TraceRequestStartParams,
+        TraceRequestEndParams,
+        TraceRequestChunkSentParams,
+    )
     from types import SimpleNamespace
     from typing import Any
     from typing import Dict
@@ -244,6 +248,7 @@ def create_trace_config():
             trace_config_ctx.request_headers = params.headers
 
     async def on_request_chunk_sent(session, trace_config_ctx, params):
+        # type: (ClientSession, SimpleNamespace, TraceRequestChunkSentParams) -> None
         if not hasattr(params, "url") or not hasattr(params, "method"):
             return
 
@@ -346,7 +351,7 @@ def _make_server_processor(weak_request):
 
 
 def _make_client_processor(trace_config_ctx, response, response_content):
-    # type: (SimpleNamespace, Response, Optional[dict]) -> EventProcessor
+    # type: (SimpleNamespace, Response, Optional[Dict[str, Any]]) -> EventProcessor
     def aiohttp_client_processor(
         event,  # type: Dict[str, Any]
         hint,  # type: Dict[str, Tuple[type, BaseException, Any]]

--- a/sentry_sdk/integrations/aiohttp.py
+++ b/sentry_sdk/integrations/aiohttp.py
@@ -5,7 +5,7 @@ import weakref
 try:
     from urllib.parse import parse_qsl
 except ImportError:
-    from urlparse import parse_qsl
+    from urlparse import parse_qsl  # type: ignore
 
 from sentry_sdk.api import continue_trace
 from sentry_sdk._compat import reraise

--- a/sentry_sdk/integrations/httpx.py
+++ b/sentry_sdk/integrations/httpx.py
@@ -12,7 +12,7 @@ try:
     from json import JSONDecodeError
 except ImportError:
     # py2 doesn't throw a specialized json error, just Value/TypeErrors
-    JSONDecodeError = ValueError
+    JSONDecodeError = ValueError  # type: ignore
 
 from sentry_sdk import Hub
 from sentry_sdk.consts import OP, SPANDATA

--- a/sentry_sdk/integrations/httpx.py
+++ b/sentry_sdk/integrations/httpx.py
@@ -1,5 +1,9 @@
 import json
-from urllib.parse import parse_qsl
+
+try:
+    from urllib.parse import parse_qsl
+except ImportError:
+    from urlparse import parse_qsl
 
 from sentry_sdk import Hub
 from sentry_sdk.consts import OP, SPANDATA

--- a/sentry_sdk/integrations/httpx.py
+++ b/sentry_sdk/integrations/httpx.py
@@ -193,7 +193,7 @@ def _make_request_processor(request, response):
 
                 query = request_info.get("data")
                 if request.method == "GET":
-                    query = dict(parse_qsl(request.url.query.decode()))
+                    query = dict(parse_qsl(parsed_url.query))
 
                 if query:
                     operation_name = _get_graphql_operation_name(query)

--- a/sentry_sdk/integrations/httpx.py
+++ b/sentry_sdk/integrations/httpx.py
@@ -3,7 +3,7 @@ import json
 try:
     from urllib.parse import parse_qsl
 except ImportError:
-    from urlparse import parse_qsl
+    from urlparse import parse_qsl  # type: ignore
 
 from sentry_sdk import Hub
 from sentry_sdk.consts import OP, SPANDATA

--- a/sentry_sdk/integrations/httpx.py
+++ b/sentry_sdk/integrations/httpx.py
@@ -207,6 +207,7 @@ def _make_request_processor(request, response):
 
 
 def _capture_graphql_errors(hub, request, response):
+    # type: (Hub, Request, Response) -> None
     if (
         request.url.path == "/graphql"
         and request.method in ("GET", "POST")

--- a/sentry_sdk/integrations/httpx.py
+++ b/sentry_sdk/integrations/httpx.py
@@ -241,7 +241,11 @@ def _capture_graphql_errors(hub, request, response):
             scope.add_event_processor(_make_request_processor(request, response))
 
             with capture_internal_exceptions():
-                response_content = response.json()
+                try:
+                    response_content = response.json()
+                except JSONDecodeError:
+                    return
+
                 if isinstance(response_content, dict) and response_content.get(
                     "errors"
                 ):

--- a/sentry_sdk/integrations/httpx.py
+++ b/sentry_sdk/integrations/httpx.py
@@ -48,6 +48,10 @@ __all__ = ["HttpxIntegration"]
 class HttpxIntegration(Integration):
     identifier = "httpx"
 
+    def __init__(self, capture_graphql_errors=True):
+        # type: (bool) -> None
+        self.capture_graphql_errors = capture_graphql_errors
+
     @staticmethod
     def setup_once():
         # type: () -> None
@@ -66,7 +70,8 @@ def _install_httpx_client():
     def send(self, request, **kwargs):
         # type: (Client, Request, **Any) -> Response
         hub = Hub.current
-        if hub.get_integration(HttpxIntegration) is None:
+        integration = hub.get_integration(HttpxIntegration)
+        if integration is None:
             return real_send(self, request, **kwargs)
 
         parsed_url = None
@@ -107,7 +112,8 @@ def _install_httpx_client():
             span.set_http_status(rv.status_code)
             span.set_data("reason", rv.reason_phrase)
 
-            _capture_graphql_errors(hub, request, rv)
+            if integration.capture_graphql_errors:
+                _capture_graphql_errors(hub, request, rv)
 
             return rv
 
@@ -121,7 +127,8 @@ def _install_httpx_async_client():
     async def send(self, request, **kwargs):
         # type: (AsyncClient, Request, **Any) -> Response
         hub = Hub.current
-        if hub.get_integration(HttpxIntegration) is None:
+        integration = hub.get_integration(HttpxIntegration)
+        if integration is None:
             return await real_send(self, request, **kwargs)
 
         parsed_url = None
@@ -162,7 +169,8 @@ def _install_httpx_async_client():
             span.set_http_status(rv.status_code)
             span.set_data("reason", rv.reason_phrase)
 
-            _capture_graphql_errors(hub, request, rv)
+            if integration.capture_graphql_errors:
+                _capture_graphql_errors(hub, request, rv)
 
             return rv
 

--- a/sentry_sdk/integrations/httpx.py
+++ b/sentry_sdk/integrations/httpx.py
@@ -1,9 +1,18 @@
 import json
 
 try:
+    # py3
     from urllib.parse import parse_qsl
 except ImportError:
+    # py2
     from urlparse import parse_qsl  # type: ignore
+
+try:
+    # py3
+    from json import JSONDecodeError
+except ImportError:
+    # py2 doesn't throw a specialized json error, just Value/TypeErrors
+    JSONDecodeError = ValueError
 
 from sentry_sdk import Hub
 from sentry_sdk.consts import OP, SPANDATA
@@ -180,7 +189,7 @@ def _make_request_processor(request, response):
             if request_content:
                 try:
                     request_info["data"] = json.loads(request_content)
-                except json.JSONDecodeError:
+                except (JSONDecodeError, TypeError):
                     pass
 
             if response:

--- a/sentry_sdk/integrations/httpx.py
+++ b/sentry_sdk/integrations/httpx.py
@@ -176,9 +176,10 @@ def _make_request_processor(request, response):
             request_info["headers"] = _filter_headers(dict(request.headers))
             request_info["query_string"] = parsed_url.query
 
-            if request.content:
+            request_content = request.read()
+            if request_content:
                 try:
-                    request_info["data"] = json.loads(request.content)
+                    request_info["data"] = json.loads(request_content)
                 except json.JSONDecodeError:
                     pass
 

--- a/sentry_sdk/integrations/stdlib.py
+++ b/sentry_sdk/integrations/stdlib.py
@@ -177,7 +177,10 @@ def _install_httplib():
                 except (JSONDecodeError, UnicodeDecodeError, TypeError):
                     return rv
 
-        if isinstance(response_body, dict) and response_body.get("errors"):
+        is_graphql_response_with_errors = isinstance(
+            response_body, dict
+        ) and response_body.get("errors")
+        if is_graphql_response_with_errors:
             method = getattr(self, "_sentrysdk_method", None)  # type: Optional[str]
             request_body = getattr(self, "_sentry_request_body", None)
             hub = Hub.current

--- a/sentry_sdk/integrations/stdlib.py
+++ b/sentry_sdk/integrations/stdlib.py
@@ -6,9 +6,18 @@ import sys
 import platform
 
 try:
+    # py3
     from urllib.parse import parse_qsl
 except ImportError:
+    # py2
     from urlparse import parse_qsl  # type: ignore
+
+try:
+    # py3
+    from json import JSONDecodeError
+except ImportError:
+    # py2 doesn't throw a specialized json error, just Value/TypeErrors
+    JSONDecodeError = ValueError
 
 from sentry_sdk.consts import OP, SPANDATA
 from sentry_sdk.hub import Hub
@@ -163,7 +172,7 @@ def _install_httplib():
                 rv.read = io.BytesIO(response_data).read
                 try:
                     response_body = json.loads(response_data)
-                except (json.JSONDecodeError, UnicodeDecodeError):
+                except (JSONDecodeError, UnicodeDecodeError, TypeError):
                     return rv
 
         if isinstance(response_body, dict) and response_body.get("errors"):

--- a/sentry_sdk/integrations/stdlib.py
+++ b/sentry_sdk/integrations/stdlib.py
@@ -127,7 +127,7 @@ def _install_httplib():
         return rv
 
     def send(self, data, *args, **kwargs):
-        # type: (HTTPConnection, Any, *Any, *Any) -> Any
+        # type: (HTTPConnection, Any, *Any, **Any) -> Any
         if getattr(self, "_sentrysdk_is_graphql_request", False):
             self._sentry_request_body = data
 

--- a/sentry_sdk/integrations/stdlib.py
+++ b/sentry_sdk/integrations/stdlib.py
@@ -171,6 +171,8 @@ def _install_httplib():
                 # app; save it so that it can be accessed again
                 rv.read = io.BytesIO(response_data).read
                 try:
+                    # py3.6+ json.loads() can deal with bytes out of the box, but
+                    # for older version we have to explicitly decode first
                     response_body = json.loads(response_data.decode())
                 except (JSONDecodeError, UnicodeDecodeError, TypeError):
                     return rv

--- a/sentry_sdk/integrations/stdlib.py
+++ b/sentry_sdk/integrations/stdlib.py
@@ -171,7 +171,7 @@ def _install_httplib():
                 # app; save it so that it can be accessed again
                 rv.read = io.BytesIO(response_data).read
                 try:
-                    response_body = json.loads(response_data)
+                    response_body = json.loads(response_data.decode())
                 except (JSONDecodeError, UnicodeDecodeError, TypeError):
                     return rv
 
@@ -221,7 +221,7 @@ def _make_request_processor(url, method, status, request_body, response_body):
             request_info["url"] = parsed_url.url
             request_info["method"] = method
             try:
-                request_info["data"] = json.loads(request_body)
+                request_info["data"] = json.loads(request_body.decode())
             except JSONDecodeError:
                 pass
 

--- a/sentry_sdk/integrations/stdlib.py
+++ b/sentry_sdk/integrations/stdlib.py
@@ -17,7 +17,7 @@ try:
     from json import JSONDecodeError
 except ImportError:
     # py2 doesn't throw a specialized json error, just Value/TypeErrors
-    JSONDecodeError = ValueError
+    JSONDecodeError = ValueError  # type: ignore
 
 from sentry_sdk.consts import OP, SPANDATA
 from sentry_sdk.hub import Hub

--- a/sentry_sdk/integrations/stdlib.py
+++ b/sentry_sdk/integrations/stdlib.py
@@ -1,3 +1,4 @@
+import io
 import json
 import os
 import subprocess
@@ -157,7 +158,9 @@ def _install_httplib():
         if getattr(self, "_sentrysdk_is_graphql_request", False):
             with capture_internal_exceptions():
                 try:
-                    response_body = json.loads(rv.read())
+                    response_data = rv.read()
+                    response_body = json.loads(response_data)
+                    rv.read = io.BytesIO(response_data).read
                 except (json.JSONDecodeError, UnicodeDecodeError):
                     return rv
 
@@ -204,7 +207,7 @@ def _make_request_processor(url, method, status, request_body, response_body):
 
             parsed_url = parse_url(url, sanitize=False)
             request_info["query_string"] = parsed_url.query
-            request_info["url"] = url
+            request_info["url"] = parsed_url.url
             request_info["method"] = method
             try:
                 request_info["data"] = json.loads(request_body)

--- a/sentry_sdk/integrations/stdlib.py
+++ b/sentry_sdk/integrations/stdlib.py
@@ -7,7 +7,7 @@ import platform
 try:
     from urllib.parse import parse_qsl
 except ImportError:
-    from urlparse import parse_qsl
+    from urlparse import parse_qsl  # type: ignore
 
 from sentry_sdk.consts import OP, SPANDATA
 from sentry_sdk.hub import Hub

--- a/sentry_sdk/integrations/stdlib.py
+++ b/sentry_sdk/integrations/stdlib.py
@@ -222,7 +222,7 @@ def _make_request_processor(url, method, status, request_body, response_body):
             request_info["method"] = method
             try:
                 request_info["data"] = json.loads(request_body)
-            except json.JSONDecodeError:
+            except JSONDecodeError:
                 pass
 
             if response_body:

--- a/sentry_sdk/integrations/stdlib.py
+++ b/sentry_sdk/integrations/stdlib.py
@@ -157,10 +157,12 @@ def _install_httplib():
         response_body = None
         if getattr(self, "_sentrysdk_is_graphql_request", False):
             with capture_internal_exceptions():
+                response_data = rv.read()
+                # once we've read() the body it can't be read() again by the
+                # app; save it so that it can be accessed again
+                rv.read = io.BytesIO(response_data).read
                 try:
-                    response_data = rv.read()
                     response_body = json.loads(response_data)
-                    rv.read = io.BytesIO(response_data).read
                 except (json.JSONDecodeError, UnicodeDecodeError):
                     return rv
 

--- a/sentry_sdk/scrubber.py
+++ b/sentry_sdk/scrubber.py
@@ -84,6 +84,14 @@ class EventScrubber(object):
                 if "data" in event["request"]:
                     self.scrub_dict(event["request"]["data"])
 
+    def scrub_response(self, event):
+        # type: (Event) -> None
+        with capture_internal_exceptions():
+            if "contexts" in event:
+                if "response" in event["contexts"]:
+                    if "data" in event["contexts"]["response"]:
+                        self.scrub_dict(event["contexts"]["response"]["data"])
+
     def scrub_extra(self, event):
         # type: (Event) -> None
         with capture_internal_exceptions():
@@ -123,6 +131,7 @@ class EventScrubber(object):
     def scrub_event(self, event):
         # type: (Event) -> None
         self.scrub_request(event)
+        self.scrub_response(event)
         self.scrub_extra(event)
         self.scrub_user(event)
         self.scrub_breadcrumbs(event)

--- a/sentry_sdk/scrubber.py
+++ b/sentry_sdk/scrubber.py
@@ -87,10 +87,12 @@ class EventScrubber(object):
     def scrub_response(self, event):
         # type: (Event) -> None
         with capture_internal_exceptions():
-            if "contexts" in event:
-                if "response" in event["contexts"]:
-                    if "data" in event["contexts"]["response"]:
-                        self.scrub_dict(event["contexts"]["response"]["data"])
+            if (
+                "contexts" in event
+                and "response" in event["contexts"]
+                and "data" in event["contexts"]["response"]
+            ):
+                self.scrub_dict(event["contexts"]["response"]["data"])
 
     def scrub_extra(self, event):
         # type: (Event) -> None

--- a/sentry_sdk/utils.py
+++ b/sentry_sdk/utils.py
@@ -1273,6 +1273,35 @@ class ServerlessTimeoutWarning(Exception):  # noqa: N818
     pass
 
 
+class SentryGraphQLClientError(Exception):
+    """Synthetic exception for GraphQL client errors."""
+
+    pass
+
+
+def _get_graphql_operation_name(query):
+    # type: (dict) -> str
+    if query.get("operationName"):
+        return query["operationName"]
+
+    query = query["query"].strip()
+
+    match = re.match(r"^[a-z]* +([a-zA-Z0-9]+) \(?.*\)? *\{", query)
+    if match:
+        return match.group(1)
+    return "anonymous"
+
+
+def _get_graphql_operation_type(query):
+    # type: (dict) -> str
+    query = query["query"].strip()
+    if query.startswith("mutation"):
+        return "mutation"
+    if query.startswith("subscription"):
+        return "subscription"
+    return "query"
+
+
 class TimeoutThread(threading.Thread):
     """Creates a Thread which runs (sleeps) for a time duration equal to
     waiting_time and raises a custom ServerlessTimeout exception.

--- a/sentry_sdk/utils.py
+++ b/sentry_sdk/utils.py
@@ -1286,7 +1286,7 @@ def _get_graphql_operation_name(query):
 
     query = query["query"].strip()
 
-    match = re.match(r"^[a-z]* +([a-zA-Z0-9]+) \(?.*\)? *\{", query)
+    match = re.match(r"^[a-z]* *([a-zA-Z0-9]+) \(?.*\)? *\{", query)
     if match:
         return match.group(1)
     return "anonymous"

--- a/sentry_sdk/utils.py
+++ b/sentry_sdk/utils.py
@@ -1287,7 +1287,7 @@ def _get_graphql_operation_name(query):
     query = query["query"].strip()
 
     match = re.match(
-        r"((query|mutation|subscription) )(?P<name>[a-zA-Z0-9]+) *\{",
+        r"((query|mutation|subscription) )(?P<name>[a-zA-Z0-9]+).*\{",
         query,
         flags=re.IGNORECASE,
     )

--- a/sentry_sdk/utils.py
+++ b/sentry_sdk/utils.py
@@ -1286,7 +1286,9 @@ def _get_graphql_operation_name(query):
 
     query = query["query"].strip()
 
-    match = re.match(r"^[a-z]* *([a-zA-Z0-9]+) \(?.*\)? *\{", query)
+    match = re.match(
+        r"^[a-z]* *([a-zA-Z0-9]+) \(?.*\)? *\{", query, flags=re.IGNORECASE
+    )
     if match:
         return match.group(1)
     return "anonymous"
@@ -1294,7 +1296,7 @@ def _get_graphql_operation_name(query):
 
 def _get_graphql_operation_type(query):
     # type: (Dict[str, Any]) -> str
-    query = query["query"].strip()
+    query = query["query"].strip().lower()
     if query.startswith("mutation"):
         return "mutation"
     if query.startswith("subscription"):

--- a/sentry_sdk/utils.py
+++ b/sentry_sdk/utils.py
@@ -1287,10 +1287,12 @@ def _get_graphql_operation_name(query):
     query = query["query"].strip()
 
     match = re.match(
-        r"^[a-z]* *([a-zA-Z0-9]+) \(?.*\)? *\{", query, flags=re.IGNORECASE
+        r"((query|mutation|subscription) )(?P<name>[a-zA-Z0-9]+) *\{",
+        query,
+        flags=re.IGNORECASE,
     )
     if match:
-        return match.group(1)
+        return match.group("name")
     return "anonymous"
 
 

--- a/sentry_sdk/utils.py
+++ b/sentry_sdk/utils.py
@@ -1280,7 +1280,7 @@ class SentryGraphQLClientError(Exception):
 
 
 def _get_graphql_operation_name(query):
-    # type: (dict) -> str
+    # type: (Dict[str, Any]) -> str
     if query.get("operationName"):
         return query["operationName"]
 
@@ -1293,7 +1293,7 @@ def _get_graphql_operation_name(query):
 
 
 def _get_graphql_operation_type(query):
-    # type: (dict) -> str
+    # type: (Dict[str, Any]) -> str
     query = query["query"].strip()
     if query.startswith("mutation"):
         return "mutation"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -584,6 +584,12 @@ class MockServerRequestHandler(BaseHTTPRequestHandler):
         self.end_headers()
         return
 
+    def do_POST(self):  # noqa: N802
+        # Process an HTTP POST request and return a response with an HTTP 200 status.
+        self.send_response(200)
+        self.end_headers()
+        return
+
 
 def get_free_port():
     s = socket.socket(socket.AF_INET, type=socket.SOCK_STREAM)

--- a/tests/integrations/aiohttp/test_aiohttp.py
+++ b/tests/integrations/aiohttp/test_aiohttp.py
@@ -1,5 +1,6 @@
 import asyncio
 import json
+import sys
 from contextlib import suppress
 from textwrap import dedent
 
@@ -15,6 +16,12 @@ try:
     from unittest import mock  # python 3.3 and above
 except ImportError:
     import mock  # python < 3.3
+
+
+def requires_python_version(major, minor, reason=None):
+    if reason is None:
+        reason = "Requires Python {}.{}".format(major, minor)
+    return pytest.mark.skipif(sys.version_info < (major, minor), reason=reason)
 
 
 @pytest.mark.asyncio
@@ -537,6 +544,7 @@ async def test_outgoing_trace_headers_append_to_baggage(
         )
 
 
+@requires_python_version(3, 8, "GraphQL aiohttp integration requires py>=3.8")
 @pytest.mark.asyncio
 async def test_graphql_get_client_error_captured(
     sentry_init, capture_events, aiohttp_raw_server, aiohttp_client
@@ -586,6 +594,7 @@ async def test_graphql_get_client_error_captured(
     )
 
 
+@requires_python_version(3, 8, "GraphQL aiohttp integration requires py>=3.8")
 @pytest.mark.asyncio
 async def test_graphql_post_client_error_captured(
     sentry_init, capture_events, aiohttp_client, aiohttp_raw_server

--- a/tests/integrations/aiohttp/test_aiohttp.py
+++ b/tests/integrations/aiohttp/test_aiohttp.py
@@ -1,11 +1,12 @@
 import asyncio
 import json
 from contextlib import suppress
+from textwrap import dedent
 
 import pytest
 from aiohttp import web
 from aiohttp.client import ServerDisconnectedError
-from aiohttp.web_request import Request
+from aiohttp.web import Request, json_response
 
 from sentry_sdk import capture_message, start_transaction
 from sentry_sdk.integrations.aiohttp import AioHttpIntegration
@@ -534,3 +535,113 @@ async def test_outgoing_trace_headers_append_to_baggage(
             resp.request_info.headers["baggage"]
             == "custom=value,sentry-trace_id=0123456789012345678901234567890,sentry-environment=production,sentry-release=d08ebdb9309e1b004c6f52202de58a09c2268e42,sentry-transaction=/interactions/other-dogs/new-dog,sentry-sample_rate=1.0,sentry-sampled=true"
         )
+
+
+@pytest.mark.asyncio
+async def test_graphql_get_client_error_captured(
+    sentry_init, capture_events, aiohttp_raw_server, aiohttp_client
+):
+    sentry_init(integrations=[AioHttpIntegration()])
+
+    graphql_response = {
+        "data": None,
+        "errors": [
+            {
+                "message": "some error",
+                "locations": [{"line": 2, "column": 3}],
+                "path": ["pet"],
+            }
+        ],
+    }
+
+    async def handler(request):
+        return json_response(graphql_response)
+
+    raw_server = await aiohttp_raw_server(handler)
+    events = capture_events()
+
+    client = await aiohttp_client(raw_server)
+    response = await client.get(
+        "/graphql", params={"query": "query GetPet {pet{name}}"}
+    )
+
+    assert response.status == 200
+    assert await response.json() == graphql_response
+
+    (event,) = events
+
+    assert event["request"]["url"] == "http://127.0.0.1:{}/graphql".format(
+        raw_server.port
+    )
+    assert event["request"]["method"] == "GET"
+    assert event["request"]["query_string"] == "query=query+GetPet+%7Bpet%7Bname%7D%7D"
+    assert "data" not in event["request"]
+    assert event["contexts"]["response"]["data"] == graphql_response
+
+    assert event["request"]["api_target"] == "graphql"
+    assert event["fingerprint"] == ["GetPet", "query", 200]
+    assert (
+        event["exception"]["values"][0]["value"]
+        == "GraphQL request failed, name: GetPet, type: query"
+    )
+
+
+@pytest.mark.asyncio
+async def test_graphql_post_client_error_captured(
+    sentry_init, capture_events, aiohttp_client, aiohttp_raw_server
+):
+    sentry_init(integrations=[AioHttpIntegration()])
+
+    graphql_request = {
+        "query": dedent(
+            """
+            mutation AddPet ($name: String!) {
+                addPet(name: $name) {
+                    id
+                    name
+                }
+            }
+        """
+        ),
+        "variables": {
+            "name": "Lucy",
+        },
+    }
+    graphql_response = {
+        "data": None,
+        "errors": [
+            {
+                "message": "already have too many pets",
+                "locations": [{"line": 1, "column": 1}],
+            }
+        ],
+    }
+
+    async def handler(request):
+        return json_response(graphql_response)
+
+    raw_server = await aiohttp_raw_server(handler)
+    events = capture_events()
+
+    client = await aiohttp_client(raw_server)
+    response = await client.post("/graphql", json=graphql_request)
+
+    assert response.status == 200
+    assert await response.json() == graphql_response
+
+    (event,) = events
+
+    assert event["request"]["url"] == "http://127.0.0.1:{}/graphql".format(
+        raw_server.port
+    )
+    assert event["request"]["method"] == "POST"
+    assert event["request"]["query_string"] == ""
+    assert event["request"]["data"] == graphql_request
+    assert event["contexts"]["response"]["data"] == graphql_response
+
+    assert event["request"]["api_target"] == "graphql"
+    assert event["fingerprint"] == ["AddPet", "mutation", 200]
+    assert (
+        event["exception"]["values"][0]["value"]
+        == "GraphQL request failed, name: AddPet, type: mutation"
+    )

--- a/tests/integrations/aiohttp/test_aiohttp.py
+++ b/tests/integrations/aiohttp/test_aiohttp.py
@@ -18,10 +18,16 @@ except ImportError:
     import mock  # python < 3.3
 
 
-def requires_python_version(major, minor, reason=None):
+def min_python_version(major, minor, reason=None):
     if reason is None:
-        reason = "Requires Python {}.{}".format(major, minor)
+        reason = "Requires Python {}.{} or higher".format(major, minor)
     return pytest.mark.skipif(sys.version_info < (major, minor), reason=reason)
+
+
+def max_python_version(major, minor, reason=None):
+    if reason is None:
+        reason = "Requires Python {}.{} or lower".format(major, minor)
+    return pytest.mark.skipif(sys.version_info > (major, minor), reason=reason)
 
 
 @pytest.mark.asyncio
@@ -544,7 +550,7 @@ async def test_outgoing_trace_headers_append_to_baggage(
         )
 
 
-@requires_python_version(3, 8, "GraphQL aiohttp integration requires py>=3.8")
+@min_python_version(3, 8, "GraphQL aiohttp integration requires py>=3.8")
 @pytest.mark.asyncio
 async def test_graphql_get_client_error_captured(
     sentry_init, capture_events, aiohttp_raw_server, aiohttp_client
@@ -594,7 +600,7 @@ async def test_graphql_get_client_error_captured(
     )
 
 
-@requires_python_version(3, 8, "GraphQL aiohttp integration requires py>=3.8")
+@min_python_version(3, 8, "GraphQL aiohttp integration requires py>=3.8")
 @pytest.mark.asyncio
 async def test_graphql_post_client_error_captured(
     sentry_init, capture_events, aiohttp_client, aiohttp_raw_server
@@ -654,3 +660,85 @@ async def test_graphql_post_client_error_captured(
         event["exception"]["values"][0]["value"]
         == "GraphQL request failed, name: AddPet, type: mutation"
     )
+
+
+@max_python_version(3, 7, "No GraphQL aiohttp integration for py<=3.7")
+@pytest.mark.asyncio
+async def test_graphql_get_client_error_not_captured(
+    sentry_init, capture_events, aiohttp_raw_server, aiohttp_client
+):
+    """Test that firing GraphQL requests works, there will just be no event."""
+    sentry_init(integrations=[AioHttpIntegration()])
+
+    graphql_response = {
+        "data": None,
+        "errors": [
+            {
+                "message": "some error",
+                "locations": [{"line": 2, "column": 3}],
+                "path": ["pet"],
+            }
+        ],
+    }
+
+    async def handler(request):
+        return json_response(graphql_response)
+
+    raw_server = await aiohttp_raw_server(handler)
+    events = capture_events()
+
+    client = await aiohttp_client(raw_server)
+    response = await client.get(
+        "/graphql", params={"query": "query GetPet {pet{name}}"}
+    )
+
+    assert response.status == 200
+    assert await response.json() == graphql_response
+    assert not events
+
+
+@max_python_version(3, 7, "No GraphQL aiohttp integration for py<=3.7")
+@pytest.mark.asyncio
+async def test_graphql_post_client_error_not_captured(
+    sentry_init, capture_events, aiohttp_client, aiohttp_raw_server
+):
+    """Test that firing GraphQL requests works, there will just be no event."""
+    sentry_init(integrations=[AioHttpIntegration()])
+
+    graphql_request = {
+        "query": dedent(
+            """
+            mutation AddPet ($name: String!) {
+                addPet(name: $name) {
+                    id
+                    name
+                }
+            }
+        """
+        ),
+        "variables": {
+            "name": "Lucy",
+        },
+    }
+    graphql_response = {
+        "data": None,
+        "errors": [
+            {
+                "message": "already have too many pets",
+                "locations": [{"line": 1, "column": 1}],
+            }
+        ],
+    }
+
+    async def handler(request):
+        return json_response(graphql_response)
+
+    raw_server = await aiohttp_raw_server(handler)
+    events = capture_events()
+
+    client = await aiohttp_client(raw_server)
+    response = await client.post("/graphql", json=graphql_request)
+
+    assert response.status == 200
+    assert await response.json() == graphql_response
+    assert not events

--- a/tests/integrations/aiohttp/test_aiohttp.py
+++ b/tests/integrations/aiohttp/test_aiohttp.py
@@ -673,6 +673,73 @@ async def test_graphql_post_client_error_captured(
 
 
 @pytest.mark.asyncio
+async def test_graphql_get_client_no_errors_returned(
+    sentry_init, capture_events, aiohttp_raw_server, aiohttp_client
+):
+    sentry_init(send_default_pii=True, integrations=[AioHttpIntegration()])
+
+    graphql_response = {
+        "data": None,
+    }
+
+    async def handler(request):
+        return json_response(graphql_response)
+
+    raw_server = await aiohttp_raw_server(handler)
+    events = capture_events()
+
+    client = await aiohttp_client(raw_server)
+    response = await client.get(
+        "/graphql", params={"query": "query GetPet {pet{name}}"}
+    )
+
+    assert response.status == 200
+    assert await response.json() == graphql_response
+
+    assert not events
+
+
+@pytest.mark.asyncio
+async def test_graphql_post_client_no_errors_returned(
+    sentry_init, capture_events, aiohttp_client, aiohttp_raw_server
+):
+    sentry_init(send_default_pii=True, integrations=[AioHttpIntegration()])
+
+    graphql_request = {
+        "query": dedent(
+            """
+            mutation AddPet ($name: String!) {
+                addPet(name: $name) {
+                    id
+                    name
+                }
+            }
+        """
+        ),
+        "variables": {
+            "name": "Lucy",
+        },
+    }
+    graphql_response = {
+        "data": None,
+    }
+
+    async def handler(request):
+        return json_response(graphql_response)
+
+    raw_server = await aiohttp_raw_server(handler)
+    events = capture_events()
+
+    client = await aiohttp_client(raw_server)
+    response = await client.post("/graphql", json=graphql_request)
+
+    assert response.status == 200
+    assert await response.json() == graphql_response
+
+    assert not events
+
+
+@pytest.mark.asyncio
 async def test_graphql_no_get_errors_if_option_is_off(
     sentry_init, capture_events, aiohttp_raw_server, aiohttp_client
 ):

--- a/tests/integrations/aiohttp/test_aiohttp.py
+++ b/tests/integrations/aiohttp/test_aiohttp.py
@@ -555,7 +555,7 @@ async def test_outgoing_trace_headers_append_to_baggage(
 async def test_graphql_get_client_error_captured(
     sentry_init, capture_events, aiohttp_raw_server, aiohttp_client
 ):
-    sentry_init(integrations=[AioHttpIntegration()])
+    sentry_init(send_default_pii=True, integrations=[AioHttpIntegration()])
 
     graphql_response = {
         "data": None,
@@ -605,7 +605,7 @@ async def test_graphql_get_client_error_captured(
 async def test_graphql_post_client_error_captured(
     sentry_init, capture_events, aiohttp_client, aiohttp_raw_server
 ):
-    sentry_init(integrations=[AioHttpIntegration()])
+    sentry_init(send_default_pii=True, integrations=[AioHttpIntegration()])
 
     graphql_request = {
         "query": dedent(
@@ -668,7 +668,7 @@ async def test_graphql_get_client_error_not_captured(
     sentry_init, capture_events, aiohttp_raw_server, aiohttp_client
 ):
     """Test that firing GraphQL requests works, there will just be no event."""
-    sentry_init(integrations=[AioHttpIntegration()])
+    sentry_init(send_default_pii=True, integrations=[AioHttpIntegration()])
 
     graphql_response = {
         "data": None,
@@ -703,7 +703,7 @@ async def test_graphql_post_client_error_not_captured(
     sentry_init, capture_events, aiohttp_client, aiohttp_raw_server
 ):
     """Test that firing GraphQL requests works, there will just be no event."""
-    sentry_init(integrations=[AioHttpIntegration()])
+    sentry_init(send_default_pii=True, integrations=[AioHttpIntegration()])
 
     graphql_request = {
         "query": dedent(

--- a/tests/integrations/httpx/test_httpx.py
+++ b/tests/integrations/httpx/test_httpx.py
@@ -623,7 +623,7 @@ def test_graphql_non_json_response(
             "name": "Lucy",
         },
     }
-    httpx_mock.add_response(method="POST", content=b"not json")
+    httpx_mock.add_response(method="POST")
 
     events = capture_events()
 
@@ -634,7 +634,6 @@ def test_graphql_non_json_response(
     else:
         response = httpx_client.post(url, json=graphql_request)
 
-    assert response.text == "not json"
     assert response.status_code == 200
 
     assert not events

--- a/tests/integrations/httpx/test_httpx.py
+++ b/tests/integrations/httpx/test_httpx.py
@@ -2,7 +2,7 @@ import asyncio
 
 import pytest
 import httpx
-import responses
+from textwrap import dedent
 
 from sentry_sdk import capture_message, start_transaction
 from sentry_sdk.consts import MATCH_ALL, SPANDATA
@@ -18,7 +18,7 @@ except ImportError:
     "httpx_client",
     (httpx.Client(), httpx.AsyncClient()),
 )
-def test_crumb_capture_and_hint(sentry_init, capture_events, httpx_client):
+def test_crumb_capture_and_hint(sentry_init, capture_events, httpx_client, httpx_mock):
     def before_breadcrumb(crumb, hint):
         crumb["data"]["extra"] = "foo"
         return crumb
@@ -26,7 +26,7 @@ def test_crumb_capture_and_hint(sentry_init, capture_events, httpx_client):
     sentry_init(integrations=[HttpxIntegration()], before_breadcrumb=before_breadcrumb)
 
     url = "http://example.com/"
-    responses.add(responses.GET, url, status=200)
+    httpx_mock.add_response()
 
     with start_transaction():
         events = capture_events()
@@ -61,11 +61,11 @@ def test_crumb_capture_and_hint(sentry_init, capture_events, httpx_client):
     "httpx_client",
     (httpx.Client(), httpx.AsyncClient()),
 )
-def test_outgoing_trace_headers(sentry_init, httpx_client):
+def test_outgoing_trace_headers(sentry_init, httpx_client, httpx_mock):
     sentry_init(traces_sample_rate=1.0, integrations=[HttpxIntegration()])
 
     url = "http://example.com/"
-    responses.add(responses.GET, url, status=200)
+    httpx_mock.add_response()
 
     with start_transaction(
         name="/interactions/other-dogs/new-dog",
@@ -93,7 +93,9 @@ def test_outgoing_trace_headers(sentry_init, httpx_client):
     "httpx_client",
     (httpx.Client(), httpx.AsyncClient()),
 )
-def test_outgoing_trace_headers_append_to_baggage(sentry_init, httpx_client):
+def test_outgoing_trace_headers_append_to_baggage(
+    sentry_init, httpx_client, httpx_mock
+):
     sentry_init(
         traces_sample_rate=1.0,
         integrations=[HttpxIntegration()],
@@ -101,7 +103,7 @@ def test_outgoing_trace_headers_append_to_baggage(sentry_init, httpx_client):
     )
 
     url = "http://example.com/"
-    responses.add(responses.GET, url, status=200)
+    httpx_mock.add_response()
 
     with start_transaction(
         name="/interactions/other-dogs/new-dog",
@@ -273,12 +275,12 @@ def test_option_trace_propagation_targets(
 
 
 @pytest.mark.tests_internal_exceptions
-def test_omit_url_data_if_parsing_fails(sentry_init, capture_events):
+def test_omit_url_data_if_parsing_fails(sentry_init, capture_events, httpx_mock):
     sentry_init(integrations=[HttpxIntegration()])
 
     httpx_client = httpx.Client()
     url = "http://example.com"
-    responses.add(responses.GET, url, status=200)
+    httpx_mock.add_response()
 
     events = capture_events()
     with mock.patch(
@@ -297,3 +299,122 @@ def test_omit_url_data_if_parsing_fails(sentry_init, capture_events):
         "reason": "OK",
         # no url related data
     }
+
+
+@pytest.mark.parametrize(
+    "httpx_client",
+    (httpx.Client(), httpx.AsyncClient()),
+)
+def test_graphql_get_client_error_captured(
+    sentry_init, capture_events, httpx_client, httpx_mock
+):
+    sentry_init(integrations=[HttpxIntegration()])
+
+    url = "http://example.com/graphql"
+    graphql_response = {
+        "data": None,
+        "errors": [
+            {
+                "message": "some error",
+                "locations": [{"line": 2, "column": 3}],
+                "path": ["user"],
+            }
+        ],
+    }
+    httpx_mock.add_response(method="GET", json=graphql_response)
+
+    events = capture_events()
+
+    if asyncio.iscoroutinefunction(httpx_client.get):
+        response = asyncio.get_event_loop().run_until_complete(
+            httpx_client.get(url, params={"query": "query QueryName {user{name}}"})
+        )
+    else:
+        response = httpx_client.get(
+            url, params={"query": "query QueryName {user{name}}"}
+        )
+
+    assert response.status_code == 200
+    assert response.json() == graphql_response
+
+    (event,) = events
+
+    assert event["request"]["url"] == url
+    assert event["request"]["method"] == "GET"
+    assert (
+        event["request"]["query_string"]
+        == "query=query%20QueryName%20%7Buser%7Bname%7D%7D"
+    )
+    assert "data" not in event["request"]
+    assert event["contexts"]["response"]["data"] == graphql_response
+
+    assert event["request"]["api_target"] == "graphql"
+    assert event["fingerprint"] == ["QueryName", "query", 200]
+    assert (
+        event["exception"]["values"][0]["value"]
+        == "GraphQL request failed, name: QueryName, type: query"
+    )
+
+
+@pytest.mark.parametrize(
+    "httpx_client",
+    (httpx.Client(), httpx.AsyncClient()),
+)
+def test_graphql_post_client_error_captured(
+    sentry_init, capture_events, httpx_client, httpx_mock
+):
+    sentry_init(integrations=[HttpxIntegration()])
+
+    url = "http://example.com/graphql"
+    graphql_request = {
+        "query": dedent(
+            """
+            mutation AddPet ($name: String!) {
+                addPet(name: $name) {
+                    id
+                    name
+                }
+            }
+        """
+        ),
+        "variables": {
+            "name": "Lucy",
+        },
+    }
+    graphql_response = {
+        "data": None,
+        "errors": [
+            {
+                "message": "already have too many pets",
+                "locations": [{"line": 1, "column": 1}],
+            }
+        ],
+    }
+    httpx_mock.add_response(method="POST", json=graphql_response)
+
+    events = capture_events()
+
+    if asyncio.iscoroutinefunction(httpx_client.post):
+        response = asyncio.get_event_loop().run_until_complete(
+            httpx_client.post(url, json=graphql_request)
+        )
+    else:
+        response = httpx_client.post(url, json=graphql_request)
+
+    assert response.status_code == 200
+    assert response.json() == graphql_response
+
+    (event,) = events
+
+    assert event["request"]["url"] == url
+    assert event["request"]["method"] == "POST"
+    assert event["request"]["query_string"] == ""
+    assert event["request"]["data"] == graphql_request
+    assert event["contexts"]["response"]["data"] == graphql_response
+
+    assert event["request"]["api_target"] == "graphql"
+    assert event["fingerprint"] == ["AddPet", "mutation", 200]
+    assert (
+        event["exception"]["values"][0]["value"]
+        == "GraphQL request failed, name: AddPet, type: mutation"
+    )

--- a/tests/integrations/httpx/test_httpx.py
+++ b/tests/integrations/httpx/test_httpx.py
@@ -313,7 +313,7 @@ def test_omit_url_data_if_parsing_fails(sentry_init, capture_events, httpx_mock)
 def test_graphql_get_client_error_captured(
     sentry_init, capture_events, httpx_client, httpx_mock
 ):
-    sentry_init(integrations=[HttpxIntegration()])
+    sentry_init(send_default_pii=True, integrations=[HttpxIntegration()])
 
     url = "http://example.com/graphql"
     graphql_response = {
@@ -365,7 +365,7 @@ def test_graphql_get_client_error_captured(
 def test_graphql_post_client_error_captured(
     sentry_init, capture_events, httpx_client, httpx_mock
 ):
-    sentry_init(integrations=[HttpxIntegration()])
+    sentry_init(send_default_pii=True, integrations=[HttpxIntegration()])
 
     url = "http://example.com/graphql"
     graphql_request = {

--- a/tests/integrations/httpx/test_httpx.py
+++ b/tests/integrations/httpx/test_httpx.py
@@ -623,7 +623,7 @@ def test_graphql_non_json_response(
             "name": "Lucy",
         },
     }
-    httpx_mock.add_response(method="POST", text="not json")
+    httpx_mock.add_response(method="POST", content=b"not json")
 
     events = capture_events()
 

--- a/tests/integrations/requests/test_requests.py
+++ b/tests/integrations/requests/test_requests.py
@@ -1,6 +1,5 @@
 import pytest
 import responses
-from textwrap import dedent
 
 requests = pytest.importorskip("requests")
 
@@ -63,92 +62,3 @@ def test_omit_url_data_if_parsing_fails(sentry_init, capture_events):
         "reason": response.reason,
         # no url related data
     }
-
-
-def test_graphql_get_client_error_captured(sentry_init, capture_events):
-    sentry_init(integrations=[StdlibIntegration()])
-
-    url = "http://example.com/graphql"
-    response = {
-        "data": None,
-        "errors": [
-            {
-                "message": "some error",
-                "locations": [{"line": 2, "column": 3}],
-                "path": ["user"],
-            }
-        ],
-    }
-    responses.add(responses.GET, url, status=200, json=response)
-
-    events = capture_events()
-
-    requests.get(url, params={"query": "query QueryName {user{name}}"})
-
-    (event,) = events
-
-    assert event["request"]["url"] == url
-    assert event["request"]["method"] == "GET"
-    assert (
-        event["request"]["query_string"]
-        == "query=query%20QueryName%20%7Buser%7Bname%7D%7D"
-    )
-    assert "data" not in event["request"]
-    assert event["contexts"]["response"]["data"] == response
-
-    assert event["request"]["api_target"] == "graphql"
-    assert event["fingerprint"] == ["QueryName", "query", 200]
-    assert (
-        event["exception"]["values"][0]["value"]
-        == "GraphQL request failed, name: QueryName, type: query"
-    )
-
-
-def test_graphql_post_client_error_captured(sentry_init, capture_events):
-    sentry_init(integrations=[StdlibIntegration()])
-
-    url = "http://example.com/graphql"
-    request = {
-        "query": dedent(
-            """
-            mutation AddPet ($name: String!) {
-                addPet(name: $name) {
-                    id
-                    name
-                }
-            }
-        """
-        ),
-        "variables": {
-            "name": "Lucy",
-        },
-    }
-    response = {
-        "data": None,
-        "errors": [
-            {
-                "message": "already have too many pets",
-                "locations": [{"line": 1, "column": 1}],
-            }
-        ],
-    }
-    responses.add(responses.POST, url, status=200, json=response)
-
-    events = capture_events()
-
-    requests.post(url, json=request)
-
-    (event,) = events
-
-    assert event["request"]["url"] == url
-    assert event["request"]["method"] == "POST"
-    assert event["request"]["query_string"] == ""
-    assert event["request"]["data"] == request
-    assert event["contexts"]["response"]["data"] == response
-
-    assert event["request"]["api_target"] == "graphql"
-    assert event["fingerprint"] == ["AddPet", "mutation", 200]
-    assert (
-        event["exception"]["values"][0]["value"]
-        == "GraphQL request failed, name: AddPet, type: mutation"
-    )

--- a/tests/integrations/requests/test_requests.py
+++ b/tests/integrations/requests/test_requests.py
@@ -1,5 +1,6 @@
 import pytest
 import responses
+from textwrap import dedent
 
 requests = pytest.importorskip("requests")
 
@@ -62,3 +63,92 @@ def test_omit_url_data_if_parsing_fails(sentry_init, capture_events):
         "reason": response.reason,
         # no url related data
     }
+
+
+def test_graphql_get_client_error_captured(sentry_init, capture_events):
+    sentry_init(integrations=[StdlibIntegration()])
+
+    url = "http://example.com/graphql"
+    response = {
+        "data": None,
+        "errors": [
+            {
+                "message": "some error",
+                "locations": [{"line": 2, "column": 3}],
+                "path": ["user"],
+            }
+        ],
+    }
+    responses.add(responses.GET, url, status=200, json=response)
+
+    events = capture_events()
+
+    requests.get(url, params={"query": "query QueryName {user{name}}"})
+
+    (event,) = events
+
+    assert event["request"]["url"] == url
+    assert event["request"]["method"] == "GET"
+    assert (
+        event["request"]["query_string"]
+        == "query=query%20QueryName%20%7Buser%7Bname%7D%7D"
+    )
+    assert "data" not in event["request"]
+    assert event["contexts"]["response"]["data"] == response
+
+    assert event["request"]["api_target"] == "graphql"
+    assert event["fingerprint"] == ["QueryName", "query", 200]
+    assert (
+        event["exception"]["values"][0]["value"]
+        == "GraphQL request failed, name: QueryName, type: query"
+    )
+
+
+def test_graphql_post_client_error_captured(sentry_init, capture_events):
+    sentry_init(integrations=[StdlibIntegration()])
+
+    url = "http://example.com/graphql"
+    request = {
+        "query": dedent(
+            """
+            mutation AddPet ($name: String!) {
+                addPet(name: $name) {
+                    id
+                    name
+                }
+            }
+        """
+        ),
+        "variables": {
+            "name": "Lucy",
+        },
+    }
+    response = {
+        "data": None,
+        "errors": [
+            {
+                "message": "already have too many pets",
+                "locations": [{"line": 1, "column": 1}],
+            }
+        ],
+    }
+    responses.add(responses.POST, url, status=200, json=response)
+
+    events = capture_events()
+
+    requests.post(url, json=request)
+
+    (event,) = events
+
+    assert event["request"]["url"] == url
+    assert event["request"]["method"] == "POST"
+    assert event["request"]["query_string"] == ""
+    assert event["request"]["data"] == request
+    assert event["contexts"]["response"]["data"] == response
+
+    assert event["request"]["api_target"] == "graphql"
+    assert event["fingerprint"] == ["AddPet", "mutation", 200]
+    assert (
+        event["exception"]["values"][0]["value"]
+        == "GraphQL request failed, name: AddPet, type: mutation"
+    )

--- a/tests/integrations/stdlib/test_httplib.py
+++ b/tests/integrations/stdlib/test_httplib.py
@@ -354,7 +354,7 @@ def test_option_trace_propagation_targets(
 
 
 def test_graphql_get_client_error_captured(sentry_init, capture_events):
-    sentry_init(integrations=[StdlibIntegration()])
+    sentry_init(send_default_pii=True, integrations=[StdlibIntegration()])
 
     params = {"query": "query QueryName {user{name}}"}
     graphql_response = {
@@ -400,7 +400,7 @@ def test_graphql_get_client_error_captured(sentry_init, capture_events):
 
 
 def test_graphql_post_client_error_captured(sentry_init, capture_events):
-    sentry_init(integrations=[StdlibIntegration()])
+    sentry_init(send_default_pii=True, integrations=[StdlibIntegration()])
 
     graphql_request = {
         "query": dedent(

--- a/tests/integrations/stdlib/test_httplib.py
+++ b/tests/integrations/stdlib/test_httplib.py
@@ -389,9 +389,7 @@ def test_graphql_get_client_error_captured(sentry_init, capture_events):
     assert event["request"]["method"] == "GET"
     assert dict(parse_qsl(event["request"]["query_string"])) == params
     assert "data" not in event["request"]
-    assert (
-        event["contexts"]["response"]["data"] == json.dumps(graphql_response).encode()
-    )
+    assert event["contexts"]["response"]["data"] == graphql_response
 
     assert event["request"]["api_target"] == "graphql"
     assert event["fingerprint"] == ["QueryName", "query", 200]

--- a/tests/integrations/stdlib/test_httplib.py
+++ b/tests/integrations/stdlib/test_httplib.py
@@ -1,4 +1,7 @@
+import json
 import random
+from textwrap import dedent
+from urllib.parse import urlencode
 
 import pytest
 
@@ -17,6 +20,13 @@ except ImportError:
     from http.client import HTTPConnection, HTTPSConnection
 
 try:
+    # py3
+    from urllib.parse import parse_qsl
+except ImportError:
+    # py2
+    from urlparse import parse_qsl  # type: ignore
+
+try:
     from unittest import mock  # python 3.3 and above
 except ImportError:
     import mock  # python < 3.3
@@ -27,7 +37,7 @@ from sentry_sdk.consts import MATCH_ALL, SPANDATA
 from sentry_sdk.tracing import Transaction
 from sentry_sdk.integrations.stdlib import StdlibIntegration
 
-from tests.conftest import create_mock_http_server
+from tests.conftest import MockServerRequestHandler, create_mock_http_server
 
 PORT = create_mock_http_server()
 
@@ -341,3 +351,110 @@ def test_option_trace_propagation_targets(
         else:
             assert "sentry-trace" not in request_headers
             assert "baggage" not in request_headers
+
+
+def test_graphql_get_client_error_captured(sentry_init, capture_events):
+    sentry_init(integrations=[StdlibIntegration()])
+
+    graphql_response = {
+        "data": None,
+        "errors": [
+            {
+                "message": "some error",
+                "locations": [{"line": 2, "column": 3}],
+                "path": ["user"],
+            }
+        ],
+    }
+
+    events = capture_events()
+
+    params = {"query": "query QueryName {user{name}}"}
+
+    def do_GET(self):
+        self.send_response(200)
+        self.end_headers()
+        self.wfile.write(json.dumps(graphql_response).encode())
+
+    with mock.patch.object(MockServerRequestHandler, "do_GET", do_GET):
+        conn = HTTPConnection("localhost:{}".format(PORT))
+        conn.request("GET", "/graphql?" + urlencode(params))
+        response = conn.getresponse()
+
+    assert response.read() == json.dumps(graphql_response).encode()
+
+    (event,) = events
+
+    assert event["request"]["url"] == "http://localhost:{}/graphql".format(PORT)
+    assert event["request"]["method"] == "GET"
+    assert dict(parse_qsl(event["request"]["query_string"])) == params
+    assert "data" not in event["request"]
+    assert (
+        event["contexts"]["response"]["data"] == json.dumps(graphql_response).encode()
+    )
+
+    assert event["request"]["api_target"] == "graphql"
+    assert event["fingerprint"] == ["QueryName", "query", 200]
+    assert (
+        event["exception"]["values"][0]["value"]
+        == "GraphQL request failed, name: QueryName, type: query"
+    )
+
+
+def test_graphql_post_client_error_captured(sentry_init, capture_events):
+    sentry_init(integrations=[StdlibIntegration()])
+
+    graphql_request = {
+        "query": dedent(
+            """
+            mutation AddPet ($name: String!) {
+                addPet(name: $name) {
+                    id
+                    name
+                }
+            }
+        """
+        ),
+        "variables": {
+            "name": "Lucy",
+        },
+    }
+    graphql_response = {
+        "data": None,
+        "errors": [
+            {
+                "message": "already have too many pets",
+                "locations": [{"line": 1, "column": 1}],
+            }
+        ],
+    }
+
+    events = capture_events()
+
+    def do_POST(self):
+        self.send_response(200)
+        self.end_headers()
+        self.wfile.write(json.dumps(graphql_response).encode())
+
+    with mock.patch.object(MockServerRequestHandler, "do_POST", do_POST):
+        conn = HTTPConnection("localhost:{}".format(PORT))
+        conn.request("POST", "/graphql", body=json.dumps(graphql_request).encode())
+        response = conn.getresponse()
+
+    # the response can still be read normally
+    assert response.read() == json.dumps(graphql_response).encode()
+
+    (event,) = events
+
+    assert event["request"]["url"] == "http://localhost:{}/graphql".format(PORT)
+    assert event["request"]["method"] == "POST"
+    assert event["request"]["query_string"] == ""
+    assert event["request"]["data"] == graphql_request
+    assert event["contexts"]["response"]["data"] == graphql_response
+
+    assert event["request"]["api_target"] == "graphql"
+    assert event["fingerprint"] == ["AddPet", "mutation", 200]
+    assert (
+        event["exception"]["values"][0]["value"]
+        == "GraphQL request failed, name: AddPet, type: mutation"
+    )

--- a/tests/integrations/stdlib/test_httplib.py
+++ b/tests/integrations/stdlib/test_httplib.py
@@ -23,7 +23,8 @@ try:
     from urllib.parse import parse_qsl, urlencode
 except ImportError:
     # py2
-    from urlparse import parse_qsl, urlencode  # type: ignore
+    from urlparse import parse_qsl  # type: ignore
+    from urllib import urlencode  # type: ignore
 
 try:
     from unittest import mock  # python 3.3 and above

--- a/tests/integrations/stdlib/test_httplib.py
+++ b/tests/integrations/stdlib/test_httplib.py
@@ -371,7 +371,7 @@ def test_graphql_get_client_error_captured(sentry_init, capture_events):
 
     params = {"query": "query QueryName {user{name}}"}
 
-    def do_GET(self):
+    def do_GET(self):  # noqa: N802
         self.send_response(200)
         self.end_headers()
         self.wfile.write(json.dumps(graphql_response).encode())
@@ -429,7 +429,7 @@ def test_graphql_post_client_error_captured(sentry_init, capture_events):
 
     events = capture_events()
 
-    def do_POST(self):
+    def do_POST(self):  # noqa: N802
         self.send_response(200)
         self.end_headers()
         self.wfile.write(json.dumps(graphql_response).encode())

--- a/tests/integrations/stdlib/test_httplib.py
+++ b/tests/integrations/stdlib/test_httplib.py
@@ -356,6 +356,7 @@ def test_option_trace_propagation_targets(
 def test_graphql_get_client_error_captured(sentry_init, capture_events):
     sentry_init(integrations=[StdlibIntegration()])
 
+    params = {"query": "query QueryName {user{name}}"}
     graphql_response = {
         "data": None,
         "errors": [
@@ -369,8 +370,6 @@ def test_graphql_get_client_error_captured(sentry_init, capture_events):
 
     events = capture_events()
 
-    params = {"query": "query QueryName {user{name}}"}
-
     def do_GET(self):  # noqa: N802
         self.send_response(200)
         self.end_headers()
@@ -381,6 +380,7 @@ def test_graphql_get_client_error_captured(sentry_init, capture_events):
         conn.request("GET", "/graphql?" + urlencode(params))
         response = conn.getresponse()
 
+    # make sure the response can still be read() normally
     assert response.read() == json.dumps(graphql_response).encode()
 
     (event,) = events
@@ -439,7 +439,7 @@ def test_graphql_post_client_error_captured(sentry_init, capture_events):
         conn.request("POST", "/graphql", body=json.dumps(graphql_request).encode())
         response = conn.getresponse()
 
-    # the response can still be read normally
+    # make sure the response can still be read() normally
     assert response.read() == json.dumps(graphql_response).encode()
 
     (event,) = events

--- a/tests/integrations/stdlib/test_httplib.py
+++ b/tests/integrations/stdlib/test_httplib.py
@@ -1,7 +1,6 @@
 import json
 import random
 from textwrap import dedent
-from urllib.parse import urlencode
 
 import pytest
 
@@ -21,10 +20,10 @@ except ImportError:
 
 try:
     # py3
-    from urllib.parse import parse_qsl
+    from urllib.parse import parse_qsl, urlencode
 except ImportError:
     # py2
-    from urlparse import parse_qsl  # type: ignore
+    from urlparse import parse_qsl, urlencode  # type: ignore
 
 try:
     from unittest import mock  # python 3.3 and above

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -11,6 +11,8 @@ from sentry_sdk.utils import (
     parse_version,
     sanitize_url,
     serialize_frame,
+    _get_graphql_operation_name,
+    _get_graphql_operation_type,
 )
 
 try:
@@ -423,3 +425,91 @@ def test_match_regex_list(item, regex_list, expected_result):
 )
 def test_parse_version(version, expected_result):
     assert parse_version(version) == expected_result
+
+
+@pytest.mark.parametrize(
+    "query,expected_result",
+    [
+        [{"query": '{cats(id: "7") {name}}'}, "anonymous"],
+        [{"query": 'query {cats(id: "7") {name}}'}, "anonymous"],
+        [{"query": 'query CatQuery {cats(id: "7") {name}}'}, "CatQuery"],
+        [
+            {
+                "query": 'mutation {addCategory(id: 6, name: "Lily", cats: [8, 2]) {name cats {name}}}'
+            },
+            "anonymous",
+        ],
+        [
+            {
+                "query": 'mutation categoryAdd {addCategory(id: 6, name: "Lily", cats: [8, 2]) {name cats {name}}}'
+            },
+            "categoryAdd",
+        ],
+        [
+            {
+                "query": "subscription {newLink {id url description postedBy {id name email}}}"
+            },
+            "anonymous",
+        ],
+        [
+            {
+                "query": "subscription PostSubcription {newLink {id url description postedBy {id name email}}}"
+            },
+            "PostSubcription",
+        ],
+        [
+            {
+                "query": 'query CatQuery {cats(id: "7") {name}}',
+                "operationName": "SomeOtherOperation",
+                "variables": {},
+            },
+            "SomeOtherOperation",
+        ],
+    ],
+)
+def test_graphql_operation_name_extraction(query, expected_result):
+    assert _get_graphql_operation_name(query) == expected_result
+
+
+@pytest.mark.parametrize(
+    "query,expected_result",
+    [
+        [{"query": '{cats(id: "7") {name}}'}, "query"],
+        [{"query": 'query {cats(id: "7") {name}}'}, "query"],
+        [{"query": 'query CatQuery {cats(id: "7") {name}}'}, "query"],
+        [
+            {
+                "query": 'mutation {addCategory(id: 6, name: "Lily", cats: [8, 2]) {name cats {name}}}'
+            },
+            "mutation",
+        ],
+        [
+            {
+                "query": 'mutation categoryAdd {addCategory(id: 6, name: "Lily", cats: [8, 2]) {name cats {name}}}'
+            },
+            "mutation",
+        ],
+        [
+            {
+                "query": "subscription {newLink {id url description postedBy {id name email}}}"
+            },
+            "subscription",
+        ],
+        [
+            {
+                "query": "subscription PostSubcription {newLink {id url description postedBy {id name email}}}"
+            },
+            "subscription",
+        ],
+        [
+            {
+                "query": 'query CatQuery {cats(id: "7") {name}}',
+                "operationName": "SomeOtherOperation",
+                "variables": {},
+            },
+            "query",
+        ],
+    ],
+)
+def test_graphql_operation_type_extraction(query, expected_result):
+    assert _get_graphql_operation_type(query) == expected_result

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -465,6 +465,12 @@ def test_parse_version(version, expected_result):
             },
             "SomeOtherOperation",
         ],
+        [
+            {
+                "query": "mutation AddPet ($name: String!) {addPet(name: $name) {id name}}}"
+            },
+            "AddPet",
+        ],
     ],
 )
 def test_graphql_operation_name_extraction(query, expected_result):
@@ -508,6 +514,12 @@ def test_graphql_operation_name_extraction(query, expected_result):
                 "variables": {},
             },
             "query",
+        ],
+        [
+            {
+                "query": "mutation AddPet ($name: String!) {addPet(name: $name) {id name}}}"
+            },
+            "mutation",
         ],
     ],
 )


### PR DESCRIPTION
Inspect requests done with our HTTP client integrations (`stdlib`, `httpx`, `aiohttp`), identify GraphQL requests, and capture a specialized error event if the response from the server contains a non-empty `errors` array.

Closes https://github.com/getsentry/sentry-python/issues/2198