### PR TITLE
ref(uwsgi): Warn if uWSGI is set up without proper thread support

### DIFF
--- a/sentry_sdk/_compat.py
+++ b/sentry_sdk/_compat.py
@@ -148,6 +148,16 @@ def check_profiler_support():
 
     print(opt)
 
+    from warnings import warn
+
+    warn(
+        Warning(
+            "We detected the use of uWSGI in preforking mode. "
+            "This might lead to issues with the profiler. "
+            'Please run uWSGI with the "--lazy-apps" flag.'
+        )
+    )
+
 
 def check_thread_support():
     # type: () -> None

--- a/sentry_sdk/_compat.py
+++ b/sentry_sdk/_compat.py
@@ -172,7 +172,7 @@ def check_uwsgi_thread_support():
             Warning(
                 "We detected the use of uWSGI without thread support. "
                 "This might lead to unexpected issues with the Sentry SDK. "
-                'Please run uWSGI with the "--enable-threads" flag for full support.'
+                'Please run uWSGI with "--enable-threads" for full support.'
             )
         )
 
@@ -185,9 +185,11 @@ def check_uwsgi_thread_support():
             Warning(
                 "We detected the use of uWSGI in preforking mode without "
                 "thread support. This might lead to crashing workers. "
-                'Please run uWSGI with the both the "--enable-threads" and '
-                '"--py-call-uwsgi-fork-hooks" flags for full support.'
+                'Please run uWSGI with the both "--enable-threads" and '
+                '"--py-call-uwsgi-fork-hooks" for full support.'
             )
         )
 
         return False
+
+    return True

--- a/sentry_sdk/_compat.py
+++ b/sentry_sdk/_compat.py
@@ -140,6 +140,15 @@ def with_metaclass(meta, *bases):
     return type.__new__(MetaClass, "temporary_class", (), {})
 
 
+def check_profiler_support():
+    try:
+        from uwsgi import opt
+    except ImportError:
+        return
+
+    print(opt)
+
+
 def check_thread_support():
     # type: () -> None
     try:

--- a/sentry_sdk/_compat.py
+++ b/sentry_sdk/_compat.py
@@ -185,7 +185,7 @@ def check_uwsgi_thread_support():
             Warning(
                 "We detected the use of uWSGI in preforking mode without "
                 "thread support. This might lead to crashing workers. "
-                'Please run uWSGI with the both "--enable-threads" and '
+                'Please run uWSGI with both "--enable-threads" and '
                 '"--py-call-uwsgi-fork-hooks" for full support.'
             )
         )

--- a/sentry_sdk/_compat.py
+++ b/sentry_sdk/_compat.py
@@ -171,7 +171,7 @@ def check_uwsgi_thread_support():
         warn(
             Warning(
                 "We detected the use of uWSGI without thread support. "
-                "This might lead to unexpected issues with the Sentry SDK. "
+                "This might lead to unexpected issues. "
                 'Please run uWSGI with "--enable-threads" for full support.'
             )
         )

--- a/sentry_sdk/_compat.py
+++ b/sentry_sdk/_compat.py
@@ -3,7 +3,6 @@ import contextlib
 from datetime import datetime, timedelta
 from functools import wraps
 
-from sentry_sdk.consts import FALSE_VALUES
 from sentry_sdk._types import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -160,7 +159,10 @@ def check_uwsgi_thread_support():
     except ImportError:
         return True
 
+    from sentry_sdk.consts import FALSE_VALUES
+
     def enabled(option):
+        # type: (str) -> bool
         value = opt.get(option, False)
         if isinstance(value, bool):
             return value

--- a/sentry_sdk/_compat.py
+++ b/sentry_sdk/_compat.py
@@ -168,7 +168,7 @@ def check_uwsgi_thread_support():
         if isinstance(value, bytes):
             try:
                 value = value.decode()
-            except:  # noqa: E722
+            except Exception:
                 pass
 
         return value and str(value).lower() not in FALSE_VALUES

