### PR TITLE
Update compatible runtimes for AWS Lambda layer

### DIFF
--- a/.craft.yml
+++ b/.craft.yml
@@ -22,6 +22,8 @@ targets:
           - python3.7
           - python3.8
           - python3.9
+          - python3.10
+          - python3.11
     license: MIT
   - name: sentry-pypi
     internalPypiRepo: getsentry/pypi

--- a/.craft.yml
+++ b/.craft.yml
@@ -18,9 +18,6 @@ targets:
           # On the other hand, AWS Lambda does not support every Python runtime.
           # The supported runtimes are available in the following link:
           # https://docs.aws.amazon.com/lambda/latest/dg/lambda-python.html
-          - python3.6
-          - python3.7
-          - python3.8
           - python3.9
           - python3.10
           - python3.11

--- a/.craft.yml
+++ b/.craft.yml
@@ -14,7 +14,7 @@ targets:
       - name: python
         versions:
           # The number of versions must be, at most, the maximum number of
-          # runtimes AWS Lambda permits for a layer.
+          # runtimes AWS Lambda permits for a layer (currently 15).
           # On the other hand, AWS Lambda does not support every Python runtime.
           # The supported runtimes are available in the following link:
           # https://docs.aws.amazon.com/lambda/latest/dg/lambda-python.html


### PR DESCRIPTION
Set the compatible runtimes in the Sentry AWS Lambda Layer to also include Python 3.10 and 3.11.

Related PRs in `sentry`:
* https://github.com/getsentry/sentry/pull/58321
* https://github.com/getsentry/sentry/pull/58320

Related docs update:
* https://github.com/getsentry/sentry-docs/pull/8246

Merge this, before merging the PRs in `sentry`.