### PR TITLE
feat(metrics): Stronger recursion protection

### DIFF
--- a/sentry_sdk/metrics.py
+++ b/sentry_sdk/metrics.py
@@ -75,6 +75,7 @@ def metrics_noop(func):
     """Convenient decorator that uses `recursion_protection` to
     make a function a noop.
     """
+
     @wraps(func)
     def new_func(*args, **kwargs):
         # type: (*Any, **Any) -> Any

--- a/sentry_sdk/metrics.py
+++ b/sentry_sdk/metrics.py
@@ -7,6 +7,7 @@ import time
 import zlib
 from functools import wraps, partial
 from threading import Event, Lock, Thread
+from contextlib import contextmanager
 
 from sentry_sdk._compat import text_type
 from sentry_sdk.hub import Hub
@@ -53,21 +54,32 @@ GOOD_TRANSACTION_SOURCES = frozenset(
 )
 
 
+@contextmanager
+def recursion_protection():
+    """Enters recursion protection and returns the old flag."""
+    # type: () -> Iterable[bool]
+    try:
+        in_metrics = _thread_local.in_metrics
+    except AttributeError:
+        in_metrics = False
+    _thread_local.in_metrics = True
+    try:
+        yield in_metrics
+    finally:
+        _thread_local.in_metrics = in_metrics
+
+
 def metrics_noop(func):
+    """Convenient decorator that uses `recursion_protection` to
+    make a function a noop.
+    """
     # type: (Any) -> Any
     @wraps(func)
     def new_func(*args, **kwargs):
         # type: (*Any, **Any) -> Any
-        try:
-            in_metrics = _thread_local.in_metrics
-        except AttributeError:
-            in_metrics = False
-        _thread_local.in_metrics = True
-        try:
+        with recursion_protection() as in_metrics:
             if not in_metrics:
                 return func(*args, **kwargs)
-        finally:
-            _thread_local.in_metrics = in_metrics
 
     return new_func
 
@@ -449,7 +461,14 @@ class MetricsAggregator(object):
         encoded_metrics = _encode_metrics(flushable_buckets)
         metric_item = Item(payload=encoded_metrics, type="statsd")
         envelope = Envelope(items=[metric_item])
-        self._capture_func(envelope)
+
+        # A malfunctioning transport might create a forever loop of metric
+        # emission when it emits a metric in capture_envelope.  We still
+        # allow the capture to take place, but interior metric incr calls
+        # or similar will be disabled.
+        with recursion_protection():
+            self._capture_func(envelope)
+
         return envelope
 
     def _serialize_tags(
@@ -495,8 +514,10 @@ def _get_aggregator_and_update_tags(key, tags):
 
     callback = client.options.get("_experiments", {}).get("before_emit_metric")
     if callback is not None:
-        if not callback(key, updated_tags):
-            return None, updated_tags
+        with recursion_protection() as in_metrics:
+            if not in_metrics:
+                if not callback(key, updated_tags):
+                    return None, updated_tags
 
     return client.metrics_aggregator, updated_tags
 

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -515,6 +515,7 @@ def test_flush_recursion_protection(sentry_init, capture_envelopes, monkeypatch)
     test_client = Hub.current.client
 
     real_capture_envelope = test_client.transport.capture_envelope
+
     def bad_capture_envelope(*args, **kwargs):
         metrics.incr("bad-metric")
         return real_capture_envelope(*args, **kwargs)

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -418,6 +418,8 @@ def test_before_emit_metric(sentry_init, capture_envelopes):
             return False
         tags["extra"] = "foo"
         del tags["release"]
+        # this better be a noop!
+        metrics.incr("shitty-recursion")
         return True
 
     sentry_init(
@@ -501,3 +503,30 @@ def test_tag_serialization(sentry_init, capture_envelopes):
         "release": "fun-release",
         "environment": "not-fun-env",
     }
+
+
+def test_flush_recursion_protection(sentry_init, capture_envelopes, monkeypatch):
+    sentry_init(
+        release="fun-release",
+        environment="not-fun-env",
+        _experiments={"enable_metrics": True},
+    )
+    envelopes = capture_envelopes()
+    test_client = Hub.current.client
+
+    real_capture_envelope = test_client.transport.capture_envelope
+    def bad_capture_envelope(*args, **kwargs):
+        metrics.incr("bad-metric")
+        return real_capture_envelope(*args, **kwargs)
+    monkeypatch.setattr(test_client.transport, "capture_envelope", bad_capture_envelope)
+
+    metrics.incr("counter")
+
+    # flush twice to see the inner metric
+    Hub.current.flush()
+    Hub.current.flush()
+
+    (envelope,) = envelopes
+    m = parse_metrics(envelope.items[0].payload.get_bytes())
+    assert len(m) == 1
+    assert m[0][1] == "counter@none"

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -519,6 +519,7 @@ def test_flush_recursion_protection(sentry_init, capture_envelopes, monkeypatch)
     def bad_capture_envelope(*args, **kwargs):
         metrics.incr("bad-metric")
         return real_capture_envelope(*args, **kwargs)
+
     monkeypatch.setattr(test_client.transport, "capture_envelope", bad_capture_envelope)
 
     metrics.incr("counter")


### PR DESCRIPTION
This strengthens the recursion protection to cover two more cases:

* `before_emit_metric` in itself reporting a metric. This was previously not protected
* A transport emitting metrics. This is technically never a recursion case in the SDK, but it leads to a never ending stream of metrics

Refs https://github.com/getsentry/sentry/pull/57791