--- a/sentry_sdk/_compat.py
+++ b/sentry_sdk/_compat.py
@@ -141,22 +141,49 @@ def with_metaclass(meta, *bases):
 
 
 def check_profiler_support():
+    # type: () -> None
+    # If uWSGI is running in preforking mode (default) and the SDK spawns a
+    # background thread on startup, i.e., before the process is forked, this
+    # can lead to segfaults in the forked workers:
+    # https://github.com/getsentry/sentry-python/issues/2699
+    # We usually don't spawn threads right on startup but rather on demand, but
+    # if someone e.g. emits some metrics at startup manually, we will create a
+    # thread before the process is forked.
+    #
+    # We've tracked the segfaults down to the use of `sys._current_frames()` in
+    # the profiler, though there might be more causes, so we might need this sort
+    # of check elsewhere as well. It seems like after the fork, something
+    # related to the originally active threads hasn't been cleaned up properly in
+    # the child processes and this can make them segfault.
+    #
+    # In Python 3.12, forking a process with live threads even issues
+    # a `DeprecationWarning`, so this is something that is generally discouraged.
+    #
+    # Here we check whether uWSGI is running in preforking mode and if so, we
+    # disable the profiler and issue a warning to switch to loading the app in
+    # each worker separately (with `--lazy-apps` or `--lazy`).
+    # https://uwsgi-docs.readthedocs.io/en/latest/articles/TheArtOfGracefulReloading.html#preforking-vs-lazy-apps-vs-lazy
     try:
         from uwsgi import opt
     except ImportError:
-        return
+        return True
 
-    print(opt)
+    if opt.get("--lazy-apps") or opt.get("--lazy"):
+        # We're not running in preforking mode, nothing to do.
+        return True
 
     from warnings import warn
 
     warn(
         Warning(
             "We detected the use of uWSGI in preforking mode. "
-            "This might lead to issues with the profiler. "
-            'Please run uWSGI with the "--lazy-apps" flag.'
+            "This might lead to issues with the workers when profiling is active. "
+            "Disabling profiling. "
+            'Please run uWSGI with the "--lazy-apps" flag to enable it.'
         )
     )
+
+    return False
 
 
 def check_thread_support():

