### PR TITLE
fix(docs): allow empty character in metric tags values

### DIFF
--- a/sentry_sdk/metrics.py
+++ b/sentry_sdk/metrics.py
@@ -55,7 +55,7 @@ if TYPE_CHECKING:
 
 _in_metrics = ContextVar("in_metrics", default=False)
 _sanitize_key = partial(re.compile(r"[^a-zA-Z0-9_/.-]+").sub, "_")
-_sanitize_value = partial(re.compile(r"[^\w\d_:/@\.{}\[\]$-]+", re.UNICODE).sub, "")
+_sanitize_value = partial(re.compile(r"[^\w\d\s_:/@\.{}\[\]$-]+", re.UNICODE).sub, "")
 _set = set  # set is shadowed below
 
 GOOD_TRANSACTION_SOURCES = frozenset(

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -811,7 +811,7 @@ def test_tag_normalization(
     metrics.distribution("a", 1.0, tags={"foo-bar": "%$foo"}, timestamp=ts)
     metrics.distribution("b", 1.0, tags={"foo$$$bar": "blah{}"}, timestamp=ts)
     metrics.distribution("c", 1.0, tags={u"foö-bar": u"snöwmän"}, timestamp=ts)
-    metrics.distribution("c", 1.0, tags={u"route": u"GET /foo"}, timestamp=ts)
+    metrics.distribution("d", 1.0, tags={"route": "GET /foo"}, timestamp=ts)
     # fmt: on
     Hub.current.flush()
 

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -811,6 +811,7 @@ def test_tag_normalization(
     metrics.distribution("a", 1.0, tags={"foo-bar": "%$foo"}, timestamp=ts)
     metrics.distribution("b", 1.0, tags={"foo$$$bar": "blah{}"}, timestamp=ts)
     metrics.distribution("c", 1.0, tags={u"foö-bar": u"snöwmän"}, timestamp=ts)
+    metrics.distribution("c", 1.0, tags={u"route": u"GET /foo"}, timestamp=ts)
     # fmt: on
     Hub.current.flush()
 
@@ -820,7 +821,7 @@ def test_tag_normalization(
     assert envelope.items[0].headers["type"] == "statsd"
     m = parse_metrics(envelope.items[0].payload.get_bytes())
 
-    assert len(m) == 3
+    assert len(m) == 4
     assert m[0][4] == {
         "foo-bar": "$foo",
         "release": "fun-release@1.0.0",
@@ -838,6 +839,11 @@ def test_tag_normalization(
         "fo_-bar": u"snöwmän",
         "release": "fun-release@1.0.0",
         "environment": "not-fun-env",
+    }
+    assert m[3][4] == {
+        "release": "fun-release@1.0.0",
+        "environment": "not-fun-env",
+        "route": "GET /foo",
     }
     # fmt: on
 


### PR DESCRIPTION
see https://github.com/getsentry/develop/pull/1171
and https://github.com/getsentry/relay/pull/3174