### PR TITLE
fix(tracing) : Add `trace` to `__all__` in top-level `__init__.py`

### DIFF
--- a/sentry_sdk/__init__.py
+++ b/sentry_sdk/__init__.py
@@ -39,6 +39,7 @@ __all__ = [  # noqa
     "get_traceparent",
     "get_baggage",
     "continue_trace",
+    "trace",
 ]
 
 # Initialize the debug support after everything is loaded


### PR DESCRIPTION
Currently, using the decorator form of `trace` like this (as mentioned in the docs [here](https://docs.sentry.io/platforms/python/performance/instrumentation/custom-instrumentation/#using-a-decorator-1)):

```python
import sentry_sdk

@sentry_sdk.trace
def do_stuff():
```

causes mypy to throw a `Module "sentry_sdk" does not explicitly export attribute "trace"  [attr-defined]` error. This adds `trace` to the top-level `__init__.py`'s `__all__` so mypy sees it as being officially exported and stops throwing the error.