### PR TITLE
Officially support Python 3.11

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -87,6 +87,7 @@ setup(
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
         "Topic :: Software Development :: Libraries :: Python Modules",
     ],
     options={"bdist_wheel": {"universal": "1"}},


### PR DESCRIPTION
Long overdue, but here it is.

We're been already running our test suite on 3.11 since January of this year.

Closes https://github.com/getsentry/sentry-python/issues/1950