### PR TITLE
Remove sorting where order is now stable

### DIFF
--- a/tests/integrations/celery/test_celery.py
+++ b/tests/integrations/celery/test_celery.py
@@ -516,16 +516,16 @@ def test_baggage_propagation(init_celery):
             headers={"baggage": "custom=value"},
         ).get()
 
-        expected_baggage = (
-            "sentry-release=abcdef,"
-            "sentry-trace_id={},"
-            "sentry-environment=production,"
-            "sentry-sample_rate=1.0,"
-            "sentry-sampled=true,"
-            "custom=value"
-        ).format(transaction.trace_id)
-
-        assert result["baggage"] == expected_baggage
+        assert sorted(result["baggage"].split(",")) == sorted(
+            [
+                "sentry-release=abcdef",
+                "sentry-trace_id={}".format(transaction.trace_id),
+                "sentry-environment=production",
+                "sentry-sample_rate=1.0",
+                "sentry-sampled=true",
+                "custom=value",
+            ]
+        )
 
 
 def test_sentry_propagate_traces_override(init_celery):

--- a/tests/integrations/celery/test_celery.py
+++ b/tests/integrations/celery/test_celery.py
@@ -516,11 +516,16 @@ def test_baggage_propagation(init_celery):
             headers={"baggage": "custom=value"},
         ).get()
 
-        assert result[
-            "baggage"
-        ] == "sentry-release=abcdef,sentry-trace_id={},sentry-environment=production,sentry-sample_rate=1.0,sentry-sampled=true,custom=value".format(
-            transaction.trace_id
-        )
+        expected_baggage = (
+            "sentry-release=abcdef,"
+            "sentry-trace_id={},"
+            "sentry-environment=production,"
+            "sentry-sample_rate=1.0,"
+            "sentry-sampled=true,"
+            "custom=value"
+        ).format(transaction.trace_id)
+
+        assert result["baggage"] == expected_baggage
 
 
 def test_sentry_propagate_traces_override(init_celery):

--- a/tests/integrations/celery/test_celery.py
+++ b/tests/integrations/celery/test_celery.py
@@ -516,15 +516,10 @@ def test_baggage_propagation(init_celery):
             headers={"baggage": "custom=value"},
         ).get()
 
