### PR TITLE
fix(scope): `set_user` should not overwrite existing user data

### DIFF
--- a/MIGRATION_GUIDE.md
+++ b/MIGRATION_GUIDE.md
@@ -8,6 +8,7 @@ Looking to upgrade from Sentry SDK 1.x to 2.x? Here's a comprehensive list of wh
 
 ## Changed
 
+- Subsequent calls to `sentry_sdk.set_user` will now update existing user data instead of overwriting it. To erase user data, call the function with an empty dictionary: `sentry_sdk.set_user({})`
 - The `BackgroundWorker` thread used to process events was renamed from `raven-sentry.BackgroundWorker` to `sentry-sdk.BackgroundWorker`.
 - The `reraise` function was moved from `sentry_sdk._compat` to `sentry_sdk.utils`.
 - Moved the contents of `tracing_utils_py3.py` to `tracing_utils.py`. The `start_child_span_decorator` is now in `sentry_sdk.tracing_utils`.

--- a/MIGRATION_GUIDE.md
+++ b/MIGRATION_GUIDE.md
@@ -8,7 +8,7 @@ Looking to upgrade from Sentry SDK 1.x to 2.x? Here's a comprehensive list of wh
 
 ## Changed
 
-- Subsequent calls to `sentry_sdk.set_user` will now update existing user data instead of overwriting it. To erase user data, call the function with an empty dictionary: `sentry_sdk.set_user({})`
+- Subsequent calls to `sentry_sdk.set_user` will now update existing user data instead of overwriting it. To reset user data, call the function with an empty dictionary: `sentry_sdk.set_user({})`
 - The `BackgroundWorker` thread used to process events was renamed from `raven-sentry.BackgroundWorker` to `sentry-sdk.BackgroundWorker`.
 - The `reraise` function was moved from `sentry_sdk._compat` to `sentry_sdk.utils`.
 - Moved the contents of `tracing_utils_py3.py` to `tracing_utils.py`. The `start_child_span_decorator` is now in `sentry_sdk.tracing_utils`.

--- a/sentry_sdk/scope.py
+++ b/sentry_sdk/scope.py
@@ -518,7 +518,12 @@ class Scope(object):
     def set_user(self, value):
         # type: (Optional[Dict[str, Any]]) -> None
         """Sets a user for the scope."""
-        self._user = value
+        if value:
+            self._user = self._user or {}
+            self._user.update(value)
+        else:
+            self._user = None
+
         if self._session is not None:
             self._session.update(user=value)
 

--- a/tests/test_scope.py
+++ b/tests/test_scope.py
@@ -191,4 +191,4 @@ def test_user_reset(sentry_init, capture_events):
     capture_exception(NameError(), scope=scope)
 
     (event,) = events
-    assert not event["user"]
+    assert "user" not in event

--- a/tests/test_scope.py
+++ b/tests/test_scope.py
@@ -182,8 +182,8 @@ def test_user_reset(sentry_init, capture_events):
     scope = Scope()
     assert scope._user is None
 
-    scope.set_user({"email": "lucy@dogs.com"})
-    assert scope._user == {"id": 23, "email": "lucy@dogs.com"}
+    scope.set_user({"id": 23, "email": "dottie@dogs.com"})
+    assert scope._user == {"id": 23, "email": "dottie@dogs.com"}
 
     scope.set_user({})
     assert scope._user is None


### PR DESCRIPTION
According to https://develop.sentry.dev/sdk/unified-api/#scope `set_user` should "shallow merge" user data. We're instead overwriting it.

Changes in this PR:
* `set_user` called with a non-empty dict will now update, rather than replace, current user data on the scope
* To reset the current user, `set_user` needs to be called with `None` or `{}` as argument. 

These are both breaking changes. Added them to the MIGRATION_GUIDE.

Session behavior is left unchanged.

Fixes https://github.com/getsentry/sentry-python/issues/933

---

## General Notes

Thank you for contributing to `sentry-python`!

Please add tests to validate your changes, and lint your code using `tox -e linters`.

Running the test suite on your PR might require maintainer approval. Some tests (AWS Lambda) additionally require a maintainer to add a special label to run and will fail if the label is not present.

#### For maintainers

Sensitive test suites require maintainer review to ensure that tests do not compromise our secrets. This review must be repeated after any code revisions.

Before running sensitive test suites, please carefully check the PR. Then, apply the `Trigger: tests using secrets` label. The label will be removed after any code changes to enforce our policy requiring maintainers to review all code revisions before running sensitive tests.
