### PR TITLE
style: Reformat with black==24.1.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
     -   id: end-of-file-fixer
 
 -   repo: https://github.com/psf/black
-    rev: 22.6.0
+    rev: 24.1.0
     hooks:
     -   id: black
         exclude: ^(.*_pb2.py|.*_pb2_grpc.py)

--- a/sentry_sdk/integrations/arq.py
+++ b/sentry_sdk/integrations/arq.py
@@ -149,12 +149,12 @@ def _make_event_processor(ctx, *args, **kwargs):
             extra = event.setdefault("extra", {})
             extra["arq-job"] = {
                 "task": ctx["job_name"],
-                "args": args
-                if _should_send_default_pii()
-                else SENSITIVE_DATA_SUBSTITUTE,
-                "kwargs": kwargs
-                if _should_send_default_pii()
-                else SENSITIVE_DATA_SUBSTITUTE,
+                "args": (
+                    args if _should_send_default_pii() else SENSITIVE_DATA_SUBSTITUTE
+                ),
+                "kwargs": (
+                    kwargs if _should_send_default_pii() else SENSITIVE_DATA_SUBSTITUTE
+                ),
                 "retry": ctx["job_try"],
             }
 

--- a/sentry_sdk/integrations/huey.py
+++ b/sentry_sdk/integrations/huey.py
@@ -73,12 +73,16 @@ def _make_event_processor(task):
             extra = event.setdefault("extra", {})
             extra["huey-job"] = {
                 "task": task.name,
-                "args": task.args
-                if _should_send_default_pii()
-                else SENSITIVE_DATA_SUBSTITUTE,
-                "kwargs": task.kwargs
-                if _should_send_default_pii()
-                else SENSITIVE_DATA_SUBSTITUTE,
+                "args": (
+                    task.args
+                    if _should_send_default_pii()
+                    else SENSITIVE_DATA_SUBSTITUTE
+                ),
+                "kwargs": (
+                    task.kwargs
+                    if _should_send_default_pii()
+                    else SENSITIVE_DATA_SUBSTITUTE
+                ),
                 "retry": (task.default_retries or 0) - task.retries,
             }
 

--- a/sentry_sdk/integrations/opentelemetry/integration.py
+++ b/sentry_sdk/integrations/opentelemetry/integration.py
@@ -3,6 +3,7 @@ IMPORTANT: The contents of this file are part of a proof of concept and as such
 are experimental and not suitable for production use. They may be changed or
 removed at any time without prior notice.
 """
+
 import sys
 from importlib import import_module
 

--- a/sentry_sdk/scope.py
+++ b/sentry_sdk/scope.py
@@ -270,9 +270,9 @@ class Scope(object):
 
         baggage = self.get_baggage()
         if baggage is not None:
-            self._propagation_context[
-                "dynamic_sampling_context"
-            ] = baggage.dynamic_sampling_context()
+            self._propagation_context["dynamic_sampling_context"] = (
+                baggage.dynamic_sampling_context()
+            )
 
         return self._propagation_context["dynamic_sampling_context"]
 

--- a/sentry_sdk/serializer.py
+++ b/sentry_sdk/serializer.py
@@ -348,9 +348,9 @@ def serialize(event, **kwargs):
                     should_repr_strings=should_repr_strings,
                     is_databag=is_databag,
                     is_request_body=is_request_body,
-                    remaining_depth=remaining_depth - 1
-                    if remaining_depth is not None
-                    else None,
+                    remaining_depth=(
+                        remaining_depth - 1 if remaining_depth is not None else None
+                    ),
                     remaining_breadth=remaining_breadth,
                 )
                 rv_dict[str_k] = v
@@ -375,9 +375,9 @@ def serialize(event, **kwargs):
                         should_repr_strings=should_repr_strings,
                         is_databag=is_databag,
                         is_request_body=is_request_body,
-                        remaining_depth=remaining_depth - 1
-                        if remaining_depth is not None
-                        else None,
+                        remaining_depth=(
+                            remaining_depth - 1 if remaining_depth is not None else None
+                        ),
                         remaining_breadth=remaining_breadth,
                     )
                 )

--- a/sentry_sdk/tracing.py
+++ b/sentry_sdk/tracing.py
@@ -544,9 +544,9 @@ class Span(object):
             rv["status"] = self.status
 
         if self.containing_transaction:
-            rv[
-                "dynamic_sampling_context"
-            ] = self.containing_transaction.get_baggage().dynamic_sampling_context()
+            rv["dynamic_sampling_context"] = (
+                self.containing_transaction.get_baggage().dynamic_sampling_context()
+            )
 
         return rv
 

--- a/tests/integrations/asyncpg/test_asyncpg.py
+++ b/tests/integrations/asyncpg/test_asyncpg.py
@@ -8,6 +8,7 @@ docker run --rm --name some-postgres -e POSTGRES_USER=foo -e POSTGRES_PASSWORD=b
 
 The tests use the following credentials to establish a database connection.
 """