-        assert sorted(result["baggage"].split(",")) == sorted(
-            [
-                "sentry-release=abcdef",
-                "sentry-trace_id={}".format(transaction.trace_id),
-                "sentry-environment=production",
-                "sentry-sample_rate=1.0",
-                "sentry-sampled=true",
-                "custom=value",
-            ]
+        assert result[
+            "baggage"
+        ] == "sentry-release=abcdef,sentry-trace_id={},sentry-environment=production,sentry-sample_rate=1.0,sentry-sampled=true,custom=value".format(
+            transaction.trace_id
         )
 
 

--- a/tests/integrations/django/test_basic.py
+++ b/tests/integrations/django/test_basic.py
@@ -793,9 +793,8 @@ def test_template_tracing_meta(sentry_init, client, capture_events):
     assert match is not None
     assert match.group(1) == traceparent
 
-    # Python 2 does not preserve sort order
     rendered_baggage = match.group(2)
-    assert sorted(rendered_baggage.split(",")) == sorted(baggage.split(","))
+    assert rendered_baggage == baggage
 
 
 @pytest.mark.parametrize("with_executing_integration", [[], [ExecutingIntegration()]])

--- a/tests/integrations/flask/test_flask.py
+++ b/tests/integrations/flask/test_flask.py
@@ -862,9 +862,8 @@ def test_template_tracing_meta(sentry_init, app, capture_events, template_string
     assert match is not None
     assert match.group(1) == traceparent
 
-    # Python 2 does not preserve sort order
     rendered_baggage = match.group(2)
-    assert sorted(rendered_baggage.split(",")) == sorted(baggage.split(","))
+    assert rendered_baggage == baggage
 
 
 def test_dont_override_sentry_trace_context(sentry_init, app):

--- a/tests/integrations/starlette/test_starlette.py
+++ b/tests/integrations/starlette/test_starlette.py
@@ -948,9 +948,8 @@ def test_template_tracing_meta(sentry_init, capture_events):
     assert match is not None
     assert match.group(1) == traceparent
 
-    # Python 2 does not preserve sort order
     rendered_baggage = match.group(2)
-    assert sorted(rendered_baggage.split(",")) == sorted(baggage.split(","))
+    assert rendered_baggage == baggage
 
 
 @pytest.mark.parametrize(

--- a/tests/integrations/stdlib/test_httplib.py
+++ b/tests/integrations/stdlib/test_httplib.py
@@ -182,16 +182,14 @@ def test_outgoing_trace_headers(sentry_init, monkeypatch):
         )
         assert request_headers["sentry-trace"] == expected_sentry_trace
 
-        expected_outgoing_baggage_items = [
-            "sentry-trace_id=771a43a4192642f0b136d5159a501700",
-            "sentry-public_key=49d0f7386ad645858ae85020e393bef3",
-            "sentry-sample_rate=0.01337",
-            "sentry-user_id=Am%C3%A9lie",
-        ]
-
-        assert sorted(request_headers["baggage"].split(",")) == sorted(
-            expected_outgoing_baggage_items
+        expected_outgoing_baggage = (
+            "sentry-trace_id=771a43a4192642f0b136d5159a501700,"
+            "sentry-public_key=49d0f7386ad645858ae85020e393bef3,"
+            "sentry-sample_rate=0.01337,"
+            "sentry-user_id=Am%C3%A9lie"
         )
+
+        assert request_headers["baggage"] == expected_outgoing_baggage
 
 
 def test_outgoing_trace_headers_head_sdk(sentry_init, monkeypatch):
@@ -225,17 +223,15 @@ def test_outgoing_trace_headers_head_sdk(sentry_init, monkeypatch):
         )
         assert request_headers["sentry-trace"] == expected_sentry_trace
 
-        expected_outgoing_baggage_items = [
-            "sentry-trace_id=%s" % transaction.trace_id,
-            "sentry-sample_rate=0.5",
-            "sentry-sampled=%s" % "true" if transaction.sampled else "false",
-            "sentry-release=foo",
-            "sentry-environment=production",
-        ]
+        expected_outgoing_baggage = (
+            "sentry-trace_id=%s,"
+            "sentry-environment=production,"
+            "sentry-release=foo,"
+            "sentry-sample_rate=0.5,"
+            "sentry-sampled=%s"
+        ) % (transaction.trace_id, "true" if transaction.sampled else "false")
 
-        assert sorted(request_headers["baggage"].split(",")) == sorted(
-            expected_outgoing_baggage_items
-        )
+        assert request_headers["baggage"] == expected_outgoing_baggage
 
 
 @pytest.mark.parametrize(

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -76,8 +76,7 @@ def test_baggage_with_tracing_disabled(sentry_init):
             propagation_context["trace_id"]
         )
     )
-    # order not guaranteed in older python versions
-    assert sorted(get_baggage().split(",")) == sorted(expected_baggage.split(","))
+    assert get_baggage() == expected_baggage
 
 
 def test_baggage_with_tracing_enabled(sentry_init):
@@ -86,8 +85,7 @@ def test_baggage_with_tracing_enabled(sentry_init):
         expected_baggage = "sentry-trace_id={},sentry-environment=dev,sentry-release=1.0.0,sentry-sample_rate=1.0,sentry-sampled={}".format(
             transaction.trace_id, "true" if transaction.sampled else "false"
         )
-        # order not guaranteed in older python versions
-        assert sorted(get_baggage().split(",")) == sorted(expected_baggage.split(","))
+        assert get_baggage() == expected_baggage
 
 
 def test_continue_trace(sentry_init):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -89,12 +89,7 @@ def _normalize_distribution_name(name):
     ],
 )
 def test_sanitize_url(url, expected_result):
-    # sort parts because old Python versions (<3.6) don't preserve order
-    sanitized_url = sanitize_url(url)
-    parts = sorted(re.split(r"\&|\?|\#", sanitized_url))
-    expected_parts = sorted(re.split(r"\&|\?|\#", expected_result))
-
-    assert parts == expected_parts
+    assert sanitize_url(url) == expected_result
 
 
 @pytest.mark.parametrize(
@@ -208,13 +203,10 @@ def test_sanitize_url(url, expected_result):
 )
 def test_sanitize_url_and_split(url, expected_result):
     sanitized_url = sanitize_url(url, split=True)
-    # sort query because old Python versions (<3.6) don't preserve order
-    query = sorted(sanitized_url.query.split("&"))
-    expected_query = sorted(expected_result.query.split("&"))
 
     assert sanitized_url.scheme == expected_result.scheme
     assert sanitized_url.netloc == expected_result.netloc
-    assert query == expected_query
+    assert sanitized_url.query == expected_result.query
     assert sanitized_url.path == expected_result.path
     assert sanitized_url.fragment == expected_result.fragment
 
@@ -341,13 +333,7 @@ def test_sanitize_url_and_split(url, expected_result):
 def test_parse_url(url, sanitize, expected_url, expected_query, expected_fragment):
     assert parse_url(url, sanitize=sanitize).url == expected_url
     assert parse_url(url, sanitize=sanitize).fragment == expected_fragment
