### PR TITLE
feat(integrations): add django signals_denylist to filter signals that are attached to by signals_span

### DIFF
--- a/sentry_sdk/integrations/django/__init__.py
+++ b/sentry_sdk/integrations/django/__init__.py
@@ -114,6 +114,7 @@ class DjangoIntegration(Integration):
     middleware_spans = None
     signals_spans = None
     cache_spans = None
+    signals_denylist = []  # type: list[signals.Signal]
 
     def __init__(
         self,
@@ -121,8 +122,9 @@ class DjangoIntegration(Integration):
         middleware_spans=True,
         signals_spans=True,
         cache_spans=False,
+        signals_denylist=None,
     ):
-        # type: (str, bool, bool, bool) -> None
+        # type: (str, bool, bool, bool, Optional[list[signals.Signal]]) -> None
         if transaction_style not in TRANSACTION_STYLE_VALUES:
             raise ValueError(
                 "Invalid value for transaction_style: %s (must be in %s)"
@@ -132,6 +134,7 @@ class DjangoIntegration(Integration):
         self.middleware_spans = middleware_spans
         self.signals_spans = signals_spans
         self.cache_spans = cache_spans
+        self.signals_denylist = signals_denylist or []
 
     @staticmethod
     def setup_once():

--- a/sentry_sdk/integrations/django/signals_handlers.py
+++ b/sentry_sdk/integrations/django/signals_handlers.py
@@ -78,7 +78,11 @@ def patch_signals():
             return wrapper
 
         integration = hub.get_integration(DjangoIntegration)
-        if integration and integration.signals_spans:
+        if (
+            integration
+            and integration.signals_spans
+            and self not in integration.signals_denylist
+        ):
             for idx, receiver in enumerate(sync_receivers):
                 sync_receivers[idx] = sentry_sync_receiver_wrapper(receiver)
 

--- a/tests/integrations/django/myapp/signals.py
+++ b/tests/integrations/django/myapp/signals.py
@@ -1,0 +1,15 @@
+from django.core import signals
+from django.dispatch import receiver
+
+myapp_custom_signal = signals.Signal()
+myapp_custom_signal_silenced = signals.Signal()
+
+
+@receiver(myapp_custom_signal)
+def signal_handler(sender, **kwargs):
+    assert sender == "hello"
+
+
+@receiver(myapp_custom_signal_silenced)
+def signal_handler_silenced(sender, **kwargs):
+    assert sender == "hello"

--- a/tests/integrations/django/myapp/urls.py
+++ b/tests/integrations/django/myapp/urls.py
@@ -76,6 +76,11 @@ urlpatterns = [
         name="csrf_hello_not_exempt",
     ),
     path("sync/thread_ids", views.thread_ids_sync, name="thread_ids_sync"),
+    path(
+        "send-myapp-custom-signal",
+        views.send_myapp_custom_signal,
+        name="send_myapp_custom_signal",
+    ),
 ]
 
 # async views

--- a/tests/integrations/django/myapp/views.py
+++ b/tests/integrations/django/myapp/views.py
@@ -2,6 +2,8 @@ import json
 import threading
 
 from django import VERSION
+from django.core import signals
+from django.dispatch import receiver
 from django.contrib.auth import login
 from django.contrib.auth.models import User
 from django.core.exceptions import PermissionDenied
@@ -253,3 +255,24 @@ else:
     my_async_view = None
     thread_ids_async = None
     post_echo_async = None
+
+
+myapp_custom_signal = signals.Signal()
+myapp_custom_signal_silenced = signals.Signal()
+
+
+@receiver(myapp_custom_signal)
+def signal_handler(sender, **kwargs):
+    assert sender == "hello"
+
+
+@receiver(myapp_custom_signal_silenced)
+def signal_handler_silenced(sender, **kwargs):
+    assert sender == "hello"
+
+
+@csrf_exempt
+def send_myapp_custom_signal(request):
+    myapp_custom_signal.send(sender="hello")
+    myapp_custom_signal_silenced.send(sender="hello")
+    return HttpResponse("ok")

--- a/tests/integrations/django/myapp/views.py
+++ b/tests/integrations/django/myapp/views.py
@@ -2,8 +2,6 @@ import json
 import threading
 
 from django import VERSION
-from django.core import signals
-from django.dispatch import receiver
 from django.contrib.auth import login
 from django.contrib.auth.models import User
 from django.core.exceptions import PermissionDenied
@@ -15,6 +13,11 @@ from django.utils.decorators import method_decorator
 from django.views.decorators.cache import cache_page
 from django.views.decorators.csrf import csrf_exempt
 from django.views.generic import ListView
+
+from tests.integrations.django.myapp.signals import (
+    myapp_custom_signal,
+    myapp_custom_signal_silenced,
+)
 
 try:
     from rest_framework.decorators import api_view
@@ -255,20 +258,6 @@ else:
     my_async_view = None
     thread_ids_async = None
     post_echo_async = None
-
-
-myapp_custom_signal = signals.Signal()
-myapp_custom_signal_silenced = signals.Signal()
-
-
-@receiver(myapp_custom_signal)
-def signal_handler(sender, **kwargs):
-    assert sender == "hello"
-
-
-@receiver(myapp_custom_signal_silenced)
-def signal_handler_silenced(sender, **kwargs):
-    assert sender == "hello"
 
 
 @csrf_exempt

