### PR TITLE
feat(redis): Add db.system to remaining redis spans

### DIFF
--- a/sentry_sdk/integrations/redis/__init__.py
+++ b/sentry_sdk/integrations/redis/__init__.py
@@ -220,6 +220,7 @@ def _get_span_description(name, *args):
 
 def _set_client_data(span, is_cluster, name, *args):
     # type: (Span, bool, str, *Any) -> None
+    span.set_data(SPANDATA.DB_SYSTEM, "redis")
     span.set_tag("redis.is_cluster", is_cluster)
     if name:
         span.set_tag("redis.command", name)


### PR DESCRIPTION
In https://github.com/getsentry/sentry-python/pull/2038 we didn't add `db.system` to all the redis spans. This PR adds `db.system` span data to the redis spans we missed.

resolves https://www.notion.so/sentry/db-system-value-is-missing-in-Redis-spans-1c381ac16d724a58bbefd98481c93545