### PR TITLE
ref(api): Improve `sentry_sdk.trace` type hints

### DIFF
--- a/sentry_sdk/tracing.py
+++ b/sentry_sdk/tracing.py
@@ -21,11 +21,13 @@ if TYPE_CHECKING:
     from typing import List
     from typing import Optional
     from typing import overload
+    from typing import ParamSpec
     from typing import Tuple
     from typing import Union
     from typing import TypeVar
 
-    T = TypeVar("T", bound=Callable[..., Any])
+    P = ParamSpec("P")
+    R = TypeVar("R")
 
     import sentry_sdk.profiler
     from sentry_sdk._types import Event, MeasurementUnit, SamplingContext
@@ -991,18 +993,18 @@ class NoOpSpan(Span):
 if TYPE_CHECKING:
 
     @overload
-    def trace(func):
-        # type: (None) -> Callable[[Any], Any]
+    def trace(func=None):
+        # type: (None) -> Callable[[Callable[P, R]], Callable[P, R]]
         pass
 
     @overload
     def trace(func):
-        # type: (T) -> T
+        # type: (Callable[P, R]) -> Callable[P, R]
         pass
 
 
 def trace(func=None):
-    # type: (Optional[T]) -> Union[T, Callable[[Any], Any]]
+    # type: (Optional[Callable[P, R]]) -> Union[Callable[P, R], Callable[[Callable[P, R]], Callable[P, R]]]
     """
     Decorator to start a child span under the existing current transaction.
     If there is no current transaction, then nothing will be traced.

--- a/sentry_sdk/tracing.py
+++ b/sentry_sdk/tracing.py
@@ -14,6 +14,7 @@ from sentry_sdk._types import TYPE_CHECKING
 if TYPE_CHECKING:
     import typing
 
+    from collections.abc import Callable
     from typing import Any
     from typing import Dict
     from typing import Iterator
@@ -21,6 +22,9 @@ if TYPE_CHECKING:
     from typing import Optional
     from typing import Tuple
     from typing import Union
+    from typing import TypeVar
+
+    T = TypeVar("T", bound=Callable)
 
     import sentry_sdk.profiler
     from sentry_sdk._types import Event, MeasurementUnit, SamplingContext
@@ -984,7 +988,7 @@ class NoOpSpan(Span):
 
 
 def trace(func=None):
-    # type: (Any) -> Any
+    # type: (T) -> T
     """
     Decorator to start a child span under the existing current transaction.
     If there is no current transaction, then nothing will be traced.

--- a/sentry_sdk/tracing.py
+++ b/sentry_sdk/tracing.py
@@ -20,11 +20,12 @@ if TYPE_CHECKING:
     from typing import Iterator
     from typing import List
     from typing import Optional
+    from typing import overload
     from typing import Tuple
     from typing import Union
     from typing import TypeVar
 
-    T = TypeVar("T", bound=Callable)
+    T = TypeVar("T", bound=Callable[..., Any])
 
     import sentry_sdk.profiler
     from sentry_sdk._types import Event, MeasurementUnit, SamplingContext
@@ -987,8 +988,21 @@ class NoOpSpan(Span):
         pass
 
 
+if TYPE_CHECKING:
+
+    @overload
+    def trace(func):
+        # type: (None) -> Callable[[Any], Any]
+        pass
+
+    @overload
+    def trace(func):
+        # type: (T) -> T
+        pass
+
+
 def trace(func=None):
-    # type: (T) -> T
+    # type: (Optional[T]) -> Union[T, Callable[[Any], Any]]
     """
     Decorator to start a child span under the existing current transaction.
     If there is no current transaction, then nothing will be traced.


### PR DESCRIPTION
<!-- Describe your PR here -->

Type hints for `sentry_sdk.trace` decorator function now indicate that the decorator returns a function with the same signature as it was called with. Previously, the type hints indicated that the decorator could return `Any`, which caused users to lose type hints for decorated functions.

Before this change:
![image](https://github.com/getsentry/sentry-python/assets/7881302/79438885-7cce-4e8d-b824-1cc0a879d13f)

After this change:
![image](https://github.com/getsentry/sentry-python/assets/7881302/09d1a705-2d61-4d5d-b14d-fc9339dbef36)

Fixes GH-2460