### PR TITLE
Re-export `Event` in `types.py`

### DIFF
--- a/sentry_sdk/types.py
+++ b/sentry_sdk/types.py
@@ -1,0 +1,14 @@
+"""
+This module contains type definitions for the Sentry SDK's public API.
+The types are re-exported from the internal module `sentry_sdk._types`.
+
+Disclaimer: Since types are a form of documentation, type definitions
+may change in minor releases. Removing a type would be considered a
+breaking change, and so we will only remove type definitions in major
+releases.
+"""
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from sentry_sdk._types import Event  # noqa: F401

--- a/sentry_sdk/types.py
+++ b/sentry_sdk/types.py
@@ -11,4 +11,4 @@ releases.
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from sentry_sdk._types import Event  # noqa: F401
+    from sentry_sdk._types import Event, Hint  # noqa: F401


### PR DESCRIPTION
End-users may need to use the `Event` type for their type hinting to work following the `Event` type changes. However, we define `Event` in a private module `sentry_sdk._types`, which provides no stability guarantees.

Therefore, this PR creates a new public module `sentry_sdk.types`, where we re-export the `Event` type, and explicitly make it available as public API via `sentry_sdk.types.Event`. The new `sentry_sdk.types` module includes a docstring to inform users that we reserve the right to modify types in minor releases, since we consider types to be a form of documentation (they are not enforced by the Python language), but that we guarantee that we will only remove type definitions in a major release.