--- a/tests/integrations/django/test_basic.py
+++ b/tests/integrations/django/test_basic.py
@@ -29,7 +29,7 @@ from sentry_sdk.integrations.executing import ExecutingIntegration
 from sentry_sdk.tracing import Span
 from tests.conftest import ApproxDict, unpack_werkzeug_response
 from tests.integrations.django.myapp.wsgi import application
-from tests.integrations.django.myapp.views import myapp_custom_signal_silenced
+from tests.integrations.django.myapp.signals import myapp_custom_signal_silenced
 from tests.integrations.django.utils import pytest_mark_django_db_decorator
 
 DJANGO_VERSION = DJANGO_VERSION[:2]
@@ -1040,7 +1040,7 @@ EXPECTED_SIGNALS_SPANS_FILTERED = """\
 - op="http.server": description=null
   - op="event.django": description="django.db.reset_queries"
   - op="event.django": description="django.db.close_old_connections"
-  - op="event.django": description="tests.integrations.django.myapp.views.signal_handler"\
+  - op="event.django": description="tests.integrations.django.myapp.signals.signal_handler"\
 """
 
 
@@ -1073,7 +1073,7 @@ def test_signals_spans_filtering(sentry_init, client, capture_events, render_spa
     assert transaction["spans"][2]["op"] == "event.django"
     assert (
         transaction["spans"][2]["description"]
-        == "tests.integrations.django.myapp.views.signal_handler"
+        == "tests.integrations.django.myapp.signals.signal_handler"
     )
 
 

--- a/tests/integrations/django/test_basic.py
+++ b/tests/integrations/django/test_basic.py
@@ -29,6 +29,7 @@ from sentry_sdk.integrations.executing import ExecutingIntegration
 from sentry_sdk.tracing import Span
 from tests.conftest import unpack_werkzeug_response
 from tests.integrations.django.myapp.wsgi import application
+from tests.integrations.django.myapp.views import myapp_custom_signal_silenced
 from tests.integrations.django.utils import pytest_mark_django_db_decorator
 
 DJANGO_VERSION = DJANGO_VERSION[:2]
@@ -1033,6 +1034,47 @@ def test_signals_spans_disabled(sentry_init, client, capture_events):
 
     assert message["message"] == "hi"
     assert not transaction["spans"]
+
+
+EXPECTED_SIGNALS_SPANS_FILTERED = """\
+- op="http.server": description=null
+  - op="event.django": description="django.db.reset_queries"
+  - op="event.django": description="django.db.close_old_connections"
+  - op="event.django": description="tests.integrations.django.myapp.views.signal_handler"\
+"""
+
+
+def test_signals_spans_filtering(sentry_init, client, capture_events, render_span_tree):
+    sentry_init(
+        integrations=[
+            DjangoIntegration(
+                middleware_spans=False,
+                signals_denylist=[
+                    myapp_custom_signal_silenced,
+                ],
+            ),
+        ],
+        traces_sample_rate=1.0,
+    )
+    events = capture_events()
+
+    client.get(reverse("send_myapp_custom_signal"))
+
+    (transaction,) = events
+
+    assert render_span_tree(transaction) == EXPECTED_SIGNALS_SPANS_FILTERED
+
+    assert transaction["spans"][0]["op"] == "event.django"
+    assert transaction["spans"][0]["description"] == "django.db.reset_queries"
+
+    assert transaction["spans"][1]["op"] == "event.django"
+    assert transaction["spans"][1]["description"] == "django.db.close_old_connections"
+
+    assert transaction["spans"][2]["op"] == "event.django"
+    assert (
+        transaction["spans"][2]["description"]
+        == "tests.integrations.django.myapp.views.signal_handler"
+    )
 
 
 def test_csrf(sentry_init, client):


### PR DESCRIPTION
This PR adds a way to exclude sentry-sdk from attaching to certain Django signals. This can be used to work around performance issues when sentry attaches to performance sensitive signals like `pre_init` and `post_init`. 

You pass a list of Django signals that you don't want Sentry to attach to:

```python
import django.db.models.signals
import sentry_sdk

sentry_sdk.init(
    ...
    integrations=[
        DjangoIntegration(
            ...
            signals_denylist=[
                django.db.models.signals.pre_init, 
                django.db.models.signals.post_init,
            ],
        ),
    ],
)
```

This potentially fixes #1826 or #1739, and https://github.com/jazzband/django-model-utils/pull/556.

---

## General Notes

Thank you for contributing to `sentry-python`!

Please add tests to validate your changes, and lint your code using `tox -e linters`.

Running the test suite on your PR might require maintainer approval. Some tests (AWS Lambda) additionally require a maintainer to add a special label to run and will fail if the label is not present.

#### For maintainers

Sensitive test suites require maintainer review to ensure that tests do not compromise our secrets. This review must be repeated after any code revisions.

Before running sensitive test suites, please carefully check the PR. Then, apply the `Trigger: tests using secrets` label. The label will be removed after any code changes to enforce our policy requiring maintainers to review all code revisions before running sensitive tests.
