### PR TITLE
fix(integrations): WSGI integrations respect SCRIPT_NAME env variable

### DIFF
--- a/sentry_sdk/integrations/wsgi.py
+++ b/sentry_sdk/integrations/wsgi.py
@@ -62,7 +62,14 @@ def get_request_url(environ, use_x_forwarded_for=False):
     return "%s://%s/%s" % (
         environ.get("wsgi.url_scheme"),
         get_host(environ, use_x_forwarded_for),
-        wsgi_decoding_dance(environ.get("PATH_INFO") or "").lstrip("/"),
+        wsgi_decoding_dance(
+            "/".join(
+                [
+                    environ.get("SCRIPT_NAME", "").rstrip("/"),
+                    environ.get("PATH_INFO", "").lstrip("/"),
+                ]
+            )
+        ).lstrip("/"),
     )
 
 

--- a/tests/integrations/wsgi/test_wsgi.py
+++ b/tests/integrations/wsgi/test_wsgi.py
@@ -67,6 +67,29 @@ def test_basic(sentry_init, crashing_app, capture_events):
     }
 
 
+def test_basic_script_name_is_respected(sentry_init, crashing_app, capture_events):
+    sentry_init(send_default_pii=True)
+    app = SentryWsgiMiddleware(crashing_app)
+    client = Client(app)
+    events = capture_events()
+
+    with pytest.raises(ZeroDivisionError):
+        # setting url with PATH_INFO: /bark, HTTP_HOST: dogs.are.great and SCRIPT_NAME: /woof/woof
+        client.get("bark/", "https://dogs.are.great/woof/woof/")
+
+    (event,) = events
+
+    assert event["transaction"] == "generic WSGI request"
+    print(event["request"])
+    assert event["request"] == {
+        "env": {"SERVER_NAME": "dogs.are.great", "SERVER_PORT": "443"},
+        "headers": {"Host": "dogs.are.great"},
+        "method": "GET",
+        "query_string": "",
+        "url": "https://dogs.are.great/woof/woof/bark/",
+    }
+
+
 @pytest.fixture(params=[0, None])
 def test_systemexit_zero_is_ignored(sentry_init, capture_events, request):
     zero_code = request.param


### PR DESCRIPTION
URLs generated using Sentry's WSGI Middleware should include SCRIPT_NAME in the event's url

Fixes #2576

<!-- Describe your PR here -->
Noticed that the problem described in the above issue wasn't specific to Django per se but general to all WSGI applications which is why I have made modifications to the `SentryWsgiMiddleware` class that should resolve this issue for Django and other integrations as well. As far as I can tell this problem should not arise for ASGI applications as the `root_path` is accounted for.

---

## General Notes

Thank you for contributing to `sentry-python`!

Please add tests to validate your changes, and lint your code using `tox -e linters`.

Running the test suite on your PR might require maintainer approval. Some tests (AWS Lambda) additionally require a maintainer to add a special label to run and will fail if the label is not present.

#### For maintainers

Sensitive test suites require maintainer review to ensure that tests do not compromise our secrets. This review must be repeated after any code revisions.

Before running sensitive test suites, please carefully check the PR. Then, apply the `Trigger: tests using secrets` label. The label will be removed after any code changes to enforce our policy requiring maintainers to review all code revisions before running sensitive tests.
