### PR TITLE
feat(transport): Expose `socket_options`

### DIFF
--- a/sentry_sdk/client.py
+++ b/sentry_sdk/client.py
@@ -148,6 +148,13 @@ def _get_options(*args, **kwargs):
     if rv["event_scrubber"] is None:
         rv["event_scrubber"] = EventScrubber()
 
+    if rv["socket_options"] and not isinstance(rv["socket_options"], list):
+        logger.warning(
+            "Ignoring socket_options because of unexpected format. See urllib3.HTTPConnection.socket_options for the expected format.",
+            type(rv["socket_options"]),
+        )
+        rv["socket_options"] = None
+
     return rv
 
 

--- a/sentry_sdk/client.py
+++ b/sentry_sdk/client.py
@@ -150,8 +150,7 @@ def _get_options(*args, **kwargs):
 
     if rv["socket_options"] and not isinstance(rv["socket_options"], list):
         logger.warning(
-            "Ignoring socket_options because of unexpected format. See urllib3.HTTPConnection.socket_options for the expected format.",
-            type(rv["socket_options"]),
+            "Ignoring socket_options because of unexpected format. See urllib3.HTTPConnection.socket_options for the expected format."
         )
         rv["socket_options"] = None
 

--- a/sentry_sdk/consts.py
+++ b/sentry_sdk/consts.py
@@ -14,6 +14,7 @@ if TYPE_CHECKING:
     from typing import Dict
     from typing import Any
     from typing import Sequence
+    from typing import Tuple
     from typing_extensions import TypedDict
 
     from sentry_sdk.integrations import Integration
@@ -260,6 +261,7 @@ class ClientConstructor(object):
         https_proxy=None,  # type: Optional[str]
         ignore_errors=[],  # type: Sequence[Union[type, str]]  # noqa: B006
         max_request_body_size="medium",  # type: str
+        socket_options=None,  # type: Optional[List[Tuple[int, int, int | bytes]]]
         before_send=None,  # type: Optional[EventProcessor]
         before_breadcrumb=None,  # type: Optional[BreadcrumbProcessor]
         debug=None,  # type: Optional[bool]

--- a/sentry_sdk/transport.py
+++ b/sentry_sdk/transport.py
@@ -1,18 +1,18 @@
 from __future__ import print_function
 
 import io
-import urllib3
-import certifi
 import gzip
 import time
-
 from datetime import timedelta
 from collections import defaultdict
+
+import urllib3
+import certifi
+from urllib3.connection import HTTPConnection
 
 from sentry_sdk.utils import Dsn, logger, capture_internal_exceptions, json_dumps
 from sentry_sdk.worker import BackgroundWorker
 from sentry_sdk.envelope import Envelope, Item, PayloadRef
-
 from sentry_sdk._compat import datetime_utcnow
 from sentry_sdk._types import TYPE_CHECKING
 
@@ -441,11 +441,18 @@ class HttpTransport(Transport):
 
     def _get_pool_options(self, ca_certs):
         # type: (Optional[Any]) -> Dict[str, Any]
-        return {
+        options = {
             "num_pools": self._num_pools,
             "cert_reqs": "CERT_REQUIRED",
             "ca_certs": ca_certs or certifi.where(),
         }
+
+        if self.options["socket_options"]:
+            options["socket_options"] = (
+                HTTPConnection.default_socket_options + self.options["socket_options"]
+            )
+
+        return options
 
     def _in_no_proxy(self, parsed_dsn):
         # type: (Dsn) -> bool

--- a/sentry_sdk/transport.py
+++ b/sentry_sdk/transport.py
@@ -8,7 +8,6 @@ from collections import defaultdict
 
 import urllib3
 import certifi
-from urllib3.connection import HTTPConnection
 
 from sentry_sdk.utils import Dsn, logger, capture_internal_exceptions, json_dumps
 from sentry_sdk.worker import BackgroundWorker
@@ -448,9 +447,7 @@ class HttpTransport(Transport):
         }
 
         if self.options["socket_options"]:
-            options["socket_options"] = (
-                HTTPConnection.default_socket_options + self.options["socket_options"]
-            )
+            options["socket_options"] = self.options["socket_options"]
 
         return options
 


### PR DESCRIPTION
The urllib3 defaults for `socket_options` work fine most of the time, but there are environments and setups where they need tweaking (e.g., enabling keep-alive). One can create a custom transport with this, but given how often users need to tweak these, it makes sense to promote this to an `init` option.

Docs: https://github.com/getsentry/sentry-docs/pull/9332

Closes https://github.com/getsentry/sentry-python/issues/2391

---

## General Notes

Thank you for contributing to `sentry-python`!

Please add tests to validate your changes, and lint your code using `tox -e linters`.

Running the test suite on your PR might require maintainer approval. Some tests (AWS Lambda) additionally require a maintainer to add a special label to run and will fail if the label is not present.

#### For maintainers

Sensitive test suites require maintainer review to ensure that tests do not compromise our secrets. This review must be repeated after any code revisions.

Before running sensitive test suites, please carefully check the PR. Then, apply the `Trigger: tests using secrets` label. The label will be removed after any code changes to enforce our policy requiring maintainers to review all code revisions before running sensitive tests.
