### PR TITLE
Pin `grpcio` versions in CI

### DIFF
--- a/sentry_sdk/integrations/grpc/__init__.py
+++ b/sentry_sdk/integrations/grpc/__init__.py
@@ -128,7 +128,7 @@ def _wrap_async_server(func: Callable[P, AsyncServer]) -> Callable[P, AsyncServe
         **kwargs: P.kwargs,
     ) -> Server:
         server_interceptor = AsyncServerInterceptor()
-        interceptors = [server_interceptor, *(interceptors or [])]
+        interceptors = (server_interceptor, *(interceptors or []))
         return func(*args, interceptors=interceptors, **kwargs)  # type: ignore
 
     return patched_aio_server  # type: ignore

--- a/tests/integrations/grpc/test_grpc_aio.py
+++ b/tests/integrations/grpc/test_grpc_aio.py
@@ -221,6 +221,8 @@ async def test_stream_unary(grpc_server):
 
 class TestService(gRPCTestServiceServicer):
     class TestException(Exception):
+        __test__ = False
+
         def __init__(self):
             super().__init__("test")
 

--- a/tox.ini
+++ b/tox.ini
@@ -407,15 +407,10 @@ deps =
     grpc: types-protobuf
     grpc: pytest-asyncio<=0.21.1
     grpc-v1.29: grpcio~=1.29.0
-    grpc-v1.29: grpcio-tools~=1.29.0
     grpc-v1.39: grpcio~=1.39.0
-    grpc-v1.39: grpcio-tools~=1.39.0
     grpc-v1.49: grpcio~=1.49.1
-    grpc-v1.49: grpcio-tools~=1.49.0
     grpc-v1.59: grpcio~=1.59.0
-    grpc-v1.59: grpcio-tools~=1.59.0
     grpc-latest: grpcio
-    grpc-latest: grpcio-tools
 
     # HTTPX
     httpx-v0.16: pytest-httpx==0.10.0

--- a/tox.ini
+++ b/tox.ini
@@ -127,8 +127,9 @@ envlist =
     {py3.7,py3.11,py3.12}-graphene-latest
 
     # gRPC
-    {py3.7,py3.10}-grpc-v{1.21,1.30,1.40}
-    {py3.7,py3.11}-grpc-v{1.50}
+    {py3.7,py3.9}-grpc-v{1.29,1.39}
+    {py3.7,py3.10}-grpc-v{1.49}
+    {py3.7,py3.11}-grpc-v{1.59}
     {py3.8,py3.11,py3.12}-grpc-latest
 
     # HTTPX
@@ -405,10 +406,15 @@ deps =
     grpc: mypy-protobuf
     grpc: types-protobuf
     grpc: pytest-asyncio<=0.21.1
-    grpc-v1.21: grpcio-tools~=1.21.0
-    grpc-v1.30: grpcio-tools~=1.30.0
-    grpc-v1.40: grpcio-tools~=1.40.0
-    grpc-v1.50: grpcio-tools~=1.50.0
+    grpc-v1.29: grpcio~=1.29.0
+    grpc-v1.29: grpcio-tools~=1.29.0
+    grpc-v1.39: grpcio~=1.39.0
+    grpc-v1.39: grpcio-tools~=1.39.0
+    grpc-v1.49: grpcio~=1.49.1
+    grpc-v1.49: grpcio-tools~=1.49.0
+    grpc-v1.59: grpcio~=1.59.0
+    grpc-v1.59: grpcio-tools~=1.59.0
+    grpc-latest: grpcio
     grpc-latest: grpcio-tools
 
     # HTTPX

--- a/tox.ini
+++ b/tox.ini
@@ -127,7 +127,7 @@ envlist =
     {py3.7,py3.11,py3.12}-graphene-latest
 
     # gRPC
-    {py3.7,py3.9}-grpc-v{1.29,1.39}
+    {py3.7,py3.9}-grpc-v{1.39}
     {py3.7,py3.10}-grpc-v{1.49}
     {py3.7,py3.11}-grpc-v{1.59}
     {py3.8,py3.11,py3.12}-grpc-latest
@@ -406,7 +406,6 @@ deps =
     grpc: mypy-protobuf
     grpc: types-protobuf
     grpc: pytest-asyncio<=0.21.1
-    grpc-v1.29: grpcio~=1.29.0
     grpc-v1.39: grpcio~=1.39.0
     grpc-v1.49: grpcio~=1.49.1
     grpc-v1.59: grpcio~=1.59.0


### PR DESCRIPTION
From https://github.com/getsentry/sentry-python/issues/2721#issuecomment-1969084637

This PR pins `grpcio` versions instead of `grpcio-tools`, as well as restructures test matrix and fixes an issue in grpc integration with `grpcio < 1.40` exposed by the fixed tests.

- `grpcio` versions for each "major" (1.xx.y) were bumped to the latest in the respective "major", e.g. `~=1.30.0` => `~=1.39.0`.
    This was done to work around [various](https://github.com/grpc/grpc/pull/28398) [build](https://github.com/grpc/grpc/issues/25112) and [runtime](https://github.com/grpc/grpc/issues/27888) issues present in earlier versions.
- max python version for `grpcio` < 1.40 (< 1.42 actually) was lowered to cpy3.9 due to https://github.com/grpc/grpc/issues/27888

There is an unresolved issue with `grpcio-1.2x.y`: `grpc.aio` module only got moved out of `grpc.experimental` in 1.32.0 (see https://github.com/grpc/grpc/pull/23240). Whether it is worth supporting this case is not for me to decide :)

---

## General Notes

Thank you for contributing to `sentry-python`!

Please add tests to validate your changes, and lint your code using `tox -e linters`.

Running the test suite on your PR might require maintainer approval. Some tests (AWS Lambda) additionally require a maintainer to add a special label to run and will fail if the label is not present.

#### For maintainers

Sensitive test suites require maintainer review to ensure that tests do not compromise our secrets. This review must be repeated after any code revisions.

Before running sensitive test suites, please carefully check the PR. Then, apply the `Trigger: tests using secrets` label. The label will be removed after any code changes to enforce our policy requiring maintainers to review all code revisions before running sensitive tests.
