### PR TITLE
Remove `object` as superclass

### DIFF
--- a/sentry_sdk/_lru_cache.py
+++ b/sentry_sdk/_lru_cache.py
@@ -72,7 +72,7 @@ KEY = 2
 VALUE = 3
 
 
-class LRUCache(object):
+class LRUCache:
     def __init__(self, max_size):
         assert max_size > 0
 

--- a/sentry_sdk/_queue.py
+++ b/sentry_sdk/_queue.py
@@ -94,7 +94,7 @@ class FullError(Exception):
     pass
 
 
-class Queue(object):
+class Queue:
     """Create a queue object with a given maximum size.
 
     If maxsize is <= 0, the queue size is infinite.

--- a/sentry_sdk/attachments.py
+++ b/sentry_sdk/attachments.py
@@ -8,7 +8,7 @@ if TYPE_CHECKING:
     from typing import Optional, Union, Callable
 
 
-class Attachment(object):
+class Attachment:
     def __init__(
         self,
         bytes=None,  # type: Union[None, bytes, Callable[[], bytes]]

--- a/sentry_sdk/client.py
+++ b/sentry_sdk/client.py
@@ -148,7 +148,7 @@ except Exception:
     module_not_found_error = ImportError  # type: ignore
 
 
-class _Client(object):
+class _Client:
     """The client is internally responsible for capturing the events and
     forwarding them to sentry through the configured transport.  It takes
     the client options as keyword arguments and optionally the DSN as first

--- a/sentry_sdk/consts.py
+++ b/sentry_sdk/consts.py
@@ -238,7 +238,7 @@ class OP:
 
 # This type exists to trick mypy and PyCharm into thinking `init` and `Client`
 # take these arguments (even though they take opaque **kwargs)
