### PR TITLE
fix(metrics): Only start thread on demand

### DIFF
--- a/sentry_sdk/metrics.py
+++ b/sentry_sdk/metrics.py
@@ -488,9 +488,9 @@ class MetricsAggregator(object):
         # type: (...) -> None
         _in_metrics.set(True)
         while self._running or self._force_flush:
-            self._flush()
             if self._running:
                 self._flush_event.wait(self.FLUSHER_SLEEP_TIME)
+            self._flush()
 
     def _flush(self):
         # type: (...) -> None

--- a/sentry_sdk/metrics.py
+++ b/sentry_sdk/metrics.py
@@ -445,7 +445,6 @@ class MetricsAggregator(object):
 
         self._flusher = None  # type: Optional[Union[threading.Thread, ThreadPool]]
         self._flusher_pid = None  # type: Optional[int]
-        self._ensure_thread()
 
     def _ensure_thread(self):
         # type: (...) -> bool

--- a/sentry_sdk/metrics.py
+++ b/sentry_sdk/metrics.py
@@ -459,6 +459,11 @@ class MetricsAggregator(object):
             return True
 
         with self._lock:
+            # Recheck to make sure another thread didn't get here and start the
+            # the flusher in the meantime
+            if self._flusher_pid == pid:
+                return True
+
             self._flusher_pid = pid
 
             if not is_gevent():

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -269,7 +269,6 @@ def test_timing_basic(sentry_init, capture_envelopes, maybe_monkeypatched_thread
     Hub.current.flush()
 
     (envelope,) = envelopes
-    (envelope,) = envelopes
     statsd_item, meta_item = envelope.items
 
     assert statsd_item.headers["type"] == "statsd"


### PR DESCRIPTION
The recent metrics-on-by-default switch is causing issues for folks on uWSGI in prefork mode.

In other places where we use threads we always create the thread on demand, but in the metrics code we create a thread right away (so presumably before the process is forked). This PR aligns the behavior.

Additionally, add a small check like we have in the profiler for potential race conditions when spawning the flusher thread.

---

## General Notes

Thank you for contributing to `sentry-python`!

Please add tests to validate your changes, and lint your code using `tox -e linters`.

Running the test suite on your PR might require maintainer approval. Some tests (AWS Lambda) additionally require a maintainer to add a special label to run and will fail if the label is not present.

#### For maintainers

Sensitive test suites require maintainer review to ensure that tests do not compromise our secrets. This review must be repeated after any code revisions.

Before running sensitive test suites, please carefully check the PR. Then, apply the `Trigger: tests using secrets` label. The label will be removed after any code changes to enforce our policy requiring maintainers to review all code revisions before running sensitive tests.
