### PR TITLE
fix(ci): Fix yaml generation script

### DIFF
--- a/.github/workflows/test-integrations-databases.yml
+++ b/.github/workflows/test-integrations-databases.yml
@@ -76,6 +76,14 @@ jobs:
         run: |
           set -x # print commands that are executed
           ./scripts/runtox.sh "py${{ matrix.python-version }}-pymongo-latest" --cov=tests --cov=sentry_sdk --cov-report= --cov-branch
+      - name: Test redis latest
+        run: |
+          set -x # print commands that are executed
+          ./scripts/runtox.sh "py${{ matrix.python-version }}-redis-latest" --cov=tests --cov=sentry_sdk --cov-report= --cov-branch
+      - name: Test rediscluster latest
+        run: |
+          set -x # print commands that are executed
+          ./scripts/runtox.sh "py${{ matrix.python-version }}-rediscluster-latest" --cov=tests --cov=sentry_sdk --cov-report= --cov-branch
       - name: Test sqlalchemy latest
         run: |
           set -x # print commands that are executed
@@ -146,6 +154,14 @@ jobs:
         run: |
           set -x # print commands that are executed
           ./scripts/runtox.sh --exclude-latest "py${{ matrix.python-version }}-pymongo" --cov=tests --cov=sentry_sdk --cov-report= --cov-branch
+      - name: Test redis pinned
+        run: |
+          set -x # print commands that are executed
+          ./scripts/runtox.sh --exclude-latest "py${{ matrix.python-version }}-redis" --cov=tests --cov=sentry_sdk --cov-report= --cov-branch
+      - name: Test rediscluster pinned
+        run: |
+          set -x # print commands that are executed
+          ./scripts/runtox.sh --exclude-latest "py${{ matrix.python-version }}-rediscluster" --cov=tests --cov=sentry_sdk --cov-report= --cov-branch
       - name: Test sqlalchemy pinned
         run: |
           set -x # print commands that are executed
@@ -205,6 +221,14 @@ jobs:
         run: |
           set -x # print commands that are executed
           ./scripts/runtox.sh --exclude-latest "py2.7-pymongo" --cov=tests --cov=sentry_sdk --cov-report= --cov-branch
+      - name: Test redis py27
+        run: |
+          set -x # print commands that are executed
+          ./scripts/runtox.sh --exclude-latest "py2.7-redis" --cov=tests --cov=sentry_sdk --cov-report= --cov-branch
+      - name: Test rediscluster py27
+        run: |
+          set -x # print commands that are executed
+          ./scripts/runtox.sh --exclude-latest "py2.7-rediscluster" --cov=tests --cov=sentry_sdk --cov-report= --cov-branch
       - name: Test sqlalchemy py27
         run: |
           set -x # print commands that are executed

--- a/.github/workflows/test-integrations-web-frameworks-2.yml
+++ b/.github/workflows/test-integrations-web-frameworks-2.yml
@@ -66,14 +66,6 @@ jobs:
         run: |
           set -x # print commands that are executed
           ./scripts/runtox.sh "py${{ matrix.python-version }}-quart-latest" --cov=tests --cov=sentry_sdk --cov-report= --cov-branch
-      - name: Test redis latest
-        run: |
-          set -x # print commands that are executed
-          ./scripts/runtox.sh "py${{ matrix.python-version }}-redis-latest" --cov=tests --cov=sentry_sdk --cov-report= --cov-branch
-      - name: Test rediscluster latest
-        run: |
-          set -x # print commands that are executed
-          ./scripts/runtox.sh "py${{ matrix.python-version }}-rediscluster-latest" --cov=tests --cov=sentry_sdk --cov-report= --cov-branch
       - name: Test sanic latest
         run: |
           set -x # print commands that are executed
@@ -142,14 +134,6 @@ jobs:
         run: |
           set -x # print commands that are executed
           ./scripts/runtox.sh --exclude-latest "py${{ matrix.python-version }}-quart" --cov=tests --cov=sentry_sdk --cov-report= --cov-branch
