### PR TITLE
fix(CI): Treat skipped test jobs as failed

### DIFF
--- a/.github/workflows/test-common.yml
+++ b/.github/workflows/test-common.yml
@@ -92,10 +92,10 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Check for failures
-        if: contains(needs.test-pinned.result, 'failure')
+        if: contains(needs.test-pinned.result, 'failure') || contains(needs.test-pinned.result, 'skipped')
         run: |
           echo "One of the dependent jobs has failed. You may need to re-run it." && exit 1
       - name: Check for 2.7 failures
-        if: contains(needs.test-py27.result, 'failure')
+        if: contains(needs.test-py27.result, 'failure') || contains(needs.test-py27.result, 'skipped')
         run: |
           echo "One of the dependent jobs has failed. You may need to re-run it." && exit 1

--- a/.github/workflows/test-common.yml
+++ b/.github/workflows/test-common.yml
@@ -85,7 +85,7 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: coverage.xml
   check_required_tests:
-    name: All common tests passed or skipped
+    name: All common tests passed
     needs: [test-pinned, test-py27]
     # Always run this, even if a dependent job failed
     if: always()

--- a/.github/workflows/test-integration-aiohttp.yml
+++ b/.github/workflows/test-integration-aiohttp.yml
@@ -103,6 +103,6 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Check for failures
-        if: contains(needs.test-pinned.result, 'failure')
+        if: contains(needs.test-pinned.result, 'failure') || contains(needs.test-pinned.result, 'skipped')
         run: |
           echo "One of the dependent jobs has failed. You may need to re-run it." && exit 1

--- a/.github/workflows/test-integration-aiohttp.yml
+++ b/.github/workflows/test-integration-aiohttp.yml
@@ -96,7 +96,7 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: coverage.xml
   check_required_tests:
-    name: All aiohttp tests passed or skipped
+    name: All aiohttp tests passed
     needs: test-pinned
     # Always run this, even if a dependent job failed
     if: always()

--- a/.github/workflows/test-integration-ariadne.yml
+++ b/.github/workflows/test-integration-ariadne.yml
@@ -103,6 +103,6 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Check for failures
-        if: contains(needs.test-pinned.result, 'failure')
+        if: contains(needs.test-pinned.result, 'failure') || contains(needs.test-pinned.result, 'skipped')
         run: |
           echo "One of the dependent jobs has failed. You may need to re-run it." && exit 1

--- a/.github/workflows/test-integration-ariadne.yml
+++ b/.github/workflows/test-integration-ariadne.yml
@@ -96,7 +96,7 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: coverage.xml
   check_required_tests:
-    name: All ariadne tests passed or skipped
+    name: All ariadne tests passed
     needs: test-pinned
     # Always run this, even if a dependent job failed
     if: always()

--- a/.github/workflows/test-integration-arq.yml
+++ b/.github/workflows/test-integration-arq.yml
@@ -103,6 +103,6 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Check for failures
-        if: contains(needs.test-pinned.result, 'failure')
+        if: contains(needs.test-pinned.result, 'failure') || contains(needs.test-pinned.result, 'skipped')
         run: |
           echo "One of the dependent jobs has failed. You may need to re-run it." && exit 1

--- a/.github/workflows/test-integration-arq.yml
+++ b/.github/workflows/test-integration-arq.yml
@@ -96,7 +96,7 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: coverage.xml
   check_required_tests:
-    name: All arq tests passed or skipped
+    name: All arq tests passed
     needs: test-pinned
     # Always run this, even if a dependent job failed
     if: always()

--- a/.github/workflows/test-integration-asgi.yml
+++ b/.github/workflows/test-integration-asgi.yml
@@ -64,6 +64,6 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Check for failures
-        if: contains(needs.test-pinned.result, 'failure')
+        if: contains(needs.test-pinned.result, 'failure') || contains(needs.test-pinned.result, 'skipped')
         run: |
           echo "One of the dependent jobs has failed. You may need to re-run it." && exit 1

--- a/.github/workflows/test-integration-asgi.yml
+++ b/.github/workflows/test-integration-asgi.yml
@@ -57,7 +57,7 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: coverage.xml
   check_required_tests:
-    name: All asgi tests passed or skipped
+    name: All asgi tests passed
     needs: test-pinned
     # Always run this, even if a dependent job failed
     if: always()

--- a/.github/workflows/test-integration-asyncpg.yml
+++ b/.github/workflows/test-integration-asyncpg.yml
@@ -145,6 +145,6 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Check for failures
-        if: contains(needs.test-pinned.result, 'failure')
+        if: contains(needs.test-pinned.result, 'failure') || contains(needs.test-pinned.result, 'skipped')
         run: |
           echo "One of the dependent jobs has failed. You may need to re-run it." && exit 1

--- a/.github/workflows/test-integration-asyncpg.yml
+++ b/.github/workflows/test-integration-asyncpg.yml
@@ -138,7 +138,7 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: coverage.xml
   check_required_tests:
-    name: All asyncpg tests passed or skipped
+    name: All asyncpg tests passed
     needs: test-pinned
     # Always run this, even if a dependent job failed
     if: always()