-
-    # sort parts because old Python versions (<3.6) don't preserve order
-    sanitized_query = parse_url(url, sanitize=sanitize).query
-    query_parts = sorted(re.split(r"\&|\?|\#", sanitized_query))
-    expected_query_parts = sorted(re.split(r"\&|\?|\#", expected_query))
-
-    assert query_parts == expected_query_parts
+    assert parse_url(url, sanitize=sanitize).query == expected_query
 
 
 @pytest.mark.parametrize(

--- a/tests/tracing/test_baggage.py
+++ b/tests/tracing/test_baggage.py
@@ -7,14 +7,16 @@ def test_third_party_baggage():
 
     assert baggage.mutable
     assert baggage.sentry_items == {}
-    assert sorted(baggage.third_party_items.split(",")) == sorted(
-        "other-vendor-value-1=foo;bar;baz,other-vendor-value-2=foo;bar;".split(",")
+    assert (
+        baggage.third_party_items
+        == "other-vendor-value-1=foo;bar;baz,other-vendor-value-2=foo;bar;"
     )
 
     assert baggage.dynamic_sampling_context() == {}
     assert baggage.serialize() == ""
-    assert sorted(baggage.serialize(include_third_party=True).split(",")) == sorted(
-        "other-vendor-value-1=foo;bar;baz,other-vendor-value-2=foo;bar;".split(",")
+    assert (
+        baggage.serialize(include_third_party=True)
+        == "other-vendor-value-1=foo;bar;baz,other-vendor-value-2=foo;bar;"
     )
 
 
@@ -50,22 +52,18 @@ def test_mixed_baggage():
         "foo": "bar",
     }
 
-    assert sorted(baggage.serialize().split(",")) == sorted(
-        (
-            "sentry-trace_id=771a43a4192642f0b136d5159a501700,"
-            "sentry-public_key=49d0f7386ad645858ae85020e393bef3,"
-            "sentry-sample_rate=0.01337,sentry-user_id=Am%C3%A9lie,"
-            "sentry-foo=bar"
-        ).split(",")
+    assert baggage.serialize() == (
+        "sentry-trace_id=771a43a4192642f0b136d5159a501700,"
+        "sentry-public_key=49d0f7386ad645858ae85020e393bef3,"
+        "sentry-sample_rate=0.01337,sentry-user_id=Am%C3%A9lie,"
+        "sentry-foo=bar"
     )
 
-    assert sorted(baggage.serialize(include_third_party=True).split(",")) == sorted(
-        (
-            "sentry-trace_id=771a43a4192642f0b136d5159a501700,"
-            "sentry-public_key=49d0f7386ad645858ae85020e393bef3,"
-            "sentry-sample_rate=0.01337,sentry-user_id=Am%C3%A9lie,sentry-foo=bar,"
-            "other-vendor-value-1=foo;bar;baz,other-vendor-value-2=foo;bar;"
-        ).split(",")
+    assert baggage.serialize(include_third_party=True) == (
+        "sentry-trace_id=771a43a4192642f0b136d5159a501700,"
+        "sentry-public_key=49d0f7386ad645858ae85020e393bef3,"
+        "sentry-sample_rate=0.01337,sentry-user_id=Am%C3%A9lie,sentry-foo=bar,"
+        "other-vendor-value-1=foo;bar;baz,other-vendor-value-2=foo;bar;"
     )
 
 

--- a/tests/tracing/test_integration_tests.py
+++ b/tests/tracing/test_integration_tests.py
@@ -177,10 +177,15 @@ def test_dynamic_sampling_head_sdk_creates_dsc(
     }
 
     expected_baggage = (
-        "sentry-environment=production,sentry-release=foo,sentry-sample_rate=%s,sentry-transaction=Head%%20SDK%%20tx,sentry-trace_id=%s,sentry-sampled=%s"
-        % (sample_rate, trace_id, "true" if transaction.sampled else "false")
+        "sentry-trace_id=%s,"
+        "sentry-environment=production,"
+        "sentry-release=foo,"
+        "sentry-transaction=Head%%20SDK%%20tx,"
+        "sentry-sample_rate=%s,"
+        "sentry-sampled=%s"
+        % (trace_id, sample_rate, "true" if transaction.sampled else "false")
     )
-    assert sorted(baggage.serialize().split(",")) == sorted(expected_baggage.split(","))
+    assert baggage.serialize() == expected_baggage
 
     (envelope,) = envelopes
     assert envelope.headers["trace"] == baggage.dynamic_sampling_context()


### PR DESCRIPTION
We were sorting key-values in couple places to account for random order. Remove this where possible.

Left at least one `sorted` as is (`test_celery.py`) since this seems to still require manual sorting.

---

## General Notes

Thank you for contributing to `sentry-python`!

Please add tests to validate your changes, and lint your code using `tox -e linters`.

Running the test suite on your PR might require maintainer approval. Some tests (AWS Lambda) additionally require a maintainer to add a special label to run and will fail if the label is not present.

#### For maintainers

Sensitive test suites require maintainer review to ensure that tests do not compromise our secrets. This review must be repeated after any code revisions.

Before running sensitive test suites, please carefully check the PR. Then, apply the `Trigger: tests using secrets` label. The label will be removed after any code changes to enforce our policy requiring maintainers to review all code revisions before running sensitive tests.
