### PR TITLE
Removed print statements because it messes with the tests

### DIFF
--- a/tests/integrations/aws_lambda/client.py
+++ b/tests/integrations/aws_lambda/client.py
@@ -240,7 +240,7 @@ def run_lambda_function(
             FunctionName=full_fn_name,
         )
         print(
-            f"Lambda function {full_fn_name} in AWS already existing, taking it (and do not create a local one)"
+            "Lambda function in AWS already existing, taking it (and do not create a local one)"
         )
     except client.exceptions.ResourceNotFoundException:
         function_exists_in_aws = False
@@ -251,14 +251,9 @@ def run_lambda_function(
         dir_already_existing = os.path.isdir(base_dir)
 
         if dir_already_existing:
-            print(
-                f"Local Lambda function directory ({base_dir}) already exists, skipping creation"
-            )
+            print("Local Lambda function directory already exists, skipping creation")
 
         if not dir_already_existing:
-            print(
-                f"Creating Lambda function package ({full_fn_name}) locally in directory {base_dir}"
-            )
             os.mkdir(base_dir)
             _create_lambda_package(
                 base_dir, code, initial_handler, layer, syntax_check, subprocess_kwargs
@@ -321,10 +316,9 @@ def run_lambda_function(
 
                 waiter = client.get_waiter("function_active_v2")
                 waiter.wait(FunctionName=full_fn_name)
-                print(f"Created Lambda function in AWS: {full_fn_name}")
         except client.exceptions.ResourceConflictException:
             print(
-                f"Lambda function ({full_fn_name}) already existing in AWS, this is fine, we will just invoke it."
+                "Lambda function already exists, this is fine, we will just invoke it."
             )
 
     response = client.invoke(


### PR DESCRIPTION
Our Lambda tests rely on parsing the stdout output of Lambda functions and only the last X bytes we can parse. So I removed those print statements because it can be that they are to long and then we can not parse the important parts of the stdout output.