### PR TITLE
feat(api): Added `error_sampler` option

### DIFF
--- a/sentry_sdk/client.py
+++ b/sentry_sdk/client.py
@@ -465,7 +465,23 @@ class _Client(object):
         else:
             sample_rate = self.options["sample_rate"]
 
-        not_in_sample_rate = sample_rate < 1.0 and random.random() >= sample_rate
+        try:
+            not_in_sample_rate = sample_rate < 1.0 and random.random() >= sample_rate
+        except TypeError:
+            parameter, verb = (
+                ("events_sampler", "returned")
+                if callable(sampler)
+                else ("sample_rate", "contains")
+            )
+            logger.warning(
+                "The provided %s %s an invalid value. The value should be a float or a bool. Defaulting to sampling the event."
+                % (parameter, verb)
+            )
+
+            # If the sample_rate has an invalid value, we should sample the event, since the default behavior
+            # (when no sample_rate or events_sampler is provided) is to sample all events.
+            not_in_sample_rate = False
+
         if not_in_sample_rate:
             # because we will not sample this event, record a "lost event".
             if self.transport:

--- a/sentry_sdk/client.py
+++ b/sentry_sdk/client.py
@@ -457,7 +457,7 @@ class _Client(object):
         hint,  # type: Hint
     ):
         # type: (...) -> bool
-        sampler = self.options.get("events_sampler", None)
+        sampler = self.options.get("error_sampler", None)
 
         if callable(sampler):
             with capture_internal_exceptions():
@@ -469,7 +469,7 @@ class _Client(object):
             not_in_sample_rate = sample_rate < 1.0 and random.random() >= sample_rate
         except TypeError:
             parameter, verb = (
-                ("events_sampler", "returned")
+                ("error_sampler", "returned")
                 if callable(sampler)
                 else ("sample_rate", "contains")
             )
@@ -479,7 +479,7 @@ class _Client(object):
             )
 
             # If the sample_rate has an invalid value, we should sample the event, since the default behavior
-            # (when no sample_rate or events_sampler is provided) is to sample all events.
+            # (when no sample_rate or error_sampler is provided) is to sample all events.
             not_in_sample_rate = False
 
         if not_in_sample_rate:

--- a/sentry_sdk/client.py
+++ b/sentry_sdk/client.py
@@ -456,10 +456,11 @@ class _Client(object):
         event,  # type: Event
     ):
         # type: (...) -> bool
-        not_in_sample_rate = (
-            self.options["sample_rate"] < 1.0
-            and random.random() >= self.options["sample_rate"]
-        )
+        try:
+            sample_rate = self.options["issues_sampler"](event)
+        except (KeyError, TypeError):
+            sample_rate = self.options["sample_rate"]
+        not_in_sample_rate = sample_rate < 1.0 and random.random() >= sample_rate
         if not_in_sample_rate:
             # because we will not sample this event, record a "lost event".
             if self.transport:

--- a/sentry_sdk/client.py
+++ b/sentry_sdk/client.py
@@ -474,8 +474,8 @@ class _Client(object):
                 else ("sample_rate", "contains")
             )
             logger.warning(
-                "The provided %s %s an invalid value. The value should be a float or a bool. Defaulting to sampling the event."
-                % (parameter, verb)
+                "The provided %s %s an invalid value of %s. The value should be a float or a bool. Defaulting to sampling the event."
+                % (parameter, verb, repr(sample_rate))
             )
 
             # If the sample_rate has an invalid value, we should sample the event, since the default behavior

--- a/sentry_sdk/client.py
+++ b/sentry_sdk/client.py
@@ -457,7 +457,7 @@ class _Client(object):
         hint,  # type: Hint
     ):
         # type: (...) -> bool
-        sampler = self.options.get("issues_sampler", None)
+        sampler = self.options.get("events_sampler", None)
 
         if callable(sampler):
             with capture_internal_exceptions():

