### PR TITLE
fix(metrics): Normalize dashes to underscores in metrics

### DIFF
--- a/sentry_sdk/metrics.py
+++ b/sentry_sdk/metrics.py
@@ -54,7 +54,7 @@ if TYPE_CHECKING:
 
 
 _thread_local = threading.local()
-_sanitize_key = partial(re.compile(r"[^a-zA-Z0-9_/.-]+").sub, "_")
+_sanitize_key = partial(re.compile(r"[^a-zA-Z0-9_/.]+").sub, "_")
 _sanitize_value = partial(re.compile(r"[^\w\d_:/@\.{}\[\]$-]+", re.UNICODE).sub, "_")
 _set = set  # set is shadowed below
 


### PR DESCRIPTION
Dashes are not supported in metric names on Sentry DDM. This updates
validation and replaces dashes with underscores. Tag keys in sentry
support dashes, too.