-      - name: Test redis pinned
-        run: |
-          set -x # print commands that are executed
-          ./scripts/runtox.sh --exclude-latest "py${{ matrix.python-version }}-redis" --cov=tests --cov=sentry_sdk --cov-report= --cov-branch
-      - name: Test rediscluster pinned
-        run: |
-          set -x # print commands that are executed
-          ./scripts/runtox.sh --exclude-latest "py${{ matrix.python-version }}-rediscluster" --cov=tests --cov=sentry_sdk --cov-report= --cov-branch
       - name: Test sanic pinned
         run: |
           set -x # print commands that are executed
@@ -207,14 +191,6 @@ jobs:
         run: |
           set -x # print commands that are executed
           ./scripts/runtox.sh --exclude-latest "py2.7-quart" --cov=tests --cov=sentry_sdk --cov-report= --cov-branch
-      - name: Test redis py27
-        run: |
-          set -x # print commands that are executed
-          ./scripts/runtox.sh --exclude-latest "py2.7-redis" --cov=tests --cov=sentry_sdk --cov-report= --cov-branch
-      - name: Test rediscluster py27
-        run: |
-          set -x # print commands that are executed
-          ./scripts/runtox.sh --exclude-latest "py2.7-rediscluster" --cov=tests --cov=sentry_sdk --cov-report= --cov-branch
       - name: Test sanic py27
         run: |
           set -x # print commands that are executed

--- a/scripts/split-tox-gh-actions/split-tox-gh-actions.py
+++ b/scripts/split-tox-gh-actions/split-tox-gh-actions.py
@@ -14,6 +14,7 @@ If the parameter `--fail-on-changes` is set, the script will raise a RuntimeErro
 files have been changed by the scripts execution. This is used in CI to check if the yaml files
 represent the current tox.ini file. (And if not the CI run fails.)
 """
+
 import configparser
 import hashlib
 import sys
@@ -155,7 +156,8 @@ def main(fail_on_changes):
 
         if old_hash != new_hash:
             raise RuntimeError(
-                "The yaml configuration files have changed. This means that tox.ini has changed "
+                "The yaml configuration files have changed. This means that either `tox.ini` "
+                "or one of the constants in `split-tox-gh-actions.py` has changed "
                 "but the changes have not been propagated to the GitHub actions config files. "
                 "Please run `python scripts/split-tox-gh-actions/split-tox-gh-actions.py` "
                 "locally and commit the changes of the yaml configuration files to continue. "
@@ -235,7 +237,7 @@ def _normalize_py_versions(py_versions):
 def get_files_hash():
     """Calculate a hash of all the yaml configuration files"""
     hasher = hashlib.md5()
-    path_pattern = (OUT_DIR / "test-integration-*.yml").as_posix()
+    path_pattern = (OUT_DIR / "test-integrations-*.yml").as_posix()
     for file in glob(path_pattern):
         with open(file, "rb") as f:
             buf = f.read()


### PR DESCRIPTION
The generation script -- when run with `--fail-on-changes` -- was supposed to raise an error if it detected that the integration test YAML files have changed but haven't been committed. The check is based on a hash of the contents of the YAML files, but there was a typo in the file names to consider (`integration` -> `integrations`), so it wasn't actually looking at any files and was always trivially true.

Now it'll properly complain if changes are made to `tox.ini` or to some of the constants in the splitting script that result in new YAML files, but those are not part of the commit.

---

## General Notes

Thank you for contributing to `sentry-python`!

Please add tests to validate your changes, and lint your code using `tox -e linters`.

Running the test suite on your PR might require maintainer approval. Some tests (AWS Lambda) additionally require a maintainer to add a special label to run and will fail if the label is not present.

#### For maintainers

Sensitive test suites require maintainer review to ensure that tests do not compromise our secrets. This review must be repeated after any code revisions.

Before running sensitive test suites, please carefully check the PR. Then, apply the `Trigger: tests using secrets` label. The label will be removed after any code changes to enforce our policy requiring maintainers to review all code revisions before running sensitive tests.
