### PR TITLE
ref(awslambda): xfail broken tests for now

### DIFF
--- a/tests/integrations/aws_lambda/test_aws.py
+++ b/tests/integrations/aws_lambda/test_aws.py
@@ -661,6 +661,9 @@ def test_traces_sampler_gets_correct_values_in_sampling_context(
     assert response["Payload"]["AssertionError raised"] is False
 
 
+@pytest.mark.xfail(
+    "The limited log output we depend on is being clogged by a new warning"
+)
 def test_serverless_no_code_instrumentation(run_lambda_function):
     """
     Test that ensures that just by adding a lambda layer containing the
@@ -705,6 +708,9 @@ def test_serverless_no_code_instrumentation(run_lambda_function):
         assert "sentry_handler" in response["LogResult"][3].decode("utf-8")
 
 
+@pytest.mark.xfail(
+    "The limited log output we depend on is being clogged by a new warning"
+)
 def test_error_has_new_trace_context_performance_enabled(run_lambda_function):
     envelopes, _, _ = run_lambda_function(
         LAMBDA_PRELUDE
@@ -767,6 +773,9 @@ def test_error_has_new_trace_context_performance_disabled(run_lambda_function):
     )
 
 
+@pytest.mark.xfail(
+    "The limited log output we depend on is being clogged by a new warning"
+)
 def test_error_has_existing_trace_context_performance_enabled(run_lambda_function):
     trace_id = "471a43a4192642f0b136d5159a501701"
     parent_span_id = "6e8f22c393e68f19"

--- a/tests/integrations/aws_lambda/test_aws.py
+++ b/tests/integrations/aws_lambda/test_aws.py
@@ -662,7 +662,7 @@ def test_traces_sampler_gets_correct_values_in_sampling_context(
 
 
 @pytest.mark.xfail(
-    "The limited log output we depend on is being clogged by a new warning"
+    reason="The limited log output we depend on is being clogged by a new warning"
 )
 def test_serverless_no_code_instrumentation(run_lambda_function):
     """
@@ -709,7 +709,7 @@ def test_serverless_no_code_instrumentation(run_lambda_function):
 
 
 @pytest.mark.xfail(
-    "The limited log output we depend on is being clogged by a new warning"
+    reason="The limited log output we depend on is being clogged by a new warning"
 )
 def test_error_has_new_trace_context_performance_enabled(run_lambda_function):
     envelopes, _, _ = run_lambda_function(
@@ -774,7 +774,7 @@ def test_error_has_new_trace_context_performance_disabled(run_lambda_function):
 
 
 @pytest.mark.xfail(
-    "The limited log output we depend on is being clogged by a new warning"
+    reason="The limited log output we depend on is being clogged by a new warning"
 )
 def test_error_has_existing_trace_context_performance_enabled(run_lambda_function):
     trace_id = "471a43a4192642f0b136d5159a501701"


### PR DESCRIPTION
We rely on the log output of our AWS Lambda tests to determine whether the tests have been successful: we log envelope and event contents and then check whether the log output looks as expected.

AWS Lambda has recently started logging a new warning when a function throws an unhandled exception. This is a scenario we're testing in some of our test cases.

The problem is that the log output is limited to the last 4kB and the new warning takes up a lot of space, so some of our events/envelopes will not fit anymore.

xfailing the tests here so that our release is not blocked now, but we'll need a proper solution, see https://github.com/getsentry/sentry-python/issues/2795

---

## General Notes

Thank you for contributing to `sentry-python`!

Please add tests to validate your changes, and lint your code using `tox -e linters`.

Running the test suite on your PR might require maintainer approval. Some tests (AWS Lambda) additionally require a maintainer to add a special label to run and will fail if the label is not present.

#### For maintainers

Sensitive test suites require maintainer review to ensure that tests do not compromise our secrets. This review must be repeated after any code revisions.

Before running sensitive test suites, please carefully check the PR. Then, apply the `Trigger: tests using secrets` label. The label will be removed after any code changes to enforce our policy requiring maintainers to review all code revisions before running sensitive tests.
