### PR TITLE
Remove Python<=3.5 compatibility code from tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,8 @@ import os
 import socket
 from threading import Thread
 from contextlib import contextmanager
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from unittest import mock
 
 import pytest
 import jsonschema
@@ -16,22 +18,6 @@ try:
     import eventlet
 except ImportError:
     eventlet = None
-
-try:
-    # Python 2
-    import BaseHTTPServer
-
-    HTTPServer = BaseHTTPServer.HTTPServer
-    BaseHTTPRequestHandler = BaseHTTPServer.BaseHTTPRequestHandler
-except Exception:
-    # Python 3
-    from http.server import BaseHTTPRequestHandler, HTTPServer
-
-
-try:
-    from unittest import mock
-except ImportError:
-    import mock
 
 import sentry_sdk
 from sentry_sdk._compat import iteritems, reraise, string_types, PY2

--- a/tests/integrations/aiohttp/test_aiohttp.py
+++ b/tests/integrations/aiohttp/test_aiohttp.py
@@ -1,6 +1,7 @@
 import asyncio
 import json
 from contextlib import suppress
+from unittest import mock
 
 import pytest
 from aiohttp import web
@@ -9,11 +10,6 @@ from aiohttp.web_request import Request
 
 from sentry_sdk import capture_message, start_transaction
 from sentry_sdk.integrations.aiohttp import AioHttpIntegration
-
-try:
-    from unittest import mock  # python 3.3 and above
-except ImportError:
-    import mock  # python < 3.3
 
 
 @pytest.mark.asyncio

--- a/tests/integrations/asgi/test_asgi.py
+++ b/tests/integrations/asgi/test_asgi.py
@@ -1,5 +1,3 @@
-import sys
-
 from collections import Counter
 
 import pytest
@@ -9,11 +7,6 @@ from sentry_sdk.integrations._asgi_common import _get_ip, _get_headers
 from sentry_sdk.integrations.asgi import SentryAsgiMiddleware, _looks_like_asgi3
 
 from async_asgi_testclient import TestClient
-
-
-minimum_python_36 = pytest.mark.skipif(
-    sys.version_info < (3, 6), reason="ASGI is only supported in Python >= 3.6"
-)
 
 
 @pytest.fixture
@@ -133,7 +126,6 @@ def asgi3_ws_app():
     return app
 
 
-@minimum_python_36
 def test_invalid_transaction_style(asgi3_app):
     with pytest.raises(ValueError) as exp:
         SentryAsgiMiddleware(asgi3_app, transaction_style="URL")
@@ -144,7 +136,6 @@ def test_invalid_transaction_style(asgi3_app):
     )
 
 
