### PR TITLE
Ensure background worker has a thread

### DIFF
--- a/sentry_sdk/worker.py
+++ b/sentry_sdk/worker.py
@@ -27,7 +27,7 @@ class BackgroundWorker(object):
         self._thread = None  # type: Optional[threading.Thread]
         self._thread_for_pid = None  # type: Optional[int]
 
-        self.start()
+        self._ensure_thread()
 
     @property
     def is_alive(self):

--- a/sentry_sdk/worker.py
+++ b/sentry_sdk/worker.py
@@ -27,6 +27,8 @@ class BackgroundWorker(object):
         self._thread = None  # type: Optional[threading.Thread]
         self._thread_for_pid = None  # type: Optional[int]
 
+        self.start()
+
     @property
     def is_alive(self):
         # type: () -> bool


### PR DESCRIPTION
We can't create new threads on interpreter shutdown. Instead, let's try making sure each background worker already has a thread active so there is no need to start one.

Closes https://github.com/getsentry/sentry-python/issues/2478