### PR TITLE
Add devenv-requirements.txt and update env setup instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,6 @@ This file outlines the process to contribute to the SDK itself. For contributing
 
 Please search the [issue tracker](https://github.com/getsentry/sentry-python/issues) before creating a new issue (a problem or an improvement request). Please also ask in our [Sentry Community on Discord](https://discord.com/invite/Ww9hbqr) before submitting a new issue. There are a ton of great people in our Discord community ready to help you!
 
-
 ## Submitting Changes
 
 - Fork the `sentry-python` repo and prepare your changes.
@@ -64,7 +63,7 @@ This will make sure that your commits will have the correct coding style.
 ```bash
 cd sentry-python
 
-pip install -r linter-requirements.txt
+pip install -r devenv-requirements.txt
 
 pip install pre-commit
 
@@ -75,12 +74,8 @@ That's it. You should be ready to make changes, run tests, and make commits! If 
 
 ## Running Tests
 
-To run the tests, first setup your development environment according to the instructions above. Then, install the required packages for running tests with the following command:
-```bash
-pip install -r test-requirements.txt
-```
+You can run all tests with the following command:
 
-Once the requirements are installed, you can run all tests with the following command:
 ```bash
 pytest tests/
 ```

--- a/devenv-requirements.txt
+++ b/devenv-requirements.txt
@@ -1,0 +1,5 @@
+-r linter-requirements.txt
+-r test-requirements.txt
+mockupdb # required by `pymongo` tests that are enabled by `pymongo` from linter requirements
+pytest<7.0.0 # https://github.com/pytest-dev/pytest/issues/9621; see tox.ini
+pytest-asyncio<=0.21.1 # https://github.com/pytest-dev/pytest-asyncio/issues/706


### PR DESCRIPTION
This is a quick fix for #2760. 

Ideally we'd do away with constraints duplication/introduction in `tox.ini`, but I don't see a way to do so without much more invasive changes, and I would prefer to not make those before discussing approaches.

---

## General Notes

Thank you for contributing to `sentry-python`!

Please add tests to validate your changes, and lint your code using `tox -e linters`.

Running the test suite on your PR might require maintainer approval. Some tests (AWS Lambda) additionally require a maintainer to add a special label to run and will fail if the label is not present.

#### For maintainers

Sensitive test suites require maintainer review to ensure that tests do not compromise our secrets. This review must be repeated after any code revisions.

Before running sensitive test suites, please carefully check the PR. Then, apply the `Trigger: tests using secrets` label. The label will be removed after any code changes to enforce our policy requiring maintainers to review all code revisions before running sensitive tests.
