### PR TITLE
Run integration tests with newest `pytest`

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,6 +1,6 @@
 pip  # always use newest pip
 mock ; python_version<'3.3'
-pytest<7
+pytest
 pytest-cov==2.8.1
 pytest-forked<=1.4.0
 pytest-localserver==0.5.1  # TODO(py3): 0.6.0 drops 2.7 support: https://github.com/pytest-dev/pytest-localserver/releases/tag/v0.6.0

--- a/tox.ini
+++ b/tox.ini
@@ -202,6 +202,9 @@ deps =
 
     # Common
     {py3.6,py3.7,py3.8,py3.9,py3.10,py3.11,py3.12}-common: pytest-asyncio
+    # See https://github.com/pytest-dev/pytest/issues/9621
+    # for justification of the upper bound on pytest
+    common: pytest<7.0.0
 
     # AIOHTTP
     aiohttp-v3.4: aiohttp>=3.4.0,<3.5.0
@@ -351,6 +354,9 @@ deps =
     # for justification why greenlet is pinned here
     py3.5-gevent: greenlet==0.4.17
     {py2.7,py3.6,py3.7,py3.8,py3.9,py3.10,py3.11,py3.12}-gevent: gevent>=22.10.0, <22.11.0
+    # See https://github.com/pytest-dev/pytest/issues/9621
+    # for justification of the upper bound on pytest
+    gevent: pytest<7.0.0
 
     # GQL
     gql: gql[all]

--- a/tox.ini
+++ b/tox.ini
@@ -358,7 +358,7 @@ deps =
     # See https://github.com/pytest-dev/pytest/issues/9621
     # and https://github.com/pytest-dev/pytest-forked/issues/67
     # for justification of the upper bound on pytest
-    {py2.7,py3.6,py3.7,py3.8,py3.9,py3.10,py3.11,py3.12}-gevent: pytest<7.0.0
+    {py3.6,py3.7,py3.8,py3.9,py3.10,py3.11,py3.12}-gevent: pytest<7.0.0
 
     # GQL
     gql: gql[all]

--- a/tox.ini
+++ b/tox.ini
@@ -203,8 +203,9 @@ deps =
     # Common
     {py3.6,py3.7,py3.8,py3.9,py3.10,py3.11,py3.12}-common: pytest-asyncio
     # See https://github.com/pytest-dev/pytest/issues/9621
+    # and https://github.com/pytest-dev/pytest-forked/issues/67
     # for justification of the upper bound on pytest
-    common: pytest<7.0.0
+    {py3.6,py3.7,py3.8,py3.9,py3.10,py3.11,py3.12}-common: pytest<7.0.0
 
     # AIOHTTP
     aiohttp-v3.4: aiohttp>=3.4.0,<3.5.0
@@ -355,8 +356,9 @@ deps =
     py3.5-gevent: greenlet==0.4.17
     {py2.7,py3.6,py3.7,py3.8,py3.9,py3.10,py3.11,py3.12}-gevent: gevent>=22.10.0, <22.11.0
     # See https://github.com/pytest-dev/pytest/issues/9621
+    # and https://github.com/pytest-dev/pytest-forked/issues/67
     # for justification of the upper bound on pytest
-    gevent: pytest<7.0.0
+    {py2.7,py3.6,py3.7,py3.8,py3.9,py3.10,py3.11,py3.12}-gevent: pytest<7.0.0
 
     # GQL
     gql: gql[all]


### PR DESCRIPTION
Our integrations tests run with the latest `pytest` out of the box. The `common`/`gevent` tests have issues with it (it doesn't play nicely with `pytest-forked`), so those will have to stay on `pytest<7` for a bit longer. 