### PR TITLE
Update sanic integration

### DIFF
--- a/sentry_sdk/integrations/sanic.py
+++ b/sentry_sdk/integrations/sanic.py
@@ -342,6 +342,8 @@ def _capture_exception(exception):
             client_options=client.options,
             mechanism={"type": "sanic", "handled": False},
         )
+        if hint and hasattr(hint["exc_info"][0], 'quiet') and hint["exc_info"][0].quiet:
+            return
         hub.capture_event(event, hint=hint)
 
 

--- a/sentry_sdk/integrations/sanic.py
+++ b/sentry_sdk/integrations/sanic.py
@@ -342,7 +342,7 @@ def _capture_exception(exception):
             client_options=client.options,
             mechanism={"type": "sanic", "handled": False},
         )
-        if hint and hasattr(hint["exc_info"][0], 'quiet') and hint["exc_info"][0].quiet:
+        if hint and hasattr(hint["exc_info"][0], "quiet") and hint["exc_info"][0].quiet:
             return
         hub.capture_event(event, hint=hint)
 


### PR DESCRIPTION
in Sanic, for some exceptions, quiet variables are set to True (https://github.com/hamedsh/sanic/blob/b8ec9ed3e6f63f4c61fd45d3e09cfc9457a53b82/sanic/exceptions.py#L9) these kinds of exceptions, do not exist in the stderr, but exist in the sentry panel. 

by this modification, these kinds of exceptions will not sent to the sentry hub.

