### PR TITLE
Run more CI checks on 2.0 branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - master
       - release/**
+      - sentry-sdk-2.0
 
   pull_request:
 

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -13,10 +13,14 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [ master ]
+    branches:
+      - master
+      - sentry-sdk-2.0
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [ master ]
+    branches:
+      - master
+      - sentry-sdk-2.0
   schedule:
     - cron: '18 18 * * 3'
 

--- a/.github/workflows/enforce-license-compliance.yml
+++ b/.github/workflows/enforce-license-compliance.yml
@@ -2,9 +2,16 @@ name: Enforce License Compliance
 
 on:
   push:
-    branches: [master, main, release/*]
+    branches:
+      - master
+      - main
+      - release/*
+      - sentry-sdk-2.0
   pull_request:
-    branches: [master, main]
+    branches:
+      - master
+      - main
+      - sentry-sdk-2.0
 
 jobs:
   enforce-license-compliance:

--- a/.github/workflows/test-integrations-aws-lambda.yml
+++ b/.github/workflows/test-integrations-aws-lambda.yml
@@ -4,6 +4,7 @@ on:
     branches:
       - master
       - release/**
+      - sentry-sdk-2.0
   # XXX: We are using `pull_request_target` instead of `pull_request` because we want
   # this to run on forks with access to the secrets necessary to run the test suite.
   # Prefer to use `pull_request` when possible.

--- a/.github/workflows/test-integrations-cloud-computing.yml
+++ b/.github/workflows/test-integrations-cloud-computing.yml
@@ -4,6 +4,7 @@ on:
     branches:
       - master
       - release/**
+      - sentry-sdk-2.0
   pull_request:
 # Cancel in progress workflows on pull_requests.
 # https://docs.github.com/en/actions/using-jobs/using-concurrency#example-using-a-fallback-value

--- a/.github/workflows/test-integrations-common.yml
+++ b/.github/workflows/test-integrations-common.yml
@@ -4,6 +4,7 @@ on:
     branches:
       - master
       - release/**
+      - sentry-sdk-2.0
   pull_request:
 # Cancel in progress workflows on pull_requests.
 # https://docs.github.com/en/actions/using-jobs/using-concurrency#example-using-a-fallback-value

--- a/.github/workflows/test-integrations-data-processing.yml
+++ b/.github/workflows/test-integrations-data-processing.yml
@@ -4,6 +4,7 @@ on:
     branches:
       - master
       - release/**
+      - sentry-sdk-2.0
   pull_request:
 # Cancel in progress workflows on pull_requests.
 # https://docs.github.com/en/actions/using-jobs/using-concurrency#example-using-a-fallback-value

--- a/.github/workflows/test-integrations-databases.yml
+++ b/.github/workflows/test-integrations-databases.yml
@@ -4,6 +4,7 @@ on:
     branches:
       - master
       - release/**
+      - sentry-sdk-2.0
   pull_request:
 # Cancel in progress workflows on pull_requests.
 # https://docs.github.com/en/actions/using-jobs/using-concurrency#example-using-a-fallback-value

--- a/.github/workflows/test-integrations-graphql.yml
+++ b/.github/workflows/test-integrations-graphql.yml
@@ -4,6 +4,7 @@ on:
     branches:
       - master
       - release/**
+      - sentry-sdk-2.0
   pull_request:
 # Cancel in progress workflows on pull_requests.
 # https://docs.github.com/en/actions/using-jobs/using-concurrency#example-using-a-fallback-value

--- a/.github/workflows/test-integrations-miscellaneous.yml
+++ b/.github/workflows/test-integrations-miscellaneous.yml
@@ -4,6 +4,7 @@ on:
     branches:
       - master
       - release/**
+      - sentry-sdk-2.0
   pull_request:
 # Cancel in progress workflows on pull_requests.
 # https://docs.github.com/en/actions/using-jobs/using-concurrency#example-using-a-fallback-value

--- a/.github/workflows/test-integrations-networking.yml
+++ b/.github/workflows/test-integrations-networking.yml
@@ -4,6 +4,7 @@ on:
     branches:
       - master
       - release/**
+      - sentry-sdk-2.0
   pull_request:
 # Cancel in progress workflows on pull_requests.
 # https://docs.github.com/en/actions/using-jobs/using-concurrency#example-using-a-fallback-value

--- a/.github/workflows/test-integrations-web-frameworks-1.yml
+++ b/.github/workflows/test-integrations-web-frameworks-1.yml
@@ -4,6 +4,7 @@ on:
     branches:
       - master
       - release/**
+      - sentry-sdk-2.0
   pull_request:
 # Cancel in progress workflows on pull_requests.
 # https://docs.github.com/en/actions/using-jobs/using-concurrency#example-using-a-fallback-value

--- a/.github/workflows/test-integrations-web-frameworks-2.yml
+++ b/.github/workflows/test-integrations-web-frameworks-2.yml
@@ -4,6 +4,7 @@ on:
     branches:
       - master
       - release/**
+      - sentry-sdk-2.0
   pull_request:
 # Cancel in progress workflows on pull_requests.
 # https://docs.github.com/en/actions/using-jobs/using-concurrency#example-using-a-fallback-value

--- a/linter-requirements.txt
+++ b/linter-requirements.txt
@@ -2,7 +2,7 @@ mypy
 black
 flake8==5.0.4  # flake8 depends on pyflakes>=3.0.0 and this dropped support for Python 2 "# type:" comments
 types-certifi
-types-protobuf
+types-protobuf==4.24.0.4  # newer raises an error on mypy sentry_sdk
 types-redis
 types-setuptools
 pymongo # There is no separate types module.

--- a/scripts/split-tox-gh-actions/templates/base.jinja
+++ b/scripts/split-tox-gh-actions/templates/base.jinja
@@ -6,6 +6,7 @@ on:
     branches:
       - master
       - release/**
+      - sentry-sdk-2.0
 
   {% if needs_github_secrets %}
   # XXX: We are using `pull_request_target` instead of `pull_request` because we want


### PR DESCRIPTION
Some CI checks aren't running on the `sentry-sdk-2.0` branch (and PRs against it) yet (see e.g. https://github.com/getsentry/sentry-python/pull/2596).

* Run all relevant workflows on `sentry-sdk-2.0`
* Fix lint step failures caused by a dependency update

---

## General Notes

Thank you for contributing to `sentry-python`!

Please add tests to validate your changes, and lint your code using `tox -e linters`.

Running the test suite on your PR might require maintainer approval. Some tests (AWS Lambda) additionally require a maintainer to add a special label to run and will fail if the label is not present.

#### For maintainers

Sensitive test suites require maintainer review to ensure that tests do not compromise our secrets. This review must be repeated after any code revisions.

Before running sensitive test suites, please carefully check the PR. Then, apply the `Trigger: tests using secrets` label. The label will be removed after any code changes to enforce our policy requiring maintainers to review all code revisions before running sensitive tests.
