### PR TITLE
Updated linting tooling

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,9 @@ updates:
   - dependency-name: pytest
     versions:
     - "> 3.7.3"
+  - dependency-name: flake8
+    versions:
+    - "> 5.0.4"
   - dependency-name: pytest-cov
     versions:
     - "> 2.8.1"
@@ -43,6 +46,6 @@ updates:
   open-pull-requests-limit: 10
 - package-ecosystem: "github-actions"
   directory: "/"
-  schedule: 
+  schedule:
     interval: weekly
   open-pull-requests-limit: 10

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,9 +12,12 @@ updates:
   - dependency-name: pytest
     versions:
     - "> 3.7.3"
-  - dependency-name: flake8
+  - dependency-name: flake8  # Later versions dropped Python 2 support
     versions:
     - "> 5.0.4"
+  - dependency-name: jsonschema  # Later versions dropped Python 2 support
+    versions:
+    - "> 3.2.0"
   - dependency-name: pytest-cov
     versions:
     - "> 2.8.1"

--- a/linter-requirements.txt
+++ b/linter-requirements.txt
@@ -1,12 +1,11 @@
-mypy==1.5.1
-black==23.7.0
-flake8==6.0.0
+mypy
+black
+flake8==5.0.4  # flake8 depends on pyflakes>=3.0.0 and this dropped support for Python 2 "# type:" comments
 types-certifi
 types-redis
 types-setuptools
 pymongo # There is no separate types module.
 loguru # There is no separate types module.
-flake8-bugbear==23.7.10
-pep8-naming==0.13.3
+flake8-bugbear
+pep8-naming
 pre-commit # local linting
-pyflakes==2.5.0

--- a/linter-requirements.txt
+++ b/linter-requirements.txt
@@ -1,6 +1,6 @@
 mypy==1.5.1
 black==23.7.0
-flake8==6.1.0
+flake8==6.0.0
 types-certifi
 types-redis
 types-setuptools
@@ -9,4 +9,3 @@ loguru # There is no separate types module.
 flake8-bugbear==23.7.10
 pep8-naming==0.13.3
 pre-commit # local linting
-pycodestyle==2.9.1

--- a/linter-requirements.txt
+++ b/linter-requirements.txt
@@ -1,11 +1,11 @@
 mypy==1.5.1
 black==23.7.0
-flake8==5.0.4
+flake8==6.1.0
 types-certifi
 types-redis
 types-setuptools
 pymongo # There is no separate types module.
 loguru # There is no separate types module.
-flake8-bugbear==22.12.6
-pep8-naming==0.13.2
+flake8-bugbear==23.7.10
+pep8-naming==0.13.3
 pre-commit # local linting

--- a/linter-requirements.txt
+++ b/linter-requirements.txt
@@ -1,11 +1,12 @@
 mypy==1.5.1
 black==23.7.0
-flake8==5.0.4
+flake8==6.1.0
 types-certifi
 types-redis
 types-setuptools
 pymongo # There is no separate types module.
 loguru # There is no separate types module.
-flake8-bugbear==22.12.6
+flake8-bugbear==23.7.10
 pep8-naming==0.13.3
 pre-commit # local linting
+pycodestyle==2.9.1

--- a/linter-requirements.txt
+++ b/linter-requirements.txt
@@ -9,3 +9,4 @@ loguru # There is no separate types module.
 flake8-bugbear==23.7.10
 pep8-naming==0.13.3
 pre-commit # local linting
+pyflakes==2.5.0

--- a/linter-requirements.txt
+++ b/linter-requirements.txt
@@ -1,11 +1,11 @@
 mypy==1.5.1
 black==23.7.0
-flake8==6.1.0
+flake8==5.0.4
 types-certifi
 types-redis
 types-setuptools
 pymongo # There is no separate types module.
 loguru # There is no separate types module.
-flake8-bugbear==23.7.10
+flake8-bugbear==22.12.6
 pep8-naming==0.13.3
 pre-commit # local linting

--- a/tests/integrations/celery/test_celery.py
+++ b/tests/integrations/celery/test_celery.py
@@ -375,7 +375,7 @@ def test_redis_backend_trace_propagation(init_celery, capture_events_forksafe):
         # Curious: Cannot use delay() here or py2.7-celery-4.2 crashes
         res = dummy_task.apply_async()
 
-    with pytest.raises(Exception):
+    with pytest.raises(Exception):  # noqa: B017
         # Celery 4.1 raises a gibberish exception
         res.wait()
 

--- a/tests/integrations/logging/test_logging.py
+++ b/tests/integrations/logging/test_logging.py
@@ -185,11 +185,11 @@ def test_logging_captured_warnings(sentry_init, capture_events, recwarn):
     events = capture_events()
 
     logging.captureWarnings(True)
-    warnings.warn("first")
-    warnings.warn("second")
+    warnings.warn("first", stacklevel=2)
+    warnings.warn("second", stacklevel=2)
     logging.captureWarnings(False)
 
-    warnings.warn("third")
+    warnings.warn("third", stacklevel=2)
 
     assert len(events) == 2
 

--- a/tests/integrations/stdlib/test_httplib.py
+++ b/tests/integrations/stdlib/test_httplib.py
@@ -114,7 +114,7 @@ def test_httplib_misuse(sentry_init, capture_events, request):
 
     conn.request("GET", "/200")
 
-    with pytest.raises(Exception):
+    with pytest.raises(Exception):  # noqa: B017
         # This raises an exception, because we didn't call `getresponse` for
         # the previous request yet.
         #

--- a/tests/test_crons.py
+++ b/tests/test_crons.py
@@ -61,7 +61,7 @@ def test_decorator_error(sentry_init):
     with mock.patch(
         "sentry_sdk.crons.decorator.capture_checkin"
     ) as fake_capture_checking:
-        with pytest.raises(Exception):
+        with pytest.raises(ZeroDivisionError):
             result = _break_world("Grace")
 
         assert "result" not in locals()
@@ -109,7 +109,7 @@ def test_contextmanager_error(sentry_init):
     with mock.patch(
         "sentry_sdk.crons.decorator.capture_checkin"
     ) as fake_capture_checking:
-        with pytest.raises(Exception):
+        with pytest.raises(ZeroDivisionError):
             result = _break_world_contextmanager("Grace")
 
         assert "result" not in locals()


### PR DESCRIPTION
Removed the pins to some of our linting tools to make sure we have the newest tools. (But pinning `flake8` because later versions dropped Python 2 support)

Also fixed some problems the new tools showed.

Also made sure that dependabot does not bug us about `flake8` and `jsonschema` anymore.