### PR TITLE
feat(metrics): Add source context to code locations

### DIFF
--- a/sentry_sdk/metrics.py
+++ b/sentry_sdk/metrics.py
@@ -76,7 +76,7 @@ def get_code_location(stacklevel):
         return None
 
     return serialize_frame(
-        frm, include_local_variables=False, include_source_context=False
+        frm, include_local_variables=False, include_source_context=True
     )
 
 

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -85,6 +85,9 @@ def test_incr(sentry_init, capture_envelopes):
                     "function": sys._getframe().f_code.co_name,
                     "module": __name__,
                     "lineno": mock.ANY,
+                    "pre_context": mock.ANY,
+                    "context_line": mock.ANY,
+                    "post_context": mock.ANY,
                 }
             ]
         },
@@ -133,6 +136,9 @@ def test_timing(sentry_init, capture_envelopes):
                     "function": sys._getframe().f_code.co_name,
                     "module": __name__,
                     "lineno": mock.ANY,
+                    "pre_context": mock.ANY,
+                    "context_line": mock.ANY,
+                    "post_context": mock.ANY,
                 }
             ]
         },
@@ -200,6 +206,9 @@ def test_timing_decorator(sentry_init, capture_envelopes):
                     "function": sys._getframe().f_code.co_name,
                     "module": __name__,
                     "lineno": mock.ANY,
+                    "pre_context": mock.ANY,
+                    "context_line": mock.ANY,
+                    "post_context": mock.ANY,
                 }
             ],
             "d:whatever-2@nanosecond": [
@@ -210,6 +219,9 @@ def test_timing_decorator(sentry_init, capture_envelopes):
                     "function": sys._getframe().f_code.co_name,
                     "module": __name__,
                     "lineno": mock.ANY,
+                    "pre_context": mock.ANY,
+                    "context_line": mock.ANY,
+                    "post_context": mock.ANY,
                 }
             ],
         },
@@ -261,6 +273,9 @@ def test_timing_basic(sentry_init, capture_envelopes):
                     "function": sys._getframe().f_code.co_name,
                     "module": __name__,
                     "lineno": mock.ANY,
+                    "pre_context": mock.ANY,
+                    "context_line": mock.ANY,
+                    "post_context": mock.ANY,
                 }
             ]
         },
@@ -311,6 +326,9 @@ def test_distribution(sentry_init, capture_envelopes):
                     "function": sys._getframe().f_code.co_name,
                     "module": __name__,
                     "lineno": mock.ANY,
+                    "pre_context": mock.ANY,
+                    "context_line": mock.ANY,
+                    "post_context": mock.ANY,
                 }
             ]
         },
@@ -360,6 +378,9 @@ def test_set(sentry_init, capture_envelopes):
                     "function": sys._getframe().f_code.co_name,
                     "module": __name__,
                     "lineno": mock.ANY,
+                    "pre_context": mock.ANY,
+                    "context_line": mock.ANY,
+                    "post_context": mock.ANY,
                 }
             ]
         },


### PR DESCRIPTION
The product is going to show source context with code locations on metrics. This
PR adds source context to the code location submission payload in the same
format that stack frames use.

Relay supports this with https://github.com/getsentry/relay/pull/2781.