--- a/sentry_sdk/_compat.py
+++ b/sentry_sdk/_compat.py
@@ -170,6 +170,7 @@ def check_uwsgi_thread_support():
 
         warn(
             Warning(
+                "IMPORTANT: "
                 "We detected the use of uWSGI without thread support. "
                 "This might lead to unexpected issues. "
                 'Please run uWSGI with "--enable-threads" for full support.'
@@ -183,6 +184,7 @@ def check_uwsgi_thread_support():
 
         warn(
             Warning(
+                "IMPORTANT: "
                 "We detected the use of uWSGI in preforking mode without "
                 "thread support. This might lead to crashing workers. "
                 'Please run uWSGI with both "--enable-threads" and '

--- a/sentry_sdk/consts.py
+++ b/sentry_sdk/consts.py
@@ -46,7 +46,6 @@ if TYPE_CHECKING:
             "transport_zlib_compression_level": Optional[int],
             "transport_num_pools": Optional[int],
             "enable_metrics": Optional[bool],
-            "force_enable_metrics": Optional[bool],
             "metrics_summary_sample_rate": Optional[float],
             "should_summarize_metric": Optional[Callable[[str, MetricTags], bool]],
             "before_emit_metric": Optional[Callable[[str, MetricTags], bool]],

--- a/sentry_sdk/hub.py
+++ b/sentry_sdk/hub.py
@@ -2,11 +2,6 @@ import copy
 import sys
 from contextlib import contextmanager
 
-try:
-    from os import register_at_fork
-except ImportError:
-    register_at_fork = None
-
 from sentry_sdk._compat import with_metaclass
 from sentry_sdk.consts import INSTRUMENTER
 from sentry_sdk.scope import Scope
@@ -704,13 +699,3 @@ class Hub(with_metaclass(HubMeta)):  # type: ignore
 
 GLOBAL_HUB = Hub()
 _local.set(GLOBAL_HUB)
-
-
-if register_at_fork is not None:
-
-    def detect_parent_with_live_threads():
-        import threading
-
-        print("ACTIVE THREADS IN PARENT:", threading.active_count())
-
-    register_at_fork(before=detect_parent_with_live_threads)

--- a/sentry_sdk/hub.py
+++ b/sentry_sdk/hub.py
@@ -2,7 +2,7 @@ import copy
 import sys
 from contextlib import contextmanager
 
-from sentry_sdk._compat import check_uwsgi_support, with_metaclass
+from sentry_sdk._compat import with_metaclass
 from sentry_sdk.consts import INSTRUMENTER
 from sentry_sdk.scope import Scope
 from sentry_sdk.client import Client
@@ -102,7 +102,6 @@ def _init(*args, **kwargs):
     client = Client(*args, **kwargs)  # type: ignore
     Hub.current.bind_client(client)
     _check_python_deprecations()
-    check_uwsgi_support()
     rv = _InitGuard(client)
     return rv
 

--- a/sentry_sdk/hub.py
+++ b/sentry_sdk/hub.py
@@ -2,7 +2,7 @@ import copy
 import sys
 from contextlib import contextmanager
 
-from sentry_sdk._compat import with_metaclass
+from sentry_sdk._compat import check_uwsgi_support, with_metaclass
 from sentry_sdk.consts import INSTRUMENTER
 from sentry_sdk.scope import Scope
 from sentry_sdk.client import Client
@@ -102,6 +102,7 @@ def _init(*args, **kwargs):
     client = Client(*args, **kwargs)  # type: ignore
     Hub.current.bind_client(client)
     _check_python_deprecations()
+    check_uwsgi_support()
     rv = _InitGuard(client)
     return rv
 

--- a/sentry_sdk/hub.py
+++ b/sentry_sdk/hub.py
@@ -1,7 +1,11 @@
 import copy
 import sys
-
 from contextlib import contextmanager
+
+try:
+    from os import register_at_fork
+except ImportError:
+    register_at_fork = None
 
 from sentry_sdk._compat import with_metaclass
 from sentry_sdk.consts import INSTRUMENTER
@@ -700,3 +704,13 @@ class Hub(with_metaclass(HubMeta)):  # type: ignore
 
 GLOBAL_HUB = Hub()
 _local.set(GLOBAL_HUB)
+
+
+if register_at_fork is not None:
+
+    def detect_parent_with_live_threads():
+        import threading
+
+        print("ACTIVE THREADS IN PARENT:", threading.active_count())
+
+    register_at_fork(before=detect_parent_with_live_threads)

--- a/sentry_sdk/profiler.py
+++ b/sentry_sdk/profiler.py
@@ -193,7 +193,9 @@ def setup_profiler(options):
         logger.warn("[Profiling] Profiler requires Python >= 3.3")
         return False
 
-    check_profiler_support()
+    supported = check_profiler_support()
+    if not supported:
+        raise RuntimeError("Incompatible uWSGI mode.")
 
     frequency = DEFAULT_SAMPLING_FREQUENCY
 

--- a/sentry_sdk/profiler.py
+++ b/sentry_sdk/profiler.py
@@ -36,7 +36,7 @@ import uuid
 from collections import deque
 
 import sentry_sdk
-from sentry_sdk._compat import PY33, PY311
+from sentry_sdk._compat import PY33, PY311, check_profiler_support
 from sentry_sdk._lru_cache import LRUCache
 from sentry_sdk._types import TYPE_CHECKING
 from sentry_sdk.utils import (
@@ -192,6 +192,8 @@ def setup_profiler(options):
     if not PY33:
         logger.warn("[Profiling] Profiler requires Python >= 3.3")
         return False
+
+    check_profiler_support()
 
     frequency = DEFAULT_SAMPLING_FREQUENCY
 

--- a/sentry_sdk/profiler.py
+++ b/sentry_sdk/profiler.py
@@ -36,7 +36,7 @@ import uuid
 from collections import deque
 
 import sentry_sdk
-from sentry_sdk._compat import PY33, PY311, check_profiler_support
+from sentry_sdk._compat import PY33, PY311
 from sentry_sdk._lru_cache import LRUCache
 from sentry_sdk._types import TYPE_CHECKING
 from sentry_sdk.utils import (
@@ -192,10 +192,6 @@ def setup_profiler(options):
     if not PY33:
         logger.warn("[Profiling] Profiler requires Python >= 3.3")
         return False
-
-    supported = check_profiler_support()
-    if not supported:
-        raise RuntimeError("Incompatible uWSGI mode.")
 
     frequency = DEFAULT_SAMPLING_FREQUENCY
 

--- a/sentry_sdk/worker.py
+++ b/sentry_sdk/worker.py
@@ -2,7 +2,6 @@ import os
 import threading
 
 from time import sleep, time
-from sentry_sdk._compat import check_thread_support
 from sentry_sdk._queue import Queue, FullError
 from sentry_sdk.utils import logger
 from sentry_sdk.consts import DEFAULT_QUEUE_SIZE
@@ -21,7 +20,6 @@ _TERMINATOR = object()
 class BackgroundWorker(object):
     def __init__(self, queue_size=DEFAULT_QUEUE_SIZE):
         # type: (int) -> None
-        check_thread_support()
         self._queue = Queue(queue_size)  # type: Queue
         self._lock = threading.Lock()
         self._thread = None  # type: Optional[threading.Thread]

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -5,8 +5,8 @@ import pytest
 import subprocess
 import sys
 import time
-
 from textwrap import dedent
+
 from sentry_sdk import (
     Hub,
     Client,
@@ -1320,22 +1320,37 @@ def test_error_sampler(_, sentry_init, capture_events, test_config):
 
 @pytest.mark.forked
 @pytest.mark.parametrize(
-    "opt,warning",
+    "opt,missing_flags",
     [
-        [{"enable-threads": True, "lazy-apps": True}, None],
-        [{"enable-threads": True, "py-call-uwsgi-fork-hooks": True}, None],
-        [{}, True],
-        [{"enable-threads": True}, True],
-        [{"py-call-uwsgi-fork-hooks": True}, True],
-        [{"lazy-apps": True}, True],
+        # lazy mode with enable-threads, no warning
+        [{"enable-threads": True, "lazy-apps": True}, []],
+        [{"enable-threads": "true", "lazy-apps": b"1"}, []],
+        # preforking mode with enable-threads and py-call-uwsgi-fork-hooks, no warning
+        [{"enable-threads": True, "py-call-uwsgi-fork-hooks": True}, []],
+        [{"enable-threads": b"true", "py-call-uwsgi-fork-hooks": b"on"}, []],
+        # lazy mode, no enable-threads, warning
+        [{"lazy-apps": True}, ["--enable-threads"]],
+        [{"enable-threads": b"false", "lazy-apps": True}, ["--enable-threads"]],
+        # preforking mode, no enable-threads or py-call-uwsgi-fork-hooks, warning
+        [{}, ["--enable-threads", "--py-call-uwsgi-fork-hooks"]],
+        [{"processes": b"2"}, ["--enable-threads", "--py-call-uwsgi-fork-hooks"]],
+        [{"enable-threads": True}, ["--py-call-uwsgi-fork-hooks"]],
+        [
+            {"enable-threads": b"false"},
+            ["--enable-threads", "--py-call-uwsgi-fork-hooks"],
+        ],
+        [{"py-call-uwsgi-fork-hooks": True}, ["--enable-threads"]],
     ],
 )
-def test_uwsgi_warnings(sentry_init, recwarn, opt, warning):
+def test_uwsgi_warnings(sentry_init, recwarn, opt, missing_flags):
     uwsgi = mock.MagicMock()
     uwsgi.opt = opt
     with mock.patch.dict("sys.modules", uwsgi=uwsgi):
         sentry_init(profiles_sample_rate=1.0)
-        if warning:
-            assert recwarn
+        if missing_flags:
+            assert len(recwarn) == 1
+            record = recwarn.pop()
+            for flag in missing_flags:
+                assert flag in str(record.message)
         else:
             assert not recwarn

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1331,10 +1331,12 @@ def test_error_sampler(_, sentry_init, capture_events, test_config):
         # lazy mode, no enable-threads, warning
         [{"lazy-apps": True}, ["--enable-threads"]],
         [{"enable-threads": b"false", "lazy-apps": True}, ["--enable-threads"]],
+        [{"enable-threads": b"0", "lazy": True}, ["--enable-threads"]],
         # preforking mode, no enable-threads or py-call-uwsgi-fork-hooks, warning
         [{}, ["--enable-threads", "--py-call-uwsgi-fork-hooks"]],
         [{"processes": b"2"}, ["--enable-threads", "--py-call-uwsgi-fork-hooks"]],
         [{"enable-threads": True}, ["--py-call-uwsgi-fork-hooks"]],
+        [{"enable-threads": b"1"}, ["--py-call-uwsgi-fork-hooks"]],
         [
             {"enable-threads": b"false"},
             ["--enable-threads", "--py-call-uwsgi-fork-hooks"],

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1318,6 +1318,7 @@ def test_error_sampler(_, sentry_init, capture_events, test_config):
         assert len(test_config.sampler_function_mock.call_args[0]) == 2
 
 
+@pytest.mark.forked
 @pytest.mark.parametrize(
     "opt,warning",
     [

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1316,3 +1316,25 @@ def test_error_sampler(_, sentry_init, capture_events, test_config):
 
         # Ensure two arguments (the event and hint) were passed to the sampler function
         assert len(test_config.sampler_function_mock.call_args[0]) == 2
+
+
+@pytest.mark.parametrize(
+    "opt,warning",
+    [
+        [{"enable-threads": True, "lazy-apps": True}, None],
+        [{"enable-threads": True, "py-call-uwsgi-fork-hooks": True}, None],
+        [{}, True],
+        [{"enable-threads": True}, True],
+        [{"py-call-uwsgi-fork-hooks": True}, True],
+        [{"lazy-apps": True}, True],
+    ],
+)
+def test_uwsgi_warnings(sentry_init, recwarn, opt, warning):
+    uwsgi = mock.MagicMock()
+    uwsgi.opt = opt
+    with mock.patch.dict("sys.modules", uwsgi=uwsgi):
+        sentry_init(profiles_sample_rate=1.0)
+        if warning:
+            assert recwarn
+        else:
+            assert not recwarn


### PR DESCRIPTION
* remove special treatment for uWSGI -- turn metrics on by default everywhere
* remove the experimental `force-enable-metrics` flag
* add a warning if uWSGI is not run with the necessary flags
* move the existing uWSGI warning check from the worker to the client

TODO (separate docs PR): Call this out in the docs for wsgi framework integrations.

See https://github.com/getsentry/sentry-python/issues/2699#issuecomment-1944336675

Closes https://github.com/getsentry/sentry-python/issues/2699

---

## General Notes

Thank you for contributing to `sentry-python`!

Please add tests to validate your changes, and lint your code using `tox -e linters`.

Running the test suite on your PR might require maintainer approval. Some tests (AWS Lambda) additionally require a maintainer to add a special label to run and will fail if the label is not present.

#### For maintainers

Sensitive test suites require maintainer review to ensure that tests do not compromise our secrets. This review must be repeated after any code revisions.

Before running sensitive test suites, please carefully check the PR. Then, apply the `Trigger: tests using secrets` label. The label will be removed after any code changes to enforce our policy requiring maintainers to review all code revisions before running sensitive tests.