--- a/.github/workflows/test-integration-aws_lambda.yml
+++ b/.github/workflows/test-integration-aws_lambda.yml
@@ -92,7 +92,7 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: coverage.xml
   check_required_tests:
-    name: All aws_lambda tests passed or skipped
+    name: All aws_lambda tests passed
     needs: test-pinned
     # Always run this, even if a dependent job failed
     if: always()

--- a/.github/workflows/test-integration-aws_lambda.yml
+++ b/.github/workflows/test-integration-aws_lambda.yml
@@ -99,6 +99,6 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Check for failures
-        if: contains(needs.test-pinned.result, 'failure')
+        if: contains(needs.test-pinned.result, 'failure') || contains(needs.test-pinned.result, 'skipped')
         run: |
           echo "One of the dependent jobs has failed. You may need to re-run it." && exit 1

--- a/.github/workflows/test-integration-beam.yml
+++ b/.github/workflows/test-integration-beam.yml
@@ -103,6 +103,6 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Check for failures
-        if: contains(needs.test-pinned.result, 'failure')
+        if: contains(needs.test-pinned.result, 'failure') || contains(needs.test-pinned.result, 'skipped')
         run: |
           echo "One of the dependent jobs has failed. You may need to re-run it." && exit 1

--- a/.github/workflows/test-integration-beam.yml
+++ b/.github/workflows/test-integration-beam.yml
@@ -96,7 +96,7 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: coverage.xml
   check_required_tests:
-    name: All beam tests passed or skipped
+    name: All beam tests passed
     needs: test-pinned
     # Always run this, even if a dependent job failed
     if: always()

--- a/.github/workflows/test-integration-boto3.yml
+++ b/.github/workflows/test-integration-boto3.yml
@@ -124,7 +124,7 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: coverage.xml
   check_required_tests:
-    name: All boto3 tests passed or skipped
+    name: All boto3 tests passed
     needs: [test-pinned, test-py27]
     # Always run this, even if a dependent job failed
     if: always()

--- a/.github/workflows/test-integration-boto3.yml
+++ b/.github/workflows/test-integration-boto3.yml
@@ -131,10 +131,10 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Check for failures
-        if: contains(needs.test-pinned.result, 'failure')
+        if: contains(needs.test-pinned.result, 'failure') || contains(needs.test-pinned.result, 'skipped')
         run: |
           echo "One of the dependent jobs has failed. You may need to re-run it." && exit 1
       - name: Check for 2.7 failures
-        if: contains(needs.test-py27.result, 'failure')
+        if: contains(needs.test-py27.result, 'failure') || contains(needs.test-py27.result, 'skipped')
         run: |
           echo "One of the dependent jobs has failed. You may need to re-run it." && exit 1

--- a/.github/workflows/test-integration-bottle.yml
+++ b/.github/workflows/test-integration-bottle.yml
@@ -131,10 +131,10 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Check for failures
-        if: contains(needs.test-pinned.result, 'failure')
+        if: contains(needs.test-pinned.result, 'failure') || contains(needs.test-pinned.result, 'skipped')
         run: |
           echo "One of the dependent jobs has failed. You may need to re-run it." && exit 1
       - name: Check for 2.7 failures
-        if: contains(needs.test-py27.result, 'failure')
+        if: contains(needs.test-py27.result, 'failure') || contains(needs.test-py27.result, 'skipped')
         run: |
           echo "One of the dependent jobs has failed. You may need to re-run it." && exit 1

--- a/.github/workflows/test-integration-bottle.yml
+++ b/.github/workflows/test-integration-bottle.yml
@@ -124,7 +124,7 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: coverage.xml
   check_required_tests:
-    name: All bottle tests passed or skipped
+    name: All bottle tests passed
     needs: [test-pinned, test-py27]
     # Always run this, even if a dependent job failed
     if: always()

--- a/.github/workflows/test-integration-celery.yml
+++ b/.github/workflows/test-integration-celery.yml
@@ -124,7 +124,7 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: coverage.xml
   check_required_tests:
-    name: All celery tests passed or skipped
+    name: All celery tests passed
     needs: [test-pinned, test-py27]
     # Always run this, even if a dependent job failed
     if: always()

--- a/.github/workflows/test-integration-celery.yml
+++ b/.github/workflows/test-integration-celery.yml
@@ -131,10 +131,10 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Check for failures
-        if: contains(needs.test-pinned.result, 'failure')
+        if: contains(needs.test-pinned.result, 'failure') || contains(needs.test-pinned.result, 'skipped')
         run: |
           echo "One of the dependent jobs has failed. You may need to re-run it." && exit 1
       - name: Check for 2.7 failures
-        if: contains(needs.test-py27.result, 'failure')
+        if: contains(needs.test-py27.result, 'failure') || contains(needs.test-py27.result, 'skipped')
         run: |
           echo "One of the dependent jobs has failed. You may need to re-run it." && exit 1

