### PR TITLE
Fix parsing of Django `path` patterns

### DIFF
--- a/sentry_sdk/integrations/django/__init__.py
+++ b/sentry_sdk/integrations/django/__init__.py
@@ -362,12 +362,13 @@ def _set_transaction_name_and_source(scope, transaction_style, request):
             transaction_name = transaction_from_function(getattr(fn, "view_class", fn))
 
         elif transaction_style == "url":
-            if hasattr(request, "urlconf"):
-                transaction_name = LEGACY_RESOLVER.resolve(
-                    request.path_info, urlconf=request.urlconf
-                )
-            else:
-                transaction_name = LEGACY_RESOLVER.resolve(request.path_info)
+            transaction_name = request.resolver_match.route
+            # if hasattr(request, "urlconf"):
+            #    transaction_name = LEGACY_RESOLVER.resolve(
+            #        request.path_info, urlconf=request.urlconf
+            #    )
+            # else:
+            #    transaction_name = LEGACY_RESOLVER.resolve(request.path_info)
 
         if transaction_name is None:
             transaction_name = request.path_info

--- a/sentry_sdk/integrations/django/__init__.py
+++ b/sentry_sdk/integrations/django/__init__.py
@@ -362,13 +362,12 @@ def _set_transaction_name_and_source(scope, transaction_style, request):
             transaction_name = transaction_from_function(getattr(fn, "view_class", fn))
 
         elif transaction_style == "url":
-            transaction_name = request.resolver_match.route
-            # if hasattr(request, "urlconf"):
-            #    transaction_name = LEGACY_RESOLVER.resolve(
-            #        request.path_info, urlconf=request.urlconf
-            #    )
-            # else:
-            #    transaction_name = LEGACY_RESOLVER.resolve(request.path_info)
+            if hasattr(request, "urlconf"):
+                transaction_name = LEGACY_RESOLVER.resolve(
+                    request.path_info, urlconf=request.urlconf
+                )
+            else:
+                transaction_name = LEGACY_RESOLVER.resolve(request.path_info)
 
         if transaction_name is None:
             transaction_name = request.path_info

--- a/sentry_sdk/integrations/django/transactions.py
+++ b/sentry_sdk/integrations/django/transactions.py
@@ -70,7 +70,11 @@ class RavenResolver(object):
         """
         # "new-style" path patterns can be parsed directly without turning them
         # into regexes first
-        if RoutePattern is not None and isinstance(pattern.pattern, RoutePattern):
+        if (
+            RoutePattern is not None
+            and hasattr(pattern, "pattern")
+            and isinstance(pattern.pattern, RoutePattern)
+        ):
             return self._new_style_group_matcher.sub(
                 lambda m: "{%s}" % m.group(2), pattern.pattern._route
             )

--- a/sentry_sdk/integrations/django/transactions.py
+++ b/sentry_sdk/integrations/django/transactions.py
@@ -63,9 +63,6 @@ class RavenResolver(object):
         To:
         > "{sport_slug}/athletes/{athlete_slug}/"
         """
-        # remove optional params
-        # TODO(dcramer): it'd be nice to change these into [%s] but it currently
-        # conflicts with the other rules because we're doing regexp matches
 
         if DJANGO_VERSION >= (2, 0):
             from django.urls.resolvers import RoutePattern
@@ -77,6 +74,9 @@ class RavenResolver(object):
 
         result = get_regex(pattern).pattern
 
+        # remove optional params
+        # TODO(dcramer): it'd be nice to change these into [%s] but it currently
+        # conflicts with the other rules because we're doing regexp matches
         # rather than parsing tokens
         result = self._optional_group_matcher.sub(lambda m: "%s" % m.group(1), result)
 

--- a/sentry_sdk/integrations/django/transactions.py
+++ b/sentry_sdk/integrations/django/transactions.py
@@ -23,6 +23,11 @@ if TYPE_CHECKING:
 
 from django import VERSION as DJANGO_VERSION
 
