### PR TITLE
Moved redis related tests to databases

### DIFF
--- a/scripts/split-tox-gh-actions/split-tox-gh-actions.py
+++ b/scripts/split-tox-gh-actions/split-tox-gh-actions.py
@@ -75,9 +75,9 @@ GROUPS = {
         "asyncpg",
         "clickhouse_driver",
         "pymongo",
-        "sqlalchemy",
         "redis",
         "rediscluster",
+        "sqlalchemy",
     ],
     "GraphQL": [
         "ariadne",

--- a/scripts/split-tox-gh-actions/split-tox-gh-actions.py
+++ b/scripts/split-tox-gh-actions/split-tox-gh-actions.py
@@ -76,6 +76,8 @@ GROUPS = {
         "clickhouse_driver",
         "pymongo",
         "sqlalchemy",
+        "redis",
+        "rediscluster",
     ],
     "GraphQL": [
         "ariadne",
@@ -102,8 +104,6 @@ GROUPS = {
         "falcon",
         "pyramid",
         "quart",
-        "redis",
-        "rediscluster",
         "sanic",
         "starlite",
         "tornado",


### PR DESCRIPTION
Moved `redis` and `redis-cluster` to the `Databases` test suite. Makes more sense there.
