### PR TITLE
[2.0] Remove `# coding: utf-8`

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 import os
 import sys
 import typing

--- a/sentry_sdk/integrations/django/__init__.py
+++ b/sentry_sdk/integrations/django/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from __future__ import absolute_import
 
 import inspect

--- a/sentry_sdk/integrations/django/signals_handlers.py
+++ b/sentry_sdk/integrations/django/signals_handlers.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from __future__ import absolute_import
 
 from django.dispatch import Signal

--- a/tests/integrations/logging/test_logging.py
+++ b/tests/integrations/logging/test_logging.py
@@ -1,4 +1,3 @@
-# coding: utf-8
 import sys
 
 import pytest

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,4 +1,3 @@
-# coding: utf-8
 import os
 import json
 import pytest

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,5 +1,3 @@
-# coding: utf-8
-
 import sys
 import time
 import linecache

--- a/tests/test_transport.py
+++ b/tests/test_transport.py
@@ -1,4 +1,3 @@
-# coding: utf-8
 import logging
 import pickle
 import gzip

--- a/tests/tracing/test_baggage.py
+++ b/tests/tracing/test_baggage.py
@@ -1,4 +1,3 @@
-# coding: utf-8
 from sentry_sdk.tracing_utils import Baggage
 
 

--- a/tests/tracing/test_integration_tests.py
+++ b/tests/tracing/test_integration_tests.py
@@ -1,4 +1,3 @@
-# coding: utf-8
 import weakref
 import gc
 import re

--- a/tests/utils/test_general.py
+++ b/tests/utils/test_general.py
@@ -1,4 +1,3 @@
-# coding: utf-8
 import sys
 import os
 


### PR DESCRIPTION
Removes `# -*- coding: utf-8 -*-` and friends.

Requires https://github.com/getsentry/sentry-python/pull/2640

---

## General Notes

Thank you for contributing to `sentry-python`!

Please add tests to validate your changes, and lint your code using `tox -e linters`.

Running the test suite on your PR might require maintainer approval. Some tests (AWS Lambda) additionally require a maintainer to add a special label to run and will fail if the label is not present.

#### For maintainers

Sensitive test suites require maintainer review to ensure that tests do not compromise our secrets. This review must be repeated after any code revisions.

Before running sensitive test suites, please carefully check the PR. Then, apply the `Trigger: tests using secrets` label. The label will be removed after any code changes to enforce our policy requiring maintainers to review all code revisions before running sensitive tests.
