### PR TITLE
Remove py3.4 from tox.ini

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -165,8 +165,6 @@ deps =
     # with the -r flag
     -r test-requirements.txt
 
-    py3.4-common: colorama==0.4.1
-    py3.4-common: watchdog==0.10.7
     py3.8-common: hypothesis
 
     linters: -r linter-requirements.txt
@@ -295,7 +293,6 @@ deps =
     # Gevent
     # See http://www.gevent.org/install.html#older-versions-of-python
     # for justification of the versions pinned below
-    py3.4-gevent: gevent==1.4.0
     py3.5-gevent: gevent==20.9.0
     # See https://stackoverflow.com/questions/51496550/runtime-warning-greenlet-greenlet-size-changed
     # for justification why greenlet is pinned here
@@ -506,7 +503,6 @@ extras =
 
 basepython =
     py2.7: python2.7
-    py3.4: python3.4
     py3.5: python3.5
     py3.6: python3.6
     py3.7: python3.7
@@ -534,7 +530,7 @@ commands =
     py3.5-flask-v{0.11,0.12}: pip install more-itertools<8.11.0
 
     ; use old pytest for old Python versions:
-    {py2.7,py3.4,py3.5}: pip install pytest-forked==1.1.3
+    {py2.7,py3.5}: pip install pytest-forked==1.1.3
 
     ; Running `py.test` as an executable suffers from an import error
     ; when loading tests in scenarios. In particular, django fails to


### PR DESCRIPTION
We don't have workflows testing on 3.4 anymore.