### PR TITLE
ref: Improve scrub_dict typing

### DIFF
--- a/sentry_sdk/scrubber.py
+++ b/sentry_sdk/scrubber.py
@@ -77,11 +77,17 @@ class EventScrubber(object):
             return
 
         for v in lst:
-            self.scrub_dict(v)
-            self.scrub_list(v)
+            self.scrub_dict(v)  # no-op unless v is a dict
+            self.scrub_list(v)  # no-op unless v is a list
 
     def scrub_dict(self, d):
         # type: (object) -> None
+        """
+        If a dictionary is passed to this method, the method scrubs the dictionary of any
+        sensitive data. The method calls itself recursively on any nested dictionaries (
+        including dictionaries nested in lists) if self.recursive is True.
+        This method does nothing if the parameter passed to it is not a dictionary.
+        """
         if not isinstance(d, dict):
             return
 
@@ -91,8 +97,8 @@ class EventScrubber(object):
             if isinstance(k, string_types) and cast(str, k).lower() in self.denylist:
                 d[k] = AnnotatedValue.substituted_because_contains_sensitive_data()
             elif self.recursive:
-                self.scrub_dict(v)
-                self.scrub_list(v)
+                self.scrub_dict(v)  # no-op unless v is a dict
+                self.scrub_list(v)  # no-op unless v is a list
 
     def scrub_request(self, event):
         # type: (Event) -> None

--- a/sentry_sdk/scrubber.py
+++ b/sentry_sdk/scrubber.py
@@ -71,10 +71,8 @@ class EventScrubber(object):
             return
 
         for v in lst:
-            if isinstance(v, dict):
-                self.scrub_dict(v)
-            elif isinstance(v, list):
-                self.scrub_list(v)
+            self.scrub_dict(v)
+            self.scrub_list(v)
 
     def scrub_dict(self, d):
         # type: (object) -> None
@@ -87,10 +85,8 @@ class EventScrubber(object):
             if isinstance(k, string_types) and cast(str, k).lower() in self.denylist:
                 d[k] = AnnotatedValue.substituted_because_contains_sensitive_data()
             elif self.recursive:
-                if isinstance(v, dict):
-                    self.scrub_dict(v)
-                elif isinstance(v, list):
-                    self.scrub_list(v)
+                self.scrub_dict(v)
+                self.scrub_list(v)
 
     def scrub_request(self, event):
         # type: (Event) -> None

--- a/sentry_sdk/scrubber.py
+++ b/sentry_sdk/scrubber.py
@@ -1,4 +1,7 @@
-from typing import cast
+try:
+    from typing import cast
+except ImportError:
+    cast = lambda _, obj: obj
 
 from sentry_sdk.utils import (
     capture_internal_exceptions,

--- a/sentry_sdk/scrubber.py
+++ b/sentry_sdk/scrubber.py
@@ -1,3 +1,5 @@
+from typing import cast
+
 from sentry_sdk.utils import (
     capture_internal_exceptions,
     AnnotatedValue,
@@ -8,8 +10,6 @@ from sentry_sdk._types import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from sentry_sdk._types import Event
-    from typing import Any
-    from typing import Dict
     from typing import List
     from typing import Optional
 
@@ -65,12 +65,14 @@ class EventScrubber(object):
         self.denylist = [x.lower() for x in self.denylist]
 
     def scrub_dict(self, d):
-        # type: (Dict[str, Any]) -> None
+        # type: (object) -> None
         if not isinstance(d, dict):
             return
 
         for k in d.keys():
-            if isinstance(k, string_types) and k.lower() in self.denylist:
+            # The cast is needed because mypy is not smart enough to figure out that k must be a
+            # string after the isinstance check.
+            if isinstance(k, string_types) and cast(str, k).lower() in self.denylist:
                 d[k] = AnnotatedValue.substituted_because_contains_sensitive_data()
 
     def scrub_request(self, event):


### PR DESCRIPTION
This change improves the typing of the `scrub_dict` method.

Previously, the `scrub_dict` method's type hints indicated that only `dict[str, Any]` was accepted as the parameter. However, the method is actually implemented to accept any object, since it checks the types of the parameters at runtime. Therefore, `object` is a more appropriate type hint for the parameter.

#2753 depends on this change for mypy to pass