### PR TITLE
Removing utcnow method deprecated at python3.12

### DIFF
--- a/sentry_sdk/__init__.py
+++ b/sentry_sdk/__init__.py
@@ -39,6 +39,7 @@ __all__ = [  # noqa
     "get_traceparent",
     "get_baggage",
     "continue_trace",
+    "trace",
 ]
 
 # Initialize the debug support after everything is loaded

--- a/sentry_sdk/_compat.py
+++ b/sentry_sdk/_compat.py
@@ -96,9 +96,11 @@ else:
     binary_sequence_types = (bytes, bytearray, memoryview)
 
     def datetime_utcnow():
+        # type: () -> datetime
         return datetime.now(timezone.utc)
 
     def utc_from_timestamp(timestamp):
+        # type: (float) -> datetime
         return datetime.fromtimestamp(timestamp, timezone.utc)
 
     def implements_str(x):

--- a/sentry_sdk/_compat.py
+++ b/sentry_sdk/_compat.py
@@ -1,5 +1,6 @@
 import sys
 import contextlib
+from datetime import datetime, timezone
 from functools import wraps
 
 from sentry_sdk._types import TYPE_CHECKING
@@ -31,6 +32,9 @@ if PY2:
     int_types = (int, long)  # noqa
     iteritems = lambda x: x.iteritems()  # noqa: B301
     binary_sequence_types = (bytearray, memoryview)
+
+    def datetime_utcnow():
+        return datetime.utcnow()
 
     def implements_str(cls):
         # type: (T) -> T
@@ -86,6 +90,9 @@ else:
     int_types = (int,)
     iteritems = lambda x: x.items()
     binary_sequence_types = (bytes, bytearray, memoryview)
+
+    def datetime_utcnow():
+        return datetime.now(timezone.utc)
 
     def implements_str(x):
         # type: (T) -> T

--- a/sentry_sdk/_compat.py
+++ b/sentry_sdk/_compat.py
@@ -1,6 +1,6 @@
 import sys
 import contextlib
-from datetime import datetime, timezone
+from datetime import datetime
 from functools import wraps
 
 from sentry_sdk._types import TYPE_CHECKING
@@ -35,6 +35,9 @@ if PY2:
 
     def datetime_utcnow():
         return datetime.utcnow()
+
+    def utc_from_timestamp(timestamp):
+        return datetime.utcfromtimestamp(timestamp)
 
     def implements_str(cls):
         # type: (T) -> T
@@ -82,6 +85,7 @@ if PY2:
         return DecoratorContextManager
 
 else:
+    from datetime import timezone
     import urllib.parse as urlparse  # noqa
 
     text_type = str
@@ -93,6 +97,9 @@ else:
 
     def datetime_utcnow():
         return datetime.now(timezone.utc)
+
+    def utc_from_timestamp(timestamp):
+        return datetime.fromtimestamp(timestamp, timezone.utc)
 
     def implements_str(x):
         # type: (T) -> T

--- a/sentry_sdk/client.py
+++ b/sentry_sdk/client.py
@@ -2,7 +2,7 @@ from importlib import import_module
 import os
 import uuid
 import random
-from datetime import datetime
+from datetime import datetime, timezone
 import socket
 
 from sentry_sdk._compat import string_types, text_type, iteritems
@@ -292,7 +292,7 @@ class _Client(object):
         # type: (...) -> Optional[Event]
 
         if event.get("timestamp") is None:
-            event["timestamp"] = datetime.utcnow()
+            event["timestamp"] = datetime.now(timezone.utc)
 
         if scope is not None:
             is_transaction = event.get("type") == "transaction"
@@ -568,7 +568,7 @@ class _Client(object):
         if should_use_envelope_endpoint:
             headers = {
                 "event_id": event_opt["event_id"],
-                "sent_at": format_timestamp(datetime.utcnow()),
+                "sent_at": format_timestamp(datetime.now(timezone.utc)),
             }
 
             if dynamic_sampling_context:

--- a/sentry_sdk/client.py
+++ b/sentry_sdk/client.py
@@ -2,10 +2,9 @@ from importlib import import_module
 import os
 import uuid
 import random
-from datetime import datetime, timezone
 import socket
 
