### PR TITLE
Remove compatibility utils for old Python

### DIFF
--- a/sentry_sdk/_compat.py
+++ b/sentry_sdk/_compat.py
@@ -1,121 +1,27 @@
 import sys
-import contextlib
-from datetime import datetime
-from functools import wraps
 
 from sentry_sdk._types import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from typing import Optional
-    from typing import Tuple
     from typing import Any
     from typing import Type
     from typing import TypeVar
-    from typing import Callable
 
     T = TypeVar("T")
 
 
-PY2 = sys.version_info[0] == 2
-PY33 = sys.version_info[0] == 3 and sys.version_info[1] >= 3
 PY37 = sys.version_info[0] == 3 and sys.version_info[1] >= 7
 PY310 = sys.version_info[0] == 3 and sys.version_info[1] >= 10
 PY311 = sys.version_info[0] == 3 and sys.version_info[1] >= 11
 
-if PY2:
-    import urlparse
 
-    text_type = unicode  # noqa
-
-    string_types = (str, text_type)
-    number_types = (int, long, float)  # noqa
-    int_types = (int, long)  # noqa
-    iteritems = lambda x: x.iteritems()  # noqa: B301
-    binary_sequence_types = (bytearray, memoryview)
-
-    def datetime_utcnow():
-        return datetime.utcnow()
-
-    def utc_from_timestamp(timestamp):
-        return datetime.utcfromtimestamp(timestamp)
-
-    def implements_str(cls):
-        # type: (T) -> T
-        cls.__unicode__ = cls.__str__
-        cls.__str__ = lambda x: unicode(x).encode("utf-8")  # noqa
-        return cls
-
-    # The line below is written as an "exec" because it triggers a syntax error in Python 3
-    exec("def reraise(tp, value, tb=None):\n raise tp, value, tb")
-
-    def contextmanager(func):
-        # type: (Callable) -> Callable
-        """
-        Decorator which creates a contextmanager that can also be used as a
-        decorator, similar to how the built-in contextlib.contextmanager
-        function works in Python 3.2+.
-        """
-        contextmanager_func = contextlib.contextmanager(func)
-
-        @wraps(func)
-        class DecoratorContextManager:
-            def __init__(self, *args, **kwargs):
-                # type: (...) -> None
-                self.the_contextmanager = contextmanager_func(*args, **kwargs)
-
-            def __enter__(self):
-                # type: () -> None
-                self.the_contextmanager.__enter__()
-
-            def __exit__(self, *args, **kwargs):
-                # type: (...) -> None
-                self.the_contextmanager.__exit__(*args, **kwargs)
-
-            def __call__(self, decorated_func):
-                # type: (Callable) -> Callable[...]
-                @wraps(decorated_func)
-                def when_called(*args, **kwargs):
-                    # type: (...) -> Any
-                    with self.the_contextmanager:
-                        return_val = decorated_func(*args, **kwargs)
-                    return return_val
-
-                return when_called
-
-        return DecoratorContextManager
-
-else:
-    from datetime import timezone
-    import urllib.parse as urlparse  # noqa
-
-    text_type = str
-    string_types = (text_type,)  # type: Tuple[type]
-    number_types = (int, float)  # type: Tuple[type, type]
-    int_types = (int,)
-    iteritems = lambda x: x.items()
-    binary_sequence_types = (bytes, bytearray, memoryview)
-
-    def datetime_utcnow():
-        # type: () -> datetime
-        return datetime.now(timezone.utc)
-
-    def utc_from_timestamp(timestamp):
-        # type: (float) -> datetime
-        return datetime.fromtimestamp(timestamp, timezone.utc)
-
-    def implements_str(x):
-        # type: (T) -> T
-        return x
-
-    def reraise(tp, value, tb=None):
-        # type: (Optional[Type[BaseException]], Optional[BaseException], Optional[Any]) -> None
-        assert value is not None
-        if value.__traceback__ is not tb:
-            raise value.with_traceback(tb)
-        raise value
-
-    # contextlib.contextmanager already can be used as decorator in Python 3.2+
-    contextmanager = contextlib.contextmanager
+def reraise(tp, value, tb=None):
+    # type: (Optional[Type[BaseException]], Optional[BaseException], Optional[Any]) -> None
+    assert value is not None
+    if value.__traceback__ is not tb:
+        raise value.with_traceback(tb)
+    raise value
 
 
 def with_metaclass(meta, *bases):

--- a/sentry_sdk/_werkzeug.py
+++ b/sentry_sdk/_werkzeug.py
@@ -32,8 +32,6 @@ THIS SOFTWARE AND DOCUMENTATION, EVEN IF ADVISED OF THE POSSIBILITY OF
 SUCH DAMAGE.
 """
 
-from sentry_sdk._compat import iteritems
-
 from sentry_sdk._types import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -54,7 +52,7 @@ def _get_headers(environ):
     """
     Returns only proper HTTP headers.
     """
-    for key, value in iteritems(environ):
+    for key, value in environ.items():
         key = str(key)
         if key.startswith("HTTP_") and key not in (
             "HTTP_CONTENT_TYPE",

--- a/sentry_sdk/crons/decorator.py
+++ b/sentry_sdk/crons/decorator.py
@@ -1,6 +1,7 @@
 import sys
+from contextlib import contextmanager
 
-from sentry_sdk._compat import contextmanager, reraise
+from sentry_sdk._compat import reraise
 from sentry_sdk._types import TYPE_CHECKING
 from sentry_sdk.crons import capture_checkin
 from sentry_sdk.crons.consts import MonitorStatus

--- a/sentry_sdk/db/explain_plan/__init__.py
+++ b/sentry_sdk/db/explain_plan/__init__.py
@@ -1,6 +1,5 @@
-import datetime
+from datetime import datetime, timedelta, timezone
 
-from sentry_sdk._compat import datetime_utcnow
 from sentry_sdk.consts import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -16,11 +15,11 @@ def cache_statement(statement, options):
     # type: (str, dict[str, Any]) -> None
     global EXPLAIN_CACHE
 
-    now = datetime_utcnow()
+    now = datetime.now(timezone.utc)
     explain_cache_timeout_seconds = options.get(
         "explain_cache_timeout_seconds", EXPLAIN_CACHE_TIMEOUT_SECONDS
     )
-    expiration_time = now + datetime.timedelta(seconds=explain_cache_timeout_seconds)
+    expiration_time = now + timedelta(seconds=explain_cache_timeout_seconds)
 
     EXPLAIN_CACHE[hash(statement)] = expiration_time
 
@@ -32,7 +31,7 @@ def remove_expired_cache_items():
     """
     global EXPLAIN_CACHE
 
