### PR TITLE
feat: Code locations for metrics

### DIFF
--- a/sentry_sdk/_types.py
+++ b/sentry_sdk/_types.py
@@ -117,3 +117,4 @@ if TYPE_CHECKING:
     FlushedMetricValue = Union[int, float]
 
     BucketKey = Tuple[MetricType, str, MeasurementUnit, MetricTagsInternal]
+    MetricMetaKey = Tuple[MetricType, str, MeasurementUnit]

--- a/sentry_sdk/client.py
+++ b/sentry_sdk/client.py
@@ -236,11 +236,13 @@ class _Client(object):
             self.session_flusher = SessionFlusher(capture_func=_capture_envelope)
 
             self.metrics_aggregator = None  # type: Optional[MetricsAggregator]
-            if self.options.get("_experiments", {}).get("enable_metrics"):
+            experiments = self.options.get("_experiments", {})
+            if experiments.get("enable_metrics"):
                 from sentry_sdk.metrics import MetricsAggregator
 
                 self.metrics_aggregator = MetricsAggregator(
-                    capture_func=_capture_envelope
+                    capture_func=_capture_envelope,
+                    enable_code_locations=bool(experiments.get("code_locations")),
                 )
 
             max_request_body_size = ("always", "never", "small", "medium")

--- a/sentry_sdk/client.py
+++ b/sentry_sdk/client.py
@@ -242,7 +242,9 @@ class _Client(object):
 
                 self.metrics_aggregator = MetricsAggregator(
                     capture_func=_capture_envelope,
-                    enable_code_locations=bool(experiments.get("code_locations")),
+                    enable_code_locations=bool(
+                        experiments.get("metric_code_locations")
+                    ),
                 )
 
             max_request_body_size = ("always", "never", "small", "medium")

--- a/sentry_sdk/consts.py
+++ b/sentry_sdk/consts.py
@@ -47,6 +47,7 @@ if TYPE_CHECKING:
             "transport_num_pools": Optional[int],
             "enable_metrics": Optional[bool],
             "before_emit_metric": Optional[Callable[[str, MetricTags], bool]],
+            "metric_code_locations": Optional[bool],
         },
         total=False,
     )

--- a/sentry_sdk/metrics.py
+++ b/sentry_sdk/metrics.py
@@ -453,7 +453,7 @@ class MetricsAggregator(object):
         unit,  # type: MeasurementUnit
         tags,  # type: Optional[MetricTags]
         timestamp=None,  # type: Optional[Union[float, datetime]]
-        stacklevel=1,  # type: int
+        stacklevel=0,  # type: int
     ):
         # type: (...) -> None
         if not self._ensure_thread() or self._flusher is None:

--- a/sentry_sdk/metrics.py
+++ b/sentry_sdk/metrics.py
@@ -71,7 +71,7 @@ GOOD_TRANSACTION_SOURCES = frozenset(
 def get_code_location(stacklevel):
     # type: (int) -> Optional[Dict[str, Any]]
     try:
-        frm = sys._getframe(stacklevel + 3)
+        frm = sys._getframe(stacklevel + 4)
     except Exception:
         return None
 
@@ -610,7 +610,7 @@ def incr(
     unit="none",  # type: MeasurementUnit
     tags=None,  # type: Optional[MetricTags]
     timestamp=None,  # type: Optional[Union[float, datetime]]
-    stacklevel=1,  # type: int
+    stacklevel=0,  # type: int
 ):
     # type: (...) -> None
     """Increments a counter."""
@@ -685,7 +685,7 @@ def timing(
     unit="second",  # type: DurationUnit
     tags=None,  # type: Optional[MetricTags]
     timestamp=None,  # type: Optional[Union[float, datetime]]
-    stacklevel=1,  # type: int
+    stacklevel=0,  # type: int
 ):
     # type: (...) -> _Timing
     """Emits a distribution with the time it takes to run the given code block.
@@ -709,7 +709,7 @@ def distribution(
     unit="none",  # type: MeasurementUnit
     tags=None,  # type: Optional[MetricTags]
     timestamp=None,  # type: Optional[Union[float, datetime]]
-    stacklevel=1,  # type: int
+    stacklevel=0,  # type: int
 ):
     # type: (...) -> None
     """Emits a distribution."""
@@ -724,7 +724,7 @@ def set(
     unit="none",  # type: MeasurementUnit
     tags=None,  # type: Optional[MetricTags]
     timestamp=None,  # type: Optional[Union[float, datetime]]
-    stacklevel=1,  # type: int
+    stacklevel=0,  # type: int
 ):
     # type: (...) -> None
     """Emits a set."""
@@ -739,7 +739,7 @@ def gauge(
     unit="none",  # type: MetricValue
     tags=None,  # type: Optional[MetricTags]
     timestamp=None,  # type: Optional[Union[float, datetime]]
-    stacklevel=1,  # type: int
+    stacklevel=0,  # type: int
 ):
     # type: (...) -> None
     """Emits a gauge."""

--- a/sentry_sdk/metrics.py
+++ b/sentry_sdk/metrics.py
@@ -492,7 +492,7 @@ class MetricsAggregator(object):
             if self._enable_code_locations:
                 meta_key = (ty, key, unit)
                 start_of_day = utc_from_timestamp(timestamp).replace(
-                    hour=0, minute=0, second=0, microsecond=0
+                    hour=0, minute=0, second=0, microsecond=0, tzinfo=None
                 )
                 start_of_day = int(to_timestamp(start_of_day))
 

--- a/sentry_sdk/metrics.py
+++ b/sentry_sdk/metrics.py
@@ -491,11 +491,10 @@ class MetricsAggregator(object):
             # Store code location once per metric and per day (of bucket timestamp)
             if self._enable_code_locations:
                 meta_key = (ty, key, unit)
-                start_of_day = int(
-                    utc_from_timestamp(timestamp)
-                    .replace(hour=0, minute=0, second=0, microsecond=0)
-                    .timestamp()
+                start_of_day = utc_from_timestamp(timestamp).replace(
+                    hour=0, minute=0, second=0, microsecond=0
                 )
+                start_of_day = int(to_timestamp(start_of_day))
 
                 if (start_of_day, meta_key) not in self._seen_locations:
                     self._seen_locations.add((start_of_day, meta_key))

--- a/sentry_sdk/metrics.py
+++ b/sentry_sdk/metrics.py
@@ -313,7 +313,9 @@ def _encode_locations(timestamp, code_locations):
     for key, loc in code_locations:
         metric_type, name, unit = key
         mri = "{}:{}@{}".format(metric_type, _sanitize_key(name), unit)
-        mapping.setdefault(mri, []).append({"type": "location", **loc})
+
+        loc["type"] = "location"
+        mapping.setdefault(mri, []).append(loc)
 
     return json_dumps({"timestamp": timestamp, "mapping": mapping})
 

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -97,6 +97,13 @@ def test_timing(sentry_init, capture_envelopes):
         "environment": "not-fun-env",
     }
 
+    loc = Hub.current.client.metrics_aggregator.code_locations
+    first_loc, = loc.values()
+    assert first_loc["filename"] == __file__
+    assert first_loc["line"] > 0
+    assert first_loc["module"] == "tests.test_metrics"
+    assert first_loc["function"] == "test_timing"
+
 
 def test_timing_decorator(sentry_init, capture_envelopes):
     sentry_init(
@@ -147,6 +154,18 @@ def test_timing_decorator(sentry_init, capture_envelopes):
         "environment": "not-fun-env",
     }
 
+    loc = Hub.current.client.metrics_aggregator.code_locations
+    assert len(loc) == 2
+    first_loc, second_loc = loc.values()
+    assert first_loc["filename"] == __file__
+    assert first_loc["line"] > 0
+    assert first_loc["module"] == "tests.test_metrics"
+    assert first_loc["function"] == "test_timing_decorator"
+    assert second_loc["filename"] == __file__
+    assert second_loc["line"] > 0
+    assert second_loc["module"] == "tests.test_metrics"
+    assert second_loc["function"] == "test_timing_decorator"
+
 
 def test_timing_basic(sentry_init, capture_envelopes):
     sentry_init(
@@ -179,6 +198,13 @@ def test_timing_basic(sentry_init, capture_envelopes):
         "release": "fun-release@1.0.0",
         "environment": "not-fun-env",
     }
+
+    loc = Hub.current.client.metrics_aggregator.code_locations
+    first_loc, = loc.values()
+    assert first_loc["filename"] == __file__
+    assert first_loc["line"] > 0
+    assert first_loc["module"] == "tests.test_metrics"
+    assert first_loc["function"] == "test_timing_basic"
 
 
 def test_distribution(sentry_init, capture_envelopes):
@@ -503,6 +529,13 @@ def test_tag_serialization(sentry_init, capture_envelopes):
         "release": "fun-release",
         "environment": "not-fun-env",
     }
+
+    loc = Hub.current.client.metrics_aggregator.code_locations
+    first_loc = next(iter(loc.values()))
+    assert first_loc["filename"] == __file__
+    assert first_loc["line"] > 0
+    assert first_loc["module"] == "tests.test_metrics"
+    assert first_loc["function"] == "test_tag_serialization"
 
 
 def test_flush_recursion_protection(sentry_init, capture_envelopes, monkeypatch):

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,6 +1,5 @@
 # coding: utf-8
 
-import json
 import sys
 import time
 
@@ -10,6 +9,7 @@ except ImportError:
     import mock  # python < 3.3
 
 from sentry_sdk import Hub, metrics, push_scope
+from sentry_sdk.envelope import parse_json
 
 
 def parse_metrics(bytes):
@@ -74,7 +74,7 @@ def test_incr(sentry_init, capture_envelopes):
     }
 
     assert meta_item.headers["type"] == "metric_meta"
-    assert json.loads(meta_item.payload.get_bytes()) == {
+    assert parse_json(meta_item.payload.get_bytes()) == {
         "timestamp": mock.ANY,
         "mapping": {
             "c:foobar@none": [
@@ -122,7 +122,7 @@ def test_timing(sentry_init, capture_envelopes):
     }
 
     assert meta_item.headers["type"] == "metric_meta"
-    assert json.loads(meta_item.payload.get_bytes()) == {
+    assert parse_json(meta_item.payload.get_bytes()) == {
         "timestamp": mock.ANY,
         "mapping": {
             "d:whatever@second": [
@@ -189,7 +189,7 @@ def test_timing_decorator(sentry_init, capture_envelopes):
     }
 
     assert meta_item.headers["type"] == "metric_meta"
-    assert json.loads(meta_item.payload.get_bytes()) == {
+    assert parse_json(meta_item.payload.get_bytes()) == {
         "timestamp": mock.ANY,
         "mapping": {
             "d:whatever-1@second": [
@@ -250,7 +250,7 @@ def test_timing_basic(sentry_init, capture_envelopes):
     }
 
     assert meta_item.headers["type"] == "metric_meta"
-    assert json.loads(meta_item.payload.get_bytes()) == {
+    assert parse_json(meta_item.payload.get_bytes()) == {
         "timestamp": mock.ANY,
         "mapping": {
             "d:timing@second": [
@@ -300,7 +300,7 @@ def test_distribution(sentry_init, capture_envelopes):
     }
 
     assert meta_item.headers["type"] == "metric_meta"
-    assert json.loads(meta_item.payload.get_bytes()) == {
+    assert parse_json(meta_item.payload.get_bytes()) == {
         "timestamp": mock.ANY,
         "mapping": {
             "d:dist@none": [
@@ -349,7 +349,7 @@ def test_set(sentry_init, capture_envelopes):
     }
 
     assert meta_item.headers["type"] == "metric_meta"
-    assert json.loads(meta_item.payload.get_bytes()) == {
+    assert parse_json(meta_item.payload.get_bytes()) == {
         "timestamp": mock.ANY,
         "mapping": {
             "s:my-set@none": [

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -3,7 +3,11 @@
 import json
 import sys
 import time
-from unittest import mock
+
+try:
+    from unittest import mock  # python 3.3 and above
+except ImportError:
+    import mock  # python < 3.3
 
 from sentry_sdk import Hub, metrics, push_scope
 
@@ -43,7 +47,7 @@ def test_incr(sentry_init, capture_envelopes):
     sentry_init(
         release="fun-release",
         environment="not-fun-env",
-        _experiments={"enable_metrics": True, "code_locations": True},
+        _experiments={"enable_metrics": True, "metric_code_locations": True},
     )
     ts = time.time()
     envelopes = capture_envelopes()
@@ -91,7 +95,7 @@ def test_timing(sentry_init, capture_envelopes):
     sentry_init(
         release="fun-release@1.0.0",
         environment="not-fun-env",
-        _experiments={"enable_metrics": True, "code_locations": True},
+        _experiments={"enable_metrics": True, "metric_code_locations": True},
     )
     ts = time.time()
     envelopes = capture_envelopes()
@@ -139,7 +143,7 @@ def test_timing_decorator(sentry_init, capture_envelopes):
     sentry_init(
         release="fun-release@1.0.0",
         environment="not-fun-env",
-        _experiments={"enable_metrics": True, "code_locations": True},
+        _experiments={"enable_metrics": True, "metric_code_locations": True},
     )
     envelopes = capture_envelopes()
 
@@ -216,7 +220,7 @@ def test_timing_basic(sentry_init, capture_envelopes):
     sentry_init(
         release="fun-release@1.0.0",
         environment="not-fun-env",
-        _experiments={"enable_metrics": True, "code_locations": True},
+        _experiments={"enable_metrics": True, "metric_code_locations": True},
     )
     ts = time.time()
     envelopes = capture_envelopes()
@@ -267,7 +271,7 @@ def test_distribution(sentry_init, capture_envelopes):
     sentry_init(
         release="fun-release@1.0.0",
         environment="not-fun-env",
-        _experiments={"enable_metrics": True, "code_locations": True},
+        _experiments={"enable_metrics": True, "metric_code_locations": True},
     )
     ts = time.time()
     envelopes = capture_envelopes()
@@ -317,7 +321,7 @@ def test_set(sentry_init, capture_envelopes):
     sentry_init(
         release="fun-release@1.0.0",
         environment="not-fun-env",
-        _experiments={"enable_metrics": True, "code_locations": True},
+        _experiments={"enable_metrics": True, "metric_code_locations": True},
     )
     ts = time.time()
     envelopes = capture_envelopes()


### PR DESCRIPTION
DDM wants to show code locations with metrics. Locations are semi-static information: they change infrequently, so they don't need to be reported with every data point.

Sentry expects locations to be reported at least once per day. With backdating of metrics, the timestamp used to report the location is the metric bucket's timestamp rounded down to the start of the day (UTC timezone).

The metrics aggregator keeps a cache of previously reported locations. When a location is seen for the first time on a day, it is added to a list of pending locations. On the next flush cycle, all pending locations are sent to Sentry in the same envelope as the metric buckets.

See: https://github.com/getsentry/relay/pull/2751
Epic: https://github.com/getsentry/sentry/issues/60260