### PR TITLE
Make async gRPC less noisy

### DIFF
--- a/sentry_sdk/integrations/grpc/aio/server.py
+++ b/sentry_sdk/integrations/grpc/aio/server.py
@@ -13,7 +13,7 @@ if MYPY:
 try:
     import grpc
     from grpc import HandlerCallDetails, RpcMethodHandler
-    from grpc.aio import ServicerContext
+    from grpc.aio import AbortError, ServicerContext
 except ImportError:
     raise DidNotEnable("grpcio is not installed")
 
@@ -52,6 +52,8 @@ class ServerInterceptor(grpc.aio.ServerInterceptor):  # type: ignore
                 with hub.start_transaction(transaction=transaction):
                     try:
                         return await handler.unary_unary(request, context)
+                    except AbortError:
+                        raise
                     except Exception as exc:
                         event, hint = event_from_exception(
                             exc,


### PR DESCRIPTION
The new aio integration for gRPC creates new Sentry events for each and every exception raised by the server. This becomes a problem if the user's server code uses `context.abort()` (like mine does!). [From the documentation](https://grpc.github.io/grpc/python/grpc_asyncio.html#grpc.aio.ServicerContext.abort):

> Raises an exception to terminate the RPC with a non-OK status.

Imagine this server code:
```py
async def GetUser(self, request, context):
        user = self._users.find_by_id(request.id)

        if not user:
            await context.abort(grpc.StatusCode.NOT_FOUND)

        return GetUserResponse(user=user)
```

`AbortError` is raised from `await context.abort()` every time a user is not found which, with the new Sentry integration, will also send an error event to Sentry every time a user is not found. This is comparable to sending an error to Sentry for every 404 (or any status code really) that your HTTP API returns, aka. probably not something you want to do :)

This PR fixes that by simply catching `AbortError` separately.