### PR TITLE
Turn typing comments into annotations

### DIFF
--- a/sentry_sdk/__init__.py
+++ b/sentry_sdk/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from sentry_sdk.hub import Hub, init
 from sentry_sdk.scope import Scope
 from sentry_sdk.transport import Transport, HttpTransport

--- a/sentry_sdk/_compat.py
+++ b/sentry_sdk/_compat.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import sys
 
 from sentry_sdk._types import TYPE_CHECKING

--- a/sentry_sdk/_compat.py
+++ b/sentry_sdk/_compat.py
@@ -14,18 +14,15 @@ PY310 = sys.version_info[0] == 3 and sys.version_info[1] >= 10
 PY311 = sys.version_info[0] == 3 and sys.version_info[1] >= 11
 
 
-def with_metaclass(meta, *bases):
-    # type: (Any, *Any) -> Any
+def with_metaclass(meta: Any, *bases: Any) -> Any:
     class MetaClass(type):
-        def __new__(metacls, name, this_bases, d):
-            # type: (Any, Any, Any, Any) -> Any
+        def __new__(metacls: Any, name: Any, this_bases: Any, d: Any) -> Any:
             return meta(name, bases, d)
 
     return type.__new__(MetaClass, "temporary_class", (), {})
 
 
-def check_thread_support():
-    # type: () -> None
+def check_thread_support() -> None:
     try:
         from uwsgi import opt  # type: ignore
     except ImportError:

--- a/sentry_sdk/_queue.py
+++ b/sentry_sdk/_queue.py
@@ -273,7 +273,7 @@ class Queue:
 
     # Initialize the queue representation
     def _init(self, maxsize):
-        self.queue = deque()  # type: Any
+        self.queue: Any = deque()
 
     def _qsize(self):
         return len(self.queue)

--- a/sentry_sdk/_werkzeug.py
+++ b/sentry_sdk/_werkzeug.py
@@ -47,8 +47,7 @@ if TYPE_CHECKING:
 # We need this function because Django does not give us a "pure" http header
 # dict. So we might as well use it for all WSGI integrations.
 #
-def _get_headers(environ):
-    # type: (Dict[str, str]) -> Iterator[Tuple[str, str]]
+def _get_headers(environ: Dict[str, str]) -> Iterator[Tuple[str, str]]:
     """
     Returns only proper HTTP headers.
     """
@@ -67,8 +66,7 @@ def _get_headers(environ):
 # `get_host` comes from `werkzeug.wsgi.get_host`
 # https://github.com/pallets/werkzeug/blob/1.0.1/src/werkzeug/wsgi.py#L145
 #
-def get_host(environ, use_x_forwarded_for=False):
-    # type: (Dict[str, str], bool) -> str
+def get_host(environ: Dict[str, str], use_x_forwarded_for: bool = False) -> str:
     """
     Return the host for the given WSGI environment.
     """

--- a/sentry_sdk/_werkzeug.py
+++ b/sentry_sdk/_werkzeug.py
@@ -32,6 +32,8 @@ THIS SOFTWARE AND DOCUMENTATION, EVEN IF ADVISED OF THE POSSIBILITY OF
 SUCH DAMAGE.
 """
 
+from __future__ import annotations
+
 from sentry_sdk._types import TYPE_CHECKING
 
 if TYPE_CHECKING:

--- a/sentry_sdk/api.py
+++ b/sentry_sdk/api.py
@@ -30,8 +30,7 @@ if TYPE_CHECKING:
     F = TypeVar("F", bound=Callable[..., Any])
 else:
 
-    def overload(x):
-        # type: (T) -> T
+    def overload(x: T) -> T:
         return x
 
 
@@ -60,8 +59,7 @@ __all__ = [
 ]
 
 
-def hubmethod(f):
-    # type: (F) -> F
+def hubmethod(f: F) -> F:
     f.__doc__ = "%s\n\n%s" % (
         "Alias for :py:meth:`sentry_sdk.Hub.%s`" % f.__name__,
         inspect.getdoc(getattr(Hub, f.__name__)),
@@ -69,8 +67,7 @@ def hubmethod(f):
     return f
 
 
-def scopemethod(f):
-    # type: (F) -> F
+def scopemethod(f: F) -> F:
     f.__doc__ = "%s\n\n%s" % (
         "Alias for :py:meth:`sentry_sdk.Scope.%s`" % f.__name__,
         inspect.getdoc(getattr(Scope, f.__name__)),
@@ -80,186 +77,163 @@ def scopemethod(f):
 
 @hubmethod
 def capture_event(
-    event,  # type: Event
-    hint=None,  # type: Optional[Hint]
-    scope=None,  # type: Optional[Any]
-    **scope_kwargs  # type: Any
-):
-    # type: (...) -> Optional[str]
+    event: Event,
+    hint: Optional[Hint] = None,
+    scope: Optional[Any] = None,
+    **scope_kwargs: Any
+) -> Optional[str]:
     return Hub.current.capture_event(event, hint, scope=scope, **scope_kwargs)
 
 
 @hubmethod
 def capture_message(
-    message,  # type: str
-    level=None,  # type: Optional[str]
-    scope=None,  # type: Optional[Any]
-    **scope_kwargs  # type: Any
-):
-    # type: (...) -> Optional[str]
+    message: str,
+    level: Optional[str] = None,
+    scope: Optional[Any] = None,
+    **scope_kwargs: Any
+) -> Optional[str]:
     return Hub.current.capture_message(message, level, scope=scope, **scope_kwargs)
 
 
 @hubmethod
 def capture_exception(
-    error=None,  # type: Optional[Union[BaseException, ExcInfo]]
-    scope=None,  # type: Optional[Any]
-    **scope_kwargs  # type: Any
-):
-    # type: (...) -> Optional[str]
+    error: Optional[Union[BaseException, ExcInfo]] = None,
+    scope: Optional[Any] = None,
+    **scope_kwargs: Any
+) -> Optional[str]:
     return Hub.current.capture_exception(error, scope=scope, **scope_kwargs)
 
 
 @hubmethod
 def add_breadcrumb(
-    crumb=None,  # type: Optional[Breadcrumb]
-    hint=None,  # type: Optional[BreadcrumbHint]
-    **kwargs  # type: Any
-):
-    # type: (...) -> None
+    crumb: Optional[Breadcrumb] = None,
+    hint: Optional[BreadcrumbHint] = None,
+    **kwargs: Any
+) -> None:
     return Hub.current.add_breadcrumb(crumb, hint, **kwargs)
 
 
 @overload
-def configure_scope():
-    # type: () -> ContextManager[Scope]
+def configure_scope() -> ContextManager[Scope]:
     pass
 
 
 @overload
 def configure_scope(  # noqa: F811
-    callback,  # type: Callable[[Scope], None]
-):
-    # type: (...) -> None
+    callback: Callable[[Scope], None],
+) -> None:
     pass
 
 
 @hubmethod
 def configure_scope(  # noqa: F811
-    callback=None,  # type: Optional[Callable[[Scope], None]]
-):
-    # type: (...) -> Optional[ContextManager[Scope]]
+    callback: Optional[Callable[[Scope], None]] = None,
+) -> Optional[ContextManager[Scope]]:
     return Hub.current.configure_scope(callback)
 
 
 @overload
-def push_scope():
-    # type: () -> ContextManager[Scope]
+def push_scope() -> ContextManager[Scope]:
     pass
 
 
 @overload
 def push_scope(  # noqa: F811
-    callback,  # type: Callable[[Scope], None]
-):
-    # type: (...) -> None
+    callback: Callable[[Scope], None],
+) -> None:
     pass
 
 
 @hubmethod
 def push_scope(  # noqa: F811
-    callback=None,  # type: Optional[Callable[[Scope], None]]
-):
-    # type: (...) -> Optional[ContextManager[Scope]]
+    callback: Optional[Callable[[Scope], None]] = None,
+) -> Optional[ContextManager[Scope]]:
     return Hub.current.push_scope(callback)
 
 
 @scopemethod
-def set_tag(key, value):
-    # type: (str, Any) -> None
+def set_tag(key: str, value: Any) -> None:
     return Hub.current.scope.set_tag(key, value)
 
 
 @scopemethod
-def set_context(key, value):
-    # type: (str, Dict[str, Any]) -> None
+def set_context(key: str, value: Dict[str, Any]) -> None:
     return Hub.current.scope.set_context(key, value)
 
 
 @scopemethod
-def set_extra(key, value):
-    # type: (str, Any) -> None
+def set_extra(key: str, value: Any) -> None:
     return Hub.current.scope.set_extra(key, value)
 
 
 @scopemethod
-def set_user(value):
-    # type: (Optional[Dict[str, Any]]) -> None
+def set_user(value: Optional[Dict[str, Any]]) -> None:
     return Hub.current.scope.set_user(value)
 
 
 @scopemethod
-def set_level(value):
-    # type: (str) -> None
+def set_level(value: str) -> None:
     return Hub.current.scope.set_level(value)
 
 
 @hubmethod
 def flush(
-    timeout=None,  # type: Optional[float]
-    callback=None,  # type: Optional[Callable[[int, float], None]]
-):
-    # type: (...) -> None
+    timeout: Optional[float] = None,
+    callback: Optional[Callable[[int, float], None]] = None,
+) -> None:
     return Hub.current.flush(timeout=timeout, callback=callback)
 
 
 @hubmethod
-def last_event_id():
-    # type: () -> Optional[str]
+def last_event_id() -> Optional[str]:
     return Hub.current.last_event_id()
 
 
 @hubmethod
-def start_span(
-    span=None,  # type: Optional[Span]
-    **kwargs  # type: Any
-):
-    # type: (...) -> Span
+def start_span(span: Optional[Span] = None, **kwargs: Any) -> Span:
     return Hub.current.start_span(span=span, **kwargs)
 
 
 @hubmethod
 def start_transaction(
-    transaction=None,  # type: Optional[Transaction]
-    **kwargs  # type: Any
-):
-    # type: (...) -> Union[Transaction, NoOpSpan]
+    transaction: Optional[Transaction] = None, **kwargs: Any
+) -> Union[Transaction, NoOpSpan]:
     return Hub.current.start_transaction(transaction, **kwargs)
 
 
-def set_measurement(name, value, unit=""):
-    # type: (str, float, MeasurementUnit) -> None
+def set_measurement(name: str, value: float, unit: MeasurementUnit = "") -> None:
     transaction = Hub.current.scope.transaction
     if transaction is not None:
         transaction.set_measurement(name, value, unit)
 
 
-def get_current_span(hub=None):
-    # type: (Optional[Hub]) -> Optional[Span]
+def get_current_span(hub: Optional[Hub] = None) -> Optional[Span]:
     """
     Returns the currently active span if there is one running, otherwise `None`
     """
     return tracing_utils.get_current_span(hub)
 
 
-def get_traceparent():
-    # type: () -> Optional[str]
+def get_traceparent() -> Optional[str]:
     """
     Returns the traceparent either from the active span or from the scope.
     """
     return Hub.current.get_traceparent()
 
 
-def get_baggage():
-    # type: () -> Optional[str]
+def get_baggage() -> Optional[str]:
     """
     Returns Baggage either from the active span or from the scope.
     """
     return Hub.current.get_baggage()
 
 
-def continue_trace(environ_or_headers, op=None, name=None, source=None):
-    # type: (Dict[str, Any], Optional[str], Optional[str], Optional[str]) -> Transaction
+def continue_trace(
+    environ_or_headers: Dict[str, Any],
+    op: Optional[str] = None,
+    name: Optional[str] = None,
+    source: Optional[str] = None,
+) -> Transaction:
     """
     Sets the propagation context from environment or headers and returns a transaction.
     """

--- a/sentry_sdk/api.py
+++ b/sentry_sdk/api.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import inspect
 
 from sentry_sdk import tracing_utils
@@ -80,7 +82,7 @@ def capture_event(
     event: Event,
     hint: Optional[Hint] = None,
     scope: Optional[Any] = None,
-    **scope_kwargs: Any
+    **scope_kwargs: Any,
 ) -> Optional[str]:
     return Hub.current.capture_event(event, hint, scope=scope, **scope_kwargs)
 
@@ -90,7 +92,7 @@ def capture_message(
     message: str,
     level: Optional[str] = None,
     scope: Optional[Any] = None,
-    **scope_kwargs: Any
+    **scope_kwargs: Any,
 ) -> Optional[str]:
     return Hub.current.capture_message(message, level, scope=scope, **scope_kwargs)
 
@@ -99,7 +101,7 @@ def capture_message(
 def capture_exception(
     error: Optional[Union[BaseException, ExcInfo]] = None,
     scope: Optional[Any] = None,
-    **scope_kwargs: Any
+    **scope_kwargs: Any,
 ) -> Optional[str]:
     return Hub.current.capture_exception(error, scope=scope, **scope_kwargs)
 
@@ -108,7 +110,7 @@ def capture_exception(
 def add_breadcrumb(
     crumb: Optional[Breadcrumb] = None,
     hint: Optional[BreadcrumbHint] = None,
-    **kwargs: Any
+    **kwargs: Any,
 ) -> None:
     return Hub.current.add_breadcrumb(crumb, hint, **kwargs)
 

--- a/sentry_sdk/attachments.py
+++ b/sentry_sdk/attachments.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 import mimetypes
 

--- a/sentry_sdk/attachments.py
+++ b/sentry_sdk/attachments.py
@@ -11,13 +11,12 @@ if TYPE_CHECKING:
 class Attachment:
     def __init__(
         self,
-        bytes=None,  # type: Union[None, bytes, Callable[[], bytes]]
-        filename=None,  # type: Optional[str]
-        path=None,  # type: Optional[str]
-        content_type=None,  # type: Optional[str]
-        add_to_transactions=False,  # type: bool
-    ):
-        # type: (...) -> None
+        bytes: Union[None, bytes, Callable[[], bytes]] = None,
+        filename: Optional[str] = None,
+        path: Optional[str] = None,
+        content_type: Optional[str] = None,
+        add_to_transactions: bool = False,
+    ) -> None:
         if bytes is None and path is None:
             raise TypeError("path or raw bytes required for attachment")
         if filename is None and path is not None:
@@ -32,10 +31,9 @@ class Attachment:
         self.content_type = content_type
         self.add_to_transactions = add_to_transactions
 
-    def to_envelope_item(self):
-        # type: () -> Item
+    def to_envelope_item(self) -> Item:
         """Returns an envelope item for this attachment."""
-        payload = None  # type: Union[None, PayloadRef, bytes]
+        payload: Union[None, PayloadRef, bytes] = None
         if self.bytes is not None:
             if callable(self.bytes):
                 payload = self.bytes()
@@ -50,6 +48,5 @@ class Attachment:
             filename=self.filename,
         )
 
-    def __repr__(self):
-        # type: () -> str
+    def __repr__(self) -> str:
         return "<Attachment %r>" % (self.filename,)

--- a/sentry_sdk/consts.py
+++ b/sentry_sdk/consts.py
@@ -241,65 +241,67 @@ class OP:
 class ClientConstructor:
     def __init__(
         self,
-        dsn=None,  # type: Optional[str]
-        max_breadcrumbs=DEFAULT_MAX_BREADCRUMBS,  # type: int
-        release=None,  # type: Optional[str]
-        environment=None,  # type: Optional[str]
-        server_name=None,  # type: Optional[str]
-        shutdown_timeout=2,  # type: float
-        integrations=[],  # type: Sequence[Integration]  # noqa: B006
-        in_app_include=[],  # type: List[str]  # noqa: B006
-        in_app_exclude=[],  # type: List[str]  # noqa: B006
-        default_integrations=True,  # type: bool
-        dist=None,  # type: Optional[str]
-        transport=None,  # type: Optional[Union[sentry_sdk.transport.Transport, Type[sentry_sdk.transport.Transport], Callable[[Event], None]]]
-        transport_queue_size=DEFAULT_QUEUE_SIZE,  # type: int
-        sample_rate=1.0,  # type: float
-        send_default_pii=False,  # type: bool
-        http_proxy=None,  # type: Optional[str]
-        https_proxy=None,  # type: Optional[str]
-        ignore_errors=[],  # type: Sequence[Union[type, str]]  # noqa: B006
-        max_request_body_size="medium",  # type: str
-        before_send=None,  # type: Optional[EventProcessor]
-        before_breadcrumb=None,  # type: Optional[BreadcrumbProcessor]
-        debug=None,  # type: Optional[bool]
-        attach_stacktrace=False,  # type: bool
-        ca_certs=None,  # type: Optional[str]
-        propagate_traces=True,  # type: bool
-        traces_sample_rate=None,  # type: Optional[float]
-        traces_sampler=None,  # type: Optional[TracesSampler]
-        profiles_sample_rate=None,  # type: Optional[float]
-        profiles_sampler=None,  # type: Optional[TracesSampler]
-        profiler_mode=None,  # type: Optional[ProfilerMode]
-        auto_enabling_integrations=True,  # type: bool
-        auto_session_tracking=True,  # type: bool
-        send_client_reports=True,  # type: bool
-        _experiments={},  # type: Experiments  # noqa: B006
-        proxy_headers=None,  # type: Optional[Dict[str, str]]
-        instrumenter=INSTRUMENTER.SENTRY,  # type: Optional[str]
-        before_send_transaction=None,  # type: Optional[TransactionProcessor]
-        project_root=None,  # type: Optional[str]
-        enable_tracing=None,  # type: Optional[bool]
-        include_local_variables=True,  # type: Optional[bool]
-        include_source_context=True,  # type: Optional[bool]
-        trace_propagation_targets=[  # noqa: B006
-            MATCH_ALL
-        ],  # type: Optional[Sequence[str]]
-        functions_to_trace=[],  # type: Sequence[Dict[str, str]]  # noqa: B006
-        event_scrubber=None,  # type: Optional[sentry_sdk.scrubber.EventScrubber]
-        max_value_length=DEFAULT_MAX_VALUE_LENGTH,  # type: int
-        enable_backpressure_handling=True,  # type: bool
-        error_sampler=None,  # type: Optional[Callable[[Event, Hint], Union[float, bool]]]
-        enable_db_query_source=False,  # type: bool
-        db_query_source_threshold_ms=100,  # type: int
-        spotlight=None,  # type: Optional[Union[bool, str]]
-    ):
-        # type: (...) -> None
+        dsn: Optional[str] = None,
+        max_breadcrumbs: int = DEFAULT_MAX_BREADCRUMBS,
+        release: Optional[str] = None,
+        environment: Optional[str] = None,
+        server_name: Optional[str] = None,
+        shutdown_timeout: float = 2,
+        integrations: Sequence[Integration] = [],  # noqa: B006
+        in_app_include: List[str] = [],  # noqa: B006
+        in_app_exclude: List[str] = [],  # noqa: B006
+        default_integrations: bool = True,
+        dist: Optional[str] = None,
+        transport: Optional[
+            Union[
+                sentry_sdk.transport.Transport,
+                Type[sentry_sdk.transport.Transport],
+                Callable[[Event], None],
+            ]
+        ] = None,
+        transport_queue_size: int = DEFAULT_QUEUE_SIZE,
+        sample_rate: float = 1.0,
+        send_default_pii: bool = False,
+        http_proxy: Optional[str] = None,
+        https_proxy: Optional[str] = None,
+        ignore_errors: Sequence[Union[type, str]] = [],  # noqa: B006
+        max_request_body_size: str = "medium",
+        before_send: Optional[EventProcessor] = None,
+        before_breadcrumb: Optional[BreadcrumbProcessor] = None,
+        debug: Optional[bool] = None,
+        attach_stacktrace: bool = False,
+        ca_certs: Optional[str] = None,
+        propagate_traces: bool = True,
+        traces_sample_rate: Optional[float] = None,
+        traces_sampler: Optional[TracesSampler] = None,
+        profiles_sample_rate: Optional[float] = None,
+        profiles_sampler: Optional[TracesSampler] = None,
+        profiler_mode: Optional[ProfilerMode] = None,
+        auto_enabling_integrations: bool = True,
+        auto_session_tracking: bool = True,
+        send_client_reports: bool = True,
+        _experiments: Experiments = {},  # noqa: B006
+        proxy_headers: Optional[Dict[str, str]] = None,
+        instrumenter: Optional[str] = INSTRUMENTER.SENTRY,
+        before_send_transaction: Optional[TransactionProcessor] = None,
+        project_root: Optional[str] = None,
+        enable_tracing: Optional[bool] = None,
+        include_local_variables: Optional[bool] = True,
+        include_source_context: Optional[bool] = True,
+        trace_propagation_targets: Optional[Sequence[str]] = [MATCH_ALL],  # noqa: B006
+        functions_to_trace: Sequence[Dict[str, str]] = [],  # noqa: B006
+        event_scrubber: Optional[sentry_sdk.scrubber.EventScrubber] = None,
+        max_value_length: int = DEFAULT_MAX_VALUE_LENGTH,
+        enable_backpressure_handling: bool = True,
+        error_sampler: Optional[Callable[[Event, Hint], Union[float, bool]]] = None,
+        enable_db_query_source: bool = False,
+        db_query_source_threshold_ms: int = 100,
+        spotlight: Optional[Union[bool, str]] = None,
+    ) -> None:
         pass
 
 
-def _get_default_options():
-    # type: () -> Dict[str, Any]
+def _get_default_options() -> Dict[str, Any]:
     import inspect
 
     if hasattr(inspect, "getfullargspec"):

--- a/sentry_sdk/consts.py
+++ b/sentry_sdk/consts.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from sentry_sdk._types import TYPE_CHECKING
 
 # up top to prevent circular import due to integration import

--- a/sentry_sdk/crons/api.py
+++ b/sentry_sdk/crons/api.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import uuid
 
 from sentry_sdk import Hub

--- a/sentry_sdk/crons/api.py
+++ b/sentry_sdk/crons/api.py
@@ -9,15 +9,14 @@ if TYPE_CHECKING:
 
 
 def _create_check_in_event(
-    monitor_slug=None,
-    check_in_id=None,
-    status=None,
-    duration_s=None,
-    monitor_config=None,
-):
-    # type: (Optional[str], Optional[str], Optional[str], Optional[float], Optional[Dict[str, Any]]) -> Dict[str, Any]
+    monitor_slug: Optional[str] = None,
+    check_in_id: Optional[str] = None,
+    status: Optional[str] = None,
+    duration_s: Optional[float] = None,
+    monitor_config: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
     options = Hub.current.client.options if Hub.current.client else {}
-    check_in_id = check_in_id or uuid.uuid4().hex  # type: str
+    check_in_id: str = check_in_id or uuid.uuid4().hex
 
     check_in = {
         "type": "check_in",
@@ -36,13 +35,12 @@ def _create_check_in_event(
 
 
 def capture_checkin(
-    monitor_slug=None,
-    check_in_id=None,
-    status=None,
-    duration=None,
-    monitor_config=None,
-):
-    # type: (Optional[str], Optional[str], Optional[str], Optional[float], Optional[Dict[str, Any]]) -> str
+    monitor_slug: Optional[str] = None,
+    check_in_id: Optional[str] = None,
+    status: Optional[str] = None,
+    duration: Optional[float] = None,
+    monitor_config: Optional[Dict[str, Any]] = None,
+) -> str:
     check_in_event = _create_check_in_event(
         monitor_slug=monitor_slug,
         check_in_id=check_in_id,

--- a/sentry_sdk/crons/decorator.py
+++ b/sentry_sdk/crons/decorator.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import sys
 from contextlib import contextmanager
 

--- a/sentry_sdk/crons/decorator.py
+++ b/sentry_sdk/crons/decorator.py
@@ -11,8 +11,7 @@ if TYPE_CHECKING:
 
 
 @contextmanager
-def monitor(monitor_slug=None):
-    # type: (Optional[str]) -> Generator[None, None, None]
+def monitor(monitor_slug: Optional[str] = None) -> Generator[None, None, None]:
     """
     Decorator/context manager to capture checkin events for a monitor.
 

--- a/sentry_sdk/db/explain_plan/__init__.py
+++ b/sentry_sdk/db/explain_plan/__init__.py
@@ -11,8 +11,7 @@ EXPLAIN_CACHE_SIZE = 50
 EXPLAIN_CACHE_TIMEOUT_SECONDS = 60 * 60 * 24
 
 
-def cache_statement(statement, options):
-    # type: (str, dict[str, Any]) -> None
+def cache_statement(statement: str, options: dict[str, Any]) -> None:
     global EXPLAIN_CACHE
 
     now = datetime.now(timezone.utc)
@@ -24,8 +23,7 @@ def cache_statement(statement, options):
     EXPLAIN_CACHE[hash(statement)] = expiration_time
 
 
-def remove_expired_cache_items():
-    # type: () -> None
+def remove_expired_cache_items() -> None:
     """
     Remove expired cache items from the cache.
     """
@@ -39,8 +37,7 @@ def remove_expired_cache_items():
             del EXPLAIN_CACHE[key]
 
 
-def should_run_explain_plan(statement, options):
-    # type: (str, dict[str, Any]) -> bool
+def should_run_explain_plan(statement: str, options: dict[str, Any]) -> bool:
     """
     Check cache if the explain plan for the given statement should be run.
     """

--- a/sentry_sdk/db/explain_plan/__init__.py
+++ b/sentry_sdk/db/explain_plan/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from datetime import datetime, timedelta, timezone
 
 from sentry_sdk.consts import TYPE_CHECKING

--- a/sentry_sdk/db/explain_plan/django.py
+++ b/sentry_sdk/db/explain_plan/django.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from sentry_sdk.consts import TYPE_CHECKING
 from sentry_sdk.db.explain_plan import cache_statement, should_run_explain_plan
 

--- a/sentry_sdk/db/explain_plan/django.py
+++ b/sentry_sdk/db/explain_plan/django.py
@@ -9,9 +9,13 @@ if TYPE_CHECKING:
 
 
 def attach_explain_plan_to_span(
-    span, connection, statement, parameters, mogrify, options
-):
-    # type: (Span, Any, str, Any, Callable[[str, Any], bytes], dict[str, Any]) -> None
+    span: Span,
+    connection: Any,
+    statement: str,
+    parameters: Any,
+    mogrify: Callable[[str, Any], bytes],
+    options: dict[str, Any],
+) -> None:
     """
     Run EXPLAIN or EXPLAIN ANALYZE on the given statement and attach the explain plan to the span data.
 

--- a/sentry_sdk/db/explain_plan/sqlalchemy.py
+++ b/sentry_sdk/db/explain_plan/sqlalchemy.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from sentry_sdk.consts import TYPE_CHECKING
 from sentry_sdk.db.explain_plan import cache_statement, should_run_explain_plan
 from sentry_sdk.integrations import DidNotEnable

--- a/sentry_sdk/db/explain_plan/sqlalchemy.py
+++ b/sentry_sdk/db/explain_plan/sqlalchemy.py
@@ -13,8 +13,13 @@ if TYPE_CHECKING:
     from sentry_sdk.tracing import Span
 
 
-def attach_explain_plan_to_span(span, connection, statement, parameters, options):
-    # type: (Span, Any, str, Any, dict[str, Any]) -> None
+def attach_explain_plan_to_span(
+    span: Span,
+    connection: Any,
+    statement: str,
+    parameters: Any,
+    options: dict[str, Any],
+) -> None:
     """
     Run EXPLAIN or EXPLAIN ANALYZE on the given statement and attach the explain plan to the span data.
 

--- a/sentry_sdk/debug.py
+++ b/sentry_sdk/debug.py
@@ -9,8 +9,7 @@ from logging import LogRecord
 
 
 class _HubBasedClientFilter(logging.Filter):
-    def filter(self, record):
-        # type: (LogRecord) -> bool
+    def filter(self, record: LogRecord) -> bool:
         if _client_init_debug.get(False):
             return True
         hub = Hub.current
@@ -19,15 +18,13 @@ class _HubBasedClientFilter(logging.Filter):
         return False
 
 
-def init_debug_support():
-    # type: () -> None
+def init_debug_support() -> None:
     if not logger.handlers:
         configure_logger()
     configure_debug_hub()
 
 
-def configure_logger():
-    # type: () -> None
+def configure_logger() -> None:
     _handler = logging.StreamHandler(sys.stderr)
     _handler.setFormatter(logging.Formatter(" [sentry] %(levelname)s: %(message)s"))
     logger.addHandler(_handler)
@@ -35,10 +32,8 @@ def configure_logger():
     logger.addFilter(_HubBasedClientFilter())
 
 
-def configure_debug_hub():
-    # type: () -> None
-    def _get_debug_hub():
-        # type: () -> Hub
+def configure_debug_hub() -> None:
+    def _get_debug_hub() -> Hub:
         return Hub.current
 
     utils._get_debug_hub = _get_debug_hub

--- a/sentry_sdk/envelope.py
+++ b/sentry_sdk/envelope.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import io
 import json
 import mimetypes
@@ -17,8 +19,7 @@ if TYPE_CHECKING:
     from sentry_sdk._types import Event, EventDataCategory
 
 
-def parse_json(data):
-    # type: (Union[bytes, str]) -> Any
+def parse_json(data: Union[bytes, str]) -> Any:
     # on some python 3 versions this needs to be bytes
     if isinstance(data, bytes):
         data = data.decode("utf-8", "replace")
@@ -28,10 +29,9 @@ def parse_json(data):
 class Envelope:
     def __init__(
         self,
-        headers=None,  # type: Optional[Dict[str, Any]]
-        items=None,  # type: Optional[List[Item]]
-    ):
-        # type: (...) -> None
+        headers: Optional[Dict[str, Any]] = None,
+        items: Optional[List[Item]] = None,
+    ) -> None:
         if headers is not None:
             headers = dict(headers)
         self.headers = headers or {}
