### PR TITLE
Move `importorskip`s in tests to `__init__.py` files

### DIFF
--- a/tests/integrations/aiohttp/__init__.py
+++ b/tests/integrations/aiohttp/__init__.py
@@ -1,3 +1,3 @@
 import pytest
 
-aiohttp = pytest.importorskip("aiohttp")
+pytest.importorskip("aiohttp")

--- a/tests/integrations/ariadne/__init__.py
+++ b/tests/integrations/ariadne/__init__.py
@@ -1,0 +1,5 @@
+import pytest
+
+pytest.importorskip("ariadne")
+pytest.importorskip("fastapi")
+pytest.importorskip("flask")

--- a/tests/integrations/ariadne/test_ariadne.py
+++ b/tests/integrations/ariadne/test_ariadne.py
@@ -1,9 +1,3 @@
-import pytest
-
-pytest.importorskip("ariadne")
-pytest.importorskip("fastapi")
-pytest.importorskip("flask")
-
 from ariadne import gql, graphql_sync, ObjectType, QueryType, make_executable_schema
 from ariadne.asgi import GraphQL
 from fastapi import FastAPI

--- a/tests/integrations/asgi/__init__.py
+++ b/tests/integrations/asgi/__init__.py
@@ -1,4 +1,5 @@
 import pytest
 
-asyncio = pytest.importorskip("asyncio")
-pytest_asyncio = pytest.importorskip("pytest_asyncio")
+pytest.importorskip("asyncio")
+pytest.importorskip("pytest_asyncio")
+pytest.importorskip("async_asgi_testclient")

--- a/tests/integrations/asgi/test_asgi.py
+++ b/tests/integrations/asgi/test_asgi.py
@@ -8,7 +8,6 @@ from sentry_sdk import capture_message
 from sentry_sdk.integrations._asgi_common import _get_ip, _get_headers
 from sentry_sdk.integrations.asgi import SentryAsgiMiddleware, _looks_like_asgi3
 
-async_asgi_testclient = pytest.importorskip("async_asgi_testclient")
 from async_asgi_testclient import TestClient
 
 

--- a/tests/integrations/asyncpg/__init__.py
+++ b/tests/integrations/asyncpg/__init__.py
@@ -1,3 +1,4 @@
 import pytest
 
 pytest.importorskip("asyncpg")
+pytest.importorskip("pytest_asyncio")

--- a/tests/integrations/asyncpg/test_asyncpg.py
+++ b/tests/integrations/asyncpg/test_asyncpg.py
@@ -22,11 +22,13 @@ import datetime
 
 import asyncpg
 import pytest
+
+import pytest_asyncio
+
 from asyncpg import connect, Connection
 
 from sentry_sdk import capture_message
 from sentry_sdk.integrations.asyncpg import AsyncPGIntegration
-from tests.integrations.asgi import pytest_asyncio
 
 
 PG_CONNECTION_URI = f"postgresql://{PG_USER}:{PG_PASSWORD}@{PG_HOST}/{PG_NAME}"

--- a/tests/integrations/aws_lambda/__init__.py
+++ b/tests/integrations/aws_lambda/__init__.py
@@ -1,0 +1,3 @@
+import pytest
+
+boto3 = pytest.importorskip("boto3")

--- a/tests/integrations/aws_lambda/__init__.py
+++ b/tests/integrations/aws_lambda/__init__.py
@@ -1,3 +1,3 @@
 import pytest
 
-boto3 = pytest.importorskip("boto3")
+pytest.importorskip("boto3")

--- a/tests/integrations/aws_lambda/test_aws.py
+++ b/tests/integrations/aws_lambda/test_aws.py
@@ -22,7 +22,6 @@ from textwrap import dedent
 
 import pytest
 