--- a/.github/workflows/test-integration-chalice.yml
+++ b/.github/workflows/test-integration-chalice.yml
@@ -103,6 +103,6 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Check for failures
-        if: contains(needs.test-pinned.result, 'failure')
+        if: contains(needs.test-pinned.result, 'failure') || contains(needs.test-pinned.result, 'skipped')
         run: |
           echo "One of the dependent jobs has failed. You may need to re-run it." && exit 1

--- a/.github/workflows/test-integration-chalice.yml
+++ b/.github/workflows/test-integration-chalice.yml
@@ -96,7 +96,7 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: coverage.xml
   check_required_tests:
-    name: All chalice tests passed or skipped
+    name: All chalice tests passed
     needs: test-pinned
     # Always run this, even if a dependent job failed
     if: always()

--- a/.github/workflows/test-integration-clickhouse_driver.yml
+++ b/.github/workflows/test-integration-clickhouse_driver.yml
@@ -105,6 +105,6 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Check for failures
-        if: contains(needs.test-pinned.result, 'failure')
+        if: contains(needs.test-pinned.result, 'failure') || contains(needs.test-pinned.result, 'skipped')
         run: |
           echo "One of the dependent jobs has failed. You may need to re-run it." && exit 1

--- a/.github/workflows/test-integration-clickhouse_driver.yml
+++ b/.github/workflows/test-integration-clickhouse_driver.yml
@@ -98,7 +98,7 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: coverage.xml
   check_required_tests:
-    name: All clickhouse_driver tests passed or skipped
+    name: All clickhouse_driver tests passed
     needs: test-pinned
     # Always run this, even if a dependent job failed
     if: always()

--- a/.github/workflows/test-integration-cloud_resource_context.yml
+++ b/.github/workflows/test-integration-cloud_resource_context.yml
@@ -57,7 +57,7 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: coverage.xml
   check_required_tests:
-    name: All cloud_resource_context tests passed or skipped
+    name: All cloud_resource_context tests passed
     needs: test-pinned
     # Always run this, even if a dependent job failed
     if: always()

--- a/.github/workflows/test-integration-cloud_resource_context.yml
+++ b/.github/workflows/test-integration-cloud_resource_context.yml
@@ -64,6 +64,6 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Check for failures
-        if: contains(needs.test-pinned.result, 'failure')
+        if: contains(needs.test-pinned.result, 'failure') || contains(needs.test-pinned.result, 'skipped')
         run: |
           echo "One of the dependent jobs has failed. You may need to re-run it." && exit 1

--- a/.github/workflows/test-integration-django.yml
+++ b/.github/workflows/test-integration-django.yml
@@ -187,7 +187,7 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: coverage.xml
   check_required_tests:
-    name: All django tests passed or skipped
+    name: All django tests passed
     needs: [test-pinned, test-py27]
     # Always run this, even if a dependent job failed
     if: always()

--- a/.github/workflows/test-integration-django.yml
+++ b/.github/workflows/test-integration-django.yml
@@ -194,10 +194,10 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Check for failures
-        if: contains(needs.test-pinned.result, 'failure')
+        if: contains(needs.test-pinned.result, 'failure') || contains(needs.test-pinned.result, 'skipped')
         run: |
           echo "One of the dependent jobs has failed. You may need to re-run it." && exit 1
       - name: Check for 2.7 failures
-        if: contains(needs.test-py27.result, 'failure')
+        if: contains(needs.test-py27.result, 'failure') || contains(needs.test-py27.result, 'skipped')
         run: |
           echo "One of the dependent jobs has failed. You may need to re-run it." && exit 1

--- a/.github/workflows/test-integration-falcon.yml
+++ b/.github/workflows/test-integration-falcon.yml
@@ -131,10 +131,10 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Check for failures
-        if: contains(needs.test-pinned.result, 'failure')
+        if: contains(needs.test-pinned.result, 'failure') || contains(needs.test-pinned.result, 'skipped')
         run: |
           echo "One of the dependent jobs has failed. You may need to re-run it." && exit 1
       - name: Check for 2.7 failures
-        if: contains(needs.test-py27.result, 'failure')
+        if: contains(needs.test-py27.result, 'failure') || contains(needs.test-py27.result, 'skipped')
         run: |
           echo "One of the dependent jobs has failed. You may need to re-run it." && exit 1

--- a/.github/workflows/test-integration-falcon.yml
+++ b/.github/workflows/test-integration-falcon.yml
@@ -124,7 +124,7 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: coverage.xml
   check_required_tests:
-    name: All falcon tests passed or skipped
+    name: All falcon tests passed
     needs: [test-pinned, test-py27]
     # Always run this, even if a dependent job failed
     if: always()

--- a/.github/workflows/test-integration-fastapi.yml
+++ b/.github/workflows/test-integration-fastapi.yml
@@ -103,6 +103,6 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Check for failures
-        if: contains(needs.test-pinned.result, 'failure')
+        if: contains(needs.test-pinned.result, 'failure') || contains(needs.test-pinned.result, 'skipped')
         run: |
           echo "One of the dependent jobs has failed. You may need to re-run it." && exit 1

