### PR TITLE
[Experiment] Added log messages where lifecycle hooks could be

### DIFF
--- a/sentry_sdk/client.py
+++ b/sentry_sdk/client.py
@@ -286,6 +286,8 @@ class _Client(object):
         if event.get("timestamp") is None:
             event["timestamp"] = datetime.utcnow()
 
+        logger.debug("[Lifecycle] event_prepare (event=)")
+
         if scope is not None:
             is_transaction = event.get("type") == "transaction"
             event_ = scope.apply_to_event(event, hint, self.options)
@@ -365,6 +367,10 @@ class _Client(object):
         ):
             new_event = None
             with capture_internal_exceptions():
+                logger.debug(
+                    "[Lifecycle] event_before_send (before_send=%s,j event=)",
+                    str(before_send),
+                )
                 new_event = before_send(event, hint or {})
             if new_event is None:
                 logger.info("before send dropped event")
@@ -382,6 +388,10 @@ class _Client(object):
         ):
             new_event = None
             with capture_internal_exceptions():
+                logger.debug(
+                    "[Lifecycle] event_before_send_transaction (before_send_transaction=%s,j event=)",
+                    str(before_send_transaction),
+                )
                 new_event = before_send_transaction(event, hint or {})
             if new_event is None:
                 logger.info("before send transaction dropped event")
@@ -578,6 +588,7 @@ class _Client(object):
                 envelope.add_event(event_opt)
 
             for attachment in attachments or ():
+                logger.debug("[Lifecycle] envelope_add_attachment (attachment=)")
                 envelope.add_item(attachment.to_envelope_item())
 
             self.transport.capture_envelope(envelope)

--- a/sentry_sdk/envelope.py
+++ b/sentry_sdk/envelope.py
@@ -5,7 +5,7 @@ import mimetypes
 from sentry_sdk._compat import text_type, PY2
 from sentry_sdk._types import TYPE_CHECKING
 from sentry_sdk.session import Session
-from sentry_sdk.utils import json_dumps, capture_internal_exceptions
+from sentry_sdk.utils import json_dumps, capture_internal_exceptions, logger
 
 if TYPE_CHECKING:
     from typing import Any
@@ -33,6 +33,7 @@ class Envelope(object):
         items=None,  # type: Optional[List[Item]]
     ):
         # type: (...) -> None
+        logger.debug("[Lifecycle] envelope_create ()")
         if headers is not None:
             headers = dict(headers)
         self.headers = headers or {}
@@ -54,30 +55,35 @@ class Envelope(object):
         self, event  # type: Event
     ):
         # type: (...) -> None
+        logger.debug("[Lifecycle] envelope_add_event (event=)")
         self.add_item(Item(payload=PayloadRef(json=event), type="event"))
 
     def add_transaction(
         self, transaction  # type: Event
     ):
         # type: (...) -> None
+        logger.debug("[Lifecycle] envelope_add_transaction (transaction=)")
         self.add_item(Item(payload=PayloadRef(json=transaction), type="transaction"))
 
     def add_profile(
         self, profile  # type: Any
     ):
         # type: (...) -> None
+        logger.debug("[Lifecycle] envelope_add_profile (profile=)")
         self.add_item(Item(payload=PayloadRef(json=profile), type="profile"))
 
     def add_checkin(
         self, checkin  # type: Any
     ):
         # type: (...) -> None
+        logger.debug("[Lifecycle] envelope_add_checkin (checkin=)")
         self.add_item(Item(payload=PayloadRef(json=checkin), type="check_in"))
 
     def add_session(
         self, session  # type: Union[Session, Any]
     ):
         # type: (...) -> None
+        logger.debug("[Lifecycle] envelope_add_session (session=)")
         if isinstance(session, Session):
             session = session.to_json()
         self.add_item(Item(payload=PayloadRef(json=session), type="session"))
@@ -86,6 +92,7 @@ class Envelope(object):
         self, sessions  # type: Any
     ):
         # type: (...) -> None
