### PR TITLE
ref(api): Type hinting for start_transaction kwargs

### DIFF
--- a/sentry_sdk/api.py
+++ b/sentry_sdk/api.py
@@ -25,7 +25,8 @@ if TYPE_CHECKING:
         ExcInfo,
         MeasurementUnit,
     )
-    from sentry_sdk.tracing import Span, TransactionKwargs
+    from sentry_sdk.scope import StartTransactionKwargs
+    from sentry_sdk.tracing import Span
 
     T = TypeVar("T")
     F = TypeVar("F", bound=Callable[..., Any])
@@ -223,7 +224,7 @@ def start_span(
 @hubmethod
 def start_transaction(
     transaction=None,  # type: Optional[Transaction]
-    **kwargs  # type: Unpack[TransactionKwargs]
+    **kwargs  # type: Unpack[StartTransactionKwargs]
 ):
     # type: (...) -> Union[Transaction, NoOpSpan]
     return Hub.current.start_transaction(transaction, **kwargs)

--- a/sentry_sdk/api.py
+++ b/sentry_sdk/api.py
@@ -15,6 +15,8 @@ if TYPE_CHECKING:
     from typing import ContextManager
     from typing import Union
 
+    from typing_extensions import Unpack
+
     from sentry_sdk._types import (
         Event,
         Hint,
@@ -23,7 +25,7 @@ if TYPE_CHECKING:
         ExcInfo,
         MeasurementUnit,
     )
-    from sentry_sdk.tracing import Span
+    from sentry_sdk.tracing import Span, TransactionKwargs
 
     T = TypeVar("T")
     F = TypeVar("F", bound=Callable[..., Any])
@@ -221,7 +223,7 @@ def start_span(
 @hubmethod
 def start_transaction(
     transaction=None,  # type: Optional[Transaction]
-    **kwargs  # type: Any
+    **kwargs  # type: Unpack[TransactionKwargs]
 ):
     # type: (...) -> Union[Transaction, NoOpSpan]
     return Hub.current.start_transaction(transaction, **kwargs)

--- a/sentry_sdk/hub.py
+++ b/sentry_sdk/hub.py
@@ -21,7 +21,6 @@ from sentry_sdk._types import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from typing import Any
-    from typing import cast
     from typing import Callable
     from typing import ContextManager
     from typing import Dict
@@ -46,7 +45,6 @@ if TYPE_CHECKING:
     )
     from sentry_sdk.consts import ClientConstructor
     from sentry_sdk.scope import StartTransactionKwargs
-    from sentry_sdk.tracing import TransactionKwargs
 
     T = TypeVar("T")
 
@@ -462,7 +460,7 @@ class Hub(with_metaclass(HubMeta)):  # type: ignore
     def start_transaction(
         self, transaction=None, instrumenter=INSTRUMENTER.SENTRY, **kwargs
     ):
-        # type: (Optional[Transaction], str, Unpack[TransactionKwargs]) -> Union[Transaction, NoOpSpan]
+        # type: (Optional[Transaction], str, Unpack[StartTransactionKwargs]) -> Union[Transaction, NoOpSpan]
         """
         Start and return a transaction.
 
@@ -488,9 +486,6 @@ class Hub(with_metaclass(HubMeta)):  # type: ignore
         For supported `**kwargs` see :py:class:`sentry_sdk.tracing.Transaction`.
         """
         client, scope = self._stack[-1]
-
-        if TYPE_CHECKING:
-            kwargs = cast(StartTransactionKwargs, kwargs)
 
         kwargs["hub"] = self
         kwargs["client"] = client

--- a/sentry_sdk/hub.py
+++ b/sentry_sdk/hub.py
@@ -21,6 +21,7 @@ from sentry_sdk._types import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from typing import Any
+    from typing import cast
     from typing import Callable
     from typing import ContextManager
     from typing import Dict
@@ -33,6 +34,8 @@ if TYPE_CHECKING:
     from typing import TypeVar
     from typing import Union
 
+    from typing_extensions import Unpack
+
     from sentry_sdk.integrations import Integration
     from sentry_sdk._types import (
         Event,
@@ -42,6 +45,8 @@ if TYPE_CHECKING:
         ExcInfo,
     )
     from sentry_sdk.consts import ClientConstructor
+    from sentry_sdk.scope import StartTransactionKwargs
+    from sentry_sdk.tracing import TransactionKwargs
 
     T = TypeVar("T")
 
@@ -457,7 +462,7 @@ class Hub(with_metaclass(HubMeta)):  # type: ignore
     def start_transaction(
         self, transaction=None, instrumenter=INSTRUMENTER.SENTRY, **kwargs
     ):
-        # type: (Optional[Transaction], str, Any) -> Union[Transaction, NoOpSpan]
+        # type: (Optional[Transaction], str, Unpack[TransactionKwargs]) -> Union[Transaction, NoOpSpan]
         """
         Start and return a transaction.
 
@@ -483,6 +488,9 @@ class Hub(with_metaclass(HubMeta)):  # type: ignore
         For supported `**kwargs` see :py:class:`sentry_sdk.tracing.Transaction`.
         """
         client, scope = self._stack[-1]
+
+        if TYPE_CHECKING:
+            kwargs = cast(StartTransactionKwargs, kwargs)
 
         kwargs["hub"] = self
         kwargs["client"] = client

--- a/sentry_sdk/scope.py
+++ b/sentry_sdk/scope.py
@@ -45,6 +45,8 @@ if TYPE_CHECKING:
     from typing import TypeVar
     from typing import Union
 
+    from typing_extensions import Unpack
+
     from sentry_sdk._types import (
         Breadcrumb,
         BreadcrumbHint,
@@ -53,10 +55,17 @@ if TYPE_CHECKING:
         EventProcessor,
         ExcInfo,
         Hint,
+        SamplingContext,
         Type,
     )
 
+    from sentry_sdk.tracing import TransactionKwargs
+
     import sentry_sdk
+
+    class StartTransactionKwargs(TransactionKwargs, total=False):
+        client: Optional[sentry_sdk.Client]
+        custom_sampling_context: SamplingContext
 
     F = TypeVar("F", bound=Callable[..., Any])
     T = TypeVar("T")
@@ -670,7 +679,7 @@ class Scope(object):
     def start_transaction(
         self, transaction=None, instrumenter=INSTRUMENTER.SENTRY, **kwargs
     ):
-        # type: (Optional[Transaction], str, Any) -> Union[Transaction, NoOpSpan]
+        # type: (Optional[Transaction], str, Unpack[StartTransactionKwargs]) -> Union[Transaction, NoOpSpan]
         """
         Start and return a transaction.
 
@@ -705,10 +714,14 @@ class Scope(object):
 
         custom_sampling_context = kwargs.pop("custom_sampling_context", {})
 
+        # kwargs at this point has type TransactionKwargs, since we have removed
+        # the client and custom_sampling_context from it.
+        transaction_kwargs = kwargs  # type: TransactionKwargs
+
         # if we haven't been given a transaction, make one
         if transaction is None:
-            kwargs.setdefault("hub", hub)
-            transaction = Transaction(**kwargs)
+            transaction_kwargs.setdefault("hub", hub)
+            transaction = Transaction(**transaction_kwargs)
 
         # use traces_sample_rate, traces_sampler, and/or inheritance to make a
         # sampling decision

--- a/sentry_sdk/tracing.py
+++ b/sentry_sdk/tracing.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import uuid
 import random
 
@@ -26,11 +28,33 @@ if TYPE_CHECKING:
     from typing import Union
     from typing import TypeVar
 
+    from typing_extensions import TypedDict, Unpack
+
     P = ParamSpec("P")
     R = TypeVar("R")
 
     import sentry_sdk.profiler
     from sentry_sdk._types import Event, MeasurementUnit, SamplingContext
+
+    class SpanKwargs(TypedDict, total=False):
+        trace_id: str
+        span_id: str
+        parent_span_id: str
+        same_process_as_parent: bool
+        sampled: bool
+        op: str
+        description: str
+        hub: Optional[sentry_sdk.Hub]
+        status: str
+        # transaction: str is deprecated, and therefore omitted here!
+        containing_transaction: Optional[Transaction]
+        start_timestamp: Optional[Union[datetime, float]]
+
+    class TransactionKwargs(SpanKwargs, total=False):
+        name: str
+        source: str
+        parent_sampled: bool
+        baggage: Baggage
 
 
 BAGGAGE_HEADER_NAME = "baggage"
@@ -256,7 +280,7 @@ class Span(object):
             trace_id=self.trace_id,
             parent_span_id=self.span_id,
             containing_transaction=self.containing_transaction,
-            **kwargs
+            **kwargs,
         )
 
         span_recorder = (
@@ -279,7 +303,7 @@ class Span(object):
     def continue_from_environ(
         cls,
         environ,  # type: typing.Mapping[str, str]
-        **kwargs  # type: Any
+        **kwargs,  # type: Any
     ):
         # type: (...) -> Transaction
         """
@@ -305,7 +329,7 @@ class Span(object):
     def continue_from_headers(
         cls,
         headers,  # type: typing.Mapping[str, str]
-        **kwargs  # type: Any
+        **kwargs,  # type: Any
     ):
         # type: (...) -> Transaction
         """
@@ -361,7 +385,7 @@ class Span(object):
     def from_traceparent(
         cls,
         traceparent,  # type: Optional[str]
-        **kwargs  # type: Any
+        **kwargs,  # type: Any
     ):
         # type: (...) -> Optional[Transaction]
         """
@@ -573,7 +597,7 @@ class Transaction(Span):
         parent_sampled=None,  # type: Optional[bool]
         baggage=None,  # type: Optional[Baggage]
         source=TRANSACTION_SOURCE_CUSTOM,  # type: str
-        **kwargs  # type: Any
+        **kwargs,  # type: Unpack[SpanKwargs]
     ):
         # type: (...) -> None
         """Constructs a new Transaction.
@@ -597,7 +621,7 @@ class Transaction(Span):
                 "Deprecated: use Transaction(name=...) to create transactions "
                 "instead of Span(transaction=...)."
             )
-            name = kwargs.pop("transaction")
+            name = kwargs.pop("transaction")  # type: ignore
 
         super(Transaction, self).__init__(**kwargs)
 

--- a/sentry_sdk/tracing.py
+++ b/sentry_sdk/tracing.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import uuid
 import random
 
@@ -47,14 +45,14 @@ if TYPE_CHECKING:
         hub: Optional[sentry_sdk.Hub]
         status: str
         # transaction: str is deprecated, and therefore omitted here!
-        containing_transaction: Optional[Transaction]
+        containing_transaction: Optional["Transaction"]
         start_timestamp: Optional[Union[datetime, float]]
 
     class TransactionKwargs(SpanKwargs, total=False):
         name: str
         source: str
         parent_sampled: bool
-        baggage: Baggage
+        baggage: "Baggage"
 
 
 BAGGAGE_HEADER_NAME = "baggage"


### PR DESCRIPTION
This PR adds be type hints for the `**kwargs` that can be passed to `sentry_sdk.start_transaction`, thereby clearly documenting the parameters that can be passed directly in the code.

Ref https://github.com/getsentry/sentry-docs/issues/5082
  - We intend to add to the docs page at least the most useful arguments defined in the `TransactionKwargs` type that this PR introduces. 