--- a/.github/workflows/test-integration-fastapi.yml
+++ b/.github/workflows/test-integration-fastapi.yml
@@ -96,7 +96,7 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: coverage.xml
   check_required_tests:
-    name: All fastapi tests passed or skipped
+    name: All fastapi tests passed
     needs: test-pinned
     # Always run this, even if a dependent job failed
     if: always()

--- a/.github/workflows/test-integration-flask.yml
+++ b/.github/workflows/test-integration-flask.yml
@@ -124,7 +124,7 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: coverage.xml
   check_required_tests:
-    name: All flask tests passed or skipped
+    name: All flask tests passed
     needs: [test-pinned, test-py27]
     # Always run this, even if a dependent job failed
     if: always()

--- a/.github/workflows/test-integration-flask.yml
+++ b/.github/workflows/test-integration-flask.yml
@@ -131,10 +131,10 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Check for failures
-        if: contains(needs.test-pinned.result, 'failure')
+        if: contains(needs.test-pinned.result, 'failure') || contains(needs.test-pinned.result, 'skipped')
         run: |
           echo "One of the dependent jobs has failed. You may need to re-run it." && exit 1
       - name: Check for 2.7 failures
-        if: contains(needs.test-py27.result, 'failure')
+        if: contains(needs.test-py27.result, 'failure') || contains(needs.test-py27.result, 'skipped')
         run: |
           echo "One of the dependent jobs has failed. You may need to re-run it." && exit 1

--- a/.github/workflows/test-integration-gcp.yml
+++ b/.github/workflows/test-integration-gcp.yml
@@ -57,7 +57,7 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: coverage.xml
   check_required_tests:
-    name: All gcp tests passed or skipped
+    name: All gcp tests passed
     needs: test-pinned
     # Always run this, even if a dependent job failed
     if: always()

--- a/.github/workflows/test-integration-gcp.yml
+++ b/.github/workflows/test-integration-gcp.yml
@@ -64,6 +64,6 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Check for failures
-        if: contains(needs.test-pinned.result, 'failure')
+        if: contains(needs.test-pinned.result, 'failure') || contains(needs.test-pinned.result, 'skipped')
         run: |
           echo "One of the dependent jobs has failed. You may need to re-run it." && exit 1

--- a/.github/workflows/test-integration-gevent.yml
+++ b/.github/workflows/test-integration-gevent.yml
@@ -92,10 +92,10 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Check for failures
-        if: contains(needs.test-pinned.result, 'failure')
+        if: contains(needs.test-pinned.result, 'failure') || contains(needs.test-pinned.result, 'skipped')
         run: |
           echo "One of the dependent jobs has failed. You may need to re-run it." && exit 1
       - name: Check for 2.7 failures
-        if: contains(needs.test-py27.result, 'failure')
+        if: contains(needs.test-py27.result, 'failure') || contains(needs.test-py27.result, 'skipped')
         run: |
           echo "One of the dependent jobs has failed. You may need to re-run it." && exit 1

--- a/.github/workflows/test-integration-gevent.yml
+++ b/.github/workflows/test-integration-gevent.yml
@@ -85,7 +85,7 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: coverage.xml
   check_required_tests:
-    name: All gevent tests passed or skipped
+    name: All gevent tests passed
     needs: [test-pinned, test-py27]
     # Always run this, even if a dependent job failed
     if: always()

--- a/.github/workflows/test-integration-gql.yml
+++ b/.github/workflows/test-integration-gql.yml
@@ -103,6 +103,6 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Check for failures
-        if: contains(needs.test-pinned.result, 'failure')
+        if: contains(needs.test-pinned.result, 'failure') || contains(needs.test-pinned.result, 'skipped')
         run: |
           echo "One of the dependent jobs has failed. You may need to re-run it." && exit 1

--- a/.github/workflows/test-integration-gql.yml
+++ b/.github/workflows/test-integration-gql.yml
@@ -96,7 +96,7 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: coverage.xml
   check_required_tests:
-    name: All gql tests passed or skipped
+    name: All gql tests passed
     needs: test-pinned
     # Always run this, even if a dependent job failed
     if: always()

--- a/.github/workflows/test-integration-graphene.yml
+++ b/.github/workflows/test-integration-graphene.yml
@@ -103,6 +103,6 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Check for failures
-        if: contains(needs.test-pinned.result, 'failure')
+        if: contains(needs.test-pinned.result, 'failure') || contains(needs.test-pinned.result, 'skipped')
         run: |
           echo "One of the dependent jobs has failed. You may need to re-run it." && exit 1

--- a/.github/workflows/test-integration-graphene.yml
+++ b/.github/workflows/test-integration-graphene.yml
@@ -96,7 +96,7 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: coverage.xml
   check_required_tests:
-    name: All graphene tests passed or skipped
+    name: All graphene tests passed
     needs: test-pinned
     # Always run this, even if a dependent job failed
     if: always()