@@ -42,97 +42,65 @@ class Envelope:
         self.items = items
 
     @property
-    def description(self):
-        # type: (...) -> str
+    def description(self) -> str:
         return "envelope with %s items (%s)" % (
             len(self.items),
             ", ".join(x.data_category for x in self.items),
         )
 
-    def add_event(
-        self, event  # type: Event
-    ):
-        # type: (...) -> None
+    def add_event(self, event: Event) -> None:
         self.add_item(Item(payload=PayloadRef(json=event), type="event"))
 
-    def add_transaction(
-        self, transaction  # type: Event
-    ):
-        # type: (...) -> None
+    def add_transaction(self, transaction: Event) -> None:
         self.add_item(Item(payload=PayloadRef(json=transaction), type="transaction"))
 
-    def add_profile(
-        self, profile  # type: Any
-    ):
-        # type: (...) -> None
+    def add_profile(self, profile: Any) -> None:
         self.add_item(Item(payload=PayloadRef(json=profile), type="profile"))
 
-    def add_checkin(
-        self, checkin  # type: Any
-    ):
-        # type: (...) -> None
+    def add_checkin(self, checkin: Any) -> None:
         self.add_item(Item(payload=PayloadRef(json=checkin), type="check_in"))
 
-    def add_session(
-        self, session  # type: Union[Session, Any]
-    ):
-        # type: (...) -> None
+    def add_session(self, session: Union[Session, Any]) -> None:
         if isinstance(session, Session):
             session = session.to_json()
         self.add_item(Item(payload=PayloadRef(json=session), type="session"))
 
-    def add_sessions(
-        self, sessions  # type: Any
-    ):
-        # type: (...) -> None
+    def add_sessions(self, sessions: Any) -> None:
         self.add_item(Item(payload=PayloadRef(json=sessions), type="sessions"))
 
-    def add_item(
-        self, item  # type: Item
-    ):
-        # type: (...) -> None
+    def add_item(self, item: Item) -> None:
         self.items.append(item)
 
-    def get_event(self):
-        # type: (...) -> Optional[Event]
+    def get_event(self) -> Optional[Event]:
         for items in self.items:
             event = items.get_event()
             if event is not None:
                 return event
         return None
 
-    def get_transaction_event(self):
-        # type: (...) -> Optional[Event]
+    def get_transaction_event(self) -> Optional[Event]:
         for item in self.items:
             event = item.get_transaction_event()
             if event is not None:
                 return event
         return None
 
-    def __iter__(self):
-        # type: (...) -> Iterator[Item]
+    def __iter__(self) -> Iterator[Item]:
         return iter(self.items)
 
-    def serialize_into(
-        self, f  # type: Any
-    ):
-        # type: (...) -> None
+    def serialize_into(self, f: Any) -> None:
         f.write(json_dumps(self.headers))
         f.write(b"\n")
         for item in self.items:
             item.serialize_into(f)
 
-    def serialize(self):
-        # type: (...) -> bytes
+    def serialize(self) -> bytes:
         out = io.BytesIO()
         self.serialize_into(out)
         return out.getvalue()
 
     @classmethod
-    def deserialize_from(
-        cls, f  # type: Any
-    ):
-        # type: (...) -> Envelope
+    def deserialize_from(cls, f: Any) -> Envelope:
         headers = parse_json(f.readline())
         items = []
         while 1:
@@ -143,31 +111,25 @@ class Envelope:
         return cls(headers=headers, items=items)
 
     @classmethod
-    def deserialize(
-        cls, bytes  # type: bytes
-    ):
-        # type: (...) -> Envelope
+    def deserialize(cls, bytes: bytes) -> Envelope:
         return cls.deserialize_from(io.BytesIO(bytes))
 
-    def __repr__(self):
-        # type: (...) -> str
+    def __repr__(self) -> str:
         return "<Envelope headers=%r items=%r>" % (self.headers, self.items)
 
 
 class PayloadRef:
     def __init__(
         self,
-        bytes=None,  # type: Optional[bytes]
-        path=None,  # type: Optional[Union[bytes, str]]
-        json=None,  # type: Optional[Any]
-    ):
-        # type: (...) -> None
+        bytes: Optional[bytes] = None,
+        path: Optional[Union[bytes, str]] = None,
+        json: Optional[Any] = None,
+    ) -> None:
         self.json = json
         self.bytes = bytes
         self.path = path
 
-    def get_bytes(self):
-        # type: (...) -> bytes
+    def get_bytes(self) -> bytes:
         if self.bytes is None:
             if self.path is not None:
                 with capture_internal_exceptions():
@@ -180,8 +142,7 @@ class PayloadRef:
         return self.bytes
 
     @property
-    def inferred_content_type(self):
-        # type: (...) -> str
+    def inferred_content_type(self) -> str:
         if self.json is not None:
             return "application/json"
         elif self.path is not None:
@@ -193,19 +154,18 @@ class PayloadRef:
                 return ty
         return "application/octet-stream"
 
-    def __repr__(self):
-        # type: (...) -> str
+    def __repr__(self) -> str:
         return "<Payload %r>" % (self.inferred_content_type,)
 
 
 class Item:
     def __init__(
         self,
-        payload,  # type: Union[bytes, str, PayloadRef]
-        headers=None,  # type: Optional[Dict[str, Any]]
-        type=None,  # type: Optional[str]
-        content_type=None,  # type: Optional[str]
-        filename=None,  # type: Optional[str]
+        payload: Union[bytes, str, PayloadRef],
+        headers: Optional[Dict[str, Any]] = None,
+        type: Optional[str] = None,
+        content_type: Optional[str] = None,
+        filename: Optional[str] = None,
     ):
         if headers is not None:
             headers = dict(headers)
@@ -230,8 +190,7 @@ class Item:
 
         self.payload = payload
 
-    def __repr__(self):
-        # type: (...) -> str
+    def __repr__(self) -> str:
         return "<Item headers=%r payload=%r data_category=%r>" % (
             self.headers,
             self.payload,
@@ -239,13 +198,11 @@ class Item:
         )
 
     @property
-    def type(self):
-        # type: (...) -> Optional[str]
+    def type(self) -> Optional[str]:
         return self.headers.get("type")
 
     @property
-    def data_category(self):
-        # type: (...) -> EventDataCategory
+    def data_category(self) -> EventDataCategory:
         ty = self.headers.get("type")
         if ty == "session":
             return "session"
@@ -266,12 +223,10 @@ class Item:
         else:
             return "default"
 
-    def get_bytes(self):
-        # type: (...) -> bytes
+    def get_bytes(self) -> bytes:
         return self.payload.get_bytes()
 
-    def get_event(self):
-        # type: (...) -> Optional[Event]
+    def get_event(self) -> Optional[Event]:
         """
         Returns an error event if there is one.
         """
@@ -279,16 +234,12 @@ class Item:
             return self.payload.json
         return None
 
-    def get_transaction_event(self):
-        # type: (...) -> Optional[Event]
+    def get_transaction_event(self) -> Optional[Event]:
         if self.type == "transaction" and self.payload.json is not None:
             return self.payload.json
         return None
 
-    def serialize_into(
-        self, f  # type: Any
-    ):
-        # type: (...) -> None
+    def serialize_into(self, f: Any) -> None:
         headers = dict(self.headers)
         bytes = self.get_bytes()
         headers["length"] = len(bytes)
@@ -297,17 +248,13 @@ class Item:
         f.write(bytes)
         f.write(b"\n")
 
-    def serialize(self):
-        # type: (...) -> bytes
+    def serialize(self) -> bytes:
         out = io.BytesIO()
         self.serialize_into(out)
         return out.getvalue()
 
     @classmethod
-    def deserialize_from(
-        cls, f  # type: Any
-    ):
-        # type: (...) -> Optional[Item]
+    def deserialize_from(cls, f: Any) -> Optional[Item]:
         line = f.readline().rstrip()
         if not line:
             return None
@@ -327,8 +274,5 @@ class Item:
         return rv
 
     @classmethod
-    def deserialize(
-        cls, bytes  # type: bytes
-    ):
-        # type: (...) -> Optional[Item]
+    def deserialize(cls, bytes: bytes) -> Optional[Item]:
         return cls.deserialize_from(io.BytesIO(bytes))

--- a/sentry_sdk/integrations/__init__.py
+++ b/sentry_sdk/integrations/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from threading import Lock
 
 from sentry_sdk._types import TYPE_CHECKING
@@ -16,20 +18,19 @@ if TYPE_CHECKING:
 _installer_lock = Lock()
 
 # Set of all integration identifiers we have attempted to install
-_processed_integrations = set()  # type: Set[str]
+_processed_integrations: Set[str] = set()
 
 # Set of all integration identifiers we have actually installed
-_installed_integrations = set()  # type: Set[str]
+_installed_integrations: Set[str] = set()
 
 
 def _generate_default_integrations_iterator(
-    integrations,  # type: List[str]
-    auto_enabling_integrations,  # type: List[str]
-):
-    # type: (...) -> Callable[[bool], Iterator[Type[Integration]]]
-
-    def iter_default_integrations(with_auto_enabling_integrations):
-        # type: (bool) -> Iterator[Type[Integration]]
+    integrations: List[str],
+    auto_enabling_integrations: List[str],
+) -> Callable[[bool], Iterator[Type[Integration]]]:
+    def iter_default_integrations(
+        with_auto_enabling_integrations: bool,
+    ) -> Iterator[Type[Integration]]:
         """Returns an iterator of the default integration classes:"""
         from importlib import import_module
 
@@ -95,9 +96,10 @@ del _generate_default_integrations_iterator
 
 
 def setup_integrations(
-    integrations, with_defaults=True, with_auto_enabling_integrations=False
-):
-    # type: (List[Integration], bool, bool) -> Dict[str, Integration]
+    integrations: List[Integration],
+    with_defaults: bool = True,
+    with_auto_enabling_integrations: bool = False,
+) -> Dict[str, Integration]:
     """
     Given a list of integration instances, this installs them all.
 
@@ -184,12 +186,11 @@ class Integration:
     install = None
     """Legacy method, do not implement."""
 
-    identifier = None  # type: str
+    identifier: str = None
     """String unique ID of integration type"""
 
     @staticmethod
-    def setup_once():
-        # type: () -> None
+    def setup_once() -> None:
         """
         Initialize the integration.
 

--- a/sentry_sdk/integrations/_asgi_common.py
+++ b/sentry_sdk/integrations/_asgi_common.py
@@ -14,12 +14,11 @@ if TYPE_CHECKING:
     from sentry_sdk.utils import AnnotatedValue
 
 
-def _get_headers(asgi_scope):
-    # type: (Any) -> Dict[str, str]
+def _get_headers(asgi_scope: Any) -> Dict[str, str]:
     """
     Extract headers from the ASGI scope, in the format that the Sentry protocol expects.
     """
-    headers = {}  # type: Dict[str, str]
+    headers: Dict[str, str] = {}
     for raw_key, raw_value in asgi_scope["headers"]:
         key = raw_key.decode("latin-1")
         value = raw_value.decode("latin-1")
@@ -31,8 +30,11 @@ def _get_headers(asgi_scope):
     return headers
 
 
-def _get_url(asgi_scope, default_scheme, host):
-    # type: (Dict[str, Any], Literal["ws", "http"], Optional[Union[AnnotatedValue, str]]) -> str
+def _get_url(
+    asgi_scope: Dict[str, Any],
+    default_scheme: Literal["ws", "http"],
+    host: Optional[Union[AnnotatedValue, str]],
+) -> str:
     """
     Extract URL from the ASGI scope, without also including the querystring.
     """
@@ -53,8 +55,7 @@ def _get_url(asgi_scope, default_scheme, host):
     return path
 
 
-def _get_query(asgi_scope):
-    # type: (Any) -> Any
+def _get_query(asgi_scope: Any) -> Any:
     """
     Extract querystring from the ASGI scope, in the format that the Sentry protocol expects.
     """
@@ -64,8 +65,7 @@ def _get_query(asgi_scope):
     return urllib.parse.unquote(qs.decode("latin-1"))
 
 
-def _get_ip(asgi_scope):
-    # type: (Any) -> str
+def _get_ip(asgi_scope: Any) -> str:
     """
     Extract IP Address from the ASGI scope based on request headers with fallback to scope client.
     """
@@ -83,12 +83,11 @@ def _get_ip(asgi_scope):
     return asgi_scope.get("client")[0]
 
 
-def _get_request_data(asgi_scope):
-    # type: (Any) -> Dict[str, Any]
+def _get_request_data(asgi_scope: Any) -> Dict[str, Any]:
     """
     Returns data related to the HTTP request from the ASGI scope.
     """
-    request_data = {}  # type: Dict[str, Any]
+    request_data: Dict[str, Any] = {}
     ty = asgi_scope["type"]
     if ty in ("http", "websocket"):
         request_data["method"] = asgi_scope.get("method")

--- a/sentry_sdk/integrations/_asgi_common.py
+++ b/sentry_sdk/integrations/_asgi_common.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import urllib
 
 from sentry_sdk.hub import _should_send_default_pii

--- a/sentry_sdk/integrations/_wsgi_common.py
+++ b/sentry_sdk/integrations/_wsgi_common.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import json
 from copy import deepcopy
 

--- a/sentry_sdk/integrations/_wsgi_common.py
+++ b/sentry_sdk/integrations/_wsgi_common.py
@@ -37,8 +37,9 @@ SENSITIVE_HEADERS = tuple(
 )
 
 
-def request_body_within_bounds(client, content_length):
-    # type: (Optional[sentry_sdk.Client], int) -> bool
+def request_body_within_bounds(
+    client: Optional[sentry_sdk.Client], content_length: int
+) -> bool:
     if client is None:
         return False
 
@@ -51,17 +52,15 @@ def request_body_within_bounds(client, content_length):
 
 
 class RequestExtractor:
-    def __init__(self, request):
-        # type: (Any) -> None
+    def __init__(self, request: Any) -> None:
         self.request = request
 
-    def extract_into_event(self, event):
-        # type: (Dict[str, Any]) -> None
+    def extract_into_event(self, event: Dict[str, Any]) -> None:
         client = Hub.current.client
         if client is None:
             return
 
-        data = None  # type: Optional[Union[AnnotatedValue, Dict[str, Any]]]
+        data: Optional[Union[AnnotatedValue, Dict[str, Any]]] = None
 
         content_length = self.content_length()
         request_info = event.get("request", {})
@@ -97,27 +96,22 @@ class RequestExtractor:
 
         event["request"] = deepcopy(request_info)
 
-    def content_length(self):
-        # type: () -> int
+    def content_length(self) -> int:
         try:
             return int(self.env().get("CONTENT_LENGTH", 0))
         except ValueError:
             return 0
 
-    def cookies(self):
-        # type: () -> Dict[str, Any]
+    def cookies(self) -> Dict[str, Any]:
         raise NotImplementedError()
 
-    def raw_data(self):
-        # type: () -> Optional[Union[str, bytes]]
+    def raw_data(self) -> Optional[Union[str, bytes]]:
         raise NotImplementedError()
 
-    def form(self):
-        # type: () -> Optional[Dict[str, Any]]
+    def form(self) -> Optional[Dict[str, Any]]:
         raise NotImplementedError()
 
-    def parsed_body(self):
-        # type: () -> Optional[Dict[str, Any]]
+    def parsed_body(self) -> Optional[Dict[str, Any]]:
         form = self.form()
         files = self.files()
         if form or files:
@@ -132,12 +126,10 @@ class RequestExtractor:
 
         return self.json()
 
-    def is_json(self):
-        # type: () -> bool
+    def is_json(self) -> bool:
         return _is_json_content_type(self.env().get("CONTENT_TYPE"))
 
-    def json(self):
-        # type: () -> Optional[Any]
+    def json(self) -> Optional[Any]:
         try:
             if not self.is_json():
                 return None
@@ -155,21 +147,17 @@ class RequestExtractor:
 
         return None
 
-    def files(self):
-        # type: () -> Optional[Dict[str, Any]]
+    def files(self) -> Optional[Dict[str, Any]]:
         raise NotImplementedError()
 
-    def size_of_file(self, file):
-        # type: (Any) -> int
+    def size_of_file(self, file: Any) -> int:
         raise NotImplementedError()
 
-    def env(self):
-        # type: () -> Dict[str, Any]
+    def env(self) -> Dict[str, Any]:
         raise NotImplementedError()
 
 
-def _is_json_content_type(ct):
-    # type: (Optional[str]) -> bool
+def _is_json_content_type(ct: Optional[str]) -> bool:
     mt = (ct or "").split(";", 1)[0]
     return (
         mt == "application/json"
@@ -178,8 +166,9 @@ def _is_json_content_type(ct):
     )
 
 
-def _filter_headers(headers):
-    # type: (Mapping[str, str]) -> Mapping[str, Union[AnnotatedValue, str]]
+def _filter_headers(
+    headers: Mapping[str, str]
+) -> Mapping[str, Union[AnnotatedValue, str]]:
     if _should_send_default_pii():
         return headers
 

--- a/sentry_sdk/integrations/aiohttp.py
+++ b/sentry_sdk/integrations/aiohttp.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import sys
 import weakref
 

--- a/sentry_sdk/integrations/argv.py
+++ b/sentry_sdk/integrations/argv.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import sys
 
 from sentry_sdk.hub import Hub

--- a/sentry_sdk/integrations/argv.py
+++ b/sentry_sdk/integrations/argv.py
@@ -16,11 +16,9 @@ class ArgvIntegration(Integration):
     identifier = "argv"
 
     @staticmethod
-    def setup_once():
-        # type: () -> None
+    def setup_once() -> None:
         @add_global_event_processor
-        def processor(event, hint):
-            # type: (Event, Optional[Hint]) -> Optional[Event]
+        def processor(event: Event, hint: Optional[Hint]) -> Optional[Event]:
             if Hub.current.get_integration(ArgvIntegration) is not None:
                 extra = event.setdefault("extra", {})
                 # If some event processor decided to set extra to e.g. an

--- a/sentry_sdk/integrations/ariadne.py
+++ b/sentry_sdk/integrations/ariadne.py
@@ -30,8 +30,7 @@ class AriadneIntegration(Integration):
     identifier = "ariadne"
 
     @staticmethod
-    def setup_once():
-        # type: () -> None
+    def setup_once() -> None:
         version = package_version("ariadne")
 
         if version is None:
@@ -45,14 +44,14 @@ class AriadneIntegration(Integration):
         _patch_graphql()
 
 
-def _patch_graphql():
-    # type: () -> None
+def _patch_graphql() -> None:
     old_parse_query = ariadne_graphql.parse_query
     old_handle_errors = ariadne_graphql.handle_graphql_errors
     old_handle_query_result = ariadne_graphql.handle_query_result
 
-    def _sentry_patched_parse_query(context_value, query_parser, data):
-        # type: (Optional[Any], Optional[QueryParser], Any) -> DocumentNode
+    def _sentry_patched_parse_query(
+        context_value: Optional[Any], query_parser: Optional[QueryParser], data: Any
+    ) -> DocumentNode:
         hub = Hub.current
         integration = hub.get_integration(AriadneIntegration)
         if integration is None:
@@ -65,8 +64,9 @@ def _patch_graphql():
         result = old_parse_query(context_value, query_parser, data)
         return result
 
-    def _sentry_patched_handle_graphql_errors(errors, *args, **kwargs):
-        # type: (List[GraphQLError], Any, Any) -> GraphQLResult
+    def _sentry_patched_handle_graphql_errors(
+        errors: List[GraphQLError], *args: Any, **kwargs: Any
+    ) -> GraphQLResult:
         hub = Hub.current
         integration = hub.get_integration(AriadneIntegration)
         if integration is None:
@@ -93,8 +93,9 @@ def _patch_graphql():
 
         return result
 
-    def _sentry_patched_handle_query_result(result, *args, **kwargs):
-        # type: (Any, Any, Any) -> GraphQLResult
+    def _sentry_patched_handle_query_result(
+        result: Any, *args: Any, **kwargs: Any
+    ) -> GraphQLResult:
         hub = Hub.current
         integration = hub.get_integration(AriadneIntegration)
         if integration is None:
@@ -126,12 +127,10 @@ def _patch_graphql():
     ariadne_graphql.handle_query_result = _sentry_patched_handle_query_result  # type: ignore
 
 
-def _make_request_event_processor(data):
-    # type: (GraphQLSchema) -> EventProcessor
+def _make_request_event_processor(data: GraphQLSchema) -> EventProcessor:
     """Add request data and api_target to events."""
 
-    def inner(event, hint):
-        # type: (Dict[str, Any], Dict[str, Any]) -> Dict[str, Any]
+    def inner(event: Dict[str, Any], hint: Dict[str, Any]) -> Dict[str, Any]:
         if not isinstance(data, dict):
             return event
 
@@ -158,12 +157,10 @@ def _make_request_event_processor(data):
     return inner
 
 
-def _make_response_event_processor(response):
-    # type: (Dict[str, Any]) -> EventProcessor
+def _make_response_event_processor(response: Dict[str, Any]) -> EventProcessor:
     """Add response data to the event's response context."""
 
-    def inner(event, hint):
-        # type: (Dict[str, Any], Dict[str, Any]) -> Dict[str, Any]
+    def inner(event: Dict[str, Any], hint: Dict[str, Any]) -> Dict[str, Any]:
         with capture_internal_exceptions():
             if _should_send_default_pii() and response.get("errors"):
                 contexts = event.setdefault("contexts", {})

--- a/sentry_sdk/integrations/ariadne.py
+++ b/sentry_sdk/integrations/ariadne.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from importlib import import_module
 
 from sentry_sdk.hub import Hub, _should_send_default_pii

--- a/sentry_sdk/integrations/arq.py
+++ b/sentry_sdk/integrations/arq.py
@@ -40,9 +40,7 @@ class ArqIntegration(Integration):
     identifier = "arq"
 
     @staticmethod
-    def setup_once():
-        # type: () -> None
-
+    def setup_once() -> None:
         try:
             if isinstance(ARQ_VERSION, str):
                 version = parse_version(ARQ_VERSION)
@@ -65,12 +63,12 @@ class ArqIntegration(Integration):
         ignore_logger("arq.worker")
 
 
-def patch_enqueue_job():
-    # type: () -> None
+def patch_enqueue_job() -> None:
     old_enqueue_job = ArqRedis.enqueue_job
 
-    async def _sentry_enqueue_job(self, function, *args, **kwargs):
-        # type: (ArqRedis, str, *Any, **Any) -> Optional[Job]
+    async def _sentry_enqueue_job(
+        self: ArqRedis, function: str, *args: Any, **kwargs: Any
+    ) -> Optional[Job]:
         hub = Hub.current
 
         if hub.get_integration(ArqIntegration) is None:
@@ -82,12 +80,10 @@ def patch_enqueue_job():
     ArqRedis.enqueue_job = _sentry_enqueue_job
 
 
-def patch_run_job():
-    # type: () -> None
+def patch_run_job() -> None:
     old_run_job = Worker.run_job
 
-    async def _sentry_run_job(self, job_id, score):
-        # type: (Worker, str, int) -> None
+    async def _sentry_run_job(self: Worker, job_id: str, score: int) -> None:
         hub = Hub(Hub.current)
 
         if hub.get_integration(ArqIntegration) is None:
@@ -110,8 +106,7 @@ def patch_run_job():
     Worker.run_job = _sentry_run_job
 
 
-def _capture_exception(exc_info):
-    # type: (ExcInfo) -> None
+def _capture_exception(exc_info: ExcInfo) -> None:
     hub = Hub.current
 
     if hub.scope.transaction is not None:
@@ -129,11 +124,10 @@ def _capture_exception(exc_info):
     hub.capture_event(event, hint=hint)
 
 
-def _make_event_processor(ctx, *args, **kwargs):
-    # type: (Dict[Any, Any], *Any, **Any) -> EventProcessor
-    def event_processor(event, hint):
-        # type: (Event, Hint) -> Optional[Event]
-
+def _make_event_processor(
+    ctx: Dict[Any, Any], *args: Any, **kwargs: Any
+) -> EventProcessor:
+    def event_processor(event: Event, hint: Hint) -> Optional[Event]:
         hub = Hub.current
 
         with capture_internal_exceptions():
@@ -161,10 +155,8 @@ def _make_event_processor(ctx, *args, **kwargs):
     return event_processor
 
 
-def _wrap_coroutine(name, coroutine):
-    # type: (str, WorkerCoroutine) -> WorkerCoroutine
-    async def _sentry_coroutine(ctx, *args, **kwargs):
-        # type: (Dict[Any, Any], *Any, **Any) -> Any
+def _wrap_coroutine(name: str, coroutine: WorkerCoroutine) -> WorkerCoroutine:
+    async def _sentry_coroutine(ctx: Dict[Any, Any], *args: Any, **kwargs: Any) -> Any:
         hub = Hub.current
         if hub.get_integration(ArqIntegration) is None:
             return await coroutine(ctx, *args, **kwargs)
@@ -185,12 +177,10 @@ def _wrap_coroutine(name, coroutine):
     return _sentry_coroutine
 
 
-def patch_create_worker():
-    # type: () -> None
+def patch_create_worker() -> None:
     old_create_worker = arq.worker.create_worker
 
-    def _sentry_create_worker(*args, **kwargs):
-        # type: (*Any, **Any) -> Worker
+    def _sentry_create_worker(*args: Any, **kwargs: Any) -> Worker:
         hub = Hub.current
 
         if hub.get_integration(ArqIntegration) is None:
@@ -221,16 +211,14 @@ def patch_create_worker():
     arq.worker.create_worker = _sentry_create_worker
 
 
-def _get_arq_function(func):
-    # type: (Union[str, Function, WorkerCoroutine]) -> Function
+def _get_arq_function(func: Union[str, Function, WorkerCoroutine]) -> Function:
     arq_func = arq.worker.func(func)
     arq_func.coroutine = _wrap_coroutine(arq_func.name, arq_func.coroutine)
 
     return arq_func
 
 
-def _get_arq_cron_job(cron_job):
-    # type: (CronJob) -> CronJob
+def _get_arq_cron_job(cron_job: CronJob) -> CronJob:
     cron_job.coroutine = _wrap_coroutine(cron_job.name, cron_job.coroutine)
 
     return cron_job

--- a/sentry_sdk/integrations/arq.py
+++ b/sentry_sdk/integrations/arq.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import sys
 
 from sentry_sdk._types import TYPE_CHECKING

--- a/sentry_sdk/integrations/asyncio.py
+++ b/sentry_sdk/integrations/asyncio.py
@@ -20,8 +20,7 @@ if TYPE_CHECKING:
     from sentry_sdk._types import ExcInfo
 
 
-def get_name(coro):
-    # type: (Any) -> str
+def get_name(coro: Any) -> str:
     return (
         getattr(coro, "__qualname__", None)
         or getattr(coro, "__name__", None)
@@ -29,18 +28,18 @@ def get_name(coro):
     )
 
 
-def patch_asyncio():
-    # type: () -> None
+def patch_asyncio() -> None:
     orig_task_factory = None
     try:
         loop = asyncio.get_running_loop()
         orig_task_factory = loop.get_task_factory()
 
-        def _sentry_task_factory(loop, coro, **kwargs):
-            # type: (asyncio.AbstractEventLoop, Coroutine[Any, Any, Any], Any) -> asyncio.Future[Any]
-
-            async def _coro_creating_hub_and_span():
-                # type: () -> Any
+        def _sentry_task_factory(
+            loop: asyncio.AbstractEventLoop,
+            coro: Coroutine[Any, Any, Any],
+            **kwargs: Any
+        ) -> asyncio.Future[Any]:
+            async def _coro_creating_hub_and_span() -> Any:
                 hub = Hub(Hub.current)
                 result = None
 
@@ -76,14 +75,13 @@ def patch_asyncio():
         pass
 
 
-def _capture_exception(hub):
-    # type: (Hub) -> ExcInfo
+def _capture_exception(hub: Hub) -> ExcInfo:
     exc_info = sys.exc_info()
 
     integration = hub.get_integration(AsyncioIntegration)
     if integration is not None:
         # If an integration is there, a client has to be there.
