### PR TITLE
ref(api): Type hinting for start_transaction kwargs

### DIFF
--- a/sentry_sdk/api.py
+++ b/sentry_sdk/api.py
@@ -17,6 +17,8 @@ if TYPE_CHECKING:
     from typing import ContextManager
     from typing import Union
 
+    from typing_extensions import Unpack
+
     from sentry_sdk.client import BaseClient
     from sentry_sdk._types import (
         Event,
@@ -26,7 +28,7 @@ if TYPE_CHECKING:
         ExcInfo,
         MeasurementUnit,
     )
-    from sentry_sdk.tracing import Span
+    from sentry_sdk.tracing import Span, TransactionKwargs
 
     T = TypeVar("T")
     F = TypeVar("F", bound=Callable[..., Any])
@@ -278,7 +280,7 @@ def start_span(
 @scopemethod
 def start_transaction(
     transaction=None,  # type: Optional[Transaction]
-    **kwargs,  # type: Any
+    **kwargs,  # type: Unpack[TransactionKwargs]
 ):
     # type: (...) -> Union[Transaction, NoOpSpan]
     return Scope.get_current_scope().start_transaction(transaction, **kwargs)

--- a/sentry_sdk/api.py
+++ b/sentry_sdk/api.py
@@ -28,7 +28,8 @@ if TYPE_CHECKING:
         ExcInfo,
         MeasurementUnit,
     )
-    from sentry_sdk.tracing import Span, TransactionKwargs
+    from sentry_sdk.scope import StartTransactionKwargs
+    from sentry_sdk.tracing import Span
 
     T = TypeVar("T")
     F = TypeVar("F", bound=Callable[..., Any])
