### PR TITLE
feat(clickhouse): Support `clickhouse-driver==0.2.7`

### DIFF
--- a/sentry_sdk/integrations/clickhouse_driver.py
+++ b/sentry_sdk/integrations/clickhouse_driver.py
@@ -59,6 +59,11 @@ class ClickhouseDriverIntegration(Integration):
         clickhouse_driver.client.Client.receive_end_of_query = _wrap_end(
             clickhouse_driver.client.Client.receive_end_of_query
         )
+        if hasattr(clickhouse_driver.client.Client, "receive_end_of_insert_query"):
+            # In 0.2.7, insert queries are handled separately via `receive_end_of_insert_query`
+            clickhouse_driver.client.Client.receive_end_of_insert_query = _wrap_end(
+                clickhouse_driver.client.Client.receive_end_of_insert_query
+            )
         clickhouse_driver.client.Client.receive_result = _wrap_end(
             clickhouse_driver.client.Client.receive_result
         )


### PR DESCRIPTION
Release 0.2.7 of clickhouse-driver treats insert queries differently than before, leading to us not capturing breadcrumbs for them anymore. We need to wrap the newly introduced `receive_end_of_insert_query` just like we do `receive_end_of_query`.

---

## General Notes

Thank you for contributing to `sentry-python`!

Please add tests to validate your changes, and lint your code using `tox -e linters`.

Running the test suite on your PR might require maintainer approval. Some tests (AWS Lambda) additionally require a maintainer to add a special label to run and will fail if the label is not present.

#### For maintainers

Sensitive test suites require maintainer review to ensure that tests do not compromise our secrets. This review must be repeated after any code revisions.

Before running sensitive test suites, please carefully check the PR. Then, apply the `Trigger: tests using secrets` label. The label will be removed after any code changes to enforce our policy requiring maintainers to review all code revisions before running sensitive tests.