-boto3 = pytest.importorskip("boto3")
 
 LAMBDA_PRELUDE = """
 from sentry_sdk.integrations.aws_lambda import AwsLambdaIntegration, get_lambda_bootstrap

--- a/tests/integrations/beam/__init__.py
+++ b/tests/integrations/beam/__init__.py
@@ -1,0 +1,3 @@
+import pytest
+
+pytest.importorskip("apache_beam")

--- a/tests/integrations/beam/test_beam.py
+++ b/tests/integrations/beam/test_beam.py
@@ -1,8 +1,6 @@
 import pytest
 import inspect
 
-pytest.importorskip("apache_beam")
-
 import dill
 
 from sentry_sdk.integrations.beam import (

--- a/tests/integrations/bottle/__init__.py
+++ b/tests/integrations/bottle/__init__.py
@@ -1,0 +1,3 @@
+import pytest
+
+pytest.importorskip("bottle")

--- a/tests/integrations/bottle/test_bottle.py
+++ b/tests/integrations/bottle/test_bottle.py
@@ -2,9 +2,6 @@ import json
 import pytest
 import logging
 
-
-pytest.importorskip("bottle")
-
 from io import BytesIO
 from bottle import Bottle, debug as set_debug, abort, redirect
 from sentry_sdk import capture_message

--- a/tests/integrations/celery/__init__.py
+++ b/tests/integrations/celery/__init__.py
@@ -1,0 +1,3 @@
+import pytest
+
+pytest.importorskip("celery")

--- a/tests/integrations/celery/test_celery.py
+++ b/tests/integrations/celery/test_celery.py
@@ -2,8 +2,6 @@ import threading
 
 import pytest
 
-pytest.importorskip("celery")
-
 from sentry_sdk import Hub, configure_scope, start_transaction, get_current_span
 from sentry_sdk.integrations.celery import CeleryIntegration, _get_headers
 

--- a/tests/integrations/celery/test_celery_beat_crons.py
+++ b/tests/integrations/celery/test_celery_beat_crons.py
@@ -1,7 +1,5 @@
 import pytest
 
-pytest.importorskip("celery")
-
 from sentry_sdk.integrations.celery import (
     _get_headers,
     _get_humanized_interval,

--- a/tests/integrations/django/__init__.py
+++ b/tests/integrations/django/__init__.py
@@ -1,3 +1,3 @@
 import pytest
 
-django = pytest.importorskip("django")
+pytest.importorskip("django")

--- a/tests/integrations/falcon/__init__.py
+++ b/tests/integrations/falcon/__init__.py
@@ -1,0 +1,3 @@
+import pytest
+
+pytest.importorskip("falcon")

--- a/tests/integrations/falcon/test_falcon.py
+++ b/tests/integrations/falcon/test_falcon.py
@@ -4,8 +4,6 @@ import logging
 
 import pytest
 
-pytest.importorskip("falcon")
-
 import falcon
 import falcon.testing
 import sentry_sdk

--- a/tests/integrations/fastapi/test_fastapi.py
+++ b/tests/integrations/fastapi/test_fastapi.py
@@ -5,8 +5,6 @@ import threading
 import pytest
 from sentry_sdk.integrations.fastapi import FastApiIntegration
 
-fastapi = pytest.importorskip("fastapi")
-
 from fastapi import FastAPI, Request
 from fastapi.testclient import TestClient
 from fastapi.middleware.trustedhost import TrustedHostMiddleware

--- a/tests/integrations/flask/__init__.py
+++ b/tests/integrations/flask/__init__.py
@@ -1,0 +1,3 @@
+import pytest
+
+pytest.importorskip("flask")

--- a/tests/integrations/flask/test_flask.py
+++ b/tests/integrations/flask/test_flask.py
@@ -5,8 +5,6 @@ import logging
 
 from io import BytesIO
 
-flask = pytest.importorskip("flask")
-
 from flask import (
     Flask,
     Response,

--- a/tests/integrations/gql/__init__.py
+++ b/tests/integrations/gql/__init__.py
@@ -1,0 +1,3 @@
+import pytest
+
+pytest.importorskip("gql")

--- a/tests/integrations/gql/test_gql.py
+++ b/tests/integrations/gql/test_gql.py
@@ -1,7 +1,5 @@
 import pytest
 
-pytest.importorskip("gql")
-
 import responses
 from gql import gql
 from gql import Client

--- a/tests/integrations/graphene/__init__.py
+++ b/tests/integrations/graphene/__init__.py
@@ -1,0 +1,5 @@
+import pytest
+
+pytest.importorskip("graphene")
+pytest.importorskip("fastapi")
+pytest.importorskip("flask")

--- a/tests/integrations/graphene/test_graphene_py3.py
+++ b/tests/integrations/graphene/test_graphene_py3.py
@@ -1,9 +1,3 @@
-import pytest
-
-pytest.importorskip("graphene")
-pytest.importorskip("fastapi")
-pytest.importorskip("flask")
-
 from fastapi import FastAPI, Request
 from fastapi.testclient import TestClient
 from flask import Flask, request, jsonify

--- a/tests/integrations/opentelemetry/__init__.py
+++ b/tests/integrations/opentelemetry/__init__.py
@@ -1,3 +1,3 @@
 import pytest
 
-django = pytest.importorskip("opentelemetry")
+pytest.importorskip("opentelemetry")

--- a/tests/integrations/pure_eval/__init__.py
+++ b/tests/integrations/pure_eval/__init__.py
@@ -1,3 +1,3 @@
 import pytest
 
-pure_eval = pytest.importorskip("pure_eval")
+pytest.importorskip("pure_eval")

--- a/tests/integrations/pyramid/__init__.py
+++ b/tests/integrations/pyramid/__init__.py
@@ -1,3 +1,3 @@
 import pytest
 
-pyramid = pytest.importorskip("pyramid")
+pytest.importorskip("pyramid")

--- a/tests/integrations/quart/__init__.py
+++ b/tests/integrations/quart/__init__.py
@@ -1,3 +1,3 @@
 import pytest
 
-quart = pytest.importorskip("quart")
+pytest.importorskip("quart")

--- a/tests/integrations/quart/test_quart.py
+++ b/tests/integrations/quart/test_quart.py
@@ -14,8 +14,6 @@ from sentry_sdk import (
 from sentry_sdk.integrations.logging import LoggingIntegration
 import sentry_sdk.integrations.quart as quart_sentry
 
-quart = pytest.importorskip("quart")
-
 from quart import Quart, Response, abort, stream_with_context
 from quart.views import View
 

--- a/tests/integrations/requests/__init__.py
+++ b/tests/integrations/requests/__init__.py
@@ -1,0 +1,3 @@
+import pytest
+
+pytest.importorskip("requests")

--- a/tests/integrations/requests/test_requests.py
+++ b/tests/integrations/requests/test_requests.py
@@ -1,7 +1,7 @@
-import pytest
+import requests
 import responses
 
-requests = pytest.importorskip("requests")
+import pytest
 
 from sentry_sdk import capture_message
 from sentry_sdk.consts import SPANDATA

--- a/tests/integrations/rq/__init__.py
+++ b/tests/integrations/rq/__init__.py
@@ -1,3 +1,3 @@
 import pytest
 
-rq = pytest.importorskip("rq")
+pytest.importorskip("rq")

--- a/tests/integrations/sanic/__init__.py
+++ b/tests/integrations/sanic/__init__.py
@@ -1,3 +1,3 @@
 import pytest
 
-sanic = pytest.importorskip("sanic")
+pytest.importorskip("sanic")

--- a/tests/integrations/spark/__init__.py
+++ b/tests/integrations/spark/__init__.py
@@ -1,0 +1,4 @@
+import pytest
+
+pytest.importorskip("pyspark")
+pytest.importorskip("py4j")

--- a/tests/integrations/spark/test_spark.py
+++ b/tests/integrations/spark/test_spark.py
@@ -8,10 +8,6 @@ from sentry_sdk.integrations.spark.spark_driver import (
 
 from sentry_sdk.integrations.spark.spark_worker import SparkWorkerIntegration
 
-
-pytest.importorskip("pyspark")
-pytest.importorskip("py4j")
-
 from pyspark import SparkContext
 
 from py4j.protocol import Py4JJavaError

--- a/tests/integrations/starlette/test_starlette.py
+++ b/tests/integrations/starlette/test_starlette.py
@@ -24,7 +24,7 @@ from sentry_sdk.integrations.starlette import (
     StarletteRequestExtractor,
 )
 
-starlette = pytest.importorskip("starlette")
+import starlette
 from starlette.authentication import (
     AuthCredentials,
     AuthenticationBackend,

--- a/tests/integrations/starlite/test_starlite.py
+++ b/tests/integrations/starlite/test_starlite.py
@@ -5,10 +5,9 @@ import pytest
 from sentry_sdk import capture_exception, capture_message, last_event_id
 from sentry_sdk.integrations.starlite import StarliteIntegration
 
-starlite = pytest.importorskip("starlite")
-
 from typing import Any, Dict
 
+import starlite
 from starlite import AbstractMiddleware, LoggingConfig, Starlite, get, Controller
 from starlite.middleware import LoggingMiddlewareConfig, RateLimitConfig
 from starlite.middleware.session.memory_backend import MemoryBackendConfig

--- a/tests/integrations/tornado/__init__.py
+++ b/tests/integrations/tornado/__init__.py
@@ -1,3 +1,3 @@
 import pytest
 
-tornado = pytest.importorskip("tornado")
+pytest.importorskip("tornado")

--- a/tests/integrations/trytond/__init__.py
+++ b/tests/integrations/trytond/__init__.py
@@ -1,0 +1,3 @@
+import pytest
+
+pytest.importorskip("trytond")

--- a/tests/integrations/trytond/test_trytond.py
+++ b/tests/integrations/trytond/test_trytond.py
@@ -1,9 +1,7 @@
-import pytest
-
-pytest.importorskip("trytond")
-
 import json
 import unittest.mock
+
+import pytest
 
 import trytond
 from trytond.exceptions import TrytonException as TrytondBaseException


### PR DESCRIPTION
In [CONTRIBUTING.md](https://github.com/getsentry/sentry-python/blob/master/CONTRIBUTING.md#adding-a-new-integration-checklist) we say:

> Create a new folder in tests/integrations/, with an __init__ file that skips the entire suite if the package is not installed.

but we're not following this everywhere ourselves. Not that it matters too much, but let's make it consistent.