### PR TITLE
fix(integrations): Fix Lambda integration with EventBridge source

### DIFF
--- a/sentry_sdk/integrations/aws_lambda.py
+++ b/sentry_sdk/integrations/aws_lambda.py
@@ -140,7 +140,7 @@ def _wrap_handler(handler):
             headers = request_data.get("headers", {})
             # Some AWS Services (ie. EventBridge) set headers as a list
             # or None, so we must ensure it is a dict
-            if type(headers) is not dict:
+            if not isinstance(headers, dict):
                 headers = {}
 
             transaction = continue_trace(

--- a/sentry_sdk/integrations/aws_lambda.py
+++ b/sentry_sdk/integrations/aws_lambda.py
@@ -137,9 +137,10 @@ def _wrap_handler(handler):
                     # Starting the thread to raise timeout warning exception
                     timeout_thread.start()
 
-            headers = request_data.get("headers")
-            # AWS Service may set an explicit `{headers: None}`, we can't rely on `.get()`'s default.
-            if headers is None:
+            headers = request_data.get("headers", {})
+            # Some AWS Services (ie. EventBridge) set headers as a list
+            # or None, so we must ensure it is a dict
+            if type(headers) is not dict:
                 headers = {}
 
             transaction = continue_trace(


### PR DESCRIPTION
When a lambda is triggered by an AWS EventBridge pipe the record contains an explicit "header" key with an empty list. This breaks the assumption that headers is always a dict or None. Update the AwsLambdaIntegration to explicitly verify that header is a dict before passing it on to the `continue_trace` function.

Fixes GH-2545