-from sentry_sdk._compat import string_types, text_type, iteritems
+from sentry_sdk._compat import datetime_utcnow, string_types, text_type, iteritems
 from sentry_sdk.utils import (
     capture_internal_exceptions,
     current_stacktrace,
@@ -292,7 +291,7 @@ class _Client(object):
         # type: (...) -> Optional[Event]
 
         if event.get("timestamp") is None:
-            event["timestamp"] = datetime.now(timezone.utc)
+            event["timestamp"] = datetime_utcnow()
 
         if scope is not None:
             is_transaction = event.get("type") == "transaction"
@@ -568,7 +567,7 @@ class _Client(object):
         if should_use_envelope_endpoint:
             headers = {
                 "event_id": event_opt["event_id"],
-                "sent_at": format_timestamp(datetime.now(timezone.utc)),
+                "sent_at": format_timestamp(datetime_utcnow()),
             }
 
             if dynamic_sampling_context:

--- a/sentry_sdk/db/explain_plan/__init__.py
+++ b/sentry_sdk/db/explain_plan/__init__.py
@@ -15,7 +15,7 @@ def cache_statement(statement, options):
     # type: (str, dict[str, Any]) -> None
     global EXPLAIN_CACHE
 
-    now = datetime.datetime.utcnow()
+    now = datetime.datetime.now(datetime.timezone.utc)
     explain_cache_timeout_seconds = options.get(
         "explain_cache_timeout_seconds", EXPLAIN_CACHE_TIMEOUT_SECONDS
     )
@@ -31,7 +31,7 @@ def remove_expired_cache_items():
     """
     global EXPLAIN_CACHE
 
-    now = datetime.datetime.utcnow()
+    now = datetime.datetime.now(datetime.timezone.utc)
 
     for key, expiration_time in EXPLAIN_CACHE.items():
         expiration_in_the_past = expiration_time < now

--- a/sentry_sdk/db/explain_plan/__init__.py
+++ b/sentry_sdk/db/explain_plan/__init__.py
@@ -1,5 +1,6 @@
 import datetime
 
+from sentry_sdk._compat import datetime_utcnow
 from sentry_sdk.consts import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -15,7 +16,7 @@ def cache_statement(statement, options):
     # type: (str, dict[str, Any]) -> None
     global EXPLAIN_CACHE
 
-    now = datetime.datetime.now(datetime.timezone.utc)
+    now = datetime_utcnow()
     explain_cache_timeout_seconds = options.get(
         "explain_cache_timeout_seconds", EXPLAIN_CACHE_TIMEOUT_SECONDS
     )
@@ -31,7 +32,7 @@ def remove_expired_cache_items():
     """
     global EXPLAIN_CACHE
 
-    now = datetime.datetime.now(datetime.timezone.utc)
+    now = datetime_utcnow()
 
     for key, expiration_time in EXPLAIN_CACHE.items():
         expiration_in_the_past = expiration_time < now

--- a/sentry_sdk/hub.py
+++ b/sentry_sdk/hub.py
@@ -1,7 +1,7 @@
 import copy
 import sys
 
-from datetime import datetime
+from datetime import datetime, timezone
 from contextlib import contextmanager
 
 from sentry_sdk._compat import with_metaclass
@@ -439,7 +439,7 @@ class Hub(with_metaclass(HubMeta)):  # type: ignore
         hint = dict(hint or ())  # type: Hint
 
         if crumb.get("timestamp") is None:
-            crumb["timestamp"] = datetime.utcnow()
+            crumb["timestamp"] = datetime.now(timezone.utc)
         if crumb.get("type") is None:
             crumb["type"] = "default"
 

--- a/sentry_sdk/hub.py
+++ b/sentry_sdk/hub.py
@@ -1,10 +1,9 @@
 import copy
 import sys
 
-from datetime import datetime, timezone
 from contextlib import contextmanager
 
-from sentry_sdk._compat import with_metaclass
+from sentry_sdk._compat import datetime_utcnow, with_metaclass
 from sentry_sdk.consts import INSTRUMENTER
 from sentry_sdk.scope import Scope
 from sentry_sdk.client import Client
@@ -439,7 +438,7 @@ class Hub(with_metaclass(HubMeta)):  # type: ignore
         hint = dict(hint or ())  # type: Hint
 
         if crumb.get("timestamp") is None:
-            crumb["timestamp"] = datetime.now(timezone.utc)
+            crumb["timestamp"] = datetime_utcnow()
         if crumb.get("type") is None:
             crumb["type"] = "default"
 

--- a/sentry_sdk/integrations/aws_lambda.py
+++ b/sentry_sdk/integrations/aws_lambda.py
@@ -1,6 +1,6 @@
 import sys
 from copy import deepcopy
-from datetime import datetime, timedelta
+from datetime import datetime, timezone, timedelta
 from os import environ
 
 from sentry_sdk.api import continue_trace
@@ -323,7 +323,7 @@ def get_lambda_bootstrap():
 
 def _make_request_event_processor(aws_event, aws_context, configured_timeout):
     # type: (Any, Any, Any) -> EventProcessor
-    start_time = datetime.utcnow()
+    start_time = datetime.now(timezone.utc)
 
     def event_processor(sentry_event, hint, start_time=start_time):
         # type: (Event, Hint, datetime) -> Optional[Event]
@@ -428,7 +428,7 @@ def _get_cloudwatch_logs_url(aws_context, start_time):
         log_group=aws_context.log_group_name,
         log_stream=aws_context.log_stream_name,
         start_time=(start_time - timedelta(seconds=1)).strftime(formatstring),
-        end_time=(datetime.utcnow() + timedelta(seconds=2)).strftime(formatstring),
+        end_time=(datetime.now(timezone.utc) + timedelta(seconds=2)).strftime(formatstring),
     )
 
     return url

