### PR TITLE
Update runtime version for AWS Lambda tests

### DIFF
--- a/tests/integrations/aws_lambda/test_aws.py
+++ b/tests/integrations/aws_lambda/test_aws.py
@@ -143,11 +143,11 @@ def lambda_client():
 
 @pytest.fixture(
     params=[
-        "python3.7",
         "python3.8",
         "python3.9",
         "python3.10",
         "python3.11",
+        "python3.12",
     ]
 )
 def lambda_runtime(request):


### PR DESCRIPTION
Python 3.7 is not supported anymore by Lambda, so removed it and added 3.12