-class ClientConstructor(object):
+class ClientConstructor:
     def __init__(
         self,
         dsn=None,  # type: Optional[str]

--- a/sentry_sdk/envelope.py
+++ b/sentry_sdk/envelope.py
@@ -26,7 +26,7 @@ def parse_json(data):
     return json.loads(data)
 
 
-class Envelope(object):
+class Envelope:
     def __init__(
         self,
         headers=None,  # type: Optional[Dict[str, Any]]
@@ -155,7 +155,7 @@ class Envelope(object):
         return "<Envelope headers=%r items=%r>" % (self.headers, self.items)
 
 
-class PayloadRef(object):
+class PayloadRef:
     def __init__(
         self,
         bytes=None,  # type: Optional[bytes]
@@ -199,7 +199,7 @@ class PayloadRef(object):
         return "<Payload %r>" % (self.inferred_content_type,)
 
 
-class Item(object):
+class Item:
     def __init__(
         self,
         payload,  # type: Union[bytes, text_type, PayloadRef]

--- a/sentry_sdk/hub.py
+++ b/sentry_sdk/hub.py
@@ -92,7 +92,7 @@ def _should_send_default_pii():
     return client.options["send_default_pii"]
 
 
-class _InitGuard(object):
+class _InitGuard:
     def __init__(self, client):
         # type: (Client) -> None
         self._client = client
@@ -173,7 +173,7 @@ class HubMeta(type):
         return GLOBAL_HUB
 
 
-class _ScopeManager(object):
+class _ScopeManager:
     def __init__(self, hub):
         # type: (Hub) -> None
         self._hub = hub

--- a/sentry_sdk/integrations/__init__.py
+++ b/sentry_sdk/integrations/__init__.py
@@ -176,7 +176,7 @@ class DidNotEnable(Exception):  # noqa: N818
     """
 
 
-class Integration(object):
+class Integration:
     """Baseclass for all integrations.
 
     To accept options for an integration, implement your own constructor that

--- a/sentry_sdk/integrations/_wsgi_common.py
+++ b/sentry_sdk/integrations/_wsgi_common.py
@@ -53,7 +53,7 @@ def request_body_within_bounds(client, content_length):
     )
 
 
-class RequestExtractor(object):
+class RequestExtractor:
     def __init__(self, request):
         # type: (Any) -> None
         self.request = request

--- a/sentry_sdk/integrations/django/transactions.py
+++ b/sentry_sdk/integrations/django/transactions.py
@@ -44,7 +44,7 @@ def get_regex(resolver_or_pattern):
     return regex
 
 
-class RavenResolver(object):
+class RavenResolver:
     _new_style_group_matcher = re.compile(
         r"<(?:([^>:]+):)?([^>]+)>"
     )  # https://github.com/django/django/blob/21382e2743d06efbf5623e7c9b6dccf2a325669b/django/urls/resolvers.py#L245-L247

--- a/sentry_sdk/integrations/falcon.py
+++ b/sentry_sdk/integrations/falcon.py
@@ -97,7 +97,7 @@ class FalconRequestExtractor(RequestExtractor):
                 return self.request._media
 
 
-class SentryFalconMiddleware(object):
+class SentryFalconMiddleware:
     """Captures exceptions in Falcon requests and send to Sentry"""
 
     def process_request(self, req, resp, *args, **kwargs):

--- a/sentry_sdk/integrations/spark/spark_driver.py
+++ b/sentry_sdk/integrations/spark/spark_driver.py
@@ -105,7 +105,7 @@ def patch_spark_context_init():
     SparkContext._do_init = _sentry_patched_spark_context_init
 
 
-class SparkListener(object):
+class SparkListener:
     def onApplicationEnd(self, applicationEnd):  # noqa: N802,N803
         # type: (Any) -> None
         pass

--- a/sentry_sdk/integrations/wsgi.py
+++ b/sentry_sdk/integrations/wsgi.py
@@ -66,7 +66,7 @@ def get_request_url(environ, use_x_forwarded_for=False):
     )
 
 
-class SentryWsgiMiddleware(object):
+class SentryWsgiMiddleware:
     __slots__ = ("app", "use_x_forwarded_for")
 
     def __init__(self, app, use_x_forwarded_for=False):
@@ -198,7 +198,7 @@ def _capture_exception(hub):
     return exc_info
 
 
-class _ScopedResponse(object):
+class _ScopedResponse:
     __slots__ = ("_response", "_hub")
 
     def __init__(self, hub, response):

--- a/sentry_sdk/metrics.py
+++ b/sentry_sdk/metrics.py
@@ -111,7 +111,7 @@ def metrics_noop(func):
     return new_func
 
 
-class Metric(object):
+class Metric:
     __slots__ = ()
 
     @property
@@ -340,7 +340,7 @@ TIMING_FUNCTIONS = {
 }
 
 
-class LocalAggregator(object):
+class LocalAggregator:
     __slots__ = ("_measurements",)
 
     def __init__(self):
@@ -394,7 +394,7 @@ class LocalAggregator(object):
         return rv
 
 
-class MetricsAggregator(object):
+class MetricsAggregator:
     ROLLUP_IN_SECONDS = 10.0
     MAX_WEIGHT = 100000
     FLUSHER_SLEEP_TIME = 5.0
@@ -756,7 +756,7 @@ def incr(
         )
 
 
-class _Timing(object):
+class _Timing:
     def __init__(
         self,
         key,  # type: str

--- a/sentry_sdk/monitor.py
+++ b/sentry_sdk/monitor.py
@@ -13,7 +13,7 @@ if TYPE_CHECKING:
 MAX_DOWNSAMPLE_FACTOR = 10
 
 
-class Monitor(object):
+class Monitor:
     """
     Performs health checks in a separate thread once every interval seconds
     and updates the internal state. Other parts of the SDK only read this state

--- a/sentry_sdk/profiler.py
+++ b/sentry_sdk/profiler.py
@@ -435,7 +435,7 @@ def get_current_thread_id(thread=None):
     return None
 
 
-class Profile(object):
+class Profile:
     def __init__(
         self,
         transaction,  # type: sentry_sdk.tracing.Transaction
@@ -751,7 +751,7 @@ class Profile(object):
         return True
 
 
-class Scheduler(object):
+class Scheduler:
     mode = "unknown"  # type: ProfilerMode
 
     def __init__(self, frequency):

--- a/sentry_sdk/scope.py
+++ b/sentry_sdk/scope.py
@@ -81,7 +81,7 @@ def _disable_capture(fn):
     return wrapper  # type: ignore
 
 
-class Scope(object):
+class Scope:
     """The scope holds extra information that should be sent with all
     events that belong to it.
     """

--- a/sentry_sdk/scrubber.py
+++ b/sentry_sdk/scrubber.py
@@ -58,7 +58,7 @@ DEFAULT_DENYLIST = [
 ]
 
 
-class EventScrubber(object):
+class EventScrubber:
     def __init__(self, denylist=None):
         # type: (Optional[List[str]]) -> None
         self.denylist = DEFAULT_DENYLIST if denylist is None else denylist

--- a/sentry_sdk/serializer.py
+++ b/sentry_sdk/serializer.py
@@ -82,7 +82,7 @@ def add_global_repr_processor(processor):
     global_repr_processors.append(processor)
 
 
-class Memo(object):
+class Memo:
     __slots__ = ("_ids", "_objs")
 
     def __init__(self):

--- a/sentry_sdk/session.py
+++ b/sentry_sdk/session.py
@@ -28,7 +28,7 @@ def _make_uuid(
     return uuid.UUID(val)
 
 
-class Session(object):
+class Session:
     def __init__(
         self,
         sid=None,  # type: Optional[Union[str, uuid.UUID]]

--- a/sentry_sdk/sessions.py
+++ b/sentry_sdk/sessions.py
@@ -59,7 +59,7 @@ def make_aggregate_envelope(aggregate_states, attrs):
     return {"attrs": dict(attrs), "aggregates": list(aggregate_states.values())}
 
 
-class SessionFlusher(object):
+class SessionFlusher:
     def __init__(
         self,
         capture_func,  # type: Callable[[Envelope], None]

--- a/sentry_sdk/spotlight.py
+++ b/sentry_sdk/spotlight.py
@@ -12,7 +12,7 @@ from sentry_sdk.utils import logger
 from sentry_sdk.envelope import Envelope
 
 
-class SpotlightClient(object):
+class SpotlightClient:
     def __init__(self, url):
         # type: (str) -> None
         self.url = url

--- a/sentry_sdk/tracing.py
+++ b/sentry_sdk/tracing.py
@@ -57,7 +57,7 @@ SOURCE_FOR_STYLE = {
 }
 
 
-class _SpanRecorder(object):
+class _SpanRecorder:
     """Limits the number of spans recorded in a transaction."""
 
     __slots__ = ("maxlen", "spans")
@@ -80,7 +80,7 @@ class _SpanRecorder(object):
             self.spans.append(span)
 
 
-class Span(object):
+class Span:
     """A span holds timing information of a block of code.
     Spans can have multiple child spans thus forming a span tree."""
 

--- a/sentry_sdk/tracing_utils.py
+++ b/sentry_sdk/tracing_utils.py
@@ -319,7 +319,7 @@ def _format_sql(cursor, sql):
     return real_sql or to_string(sql)
 
 
-class Baggage(object):
+class Baggage:
     """
     The W3C Baggage header information (see https://www.w3.org/TR/baggage/).
     """

--- a/sentry_sdk/transport.py
+++ b/sentry_sdk/transport.py
@@ -41,7 +41,7 @@ except ImportError:
     from urllib import getproxies  # type: ignore
 
 
-class Transport(object):
+class Transport:
     """Baseclass for all transports.
 
     A transport is used to send an event to sentry.

--- a/sentry_sdk/utils.py
+++ b/sentry_sdk/utils.py
@@ -180,7 +180,7 @@ def get_sdk_name(installed_integrations):
     return "sentry.python"
 
 
-class CaptureInternalException(object):
+class CaptureInternalException:
     __slots__ = ()
 
     def __enter__(self):
@@ -237,7 +237,7 @@ class BadDsn(ValueError):
 
 
 @implements_str
-class Dsn(object):
+class Dsn:
     """Represents a DSN."""
 
     def __init__(self, value):
@@ -310,7 +310,7 @@ class Dsn(object):
         )
 
 
-class Auth(object):
+class Auth:
     """Helper object that represents the auth info."""
 
     def __init__(
@@ -367,7 +367,7 @@ class Auth(object):
         return "Sentry " + ", ".join("%s=%s" % (key, value) for key, value in rv)
 
 
-class AnnotatedValue(object):
+class AnnotatedValue:
     """
     Meta information for a data field in the event payload.
     This is to tell Relay that we have tampered with the fields value.
@@ -1245,7 +1245,7 @@ def _is_contextvars_broken():
 
 def _make_threadlocal_contextvars(local):
     # type: (type) -> type
-    class ContextVar(object):
+    class ContextVar:
         # Super-limited impl of ContextVar
 
         def __init__(self, name):

--- a/sentry_sdk/worker.py
+++ b/sentry_sdk/worker.py
@@ -18,7 +18,7 @@ if TYPE_CHECKING:
 _TERMINATOR = object()
 
 
-class BackgroundWorker(object):
+class BackgroundWorker:
     def __init__(self, queue_size=DEFAULT_QUEUE_SIZE):
         # type: (int) -> None
         check_thread_support()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -328,7 +328,7 @@ def capture_events_forksafe(monkeypatch, capture_events, request):
     return inner
 
 
-class EventStreamReader(object):
+class EventStreamReader:
     def __init__(self, read_file, write_file):
         self.read_file = read_file
         self.write_file = write_file
@@ -420,7 +420,7 @@ def string_containing_matcher():
 
     """
 
-    class StringContaining(object):
+    class StringContaining:
         def __init__(self, substring):
             self.substring = substring
 
@@ -503,7 +503,7 @@ def dictionary_containing_matcher():
     >>> f.assert_any_call(DictionaryContaining({"dogs": "yes"})) # no AssertionError
     """
 
-    class DictionaryContaining(object):
+    class DictionaryContaining:
         def __init__(self, subdict):
             self.subdict = subdict
 
@@ -543,7 +543,7 @@ def object_described_by_matcher():
 
     Used like this:
 
-    >>> class Dog(object):
+    >>> class Dog:
     ...     pass
     ...
     >>> maisey = Dog()
@@ -555,7 +555,7 @@ def object_described_by_matcher():
     >>> f.assert_any_call(ObjectDescribedBy(attrs={"name": "Maisey"})) # no AssertionError
     """
 
-    class ObjectDescribedBy(object):
+    class ObjectDescribedBy:
         def __init__(self, type=None, attrs=None):
             self.type = type
             self.attrs = attrs

--- a/tests/integrations/boto3/aws_mock.py
+++ b/tests/integrations/boto3/aws_mock.py
@@ -10,7 +10,7 @@ class Body(BytesIO):
             contents = self.read()
 
 
-class MockResponse(object):
+class MockResponse:
     def __init__(self, client, status_code, headers, body):
         self._client = client
         self._status_code = status_code

--- a/tests/integrations/django/myapp/views.py
+++ b/tests/integrations/django/myapp/views.py
@@ -84,14 +84,14 @@ def view_with_cached_template_fragment(request):
 # interesting property of this one is that csrf_exempt, as a class attribute,
 # is not in __dict__, so regular use of functools.wraps will not forward the
 # attribute.
-class SentryClassBasedView(object):
+class SentryClassBasedView:
     csrf_exempt = True
 
     def __call__(self, request):
         return HttpResponse("ok")
 
 
-class SentryClassBasedViewWithCsrf(object):
+class SentryClassBasedViewWithCsrf:
     def __call__(self, request):
         return HttpResponse("ok")
 

--- a/tests/integrations/django/test_basic.py
+++ b/tests/integrations/django/test_basic.py
@@ -669,7 +669,7 @@ def test_db_connection_span_data(sentry_init, client, capture_events):
 
 
 def test_set_db_data_custom_backend():
-    class DummyBackend(object):
+    class DummyBackend:
         # https://github.com/mongodb/mongo-python-driver/blob/6ffae5522c960252b8c9adfe2a19b29ff28187cb/pymongo/collection.py#L126
         def __getattr__(self, attr):
             return self

--- a/tests/integrations/flask/test_flask.py
+++ b/tests/integrations/flask/test_flask.py
@@ -212,7 +212,7 @@ def test_flask_login_configured(
 ):
     sentry_init(send_default_pii=send_default_pii, **integration_enabled_params)
 
-    class User(object):
+    class User:
         is_authenticated = is_active = True
         is_anonymous = user_id is not None
 

--- a/tests/integrations/grpc/grpc_test_service_pb2_grpc.py
+++ b/tests/integrations/grpc/grpc_test_service_pb2_grpc.py
@@ -5,7 +5,7 @@ import grpc
 import grpc_test_service_pb2 as grpc__test__service__pb2
 
 
-class gRPCTestServiceStub(object):
+class gRPCTestServiceStub:
     """Missing associated documentation comment in .proto file."""
 
     def __init__(self, channel):
@@ -15,151 +15,200 @@ class gRPCTestServiceStub(object):
             channel: A grpc.Channel.
         """
         self.TestServe = channel.unary_unary(
-                '/grpc_test_server.gRPCTestService/TestServe',
-                request_serializer=grpc__test__service__pb2.gRPCTestMessage.SerializeToString,
-                response_deserializer=grpc__test__service__pb2.gRPCTestMessage.FromString,
-                )
+            "/grpc_test_server.gRPCTestService/TestServe",
+            request_serializer=grpc__test__service__pb2.gRPCTestMessage.SerializeToString,
+            response_deserializer=grpc__test__service__pb2.gRPCTestMessage.FromString,
+        )
         self.TestUnaryStream = channel.unary_stream(
-                '/grpc_test_server.gRPCTestService/TestUnaryStream',
-                request_serializer=grpc__test__service__pb2.gRPCTestMessage.SerializeToString,
-                response_deserializer=grpc__test__service__pb2.gRPCTestMessage.FromString,
-                )
+            "/grpc_test_server.gRPCTestService/TestUnaryStream",
+            request_serializer=grpc__test__service__pb2.gRPCTestMessage.SerializeToString,
+            response_deserializer=grpc__test__service__pb2.gRPCTestMessage.FromString,
+        )
         self.TestStreamStream = channel.stream_stream(
-                '/grpc_test_server.gRPCTestService/TestStreamStream',
-                request_serializer=grpc__test__service__pb2.gRPCTestMessage.SerializeToString,
-                response_deserializer=grpc__test__service__pb2.gRPCTestMessage.FromString,
-                )
+            "/grpc_test_server.gRPCTestService/TestStreamStream",
+            request_serializer=grpc__test__service__pb2.gRPCTestMessage.SerializeToString,
+            response_deserializer=grpc__test__service__pb2.gRPCTestMessage.FromString,
+        )
         self.TestStreamUnary = channel.stream_unary(
-                '/grpc_test_server.gRPCTestService/TestStreamUnary',
-                request_serializer=grpc__test__service__pb2.gRPCTestMessage.SerializeToString,
-                response_deserializer=grpc__test__service__pb2.gRPCTestMessage.FromString,
-                )
+            "/grpc_test_server.gRPCTestService/TestStreamUnary",
+            request_serializer=grpc__test__service__pb2.gRPCTestMessage.SerializeToString,
+            response_deserializer=grpc__test__service__pb2.gRPCTestMessage.FromString,
+        )
 
 
-class gRPCTestServiceServicer(object):
+class gRPCTestServiceServicer:
     """Missing associated documentation comment in .proto file."""
 
     def TestServe(self, request, context):
         """Missing associated documentation comment in .proto file."""
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
-        context.set_details('Method not implemented!')
-        raise NotImplementedError('Method not implemented!')
+        context.set_details("Method not implemented!")
+        raise NotImplementedError("Method not implemented!")
 
     def TestUnaryStream(self, request, context):
         """Missing associated documentation comment in .proto file."""
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
-        context.set_details('Method not implemented!')
-        raise NotImplementedError('Method not implemented!')
+        context.set_details("Method not implemented!")
+        raise NotImplementedError("Method not implemented!")
 
     def TestStreamStream(self, request_iterator, context):
         """Missing associated documentation comment in .proto file."""
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
-        context.set_details('Method not implemented!')
-        raise NotImplementedError('Method not implemented!')
+        context.set_details("Method not implemented!")
+        raise NotImplementedError("Method not implemented!")
 
     def TestStreamUnary(self, request_iterator, context):
         """Missing associated documentation comment in .proto file."""
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
-        context.set_details('Method not implemented!')
-        raise NotImplementedError('Method not implemented!')
+        context.set_details("Method not implemented!")
+        raise NotImplementedError("Method not implemented!")
 
 
 def add_gRPCTestServiceServicer_to_server(servicer, server):
     rpc_method_handlers = {
-            'TestServe': grpc.unary_unary_rpc_method_handler(
-                    servicer.TestServe,
-                    request_deserializer=grpc__test__service__pb2.gRPCTestMessage.FromString,
-                    response_serializer=grpc__test__service__pb2.gRPCTestMessage.SerializeToString,
-            ),
-            'TestUnaryStream': grpc.unary_stream_rpc_method_handler(
-                    servicer.TestUnaryStream,
-                    request_deserializer=grpc__test__service__pb2.gRPCTestMessage.FromString,
-                    response_serializer=grpc__test__service__pb2.gRPCTestMessage.SerializeToString,
-            ),
-            'TestStreamStream': grpc.stream_stream_rpc_method_handler(
-                    servicer.TestStreamStream,
-                    request_deserializer=grpc__test__service__pb2.gRPCTestMessage.FromString,
-                    response_serializer=grpc__test__service__pb2.gRPCTestMessage.SerializeToString,
-            ),
-            'TestStreamUnary': grpc.stream_unary_rpc_method_handler(
-                    servicer.TestStreamUnary,
-                    request_deserializer=grpc__test__service__pb2.gRPCTestMessage.FromString,
-                    response_serializer=grpc__test__service__pb2.gRPCTestMessage.SerializeToString,
-            ),
+        "TestServe": grpc.unary_unary_rpc_method_handler(
+            servicer.TestServe,
+            request_deserializer=grpc__test__service__pb2.gRPCTestMessage.FromString,
+            response_serializer=grpc__test__service__pb2.gRPCTestMessage.SerializeToString,
+        ),
+        "TestUnaryStream": grpc.unary_stream_rpc_method_handler(
+            servicer.TestUnaryStream,
+            request_deserializer=grpc__test__service__pb2.gRPCTestMessage.FromString,
+            response_serializer=grpc__test__service__pb2.gRPCTestMessage.SerializeToString,
+        ),
+        "TestStreamStream": grpc.stream_stream_rpc_method_handler(
+            servicer.TestStreamStream,
+            request_deserializer=grpc__test__service__pb2.gRPCTestMessage.FromString,
+            response_serializer=grpc__test__service__pb2.gRPCTestMessage.SerializeToString,
+        ),
+        "TestStreamUnary": grpc.stream_unary_rpc_method_handler(
+            servicer.TestStreamUnary,
+            request_deserializer=grpc__test__service__pb2.gRPCTestMessage.FromString,
+            response_serializer=grpc__test__service__pb2.gRPCTestMessage.SerializeToString,
+        ),
     }
     generic_handler = grpc.method_handlers_generic_handler(
-            'grpc_test_server.gRPCTestService', rpc_method_handlers)
+        "grpc_test_server.gRPCTestService", rpc_method_handlers
+    )
     server.add_generic_rpc_handlers((generic_handler,))
 
 
- # This class is part of an EXPERIMENTAL API.
-class gRPCTestService(object):
+# This class is part of an EXPERIMENTAL API.
+class gRPCTestService:
     """Missing associated documentation comment in .proto file."""
 
     @staticmethod
-    def TestServe(request,
+    def TestServe(
+        request,
+        target,
+        options=(),
+        channel_credentials=None,
+        call_credentials=None,
+        insecure=False,
+        compression=None,
+        wait_for_ready=None,
+        timeout=None,
+        metadata=None,
+    ):
+        return grpc.experimental.unary_unary(
+            request,
             target,
-            options=(),
-            channel_credentials=None,
-            call_credentials=None,
-            insecure=False,
-            compression=None,
-            wait_for_ready=None,
-            timeout=None,
-            metadata=None):
-        return grpc.experimental.unary_unary(request, target, '/grpc_test_server.gRPCTestService/TestServe',
+            "/grpc_test_server.gRPCTestService/TestServe",
             grpc__test__service__pb2.gRPCTestMessage.SerializeToString,
             grpc__test__service__pb2.gRPCTestMessage.FromString,
-            options, channel_credentials,
-            insecure, call_credentials, compression, wait_for_ready, timeout, metadata)
+            options,
+            channel_credentials,
+            insecure,
+            call_credentials,
+            compression,
+            wait_for_ready,
+            timeout,
+            metadata,
+        )
 
     @staticmethod
-    def TestUnaryStream(request,
+    def TestUnaryStream(
+        request,
+        target,
+        options=(),
+        channel_credentials=None,
+        call_credentials=None,
+        insecure=False,
+        compression=None,
+        wait_for_ready=None,
+        timeout=None,
+        metadata=None,
+    ):
+        return grpc.experimental.unary_stream(
+            request,
             target,
-            options=(),
-            channel_credentials=None,
-            call_credentials=None,
-            insecure=False,
-            compression=None,
-            wait_for_ready=None,
-            timeout=None,
-            metadata=None):
-        return grpc.experimental.unary_stream(request, target, '/grpc_test_server.gRPCTestService/TestUnaryStream',
+            "/grpc_test_server.gRPCTestService/TestUnaryStream",
             grpc__test__service__pb2.gRPCTestMessage.SerializeToString,
             grpc__test__service__pb2.gRPCTestMessage.FromString,
-            options, channel_credentials,
-            insecure, call_credentials, compression, wait_for_ready, timeout, metadata)
+            options,
+            channel_credentials,
+            insecure,
+            call_credentials,
+            compression,
+            wait_for_ready,
+            timeout,
+            metadata,
+        )
 
     @staticmethod
-    def TestStreamStream(request_iterator,
+    def TestStreamStream(
+        request_iterator,
+        target,
+        options=(),
+        channel_credentials=None,
+        call_credentials=None,
+        insecure=False,
+        compression=None,
+        wait_for_ready=None,
+        timeout=None,
+        metadata=None,
+    ):
+        return grpc.experimental.stream_stream(
+            request_iterator,
             target,
-            options=(),
-            channel_credentials=None,
-            call_credentials=None,
-            insecure=False,
-            compression=None,
-            wait_for_ready=None,
-            timeout=None,
-            metadata=None):
-        return grpc.experimental.stream_stream(request_iterator, target, '/grpc_test_server.gRPCTestService/TestStreamStream',
+            "/grpc_test_server.gRPCTestService/TestStreamStream",
             grpc__test__service__pb2.gRPCTestMessage.SerializeToString,
             grpc__test__service__pb2.gRPCTestMessage.FromString,
-            options, channel_credentials,
-            insecure, call_credentials, compression, wait_for_ready, timeout, metadata)
+            options,
+            channel_credentials,
+            insecure,
+            call_credentials,
+            compression,
+            wait_for_ready,
+            timeout,
+            metadata,
+        )
 
     @staticmethod
-    def TestStreamUnary(request_iterator,
+    def TestStreamUnary(
+        request_iterator,
+        target,
+        options=(),
+        channel_credentials=None,
+        call_credentials=None,
+        insecure=False,
+        compression=None,
+        wait_for_ready=None,
+        timeout=None,
+        metadata=None,
+    ):
+        return grpc.experimental.stream_unary(
+            request_iterator,
             target,
-            options=(),
-            channel_credentials=None,
-            call_credentials=None,
-            insecure=False,
-            compression=None,
-            wait_for_ready=None,
-            timeout=None,
-            metadata=None):
-        return grpc.experimental.stream_unary(request_iterator, target, '/grpc_test_server.gRPCTestService/TestStreamUnary',
+            "/grpc_test_server.gRPCTestService/TestStreamUnary",
             grpc__test__service__pb2.gRPCTestMessage.SerializeToString,
             grpc__test__service__pb2.gRPCTestMessage.FromString,
-            options, channel_credentials,
-            insecure, call_credentials, compression, wait_for_ready, timeout, metadata)
+            options,
+            channel_credentials,
+            insecure,
+            call_credentials,
+            compression,
+            wait_for_ready,
+            timeout,
+            metadata,
+        )

--- a/tests/integrations/grpc/grpc_test_service_pb2_grpc.py
+++ b/tests/integrations/grpc/grpc_test_service_pb2_grpc.py
@@ -5,7 +5,7 @@ import grpc
 import grpc_test_service_pb2 as grpc__test__service__pb2
 
 
-class gRPCTestServiceStub:
+class gRPCTestServiceStub(object):
     """Missing associated documentation comment in .proto file."""
 
     def __init__(self, channel):
@@ -15,200 +15,151 @@ class gRPCTestServiceStub:
             channel: A grpc.Channel.
         """
         self.TestServe = channel.unary_unary(
-            "/grpc_test_server.gRPCTestService/TestServe",
-            request_serializer=grpc__test__service__pb2.gRPCTestMessage.SerializeToString,
-            response_deserializer=grpc__test__service__pb2.gRPCTestMessage.FromString,
-        )
+                '/grpc_test_server.gRPCTestService/TestServe',
+                request_serializer=grpc__test__service__pb2.gRPCTestMessage.SerializeToString,
+                response_deserializer=grpc__test__service__pb2.gRPCTestMessage.FromString,
+                )
         self.TestUnaryStream = channel.unary_stream(
-            "/grpc_test_server.gRPCTestService/TestUnaryStream",
-            request_serializer=grpc__test__service__pb2.gRPCTestMessage.SerializeToString,
-            response_deserializer=grpc__test__service__pb2.gRPCTestMessage.FromString,
-        )
+                '/grpc_test_server.gRPCTestService/TestUnaryStream',
+                request_serializer=grpc__test__service__pb2.gRPCTestMessage.SerializeToString,
+                response_deserializer=grpc__test__service__pb2.gRPCTestMessage.FromString,
+                )
         self.TestStreamStream = channel.stream_stream(
-            "/grpc_test_server.gRPCTestService/TestStreamStream",
-            request_serializer=grpc__test__service__pb2.gRPCTestMessage.SerializeToString,
-            response_deserializer=grpc__test__service__pb2.gRPCTestMessage.FromString,
-        )
+                '/grpc_test_server.gRPCTestService/TestStreamStream',
+                request_serializer=grpc__test__service__pb2.gRPCTestMessage.SerializeToString,
+                response_deserializer=grpc__test__service__pb2.gRPCTestMessage.FromString,
+                )
         self.TestStreamUnary = channel.stream_unary(
-            "/grpc_test_server.gRPCTestService/TestStreamUnary",
-            request_serializer=grpc__test__service__pb2.gRPCTestMessage.SerializeToString,
-            response_deserializer=grpc__test__service__pb2.gRPCTestMessage.FromString,
-        )
+                '/grpc_test_server.gRPCTestService/TestStreamUnary',
+                request_serializer=grpc__test__service__pb2.gRPCTestMessage.SerializeToString,
+                response_deserializer=grpc__test__service__pb2.gRPCTestMessage.FromString,
+                )
 
 
-class gRPCTestServiceServicer:
+class gRPCTestServiceServicer(object):
     """Missing associated documentation comment in .proto file."""
 
     def TestServe(self, request, context):
         """Missing associated documentation comment in .proto file."""
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
-        context.set_details("Method not implemented!")
-        raise NotImplementedError("Method not implemented!")
+        context.set_details('Method not implemented!')
+        raise NotImplementedError('Method not implemented!')
 
     def TestUnaryStream(self, request, context):
         """Missing associated documentation comment in .proto file."""
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
-        context.set_details("Method not implemented!")
-        raise NotImplementedError("Method not implemented!")
+        context.set_details('Method not implemented!')
+        raise NotImplementedError('Method not implemented!')
 
     def TestStreamStream(self, request_iterator, context):
         """Missing associated documentation comment in .proto file."""
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
-        context.set_details("Method not implemented!")
-        raise NotImplementedError("Method not implemented!")
+        context.set_details('Method not implemented!')
+        raise NotImplementedError('Method not implemented!')
 
     def TestStreamUnary(self, request_iterator, context):
         """Missing associated documentation comment in .proto file."""
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
-        context.set_details("Method not implemented!")
-        raise NotImplementedError("Method not implemented!")
+        context.set_details('Method not implemented!')
+        raise NotImplementedError('Method not implemented!')
 
 
 def add_gRPCTestServiceServicer_to_server(servicer, server):
     rpc_method_handlers = {
-        "TestServe": grpc.unary_unary_rpc_method_handler(
-            servicer.TestServe,
-            request_deserializer=grpc__test__service__pb2.gRPCTestMessage.FromString,
-            response_serializer=grpc__test__service__pb2.gRPCTestMessage.SerializeToString,
-        ),
-        "TestUnaryStream": grpc.unary_stream_rpc_method_handler(
-            servicer.TestUnaryStream,
-            request_deserializer=grpc__test__service__pb2.gRPCTestMessage.FromString,
-            response_serializer=grpc__test__service__pb2.gRPCTestMessage.SerializeToString,
-        ),
-        "TestStreamStream": grpc.stream_stream_rpc_method_handler(
-            servicer.TestStreamStream,
-            request_deserializer=grpc__test__service__pb2.gRPCTestMessage.FromString,
-            response_serializer=grpc__test__service__pb2.gRPCTestMessage.SerializeToString,
-        ),
-        "TestStreamUnary": grpc.stream_unary_rpc_method_handler(
-            servicer.TestStreamUnary,
-            request_deserializer=grpc__test__service__pb2.gRPCTestMessage.FromString,
-            response_serializer=grpc__test__service__pb2.gRPCTestMessage.SerializeToString,
-        ),
+            'TestServe': grpc.unary_unary_rpc_method_handler(
+                    servicer.TestServe,
+                    request_deserializer=grpc__test__service__pb2.gRPCTestMessage.FromString,
+                    response_serializer=grpc__test__service__pb2.gRPCTestMessage.SerializeToString,
+            ),
+            'TestUnaryStream': grpc.unary_stream_rpc_method_handler(
+                    servicer.TestUnaryStream,
+                    request_deserializer=grpc__test__service__pb2.gRPCTestMessage.FromString,
+                    response_serializer=grpc__test__service__pb2.gRPCTestMessage.SerializeToString,
+            ),
+            'TestStreamStream': grpc.stream_stream_rpc_method_handler(
+                    servicer.TestStreamStream,
+                    request_deserializer=grpc__test__service__pb2.gRPCTestMessage.FromString,
+                    response_serializer=grpc__test__service__pb2.gRPCTestMessage.SerializeToString,
+            ),
+            'TestStreamUnary': grpc.stream_unary_rpc_method_handler(
+                    servicer.TestStreamUnary,
+                    request_deserializer=grpc__test__service__pb2.gRPCTestMessage.FromString,
+                    response_serializer=grpc__test__service__pb2.gRPCTestMessage.SerializeToString,
+            ),
     }
     generic_handler = grpc.method_handlers_generic_handler(
-        "grpc_test_server.gRPCTestService", rpc_method_handlers
-    )
+            'grpc_test_server.gRPCTestService', rpc_method_handlers)
     server.add_generic_rpc_handlers((generic_handler,))
 
 
