### PR TITLE
Fix opentelemetry-distro version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,7 @@ setup(
         "httpx": ["httpx>=0.16.0"],
         "huey": ["huey>=2"],
         "loguru": ["loguru>=0.5"],
-        "opentelemetry": ["opentelemetry-distro>=0.35b0"],
+        "opentelemetry": ["opentelemetry-distro>=0.40b0"],
         "opentelemetry-experimental": [
             "opentelemetry-distro~=0.40b0",
             "opentelemetry-instrumentation-aiohttp-client~=0.40b0",


### PR DESCRIPTION
Current version of the dependency is incorrect, since integration code:
https://github.com/getsentry/sentry-python/blob/ba6de38d915a2d66a7633017306c425ba4b34a72/sentry_sdk/integrations/opentelemetry/integration.py#L18
requires:
```
opentelemetry.instrumentation.auto_instrumentation._load
```
module to be present, but it was introduced only in `0.40b`:
https://github.com/open-telemetry/opentelemetry-python-contrib/commits/main/opentelemetry-instrumentation/src/opentelemetry/instrumentation/auto_instrumentation/_load.py
