### PR TITLE
Guard against sentry initialization mid sqlalchemy cursor

### DIFF
--- a/sentry_sdk/integrations/sqlalchemy.py
+++ b/sentry_sdk/integrations/sqlalchemy.py
@@ -95,7 +95,7 @@ def _after_cursor_execute(conn, cursor, statement, parameters, context, *args):
         context._sentry_sql_span_manager = None
         ctx_mgr.__exit__(None, None, None)
 
-    span = context._sentry_sql_span
+    span = getattr(context, "_sentry_sql_span", None)  # type: Optional[Span]
     if span is not None:
         with capture_internal_exceptions():
             add_query_source(hub, span)


### PR DESCRIPTION
In an application that is executing sqlalchemy cursors on a thread concurrently with another thread calling `sentry_sdk.init` it is possible for `_after_cursor_execute` to be called on a cursor that never had `_before_cursor_execute` called.

```
  File "site-packages/sentry_sdk/integrations/sqlalchemy.py", line 98, in _after_cursor_execute
    span = context._sentry_sql_span
           ^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'PGExecutionContext_psycopg2' object has no attribute '_sentry_sql_span'
```
