### PR TITLE
Revert "Move `add_breadcrumb` and session function from Hub to Scope …

### DIFF
--- a/sentry_sdk/client.py
+++ b/sentry_sdk/client.py
@@ -43,10 +43,7 @@ if TYPE_CHECKING:
     from typing import Dict
     from typing import Optional
     from typing import Sequence
-    from typing import Type
-    from typing import Union
 
-    from sentry_sdk.integrations import Integration
     from sentry_sdk.scope import Scope
     from sentry_sdk._types import Event, Hint
     from sentry_sdk.session import Session
@@ -655,22 +652,6 @@ class _Client(object):
             logger.info("Discarded session update because of missing release")
         else:
             self.session_flusher.add_session(session)
-
-    def get_integration(
-        self, name_or_class  # type: Union[str, Type[Integration]]
-    ):
-        # type: (...) -> Any
-        """Returns the integration for this client by name or class.
-        If the client does not have that integration then `None` is returned.
-        """
-        if isinstance(name_or_class, str):
-            integration_name = name_or_class
-        elif name_or_class.identifier is not None:
-            integration_name = name_or_class.identifier
-        else:
-            raise ValueError("Integration has no name")
-
-        return self.integrations.get(integration_name)
 
     def close(
         self,


### PR DESCRIPTION
…(#2544)"

This reverts commit 354d7bb0a0851d75ba211f2386a0493b6994a70b.

<!-- Describe your PR here -->

---

## General Notes

Thank you for contributing to `sentry-python`!

Please add tests to validate your changes, and lint your code using `tox -e linters`.

Running the test suite on your PR might require maintainer approval. Some tests (AWS Lambda) additionally require a maintainer to add a special label to run and will fail if the label is not present.

#### For maintainers

Sensitive test suites require maintainer review to ensure that tests do not compromise our secrets. This review must be repeated after any code revisions.

Before running sensitive test suites, please carefully check the PR. Then, apply the `Trigger: tests using secrets` label. The label will be removed after any code changes to enforce our policy requiring maintainers to review all code revisions before running sensitive tests.
