### PR TITLE
Add Python 3.12 to `classifiers`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -100,6 +100,7 @@ setup(
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
         "Topic :: Software Development :: Libraries :: Python Modules",
     ],
     options={"bdist_wheel": {"universal": "1"}},


### PR DESCRIPTION
Closes https://github.com/getsentry/sentry-python/issues/2480