### PR TITLE
feat(summary): Fixed the incorrect emission of span metric summaries

### DIFF
--- a/sentry_sdk/metrics.py
+++ b/sentry_sdk/metrics.py
@@ -382,13 +382,15 @@ class LocalAggregator(object):
             v_count,
             v_sum,
         ) in self._measurements.items():
-            rv[export_key] = {
-                "tags": _tags_to_dict(tags),
-                "min": v_min,
-                "max": v_max,
-                "count": v_count,
-                "sum": v_sum,
-            }
+            rv.setdefault(export_key, []).append(
+                {
+                    "tags": _tags_to_dict(tags),
+                    "min": v_min,
+                    "max": v_max,
+                    "count": v_count,
+                    "sum": v_sum,
+                }
+            )
         return rv
 
 

--- a/sentry_sdk/metrics.py
+++ b/sentry_sdk/metrics.py
@@ -375,7 +375,7 @@ class LocalAggregator(object):
 
     def to_json(self):
         # type: (...) -> Dict[str, Any]
-        rv = {}
+        rv = {}  # type: Any
         for (export_key, tags), (
             v_min,
             v_max,


### PR DESCRIPTION
Fixes a bug where only the last tag combination for a metric summary was emitted. This now correctly emits arrays as intended by the RFC.