+if DJANGO_VERSION >= (2, 0):
+    from django.urls.resolvers import RoutePattern
+else:
+    RoutePattern = None
+
 try:
     from django.urls import get_resolver
 except ImportError:
@@ -65,13 +70,10 @@ class RavenResolver(object):
         """
         # "new-style" path patterns can be parsed directly without turning them
         # into regexes first
-        if DJANGO_VERSION >= (2, 0):
-            from django.urls.resolvers import RoutePattern
-
-            if isinstance(pattern.pattern, RoutePattern):
-                return self._new_style_group_matcher.sub(
-                    lambda m: "{%s}" % m.group(2), pattern.pattern._route
-                )
+        if RoutePattern is not None and isinstance(pattern.pattern, RoutePattern):
+            return self._new_style_group_matcher.sub(
+                lambda m: "{%s}" % m.group(2), pattern.pattern._route
+            )
 
         result = get_regex(pattern).pattern
 

--- a/sentry_sdk/integrations/django/transactions.py
+++ b/sentry_sdk/integrations/django/transactions.py
@@ -12,13 +12,14 @@ import re
 from sentry_sdk._types import TYPE_CHECKING
 
 if TYPE_CHECKING:
+    from django.urls.resolvers import URLResolver
     from typing import Dict
     from typing import List
     from typing import Optional
+    from django.urls.resolvers import URLPattern
     from typing import Tuple
     from typing import Union
     from re import Pattern
-    from django.urls.resolvers import URLPattern, URLResolver
 
 from django import VERSION as DJANGO_VERSION
 

--- a/sentry_sdk/integrations/django/transactions.py
+++ b/sentry_sdk/integrations/django/transactions.py
@@ -63,7 +63,8 @@ class RavenResolver(object):
         To:
         > "{sport_slug}/athletes/{athlete_slug}/"
         """
-
+        # "new-style" path patterns can be parsed directly without turning them
+        # into regexes first
         if DJANGO_VERSION >= (2, 0):
             from django.urls.resolvers import RoutePattern
 

--- a/sentry_sdk/integrations/django/transactions.py
+++ b/sentry_sdk/integrations/django/transactions.py
@@ -57,7 +57,7 @@ class RavenResolver(object):
     _cache = {}  # type: Dict[URLPattern, str]
 
     def _simplify(self, pattern):
