### PR TITLE
[2.0] Drop Python 2.7, 3.5 from CI (1)

### DIFF
--- a/.github/workflows/test-integrations-aws-lambda.yml
+++ b/.github/workflows/test-integrations-aws-lambda.yml
@@ -53,7 +53,6 @@ jobs:
   test-aws_lambda-pinned:
     name: AWS Lambda (pinned)
     timeout-minutes: 30
-    needs: check-permissions
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -64,6 +63,7 @@ jobs:
         # ubuntu-20.04 is the last version that supported python3.6
         # see https://github.com/actions/setup-python/issues/544#issuecomment-1332535877
         os: [ubuntu-20.04]
+    needs: check-permissions
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/test-integrations-cloud-computing.yml
+++ b/.github/workflows/test-integrations-cloud-computing.yml
@@ -114,55 +114,14 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: coverage.xml
-  test-cloud_computing-py27:
-    name: Cloud Computing (py27)
-    timeout-minutes: 30
-    runs-on: ubuntu-20.04
-    container: python:2.7
-    steps:
-      - uses: actions/checkout@v4
-      - name: Setup Test Env
-        run: |
-          pip install coverage "tox>=3,<4"
-      - name: Erase coverage
-        run: |
-          coverage erase
-      - name: Test boto3 py27
-        run: |
-          set -x # print commands that are executed
-          ./scripts/runtox.sh --exclude-latest "py2.7-boto3" --cov=tests --cov=sentry_sdk --cov-report= --cov-branch
-      - name: Test chalice py27
-        run: |
-          set -x # print commands that are executed
-          ./scripts/runtox.sh --exclude-latest "py2.7-chalice" --cov=tests --cov=sentry_sdk --cov-report= --cov-branch
-      - name: Test cloud_resource_context py27
-        run: |
-          set -x # print commands that are executed
-          ./scripts/runtox.sh --exclude-latest "py2.7-cloud_resource_context" --cov=tests --cov=sentry_sdk --cov-report= --cov-branch
-      - name: Test gcp py27
-        run: |
-          set -x # print commands that are executed
-          ./scripts/runtox.sh --exclude-latest "py2.7-gcp" --cov=tests --cov=sentry_sdk --cov-report= --cov-branch
-      - name: Generate coverage XML
-        run: |
-          coverage combine .coverage*
-          coverage xml -i
-      - uses: codecov/codecov-action@v3
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          files: coverage.xml
   check_required_tests:
     name: All Cloud Computing tests passed
-    needs: [test-cloud_computing-pinned, test-cloud_computing-py27]
+    needs: test-cloud_computing-pinned
     # Always run this, even if a dependent job failed
     if: always()
     runs-on: ubuntu-20.04
     steps:
       - name: Check for failures
         if: contains(needs.test-cloud_computing-pinned.result, 'failure') || contains(needs.test-cloud_computing-pinned.result, 'skipped')
-        run: |
-          echo "One of the dependent jobs has failed. You may need to re-run it." && exit 1
-      - name: Check for 2.7 failures
-        if: contains(needs.test-cloud_computing-py27.result, 'failure') || contains(needs.test-cloud_computing-py27.result, 'skipped')
         run: |
           echo "One of the dependent jobs has failed. You may need to re-run it." && exit 1

--- a/.github/workflows/test-integrations-common.yml
+++ b/.github/workflows/test-integrations-common.yml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.5","3.6","3.7","3.8","3.9","3.10","3.11","3.12"]
+        python-version: ["3.6","3.7","3.8","3.9","3.10","3.11","3.12"]
         # python3.6 reached EOL and is no longer being supported on
         # new versions of hosted runners on Github Actions
         # ubuntu-20.04 is the last version that supported python3.6
@@ -54,43 +54,14 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: coverage.xml
-  test-common-py27:
-    name: Common (py27)
-    timeout-minutes: 30
-    runs-on: ubuntu-20.04
-    container: python:2.7
-    steps:
-      - uses: actions/checkout@v4
-      - name: Setup Test Env
-        run: |
-          pip install coverage "tox>=3,<4"
-      - name: Erase coverage
-        run: |
-          coverage erase
-      - name: Test common py27
-        run: |
-          set -x # print commands that are executed
-          ./scripts/runtox.sh --exclude-latest "py2.7-common" --cov=tests --cov=sentry_sdk --cov-report= --cov-branch
-      - name: Generate coverage XML
-        run: |
-          coverage combine .coverage*
-          coverage xml -i
-      - uses: codecov/codecov-action@v3
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          files: coverage.xml
   check_required_tests:
     name: All Common tests passed
-    needs: [test-common-pinned, test-common-py27]
+    needs: test-common-pinned
     # Always run this, even if a dependent job failed
     if: always()
     runs-on: ubuntu-20.04
     steps:
       - name: Check for failures
         if: contains(needs.test-common-pinned.result, 'failure') || contains(needs.test-common-pinned.result, 'skipped')
-        run: |
-          echo "One of the dependent jobs has failed. You may need to re-run it." && exit 1
-      - name: Check for 2.7 failures
-        if: contains(needs.test-common-py27.result, 'failure') || contains(needs.test-common-py27.result, 'skipped')
         run: |
           echo "One of the dependent jobs has failed. You may need to re-run it." && exit 1

--- a/.github/workflows/test-integrations-data-processing.yml
+++ b/.github/workflows/test-integrations-data-processing.yml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.5","3.7","3.8","3.11","3.12"]
+        python-version: ["3.7","3.8","3.11","3.12"]
         # python3.6 reached EOL and is no longer being supported on
         # new versions of hosted runners on Github Actions
         # ubuntu-20.04 is the last version that supported python3.6
@@ -77,7 +77,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.5","3.6","3.7","3.8","3.9","3.10","3.11","3.12"]
+        python-version: ["3.6","3.7","3.8","3.9","3.10","3.11","3.12"]
         # python3.6 reached EOL and is no longer being supported on
         # new versions of hosted runners on Github Actions
         # ubuntu-20.04 is the last version that supported python3.6
