### PR TITLE
ref(crons): Add information to short-interval cron error message

### DIFF
--- a/sentry_sdk/integrations/celery.py
+++ b/sentry_sdk/integrations/celery.py
@@ -395,8 +395,8 @@ def _get_humanized_interval(seconds):
     return (int(seconds), "second")
 
 
-def _get_monitor_config(celery_schedule, app):
-    # type: (Any, Celery) -> Dict[str, Any]
+def _get_monitor_config(celery_schedule, app, monitor_name):
+    # type: (Any, Celery, str) -> Dict[str, Any]
     monitor_config = {}  # type: Dict[str, Any]
     schedule_type = None  # type: Optional[str]
     schedule_value = None  # type: Optional[Union[str, int]]
@@ -419,7 +419,9 @@ def _get_monitor_config(celery_schedule, app):
 
         if schedule_unit == "second":
             logger.warning(
-                "Intervals shorter than one minute are not supported by Sentry Crons."
+                "Intervals shorter than one minute are not supported by Sentry Crons. Monitor '%s' has an interval of %s seconds. Use the `exclude_beat_tasks` option in the celery integration to exclude it.",
+                monitor_name,
+                schedule_value,
             )
             return {}
 
@@ -466,7 +468,7 @@ def _patch_beat_apply_entry():
             # When tasks are started from Celery Beat, make sure each task has its own trace.
             scope.set_new_propagation_context()
 
-            monitor_config = _get_monitor_config(celery_schedule, app)
+            monitor_config = _get_monitor_config(celery_schedule, app, monitor_name)
 
             is_supported_schedule = bool(monitor_config)
             if is_supported_schedule:

--- a/tests/integrations/celery/test_celery_beat_crons.py
+++ b/tests/integrations/celery/test_celery_beat_crons.py
@@ -213,7 +213,7 @@ def test_get_monitor_config_crontab():
     app.conf.timezone = "Europe/Vienna"
 
     celery_schedule = crontab(day_of_month="3", hour="12", minute="*/10")
-    monitor_config = _get_monitor_config(celery_schedule, app)
+    monitor_config = _get_monitor_config(celery_schedule, app, "foo")
     assert monitor_config == {
         "schedule": {
             "type": "crontab",
@@ -230,8 +230,17 @@ def test_get_monitor_config_seconds():
     app.conf.timezone = "Europe/Vienna"
 
     celery_schedule = schedule(run_every=3)  # seconds
-    monitor_config = _get_monitor_config(celery_schedule, app)
-    assert monitor_config == {}
+
+    with mock.patch(
+        "sentry_sdk.integrations.celery.logger.warning"
+    ) as mock_logger_warning:
+        monitor_config = _get_monitor_config(celery_schedule, app, "foo")
+        mock_logger_warning.assert_called_with(
+            "Intervals shorter than one minute are not supported by Sentry Crons. Monitor '%s' has an interval of %s seconds. Use the `exclude_beat_tasks` option in the celery integration to exclude it.",
+            "foo",
+            3,
+        )
+        assert monitor_config == {}
 
 
 def test_get_monitor_config_minutes():
@@ -240,7 +249,7 @@ def test_get_monitor_config_minutes():
     app.conf.timezone = "Europe/Vienna"
 
     celery_schedule = schedule(run_every=60)  # seconds
-    monitor_config = _get_monitor_config(celery_schedule, app)
+    monitor_config = _get_monitor_config(celery_schedule, app, "foo")
     assert monitor_config == {
         "schedule": {
             "type": "interval",
@@ -257,7 +266,7 @@ def test_get_monitor_config_unknown():
     app.conf.timezone = "Europe/Vienna"
 
     unknown_celery_schedule = MagicMock()
-    monitor_config = _get_monitor_config(unknown_celery_schedule, app)
+    monitor_config = _get_monitor_config(unknown_celery_schedule, app, "foo")
     assert monitor_config == {}
 
 
@@ -268,7 +277,7 @@ def test_get_monitor_config_default_timezone():
 
     celery_schedule = crontab(day_of_month="3", hour="12", minute="*/10")
 
-    monitor_config = _get_monitor_config(celery_schedule, app)
+    monitor_config = _get_monitor_config(celery_schedule, app, "foo")
 
     assert monitor_config["timezone"] == "UTC"
 


### PR DESCRIPTION
This adds both the name of the problematic monitor and a suggestion of how to fix the problem to the error message about crons with < 1 min intervals.