### PR TITLE
Disable metrics if `gevent` is used

### DIFF
--- a/sentry_sdk/client.py
+++ b/sentry_sdk/client.py
@@ -252,7 +252,7 @@ class _Client(object):
             experiments = self.options.get("_experiments", {})
             if experiments.get("enable_metrics", True):
                 if is_gevent():
-                    logger.warning("Metrics are currently not supported with gevent.")
+                    logger.warning("Metrics currently not supported with gevent.")
 
                 else:
                     from sentry_sdk.metrics import MetricsAggregator

--- a/sentry_sdk/client.py
+++ b/sentry_sdk/client.py
@@ -15,6 +15,7 @@ from sentry_sdk.utils import (
     get_default_release,
     handle_in_app,
     logger,
+    is_gevent,
 )
 from sentry_sdk.serializer import serialize
 from sentry_sdk.tracing import trace, has_tracing_enabled
@@ -250,14 +251,18 @@ class _Client(object):
             self.metrics_aggregator = None  # type: Optional[MetricsAggregator]
             experiments = self.options.get("_experiments", {})
             if experiments.get("enable_metrics", True):
-                from sentry_sdk.metrics import MetricsAggregator
+                if is_gevent():
+                    logger.warning("Metrics are currently not supported with gevent.")
 
-                self.metrics_aggregator = MetricsAggregator(
-                    capture_func=_capture_envelope,
-                    enable_code_locations=bool(
-                        experiments.get("metric_code_locations", True)
-                    ),
-                )
+                else:
+                    from sentry_sdk.metrics import MetricsAggregator
+
+                    self.metrics_aggregator = MetricsAggregator(
+                        capture_func=_capture_envelope,
+                        enable_code_locations=bool(
+                            experiments.get("metric_code_locations", True)
+                        ),
+                    )
 
             max_request_body_size = ("always", "never", "small", "medium")
             if self.options["max_request_body_size"] not in max_request_body_size:

--- a/sentry_sdk/utils.py
+++ b/sentry_sdk/utils.py
@@ -1747,10 +1747,6 @@ try:
     from gevent.monkey import is_module_patched
 except ImportError:
 
-    def get_gevent_hub():
-        # type: () -> Any
-        return None
-
     def is_module_patched(*args, **kwargs):
         # type: (*Any, **Any) -> bool
         # unable to import from gevent means no modules have been patched

--- a/sentry_sdk/utils.py
+++ b/sentry_sdk/utils.py
@@ -1741,3 +1741,22 @@ else:
     def now():
         # type: () -> float
         return time.perf_counter()
+
+
+try:
+    from gevent.monkey import is_module_patched  # type: ignore
+except ImportError:
+
+    def get_gevent_hub():
+        # type: () -> Any
+        return None
+
+    def is_module_patched(*args, **kwargs):
+        # type: (*Any, **Any) -> bool
+        # unable to import from gevent means no modules have been patched
+        return False
+
+
+def is_gevent():
+    # type: () -> bool
+    return is_module_patched("threading") or is_module_patched("_thread")

--- a/sentry_sdk/utils.py
+++ b/sentry_sdk/utils.py
@@ -1744,7 +1744,7 @@ else:
 
 
 try:
-    from gevent.monkey import is_module_patched  # type: ignore
+    from gevent.monkey import is_module_patched
 except ImportError:
 
     def get_gevent_hub():

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -52,23 +52,6 @@ def parse_metrics(bytes):
     return rv
 
 
-@requires_gevent
-def test_metrics_disabled_with_gevent(sentry_init, capture_envelopes):
-    sentry_init(
-        release="fun-release",
-        environment="not-fun-env",
-        _experiments={"enable_metrics": True, "metric_code_locations": True},
-    )
-    ts = time.time()
-    envelopes = capture_envelopes()
-
-    metrics.incr("foobar", 1.0, tags={"foo": "bar", "blub": "blah"}, timestamp=ts)
-    metrics.incr("foobar", 2.0, tags={"foo": "bar", "blub": "blah"}, timestamp=ts)
-    Hub.current.flush()
-
-    assert len(envelopes) == 0
-
-
 def test_incr(sentry_init, capture_envelopes):
     sentry_init(
         release="fun-release",
@@ -971,3 +954,26 @@ def test_flush_recursion_protection_background_flush(
     m = parse_metrics(envelope.items[0].payload.get_bytes())
     assert len(m) == 1
     assert m[0][1] == "counter@none"
+
+
+@pytest.mark.forked
+@requires_gevent
+def test_no_metrics_with_gevent(sentry_init, capture_envelopes):
+    from gevent import monkey
+
+    monkey.patch_all()
+
+    sentry_init(
+        release="fun-release",
+        environment="not-fun-env",
+        _experiments={"enable_metrics": True, "metric_code_locations": True},
+    )
+    ts = time.time()
+    envelopes = capture_envelopes()
+
+    metrics.incr("foobar", 1.0, tags={"foo": "bar", "blub": "blah"}, timestamp=ts)
+    metrics.incr("foobar", 2.0, tags={"foo": "bar", "blub": "blah"}, timestamp=ts)
+    Hub.current.flush()
+
+    assert Hub.current.client.metrics_aggregator is None
+    assert len(envelopes) == 0


### PR DESCRIPTION
[Enabling metrics by default](https://github.com/getsentry/sentry-python/pull/2685) leads to a deadlock when `gevent` is installed.

For now, we will disable metrics when `gevent` is used. In the next step, [we'll make metrics work with `gevent`](https://github.com/getsentry/sentry-python/issues/2689).

---

## General Notes

Thank you for contributing to `sentry-python`!

Please add tests to validate your changes, and lint your code using `tox -e linters`.

Running the test suite on your PR might require maintainer approval. Some tests (AWS Lambda) additionally require a maintainer to add a special label to run and will fail if the label is not present.

#### For maintainers

Sensitive test suites require maintainer review to ensure that tests do not compromise our secrets. This review must be repeated after any code revisions.

Before running sensitive test suites, please carefully check the PR. Then, apply the `Trigger: tests using secrets` label. The label will be removed after any code changes to enforce our policy requiring maintainers to review all code revisions before running sensitive tests.