-    now = datetime_utcnow()
+    now = datetime.now(timezone.utc)
 
     for key, expiration_time in EXPLAIN_CACHE.items():
         expiration_in_the_past = expiration_time < now

--- a/sentry_sdk/envelope.py
+++ b/sentry_sdk/envelope.py
@@ -2,7 +2,6 @@ import io
 import json
 import mimetypes
 
-from sentry_sdk._compat import text_type, PY2
 from sentry_sdk._types import TYPE_CHECKING
 from sentry_sdk.session import Session
 from sentry_sdk.utils import json_dumps, capture_internal_exceptions
@@ -19,9 +18,9 @@ if TYPE_CHECKING:
 
 
 def parse_json(data):
-    # type: (Union[bytes, text_type]) -> Any
+    # type: (Union[bytes, str]) -> Any
     # on some python 3 versions this needs to be bytes
-    if not PY2 and isinstance(data, bytes):
+    if isinstance(data, bytes):
         data = data.decode("utf-8", "replace")
     return json.loads(data)
 
@@ -159,7 +158,7 @@ class PayloadRef(object):
     def __init__(
         self,
         bytes=None,  # type: Optional[bytes]
-        path=None,  # type: Optional[Union[bytes, text_type]]
+        path=None,  # type: Optional[Union[bytes, str]]
         json=None,  # type: Optional[Any]
     ):
         # type: (...) -> None
