### PR TITLE
Turn off metrics for uWSGI

### DIFF
--- a/sentry_sdk/client.py
+++ b/sentry_sdk/client.py
@@ -251,7 +251,7 @@ class _Client(object):
             experiments = self.options.get("_experiments", {})
             if experiments.get("enable_metrics", True):
                 try:
-                    import uwsgi
+                    import uwsgi  # type: ignore
                 except ImportError:
                     uwsgi = None
 

--- a/sentry_sdk/client.py
+++ b/sentry_sdk/client.py
@@ -249,13 +249,17 @@ class _Client(object):
 
             self.metrics_aggregator = None  # type: Optional[MetricsAggregator]
             experiments = self.options.get("_experiments", {})
-            if experiments.get("enable_metrics", True):
+            if experiments.get("enable_metrics", True) or experiments.get(
+                "force_enable_metrics", False
+            ):
                 try:
                     import uwsgi  # type: ignore
                 except ImportError:
                     uwsgi = None
 
-                if uwsgi is not None:
+                if uwsgi is not None and not experiments.get(
+                    "force_enable_metrics", False
+                ):
                     logger.warning("Metrics currently not supported with uWSGI.")
 
                 else:

--- a/sentry_sdk/client.py
+++ b/sentry_sdk/client.py
@@ -250,14 +250,23 @@ class _Client(object):
             self.metrics_aggregator = None  # type: Optional[MetricsAggregator]
             experiments = self.options.get("_experiments", {})
             if experiments.get("enable_metrics", True):
-                from sentry_sdk.metrics import MetricsAggregator
+                try:
+                    import uwsgi
+                except ImportError:
+                    uwsgi = None
 
-                self.metrics_aggregator = MetricsAggregator(
-                    capture_func=_capture_envelope,
-                    enable_code_locations=bool(
-                        experiments.get("metric_code_locations", True)
-                    ),
-                )
+                if uwsgi is not None:
+                    logger.warning("Metrics currently not supported with uWSGI.")
+
+                else:
+                    from sentry_sdk.metrics import MetricsAggregator
+
+                    self.metrics_aggregator = MetricsAggregator(
+                        capture_func=_capture_envelope,
+                        enable_code_locations=bool(
+                            experiments.get("metric_code_locations", True)
+                        ),
+                    )
 
             max_request_body_size = ("always", "never", "small", "medium")
             if self.options["max_request_body_size"] not in max_request_body_size:

--- a/sentry_sdk/consts.py
+++ b/sentry_sdk/consts.py
@@ -46,6 +46,7 @@ if TYPE_CHECKING:
             "transport_zlib_compression_level": Optional[int],
             "transport_num_pools": Optional[int],
             "enable_metrics": Optional[bool],
+            "force_enable_metrics": Optional[bool],
             "metrics_summary_sample_rate": Optional[float],
             "should_summarize_metric": Optional[Callable[[str, MetricTags], bool]],
             "before_emit_metric": Optional[Callable[[str, MetricTags], bool]],


### PR DESCRIPTION
Metrics are [broken under uWSGI](https://github.com/getsentry/sentry-python/issues/2699). Take the feature down for uWSGI until we figure out a fix.

---

## General Notes

Thank you for contributing to `sentry-python`!

Please add tests to validate your changes, and lint your code using `tox -e linters`.

Running the test suite on your PR might require maintainer approval. Some tests (AWS Lambda) additionally require a maintainer to add a special label to run and will fail if the label is not present.

#### For maintainers

Sensitive test suites require maintainer review to ensure that tests do not compromise our secrets. This review must be repeated after any code revisions.

Before running sensitive test suites, please carefully check the PR. Then, apply the `Trigger: tests using secrets` label. The label will be removed after any code changes to enforce our policy requiring maintainers to review all code revisions before running sensitive tests.