-@minimum_python_36
 @pytest.mark.asyncio
 async def test_capture_transaction(
     sentry_init,
@@ -176,7 +167,6 @@ async def test_capture_transaction(
     }
 
 
-@minimum_python_36
 @pytest.mark.asyncio
 async def test_capture_transaction_with_error(
     sentry_init,
@@ -214,7 +204,6 @@ async def test_capture_transaction_with_error(
     assert transaction_event["request"] == error_event["request"]
 
 
-@minimum_python_36
 @pytest.mark.asyncio
 async def test_has_trace_if_performance_enabled(
     sentry_init,
@@ -247,7 +236,6 @@ async def test_has_trace_if_performance_enabled(
     )
 
 
-@minimum_python_36
 @pytest.mark.asyncio
 async def test_has_trace_if_performance_disabled(
     sentry_init,
@@ -271,7 +259,6 @@ async def test_has_trace_if_performance_disabled(
     assert "trace_id" in error_event["contexts"]["trace"]
 
 
-@minimum_python_36
 @pytest.mark.asyncio
 async def test_trace_from_headers_if_performance_enabled(
     sentry_init,
@@ -305,7 +292,6 @@ async def test_trace_from_headers_if_performance_enabled(
     assert transaction_event["contexts"]["trace"]["trace_id"] == trace_id
 
 
-@minimum_python_36
 @pytest.mark.asyncio
 async def test_trace_from_headers_if_performance_disabled(
     sentry_init,
@@ -334,7 +320,6 @@ async def test_trace_from_headers_if_performance_disabled(
     assert error_event["contexts"]["trace"]["trace_id"] == trace_id
 
 
-@minimum_python_36
 @pytest.mark.asyncio
 async def test_websocket(sentry_init, asgi3_ws_app, capture_events, request):
     sentry_init(debug=True, send_default_pii=True)
@@ -367,7 +352,6 @@ async def test_websocket(sentry_init, asgi3_ws_app, capture_events, request):
     assert exc["value"] == "Oh no"
 
 
-@minimum_python_36
 @pytest.mark.asyncio
 async def test_auto_session_tracking_with_aggregates(
     sentry_init, asgi3_app, capture_envelopes
@@ -406,7 +390,6 @@ async def test_auto_session_tracking_with_aggregates(
     assert len(session_aggregates) == 1
 
 
-@minimum_python_36
 @pytest.mark.parametrize(
     "url,transaction_style,expected_transaction,expected_source",
     [
@@ -470,7 +453,6 @@ class MockAsgi3App(MockAsgi2App):
         pass
 
 
-@minimum_python_36
 def test_looks_like_asgi3(asgi3_app):
     # branch: inspect.isclass(app)
     assert _looks_like_asgi3(MockAsgi3App)
@@ -487,7 +469,6 @@ def test_looks_like_asgi3(asgi3_app):
     assert not _looks_like_asgi3(asgi2)
 
 
-@minimum_python_36
 def test_get_ip_x_forwarded_for():
     headers = [
         (b"x-forwarded-for", b"8.8.8.8"),
@@ -525,7 +506,6 @@ def test_get_ip_x_forwarded_for():
     assert ip == "5.5.5.5"
 
 
-@minimum_python_36
 def test_get_ip_x_real_ip():
     headers = [
         (b"x-real-ip", b"10.10.10.10"),
@@ -550,7 +530,6 @@ def test_get_ip_x_real_ip():
     assert ip == "8.8.8.8"
 
 
-@minimum_python_36
 def test_get_ip():
     # if now headers are provided the ip is taken from the client.
     headers = []
@@ -584,7 +563,6 @@ def test_get_ip():
     assert ip == "10.10.10.10"
 
 
-@minimum_python_36
 def test_get_headers():
     headers = [
         (b"x-real-ip", b"10.10.10.10"),
@@ -602,7 +580,6 @@ def test_get_headers():
     }
 
 
-@minimum_python_36
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
     "request_url,transaction_style,expected_transaction_name,expected_transaction_source",
@@ -654,7 +631,6 @@ async def test_transaction_name(
     )
 
 
-@minimum_python_36
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
     "request_url, transaction_style,expected_transaction_name,expected_transaction_source",

--- a/tests/integrations/asyncio/test_asyncio_py3.py
+++ b/tests/integrations/asyncio/test_asyncio_py3.py
@@ -1,17 +1,13 @@
 import asyncio
 import inspect
 import sys
+from unittest.mock import MagicMock, patch
 
 import pytest
 
 import sentry_sdk
 from sentry_sdk.consts import OP
 from sentry_sdk.integrations.asyncio import AsyncioIntegration, patch_asyncio
-
-try:
-    from unittest.mock import MagicMock, patch
-except ImportError:
-    from mock import MagicMock, patch
 
 try:
     from contextvars import Context, ContextVar

--- a/tests/integrations/aws_lambda/test_aws.py
+++ b/tests/integrations/aws_lambda/test_aws.py
@@ -600,10 +600,7 @@ def test_traces_sampler_gets_correct_values_in_sampling_context(
         + dedent(inspect.getsource(ObjectDescribedBy))
         + dedent(
             """
-            try:
-                from unittest import mock  # python 3.3 and above
-            except ImportError:
-                import mock  # python < 3.3
+            from unittest import mock
 
             def _safe_is_equal(x, y):
                 # copied from conftest.py - see docstring and comments there

--- a/tests/integrations/boto3/test_s3.py
+++ b/tests/integrations/boto3/test_s3.py
@@ -1,16 +1,12 @@
-import pytest
+from unittest import mock
 
 import boto3
+import pytest
 
 from sentry_sdk import Hub
 from sentry_sdk.integrations.boto3 import Boto3Integration
-from tests.integrations.boto3.aws_mock import MockResponse
 from tests.integrations.boto3 import read_fixture
-
-try:
-    from unittest import mock  # python 3.3 and above
-except ImportError:
-    import mock  # python < 3.3
+from tests.integrations.boto3.aws_mock import MockResponse
 
 
 session = boto3.Session(

--- a/tests/integrations/celery/test_celery.py
+++ b/tests/integrations/celery/test_celery.py
@@ -1,6 +1,9 @@
 import threading
+from unittest import mock
 
 import pytest
+from celery import Celery, VERSION
+from celery.bin import worker
 
 from sentry_sdk import Hub, configure_scope, start_transaction, get_current_span
 from sentry_sdk.integrations.celery import (
@@ -10,14 +13,6 @@ from sentry_sdk.integrations.celery import (
 )
 
 from sentry_sdk._compat import text_type
-
-from celery import Celery, VERSION
-from celery.bin import worker
-
-try:
-    from unittest import mock  # python 3.3 and above
-except ImportError:
-    import mock  # python < 3.3
 
 
 @pytest.fixture

--- a/tests/integrations/celery/test_celery_beat_crons.py
+++ b/tests/integrations/celery/test_celery_beat_crons.py
@@ -1,8 +1,11 @@
 import datetime
-import sys
+from unittest import mock
+from unittest.mock import MagicMock
 
 import pytest
+from celery.schedules import crontab, schedule
 
+from sentry_sdk.crons import MonitorStatus
 from sentry_sdk.integrations.celery import (
     _get_headers,
     _get_humanized_interval,
@@ -12,15 +15,6 @@ from sentry_sdk.integrations.celery import (
     crons_task_failure,
     crons_task_retry,
 )
-from sentry_sdk.crons import MonitorStatus
-from celery.schedules import crontab, schedule
-
-try:
-    from unittest import mock  # python 3.3 and above
-    from unittest.mock import MagicMock
-except ImportError:
-    import mock  # python < 3.3
-    from mock import MagicMock
 
 
 def test_get_headers():
@@ -378,10 +372,6 @@ def test_get_monitor_config_timezone_in_app_conf():
     assert monitor_config["timezone"] == "Asia/Karachi"
 
 
-@pytest.mark.skipif(
-    sys.version_info < (3, 0),
-    reason="no datetime.timezone for Python 2, so skipping this test.",
-)
 def test_get_monitor_config_timezone_in_celery_schedule():
     app = MagicMock()
     app.timezone = "Asia/Karachi"

--- a/tests/integrations/cloud_resource_context/test_cloud_resource_context.py
+++ b/tests/integrations/cloud_resource_context/test_cloud_resource_context.py
@@ -1,13 +1,8 @@
 import json
+from unittest import mock  # python 3.3 and above
+from unittest.mock import MagicMock
 
 import pytest
-
-try:
-    from unittest import mock  # python 3.3 and above
-    from unittest.mock import MagicMock
-except ImportError:
-    import mock  # python < 3.3
-    from mock import MagicMock
 
 from sentry_sdk.integrations.cloud_resource_context import (
     CLOUD_PLATFORM,

--- a/tests/integrations/django/asgi/test_asgi.py
+++ b/tests/integrations/django/asgi/test_asgi.py
@@ -1,6 +1,7 @@
 import base64
 import json
 import os
+from unittest import mock
 
 import django
 import pytest
@@ -14,10 +15,6 @@ try:
 except ImportError:
     from django.core.urlresolvers import reverse
 
-try:
-    from unittest import mock  # python 3.3 and above
-except ImportError:
-    import mock  # python < 3.3
 
 APPS = [channels_application]
 if django.VERSION >= (3, 0):

--- a/tests/integrations/django/test_transactions.py
+++ b/tests/integrations/django/test_transactions.py
@@ -1,12 +1,8 @@
 from __future__ import absolute_import
+from unittest import mock
 
 import pytest
 import django
-
-try:
-    from unittest import mock  # python 3.3 and above
-except ImportError:
-    import mock  # python < 3.3
 
 
 # django<2.0 has only `url` with regex based patterns.

--- a/tests/integrations/fastapi/test_fastapi.py
+++ b/tests/integrations/fastapi/test_fastapi.py
@@ -1,21 +1,17 @@
 import json
 import logging
 import threading
+from unittest import mock
 
 import pytest
-from sentry_sdk.integrations.fastapi import FastApiIntegration
-
 from fastapi import FastAPI, Request
 from fastapi.testclient import TestClient
 from fastapi.middleware.trustedhost import TrustedHostMiddleware
-from sentry_sdk import capture_message
-from sentry_sdk.integrations.starlette import StarletteIntegration
-from sentry_sdk.integrations.asgi import SentryAsgiMiddleware
 
-try:
-    from unittest import mock  # python 3.3 and above
-except ImportError:
-    import mock  # python < 3.3
+from sentry_sdk import capture_message
+from sentry_sdk.integrations.asgi import SentryAsgiMiddleware
+from sentry_sdk.integrations.fastapi import FastApiIntegration
+from sentry_sdk.integrations.starlette import StarletteIntegration
 
 
 def fastapi_app_factory():

--- a/tests/integrations/gcp/test_gcp.py
+++ b/tests/integrations/gcp/test_gcp.py
@@ -12,10 +12,6 @@ import pytest
 import os.path
 import os
 
-pytestmark = pytest.mark.skipif(
-    not hasattr(tempfile, "TemporaryDirectory"), reason="need Python 3.2+"
-)
-
 
 FUNCTIONS_PRELUDE = """
 from unittest.mock import Mock

--- a/tests/integrations/httpx/test_httpx.py
+++ b/tests/integrations/httpx/test_httpx.py
@@ -1,17 +1,13 @@
 import asyncio
+from unittest import mock
 
-import pytest
 import httpx
+import pytest
 import responses
 
 from sentry_sdk import capture_message, start_transaction
 from sentry_sdk.consts import MATCH_ALL, SPANDATA
 from sentry_sdk.integrations.httpx import HttpxIntegration
-
-try:
-    from unittest import mock  # python 3.3 and above
-except ImportError:
-    import mock  # python < 3.3
 
 
 @pytest.mark.parametrize(

--- a/tests/integrations/logging/test_logging.py
+++ b/tests/integrations/logging/test_logging.py
@@ -1,8 +1,7 @@
-import sys
-
-import pytest
 import logging
 import warnings
+
+import pytest
 
 from sentry_sdk.integrations.logging import LoggingIntegration, ignore_logger
 
@@ -78,7 +77,6 @@ def test_logging_extra_data_integer_keys(sentry_init, capture_events):
     assert event["extra"] == {"1": 1}
 
 
-@pytest.mark.xfail(sys.version_info[:2] == (3, 4), reason="buggy logging module")
 def test_logging_stack(sentry_init, capture_events):
     sentry_init(integrations=[LoggingIntegration()], default_integrations=False)
     events = capture_events()

--- a/tests/integrations/opentelemetry/test_experimental.py
+++ b/tests/integrations/opentelemetry/test_experimental.py
@@ -1,9 +1,4 @@
-try:
-    # python 3.3 and above
-    from unittest.mock import MagicMock
-except ImportError:
-    # python < 3.3
-    from mock import MagicMock
+from unittest.mock import MagicMock
 
 from sentry_sdk.integrations.opentelemetry.integration import OpenTelemetryIntegration
 

--- a/tests/integrations/opentelemetry/test_propagator.py
+++ b/tests/integrations/opentelemetry/test_propagator.py
@@ -1,9 +1,5 @@
-try:
-    from unittest import mock  # python 3.3 and above
-    from unittest.mock import MagicMock
-except ImportError:
-    import mock  # python < 3.3
-    from mock import MagicMock
+from unittest import mock
+from unittest.mock import MagicMock
 
 from opentelemetry.context import get_current
 from opentelemetry.trace.propagation import get_current_span
@@ -16,7 +12,6 @@ from sentry_sdk.integrations.opentelemetry.consts import (
     SENTRY_BAGGAGE_KEY,
     SENTRY_TRACE_KEY,
 )
-
 from sentry_sdk.integrations.opentelemetry.propagator import SentryPropagator
 from sentry_sdk.integrations.opentelemetry.span_processor import SentrySpanProcessor
 from sentry_sdk.tracing_utils import Baggage

--- a/tests/integrations/opentelemetry/test_span_processor.py
+++ b/tests/integrations/opentelemetry/test_span_processor.py
@@ -1,21 +1,16 @@
-from datetime import datetime
 import time
-import pytest
+from datetime import datetime
+from unittest import mock
+from unittest.mock import MagicMock
 
-try:
-    from unittest import mock  # python 3.3 and above
-    from unittest.mock import MagicMock
-except ImportError:
-    import mock
-    from mock import MagicMock  # python < 3.3
+import pytest
+from opentelemetry.trace import SpanKind, SpanContext, Status, StatusCode
 
 from sentry_sdk.integrations.opentelemetry.span_processor import (
     SentrySpanProcessor,
     link_trace_context_to_error_event,
 )
 from sentry_sdk.tracing import Span, Transaction
-
-from opentelemetry.trace import SpanKind, SpanContext, Status, StatusCode
 from sentry_sdk.tracing_utils import extract_sentrytrace_data
 
 

--- a/tests/integrations/pure_eval/test_pure_eval.py
+++ b/tests/integrations/pure_eval/test_pure_eval.py
@@ -1,4 +1,3 @@
-import sys
 from types import SimpleNamespace
 
 import pytest
@@ -64,10 +63,7 @@ def test_include_local_variables_enabled(sentry_init, capture_events, integratio
             "u",
             "y",
         ]
-        if sys.version_info[:2] == (3, 5):
-            assert frame_vars.keys() == set(expected_keys)
-        else:
-            assert list(frame_vars.keys()) == expected_keys
+        assert list(frame_vars.keys()) == expected_keys
         assert frame_vars["namespace.d"] == {"1": "2"}
         assert frame_vars["namespace.d[1]"] == "2"
     else:

--- a/tests/integrations/redis/test_redis.py
+++ b/tests/integrations/redis/test_redis.py
@@ -1,15 +1,11 @@
+from unittest import mock
+
 import pytest
+from fakeredis import FakeStrictRedis
 
 from sentry_sdk import capture_message, start_transaction
 from sentry_sdk.consts import SPANDATA
 from sentry_sdk.integrations.redis import RedisIntegration
-
-from fakeredis import FakeStrictRedis
-
-try:
-    from unittest import mock  # python 3.3 and above
-except ImportError:
-    import mock  # python < 3.3
 
 
 MOCK_CONNECTION_POOL = mock.MagicMock()

--- a/tests/integrations/requests/test_requests.py
+++ b/tests/integrations/requests/test_requests.py
@@ -1,16 +1,12 @@
-import requests
-import responses
+from unittest import mock
 
 import pytest
+import requests
+import responses
 
 from sentry_sdk import capture_message
 from sentry_sdk.consts import SPANDATA
 from sentry_sdk.integrations.stdlib import StdlibIntegration
-
-try:
-    from unittest import mock  # python 3.3 and above
-except ImportError:
-    import mock  # python < 3.3
 
 
 def test_crumb_capture(sentry_init, capture_events):

--- a/tests/integrations/rq/test_rq.py
+++ b/tests/integrations/rq/test_rq.py
@@ -1,15 +1,12 @@
+from unittest import mock
+
 import pytest
+import rq
 from fakeredis import FakeStrictRedis
+
 from sentry_sdk import configure_scope, start_transaction
 from sentry_sdk.integrations.rq import RqIntegration
 from sentry_sdk.utils import parse_version
-
-import rq
-
-try:
-    from unittest import mock  # python 3.3 and above
-except ImportError:
-    import mock  # python < 3.3
 
 
 @pytest.fixture(autouse=True)

--- a/tests/integrations/sqlalchemy/test_sqlalchemy.py
+++ b/tests/integrations/sqlalchemy/test_sqlalchemy.py
@@ -1,4 +1,3 @@
-import sys
 import pytest
 
 from sqlalchemy import Column, ForeignKey, Integer, String, create_engine
@@ -72,9 +71,6 @@ def test_orm_queries(sentry_init, capture_events):
     ]
 
 
-@pytest.mark.skipif(
-    sys.version_info < (3,), reason="This sqla usage seems to be broken on Py2"
-)
 def test_transactions(sentry_init, capture_events, render_span_tree):
     sentry_init(
         integrations=[SqlalchemyIntegration()],

--- a/tests/integrations/starlette/test_starlette.py
+++ b/tests/integrations/starlette/test_starlette.py
@@ -6,23 +6,17 @@ import logging
 import os
 import re
 import threading
+from unittest import mock
 
 import pytest
 
-from sentry_sdk import last_event_id, capture_exception
+from sentry_sdk import last_event_id, capture_exception, capture_message
 from sentry_sdk.integrations.asgi import SentryAsgiMiddleware
-from sentry_sdk.utils import parse_version
-
-try:
-    from unittest import mock  # python 3.3 and above
-except ImportError:
-    import mock  # python < 3.3
-
-from sentry_sdk import capture_message
 from sentry_sdk.integrations.starlette import (
     StarletteIntegration,
     StarletteRequestExtractor,
 )
+from sentry_sdk.utils import parse_version
 
 import starlette
 from starlette.authentication import (

--- a/tests/integrations/stdlib/test_httplib.py
+++ b/tests/integrations/stdlib/test_httplib.py
@@ -1,26 +1,9 @@
 import random
+from http.client import HTTPConnection, HTTPSConnection
+from urllib.request import urlopen
+from unittest import mock
 
 import pytest
-
-try:
-    # py3
-    from urllib.request import urlopen
-except ImportError:
-    # py2
-    from urllib import urlopen
-
-try:
-    # py2
-    from httplib import HTTPConnection, HTTPSConnection
-except ImportError:
-    # py3
-    from http.client import HTTPConnection, HTTPSConnection
-
-try:
-    from unittest import mock  # python 3.3 and above
-except ImportError:
-    import mock  # python < 3.3
-
 
 from sentry_sdk import capture_message, start_transaction
 from sentry_sdk.consts import MATCH_ALL, SPANDATA

--- a/tests/integrations/wsgi/test_wsgi.py
+++ b/tests/integrations/wsgi/test_wsgi.py
@@ -1,4 +1,3 @@
-import sys
 from collections import Counter
 from unittest import mock
 
@@ -413,9 +412,6 @@ def test_auto_session_tracking_with_aggregates(sentry_init, capture_envelopes):
     assert len(session_aggregates) == 1
 
 
-@pytest.mark.skipif(
-    sys.version_info < (3, 3), reason="Profiling is only supported in Python >= 3.3"
-)
 @mock.patch("sentry_sdk.profiler.PROFILE_MINIMUM_SAMPLES", 0)
 def test_profile_sent(
     sentry_init,

--- a/tests/integrations/wsgi/test_wsgi.py
+++ b/tests/integrations/wsgi/test_wsgi.py
@@ -1,18 +1,13 @@
 import sys
-
-from werkzeug.test import Client
+from collections import Counter
+from unittest import mock
 
 import pytest
+from werkzeug.test import Client
 
 import sentry_sdk
 from sentry_sdk import capture_message
 from sentry_sdk.integrations.wsgi import SentryWsgiMiddleware
-from collections import Counter
-
-try:
-    from unittest import mock  # python 3.3 and above
-except ImportError:
-    import mock  # python < 3.3
 
 
 @pytest.fixture

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,3 +1,5 @@
+from unittest import mock
+
 from sentry_sdk import (
     configure_scope,
     continue_trace,
@@ -7,11 +9,6 @@ from sentry_sdk import (
     start_transaction,
 )
 from sentry_sdk.hub import Hub
-
-try:
-    from unittest import mock  # python 3.3 and above
-except ImportError:
-    import mock  # python < 3.3
 
 
 def test_get_current_span():

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,11 +1,13 @@
 import os
 import json
-import pytest
 import subprocess
 import sys
 import time
-
 from textwrap import dedent
+from unittest import mock
+
+import pytest
+
 from sentry_sdk import (
     Hub,
     Client,
@@ -20,7 +22,6 @@ from sentry_sdk import (
 from sentry_sdk.integrations.executing import ExecutingIntegration
 from sentry_sdk.transport import Transport
 from sentry_sdk._compat import reraise, text_type, PY2
-from sentry_sdk.utils import HAS_CHAINED_EXCEPTIONS
 from sentry_sdk.utils import logger
 from sentry_sdk.serializer import MAX_DATABAG_BREADTH
 from sentry_sdk.consts import DEFAULT_MAX_BREADCRUMBS, DEFAULT_MAX_VALUE_LENGTH
@@ -30,11 +31,6 @@ if TYPE_CHECKING:
     from collections.abc import Callable
     from typing import Any, Optional, Union
     from sentry_sdk._types import Event
-
-try:
-    from unittest import mock  # python 3.3 and above
-except ImportError:
-    import mock  # python < 3.3
 
 if PY2:
     # Importing ABCs from collections is deprecated, and will stop working in 3.8
@@ -807,7 +803,6 @@ def test_databag_breadth_stripping(sentry_init, capture_events, benchmark):
         assert len(json.dumps(event)) < 10000
 
 
-@pytest.mark.skipif(not HAS_CHAINED_EXCEPTIONS, reason="Only works on 3.3+")
 def test_chained_exceptions(sentry_init, capture_events):
     sentry_init()
     events = capture_events()

--- a/tests/test_crons.py
+++ b/tests/test_crons.py
@@ -1,15 +1,10 @@
 import pytest
 import uuid
+from unittest import mock
 
 import sentry_sdk
-from sentry_sdk.crons import capture_checkin
-
 from sentry_sdk import Hub, configure_scope, set_level
-
-try:
-    from unittest import mock  # python 3.3 and above
-except ImportError:
-    import mock  # python < 3.3
+from sentry_sdk.crons import capture_checkin
 
 
 @sentry_sdk.monitor(monitor_slug="abc123")

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,15 +1,11 @@
 import sys
 import time
 import linecache
+from unittest import mock
 
 from sentry_sdk import Hub, metrics, push_scope, start_transaction
 from sentry_sdk.tracing import TRANSACTION_SOURCE_ROUTE
 from sentry_sdk.envelope import parse_json
-
-try:
-    from unittest import mock  # python 3.3 and above
-except ImportError:
-    import mock  # python < 3.3
 
 
 def parse_metrics(bytes):

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -1,12 +1,8 @@
 import random
+from unittest import mock
 
 from sentry_sdk import Hub, start_transaction
 from sentry_sdk.transport import Transport
-
-try:
-    from unittest import mock  # python 3.3 and above
-except ImportError:
-    import mock  # python < 3.3
 
 
 class HealthyTestTransport(Transport):

--- a/tests/test_profiler.py
+++ b/tests/test_profiler.py
@@ -3,10 +3,11 @@ import os
 import sys
 import threading
 import time
+from collections import defaultdict
+from unittest import mock
 
 import pytest
 
-from collections import defaultdict
 from sentry_sdk import start_transaction
 from sentry_sdk.profiler import (
     GeventScheduler,
@@ -25,20 +26,9 @@ from sentry_sdk._lru_cache import LRUCache
 from sentry_sdk._queue import Queue
 
 try:
-    from unittest import mock  # python 3.3 and above
-except ImportError:
-    import mock  # python < 3.3
-
-try:
     import gevent
 except ImportError:
     gevent = None
-
-
-def requires_python_version(major, minor, reason=None):
-    if reason is None:
-        reason = "Requires Python {}.{}".format(major, minor)
-    return pytest.mark.skipif(sys.version_info < (major, minor), reason=reason)
 
 
 requires_gevent = pytest.mark.skipif(gevent is None, reason="gevent not enabled")
@@ -59,7 +49,6 @@ def experimental_options(mode=None, sample_rate=None):
     }
 
 
-@requires_python_version(3, 3)
 @pytest.mark.parametrize(
     "mode",
     [
@@ -82,7 +71,6 @@ def test_profiler_invalid_mode(mode, make_options, teardown_profiling):
         setup_profiler(make_options(mode))
 
 
-@requires_python_version(3, 3)
 @pytest.mark.parametrize(
     "mode",
     [
@@ -103,7 +91,6 @@ def test_profiler_valid_mode(mode, make_options, teardown_profiling):
     setup_profiler(make_options(mode))
 
 
-@requires_python_version(3, 3)
 @pytest.mark.parametrize(
     "make_options",
     [
@@ -118,7 +105,6 @@ def test_profiler_setup_twice(make_options, teardown_profiling):
     assert not setup_profiler(make_options())
 
 
-@requires_python_version(3, 3)
 @pytest.mark.parametrize(
     "mode",
     [
@@ -184,7 +170,6 @@ def test_profiles_sample_rate(
         assert reports == [("sample_rate", "profile")]
 
 
-@requires_python_version(3, 3)
 @pytest.mark.parametrize(
     "mode",
     [
@@ -252,7 +237,6 @@ def test_profiles_sampler(
         assert reports == [("sample_rate", "profile")]
 
 
-@requires_python_version(3, 3)
 def test_minimum_unique_samples_required(
     sentry_init,
     capture_envelopes,
@@ -282,7 +266,6 @@ def test_minimum_unique_samples_required(
     assert reports == [("insufficient_data", "profile")]
 
 
-@requires_python_version(3, 3)
 def test_profile_captured(
     sentry_init,
     capture_envelopes,
@@ -372,7 +355,6 @@ class GetFrame(GetFrameBase):
         return inspect.currentframe()
 
 
-@requires_python_version(3, 3)
 @pytest.mark.parametrize(
     ("frame", "frame_name"),
     [
@@ -452,7 +434,6 @@ def test_get_frame_name(frame, frame_name):
     assert get_frame_name(frame) == frame_name
 
 
-@requires_python_version(3, 3)
 @pytest.mark.parametrize(
     ("get_frame", "function"),
     [
@@ -480,7 +461,6 @@ def test_extract_frame(get_frame, function):
     assert isinstance(extracted_frame["lineno"], int)
 
 
-@requires_python_version(3, 3)
 @pytest.mark.parametrize(
     ("depth", "max_stack_depth", "actual_depth"),
     [
@@ -522,7 +502,6 @@ def test_extract_stack_with_max_depth(depth, max_stack_depth, actual_depth):
         assert frames[actual_depth]["function"] == "<lambda>", actual_depth
 
 
-@requires_python_version(3, 3)
 @pytest.mark.parametrize(
     ("frame", "depth"),
     [(get_frame(depth=1), len(inspect.stack()))],
@@ -545,7 +524,6 @@ def test_extract_stack_with_cache(frame, depth):
         assert frame1 is frame2, i
 
 
-@requires_python_version(3, 3)
 def test_get_current_thread_id_explicit_thread():
     results = Queue(maxsize=1)
 
@@ -567,7 +545,6 @@ def test_get_current_thread_id_explicit_thread():
     assert thread1.ident == results.get(timeout=1)
 
 
-@requires_python_version(3, 3)
 @requires_gevent
 def test_get_current_thread_id_gevent_in_thread():
     results = Queue(maxsize=1)
@@ -583,7 +560,6 @@ def test_get_current_thread_id_gevent_in_thread():
     assert thread.ident == results.get(timeout=1)
 
 
-@requires_python_version(3, 3)
 def test_get_current_thread_id_running_thread():
     results = Queue(maxsize=1)
 
@@ -596,7 +572,6 @@ def test_get_current_thread_id_running_thread():
     assert thread.ident == results.get(timeout=1)
 
 
-@requires_python_version(3, 3)
 def test_get_current_thread_id_main_thread():
     results = Queue(maxsize=1)
 
@@ -617,7 +592,6 @@ def get_scheduler_threads(scheduler):
     return [thread for thread in threading.enumerate() if thread.name == scheduler.name]
 
 
-@requires_python_version(3, 3)
 @pytest.mark.parametrize(
     ("scheduler_class",),
     [
@@ -661,7 +635,6 @@ def test_thread_scheduler_single_background_thread(scheduler_class):
     assert len(get_scheduler_threads(scheduler)) == 0
 
 
-@requires_python_version(3, 3)
 @pytest.mark.parametrize(
     ("scheduler_class",),
     [
@@ -706,7 +679,6 @@ def test_thread_scheduler_no_thread_on_shutdown(scheduler_class):
     assert len(get_scheduler_threads(scheduler)) == 0
 
 
-@requires_python_version(3, 3)
 @pytest.mark.parametrize(
     ("scheduler_class",),
     [
@@ -784,7 +756,6 @@ sample_stacks = [
 ]
 
 
-@requires_python_version(3, 3)
 @pytest.mark.parametrize(
     ("samples", "expected"),
     [

--- a/tests/test_profiler.py
+++ b/tests/test_profiler.py
@@ -580,7 +580,7 @@ def test_get_current_thread_id_main_thread():
         with mock.patch("threading.current_thread", side_effect=[None]):
             results.put(get_current_thread_id())
 
-    thread_id = threading.main_thread().ident if sys.version_info >= (3, 4) else None
+    thread_id = threading.main_thread().ident
 
     thread = threading.Thread(target=target)
     thread.start()

--- a/tests/test_scope.py
+++ b/tests/test_scope.py
@@ -1,13 +1,10 @@
 import copy
 import os
 import pytest
+from unittest import mock
+
 from sentry_sdk import capture_exception
 from sentry_sdk.scope import Scope
-
-try:
-    from unittest import mock  # python 3.3 and above
-except ImportError:
-    import mock  # python < 3.3
 
 
 def test_copying():

--- a/tests/test_serializer.py
+++ b/tests/test_serializer.py
@@ -1,5 +1,5 @@
 import re
-import sys
+
 import pytest
 
 from sentry_sdk.serializer import MAX_DATABAG_BREADTH, MAX_DATABAG_DEPTH, serialize
@@ -64,7 +64,6 @@ def test_bytes_serialization_decode(message_normalizer):
     assert result == "abc123\ufffd\U0001f355"
 
 
-@pytest.mark.xfail(sys.version_info < (3,), reason="Known safe_repr bugs in Py2.7")
 def test_bytes_serialization_repr(message_normalizer):
     binary = b"abc123\x80\xf0\x9f\x8d\x95"
     result = message_normalizer(binary, should_repr_strings=True)
@@ -77,7 +76,6 @@ def test_bytearray_serialization_decode(message_normalizer):
     assert result == "abc123\ufffd\U0001f355"
 
 
-@pytest.mark.xfail(sys.version_info < (3,), reason="Known safe_repr bugs in Py2.7")
 def test_bytearray_serialization_repr(message_normalizer):
     binary = bytearray(b"abc123\x80\xf0\x9f\x8d\x95")
     result = message_normalizer(binary, should_repr_strings=True)

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -1,12 +1,8 @@
-import sentry_sdk
+from unittest import mock
 
+import sentry_sdk
 from sentry_sdk import Hub
 from sentry_sdk.sessions import auto_session_tracking
-
-try:
-    from unittest import mock  # python 3.3 and above
-except ImportError:
-    import mock  # python < 3.3
 
 
 def sorted_aggregates(item):

--- a/tests/test_transport.py
+++ b/tests/test_transport.py
@@ -2,14 +2,13 @@ import logging
 import pickle
 import gzip
 import io
-
+from collections import namedtuple
 from datetime import datetime, timedelta
+from unittest import mock
 
 import pytest
-from collections import namedtuple
-from werkzeug.wrappers import Request, Response
-
 from pytest_localserver.http import WSGIServer
+from werkzeug.wrappers import Request, Response
 
 from sentry_sdk import Hub, Client, add_breadcrumb, capture_message, Scope
 from sentry_sdk._compat import datetime_utcnow
@@ -17,10 +16,6 @@ from sentry_sdk.transport import _parse_rate_limits
 from sentry_sdk.envelope import Envelope, parse_json
 from sentry_sdk.integrations.logging import LoggingIntegration
 
-try:
-    from unittest import mock  # python 3.3 and above
-except ImportError:
-    import mock  # python < 3.3
 
 CapturedData = namedtuple("CapturedData", ["path", "event", "envelope", "compressed"])
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,7 +1,9 @@
 import pytest
 import re
 import sys
+from unittest import mock
 
+import sentry_sdk
 from sentry_sdk.utils import (
     Components,
     Dsn,
@@ -19,20 +21,6 @@ from sentry_sdk.utils import (
     is_sentry_url,
     _get_installed_modules,
 )
-
-import sentry_sdk
-
-try:
-    from unittest import mock  # python 3.3 and above
-except ImportError:
-    import mock  # python < 3.3
-
-try:
-    # Python 3
-    FileNotFoundError
-except NameError:
-    # Python 2
-    FileNotFoundError = IOError
 
 
 def _normalize_distribution_name(name):

--- a/tests/tracing/test_decorator_async_py3.py
+++ b/tests/tracing/test_decorator_async_py3.py
@@ -1,6 +1,6 @@
 from unittest import mock
+
 import pytest
-import sys
 
 from tests.conftest import patch_start_tracing_child
 
@@ -8,9 +8,6 @@ from sentry_sdk.tracing_utils_py3 import (
     start_child_span_decorator as start_child_span_decorator_py3,
 )
 from sentry_sdk.utils import logger
-
-if sys.version_info < (3, 6):
-    pytest.skip("Async decorator only works on Python 3.6+", allow_module_level=True)
 
 
 async def my_async_example_function():

--- a/tests/tracing/test_decorator_sync.py
+++ b/tests/tracing/test_decorator_sync.py
@@ -1,3 +1,5 @@
+from unittest import mock
+
 from sentry_sdk._compat import PY2
 
 if PY2:
@@ -8,11 +10,6 @@ else:
 from sentry_sdk.utils import logger
 
 from tests.conftest import patch_start_tracing_child
-
-try:
-    from unittest import mock  # python 3.3 and above
-except ImportError:
-    import mock  # python < 3.3
 
 
 def my_example_function():

--- a/tests/tracing/test_http_headers.py
+++ b/tests/tracing/test_http_headers.py
@@ -1,13 +1,9 @@
+from unittest import mock
+
 import pytest
 
 from sentry_sdk.tracing import Transaction
 from sentry_sdk.tracing_utils import extract_sentrytrace_data
-
-
-try:
-    from unittest import mock  # python 3.3 and above
-except ImportError:
-    import mock  # python < 3.3
 
 
 @pytest.mark.parametrize("sampled", [True, False, None])

--- a/tests/tracing/test_misc.py
+++ b/tests/tracing/test_misc.py
@@ -2,6 +2,8 @@ import pytest
 import gc
 import uuid
 import os
+from unittest import mock
+from unittest.mock import MagicMock
 
 import sentry_sdk
 from sentry_sdk import Hub, start_span, start_transaction, set_measurement, push_scope
@@ -9,13 +11,6 @@ from sentry_sdk.consts import MATCH_ALL
 from sentry_sdk.tracing import Span, Transaction
 from sentry_sdk.tracing_utils import should_propagate_trace
 from sentry_sdk.utils import Dsn
-
-try:
-    from unittest import mock  # python 3.3 and above
-    from unittest.mock import MagicMock
-except ImportError:
-    import mock  # python < 3.3
-    from mock import MagicMock
 
 
 def test_span_trimming(sentry_init, capture_events):

--- a/tests/tracing/test_sampling.py
+++ b/tests/tracing/test_sampling.py
@@ -1,15 +1,11 @@
 import random
+from unittest import mock
 
 import pytest
 
 from sentry_sdk import Hub, start_span, start_transaction, capture_exception
 from sentry_sdk.tracing import Transaction
 from sentry_sdk.utils import logger
-
-try:
-    from unittest import mock  # python 3.3 and above
-except ImportError:
-    import mock  # python < 3.3
 
 
 def test_sampling_decided_only_for_transactions(sentry_init, capture_events):

--- a/tests/utils/test_general.py
+++ b/tests/utils/test_general.py
@@ -39,10 +39,6 @@ def test_safe_repr_regressions():
     assert "лошадь" in safe_repr("лошадь")
 
 
-@pytest.mark.xfail(
-    sys.version_info < (3,),
-    reason="Fixing this in Python 2 would break other behaviors",
-)
 @pytest.mark.parametrize("prefix", ("", "abcd", "лошадь"))
 @pytest.mark.parametrize("character", "\x00\x07\x1b\n")
 def test_safe_repr_non_printable(prefix, character):

--- a/tests/utils/test_transaction.py
+++ b/tests/utils/test_transaction.py
@@ -1,14 +1,6 @@
-import sys
-from functools import partial
-
-import pytest
+from functools import partial, partialmethod
 
 from sentry_sdk.utils import transaction_from_function
-
-try:
-    from functools import partialmethod
-except ImportError:
-    pass
 
 
 class MyClass:
@@ -48,7 +40,6 @@ def test_transaction_from_function():
     )
 
 
-@pytest.mark.skipif(sys.version_info < (3, 4), reason="Require python 3.4 or higher")
 def test_transaction_from_function_partialmethod():
     x = transaction_from_function
 


### PR DESCRIPTION
- remove py<=3.5 specific imports
- remove test markers for skipping/xfailing tests on py<=3.5

---

## General Notes

Thank you for contributing to `sentry-python`!

Please add tests to validate your changes, and lint your code using `tox -e linters`.

Running the test suite on your PR might require maintainer approval. Some tests (AWS Lambda) additionally require a maintainer to add a special label to run and will fail if the label is not present.

#### For maintainers

Sensitive test suites require maintainer review to ensure that tests do not compromise our secrets. This review must be repeated after any code revisions.

Before running sensitive test suites, please carefully check the PR. Then, apply the `Trigger: tests using secrets` label. The label will be removed after any code changes to enforce our policy requiring maintainers to review all code revisions before running sensitive tests.