@@ -122,59 +122,14 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: coverage.xml
-  test-data_processing-py27:
-    name: Data Processing (py27)
-    timeout-minutes: 30
-    runs-on: ubuntu-20.04
-    container: python:2.7
-    steps:
-      - uses: actions/checkout@v4
-      - name: Setup Test Env
-        run: |
-          pip install coverage "tox>=3,<4"
-      - name: Erase coverage
-        run: |
-          coverage erase
-      - name: Test arq py27
-        run: |
-          set -x # print commands that are executed
-          ./scripts/runtox.sh --exclude-latest "py2.7-arq" --cov=tests --cov=sentry_sdk --cov-report= --cov-branch
-      - name: Test beam py27
-        run: |
-          set -x # print commands that are executed
-          ./scripts/runtox.sh --exclude-latest "py2.7-beam" --cov=tests --cov=sentry_sdk --cov-report= --cov-branch
-      - name: Test celery py27
-        run: |
-          set -x # print commands that are executed
-          ./scripts/runtox.sh --exclude-latest "py2.7-celery" --cov=tests --cov=sentry_sdk --cov-report= --cov-branch
-      - name: Test huey py27
-        run: |
-          set -x # print commands that are executed
-          ./scripts/runtox.sh --exclude-latest "py2.7-huey" --cov=tests --cov=sentry_sdk --cov-report= --cov-branch
-      - name: Test rq py27
-        run: |
-          set -x # print commands that are executed
-          ./scripts/runtox.sh --exclude-latest "py2.7-rq" --cov=tests --cov=sentry_sdk --cov-report= --cov-branch
-      - name: Generate coverage XML
-        run: |
-          coverage combine .coverage*
-          coverage xml -i
-      - uses: codecov/codecov-action@v3
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          files: coverage.xml
   check_required_tests:
     name: All Data Processing tests passed
-    needs: [test-data_processing-pinned, test-data_processing-py27]
+    needs: test-data_processing-pinned
     # Always run this, even if a dependent job failed
     if: always()
     runs-on: ubuntu-20.04
     steps:
       - name: Check for failures
         if: contains(needs.test-data_processing-pinned.result, 'failure') || contains(needs.test-data_processing-pinned.result, 'skipped')
-        run: |
-          echo "One of the dependent jobs has failed. You may need to re-run it." && exit 1
-      - name: Check for 2.7 failures
-        if: contains(needs.test-data_processing-py27.result, 'failure') || contains(needs.test-data_processing-py27.result, 'skipped')
         run: |
           echo "One of the dependent jobs has failed. You may need to re-run it." && exit 1

--- a/.github/workflows/test-integrations-data-processing.yml
+++ b/.github/workflows/test-integrations-data-processing.yml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.7","3.8","3.11","3.12"]
+        python-version: ["3.6","3.7","3.8","3.11","3.12"]
         # python3.6 reached EOL and is no longer being supported on
         # new versions of hosted runners on Github Actions
         # ubuntu-20.04 is the last version that supported python3.6

--- a/.github/workflows/test-integrations-databases.yml
+++ b/.github/workflows/test-integrations-databases.yml
@@ -158,77 +158,14 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: coverage.xml
-  test-databases-py27:
-    name: Databases (py27)
-    timeout-minutes: 30
-    runs-on: ubuntu-20.04
-    container: python:2.7
-    services:
-      postgres:
-        image: postgres
-        env:
-          POSTGRES_PASSWORD: sentry
-        # Set health checks to wait until postgres has started
-        options: >-
-          --health-cmd pg_isready
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
-        # Maps tcp port 5432 on service container to the host
-        ports:
-          - 5432:5432
-    env:
-      SENTRY_PYTHON_TEST_POSTGRES_USER: postgres
-      SENTRY_PYTHON_TEST_POSTGRES_PASSWORD: sentry
-      SENTRY_PYTHON_TEST_POSTGRES_NAME: ci_test
-      SENTRY_PYTHON_TEST_POSTGRES_HOST: postgres
-    steps:
-      - uses: actions/checkout@v4
-      - uses: getsentry/action-clickhouse-in-ci@v1
-      - name: Setup Test Env
-        run: |
-          pip install coverage "tox>=3,<4"
-          psql postgresql://postgres:sentry@postgres:5432 -c "create database ${SENTRY_PYTHON_TEST_POSTGRES_NAME};" || true
-          psql postgresql://postgres:sentry@postgres:5432 -c "grant all privileges on database ${SENTRY_PYTHON_TEST_POSTGRES_NAME} to ${SENTRY_PYTHON_TEST_POSTGRES_USER};" || true
-      - name: Erase coverage
-        run: |
-          coverage erase
-      - name: Test asyncpg py27
-        run: |
-          set -x # print commands that are executed
-          ./scripts/runtox.sh --exclude-latest "py2.7-asyncpg" --cov=tests --cov=sentry_sdk --cov-report= --cov-branch
-      - name: Test clickhouse_driver py27
-        run: |
-          set -x # print commands that are executed
-          ./scripts/runtox.sh --exclude-latest "py2.7-clickhouse_driver" --cov=tests --cov=sentry_sdk --cov-report= --cov-branch
-      - name: Test pymongo py27
-        run: |
-          set -x # print commands that are executed
-          ./scripts/runtox.sh --exclude-latest "py2.7-pymongo" --cov=tests --cov=sentry_sdk --cov-report= --cov-branch
-      - name: Test sqlalchemy py27
-        run: |
-          set -x # print commands that are executed
-          ./scripts/runtox.sh --exclude-latest "py2.7-sqlalchemy" --cov=tests --cov=sentry_sdk --cov-report= --cov-branch
-      - name: Generate coverage XML
-        run: |
-          coverage combine .coverage*
-          coverage xml -i
-      - uses: codecov/codecov-action@v3
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          files: coverage.xml
   check_required_tests:
     name: All Databases tests passed
-    needs: [test-databases-pinned, test-databases-py27]
+    needs: test-databases-pinned
     # Always run this, even if a dependent job failed
     if: always()
     runs-on: ubuntu-20.04
     steps:
       - name: Check for failures
         if: contains(needs.test-databases-pinned.result, 'failure') || contains(needs.test-databases-pinned.result, 'skipped')
-        run: |
-          echo "One of the dependent jobs has failed. You may need to re-run it." && exit 1
-      - name: Check for 2.7 failures
-        if: contains(needs.test-databases-py27.result, 'failure') || contains(needs.test-databases-py27.result, 'skipped')
         run: |
           echo "One of the dependent jobs has failed. You may need to re-run it." && exit 1

--- a/.github/workflows/test-integrations-miscellaneous.yml
+++ b/.github/workflows/test-integrations-miscellaneous.yml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8","3.11","3.12"]
+        python-version: ["3.6","3.8","3.11","3.12"]
         # python3.6 reached EOL and is no longer being supported on
         # new versions of hosted runners on Github Actions
         # ubuntu-20.04 is the last version that supported python3.6

