### PR TITLE
fix(metrics): Replace invalid tag values with an empty string instead of _

### DIFF
--- a/sentry_sdk/metrics.py
+++ b/sentry_sdk/metrics.py
@@ -55,7 +55,7 @@ if TYPE_CHECKING:
 
 _in_metrics = ContextVar("in_metrics", default=False)
 _sanitize_key = partial(re.compile(r"[^a-zA-Z0-9_/.-]+").sub, "_")
-_sanitize_value = partial(re.compile(r"[^\w\d_:/@\.{}\[\]$-]+", re.UNICODE).sub, "_")
+_sanitize_value = partial(re.compile(r"[^\w\d_:/@\.{}\[\]$-]+", re.UNICODE).sub, "")
 _set = set  # set is shadowed below
 
 GOOD_TRANSACTION_SOURCES = frozenset(

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -822,7 +822,7 @@ def test_tag_normalization(
 
     assert len(m) == 3
     assert m[0][4] == {
-        "foo-bar": "_$foo",
+        "foo-bar": "$foo",
         "release": "fun-release@1.0.0",
         "environment": "not-fun-env",
     }


### PR DESCRIPTION
[According to our spec](https://develop.sentry.dev/sdk/metrics/#normalization) invalid tag values should be replaced with no string.

> Tag Values: regex [^\w\d_:/@\.{}\[\]$-]+ with no replacement character.

I cross checked with [PHP](https://github.com/getsentry/sentry-php/blob/6f8cce5441da92829e84c3c2549625860f11787f/src/Serializer/EnvelopItems/MetricsItem.php#L59) and [JS](https://github.com/getsentry/sentry-javascript/blob/2a8ef4094ff283a207d3522db3e4c3357d73bb30/packages/core/src/metrics/utils.ts#L65): both of them also use no replacement character.