-# This class is part of an EXPERIMENTAL API.
-class gRPCTestService:
+ # This class is part of an EXPERIMENTAL API.
+class gRPCTestService(object):
     """Missing associated documentation comment in .proto file."""
 
     @staticmethod
-    def TestServe(
-        request,
-        target,
-        options=(),
-        channel_credentials=None,
-        call_credentials=None,
-        insecure=False,
-        compression=None,
-        wait_for_ready=None,
-        timeout=None,
-        metadata=None,
-    ):
-        return grpc.experimental.unary_unary(
-            request,
+    def TestServe(request,
             target,
-            "/grpc_test_server.gRPCTestService/TestServe",
+            options=(),
+            channel_credentials=None,
+            call_credentials=None,
+            insecure=False,
+            compression=None,
+            wait_for_ready=None,
+            timeout=None,
+            metadata=None):
+        return grpc.experimental.unary_unary(request, target, '/grpc_test_server.gRPCTestService/TestServe',
             grpc__test__service__pb2.gRPCTestMessage.SerializeToString,
             grpc__test__service__pb2.gRPCTestMessage.FromString,
-            options,
-            channel_credentials,
-            insecure,
-            call_credentials,
-            compression,
-            wait_for_ready,
-            timeout,
-            metadata,
-        )
+            options, channel_credentials,
+            insecure, call_credentials, compression, wait_for_ready, timeout, metadata)
 
     @staticmethod
