### PR TITLE
fix(metrics): Small typo in need_code_location

### DIFF
--- a/sentry_sdk/metrics.py
+++ b/sentry_sdk/metrics.py
@@ -591,7 +591,7 @@ class MetricsAggregator(object):
                 )
 
     @metrics_noop
-    def need_code_loation(
+    def need_code_location(
         self,
         ty,  # type: MetricType
         key,  # type: str


### PR DESCRIPTION
Rename need_code_loation to need_code_location.