--- a/.github/workflows/test-integration-grpc.yml
+++ b/.github/workflows/test-integration-grpc.yml
@@ -103,6 +103,6 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Check for failures
-        if: contains(needs.test-pinned.result, 'failure')
+        if: contains(needs.test-pinned.result, 'failure') || contains(needs.test-pinned.result, 'skipped')
         run: |
           echo "One of the dependent jobs has failed. You may need to re-run it." && exit 1

--- a/.github/workflows/test-integration-grpc.yml
+++ b/.github/workflows/test-integration-grpc.yml
@@ -96,7 +96,7 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: coverage.xml
   check_required_tests:
-    name: All grpc tests passed or skipped
+    name: All grpc tests passed
     needs: test-pinned
     # Always run this, even if a dependent job failed
     if: always()

--- a/.github/workflows/test-integration-httpx.yml
+++ b/.github/workflows/test-integration-httpx.yml
@@ -103,6 +103,6 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Check for failures
-        if: contains(needs.test-pinned.result, 'failure')
+        if: contains(needs.test-pinned.result, 'failure') || contains(needs.test-pinned.result, 'skipped')
         run: |
           echo "One of the dependent jobs has failed. You may need to re-run it." && exit 1

--- a/.github/workflows/test-integration-httpx.yml
+++ b/.github/workflows/test-integration-httpx.yml
@@ -96,7 +96,7 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: coverage.xml
   check_required_tests:
-    name: All httpx tests passed or skipped
+    name: All httpx tests passed
     needs: test-pinned
     # Always run this, even if a dependent job failed
     if: always()

--- a/.github/workflows/test-integration-huey.yml
+++ b/.github/workflows/test-integration-huey.yml
@@ -124,7 +124,7 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: coverage.xml
   check_required_tests:
-    name: All huey tests passed or skipped
+    name: All huey tests passed
     needs: [test-pinned, test-py27]
     # Always run this, even if a dependent job failed
     if: always()

--- a/.github/workflows/test-integration-huey.yml
+++ b/.github/workflows/test-integration-huey.yml
@@ -131,10 +131,10 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Check for failures
-        if: contains(needs.test-pinned.result, 'failure')
+        if: contains(needs.test-pinned.result, 'failure') || contains(needs.test-pinned.result, 'skipped')
         run: |
           echo "One of the dependent jobs has failed. You may need to re-run it." && exit 1
       - name: Check for 2.7 failures
-        if: contains(needs.test-py27.result, 'failure')
+        if: contains(needs.test-py27.result, 'failure') || contains(needs.test-py27.result, 'skipped')
         run: |
           echo "One of the dependent jobs has failed. You may need to re-run it." && exit 1

--- a/.github/workflows/test-integration-loguru.yml
+++ b/.github/workflows/test-integration-loguru.yml
@@ -103,6 +103,6 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Check for failures
-        if: contains(needs.test-pinned.result, 'failure')
+        if: contains(needs.test-pinned.result, 'failure') || contains(needs.test-pinned.result, 'skipped')
         run: |
           echo "One of the dependent jobs has failed. You may need to re-run it." && exit 1

--- a/.github/workflows/test-integration-loguru.yml
+++ b/.github/workflows/test-integration-loguru.yml
@@ -96,7 +96,7 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: coverage.xml
   check_required_tests:
-    name: All loguru tests passed or skipped
+    name: All loguru tests passed
     needs: test-pinned
     # Always run this, even if a dependent job failed
     if: always()

--- a/.github/workflows/test-integration-opentelemetry.yml
+++ b/.github/workflows/test-integration-opentelemetry.yml
@@ -64,6 +64,6 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Check for failures
-        if: contains(needs.test-pinned.result, 'failure')
+        if: contains(needs.test-pinned.result, 'failure') || contains(needs.test-pinned.result, 'skipped')
         run: |
           echo "One of the dependent jobs has failed. You may need to re-run it." && exit 1

--- a/.github/workflows/test-integration-opentelemetry.yml
+++ b/.github/workflows/test-integration-opentelemetry.yml
@@ -57,7 +57,7 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: coverage.xml
   check_required_tests:
-    name: All opentelemetry tests passed or skipped
+    name: All opentelemetry tests passed
     needs: test-pinned
     # Always run this, even if a dependent job failed
     if: always()

--- a/.github/workflows/test-integration-pure_eval.yml
+++ b/.github/workflows/test-integration-pure_eval.yml
@@ -57,7 +57,7 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: coverage.xml
   check_required_tests:
-    name: All pure_eval tests passed or skipped
+    name: All pure_eval tests passed
     needs: test-pinned
     # Always run this, even if a dependent job failed
     if: always()

--- a/.github/workflows/test-integration-pure_eval.yml
+++ b/.github/workflows/test-integration-pure_eval.yml
@@ -64,6 +64,6 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Check for failures
-        if: contains(needs.test-pinned.result, 'failure')
+        if: contains(needs.test-pinned.result, 'failure') || contains(needs.test-pinned.result, 'skipped')
         run: |
           echo "One of the dependent jobs has failed. You may need to re-run it." && exit 1

