### PR TITLE
ref(integrations): Rename `request_bodies` to `max_request_body_size`

### DIFF
--- a/sentry_sdk/client.py
+++ b/sentry_sdk/client.py
@@ -86,6 +86,16 @@ def _get_options(*args, **kwargs):
                 rv["include_local_variables"] = value
                 continue
 
+            # Option "request_bodies" was renamed to "max_request_body_size"
+            if key == "request_bodies":
+                msg = (
+                    "Deprecated: The option 'request_bodies' was renamed to 'max_request_body_size'. "
+                    "Please use 'max_request_body_size'. The option 'request_bodies' will be removed in the future."
+                )
+                logger.warning(msg)
+                rv["max_request_body_size"] = value
+                continue
+
             raise TypeError("Unknown option %r" % (key,))
 
         rv[key] = value
@@ -220,11 +230,11 @@ class _Client(object):
 
             self.session_flusher = SessionFlusher(capture_func=_capture_envelope)
 
-            request_bodies = ("always", "never", "small", "medium")
-            if self.options["request_bodies"] not in request_bodies:
+            max_request_body_size = ("always", "never", "small", "medium")
+            if self.options["max_request_body_size"] not in max_request_body_size:
                 raise ValueError(
-                    "Invalid value for request_bodies. Must be one of {}".format(
-                        request_bodies
+                    "Invalid value for max_request_body_size. Must be one of {}".format(
+                        max_request_body_size
                     )
                 )
 
@@ -328,7 +338,9 @@ class _Client(object):
         # Postprocess the event here so that annotated types do
         # generally not surface in before_send
         if event is not None:
-            event = serialize(event, request_bodies=self.options.get("request_bodies"))
+            event = serialize(
+                event, max_request_body_size=self.options.get("max_request_body_size")
+            )
 
         before_send = self.options["before_send"]
         if (

--- a/sentry_sdk/consts.py
+++ b/sentry_sdk/consts.py
@@ -178,7 +178,7 @@ class ClientConstructor(object):
         http_proxy=None,  # type: Optional[str]
         https_proxy=None,  # type: Optional[str]
         ignore_errors=[],  # type: Sequence[Union[type, str]]  # noqa: B006
-        request_bodies="medium",  # type: str
+        max_request_body_size="medium",  # type: str
         before_send=None,  # type: Optional[EventProcessor]
         before_breadcrumb=None,  # type: Optional[BreadcrumbProcessor]
         debug=False,  # type: bool

--- a/sentry_sdk/integrations/_wsgi_common.py
+++ b/sentry_sdk/integrations/_wsgi_common.py
@@ -37,7 +37,7 @@ def request_body_within_bounds(client, content_length):
     if client is None:
         return False
 
-    bodies = client.options["request_bodies"]
+    bodies = client.options["max_request_body_size"]
     return not (
         bodies == "never"
         or (bodies == "small" and content_length > 10**3)

--- a/sentry_sdk/serializer.py
+++ b/sentry_sdk/serializer.py
@@ -68,7 +68,7 @@ else:
 MAX_EVENT_BYTES = 10**6
 
 # Maximum depth and breadth of databags. Excess data will be trimmed. If
-# request_bodies is "always", request bodies won't be trimmed.
+# max_request_body_size is "always", request bodies won't be trimmed.
 MAX_DATABAG_DEPTH = 5
 MAX_DATABAG_BREADTH = 10
 CYCLE_MARKER = "<cyclic>"
@@ -120,7 +120,9 @@ def serialize(event, **kwargs):
     path = []  # type: List[Segment]
     meta_stack = []  # type: List[Dict[str, Any]]
 
-    keep_request_bodies = kwargs.pop("request_bodies", None) == "always"  # type: bool
+    keep_request_bodies = (
+        kwargs.pop("max_request_body_size", None) == "always"
+    )  # type: bool
 
     def _annotate(**meta):
         # type: (**Any) -> None

--- a/sentry_sdk/utils.py
+++ b/sentry_sdk/utils.py
@@ -387,7 +387,7 @@ class AnnotatedValue(object):
     @classmethod
     def removed_because_over_size_limit(cls):
         # type: () -> AnnotatedValue
-        """The actual value was removed because the size of the field exceeded the configured maximum size (specified with the request_bodies sdk option)"""
+        """The actual value was removed because the size of the field exceeded the configured maximum size (specified with the max_request_body_size sdk option)"""
         return AnnotatedValue(
             value="",
             metadata={

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -13,3 +13,4 @@ asttokens
 responses
 pysocks
 ipdb
+mockupdb

--- a/tests/integrations/bottle/test_bottle.py
+++ b/tests/integrations/bottle/test_bottle.py
@@ -211,7 +211,7 @@ def test_too_large_raw_request(
     sentry_init, input_char, capture_events, app, get_client
 ):
     sentry_init(
-        integrations=[bottle_sentry.BottleIntegration()], request_bodies="small"
+        integrations=[bottle_sentry.BottleIntegration()], max_request_body_size="small"
     )
 
     data = input_char * 2000
@@ -241,7 +241,7 @@ def test_too_large_raw_request(
 
 def test_files_and_form(sentry_init, capture_events, app, get_client):
     sentry_init(
-        integrations=[bottle_sentry.BottleIntegration()], request_bodies="always"
+        integrations=[bottle_sentry.BottleIntegration()], max_request_body_size="always"
     )
 
     data = {"foo": "a" * 2000, "file": (BytesIO(b"hello"), "hello.txt")}
@@ -276,11 +276,11 @@ def test_files_and_form(sentry_init, capture_events, app, get_client):
     assert not event["request"]["data"]["file"]
 
 
-def test_json_not_truncated_if_request_bodies_is_always(
+def test_json_not_truncated_if_max_request_body_size_is_always(
     sentry_init, capture_events, app, get_client
 ):
     sentry_init(
-        integrations=[bottle_sentry.BottleIntegration()], request_bodies="always"
+        integrations=[bottle_sentry.BottleIntegration()], max_request_body_size="always"
     )
 
     data = {

--- a/tests/integrations/flask/test_flask.py
+++ b/tests/integrations/flask/test_flask.py
@@ -394,7 +394,9 @@ def test_flask_formdata_request_appear_transaction_body(
 
 @pytest.mark.parametrize("input_char", ["a", b"a"])
 def test_flask_too_large_raw_request(sentry_init, input_char, capture_events, app):
-    sentry_init(integrations=[flask_sentry.FlaskIntegration()], request_bodies="small")
+    sentry_init(
+        integrations=[flask_sentry.FlaskIntegration()], max_request_body_size="small"
+    )
 
     data = input_char * 2000
 
@@ -421,7 +423,9 @@ def test_flask_too_large_raw_request(sentry_init, input_char, capture_events, ap
 
 
 def test_flask_files_and_form(sentry_init, capture_events, app):
-    sentry_init(integrations=[flask_sentry.FlaskIntegration()], request_bodies="always")
+    sentry_init(
+        integrations=[flask_sentry.FlaskIntegration()], max_request_body_size="always"
+    )
 
     data = {"foo": "a" * 2000, "file": (BytesIO(b"hello"), "hello.txt")}
 
@@ -449,10 +453,12 @@ def test_flask_files_and_form(sentry_init, capture_events, app):
     assert not event["request"]["data"]["file"]
 
 
-def test_json_not_truncated_if_request_bodies_is_always(
+def test_json_not_truncated_if_max_request_body_size_is_always(
     sentry_init, capture_events, app
 ):
-    sentry_init(integrations=[flask_sentry.FlaskIntegration()], request_bodies="always")
+    sentry_init(
+        integrations=[flask_sentry.FlaskIntegration()], max_request_body_size="always"
+    )
 
     data = {
         "key{}".format(i): "value{}".format(i) for i in range(MAX_DATABAG_BREADTH + 10)

--- a/tests/integrations/pyramid/test_pyramid.py
+++ b/tests/integrations/pyramid/test_pyramid.py
@@ -203,10 +203,10 @@ def test_flask_empty_json_request(sentry_init, capture_events, route, get_client
     assert event["request"]["data"] == data
 
 
-def test_json_not_truncated_if_request_bodies_is_always(
+def test_json_not_truncated_if_max_request_body_size_is_always(
     sentry_init, capture_events, route, get_client
 ):
-    sentry_init(integrations=[PyramidIntegration()], request_bodies="always")
+    sentry_init(integrations=[PyramidIntegration()], max_request_body_size="always")
 
     data = {
         "key{}".format(i): "value{}".format(i) for i in range(MAX_DATABAG_BREADTH + 10)
@@ -229,7 +229,7 @@ def test_json_not_truncated_if_request_bodies_is_always(
 
 
 def test_files_and_form(sentry_init, capture_events, route, get_client):
-    sentry_init(integrations=[PyramidIntegration()], request_bodies="always")
+    sentry_init(integrations=[PyramidIntegration()], max_request_body_size="always")
 
     data = {"foo": "a" * 2000, "file": (BytesIO(b"hello"), "hello.txt")}
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -412,6 +412,20 @@ def test_include_local_variables_deprecation(sentry_init):
         fake_warning.assert_not_called()
 
 
+def test_request_bodies_deprecation(sentry_init):
+    with mock.patch.object(logger, "warning", mock.Mock()) as fake_warning:
+        sentry_init(request_bodies="small")
+
+        client = Hub.current.client
+        assert "request_bodies" not in client.options
+        assert "max_request_body_size" in client.options
+        assert client.options["max_request_body_size"] == "small"
+
+        fake_warning.assert_called_once_with(
+            "Deprecated: The option 'request_bodies' was renamed to 'max_request_body_size'. Please use 'max_request_body_size'. The option 'request_bodies' will be removed in the future."
+        )
+
+
 def test_include_local_variables_enabled(sentry_init, capture_events):
     sentry_init(include_local_variables=True)
     events = capture_events()

--- a/tests/test_serializer.py
+++ b/tests/test_serializer.py
@@ -132,7 +132,7 @@ def test_trim_databag_breadth(body_normalizer):
         assert data.get(key) == value
 
 
-def test_no_trimming_if_request_bodies_is_always(body_normalizer):
+def test_no_trimming_if_max_request_body_size_is_always(body_normalizer):
     data = {
         "key{}".format(i): "value{}".format(i) for i in range(MAX_DATABAG_BREADTH + 10)
     }
@@ -141,6 +141,6 @@ def test_no_trimming_if_request_bodies_is_always(body_normalizer):
         curr["nested"] = {}
         curr = curr["nested"]
 
-    result = body_normalizer(data, request_bodies="always")
+    result = body_normalizer(data, max_request_body_size="always")
 
     assert result == data


### PR DESCRIPTION
Hi!

This PR fixes https://github.com/getsentry/sentry-python/issues/926

~🎗️ Question: Where can I update the Sentry's documentation for this change? https://docs.sentry.io/platforms/python/configuration/options/#request-bodies~