--- a/sentry_sdk/consts.py
+++ b/sentry_sdk/consts.py
@@ -262,7 +262,7 @@ class ClientConstructor(object):
         event_scrubber=None,  # type: Optional[sentry_sdk.scrubber.EventScrubber]
         max_value_length=DEFAULT_MAX_VALUE_LENGTH,  # type: int
         enable_backpressure_handling=True,  # type: bool
-        events_sampler=None,  # type: Optional[Callable[[Event, Hint], Union[float, bool]]]
+        error_sampler=None,  # type: Optional[Callable[[Event, Hint], Union[float, bool]]]
     ):
         # type: (...) -> None
         pass

--- a/sentry_sdk/consts.py
+++ b/sentry_sdk/consts.py
@@ -261,6 +261,7 @@ class ClientConstructor(object):
         event_scrubber=None,  # type: Optional[sentry_sdk.scrubber.EventScrubber]
         max_value_length=DEFAULT_MAX_VALUE_LENGTH,  # type: int
         enable_backpressure_handling=True,  # type: bool
+        issues_sampler=None,  # type: Optional[Callable[[Event], Union[float, bool]]]
     ):
         # type: (...) -> None
         pass

--- a/sentry_sdk/consts.py
+++ b/sentry_sdk/consts.py
@@ -262,7 +262,7 @@ class ClientConstructor(object):
         event_scrubber=None,  # type: Optional[sentry_sdk.scrubber.EventScrubber]
         max_value_length=DEFAULT_MAX_VALUE_LENGTH,  # type: int
         enable_backpressure_handling=True,  # type: bool
-        issues_sampler=None,  # type: Optional[Callable[[Event, Hint], Union[float, bool]]]
+        events_sampler=None,  # type: Optional[Callable[[Event, Hint], Union[float, bool]]]
     ):
         # type: (...) -> None
         pass

--- a/sentry_sdk/consts.py
+++ b/sentry_sdk/consts.py
@@ -22,6 +22,7 @@ if TYPE_CHECKING:
         BreadcrumbProcessor,
         Event,
         EventProcessor,
+        Hint,
         ProfilerMode,
         TracesSampler,
         TransactionProcessor,
@@ -261,7 +262,7 @@ class ClientConstructor(object):
         event_scrubber=None,  # type: Optional[sentry_sdk.scrubber.EventScrubber]
         max_value_length=DEFAULT_MAX_VALUE_LENGTH,  # type: int
         enable_backpressure_handling=True,  # type: bool
-        issues_sampler=None,  # type: Optional[Callable[[Event], Union[float, bool]]]
+        issues_sampler=None,  # type: Optional[Callable[[Event, Hint], Union[float, bool]]]
     ):
         # type: (...) -> None
         pass

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1225,7 +1225,7 @@ class IssuesSamplerTestConfig:
     def init_sdk(self, sentry_init):
         # type: (Callable[[*Any], None]) -> None
         sentry_init(
-            events_sampler=self.sampler_function_mock, sample_rate=self.sample_rate
+            error_sampler=self.sampler_function_mock, sample_rate=self.sample_rate
         )
 
     def raise_exception(self):
@@ -1237,7 +1237,7 @@ class IssuesSamplerTestConfig:
 @pytest.mark.parametrize(
     "test_config",
     (
-        # Baseline test with events_sampler only, both floats and bools
+        # Baseline test with error_sampler only, both floats and bools
         IssuesSamplerTestConfig(sampler_function=lambda *_: 1.0, expected_events=1),
         IssuesSamplerTestConfig(sampler_function=lambda *_: 0.7, expected_events=1),
         IssuesSamplerTestConfig(sampler_function=lambda *_: 0.6, expected_events=0),
@@ -1249,7 +1249,7 @@ class IssuesSamplerTestConfig:
         IssuesSamplerTestConfig(sample_rate=0.7, expected_events=1),
         IssuesSamplerTestConfig(sample_rate=0.6, expected_events=0),
         IssuesSamplerTestConfig(sample_rate=0.0, expected_events=0),
-        # events_sampler takes precedence over sample_rate
+        # error_sampler takes precedence over sample_rate
         IssuesSamplerTestConfig(
             sampler_function=lambda *_: 1.0, sample_rate=0.0, expected_events=1
         ),
@@ -1296,7 +1296,7 @@ class IssuesSamplerTestConfig:
         ),
     ),
 )