-        # type: (str) -> str
+        # type: (Union[URLPattern, URLResolver]) -> str
         r"""
         Clean up urlpattern regexes into something readable by humans:
 

--- a/sentry_sdk/integrations/django/transactions.py
+++ b/sentry_sdk/integrations/django/transactions.py
@@ -73,11 +73,11 @@ class RavenResolver(object):
         # conflicts with the other rules because we're doing regexp matches
 
         if DJANGO_VERSION >= (2, 0) and isinstance(pattern.pattern, RoutePattern):
-            result = self._new_style_group_matcher.sub(
+            return self._new_style_group_matcher.sub(
                 lambda m: "{%s}" % m.group(2), pattern.pattern._route
             )
-        else:
-            result = get_regex(pattern).pattern
+
+        result = get_regex(pattern).pattern
 
         # rather than parsing tokens
         result = self._optional_group_matcher.sub(lambda m: "%s" % m.group(1), result)

--- a/sentry_sdk/integrations/django/transactions.py
+++ b/sentry_sdk/integrations/django/transactions.py
@@ -28,11 +28,6 @@ try:
 except ImportError:
     from django.core.urlresolvers import get_resolver
 
-try:
-    from django.urls.resolvers import RoutePattern
-except ImportError:
-    RoutePattern = type(None)
-
 
 def get_regex(resolver_or_pattern):
     # type: (Union[URLPattern, URLResolver]) -> Pattern[str]
@@ -72,10 +67,13 @@ class RavenResolver(object):
         # TODO(dcramer): it'd be nice to change these into [%s] but it currently
         # conflicts with the other rules because we're doing regexp matches
 
-        if DJANGO_VERSION >= (2, 0) and isinstance(pattern.pattern, RoutePattern):
-            return self._new_style_group_matcher.sub(
-                lambda m: "{%s}" % m.group(2), pattern.pattern._route
-            )
+        if DJANGO_VERSION >= (2, 0):
+            from django.urls.resolvers import RoutePattern
+
+            if isinstance(pattern.pattern, RoutePattern):
+                return self._new_style_group_matcher.sub(
+                    lambda m: "{%s}" % m.group(2), pattern.pattern._route
+                )
 
         result = get_regex(pattern).pattern
 

--- a/tests/integrations/django/test_transactions.py
+++ b/tests/integrations/django/test_transactions.py
@@ -10,11 +10,9 @@ from werkzeug.test import Client
 if django.VERSION >= (2, 0):
     from django.urls import path, re_path
     from django.conf.urls import include
-    from django.urls.converters import PathConverter
 else:
     from django.conf.urls import url as re_path, include
 
-from sentry_sdk.integrations.django import DjangoIntegration
 from sentry_sdk.integrations.django.transactions import RavenResolver
 from tests.integrations.django.myapp.wsgi import application
 
@@ -47,13 +45,13 @@ def test_resolver_no_match():
     assert result is None
 
 
-def test_resolver_complex_match():
+def test_resolver_re_path_complex_match():
     resolver = RavenResolver()
     result = resolver.resolve("/api/1234/store/", example_url_conf)
     assert result == "/api/{project_id}/store/"
 
 
-def test_resolver_complex_either_match():
+def test_resolver_re_path_complex_either_match():
     resolver = RavenResolver()
     result = resolver.resolve("/api/v1/author/", example_url_conf)
     assert result == "/api/{version}/author/"
@@ -61,13 +59,13 @@ def test_resolver_complex_either_match():
     assert result == "/api/{version}/author/"
 
 
-def test_resolver_included_match():
+def test_resolver_re_path_included_match():
     resolver = RavenResolver()
     result = resolver.resolve("/example/foo/bar/baz", example_url_conf)
     assert result == "/example/foo/bar/{param}"
 
 
-def test_resolver_multiple_groups():
+def test_resolver_re_path_multiple_groups():
     resolver = RavenResolver()
     result = resolver.resolve(
         "/api/myproject/product/cb4ef1caf3554c34ae134f3c1b3d605f/", example_url_conf
@@ -76,7 +74,7 @@ def test_resolver_multiple_groups():
 
 
 @pytest.mark.skipif(django.VERSION < (2, 0), reason="Requires Django > 2.0")
-def test_resolver_new_style_group():
+def test_resolver_path_group():
     url_conf = (path("api/v2/<int:project_id>/store/", lambda x: ""),)
     resolver = RavenResolver()
     result = resolver.resolve("/api/v2/1234/store/", url_conf)
@@ -84,7 +82,7 @@ def test_resolver_new_style_group():
 
 
 @pytest.mark.skipif(django.VERSION < (2, 0), reason="Requires Django > 2.0")
-def test_resolver_new_style_multiple_groups():
+def test_resolver_path_multiple_groups():
     url_conf = (path("api/v2/<int:project_id>/product/<int:pid>", lambda x: ""),)
     resolver = RavenResolver()
     result = resolver.resolve("/api/v2/1234/product/5689", url_conf)

--- a/tests/integrations/django/test_transactions.py
+++ b/tests/integrations/django/test_transactions.py
@@ -115,3 +115,14 @@ def test_resolver_path_complex_path():
         resolver = RavenResolver()
         result = resolver.resolve("/api/v3/abc/def/ghi", url_conf)
         assert result == "/api/v3/{custom_path}"
+
+
+@pytest.mark.skipif(
+    django.VERSION < (2, 0),
+    reason="Django>=2.0 required for <converter:parameter> patterns",
+)
+def test_resolver_path_no_converter():
+    url_conf = (path("api/v4/<project_id>", lambda x: ""),)
+    resolver = RavenResolver()
+    result = resolver.resolve("/api/v4/myproject", url_conf)
+    assert result == "/api/v4/{project_id}"

--- a/tests/integrations/django/test_transactions.py
+++ b/tests/integrations/django/test_transactions.py
@@ -2,48 +2,58 @@ from __future__ import absolute_import
 
 import pytest
 import django
+from werkzeug.test import Client
 
+# django<2.0 had only `url` with regex based patterns.
+# django>=2.0 renamed `url` to `re_path`, and additionally introduced `path`
+# for new style URL patterns, e.g. <article_id:int>.
 if django.VERSION >= (2, 0):
-    # TODO: once we stop supporting django < 2, use the real name of this
-    # function (re_path)
-    from django.urls import re_path as url
+    from django.urls import path, re_path
     from django.conf.urls import include
+    from django.urls.converters import PathConverter
 else:
-    from django.conf.urls import url, include
+    from django.conf.urls import url as re_path, include
+
+from sentry_sdk.integrations.django import DjangoIntegration
+from sentry_sdk.integrations.django.transactions import RavenResolver
+from tests.integrations.django.myapp.wsgi import application
+
+
+@pytest.fixture
+def client():
+    return Client(application)
+
 
 if django.VERSION < (1, 9):
-    included_url_conf = (url(r"^foo/bar/(?P<param>[\w]+)", lambda x: ""),), "", ""
+    included_url_conf = (re_path(r"^foo/bar/(?P<param>[\w]+)", lambda x: ""),), "", ""
 else:
-    included_url_conf = ((url(r"^foo/bar/(?P<param>[\w]+)", lambda x: ""),), "")
-
-from sentry_sdk.integrations.django.transactions import RavenResolver
-
+    included_url_conf = ((re_path(r"^foo/bar/(?P<param>[\w]+)", lambda x: ""),), "")
 
 example_url_conf = (
-    url(r"^api/(?P<project_id>[\w_-]+)/store/$", lambda x: ""),
-    url(r"^api/(?P<version>(v1|v2))/author/$", lambda x: ""),
-    url(
+    re_path(r"^api/(?P<project_id>[\w_-]+)/store/$", lambda x: ""),
+    re_path(r"^api/(?P<version>(v1|v2))/author/$", lambda x: ""),
+    re_path(
         r"^api/(?P<project_id>[^\/]+)/product/(?P<pid>(?:\d+|[A-Fa-f0-9-]{32,36}))/$",
         lambda x: "",
     ),
-    url(r"^report/", lambda x: ""),
-    url(r"^example/", include(included_url_conf)),
+    re_path(r"^report/", lambda x: ""),
+    re_path(r"^example/", include(included_url_conf)),
 )
 
 
-def test_legacy_resolver_no_match():
+def test_resolver_no_match():
     resolver = RavenResolver()
     result = resolver.resolve("/foo/bar", example_url_conf)
     assert result is None
 
 
-def test_legacy_resolver_complex_match():
+def test_resolver_complex_match():
     resolver = RavenResolver()
     result = resolver.resolve("/api/1234/store/", example_url_conf)
     assert result == "/api/{project_id}/store/"
 
 
-def test_legacy_resolver_complex_either_match():
+def test_resolver_complex_either_match():
     resolver = RavenResolver()
     result = resolver.resolve("/api/v1/author/", example_url_conf)
     assert result == "/api/{version}/author/"
@@ -51,13 +61,13 @@ def test_legacy_resolver_complex_either_match():
     assert result == "/api/{version}/author/"
 
 
-def test_legacy_resolver_included_match():
+def test_resolver_included_match():
     resolver = RavenResolver()
     result = resolver.resolve("/example/foo/bar/baz", example_url_conf)
     assert result == "/example/foo/bar/{param}"
 
 
-def test_capture_multiple_named_groups():
+def test_resolver_multiple_groups():
     resolver = RavenResolver()
     result = resolver.resolve(
         "/api/myproject/product/cb4ef1caf3554c34ae134f3c1b3d605f/", example_url_conf
@@ -66,9 +76,7 @@ def test_capture_multiple_named_groups():
 
 
 @pytest.mark.skipif(django.VERSION < (2, 0), reason="Requires Django > 2.0")
-def test_legacy_resolver_newstyle_django20_urlconf():
-    from django.urls import path
-
+def test_resolver_new_style_group():
     url_conf = (path("api/v2/<int:project_id>/store/", lambda x: ""),)
     resolver = RavenResolver()
     result = resolver.resolve("/api/v2/1234/store/", url_conf)
@@ -76,9 +84,7 @@ def test_legacy_resolver_newstyle_django20_urlconf():
 
 
 @pytest.mark.skipif(django.VERSION < (2, 0), reason="Requires Django > 2.0")
-def test_legacy_resolver_newstyle_django20_urlconf_multiple_groups():
-    from django.urls import path
-
+def test_resolver_new_style_multiple_groups():
     url_conf = (path("api/v2/<int:project_id>/product/<int:pid>", lambda x: ""),)
     resolver = RavenResolver()
     result = resolver.resolve("/api/v2/1234/product/5689", url_conf)

--- a/tests/integrations/django/test_transactions.py
+++ b/tests/integrations/django/test_transactions.py
@@ -19,13 +19,13 @@ if django.VERSION >= (2, 0):
 else:
     from django.conf.urls import url as re_path, include
 
-from sentry_sdk.integrations.django.transactions import RavenResolver
-
-
 if django.VERSION < (1, 9):
     included_url_conf = (re_path(r"^foo/bar/(?P<param>[\w]+)", lambda x: ""),), "", ""
 else:
     included_url_conf = ((re_path(r"^foo/bar/(?P<param>[\w]+)", lambda x: ""),), "")
+
+from sentry_sdk.integrations.django.transactions import RavenResolver
+
 
 example_url_conf = (
     re_path(r"^api/(?P<project_id>[\w_-]+)/store/$", lambda x: ""),


### PR DESCRIPTION
TL;DR: Our way of [parsing](https://github.com/getsentry/sentry-python/blob/085595b5f02931a3268c2de2a58b6986f3766d75/sentry_sdk/integrations/django/transactions.py#L48) named group regexes out of Django URL patterns is [not ideal](https://github.com/getsentry/sentry-python/issues/2392#issuecomment-1755797139). If someone is using (Django 2.0+) `<converter:parameter>` `path` patterns, we can parse those directly without turning them into regexes first and potentially hitting our limitations there.

### Background

When instrumenting Django for performance monitoring, the Sentry Python SDK will by default name the transactions based on the URL pattern rule that was used to serve the request.

There are two main ways of creating a URL pattern in Django: by using regexes in the rule directly, or (since Django 2.0) by using the custom `<converter:parameter>` syntax, like so:

```python
urlpatterns = [
    path('articles/<int:year>/<int:month>/', views.month_archive),
]
```

These `<converter:parameter>` style patterns are also regexes in the background. Each of the converters defines its own regex (see e.g. the [IntConverter](https://github.com/django/django/blob/7bb741d787ba360a9f0d490db92e22e0d28204ed/django/urls/converters.py#L5-L12)) that is then used for matching URLs to the patterns.

The SDK is [parsing](https://github.com/getsentry/sentry-python/blob/085595b5f02931a3268c2de2a58b6986f3766d75/sentry_sdk/integrations/django/transactions.py#L48) both types of patterns with the aim of replacing all named groups with placeholders, so that e.g. the URL pattern above creates transactions with the name `articles/{year}/{month}`. To do this, the URL pattern is first turned into its regex form and then parsed with the RavenResolver.

This is not a problem with the default set of converters Django offers, but if folks define [their own custom converters](https://github.com/getsentry/sentry-python/issues/2446) whose regexes don't play nice with our RavenResolver, we fail to extract the transaction name correctly. This can be prevented by parsing the original, simpler URL pattern instead without turning it into its regex form.

Note that this doesn't solve all transaction name problems as `re_path`s are still vulnerable, but it should make new-style `path`s work.


Closes https://github.com/getsentry/sentry-python/issues/2446