--- a/.github/workflows/test-integrations-miscellaneous.yml
+++ b/.github/workflows/test-integrations-miscellaneous.yml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.5","3.8","3.11","3.12"]
+        python-version: ["3.8","3.11","3.12"]
         # python3.6 reached EOL and is no longer being supported on
         # new versions of hosted runners on Github Actions
         # ubuntu-20.04 is the last version that supported python3.6
@@ -73,7 +73,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.5","3.6","3.7","3.8","3.9","3.11","3.12"]
+        python-version: ["3.6","3.7","3.8","3.9","3.11","3.12"]
         # python3.6 reached EOL and is no longer being supported on
         # new versions of hosted runners on Github Actions
         # ubuntu-20.04 is the last version that supported python3.6

--- a/.github/workflows/test-integrations-networking.yml
+++ b/.github/workflows/test-integrations-networking.yml
@@ -114,55 +114,14 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: coverage.xml
-  test-networking-py27:
-    name: Networking (py27)
-    timeout-minutes: 30
-    runs-on: ubuntu-20.04
-    container: python:2.7
-    steps:
-      - uses: actions/checkout@v4
-      - name: Setup Test Env
-        run: |
-          pip install coverage "tox>=3,<4"
-      - name: Erase coverage
-        run: |
-          coverage erase
-      - name: Test gevent py27
-        run: |
-          set -x # print commands that are executed
-          ./scripts/runtox.sh --exclude-latest "py2.7-gevent" --cov=tests --cov=sentry_sdk --cov-report= --cov-branch
-      - name: Test grpc py27
-        run: |
-          set -x # print commands that are executed
-          ./scripts/runtox.sh --exclude-latest "py2.7-grpc" --cov=tests --cov=sentry_sdk --cov-report= --cov-branch
-      - name: Test httpx py27
-        run: |
-          set -x # print commands that are executed
-          ./scripts/runtox.sh --exclude-latest "py2.7-httpx" --cov=tests --cov=sentry_sdk --cov-report= --cov-branch
-      - name: Test requests py27
-        run: |
-          set -x # print commands that are executed
-          ./scripts/runtox.sh --exclude-latest "py2.7-requests" --cov=tests --cov=sentry_sdk --cov-report= --cov-branch
-      - name: Generate coverage XML
-        run: |
-          coverage combine .coverage*
-          coverage xml -i
-      - uses: codecov/codecov-action@v3
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          files: coverage.xml
   check_required_tests:
     name: All Networking tests passed
-    needs: [test-networking-pinned, test-networking-py27]
+    needs: test-networking-pinned
     # Always run this, even if a dependent job failed
     if: always()
     runs-on: ubuntu-20.04
     steps:
       - name: Check for failures
         if: contains(needs.test-networking-pinned.result, 'failure') || contains(needs.test-networking-pinned.result, 'skipped')
-        run: |
-          echo "One of the dependent jobs has failed. You may need to re-run it." && exit 1
-      - name: Check for 2.7 failures
-        if: contains(needs.test-networking-py27.result, 'failure') || contains(needs.test-networking-py27.result, 'skipped')
         run: |
           echo "One of the dependent jobs has failed. You may need to re-run it." && exit 1

--- a/.github/workflows/test-integrations-web-frameworks-1.yml
+++ b/.github/workflows/test-integrations-web-frameworks-1.yml
@@ -94,7 +94,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.5","3.6","3.7","3.8","3.9","3.10","3.11","3.12"]
+        python-version: ["3.6","3.7","3.8","3.9","3.10","3.11","3.12"]
         # python3.6 reached EOL and is no longer being supported on
         # new versions of hosted runners on Github Actions
         # ubuntu-20.04 is the last version that supported python3.6
@@ -156,76 +156,14 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: coverage.xml
-  test-web_frameworks_1-py27:
-    name: Web Frameworks 1 (py27)
-    timeout-minutes: 30
-    runs-on: ubuntu-20.04
-    container: python:2.7
-    services:
-      postgres:
-        image: postgres
-        env:
-          POSTGRES_PASSWORD: sentry
-        # Set health checks to wait until postgres has started
-        options: >-
-          --health-cmd pg_isready
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
-        # Maps tcp port 5432 on service container to the host
-        ports:
-          - 5432:5432
-    env:
-      SENTRY_PYTHON_TEST_POSTGRES_USER: postgres
-      SENTRY_PYTHON_TEST_POSTGRES_PASSWORD: sentry
-      SENTRY_PYTHON_TEST_POSTGRES_NAME: ci_test
-      SENTRY_PYTHON_TEST_POSTGRES_HOST: postgres
-    steps:
-      - uses: actions/checkout@v4
-      - name: Setup Test Env
-        run: |
-          pip install coverage "tox>=3,<4"
-          psql postgresql://postgres:sentry@postgres:5432 -c "create database ${SENTRY_PYTHON_TEST_POSTGRES_NAME};" || true
-          psql postgresql://postgres:sentry@postgres:5432 -c "grant all privileges on database ${SENTRY_PYTHON_TEST_POSTGRES_NAME} to ${SENTRY_PYTHON_TEST_POSTGRES_USER};" || true
-      - name: Erase coverage
-        run: |
-          coverage erase
-      - name: Test django py27
-        run: |
-          set -x # print commands that are executed
-          ./scripts/runtox.sh --exclude-latest "py2.7-django" --cov=tests --cov=sentry_sdk --cov-report= --cov-branch
-      - name: Test fastapi py27
-        run: |
-          set -x # print commands that are executed
-          ./scripts/runtox.sh --exclude-latest "py2.7-fastapi" --cov=tests --cov=sentry_sdk --cov-report= --cov-branch
-      - name: Test flask py27
-        run: |
-          set -x # print commands that are executed
-          ./scripts/runtox.sh --exclude-latest "py2.7-flask" --cov=tests --cov=sentry_sdk --cov-report= --cov-branch
-      - name: Test starlette py27
-        run: |
-          set -x # print commands that are executed
-          ./scripts/runtox.sh --exclude-latest "py2.7-starlette" --cov=tests --cov=sentry_sdk --cov-report= --cov-branch
-      - name: Generate coverage XML
-        run: |
-          coverage combine .coverage*
-          coverage xml -i
-      - uses: codecov/codecov-action@v3
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          files: coverage.xml
   check_required_tests:
     name: All Web Frameworks 1 tests passed
-    needs: [test-web_frameworks_1-pinned, test-web_frameworks_1-py27]
+    needs: test-web_frameworks_1-pinned
     # Always run this, even if a dependent job failed
     if: always()
     runs-on: ubuntu-20.04
     steps:
       - name: Check for failures
         if: contains(needs.test-web_frameworks_1-pinned.result, 'failure') || contains(needs.test-web_frameworks_1-pinned.result, 'skipped')