-    def TestUnaryStream(
-        request,
-        target,
-        options=(),
-        channel_credentials=None,
-        call_credentials=None,
-        insecure=False,
-        compression=None,
-        wait_for_ready=None,
-        timeout=None,
-        metadata=None,
-    ):
-        return grpc.experimental.unary_stream(
-            request,
+    def TestUnaryStream(request,
             target,
-            "/grpc_test_server.gRPCTestService/TestUnaryStream",
+            options=(),
+            channel_credentials=None,
+            call_credentials=None,
+            insecure=False,
+            compression=None,
+            wait_for_ready=None,
+            timeout=None,
+            metadata=None):
+        return grpc.experimental.unary_stream(request, target, '/grpc_test_server.gRPCTestService/TestUnaryStream',
             grpc__test__service__pb2.gRPCTestMessage.SerializeToString,
             grpc__test__service__pb2.gRPCTestMessage.FromString,
-            options,
-            channel_credentials,
-            insecure,
-            call_credentials,
-            compression,
-            wait_for_ready,
-            timeout,
-            metadata,
-        )
+            options, channel_credentials,
+            insecure, call_credentials, compression, wait_for_ready, timeout, metadata)
 
     @staticmethod
-    def TestStreamStream(
-        request_iterator,
-        target,
-        options=(),
-        channel_credentials=None,
-        call_credentials=None,
-        insecure=False,
-        compression=None,
-        wait_for_ready=None,
-        timeout=None,
-        metadata=None,
-    ):
-        return grpc.experimental.stream_stream(
-            request_iterator,
+    def TestStreamStream(request_iterator,
             target,
-            "/grpc_test_server.gRPCTestService/TestStreamStream",
+            options=(),
+            channel_credentials=None,
+            call_credentials=None,
+            insecure=False,
+            compression=None,
+            wait_for_ready=None,
+            timeout=None,
+            metadata=None):
+        return grpc.experimental.stream_stream(request_iterator, target, '/grpc_test_server.gRPCTestService/TestStreamStream',
             grpc__test__service__pb2.gRPCTestMessage.SerializeToString,
             grpc__test__service__pb2.gRPCTestMessage.FromString,
-            options,
-            channel_credentials,
-            insecure,
-            call_credentials,
-            compression,
-            wait_for_ready,
-            timeout,
-            metadata,
-        )
+            options, channel_credentials,
+            insecure, call_credentials, compression, wait_for_ready, timeout, metadata)
 
     @staticmethod
