### PR TITLE
Remove OpenTelemetry integration from integration __init__.py

### DIFF
--- a/sentry_sdk/client.py
+++ b/sentry_sdk/client.py
@@ -243,7 +243,7 @@ class _Client(object):
                 )
                 self.options["instrumenter"] = INSTRUMENTER.OTEL
                 _DEFAULT_INTEGRATIONS.append(
-                    "sentry_sdk.integrations.opentelemetry.OpenTelemetryIntegration",
+                    "sentry_sdk.integrations.opentelemetry.integration.OpenTelemetryIntegration",
                 )
 
             self.integrations = setup_integrations(

--- a/sentry_sdk/integrations/opentelemetry/__init__.py
+++ b/sentry_sdk/integrations/opentelemetry/__init__.py
@@ -1,7 +1,3 @@
-from sentry_sdk.integrations.opentelemetry.integration import (  # noqa: F401
-    OpenTelemetryIntegration,
-)
-
 from sentry_sdk.integrations.opentelemetry.span_processor import (  # noqa: F401
     SentrySpanProcessor,
 )


### PR DESCRIPTION
Always importing the experimental integration module that requires a higher version of the `opentelemetry-distro` package causes [packaging issues on some systems](https://github.com/getsentry/sentry-python/pull/2349) where the newer OTel packages don't exist.