--- a/.github/workflows/test-integration-pymongo.yml
+++ b/.github/workflows/test-integration-pymongo.yml
@@ -131,10 +131,10 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Check for failures
-        if: contains(needs.test-pinned.result, 'failure')
+        if: contains(needs.test-pinned.result, 'failure') || contains(needs.test-pinned.result, 'skipped')
         run: |
           echo "One of the dependent jobs has failed. You may need to re-run it." && exit 1
       - name: Check for 2.7 failures
-        if: contains(needs.test-py27.result, 'failure')
+        if: contains(needs.test-py27.result, 'failure') || contains(needs.test-py27.result, 'skipped')
         run: |
           echo "One of the dependent jobs has failed. You may need to re-run it." && exit 1

--- a/.github/workflows/test-integration-pymongo.yml
+++ b/.github/workflows/test-integration-pymongo.yml
@@ -124,7 +124,7 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: coverage.xml
   check_required_tests:
-    name: All pymongo tests passed or skipped
+    name: All pymongo tests passed
     needs: [test-pinned, test-py27]
     # Always run this, even if a dependent job failed
     if: always()

--- a/.github/workflows/test-integration-pyramid.yml
+++ b/.github/workflows/test-integration-pyramid.yml
@@ -131,10 +131,10 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Check for failures
-        if: contains(needs.test-pinned.result, 'failure')
+        if: contains(needs.test-pinned.result, 'failure') || contains(needs.test-pinned.result, 'skipped')
         run: |
           echo "One of the dependent jobs has failed. You may need to re-run it." && exit 1
       - name: Check for 2.7 failures
-        if: contains(needs.test-py27.result, 'failure')
+        if: contains(needs.test-py27.result, 'failure') || contains(needs.test-py27.result, 'skipped')
         run: |
           echo "One of the dependent jobs has failed. You may need to re-run it." && exit 1

--- a/.github/workflows/test-integration-pyramid.yml
+++ b/.github/workflows/test-integration-pyramid.yml
@@ -124,7 +124,7 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: coverage.xml
   check_required_tests:
-    name: All pyramid tests passed or skipped
+    name: All pyramid tests passed
     needs: [test-pinned, test-py27]
     # Always run this, even if a dependent job failed
     if: always()

--- a/.github/workflows/test-integration-quart.yml
+++ b/.github/workflows/test-integration-quart.yml
@@ -103,6 +103,6 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Check for failures
-        if: contains(needs.test-pinned.result, 'failure')
+        if: contains(needs.test-pinned.result, 'failure') || contains(needs.test-pinned.result, 'skipped')
         run: |
           echo "One of the dependent jobs has failed. You may need to re-run it." && exit 1

--- a/.github/workflows/test-integration-quart.yml
+++ b/.github/workflows/test-integration-quart.yml
@@ -96,7 +96,7 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: coverage.xml
   check_required_tests:
-    name: All quart tests passed or skipped
+    name: All quart tests passed
     needs: test-pinned
     # Always run this, even if a dependent job failed
     if: always()

--- a/.github/workflows/test-integration-redis.yml
+++ b/.github/workflows/test-integration-redis.yml
@@ -131,10 +131,10 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Check for failures
-        if: contains(needs.test-pinned.result, 'failure')
+        if: contains(needs.test-pinned.result, 'failure') || contains(needs.test-pinned.result, 'skipped')
         run: |
           echo "One of the dependent jobs has failed. You may need to re-run it." && exit 1
       - name: Check for 2.7 failures
-        if: contains(needs.test-py27.result, 'failure')
+        if: contains(needs.test-py27.result, 'failure') || contains(needs.test-py27.result, 'skipped')
         run: |
           echo "One of the dependent jobs has failed. You may need to re-run it." && exit 1

--- a/.github/workflows/test-integration-redis.yml
+++ b/.github/workflows/test-integration-redis.yml
@@ -124,7 +124,7 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: coverage.xml
   check_required_tests:
-    name: All redis tests passed or skipped
+    name: All redis tests passed
     needs: [test-pinned, test-py27]
     # Always run this, even if a dependent job failed
     if: always()

--- a/.github/workflows/test-integration-rediscluster.yml
+++ b/.github/workflows/test-integration-rediscluster.yml
@@ -92,10 +92,10 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Check for failures
-        if: contains(needs.test-pinned.result, 'failure')
+        if: contains(needs.test-pinned.result, 'failure') || contains(needs.test-pinned.result, 'skipped')
         run: |
           echo "One of the dependent jobs has failed. You may need to re-run it." && exit 1
       - name: Check for 2.7 failures
-        if: contains(needs.test-py27.result, 'failure')
+        if: contains(needs.test-py27.result, 'failure') || contains(needs.test-py27.result, 'skipped')
         run: |
           echo "One of the dependent jobs has failed. You may need to re-run it." && exit 1

--- a/.github/workflows/test-integration-rediscluster.yml
+++ b/.github/workflows/test-integration-rediscluster.yml
@@ -85,7 +85,7 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: coverage.xml
   check_required_tests:
-    name: All rediscluster tests passed or skipped
+    name: All rediscluster tests passed
     needs: [test-pinned, test-py27]
     # Always run this, even if a dependent job failed
     if: always()

