### PR TITLE
Fix mypy errors

### DIFF
--- a/sentry_sdk/integrations/asyncpg.py
+++ b/sentry_sdk/integrations/asyncpg.py
@@ -12,7 +12,7 @@ from sentry_sdk.tracing_utils import record_sql_queries
 from sentry_sdk.utils import parse_version, capture_internal_exceptions
 
 try:
-    import asyncpg  # type: ignore[import]
+    import asyncpg  # type: ignore[import-not-found]
 
 except ImportError:
     raise DidNotEnable("asyncpg not installed.")

--- a/sentry_sdk/integrations/clickhouse_driver.py
+++ b/sentry_sdk/integrations/clickhouse_driver.py
@@ -30,7 +30,7 @@ else:
 
 
 try:
-    import clickhouse_driver  # type: ignore[import]
+    import clickhouse_driver  # type: ignore[import-not-found]
 
 except ImportError:
     raise DidNotEnable("clickhouse-driver not installed.")

--- a/sentry_sdk/integrations/gql.py
+++ b/sentry_sdk/integrations/gql.py
@@ -3,10 +3,10 @@ from sentry_sdk.hub import Hub, _should_send_default_pii
 from sentry_sdk.integrations import DidNotEnable, Integration
 
 try:
-    import gql  # type: ignore[import]
-    from graphql import print_ast, get_operation_ast, DocumentNode, VariableDefinitionNode  # type: ignore[import]
-    from gql.transport import Transport, AsyncTransport  # type: ignore[import]
-    from gql.transport.exceptions import TransportQueryError  # type: ignore[import]
+    import gql  # type: ignore[import-not-found]
+    from graphql import print_ast, get_operation_ast, DocumentNode, VariableDefinitionNode  # type: ignore[import-not-found]
+    from gql.transport import Transport, AsyncTransport  # type: ignore[import-not-found]
+    from gql.transport.exceptions import TransportQueryError  # type: ignore[import-not-found]
 except ImportError:
     raise DidNotEnable("gql is not installed")
 


### PR DESCRIPTION
mypy 1.6.0 came out yesterday and the lint step is now [failing on master](https://github.com/getsentry/sentry-python/actions/runs/6479197446/job/17592281998).