### PR TITLE
Introduce authorize step for external PRs

### DIFF
--- a/.github/workflows/test-common.yml
+++ b/.github/workflows/test-common.yml
@@ -23,6 +23,7 @@ env:
     ${{ github.workspace }}/dist-serverless
 
 jobs:
+
   test:
     name: common, python ${{ matrix.python-version }}, ${{ matrix.os }}
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/test-integration-aiohttp.yml
+++ b/.github/workflows/test-integration-aiohttp.yml
@@ -23,6 +23,7 @@ env:
     ${{ github.workspace }}/dist-serverless
 
 jobs:
+
   test:
     name: aiohttp, python ${{ matrix.python-version }}, ${{ matrix.os }}
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/test-integration-ariadne.yml
+++ b/.github/workflows/test-integration-ariadne.yml
@@ -23,6 +23,7 @@ env:
     ${{ github.workspace }}/dist-serverless
 
 jobs:
+
   test:
     name: ariadne, python ${{ matrix.python-version }}, ${{ matrix.os }}
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/test-integration-arq.yml
+++ b/.github/workflows/test-integration-arq.yml
@@ -23,6 +23,7 @@ env:
     ${{ github.workspace }}/dist-serverless
 
 jobs:
+
   test:
     name: arq, python ${{ matrix.python-version }}, ${{ matrix.os }}
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/test-integration-asgi.yml
+++ b/.github/workflows/test-integration-asgi.yml
@@ -23,6 +23,7 @@ env:
     ${{ github.workspace }}/dist-serverless
 
 jobs:
+
   test:
     name: asgi, python ${{ matrix.python-version }}, ${{ matrix.os }}
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/test-integration-asyncpg.yml
+++ b/.github/workflows/test-integration-asyncpg.yml
@@ -23,6 +23,7 @@ env:
     ${{ github.workspace }}/dist-serverless
 
 jobs:
+
   test:
     name: asyncpg, python ${{ matrix.python-version }}, ${{ matrix.os }}
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/test-integration-aws_lambda.yml
+++ b/.github/workflows/test-integration-aws_lambda.yml
@@ -26,7 +26,7 @@ env:
 
 jobs:
   authorize:
-    name: Require approval
+    name: Determine environment
     environment:
       ${{ github.event_name == 'pull_request_target' &&
       github.event.pull_request.head.repo.full_name != github.repository &&

--- a/.github/workflows/test-integration-aws_lambda.yml
+++ b/.github/workflows/test-integration-aws_lambda.yml
@@ -53,6 +53,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.ref }}
       - uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}