-    def TestStreamUnary(
-        request_iterator,
-        target,
-        options=(),
-        channel_credentials=None,
-        call_credentials=None,
-        insecure=False,
-        compression=None,
-        wait_for_ready=None,
-        timeout=None,
-        metadata=None,
-    ):
-        return grpc.experimental.stream_unary(
-            request_iterator,
+    def TestStreamUnary(request_iterator,
             target,
-            "/grpc_test_server.gRPCTestService/TestStreamUnary",
+            options=(),
+            channel_credentials=None,
+            call_credentials=None,
+            insecure=False,
+            compression=None,
+            wait_for_ready=None,
+            timeout=None,
+            metadata=None):
+        return grpc.experimental.stream_unary(request_iterator, target, '/grpc_test_server.gRPCTestService/TestStreamUnary',
             grpc__test__service__pb2.gRPCTestMessage.SerializeToString,
             grpc__test__service__pb2.gRPCTestMessage.FromString,
-            options,
-            channel_credentials,
-            insecure,
-            call_credentials,
-            compression,
-            wait_for_ready,
-            timeout,
-            metadata,
-        )
+            options, channel_credentials,
+            insecure, call_credentials, compression, wait_for_ready, timeout, metadata)

--- a/tests/integrations/pyramid/test_pyramid.py
+++ b/tests/integrations/pyramid/test_pyramid.py
@@ -366,7 +366,7 @@ def test_error_in_authenticated_userid(
     )
     logger = logging.getLogger("test_pyramid")
 
