### PR TITLE
Mitigate CPU spikes when sending lots of events with lots of data

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,7 +33,7 @@ Before you can contribute, you will need to [fork the `sentry-python` repository
 ### Create a Virtual Environment
 
 To keep your Python development environment and packages separate from the ones
-used by your operation system, create a virtual environment:
+used by your operation system, create a [virtual environment](https://docs.python.org/3/tutorial/venv.html):
 
 ```bash
 cd sentry-python

--- a/sentry_sdk/consts.py
+++ b/sentry_sdk/consts.py
@@ -43,6 +43,7 @@ if TYPE_CHECKING:
             "profiler_mode": Optional[ProfilerMode],
             "otel_powered_performance": Optional[bool],
             "transport_zlib_compression_level": Optional[int],
+            "transport_num_pools": Optional[int],
             "enable_metrics": Optional[bool],
             "before_emit_metric": Optional[Callable[[str, MetricTags], bool]],
         },

--- a/sentry_sdk/transport.py
+++ b/sentry_sdk/transport.py
@@ -263,8 +263,9 @@ class HttpTransport(Transport):
 
             elif response.status >= 300 or response.status < 200:
                 logger.error(
-                    "Unexpected status code: %s",
+                    "Unexpected status code: %s (body: %s)",
                     response.status,
+                    response.data,
                 )
                 self.on_dropped_event("status_{}".format(response.status))
                 record_loss("network_error")

--- a/sentry_sdk/transport.py
+++ b/sentry_sdk/transport.py
@@ -170,6 +170,9 @@ class HttpTransport(Transport):
         )
         self._compresslevel = 9 if compresslevel is None else int(compresslevel)
 
+        num_pools = options.get("_experiments", {}).get("transport_num_pools")
+        self._num_pools = 2 if num_pools is None else int(num_pools)
+
         from sentry_sdk import Hub
 
         self.hub_cls = Hub
@@ -439,7 +442,7 @@ class HttpTransport(Transport):
     def _get_pool_options(self, ca_certs):
         # type: (Optional[Any]) -> Dict[str, Any]
         return {
-            "num_pools": 10,
+            "num_pools": self._num_pools,
             "cert_reqs": "CERT_REQUIRED",
             "ca_certs": ca_certs or certifi.where(),
         }

--- a/sentry_sdk/transport.py
+++ b/sentry_sdk/transport.py
@@ -440,7 +440,7 @@ class HttpTransport(Transport):
     def _get_pool_options(self, ca_certs):
         # type: (Optional[Any]) -> Dict[str, Any]
         return {
-            "num_pools": 2,
+            "num_pools": 10,
             "cert_reqs": "CERT_REQUIRED",
             "ca_certs": ca_certs or certifi.where(),
         }

--- a/sentry_sdk/transport.py
+++ b/sentry_sdk/transport.py
@@ -157,14 +157,6 @@ class HttpTransport(Transport):
         )  # type: DefaultDict[Tuple[str, str], int]
         self._last_client_report_sent = time.time()
 
-        self._pool = self._make_pool(
-            self.parsed_dsn,
-            http_proxy=options["http_proxy"],
-            https_proxy=options["https_proxy"],
-            ca_certs=options["ca_certs"],
-            proxy_headers=options["proxy_headers"],
-        )
-
         compresslevel = options.get("_experiments", {}).get(
             "transport_zlib_compression_level"
         )
@@ -172,6 +164,14 @@ class HttpTransport(Transport):
 
         num_pools = options.get("_experiments", {}).get("transport_num_pools")
         self._num_pools = 2 if num_pools is None else int(num_pools)
+
+        self._pool = self._make_pool(
+            self.parsed_dsn,
+            http_proxy=options["http_proxy"],
+            https_proxy=options["https_proxy"],
+            ca_certs=options["ca_certs"],
+            proxy_headers=options["proxy_headers"],
+        )
 
         from sentry_sdk import Hub
 

--- a/sentry_sdk/transport.py
+++ b/sentry_sdk/transport.py
@@ -244,7 +244,9 @@ class HttpTransport(Transport):
                 str(self._auth.get_api_url(endpoint_type)),
                 body=body,
                 headers=headers,
+                preload_content=False,
             )
+            response.release_conn()
         except Exception:
             self.on_dropped_event("network")
             record_loss("network_error")
@@ -263,9 +265,8 @@ class HttpTransport(Transport):
 
             elif response.status >= 300 or response.status < 200:
                 logger.error(
-                    "Unexpected status code: %s (body: %s)",
+                    "Unexpected status code: %s",
                     response.status,
-                    response.data,
                 )
                 self.on_dropped_event("status_{}".format(response.status))
                 record_loss("network_error")

--- a/sentry_sdk/transport.py
+++ b/sentry_sdk/transport.py
@@ -244,9 +244,7 @@ class HttpTransport(Transport):
                 str(self._auth.get_api_url(endpoint_type)),
                 body=body,
                 headers=headers,
-                preload_content=False,
             )
-            response.release_conn()
         except Exception:
             self.on_dropped_event("network")
             record_loss("network_error")

--- a/tests/test_transport.py
+++ b/tests/test_transport.py
@@ -132,6 +132,25 @@ def test_transport_works(
     assert any("Sending event" in record.msg for record in caplog.records) == debug
 
 
+@pytest.mark.parametrize(
+    "num_pools,expected_num_pools",
+    (
+        (None, 2),
+        (2, 2),
+        (10, 10),
+    ),
+)
+def test_transport_num_pools(make_client, num_pools, expected_num_pools):
+    _experiments = {}
+    if num_pools is not None:
+        _experiments["transport_num_pools"] = num_pools
+
+    client = make_client(_experiments=_experiments)
+
+    options = client.transport._get_pool_options([])
+    assert options["num_pools"] == expected_num_pools
+
+
 def test_transport_infinite_loop(capturing_server, request, make_client):
     client = make_client(
         debug=True,


### PR DESCRIPTION
Increasing the HTTP pool size to better handle the requests. Also not reading the response saves some CPU cycles because TLS stuff uses CPU.

This does not fix all CPU spikes, but instead of spikes happening every 1 in 3-4 times it only happens 1 in 7-8 times with my test script. 

FIxes #2384 