### PR TITLE
(1) Move `add_breadcrumb` and session function from Hub to Scope

### DIFF
--- a/sentry_sdk/client.py
+++ b/sentry_sdk/client.py
@@ -43,7 +43,10 @@ if TYPE_CHECKING:
     from typing import Dict
     from typing import Optional
     from typing import Sequence
+    from typing import Type
+    from typing import Union
 
+    from sentry_sdk.integrations import Integration
     from sentry_sdk.scope import Scope
     from sentry_sdk._types import Event, Hint
     from sentry_sdk.session import Session
@@ -652,6 +655,22 @@ class _Client(object):
             logger.info("Discarded session update because of missing release")
         else:
             self.session_flusher.add_session(session)
+
+    def get_integration(
+        self, name_or_class  # type: Union[str, Type[Integration]]
+    ):
+        # type: (...) -> Any
+        """Returns the integration for this client by name or class.
+        If the client does not have that integration then `None` is returned.
+        """
+        if isinstance(name_or_class, str):
+            integration_name = name_or_class
+        elif name_or_class.identifier is not None:
+            integration_name = name_or_class.identifier
+        else:
+            raise ValueError("Integration has no name")
+
+        return self.integrations.get(integration_name)
 
     def close(
         self,

--- a/sentry_sdk/hub.py
+++ b/sentry_sdk/hub.py
@@ -420,8 +420,7 @@ class Hub(with_metaclass(HubMeta)):  # type: ignore
             logger.info("Dropped breadcrumb because no client bound")
             return
 
-        kwargs["before_breadcrumb"] = client.options.get("before_breadcrumb")
-        kwargs["max_breadcrumbs"] = client.options.get("max_breadcrumbs")
+        kwargs["client"] = client
 
         scope.add_breadcrumb(crumb, hint, **kwargs)
 

--- a/sentry_sdk/hub.py
+++ b/sentry_sdk/hub.py
@@ -294,18 +294,9 @@ class Hub(with_metaclass(HubMeta)):  # type: ignore
         If the return value is not `None` the hub is guaranteed to have a
         client attached.
         """
-        if isinstance(name_or_class, str):
-            integration_name = name_or_class
-        elif name_or_class.identifier is not None:
-            integration_name = name_or_class.identifier
-        else:
-            raise ValueError("Integration has no name")
-
         client = self.client
         if client is not None:
-            rv = client.integrations.get(integration_name)
-            if rv is not None:
-                return rv
+            return client.get_integration(name_or_class)
 
     @property
     def client(self):

--- a/sentry_sdk/scope.py
+++ b/sentry_sdk/scope.py
@@ -555,11 +555,7 @@ class Scope(object):
         while len(self._breadcrumbs) > max_breadcrumbs:
             self._breadcrumbs.popleft()
 
-    def start_session(
-        self,
-        *args,
-        **kwargs,
-    ):
+    def start_session(self, *args, **kwargs):
         # type: (*Any, **Any) -> None
         """Starts a new session."""
         client = kwargs.pop("client", None)

--- a/sentry_sdk/scope.py
+++ b/sentry_sdk/scope.py
@@ -6,7 +6,9 @@ import uuid
 
 from sentry_sdk.attachments import Attachment
 from sentry_sdk._compat import datetime_utcnow
+from sentry_sdk.consts import DEFAULT_MAX_BREADCRUMBS, FALSE_VALUES
 from sentry_sdk._functools import wraps
+from sentry_sdk.session import Session
 from sentry_sdk.tracing_utils import (
     Baggage,
     extract_sentrytrace_data,
@@ -20,9 +22,6 @@ from sentry_sdk.tracing import (
 )
 from sentry_sdk._types import TYPE_CHECKING
 from sentry_sdk.utils import logger, capture_internal_exceptions
-
-from sentry_sdk.consts import DEFAULT_MAX_BREADCRUMBS, FALSE_VALUES
-
 
 if TYPE_CHECKING:
     from typing import Any
@@ -48,7 +47,6 @@ if TYPE_CHECKING:
 
     from sentry_sdk.profiler import Profile
     from sentry_sdk.tracing import Span
-    from sentry_sdk.session import Session
 
     F = TypeVar("F", bound=Callable[..., Any])
     T = TypeVar("T")

--- a/sentry_sdk/scope.py
+++ b/sentry_sdk/scope.py
@@ -6,7 +6,7 @@ import uuid
 
 from sentry_sdk.attachments import Attachment
 from sentry_sdk._compat import datetime_utcnow
-from sentry_sdk.consts import DEFAULT_MAX_BREADCRUMBS, FALSE_VALUES
+from sentry_sdk.consts import FALSE_VALUES
 from sentry_sdk._functools import wraps
 from sentry_sdk.session import Session
 from sentry_sdk.tracing_utils import (
@@ -527,8 +527,12 @@ class Scope(object):
         :param hint: An optional value that can be used by `before_breadcrumb`
             to customize the breadcrumbs that are emitted.
         """
-        before_breadcrumb = kwargs.pop("before_breadcrumb")
-        max_breadcrumbs = kwargs.pop("max_breadcrumbs", DEFAULT_MAX_BREADCRUMBS)
+        client = kwargs.pop("client", None)
+        if client is None:
+            return
+
+        before_breadcrumb = client.options.get("before_breadcrumb")
+        max_breadcrumbs = client.options.get("max_breadcrumbs")
 
         crumb = dict(crumb or ())  # type: Breadcrumb
         crumb.update(kwargs)


### PR DESCRIPTION
Moved some functionality from Hub to Scope or Client:
- moved `add_breadcrumb` from Hub to Scope
- moved session functions from Hub to Scope
- moved `get_integration1` from Hub to Client.

This is preparation work for refactoring how we deal with Hubs and Scopes in the future.
Each commit is moving one function, so it should be easy to review commit by commit.