### PR TITLE
refactor: Add recursive scrubbing to EventScrubber with tests

### DIFF
--- a/sentry_sdk/scrubber.py
+++ b/sentry_sdk/scrubber.py
@@ -66,7 +66,7 @@ class EventScrubber(object):
         self.recursive = recursive
 
     def scrub_list(self, lst):
-        # type: (List) -> None
+        # type: (List[Any]) -> None
         if not isinstance(lst, list):
             return
 

--- a/sentry_sdk/scrubber.py
+++ b/sentry_sdk/scrubber.py
@@ -60,7 +60,7 @@ DEFAULT_DENYLIST = [
 
 class EventScrubber(object):
     def __init__(self, denylist=None, recursive=False):
-        # type: (Optional[List[str]]) -> None
+        # type: (Optional[List[str]], bool) -> None
         self.denylist = DEFAULT_DENYLIST if denylist is None else denylist
         self.denylist = [x.lower() for x in self.denylist]
         self.recursive = recursive

--- a/tests/test_scrubber.py
+++ b/tests/test_scrubber.py
@@ -2,7 +2,7 @@ import sys
 import logging
 
 from sentry_sdk import capture_exception, capture_event, start_transaction, start_span
-from sentry_sdk.utils import event_from_exception, AnnotatedValue
+from sentry_sdk.utils import event_from_exception
 from sentry_sdk.scrubber import EventScrubber
 
 
@@ -171,10 +171,9 @@ def test_scrubbing_doesnt_affect_local_vars(sentry_init, capture_events):
     assert password == "cat123"
 
 
-def test_recursive_EventScrubber(sentry_init, capture_events):
-    sentry_init()
+def test_recursive_event_scrubber(sentry_init, capture_events):
+    sentry_init(event_scrubber=EventScrubber(recursive=True))
     events = capture_events()
-    customScrubber = EventScrubber(recursive=True)
     complex_structure = {
         "deep": {
             "deeper": [{"deepest": {"password": "my_darkest_secret"}}],
@@ -184,7 +183,4 @@ def test_recursive_EventScrubber(sentry_init, capture_events):
     capture_event({"extra": complex_structure})
 
     (event,) = events
-    customScrubber.scrub_event(event)
-    assert isinstance(
-        event["extra"]["deep"]["deeper"][0]["deepest"]["password"], AnnotatedValue
-    )
+    assert event["extra"]["deep"]["deeper"][0]["deepest"]["password"] == "'[Filtered]'"


### PR DESCRIPTION
<!-- Describe your PR here -->
Should fix #2743
I added a "recursive" flag (default: False) to the EventScrubber that will scrub sensitive PII in dicts and lists recursively if set to True. Also added a test which uses a EventScrubber with recursive=True to scrub an event and check if it finds the sensitive stuff in deeply nested dicts/lists. Hope this is how you wanted it :)
---

## General Notes

Thank you for contributing to `sentry-python`!

Please add tests to validate your changes, and lint your code using `tox -e linters`.

Running the test suite on your PR might require maintainer approval. Some tests (AWS Lambda) additionally require a maintainer to add a special label to run and will fail if the label is not present.

#### For maintainers

Sensitive test suites require maintainer review to ensure that tests do not compromise our secrets. This review must be repeated after any code revisions.

Before running sensitive test suites, please carefully check the PR. Then, apply the `Trigger: tests using secrets` label. The label will be removed after any code changes to enforce our policy requiring maintainers to review all code revisions before running sensitive tests.