+        logger.debug("[Lifecycle] envelope_add_sessions (plural!) (sessions=)")
         self.add_item(Item(payload=PayloadRef(json=sessions), type="sessions"))
 
     def add_item(

--- a/sentry_sdk/hub.py
+++ b/sentry_sdk/hub.py
@@ -431,6 +431,8 @@ class Hub(with_metaclass(HubMeta)):  # type: ignore
             logger.info("Dropped breadcrumb because no client bound")
             return
 
+        logger.debug("[Lifecycle] breadcrumb_add (crumb=%s, hint=%s)", crumb, hint)
+
         crumb = dict(crumb or ())  # type: Breadcrumb
         crumb.update(kwargs)
         if not crumb:
@@ -502,6 +504,7 @@ class Hub(with_metaclass(HubMeta)):  # type: ignore
 
         span = self.scope.span
         if span is not None:
+            logger.debug("[Lifecycle] span_start_child (parent=%s, child=)", span)
             return span.start_child(**kwargs)
 
         # If there is already a trace_id in the propagation context, use it.
@@ -511,6 +514,9 @@ class Hub(with_metaclass(HubMeta)):  # type: ignore
             if trace_id is not None:
                 kwargs["trace_id"] = trace_id
 
+        logger.debug(
+            "[Lifecycle] span_start (span=)",
+        )
         return Span(**kwargs)
 
     def start_transaction(
@@ -564,6 +570,8 @@ class Hub(with_metaclass(HubMeta)):  # type: ignore
 
         profile = Profile(transaction, hub=self)
         profile._set_initial_sampling_decision(sampling_context=sampling_context)
+
+        logger.debug("[Lifecycle] transaction_start (%s)", transaction)
 
         # we don't bother to keep spans if we already know we're not going to
         # send the transaction

--- a/sentry_sdk/scope.py
+++ b/sentry_sdk/scope.py
@@ -569,6 +569,7 @@ class Scope(object):
     ):
         # type: (...) -> Optional[Event]
         """Applies the information contained on the scope to the given event."""
+        logger.debug("[Lifecycle] scope_apply_to_event (event=, scope=%s)", self)
 
         def _drop(cause, ty):
             # type: (Any, str) -> Optional[Any]

--- a/sentry_sdk/tracing.py
+++ b/sentry_sdk/tracing.py
@@ -424,6 +424,8 @@ class Span(object):
         # type: (Optional[sentry_sdk.Hub], Optional[datetime]) -> Optional[str]
         # XXX: would be type: (Optional[sentry_sdk.Hub]) -> None, but that leads
         # to incompatible return types for Span.finish and Transaction.finish.
+        logger.debug("[Lifecycle] span_finish (span=%s)", self)
+
         if self.timestamp is not None:
             # This span is already finished, ignore.
             return None
@@ -576,6 +578,8 @@ class Transaction(Span):
 
     def finish(self, hub=None, end_timestamp=None):
         # type: (Optional[sentry_sdk.Hub], Optional[datetime]) -> Optional[str]
+        logger.debug("[Lifecycle] transaction_finish (transaction=%s)", self)
+
         if self.timestamp is not None:
             # This transaction is already finished, ignore.
             return None
@@ -635,6 +639,11 @@ class Transaction(Span):
         contexts = {}
         contexts.update(self._contexts)
         contexts.update({"trace": self.get_trace_context()})
+
+        logger.debug(
+            "[Lifecycle] event_create_from_transaction (and/or span?) (transaction=%s)",
+            self,
+        )
 
         event = {
             "type": "transaction",

--- a/sentry_sdk/transport.py
+++ b/sentry_sdk/transport.py
@@ -342,6 +342,7 @@ class HttpTransport(Transport):
             f.write(json_dumps(event))
 
         assert self.parsed_dsn is not None
+        logger.debug("[Lifecycle] transport_send_event (event=)")
         logger.debug(
             "Sending event, type:%s level:%s event_id:%s project:%s host:%s"
             % (
@@ -394,6 +395,7 @@ class HttpTransport(Transport):
             envelope.serialize_into(f)
 
         assert self.parsed_dsn is not None
+        logger.debug("[Lifecycle] transport_send_envelope (envelope=)")
         logger.debug(
             "Sending envelope [%s] project:%s host:%s",
             envelope.description,
@@ -482,6 +484,10 @@ class HttpTransport(Transport):
         self, event  # type: Event
     ):
         # type: (...) -> None
+        logger.debug(
+            "[Lifecycle] transport_before_send_event (/store endpointm, DEPRECATED) (event=)"
+        )
+
         hub = self.hub_cls.current
 
         def send_event_wrapper():
@@ -499,6 +505,9 @@ class HttpTransport(Transport):
         self, envelope  # type: Envelope
     ):
         # type: (...) -> None
+        logger.debug(
+            "[Lifecycle] transport_before_send_envelope (/envelope endpoint) (event=)"
+        )
         hub = self.hub_cls.current
 
         def send_envelope_wrapper():


### PR DESCRIPTION
If we want to make [lifecycle hooks](https://github.com/getsentry/rfcs/blob/main/text/0034-sdk-lifecycle-hooks.md) a reality at some point, I guess we start with small steps. 

I added some debug messages to places where lifecycle hooks could be. We can bike-shed about the names in this PR!

This already uncovered some places where our architecture needs some improvements to have a nice implementation.

This absolutely floods our debug log with messages, so maybe we remove some before we merge these.