### PR TITLE
fix(crons): Change `data_category` from `check_in` to `monitor`

### DIFF
--- a/sentry_sdk/_types.py
+++ b/sentry_sdk/_types.py
@@ -54,7 +54,7 @@ if TYPE_CHECKING:
         "internal",
         "profile",
         "statsd",
-        "check_in",
+        "monitor",
     ]
     SessionStatus = Literal["ok", "exited", "crashed", "abnormal"]
     EndpointType = Literal["store", "envelope"]

--- a/sentry_sdk/envelope.py
+++ b/sentry_sdk/envelope.py
@@ -263,7 +263,7 @@ class Item(object):
         elif ty == "statsd":
             return "statsd"
         elif ty == "check_in":
-            return "check_in"
+            return "monitor"
         else:
             return "default"
 


### PR DESCRIPTION
Looks like we're using a wrong data category for cron client reports. Should be `monitor`.

Closes https://github.com/getsentry/sentry-python/issues/2589