### PR TITLE
docs(scope): Correct `use_scope` comment

### DIFF
--- a/sentry_sdk/scope.py
+++ b/sentry_sdk/scope.py
@@ -1514,12 +1514,14 @@ def use_scope(scope):
     After the wrapped code is executed, the original scope is restored.
 
     Example Usage:
+    Suppose the variable `scope` contains a `Scope` object, which is not currently
+    the active scope.
 
     .. code-block:: python
 
         import sentry_sdk
 
-        with sentry_sdk.new_scope() as scope:
+        with sentry_sdk.use_scope(scope):
             scope.set_tag("color", "green")
             sentry_sdk.capture_message("hello") # will include `color` tag.
 


### PR DESCRIPTION
The example in the `use_scope` comment appears to have been copied directly from the `new_scope` example verbatim.

This change fixes the example, so the example demonstrates how to call `use_scope` rather than how to call `new_scope`.

@antonpirker, please make sure that I got the usage in the example correct; I think this is how `use_scope` is used but I'm less than 100% sure.