### PR TITLE
Fix chalice tests

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -237,6 +237,9 @@ deps =
     chalice-v1.24: chalice>=1.24.0,<1.25.0
     chalice: pytest-chalice==0.0.5
 
+    {py3.7}-chalice: botocore==1.31.14
+    {py3.8}-chalice: botocore==1.31.14
+
     # Django
     django: Werkzeug<2.1.0
     django-v{1.11,2.0,2.1,2.2,3.0,3.1,3.2}: djangorestframework>=3.0.0,<4.0.0

--- a/tox.ini
+++ b/tox.ini
@@ -50,7 +50,7 @@ envlist =
     # TODO: enable when celery is ready {py3.7,py3.8,py3.9,py3.10,py3.11}-celery-v{5.3}
 
     # Chalice
-    {py3.6,py3.7,py3.8}-chalice-v{1.16,1.17,1.18,1.19,1.20}
+    {py3.6,py3.7,py3.8}-chalice-v{1.18,1.20,1.22,1.24}
 
     # Cloud Resource Context
     {py3.6,py3.7,py3.8,py3.9,py3.10,py3.11}-cloud_resource_context
@@ -231,11 +231,10 @@ deps =
     {py2.7,py3.6,py3.7,py3.8,py3.9,py3.10,py3.11}-celery: newrelic
 
     # Chalice
-    chalice-v1.16: chalice>=1.16.0,<1.17.0
-    chalice-v1.17: chalice>=1.17.0,<1.18.0
     chalice-v1.18: chalice>=1.18.0,<1.19.0
-    chalice-v1.19: chalice>=1.19.0,<1.20.0
     chalice-v1.20: chalice>=1.20.0,<1.21.0
+    chalice-v1.22: chalice>=1.22.0,<1.23.0
+    chalice-v1.24: chalice>=1.24.0,<1.25.0
     chalice: pytest-chalice==0.0.5
 
     # Django

--- a/tox.ini
+++ b/tox.ini
@@ -237,8 +237,8 @@ deps =
     chalice-v1.24: chalice>=1.24.0,<1.25.0
     chalice: pytest-chalice==0.0.5
 
-    {py3.7}-chalice: botocore==1.31.14
-    {py3.8}-chalice: botocore==1.31.14
+    {py3.7}-chalice: botocore~=1.31
+    {py3.8}-chalice: botocore~=1.31
 
     # Django
     django: Werkzeug<2.1.0


### PR DESCRIPTION
The dependency resolution for some of our chalice tests had a hard time identifying a good version of botocore (a chalice dependency) to install. Pinning it now.

Taking this out of https://github.com/getsentry/sentry-python/pull/2274