### PR TITLE
fix(utils): Filter out empty string releases

### DIFF
--- a/sentry_sdk/utils.py
+++ b/sentry_sdk/utils.py
@@ -130,7 +130,7 @@ def get_default_release():
         return release
 
     release = get_git_revision()
-    if release is not None:
+    if release:
         return release
 
     for var in (

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -5,6 +5,7 @@ import sys
 from sentry_sdk.utils import (
     Components,
     Dsn,
+    get_default_release,
     get_error_message,
     get_git_revision,
     is_valid_sample_rate,
@@ -579,3 +580,15 @@ def test_devnull_not_found():
         revision = get_git_revision()
 
     assert revision is None
+
+
+def test_default_release():
+    release = get_default_release()
+    assert release is not None
+
+
+def test_default_release_empty_string():
+    with mock.patch("sentry_sdk.utils.get_git_revision", return_value=""):
+        release = get_default_release()
+
+    assert release is None


### PR DESCRIPTION
We introduced a small regression in https://github.com/getsentry/sentry-python/pull/2557/files. Instead of only allowing truthy releases, we [are now allowing all non-`None` releases](https://github.com/getsentry/sentry-python/pull/2557#issuecomment-1853486609), which includes empty strings. Changing this back to the original behavior.
