### PR TITLE
feat(api): Support capturing user feedback

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -12,6 +12,7 @@ Capturing Data
 .. autofunction:: sentry_sdk.api.capture_event
 .. autofunction:: sentry_sdk.api.capture_exception
 .. autofunction:: sentry_sdk.api.capture_message
+.. autofunction:: sentry_sdk.api.capture_user_feedback
 
 
 Enriching Events

--- a/sentry_sdk/__init__.py
+++ b/sentry_sdk/__init__.py
@@ -22,6 +22,7 @@ __all__ = [  # noqa
     "capture_event",
     "capture_message",
     "capture_exception",
+    "capture_user_feedback",
     "add_breadcrumb",
     "configure_scope",
     "push_scope",

--- a/sentry_sdk/_types.py
+++ b/sentry_sdk/_types.py
@@ -19,7 +19,7 @@ if TYPE_CHECKING:
     from typing import Tuple
     from typing import Type
     from typing import Union
-    from typing_extensions import Literal
+    from typing_extensions import Literal, TypedDict
 
     ExcInfo = Tuple[
         Optional[Type[BaseException]], Optional[BaseException], Optional[TracebackType]
@@ -54,6 +54,7 @@ if TYPE_CHECKING:
         "internal",
         "profile",
         "statsd",
+        "user_report",
     ]
     SessionStatus = Literal["ok", "exited", "crashed", "abnormal"]
     EndpointType = Literal["store", "envelope"]
@@ -116,3 +117,5 @@ if TYPE_CHECKING:
     FlushedMetricValue = Union[int, float]
 
     BucketKey = Tuple[MetricType, str, MeasurementUnit, MetricTagsInternal]
+
+    UserFeedback = TypedDict('UserFeedback', {"event_id": str, "email": str, "name": str, "comments": str})

--- a/sentry_sdk/api.py
+++ b/sentry_sdk/api.py
@@ -22,6 +22,7 @@ if TYPE_CHECKING:
         BreadcrumbHint,
         ExcInfo,
         MeasurementUnit,
+        UserFeedback,
     )
     from sentry_sdk.tracing import Span
 
@@ -39,6 +40,7 @@ __all__ = [
     "capture_event",
     "capture_message",
     "capture_exception",
+    "capture_user_feedback",
     "add_breadcrumb",
     "configure_scope",
     "push_scope",
@@ -107,6 +109,14 @@ def capture_exception(
 ):
     # type: (...) -> Optional[str]
     return Hub.current.capture_exception(error, scope=scope, **scope_args)
+
+
+@hubmethod
+def capture_user_feedback(
+    feedback  # type: UserFeedback
+):
+    # type: (...) -> None
+    return Hub.current.capture_user_feedback(feedback)
 
 
 @hubmethod

--- a/sentry_sdk/client.py
+++ b/sentry_sdk/client.py
@@ -44,7 +44,7 @@ if TYPE_CHECKING:
     from typing import Sequence
 
     from sentry_sdk.scope import Scope
-    from sentry_sdk._types import Event, Hint
+    from sentry_sdk._types import Event, Hint, UserFeedback
     from sentry_sdk.session import Session
 
 
@@ -632,6 +632,23 @@ class _Client(object):
             logger.info("Discarded session update because of missing release")
         else:
             self.session_flusher.add_session(session)
+
+    def capture_user_feedback(
+        self,
+        feedback,  # type: UserFeedback
+    ):
+        # type: (...) -> None
+        """Captures user feedback.
+
+        :param feedback: The user feedback to send to Sentry.
+        """
+        headers = {
+            "event_id": feedback["event_id"],
+            "sent_at": format_timestamp(datetime_utcnow()),
+        }
+        envelope = Envelope(headers=headers)
+        envelope.add_user_feedback(feedback)
+        self.transport.capture_envelope(envelope)
 
     def close(
         self,

--- a/sentry_sdk/envelope.py
+++ b/sentry_sdk/envelope.py
@@ -15,7 +15,7 @@ if TYPE_CHECKING:
     from typing import List
     from typing import Iterator
 
-    from sentry_sdk._types import Event, EventDataCategory
+    from sentry_sdk._types import Event, EventDataCategory, UserFeedback
 
 
 def parse_json(data):
@@ -93,6 +93,13 @@ class Envelope(object):
     ):
         # type: (...) -> None
         self.items.append(item)
+
+    def add_user_feedback(
+        self,
+        feedback,  # type: UserFeedback
+    ):
+        # type: (...) -> None
+        self.add_item(Item(payload=PayloadRef(json=feedback), type="user_report"))
 
     def get_event(self):
         # type: (...) -> Optional[Event]
@@ -258,6 +265,8 @@ class Item(object):
             return "error"
         elif ty == "client_report":
             return "internal"
+        elif ty == "user_report":
+            return "user_report"
         elif ty == "profile":
             return "profile"
         elif ty == "statsd":

--- a/sentry_sdk/hub.py
+++ b/sentry_sdk/hub.py
@@ -51,6 +51,7 @@ if TYPE_CHECKING:
         Breadcrumb,
         BreadcrumbHint,
         ExcInfo,
+        UserFeedback,
     )
     from sentry_sdk.consts import ClientConstructor
 
@@ -400,6 +401,21 @@ class Hub(with_metaclass(HubMeta)):  # type: ignore
             return self.capture_event(event, hint=hint, scope=scope, **scope_args)
         except Exception:
             self._capture_internal_exception(sys.exc_info())
+
+        return None
+
+    def capture_user_feedback(self, feedback):
+        # type: (UserFeedback) -> None
+        """
+        Captures user feedback.
+
+        :param feedback: The user feedback to send to Sentry.
+
+        Alias of :py:meth:`sentry_sdk.Client.capture_user_feedback`.
+        """
+        client, _ = self._stack[-1]
+        if client is not None:
+            client.capture_user_feedback(feedback)
 
         return None
 


### PR DESCRIPTION
This adds an API to the Sentry Python SDK that captures user feedback via envelope.

This is implemented very similiarly to how it is done for the JavaScript SDK, see https://github.com/getsentry/sentry-javascript/pull/7729.

Fixes GH-1064

Also see my comments at https://github.com/getsentry/sentry-python/issues/1064#issuecomment-1758485928

---

The usage is pretty much like it's [explained](https://docs.sentry.io/platforms/javascript/enriching-events/user-feedback/#user-feedback-api) for the JavaScript SDK.

Example usage:
```py
import sentry_sdk

test_event = sentry_sdk.capture_message("test_message")
assert test_event is not None

sentry_sdk.capture_user_feedback(
    {
        "event_id": test_event,  # or sentry_sdk.last_event_id()
        "name": "Tester",
        "email": "test@example.com",
        "comments": "Test comments",
    }
)

