### PR TITLE
Deprecate profiler `_experiments` options

### DIFF
--- a/MIGRATION_GUIDE.md
+++ b/MIGRATION_GUIDE.md
@@ -39,3 +39,11 @@
 
 - Deprecated `sentry_sdk.transport.Transport.capture_event`. Please use `sentry_sdk.transport.Transport.capture_envelope`, instead.
 - Passing a function to `sentry_sdk.init`'s `transport` keyword argument has been deprecated. If you wish to provide a custom transport, please pass a `sentry_sdk.transport.Transport` instance or a subclass.
+- `profiler_mode` and `profiles_sample_rate` have been deprecated as `_experiments` options. Use them as top level options instead:
+    ```python
+        sentry_sdk.init(
+            ...,
+            profiler_mode="thread",
+            profiles_sample_rate=1.0,
+        )
+    ```

--- a/sentry_sdk/consts.py
+++ b/sentry_sdk/consts.py
@@ -52,9 +52,6 @@ if TYPE_CHECKING:
             "attach_explain_plans": dict[str, Any],
             "max_spans": Optional[int],
             "record_sql_params": Optional[bool],
-            # TODO: Remove these 2 profiling related experiments
-            "profiles_sample_rate": Optional[float],
-            "profiler_mode": Optional[ProfilerMode],
             "otel_powered_performance": Optional[bool],
             "transport_zlib_compression_level": Optional[int],
             "transport_num_pools": Optional[int],

--- a/sentry_sdk/profiler.py
+++ b/sentry_sdk/profiler.py
@@ -175,8 +175,14 @@ def has_profiling_enabled(options):
         return True
 
     profiles_sample_rate = options["_experiments"].get("profiles_sample_rate")
-    if profiles_sample_rate is not None and profiles_sample_rate > 0:
-        return True
+    if profiles_sample_rate is not None:
+        logger.warning(
+            "_experiments['profiles_sample_rate'] is deprecated. "
+            "Please use the non-experimental profiles_sample_rate option "
+            "directly."
+        )
+        if profiles_sample_rate > 0:
+            return True
 
     return False
 
@@ -206,6 +212,10 @@ def setup_profiler(options):
         profiler_mode = (
             options.get("_experiments", {}).get("profiler_mode")
             or default_profiler_mode
+        )
+        logger.warning(
+            "_experiments['profiler_mode'] is deprecated. Please use the "
+            "non-experimental profiler_mode option directly."
         )
 
     if (

--- a/sentry_sdk/profiler.py
+++ b/sentry_sdk/profiler.py
@@ -209,14 +209,13 @@ def setup_profiler(options):
     if options.get("profiler_mode") is not None:
         profiler_mode = options["profiler_mode"]
     else:
-        profiler_mode = (
-            options.get("_experiments", {}).get("profiler_mode")
-            or default_profiler_mode
-        )
-        logger.warning(
-            "_experiments['profiler_mode'] is deprecated. Please use the "
-            "non-experimental profiler_mode option directly."
-        )
+        profiler_mode = options.get("_experiments", {}).get("profiler_mode")
+        if profiler_mode is not None:
+            logger.warning(
+                "_experiments['profiler_mode'] is deprecated. Please use the "
+                "non-experimental profiler_mode option directly."
+            )
+        profiler_mode = profiler_mode or default_profiler_mode
 
     if (
         profiler_mode == ThreadScheduler.mode


### PR DESCRIPTION
`_experiments` options technically don't need deprecating since we explicitly say that they can change at any point, but I've seen many people actually use these profiler options, so let's give them a heads up before removing them.

---

## General Notes

Thank you for contributing to `sentry-python`!

Please add tests to validate your changes, and lint your code using `tox -e linters`.

Running the test suite on your PR might require maintainer approval. Some tests (AWS Lambda) additionally require a maintainer to add a special label to run and will fail if the label is not present.

#### For maintainers

Sensitive test suites require maintainer review to ensure that tests do not compromise our secrets. This review must be repeated after any code revisions.

Before running sensitive test suites, please carefully check the PR. Then, apply the `Trigger: tests using secrets` label. The label will be removed after any code changes to enforce our policy requiring maintainers to review all code revisions before running sensitive tests.