-def test_events_sampler(_, sentry_init, capture_events, test_config):
+def test_error_sampler(_, sentry_init, capture_events, test_config):
     test_config.init_sdk(sentry_init)
 
     events = capture_events()

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1287,12 +1287,8 @@ def test_issues_sampler(_, sentry_init, capture_events, test_config):
 
     assert len(events) == test_config.expected_events
 
-    try:
+    if test_config.sampler_function_mock is not None:
         assert test_config.sampler_function_mock.call_count == 1
 
         # Ensure one argument (the event) was passed to the sampler function
         assert len(test_config.sampler_function_mock.call_args[0]) == 1
-    except AttributeError:
-        # sampler_function_mock should be None in this case,
-        # but let's double-check to ensure the test is working correctly
-        assert test_config.sampler_function_mock is None

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1289,6 +1289,11 @@ class IssuesSamplerTestConfig:
             exception_to_raise=AttributeError,
             expected_events=0,
         ),
+        # If sampler returns invalid value, we should still send the event
+        IssuesSamplerTestConfig(
+            sampler_function=lambda *_: "This is an invalid return value for the sampler",
+            expected_events=1,
+        ),
     ),
 )
 def test_events_sampler(_, sentry_init, capture_events, test_config):

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1225,7 +1225,7 @@ class IssuesSamplerTestConfig:
     def init_sdk(self, sentry_init):
         # type: (Callable[[*Any], None]) -> None
         sentry_init(
-            issues_sampler=self.sampler_function_mock, sample_rate=self.sample_rate
+            events_sampler=self.sampler_function_mock, sample_rate=self.sample_rate
         )
 
     def raise_exception(self):
@@ -1237,7 +1237,7 @@ class IssuesSamplerTestConfig:
 @pytest.mark.parametrize(
     "test_config",
     (
-        # Baseline test with issues_sampler only, both floats and bools
+        # Baseline test with events_sampler only, both floats and bools
         IssuesSamplerTestConfig(sampler_function=lambda *_: 1.0, expected_events=1),
         IssuesSamplerTestConfig(sampler_function=lambda *_: 0.7, expected_events=1),
         IssuesSamplerTestConfig(sampler_function=lambda *_: 0.6, expected_events=0),
@@ -1249,7 +1249,7 @@ class IssuesSamplerTestConfig:
         IssuesSamplerTestConfig(sample_rate=0.7, expected_events=1),
         IssuesSamplerTestConfig(sample_rate=0.6, expected_events=0),
         IssuesSamplerTestConfig(sample_rate=0.0, expected_events=0),
-        # issues_sampler takes precedence over sample_rate
+        # events_sampler takes precedence over sample_rate
         IssuesSamplerTestConfig(
             sampler_function=lambda *_: 1.0, sample_rate=0.0, expected_events=1
         ),
@@ -1291,7 +1291,7 @@ class IssuesSamplerTestConfig:
         ),
     ),
 )
-def test_issues_sampler(_, sentry_init, capture_events, test_config):
+def test_events_sampler(_, sentry_init, capture_events, test_config):
     test_config.init_sdk(sentry_init)
 
     events = capture_events()

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1230,5 +1230,10 @@ def test_issues_sampler(
 
     try:
         sampler_function_mock.assert_called_once()
+
+        # Ensure one argument (the event) was passed to the sampler function
+        assert len(sampler_function_mock.call_args[0]) == 1
     except AttributeError:
-        ...  # sampler_function_mock is None
+        # sampler_function_mock should be None in this case,
+        # but let's double-check to ensure the test is working correctly
+        assert sampler_function_mock is None


### PR DESCRIPTION
Now, it is possible for Python SDK users to dynamically sample errors using the `error_sampler` option, similar how they are able to sample transactions dynamically with the `traces_sampler` option.

In other words, the new `error_sampler` is to the `sample_rate` as the existing `traces_sampler` is to the `traces_sample_rate`.

Fixes #2440 