+
 import os
 
 

--- a/tests/integrations/aws_lambda/client.py
+++ b/tests/integrations/aws_lambda/client.py
@@ -386,12 +386,14 @@ else:
                 _REPL_CODE.format(line=line),
                 b"",
                 cleanup.append,
-                subprocess_kwargs={
-                    "stdout": subprocess.DEVNULL,
-                    "stderr": subprocess.DEVNULL,
-                }
-                if not verbose
-                else {},
+                subprocess_kwargs=(
+                    {
+                        "stdout": subprocess.DEVNULL,
+                        "stderr": subprocess.DEVNULL,
+                    }
+                    if not verbose
+                    else {}
+                ),
             )
 
             for line in base64.b64decode(response["LogResult"]).splitlines():

--- a/tests/integrations/clickhouse_driver/test_clickhouse_driver.py
+++ b/tests/integrations/clickhouse_driver/test_clickhouse_driver.py
@@ -4,6 +4,7 @@ Tests need a local clickhouse instance running, this can best be done using
 docker run -d -p 18123:8123 -p9000:9000 --name clickhouse-test --ulimit nofile=262144:262144 --rm clickhouse/clickhouse-server
 ```
 """
+
 import clickhouse_driver
 from clickhouse_driver import Client, connect
 

--- a/tests/integrations/django/myapp/custom_urls.py
+++ b/tests/integrations/django/myapp/custom_urls.py
@@ -13,6 +13,7 @@ Including another URLconf
     1. Import the include() function: from django.urls import include, path
     2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
+
 from __future__ import absolute_import
 
 try:

--- a/tests/integrations/django/myapp/settings.py
+++ b/tests/integrations/django/myapp/settings.py
@@ -10,7 +10,6 @@ For the full list of settings and their values, see
 https://docs.djangoproject.com/en/2.0/ref/settings/
 """
 
-
 # We shouldn't access settings while setting up integrations. Initialize SDK
 # here to provoke any errors that might occur.
 import sentry_sdk

--- a/tests/integrations/django/myapp/urls.py
+++ b/tests/integrations/django/myapp/urls.py
@@ -13,6 +13,7 @@ Including another URLconf
     1. Import the include() function: from django.urls import include, path
     2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
+
 from __future__ import absolute_import
 
 try:

--- a/tests/integrations/gcp/test_gcp.py
+++ b/tests/integrations/gcp/test_gcp.py
@@ -2,6 +2,7 @@
 # GCP Cloud Functions unit tests
 
 """
+
 import json
 from textwrap import dedent
 import tempfile

--- a/tests/integrations/starlette/test_starlette.py
+++ b/tests/integrations/starlette/test_starlette.py
@@ -779,9 +779,11 @@ def test_middleware_partial_receive_send(sentry_init, capture_events):
         },
         {
             "op": "middleware.starlette.receive",
-            "description": "_ASGIAdapter.send.<locals>.receive"
-            if STARLETTE_VERSION < (0, 21)
-            else "_TestClientTransport.handle_request.<locals>.receive",
+            "description": (
+                "_ASGIAdapter.send.<locals>.receive"
+                if STARLETTE_VERSION < (0, 21)
+                else "_TestClientTransport.handle_request.<locals>.receive"
+            ),
             "tags": {"starlette.middleware_name": "ServerErrorMiddleware"},
         },
         {

--- a/tests/test_profiler.py
+++ b/tests/test_profiler.py
@@ -393,9 +393,11 @@ class GetFrame(GetFrameBase):
         ),
         pytest.param(
             GetFrame().instance_method_wrapped()(),
-            "wrapped"
-            if sys.version_info < (3, 11)
-            else "GetFrame.instance_method_wrapped.<locals>.wrapped",
+            (
+                "wrapped"
+                if sys.version_info < (3, 11)
+                else "GetFrame.instance_method_wrapped.<locals>.wrapped"
+            ),
             id="instance_method_wrapped",
         ),
         pytest.param(
@@ -405,9 +407,11 @@ class GetFrame(GetFrameBase):
         ),
         pytest.param(
             GetFrame().class_method_wrapped()(),
-            "wrapped"
-            if sys.version_info < (3, 11)
-            else "GetFrame.class_method_wrapped.<locals>.wrapped",
+            (
+                "wrapped"
+                if sys.version_info < (3, 11)
+                else "GetFrame.class_method_wrapped.<locals>.wrapped"
+            ),
             id="class_method_wrapped",
         ),
         pytest.param(
@@ -422,9 +426,11 @@ class GetFrame(GetFrameBase):
         ),
         pytest.param(
             GetFrame().inherited_instance_method_wrapped()(),
-            "wrapped"
-            if sys.version_info < (3, 11)
-            else "GetFrameBase.inherited_instance_method_wrapped.<locals>.wrapped",
+            (
+                "wrapped"
+                if sys.version_info < (3, 11)
+                else "GetFrameBase.inherited_instance_method_wrapped.<locals>.wrapped"
+            ),
             id="instance_method_wrapped",
         ),
         pytest.param(
@@ -434,16 +440,20 @@ class GetFrame(GetFrameBase):
         ),
         pytest.param(
             GetFrame().inherited_class_method_wrapped()(),
-            "wrapped"
-            if sys.version_info < (3, 11)
-            else "GetFrameBase.inherited_class_method_wrapped.<locals>.wrapped",
+            (
+                "wrapped"
+                if sys.version_info < (3, 11)
+                else "GetFrameBase.inherited_class_method_wrapped.<locals>.wrapped"
+            ),
             id="inherited_class_method_wrapped",
         ),
         pytest.param(
             GetFrame().inherited_static_method(),
-            "inherited_static_method"
-            if sys.version_info < (3, 11)
-            else "GetFrameBase.inherited_static_method",
+            (
+                "inherited_static_method"
+                if sys.version_info < (3, 11)
+                else "GetFrameBase.inherited_static_method"
+            ),
             id="inherited_static_method",
         ),
     ],


### PR DESCRIPTION
The lint CI step on new/updated PRs was [failing](https://github.com/getsentry/sentry-python/actions/runs/7667138132/job/20896357477?pr=2675) because a [recently released version of black](https://github.com/psf/black/releases/tag/24.1.0) introduced some formatting changes. Applying them here.

---

## General Notes

Thank you for contributing to `sentry-python`!

Please add tests to validate your changes, and lint your code using `tox -e linters`.

Running the test suite on your PR might require maintainer approval. Some tests (AWS Lambda) additionally require a maintainer to add a special label to run and will fail if the label is not present.

#### For maintainers

Sensitive test suites require maintainer review to ensure that tests do not compromise our secrets. This review must be repeated after any code revisions.

Before running sensitive test suites, please carefully check the PR. Then, apply the `Trigger: tests using secrets` label. The label will be removed after any code changes to enforce our policy requiring maintainers to review all code revisions before running sensitive tests.
