### PR TITLE
Capture multiple named groups again

### DIFF
--- a/sentry_sdk/integrations/django/transactions.py
+++ b/sentry_sdk/integrations/django/transactions.py
@@ -37,7 +37,7 @@ def get_regex(resolver_or_pattern):
 
 class RavenResolver(object):
     _optional_group_matcher = re.compile(r"\(\?\:([^\)]+)\)")
-    _named_group_matcher = re.compile(r"\(\?P<(\w+)>.*\)")
+    _named_group_matcher = re.compile(r"\(\?P<(\w+)>[^\)]+\)+")
     _non_named_group_matcher = re.compile(r"\([^\)]+\)")
     # [foo|bar|baz]
     _either_option_matcher = re.compile(r"\[([^\]]+)\|([^\]]+)\]")

--- a/tests/integrations/django/test_transactions.py
+++ b/tests/integrations/django/test_transactions.py
@@ -60,9 +60,9 @@ def test_legacy_resolver_included_match():
 def test_capture_multiple_named_groups():
     resolver = RavenResolver()
     result = resolver.resolve(
-        "/api/myproject/product/cb4ef1caf3554c34ae134f3c1b3d605f", example_url_conf
+        "/api/myproject/product/cb4ef1caf3554c34ae134f3c1b3d605f/", example_url_conf
     )
-    assert result == "/api/{project_id}/product/{pid}"
+    assert result == "/api/{project_id}/product/{pid}/"
 
 
 @pytest.mark.skipif(django.VERSION < (2, 0), reason="Requires Django > 2.0")
@@ -82,4 +82,4 @@ def test_legacy_resolver_newstyle_django20_urlconf_multiple_groups():
     url_conf = (path("api/v2/<int:project_id>/product/<int:pid>", lambda x: ""),)
     resolver = RavenResolver()
     result = resolver.resolve("/api/v2/1234/product/5689", url_conf)
-    assert result == "/api/v2/{project_id}/store/{pid}"
+    assert result == "/api/v2/{project_id}/product/{pid}"

--- a/tests/integrations/django/test_transactions.py
+++ b/tests/integrations/django/test_transactions.py
@@ -24,9 +24,6 @@ example_url_conf = (
     url(r"^api/(?P<version>(v1|v2))/author/$", lambda x: ""),
     url(r"^report/", lambda x: ""),
     url(r"^example/", include(included_url_conf)),
-    url(
-        r"^(?P<slug>[$\\-_.+!*(),\\w//]+)/$", lambda x: ""
-    ),  # example of complex regex from django-cms
 )
 
 
@@ -54,16 +51,6 @@ def test_legacy_resolver_included_match():
     resolver = RavenResolver()
     result = resolver.resolve("/example/foo/bar/baz", example_url_conf)
     assert result == "/example/foo/bar/{param}"
-
-
-def test_complex_regex_from_django_cms():
-    """
-    Reference: https://github.com/getsentry/sentry-python/issues/1527
-    """
-
-    resolver = RavenResolver()
-    result = resolver.resolve("/,/", example_url_conf)
-    assert result == "/{slug}/"
 
 
 @pytest.mark.skipif(django.VERSION < (2, 0), reason="Requires Django > 2.0")

--- a/tests/integrations/django/test_transactions.py
+++ b/tests/integrations/django/test_transactions.py
@@ -22,6 +22,10 @@ from sentry_sdk.integrations.django.transactions import RavenResolver
 example_url_conf = (
     url(r"^api/(?P<project_id>[\w_-]+)/store/$", lambda x: ""),
     url(r"^api/(?P<version>(v1|v2))/author/$", lambda x: ""),
+    url(
+        r"^api/(?P<project_id>[^\/]+)/product/(?P<pid>(?:\d+|[A-Fa-f0-9-]{32,36}))/$",
+        lambda x: "",
+    ),
     url(r"^report/", lambda x: ""),
     url(r"^example/", include(included_url_conf)),
 )
@@ -51,6 +55,14 @@ def test_legacy_resolver_included_match():
     resolver = RavenResolver()
     result = resolver.resolve("/example/foo/bar/baz", example_url_conf)
     assert result == "/example/foo/bar/{param}"
+
+
+def test_capture_multiple_named_groups():
+    resolver = RavenResolver()
+    result = resolver.resolve(
+        "/api/myproject/product/cb4ef1caf3554c34ae134f3c1b3d605f", example_url_conf
+    )
+    assert result == "/api/{project_id}/product/{pid}"
 
 
 @pytest.mark.skipif(django.VERSION < (2, 0), reason="Requires Django > 2.0")

--- a/tests/integrations/django/test_transactions.py
+++ b/tests/integrations/django/test_transactions.py
@@ -73,3 +73,13 @@ def test_legacy_resolver_newstyle_django20_urlconf():
     resolver = RavenResolver()
     result = resolver.resolve("/api/v2/1234/store/", url_conf)
     assert result == "/api/v2/{project_id}/store/"
+
+
+@pytest.mark.skipif(django.VERSION < (2, 0), reason="Requires Django > 2.0")
+def test_legacy_resolver_newstyle_django20_urlconf_multiple_groups():
+    from django.urls import path
+
+    url_conf = (path("api/v2/<int:project_id>/product/<int:pid>", lambda x: ""),)
+    resolver = RavenResolver()
+    result = resolver.resolve("/api/v2/1234/product/5689", url_conf)
+    assert result == "/api/v2/{project_id}/store/{pid}"


### PR DESCRIPTION
We implemented [support](https://github.com/getsentry/sentry-python/issues/1527) for more complex Django CMS URL patterns in https://github.com/getsentry/sentry-python/pull/1773, however this led to [a regression](https://github.com/getsentry/sentry-python/issues/2392) in how we capture multiple named groups in a URL pattern.

This PR reverts the Django CMS change and adds test cases that'll allow us to spot the regression should it happen again.

I'll include some rationale behind why I'm reverting the change vs. trying to make it work for both the Django CMS-style and multiple placeholder URL patterns in [the issue where we track this regression](https://github.com/getsentry/sentry-python/issues/2392).

Closes https://github.com/getsentry/sentry-python/issues/2392