### PR TITLE
ref(transport): Remove compatibility import

### DIFF
--- a/sentry_sdk/transport.py
+++ b/sentry_sdk/transport.py
@@ -6,6 +6,7 @@ import gzip
 import time
 from datetime import datetime, timedelta, timezone
 from collections import defaultdict
+from urllib.request import getproxies
 
 from sentry_sdk.consts import EndpointType
 from sentry_sdk.utils import Dsn, logger, capture_internal_exceptions
@@ -30,11 +31,6 @@ if TYPE_CHECKING:
     from sentry_sdk._types import Event
 
     DataCategory = Optional[str]
-
-try:
-    from urllib.request import getproxies
-except ImportError:
-    from urllib import getproxies  # type: ignore
 
 
 class Transport:


### PR DESCRIPTION
Found one more compat import.

---

## General Notes

Thank you for contributing to `sentry-python`!

Please add tests to validate your changes, and lint your code using `tox -e linters`.

Running the test suite on your PR might require maintainer approval. Some tests (AWS Lambda) additionally require a maintainer to add a special label to run and will fail if the label is not present.

#### For maintainers

Sensitive test suites require maintainer review to ensure that tests do not compromise our secrets. This review must be repeated after any code revisions.

Before running sensitive test suites, please carefully check the PR. Then, apply the `Trigger: tests using secrets` label. The label will be removed after any code changes to enforce our policy requiring maintainers to review all code revisions before running sensitive tests.
