### PR TITLE
Remove `user.segment`

### DIFF
--- a/MIGRATION_GUIDE.md
+++ b/MIGRATION_GUIDE.md
@@ -33,6 +33,7 @@
 - Removed support for the `install` method for custom integrations. Please use `setup_once` instead.
 - Removed `sentry_sdk.tracing.Span.new_span`. Use `sentry_sdk.tracing.Span.start_child` instead.
 - Removed `sentry_sdk.tracing.Transaction.new_span`. Use `sentry_sdk.tracing.Transaction.start_child` instead.
+- Removed support for `user.segment`. It was also removed from the trace header as well as from the dynamic sampling context.
 
 ## Deprecated
 

--- a/sentry_sdk/tracing_utils.py
+++ b/sentry_sdk/tracing_utils.py
@@ -395,10 +395,6 @@ class Baggage:
         if options.get("traces_sample_rate"):
             sentry_items["sample_rate"] = options["traces_sample_rate"]
 
-        user = (scope and scope._user) or {}
-        if user.get("segment"):
-            sentry_items["user_segment"] = user["segment"]
-
         return Baggage(sentry_items, third_party_items, mutable)
 
     @classmethod
@@ -416,7 +412,6 @@ class Baggage:
             return Baggage(sentry_items)
 
         options = client.options or {}
-        user = (hub.scope and hub.scope._user) or {}
 
         sentry_items["trace_id"] = transaction.trace_id
 
@@ -434,9 +429,6 @@ class Baggage:
             and transaction.source not in LOW_QUALITY_TRANSACTION_SOURCES
         ):
             sentry_items["transaction"] = transaction.name
-
-        if user.get("segment"):
-            sentry_items["user_segment"] = user["segment"]
 
         if transaction.sample_rate is not None:
             sentry_items["sample_rate"] = str(transaction.sample_rate)

--- a/tests/test_envelope.py
+++ b/tests/test_envelope.py
@@ -24,7 +24,6 @@ def generate_transaction_item():
                     "environment": "dogpark",
                     "release": "off.leash.park",
                     "public_key": "dogsarebadatkeepingsecrets",
-                    "user_segment": "bigs",
                     "transaction": "/interactions/other-dogs/new-dog",
                 },
             }
@@ -105,7 +104,6 @@ def test_envelope_headers(sentry_init, capture_envelopes, monkeypatch):
             "environment": "dogpark",
             "release": "off.leash.park",
             "public_key": "dogsarebadatkeepingsecrets",
-            "user_segment": "bigs",
             "transaction": "/interactions/other-dogs/new-dog",
         },
     }


### PR DESCRIPTION
Closes https://github.com/getsentry/sentry-python/issues/2718

---

## General Notes

Thank you for contributing to `sentry-python`!

Please add tests to validate your changes, and lint your code using `tox -e linters`.

Running the test suite on your PR might require maintainer approval. Some tests (AWS Lambda) additionally require a maintainer to add a special label to run and will fail if the label is not present.

#### For maintainers

Sensitive test suites require maintainer review to ensure that tests do not compromise our secrets. This review must be repeated after any code revisions.

Before running sensitive test suites, please carefully check the PR. Then, apply the `Trigger: tests using secrets` label. The label will be removed after any code changes to enforce our policy requiring maintainers to review all code revisions before running sensitive tests.