-        client = hub.client  # type: Any
+        client: Any = hub.client
 
         event, hint = event_from_exception(
             exc_info,
@@ -99,6 +97,5 @@ class AsyncioIntegration(Integration):
     identifier = "asyncio"
 
     @staticmethod
-    def setup_once():
-        # type: () -> None
+    def setup_once() -> None:
         patch_asyncio()

--- a/sentry_sdk/integrations/asyncpg.py
+++ b/sentry_sdk/integrations/asyncpg.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 import contextlib
 from typing import Any, TypeVar, Callable, Awaitable, Iterator
 

--- a/sentry_sdk/integrations/atexit.py
+++ b/sentry_sdk/integrations/atexit.py
@@ -13,15 +13,13 @@ if TYPE_CHECKING:
     from typing import Optional
 
 
-def default_callback(pending, timeout):
-    # type: (int, int) -> None
+def default_callback(pending: int, timeout: int) -> None:
     """This is the default shutdown callback that is set on the options.
     It prints out a message to stderr that informs the user that some events
     are still pending and the process is waiting for them to flush out.
     """
 
-    def echo(msg):
-        # type: (str) -> None
+    def echo(msg: str) -> None:
         sys.stderr.write(msg + "\n")
 
     echo("Sentry is attempting to send %i pending events" % pending)
@@ -33,18 +31,15 @@ def default_callback(pending, timeout):
 class AtexitIntegration(Integration):
     identifier = "atexit"
 
-    def __init__(self, callback=None):
-        # type: (Optional[Any]) -> None
+    def __init__(self, callback: Optional[Any] = None) -> None:
         if callback is None:
             callback = default_callback
         self.callback = callback
 
     @staticmethod
-    def setup_once():
-        # type: () -> None
+    def setup_once() -> None:
         @atexit.register
-        def _shutdown():
-            # type: () -> None
+        def _shutdown() -> None:
             logger.debug("atexit: got shutdown signal")
             hub = Hub.main
             integration = hub.get_integration(AtexitIntegration)
@@ -55,5 +50,5 @@ class AtexitIntegration(Integration):
                 hub.end_session()
 
                 # If an integration is there, a client has to be there.
-                client = hub.client  # type: Any
+                client: Any = hub.client
                 client.close(callback=integration.callback)

--- a/sentry_sdk/integrations/atexit.py
+++ b/sentry_sdk/integrations/atexit.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 import sys
 import atexit

--- a/sentry_sdk/integrations/aws_lambda.py
+++ b/sentry_sdk/integrations/aws_lambda.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import sys
 from copy import deepcopy
 from datetime import datetime, timedelta, timezone

--- a/sentry_sdk/integrations/beam.py
+++ b/sentry_sdk/integrations/beam.py
@@ -31,8 +31,7 @@ class BeamIntegration(Integration):
     identifier = "beam"
 
     @staticmethod
-    def setup_once():
-        # type: () -> None
+    def setup_once() -> None:
         from apache_beam.transforms.core import DoFn, ParDo  # type: ignore
 
         ignore_logger("root")
@@ -48,8 +47,7 @@ class BeamIntegration(Integration):
 
         old_init = ParDo.__init__
 
-        def sentry_init_pardo(self, fn, *args, **kwargs):
-            # type: (ParDo, Any, *Any, **Any) -> Any
+        def sentry_init_pardo(self: ParDo, fn: Any, *args: Any, **kwargs: Any) -> Any:
             # Do not monkey patch init twice
             if not getattr(self, "_sentry_is_patched", False):
                 for func_name in function_patches:
@@ -75,14 +73,11 @@ class BeamIntegration(Integration):
         ParDo.__init__ = sentry_init_pardo
 
 
-def _wrap_inspect_call(cls, func_name):
-    # type: (Any, Any) -> Any
-
+def _wrap_inspect_call(cls: Any, func_name: Any) -> Any:
     if not hasattr(cls, func_name):
         return None
 
-    def _inspect(self):
-        # type: (Any) -> Any
+    def _inspect(self: Any) -> Any:
         """
         Inspect function overrides the way Beam gets argspec.
         """
@@ -109,8 +104,7 @@ def _wrap_inspect_call(cls, func_name):
     return _inspect
 
 
-def _wrap_task_call(func):
-    # type: (F) -> F
+def _wrap_task_call(func: F) -> F:
     """
     Wrap task call with a try catch to get exceptions.
     Pass the client on to raise_exception so it can get rebinded.
@@ -118,8 +112,7 @@ def _wrap_task_call(func):
     client = Hub.current.client
 
     @wraps(func)
-    def _inner(*args, **kwargs):
-        # type: (*Any, **Any) -> Any
+    def _inner(*args: Any, **kwargs: Any) -> Any:
         try:
             gen = func(*args, **kwargs)
         except Exception:
@@ -133,8 +126,7 @@ def _wrap_task_call(func):
     return _inner  # type: ignore
 
 
-def _capture_exception(exc_info, hub):
-    # type: (ExcInfo, Hub) -> None
+def _capture_exception(exc_info: ExcInfo, hub: Hub) -> None:
     """
     Send Beam exception to Sentry.
     """
@@ -154,8 +146,7 @@ def _capture_exception(exc_info, hub):
     hub.capture_event(event, hint=hint)
 
 
-def raise_exception(client):
-    # type: (Optional[Client]) -> None
+def raise_exception(client: Optional[Client]) -> None:
     """
     Raise an exception. If the client is not in the hub, rebind it.
     """
@@ -168,8 +159,7 @@ def raise_exception(client):
     reraise(*exc_info)
 
 
-def _wrap_generator_call(gen, client):
-    # type: (Iterator[T], Optional[Client]) -> Iterator[T]
+def _wrap_generator_call(gen: Iterator[T], client: Optional[Client]) -> Iterator[T]:
     """
     Wrap the generator to handle any failures.
     """

--- a/sentry_sdk/integrations/beam.py
+++ b/sentry_sdk/integrations/beam.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import sys
 import types
 from functools import wraps

--- a/sentry_sdk/integrations/boto3.py
+++ b/sentry_sdk/integrations/boto3.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from functools import partial
 
 from sentry_sdk import Hub

--- a/sentry_sdk/integrations/bottle.py
+++ b/sentry_sdk/integrations/bottle.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from sentry_sdk.hub import Hub
 from sentry_sdk.tracing import SOURCE_FOR_STYLE
 from sentry_sdk.utils import (

--- a/sentry_sdk/integrations/celery.py
+++ b/sentry_sdk/integrations/celery.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import sys
 import time
 from functools import wraps

--- a/sentry_sdk/integrations/chalice.py
+++ b/sentry_sdk/integrations/chalice.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import sys
 from functools import wraps
 

--- a/sentry_sdk/integrations/chalice.py
+++ b/sentry_sdk/integrations/chalice.py
@@ -32,10 +32,9 @@ except ImportError:
 
 
 class EventSourceHandler(ChaliceEventSourceHandler):  # type: ignore
-    def __call__(self, event, context):
-        # type: (Any, Any) -> Any
+    def __call__(self, event: Any, context: Any) -> Any:
         hub = Hub.current
-        client = hub.client  # type: Any
+        client: Any = hub.client
 
         with hub.push_scope() as scope:
             with capture_internal_exceptions():
@@ -57,13 +56,11 @@ class EventSourceHandler(ChaliceEventSourceHandler):  # type: ignore
                 reraise(*exc_info)
 
 
-def _get_view_function_response(app, view_function, function_args):
-    # type: (Any, F, Any) -> F
+def _get_view_function_response(app: Any, view_function: F, function_args: Any) -> F:
     @wraps(view_function)
-    def wrapped_view_function(**function_args):
-        # type: (**Any) -> Any
+    def wrapped_view_function(**function_args: Any) -> Any:
         hub = Hub.current
-        client = hub.client  # type: Any
+        client: Any = hub.client
         with hub.push_scope() as scope:
             with capture_internal_exceptions():
                 configured_time = app.lambda_context.get_remaining_time_in_millis()
@@ -101,9 +98,7 @@ class ChaliceIntegration(Integration):
     identifier = "chalice"
 
     @staticmethod
-    def setup_once():
-        # type: () -> None
-
+    def setup_once() -> None:
         version = parse_version(CHALICE_VERSION)
 
         if version is None:
@@ -118,8 +113,9 @@ class ChaliceIntegration(Integration):
                 RestAPIEventHandler._get_view_function_response
             )
 
-        def sentry_event_response(app, view_function, function_args):
-            # type: (Any, F, Dict[str, Any]) -> Any
+        def sentry_event_response(
+            app: Any, view_function: F, function_args: Dict[str, Any]
+        ) -> Any:
             wrapped_view_function = _get_view_function_response(
                 app, view_function, function_args
             )

--- a/sentry_sdk/integrations/clickhouse_driver.py
+++ b/sentry_sdk/integrations/clickhouse_driver.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from sentry_sdk import Hub
 from sentry_sdk.consts import OP, SPANDATA
 from sentry_sdk.hub import _should_send_default_pii

--- a/sentry_sdk/integrations/clickhouse_driver.py
+++ b/sentry_sdk/integrations/clickhouse_driver.py
@@ -124,7 +124,7 @@ def _wrap_end(f: Callable[P, T]) -> Callable[P, T]:
 
 def _wrap_send_data(f: Callable[P, T]) -> Callable[P, T]:
     def _inner_send_data(*args: P.args, **kwargs: P.kwargs) -> T:
-        instance = args[0]  # type: clickhouse_driver.client.Client
+        instance: clickhouse_driver.client.Client = args[0]
         data = args[2]
         span = instance.connection._sentry_span
 

--- a/sentry_sdk/integrations/cloud_resource_context.py
+++ b/sentry_sdk/integrations/cloud_resource_context.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import json
 import urllib3
 

--- a/sentry_sdk/integrations/cloud_resource_context.py
+++ b/sentry_sdk/integrations/cloud_resource_context.py
@@ -63,13 +63,11 @@ class CloudResourceContextIntegration(Integration):
 
     gcp_metadata = None
 
-    def __init__(self, cloud_provider=""):
-        # type: (str) -> None
+    def __init__(self, cloud_provider: str = "") -> None:
         CloudResourceContextIntegration.cloud_provider = cloud_provider
 
     @classmethod
-    def _is_aws(cls):
-        # type: () -> bool
+    def _is_aws(cls) -> bool:
         try:
             r = cls.http.request(
                 "PUT",
@@ -87,8 +85,7 @@ class CloudResourceContextIntegration(Integration):
             return False
 
     @classmethod
-    def _get_aws_context(cls):
-        # type: () -> Dict[str, str]
+    def _get_aws_context(cls) -> Dict[str, str]:
         ctx = {
             "cloud.provider": CLOUD_PROVIDER.AWS,
             "cloud.platform": CLOUD_PLATFORM.AWS_EC2,
@@ -137,8 +134,7 @@ class CloudResourceContextIntegration(Integration):
         return ctx
 
     @classmethod
-    def _is_gcp(cls):
-        # type: () -> bool
+    def _is_gcp(cls) -> bool:
         try:
             r = cls.http.request(
                 "GET",
@@ -156,8 +152,7 @@ class CloudResourceContextIntegration(Integration):
             return False
 
     @classmethod
-    def _get_gcp_context(cls):
-        # type: () -> Dict[str, str]
+    def _get_gcp_context(cls) -> Dict[str, str]:
         ctx = {
             "cloud.provider": CLOUD_PROVIDER.GCP,
             "cloud.platform": CLOUD_PLATFORM.GCP_COMPUTE_ENGINE,
@@ -207,8 +202,7 @@ class CloudResourceContextIntegration(Integration):
         return ctx
 
     @classmethod
-    def _get_cloud_provider(cls):
-        # type: () -> str
+    def _get_cloud_provider(cls) -> str:
         if cls._is_aws():
             return CLOUD_PROVIDER.AWS
 
@@ -218,8 +212,7 @@ class CloudResourceContextIntegration(Integration):
         return ""
 
     @classmethod
-    def _get_cloud_resource_context(cls):
-        # type: () -> Dict[str, str]
+    def _get_cloud_resource_context(cls) -> Dict[str, str]:
         cloud_provider = (
             cls.cloud_provider
             if cls.cloud_provider != ""
@@ -231,8 +224,7 @@ class CloudResourceContextIntegration(Integration):
         return {}
 
     @staticmethod
-    def setup_once():
-        # type: () -> None
+    def setup_once() -> None:
         cloud_provider = CloudResourceContextIntegration.cloud_provider
         unsupported_cloud_provider = (
             cloud_provider != "" and cloud_provider not in context_getters.keys()

--- a/sentry_sdk/integrations/dedupe.py
+++ b/sentry_sdk/integrations/dedupe.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from sentry_sdk.hub import Hub
 from sentry_sdk.utils import ContextVar
 from sentry_sdk.integrations import Integration

--- a/sentry_sdk/integrations/dedupe.py
+++ b/sentry_sdk/integrations/dedupe.py
@@ -14,16 +14,13 @@ if TYPE_CHECKING:
 class DedupeIntegration(Integration):
     identifier = "dedupe"
 
-    def __init__(self):
-        # type: () -> None
+    def __init__(self) -> None:
         self._last_seen = ContextVar("last-seen")
 
     @staticmethod
-    def setup_once():
-        # type: () -> None
+    def setup_once() -> None:
         @add_global_event_processor
-        def processor(event, hint):
-            # type: (Event, Optional[Hint]) -> Optional[Event]
+        def processor(event: Event, hint: Optional[Hint]) -> Optional[Event]:
             if hint is None:
                 return event
 

--- a/sentry_sdk/integrations/django/__init__.py
+++ b/sentry_sdk/integrations/django/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import inspect
 import sys
 import threading

--- a/sentry_sdk/integrations/django/asgi.py
+++ b/sentry_sdk/integrations/django/asgi.py
@@ -6,6 +6,8 @@ Since this file contains `async def` it is conditionally imported in
 `django.core.handlers.asgi`.
 """
 
+from __future__ import annotations
+
 import asyncio
 import functools
 

--- a/sentry_sdk/integrations/django/caching.py
+++ b/sentry_sdk/integrations/django/caching.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import functools
 from typing import TYPE_CHECKING
 

--- a/sentry_sdk/integrations/django/middleware.py
+++ b/sentry_sdk/integrations/django/middleware.py
@@ -35,14 +35,12 @@ else:
     from .asgi import _asgi_middleware_mixin_factory
 
 
-def patch_django_middlewares():
-    # type: () -> None
+def patch_django_middlewares() -> None:
     from django.core.handlers import base
 
     old_import_string = base.import_string
 
-    def sentry_patched_import_string(dotted_path):
-        # type: (str) -> Any
+    def sentry_patched_import_string(dotted_path: str) -> Any:
         rv = old_import_string(dotted_path)
 
         if _import_string_should_wrap_middleware.get(None):
@@ -54,8 +52,7 @@ def patch_django_middlewares():
 
     old_load_middleware = base.BaseHandler.load_middleware
 
-    def sentry_patched_load_middleware(*args, **kwargs):
-        # type: (Any, Any) -> Any
+    def sentry_patched_load_middleware(*args: Any, **kwargs: Any) -> Any:
         _import_string_should_wrap_middleware.set(True)
         try:
             return old_load_middleware(*args, **kwargs)
@@ -65,12 +62,10 @@ def patch_django_middlewares():
     base.BaseHandler.load_middleware = sentry_patched_load_middleware
 
 
-def _wrap_middleware(middleware, middleware_name):
-    # type: (Any, str) -> Any
+def _wrap_middleware(middleware: Any, middleware_name: str) -> Any:
     from sentry_sdk.integrations.django import DjangoIntegration
 
-    def _check_middleware_span(old_method):
-        # type: (Callable[..., Any]) -> Optional[Span]
+    def _check_middleware_span(old_method: Callable[..., Any]) -> Optional[Span]:
         hub = Hub.current
         integration = hub.get_integration(DjangoIntegration)
         if integration is None or not integration.middleware_spans:
@@ -91,12 +86,10 @@ def _wrap_middleware(middleware, middleware_name):
 
         return middleware_span
 
-    def _get_wrapped_method(old_method):
-        # type: (F) -> F
+    def _get_wrapped_method(old_method: F) -> F:
         with capture_internal_exceptions():
 
-            def sentry_wrapped_method(*args, **kwargs):
-                # type: (*Any, **Any) -> Any
+            def sentry_wrapped_method(*args: Any, **kwargs: Any) -> Any:
                 middleware_span = _check_middleware_span(old_method)
 
                 if middleware_span is None:
@@ -123,8 +116,12 @@ def _wrap_middleware(middleware, middleware_name):
     ):
         async_capable = getattr(middleware, "async_capable", False)
 
-        def __init__(self, get_response=None, *args, **kwargs):
-            # type: (Optional[Callable[..., Any]], *Any, **Any) -> None
+        def __init__(
+            self,
+            get_response: Optional[Callable[..., Any]] = None,
+            *args: Any,
+            **kwargs: Any
+        ) -> None:
             if get_response:
                 self._inner = middleware(get_response, *args, **kwargs)
             else:
@@ -136,8 +133,7 @@ def _wrap_middleware(middleware, middleware_name):
 
         # We need correct behavior for `hasattr()`, which we can only determine
         # when we have an instance of the middleware we're wrapping.
-        def __getattr__(self, method_name):
-            # type: (str) -> Any
+        def __getattr__(self, method_name: str) -> Any:
             if method_name not in (
                 "process_request",
                 "process_view",
@@ -152,8 +148,7 @@ def _wrap_middleware(middleware, middleware_name):
             self.__dict__[method_name] = rv
             return rv
 
-        def __call__(self, *args, **kwargs):
-            # type: (*Any, **Any) -> Any
+        def __call__(self, *args: Any, **kwargs: Any) -> Any:
             if hasattr(self, "async_route_check") and self.async_route_check():
                 return self.__acall__(*args, **kwargs)
 

--- a/sentry_sdk/integrations/django/middleware.py
+++ b/sentry_sdk/integrations/django/middleware.py
@@ -2,6 +2,8 @@
 Create spans from Django middleware invocations
 """
 
+from __future__ import annotations
+
 from functools import wraps
 
 from django import VERSION as DJANGO_VERSION
@@ -120,7 +122,7 @@ def _wrap_middleware(middleware: Any, middleware_name: str) -> Any:
             self,
             get_response: Optional[Callable[..., Any]] = None,
             *args: Any,
-            **kwargs: Any
+            **kwargs: Any,
         ) -> None:
             if get_response:
                 self._inner = middleware(get_response, *args, **kwargs)

--- a/sentry_sdk/integrations/django/signals_handlers.py
+++ b/sentry_sdk/integrations/django/signals_handlers.py
@@ -13,8 +13,7 @@ if TYPE_CHECKING:
     from typing import Any, Union
 
 
-def _get_receiver_name(receiver):
-    # type: (Callable[..., Any]) -> str
+def _get_receiver_name(receiver: Callable[..., Any]) -> str:
     name = ""
 
     if hasattr(receiver, "__qualname__"):
@@ -38,8 +37,7 @@ def _get_receiver_name(receiver):
     return name
 
 
-def patch_signals():
-    # type: () -> None
+def patch_signals() -> None:
     """
     Patch django signal receivers to create a span.
 
@@ -50,8 +48,10 @@ def patch_signals():
 
     old_live_receivers = Signal._live_receivers
 
-    def _sentry_live_receivers(self, sender):
-        # type: (Signal, Any) -> Union[tuple[list[Callable[..., Any]], list[Callable[..., Any]]], list[Callable[..., Any]]]
+    def _sentry_live_receivers(self: Signal, sender: Any) -> Union[
+        tuple[list[Callable[..., Any]], list[Callable[..., Any]]],
+        list[Callable[..., Any]],
+    ]:
         hub = Hub.current
 
         if DJANGO_VERSION >= (5, 0):
@@ -60,11 +60,11 @@ def patch_signals():
             sync_receivers = old_live_receivers(self, sender)
             async_receivers = []
 
-        def sentry_sync_receiver_wrapper(receiver):
-            # type: (Callable[..., Any]) -> Callable[..., Any]
+        def sentry_sync_receiver_wrapper(
+            receiver: Callable[..., Any]
+        ) -> Callable[..., Any]:
             @wraps(receiver)
-            def wrapper(*args, **kwargs):
-                # type: (Any, Any) -> Any
+            def wrapper(*args: Any, **kwargs: Any) -> Any:
                 signal_name = _get_receiver_name(receiver)
                 with hub.start_span(
                     op=OP.EVENT_DJANGO,

--- a/sentry_sdk/integrations/django/signals_handlers.py
+++ b/sentry_sdk/integrations/django/signals_handlers.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from functools import wraps
 
 from django.dispatch import Signal

--- a/sentry_sdk/integrations/django/templates.py
+++ b/sentry_sdk/integrations/django/templates.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import functools
 
 from django.template import TemplateSyntaxError
@@ -87,7 +89,7 @@ def patch_templates() -> None:
         template_name: str,
         context: Optional[Dict[str, Any]] = None,
         *args: Any,
-        **kwargs: Any
+        **kwargs: Any,
     ) -> django.http.HttpResponse:
         hub = Hub.current
         if hub.get_integration(DjangoIntegration) is None:

--- a/sentry_sdk/integrations/django/templates.py
+++ b/sentry_sdk/integrations/django/templates.py
@@ -23,9 +23,9 @@ except ImportError:
     from django.template.loader import LoaderOrigin as Origin
 
 
-def get_template_frame_from_exception(exc_value):
-    # type: (Optional[BaseException]) -> Optional[Dict[str, Any]]
-
+def get_template_frame_from_exception(
+    exc_value: Optional[BaseException],
+) -> Optional[Dict[str, Any]]:
     # As of Django 1.9 or so the new template debug thing showed up.
     if hasattr(exc_value, "template_debug"):
         return _get_template_frame_from_debug(exc_value.template_debug)  # type: ignore
@@ -46,8 +46,7 @@ def get_template_frame_from_exception(exc_value):
     return None
 
 
-def _get_template_name_description(template_name):
-    # type: (str) -> str
+def _get_template_name_description(template_name: str) -> str:
     if isinstance(template_name, (list, tuple)):
         if template_name:
             return "[{}, ...]".format(template_name[0])
@@ -55,16 +54,14 @@ def _get_template_name_description(template_name):
         return template_name
 
 
-def patch_templates():
-    # type: () -> None
+def patch_templates() -> None:
     from django.template.response import SimpleTemplateResponse
     from sentry_sdk.integrations.django import DjangoIntegration
 
     real_rendered_content = SimpleTemplateResponse.rendered_content
 
     @property  # type: ignore
-    def rendered_content(self):
-        # type: (SimpleTemplateResponse) -> str
+    def rendered_content(self: SimpleTemplateResponse) -> str:
         hub = Hub.current
         if hub.get_integration(DjangoIntegration) is None:
             return real_rendered_content.fget(self)
@@ -85,8 +82,13 @@ def patch_templates():
     real_render = django.shortcuts.render
 
     @functools.wraps(real_render)
-    def render(request, template_name, context=None, *args, **kwargs):
-        # type: (django.http.HttpRequest, str, Optional[Dict[str, Any]], *Any, **Any) -> django.http.HttpResponse
+    def render(
+        request: django.http.HttpRequest,
+        template_name: str,
+        context: Optional[Dict[str, Any]] = None,
+        *args: Any,
+        **kwargs: Any
+    ) -> django.http.HttpResponse:
         hub = Hub.current
         if hub.get_integration(DjangoIntegration) is None:
             return real_render(request, template_name, context, *args, **kwargs)
@@ -106,8 +108,7 @@ def patch_templates():
     django.shortcuts.render = render
 
 
-def _get_template_frame_from_debug(debug):
-    # type: (Dict[str, Any]) -> Dict[str, Any]
+def _get_template_frame_from_debug(debug: Dict[str, Any]) -> Dict[str, Any]:
     if debug is None:
         return None
 
@@ -138,8 +139,7 @@ def _get_template_frame_from_debug(debug):
     }
 
 
-def _linebreak_iter(template_source):
-    # type: (str) -> Iterator[int]
+def _linebreak_iter(template_source: str) -> Iterator[int]:
     yield 0
     p = template_source.find("\n")
     while p >= 0:
@@ -147,8 +147,9 @@ def _linebreak_iter(template_source):
         p = template_source.find("\n", p + 1)
 
 
-def _get_template_frame_from_source(source):
-    # type: (Tuple[Origin, Tuple[int, int]]) -> Optional[Dict[str, Any]]
+def _get_template_frame_from_source(
+    source: Tuple[Origin, Tuple[int, int]]
+) -> Optional[Dict[str, Any]]:
     if not source:
         return None
 

--- a/sentry_sdk/integrations/django/transactions.py
+++ b/sentry_sdk/integrations/django/transactions.py
@@ -32,8 +32,7 @@ except ImportError:
     from django.core.urlresolvers import get_resolver
 
 
-def get_regex(resolver_or_pattern):
-    # type: (Union[URLPattern, URLResolver]) -> Pattern[str]
+def get_regex(resolver_or_pattern: Union[URLPattern, URLResolver]) -> Pattern[str]:
     """Utility method for django's deprecated resolver.regex"""
     try:
         regex = resolver_or_pattern.regex
@@ -53,10 +52,9 @@ class RavenResolver:
     _either_option_matcher = re.compile(r"\[([^\]]+)\|([^\]]+)\]")
     _camel_re = re.compile(r"([A-Z]+)([a-z])")
 
-    _cache = {}  # type: Dict[URLPattern, str]
+    _cache: Dict[URLPattern, str] = {}
 
-    def _simplify(self, pattern):
-        # type: (Union[URLPattern, URLResolver]) -> str
+    def _simplify(self, pattern: Union[URLPattern, URLResolver]) -> str:
         r"""
         Clean up urlpattern regexes into something readable by humans:
 
@@ -107,9 +105,12 @@ class RavenResolver:
 
         return result
 
-    def _resolve(self, resolver, path, parents=None):
-        # type: (URLResolver, str, Optional[List[URLResolver]]) -> Optional[str]
-
+    def _resolve(
+        self,
+        resolver: URLResolver,
+        path: str,
+        parents: Optional[List[URLResolver]] = None,
+    ) -> Optional[str]:
         match = get_regex(resolver).search(path)  # Django < 2.0
 
         if not match:
@@ -147,10 +148,11 @@ class RavenResolver:
 
     def resolve(
         self,
-        path,  # type: str
-        urlconf=None,  # type: Union[None, Tuple[URLPattern, URLPattern, URLResolver], Tuple[URLPattern]]
-    ):
-        # type: (...) -> Optional[str]
+        path: str,
+        urlconf: Union[
+            None, Tuple[URLPattern, URLPattern, URLResolver], Tuple[URLPattern]
+        ] = None,
+    ) -> Optional[str]:
         resolver = get_resolver(urlconf)
         match = self._resolve(resolver, path)
         return match

--- a/sentry_sdk/integrations/django/transactions.py
+++ b/sentry_sdk/integrations/django/transactions.py
@@ -5,6 +5,8 @@ Despite being called "legacy" in some places this resolver is very much still
 in use.
 """
 
+from __future__ import annotations
+
 import re
 
 from sentry_sdk._types import TYPE_CHECKING

--- a/sentry_sdk/integrations/django/views.py
+++ b/sentry_sdk/integrations/django/views.py
@@ -20,9 +20,7 @@ except (ImportError, SyntaxError):
     wrap_async_view = None  # type: ignore
 
 
-def patch_views():
-    # type: () -> None
-
+def patch_views() -> None:
     from django.core.handlers.base import BaseHandler
     from django.template.response import SimpleTemplateResponse
     from sentry_sdk.integrations.django import DjangoIntegration
@@ -30,8 +28,7 @@ def patch_views():
     old_make_view_atomic = BaseHandler.make_view_atomic
     old_render = SimpleTemplateResponse.render
 