--- a/.github/workflows/test-integration-requests.yml
+++ b/.github/workflows/test-integration-requests.yml
@@ -92,10 +92,10 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Check for failures
-        if: contains(needs.test-pinned.result, 'failure')
+        if: contains(needs.test-pinned.result, 'failure') || contains(needs.test-pinned.result, 'skipped')
         run: |
           echo "One of the dependent jobs has failed. You may need to re-run it." && exit 1
       - name: Check for 2.7 failures
-        if: contains(needs.test-py27.result, 'failure')
+        if: contains(needs.test-py27.result, 'failure') || contains(needs.test-py27.result, 'skipped')
         run: |
           echo "One of the dependent jobs has failed. You may need to re-run it." && exit 1

--- a/.github/workflows/test-integration-requests.yml
+++ b/.github/workflows/test-integration-requests.yml
@@ -85,7 +85,7 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: coverage.xml
   check_required_tests:
-    name: All requests tests passed or skipped
+    name: All requests tests passed
     needs: [test-pinned, test-py27]
     # Always run this, even if a dependent job failed
     if: always()

--- a/.github/workflows/test-integration-rq.yml
+++ b/.github/workflows/test-integration-rq.yml
@@ -124,7 +124,7 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: coverage.xml
   check_required_tests:
-    name: All rq tests passed or skipped
+    name: All rq tests passed
     needs: [test-pinned, test-py27]
     # Always run this, even if a dependent job failed
     if: always()

--- a/.github/workflows/test-integration-rq.yml
+++ b/.github/workflows/test-integration-rq.yml
@@ -131,10 +131,10 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Check for failures
-        if: contains(needs.test-pinned.result, 'failure')
+        if: contains(needs.test-pinned.result, 'failure') || contains(needs.test-pinned.result, 'skipped')
         run: |
           echo "One of the dependent jobs has failed. You may need to re-run it." && exit 1
       - name: Check for 2.7 failures
-        if: contains(needs.test-py27.result, 'failure')
+        if: contains(needs.test-py27.result, 'failure') || contains(needs.test-py27.result, 'skipped')
         run: |
           echo "One of the dependent jobs has failed. You may need to re-run it." && exit 1

--- a/.github/workflows/test-integration-sanic.yml
+++ b/.github/workflows/test-integration-sanic.yml
@@ -103,6 +103,6 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Check for failures
-        if: contains(needs.test-pinned.result, 'failure')
+        if: contains(needs.test-pinned.result, 'failure') || contains(needs.test-pinned.result, 'skipped')
         run: |
           echo "One of the dependent jobs has failed. You may need to re-run it." && exit 1

--- a/.github/workflows/test-integration-sanic.yml
+++ b/.github/workflows/test-integration-sanic.yml
@@ -96,7 +96,7 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: coverage.xml
   check_required_tests:
-    name: All sanic tests passed or skipped
+    name: All sanic tests passed
     needs: test-pinned
     # Always run this, even if a dependent job failed
     if: always()

--- a/.github/workflows/test-integration-sqlalchemy.yml
+++ b/.github/workflows/test-integration-sqlalchemy.yml
@@ -131,10 +131,10 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Check for failures
-        if: contains(needs.test-pinned.result, 'failure')
+        if: contains(needs.test-pinned.result, 'failure') || contains(needs.test-pinned.result, 'skipped')
         run: |
           echo "One of the dependent jobs has failed. You may need to re-run it." && exit 1
       - name: Check for 2.7 failures
-        if: contains(needs.test-py27.result, 'failure')
+        if: contains(needs.test-py27.result, 'failure') || contains(needs.test-py27.result, 'skipped')
         run: |
           echo "One of the dependent jobs has failed. You may need to re-run it." && exit 1

--- a/.github/workflows/test-integration-sqlalchemy.yml
+++ b/.github/workflows/test-integration-sqlalchemy.yml
@@ -124,7 +124,7 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: coverage.xml
   check_required_tests:
-    name: All sqlalchemy tests passed or skipped
+    name: All sqlalchemy tests passed
     needs: [test-pinned, test-py27]
     # Always run this, even if a dependent job failed
     if: always()

--- a/.github/workflows/test-integration-starlette.yml
+++ b/.github/workflows/test-integration-starlette.yml
@@ -103,6 +103,6 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Check for failures
-        if: contains(needs.test-pinned.result, 'failure')
+        if: contains(needs.test-pinned.result, 'failure') || contains(needs.test-pinned.result, 'skipped')
         run: |
           echo "One of the dependent jobs has failed. You may need to re-run it." && exit 1

--- a/.github/workflows/test-integration-starlette.yml
+++ b/.github/workflows/test-integration-starlette.yml
@@ -96,7 +96,7 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: coverage.xml
   check_required_tests:
-    name: All starlette tests passed or skipped
+    name: All starlette tests passed
     needs: test-pinned
     # Always run this, even if a dependent job failed
     if: always()

