### PR TITLE
Handle `os.path.devnull` access issues

### DIFF
--- a/sentry_sdk/utils.py
+++ b/sentry_sdk/utils.py
@@ -97,8 +97,8 @@ def _get_debug_hub():
 
 def get_git_revision():
     # type: () -> Optional[str]
-    with open(os.path.devnull, "w+") as null:
-        try:
+    try:
+        with open(os.path.devnull, "w+") as null:
             revision = (
                 subprocess.Popen(
                     ["git", "rev-parse", "HEAD"],
@@ -110,8 +110,8 @@ def get_git_revision():
                 .strip()
                 .decode("utf-8")
             )
-        except (OSError, IOError):
-            return None
+    except (OSError, IOError, FileNotFoundError):
+        return None
 
     return revision
 

--- a/sentry_sdk/utils.py
+++ b/sentry_sdk/utils.py
@@ -21,7 +21,6 @@ try:
     from urllib.parse import urlencode
     from urllib.parse import urlsplit
     from urllib.parse import urlunsplit
-
 except ImportError:
     # Python 2
     from cgi import parse_qs  # type: ignore
@@ -29,6 +28,13 @@ except ImportError:
     from urllib import urlencode  # type: ignore
     from urlparse import urlsplit  # type: ignore
     from urlparse import urlunsplit  # type: ignore
+
+try:
+    # Python 3
+    FileNotFoundError
+except NameError:
+    # Python 2
+    FileNotFoundError = IOError
 
 try:
     # Python 3.11

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -6,6 +6,7 @@ from sentry_sdk.utils import (
     Components,
     Dsn,
     get_error_message,
+    get_git_revision,
     is_valid_sample_rate,
     logger,
     match_regex_list,
@@ -557,3 +558,17 @@ def test_installed_modules_caching():
 
             _get_installed_modules()
             mock_generate_installed_modules.assert_not_called()
+
+
+def test_devnull_inaccessible():
+    with mock.patch("sentry_sdk.utils.open", side_effect=OSError("oh no")):
+        revision = get_git_revision()
+
+    assert revision is None
+
+
+def test_devnull_not_found():
+    with mock.patch("sentry_sdk.utils.open", side_effect=FileNotFoundError("oh no")):
+        revision = get_git_revision()
+
+    assert revision is None

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -26,6 +26,13 @@ try:
 except ImportError:
     import mock  # python < 3.3
 
+try:
+    # Python 3
+    FileNotFoundError
+except NameError:
+    # Python 2
+    FileNotFoundError = IOError
+
 
 def _normalize_distribution_name(name):
     # type: (str) -> str


### PR DESCRIPTION
Our release checking can fail because `os.path.devnull` is not there/is not properly accessible on some setups.

Closes https://github.com/getsentry/sentry-python/issues/1496
Closes https://github.com/getsentry/sentry-python/issues/2334

---

## General Notes

Thank you for contributing to `sentry-python`!

Please add tests to validate your changes, and lint your code using `tox -e linters`.

Running the test suite on your PR might require maintainer approval. Some tests (AWS Lambda) additionally require a maintainer to add a special label to run and will fail if the label is not present.

#### For maintainers

Sensitive test suites require maintainer review to ensure that tests do not compromise our secrets. This review must be repeated after any code revisions.

Before running sensitive test suites, please carefully check the PR. Then, apply the `Trigger: tests using secrets` label. The label will be removed after any code changes to enforce our policy requiring maintainers to review all code revisions before running sensitive tests.
