### PR TITLE
Make `Scope.update_from_*` appear in apidocs

### DIFF
--- a/sentry_sdk/scope.py
+++ b/sentry_sdk/scope.py
@@ -653,6 +653,7 @@ class Scope(object):
 
     def update_from_scope(self, scope):
         # type: (Scope) -> None
+        """Update the scope with another scope's data."""
         if scope._level is not None:
             self._level = scope._level
         if scope._fingerprint is not None:
@@ -690,6 +691,7 @@ class Scope(object):
         fingerprint=None,  # type: Optional[List[str]]
     ):
         # type: (...) -> None
+        """Update the scope's attributes."""
         if level is not None:
             self._level = level
         if user is not None:


### PR DESCRIPTION
The docstrings themselves don't really add much value but including them makes the methods appear in our [apidocs](https://getsentry.github.io/sentry-python/api.html).

Fixes https://github.com/getsentry/sentry-python/issues/2309