### PR TITLE
Make `debug` option also configurable via environment

### DIFF
--- a/sentry_sdk/client.py
+++ b/sentry_sdk/client.py
@@ -109,6 +109,13 @@ def _get_options(*args, **kwargs):
     if rv["environment"] is None:
         rv["environment"] = os.environ.get("SENTRY_ENVIRONMENT") or "production"
 
+    if rv["debug"] is None:
+        rv["debug"] = os.environ.get("SENTRY_DEBUG", "False").lower() in (
+            "true",
+            "1",
+            "t",
+        )
+
     if rv["server_name"] is None and hasattr(socket, "gethostname"):
         rv["server_name"] = socket.gethostname()
 

--- a/sentry_sdk/consts.py
+++ b/sentry_sdk/consts.py
@@ -233,7 +233,7 @@ class ClientConstructor(object):
         max_request_body_size="medium",  # type: str
         before_send=None,  # type: Optional[EventProcessor]
         before_breadcrumb=None,  # type: Optional[BreadcrumbProcessor]
-        debug=False,  # type: bool
+        debug=None,  # type: Optional[bool]
         attach_stacktrace=False,  # type: bool
         ca_certs=None,  # type: Optional[str]
         propagate_traces=True,  # type: bool

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1136,3 +1136,66 @@ def test_max_value_length_option(
     capture_message("a" * 2000)
 
     assert len(events[0]["message"]) == expected_data_length
+
+
+@pytest.mark.parametrize(
+    "client_option,env_var_value,debug_output_expected",
+    [
+        (None, "", False),
+        (None, "t", True),
+        (None, "1", True),
+        (None, "True", True),
+        (None, "true", True),
+        (None, "f", False),
+        (None, "0", False),
+        (None, "False", False),
+        (None, "false", False),
+        (None, "xxx", False),
+        (True, "", True),
+        (True, "t", True),
+        (True, "1", True),
+        (True, "True", True),
+        (True, "true", True),
+        (True, "f", True),
+        (True, "0", True),
+        (True, "False", True),
+        (True, "false", True),
+        (True, "xxx", True),
+        (False, "", False),
+        (False, "t", False),
+        (False, "1", False),
+        (False, "True", False),
+        (False, "true", False),
+        (False, "f", False),
+        (False, "0", False),
+        (False, "False", False),
+        (False, "false", False),
+        (False, "xxx", False),
+    ],
+)
+@pytest.mark.tests_internal_exceptions
+def test_debug_option(
+    sentry_init,
+    monkeypatch,
+    caplog,
+    client_option,
+    env_var_value,
+    debug_output_expected,
+):
+    if env_var_value is None and "SENTRY_DEBUG" in os.environ:
+        monkeypatch.delenv("SENTRY_DEBUG")
+    else:
+        monkeypatch.setenv("SENTRY_DEBUG", env_var_value)
+
+    if client_option is None:
+        sentry_init()
+    else:
+        sentry_init(debug=client_option)
+
+    Hub.current._capture_internal_exception(
+        (ValueError, ValueError("something is wrong"), None)
+    )
+    if debug_output_expected:
+        assert "something is wrong" in caplog.text
+    else:
+        assert "something is wrong" not in caplog.text

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1182,10 +1182,7 @@ def test_debug_option(
     env_var_value,
     debug_output_expected,
 ):
-    if env_var_value is None and "SENTRY_DEBUG" in os.environ:
-        monkeypatch.delenv("SENTRY_DEBUG")
-    else:
-        monkeypatch.setenv("SENTRY_DEBUG", env_var_value)
+    monkeypatch.setenv("SENTRY_DEBUG", env_var_value)
 
     if client_option is None:
         sentry_init()


### PR DESCRIPTION
Introducing new `SENTRY_DEBUG` environment variable that can be used to set the `debug` option in `sentry_sdk.init()`.