-        run: |
-          echo "One of the dependent jobs has failed. You may need to re-run it." && exit 1
-      - name: Check for 2.7 failures
-        if: contains(needs.test-web_frameworks_1-py27.result, 'failure') || contains(needs.test-web_frameworks_1-py27.result, 'skipped')
         run: |
           echo "One of the dependent jobs has failed. You may need to re-run it." && exit 1

--- a/.github/workflows/test-integrations-web-frameworks-2.yml
+++ b/.github/workflows/test-integrations-web-frameworks-2.yml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.5","3.6","3.7","3.8","3.11","3.12"]
+        python-version: ["3.6","3.7","3.8","3.11","3.12"]
         # python3.6 reached EOL and is no longer being supported on
         # new versions of hosted runners on Github Actions
         # ubuntu-20.04 is the last version that supported python3.6
@@ -101,7 +101,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.5","3.6","3.7","3.8","3.9","3.11","3.12"]
+        python-version: ["3.6","3.7","3.8","3.9","3.11","3.12"]
         # python3.6 reached EOL and is no longer being supported on
         # new versions of hosted runners on Github Actions
         # ubuntu-20.04 is the last version that supported python3.6
@@ -170,83 +170,14 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: coverage.xml
-  test-web_frameworks_2-py27:
-    name: Web Frameworks 2 (py27)
-    timeout-minutes: 30
-    runs-on: ubuntu-20.04
-    container: python:2.7
-    steps:
-      - uses: actions/checkout@v4
-      - name: Setup Test Env
-        run: |
-          pip install coverage "tox>=3,<4"
-      - name: Erase coverage
-        run: |
-          coverage erase
-      - name: Test aiohttp py27
-        run: |
-          set -x # print commands that are executed
-          ./scripts/runtox.sh --exclude-latest "py2.7-aiohttp" --cov=tests --cov=sentry_sdk --cov-report= --cov-branch
-      - name: Test asgi py27
-        run: |
-          set -x # print commands that are executed
-          ./scripts/runtox.sh --exclude-latest "py2.7-asgi" --cov=tests --cov=sentry_sdk --cov-report= --cov-branch
-      - name: Test bottle py27
-        run: |
-          set -x # print commands that are executed
-          ./scripts/runtox.sh --exclude-latest "py2.7-bottle" --cov=tests --cov=sentry_sdk --cov-report= --cov-branch
-      - name: Test falcon py27
-        run: |
-          set -x # print commands that are executed
-          ./scripts/runtox.sh --exclude-latest "py2.7-falcon" --cov=tests --cov=sentry_sdk --cov-report= --cov-branch
-      - name: Test pyramid py27
-        run: |
-          set -x # print commands that are executed
-          ./scripts/runtox.sh --exclude-latest "py2.7-pyramid" --cov=tests --cov=sentry_sdk --cov-report= --cov-branch
-      - name: Test quart py27
-        run: |
-          set -x # print commands that are executed
-          ./scripts/runtox.sh --exclude-latest "py2.7-quart" --cov=tests --cov=sentry_sdk --cov-report= --cov-branch
-      - name: Test redis py27
-        run: |
-          set -x # print commands that are executed
-          ./scripts/runtox.sh --exclude-latest "py2.7-redis" --cov=tests --cov=sentry_sdk --cov-report= --cov-branch
-      - name: Test rediscluster py27
-        run: |
-          set -x # print commands that are executed
-          ./scripts/runtox.sh --exclude-latest "py2.7-rediscluster" --cov=tests --cov=sentry_sdk --cov-report= --cov-branch
-      - name: Test sanic py27
-        run: |
-          set -x # print commands that are executed
-          ./scripts/runtox.sh --exclude-latest "py2.7-sanic" --cov=tests --cov=sentry_sdk --cov-report= --cov-branch
-      - name: Test starlite py27
-        run: |
-          set -x # print commands that are executed
-          ./scripts/runtox.sh --exclude-latest "py2.7-starlite" --cov=tests --cov=sentry_sdk --cov-report= --cov-branch
-      - name: Test tornado py27
-        run: |
-          set -x # print commands that are executed
-          ./scripts/runtox.sh --exclude-latest "py2.7-tornado" --cov=tests --cov=sentry_sdk --cov-report= --cov-branch
-      - name: Generate coverage XML
-        run: |
-          coverage combine .coverage*
-          coverage xml -i
-      - uses: codecov/codecov-action@v3
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          files: coverage.xml
   check_required_tests:
     name: All Web Frameworks 2 tests passed
-    needs: [test-web_frameworks_2-pinned, test-web_frameworks_2-py27]
+    needs: test-web_frameworks_2-pinned
     # Always run this, even if a dependent job failed
     if: always()
     runs-on: ubuntu-20.04
     steps:
       - name: Check for failures
         if: contains(needs.test-web_frameworks_2-pinned.result, 'failure') || contains(needs.test-web_frameworks_2-pinned.result, 'skipped')
-        run: |
-          echo "One of the dependent jobs has failed. You may need to re-run it." && exit 1
-      - name: Check for 2.7 failures
-        if: contains(needs.test-web_frameworks_2-py27.result, 'failure') || contains(needs.test-web_frameworks_2-py27.result, 'skipped')
         run: |
           echo "One of the dependent jobs has failed. You may need to re-run it." && exit 1

--- a/MIGRATION_GUIDE.md
+++ b/MIGRATION_GUIDE.md
@@ -8,4 +8,9 @@
 
 ## Removed
 
+- Removed support for Python 2 and Python 3.5. The SDK now requires at least Python 3.6.
+- Removed support for Celery 3.\*.
+- Removed support for Django 1.8, 1.9, 1.10.
+- Removed support for Flask 0.\*.
+
 ## Deprecated

--- a/scripts/split-tox-gh-actions/split-tox-gh-actions.py
+++ b/scripts/split-tox-gh-actions/split-tox-gh-actions.py
@@ -260,11 +260,6 @@ def render_template(group, frameworks, py_versions_pinned, py_versions_latest):
         if py_versions_latest[framework]:
             categories.add("latest")
             py_versions["latest"] |= set(py_versions_latest[framework])
