### PR TITLE
removing redundant code in Django tests

### DIFF
--- a/tests/integrations/django/test_basic.py
+++ b/tests/integrations/django/test_basic.py
@@ -972,14 +972,7 @@ def test_middleware_spans_disabled(sentry_init, client, capture_events):
     assert not len(transaction["spans"])
 
 
-if DJANGO_VERSION >= (1, 10):
-    EXPECTED_SIGNALS_SPANS = """\
-- op="http.server": description=null
-  - op="event.django": description="django.db.reset_queries"
-  - op="event.django": description="django.db.close_old_connections"\
-"""
-else:
-    EXPECTED_SIGNALS_SPANS = """\
+EXPECTED_SIGNALS_SPANS = """\
 - op="http.server": description=null
   - op="event.django": description="django.db.reset_queries"
   - op="event.django": description="django.db.close_old_connections"\


### PR DESCRIPTION
removing redundant code in Django tests