--- a/sentry_sdk/integrations/aws_lambda.py
+++ b/sentry_sdk/integrations/aws_lambda.py
@@ -1,6 +1,6 @@
 import sys
 from copy import deepcopy
-from datetime import datetime, timezone, timedelta
+from datetime import timedelta
 from os import environ
 
 from sentry_sdk.api import continue_trace
@@ -16,7 +16,7 @@ from sentry_sdk.utils import (
 )
 from sentry_sdk.integrations import Integration
 from sentry_sdk.integrations._wsgi_common import _filter_headers
-from sentry_sdk._compat import reraise
+from sentry_sdk._compat import datetime_utcnow, reraise
 from sentry_sdk._types import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -323,7 +323,7 @@ def get_lambda_bootstrap():
 
 def _make_request_event_processor(aws_event, aws_context, configured_timeout):
     # type: (Any, Any, Any) -> EventProcessor
-    start_time = datetime.now(timezone.utc)
+    start_time = datetime_utcnow()
 
     def event_processor(sentry_event, hint, start_time=start_time):
         # type: (Event, Hint, datetime) -> Optional[Event]
@@ -428,7 +428,7 @@ def _get_cloudwatch_logs_url(aws_context, start_time):
         log_group=aws_context.log_group_name,
         log_stream=aws_context.log_stream_name,
         start_time=(start_time - timedelta(seconds=1)).strftime(formatstring),
-        end_time=(datetime.now(timezone.utc) + timedelta(seconds=2)).strftime(formatstring),
+        end_time=(datetime_utcnow() + timedelta(seconds=2)).strftime(formatstring),
     )
 
     return url

--- a/sentry_sdk/integrations/aws_lambda.py
+++ b/sentry_sdk/integrations/aws_lambda.py
@@ -20,6 +20,7 @@ from sentry_sdk._compat import datetime_utcnow, reraise
 from sentry_sdk._types import TYPE_CHECKING
 
 if TYPE_CHECKING:
+    from datetime import datetime
     from typing import Any
     from typing import TypeVar
     from typing import Callable

--- a/sentry_sdk/integrations/gcp.py
+++ b/sentry_sdk/integrations/gcp.py
@@ -1,6 +1,6 @@
 import sys
 from copy import deepcopy
-from datetime import datetime, timedelta
+from datetime import datetime, timezone, timedelta
 from os import environ
 
 from sentry_sdk.api import continue_trace
@@ -57,7 +57,7 @@ def _wrap_func(func):
 
         configured_time = int(configured_time)
 
-        initial_time = datetime.utcnow()
+        initial_time = datetime.now(timezone.utc)
 
         with hub.push_scope() as scope:
             with capture_internal_exceptions():
