### PR TITLE
Fix/guard against none

### DIFF
--- a/sentry_sdk/integrations/strawberry.py
+++ b/sentry_sdk/integrations/strawberry.py
@@ -145,6 +145,9 @@ class SentryAsyncExtension(SchemaExtension):  # type: ignore
         operation_type = "query"
         op = OP.GRAPHQL_QUERY
 
+        if self.execution_context.query is None:
+            self.execution_context.query = ""
+
         if self.execution_context.query.strip().startswith("mutation"):
             operation_type = "mutation"
             op = OP.GRAPHQL_MUTATION

--- a/tests/integrations/strawberry/test_strawberry_py3.py
+++ b/tests/integrations/strawberry/test_strawberry_py3.py
@@ -591,3 +591,30 @@ def test_transaction_mutation(
         "graphql.field_path": "Mutation.change",
         "graphql.path": "change",
     }
+
+
+@parameterize_strawberry_test
+def test_handle_none_query_gracefully(
+    request,
+    sentry_init,
+    capture_events,
+    client_factory,
+    async_execution,
+    framework_integrations,
+):
+    sentry_init(
+        integrations=[
+            StrawberryIntegration(async_execution=async_execution),
+        ]
+        + framework_integrations,
+    )
+    events = capture_events()
+
+    schema = strawberry.Schema(Query)
+
+    client_factory = request.getfixturevalue(client_factory)
+    client = client_factory(schema)
+
+    client.post("/graphql", json={})
+
+    assert len(events) == 0, "expected no events to be sent to Sentry"


### PR DESCRIPTION
This fixes #2715 by setting a fallback value for `execution_context.query`.

---

## General Notes

Thank you for contributing to `sentry-python`!

Please add tests to validate your changes, and lint your code using `tox -e linters`.

Running the test suite on your PR might require maintainer approval. Some tests (AWS Lambda) additionally require a maintainer to add a special label to run and will fail if the label is not present.

#### For maintainers

Sensitive test suites require maintainer review to ensure that tests do not compromise our secrets. This review must be repeated after any code revisions.

Before running sensitive test suites, please carefully check the PR. Then, apply the `Trigger: tests using secrets` label. The label will be removed after any code changes to enforce our policy requiring maintainers to review all code revisions before running sensitive tests.
