### PR TITLE
Pin `pytest-asyncio`

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -241,7 +241,7 @@ deps =
     linters: werkzeug<2.3.0
 
     # Common
-    {py3.6,py3.7,py3.8,py3.9,py3.10,py3.11,py3.12}-common: pytest-asyncio
+    {py3.6,py3.7,py3.8,py3.9,py3.10,py3.11,py3.12}-common: pytest-asyncio==0.21.1
     # See https://github.com/pytest-dev/pytest/issues/9621
     # and https://github.com/pytest-dev/pytest-forked/issues/67
     # for justification of the upper bound on pytest
@@ -265,17 +265,17 @@ deps =
     arq-v0.23: pydantic<2
     arq-latest: arq
     arq: fakeredis>=2.2.0,<2.8
-    arq: pytest-asyncio
+    arq: pytest-asyncio==0.21.1
     arq: async-timeout
 
     # Asgi
-    asgi: pytest-asyncio
+    asgi: pytest-asyncio==0.21.1
     asgi: async-asgi-testclient
 
     # Asyncpg
     asyncpg-v0.23: asyncpg~=0.23.0
     asyncpg-latest: asyncpg
-    asyncpg: pytest-asyncio
+    asyncpg: pytest-asyncio==0.21.1
 
     # AWS Lambda
     aws_lambda: boto3
@@ -329,10 +329,10 @@ deps =
     django-v{1.8,1.11,2.0}: pytest-django<4.0
     django-v{2.2,3.0,3.2,4.0,4.1,4.2,5.0}: pytest-django
     django-v{4.0,4.1,4.2,5.0}: djangorestframework
-    django-v{4.0,4.1,4.2,5.0}: pytest-asyncio
+    django-v{4.0,4.1,4.2,5.0}: pytest-asyncio==0.21.1
     django-v{4.0,4.1,4.2,5.0}: Werkzeug
     django-latest: djangorestframework
-    django-latest: pytest-asyncio
+    django-latest: pytest-asyncio==0.21.1
     django-latest: pytest-django
     django-latest: Werkzeug
     django-latest: channels[daphne]
@@ -360,7 +360,7 @@ deps =
     # FastAPI
     fastapi: httpx
     fastapi: anyio<4.0.0 # thats a dep of httpx
-    fastapi: pytest-asyncio
+    fastapi: pytest-asyncio==0.21.1
     fastapi: python-multipart
     fastapi: requests
     fastapi-v{0.79}: fastapi~=0.79.0
@@ -407,7 +407,7 @@ deps =
     grpc: protobuf
     grpc: mypy-protobuf
     grpc: types-protobuf
-    grpc: pytest-asyncio
+    grpc: pytest-asyncio==0.21.1
     grpc-v1.21: grpcio-tools~=1.21.0
     grpc-v1.30: grpcio-tools~=1.30.0
     grpc-v1.40: grpcio-tools~=1.40.0
@@ -466,7 +466,7 @@ deps =
 
     # Quart
     quart: quart-auth
-    quart: pytest-asyncio
+    quart: pytest-asyncio==0.21.1
     quart-v0.16: blinker<1.6
     quart-v0.16: jinja2<3.1.0
     quart-v0.16: Werkzeug<2.1.0
@@ -478,7 +478,7 @@ deps =
 
     # Redis
     redis: fakeredis!=1.7.4
-    {py3.7,py3.8,py3.9,py3.10,py3.11}-redis: pytest-asyncio
+    {py3.7,py3.8,py3.9,py3.10,py3.11}-redis: pytest-asyncio==0.21.1
     redis-v3: redis~=3.0
     redis-v4: redis~=4.0
     redis-v5: redis~=5.0
@@ -520,7 +520,7 @@ deps =
     sanic-latest: sanic
 
     # Starlette
-    starlette: pytest-asyncio
+    starlette: pytest-asyncio==0.21.1
     starlette: python-multipart
     starlette: requests
     starlette: httpx
@@ -534,7 +534,7 @@ deps =
     starlette-latest: starlette
 
     # Starlite
-    starlite: pytest-asyncio
+    starlite: pytest-asyncio==0.21.1
     starlite: python-multipart
     starlite: requests
     starlite: cryptography


### PR DESCRIPTION
Seems like the recent release of pytest-asyncio 0.23 might have broken some of our tests -- validating that assumption. 