@@ -154,7 +154,7 @@ def _make_request_event_processor(gcp_event, configured_timeout, initial_time):
     def event_processor(event, hint):
         # type: (Event, Hint) -> Optional[Event]
 
-        final_time = datetime.utcnow()
+        final_time = datetime.now(timezone.utc)
         time_diff = final_time - initial_time
 
         execution_duration_in_millis = time_diff.microseconds / MILLIS_TO_SECONDS

--- a/sentry_sdk/integrations/gcp.py
+++ b/sentry_sdk/integrations/gcp.py
@@ -25,6 +25,7 @@ TIMEOUT_WARNING_BUFFER = 1.5  # Buffer time required to send timeout warning to 
 MILLIS_TO_SECONDS = 1000.0
 
 if TYPE_CHECKING:
+    from datetime import datetime
     from typing import Any
     from typing import TypeVar
     from typing import Callable

--- a/sentry_sdk/integrations/gcp.py
+++ b/sentry_sdk/integrations/gcp.py
@@ -1,13 +1,13 @@
 import sys
 from copy import deepcopy
-from datetime import datetime, timezone, timedelta
+from datetime import timedelta
 from os import environ
 
 from sentry_sdk.api import continue_trace
 from sentry_sdk.consts import OP
 from sentry_sdk.hub import Hub, _should_send_default_pii
 from sentry_sdk.tracing import TRANSACTION_SOURCE_COMPONENT
-from sentry_sdk._compat import reraise
+from sentry_sdk._compat import datetime_utcnow, reraise
 from sentry_sdk.utils import (
     AnnotatedValue,
     capture_internal_exceptions,
@@ -57,7 +57,7 @@ def _wrap_func(func):
 
         configured_time = int(configured_time)
 
-        initial_time = datetime.now(timezone.utc)
+        initial_time = datetime_utcnow()
 
         with hub.push_scope() as scope:
             with capture_internal_exceptions():
@@ -154,7 +154,7 @@ def _make_request_event_processor(gcp_event, configured_timeout, initial_time):
     def event_processor(event, hint):
         # type: (Event, Hint) -> Optional[Event]
 
-        final_time = datetime.now(timezone.utc)
+        final_time = datetime_utcnow()
         time_diff = final_time - initial_time
 
         execution_duration_in_millis = time_diff.microseconds / MILLIS_TO_SECONDS

--- a/sentry_sdk/integrations/logging.py
+++ b/sentry_sdk/integrations/logging.py
@@ -1,7 +1,6 @@
 from __future__ import absolute_import
 
 import logging
-import datetime
 from fnmatch import fnmatch
 
 from sentry_sdk.hub import Hub
@@ -12,7 +11,7 @@ from sentry_sdk.utils import (
     capture_internal_exceptions,
 )
 from sentry_sdk.integrations import Integration
-from sentry_sdk._compat import iteritems
+from sentry_sdk._compat import iteritems, utc_from_timestamp
 
 from sentry_sdk._types import TYPE_CHECKING
 
@@ -282,6 +281,6 @@ class BreadcrumbHandler(_BaseHandler):
             "level": self._logging_to_event_level(record),
             "category": record.name,
             "message": record.message,
-            "timestamp": datetime.datetime.utcfromtimestamp(record.created),
+            "timestamp": utc_from_timestamp(record.created),
             "data": self._extra_from_record(record),
         }

--- a/sentry_sdk/session.py
+++ b/sentry_sdk/session.py
@@ -1,5 +1,5 @@
 import uuid
-from datetime import datetime
+from datetime import datetime, timezone
 
 from sentry_sdk._types import TYPE_CHECKING
 from sentry_sdk.utils import format_timestamp
@@ -48,7 +48,7 @@ class Session(object):
         if sid is None:
             sid = uuid.uuid4()
         if started is None:
-            started = datetime.utcnow()
+            started = datetime.now(timezone.utc)
         if status is None:
             status = "ok"
         self.status = status
@@ -108,7 +108,7 @@ class Session(object):
         if did is not None:
             self.did = str(did)
         if timestamp is None:
-            timestamp = datetime.utcnow()
+            timestamp = datetime.now(timezone.utc)
         self.timestamp = timestamp
         if started is not None:
             self.started = started