-    def sentry_patched_render(self):
-        # type: (SimpleTemplateResponse) -> Any
+    def sentry_patched_render(self: SimpleTemplateResponse) -> Any:
         hub = Hub.current
         with hub.start_span(
             op=OP.VIEW_RESPONSE_RENDER, description="serialize response"
@@ -39,8 +36,7 @@ def patch_views():
             return old_render(self)
 
     @functools.wraps(old_make_view_atomic)
-    def sentry_patched_make_view_atomic(self, *args, **kwargs):
-        # type: (Any, *Any, **Any) -> Any
+    def sentry_patched_make_view_atomic(self: Any, *args: Any, **kwargs: Any) -> Any:
         callback = old_make_view_atomic(self, *args, **kwargs)
 
         # XXX: The wrapper function is created for every request. Find more
@@ -68,11 +64,9 @@ def patch_views():
     BaseHandler.make_view_atomic = sentry_patched_make_view_atomic
 
 
-def _wrap_sync_view(hub, callback):
-    # type: (Hub, Any) -> Any
+def _wrap_sync_view(hub: Hub, callback: Any) -> Any:
     @functools.wraps(callback)
-    def sentry_wrapped_callback(request, *args, **kwargs):
-        # type: (Any, *Any, **Any) -> Any
+    def sentry_wrapped_callback(request: Any, *args: Any, **kwargs: Any) -> Any:
         with hub.configure_scope() as sentry_scope:
             # set the active thread id to the handler thread for sync views
             # this isn't necessary for async views since that runs on main

--- a/sentry_sdk/integrations/django/views.py
+++ b/sentry_sdk/integrations/django/views.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import functools
 
 from sentry_sdk.consts import OP

--- a/sentry_sdk/integrations/excepthook.py
+++ b/sentry_sdk/integrations/excepthook.py
@@ -25,9 +25,7 @@ class ExcepthookIntegration(Integration):
 
     always_run = False
 
-    def __init__(self, always_run=False):
-        # type: (bool) -> None
-
+    def __init__(self, always_run: bool = False) -> None:
         if not isinstance(always_run, bool):
             raise ValueError(
                 "Invalid value for always_run: %s (must be type boolean)"
@@ -36,21 +34,22 @@ class ExcepthookIntegration(Integration):
         self.always_run = always_run
 
     @staticmethod
-    def setup_once():
-        # type: () -> None
+    def setup_once() -> None:
         sys.excepthook = _make_excepthook(sys.excepthook)
 
 
-def _make_excepthook(old_excepthook):
-    # type: (Excepthook) -> Excepthook
-    def sentry_sdk_excepthook(type_, value, traceback):
-        # type: (Type[BaseException], BaseException, Optional[TracebackType]) -> None
+def _make_excepthook(old_excepthook: Excepthook) -> Excepthook:
+    def sentry_sdk_excepthook(
+        type_: Type[BaseException],
+        value: BaseException,
+        traceback: Optional[TracebackType],
+    ) -> None:
         hub = Hub.current
         integration = hub.get_integration(ExcepthookIntegration)
 
         if integration is not None and _should_send(integration.always_run):
             # If an integration is there, a client has to be there.
-            client = hub.client  # type: Any
+            client: Any = hub.client
 
             with capture_internal_exceptions():
                 event, hint = event_from_exception(
@@ -65,8 +64,7 @@ def _make_excepthook(old_excepthook):
     return sentry_sdk_excepthook
 
 
-def _should_send(always_run=False):
-    # type: (bool) -> bool
+def _should_send(always_run: bool = False) -> bool:
     if always_run:
         return True
 

--- a/sentry_sdk/integrations/excepthook.py
+++ b/sentry_sdk/integrations/excepthook.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import sys
 
 from sentry_sdk.hub import Hub

--- a/sentry_sdk/integrations/executing.py
+++ b/sentry_sdk/integrations/executing.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from sentry_sdk import Hub
 from sentry_sdk._types import TYPE_CHECKING
 from sentry_sdk.integrations import Integration, DidNotEnable

--- a/sentry_sdk/integrations/executing.py
+++ b/sentry_sdk/integrations/executing.py
@@ -19,12 +19,9 @@ class ExecutingIntegration(Integration):
     identifier = "executing"
 
     @staticmethod
-    def setup_once():
-        # type: () -> None
-
+    def setup_once() -> None:
         @add_global_event_processor
-        def add_executing_info(event, hint):
-            # type: (Event, Optional[Hint]) -> Optional[Event]
+        def add_executing_info(event: Event, hint: Optional[Hint]) -> Optional[Event]:
             if Hub.current.get_integration(ExecutingIntegration) is None:
                 return event
 

--- a/sentry_sdk/integrations/falcon.py
+++ b/sentry_sdk/integrations/falcon.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from sentry_sdk.hub import Hub
 from sentry_sdk.integrations import Integration, DidNotEnable
 from sentry_sdk.integrations._wsgi_common import RequestExtractor

--- a/sentry_sdk/integrations/falcon.py
+++ b/sentry_sdk/integrations/falcon.py
@@ -43,25 +43,19 @@ except ImportError:
 
 
 class FalconRequestExtractor(RequestExtractor):
-    def env(self):
-        # type: () -> Dict[str, Any]
+    def env(self) -> Dict[str, Any]:
         return self.request.env
 
-    def cookies(self):
-        # type: () -> Dict[str, Any]
+    def cookies(self) -> Dict[str, Any]:
         return self.request.cookies
 
-    def form(self):
-        # type: () -> None
+    def form(self) -> None:
         return None  # No such concept in Falcon
 
-    def files(self):
-        # type: () -> None
+    def files(self) -> None:
         return None  # No such concept in Falcon
 
-    def raw_data(self):
-        # type: () -> Optional[str]
-
+    def raw_data(self) -> Optional[str]:
         # As request data can only be read once we won't make this available
         # to Sentry. Just send back a dummy string in case there was a
         # content length.
@@ -74,8 +68,7 @@ class FalconRequestExtractor(RequestExtractor):
 
     if FALCON3:
 
-        def json(self):
-            # type: () -> Optional[Dict[str, Any]]
+        def json(self) -> Optional[Dict[str, Any]]:
             try:
                 return self.request.media
             except falcon.errors.HTTPBadRequest:
@@ -83,8 +76,7 @@ class FalconRequestExtractor(RequestExtractor):
 
     else:
 
-        def json(self):
-            # type: () -> Optional[Dict[str, Any]]
+        def json(self) -> Optional[Dict[str, Any]]:
             try:
                 return self.request.media
             except falcon.errors.HTTPBadRequest:
@@ -98,8 +90,7 @@ class FalconRequestExtractor(RequestExtractor):
 class SentryFalconMiddleware:
     """Captures exceptions in Falcon requests and send to Sentry"""
 
-    def process_request(self, req, resp, *args, **kwargs):
-        # type: (Any, Any, *Any, **Any) -> None
+    def process_request(self, req: Any, resp: Any, *args: Any, **kwargs: Any) -> None:
         hub = Hub.current
         integration = hub.get_integration(FalconIntegration)
         if integration is None:
@@ -118,8 +109,7 @@ class FalconIntegration(Integration):
 
     transaction_style = ""
 
-    def __init__(self, transaction_style="uri_template"):
-        # type: (str) -> None
+    def __init__(self, transaction_style: str = "uri_template") -> None:
         if transaction_style not in TRANSACTION_STYLE_VALUES:
             raise ValueError(
                 "Invalid value for transaction_style: %s (must be in %s)"
@@ -128,9 +118,7 @@ class FalconIntegration(Integration):
         self.transaction_style = transaction_style
 
     @staticmethod
-    def setup_once():
-        # type: () -> None
-
+    def setup_once() -> None:
         version = parse_version(FALCON_VERSION)
 
         if version is None:
@@ -144,12 +132,10 @@ class FalconIntegration(Integration):
         _patch_prepare_middleware()
 
 
-def _patch_wsgi_app():
-    # type: () -> None
+def _patch_wsgi_app() -> None:
     original_wsgi_app = falcon_app_class.__call__
 
-    def sentry_patched_wsgi_app(self, env, start_response):
-        # type: (falcon.API, Any, Any) -> Any
+    def sentry_patched_wsgi_app(self: falcon.API, env: Any, start_response: Any) -> Any:
         hub = Hub.current
         integration = hub.get_integration(FalconIntegration)
         if integration is None:
@@ -164,12 +150,10 @@ def _patch_wsgi_app():
     falcon_app_class.__call__ = sentry_patched_wsgi_app
 
 
-def _patch_handle_exception():
-    # type: () -> None
+def _patch_handle_exception() -> None:
     original_handle_exception = falcon_app_class._handle_exception
 
-    def sentry_patched_handle_exception(self, *args):
-        # type: (falcon.API, *Any) -> Any
+    def sentry_patched_handle_exception(self: falcon.API, *args: Any) -> Any:
         # NOTE(jmagnusson): falcon 2.0 changed falcon.API._handle_exception
         # method signature from `(ex, req, resp, params)` to
         # `(req, resp, ex, params)`
@@ -193,7 +177,7 @@ def _patch_handle_exception():
 
         if integration is not None and _exception_leads_to_http_5xx(ex, response):
             # If an integration is there, a client has to be there.
-            client = hub.client  # type: Any
+            client: Any = hub.client
 
             event, hint = event_from_exception(
                 ex,
@@ -207,14 +191,12 @@ def _patch_handle_exception():
     falcon_app_class._handle_exception = sentry_patched_handle_exception
 
 
-def _patch_prepare_middleware():
-    # type: () -> None
+def _patch_prepare_middleware() -> None:
     original_prepare_middleware = falcon_helpers.prepare_middleware
 
     def sentry_patched_prepare_middleware(
-        middleware=None, independent_middleware=False, asgi=False
-    ):
-        # type: (Any, Any, bool) -> Any
+        middleware: Any = None, independent_middleware: Any = False, asgi: bool = False
+    ) -> Any:
         if asgi:
             # We don't support ASGI Falcon apps, so we don't patch anything here
             return original_prepare_middleware(middleware, independent_middleware, asgi)
@@ -231,8 +213,7 @@ def _patch_prepare_middleware():
     falcon_helpers.prepare_middleware = sentry_patched_prepare_middleware
 
 
-def _exception_leads_to_http_5xx(ex, response):
-    # type: (Exception, falcon.Response) -> bool
+def _exception_leads_to_http_5xx(ex: Exception, response: falcon.Response) -> bool:
     is_server_error = isinstance(ex, falcon.HTTPError) and (ex.status or "").startswith(
         "5"
     )
@@ -250,13 +231,13 @@ def _exception_leads_to_http_5xx(ex, response):
     )
 
 
-def _has_http_5xx_status(response):
-    # type: (falcon.Response) -> bool
+def _has_http_5xx_status(response: falcon.Response) -> bool:
     return response.status.startswith("5")
 
 
-def _set_transaction_name_and_source(event, transaction_style, request):
-    # type: (Dict[str, Any], str, falcon.Request) -> None
+def _set_transaction_name_and_source(
+    event: Dict[str, Any], transaction_style: str, request: falcon.Request
+) -> None:
     name_for_style = {
         "uri_template": request.uri_template,
         "path": request.path,
@@ -265,11 +246,10 @@ def _set_transaction_name_and_source(event, transaction_style, request):
     event["transaction_info"] = {"source": SOURCE_FOR_STYLE[transaction_style]}
 
 
-def _make_request_event_processor(req, integration):
-    # type: (falcon.Request, FalconIntegration) -> EventProcessor
-
-    def event_processor(event, hint):
-        # type: (Dict[str, Any], Dict[str, Any]) -> Dict[str, Any]
+def _make_request_event_processor(
+    req: falcon.Request, integration: FalconIntegration
+) -> EventProcessor:
+    def event_processor(event: Dict[str, Any], hint: Dict[str, Any]) -> Dict[str, Any]:
         _set_transaction_name_and_source(event, integration.transaction_style, req)
 
         with capture_internal_exceptions():

--- a/sentry_sdk/integrations/fastapi.py
+++ b/sentry_sdk/integrations/fastapi.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import asyncio
 from copy import deepcopy
 from functools import wraps

--- a/sentry_sdk/integrations/flask.py
+++ b/sentry_sdk/integrations/flask.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from sentry_sdk._types import TYPE_CHECKING
 from sentry_sdk.hub import Hub, _should_send_default_pii
 from sentry_sdk.integrations import DidNotEnable, Integration

--- a/sentry_sdk/integrations/gcp.py
+++ b/sentry_sdk/integrations/gcp.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import sys
 from copy import deepcopy
 from datetime import datetime, timedelta, timezone

--- a/sentry_sdk/integrations/gcp.py
+++ b/sentry_sdk/integrations/gcp.py
@@ -35,18 +35,17 @@ if TYPE_CHECKING:
     F = TypeVar("F", bound=Callable[..., Any])
 
 
-def _wrap_func(func):
-    # type: (F) -> F
-    def sentry_func(functionhandler, gcp_event, *args, **kwargs):
-        # type: (Any, Any, *Any, **Any) -> Any
-
+def _wrap_func(func: F) -> F:
+    def sentry_func(
+        functionhandler: Any, gcp_event: Any, *args: Any, **kwargs: Any
+    ) -> Any:
         hub = Hub.current
         integration = hub.get_integration(GcpIntegration)
         if integration is None:
             return func(functionhandler, gcp_event, *args, **kwargs)
 
         # If an integration is there, a client has to be there.
-        client = hub.client  # type: Any
+        client: Any = hub.client
 
         configured_time = environ.get("FUNCTION_TIMEOUT_SEC")
         if not configured_time:
@@ -126,13 +125,11 @@ def _wrap_func(func):
 class GcpIntegration(Integration):
     identifier = "gcp"
 
-    def __init__(self, timeout_warning=False):
-        # type: (bool) -> None
+    def __init__(self, timeout_warning: bool = False) -> None:
         self.timeout_warning = timeout_warning
 
     @staticmethod
-    def setup_once():
-        # type: () -> None
+    def setup_once() -> None:
         import __main__ as gcp_functions
 
         if not hasattr(gcp_functions, "worker_v1"):
@@ -148,12 +145,10 @@ class GcpIntegration(Integration):
         )
 
 
-def _make_request_event_processor(gcp_event, configured_timeout, initial_time):
-    # type: (Any, Any, Any) -> EventProcessor
-
-    def event_processor(event, hint):
-        # type: (Event, Hint) -> Optional[Event]
-
+def _make_request_event_processor(
+    gcp_event: Any, configured_timeout: Any, initial_time: Any
+) -> EventProcessor:
+    def event_processor(event: Event, hint: Hint) -> Optional[Event]:
         final_time = datetime.now(timezone.utc)
         time_diff = final_time - initial_time
 
@@ -203,8 +198,7 @@ def _make_request_event_processor(gcp_event, configured_timeout, initial_time):
     return event_processor
 
 
-def _get_google_cloud_logs_url(final_time):
-    # type: (datetime) -> str
+def _get_google_cloud_logs_url(final_time: datetime) -> str:
     """
     Generates a Google Cloud Logs console URL based on the environment variables
     Arguments:

--- a/sentry_sdk/integrations/gnu_backtrace.py
+++ b/sentry_sdk/integrations/gnu_backtrace.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import re
 
 from sentry_sdk.hub import Hub

--- a/sentry_sdk/integrations/gnu_backtrace.py
+++ b/sentry_sdk/integrations/gnu_backtrace.py
@@ -38,17 +38,18 @@ class GnuBacktraceIntegration(Integration):
     identifier = "gnu_backtrace"
 
     @staticmethod
-    def setup_once():
-        # type: () -> None
+    def setup_once() -> None:
         @add_global_event_processor
-        def process_gnu_backtrace(event, hint):
-            # type: (Dict[str, Any], Dict[str, Any]) -> Dict[str, Any]
+        def process_gnu_backtrace(
+            event: Dict[str, Any], hint: Dict[str, Any]
+        ) -> Dict[str, Any]:
             with capture_internal_exceptions():
                 return _process_gnu_backtrace(event, hint)
 
 
-def _process_gnu_backtrace(event, hint):
-    # type: (Dict[str, Any], Dict[str, Any]) -> Dict[str, Any]
+def _process_gnu_backtrace(
+    event: Dict[str, Any], hint: Dict[str, Any]
+) -> Dict[str, Any]:
     if Hub.current.get_integration(GnuBacktraceIntegration) is None:
         return event
 

--- a/sentry_sdk/integrations/gql.py
+++ b/sentry_sdk/integrations/gql.py
@@ -25,8 +25,7 @@ class GQLIntegration(Integration):
     identifier = "gql"
 
     @staticmethod
-    def setup_once():
-        # type: () -> None
+    def setup_once() -> None:
         gql_version = parse_version(gql.__version__)
         if gql_version is None or gql_version < MIN_GQL_VERSION:
             raise DidNotEnable(
@@ -36,11 +35,10 @@ class GQLIntegration(Integration):
         _patch_execute()
 
 
-def _data_from_document(document):
-    # type: (DocumentNode) -> EventDataType
+def _data_from_document(document: DocumentNode) -> EventDataType:
     try:
         operation_ast = get_operation_ast(document)
-        data = {"query": print_ast(document)}  # type: EventDataType
+        data: EventDataType = {"query": print_ast(document)}
 
         if operation_ast is not None:
             data["variables"] = operation_ast.variable_definitions
@@ -52,8 +50,7 @@ def _data_from_document(document):
         return dict()
 
 
-def _transport_method(transport):
-    # type: (Union[Transport, AsyncTransport]) -> str
+def _transport_method(transport: Union[Transport, AsyncTransport]) -> str:
     """
     The RequestsHTTPTransport allows defining the HTTP method; all
     other transports use POST.
@@ -64,8 +61,9 @@ def _transport_method(transport):
         return "POST"
 
 
-def _request_info_from_transport(transport):
-    # type: (Union[Transport, AsyncTransport, None]) -> Dict[str, str]
+def _request_info_from_transport(
+    transport: Union[Transport, AsyncTransport, None]
+) -> Dict[str, str]:
     if transport is None:
         return {}
 
@@ -81,12 +79,12 @@ def _request_info_from_transport(transport):
     return request_info
 
 
-def _patch_execute():
-    # type: () -> None
+def _patch_execute() -> None:
     real_execute = gql.Client.execute
 
-    def sentry_patched_execute(self, document, *args, **kwargs):
-        # type: (gql.Client, DocumentNode, Any, Any) -> Any
+    def sentry_patched_execute(
+        self: gql.Client, document: DocumentNode, *args: Any, **kwargs: Any
+    ) -> Any:
         hub = Hub.current
         if hub.get_integration(GQLIntegration) is None:
             return real_execute(self, document, *args, **kwargs)
@@ -109,10 +107,10 @@ def _patch_execute():
     gql.Client.execute = sentry_patched_execute
 
 
-def _make_gql_event_processor(client, document):
-    # type: (gql.Client, DocumentNode) -> EventProcessor
-    def processor(event, hint):
-        # type: (Dict[str, Any], Dict[str, Any]) -> Dict[str, Any]
+def _make_gql_event_processor(
+    client: gql.Client, document: DocumentNode
+) -> EventProcessor:
+    def processor(event: Dict[str, Any], hint: Dict[str, Any]) -> Dict[str, Any]:
         try:
             errors = hint["exc_info"][1].errors
         except (AttributeError, KeyError):

--- a/sentry_sdk/integrations/gql.py
+++ b/sentry_sdk/integrations/gql.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from sentry_sdk.utils import event_from_exception, parse_version
 from sentry_sdk.hub import Hub, _should_send_default_pii
 from sentry_sdk.integrations import DidNotEnable, Integration

--- a/sentry_sdk/integrations/graphene.py
+++ b/sentry_sdk/integrations/graphene.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from sentry_sdk.hub import Hub, _should_send_default_pii
 from sentry_sdk.integrations import DidNotEnable, Integration
 from sentry_sdk.utils import (

--- a/sentry_sdk/integrations/graphene.py
+++ b/sentry_sdk/integrations/graphene.py
@@ -25,8 +25,7 @@ class GrapheneIntegration(Integration):
     identifier = "graphene"
 
     @staticmethod
-    def setup_once():
-        # type: () -> None
+    def setup_once() -> None:
         version = package_version("graphene")
 
         if version is None:
@@ -38,13 +37,13 @@ class GrapheneIntegration(Integration):
         _patch_graphql()
 
 
-def _patch_graphql():
-    # type: () -> None
+def _patch_graphql() -> None:
     old_graphql_sync = graphene_schema.graphql_sync
     old_graphql_async = graphene_schema.graphql
 
-    def _sentry_patched_graphql_sync(schema, source, *args, **kwargs):
-        # type: (GraphQLSchema, Union[str, Source], Any, Any) -> ExecutionResult
+    def _sentry_patched_graphql_sync(
+        schema: GraphQLSchema, source: Union[str, Source], *args: Any, **kwargs: Any
+    ) -> ExecutionResult:
         hub = Hub.current
         integration = hub.get_integration(GrapheneIntegration)
         if integration is None:
@@ -69,8 +68,9 @@ def _patch_graphql():
 
         return result
 
-    async def _sentry_patched_graphql_async(schema, source, *args, **kwargs):
-        # type: (GraphQLSchema, Union[str, Source], Any, Any) -> ExecutionResult
+    async def _sentry_patched_graphql_async(
+        schema: GraphQLSchema, source: Union[str, Source], *args: Any, **kwargs: Any
+    ) -> ExecutionResult:
         hub = Hub.current
         integration = hub.get_integration(GrapheneIntegration)
         if integration is None:
@@ -99,8 +99,7 @@ def _patch_graphql():
     graphene_schema.graphql = _sentry_patched_graphql_async
 
 
-def _event_processor(event, hint):
-    # type: (Dict[str, Any], Dict[str, Any]) -> Dict[str, Any]
+def _event_processor(event: Dict[str, Any], hint: Dict[str, Any]) -> Dict[str, Any]:
     if _should_send_default_pii():
         request_info = event.setdefault("request", {})
         request_info["api_target"] = "graphql"

--- a/sentry_sdk/integrations/grpc/aio/server.py
+++ b/sentry_sdk/integrations/grpc/aio/server.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from sentry_sdk import Hub
 from sentry_sdk._types import MYPY
 from sentry_sdk.consts import OP
@@ -19,22 +21,26 @@ except ImportError:
 
 
 class ServerInterceptor(grpc.aio.ServerInterceptor):  # type: ignore
-    def __init__(self, find_name=None):
-        # type: (ServerInterceptor, Callable[[ServicerContext], str] | None) -> None
+    def __init__(
+        self: ServerInterceptor,
+        find_name: Callable[[ServicerContext], str] | None = None,
+    ) -> None:
         self._find_method_name = find_name or self._find_name
 
         super(ServerInterceptor, self).__init__()
 
-    async def intercept_service(self, continuation, handler_call_details):
-        # type: (ServerInterceptor, Callable[[HandlerCallDetails], Awaitable[RpcMethodHandler]], HandlerCallDetails) -> Awaitable[RpcMethodHandler]
+    async def intercept_service(
+        self: ServerInterceptor,
+        continuation: Callable[[HandlerCallDetails], Awaitable[RpcMethodHandler]],
+        handler_call_details: HandlerCallDetails,
+    ) -> Awaitable[RpcMethodHandler]:
         self._handler_call_details = handler_call_details
         handler = await continuation(handler_call_details)
 
         if not handler.request_streaming and not handler.response_streaming:
             handler_factory = grpc.unary_unary_rpc_method_handler
 
-            async def wrapped(request, context):
-                # type: (Any, ServicerContext) -> Any
+            async def wrapped(request: Any, context: ServicerContext) -> Any:
                 name = self._find_method_name(context)
                 if not name:
                     return await handler(request, context)
@@ -65,24 +71,21 @@ class ServerInterceptor(grpc.aio.ServerInterceptor):  # type: ignore
         elif not handler.request_streaming and handler.response_streaming:
             handler_factory = grpc.unary_stream_rpc_method_handler
 
-            async def wrapped(request, context):  # type: ignore
-                # type: (Any, ServicerContext) -> Any
+            async def wrapped(request: Any, context: ServicerContext) -> Any:  # type: ignore
                 async for r in handler.unary_stream(request, context):
                     yield r
 
         elif handler.request_streaming and not handler.response_streaming:
             handler_factory = grpc.stream_unary_rpc_method_handler
 
-            async def wrapped(request, context):
-                # type: (Any, ServicerContext) -> Any
+            async def wrapped(request: Any, context: ServicerContext) -> Any:
                 response = handler.stream_unary(request, context)
                 return await response
 
         elif handler.request_streaming and handler.response_streaming:
             handler_factory = grpc.stream_stream_rpc_method_handler
 
-            async def wrapped(request, context):  # type: ignore
-                # type: (Any, ServicerContext) -> Any
+            async def wrapped(request: Any, context: ServicerContext) -> Any:  # type: ignore
                 async for r in handler.stream_stream(request, context):
                     yield r
 
@@ -92,6 +95,5 @@ class ServerInterceptor(grpc.aio.ServerInterceptor):  # type: ignore
             response_serializer=handler.response_serializer,
         )
 
-    def _find_name(self, context):
-        # type: (ServicerContext) -> str
+    def _find_name(self, context: ServicerContext) -> str:
         return self._handler_call_details.method

--- a/sentry_sdk/integrations/grpc/client.py
+++ b/sentry_sdk/integrations/grpc/client.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from sentry_sdk import Hub
 from sentry_sdk._types import MYPY
 from sentry_sdk.consts import OP
@@ -21,8 +23,12 @@ class ClientInterceptor(
 ):
     _is_intercepted = False
 
-    def intercept_unary_unary(self, continuation, client_call_details, request):
-        # type: (ClientInterceptor, Callable[[ClientCallDetails, Message], _UnaryOutcome], ClientCallDetails, Message) -> _UnaryOutcome
+    def intercept_unary_unary(
+        self: ClientInterceptor,
+        continuation: Callable[[ClientCallDetails, Message], _UnaryOutcome],
+        client_call_details: ClientCallDetails,
+        request: Message,
+    ) -> _UnaryOutcome:
         hub = Hub.current
         method = client_call_details.method
 
@@ -41,8 +47,14 @@ class ClientInterceptor(
 
             return response
 
-    def intercept_unary_stream(self, continuation, client_call_details, request):
-        # type: (ClientInterceptor, Callable[[ClientCallDetails, Message], Union[Iterable[Any], UnaryStreamCall]], ClientCallDetails, Message) -> Union[Iterator[Message], Call]
+    def intercept_unary_stream(
+        self: ClientInterceptor,
+        continuation: Callable[
+            [ClientCallDetails, Message], Union[Iterable[Any], UnaryStreamCall]
+        ],
+        client_call_details: ClientCallDetails,
+        request: Message,
+    ) -> Union[Iterator[Message], Call]:
         hub = Hub.current
         method = client_call_details.method
 
@@ -56,17 +68,16 @@ class ClientInterceptor(
                 client_call_details, hub
             )
 
-            response = continuation(
-                client_call_details, request
-            )  # type: UnaryStreamCall
+            response: UnaryStreamCall = continuation(client_call_details, request)
             # Setting code on unary-stream leads to execution getting stuck
             # span.set_data("code", response.code().name)
 
             return response
 
     @staticmethod
-    def _update_client_call_details_metadata_from_hub(client_call_details, hub):
-        # type: (ClientCallDetails, Hub) -> ClientCallDetails
+    def _update_client_call_details_metadata_from_hub(
+        client_call_details: ClientCallDetails, hub: Hub
+    ) -> ClientCallDetails:
         metadata = (
             list(client_call_details.metadata) if client_call_details.metadata else []
         )

--- a/sentry_sdk/integrations/grpc/server.py
+++ b/sentry_sdk/integrations/grpc/server.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from sentry_sdk import Hub
 from sentry_sdk._types import MYPY
 from sentry_sdk.consts import OP
@@ -16,20 +18,24 @@ except ImportError:
 
 
 class ServerInterceptor(grpc.ServerInterceptor):  # type: ignore
-    def __init__(self, find_name=None):
-        # type: (ServerInterceptor, Optional[Callable[[ServicerContext], str]]) -> None
+    def __init__(
+        self: ServerInterceptor,
+        find_name: Optional[Callable[[ServicerContext], str]] = None,
+    ) -> None:
         self._find_method_name = find_name or ServerInterceptor._find_name
 
         super(ServerInterceptor, self).__init__()
 
-    def intercept_service(self, continuation, handler_call_details):
-        # type: (ServerInterceptor, Callable[[HandlerCallDetails], RpcMethodHandler], HandlerCallDetails) -> RpcMethodHandler
+    def intercept_service(
+        self: ServerInterceptor,
+        continuation: Callable[[HandlerCallDetails], RpcMethodHandler],
+        handler_call_details: HandlerCallDetails,
+    ) -> RpcMethodHandler:
         handler = continuation(handler_call_details)
         if not handler or not handler.unary_unary:
             return handler
 
-        def behavior(request, context):
-            # type: (Message, ServicerContext) -> Message
+        def behavior(request: Message, context: ServicerContext) -> Message:
             hub = Hub(Hub.current)
 
             name = self._find_method_name(context)
@@ -59,6 +65,5 @@ class ServerInterceptor(grpc.ServerInterceptor):  # type: ignore
         )
 
     @staticmethod
-    def _find_name(context):
-        # type: (ServicerContext) -> str
+    def _find_name(context: ServicerContext) -> str:
         return context._rpc_event.call_details.method.decode()

--- a/sentry_sdk/integrations/httpx.py
+++ b/sentry_sdk/integrations/httpx.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from sentry_sdk import Hub
 from sentry_sdk.consts import OP, SPANDATA
 from sentry_sdk.integrations import Integration, DidNotEnable

--- a/sentry_sdk/integrations/httpx.py
+++ b/sentry_sdk/integrations/httpx.py
@@ -28,8 +28,7 @@ class HttpxIntegration(Integration):
     identifier = "httpx"
 
     @staticmethod
-    def setup_once():
-        # type: () -> None
+    def setup_once() -> None:
         """
         httpx has its own transport layer and can be customized when needed,
         so patch Client.send and AsyncClient.send to support both synchronous and async interfaces.
@@ -38,12 +37,10 @@ class HttpxIntegration(Integration):
         _install_httpx_async_client()
 
 
-def _install_httpx_client():
-    # type: () -> None
+def _install_httpx_client() -> None:
     real_send = Client.send
 
-    def send(self, request, **kwargs):
-        # type: (Client, Request, **Any) -> Response
+    def send(self: Client, request: Request, **kwargs: Any) -> Response:
         hub = Hub.current
         if hub.get_integration(HttpxIntegration) is None:
             return real_send(self, request, **kwargs)
@@ -91,12 +88,10 @@ def _install_httpx_client():
     Client.send = send
 
 
-def _install_httpx_async_client():
-    # type: () -> None
+def _install_httpx_async_client() -> None:
     real_send = AsyncClient.send
 
-    async def send(self, request, **kwargs):
-        # type: (AsyncClient, Request, **Any) -> Response
+    async def send(self: AsyncClient, request: Request, **kwargs: Any) -> Response:
         hub = Hub.current
         if hub.get_integration(HttpxIntegration) is None:
             return await real_send(self, request, **kwargs)

--- a/sentry_sdk/integrations/huey.py
+++ b/sentry_sdk/integrations/huey.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import sys
 from datetime import datetime
 

--- a/sentry_sdk/integrations/logging.py
+++ b/sentry_sdk/integrations/logging.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import logging
 from datetime import datetime, timezone
 from fnmatch import fnmatch

--- a/sentry_sdk/integrations/loguru.py
+++ b/sentry_sdk/integrations/loguru.py
@@ -36,7 +36,7 @@ DEFAULT_EVENT_LEVEL = LoggingLevels.ERROR.value
 # in tests (they call `LoguruIntegration.__init__` multiple times,
 # and we can't use `setup_once` because it's called before
 # than we get configuration).
-_ADDED_HANDLERS = (None, None)  # type: Tuple[Optional[int], Optional[int]]
+_ADDED_HANDLERS: Tuple[Optional[int], Optional[int]] = (None, None)
 
 
 class LoguruIntegration(Integration):
@@ -44,12 +44,11 @@ class LoguruIntegration(Integration):
 
     def __init__(
         self,
-        level=DEFAULT_LEVEL,
-        event_level=DEFAULT_EVENT_LEVEL,
-        breadcrumb_format=DEFAULT_FORMAT,
-        event_format=DEFAULT_FORMAT,
-    ):
-        # type: (Optional[int], Optional[int], str | loguru.FormatFunction, str | loguru.FormatFunction) -> None
+        level: Optional[int] = DEFAULT_LEVEL,
+        event_level: Optional[int] = DEFAULT_EVENT_LEVEL,
+        breadcrumb_format: str | loguru.FormatFunction = DEFAULT_FORMAT,
+        event_format: str | loguru.FormatFunction = DEFAULT_FORMAT,
+    ) -> None:
         global _ADDED_HANDLERS
         breadcrumb_handler, event_handler = _ADDED_HANDLERS
 
@@ -77,14 +76,12 @@ class LoguruIntegration(Integration):
         _ADDED_HANDLERS = (breadcrumb_handler, event_handler)
 
     @staticmethod
-    def setup_once():
-        # type: () -> None
+    def setup_once() -> None:
         pass  # we do everything in __init__
 
 
 class _LoguruBaseHandler(_BaseHandler):
-    def _logging_to_event_level(self, record):
-        # type: (LogRecord) -> str
+    def _logging_to_event_level(self, record: LogRecord) -> str:
         try:
             return LoggingLevels(record.levelno).name.lower()
         except ValueError:

--- a/sentry_sdk/integrations/loguru.py
+++ b/sentry_sdk/integrations/loguru.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import enum
 
 from sentry_sdk._types import TYPE_CHECKING

--- a/sentry_sdk/integrations/modules.py
+++ b/sentry_sdk/integrations/modules.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from sentry_sdk.hub import Hub
 from sentry_sdk.integrations import Integration
 from sentry_sdk.scope import add_global_event_processor

--- a/sentry_sdk/integrations/modules.py
+++ b/sentry_sdk/integrations/modules.py
@@ -16,11 +16,9 @@ class ModulesIntegration(Integration):
     identifier = "modules"
 
     @staticmethod
-    def setup_once():
-        # type: () -> None
+    def setup_once() -> None:
         @add_global_event_processor
-        def processor(event, hint):
-            # type: (Event, Any) -> Dict[str, Any]
+        def processor(event: Event, hint: Any) -> Dict[str, Any]:
             if event.get("type") == "transaction":
                 return event
 

--- a/sentry_sdk/integrations/opentelemetry/integration.py
+++ b/sentry_sdk/integrations/opentelemetry/integration.py
@@ -4,6 +4,8 @@ are experimental and not suitable for production use. They may be changed or
 removed at any time without prior notice.
 """
 
+from __future__ import annotations
+
 import sys
 from importlib import import_module
 

--- a/sentry_sdk/integrations/opentelemetry/integration.py
+++ b/sentry_sdk/integrations/opentelemetry/integration.py
@@ -41,8 +41,7 @@ class OpenTelemetryIntegration(Integration):
     identifier = "opentelemetry"
 
     @staticmethod
-    def setup_once():
-        # type: () -> None
+    def setup_once() -> None:
         logger.warning(
             "[OTel] Initializing highly experimental OpenTelemetry support. "
             "Use at your own risk."
@@ -70,8 +69,7 @@ class OpenTelemetryIntegration(Integration):
         logger.debug("[OTel] Finished setting up OpenTelemetry integration")
 
 
-def _record_unpatched_classes():
-    # type: () -> Dict[str, type]
+def _record_unpatched_classes() -> Dict[str, type]:
     """
     Keep references to classes that are about to be instrumented.
 
@@ -95,8 +93,7 @@ def _record_unpatched_classes():
     return original_classes
 
 
-def _patch_remaining_classes(original_classes):
-    # type: (Dict[str, type]) -> None
+def _patch_remaining_classes(original_classes: Dict[str, type]) -> None:
     """
     Best-effort attempt to patch any uninstrumented classes in sys.modules.
 
@@ -157,14 +154,12 @@ def _patch_remaining_classes(original_classes):
                     setattr(module, var_name, instrumented_classes[package])
 
 
-def _import_by_path(path):
-    # type: (str) -> type
+def _import_by_path(path: str) -> type:
     parts = path.rsplit(".", maxsplit=1)
     return getattr(import_module(parts[0]), parts[-1])
 
 
-def _setup_sentry_tracing():
-    # type: () -> None
+def _setup_sentry_tracing() -> None:
     provider = TracerProvider()
 
     provider.add_span_processor(SentrySpanProcessor())

--- a/sentry_sdk/integrations/opentelemetry/propagator.py
+++ b/sentry_sdk/integrations/opentelemetry/propagator.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from opentelemetry import trace  # type: ignore
 from opentelemetry.context import (  # type: ignore
     Context,

--- a/sentry_sdk/integrations/opentelemetry/propagator.py
+++ b/sentry_sdk/integrations/opentelemetry/propagator.py
@@ -42,8 +42,12 @@ class SentryPropagator(TextMapPropagator):  # type: ignore
     Propagates tracing headers for Sentry's tracing system in a way OTel understands.
     """
 
-    def extract(self, carrier, context=None, getter=default_getter):
-        # type: (CarrierT, Optional[Context], Getter) -> Context
+    def extract(
+        self,
+        carrier: CarrierT,
+        context: Optional[Context] = None,
+        getter: Getter = default_getter,
+    ) -> Context:
         if context is None:
             context = get_current()
 
@@ -84,8 +88,12 @@ class SentryPropagator(TextMapPropagator):  # type: ignore
         modified_context = trace.set_span_in_context(span, context)
         return modified_context
 
-    def inject(self, carrier, context=None, setter=default_setter):
-        # type: (CarrierT, Optional[Context], Setter) -> None
+    def inject(
+        self,
+        carrier: CarrierT,
+        context: Optional[Context] = None,
+        setter: Setter = default_setter,
+    ) -> None:
         if context is None:
             context = get_current()
 
@@ -110,6 +118,5 @@ class SentryPropagator(TextMapPropagator):  # type: ignore
                 setter.set(carrier, BAGGAGE_HEADER_NAME, baggage.serialize())
 
     @property
-    def fields(self):
-        # type: () -> Set[str]
+    def fields(self) -> Set[str]:
         return {SENTRY_TRACE_HEADER_NAME, BAGGAGE_HEADER_NAME}

--- a/sentry_sdk/integrations/pure_eval.py
+++ b/sentry_sdk/integrations/pure_eval.py
@@ -33,12 +33,9 @@ class PureEvalIntegration(Integration):
     identifier = "pure_eval"
 
     @staticmethod
-    def setup_once():
-        # type: () -> None
-
+    def setup_once() -> None:
         @add_global_event_processor
-        def add_executing_info(event, hint):
-            # type: (Event, Optional[Hint]) -> Optional[Event]
+        def add_executing_info(event: Event, hint: Optional[Hint]) -> Optional[Event]:
             if Hub.current.get_integration(PureEvalIntegration) is None:
                 return event
 
@@ -79,8 +76,7 @@ class PureEvalIntegration(Integration):
             return event
 
 
-def pure_eval_frame(frame):
-    # type: (FrameType) -> Dict[str, Any]
+def pure_eval_frame(frame: FrameType) -> Dict[str, Any]:
     source = executing.Source.for_frame(frame)
     if not source.tree:
         return {}
@@ -101,16 +97,14 @@ def pure_eval_frame(frame):
     evaluator = pure_eval.Evaluator.from_frame(frame)
     expressions = evaluator.interesting_expressions_grouped(scope)
 
-    def closeness(expression):
-        # type: (Tuple[List[Any], Any]) -> Tuple[int, int]
+    def closeness(expression: Tuple[List[Any], Any]) -> Tuple[int, int]:
         # Prioritise expressions with a node closer to the statement executed
         # without being after that statement
         # A higher return value is better - the expression will appear
         # earlier in the list of values and is less likely to be trimmed
         nodes, _value = expression
 
-        def start(n):
-            # type: (ast.expr) -> Tuple[int, int]
+        def start(n: ast.expr) -> Tuple[int, int]:
             return (n.lineno, n.col_offset)
 
         nodes_before_stmt = [

--- a/sentry_sdk/integrations/pure_eval.py
+++ b/sentry_sdk/integrations/pure_eval.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import ast
 
 from sentry_sdk import Hub, serializer

--- a/sentry_sdk/integrations/pymongo.py
+++ b/sentry_sdk/integrations/pymongo.py
@@ -41,8 +41,7 @@ SAFE_COMMAND_ATTRIBUTES = [
 ]
 
 
-def _strip_pii(command):
-    # type: (Dict[str, Any]) -> Dict[str, Any]
+def _strip_pii(command: Dict[str, Any]) -> Dict[str, Any]:
     for key in command:
         is_safe_field = key in SAFE_COMMAND_ATTRIBUTES
         if is_safe_field:
@@ -84,8 +83,7 @@ def _strip_pii(command):
     return command
 
 
-def _get_db_data(event):
-    # type: (Any) -> Dict[str, Any]
+def _get_db_data(event: Any) -> Dict[str, Any]:
     data = {}
 
     data[SPANDATA.DB_SYSTEM] = "mongodb"
@@ -106,16 +104,16 @@ def _get_db_data(event):
 
 
 class CommandTracer(monitoring.CommandListener):
-    def __init__(self):
-        # type: () -> None
-        self._ongoing_operations = {}  # type: Dict[int, Span]
+    def __init__(self) -> None:
+        self._ongoing_operations: Dict[int, Span] = {}
 
-    def _operation_key(self, event):
-        # type: (Union[CommandFailedEvent, CommandStartedEvent, CommandSucceededEvent]) -> int
+    def _operation_key(
+        self,
+        event: Union[CommandFailedEvent, CommandStartedEvent, CommandSucceededEvent],
+    ) -> int:
         return event.request_id
 
-    def started(self, event):
-        # type: (CommandStartedEvent) -> None
+    def started(self, event: CommandStartedEvent) -> None:
         hub = Hub.current
         if hub.get_integration(PyMongoIntegration) is None:
             return
@@ -140,7 +138,7 @@ class CommandTracer(monitoring.CommandListener):
             except TypeError:
                 pass
 
-            data = {"operation_ids": {}}  # type: Dict[str, Any]
+            data: Dict[str, Any] = {"operation_ids": {}}
             data["operation_ids"]["operation"] = event.operation_id
             data["operation_ids"]["request"] = event.request_id
 
@@ -169,8 +167,7 @@ class CommandTracer(monitoring.CommandListener):
 
             self._ongoing_operations[self._operation_key(event)] = span.__enter__()
 
-    def failed(self, event):
-        # type: (CommandFailedEvent) -> None
+    def failed(self, event: CommandFailedEvent) -> None:
         hub = Hub.current
         if hub.get_integration(PyMongoIntegration) is None:
             return
@@ -182,8 +179,7 @@ class CommandTracer(monitoring.CommandListener):
         except KeyError:
             return
 
-    def succeeded(self, event):
-        # type: (CommandSucceededEvent) -> None
+    def succeeded(self, event: CommandSucceededEvent) -> None:
         hub = Hub.current
         if hub.get_integration(PyMongoIntegration) is None:
             return
@@ -200,6 +196,5 @@ class PyMongoIntegration(Integration):
     identifier = "pymongo"
 
     @staticmethod
-    def setup_once():
-        # type: () -> None
+    def setup_once() -> None:
         monitoring.register(CommandTracer())

--- a/sentry_sdk/integrations/pymongo.py
+++ b/sentry_sdk/integrations/pymongo.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import copy
 
 from sentry_sdk import Hub

--- a/sentry_sdk/integrations/pyramid.py
+++ b/sentry_sdk/integrations/pyramid.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 import sys
 import weakref

--- a/sentry_sdk/integrations/quart.py
+++ b/sentry_sdk/integrations/quart.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import asyncio
 import inspect
 import threading

--- a/sentry_sdk/integrations/redis/__init__.py
+++ b/sentry_sdk/integrations/redis/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from sentry_sdk import Hub
 from sentry_sdk.consts import OP, SPANDATA
 from sentry_sdk.hub import _should_send_default_pii

--- a/sentry_sdk/integrations/redis/asyncio.py
+++ b/sentry_sdk/integrations/redis/asyncio.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from sentry_sdk import Hub
 from sentry_sdk.consts import OP
 from sentry_sdk.integrations.redis import (

--- a/sentry_sdk/integrations/redis/asyncio.py
+++ b/sentry_sdk/integrations/redis/asyncio.py
@@ -18,13 +18,14 @@ if TYPE_CHECKING:
 
 
 def patch_redis_async_pipeline(
-    pipeline_cls, is_cluster, get_command_args_fn, set_db_data_fn
-):
-    # type: (Union[type[Pipeline[Any]], type[ClusterPipeline[Any]]], bool, Any, Callable[[Span, Any], None]) -> None
+    pipeline_cls: Union[type[Pipeline[Any]], type[ClusterPipeline[Any]]],
+    is_cluster: bool,
+    get_command_args_fn: Any,
+    set_db_data_fn: Callable[[Span, Any], None],
+) -> None:
     old_execute = pipeline_cls.execute
 
-    async def _sentry_execute(self, *args, **kwargs):
-        # type: (Any, *Any, **Any) -> Any
+    async def _sentry_execute(self: Any, *args: Any, **kwargs: Any) -> Any:
         hub = Hub.current
 
         if hub.get_integration(RedisIntegration) is None:
@@ -48,12 +49,16 @@ def patch_redis_async_pipeline(
     pipeline_cls.execute = _sentry_execute  # type: ignore[method-assign]
 
 
-def patch_redis_async_client(cls, is_cluster, set_db_data_fn):
-    # type: (Union[type[StrictRedis[Any]], type[RedisCluster[Any]]], bool, Callable[[Span, Any], None]) -> None
+def patch_redis_async_client(
+    cls: Union[type[StrictRedis[Any]], type[RedisCluster[Any]]],
+    is_cluster: bool,
+    set_db_data_fn: Callable[[Span, Any], None],
+) -> None:
     old_execute_command = cls.execute_command
 
-    async def _sentry_execute_command(self, name, *args, **kwargs):
-        # type: (Any, str, *Any, **Any) -> Any
+    async def _sentry_execute_command(
+        self: Any, name: str, *args: Any, **kwargs: Any
+    ) -> Any:
         hub = Hub.current
 
         if hub.get_integration(RedisIntegration) is None:

--- a/sentry_sdk/integrations/rq.py
+++ b/sentry_sdk/integrations/rq.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import weakref
 
 from sentry_sdk.consts import OP

--- a/sentry_sdk/integrations/sanic.py
+++ b/sentry_sdk/integrations/sanic.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import sys
 import weakref
 from inspect import isawaitable

--- a/sentry_sdk/integrations/serverless.py
+++ b/sentry_sdk/integrations/serverless.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import sys
 from functools import wraps
 
@@ -18,30 +20,28 @@ if TYPE_CHECKING:
 
 else:
 
-    def overload(x):
-        # type: (F) -> F
+    def overload(x: F) -> F:
         return x
 
 
 @overload
-def serverless_function(f, flush=True):
-    # type: (F, bool) -> F
+def serverless_function(f: F, flush: bool = True) -> F:
     pass
 
 
 @overload
-def serverless_function(f=None, flush=True):  # noqa: F811
-    # type: (None, bool) -> Callable[[F], F]
+def serverless_function(  # noqa: F811
+    f: None = None, flush: bool = True
+) -> Callable[[F], F]:
     pass
 
 
-def serverless_function(f=None, flush=True):  # noqa
-    # type: (Optional[F], bool) -> Union[F, Callable[[F], F]]
-    def wrapper(f):
-        # type: (F) -> F
+def serverless_function(  # noqa: F811
+    f: Optional[F] = None, flush: bool = True
+) -> Union[F, Callable[[F], F]]:
+    def wrapper(f: F) -> F:
         @wraps(f)
-        def inner(*args, **kwargs):
-            # type: (*Any, **Any) -> Any
+        def inner(*args: Any, **kwargs: Any) -> Any:
             with Hub(Hub.current) as hub:
                 with hub.configure_scope() as scope:
                     scope.clear_breadcrumbs()
@@ -62,8 +62,7 @@ def serverless_function(f=None, flush=True):  # noqa
         return wrapper(f)
 
 
-def _capture_and_reraise():
-    # type: () -> None
+def _capture_and_reraise() -> None:
     exc_info = sys.exc_info()
     hub = Hub.current
     if hub.client is not None:
@@ -77,6 +76,5 @@ def _capture_and_reraise():
     reraise(*exc_info)
 
 
-def _flush_client():
-    # type: () -> None
+def _flush_client() -> None:
     return Hub.current.flush()

--- a/sentry_sdk/integrations/socket.py
+++ b/sentry_sdk/integrations/socket.py
@@ -1,10 +1,12 @@
+from __future__ import annotations
+
 import socket
 from sentry_sdk import Hub
-from sentry_sdk._types import MYPY
+from sentry_sdk._types import TYPE_CHECKING
 from sentry_sdk.consts import OP
 from sentry_sdk.integrations import Integration
 
-if MYPY:
+if TYPE_CHECKING:
     from socket import AddressFamily, SocketKind
     from typing import Tuple, Optional, Union, List
 

--- a/sentry_sdk/integrations/socket.py
+++ b/sentry_sdk/integrations/socket.py
@@ -15,8 +15,7 @@ class SocketIntegration(Integration):
     identifier = "socket"
 
     @staticmethod
-    def setup_once():
-        # type: () -> None
+    def setup_once() -> None:
         """
         patches two of the most used functions of socket: create_connection and getaddrinfo(dns resolver)
         """
@@ -24,9 +23,9 @@ class SocketIntegration(Integration):
         _patch_getaddrinfo()
 
 
-def _get_span_description(host, port):
-    # type: (Union[bytes, str, None], Union[str, int, None]) -> str
-
+def _get_span_description(
+    host: Union[bytes, str, None], port: Union[str, int, None]
+) -> str:
     try:
         host = host.decode()  # type: ignore
     except (UnicodeDecodeError, AttributeError):
@@ -37,16 +36,14 @@ def _get_span_description(host, port):
     return description
 
 
-def _patch_create_connection():
-    # type: () -> None
+def _patch_create_connection() -> None:
     real_create_connection = socket.create_connection
 
     def create_connection(
-        address,
-        timeout=socket._GLOBAL_DEFAULT_TIMEOUT,  # type: ignore
-        source_address=None,
-    ):
-        # type: (Tuple[Optional[str], int], Optional[float], Optional[Tuple[Union[bytearray, bytes, str], int]])-> socket.socket
+        address: Tuple[Optional[str], int],
+        timeout: Optional[float] = socket._GLOBAL_DEFAULT_TIMEOUT,  # type: ignore
+        source_address: Optional[Tuple[Union[bytearray, bytes, str], int]] = None,
+    ) -> socket.socket:
         hub = Hub.current
         if hub.get_integration(SocketIntegration) is None:
             return real_create_connection(
@@ -68,12 +65,25 @@ def _patch_create_connection():
     socket.create_connection = create_connection  # type: ignore
 
 
-def _patch_getaddrinfo():
-    # type: () -> None
+def _patch_getaddrinfo() -> None:
     real_getaddrinfo = socket.getaddrinfo
 
-    def getaddrinfo(host, port, family=0, type=0, proto=0, flags=0):
-        # type: (Union[bytes, str, None], Union[str, int, None], int, int, int, int) -> List[Tuple[AddressFamily, SocketKind, int, str, Union[Tuple[str, int], Tuple[str, int, int, int]]]]
+    def getaddrinfo(
+        host: Union[bytes, str, None],
+        port: Union[str, int, None],
+        family: int = 0,
+        type: int = 0,
+        proto: int = 0,
+        flags: int = 0,
+    ) -> List[
+        Tuple[
+            AddressFamily,
+            SocketKind,
+            int,
+            str,
+            Union[Tuple[str, int], Tuple[str, int, int, int]],
+        ]
+    ]:
         hub = Hub.current
         if hub.get_integration(SocketIntegration) is None:
             return real_getaddrinfo(host, port, family, type, proto, flags)

--- a/sentry_sdk/integrations/spark/spark_driver.py
+++ b/sentry_sdk/integrations/spark/spark_driver.py
@@ -16,13 +16,11 @@ class SparkIntegration(Integration):
     identifier = "spark"
 
     @staticmethod
-    def setup_once():
-        # type: () -> None
+    def setup_once() -> None:
         patch_spark_context_init()
 
 
-def _set_app_properties():
-    # type: () -> None
+def _set_app_properties() -> None:
     """
     Set properties in driver that propagate to worker processes, allowing for workers to have access to those properties.
     This allows worker integration to have access to app_name and application_id.
@@ -37,8 +35,7 @@ def _set_app_properties():
         )
 
 
-def _start_sentry_listener(sc):
-    # type: (Any) -> None
+def _start_sentry_listener(sc: Any) -> None:
     """
     Start java gateway server to add custom `SparkListener`
     """
@@ -50,14 +47,14 @@ def _start_sentry_listener(sc):
     sc._jsc.sc().addSparkListener(listener)
 
 
-def patch_spark_context_init():
-    # type: () -> None
+def patch_spark_context_init() -> None:
     from pyspark import SparkContext
 
     spark_context_init = SparkContext._do_init
 
-    def _sentry_patched_spark_context_init(self, *args, **kwargs):
-        # type: (SparkContext, *Any, **Any) -> Optional[Any]
+    def _sentry_patched_spark_context_init(
+        self: SparkContext, *args: Any, **kwargs: Any
+    ) -> Optional[Any]:
         init = spark_context_init(self, *args, **kwargs)
 
         if Hub.current.get_integration(SparkIntegration) is None:
@@ -69,8 +66,7 @@ def patch_spark_context_init():
         with configure_scope() as scope:
 
             @scope.add_event_processor
-            def process_event(event, hint):
-                # type: (Event, Hint) -> Optional[Event]
+            def process_event(event: Event, hint: Hint) -> Optional[Event]:
                 with capture_internal_exceptions():
                     if Hub.current.get_integration(SparkIntegration) is None:
                         return event
@@ -106,102 +102,88 @@ def patch_spark_context_init():
 
 
 class SparkListener:
-    def onApplicationEnd(self, applicationEnd):  # noqa: N802,N803
-        # type: (Any) -> None
+    def onApplicationEnd(self, applicationEnd: Any) -> None:  # noqa: N802,N803
         pass
 
-    def onApplicationStart(self, applicationStart):  # noqa: N802,N803
-        # type: (Any) -> None
+    def onApplicationStart(self, applicationStart: Any) -> None:  # noqa: N802,N803
         pass
 
-    def onBlockManagerAdded(self, blockManagerAdded):  # noqa: N802,N803
-        # type: (Any) -> None
+    def onBlockManagerAdded(self, blockManagerAdded: Any) -> None:  # noqa: N802,N803
         pass
 
-    def onBlockManagerRemoved(self, blockManagerRemoved):  # noqa: N802,N803
-        # type: (Any) -> None
+    def onBlockManagerRemoved(
+        self, blockManagerRemoved: Any
+    ) -> None:  # noqa: N802,N803
         pass
 
-    def onBlockUpdated(self, blockUpdated):  # noqa: N802,N803
-        # type: (Any) -> None
+    def onBlockUpdated(self, blockUpdated: Any) -> None:  # noqa: N802,N803
         pass
 
-    def onEnvironmentUpdate(self, environmentUpdate):  # noqa: N802,N803
-        # type: (Any) -> None
+    def onEnvironmentUpdate(self, environmentUpdate: Any) -> None:  # noqa: N802,N803
         pass
 
-    def onExecutorAdded(self, executorAdded):  # noqa: N802,N803
-        # type: (Any) -> None
+    def onExecutorAdded(self, executorAdded: Any) -> None:  # noqa: N802,N803
         pass
 
-    def onExecutorBlacklisted(self, executorBlacklisted):  # noqa: N802,N803
-        # type: (Any) -> None
+    def onExecutorBlacklisted(
+        self, executorBlacklisted: Any
+    ) -> None:  # noqa: N802,N803
         pass
 
     def onExecutorBlacklistedForStage(  # noqa: N802
-        self, executorBlacklistedForStage  # noqa: N803
-    ):
-        # type: (Any) -> None
+        self, executorBlacklistedForStage: Any  # noqa: N803
+    ) -> None:
         pass
 
-    def onExecutorMetricsUpdate(self, executorMetricsUpdate):  # noqa: N802,N803
-        # type: (Any) -> None
+    def onExecutorMetricsUpdate(
+        self, executorMetricsUpdate: Any
+    ) -> None:  # noqa: N802,N803
         pass
 
-    def onExecutorRemoved(self, executorRemoved):  # noqa: N802,N803
-        # type: (Any) -> None
+    def onExecutorRemoved(self, executorRemoved: Any) -> None:  # noqa: N802,N803
         pass
 
-    def onJobEnd(self, jobEnd):  # noqa: N802,N803
-        # type: (Any) -> None
+    def onJobEnd(self, jobEnd: Any) -> None:  # noqa: N802,N803
         pass
 
-    def onJobStart(self, jobStart):  # noqa: N802,N803
-        # type: (Any) -> None
+    def onJobStart(self, jobStart: Any) -> None:  # noqa: N802,N803
         pass
 
-    def onNodeBlacklisted(self, nodeBlacklisted):  # noqa: N802,N803
-        # type: (Any) -> None
+    def onNodeBlacklisted(self, nodeBlacklisted: Any) -> None:  # noqa: N802,N803
         pass
 
-    def onNodeBlacklistedForStage(self, nodeBlacklistedForStage):  # noqa: N802,N803
-        # type: (Any) -> None
+    def onNodeBlacklistedForStage(
+        self, nodeBlacklistedForStage: Any
+    ) -> None:  # noqa: N802,N803
         pass
 
-    def onNodeUnblacklisted(self, nodeUnblacklisted):  # noqa: N802,N803
-        # type: (Any) -> None
+    def onNodeUnblacklisted(self, nodeUnblacklisted: Any) -> None:  # noqa: N802,N803
         pass
 
-    def onOtherEvent(self, event):  # noqa: N802,N803
-        # type: (Any) -> None
+    def onOtherEvent(self, event: Any) -> None:  # noqa: N802,N803
         pass
 
-    def onSpeculativeTaskSubmitted(self, speculativeTask):  # noqa: N802,N803
-        # type: (Any) -> None
+    def onSpeculativeTaskSubmitted(
+        self, speculativeTask: Any
+    ) -> None:  # noqa: N802,N803
         pass
 
-    def onStageCompleted(self, stageCompleted):  # noqa: N802,N803
-        # type: (Any) -> None
+    def onStageCompleted(self, stageCompleted: Any) -> None:  # noqa: N802,N803
         pass
 
-    def onStageSubmitted(self, stageSubmitted):  # noqa: N802,N803
-        # type: (Any) -> None
+    def onStageSubmitted(self, stageSubmitted: Any) -> None:  # noqa: N802,N803
         pass
 
-    def onTaskEnd(self, taskEnd):  # noqa: N802,N803
-        # type: (Any) -> None
+    def onTaskEnd(self, taskEnd: Any) -> None:  # noqa: N802,N803
         pass
 
-    def onTaskGettingResult(self, taskGettingResult):  # noqa: N802,N803
-        # type: (Any) -> None
+    def onTaskGettingResult(self, taskGettingResult: Any) -> None:  # noqa: N802,N803
         pass
 
-    def onTaskStart(self, taskStart):  # noqa: N802,N803
-        # type: (Any) -> None
+    def onTaskStart(self, taskStart: Any) -> None:  # noqa: N802,N803
         pass
 
-    def onUnpersistRDD(self, unpersistRDD):  # noqa: N802,N803
-        # type: (Any) -> None
+    def onUnpersistRDD(self, unpersistRDD: Any) -> None:  # noqa: N802,N803
         pass
 
     class Java:
@@ -209,18 +191,15 @@ class SparkListener:
 
 
 class SentryListener(SparkListener):
-    def __init__(self):
-        # type: () -> None
+    def __init__(self) -> None:
         self.hub = Hub.current
 
-    def onJobStart(self, jobStart):  # noqa: N802,N803
-        # type: (Any) -> None
+    def onJobStart(self, jobStart: Any) -> None:  # noqa: N802,N803
         message = "Job {} Started".format(jobStart.jobId())
         self.hub.add_breadcrumb(level="info", message=message)
         _set_app_properties()
 
-    def onJobEnd(self, jobEnd):  # noqa: N802,N803
-        # type: (Any) -> None
+    def onJobEnd(self, jobEnd: Any) -> None:  # noqa: N802,N803
         level = ""
         message = ""
         data = {"result": jobEnd.jobResult().toString()}
@@ -234,16 +213,14 @@ class SentryListener(SparkListener):
 
         self.hub.add_breadcrumb(level=level, message=message, data=data)
 
-    def onStageSubmitted(self, stageSubmitted):  # noqa: N802,N803
-        # type: (Any) -> None
+    def onStageSubmitted(self, stageSubmitted: Any) -> None:  # noqa: N802,N803
         stage_info = stageSubmitted.stageInfo()
         message = "Stage {} Submitted".format(stage_info.stageId())
         data = {"attemptId": stage_info.attemptId(), "name": stage_info.name()}
         self.hub.add_breadcrumb(level="info", message=message, data=data)
         _set_app_properties()
 
-    def onStageCompleted(self, stageCompleted):  # noqa: N802,N803
-        # type: (Any) -> None
+    def onStageCompleted(self, stageCompleted: Any) -> None:  # noqa: N802,N803
         from py4j.protocol import Py4JJavaError  # type: ignore
 
         stage_info = stageCompleted.stageInfo()

--- a/sentry_sdk/integrations/spark/spark_worker.py
+++ b/sentry_sdk/integrations/spark/spark_worker.py
@@ -24,15 +24,13 @@ class SparkWorkerIntegration(Integration):
     identifier = "spark_worker"
 
     @staticmethod
-    def setup_once():
-        # type: () -> None
+    def setup_once() -> None:
         import pyspark.daemon as original_daemon
 
         original_daemon.worker_main = _sentry_worker_main
 
 
-def _capture_exception(exc_info, hub):
-    # type: (ExcInfo, Hub) -> None
+def _capture_exception(exc_info: ExcInfo, hub: Hub) -> None:
     client = hub.client
 
     client_options = client.options  # type: ignore
@@ -63,15 +61,13 @@ def _capture_exception(exc_info, hub):
         hub.capture_event(event, hint=hint)
 
 
-def _tag_task_context():
-    # type: () -> None
+def _tag_task_context() -> None:
     from pyspark.taskcontext import TaskContext
 
     with configure_scope() as scope:
 
         @scope.add_event_processor
-        def process_event(event, hint):
-            # type: (Event, Hint) -> Optional[Event]
+        def process_event(event: Event, hint: Hint) -> Optional[Event]:
             with capture_internal_exceptions():
                 integration = Hub.current.get_integration(SparkWorkerIntegration)
                 task_context = TaskContext.get()
@@ -108,8 +104,7 @@ def _tag_task_context():
             return event
 
 
-def _sentry_worker_main(*args, **kwargs):
-    # type: (*Optional[Any], **Optional[Any]) -> None
+def _sentry_worker_main(*args: Optional[Any], **kwargs: Optional[Any]) -> None:
     import pyspark.worker as original_worker
 
     try:

--- a/sentry_sdk/integrations/sqlalchemy.py
+++ b/sentry_sdk/integrations/sqlalchemy.py
@@ -25,9 +25,7 @@ class SqlalchemyIntegration(Integration):
     identifier = "sqlalchemy"
 
     @staticmethod
-    def setup_once():
-        # type: () -> None
-
+    def setup_once() -> None:
         version = parse_version(SQLALCHEMY_VERSION)
 
         if version is None:
@@ -44,9 +42,14 @@ class SqlalchemyIntegration(Integration):
 
 
 def _before_cursor_execute(
-    conn, cursor, statement, parameters, context, executemany, *args
-):
-    # type: (Any, Any, Any, Any, Any, bool, *Any) -> None
+    conn: Any,
+    cursor: Any,
+    statement: Any,
+    parameters: Any,
+    context: Any,
+    executemany: bool,
+    *args: Any
+) -> None:
     hub = Hub.current
     if hub.get_integration(SqlalchemyIntegration) is None:
         return
@@ -78,15 +81,16 @@ def _before_cursor_execute(
         context._sentry_sql_span = span
 
 
-def _after_cursor_execute(conn, cursor, statement, parameters, context, *args):
-    # type: (Any, Any, Any, Any, Any, *Any) -> None
+def _after_cursor_execute(
+    conn: Any, cursor: Any, statement: Any, parameters: Any, context: Any, *args: Any
+) -> None:
     hub = Hub.current
     if hub.get_integration(SqlalchemyIntegration) is None:
         return
 
-    ctx_mgr = getattr(
+    ctx_mgr: Optional[ContextManager[Any]] = getattr(
         context, "_sentry_sql_span_manager", None
-    )  # type: Optional[ContextManager[Any]]
+    )
 
     if ctx_mgr is not None:
         context._sentry_sql_span_manager = None
@@ -98,13 +102,12 @@ def _after_cursor_execute(conn, cursor, statement, parameters, context, *args):
             add_query_source(hub, span)
 
 
-def _handle_error(context, *args):
-    # type: (Any, *Any) -> None
+def _handle_error(context: Any, *args: Any) -> None:
     execution_context = context.execution_context
     if execution_context is None:
         return
 
-    span = getattr(execution_context, "_sentry_sql_span", None)  # type: Optional[Span]
+    span: Optional[Span] = getattr(execution_context, "_sentry_sql_span", None)
 
     if span is not None:
         span.set_status("internal_error")
@@ -112,9 +115,9 @@ def _handle_error(context, *args):
     # _after_cursor_execute does not get called for crashing SQL stmts. Judging
     # from SQLAlchemy codebase it does seem like any error coming into this
     # handler is going to be fatal.
-    ctx_mgr = getattr(
+    ctx_mgr: Optional[ContextManager[Any]] = getattr(
         execution_context, "_sentry_sql_span_manager", None
-    )  # type: Optional[ContextManager[Any]]
+    )
 
     if ctx_mgr is not None:
         execution_context._sentry_sql_span_manager = None
@@ -122,8 +125,7 @@ def _handle_error(context, *args):
 
 
 # See: https://docs.sqlalchemy.org/en/20/dialects/index.html
-def _get_db_system(name):
-    # type: (str) -> Optional[str]
+def _get_db_system(name: str) -> Optional[str]:
     name = str(name)
 
     if "sqlite" in name:
@@ -144,8 +146,7 @@ def _get_db_system(name):
     return None
 
 
-def _set_db_data(span, conn):
-    # type: (Span, Any) -> None
+def _set_db_data(span: Span, conn: Any) -> None:
     db_system = _get_db_system(conn.engine.name)
     if db_system is not None:
         span.set_data(SPANDATA.DB_SYSTEM, db_system)

--- a/sentry_sdk/integrations/sqlalchemy.py
+++ b/sentry_sdk/integrations/sqlalchemy.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from sentry_sdk._types import TYPE_CHECKING
 from sentry_sdk.consts import SPANDATA
 from sentry_sdk.db.explain_plan.sqlalchemy import attach_explain_plan_to_span
@@ -48,7 +50,7 @@ def _before_cursor_execute(
     parameters: Any,
     context: Any,
     executemany: bool,
-    *args: Any
+    *args: Any,
 ) -> None:
     hub = Hub.current
     if hub.get_integration(SqlalchemyIntegration) is None:

--- a/sentry_sdk/integrations/starlette.py
+++ b/sentry_sdk/integrations/starlette.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import asyncio
 import functools
 from copy import deepcopy
@@ -69,8 +71,7 @@ class StarletteIntegration(Integration):
 
     transaction_style = ""
 
-    def __init__(self, transaction_style="url"):
-        # type: (str) -> None
+    def __init__(self, transaction_style: str = "url") -> None:
         if transaction_style not in TRANSACTION_STYLE_VALUES:
             raise ValueError(
                 "Invalid value for transaction_style: %s (must be in %s)"
@@ -79,8 +80,7 @@ class StarletteIntegration(Integration):
         self.transaction_style = transaction_style
 
     @staticmethod
-    def setup_once():
-        # type: () -> None
+    def setup_once() -> None:
         version = parse_version(STARLETTE_VERSION)
 
         if version is None:
@@ -96,12 +96,16 @@ class StarletteIntegration(Integration):
             patch_templates()
 
 
-def _enable_span_for_middleware(middleware_class):
-    # type: (Any) -> type
+def _enable_span_for_middleware(middleware_class: Any) -> type:
     old_call = middleware_class.__call__
 
-    async def _create_span_call(app, scope, receive, send, **kwargs):
-        # type: (Any, Dict[str, Any], Callable[[], Awaitable[Dict[str, Any]]], Callable[[Dict[str, Any]], Awaitable[None]], Any) -> None
+    async def _create_span_call(
+        app: Any,
+        scope: Dict[str, Any],
+        receive: Callable[[], Awaitable[Dict[str, Any]]],
+        send: Callable[[Dict[str, Any]], Awaitable[None]],
+        **kwargs: Any,
+    ) -> None:
         hub = Hub.current
         integration = hub.get_integration(StarletteIntegration)
         if integration is not None:
@@ -122,8 +126,7 @@ def _enable_span_for_middleware(middleware_class):
                 middleware_span.set_tag("starlette.middleware_name", middleware_name)
 
                 # Creating spans for the "receive" callback
-                async def _sentry_receive(*args, **kwargs):
-                    # type: (*Any, **Any) -> Any
+                async def _sentry_receive(*args: Any, **kwargs: Any) -> Any:
                     hub = Hub.current
                     with hub.start_span(
                         op=OP.MIDDLEWARE_STARLETTE_RECEIVE,
@@ -137,8 +140,7 @@ def _enable_span_for_middleware(middleware_class):
                 new_receive = _sentry_receive if not receive_patched else receive
 
                 # Creating spans for the "send" callback
-                async def _sentry_send(*args, **kwargs):
-                    # type: (*Any, **Any) -> Any
+                async def _sentry_send(*args: Any, **kwargs: Any) -> Any:
                     hub = Hub.current
                     with hub.start_span(
                         op=OP.MIDDLEWARE_STARLETTE_SEND,
@@ -168,8 +170,7 @@ def _enable_span_for_middleware(middleware_class):
     return middleware_class
 
 
-def _capture_exception(exception, handled=False):
-    # type: (BaseException, **Any) -> None
+def _capture_exception(exception: BaseException, handled: Any = False) -> None:
     hub = Hub.current
     if hub.get_integration(StarletteIntegration) is None:
         return
@@ -183,8 +184,7 @@ def _capture_exception(exception, handled=False):
     hub.capture_event(event, hint=hint)
 
 
-def patch_exception_middleware(middleware_class):
-    # type: (Any) -> None
+def patch_exception_middleware(middleware_class: Any) -> None:
     """
     Capture all exceptions in Starlette app and
     also extract user information.
@@ -195,15 +195,15 @@ def patch_exception_middleware(middleware_class):
 
     if not_yet_patched:
 
-        def _sentry_middleware_init(self, *args, **kwargs):
-            # type: (Any, Any, Any) -> None
+        def _sentry_middleware_init(self: Any, *args: Any, **kwargs: Any) -> None:
             old_middleware_init(self, *args, **kwargs)
 
             # Patch existing exception handlers
             old_handlers = self._exception_handlers.copy()
 
-            async def _sentry_patched_exception_handler(self, *args, **kwargs):
-                # type: (Any, Any, Any) -> None
+            async def _sentry_patched_exception_handler(
+                self: Any, *args: Any, **kwargs: Any
+            ) -> None:
                 exp = args[0]
 
                 is_http_server_error = (
@@ -236,8 +236,12 @@ def patch_exception_middleware(middleware_class):
 
         old_call = middleware_class.__call__
 
-        async def _sentry_exceptionmiddleware_call(self, scope, receive, send):
-            # type: (Dict[str, Any], Dict[str, Any], Callable[[], Awaitable[Dict[str, Any]]], Callable[[Dict[str, Any]], Awaitable[None]]) -> None
+        async def _sentry_exceptionmiddleware_call(
+            self: Dict[str, Any],
+            scope: Dict[str, Any],
+            receive: Callable[[], Awaitable[Dict[str, Any]]],
+            send: Callable[[Dict[str, Any]], Awaitable[None]],
+        ) -> None:
             # Also add the user (that was eventually set by be Authentication middle
             # that was called before this middleware). This is done because the authentication
             # middleware sets the user in the scope and then (in the same function)
@@ -255,8 +259,7 @@ def patch_exception_middleware(middleware_class):
         middleware_class.__call__ = _sentry_exceptionmiddleware_call
 
 
-def _add_user_to_sentry_scope(scope):
-    # type: (Dict[str, Any]) -> None
+def _add_user_to_sentry_scope(scope: Dict[str, Any]) -> None:
     """
     Extracts user information from the ASGI scope and
     adds it to Sentry's scope.
@@ -272,7 +275,7 @@ def _add_user_to_sentry_scope(scope):
         return
 
     with hub.configure_scope() as sentry_scope:
-        user_info = {}  # type: Dict[str, Any]
+        user_info: Dict[str, Any] = {}
         starlette_user = scope["user"]
 
         username = getattr(starlette_user, "username", None)
@@ -290,8 +293,7 @@ def _add_user_to_sentry_scope(scope):
         sentry_scope.user = user_info
 
 
-def patch_authentication_middleware(middleware_class):
-    # type: (Any) -> None
+def patch_authentication_middleware(middleware_class: Any) -> None:
     """
     Add user information to Sentry scope.
     """
@@ -301,16 +303,19 @@ def patch_authentication_middleware(middleware_class):
 
     if not_yet_patched:
 
-        async def _sentry_authenticationmiddleware_call(self, scope, receive, send):
-            # type: (Dict[str, Any], Dict[str, Any], Callable[[], Awaitable[Dict[str, Any]]], Callable[[Dict[str, Any]], Awaitable[None]]) -> None
+        async def _sentry_authenticationmiddleware_call(
+            self: Dict[str, Any],
+            scope: Dict[str, Any],
+            receive: Callable[[], Awaitable[Dict[str, Any]]],
+            send: Callable[[Dict[str, Any]], Awaitable[None]],
+        ) -> None:
             await old_call(self, scope, receive, send)
             _add_user_to_sentry_scope(scope)
 
         middleware_class.__call__ = _sentry_authenticationmiddleware_call
 
 
-def patch_middlewares():
-    # type: () -> None
+def patch_middlewares() -> None:
     """
     Patches Starlettes `Middleware` class to record
     spans for every middleware invoked.
@@ -321,8 +326,7 @@ def patch_middlewares():
 
     if not_yet_patched:
 
-        def _sentry_middleware_init(self, cls, **options):
-            # type: (Any, Any, Any) -> None
+        def _sentry_middleware_init(self: Any, cls: Any, **options: Any) -> None:
             if cls == SentryAsgiMiddleware:
                 return old_middleware_init(self, cls, **options)
 
@@ -338,15 +342,15 @@ def patch_middlewares():
         Middleware.__init__ = _sentry_middleware_init
 
 
-def patch_asgi_app():
-    # type: () -> None
+def patch_asgi_app() -> None:
     """
     Instrument Starlette ASGI app using the SentryAsgiMiddleware.
     """
     old_app = Starlette.__call__
 
-    async def _sentry_patched_asgi_app(self, scope, receive, send):
-        # type: (Starlette, StarletteScope, Receive, Send) -> None
+    async def _sentry_patched_asgi_app(
+        self: Starlette, scope: StarletteScope, receive: Receive, send: Send
+    ) -> None:
         integration = Hub.current.get_integration(StarletteIntegration)
         if integration is None:
             return await old_app(self, scope, receive, send)
@@ -365,8 +369,7 @@ def patch_asgi_app():
 
 # This was vendored in from Starlette to support Starlette 0.19.1 because
 # this function was only introduced in 0.20.x
-def _is_async_callable(obj):
-    # type: (Any) -> bool
+def _is_async_callable(obj: Any) -> bool:
     while isinstance(obj, functools.partial):
         obj = obj.func
 
@@ -375,19 +378,16 @@ def _is_async_callable(obj):
     )
 
 
-def patch_request_response():
-    # type: () -> None
+def patch_request_response() -> None:
     old_request_response = starlette.routing.request_response
 
-    def _sentry_request_response(func):
-        # type: (Callable[[Any], Any]) -> ASGIApp
+    def _sentry_request_response(func: Callable[[Any], Any]) -> ASGIApp:
         old_func = func
 
         is_coroutine = _is_async_callable(old_func)
         if is_coroutine:
 
-            async def _sentry_async_func(*args, **kwargs):
-                # type: (*Any, **Any) -> Any
+            async def _sentry_async_func(*args: Any, **kwargs: Any) -> Any:
                 hub = Hub.current
                 integration = hub.get_integration(StarletteIntegration)
                 if integration is None:
@@ -403,11 +403,12 @@ def patch_request_response():
                     extractor = StarletteRequestExtractor(request)
                     info = await extractor.extract_request_info()
 
-                    def _make_request_event_processor(req, integration):
-                        # type: (Any, Any) -> Callable[[Dict[str, Any], Dict[str, Any]], Dict[str, Any]]
-                        def event_processor(event, hint):
-                            # type: (Dict[str, Any], Dict[str, Any]) -> Dict[str, Any]
-
+                    def _make_request_event_processor(
+                        req: Any, integration: Any
+                    ) -> Callable[[Dict[str, Any], Dict[str, Any]], Dict[str, Any]]:
+                        def event_processor(
+                            event: Dict[str, Any], hint: Dict[str, Any]
+                        ) -> Dict[str, Any]:
                             # Add info from request to event
                             request_info = event.get("request", {})
                             if info:
@@ -431,8 +432,7 @@ def patch_request_response():
             func = _sentry_async_func
         else:
 
-            def _sentry_sync_func(*args, **kwargs):
-                # type: (*Any, **Any) -> Any
+            def _sentry_sync_func(*args: Any, **kwargs: Any) -> Any:
                 hub = Hub.current
                 integration = hub.get_integration(StarletteIntegration)
                 if integration is None:
@@ -451,11 +451,12 @@ def patch_request_response():
                     extractor = StarletteRequestExtractor(request)
                     cookies = extractor.extract_cookies_from_request()
 
-                    def _make_request_event_processor(req, integration):
-                        # type: (Any, Any) -> Callable[[Dict[str, Any], Dict[str, Any]], Dict[str, Any]]
-                        def event_processor(event, hint):
-                            # type: (Dict[str, Any], Dict[str, Any]) -> Dict[str, Any]
-
+                    def _make_request_event_processor(
+                        req: Any, integration: Any
+                    ) -> Callable[[Dict[str, Any], Dict[str, Any]], Dict[str, Any]]:
+                        def event_processor(
+                            event: Dict[str, Any], hint: Dict[str, Any]
+                        ) -> Dict[str, Any]:
                             # Extract information from request
                             request_info = event.get("request", {})
                             if cookies:
@@ -481,9 +482,7 @@ def patch_request_response():
     starlette.routing.request_response = _sentry_request_response
 
 
-def patch_templates():
-    # type: () -> None
-
+def patch_templates() -> None:
     # If markupsafe is not installed, then Jinja2 is not installed
     # (markupsafe is a dependency of Jinja2)
     # In this case we do not need to patch the Jinja2Templates class
@@ -502,10 +501,10 @@ def patch_templates():
 
     if not_yet_patched:
 
-        def _sentry_jinja2templates_init(self, *args, **kwargs):
-            # type: (Jinja2Templates, *Any, **Any) -> None
-            def add_sentry_trace_meta(request):
-                # type: (Request) -> Dict[str, Any]
+        def _sentry_jinja2templates_init(
+            self: Jinja2Templates, *args: Any, **kwargs: Any
+        ) -> None:
+            def add_sentry_trace_meta(request: Request) -> Dict[str, Any]:
                 hub = Hub.current
                 trace_meta = Markup(hub.trace_propagation_meta())
                 return {
@@ -528,31 +527,32 @@ class StarletteRequestExtractor:
     (like form data or cookies) and adds it to the Sentry event.
     """
 
-    request = None  # type: Request
+    request: Request = None
 
-    def __init__(self, request):
-        # type: (StarletteRequestExtractor, Request) -> None
+    def __init__(self: StarletteRequestExtractor, request: Request) -> None:
         self.request = request
 
-    def extract_cookies_from_request(self):
-        # type: (StarletteRequestExtractor) -> Optional[Dict[str, Any]]
+    def extract_cookies_from_request(
+        self: StarletteRequestExtractor,
+    ) -> Optional[Dict[str, Any]]:
         client = Hub.current.client
         if client is None:
             return None
 
-        cookies = None  # type: Optional[Dict[str, Any]]
+        cookies: Optional[Dict[str, Any]] = None
         if _should_send_default_pii():
             cookies = self.cookies()
 
         return cookies
 
-    async def extract_request_info(self):
-        # type: (StarletteRequestExtractor) -> Optional[Dict[str, Any]]
+    async def extract_request_info(
+        self: StarletteRequestExtractor,
+    ) -> Optional[Dict[str, Any]]:
         client = Hub.current.client
         if client is None:
             return None
 
-        request_info = {}  # type: Dict[str, Any]
+        request_info: Dict[str, Any] = {}
 
         with capture_internal_exceptions():
             # Add cookies
@@ -596,19 +596,16 @@ class StarletteRequestExtractor:
             request_info["data"] = AnnotatedValue.removed_because_raw_data()
             return request_info
 
-    async def content_length(self):
-        # type: (StarletteRequestExtractor) -> Optional[int]
+    async def content_length(self: StarletteRequestExtractor) -> Optional[int]:
         if "content-length" in self.request.headers:
             return int(self.request.headers["content-length"])
 
         return None
 
-    def cookies(self):
-        # type: (StarletteRequestExtractor) -> Dict[str, Any]
+    def cookies(self: StarletteRequestExtractor) -> Dict[str, Any]:
         return self.request.cookies
 
-    async def form(self):
-        # type: (StarletteRequestExtractor) -> Any
+    async def form(self: StarletteRequestExtractor) -> Any:
         if multipart is None:
             return None
 
@@ -620,20 +617,17 @@ class StarletteRequestExtractor:
 
         return await self.request.form()
 
-    def is_json(self):
-        # type: (StarletteRequestExtractor) -> bool
+    def is_json(self: StarletteRequestExtractor) -> bool:
         return _is_json_content_type(self.request.headers.get("content-type"))
 
-    async def json(self):
-        # type: (StarletteRequestExtractor) -> Optional[Dict[str, Any]]
+    async def json(self: StarletteRequestExtractor) -> Optional[Dict[str, Any]]:
         if not self.is_json():
             return None
 
         return await self.request.json()
 
 
-def _transaction_name_from_router(scope):
-    # type: (StarletteScope) -> Optional[str]
+def _transaction_name_from_router(scope: StarletteScope) -> Optional[str]:
     router = scope.get("router")
     if not router:
         return None
@@ -646,8 +640,9 @@ def _transaction_name_from_router(scope):
     return None
 
 
-def _set_transaction_name_and_source(scope, transaction_style, request):
-    # type: (SentryScope, str, Any) -> None
+def _set_transaction_name_and_source(
+    scope: SentryScope, transaction_style: str, request: Any
+) -> None:
     name = None
     source = SOURCE_FOR_STYLE[transaction_style]
 
@@ -669,8 +664,9 @@ def _set_transaction_name_and_source(scope, transaction_style, request):
     )
 
 
-def _get_transaction_from_middleware(app, asgi_scope, integration):
-    # type: (Any, Dict[str, Any], StarletteIntegration) -> Tuple[Optional[str], Optional[str]]
+def _get_transaction_from_middleware(
+    app: Any, asgi_scope: Dict[str, Any], integration: StarletteIntegration
+) -> Tuple[Optional[str], Optional[str]]:
     name = None
     source = None
 

--- a/sentry_sdk/integrations/starlite.py
+++ b/sentry_sdk/integrations/starlite.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import TYPE_CHECKING
 
 from pydantic import BaseModel  # type: ignore

--- a/sentry_sdk/integrations/stdlib.py
+++ b/sentry_sdk/integrations/stdlib.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 import subprocess
 import sys

--- a/sentry_sdk/integrations/strawberry.py
+++ b/sentry_sdk/integrations/strawberry.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import hashlib
 from functools import cached_property
 from inspect import isawaitable

--- a/sentry_sdk/integrations/threading.py
+++ b/sentry_sdk/integrations/threading.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import sys
 from functools import wraps
 from threading import Thread, current_thread

--- a/sentry_sdk/integrations/threading.py
+++ b/sentry_sdk/integrations/threading.py
@@ -21,18 +21,15 @@ if TYPE_CHECKING:
 class ThreadingIntegration(Integration):
     identifier = "threading"
 
-    def __init__(self, propagate_hub=False):
-        # type: (bool) -> None
+    def __init__(self, propagate_hub: bool = False) -> None:
         self.propagate_hub = propagate_hub
 
     @staticmethod
-    def setup_once():
-        # type: () -> None
+    def setup_once() -> None:
         old_start = Thread.start
 
         @wraps(old_start)
-        def sentry_start(self, *a, **kw):
-            # type: (Thread, *Any, **Any) -> Any
+        def sentry_start(self: Thread, *a: Any, **kw: Any) -> Any:
             hub = Hub.current
             integration = hub.get_integration(ThreadingIntegration)
             if integration is not None:
@@ -55,11 +52,9 @@ class ThreadingIntegration(Integration):
         Thread.start = sentry_start  # type: ignore
 
 
-def _wrap_run(parent_hub, old_run_func):
-    # type: (Optional[Hub], F) -> F
+def _wrap_run(parent_hub: Optional[Hub], old_run_func: F) -> F:
     @wraps(old_run_func)
-    def run(*a, **kw):
-        # type: (*Any, **Any) -> Any
+    def run(*a: Any, **kw: Any) -> Any:
         hub = parent_hub or Hub.current
         with hub:
             try:
@@ -71,14 +66,13 @@ def _wrap_run(parent_hub, old_run_func):
     return run  # type: ignore
 
 
-def _capture_exception():
-    # type: () -> ExcInfo
+def _capture_exception() -> ExcInfo:
     hub = Hub.current
     exc_info = sys.exc_info()
 
     if hub.get_integration(ThreadingIntegration) is not None:
         # If an integration is there, a client has to be there.
-        client = hub.client  # type: Any
+        client: Any = hub.client
 
         event, hint = event_from_exception(
             exc_info,

--- a/sentry_sdk/integrations/tornado.py
+++ b/sentry_sdk/integrations/tornado.py
@@ -47,8 +47,7 @@ class TornadoIntegration(Integration):
     identifier = "tornado"
 
     @staticmethod
-    def setup_once():
-        # type: () -> None
+    def setup_once() -> None:
         if TORNADO_VERSION < (5, 0):
             raise DidNotEnable("Tornado 5+ required")
 
@@ -69,16 +68,18 @@ class TornadoIntegration(Integration):
         if awaitable:
             # Starting Tornado 6 RequestHandler._execute method is a standard Python coroutine (async/await)
             # In that case our method should be a coroutine function too
-            async def sentry_execute_request_handler(self, *args, **kwargs):
-                # type: (RequestHandler, *Any, **Any) -> Any
+            async def sentry_execute_request_handler(
+                self: RequestHandler, *args: Any, **kwargs: Any
+            ) -> Any:
                 with _handle_request_impl(self):
                     return await old_execute(self, *args, **kwargs)
 
         else:
 
             @coroutine  # type: ignore
-            def sentry_execute_request_handler(self, *args, **kwargs):
-                # type: (RequestHandler, *Any, **Any) -> Any
+            def sentry_execute_request_handler(
+                self: RequestHandler, *args: Any, **kwargs: Any
+            ) -> Any:
                 with _handle_request_impl(self):
                     result = yield from old_execute(self, *args, **kwargs)
                     return result
@@ -87,8 +88,14 @@ class TornadoIntegration(Integration):
 
         old_log_exception = RequestHandler.log_exception
 
-        def sentry_log_exception(self, ty, value, tb, *args, **kwargs):
-            # type: (Any, type, BaseException, Any, *Any, **Any) -> Optional[Any]
+        def sentry_log_exception(
+            self: Any,
+            ty: type,
+            value: BaseException,
+            tb: Any,
+            *args: Any,
+            **kwargs: Any
+        ) -> Optional[Any]:
             _capture_exception(ty, value, tb)
             return old_log_exception(self, ty, value, tb, *args, **kwargs)
 
@@ -96,8 +103,7 @@ class TornadoIntegration(Integration):
 
 
 @contextlib.contextmanager
-def _handle_request_impl(self):
-    # type: (RequestHandler) -> Generator[None, None, None]
+def _handle_request_impl(self: RequestHandler) -> Generator[None, None, None]:
     hub = Hub.current
     integration = hub.get_integration(TornadoIntegration)
 
@@ -131,8 +137,7 @@ def _handle_request_impl(self):
             yield
 
 
-def _capture_exception(ty, value, tb):
-    # type: (type, BaseException, Any) -> None
+def _capture_exception(ty: type, value: BaseException, tb: Any) -> None:
     hub = Hub.current
     if hub.get_integration(TornadoIntegration) is None:
         return
@@ -140,7 +145,7 @@ def _capture_exception(ty, value, tb):
         return
 
     # If an integration is there, a client has to be there.
-    client = hub.client  # type: Any
+    client: Any = hub.client
 
     event, hint = event_from_exception(
         (ty, value, tb),
@@ -151,10 +156,10 @@ def _capture_exception(ty, value, tb):
     hub.capture_event(event, hint=hint)
 
 
-def _make_event_processor(weak_handler):
-    # type: (Callable[[], RequestHandler]) -> EventProcessor
-    def tornado_processor(event, hint):
-        # type: (Dict[str, Any], Dict[str, Any]) -> Dict[str, Any]
+def _make_event_processor(weak_handler: Callable[[], RequestHandler]) -> EventProcessor:
+    def tornado_processor(
+        event: Dict[str, Any], hint: Dict[str, Any]
+    ) -> Dict[str, Any]:
         handler = weak_handler()
         if handler is None:
             return event
@@ -193,35 +198,28 @@ def _make_event_processor(weak_handler):
 
 
 class TornadoRequestExtractor(RequestExtractor):
-    def content_length(self):
-        # type: () -> int
+    def content_length(self) -> int:
         if self.request.body is None:
             return 0
         return len(self.request.body)
 
-    def cookies(self):
-        # type: () -> Dict[str, str]
+    def cookies(self) -> Dict[str, str]:
         return {k: v.value for k, v in self.request.cookies.items()}
 
-    def raw_data(self):
-        # type: () -> bytes
+    def raw_data(self) -> bytes:
         return self.request.body
 
-    def form(self):
-        # type: () -> Dict[str, Any]
+    def form(self) -> Dict[str, Any]:
         return {
             k: [v.decode("latin1", "replace") for v in vs]
             for k, vs in self.request.body_arguments.items()
         }
 
-    def is_json(self):
-        # type: () -> bool
+    def is_json(self) -> bool:
         return _is_json_content_type(self.request.headers.get("content-type"))
 
-    def files(self):
-        # type: () -> Dict[str, Any]
+    def files(self) -> Dict[str, Any]:
         return {k: v[0] for k, v in self.request.files.items() if v}
 
-    def size_of_file(self, file):
-        # type: (Any) -> int
+    def size_of_file(self, file: Any) -> int:
         return len(file.body or ())

--- a/sentry_sdk/integrations/tornado.py
+++ b/sentry_sdk/integrations/tornado.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import weakref
 import contextlib
 from inspect import iscoroutinefunction
@@ -94,7 +96,7 @@ class TornadoIntegration(Integration):
             value: BaseException,
             tb: Any,
             *args: Any,
-            **kwargs: Any
+            **kwargs: Any,
         ) -> Optional[Any]:
             _capture_exception(ty, value, tb)
             return old_log_exception(self, ty, value, tb, *args, **kwargs)

--- a/sentry_sdk/integrations/trytond.py
+++ b/sentry_sdk/integrations/trytond.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import sentry_sdk.hub
 import sentry_sdk.utils
 import sentry_sdk.integrations

--- a/sentry_sdk/integrations/trytond.py
+++ b/sentry_sdk/integrations/trytond.py
@@ -17,14 +17,14 @@ if TYPE_CHECKING:
 class TrytondWSGIIntegration(sentry_sdk.integrations.Integration):
     identifier = "trytond_wsgi"
 
-    def __init__(self):  # type: () -> None
+    def __init__(self) -> None:
         pass
 
     @staticmethod
-    def setup_once():  # type: () -> None
+    def setup_once() -> None:
         app.wsgi_app = sentry_sdk.integrations.wsgi.SentryWsgiMiddleware(app.wsgi_app)
 
-        def error_handler(e):  # type: (Exception) -> None
+        def error_handler(e: Exception) -> None:
             hub = sentry_sdk.hub.Hub.current
 
             if hub.get_integration(TrytondWSGIIntegration) is None:
@@ -33,7 +33,7 @@ class TrytondWSGIIntegration(sentry_sdk.integrations.Integration):
                 return
             else:
                 # If an integration is there, a client has to be there.
-                client = hub.client  # type: Any
+                client: Any = hub.client
                 event, hint = sentry_sdk.utils.event_from_exception(
                     e,
                     client_options=client.options,

--- a/sentry_sdk/monitor.py
+++ b/sentry_sdk/monitor.py
@@ -22,21 +22,21 @@ class Monitor:
 
     name = "sentry.monitor"
 
-    def __init__(self, transport, interval=10):
-        # type: (sentry_sdk.transport.Transport, float) -> None
-        self.transport = transport  # type: sentry_sdk.transport.Transport
-        self.interval = interval  # type: float
+    def __init__(
+        self, transport: sentry_sdk.transport.Transport, interval: float = 10
+    ) -> None:
+        self.transport: sentry_sdk.transport.Transport = transport
+        self.interval: float = interval
 
         self._healthy = True
-        self._downsample_factor = 0  # type: int
+        self._downsample_factor: int = 0
 
-        self._thread = None  # type: Optional[Thread]
+        self._thread: Optional[Thread] = None
         self._thread_lock = Lock()
-        self._thread_for_pid = None  # type: Optional[int]
+        self._thread_for_pid: Optional[int] = None
         self._running = True
 
-    def _ensure_running(self):
-        # type: () -> None
+    def _ensure_running(self) -> None:
         """
         Check that the monitor has an active thread to run in, or create one if not.
 
@@ -51,8 +51,7 @@ class Monitor:
             if self._thread_for_pid == os.getpid() and self._thread is not None:
                 return None
 
-            def _thread():
-                # type: (...) -> None
+            def _thread() -> None:
                 while self._running:
                     time.sleep(self.interval)
                     if self._running:
@@ -73,13 +72,11 @@ class Monitor:
 
         return None
 
-    def run(self):
-        # type: () -> None
+    def run(self) -> None:
         self.check_health()
         self.set_downsample_factor()
 
-    def set_downsample_factor(self):
-        # type: () -> None
+    def set_downsample_factor(self) -> None:
         if self._healthy:
             if self._downsample_factor > 0:
                 logger.debug(
@@ -94,8 +91,7 @@ class Monitor:
                 self._downsample_factor,
             )
 
-    def check_health(self):
-        # type: () -> None
+    def check_health(self) -> None:
         """
         Perform the actual health checks,
         currently only checks if the transport is rate-limited.
@@ -103,21 +99,17 @@ class Monitor:
         """
         self._healthy = self.transport.is_healthy()
 
-    def is_healthy(self):
-        # type: () -> bool
+    def is_healthy(self) -> bool:
         self._ensure_running()
         return self._healthy
 
     @property
-    def downsample_factor(self):
-        # type: () -> int
+    def downsample_factor(self) -> int:
         self._ensure_running()
         return self._downsample_factor
 
-    def kill(self):
-        # type: () -> None
+    def kill(self) -> None:
         self._running = False
 
-    def __del__(self):
-        # type: () -> None
+    def __del__(self) -> None:
         self.kill()

--- a/sentry_sdk/profiler.py
+++ b/sentry_sdk/profiler.py
@@ -25,6 +25,8 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 """
 
+from __future__ import annotations
+
 import atexit
 import os
 import platform
@@ -133,26 +135,23 @@ try:
     thread_sleep = get_original("time", "sleep")
 except ImportError:
 
-    def get_gevent_hub():
-        # type: () -> Any
+    def get_gevent_hub() -> Any:
         return None
 
     thread_sleep = time.sleep
 
-    def is_module_patched(*args, **kwargs):
-        # type: (*Any, **Any) -> bool
+    def is_module_patched(*args: Any, **kwargs: Any) -> bool:
         # unable to import from gevent means no modules have been patched
         return False
 
     ThreadPool = None
 
 
-def is_gevent():
-    # type: () -> bool
+def is_gevent() -> bool:
     return is_module_patched("threading") or is_module_patched("_thread")
 
 
-_scheduler = None  # type: Optional[Scheduler]
+_scheduler: Optional[Scheduler] = None
 
 # The default sampling frequency to use. This is set at 101 in order to
 # mitigate the effects of lockstep sampling.
@@ -164,8 +163,7 @@ DEFAULT_SAMPLING_FREQUENCY = 101
 PROFILE_MINIMUM_SAMPLES = 2
 
 
-def has_profiling_enabled(options):
-    # type: (Dict[str, Any]) -> bool
+def has_profiling_enabled(options: Dict[str, Any]) -> bool:
     profiles_sampler = options["profiles_sampler"]
     if profiles_sampler is not None:
         return True
@@ -181,8 +179,7 @@ def has_profiling_enabled(options):
     return False
 
 
-def setup_profiler(options):
-    # type: (Dict[str, Any]) -> bool
+def setup_profiler(options: Dict[str, Any]) -> bool:
     global _scheduler
 
     if _scheduler is not None:
@@ -229,9 +226,7 @@ def setup_profiler(options):
     return True
 
 
-def teardown_profiler():
-    # type: () -> None
-
+def teardown_profiler() -> None:
     global _scheduler
 
     if _scheduler is not None:
@@ -245,12 +240,11 @@ MAX_STACK_DEPTH = 128
 
 
 def extract_stack(
-    raw_frame,  # type: Optional[FrameType]
-    cache,  # type: LRUCache
-    cwd,  # type: str
-    max_stack_depth=MAX_STACK_DEPTH,  # type: int
-):
-    # type: (...) -> ExtractedStack
+    raw_frame: Optional[FrameType],
+    cache: LRUCache,
+    cwd: str,
+    max_stack_depth: int = MAX_STACK_DEPTH,
+) -> ExtractedStack:
     """
     Extracts the stack starting the specified frame. The extracted stack
     assumes the specified frame is the top of the stack, and works back
@@ -260,7 +254,7 @@ def extract_stack(
     only the first `MAX_STACK_DEPTH` frames will be returned.
     """
 
-    raw_frames = deque(maxlen=max_stack_depth)  # type: Deque[FrameType]
+    raw_frames: Deque[FrameType] = deque(maxlen=max_stack_depth)
 
     while raw_frame is not None:
         f_back = raw_frame.f_back
@@ -292,13 +286,11 @@ def extract_stack(
     return stack_id, frame_ids, frames
 
 
-def frame_id(raw_frame):
-    # type: (FrameType) -> FrameId
+def frame_id(raw_frame: FrameType) -> FrameId:
     return (raw_frame.f_code.co_filename, raw_frame.f_lineno, get_frame_name(raw_frame))
 
 
-def extract_frame(fid, raw_frame, cwd):
-    # type: (FrameId, FrameType, str) -> ProcessedFrame
+def extract_frame(fid: FrameId, raw_frame: FrameType, cwd: str) -> ProcessedFrame:
     abs_path = raw_frame.f_code.co_filename
 
     try:
@@ -328,15 +320,12 @@ def extract_frame(fid, raw_frame, cwd):
 
 if PY311:
 
-    def get_frame_name(frame):
-        # type: (FrameType) -> str
+    def get_frame_name(frame: FrameType) -> str:
         return frame.f_code.co_qualname
 
 else:
 
-    def get_frame_name(frame):
-        # type: (FrameType) -> str
-
+    def get_frame_name(frame: FrameType) -> str:
         f_code = frame.f_code
         co_varnames = f_code.co_varnames
 
@@ -385,8 +374,7 @@ else:
 MAX_PROFILE_DURATION_NS = int(3e10)  # 30 seconds
 
 
-def get_current_thread_id(thread=None):
-    # type: (Optional[threading.Thread]) -> Optional[int]
+def get_current_thread_id(thread: Optional[threading.Thread] = None) -> Optional[int]:
     """
     Try to get the id of the current thread, with various fall backs.
     """
@@ -434,47 +422,45 @@ def get_current_thread_id(thread=None):
 class Profile:
     def __init__(
         self,
-        transaction,  # type: sentry_sdk.tracing.Transaction
-        hub=None,  # type: Optional[sentry_sdk.Hub]
-        scheduler=None,  # type: Optional[Scheduler]
-    ):
-        # type: (...) -> None
+        transaction: sentry_sdk.tracing.Transaction,
+        hub: Optional[sentry_sdk.Hub] = None,
+        scheduler: Optional[Scheduler] = None,
+    ) -> None:
         self.scheduler = _scheduler if scheduler is None else scheduler
         self.hub = hub
 
-        self.event_id = uuid.uuid4().hex  # type: str
+        self.event_id: str = uuid.uuid4().hex
 
         # Here, we assume that the sampling decision on the transaction has been finalized.
         #
         # We cannot keep a reference to the transaction around here because it'll create
         # a reference cycle. So we opt to pull out just the necessary attributes.
-        self.sampled = transaction.sampled  # type: Optional[bool]
+        self.sampled: Optional[bool] = transaction.sampled
 
         # Various framework integrations are capable of overwriting the active thread id.
         # If it is set to `None` at the end of the profile, we fall back to the default.
-        self._default_active_thread_id = get_current_thread_id() or 0  # type: int
-        self.active_thread_id = None  # type: Optional[int]
+        self._default_active_thread_id: int = get_current_thread_id() or 0
+        self.active_thread_id: Optional[int] = None
 
         try:
-            self.start_ns = transaction._start_timestamp_monotonic_ns  # type: int
+            self.start_ns: int = transaction._start_timestamp_monotonic_ns
         except AttributeError:
             self.start_ns = 0
 
-        self.stop_ns = 0  # type: int
-        self.active = False  # type: bool
+        self.stop_ns: int = 0
+        self.active: bool = False
 
-        self.indexed_frames = {}  # type: Dict[FrameId, int]
-        self.indexed_stacks = {}  # type: Dict[StackId, int]
-        self.frames = []  # type: List[ProcessedFrame]
-        self.stacks = []  # type: List[ProcessedStack]
-        self.samples = []  # type: List[ProcessedSample]
+        self.indexed_frames: Dict[FrameId, int] = {}
+        self.indexed_stacks: Dict[StackId, int] = {}
+        self.frames: List[ProcessedFrame] = []
+        self.stacks: List[ProcessedStack] = []
+        self.samples: List[ProcessedSample] = []
 
         self.unique_samples = 0
 
         transaction._profile = self
 
-    def update_active_thread_id(self):
-        # type: () -> None
+    def update_active_thread_id(self) -> None:
         self.active_thread_id = get_current_thread_id()
         logger.debug(
             "[Profiling] updating active thread id to {tid}".format(
@@ -482,8 +468,7 @@ class Profile:
             )
         )
 
-    def _set_initial_sampling_decision(self, sampling_context):
-        # type: (SamplingContext) -> None
+    def _set_initial_sampling_decision(self, sampling_context: SamplingContext) -> None:
         """
         Sets the profile's sampling decision according to the following
         precdence rules:
@@ -558,8 +543,7 @@ class Profile:
                 )
             )
 
-    def start(self):
-        # type: () -> None
+    def start(self) -> None:
         if not self.sampled or self.active:
             return
 
@@ -570,8 +554,7 @@ class Profile:
             self.start_ns = nanosecond_time()
         self.scheduler.start_profiling(self)
 
-    def stop(self):
-        # type: () -> None
+    def stop(self) -> None:
         if not self.sampled or not self.active:
             return
 
@@ -581,8 +564,7 @@ class Profile:
         self.scheduler.stop_profiling(self)
         self.stop_ns = nanosecond_time()
 
-    def __enter__(self):
-        # type: () -> Profile
+    def __enter__(self) -> Profile:
         hub = self.hub or sentry_sdk.Hub.current
 
         _, scope = hub._stack[-1]
@@ -595,8 +577,9 @@ class Profile:
 
         return self
 
-    def __exit__(self, ty, value, tb):
-        # type: (Optional[Any], Optional[Any], Optional[Any]) -> None
+    def __exit__(
+        self, ty: Optional[Any], value: Optional[Any], tb: Optional[Any]
+    ) -> None:
         self.stop()
 
         _, scope, old_profile = self._context_manager_state
@@ -604,8 +587,7 @@ class Profile:
 
         scope.profile = old_profile
 
-    def write(self, ts, sample):
-        # type: (int, ExtractedSample) -> None
+    def write(self, ts: int, sample: ExtractedSample) -> None:
         if not self.active:
             return
 
@@ -648,18 +630,16 @@ class Profile:
                 # When this happens, we abandon the current sample as it's bad.
                 capture_internal_exception(sys.exc_info())
 
-    def process(self):
-        # type: () -> ProcessedProfile
-
+    def process(self) -> ProcessedProfile:
         # This collects the thread metadata at the end of a profile. Doing it
         # this way means that any threads that terminate before the profile ends
         # will not have any metadata associated with it.
-        thread_metadata = {
+        thread_metadata: Dict[str, ProcessedThreadMetadata] = {
             str(thread.ident): {
                 "name": str(thread.name),
             }
             for thread in threading.enumerate()
-        }  # type: Dict[str, ProcessedThreadMetadata]
+        }
 
         return {
             "frames": self.frames,
@@ -668,8 +648,9 @@ class Profile:
             "thread_metadata": thread_metadata,
         }
 
-    def to_json(self, event_opt, options):
-        # type: (Any, Dict[str, Any], Dict[str, Any]) -> Dict[str, Any]
+    def to_json(
+        self: Any, event_opt: Dict[str, Any], options: Dict[str, Any]
+    ) -> Dict[str, Any]:
         profile = self.process()
 
         set_in_app_in_frames(
@@ -719,8 +700,7 @@ class Profile:
             ],
         }
 
-    def valid(self):
-        # type: () -> bool
+    def valid(self) -> bool:
         hub = self.hub or sentry_sdk.Hub.current
         client = hub.client
         if client is None:
@@ -748,56 +728,48 @@ class Profile:
 
 
 class Scheduler:
-    mode = "unknown"  # type: ProfilerMode
+    mode: ProfilerMode = "unknown"
 
-    def __init__(self, frequency):
-        # type: (int) -> None
+    def __init__(self, frequency: int) -> None:
         self.interval = 1.0 / frequency
 
         self.sampler = self.make_sampler()
 
         # cap the number of new profiles at any time so it does not grow infinitely
-        self.new_profiles = deque(maxlen=128)  # type: Deque[Profile]
-        self.active_profiles = set()  # type: Set[Profile]
+        self.new_profiles: Deque[Profile] = deque(maxlen=128)
+        self.active_profiles: Set[Profile] = set()
 
-    def __enter__(self):
-        # type: () -> Scheduler
+    def __enter__(self) -> Scheduler:
         self.setup()
         return self
 
-    def __exit__(self, ty, value, tb):
-        # type: (Optional[Any], Optional[Any], Optional[Any]) -> None
+    def __exit__(
+        self, ty: Optional[Any], value: Optional[Any], tb: Optional[Any]
+    ) -> None:
         self.teardown()
 
-    def setup(self):
-        # type: () -> None
+    def setup(self) -> None:
         raise NotImplementedError
 
-    def teardown(self):
-        # type: () -> None
+    def teardown(self) -> None:
         raise NotImplementedError
 
-    def ensure_running(self):
-        # type: () -> None
+    def ensure_running(self) -> None:
         raise NotImplementedError
 
-    def start_profiling(self, profile):
-        # type: (Profile) -> None
+    def start_profiling(self, profile: Profile) -> None:
         self.ensure_running()
         self.new_profiles.append(profile)
 
-    def stop_profiling(self, profile):
-        # type: (Profile) -> None
+    def stop_profiling(self, profile: Profile) -> None:
         pass
 
-    def make_sampler(self):
-        # type: () -> Callable[..., None]
+    def make_sampler(self) -> Callable[..., None]:
         cwd = os.getcwd()
 
         cache = LRUCache(max_size=256)
 
-        def _sample_stack(*args, **kwargs):
-            # type: (*Any, **Any) -> None
+        def _sample_stack(*args: Any, **kwargs: Any) -> None:
             """
             Take a sample of the stack on all the threads in the process.
             This should be called at a regular interval to collect samples.
@@ -868,32 +840,28 @@ class ThreadScheduler(Scheduler):
     the sampler at a regular interval.
     """
 
-    mode = "thread"  # type: ProfilerMode
+    mode: ProfilerMode = "thread"
     name = "sentry.profiler.ThreadScheduler"
 
-    def __init__(self, frequency):
-        # type: (int) -> None
+    def __init__(self, frequency: int) -> None:
         super(ThreadScheduler, self).__init__(frequency=frequency)
 
         # used to signal to the thread that it should stop
         self.running = False
-        self.thread = None  # type: Optional[threading.Thread]
-        self.pid = None  # type: Optional[int]
+        self.thread: Optional[threading.Thread] = None
+        self.pid: Optional[int] = None
         self.lock = threading.Lock()
 
-    def setup(self):
-        # type: () -> None
+    def setup(self) -> None:
         pass
 
-    def teardown(self):
-        # type: () -> None
+    def teardown(self) -> None:
         if self.running:
             self.running = False
             if self.thread is not None:
                 self.thread.join()
 
-    def ensure_running(self):
-        # type: () -> None
+    def ensure_running(self) -> None:
         """
         Check that the profiler has an active thread to run in, and start one if
         that's not the case.
@@ -931,8 +899,7 @@ class ThreadScheduler(Scheduler):
                 self.thread = None
                 return
 
-    def run(self):
-        # type: () -> None
+    def run(self) -> None:
         last = time.perf_counter()
 
         while self.running:
@@ -964,12 +931,10 @@ class GeventScheduler(Scheduler):
        results in a sample containing only the sampler's code.
     """
 
-    mode = "gevent"  # type: ProfilerMode
+    mode: ProfilerMode = "gevent"
     name = "sentry.profiler.GeventScheduler"
 
-    def __init__(self, frequency):
-        # type: (int) -> None
-
+    def __init__(self, frequency: int) -> None:
         if ThreadPool is None:
             raise ValueError("Profiler mode: {} is not available".format(self.mode))
 
@@ -977,27 +942,24 @@ class GeventScheduler(Scheduler):
 
         # used to signal to the thread that it should stop
         self.running = False
-        self.thread = None  # type: Optional[ThreadPool]
-        self.pid = None  # type: Optional[int]
+        self.thread: Optional[ThreadPool] = None
+        self.pid: Optional[int] = None
 
         # This intentionally uses the gevent patched threading.Lock.
         # The lock will be required when first trying to start profiles
         # as we need to spawn the profiler thread from the greenlets.
         self.lock = threading.Lock()
 
-    def setup(self):
-        # type: () -> None
+    def setup(self) -> None:
         pass
 
-    def teardown(self):
-        # type: () -> None
+    def teardown(self) -> None:
         if self.running:
             self.running = False
             if self.thread is not None:
                 self.thread.join()
 
-    def ensure_running(self):
-        # type: () -> None
+    def ensure_running(self) -> None:
         pid = os.getpid()
 
         # is running on the right process
@@ -1024,8 +986,7 @@ class GeventScheduler(Scheduler):
                 self.thread = None
                 return
 
-    def run(self):
-        # type: () -> None
+    def run(self) -> None:
         last = time.perf_counter()
 
         while self.running:

--- a/sentry_sdk/scrubber.py
+++ b/sentry_sdk/scrubber.py
@@ -58,13 +58,11 @@ DEFAULT_DENYLIST = [
 
 
 class EventScrubber:
-    def __init__(self, denylist=None):
-        # type: (Optional[List[str]]) -> None
+    def __init__(self, denylist: Optional[List[str]] = None) -> None:
         self.denylist = DEFAULT_DENYLIST if denylist is None else denylist
         self.denylist = [x.lower() for x in self.denylist]
 
-    def scrub_dict(self, d):
-        # type: (Dict[str, Any]) -> None
+    def scrub_dict(self, d: Dict[str, Any]) -> None:
         if not isinstance(d, dict):
             return
 
@@ -72,8 +70,7 @@ class EventScrubber:
             if isinstance(k, str) and k.lower() in self.denylist:
                 d[k] = AnnotatedValue.substituted_because_contains_sensitive_data()
 
-    def scrub_request(self, event):
-        # type: (Event) -> None
+    def scrub_request(self, event: Event) -> None:
         with capture_internal_exceptions():
             if "request" in event:
                 if "headers" in event["request"]:
@@ -83,20 +80,17 @@ class EventScrubber:
                 if "data" in event["request"]:
                     self.scrub_dict(event["request"]["data"])
 
-    def scrub_extra(self, event):
-        # type: (Event) -> None
+    def scrub_extra(self, event: Event) -> None:
         with capture_internal_exceptions():
             if "extra" in event:
                 self.scrub_dict(event["extra"])
 
-    def scrub_user(self, event):
-        # type: (Event) -> None
+    def scrub_user(self, event: Event) -> None:
         with capture_internal_exceptions():
             if "user" in event:
                 self.scrub_dict(event["user"])
 
-    def scrub_breadcrumbs(self, event):
-        # type: (Event) -> None
+    def scrub_breadcrumbs(self, event: Event) -> None:
         with capture_internal_exceptions():
             if "breadcrumbs" in event:
                 if "values" in event["breadcrumbs"]:
@@ -104,23 +98,20 @@ class EventScrubber:
                         if "data" in value:
                             self.scrub_dict(value["data"])
 
-    def scrub_frames(self, event):
-        # type: (Event) -> None
+    def scrub_frames(self, event: Event) -> None:
         with capture_internal_exceptions():
             for frame in iter_event_frames(event):
                 if "vars" in frame:
                     self.scrub_dict(frame["vars"])
 
-    def scrub_spans(self, event):
-        # type: (Event) -> None
+    def scrub_spans(self, event: Event) -> None:
         with capture_internal_exceptions():
             if "spans" in event:
                 for span in event["spans"]:
                     if "data" in span:
                         self.scrub_dict(span["data"])
 
-    def scrub_event(self, event):
-        # type: (Event) -> None
+    def scrub_event(self, event: Event) -> None:
         self.scrub_request(event)
         self.scrub_extra(event)
         self.scrub_user(event)

--- a/sentry_sdk/scrubber.py
+++ b/sentry_sdk/scrubber.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from sentry_sdk.utils import (
     capture_internal_exceptions,
     AnnotatedValue,

--- a/sentry_sdk/serializer.py
+++ b/sentry_sdk/serializer.py
@@ -54,29 +54,25 @@ MAX_DATABAG_BREADTH = 10
 CYCLE_MARKER = "<cyclic>"
 
 
-global_repr_processors = []  # type: List[ReprProcessor]
+global_repr_processors: List[ReprProcessor] = []
 
 
-def add_global_repr_processor(processor):
-    # type: (ReprProcessor) -> None
+def add_global_repr_processor(processor: ReprProcessor) -> None:
     global_repr_processors.append(processor)
 
 
 class Memo:
     __slots__ = ("_ids", "_objs")
 
-    def __init__(self):
-        # type: () -> None
-        self._ids = {}  # type: Dict[int, Any]
-        self._objs = []  # type: List[Any]
+    def __init__(self) -> None:
+        self._ids: Dict[int, Any] = {}
+        self._objs: List[Any] = []
 
-    def memoize(self, obj):
-        # type: (Any) -> ContextManager[bool]
+    def memoize(self, obj: Any) -> ContextManager[bool]:
         self._objs.append(obj)
         return self
 
-    def __enter__(self):
-        # type: () -> bool
+    def __enter__(self) -> bool:
         obj = self._objs[-1]
         if id(obj) in self._ids:
             return True
@@ -86,27 +82,22 @@ class Memo:
 
     def __exit__(
         self,
-        ty,  # type: Optional[Type[BaseException]]
-        value,  # type: Optional[BaseException]
-        tb,  # type: Optional[TracebackType]
-    ):
-        # type: (...) -> None
+        ty: Optional[Type[BaseException]],
+        value: Optional[BaseException],
+        tb: Optional[TracebackType],
+    ) -> None:
         self._ids.pop(id(self._objs.pop()), None)
 
 
-def serialize(event, **kwargs):
-    # type: (Event, **Any) -> Event
+def serialize(event: Event, **kwargs: Any) -> Event:
     memo = Memo()
-    path = []  # type: List[Segment]
-    meta_stack = []  # type: List[Dict[str, Any]]
+    path: List[Segment] = []
+    meta_stack: List[Dict[str, Any]] = []
 
-    keep_request_bodies = (
-        kwargs.pop("max_request_body_size", None) == "always"
-    )  # type: bool
-    max_value_length = kwargs.pop("max_value_length", None)  # type: Optional[int]
+    keep_request_bodies: bool = kwargs.pop("max_request_body_size", None) == "always"
+    max_value_length: Optional[int] = kwargs.pop("max_value_length", None)
 
-    def _annotate(**meta):
-        # type: (**Any) -> None
+    def _annotate(**meta: Any) -> None:
         while len(meta_stack) <= len(path):
             try:
                 segment = path[len(meta_stack) - 1]
@@ -118,8 +109,7 @@ def serialize(event, **kwargs):
 
         meta_stack[-1].setdefault("", {}).update(meta)
 
-    def _should_repr_strings():
-        # type: () -> Optional[bool]
+    def _should_repr_strings() -> Optional[bool]:
         """
         By default non-serializable objects are going through
         safe_repr(). For certain places in the event (local vars) we
@@ -156,8 +146,7 @@ def serialize(event, **kwargs):
 
         return False
 
-    def _is_databag():
-        # type: () -> Optional[bool]
+    def _is_databag() -> Optional[bool]:
         """
         A databag is any value that we need to trim.
 
@@ -186,8 +175,7 @@ def serialize(event, **kwargs):
 
         return False
 
-    def _is_request_body():
-        # type: () -> Optional[bool]
+    def _is_request_body() -> Optional[bool]:
         try:
             if path[0] == "request" and path[1] == "data":
                 return True
@@ -197,15 +185,14 @@ def serialize(event, **kwargs):
         return False
 
     def _serialize_node(
-        obj,  # type: Any
-        is_databag=None,  # type: Optional[bool]
-        is_request_body=None,  # type: Optional[bool]
-        should_repr_strings=None,  # type: Optional[bool]
-        segment=None,  # type: Optional[Segment]
-        remaining_breadth=None,  # type: Optional[Union[int, float]]
-        remaining_depth=None,  # type: Optional[Union[int, float]]
-    ):
-        # type: (...) -> Any
+        obj: Any,
+        is_databag: Optional[bool] = None,
+        is_request_body: Optional[bool] = None,
+        should_repr_strings: Optional[bool] = None,
+        segment: Optional[Segment] = None,
+        remaining_breadth: Optional[Union[int, float]] = None,
+        remaining_depth: Optional[Union[int, float]] = None,
+    ) -> Any:
         if segment is not None:
             path.append(segment)
 
@@ -234,22 +221,20 @@ def serialize(event, **kwargs):
                 path.pop()
                 del meta_stack[len(path) + 1 :]
 
-    def _flatten_annotated(obj):
-        # type: (Any) -> Any
+    def _flatten_annotated(obj: Any) -> Any:
         if isinstance(obj, AnnotatedValue):
             _annotate(**obj.metadata)
             obj = obj.value
         return obj
 
     def _serialize_node_impl(
-        obj,
-        is_databag,
-        is_request_body,
-        should_repr_strings,
-        remaining_depth,
-        remaining_breadth,
-    ):
-        # type: (Any, Optional[bool], Optional[bool], Optional[bool], Optional[Union[float, int]], Optional[Union[float, int]]) -> Any
+        obj: Any,
+        is_databag: Optional[bool],
+        is_request_body: Optional[bool],
+        should_repr_strings: Optional[bool],
+        remaining_depth: Optional[Union[float, int]],
+        remaining_breadth: Optional[Union[float, int]],
+    ) -> Any:
         if isinstance(obj, AnnotatedValue):
             should_repr_strings = False
         if should_repr_strings is None:
@@ -313,7 +298,7 @@ def serialize(event, **kwargs):
             # might mutate our dictionary while we're still iterating over it.
             obj = dict(obj.items())
 
-            rv_dict = {}  # type: Dict[str, Any]
+            rv_dict: Dict[str, Any] = {}
             i = 0
 
             for k, v in obj.items():

--- a/sentry_sdk/serializer.py
+++ b/sentry_sdk/serializer.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import sys
 import math
 from collections.abc import Mapping, Sequence, Set

--- a/sentry_sdk/session.py
+++ b/sentry_sdk/session.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import uuid
 from datetime import datetime, timezone
 

--- a/sentry_sdk/session.py
+++ b/sentry_sdk/session.py
@@ -13,15 +13,13 @@ if TYPE_CHECKING:
     from sentry_sdk._types import SessionStatus
 
 
-def _minute_trunc(ts):
-    # type: (datetime) -> datetime
+def _minute_trunc(ts: datetime) -> datetime:
     return ts.replace(second=0, microsecond=0)
 
 
 def _make_uuid(
-    val,  # type: Union[str, uuid.UUID]
-):
-    # type: (...) -> uuid.UUID
+    val: Union[str, uuid.UUID],
+) -> uuid.UUID:
     if isinstance(val, uuid.UUID):
         return val
     return uuid.UUID(val)
@@ -30,21 +28,20 @@ def _make_uuid(
 class Session:
     def __init__(
         self,
-        sid=None,  # type: Optional[Union[str, uuid.UUID]]
-        did=None,  # type: Optional[str]
-        timestamp=None,  # type: Optional[datetime]
-        started=None,  # type: Optional[datetime]
-        duration=None,  # type: Optional[float]
-        status=None,  # type: Optional[SessionStatus]
-        release=None,  # type: Optional[str]
-        environment=None,  # type: Optional[str]
-        user_agent=None,  # type: Optional[str]
-        ip_address=None,  # type: Optional[str]
-        errors=None,  # type: Optional[int]
-        user=None,  # type: Optional[Any]
-        session_mode="application",  # type: str
-    ):
-        # type: (...) -> None
+        sid: Optional[Union[str, uuid.UUID]] = None,
+        did: Optional[str] = None,
+        timestamp: Optional[datetime] = None,
+        started: Optional[datetime] = None,
+        duration: Optional[float] = None,
+        status: Optional[SessionStatus] = None,
+        release: Optional[str] = None,
+        environment: Optional[str] = None,
+        user_agent: Optional[str] = None,
+        ip_address: Optional[str] = None,
+        errors: Optional[int] = None,
+        user: Optional[Any] = None,
+        session_mode: str = "application",
+    ) -> None:
         if sid is None:
             sid = uuid.uuid4()
         if started is None:
@@ -52,14 +49,14 @@ class Session:
         if status is None:
             status = "ok"
         self.status = status
-        self.did = None  # type: Optional[str]
+        self.did: Optional[str] = None
         self.started = started
-        self.release = None  # type: Optional[str]
-        self.environment = None  # type: Optional[str]
-        self.duration = None  # type: Optional[float]
-        self.user_agent = None  # type: Optional[str]
-        self.ip_address = None  # type: Optional[str]
-        self.session_mode = session_mode  # type: str
+        self.release: Optional[str] = None
+        self.environment: Optional[str] = None
+        self.duration: Optional[float] = None
+        self.user_agent: Optional[str] = None
+        self.ip_address: Optional[str] = None
+        self.session_mode: str = session_mode
         self.errors = 0
 
         self.update(
@@ -76,26 +73,24 @@ class Session:
         )
 
     @property
-    def truncated_started(self):
-        # type: (...) -> datetime
+    def truncated_started(self) -> datetime:
         return _minute_trunc(self.started)
 
     def update(
         self,
-        sid=None,  # type: Optional[Union[str, uuid.UUID]]
-        did=None,  # type: Optional[str]
-        timestamp=None,  # type: Optional[datetime]
-        started=None,  # type: Optional[datetime]
-        duration=None,  # type: Optional[float]
-        status=None,  # type: Optional[SessionStatus]
-        release=None,  # type: Optional[str]
-        environment=None,  # type: Optional[str]
-        user_agent=None,  # type: Optional[str]
-        ip_address=None,  # type: Optional[str]
-        errors=None,  # type: Optional[int]
-        user=None,  # type: Optional[Any]
-    ):
-        # type: (...) -> None
+        sid: Optional[Union[str, uuid.UUID]] = None,
+        did: Optional[str] = None,
+        timestamp: Optional[datetime] = None,
+        started: Optional[datetime] = None,
+        duration: Optional[float] = None,
+        status: Optional[SessionStatus] = None,
+        release: Optional[str] = None,
+        environment: Optional[str] = None,
+        user_agent: Optional[str] = None,
+        ip_address: Optional[str] = None,
+        errors: Optional[int] = None,
+        user: Optional[Any] = None,
+    ) -> None:
         # If a user is supplied we pull some data form it
         if user:
             if ip_address is None:
@@ -128,19 +123,13 @@ class Session:
         if status is not None:
             self.status = status
 
-    def close(
-        self, status=None  # type: Optional[SessionStatus]
-    ):
-        # type: (...) -> Any
+    def close(self, status: Optional[SessionStatus] = None) -> Any:
         if status is None and self.status == "ok":
             status = "exited"
         if status is not None:
             self.update(status=status)
 
-    def get_json_attrs(
-        self, with_user_info=True  # type: Optional[bool]
-    ):
-        # type: (...) -> Any
+    def get_json_attrs(self, with_user_info: Optional[bool] = True) -> Any:
         attrs = {}
         if self.release is not None:
             attrs["release"] = self.release
@@ -153,15 +142,14 @@ class Session:
                 attrs["user_agent"] = self.user_agent
         return attrs
 
-    def to_json(self):
-        # type: (...) -> Any
-        rv = {
+    def to_json(self) -> Any:
+        rv: Dict[str, Any] = {
             "sid": str(self.sid),
             "init": True,
             "started": format_timestamp(self.started),
             "timestamp": format_timestamp(self.timestamp),
             "status": self.status,
-        }  # type: Dict[str, Any]
+        }
         if self.errors:
             rv["errors"] = self.errors
         if self.did is not None:

--- a/sentry_sdk/sessions.py
+++ b/sentry_sdk/sessions.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 import time
 from threading import Thread, Lock

--- a/sentry_sdk/spotlight.py
+++ b/sentry_sdk/spotlight.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import io
 import urllib3
 

--- a/sentry_sdk/spotlight.py
+++ b/sentry_sdk/spotlight.py
@@ -13,14 +13,12 @@ from sentry_sdk.envelope import Envelope
 
 
 class SpotlightClient:
-    def __init__(self, url):
-        # type: (str) -> None
+    def __init__(self, url: str) -> None:
         self.url = url
         self.http = urllib3.PoolManager()
         self.tries = 0
 
-    def capture_envelope(self, envelope):
-        # type: (Envelope) -> None
+    def capture_envelope(self, envelope: Envelope) -> None:
         if self.tries > 3:
             logger.warning(
                 "Too many errors sending to Spotlight, stop sending events there."
@@ -43,9 +41,7 @@ class SpotlightClient:
             logger.warning(str(e))
 
 
-def setup_spotlight(options):
-    # type: (Dict[str, Any]) -> Optional[SpotlightClient]
-
+def setup_spotlight(options: Dict[str, Any]) -> Optional[SpotlightClient]:
     url = options.get("spotlight")
 
     if isinstance(url, str):

--- a/sentry_sdk/transport.py
+++ b/sentry_sdk/transport.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import io
 import urllib3
 import certifi

--- a/sentry_sdk/transport.py
+++ b/sentry_sdk/transport.py
@@ -41,32 +41,23 @@ class Transport:
     A transport is used to send an event to sentry.
     """
 
-    parsed_dsn = None  # type: Optional[Dsn]
+    parsed_dsn: Optional[Dsn] = None
 
-    def __init__(
-        self, options=None  # type: Optional[Dict[str, Any]]
-    ):
-        # type: (...) -> None
+    def __init__(self, options: Optional[Dict[str, Any]] = None) -> None:
         self.options = options
         if options and options["dsn"] is not None and options["dsn"]:
             self.parsed_dsn = Dsn(options["dsn"])
         else:
             self.parsed_dsn = None
 
-    def capture_event(
-        self, event  # type: Event
-    ):
-        # type: (...) -> None
+    def capture_event(self, event: Event) -> None:
         """
         This gets invoked with the event dictionary when an event should
         be sent to sentry.
         """
         raise NotImplementedError()
 
-    def capture_envelope(
-        self, envelope  # type: Envelope
-    ):
-        # type: (...) -> None
+    def capture_envelope(self, envelope: Envelope) -> None:
         """
         Send an envelope to Sentry.
 
@@ -79,44 +70,40 @@ class Transport:
 
     def flush(
         self,
-        timeout,  # type: float
-        callback=None,  # type: Optional[Any]
-    ):
-        # type: (...) -> None
+        timeout: float,
+        callback: Optional[Any] = None,
+    ) -> None:
         """Wait `timeout` seconds for the current events to be sent out."""
         pass
 
-    def kill(self):
-        # type: () -> None
+    def kill(self) -> None:
         """Forcefully kills the transport."""
         pass
 
     def record_lost_event(
         self,
-        reason,  # type: str
-        data_category=None,  # type: Optional[str]
-        item=None,  # type: Optional[Item]
-    ):
-        # type: (...) -> None
+        reason: str,
+        data_category: Optional[str] = None,
+        item: Optional[Item] = None,
+    ) -> None:
         """This increments a counter for event loss by reason and
         data category.
         """
         return None
 
-    def is_healthy(self):
-        # type: () -> bool
+    def is_healthy(self) -> bool:
         return True
 
-    def __del__(self):
-        # type: () -> None
+    def __del__(self) -> None:
         try:
             self.kill()
         except Exception:
             pass
 
 
-def _parse_rate_limits(header, now=None):
-    # type: (Any, Optional[datetime]) -> Iterable[Tuple[DataCategory, datetime]]
+def _parse_rate_limits(
+    header: Any, now: Optional[datetime] = None
+) -> Iterable[Tuple[DataCategory, datetime]]:
     if now is None:
         now = datetime.now(timezone.utc)
 
@@ -133,22 +120,17 @@ def _parse_rate_limits(header, now=None):
 class HttpTransport(Transport):
     """The default HTTP transport."""
 
-    def __init__(
-        self, options  # type: Dict[str, Any]
-    ):
-        # type: (...) -> None
+    def __init__(self, options: Dict[str, Any]) -> None:
         from sentry_sdk.consts import VERSION
 
         Transport.__init__(self, options)
         assert self.parsed_dsn is not None
-        self.options = options  # type: Dict[str, Any]
+        self.options: Dict[str, Any] = options
         self._worker = BackgroundWorker(queue_size=options["transport_queue_size"])
         self._auth = self.parsed_dsn.to_auth("sentry.python/%s" % VERSION)
-        self._disabled_until = {}  # type: Dict[DataCategory, datetime]
+        self._disabled_until: Dict[DataCategory, datetime] = {}
         self._retry = urllib3.util.Retry()
-        self._discarded_events = defaultdict(
-            int
-        )  # type: DefaultDict[Tuple[str, str], int]
+        self._discarded_events: DefaultDict[Tuple[str, str], int] = defaultdict(int)
         self._last_client_report_sent = time.time()
 
         compresslevel = options.get("_experiments", {}).get(
@@ -173,11 +155,10 @@ class HttpTransport(Transport):
 
     def record_lost_event(
         self,
-        reason,  # type: str
-        data_category=None,  # type: Optional[str]
-        item=None,  # type: Optional[Item]
-    ):
-        # type: (...) -> None
+        reason: str,
+        data_category: Optional[str] = None,
+        item: Optional[Item] = None,
+    ) -> None:
         if not self.options["send_client_reports"]:
             return
 
@@ -193,9 +174,7 @@ class HttpTransport(Transport):
 
         self._discarded_events[data_category, reason] += quantity
 
-    def _update_rate_limits(self, response):
-        # type: (urllib3.BaseHTTPResponse) -> None
-
+    def _update_rate_limits(self, response: urllib3.BaseHTTPResponse) -> None:
         # new sentries with more rate limit insights.  We honor this header
         # no matter of the status code to update our internal rate limits.
         header = response.headers.get("x-sentry-rate-limits")
@@ -214,15 +193,12 @@ class HttpTransport(Transport):
 
     def _send_request(
         self,
-        body,  # type: bytes
-        headers,  # type: Dict[str, str]
-        endpoint_type="store",  # type: EndpointType
-        envelope=None,  # type: Optional[Envelope]
-    ):
-        # type: (...) -> None
-
-        def record_loss(reason):
-            # type: (str) -> None
+        body: bytes,
+        headers: Dict[str, str],
+        endpoint_type: EndpointType = "store",
+        envelope: Optional[Envelope] = None,
+    ) -> None:
+        def record_loss(reason: str) -> None:
             if envelope is None:
                 self.record_lost_event(reason, data_category="error")
             else:
@@ -269,12 +245,12 @@ class HttpTransport(Transport):
         finally:
             response.close()
 
-    def on_dropped_event(self, reason):
-        # type: (str) -> None
+    def on_dropped_event(self, reason: str) -> None:
         return None
 
-    def _fetch_pending_client_report(self, force=False, interval=60):
-        # type: (bool, int) -> Optional[Item]
+    def _fetch_pending_client_report(
+        self, force: bool = False, interval: int = 60
+    ) -> Optional[Item]:
         if not self.options["send_client_reports"]:
             return None
 
@@ -304,40 +280,30 @@ class HttpTransport(Transport):
             type="client_report",
         )
 
-    def _flush_client_reports(self, force=False):
-        # type: (bool) -> None
+    def _flush_client_reports(self, force: bool = False) -> None:
         client_report = self._fetch_pending_client_report(force=force, interval=60)
         if client_report is not None:
             self.capture_envelope(Envelope(items=[client_report]))
 
-    def _check_disabled(self, category):
-        # type: (str) -> bool
-        def _disabled(bucket):
-            # type: (Any) -> bool
+    def _check_disabled(self, category: str) -> bool:
+        def _disabled(bucket: Any) -> bool:
             ts = self._disabled_until.get(bucket)
             return ts is not None and ts > datetime.now(timezone.utc)
 
         return _disabled(category) or _disabled(None)
 
-    def _is_rate_limited(self):
-        # type: () -> bool
+    def _is_rate_limited(self) -> bool:
         return any(
             ts > datetime.now(timezone.utc) for ts in self._disabled_until.values()
         )
 
-    def _is_worker_full(self):
-        # type: () -> bool
+    def _is_worker_full(self) -> bool:
         return self._worker.full()
 
-    def is_healthy(self):
-        # type: () -> bool
+    def is_healthy(self) -> bool:
         return not (self._is_worker_full() or self._is_rate_limited())
 
-    def _send_event(
-        self, event  # type: Event
-    ):
-        # type: (...) -> None
-
+    def _send_event(self, event: Event) -> None:
         if self._check_disabled("error"):
             self.on_dropped_event("self_rate_limits")
             self.record_lost_event("ratelimit_backoff", data_category="error")
@@ -373,11 +339,7 @@ class HttpTransport(Transport):
         self._send_request(body.getvalue(), headers=headers)
         return None
 
-    def _send_envelope(
-        self, envelope  # type: Envelope
-    ):
-        # type: (...) -> None
-
+    def _send_envelope(self, envelope: Envelope) -> None:
         # remove all items from the envelope which are over quota
         new_items = []
         for item in envelope.items:
@@ -435,16 +397,14 @@ class HttpTransport(Transport):
         )
         return None
 
-    def _get_pool_options(self, ca_certs):
-        # type: (Optional[Any]) -> Dict[str, Any]
+    def _get_pool_options(self, ca_certs: Optional[Any]) -> Dict[str, Any]:
         return {
             "num_pools": self._num_pools,
             "cert_reqs": "CERT_REQUIRED",
             "ca_certs": ca_certs or certifi.where(),
         }
 
-    def _in_no_proxy(self, parsed_dsn):
-        # type: (Dsn) -> bool
+    def _in_no_proxy(self, parsed_dsn: Dsn) -> bool:
         no_proxy = getproxies().get("no")
         if not no_proxy:
             return False
@@ -456,13 +416,12 @@ class HttpTransport(Transport):
 
     def _make_pool(
         self,
-        parsed_dsn,  # type: Dsn
-        http_proxy,  # type: Optional[str]
-        https_proxy,  # type: Optional[str]
-        ca_certs,  # type: Optional[Any]
-        proxy_headers,  # type: Optional[Dict[str, str]]
-    ):
-        # type: (...) -> Union[PoolManager, ProxyManager]
+        parsed_dsn: Dsn,
+        http_proxy: Optional[str],
+        https_proxy: Optional[str],
+        ca_certs: Optional[Any],
+        proxy_headers: Optional[Dict[str, str]],
+    ) -> Union[PoolManager, ProxyManager]:
         proxy = None
         no_proxy = self._in_no_proxy(parsed_dsn)
 
@@ -501,14 +460,10 @@ class HttpTransport(Transport):
         else:
             return urllib3.PoolManager(**opts)
 
-    def capture_event(
-        self, event  # type: Event
-    ):
-        # type: (...) -> None
+    def capture_event(self, event: Event) -> None:
         hub = self.hub_cls.current
 
-        def send_event_wrapper():
-            # type: () -> None
+        def send_event_wrapper() -> None:
             with hub:
                 with capture_internal_exceptions():
                     self._send_event(event)
@@ -518,14 +473,10 @@ class HttpTransport(Transport):
             self.on_dropped_event("full_queue")
             self.record_lost_event("queue_overflow", data_category="error")
 
-    def capture_envelope(
-        self, envelope  # type: Envelope
-    ):
-        # type: (...) -> None
+    def capture_envelope(self, envelope: Envelope) -> None:
         hub = self.hub_cls.current
 
-        def send_envelope_wrapper():
-            # type: () -> None
+        def send_envelope_wrapper() -> None:
             with hub:
                 with capture_internal_exceptions():
                     self._send_envelope(envelope)
@@ -538,45 +489,36 @@ class HttpTransport(Transport):
 
     def flush(
         self,
-        timeout,  # type: float
-        callback=None,  # type: Optional[Any]
-    ):
-        # type: (...) -> None
+        timeout: float,
+        callback: Optional[Any] = None,
+    ) -> None:
         logger.debug("Flushing HTTP transport")
 
         if timeout > 0:
             self._worker.submit(lambda: self._flush_client_reports(force=True))
             self._worker.flush(timeout, callback)
 
-    def kill(self):
-        # type: () -> None
+    def kill(self) -> None:
         logger.debug("Killing HTTP transport")
         self._worker.kill()
 
 
 class _FunctionTransport(Transport):
-    def __init__(
-        self, func  # type: Callable[[Event], None]
-    ):
-        # type: (...) -> None
+    def __init__(self, func: Callable[[Event], None]) -> None:
         Transport.__init__(self)
         self._func = func
 
-    def capture_event(
-        self, event  # type: Event
-    ):
-        # type: (...) -> None
+    def capture_event(self, event: Event) -> None:
         self._func(event)
         return None
 
 
-def make_transport(options):
-    # type: (Dict[str, Any]) -> Optional[Transport]
+def make_transport(options: Dict[str, Any]) -> Optional[Transport]:
     ref_transport = options["transport"]
 
     # If no transport is given, we use the http transport class
     if ref_transport is None:
-        transport_cls = HttpTransport  # type: Type[Transport]
+        transport_cls: Type[Transport] = HttpTransport
     elif isinstance(ref_transport, Transport):
         return ref_transport
     elif isinstance(ref_transport, type) and issubclass(ref_transport, Transport):

--- a/sentry_sdk/worker.py
+++ b/sentry_sdk/worker.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 import threading
 

--- a/sentry_sdk/worker.py
+++ b/sentry_sdk/worker.py
@@ -19,30 +19,26 @@ _TERMINATOR = object()
 
 
 class BackgroundWorker:
-    def __init__(self, queue_size=DEFAULT_QUEUE_SIZE):
-        # type: (int) -> None
+    def __init__(self, queue_size: int = DEFAULT_QUEUE_SIZE) -> None:
         check_thread_support()
-        self._queue = Queue(queue_size)  # type: Queue
+        self._queue: Queue = Queue(queue_size)
         self._lock = threading.Lock()
-        self._thread = None  # type: Optional[threading.Thread]
-        self._thread_for_pid = None  # type: Optional[int]
+        self._thread: Optional[threading.Thread] = None
+        self._thread_for_pid: Optional[int] = None
 
     @property
-    def is_alive(self):
-        # type: () -> bool
+    def is_alive(self) -> bool:
         if self._thread_for_pid != os.getpid():
             return False
         if not self._thread:
             return False
         return self._thread.is_alive()
 
-    def _ensure_thread(self):
-        # type: () -> None
+    def _ensure_thread(self) -> None:
         if not self.is_alive:
             self.start()
 
-    def _timed_queue_join(self, timeout):
-        # type: (float) -> bool
+    def _timed_queue_join(self, timeout: float) -> bool:
         deadline = time() + timeout
         queue = self._queue
 
@@ -59,8 +55,7 @@ class BackgroundWorker:
         finally:
             queue.all_tasks_done.release()
 
-    def start(self):
-        # type: () -> None
+    def start(self) -> None:
         with self._lock:
             if not self.is_alive:
                 self._thread = threading.Thread(
@@ -76,8 +71,7 @@ class BackgroundWorker:
                     # send out events.
                     self._thread = None
 
-    def kill(self):
-        # type: () -> None
+    def kill(self) -> None:
         """
         Kill worker thread. Returns immediately. Not useful for
         waiting on shutdown for events, use `flush` for that.
@@ -93,20 +87,17 @@ class BackgroundWorker:
                 self._thread = None
                 self._thread_for_pid = None
 
-    def flush(self, timeout, callback=None):
-        # type: (float, Optional[Any]) -> None
+    def flush(self, timeout: float, callback: Optional[Any] = None) -> None:
         logger.debug("background worker got flush request")
         with self._lock:
             if self.is_alive and timeout > 0.0:
                 self._wait_flush(timeout, callback)
         logger.debug("background worker flushed")
 
-    def full(self):
-        # type: () -> bool
+    def full(self) -> bool:
         return self._queue.full()
 
-    def _wait_flush(self, timeout, callback):
-        # type: (float, Optional[Any]) -> None
+    def _wait_flush(self, timeout: float, callback: Optional[Any]) -> None:
         initial_timeout = min(0.1, timeout)
         if not self._timed_queue_join(initial_timeout):
             pending = self._queue.qsize() + 1
@@ -118,8 +109,7 @@ class BackgroundWorker:
                 pending = self._queue.qsize() + 1
                 logger.error("flush timed out, dropped %s events", pending)
 
-    def submit(self, callback):
-        # type: (Callable[[], None]) -> bool
+    def submit(self, callback: Callable[[], None]) -> bool:
         self._ensure_thread()
         try:
             self._queue.put_nowait(callback)
@@ -127,8 +117,7 @@ class BackgroundWorker:
         except FullError:
             return False
 
-    def _target(self):
-        # type: () -> None
+    def _target(self) -> None:
         while True:
             callback = self._queue.get()
             try:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -614,8 +614,9 @@ def werkzeug_set_cookie(client, servername, key, value):
 
 
 @contextmanager
-def patch_start_tracing_child(fake_transaction_is_none=False):
-    # type: (bool) -> Iterator[Optional[mock.MagicMock]]
+def patch_start_tracing_child(
+    fake_transaction_is_none: bool = False,
+) -> Iterator[Optional[mock.MagicMock]]:
     if not fake_transaction_is_none:
         fake_transaction = mock.MagicMock()
         fake_start_child = mock.MagicMock()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import json
 import os
 import socket

--- a/tests/integrations/chalice/test_chalice.py
+++ b/tests/integrations/chalice/test_chalice.py
@@ -10,11 +10,10 @@ from sentry_sdk.utils import parse_version
 from pytest_chalice.handlers import RequestHandler
 
 
-def _generate_lambda_context(self):
+def _generate_lambda_context(self) -> LambdaContext:
     # Monkeypatch of the function _generate_lambda_context
     # from the class LocalGateway
     # for mock the timeout
-    # type: () -> LambdaContext
     if self._config.lambda_timeout is None:
         timeout = 10 * 1000
     else:

--- a/tests/integrations/sanic/test_sanic.py
+++ b/tests/integrations/sanic/test_sanic.py
@@ -340,13 +340,12 @@ class TransactionTestConfig:
 
     def __init__(
         self,
-        integration_args,
-        url,
-        expected_status,
-        expected_transaction_name,
-        expected_source=None,
-    ):
-        # type: (Iterable[Optional[Container[int]]], str, int, Optional[str], Optional[str]) -> None
+        integration_args: Iterable[Optional[Container[int]]],
+        url: str,
+        expected_status: int,
+        expected_transaction_name: Optional[str],
+        expected_source: Optional[str] = None,
+    ) -> None:
         """
         expected_transaction_name of None indicates we expect to not receive a transaction
         """
@@ -403,9 +402,9 @@ class TransactionTestConfig:
         ),
     ],
 )
-def test_transactions(test_config, sentry_init, app, capture_events):
-    # type: (TransactionTestConfig, Any, Any, Any) -> None
-
+def test_transactions(
+    test_config: TransactionTestConfig, sentry_init: Any, app: Any, capture_events: Any
+) -> None:
     # Init the SanicIntegration with the desired arguments
     sentry_init(
         integrations=[SanicIntegration(*test_config.integration_args)],

--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -34,7 +34,7 @@ from sentry_sdk.utils import get_sdk_name, reraise
 from sentry_sdk.tracing_utils import has_tracing_enabled
 
 
-def _redis_installed():  # type: () -> bool
+def _redis_installed() -> bool:
     """
     Determines whether Redis is installed.
     """
@@ -54,10 +54,10 @@ class NoOpIntegration(Integration):
     identifier = "noop"
 
     @staticmethod
-    def setup_once():  # type: () -> None
+    def setup_once() -> None:
         pass
 
-    def __eq__(self, __value):  # type: (object) -> bool
+    def __eq__(self, __value: object) -> bool:
         """
         All instances of NoOpIntegration should be considered equal to each other.
         """

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1193,12 +1193,11 @@ def test_debug_option(
 class IssuesSamplerTestConfig:
     def __init__(
         self,
-        expected_events,
-        sampler_function=None,
-        sample_rate=None,
-        exception_to_raise=Exception,
-    ):
-        # type: (int, Optional[Callable[[Event], Union[float, bool]]], Optional[float], type[Exception]) -> None
+        expected_events: int,
+        sampler_function: Optional[Callable[[Event], Union[float, bool]]] = None,
+        sample_rate: Optional[float] = None,
+        exception_to_raise: type[Exception] = Exception,
+    ) -> None:
         self.sampler_function_mock = (
             None
             if sampler_function is None
@@ -1208,14 +1207,12 @@ class IssuesSamplerTestConfig:
         self.sample_rate = sample_rate
         self.exception_to_raise = exception_to_raise
 
-    def init_sdk(self, sentry_init):
-        # type: (Callable[[*Any], None]) -> None
+    def init_sdk(self, sentry_init: Callable[[*Any], None]) -> None:
         sentry_init(
             error_sampler=self.sampler_function_mock, sample_rate=self.sample_rate
         )
 
-    def raise_exception(self):
-        # type: () -> None
+    def raise_exception(self) -> None:
         raise self.exception_to_raise()
 
 

--- a/tests/test_profiler.py
+++ b/tests/test_profiler.py
@@ -729,16 +729,13 @@ def test_max_profile_duration_reached(scheduler_class):
 
 
 class NoopScheduler(Scheduler):
-    def setup(self):
-        # type: () -> None
+    def setup(self) -> None:
         pass
 
-    def teardown(self):
-        # type: () -> None
+    def teardown(self) -> None:
         pass
 
-    def ensure_running(self):
-        # type: () -> None
+    def ensure_running(self) -> None:
         pass
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -23,8 +23,7 @@ from sentry_sdk.utils import (
 )
 
 
-def _normalize_distribution_name(name):
-    # type: (str) -> str
+def _normalize_distribution_name(name: str) -> str:
     """Normalize distribution name according to PEP-0503.
 
     See:


### PR DESCRIPTION
Trying out [an automated tool](https://github.com/ilevkivskyi/com2ann) to translate type comments to Python 3 compatible annotations.

---

## General Notes

Thank you for contributing to `sentry-python`!

Please add tests to validate your changes, and lint your code using `tox -e linters`.

Running the test suite on your PR might require maintainer approval. Some tests (AWS Lambda) additionally require a maintainer to add a special label to run and will fail if the label is not present.

#### For maintainers

Sensitive test suites require maintainer review to ensure that tests do not compromise our secrets. This review must be repeated after any code revisions.

Before running sensitive test suites, please carefully check the PR. Then, apply the `Trigger: tests using secrets` label. The label will be removed after any code changes to enforce our policy requiring maintainers to review all code revisions before running sensitive tests.