--- a/.github/workflows/test-integration-starlite.yml
+++ b/.github/workflows/test-integration-starlite.yml
@@ -57,7 +57,7 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: coverage.xml
   check_required_tests:
-    name: All starlite tests passed or skipped
+    name: All starlite tests passed
     needs: test-pinned
     # Always run this, even if a dependent job failed
     if: always()

--- a/.github/workflows/test-integration-starlite.yml
+++ b/.github/workflows/test-integration-starlite.yml
@@ -64,6 +64,6 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Check for failures
-        if: contains(needs.test-pinned.result, 'failure')
+        if: contains(needs.test-pinned.result, 'failure') || contains(needs.test-pinned.result, 'skipped')
         run: |
           echo "One of the dependent jobs has failed. You may need to re-run it." && exit 1

--- a/.github/workflows/test-integration-strawberry.yml
+++ b/.github/workflows/test-integration-strawberry.yml
@@ -103,6 +103,6 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Check for failures
-        if: contains(needs.test-pinned.result, 'failure')
+        if: contains(needs.test-pinned.result, 'failure') || contains(needs.test-pinned.result, 'skipped')
         run: |
           echo "One of the dependent jobs has failed. You may need to re-run it." && exit 1

--- a/.github/workflows/test-integration-strawberry.yml
+++ b/.github/workflows/test-integration-strawberry.yml
@@ -96,7 +96,7 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: coverage.xml
   check_required_tests:
-    name: All strawberry tests passed or skipped
+    name: All strawberry tests passed
     needs: test-pinned
     # Always run this, even if a dependent job failed
     if: always()

--- a/.github/workflows/test-integration-tornado.yml
+++ b/.github/workflows/test-integration-tornado.yml
@@ -103,6 +103,6 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Check for failures
-        if: contains(needs.test-pinned.result, 'failure')
+        if: contains(needs.test-pinned.result, 'failure') || contains(needs.test-pinned.result, 'skipped')
         run: |
           echo "One of the dependent jobs has failed. You may need to re-run it." && exit 1

--- a/.github/workflows/test-integration-tornado.yml
+++ b/.github/workflows/test-integration-tornado.yml
@@ -96,7 +96,7 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: coverage.xml
   check_required_tests:
-    name: All tornado tests passed or skipped
+    name: All tornado tests passed
     needs: test-pinned
     # Always run this, even if a dependent job failed
     if: always()

--- a/.github/workflows/test-integration-trytond.yml
+++ b/.github/workflows/test-integration-trytond.yml
@@ -103,6 +103,6 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Check for failures
-        if: contains(needs.test-pinned.result, 'failure')
+        if: contains(needs.test-pinned.result, 'failure') || contains(needs.test-pinned.result, 'skipped')
         run: |
           echo "One of the dependent jobs has failed. You may need to re-run it." && exit 1

--- a/.github/workflows/test-integration-trytond.yml
+++ b/.github/workflows/test-integration-trytond.yml
@@ -96,7 +96,7 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: coverage.xml
   check_required_tests:
-    name: All trytond tests passed or skipped
+    name: All trytond tests passed
     needs: test-pinned
     # Always run this, even if a dependent job failed
     if: always()

--- a/scripts/split-tox-gh-actions/templates/check_required.jinja
+++ b/scripts/split-tox-gh-actions/templates/check_required.jinja
@@ -1,5 +1,5 @@
   check_required_tests:
-    name: All {{ framework }} tests passed or skipped
+    name: All {{ framework }} tests passed
     {% if py_versions.pinned and py_versions.py27 %}
     needs: [test-pinned, test-py27]
     {% elif py_versions.pinned %}

--- a/scripts/split-tox-gh-actions/templates/check_required.jinja
+++ b/scripts/split-tox-gh-actions/templates/check_required.jinja
@@ -12,12 +12,12 @@
     runs-on: ubuntu-20.04
     steps:
       - name: Check for failures
-        if: contains(needs.test-pinned.result, 'failure')
+        if: contains(needs.test-pinned.result, 'failure') || contains(needs.test-pinned.result, 'skipped')
         run: |
           echo "One of the dependent jobs has failed. You may need to re-run it." && exit 1
       {% if py_versions.py27 %}
       - name: Check for 2.7 failures
-        if: contains(needs.test-py27.result, 'failure')
+        if: contains(needs.test-py27.result, 'failure') || contains(needs.test-py27.result, 'skipped')
         run: |
           echo "One of the dependent jobs has failed. You may need to re-run it." && exit 1
       {% endif %}


### PR DESCRIPTION
If the `check-permissions` check fails, the dependent test step will be skipped. The step that actually checks whether a test job was successful only checks for failures, so skipped test jobs are treated as successful, which shouldn't be the case.

So for example in the case of the AWS Lambda suite running on a contributor PR without the `Trigger: tests using secrets` label, the permissions check will be a failure, so the actual Lambda tests will be skipped, but the overall "All AWS Lambda tests were successful" check will still be green because technically there were no failures.

With this PR we also consider [skipped test steps](https://docs.github.com/en/actions/learn-github-actions/contexts#needs-context) as an overall failure.