### PR TITLE
Handle failure during thread creation

### DIFF
--- a/sentry_sdk/metrics.py
+++ b/sentry_sdk/metrics.py
@@ -348,7 +348,7 @@ class MetricsAggregator(object):
             try:
                 self._flusher.start()
             except RuntimeError:
-                # Unfortunately at this point the interpreter is in a start that no
+                # Unfortunately at this point the interpreter is in a state that no
                 # longer allows us to spawn a thread and we have to bail.
                 self._running = False
                 return False

--- a/sentry_sdk/monitor.py
+++ b/sentry_sdk/monitor.py
@@ -53,7 +53,14 @@ class Monitor(object):
 
             thread = Thread(name=self.name, target=_thread)
             thread.daemon = True
-            thread.start()
+            try:
+                thread.start()
+            except RuntimeError:
+                # Unfortunately at this point the interpreter is in a state that no
+                # longer allows us to spawn a thread and we have to bail.
+                self._running = False
+                return None
+
             self._thread = thread
             self._thread_for_pid = os.getpid()
 

--- a/sentry_sdk/monitor.py
+++ b/sentry_sdk/monitor.py
@@ -37,6 +37,13 @@ class Monitor(object):
 
     def _ensure_running(self):
         # type: () -> None
+        """
+        Check that the monitor has an active thread to run in, or create one if not.
+
+        Note that this might fail (e.g. in Python 3.12 it's not possible to
+        spawn new threads at interpreter shutdown). In that case self._running
+        will be False after running this function.
+        """
         if self._thread_for_pid == os.getpid() and self._thread is not None:
             return None
 

--- a/sentry_sdk/profiler.py
+++ b/sentry_sdk/profiler.py
@@ -921,7 +921,7 @@ class ThreadScheduler(Scheduler):
             try:
                 self.thread.start()
             except RuntimeError:
-                # Unfortunately at this point the interpreter is in a start that no
+                # Unfortunately at this point the interpreter is in a state that no
                 # longer allows us to spawn a thread and we have to bail.
                 self.running = False
                 return

--- a/sentry_sdk/profiler.py
+++ b/sentry_sdk/profiler.py
@@ -918,7 +918,13 @@ class ThreadScheduler(Scheduler):
             # can keep the application running after other threads
             # have exited
             self.thread = threading.Thread(name=self.name, target=self.run, daemon=True)
-            self.thread.start()
+            try:
+                self.thread.start()
+            except RuntimeError:
+                # Unfortunately at this point the interpreter is in a start that no
+                # longer allows us to spawn a thread and we have to bail.
+                self.running = False
+                return
 
     def run(self):
         # type: () -> None

--- a/sentry_sdk/profiler.py
+++ b/sentry_sdk/profiler.py
@@ -1018,7 +1018,13 @@ class GeventScheduler(Scheduler):
             self.running = True
 
             self.thread = ThreadPool(1)
-            self.thread.spawn(self.run)
+            try:
+                self.thread.spawn(self.run)
+            except RuntimeError:
+                # Unfortunately at this point the interpreter is in a state that no
+                # longer allows us to spawn a thread and we have to bail.
+                self.running = False
+                return
 
     def run(self):
         # type: () -> None

--- a/sentry_sdk/profiler.py
+++ b/sentry_sdk/profiler.py
@@ -932,6 +932,7 @@ class ThreadScheduler(Scheduler):
                 # Unfortunately at this point the interpreter is in a state that no
                 # longer allows us to spawn a thread and we have to bail.
                 self.running = False
+                self.thread = None
                 return
 
     def run(self):
@@ -1024,6 +1025,7 @@ class GeventScheduler(Scheduler):
                 # Unfortunately at this point the interpreter is in a state that no
                 # longer allows us to spawn a thread and we have to bail.
                 self.running = False
+                self.thread = None
                 return
 
     def run(self):

--- a/sentry_sdk/profiler.py
+++ b/sentry_sdk/profiler.py
@@ -788,8 +788,7 @@ class Scheduler(object):
     def start_profiling(self, profile):
         # type: (Profile) -> None
         self.ensure_running()
-        if self.running:
-            self.new_profiles.append(profile)
+        self.new_profiles.append(profile)
 
     def stop_profiling(self, profile):
         # type: (Profile) -> None

--- a/sentry_sdk/profiler.py
+++ b/sentry_sdk/profiler.py
@@ -788,7 +788,8 @@ class Scheduler(object):
     def start_profiling(self, profile):
         # type: (Profile) -> None
         self.ensure_running()
-        self.new_profiles.append(profile)
+        if self.running:
+            self.new_profiles.append(profile)
 
     def stop_profiling(self, profile):
         # type: (Profile) -> None
@@ -898,6 +899,14 @@ class ThreadScheduler(Scheduler):
 
     def ensure_running(self):
         # type: () -> None
+        """
+        Check that the profiler has an active thread to run in, and start one if
+        that's not the case.
+
+        Note that this might fail (e.g. in Python 3.12 it's not possible to
+        spawn new threads at interpreter shutdown). In that case self.running
+        will be False after running this function.
+        """
         pid = os.getpid()
 
         # is running on the right process

--- a/sentry_sdk/sessions.py
+++ b/sentry_sdk/sessions.py
@@ -105,6 +105,13 @@ class SessionFlusher(object):
 
     def _ensure_running(self):
         # type: (...) -> None
+        """
+        Check that we have an active thread to run in, or create one if not.
+
+        Note that this might fail (e.g. in Python 3.12 it's not possible to
+        spawn new threads at interpreter shutdown). In that case self._running
+        will be False after running this function.
+        """
         if self._thread_for_pid == os.getpid() and self._thread is not None:
             return None
         with self._thread_lock:

--- a/sentry_sdk/sessions.py
+++ b/sentry_sdk/sessions.py
@@ -120,9 +120,17 @@ class SessionFlusher(object):
 
             thread = Thread(target=_thread)
             thread.daemon = True
-            thread.start()
+            try:
+                thread.start()
+            except RuntimeError:
+                # Unfortunately at this point the interpreter is in a state that no
+                # longer allows us to spawn a thread and we have to bail.
+                self._running = False
+                return None
+
             self._thread = thread
             self._thread_for_pid = os.getpid()
+
         return None
 
     def add_aggregate_session(


### PR DESCRIPTION
In Python 3.12 when you try to start a thread during shutdown a `RunTimeErrror` is raised. Handle this case with grace