@@ -280,7 +281,7 @@ def start_span(
 @scopemethod
 def start_transaction(
     transaction=None,  # type: Optional[Transaction]
-    **kwargs,  # type: Unpack[TransactionKwargs]
+    **kwargs,  # type: Unpack[StartTransactionKwargs]
 ):
     # type: (...) -> Union[Transaction, NoOpSpan]
     return Scope.get_current_scope().start_transaction(transaction, **kwargs)

--- a/sentry_sdk/hub.py
+++ b/sentry_sdk/hub.py
@@ -19,6 +19,7 @@ from sentry_sdk._types import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from typing import Any
+    from typing import cast
     from typing import Callable
     from typing import ContextManager
     from typing import Dict
@@ -31,6 +32,8 @@ if TYPE_CHECKING:
     from typing import TypeVar
     from typing import Union
 
+    from typing_extensions import Unpack
+
     from sentry_sdk.client import BaseClient
     from sentry_sdk.integrations import Integration
     from sentry_sdk._types import (
@@ -41,6 +44,8 @@ if TYPE_CHECKING:
         ExcInfo,
     )
     from sentry_sdk.consts import ClientConstructor
+    from sentry_sdk.scope import StartTransactionKwargs
+    from sentry_sdk.tracing import TransactionKwargs
 
     T = TypeVar("T")
 
@@ -468,7 +473,7 @@ class Hub(with_metaclass(HubMeta)):  # type: ignore
     def start_transaction(
         self, transaction=None, instrumenter=INSTRUMENTER.SENTRY, **kwargs
     ):
-        # type: (Optional[Transaction], str, Any) -> Union[Transaction, NoOpSpan]
+        # type: (Optional[Transaction], str, Unpack[TransactionKwargs]) -> Union[Transaction, NoOpSpan]
         """
         .. deprecated:: 2.0.0
             This function is deprecated and will be removed in a future release.
@@ -498,6 +503,9 @@ class Hub(with_metaclass(HubMeta)):  # type: ignore
         For supported `**kwargs` see :py:class:`sentry_sdk.tracing.Transaction`.
         """
         scope = Scope.get_current_scope()
+
+        if TYPE_CHECKING:
+            kwargs = cast(StartTransactionKwargs, kwargs)
 
         # For backwards compatibility, we allow passing the scope as the hub.
         # We need a major release to make this nice. (if someone searches the code: deprecated)

--- a/sentry_sdk/hub.py
+++ b/sentry_sdk/hub.py
@@ -504,7 +504,8 @@ class Hub(with_metaclass(HubMeta)):  # type: ignore
 
         # For backwards compatibility, we allow passing the scope as the hub.
         # We need a major release to make this nice. (if someone searches the code: deprecated)
-        kwargs["hub"] = scope
+        # Type checking disabled for this line because deprecated keys are not allowed in the type signature.
+        kwargs["hub"] = scope  # type: ignore
 
         return scope.start_transaction(
             transaction=transaction, instrumenter=instrumenter, **kwargs

--- a/sentry_sdk/hub.py
+++ b/sentry_sdk/hub.py
@@ -19,7 +19,6 @@ from sentry_sdk._types import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from typing import Any
-    from typing import cast
     from typing import Callable
     from typing import ContextManager
     from typing import Dict
@@ -45,7 +44,6 @@ if TYPE_CHECKING:
     )
     from sentry_sdk.consts import ClientConstructor
     from sentry_sdk.scope import StartTransactionKwargs
-    from sentry_sdk.tracing import TransactionKwargs
 
     T = TypeVar("T")
 
@@ -473,7 +471,7 @@ class Hub(with_metaclass(HubMeta)):  # type: ignore
     def start_transaction(
         self, transaction=None, instrumenter=INSTRUMENTER.SENTRY, **kwargs
     ):
-        # type: (Optional[Transaction], str, Unpack[TransactionKwargs]) -> Union[Transaction, NoOpSpan]
+        # type: (Optional[Transaction], str, Unpack[StartTransactionKwargs]) -> Union[Transaction, NoOpSpan]
         """
         .. deprecated:: 2.0.0
             This function is deprecated and will be removed in a future release.
@@ -503,9 +501,6 @@ class Hub(with_metaclass(HubMeta)):  # type: ignore
         For supported `**kwargs` see :py:class:`sentry_sdk.tracing.Transaction`.
         """
         scope = Scope.get_current_scope()
-
-        if TYPE_CHECKING:
-            kwargs = cast(StartTransactionKwargs, kwargs)
 
         # For backwards compatibility, we allow passing the scope as the hub.
         # We need a major release to make this nice. (if someone searches the code: deprecated)

--- a/sentry_sdk/scope.py
+++ b/sentry_sdk/scope.py
@@ -68,7 +68,7 @@ if TYPE_CHECKING:
     import sentry_sdk
 
     class StartTransactionKwargs(TransactionKwargs, total=False):
-        client: Optional[sentry_sdk.Client]
+        client: Optional["sentry_sdk.Client"]
         custom_sampling_context: SamplingContext
 
     P = ParamSpec("P")

--- a/sentry_sdk/scope.py
+++ b/sentry_sdk/scope.py
@@ -49,6 +49,8 @@ if TYPE_CHECKING:
     from typing import TypeVar
     from typing import Union
 
+    from typing_extensions import Unpack
+
     from sentry_sdk._types import (
         Breadcrumb,
         BreadcrumbHint,
@@ -57,10 +59,17 @@ if TYPE_CHECKING:
         EventProcessor,
         ExcInfo,
         Hint,
+        SamplingContext,
         Type,
     )
 
+    from sentry_sdk.tracing import TransactionKwargs
+
     import sentry_sdk
+
+    class StartTransactionKwargs(TransactionKwargs, total=False):
+        client: Optional[sentry_sdk.Client]
+        custom_sampling_context: SamplingContext
 
     P = ParamSpec("P")
     R = TypeVar("R")
@@ -935,7 +944,7 @@ class Scope(object):
     def start_transaction(
         self, transaction=None, instrumenter=INSTRUMENTER.SENTRY, **kwargs
     ):
-        # type: (Optional[Transaction], str, Any) -> Union[Transaction, NoOpSpan]
+        # type: (Optional[Transaction], str, Unpack[StartTransactionKwargs]) -> Union[Transaction, NoOpSpan]
         """
         Start and return a transaction.
 
@@ -971,9 +980,13 @@ class Scope(object):
 
         custom_sampling_context = kwargs.pop("custom_sampling_context", {})
 
+        # kwargs at this point has type TransactionKwargs, since we have removed
+        # the client and custom_sampling_context from it.
+        transaction_kwargs = kwargs  # type: TransactionKwargs
+
         # if we haven't been given a transaction, make one
         if transaction is None:
-            transaction = Transaction(**kwargs)
+            transaction = Transaction(**transaction_kwargs)
 
         # use traces_sample_rate, traces_sampler, and/or inheritance to make a
         # sampling decision

--- a/sentry_sdk/tracing.py
+++ b/sentry_sdk/tracing.py
@@ -38,11 +38,12 @@ if TYPE_CHECKING:
         sampled: bool
         op: str
         description: str
-        hub: Optional[sentry_sdk.Hub]
+        # hub: Optional[sentry_sdk.Hub] is deprecated, and therefore omitted here!
         status: str
         # transaction: str is deprecated, and therefore omitted here!
         containing_transaction: Optional["Transaction"]
         start_timestamp: Optional[Union[datetime, float]]
+        scope: sentry_sdk.Scope
 
     class TransactionKwargs(SpanKwargs, total=False):
         name: str

--- a/sentry_sdk/tracing.py
+++ b/sentry_sdk/tracing.py
@@ -43,7 +43,7 @@ if TYPE_CHECKING:
         # transaction: str is deprecated, and therefore omitted here!
         containing_transaction: Optional["Transaction"]
         start_timestamp: Optional[Union[datetime, float]]
-        scope: sentry_sdk.Scope
+        scope: "sentry_sdk.Scope"
 
     class TransactionKwargs(SpanKwargs, total=False):
         name: str

--- a/sentry_sdk/tracing.py
+++ b/sentry_sdk/tracing.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import uuid
 import random
 from datetime import datetime, timedelta, timezone
@@ -43,14 +41,14 @@ if TYPE_CHECKING:
         hub: Optional[sentry_sdk.Hub]
         status: str
         # transaction: str is deprecated, and therefore omitted here!
-        containing_transaction: Optional[Transaction]
+        containing_transaction: Optional["Transaction"]
         start_timestamp: Optional[Union[datetime, float]]
 
     class TransactionKwargs(SpanKwargs, total=False):
         name: str
         source: str
         parent_sampled: bool
-        baggage: Baggage
+        baggage: "Baggage"
 
 
 BAGGAGE_HEADER_NAME = "baggage"


### PR DESCRIPTION
This PR adds be type hints for the **kwargs that can be passed to sentry_sdk.start_transaction, thereby clearly documenting the parameters that can be passed directly in the code.

Ref https://github.com/getsentry/sentry-docs/issues/5082

  - We intend to add to the docs page at least the most useful arguments defined in the TransactionKwargs type that this PR introduces.

This PR replaces #2787