--- a/.github/workflows/test-integration-aws_lambda.yml
+++ b/.github/workflows/test-integration-aws_lambda.yml
@@ -6,7 +6,7 @@ on:
       - master
       - release/**
 
-  pull_request:
+  pull_request_target:
 
 # Cancel in progress workflows on pull_requests.
 # https://docs.github.com/en/actions/using-jobs/using-concurrency#example-using-a-fallback-value
@@ -25,7 +25,18 @@ env:
     ${{ github.workspace }}/dist-serverless
 
 jobs:
+  authorize:
+    name: Require approval
+    environment:
+      ${{ github.event_name == 'pull_request_target' &&
+      github.event.pull_request.head.repo.full_name != github.repository &&
+      'external' || 'internal' }}
+    runs-on: ubuntu-latest
+    steps:
+      - run: true
+
   test:
+    needs: authorize
     name: aws_lambda, python ${{ matrix.python-version }}, ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30

--- a/.github/workflows/test-integration-beam.yml
+++ b/.github/workflows/test-integration-beam.yml
@@ -23,6 +23,7 @@ env:
     ${{ github.workspace }}/dist-serverless
 
 jobs:
+
   test:
     name: beam, python ${{ matrix.python-version }}, ${{ matrix.os }}
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/test-integration-boto3.yml
+++ b/.github/workflows/test-integration-boto3.yml
@@ -23,6 +23,7 @@ env:
     ${{ github.workspace }}/dist-serverless
 
 jobs:
+
   test:
     name: boto3, python ${{ matrix.python-version }}, ${{ matrix.os }}
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/test-integration-bottle.yml
+++ b/.github/workflows/test-integration-bottle.yml
@@ -23,6 +23,7 @@ env:
     ${{ github.workspace }}/dist-serverless
 
 jobs:
+
   test:
     name: bottle, python ${{ matrix.python-version }}, ${{ matrix.os }}
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/test-integration-celery.yml
+++ b/.github/workflows/test-integration-celery.yml
@@ -23,6 +23,7 @@ env:
     ${{ github.workspace }}/dist-serverless
 
 jobs:
+
   test:
     name: celery, python ${{ matrix.python-version }}, ${{ matrix.os }}
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/test-integration-chalice.yml
+++ b/.github/workflows/test-integration-chalice.yml
@@ -23,6 +23,7 @@ env:
     ${{ github.workspace }}/dist-serverless
 
 jobs:
+
   test:
     name: chalice, python ${{ matrix.python-version }}, ${{ matrix.os }}
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/test-integration-clickhouse_driver.yml
+++ b/.github/workflows/test-integration-clickhouse_driver.yml
@@ -23,6 +23,7 @@ env:
     ${{ github.workspace }}/dist-serverless
 
 jobs:
+
   test:
     name: clickhouse_driver, python ${{ matrix.python-version }}, ${{ matrix.os }}
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/test-integration-cloud_resource_context.yml
+++ b/.github/workflows/test-integration-cloud_resource_context.yml
@@ -23,6 +23,7 @@ env:
     ${{ github.workspace }}/dist-serverless
 
 jobs:
+
   test:
     name: cloud_resource_context, python ${{ matrix.python-version }}, ${{ matrix.os }}
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/test-integration-django.yml
+++ b/.github/workflows/test-integration-django.yml
@@ -23,6 +23,7 @@ env:
     ${{ github.workspace }}/dist-serverless
 
 jobs:
+
   test:
     name: django, python ${{ matrix.python-version }}, ${{ matrix.os }}
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/test-integration-falcon.yml
+++ b/.github/workflows/test-integration-falcon.yml
@@ -23,6 +23,7 @@ env:
     ${{ github.workspace }}/dist-serverless
 
 jobs:
+
   test:
     name: falcon, python ${{ matrix.python-version }}, ${{ matrix.os }}
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/test-integration-fastapi.yml
+++ b/.github/workflows/test-integration-fastapi.yml
@@ -23,6 +23,7 @@ env:
     ${{ github.workspace }}/dist-serverless
 
 jobs:
+
   test:
     name: fastapi, python ${{ matrix.python-version }}, ${{ matrix.os }}
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/test-integration-flask.yml
+++ b/.github/workflows/test-integration-flask.yml
@@ -23,6 +23,7 @@ env:
     ${{ github.workspace }}/dist-serverless
 
 jobs:
+
   test:
     name: flask, python ${{ matrix.python-version }}, ${{ matrix.os }}
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/test-integration-gcp.yml
+++ b/.github/workflows/test-integration-gcp.yml
@@ -23,6 +23,7 @@ env:
     ${{ github.workspace }}/dist-serverless
 
 jobs:
+
   test:
     name: gcp, python ${{ matrix.python-version }}, ${{ matrix.os }}
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/test-integration-gevent.yml
+++ b/.github/workflows/test-integration-gevent.yml
@@ -23,6 +23,7 @@ env:
     ${{ github.workspace }}/dist-serverless
 
 jobs:
+
   test:
     name: gevent, python ${{ matrix.python-version }}, ${{ matrix.os }}
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/test-integration-gql.yml
+++ b/.github/workflows/test-integration-gql.yml
@@ -23,6 +23,7 @@ env:
     ${{ github.workspace }}/dist-serverless
 
 jobs:
+
   test:
     name: gql, python ${{ matrix.python-version }}, ${{ matrix.os }}
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/test-integration-graphene.yml
+++ b/.github/workflows/test-integration-graphene.yml
@@ -23,6 +23,7 @@ env:
     ${{ github.workspace }}/dist-serverless
 
 jobs:
+
   test:
     name: graphene, python ${{ matrix.python-version }}, ${{ matrix.os }}
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/test-integration-grpc.yml
+++ b/.github/workflows/test-integration-grpc.yml
@@ -23,6 +23,7 @@ env:
     ${{ github.workspace }}/dist-serverless
 
 jobs:
+
   test:
     name: grpc, python ${{ matrix.python-version }}, ${{ matrix.os }}
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/test-integration-httpx.yml
+++ b/.github/workflows/test-integration-httpx.yml
@@ -23,6 +23,7 @@ env:
     ${{ github.workspace }}/dist-serverless
 
 jobs:
+
   test:
     name: httpx, python ${{ matrix.python-version }}, ${{ matrix.os }}
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/test-integration-huey.yml
+++ b/.github/workflows/test-integration-huey.yml
@@ -23,6 +23,7 @@ env:
     ${{ github.workspace }}/dist-serverless
 
 jobs:
+
   test:
     name: huey, python ${{ matrix.python-version }}, ${{ matrix.os }}
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/test-integration-loguru.yml
+++ b/.github/workflows/test-integration-loguru.yml
@@ -23,6 +23,7 @@ env:
     ${{ github.workspace }}/dist-serverless
 
 jobs:
+
   test:
     name: loguru, python ${{ matrix.python-version }}, ${{ matrix.os }}
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/test-integration-opentelemetry.yml
+++ b/.github/workflows/test-integration-opentelemetry.yml
@@ -23,6 +23,7 @@ env:
     ${{ github.workspace }}/dist-serverless
 
 jobs:
+
   test:
     name: opentelemetry, python ${{ matrix.python-version }}, ${{ matrix.os }}
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/test-integration-pure_eval.yml
+++ b/.github/workflows/test-integration-pure_eval.yml
@@ -23,6 +23,7 @@ env:
     ${{ github.workspace }}/dist-serverless
 
 jobs:
+
   test:
     name: pure_eval, python ${{ matrix.python-version }}, ${{ matrix.os }}
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/test-integration-pymongo.yml
+++ b/.github/workflows/test-integration-pymongo.yml
@@ -23,6 +23,7 @@ env:
     ${{ github.workspace }}/dist-serverless
 
 jobs:
+
   test:
     name: pymongo, python ${{ matrix.python-version }}, ${{ matrix.os }}
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/test-integration-pyramid.yml
+++ b/.github/workflows/test-integration-pyramid.yml
@@ -23,6 +23,7 @@ env:
     ${{ github.workspace }}/dist-serverless
 
 jobs:
+
   test:
     name: pyramid, python ${{ matrix.python-version }}, ${{ matrix.os }}
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/test-integration-quart.yml
+++ b/.github/workflows/test-integration-quart.yml
@@ -23,6 +23,7 @@ env:
     ${{ github.workspace }}/dist-serverless
 
 jobs:
+
   test:
     name: quart, python ${{ matrix.python-version }}, ${{ matrix.os }}
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/test-integration-redis.yml
+++ b/.github/workflows/test-integration-redis.yml
@@ -23,6 +23,7 @@ env:
     ${{ github.workspace }}/dist-serverless
 
 jobs:
+
   test:
     name: redis, python ${{ matrix.python-version }}, ${{ matrix.os }}
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/test-integration-rediscluster.yml
+++ b/.github/workflows/test-integration-rediscluster.yml
@@ -23,6 +23,7 @@ env:
     ${{ github.workspace }}/dist-serverless
 
 jobs:
+
   test:
     name: rediscluster, python ${{ matrix.python-version }}, ${{ matrix.os }}
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/test-integration-requests.yml
+++ b/.github/workflows/test-integration-requests.yml
@@ -23,6 +23,7 @@ env:
     ${{ github.workspace }}/dist-serverless
 
 jobs:
+
   test:
     name: requests, python ${{ matrix.python-version }}, ${{ matrix.os }}
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/test-integration-rq.yml
+++ b/.github/workflows/test-integration-rq.yml
@@ -23,6 +23,7 @@ env:
     ${{ github.workspace }}/dist-serverless
 
 jobs:
+
   test:
     name: rq, python ${{ matrix.python-version }}, ${{ matrix.os }}
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/test-integration-sanic.yml
+++ b/.github/workflows/test-integration-sanic.yml
@@ -23,6 +23,7 @@ env:
     ${{ github.workspace }}/dist-serverless
 
 jobs:
+
   test:
     name: sanic, python ${{ matrix.python-version }}, ${{ matrix.os }}
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/test-integration-sqlalchemy.yml
+++ b/.github/workflows/test-integration-sqlalchemy.yml
@@ -23,6 +23,7 @@ env:
     ${{ github.workspace }}/dist-serverless
 
 jobs:
+
   test:
     name: sqlalchemy, python ${{ matrix.python-version }}, ${{ matrix.os }}
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/test-integration-starlette.yml
+++ b/.github/workflows/test-integration-starlette.yml
@@ -23,6 +23,7 @@ env:
     ${{ github.workspace }}/dist-serverless
 
 jobs:
+
   test:
     name: starlette, python ${{ matrix.python-version }}, ${{ matrix.os }}
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/test-integration-starlite.yml
+++ b/.github/workflows/test-integration-starlite.yml
@@ -23,6 +23,7 @@ env:
     ${{ github.workspace }}/dist-serverless
 
 jobs:
+
   test:
     name: starlite, python ${{ matrix.python-version }}, ${{ matrix.os }}
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/test-integration-strawberry.yml
+++ b/.github/workflows/test-integration-strawberry.yml
@@ -23,6 +23,7 @@ env:
     ${{ github.workspace }}/dist-serverless
 
 jobs:
+
   test:
     name: strawberry, python ${{ matrix.python-version }}, ${{ matrix.os }}
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/test-integration-tornado.yml
+++ b/.github/workflows/test-integration-tornado.yml
@@ -23,6 +23,7 @@ env:
     ${{ github.workspace }}/dist-serverless
 
 jobs:
+
   test:
     name: tornado, python ${{ matrix.python-version }}, ${{ matrix.os }}
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/test-integration-trytond.yml
+++ b/.github/workflows/test-integration-trytond.yml
@@ -23,6 +23,7 @@ env:
     ${{ github.workspace }}/dist-serverless
 
 jobs:
+
   test:
     name: trytond, python ${{ matrix.python-version }}, ${{ matrix.os }}
     runs-on: ${{ matrix.os }}

--- a/scripts/split-tox-gh-actions/ci-yaml-authorize-snippet.txt
+++ b/scripts/split-tox-gh-actions/ci-yaml-authorize-snippet.txt
@@ -1,0 +1,9 @@
+  authorize:
+    name: Require approval
+    environment:
+      ${{ github.event_name == 'pull_request_target' &&
+      github.event.pull_request.head.repo.full_name != github.repository &&
+      'external' || 'internal' }}
+    runs-on: ubuntu-latest
+    steps:
+      - run: true

--- a/scripts/split-tox-gh-actions/ci-yaml-authorize-snippet.txt
+++ b/scripts/split-tox-gh-actions/ci-yaml-authorize-snippet.txt
@@ -1,5 +1,5 @@
   authorize:
-    name: Require approval
+    name: Determine environment
     environment:
       ${{ github.event_name == 'pull_request_target' &&
       github.event.pull_request.head.repo.full_name != github.repository &&

--- a/scripts/split-tox-gh-actions/ci-yaml-test-py27-snippet.txt
+++ b/scripts/split-tox-gh-actions/ci-yaml-test-py27-snippet.txt
@@ -7,6 +7,7 @@
 
     steps:
       - uses: actions/checkout@v4
+{{ checkout_with }}
 
       - name: Setup Test Env
         run: |

--- a/scripts/split-tox-gh-actions/ci-yaml-test-snippet.txt
+++ b/scripts/split-tox-gh-actions/ci-yaml-test-snippet.txt
@@ -7,6 +7,7 @@
 
     steps:
       - uses: actions/checkout@v4
+{{ checkout_with }}
       - uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}

--- a/scripts/split-tox-gh-actions/ci-yaml.txt
+++ b/scripts/split-tox-gh-actions/ci-yaml.txt
@@ -6,7 +6,7 @@ on:
       - master
       - release/**
 
-  pull_request:
+{{ on_pull_request }}
 
 # Cancel in progress workflows on pull_requests.
 # https://docs.github.com/en/actions/using-jobs/using-concurrency#example-using-a-fallback-value
@@ -24,6 +24,8 @@ env:
     ${{ github.workspace }}/dist-serverless
 
 jobs:
+{{ authorize }}
+
 {{ test }}
 
 {{ test_py27 }}


### PR DESCRIPTION
[DO NOT MERGE] The `external` environment has to be set up correctly first and this needs to be looked at by the security team.

![Screenshot 2023-11-07 at 15 35 46](https://github.com/getsentry/sentry-python/assets/131587164/3ef7d10d-32d4-44b5-84ee-39038cda90c2)

---

Introduce an `authorize` step to all workflows that require access to secrets (currently just the AWS Lambda test suite). The workflow for fork PRs after this PR will be as follows:

- an external contributor submits a PR
- all workflows that don't need access to secrets run as before
- any workflows that need access to secrets (currently just AWS Lambda):
  - will now be run on `pull_request_target` instead of `pull_request`, which means they'll run against the base branch of the main repo and will have access to secrets
  - will get an extra initial `authorize` step that checks whether the PR was made from a fork and if so, sets the environment to `external`
- if any PR is running in the `external` environment, the repo is set up to require explicit approval from a Sentry employee before the workflow can be run
- a Sentry employee checks the PR and manually approves the AWS Lambda test suite to run with access to secrets

## Background

Our AWS Lambda test suite requires GitHub secrets to run. These are by default not accessible to PRs from forks. GitHub offers a solution for private repos, but for public repos, there is no dedicated solution.

The only way for fork PRs to get access to GH secrets of the original repo is to use [`pull_request_target`](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target). However, if this is used incorrectly it's an obvious security concern (see [this](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/) and [this](https://nathandavison.com/blog/github-actions-and-the-threat-of-malicious-pull-requests)). There are some options to prevent this, most of them relying on some sort of explicit approval from a maintainer. The two most prominent ones are:

* creating a dedicated label that, when applied to a PR, triggers a test run
* automatically applying a more restrictive environment to external PRs that requires explicit maintainer approval to run the tests (see https://iterative.ai/blog/testing-external-contributions-using-github-actions-secrets)

The former has the potential for race conditions. Since the label is not tied to a specific commit, a malicious code change pushed at roughly the same time the label was applied, but before the workflow has run, could lead to the workflow running unsafe code.

The latter (which is the solution in this PR) should not allow this since the test run is directly tied to a specific commit and any new code change invalidates any previous approval.


Closes https://github.com/getsentry/sentry-python/issues/2487