### PR TITLE
Update Django version in tests

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -346,8 +346,7 @@ deps =
     django-v4.0: Django~=4.0.0
     django-v4.1: Django~=4.1.0
     django-v4.2: Django~=4.2.0
-    # TODO: change to final when available
-    django-v5.0: Django==5.0rc1
+    django-v5.0: Django~=5.0.0
     django-latest: Django
 
     # Falcon


### PR DESCRIPTION
Django 5.0 stable has been released, let's run our test suite against it instead of the RC.