### PR TITLE
fix(api): Fix Celery `TypeError` with no-argument `apply_async`

### DIFF
--- a/sentry_sdk/integrations/celery.py
+++ b/sentry_sdk/integrations/celery.py
@@ -167,7 +167,7 @@ def _wrap_apply_async(f):
 
         try:
             task_started_from_beat = args[1][0] == "BEAT"
-        except IndexError:
+        except (IndexError, TypeError):
             task_started_from_beat = False
 
         task = args[0]

--- a/tests/integrations/celery/test_celery.py
+++ b/tests/integrations/celery/test_celery.py
@@ -593,3 +593,16 @@ def test_apply_async_from_beat_no_span(sentry_init):
         ],
         headers={},
     )
+
+
+def test_apply_async_no_args(init_celery):
+    celery = init_celery()
+
+    @celery.task
+    def example_task():
+        pass
+
+    try:
+        example_task.apply_async(None, {})
+    except TypeError:
+        pytest.fail("Calling `apply_async` without arguments raised a TypeError")


### PR DESCRIPTION
Fix a bug where calling `task.apply_async(None, {})` (where `task` is some Celery task) raises an unhandled `TypeError`. Also, add a test that validates that the call succeeds.

Fixes GH-2554