### PR TITLE
Run more `requests`, `celery`, `falcon` tests

### DIFF
--- a/.github/workflows/test-integration-celery.yml
+++ b/.github/workflows/test-integration-celery.yml
@@ -31,7 +31,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.5","3.6","3.7","3.8","3.9","3.10"]
+        python-version: ["3.5","3.6","3.7","3.8","3.9","3.10","3.11"]
         # python3.6 reached EOL and is no longer being supported on
         # new versions of hosted runners on Github Actions
         # ubuntu-20.04 is the last version that supported python3.6

--- a/.github/workflows/test-integration-falcon.yml
+++ b/.github/workflows/test-integration-falcon.yml
@@ -31,7 +31,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.5","3.6","3.7","3.8","3.9"]
+        python-version: ["3.5","3.6","3.7","3.8","3.9","3.10","3.11"]
         # python3.6 reached EOL and is no longer being supported on
         # new versions of hosted runners on Github Actions
         # ubuntu-20.04 is the last version that supported python3.6

--- a/.github/workflows/test-integration-requests.yml
+++ b/.github/workflows/test-integration-requests.yml
@@ -31,7 +31,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8","3.9"]
+        python-version: ["3.8","3.9","3.10","3.11"]
         # python3.6 reached EOL and is no longer being supported on
         # new versions of hosted runners on Github Actions
         # ubuntu-20.04 is the last version that supported python3.6

--- a/tox.ini
+++ b/tox.ini
@@ -80,7 +80,7 @@ envlist =
     # Falcon
     {py2.7,py3.5,py3.6,py3.7}-falcon-v{1.4}
     {py2.7,py3.5,py3.6,py3.7}-falcon-v{2.0}
-    {py3.5,py3.6,py3.7,py3.8,py3.9}-falcon-v{3.0}
+    {py3.5,py3.6,py3.7,py3.8,py3.9,py3.10,py3.11}-falcon-v{3.0}
 
     # FastAPI
     {py3.7,py3.8,py3.9,py3.10,py3.11}-fastapi

--- a/tox.ini
+++ b/tox.ini
@@ -53,7 +53,7 @@ envlist =
     {py2.7,py3.5,py3.6,py3.7,py3.8}-celery-v{4.3,4.4}
     {py3.6,py3.7,py3.8}-celery-v{5.0}
     {py3.7,py3.8,py3.9,py3.10}-celery-v{5.1,5.2}
-    # TODO: enable when celery is ready {py3.7,py3.8,py3.9,py3.10,py3.11}-celery-v{5.3}
+    {py3.7,py3.8,py3.9,py3.10,py3.11}-celery-v{5.3}
 
     # Chalice
     {py3.6,py3.7,py3.8}-chalice-v{1.18,1.20,1.22,1.24}
@@ -251,6 +251,7 @@ deps =
     celery-v5.0: Celery>=5.0,<5.1
     celery-v5.1: Celery>=5.1,<5.2
     celery-v5.2: Celery>=5.2,<5.3
+    celery-v5.3: Celery>=5.3,<5.4
 
     {py3.5}-celery: newrelic<6.0.0
     {py3.7}-celery: importlib-metadata<5.0

--- a/tox.ini
+++ b/tox.ini
@@ -53,7 +53,7 @@ envlist =
     {py2.7,py3.5,py3.6,py3.7,py3.8}-celery-v{4.3,4.4}
     {py3.6,py3.7,py3.8}-celery-v{5.0}
     {py3.7,py3.8,py3.9,py3.10}-celery-v{5.1,5.2}
-    {py3.7,py3.8,py3.9,py3.10,py3.11}-celery-v{5.3}
+    {py3.8,py3.9,py3.10,py3.11}-celery-v{5.3}
 
     # Chalice
     {py3.6,py3.7,py3.8}-chalice-v{1.18,1.20,1.22,1.24}

--- a/tox.ini
+++ b/tox.ini
@@ -142,7 +142,7 @@ envlist =
     {py2.7,py3.7,py3.8,py3.9}-rediscluster-v{1,2.1.0,2}
 
     # Requests
-    {py2.7,py3.8,py3.9}-requests
+    {py2.7,py3.8,py3.9,py3.10,py3.11}-requests
 
     # RQ (Redis Queue)
     {py2.7,py3.5,py3.6}-rq-v{0.6,0.7,0.8,0.9,0.10,0.11}


### PR DESCRIPTION
- Run our `requests` and `falcon` test suites on newer Python versions, too.
- Run the `celery` test suite for Celery 5.3.
