### PR TITLE
Fix relative path in db query source 

### DIFF
--- a/sentry_sdk/tracing_utils.py
+++ b/sentry_sdk/tracing_utils.py
@@ -257,7 +257,7 @@ def add_query_source(hub, span):
         if filepath is not None:
             if project_root is not None and filepath.startswith(project_root):
                 in_app_path = filepath.replace(project_root, "").lstrip(os.sep)
-            else: 
+            else:
                 in_app_path = filepath
             span.set_data(SPANDATA.CODE_FILEPATH, in_app_path)
 

--- a/sentry_sdk/tracing_utils.py
+++ b/sentry_sdk/tracing_utils.py
@@ -255,7 +255,10 @@ def add_query_source(hub, span):
         except Exception:
             filepath = None
         if filepath is not None:
-            in_app_path = filepath.replace(project_root, "")
+            if project_root is not None and filepath.startswith(project_root):
+                in_app_path = filepath.replace(project_root, "").lstrip(os.sep)
+            else: 
+                in_app_path = filepath
             span.set_data(SPANDATA.CODE_FILEPATH, in_app_path)
 
         try:

--- a/tests/integrations/asyncpg/test_asyncpg.py
+++ b/tests/integrations/asyncpg/test_asyncpg.py
@@ -542,4 +542,8 @@ async def test_query_source(sentry_init, capture_events):
     assert data.get(SPANDATA.CODE_FILEPATH).endswith(
         "tests/integrations/asyncpg/test_asyncpg.py"
     )
+    
+    is_relative_path = data.get(SPANDATA.CODE_FILEPATH)[0] != os.sep
+    assert is_relative_path
+
     assert data.get(SPANDATA.CODE_FUNCTION) == "test_query_source"

--- a/tests/integrations/asyncpg/test_asyncpg.py
+++ b/tests/integrations/asyncpg/test_asyncpg.py
@@ -542,7 +542,7 @@ async def test_query_source(sentry_init, capture_events):
     assert data.get(SPANDATA.CODE_FILEPATH).endswith(
         "tests/integrations/asyncpg/test_asyncpg.py"
     )
-    
+
     is_relative_path = data.get(SPANDATA.CODE_FILEPATH)[0] != os.sep
     assert is_relative_path
 

--- a/tests/integrations/django/test_db_query_data.py
+++ b/tests/integrations/django/test_db_query_data.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import
 
+import os
 import pytest
 
 from django import VERSION as DJANGO_VERSION
@@ -109,6 +110,10 @@ def test_query_source(sentry_init, client, capture_events):
             assert data.get(SPANDATA.CODE_FILEPATH).endswith(
                 "tests/integrations/django/myapp/views.py"
             )
+
+            is_relative_path = data.get(SPANDATA.CODE_FILEPATH)[0] != os.sep
+            assert is_relative_path
+
             assert data.get(SPANDATA.CODE_FUNCTION) == "postgres_select_orm"
 
             break

--- a/tests/integrations/sqlalchemy/test_sqlalchemy.py
+++ b/tests/integrations/sqlalchemy/test_sqlalchemy.py
@@ -1,5 +1,6 @@
-import sys
+import os
 import pytest
+import sys
 
 from sqlalchemy import Column, ForeignKey, Integer, String, create_engine
 from sqlalchemy.exc import IntegrityError
@@ -327,6 +328,10 @@ def test_query_source(sentry_init, capture_events):
             assert data.get(SPANDATA.CODE_FILEPATH).endswith(
                 "tests/integrations/sqlalchemy/test_sqlalchemy.py"
             )
+
+            is_relative_path = data.get(SPANDATA.CODE_FILEPATH)[0] != os.sep
+            assert is_relative_path
+
             assert data.get(SPANDATA.CODE_FUNCTION) == "test_query_source"
             break
     else:


### PR DESCRIPTION
If we send a relative path, make sure there is no leading path separator.