### PR TITLE
fix(utils): Fix `UnicodeDecodeError` on Python 2

### DIFF
--- a/sentry_sdk/utils.py
+++ b/sentry_sdk/utils.py
@@ -388,9 +388,6 @@ class AnnotatedValue(object):
 
         return self.value == other.value and self.metadata == other.metadata
 
-    def __repr__(self):
-        return self.value
-
     @classmethod
     def removed_because_raw_data(cls):
         # type: () -> AnnotatedValue
@@ -1128,18 +1125,26 @@ def _is_in_project_root(abs_path, project_root):
 
 
 def _truncate_by_bytes(string, max_bytes):
-    # type: (Union[str, bytes], int) -> str
+    # type: (str, int) -> str
     """
     Truncate a UTF-8-encodable string to the last full codepoint so that it fits in max_bytes.
     """
-    truncated = string.encode("utf-8")[: max_bytes - 3].decode("utf-8", errors="ignore")
+    # This function technically supports bytes, but only for Python 2 compat.
+    # XXX remove support for bytes when we drop Python 2
+    if isinstance(string, bytes):
+        truncated = string[: max_bytes - 3]
+    else:
+        truncated = string.encode("utf-8")[: max_bytes - 3].decode(
+            "utf-8", errors="ignore"
+        )
+
     return truncated + "..."
 
 
 def _get_size_in_bytes(value):
-    # type: (Union[str, bytes]) -> Optional[int]
-    # XXX: broken 'unicodehere' py2 -- can't be encoded
-    # XXX remove repr
+    # type: (str) -> Optional[int]
+    # This function technically supports bytes, but only for Python 2 compat.
+    # XXX remove support for bytes when we drop Python 2
     if not isinstance(value, (bytes, text_type)):
         return None
 

--- a/sentry_sdk/utils.py
+++ b/sentry_sdk/utils.py
@@ -1126,7 +1126,13 @@ def strip_string(value, max_length=None):
     if max_length is None:
         max_length = DEFAULT_MAX_VALUE_LENGTH
 
-    length = len(value.encode("utf-8"))
+    length = len(value)
+    if isinstance(value, text_type):
+        # we want the size in bytes rather than characters, if possible
+        try:
+            length = len(value.encode("utf-8"))
+        except UnicodeDecodeError:
+            pass
 
     if length > max_length:
         return AnnotatedValue(

--- a/sentry_sdk/utils.py
+++ b/sentry_sdk/utils.py
@@ -383,6 +383,7 @@ class AnnotatedValue(object):
         self.metadata = metadata
 
     def __eq__(self, other):
+        # type: (Any) -> bool
         if not isinstance(other, AnnotatedValue):
             return False
 

--- a/tests/utils/test_general.py
+++ b/tests/utils/test_general.py
@@ -17,8 +17,6 @@ from sentry_sdk.utils import (
     set_in_app_in_frames,
     strip_string,
     AnnotatedValue,
-    _get_size_in_bytes,
-    _truncate_string_by_bytes,
 )
 from sentry_sdk._compat import text_type, string_types
 
@@ -588,38 +586,18 @@ def test_failed_base64_conversion(input):
             ),
         ],
         # fmt: off
-        [u"éêéê", None, u"éêéê"],
-        [u"éêéê", 4, AnnotatedValue(value=u"é...", metadata={"len": 8, "rem": [["!limit", "x", 1, 4]]})],
+        [u"éééé", None, u"éééé"],
+        [u"éééé", 5, AnnotatedValue(value=u"é...", metadata={"len": 8, "rem": [["!limit", "x", 2, 5]]})],
         # fmt: on
-        ["éêéê", None, "éêéê"],
+        ["éééé", None, "éééé"],
         [
-            "éêéê",
-            4,
+            "éééé",
+            5,
             AnnotatedValue(
-                value="é...", metadata={"len": 8, "rem": [["!limit", "x", 1, 4]]}
+                value="é...", metadata={"len": 8, "rem": [["!limit", "x", 2, 5]]}
             ),
         ],
     ],
 )
 def test_strip_string(input, max_length, result):
     assert strip_string(input, max_length) == result
-
-
-@pytest.mark.parametrize(
-    "input,max_bytes,result",
-    [
-        [None, None],
-    ],
-)
-def test_truncate_by_bytes(input, max_bytes, result):
-    assert _truncate_string_by_bytes(input, max_bytes) == result
-
-
-@pytest.mark.parametrize(
-    "input,result",
-    [
-        ["abc", 3],
-    ],
-)
-def test_get_size_in_bytes(input, max_bytes, result):
-    assert _get_size_in_bytes(input, max_bytes) == result

--- a/tests/utils/test_general.py
+++ b/tests/utils/test_general.py
@@ -591,3 +591,7 @@ def test_strip_string():
     text_with_unicode_character = u"éê"
     assert strip_string(text_with_unicode_character, max_length=2).value == u"é..."
     # fmt: on
+
+    # This was causing UnicodeDecodeErrors in Python 2
+    text_with_unicode_character = "éê"
+    assert strip_string(text_with_unicode_character, max_length=2).value == "éê"


### PR DESCRIPTION
There were at least two things wrong with our [`strip_string`](https://github.com/getsentry/sentry-python/blob/2f05ccbae7298978d2f1a8774a07386a018bcce9/sentry_sdk/utils.py#L1121) implementation:

* https://github.com/getsentry/sentry-python/issues/2612: It could lead to `UnicodeDecodeError`s on Python 2 if a non-unicode string (i.e., `bytes` in Python 2) was provided. When encoding such a (byte) string, Python 2 will first try to coerce it to a unicode string, using `ascii` to decode, leading to a `UnicodeDecodeError` if the byte string contains anything beyond ascii.
* https://github.com/getsentry/sentry-python/issues/2634: We found out how many bytes should be stripped from the string, but were then actually stripping that many characters/code points, not bytes.

This PR addresses both issues.

Closes https://github.com/getsentry/sentry-python/issues/2612
Closes https://github.com/getsentry/sentry-python/issues/2634

---

## General Notes

Thank you for contributing to `sentry-python`!

Please add tests to validate your changes, and lint your code using `tox -e linters`.

Running the test suite on your PR might require maintainer approval. Some tests (AWS Lambda) additionally require a maintainer to add a special label to run and will fail if the label is not present.

#### For maintainers

Sensitive test suites require maintainer review to ensure that tests do not compromise our secrets. This review must be repeated after any code revisions.

Before running sensitive test suites, please carefully check the PR. Then, apply the `Trigger: tests using secrets` label. The label will be removed after any code changes to enforce our policy requiring maintainers to review all code revisions before running sensitive tests.