@@ -202,7 +201,7 @@ class PayloadRef(object):
 class Item(object):
     def __init__(
         self,
-        payload,  # type: Union[bytes, text_type, PayloadRef]
+        payload,  # type: Union[bytes, str, PayloadRef]
         headers=None,  # type: Optional[Dict[str, Any]]
         type=None,  # type: Optional[str]
         content_type=None,  # type: Optional[str]
@@ -215,7 +214,7 @@ class Item(object):
         self.headers = headers
         if isinstance(payload, bytes):
             payload = PayloadRef(bytes=payload)
-        elif isinstance(payload, text_type):
+        elif isinstance(payload, str):
             payload = PayloadRef(bytes=payload.encode("utf-8"))
         else:
             payload = payload

--- a/sentry_sdk/hub.py
+++ b/sentry_sdk/hub.py
@@ -1,9 +1,9 @@
 import copy
 import sys
-
 from contextlib import contextmanager
+from datetime import datetime, timezone
 
-from sentry_sdk._compat import datetime_utcnow, with_metaclass
+from sentry_sdk._compat import with_metaclass
 from sentry_sdk.consts import INSTRUMENTER
 from sentry_sdk.scope import Scope
 from sentry_sdk.client import Client
@@ -438,7 +438,7 @@ class Hub(with_metaclass(HubMeta)):  # type: ignore
         hint = dict(hint or ())  # type: Hint
 
         if crumb.get("timestamp") is None:
-            crumb["timestamp"] = datetime_utcnow()
+            crumb["timestamp"] = datetime.now(timezone.utc)
         if crumb.get("type") is None:
             crumb["type"] = "default"
 

--- a/sentry_sdk/integrations/__init__.py
+++ b/sentry_sdk/integrations/__init__.py
@@ -1,7 +1,6 @@
 from __future__ import absolute_import
 from threading import Lock
 
-from sentry_sdk._compat import iteritems
 from sentry_sdk._types import TYPE_CHECKING
 from sentry_sdk.utils import logger
 
@@ -124,7 +123,7 @@ def setup_integrations(
                 integrations[instance.identifier] = instance
                 used_as_default_integration.add(instance.identifier)
 
-    for identifier, integration in iteritems(integrations):
+    for identifier, integration in integrations.items():
         with _installer_lock:
             if identifier not in _processed_integrations:
                 logger.debug(
@@ -156,7 +155,7 @@ def setup_integrations(
 
     integrations = {
         identifier: integration
-        for identifier, integration in iteritems(integrations)
+        for identifier, integration in integrations.items()
         if identifier in _installed_integrations
     }
 

--- a/sentry_sdk/integrations/_wsgi_common.py
+++ b/sentry_sdk/integrations/_wsgi_common.py
@@ -5,8 +5,6 @@ from copy import deepcopy
 
 from sentry_sdk.hub import Hub, _should_send_default_pii
 from sentry_sdk.utils import AnnotatedValue
-from sentry_sdk._compat import text_type, iteritems
-
 from sentry_sdk._types import TYPE_CHECKING
 
 try:
@@ -124,8 +122,8 @@ class RequestExtractor(object):
         form = self.form()
         files = self.files()
         if form or files:
-            data = dict(iteritems(form))
-            for key, _ in iteritems(files):
+            data = dict(form.items())
+            for key in files.keys():
                 data[key] = AnnotatedValue.removed_because_raw_data()
 
             return data
@@ -146,7 +144,7 @@ class RequestExtractor(object):
             if raw_data is None:
                 return None
 
-            if isinstance(raw_data, text_type):
+            if isinstance(raw_data, str):
                 return json.loads(raw_data)
             else:
                 return json.loads(raw_data.decode("utf-8"))
@@ -189,5 +187,5 @@ def _filter_headers(headers):
             if k.upper().replace("-", "_") not in SENSITIVE_HEADERS
             else AnnotatedValue.removed_because_over_size_limit()
         )
-        for k, v in iteritems(headers)
+        for k, v in headers.items()
     }

--- a/sentry_sdk/integrations/aws_lambda.py
+++ b/sentry_sdk/integrations/aws_lambda.py
@@ -1,6 +1,6 @@
 import sys
 from copy import deepcopy
-from datetime import timedelta
+from datetime import datetime, timedelta, timezone
 from os import environ
 
 from sentry_sdk.api import continue_trace
@@ -16,11 +16,10 @@ from sentry_sdk.utils import (
 )
 from sentry_sdk.integrations import Integration
 from sentry_sdk.integrations._wsgi_common import _filter_headers
-from sentry_sdk._compat import datetime_utcnow, reraise
+from sentry_sdk._compat import reraise
 from sentry_sdk._types import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from datetime import datetime
     from typing import Any
     from typing import TypeVar
     from typing import Callable
@@ -325,7 +324,7 @@ def get_lambda_bootstrap():
 
 def _make_request_event_processor(aws_event, aws_context, configured_timeout):
     # type: (Any, Any, Any) -> EventProcessor
-    start_time = datetime_utcnow()
+    start_time = datetime.now(timezone.utc)
 
     def event_processor(sentry_event, hint, start_time=start_time):
         # type: (Event, Hint, datetime) -> Optional[Event]
@@ -430,7 +429,9 @@ def _get_cloudwatch_logs_url(aws_context, start_time):
         log_group=aws_context.log_group_name,
         log_stream=aws_context.log_stream_name,
         start_time=(start_time - timedelta(seconds=1)).strftime(formatstring),
-        end_time=(datetime_utcnow() + timedelta(seconds=2)).strftime(formatstring),
+        end_time=(datetime.now(timezone.utc) + timedelta(seconds=2)).strftime(
+            formatstring
+        ),
     )
 
     return url

--- a/sentry_sdk/integrations/django/__init__.py
+++ b/sentry_sdk/integrations/django/__init__.py
@@ -7,7 +7,6 @@ import threading
 import weakref
 from importlib import import_module
 
-from sentry_sdk._compat import string_types, text_type
 from sentry_sdk._types import TYPE_CHECKING
 from sentry_sdk.consts import OP, SPANDATA
 from sentry_sdk.db.explain_plan.django import attach_explain_plan_to_span
@@ -393,7 +392,7 @@ def _set_transaction_name_and_source(scope, transaction_style, request):
         # So we don't check here what style is configured
         if hasattr(urlconf, "handler404"):
             handler = urlconf.handler404
-            if isinstance(handler, string_types):
+            if isinstance(handler, str):
                 scope.transaction = handler
             else:
                 scope.transaction = transaction_from_function(
@@ -723,7 +722,7 @@ def _set_db_data(span, cursor_or_db):
 
     server_port = connection_params.get("port")
     if server_port is not None:
-        span.set_data(SPANDATA.SERVER_PORT, text_type(server_port))
+        span.set_data(SPANDATA.SERVER_PORT, str(server_port))
 
     server_socket_address = connection_params.get("unix_socket")
     if server_socket_address is not None:

--- a/sentry_sdk/integrations/django/caching.py
+++ b/sentry_sdk/integrations/django/caching.py
@@ -6,7 +6,6 @@ from django.core.cache import CacheHandler
 
 from sentry_sdk import Hub
 from sentry_sdk.consts import OP, SPANDATA
-from sentry_sdk._compat import text_type
 
 
 if TYPE_CHECKING:
@@ -25,9 +24,9 @@ def _get_span_description(method_name, args, kwargs):
     description = "{} ".format(method_name)
 
     if args is not None and len(args) >= 1:
-        description += text_type(args[0])
+        description += str(args[0])
     elif kwargs is not None and "key" in kwargs:
-        description += text_type(kwargs["key"])
+        description += str(kwargs["key"])
 
     return description
 
@@ -51,7 +50,7 @@ def _patch_cache_method(cache, method_name):
             if value:
                 span.set_data(SPANDATA.CACHE_HIT, True)
 
-                size = len(text_type(value))
+                size = len(str(value))
                 span.set_data(SPANDATA.CACHE_ITEM_SIZE, size)
 
             else:

--- a/sentry_sdk/integrations/gcp.py
+++ b/sentry_sdk/integrations/gcp.py
@@ -1,13 +1,13 @@
 import sys
 from copy import deepcopy
-from datetime import timedelta
+from datetime import datetime, timedelta, timezone
 from os import environ
 
 from sentry_sdk.api import continue_trace
 from sentry_sdk.consts import OP
 from sentry_sdk.hub import Hub, _should_send_default_pii
 from sentry_sdk.tracing import TRANSACTION_SOURCE_COMPONENT
-from sentry_sdk._compat import datetime_utcnow, reraise
+from sentry_sdk._compat import reraise
 from sentry_sdk.utils import (
     AnnotatedValue,
     capture_internal_exceptions,
@@ -25,7 +25,6 @@ TIMEOUT_WARNING_BUFFER = 1.5  # Buffer time required to send timeout warning to 
 MILLIS_TO_SECONDS = 1000.0
 
 if TYPE_CHECKING:
-    from datetime import datetime
     from typing import Any
     from typing import TypeVar
     from typing import Callable
@@ -58,7 +57,7 @@ def _wrap_func(func):
 
         configured_time = int(configured_time)
 
-        initial_time = datetime_utcnow()
+        initial_time = datetime.now(timezone.utc)
 
         with hub.push_scope() as scope:
             with capture_internal_exceptions():
@@ -155,7 +154,7 @@ def _make_request_event_processor(gcp_event, configured_timeout, initial_time):
     def event_processor(event, hint):
         # type: (Event, Hint) -> Optional[Event]
 
-        final_time = datetime_utcnow()
+        final_time = datetime.now(timezone.utc)
         time_diff = final_time - initial_time
 
         execution_duration_in_millis = time_diff.microseconds / MILLIS_TO_SECONDS

--- a/sentry_sdk/integrations/logging.py
+++ b/sentry_sdk/integrations/logging.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import
 
 import logging
+from datetime import datetime, timezone
 from fnmatch import fnmatch
 
 from sentry_sdk.hub import Hub
@@ -11,8 +12,6 @@ from sentry_sdk.utils import (
     capture_internal_exceptions,
 )
 from sentry_sdk.integrations import Integration
-from sentry_sdk._compat import iteritems, utc_from_timestamp
-
 from sentry_sdk._types import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -159,7 +158,7 @@ class _BaseHandler(logging.Handler, object):
         # type: (LogRecord) -> Dict[str, None]
         return {
             k: v
-            for k, v in iteritems(vars(record))
+            for k, v in vars(record).items()
             if k not in self.COMMON_RECORD_ATTRS
             and (not isinstance(k, str) or not k.startswith("_"))
         }
@@ -286,6 +285,6 @@ class BreadcrumbHandler(_BaseHandler):
             "level": self._logging_to_event_level(record),
             "category": record.name,
             "message": record.message,
-            "timestamp": utc_from_timestamp(record.created),
+            "timestamp": datetime.fromtimestamp(record.created, timezone.utc),
             "data": self._extra_from_record(record),
         }

--- a/sentry_sdk/integrations/pyramid.py
+++ b/sentry_sdk/integrations/pyramid.py
@@ -11,7 +11,7 @@ from sentry_sdk.utils import (
     capture_internal_exceptions,
     event_from_exception,
 )
-from sentry_sdk._compat import reraise, iteritems
+from sentry_sdk._compat import reraise
 
 from sentry_sdk.integrations import Integration, DidNotEnable
 from sentry_sdk.integrations._wsgi_common import RequestExtractor
@@ -192,7 +192,7 @@ class PyramidRequestExtractor(RequestExtractor):
         # type: () -> Dict[str, str]
         return {
             key: value
-            for key, value in iteritems(self.request.POST)
+            for key, value in self.request.POST.items()
             if not getattr(value, "filename", None)
         }
 
@@ -200,7 +200,7 @@ class PyramidRequestExtractor(RequestExtractor):
         # type: () -> Dict[str, cgi_FieldStorage]
         return {
             key: value
-            for key, value in iteritems(self.request.POST)
+            for key, value in self.request.POST.items()
             if getattr(value, "filename", None)
         }
 

--- a/sentry_sdk/integrations/redis/__init__.py
+++ b/sentry_sdk/integrations/redis/__init__.py
@@ -2,7 +2,6 @@ from __future__ import absolute_import
 
 from sentry_sdk import Hub
 from sentry_sdk.consts import OP, SPANDATA
-from sentry_sdk._compat import text_type
 from sentry_sdk.hub import _should_send_default_pii
 from sentry_sdk.integrations import Integration, DidNotEnable
 from sentry_sdk._types import TYPE_CHECKING
@@ -129,7 +128,7 @@ def _set_db_data_on_span(span, connection_params):
 
     db = connection_params.get("db")
     if db is not None:
-        span.set_data(SPANDATA.DB_NAME, text_type(db))
+        span.set_data(SPANDATA.DB_NAME, str(db))
 
     host = connection_params.get("host")
     if host is not None:

--- a/sentry_sdk/integrations/sanic.py
+++ b/sentry_sdk/integrations/sanic.py
@@ -1,9 +1,10 @@
 import sys
 import weakref
 from inspect import isawaitable
+from urllib.parse import urlsplit
 
 from sentry_sdk import continue_trace
-from sentry_sdk._compat import urlparse, reraise
+from sentry_sdk._compat import reraise
 from sentry_sdk.consts import OP
 from sentry_sdk.hub import Hub
 from sentry_sdk.tracing import TRANSACTION_SOURCE_COMPONENT, TRANSACTION_SOURCE_URL
@@ -365,7 +366,7 @@ def _make_request_processor(weak_request):
             extractor.extract_into_event(event)
 
             request_info = event["request"]
-            urlparts = urlparse.urlsplit(request.url)
+            urlparts = urlsplit(request.url)
 
             request_info["url"] = "%s://%s%s" % (
                 urlparts.scheme,

--- a/sentry_sdk/integrations/sqlalchemy.py
+++ b/sentry_sdk/integrations/sqlalchemy.py
@@ -1,6 +1,5 @@
 from __future__ import absolute_import
 
-from sentry_sdk._compat import text_type
 from sentry_sdk._types import TYPE_CHECKING
 from sentry_sdk.consts import SPANDATA
 from sentry_sdk.db.explain_plan.sqlalchemy import attach_explain_plan_to_span
@@ -127,7 +126,7 @@ def _handle_error(context, *args):
 # See: https://docs.sqlalchemy.org/en/20/dialects/index.html
 def _get_db_system(name):
     # type: (str) -> Optional[str]
-    name = text_type(name)
+    name = str(name)
 
     if "sqlite" in name:
         return "sqlite"

--- a/sentry_sdk/integrations/starlette.py
+++ b/sentry_sdk/integrations/starlette.py
@@ -4,7 +4,6 @@ import asyncio
 import functools
 from copy import deepcopy
 
-from sentry_sdk._compat import iteritems
 from sentry_sdk._types import TYPE_CHECKING
 from sentry_sdk.consts import OP
 from sentry_sdk.hub import Hub, _should_send_default_pii
@@ -584,7 +583,7 @@ class StarletteRequestExtractor:
             form = await self.form()
             if form:
                 form_data = {}
-                for key, val in iteritems(form):
+                for key, val in form.items():
                     is_file = isinstance(val, UploadFile)
                     form_data[key] = (
                         val

--- a/sentry_sdk/integrations/tornado.py
+++ b/sentry_sdk/integrations/tornado.py
@@ -23,7 +23,6 @@ from sentry_sdk.integrations._wsgi_common import (
     _is_json_content_type,
 )
 from sentry_sdk.integrations.logging import ignore_logger
-from sentry_sdk._compat import iteritems
 
 try:
     from tornado import version_info as TORNADO_VERSION
@@ -202,7 +201,7 @@ class TornadoRequestExtractor(RequestExtractor):
 
     def cookies(self):
         # type: () -> Dict[str, str]
-        return {k: v.value for k, v in iteritems(self.request.cookies)}
+        return {k: v.value for k, v in self.request.cookies.items()}
 
     def raw_data(self):
         # type: () -> bytes
@@ -212,7 +211,7 @@ class TornadoRequestExtractor(RequestExtractor):
         # type: () -> Dict[str, Any]
         return {
             k: [v.decode("latin1", "replace") for v in vs]
-            for k, vs in iteritems(self.request.body_arguments)
+            for k, vs in self.request.body_arguments.items()
         }
 
     def is_json(self):
@@ -221,7 +220,7 @@ class TornadoRequestExtractor(RequestExtractor):
 
     def files(self):
         # type: () -> Dict[str, Any]
-        return {k: v[0] for k, v in iteritems(self.request.files) if v}
+        return {k: v[0] for k, v in self.request.files.items() if v}
 
     def size_of_file(self, file):
         # type: (Any) -> int

--- a/sentry_sdk/integrations/wsgi.py
+++ b/sentry_sdk/integrations/wsgi.py
@@ -1,6 +1,6 @@
 import sys
 
-from sentry_sdk._compat import PY2, reraise
+from sentry_sdk._compat import reraise
 from sentry_sdk._functools import partial
 from sentry_sdk._types import TYPE_CHECKING
 from sentry_sdk._werkzeug import get_host, _get_headers
@@ -42,17 +42,9 @@ if TYPE_CHECKING:
 _wsgi_middleware_applied = ContextVar("sentry_wsgi_middleware_applied")
 
 
-if PY2:
-
-    def wsgi_decoding_dance(s, charset="utf-8", errors="replace"):
-        # type: (str, str, str) -> str
-        return s.decode(charset, errors)
-
-else:
-
-    def wsgi_decoding_dance(s, charset="utf-8", errors="replace"):
-        # type: (str, str, str) -> str
-        return s.encode("latin1").decode(charset, errors)
+def wsgi_decoding_dance(s, charset="utf-8", errors="replace"):
+    # type: (str, str, str) -> str
+    return s.encode("latin1").decode(charset, errors)
 
 
 def get_request_url(environ, use_x_forwarded_for=False):

--- a/sentry_sdk/metrics.py
+++ b/sentry_sdk/metrics.py
@@ -6,13 +6,12 @@ import threading
 import random
 import time
 import zlib
-from datetime import datetime
+from datetime import datetime, timezone
 from functools import wraps, partial
 from threading import Event, Lock, Thread
 from contextlib import contextmanager
 
 import sentry_sdk
-from sentry_sdk._compat import text_type, utc_from_timestamp, iteritems
 from sentry_sdk.utils import (
     now,
     nanosecond_time,
@@ -270,7 +269,7 @@ def _encode_metrics(flushable_buckets):
     # relay side emission and should not happen commonly.
 
     for timestamp, buckets in flushable_buckets:
-        for bucket_key, metric in iteritems(buckets):
+        for bucket_key, metric in buckets.items():
             metric_type, metric_name, metric_unit, metric_tags = bucket_key
             metric_name = _sanitize_key(metric_name)
             _write(metric_name.encode("utf-8"))
@@ -478,14 +477,14 @@ class MetricsAggregator(object):
                 self._force_flush = False
             else:
                 flushable_buckets = []
-                for buckets_timestamp, buckets in iteritems(self.buckets):
+                for buckets_timestamp, buckets in self.buckets.items():
                     # If the timestamp of the bucket is newer that the rollup we want to skip it.
                     if buckets_timestamp <= cutoff:
                         flushable_buckets.append((buckets_timestamp, buckets))
 
                 # We will clear the elements while holding the lock, in order to avoid requesting it downstream again.
                 for buckets_timestamp, buckets in flushable_buckets:
-                    for _, metric in iteritems(buckets):
+                    for metric in buckets.values():
                         weight_to_remove += metric.weight
                     del self.buckets[buckets_timestamp]
 
@@ -568,7 +567,7 @@ class MetricsAggregator(object):
         if timestamp is None:
             timestamp = time.time()
         meta_key = (ty, key, unit)
-        start_of_day = utc_from_timestamp(timestamp).replace(
+        start_of_day = datetime.fromtimestamp(timestamp, timezone.utc).replace(
             hour=0, minute=0, second=0, microsecond=0, tzinfo=None
         )
         start_of_day = int(to_timestamp(start_of_day))
@@ -595,7 +594,7 @@ class MetricsAggregator(object):
         if self._enable_code_locations:
             return False
         meta_key = (ty, key, unit)
-        start_of_day = utc_from_timestamp(timestamp).replace(
+        start_of_day = datetime.fromtimestamp(timestamp, timezone.utc).replace(
             hour=0, minute=0, second=0, microsecond=0, tzinfo=None
         )
         start_of_day = int(to_timestamp(start_of_day))
@@ -637,7 +636,7 @@ class MetricsAggregator(object):
             encoded_metrics = _encode_metrics(flushable_buckets)
             envelope.add_item(Item(payload=encoded_metrics, type="statsd"))
 
-        for timestamp, locations in iteritems(code_locations):
+        for timestamp, locations in code_locations.items():
             encoded_locations = _encode_locations(timestamp, locations)
             envelope.add_item(Item(payload=encoded_locations, type="metric_meta"))
 
@@ -655,14 +654,14 @@ def _serialize_tags(
         return ()
 
     rv = []
-    for key, value in iteritems(tags):
+    for key, value in tags.items():
         # If the value is a collection, we want to flatten it.
         if isinstance(value, (list, tuple)):
             for inner_value in value:
                 if inner_value is not None:
-                    rv.append((key, text_type(inner_value)))
+                    rv.append((key, str(inner_value)))
         elif value is not None:
-            rv.append((key, text_type(value)))
+            rv.append((key, str(value)))
 
     # It's very important to sort the tags in order to obtain the
     # same bucket key.

--- a/sentry_sdk/profiler.py
+++ b/sentry_sdk/profiler.py
@@ -36,7 +36,7 @@ import uuid
 from collections import deque
 
 import sentry_sdk
-from sentry_sdk._compat import PY33, PY311
+from sentry_sdk._compat import PY311
 from sentry_sdk._lru_cache import LRUCache
 from sentry_sdk._types import TYPE_CHECKING
 from sentry_sdk.utils import (
@@ -187,10 +187,6 @@ def setup_profiler(options):
 
     if _scheduler is not None:
         logger.debug("[Profiling] Profiler is already setup")
-        return False
-
-    if not PY33:
-        logger.warn("[Profiling] Profiler requires Python >= 3.3")
         return False
 
     frequency = DEFAULT_SAMPLING_FREQUENCY

--- a/sentry_sdk/scrubber.py
+++ b/sentry_sdk/scrubber.py
@@ -3,7 +3,6 @@ from sentry_sdk.utils import (
     AnnotatedValue,
     iter_event_frames,
 )
-from sentry_sdk._compat import string_types
 from sentry_sdk._types import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -70,7 +69,7 @@ class EventScrubber(object):
             return
 
         for k in d.keys():
-            if isinstance(k, string_types) and k.lower() in self.denylist:
+            if isinstance(k, str) and k.lower() in self.denylist:
                 d[k] = AnnotatedValue.substituted_because_contains_sensitive_data()
 
     def scrub_request(self, event):

--- a/sentry_sdk/serializer.py
+++ b/sentry_sdk/serializer.py
@@ -1,6 +1,6 @@
 import sys
 import math
-
+from collections.abc import Mapping, Sequence, Set
 from datetime import datetime
 
 from sentry_sdk.utils import (
@@ -10,14 +10,6 @@ from sentry_sdk.utils import (
     format_timestamp,
     safe_repr,
     strip_string,
-)
-from sentry_sdk._compat import (
-    text_type,
-    PY2,
-    string_types,
-    number_types,
-    iteritems,
-    binary_sequence_types,
 )
 from sentry_sdk._types import TYPE_CHECKING
 
@@ -41,20 +33,8 @@ if TYPE_CHECKING:
     Segment = Union[str, int]
 
 
-if PY2:
-    # Importing ABCs from collections is deprecated, and will stop working in 3.8
-    # https://github.com/python/cpython/blob/master/Lib/collections/__init__.py#L49
-    from collections import Mapping, Sequence, Set
-
-    serializable_str_types = string_types + binary_sequence_types
-
-else:
-    # New in 3.3
-    # https://docs.python.org/3/library/collections.abc.html
-    from collections.abc import Mapping, Sequence, Set
-
-    # Bytes are technically not strings in Python 3, but we can serialize them
-    serializable_str_types = string_types + binary_sequence_types
+# Bytes are technically not strings in Python 3, but we can serialize them
+serializable_str_types = (str, bytes, bytearray, memoryview)
 
 
 # Maximum length of JSON-serialized event payloads that can be safely sent
@@ -130,7 +110,7 @@ def serialize(event, **kwargs):
         while len(meta_stack) <= len(path):
             try:
                 segment = path[len(meta_stack) - 1]
-                node = meta_stack[-1].setdefault(text_type(segment), {})
+                node = meta_stack[-1].setdefault(str(segment), {})
             except IndexError:
                 node = {}
 
@@ -310,7 +290,7 @@ def serialize(event, **kwargs):
 
         sentry_repr = getattr(type(obj), "__sentry_repr__", None)
 
-        if obj is None or isinstance(obj, (bool, number_types)):
+        if obj is None or isinstance(obj, (bool, int, float)):
             if should_repr_strings or (
                 isinstance(obj, float) and (math.isinf(obj) or math.isnan(obj))
             ):
@@ -323,7 +303,7 @@ def serialize(event, **kwargs):
 
         elif isinstance(obj, datetime):
             return (
-                text_type(format_timestamp(obj))
+                str(format_timestamp(obj))
                 if not should_repr_strings
                 else safe_repr(obj)
             )
@@ -331,17 +311,17 @@ def serialize(event, **kwargs):
         elif isinstance(obj, Mapping):
             # Create temporary copy here to avoid calling too much code that
             # might mutate our dictionary while we're still iterating over it.
-            obj = dict(iteritems(obj))
+            obj = dict(obj.items())
 
             rv_dict = {}  # type: Dict[str, Any]
             i = 0
 
-            for k, v in iteritems(obj):
+            for k, v in obj.items():
                 if remaining_breadth is not None and i >= remaining_breadth:
                     _annotate(len=len(obj))
                     break
 
-                str_k = text_type(k)
+                str_k = str(k)
                 v = _serialize_node(
                     v,
                     segment=str_k,
@@ -390,7 +370,7 @@ def serialize(event, **kwargs):
             if isinstance(obj, bytes) or isinstance(obj, bytearray):
                 obj = obj.decode("utf-8", "replace")
 
-            if not isinstance(obj, string_types):
+            if not isinstance(obj, str):
                 obj = safe_repr(obj)
 
         is_span_description = (

--- a/sentry_sdk/session.py
+++ b/sentry_sdk/session.py
@@ -1,11 +1,10 @@
 import uuid
+from datetime import datetime, timezone
 
-from sentry_sdk._compat import datetime_utcnow
 from sentry_sdk._types import TYPE_CHECKING
 from sentry_sdk.utils import format_timestamp
 
 if TYPE_CHECKING:
-    from datetime import datetime
     from typing import Optional
     from typing import Union
     from typing import Any
@@ -49,7 +48,7 @@ class Session(object):
         if sid is None:
             sid = uuid.uuid4()
         if started is None:
-            started = datetime_utcnow()
+            started = datetime.now(timezone.utc)
         if status is None:
             status = "ok"
         self.status = status
@@ -109,7 +108,7 @@ class Session(object):
         if did is not None:
             self.did = str(did)
         if timestamp is None:
-            timestamp = datetime_utcnow()
+            timestamp = datetime.now(timezone.utc)
         self.timestamp = timestamp
         if started is not None:
             self.started = started

--- a/sentry_sdk/tracing.py
+++ b/sentry_sdk/tracing.py
@@ -1,23 +1,20 @@
 import uuid
 import random
-
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 import sentry_sdk
 from sentry_sdk.consts import INSTRUMENTER
 from sentry_sdk.utils import is_valid_sample_rate, logger, nanosecond_time
-from sentry_sdk._compat import datetime_utcnow, utc_from_timestamp, PY2
 from sentry_sdk.consts import SPANDATA
 from sentry_sdk._types import TYPE_CHECKING
 
 
 if TYPE_CHECKING:
-    import typing
-
     from typing import Any
     from typing import Dict
     from typing import Iterator
     from typing import List
+    from typing import Mapping
     from typing import Optional
     from typing import Tuple
     from typing import Union
@@ -148,9 +145,9 @@ class Span(object):
         self._data = {}  # type: Dict[str, Any]
         self._containing_transaction = containing_transaction
         if start_timestamp is None:
-            start_timestamp = datetime_utcnow()
+            start_timestamp = datetime.now(timezone.utc)
         elif isinstance(start_timestamp, float):
-            start_timestamp = utc_from_timestamp(start_timestamp)
+            start_timestamp = datetime.fromtimestamp(start_timestamp, timezone.utc)
         self.start_timestamp = start_timestamp
         try:
             # profiling depends on this value and requires that
@@ -271,7 +268,7 @@ class Span(object):
     @classmethod
     def continue_from_environ(
         cls,
-        environ,  # type: typing.Mapping[str, str]
+        environ,  # type: Mapping[str, str]
         **kwargs  # type: Any
     ):
         # type: (...) -> Transaction
@@ -297,7 +294,7 @@ class Span(object):
     @classmethod
     def continue_from_headers(
         cls,
-        headers,  # type: typing.Mapping[str, str]
+        headers,  # type: Mapping[str, str]
         **kwargs  # type: Any
     ):
         # type: (...) -> Transaction
@@ -477,7 +474,7 @@ class Span(object):
         try:
             if end_timestamp:
                 if isinstance(end_timestamp, float):
-                    end_timestamp = utc_from_timestamp(end_timestamp)
+                    end_timestamp = datetime.fromtimestamp(end_timestamp, timezone.utc)
                 self.timestamp = end_timestamp
             else:
                 elapsed = nanosecond_time() - self._start_timestamp_monotonic_ns
@@ -485,7 +482,7 @@ class Span(object):
                     microseconds=elapsed / 1000
                 )
         except AttributeError:
-            self.timestamp = datetime_utcnow()
+            self.timestamp = datetime.now(timezone.utc)
 
         maybe_create_breadcrumbs_from_span(hub, self)
 
@@ -1002,10 +999,7 @@ def trace(func=None):
         async def my_async_function():
             ...
     """
-    if PY2:
-        from sentry_sdk.tracing_utils_py2 import start_child_span_decorator
-    else:
-        from sentry_sdk.tracing_utils_py3 import start_child_span_decorator
+    from sentry_sdk.tracing_utils_py3 import start_child_span_decorator
 
     # This patterns allows usage of both @sentry_traced and @sentry_traced(...)
     # See https://stackoverflow.com/questions/52126071/decorator-with-arguments-avoid-parenthesis-when-no-arguments/52126278

--- a/sentry_sdk/tracing_utils.py
+++ b/sentry_sdk/tracing_utils.py
@@ -1,7 +1,8 @@
 import contextlib
-import os
 import re
 import sys
+from collections.abc import Mapping
+from urllib.parse import quote, unquote
 
 import sentry_sdk
 from sentry_sdk.consts import OP, SPANDATA
@@ -14,19 +15,9 @@ from sentry_sdk.utils import (
     _is_external_source,
     _module_in_list,
 )
-from sentry_sdk._compat import PY2, iteritems
 from sentry_sdk._types import TYPE_CHECKING
 
-if PY2:
-    from collections import Mapping
-    from urllib import quote, unquote
-else:
-    from collections.abc import Mapping
-    from urllib.parse import quote, unquote
-
 if TYPE_CHECKING:
-    import typing
-
     from typing import Any
     from typing import Dict
     from typing import Generator
@@ -59,7 +50,7 @@ base64_stripped = (
 class EnvironHeaders(Mapping):  # type: ignore
     def __init__(
         self,
-        environ,  # type: typing.Mapping[str, str]
+        environ,  # type: Mapping[str, str]
         prefix="HTTP_",  # type: str
     ):
         # type: (...) -> None
@@ -200,8 +191,6 @@ def add_query_source(hub, span):
     while frame is not None:
         try:
             abs_path = frame.f_code.co_filename
-            if abs_path and PY2:
-                abs_path = os.path.abspath(abs_path)
         except Exception:
             abs_path = ""
 
@@ -462,7 +451,7 @@ class Baggage(object):
         # type: () -> Dict[str, str]
         header = {}
 
-        for key, item in iteritems(self.sentry_items):
+        for key, item in self.sentry_items.items():
             header[key] = item
 
         return header
@@ -471,7 +460,7 @@ class Baggage(object):
         # type: (bool) -> str
         items = []
 
-        for key, val in iteritems(self.sentry_items):
+        for key, val in self.sentry_items.items():
             with capture_internal_exceptions():
                 item = Baggage.SENTRY_PREFIX + quote(key) + "=" + quote(str(val))
                 items.append(item)

--- a/sentry_sdk/transport.py
+++ b/sentry_sdk/transport.py
@@ -5,19 +5,15 @@ import urllib3
 import certifi
 import gzip
 import time
-
-from datetime import timedelta
+from datetime import datetime, timedelta, timezone
 from collections import defaultdict
 
 from sentry_sdk.utils import Dsn, logger, capture_internal_exceptions, json_dumps
 from sentry_sdk.worker import BackgroundWorker
 from sentry_sdk.envelope import Envelope, Item, PayloadRef
-
-from sentry_sdk._compat import datetime_utcnow
 from sentry_sdk._types import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from datetime import datetime
     from typing import Any
     from typing import Callable
     from typing import Dict
@@ -124,7 +120,7 @@ class Transport(object):
 def _parse_rate_limits(header, now=None):
     # type: (Any, Optional[datetime]) -> Iterable[Tuple[DataCategory, datetime]]
     if now is None:
-        now = datetime_utcnow()
+        now = datetime.now(timezone.utc)
 
     for limit in header.split(","):
         try:
@@ -214,7 +210,7 @@ class HttpTransport(Transport):
         # sentries if a proxy in front wants to globally slow things down.
         elif response.status == 429:
             logger.warning("Rate-limited via 429")
-            self._disabled_until[None] = datetime_utcnow() + timedelta(
+            self._disabled_until[None] = datetime.now(timezone.utc) + timedelta(
                 seconds=self._retry.get_retry_after(response) or 60
             )
 
@@ -321,13 +317,15 @@ class HttpTransport(Transport):
         def _disabled(bucket):
             # type: (Any) -> bool
             ts = self._disabled_until.get(bucket)
-            return ts is not None and ts > datetime_utcnow()
+            return ts is not None and ts > datetime.now(timezone.utc)
 
         return _disabled(category) or _disabled(None)
 
     def _is_rate_limited(self):
         # type: () -> bool
-        return any(ts > datetime_utcnow() for ts in self._disabled_until.values())
+        return any(
+            ts > datetime.now(timezone.utc) for ts in self._disabled_until.values()
+        )
 
     def _is_worker_full(self):
         # type: () -> bool

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -34,7 +34,7 @@ except ImportError:
     import mock
 
 import sentry_sdk
-from sentry_sdk._compat import iteritems, reraise, string_types, PY2
+from sentry_sdk._compat import reraise
 from sentry_sdk.envelope import Envelope
 from sentry_sdk.integrations import _processed_integrations  # noqa: F401
 from sentry_sdk.profiler import teardown_profiler
@@ -158,8 +158,8 @@ def _capture_internal_warnings():
 def monkeypatch_test_transport(monkeypatch, validate_event_schema):
     def check_event(event):
         def check_string_keys(map):
-            for key, value in iteritems(map):
-                assert isinstance(key, string_types)
+            for key, value in map.items():
+                assert isinstance(key, str)
                 if isinstance(value, dict):
                     check_string_keys(value)
 
@@ -423,13 +423,7 @@ def string_containing_matcher():
     class StringContaining(object):
         def __init__(self, substring):
             self.substring = substring
-
-            try:
-                # the `unicode` type only exists in python 2, so if this blows up,
-                # we must be in py3 and have the `bytes` type
-                self.valid_types = (str, unicode)
-            except NameError:
-                self.valid_types = (str, bytes)
+            self.valid_types = (str, bytes)
 
         def __eq__(self, test_string):
             if not isinstance(test_string, self.valid_types):
@@ -645,10 +639,8 @@ def patch_start_tracing_child(fake_transaction_is_none=False):
         fake_transaction = None
         fake_start_child = None
 
-    version = "2" if PY2 else "3"
-
     with mock.patch(
-        "sentry_sdk.tracing_utils_py%s.get_current_span" % version,
+        "sentry_sdk.tracing_utils_py3.get_current_span",
         return_value=fake_transaction,
     ):
         yield fake_start_child

--- a/tests/integrations/celery/test_celery.py
+++ b/tests/integrations/celery/test_celery.py
@@ -9,8 +9,6 @@ from sentry_sdk.integrations.celery import (
     _wrap_apply_async,
 )
 
-from sentry_sdk._compat import text_type
-
 from celery import Celery, VERSION
 from celery.bin import worker
 
@@ -225,7 +223,7 @@ def test_transaction_events(capture_events, init_celery, celery_invocation, task
             "span_id": submission_event["spans"][0]["span_id"],
             "start_timestamp": submission_event["spans"][0]["start_timestamp"],
             "timestamp": submission_event["spans"][0]["timestamp"],
-            "trace_id": text_type(transaction.trace_id),
+            "trace_id": str(transaction.trace_id),
         }
     ]
 

--- a/tests/integrations/django/test_basic.py
+++ b/tests/integrations/django/test_basic.py
@@ -19,7 +19,7 @@ try:
 except ImportError:
     from django.core.urlresolvers import reverse
 
-from sentry_sdk._compat import PY2, PY310
+from sentry_sdk._compat import PY310
 from sentry_sdk import capture_message, capture_exception, configure_scope
 from sentry_sdk.consts import SPANDATA
 from sentry_sdk.integrations.django import DjangoIntegration, _set_db_data
@@ -1114,13 +1114,10 @@ def test_get_receiver_name():
 
     name = _get_receiver_name(dummy)
 
-    if PY2:
-        assert name == "tests.integrations.django.test_basic.dummy"
-    else:
-        assert (
-            name
-            == "tests.integrations.django.test_basic.test_get_receiver_name.<locals>.dummy"
-        )
+    assert (
+        name
+        == "tests.integrations.django.test_basic.test_get_receiver_name.<locals>.dummy"
+    )
 
     a_partial = partial(dummy)
     name = _get_receiver_name(a_partial)

--- a/tests/integrations/stdlib/test_subprocess.py
+++ b/tests/integrations/stdlib/test_subprocess.py
@@ -2,18 +2,12 @@ import os
 import platform
 import subprocess
 import sys
+from collections.abc import Mapping
 
 import pytest
 
 from sentry_sdk import capture_message, start_transaction
-from sentry_sdk._compat import PY2
 from sentry_sdk.integrations.stdlib import StdlibIntegration
-
-
-if PY2:
-    from collections import Mapping
-else:
-    from collections.abc import Mapping
 
 
 class ImmutableDict(Mapping):

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -5,8 +5,10 @@ import pytest
 import subprocess
 import sys
 import time
-
+from collections.abc import Mapping
 from textwrap import dedent
+from unittest import mock
+
 from sentry_sdk import (
     Hub,
     Client,
@@ -20,31 +22,17 @@ from sentry_sdk import (
 )
 from sentry_sdk.integrations.executing import ExecutingIntegration
 from sentry_sdk.transport import Transport
-from sentry_sdk._compat import reraise, text_type, PY2
 from sentry_sdk.utils import HAS_CHAINED_EXCEPTIONS
 from sentry_sdk.utils import logger
 from sentry_sdk.serializer import MAX_DATABAG_BREADTH
 from sentry_sdk.consts import DEFAULT_MAX_BREADCRUMBS, DEFAULT_MAX_VALUE_LENGTH
+from sentry_sdk._compat import reraise
 from sentry_sdk._types import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from collections.abc import Callable
     from typing import Any, Optional, Union
     from sentry_sdk._types import Event
-
-try:
-    from unittest import mock  # python 3.3 and above
-except ImportError:
-    import mock  # python < 3.3
-
-if PY2:
-    # Importing ABCs from collections is deprecated, and will stop working in 3.8
-    # https://github.com/python/cpython/blob/master/Lib/collections/__init__.py#L49
-    from collections import Mapping
-else:
-    # New in 3.3
-    # https://docs.python.org/3/library/collections.abc.html
-    from collections.abc import Mapping
 
 
 class EventCapturedError(Exception):
@@ -67,7 +55,7 @@ def test_transport_option(monkeypatch):
 
     monkeypatch.setenv("SENTRY_DSN", dsn)
     transport = Transport({"dsn": dsn2})
-    assert text_type(transport.parsed_dsn) == dsn2
+    assert str(transport.parsed_dsn) == dsn2
     assert str(Client(transport=transport).dsn) == dsn
 
 

--- a/tests/test_transport.py
+++ b/tests/test_transport.py
@@ -3,25 +3,19 @@ import logging
 import pickle
 import gzip
 import io
-
-from datetime import datetime, timedelta
+from collections import namedtuple
+from datetime import datetime, timedelta, timezone
+from unittest import mock
 
 import pytest
-from collections import namedtuple
+from pytest_localserver.http import WSGIServer
 from werkzeug.wrappers import Request, Response
 
-from pytest_localserver.http import WSGIServer
-
 from sentry_sdk import Hub, Client, add_breadcrumb, capture_message, Scope
-from sentry_sdk._compat import datetime_utcnow
 from sentry_sdk.transport import _parse_rate_limits
 from sentry_sdk.envelope import Envelope, parse_json
 from sentry_sdk.integrations.logging import LoggingIntegration
 
-try:
-    from unittest import mock  # python 3.3 and above
-except ImportError:
-    import mock  # python < 3.3
 
 CapturedData = namedtuple("CapturedData", ["path", "event", "envelope", "compressed"])
 
@@ -123,7 +117,9 @@ def test_transport_works(
     Hub.current.bind_client(client)
     request.addfinalizer(lambda: Hub.current.bind_client(None))
 
-    add_breadcrumb(level="info", message="i like bread", timestamp=datetime_utcnow())
+    add_breadcrumb(
+        level="info", message="i like bread", timestamp=datetime.now(timezone.utc)
+    )
     capture_message("löl")
 
     getattr(client, client_flush_method)()

--- a/tests/utils/test_general.py
+++ b/tests/utils/test_general.py
@@ -18,7 +18,6 @@ from sentry_sdk.utils import (
     strip_string,
     AnnotatedValue,
 )
-from sentry_sdk._compat import text_type, string_types
 
 
 try:
@@ -32,7 +31,7 @@ else:
     @given(x=any_string)
     def test_safe_repr_never_broken_for_strings(x):
         r = safe_repr(x)
-        assert isinstance(r, text_type)
+        assert isinstance(r, str)
         assert "broken repr" not in r
 
 
@@ -568,7 +567,7 @@ def test_failed_base64_conversion(input):
 
     # any string can be converted to base64, so only type errors will cause
     # failures
-    if type(input) not in string_types:
+    if not isinstance(input, str):
         assert to_base64(input) is None
 
 


### PR DESCRIPTION
- remove Python 2.7 and 3.5 compatibility utils from `_compat.py` and replace them with their Python 3.6+ versions

Note: This PR removes some imports that are different between py2 and py3, but not all -- this will be done in a separate PR.

---

## General Notes

Thank you for contributing to `sentry-python`!

Please add tests to validate your changes, and lint your code using `tox -e linters`.

Running the test suite on your PR might require maintainer approval. Some tests (AWS Lambda) additionally require a maintainer to add a special label to run and will fail if the label is not present.

#### For maintainers

Sensitive test suites require maintainer review to ensure that tests do not compromise our secrets. This review must be repeated after any code revisions.

Before running sensitive test suites, please carefully check the PR. Then, apply the `Trigger: tests using secrets` label. The label will be removed after any code changes to enforce our policy requiring maintainers to review all code revisions before running sensitive tests.
