### PR TITLE
Fix GraphQL integration swallowing responses

### DIFF
--- a/sentry_sdk/integrations/stdlib.py
+++ b/sentry_sdk/integrations/stdlib.py
@@ -185,7 +185,9 @@ def _install_httplib():
                     response_data = rv.read()
                     # once we've read() the body it can't be read() again by the
                     # app; save it so that it can be accessed again
-                    rv.read = io.BytesIO(response_data).read
+                    saved_response = io.BytesIO(response_data)
+                    rv.read = saved_response.read
+                    rv.fp = saved_response
                     try:
                         # py3.6+ json.loads() can deal with bytes out of the box, but
                         # for older version we have to explicitly decode first

--- a/tests/integrations/requests/test_requests.py
+++ b/tests/integrations/requests/test_requests.py
@@ -1,3 +1,4 @@
+import json
 import pytest
 import responses
 
@@ -7,10 +8,14 @@ from sentry_sdk import capture_message
 from sentry_sdk.consts import SPANDATA
 from sentry_sdk.integrations.stdlib import StdlibIntegration
 
+from tests.conftest import MockServerRequestHandler, create_mock_http_server
+
 try:
     from unittest import mock  # python 3.3 and above
 except ImportError:
     import mock  # python < 3.3
+
+PORT = create_mock_http_server()
 
 
 def test_crumb_capture(sentry_init, capture_events):
@@ -62,3 +67,19 @@ def test_omit_url_data_if_parsing_fails(sentry_init, capture_events):
         "reason": response.reason,
         # no url related data
     }
+
+
+def test_graphql_integration_doesnt_affect_responses(sentry_init):
+    sentry_init(integrations=[StdlibIntegration()])
+
+    msg = {"errors": [{"message": "some message"}]}
+
+    def do_POST(self):  # noqa: N802
+        self.send_response(200)
+        self.end_headers()
+        self.wfile.write(json.dumps(msg).encode())
+
+    with mock.patch.object(MockServerRequestHandler, "do_POST", do_POST):
+        response = requests.post("http://localhost:{}".format(PORT) + "/graphql")
+
+    assert response.json() == msg

--- a/tests/integrations/requests/test_requests.py
+++ b/tests/integrations/requests/test_requests.py
@@ -69,8 +69,10 @@ def test_omit_url_data_if_parsing_fails(sentry_init, capture_events):
     }
 
 
-def test_graphql_integration_doesnt_affect_responses(sentry_init):
+def test_graphql_integration_doesnt_affect_responses(sentry_init, capture_events):
     sentry_init(integrations=[StdlibIntegration()])
+
+    events = capture_events()
 
     msg = {"errors": [{"message": "some message"}]}
 
@@ -82,4 +84,5 @@ def test_graphql_integration_doesnt_affect_responses(sentry_init):
     with mock.patch.object(MockServerRequestHandler, "do_POST", do_POST):
         response = requests.post("http://localhost:{}".format(PORT) + "/graphql")
 
+    assert len(events) == 1
     assert response.json() == msg


### PR DESCRIPTION
For capturing GraphQL responses we're `read()`ing the `HTTPResponse` returned by `http.client.HTTPConnection.getresponse`, which exhausts the payload and it can't be read again by client applications. The original workaround for this was saving the payload in a `BytesIO` and aliasing `HTTPResponse.read` to the `BytesIO`'s `read`. This works when using http.client directly, but stops working with `urllib3`, which tries to determine whether there's anything left to read by checking if the response is closed, which in turn checks the internal `fp` file object. By the time we've `read()` the response, `fp` is `None`, and the response appears closed. This PR patches `fp` to point to the `BytesIO` saved response.

Fixes https://github.com/getsentry/sentry-python/issues/2285