### PR TITLE
Skip permissions step on `push` events

### DIFF
--- a/.github/workflows/test-integration-aws_lambda.yml
+++ b/.github/workflows/test-integration-aws_lambda.yml
@@ -32,7 +32,8 @@ jobs:
       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
         with:
           persist-credentials: false
-      - name: permissions
+      - name: Check permissions on PR
+        if: github.event_name == 'pull_request_target'
         run: |
           python3 -uS .github/workflows/scripts/trigger_tests_on_label.py \
               --repo-id ${{ github.event.repository.id }} \
@@ -45,6 +46,9 @@ jobs:
           # these can contain special characters
           ARG_USERNAME: ${{ github.event.pull_request.user.login }}
           ARG_LABEL_NAMES: ${{ toJSON(github.event.pull_request.labels.*.name) }}
+      - name: Check permissions on repo branch
+        if: github.event_name == 'push'
+        run: true
   test-pinned:
     needs: check-permissions
     timeout-minutes: 30

--- a/scripts/split-tox-gh-actions/templates/check_permissions.jinja
+++ b/scripts/split-tox-gh-actions/templates/check_permissions.jinja
@@ -6,7 +6,8 @@
         with:
           persist-credentials: false
 
-      - name: permissions
+      - name: Check permissions on PR
+        if: github.event_name == 'pull_request_target'
         run: |
           {% raw %}
           python3 -uS .github/workflows/scripts/trigger_tests_on_label.py \
@@ -23,3 +24,7 @@
           ARG_USERNAME: ${{ github.event.pull_request.user.login }}
           ARG_LABEL_NAMES: ${{ toJSON(github.event.pull_request.labels.*.name) }}
           {% endraw %}
+
+      - name: Check permissions on repo branch
+        if: github.event_name == 'push'
+        run: true


### PR DESCRIPTION
The AWS Lambda test suite is failing on master. It runs a script to check whether a PR author has the right permissions to run the test suite, but the event that triggers the workflow is not a PR being opened/updated, but rather pushing to a repo branch.

In the patch here we treat the two possible event types differently:
* on `push`, we skip the permissions check entirely since the `push` event is only emitted on changes to repo branches (and we only limit it to `master` and `release/` branches), which can only be triggered by people with write permissions
* on `pull_request_target`, we run the permissions check as before