### PR TITLE
[2.0] Remove unicode literals

### DIFF
--- a/tests/integrations/logging/test_logging.py
+++ b/tests/integrations/logging/test_logging.py
@@ -128,9 +128,7 @@ def test_custom_log_level_names(sentry_init, capture_events):
     }
 
     # set custom log level names
-    # fmt: off
-    logging.addLevelName(logging.DEBUG, u"custom level debüg: ")
-    # fmt: on
+    logging.addLevelName(logging.DEBUG, "custom level debüg: ")
     logging.addLevelName(logging.INFO, "")
     logging.addLevelName(logging.WARN, "custom level warn: ")
     logging.addLevelName(logging.WARNING, "custom level warning: ")

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -683,9 +683,7 @@ def test_scope_initialized_before_client(sentry_init, capture_events):
 def test_weird_chars(sentry_init, capture_events):
     sentry_init()
     events = capture_events()
-    # fmt: off
-    capture_message(u"föö".encode("latin1"))
-    # fmt: on
+    capture_message("föö".encode("latin1"))
     (event,) = events
     assert json.loads(json.dumps(event)) == event
 

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -755,11 +755,9 @@ def test_tag_normalization(sentry_init, capture_envelopes):
     ts = time.time()
     envelopes = capture_envelopes()
 
-    # fmt: off
     metrics.distribution("a", 1.0, tags={"foo-bar": "%$foo"}, timestamp=ts)
     metrics.distribution("b", 1.0, tags={"foo$$$bar": "blah{}"}, timestamp=ts)
-    metrics.distribution("c", 1.0, tags={u"foö-bar": u"snöwmän"}, timestamp=ts)
-    # fmt: on
+    metrics.distribution("c", 1.0, tags={"foö-bar": "snöwmän"}, timestamp=ts)
     Hub.current.flush()
 
     (envelope,) = envelopes
@@ -781,13 +779,11 @@ def test_tag_normalization(sentry_init, capture_envelopes):
         "environment": "not-fun-env",
     }
 
-    # fmt: off
     assert m[2][4] == {
-        "fo_-bar": u"snöwmän",
+        "fo_-bar": "snöwmän",
         "release": "fun-release@1.0.0",
         "environment": "not-fun-env",
     }
-    # fmt: on
 
 
 def test_before_emit_metric(sentry_init, capture_envelopes):

--- a/tests/test_serializer.py
+++ b/tests/test_serializer.py
@@ -61,9 +61,7 @@ def body_normalizer(validate_event_schema):
 def test_bytes_serialization_decode(message_normalizer):
     binary = b"abc123\x80\xf0\x9f\x8d\x95"
     result = message_normalizer(binary, should_repr_strings=False)
-    # fmt: off
-    assert result == u"abc123\ufffd\U0001f355"
-    # fmt: on
+    assert result == "abc123\ufffd\U0001f355"
 
 
 @pytest.mark.xfail(sys.version_info < (3,), reason="Known safe_repr bugs in Py2.7")
@@ -76,9 +74,7 @@ def test_bytes_serialization_repr(message_normalizer):
 def test_bytearray_serialization_decode(message_normalizer):
     binary = bytearray(b"abc123\x80\xf0\x9f\x8d\x95")
     result = message_normalizer(binary, should_repr_strings=False)
-    # fmt: off
-    assert result == u"abc123\ufffd\U0001f355"
-    # fmt: on
+    assert result == "abc123\ufffd\U0001f355"
 
 
 @pytest.mark.xfail(sys.version_info < (3,), reason="Known safe_repr bugs in Py2.7")

--- a/tests/utils/test_general.py
+++ b/tests/utils/test_general.py
@@ -37,19 +37,15 @@ else:
 
 
 def test_safe_repr_regressions():
-    # fmt: off
-    assert u"лошадь" in safe_repr(u"лошадь")
-    # fmt: on
+    assert "лошадь" in safe_repr("лошадь")
 
 
 @pytest.mark.xfail(
     sys.version_info < (3,),
     reason="Fixing this in Python 2 would break other behaviors",
 )
-# fmt: off
-@pytest.mark.parametrize("prefix", ("", "abcd", u"лошадь"))
-@pytest.mark.parametrize("character", u"\x00\x07\x1b\n")
-# fmt: on
+@pytest.mark.parametrize("prefix", ("", "abcd", "лошадь"))
+@pytest.mark.parametrize("character", "\x00\x07\x1b\n")
 def test_safe_repr_non_printable(prefix, character):
     """Check that non-printable characters are escaped"""
     string = prefix + character
@@ -517,27 +513,25 @@ def test_iter_stacktraces():
     ) == {1, 2, 3}
 
 
-# fmt: off
 @pytest.mark.parametrize(
     ("original", "base64_encoded"),
     [
         # ascii only
         ("Dogs are great!", "RG9ncyBhcmUgZ3JlYXQh"),
         # emoji
-        (u"🐶", "8J+Qtg=="),
+        ("🐶", "8J+Qtg=="),
         # non-ascii
         (
-            u"Καλό κορίτσι, Μάιζεϊ!",
+            "Καλό κορίτσι, Μάιζεϊ!",
             "zprOsc67z4wgzrrOv8+Bzq/PhM+DzrksIM6czqzOuc62zrXPiiE=",
         ),
         # mix of ascii and non-ascii
         (
-            u"Of margir hundar! Ég geri ráð fyrir að ég þurfi stærra rúm.",
+            "Of margir hundar! Ég geri ráð fyrir að ég þurfi stærra rúm.",
             "T2YgbWFyZ2lyIGh1bmRhciEgw4lnIGdlcmkgcsOhw7AgZnlyaXIgYcOwIMOpZyDDvnVyZmkgc3TDpnJyYSByw7ptLg==",
         ),
     ],
 )
-# fmt: on
 def test_successful_base64_conversion(original, base64_encoded):
     # all unicode characters should be handled correctly
     assert to_base64(original) == base64_encoded
@@ -587,7 +581,5 @@ def test_strip_string():
     assert stripped_text.value.count("a") == 1021  # + '...' is 1024
 
     # If text has unicode characters, it counts bytes and not number of characters.
-    # fmt: off
-    text_with_unicode_character = u"éê"
-    assert strip_string(text_with_unicode_character, max_length=2).value == u"é..."
-    # fmt: on
+    text_with_unicode_character = "éê"
+    assert strip_string(text_with_unicode_character, max_length=2).value == "é..."


### PR DESCRIPTION
* remove Python 2.7 `u"unicode literals"`
* remove `fmt: off` used for keeping unicode literals intact

---

## General Notes

Thank you for contributing to `sentry-python`!

Please add tests to validate your changes, and lint your code using `tox -e linters`.

Running the test suite on your PR might require maintainer approval. Some tests (AWS Lambda) additionally require a maintainer to add a special label to run and will fail if the label is not present.

#### For maintainers

Sensitive test suites require maintainer review to ensure that tests do not compromise our secrets. This review must be repeated after any code revisions.

Before running sensitive test suites, please carefully check the PR. Then, apply the `Trigger: tests using secrets` label. The label will be removed after any code changes to enforce our policy requiring maintainers to review all code revisions before running sensitive tests.
