### PR TITLE
Sangeet/handle lost event

### DIFF
--- a/sentry_sdk/transport.py
+++ b/sentry_sdk/transport.py
@@ -548,6 +548,10 @@ class HttpTransport(Transport):
         # type: (...) -> None
         logger.debug("Flushing HTTP transport")
 
+        while self._worker._queue.qsize() > 0:
+            logger.info("Waiting for worker to finish pending tasks.")
+            time.sleep(0.5)
+    
         if timeout > 0:
             self._worker.submit(lambda: self._flush_client_reports(force=True))
             self._worker.flush(timeout, callback)

--- a/sentry_sdk/worker.py
+++ b/sentry_sdk/worker.py
@@ -122,7 +122,7 @@ class BackgroundWorker(object):
         # type: (Callable[[], None]) -> bool
         self._ensure_thread()
         try:
-            self._queue.put_nowait(callback)
+            self._queue.put(callback)
             return True
         except FullError:
             return False


### PR DESCRIPTION
This custom transport class is used for handling 2 cases:
 1) Sentry does not put "send_event_wrapper" callback to worker queue if it is full. This will lead to loss of events.
 To handle this we will wait for queue until its size is less than maxsize.
Ref: https://github.com/getsentry/sentry-python/blob/e373e35851b8dbb57aac84edbd8ef75730081753/sentry_sdk/transport.py#L521
 2) Sentry worker send events asynchronously, so it is possible that we exit the main process before all events are uploaded.
 so, sentry wait for 2 seconds for worker to finsh pending events. The events which did't get uploaded even after 2 seconds are lost.
 To handle this, we will wait for queue to be empty.
Ref: https://github.com/getsentry/sentry-python/blob/e373e35851b8dbb57aac84edbd8ef75730081753/sentry_sdk/consts.py#L249C9-L249C25
Ref: https://github.com/getsentry/sentry-python/blob/e373e35851b8dbb57aac84edbd8ef75730081753/sentry_sdk/integrations/atexit.py#L29
