### PR TITLE
Fix `UnicodeDecodeError` on Python 2.7

### DIFF
--- a/sentry_sdk/utils.py
+++ b/sentry_sdk/utils.py
@@ -1126,7 +1126,13 @@ def strip_string(value, max_length=None):
     if max_length is None:
         max_length = DEFAULT_MAX_VALUE_LENGTH
 
-    length = len(value.encode("utf-8"))
+    length = len(value)
+    if isinstance(value, text_type):
+        # we want the size in bytes rather than characters, if possible
+        try:
+            length = len(value.encode("utf-8"))
+        except UnicodeDecodeError:
+            pass
 
     if length > max_length:
         return AnnotatedValue(

--- a/tests/utils/test_general.py
+++ b/tests/utils/test_general.py
@@ -591,3 +591,7 @@ def test_strip_string():
     text_with_unicode_character = u"éê"
     assert strip_string(text_with_unicode_character, max_length=2).value == u"é..."
     # fmt: on
+
+    # This was causing UnicodeDecodeErrors in Python 2
+    text_with_unicode_character = "éê"
+    assert strip_string(text_with_unicode_character, max_length=2).value == "éê"


### PR DESCRIPTION
The `strip_string` function is causing issues on Python 2.7:

* `value.encode("utf-8")` will throw a `UnicodeDecodeError` if `value` is a (non-unicode) `str` that contains non-ascii characters
* `value.encode("utf-8")` will also throw a `UnicodeDecodeError` if the encoding of the file is not utf-8

---

## General Notes

Thank you for contributing to `sentry-python`!

Please add tests to validate your changes, and lint your code using `tox -e linters`.

Running the test suite on your PR might require maintainer approval. Some tests (AWS Lambda) additionally require a maintainer to add a special label to run and will fail if the label is not present.

#### For maintainers

Sensitive test suites require maintainer review to ensure that tests do not compromise our secrets. This review must be repeated after any code revisions.

Before running sensitive test suites, please carefully check the PR. Then, apply the `Trigger: tests using secrets` label. The label will be removed after any code changes to enforce our policy requiring maintainers to review all code revisions before running sensitive tests.
