### PR TITLE
Arq integration ctx

### DIFF
--- a/sentry_sdk/integrations/arq.py
+++ b/sentry_sdk/integrations/arq.py
@@ -169,7 +169,7 @@ def _wrap_coroutine(name, coroutine):
         # type: (Dict[Any, Any], *Any, **Any) -> Any
         hub = Hub.current
         if hub.get_integration(ArqIntegration) is None:
-            return await coroutine(*args, **kwargs)
+            return await coroutine(ctx, *args, **kwargs)
 
         hub.scope.add_event_processor(
             _make_event_processor({**ctx, "job_name": name}, *args, **kwargs)


### PR DESCRIPTION
Arq is broken if the integration is missing because the context is not being passed, here is my tiny fix and a test

---

## General Notes

Thank you for contributing to `sentry-python`!

Please add tests to validate your changes, and lint your code using `tox -e linters`.

Running the test suite on your PR might require maintainer approval. Some tests (AWS Lambda) additionally require a maintainer to add a special label to run and will fail if the label is not present.

