### PR TITLE
fix(ci): Fix AWS Lambda workflow

### DIFF
--- a/.github/workflows/test-integrations-aws-lambda.yml
+++ b/.github/workflows/test-integrations-aws-lambda.yml
@@ -30,7 +30,7 @@ jobs:
     name: permissions check
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@4.1.1
+      - uses: actions/checkout@v4.1.1
         with:
           persist-credentials: false
       - name: Check permissions on PR

--- a/scripts/split-tox-gh-actions/templates/check_permissions.jinja
+++ b/scripts/split-tox-gh-actions/templates/check_permissions.jinja
@@ -2,7 +2,7 @@
     name: permissions check
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@4.1.1
+      - uses: actions/checkout@v4.1.1
         with:
           persist-credentials: false
 


### PR DESCRIPTION
Fixing a typo.

The AWS Lambda test suite will fail on this PR because it's running against `pull_request_target`, but it should work once we merge this.

---

## General Notes

Thank you for contributing to `sentry-python`!

Please add tests to validate your changes, and lint your code using `tox -e linters`.

Running the test suite on your PR might require maintainer approval. Some tests (AWS Lambda) additionally require a maintainer to add a special label to run and will fail if the label is not present.

#### For maintainers

Sensitive test suites require maintainer review to ensure that tests do not compromise our secrets. This review must be repeated after any code revisions.

Before running sensitive test suites, please carefully check the PR. Then, apply the `Trigger: tests using secrets` label. The label will be removed after any code changes to enforce our policy requiring maintainers to review all code revisions before running sensitive tests.
