### PR TITLE
[2.0] Add a migration guide

### DIFF
--- a/MIGRATION_GUIDE.md
+++ b/MIGRATION_GUIDE.md
@@ -1,0 +1,11 @@
+# Sentry SDK 2.0 Migration Guide
+
+**WIP:** Please add any 2.0 changes here with instructions how to adapt to the new behavior, if applicable.
+
+## New Features
+
+## Changed
+
+## Removed
+
+## Deprecated


### PR DESCRIPTION
Adding a migration guide that we can update with each change merged into 2.0 to avoid having to document everything at the end.