### PR TITLE
Enable backpressure handling by default

### DIFF
--- a/sentry_sdk/client.py
+++ b/sentry_sdk/client.py
@@ -224,9 +224,7 @@ class _Client(object):
 
             self.monitor = None
             if self.transport:
-                if self.options["_experiments"].get(
-                    "enable_backpressure_handling", False
-                ):
+                if self.options["enable_backpressure_handling"]:
                     self.monitor = Monitor(self.transport)
 
             self.session_flusher = SessionFlusher(capture_func=_capture_envelope)

--- a/sentry_sdk/consts.py
+++ b/sentry_sdk/consts.py
@@ -39,7 +39,6 @@ if TYPE_CHECKING:
             # TODO: Remove these 2 profiling related experiments
             "profiles_sample_rate": Optional[float],
             "profiler_mode": Optional[ProfilerMode],
-            "enable_backpressure_handling": Optional[bool],
         },
         total=False,
     )
@@ -240,6 +239,7 @@ class ClientConstructor(object):
         functions_to_trace=[],  # type: Sequence[Dict[str, str]]  # noqa: B006
         event_scrubber=None,  # type: Optional[sentry_sdk.scrubber.EventScrubber]
         max_value_length=DEFAULT_MAX_VALUE_LENGTH,  # type: int
+        enable_backpressure_handling=True,  # type: bool
     ):
         # type: (...) -> None
         pass

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -21,15 +21,16 @@ class UnhealthyTestTransport(HealthyTestTransport):
 
 
 def test_no_monitor_if_disabled(sentry_init):
-    sentry_init(transport=HealthyTestTransport())
+    sentry_init(
+        transport=HealthyTestTransport(),
+        enable_backpressure_handling=False,
+    )
+
     assert Hub.current.client.monitor is None
 
 
 def test_monitor_if_enabled(sentry_init):
-    sentry_init(
-        transport=HealthyTestTransport(),
-        _experiments={"enable_backpressure_handling": True},
-    )
+    sentry_init(transport=HealthyTestTransport())
 
     monitor = Hub.current.client.monitor
     assert monitor is not None
@@ -42,10 +43,7 @@ def test_monitor_if_enabled(sentry_init):
 
 
 def test_monitor_unhealthy(sentry_init):
-    sentry_init(
-        transport=UnhealthyTestTransport(),
-        _experiments={"enable_backpressure_handling": True},
-    )
+    sentry_init(transport=UnhealthyTestTransport())
 
     monitor = Hub.current.client.monitor
     monitor.interval = 0.1
@@ -64,7 +62,6 @@ def test_transaction_uses_downsampled_rate(
     sentry_init(
         traces_sample_rate=1.0,
         transport=UnhealthyTestTransport(),
-        _experiments={"enable_backpressure_handling": True},
     )
 
     reports = capture_client_reports()


### PR DESCRIPTION
closes https://github.com/getsentry/sentry-python/issues/2095 