--- a/sentry_sdk/session.py
+++ b/sentry_sdk/session.py
@@ -5,6 +5,7 @@ from sentry_sdk._types import TYPE_CHECKING
 from sentry_sdk.utils import format_timestamp
 
 if TYPE_CHECKING:
+    from datetime import datetime
     from typing import Optional
     from typing import Union
     from typing import Any

--- a/sentry_sdk/session.py
+++ b/sentry_sdk/session.py
@@ -1,6 +1,6 @@
 import uuid
-from datetime import datetime, timezone
 
+from sentry_sdk._compat import datetime_utcnow
 from sentry_sdk._types import TYPE_CHECKING
 from sentry_sdk.utils import format_timestamp
 
@@ -48,7 +48,7 @@ class Session(object):
         if sid is None:
             sid = uuid.uuid4()
         if started is None:
-            started = datetime.now(timezone.utc)
+            started = datetime_utcnow()
         if status is None:
             status = "ok"
         self.status = status
@@ -108,7 +108,7 @@ class Session(object):
         if did is not None:
             self.did = str(did)
         if timestamp is None:
-            timestamp = datetime.now(timezone.utc)
+            timestamp = datetime_utcnow()
         self.timestamp = timestamp
         if started is not None:
             self.started = started

--- a/sentry_sdk/tracing.py
+++ b/sentry_sdk/tracing.py
@@ -14,6 +14,7 @@ from sentry_sdk._types import TYPE_CHECKING
 if TYPE_CHECKING:
     import typing
 
+    from datetime import datetime
     from typing import Any
     from typing import Dict
     from typing import Iterator

--- a/sentry_sdk/tracing.py
+++ b/sentry_sdk/tracing.py
@@ -1,12 +1,12 @@
 import uuid
 import random
 
-from datetime import datetime, timezone, timedelta
+from datetime import timedelta
 
 import sentry_sdk
 from sentry_sdk.consts import INSTRUMENTER
 from sentry_sdk.utils import is_valid_sample_rate, logger, nanosecond_time
-from sentry_sdk._compat import PY2
+from sentry_sdk._compat import datetime_utcnow, PY2
 from sentry_sdk.consts import SPANDATA
 from sentry_sdk._types import TYPE_CHECKING
 
@@ -145,7 +145,7 @@ class Span(object):
         self._tags = {}  # type: Dict[str, str]
         self._data = {}  # type: Dict[str, Any]
         self._containing_transaction = containing_transaction
-        self.start_timestamp = start_timestamp or datetime.now(timezone.utc)
+        self.start_timestamp = start_timestamp or datetime_utcnow()
         try:
             # profiling depends on this value and requires that
             # it is measured in nanoseconds
@@ -469,7 +469,7 @@ class Span(object):
                     microseconds=elapsed / 1000
                 )
         except AttributeError:
-            self.timestamp = datetime.now(timezone.utc)
+            self.timestamp = datetime_utcnow()
 
         maybe_create_breadcrumbs_from_span(hub, self)
         return None

--- a/sentry_sdk/tracing.py
+++ b/sentry_sdk/tracing.py
@@ -1,7 +1,7 @@
 import uuid
 import random
 
-from datetime import datetime, timedelta
+from datetime import datetime, timezone, timedelta
 
 import sentry_sdk
 from sentry_sdk.consts import INSTRUMENTER
@@ -145,7 +145,7 @@ class Span(object):
         self._tags = {}  # type: Dict[str, str]
         self._data = {}  # type: Dict[str, Any]
         self._containing_transaction = containing_transaction
-        self.start_timestamp = start_timestamp or datetime.utcnow()
+        self.start_timestamp = start_timestamp or datetime.now(timezone.utc)
         try:
             # profiling depends on this value and requires that
             # it is measured in nanoseconds
@@ -469,7 +469,7 @@ class Span(object):
                     microseconds=elapsed / 1000
                 )
         except AttributeError:
-            self.timestamp = datetime.utcnow()
+            self.timestamp = datetime.now(timezone.utc)
 
         maybe_create_breadcrumbs_from_span(hub, self)
         return None

--- a/sentry_sdk/transport.py
+++ b/sentry_sdk/transport.py
@@ -6,13 +6,14 @@ import certifi
 import gzip
 import time
 