-        if "2.7" in py_versions_pinned[framework]:
-            categories.add("py27")
-
-    py_versions["pinned"].discard("2.7")
-    py_versions["latest"].discard("2.7")
 
     context = {
         "group": group,

--- a/scripts/split-tox-gh-actions/templates/check_required.jinja
+++ b/scripts/split-tox-gh-actions/templates/check_required.jinja
@@ -1,8 +1,6 @@
   check_required_tests:
     name: All {{ group }} tests passed
-    {% if "pinned" in categories and "py27" in categories %}
-    needs: [test-{{ group | replace(" ", "_") | lower }}-pinned, test-{{ group | replace(" ", "_") | lower }}-py27]
-    {% elif "pinned" in categories %}
+    {% if "pinned" in categories %}
     needs: test-{{ group | replace(" ", "_") | lower }}-pinned
     {% endif %}
     # Always run this, even if a dependent job failed
@@ -13,9 +11,3 @@
         if: contains(needs.test-{{ lowercase_group }}-pinned.result, 'failure') || contains(needs.test-{{ lowercase_group }}-pinned.result, 'skipped')
         run: |
           echo "One of the dependent jobs has failed. You may need to re-run it." && exit 1
-      {% if "py27" in categories %}
-      - name: Check for 2.7 failures
-        if: contains(needs.test-{{ lowercase_group }}-py27.result, 'failure') || contains(needs.test-{{ lowercase_group }}-py27.result, 'skipped')
-        run: |
-          echo "One of the dependent jobs has failed. You may need to re-run it." && exit 1
-      {% endif %}

--- a/scripts/split-tox-gh-actions/templates/test_group.jinja
+++ b/scripts/split-tox-gh-actions/templates/test_group.jinja
@@ -1,15 +1,6 @@
   test-{{ lowercase_group }}-{{ category }}:
     name: {{ group }} ({{ category }})
     timeout-minutes: 30
-
-    {% if needs_github_secrets %}
-    needs: check-permissions
-    {% endif %}
-
-    {% if category == "py27" %}
-    runs-on: ubuntu-20.04
-    container: python:2.7
-    {% else %}
     runs-on: {% raw %}${{ matrix.os }}{% endraw %}
     strategy:
       fail-fast: false
@@ -20,6 +11,9 @@
         # ubuntu-20.04 is the last version that supported python3.6
         # see https://github.com/actions/setup-python/issues/544#issuecomment-1332535877
         os: [ubuntu-20.04]
+
+    {% if needs_github_secrets %}
+    needs: check-permissions
     {% endif %}
 
     {% if needs_postgres %}
@@ -41,7 +35,7 @@
       SENTRY_PYTHON_TEST_POSTGRES_USER: postgres
       SENTRY_PYTHON_TEST_POSTGRES_PASSWORD: sentry
       SENTRY_PYTHON_TEST_POSTGRES_NAME: ci_test
-      SENTRY_PYTHON_TEST_POSTGRES_HOST: {% if category == "py27" %}postgres{% else %}localhost{% endif %}
+      SENTRY_PYTHON_TEST_POSTGRES_HOST: localhost
     {% endif %}
 
     steps:
@@ -52,11 +46,9 @@
           ref: ${{ github.event.pull_request.head.sha || github.ref }}
       {% endraw %}
       {% endif %}
-      {% if category != "py27" %}
       - uses: actions/setup-python@v4
         with:
           python-version: {% raw %}${{ matrix.python-version }}{% endraw %}
-      {% endif %}
       {% if needs_clickhouse %}
       - uses: getsentry/action-clickhouse-in-ci@v1
       {% endif %}
@@ -65,13 +57,8 @@
         run: |
           pip install coverage "tox>=3,<4"
           {% if needs_postgres %}
-          {% if category == "py27" %}
-          psql postgresql://postgres:sentry@postgres:5432 -c "create database ${SENTRY_PYTHON_TEST_POSTGRES_NAME};" || true
-          psql postgresql://postgres:sentry@postgres:5432 -c "grant all privileges on database ${SENTRY_PYTHON_TEST_POSTGRES_NAME} to ${SENTRY_PYTHON_TEST_POSTGRES_USER};" || true
-          {% else %}
           psql postgresql://postgres:sentry@localhost:5432 -c "create database ${SENTRY_PYTHON_TEST_POSTGRES_NAME};" || true
           psql postgresql://postgres:sentry@localhost:5432 -c "grant all privileges on database ${SENTRY_PYTHON_TEST_POSTGRES_NAME} to ${SENTRY_PYTHON_TEST_POSTGRES_USER};" || true
-          {% endif %}
           {% endif %}
 
       - name: Erase coverage
@@ -83,9 +70,7 @@
         run: |
           set -x # print commands that are executed
 
-          {% if category == "py27" %}
-          ./scripts/runtox.sh --exclude-latest "py2.7-{{ framework }}" --cov=tests --cov=sentry_sdk --cov-report= --cov-branch
-          {% elif category == "pinned" %}
+          {% if category == "pinned" %}
           ./scripts/runtox.sh --exclude-latest "{% raw %}py${{ matrix.python-version }}{% endraw %}-{{ framework }}" --cov=tests --cov=sentry_sdk --cov-report= --cov-branch
           {% elif category == "latest" %}
           ./scripts/runtox.sh "{% raw %}py${{ matrix.python-version }}{% endraw %}-{{ framework }}-latest" --cov=tests --cov=sentry_sdk --cov-report= --cov-branch

--- a/tox.ini
+++ b/tox.ini
@@ -58,11 +58,11 @@ envlist =
     {py3.7,py3.11,py3.12}-boto3-latest
 
     # Bottle
-    {py3.9}-bottle-v{0.12}
-    {py3.11,py3.12}-bottle-latest
+    {py3.6,py3.9}-bottle-v{0.12}
+    {py3.6,py3.11,py3.12}-bottle-latest
 
     # Celery
-    {py3.8}-celery-v{4}
+    {py3.6,py3.8}-celery-v{4}
     {py3.6,py3.8}-celery-v{5.0}
     {py3.7,py3.10}-celery-v{5.1,5.2}
     {py3.8,py3.11}-celery-v{5.3}
@@ -81,10 +81,10 @@ envlist =
 
     # Django
     # - Django 1.x
-    {py3.7}-django-v{1.11}
+    {py3.6,py3.7}-django-v{1.11}
     # - Django 2.x
-    {py3.7}-django-v{2.0}
-    {py3.9}-django-v{2.2}
+    {py3.6,py3.7}-django-v{2.0}
+    {py3.6,py3.9}-django-v{2.2}
     # - Django 3.x
     {py3.6,py3.9}-django-v{3.0}
     {py3.6,py3.11}-django-v{3.2}
@@ -95,7 +95,7 @@ envlist =
     {py3.10,py3.11,py3.12}-django-latest
 
     # Falcon
-    {py3.7}-falcon-v{1,1.4,2}
+    {py3.6,py3.7}-falcon-v{1,1.4,2}
     {py3.6,py3.11,py3.12}-falcon-v{3}
     {py3.7,py3.11,py3.12}-falcon-latest
 
@@ -104,7 +104,7 @@ envlist =
     {py3.8,py3.11,py3.12}-fastapi-latest
 
     # Flask
-    {py3.8}-flask-v{1}
+    {py3.6,py3.8}-flask-v{1}
     {py3.8,py3.11,py3.12}-flask-v{2}
     {py3.10,py3.11,py3.12}-flask-v{3}
     {py3.10,py3.11,py3.12}-flask-latest
@@ -136,12 +136,12 @@ envlist =
     {py3.9,py3.11,py3.12}-httpx-latest
 
     # Huey
-    {py3.11,py3.12}-huey-v{2.0}
-    {py3.11,py3.12}-huey-latest
+    {py3.6,py3.11,py3.12}-huey-v{2.0}
+    {py3.6,py3.11,py3.12}-huey-latest
 
     # Loguru
-    {py3.11,py3.12}-loguru-v{0.5}
-    {py3.11,py3.12}-loguru-latest
+    {py3.6,py3.11,py3.12}-loguru-v{0.5}
+    {py3.6,py3.11,py3.12}-loguru-latest
 
     # OpenTelemetry (OTel)
     {py3.7,py3.9,py3.11,py3.12}-opentelemetry
@@ -157,8 +157,8 @@ envlist =
     {py3.7,py3.11,py3.12}-pymongo-latest
 
     # Pyramid
-    {py3.11}-pyramid-v{1.6}
-    {py3.11,py3.12}-pyramid-v{1.10}
+    {py3.6,py3.11}-pyramid-v{1.6}
+    {py3.6,py3.11,py3.12}-pyramid-v{1.10}
     {py3.6,py3.11,py3.12}-pyramid-v{2.0}
     {py3.6,py3.11,py3.12}-pyramid-latest
 
@@ -182,13 +182,13 @@ envlist =
 
     # RQ (Redis Queue)
     {py3.6}-rq-v{0.6}
-    {py3.9}-rq-v{0.13,1.0}
-    {py3.11}-rq-v{1.5,1.10}
+    {py3.6,py3.9}-rq-v{0.13,1.0}
+    {py3.6,py3.11}-rq-v{1.5,1.10}
     {py3.7,py3.11,py3.12}-rq-v{1.15}
     {py3.7,py3.11,py3.12}-rq-latest
 
     # Sanic
-    {py3.7}-sanic-v{0.8}
+    {py3.6,py3.7}-sanic-v{0.8}
     {py3.6,py3.8}-sanic-v{20}
     {py3.7,py3.11}-sanic-v{22}
     {py3.7,py3.11}-sanic-v{23}

--- a/tox.ini
+++ b/tox.ini
@@ -147,7 +147,7 @@ envlist =
     {py3.7,py3.9,py3.11,py3.12}-opentelemetry
 
     # pure_eval
-    {py3.11,py3.12}-pure_eval
+    {py3.6,py3.11,py3.12}-pure_eval
 
     # PyMongo (Mongo DB)
     {py3.6}-pymongo-v{3.1}
@@ -168,17 +168,17 @@ envlist =
     {py3.8,py3.11,py3.12}-quart-latest
 
     # Redis
-    {py3.7,py3.8}-redis-v{3}
+    {py3.6,py3.8}-redis-v{3}
     {py3.7,py3.8,py3.11}-redis-v{4}
     {py3.7,py3.11,py3.12}-redis-v{5}
     {py3.7,py3.11,py3.12}-redis-latest
 
     # Redis Cluster
-    {py3.7,py3.8}-rediscluster-v{1,2}
+    {py3.6,py3.8}-rediscluster-v{1,2}
     # no -latest, not developed anymore
 
     # Requests
-    {py3.8,py3.11,py3.12}-requests
+    {py3.6,py3.8,py3.11,py3.12}-requests
 
     # RQ (Redis Queue)
     {py3.6}-rq-v{0.6}
@@ -205,7 +205,7 @@ envlist =
     # 1.51.14 is the last starlite version; the project continues as litestar
 
     # SQL Alchemy
-    {py3.7,py3.9}-sqlalchemy-v{1.2,1.4}
+    {py3.6,py3.9}-sqlalchemy-v{1.2,1.4}
     {py3.7,py3.11}-sqlalchemy-v{2.0}
     {py3.7,py3.11,py3.12}-sqlalchemy-latest
 

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,7 @@
 [tox]
 envlist =
     # === Common ===
-    {py2.7,py3.5,py3.6,py3.7,py3.8,py3.9,py3.10,py3.11,py3.12}-common
+    {py3.6,py3.7,py3.8,py3.9,py3.10,py3.11,py3.12}-common
 
     # === Integrations ===
     # General format is {pythonversion}-{integrationname}-v{frameworkversion}
@@ -52,18 +52,17 @@ envlist =
     {py3.8,py3.11}-beam-latest
 
     # Boto3
-    {py2.7,py3.6,py3.7}-boto3-v{1.12}
+    {py3.6,py3.7}-boto3-v{1.12}
     {py3.7,py3.11,py3.12}-boto3-v{1.21}
     {py3.7,py3.11,py3.12}-boto3-v{1.29}
     {py3.7,py3.11,py3.12}-boto3-latest
 
     # Bottle
-    {py2.7,py3.5,py3.9}-bottle-v{0.12}
-    {py3.5,py3.11,py3.12}-bottle-latest
+    {py3.9}-bottle-v{0.12}
+    {py3.11,py3.12}-bottle-latest
 
     # Celery
-    {py2.7}-celery-v{3}
-    {py2.7,py3.5,py3.8}-celery-v{4}
+    {py3.8}-celery-v{4}
     {py3.6,py3.8}-celery-v{5.0}
     {py3.7,py3.10}-celery-v{5.1,5.2}
     {py3.8,py3.11}-celery-v{5.3}
@@ -82,11 +81,10 @@ envlist =
 
     # Django
     # - Django 1.x
-    {py2.7,py3.5}-django-v{1.8}
-    {py2.7,py3.5,py3.7}-django-v{1.11}
+    {py3.7}-django-v{1.11}
     # - Django 2.x
-    {py3.5,py3.7}-django-v{2.0}
-    {py3.5,py3.9}-django-v{2.2}
+    {py3.7}-django-v{2.0}
+    {py3.9}-django-v{2.2}
     # - Django 3.x
     {py3.6,py3.9}-django-v{3.0}
     {py3.6,py3.11}-django-v{3.2}
@@ -97,8 +95,8 @@ envlist =
     {py3.10,py3.11,py3.12}-django-latest
 
     # Falcon
-    {py2.7,py3.5,py3.7}-falcon-v{1,1.4,2}
-    {py3.5,py3.6,py3.11,py3.12}-falcon-v{3}
+    {py3.7}-falcon-v{1,1.4,2}
+    {py3.6,py3.11,py3.12}-falcon-v{3}
     {py3.7,py3.11,py3.12}-falcon-latest
 
     # FastAPI
@@ -106,14 +104,13 @@ envlist =
     {py3.8,py3.11,py3.12}-fastapi-latest
 
     # Flask
-    {py2.7,py3.5}-flask-v{0,0.11}
-    {py2.7,py3.5,py3.8}-flask-v{1}
+    {py3.8}-flask-v{1}
     {py3.8,py3.11,py3.12}-flask-v{2}
     {py3.10,py3.11,py3.12}-flask-v{3}
     {py3.10,py3.11,py3.12}-flask-latest
 
     # Gevent
-    {py2.7,py3.6,py3.8,py3.10,py3.11}-gevent
+    {py3.6,py3.8,py3.10,py3.11}-gevent
 
     # GCP
     {py3.7}-gcp
@@ -139,29 +136,29 @@ envlist =
     {py3.9,py3.11,py3.12}-httpx-latest
 
     # Huey
-    {py2.7,py3.5,py3.11,py3.12}-huey-v{2.0}
-    {py3.5,py3.11,py3.12}-huey-latest
+    {py3.11,py3.12}-huey-v{2.0}
+    {py3.11,py3.12}-huey-latest
 
     # Loguru
-    {py3.5,py3.11,py3.12}-loguru-v{0.5}
-    {py3.5,py3.11,py3.12}-loguru-latest
+    {py3.11,py3.12}-loguru-v{0.5}
+    {py3.11,py3.12}-loguru-latest
 
     # OpenTelemetry (OTel)
     {py3.7,py3.9,py3.11,py3.12}-opentelemetry
 
     # pure_eval
-    {py3.5,py3.11,py3.12}-pure_eval
+    {py3.11,py3.12}-pure_eval
 
     # PyMongo (Mongo DB)
-    {py2.7,py3.6}-pymongo-v{3.1}
-    {py2.7,py3.6,py3.9}-pymongo-v{3.12}
+    {py3.6}-pymongo-v{3.1}
+    {py3.6,py3.9}-pymongo-v{3.12}
     {py3.6,py3.11}-pymongo-v{4.0}
     {py3.7,py3.11,py3.12}-pymongo-v{4.3,4.6}
     {py3.7,py3.11,py3.12}-pymongo-latest
 
     # Pyramid
-    {py2.7,py3.5,py3.11}-pyramid-v{1.6}
-    {py2.7,py3.5,py3.11,py3.12}-pyramid-v{1.10}
+    {py3.11}-pyramid-v{1.6}
+    {py3.11,py3.12}-pyramid-v{1.10}
     {py3.6,py3.11,py3.12}-pyramid-v{2.0}
     {py3.6,py3.11,py3.12}-pyramid-latest
 
@@ -171,27 +168,27 @@ envlist =
     {py3.8,py3.11,py3.12}-quart-latest
 
     # Redis
-    {py2.7,py3.7,py3.8}-redis-v{3}
+    {py3.7,py3.8}-redis-v{3}
     {py3.7,py3.8,py3.11}-redis-v{4}
     {py3.7,py3.11,py3.12}-redis-v{5}
     {py3.7,py3.11,py3.12}-redis-latest
 
     # Redis Cluster
-    {py2.7,py3.7,py3.8}-rediscluster-v{1,2}
+    {py3.7,py3.8}-rediscluster-v{1,2}
     # no -latest, not developed anymore
 
     # Requests
-    {py2.7,py3.8,py3.11,py3.12}-requests
+    {py3.8,py3.11,py3.12}-requests
 
     # RQ (Redis Queue)
-    {py2.7,py3.5,py3.6}-rq-v{0.6}
-    {py2.7,py3.5,py3.9}-rq-v{0.13,1.0}
-    {py3.5,py3.11}-rq-v{1.5,1.10}
+    {py3.6}-rq-v{0.6}
+    {py3.9}-rq-v{0.13,1.0}
+    {py3.11}-rq-v{1.5,1.10}
     {py3.7,py3.11,py3.12}-rq-v{1.15}
     {py3.7,py3.11,py3.12}-rq-latest
 
     # Sanic
-    {py3.5,py3.7}-sanic-v{0.8}
+    {py3.7}-sanic-v{0.8}
     {py3.6,py3.8}-sanic-v{20}
     {py3.7,py3.11}-sanic-v{22}
     {py3.7,py3.11}-sanic-v{23}
@@ -208,7 +205,7 @@ envlist =
     # 1.51.14 is the last starlite version; the project continues as litestar
 
     # SQL Alchemy
-    {py2.7,py3.7,py3.9}-sqlalchemy-v{1.2,1.4}
+    {py3.7,py3.9}-sqlalchemy-v{1.2,1.4}
     {py3.7,py3.11}-sqlalchemy-v{2.0}
     {py3.7,py3.11,py3.12}-sqlalchemy-latest
 
@@ -222,7 +219,7 @@ envlist =
     {py3.8,py3.11,py3.12}-tornado-latest
 
     # Trytond
-    {py3.5,py3.6}-trytond-v{4}
+    {py3.6}-trytond-v{4}
     {py3.6,py3.8}-trytond-v{5}
     {py3.6,py3.11}-trytond-v{6}
     {py3.8,py3.11,py3.12}-trytond-v{7}
@@ -299,7 +296,6 @@ deps =
 
     # Celery
     celery: redis
-    celery-v3: Celery~=3.0
     celery-v4: Celery~=4.0
     celery-v5.0: Celery~=5.0.0
     celery-v5.1: Celery~=5.1.0
@@ -307,9 +303,8 @@ deps =
     celery-v5.3: Celery~=5.3.0
     celery-latest: Celery
 
-    {py3.5}-celery: newrelic<6.0.0
     {py3.7}-celery: importlib-metadata<5.0
-    {py2.7,py3.6,py3.7,py3.8,py3.9,py3.10,py3.11}-celery: newrelic
+    {py3.6,py3.7,py3.8,py3.9,py3.10,py3.11}-celery: newrelic
 
     # Chalice
     chalice-v1.16: chalice~=1.16.0
@@ -327,8 +322,8 @@ deps =
     django: psycopg2-binary
     django-v{1.11,2.0,2.1,2.2,3.0,3.1,3.2}: djangorestframework>=3.0.0,<4.0.0
     django-v{2.0,2.2,3.0,3.2,4.0,4.1,4.2,5.0}: channels[daphne]
-    django-v{1.8,1.11,2.0,2.2,3.0,3.2}: Werkzeug<2.1.0
-    django-v{1.8,1.11,2.0}: pytest-django<4.0
+    django-v{1.11,2.0,2.2,3.0,3.2}: Werkzeug<2.1.0
+    django-v{1.11,2.0}: pytest-django<4.0
     django-v{2.2,3.0,3.2,4.0,4.1,4.2,5.0}: pytest-django
     django-v{4.0,4.1,4.2,5.0}: djangorestframework
     django-v{4.0,4.1,4.2,5.0}: pytest-asyncio<=0.21.1
@@ -339,7 +334,6 @@ deps =
     django-latest: Werkzeug
     django-latest: channels[daphne]
 
-    django-v1.8: Django~=1.8.0
     django-v1.11: Django~=1.11.0
     django-v2.0: Django~=2.0.0
     django-v2.2: Django~=2.2.0
@@ -369,24 +363,15 @@ deps =
 
     # Flask
     flask: flask-login
-    flask-v{0.11,0,1,2.0}: Werkzeug<2.1.0
-    flask-v{0.11,0,1,2.0}: markupsafe<2.1.0
+    flask-v{1,2.0}: Werkzeug<2.1.0
+    flask-v{1,2.0}: markupsafe<2.1.0
     flask-v{3}: Werkzeug
-    flask-v0.11: Flask~=0.11.0
-    flask-v0: Flask~=0.11
     flask-v1: Flask~=1.0
     flask-v2: Flask~=2.0
     flask-v3: Flask~=3.0
     flask-latest: Flask
 
-    # Gevent
-    # See http://www.gevent.org/install.html#older-versions-of-python
-    # for justification of the versions pinned below
-    py3.5-gevent: gevent==20.9.0
-    # See https://stackoverflow.com/questions/51496550/runtime-warning-greenlet-greenlet-size-changed
-    # for justification why greenlet is pinned here
-    py3.5-gevent: greenlet==0.4.17
-    {py2.7,py3.6,py3.7,py3.8,py3.9,py3.10,py3.11,py3.12}-gevent: gevent>=22.10.0, <22.11.0
+    {py3.6,py3.7,py3.8,py3.9,py3.10,py3.11,py3.12}-gevent: gevent>=22.10.0, <22.11.0
     # See https://github.com/pytest-dev/pytest/issues/9621
     # and https://github.com/pytest-dev/pytest-forked/issues/67
     # for justification of the upper bound on pytest
@@ -512,8 +497,7 @@ deps =
     sanic: aiohttp
     sanic-v{22,23}: sanic_testing
     sanic-latest: sanic_testing
-    {py3.5,py3.6}-sanic: aiocontextvars==0.2.1
-    {py3.5}-sanic: ujson<4
+    {py3.6}-sanic: aiocontextvars==0.2.1
     sanic-v0.8: sanic~=0.8.0
     sanic-v20: sanic~=20.0
     sanic-v22: sanic~=22.0
@@ -636,8 +620,6 @@ extras =
     pymongo: pymongo
 
 basepython =
-    py2.7: python2.7
-    py3.5: python3.5
     py3.6: python3.6
     py3.7: python3.7
     py3.8: python3.8
@@ -657,21 +639,15 @@ commands =
     {py3.7,py3.8}-boto3: pip install urllib3<2.0.0
 
     ; https://github.com/pytest-dev/pytest/issues/5532
-    {py3.5,py3.6,py3.7,py3.8,py3.9}-flask-v{0.11,0.12}: pip install pytest<5
+    {py3.6,py3.7,py3.8,py3.9}-flask-v{0.11,0.12}: pip install pytest<5
     {py3.6,py3.7,py3.8,py3.9}-flask-v{0.11}: pip install Werkzeug<2
     ; https://github.com/pallets/flask/issues/4455
     {py3.7,py3.8,py3.9,py3.10,py3.11}-flask-v{0.11,0.12,1.0,1.1}: pip install "itsdangerous>=0.24,<2.0" "markupsafe<2.0.0" "jinja2<3.1.1"
-    ; https://github.com/more-itertools/more-itertools/issues/578
-    py3.5-flask-v{0.11,0.12}: pip install more-itertools<8.11.0
-
-    ; use old pytest for old Python versions:
-    {py2.7,py3.5}: pip install pytest-forked==1.1.3
 
     ; Running `py.test` as an executable suffers from an import error
     ; when loading tests in scenarios. In particular, django fails to
     ; load the settings from the test module.
-    {py2.7}: python -m pytest --ignore-glob='*py3.py' -rsx -s --durations=5 -vvv {env:TESTPATH} {posargs}
-    {py3.5,py3.6,py3.7,py3.8,py3.9,py3.10,py3.11,py3.12}: python -m pytest -rsx -s --durations=5 -vvv {env:TESTPATH} {posargs}
+    {py3.6,py3.7,py3.8,py3.9,py3.10,py3.11,py3.12}: python -m pytest -rsx -s --durations=5 -vvv {env:TESTPATH} {posargs}
 
 [testenv:linters]
 commands =


### PR DESCRIPTION
- remove special treatment for Python 2.7 from CI YAML generation
- remove Python 2.7, 3.5 test environments from `tox.ini`
- remove tests for framework versions that don't support at least Python 3.6


---

## General Notes

Thank you for contributing to `sentry-python`!

Please add tests to validate your changes, and lint your code using `tox -e linters`.

Running the test suite on your PR might require maintainer approval. Some tests (AWS Lambda) additionally require a maintainer to add a special label to run and will fail if the label is not present.

#### For maintainers

Sensitive test suites require maintainer review to ensure that tests do not compromise our secrets. This review must be repeated after any code revisions.

Before running sensitive test suites, please carefully check the PR. Then, apply the `Trigger: tests using secrets` label. The label will be removed after any code changes to enforce our policy requiring maintainers to review all code revisions before running sensitive tests.
