### PR TITLE
Run common test suite on Python 3.12

### DIFF
--- a/.github/workflows/test-common.yml
+++ b/.github/workflows/test-common.yml
@@ -31,7 +31,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.5","3.6","3.7","3.8","3.9","3.10","3.11"]
+        python-version: ["3.5","3.6","3.7","3.8","3.9","3.10","3.11","3.12"]
         # python3.6 reached EOL and is no longer being supported on
         # new versions of hosted runners on Github Actions
         # ubuntu-20.04 is the last version that supported python3.6

--- a/sentry_sdk/integrations/logging.py
+++ b/sentry_sdk/integrations/logging.py
@@ -130,6 +130,7 @@ class _BaseHandler(logging.Handler, object):
             "relativeCreated",
             "stack",
             "tags",
+            "taskName",
             "thread",
             "threadName",
             "stack_info",

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,7 @@
 [tox]
 envlist =
     # === Common ===
-    {py2.7,py3.5,py3.6,py3.7,py3.8,py3.9,py3.10,py3.11}-common
+    {py2.7,py3.5,py3.6,py3.7,py3.8,py3.9,py3.10,py3.11,py3.12}-common
 
     # === Integrations ===
     # General format is {pythonversion}-{integrationname}-v{frameworkversion}
@@ -195,7 +195,7 @@ deps =
     linters: werkzeug<2.3.0
 
     # Common
-    {py3.6,py3.7,py3.8,py3.9,py3.10,py3.11}-common: pytest-asyncio
+    {py3.6,py3.7,py3.8,py3.9,py3.10,py3.11,py3.12}-common: pytest-asyncio
 
     # AIOHTTP
     aiohttp-v3.4: aiohttp>=3.4.0,<3.5.0
@@ -341,7 +341,7 @@ deps =
     # See https://stackoverflow.com/questions/51496550/runtime-warning-greenlet-greenlet-size-changed
     # for justification why greenlet is pinned here
     py3.5-gevent: greenlet==0.4.17
-    {py2.7,py3.6,py3.7,py3.8,py3.9,py3.10,py3.11}-gevent: gevent>=22.10.0, <22.11.0
+    {py2.7,py3.6,py3.7,py3.8,py3.9,py3.10,py3.11,py3.12}-gevent: gevent>=22.10.0, <22.11.0
 
     # GQL
     gql: gql[all]
@@ -597,6 +597,7 @@ basepython =
     py3.9: python3.9
     py3.10: python3.10
     py3.11: python3.11
+    py3.12: python3.12
 
     # Python version is pinned here because flake8 actually behaves differently
     # depending on which version is used. You can patch this out to point to
@@ -623,7 +624,7 @@ commands =
     ; when loading tests in scenarios. In particular, django fails to
     ; load the settings from the test module.
     {py2.7}: python -m pytest --ignore-glob='*py3.py' -rsx -s --durations=5 -vvv {env:TESTPATH} {posargs}
-    {py3.5,py3.6,py3.7,py3.8,py3.9,py3.10,py3.11}: python -m pytest -rsx -s --durations=5 -vvv {env:TESTPATH} {posargs}
+    {py3.5,py3.6,py3.7,py3.8,py3.9,py3.10,py3.11,py3.12}: python -m pytest -rsx -s --durations=5 -vvv {env:TESTPATH} {posargs}
 
 [testenv:linters]
 commands =


### PR DESCRIPTION
Add 3.12 to the test matrix and make a tiny change to the logging integration (3.12 added `taskName` to [LogRecord attributes](https://docs.python.org/3/library/logging.html#logrecord-attributes), we're now ignoring that as we do the rest).

Split off from https://github.com/getsentry/sentry-python/pull/2408.