-from datetime import datetime, timezone, timedelta
+from datetime import timedelta
 from collections import defaultdict
 
 from sentry_sdk.utils import Dsn, logger, capture_internal_exceptions, json_dumps
 from sentry_sdk.worker import BackgroundWorker
 from sentry_sdk.envelope import Envelope, Item, PayloadRef
 
+from sentry_sdk._compat import datetime_utcnow
 from sentry_sdk._types import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -122,7 +123,7 @@ class Transport(object):
 def _parse_rate_limits(header, now=None):
     # type: (Any, Optional[datetime]) -> Iterable[Tuple[DataCategory, datetime]]
     if now is None:
-        now = datetime.now(timezone.utc)
+        now = datetime_utcnow()
 
     for limit in header.split(","):
         try:
@@ -209,7 +210,7 @@ class HttpTransport(Transport):
         # sentries if a proxy in front wants to globally slow things down.
         elif response.status == 429:
             logger.warning("Rate-limited via 429")
-            self._disabled_until[None] = datetime.now(timezone.utc) + timedelta(
+            self._disabled_until[None] = datetime_utcnow() + timedelta(
                 seconds=self._retry.get_retry_after(response) or 60
             )
 
@@ -316,13 +317,13 @@ class HttpTransport(Transport):
         def _disabled(bucket):
             # type: (Any) -> bool
             ts = self._disabled_until.get(bucket)
-            return ts is not None and ts > datetime.now(timezone.utc)
+            return ts is not None and ts > datetime_utcnow()
 
         return _disabled(category) or _disabled(None)
 
     def _is_rate_limited(self):
         # type: () -> bool
-        return any(ts > datetime.now(timezone.utc) for ts in self._disabled_until.values())
+        return any(ts > datetime_utcnow() for ts in self._disabled_until.values())
 
     def _is_worker_full(self):
         # type: () -> bool

--- a/sentry_sdk/transport.py
+++ b/sentry_sdk/transport.py
@@ -17,6 +17,7 @@ from sentry_sdk._compat import datetime_utcnow
 from sentry_sdk._types import TYPE_CHECKING
 
 if TYPE_CHECKING:
+    from datetime import datetime
     from typing import Any
     from typing import Callable
     from typing import Dict

--- a/tests/test_transport.py
+++ b/tests/test_transport.py
@@ -4,7 +4,7 @@ import pickle
 import gzip
 import io
 
-from datetime import datetime, timezone, timedelta
+from datetime import datetime, timedelta
 
 import pytest
 from collections import namedtuple
@@ -13,6 +13,7 @@ from werkzeug.wrappers import Request, Response
 from pytest_localserver.http import WSGIServer
 
 from sentry_sdk import Hub, Client, add_breadcrumb, capture_message, Scope
+from sentry_sdk._compat import datetime_utcnow
 from sentry_sdk.transport import _parse_rate_limits
 from sentry_sdk.envelope import Envelope, parse_json
 from sentry_sdk.integrations.logging import LoggingIntegration
@@ -118,7 +119,7 @@ def test_transport_works(
     Hub.current.bind_client(client)
     request.addfinalizer(lambda: Hub.current.bind_client(None))
 
-    add_breadcrumb(level="info", message="i like bread", timestamp=datetime.now(timezone.utc))
+    add_breadcrumb(level="info", message="i like bread", timestamp=datetime_utcnow())
     capture_message("löl")
 
     getattr(client, client_flush_method)()

--- a/tests/test_transport.py
+++ b/tests/test_transport.py
@@ -4,7 +4,7 @@ import pickle
 import gzip
 import io
 
-from datetime import datetime, timedelta
+from datetime import datetime, timezone, timedelta
 
 import pytest
 from collections import namedtuple
@@ -118,7 +118,7 @@ def test_transport_works(
     Hub.current.bind_client(client)
     request.addfinalizer(lambda: Hub.current.bind_client(None))
 
-    add_breadcrumb(level="info", message="i like bread", timestamp=datetime.utcnow())
+    add_breadcrumb(level="info", message="i like bread", timestamp=datetime.now(timezone.utc))
     capture_message("löl")
 
     getattr(client, client_flush_method)()


### PR DESCRIPTION
Replacing `datetime.utcnow()` due to deprecation as discussed in #2407 