### PR TITLE
Add a pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,8 +6,12 @@
 
 Thank you for contributing to `sentry-python`!
 
-Please make sure to include tests for your changes and run your code through linters (`tox -e linters`).
+Please add tests to validate your changes and lint your code using `tox -e linters`.
 
 Running the test suite on your PR might require maintainer approval. Some tests (AWS Lambda) additionally require a maintainer to add a special label to run and will fail if the label is not present.
 
-_For maintainers:_ Carefully check the PR and then apply the `Trigger: tests using secrets` label to run sensitive test suites. The label will be removed on any code changes for security reasons, in which case the PR has to be re-checked and the label manually reapplied again.
+#### For maintainers
+
+Sensitive test suites require maintainer review to ensure that tests do not compromise our secrets. This review must be repeated after any code revisions.
+
+Before running sensitive test suites, please carefully check the PR. Then, apply the `Trigger: tests using secrets` label. The label will be removed after any code changes to enforce our policy requiring maintainers to review all code revisions before running sensitive tests.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,15 @@
+<!-- What problem does this PR solve, what feature does it add? -->
+
+---
+
+## General Notes
+
+Thank you for contributing to `sentry-python`!
+
+Please make sure to include tests for your changes and run your code through linters (`tox -e linters`).
+
+If this is your first `sentry-python` pull request, running the test suite will require maintainer approval. Some tests (AWS Lambda) additionally require a special label to run and will always fail if the label is not present.
+
+---
+
+For maintainers: Carefully check the PR and then apply the `Trigger: tests using secrets` to run sensitive test suites.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,6 +8,6 @@ Thank you for contributing to `sentry-python`!
 
 Please make sure to include tests for your changes and run your code through linters (`tox -e linters`).
 
-If this is your first `sentry-python` contribution, running the test suite will require maintainer approval. Some tests (AWS Lambda) additionally require a maintainer to add a special label to run and will fail if the label is not present.
+Running the test suite on your PR might require maintainer approval. Some tests (AWS Lambda) additionally require a maintainer to add a special label to run and will fail if the label is not present.
 
 _For maintainers:_ Carefully check the PR and then apply the `Trigger: tests using secrets` label to run sensitive test suites. The label will be removed on any code changes for security reasons, in which case the PR has to be re-checked and the label manually reapplied again.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,4 @@
-<!-- What problem does this PR solve, what feature does it add? -->
+<!-- Describe your PR here -->
 
 ---
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,7 +8,7 @@ Thank you for contributing to `sentry-python`!
 
 Please make sure to include tests for your changes and run your code through linters (`tox -e linters`).
 
-If this is your first `sentry-python` pull request, running the test suite will require maintainer approval. Some tests (AWS Lambda) additionally require a special label to run and will always fail if the label is not present.
+If this is your first `sentry-python` pull request, running the test suite will require maintainer approval. Some tests (AWS Lambda) additionally require a maintainer to add a special label to run and will fail if the label is not present.
 
 ---
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,7 +6,7 @@
 
 Thank you for contributing to `sentry-python`!
 
-Please add tests to validate your changes and lint your code using `tox -e linters`.
+Please add tests to validate your changes, and lint your code using `tox -e linters`.
 
 Running the test suite on your PR might require maintainer approval. Some tests (AWS Lambda) additionally require a maintainer to add a special label to run and will fail if the label is not present.
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -10,4 +10,4 @@ Please make sure to include tests for your changes and run your code through lin
 
 If this is your first `sentry-python` contribution, running the test suite will require maintainer approval. Some tests (AWS Lambda) additionally require a maintainer to add a special label to run and will fail if the label is not present.
 
-_For maintainers:_ Carefully check the PR and then apply the `Trigger: tests using secrets` to run sensitive test suites.
+_For maintainers:_ Carefully check the PR and then apply the `Trigger: tests using secrets` to run sensitive test suites. The label will be removed on any code changes for security reasons, in which case the PR has to be re-checked and the label manually reapplied again.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -10,6 +10,4 @@ Please make sure to include tests for your changes and run your code through lin
 
 If this is your first `sentry-python` pull request, running the test suite will require maintainer approval. Some tests (AWS Lambda) additionally require a maintainer to add a special label to run and will fail if the label is not present.
 
----
-
-For maintainers: Carefully check the PR and then apply the `Trigger: tests using secrets` to run sensitive test suites.
+_For maintainers:_ Carefully check the PR and then apply the `Trigger: tests using secrets` to run sensitive test suites.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,6 +8,6 @@ Thank you for contributing to `sentry-python`!
 
 Please make sure to include tests for your changes and run your code through linters (`tox -e linters`).
 
-If this is your first `sentry-python` pull request, running the test suite will require maintainer approval. Some tests (AWS Lambda) additionally require a maintainer to add a special label to run and will fail if the label is not present.
+If this is your first `sentry-python` contribution, running the test suite will require maintainer approval. Some tests (AWS Lambda) additionally require a maintainer to add a special label to run and will fail if the label is not present.
 
 _For maintainers:_ Carefully check the PR and then apply the `Trigger: tests using secrets` to run sensitive test suites.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -10,4 +10,4 @@ Please make sure to include tests for your changes and run your code through lin
 
 If this is your first `sentry-python` contribution, running the test suite will require maintainer approval. Some tests (AWS Lambda) additionally require a maintainer to add a special label to run and will fail if the label is not present.
 
-_For maintainers:_ Carefully check the PR and then apply the `Trigger: tests using secrets` to run sensitive test suites. The label will be removed on any code changes for security reasons, in which case the PR has to be re-checked and the label manually reapplied again.
+_For maintainers:_ Carefully check the PR and then apply the `Trigger: tests using secrets` label to run sensitive test suites. The label will be removed on any code changes for security reasons, in which case the PR has to be re-checked and the label manually reapplied again.


### PR DESCRIPTION
Since we've changed our PR workflow with the addition of the `Trigger: tests using secrets` label, let's persist this info somewhere for both external contributors and folks maintaining the repo.