-    class AuthenticationPolicy(object):
+    class AuthenticationPolicy:
         def authenticated_userid(self, request):
             logger.error("failed to identify user")
 

--- a/tests/integrations/wsgi/test_wsgi.py
+++ b/tests/integrations/wsgi/test_wsgi.py
@@ -23,7 +23,7 @@ def crashing_app():
     return app
 
 
-class IterableApp(object):
+class IterableApp:
     def __init__(self, iterable):
         self.iterable = iterable
 
@@ -31,7 +31,7 @@ class IterableApp(object):
         return self.iterable
 
 
-class ExitingIterable(object):
+class ExitingIterable:
     def __init__(self, exc_func):
         self._exc_func = exc_func
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -903,7 +903,7 @@ def test_object_sends_exception(sentry_init, capture_events):
     sentry_init()
     events = capture_events()
 
-    class C(object):
+    class C:
         def __repr__(self):
             try:
                 1 / 0
@@ -971,7 +971,7 @@ def test_dict_changed_during_iteration(sentry_init, capture_events):
     sentry_init(send_default_pii=True)
     events = capture_events()
 
-    class TooSmartClass(object):
+    class TooSmartClass:
         def __init__(self, environ):
             self.environ = environ
 

--- a/tests/test_conftest.py
+++ b/tests/test_conftest.py
@@ -53,7 +53,7 @@ def test_dictionary_containing(
     ) is expected_result
 
 
-class Animal(object):  # noqa: B903
+class Animal:  # noqa: B903
     def __init__(self, name=None, age=None, description=None):
         self.name = name
         self.age = age


### PR DESCRIPTION
Only new-style classes exist in Python 3. No need to specify they're inheriting from `object` anymore.

Left one occurrence as is in `tests/integrations/grpc/grpc_test_service_pb2_grpc.py` since that's an auto-generated file.

---

## General Notes

Thank you for contributing to `sentry-python`!

Please add tests to validate your changes, and lint your code using `tox -e linters`.

Running the test suite on your PR might require maintainer approval. Some tests (AWS Lambda) additionally require a maintainer to add a special label to run and will fail if the label is not present.

#### For maintainers

Sensitive test suites require maintainer review to ensure that tests do not compromise our secrets. This review must be repeated after any code revisions.

Before running sensitive test suites, please carefully check the PR. Then, apply the `Trigger: tests using secrets` label. The label will be removed after any code changes to enforce our policy requiring maintainers to review all code revisions before running sensitive tests.
