### PR TITLE
test: Fork `test_cloud_resource_context` test

### DIFF
--- a/tests/integrations/cloud_resource_context/test_cloud_resource_context.py
+++ b/tests/integrations/cloud_resource_context/test_cloud_resource_context.py
@@ -352,7 +352,6 @@ def test_get_cloud_resource_context_supported_providers(cloud_provider):
     assert CloudResourceContextIntegration._get_cloud_resource_context() != {}
 
 
-@pytest.mark.forked
 @pytest.mark.parametrize(
     "cloud_provider, cloud_resource_context, warning_called, set_context_called",
     [
@@ -368,6 +367,7 @@ def test_get_cloud_resource_context_supported_providers(cloud_provider):
         [CLOUD_PROVIDER.GCP, {"some": "context"}, False, True],
     ],
 )
+@pytest.mark.forked
 def test_setup_once(
     cloud_provider, cloud_resource_context, warning_called, set_context_called
 ):

--- a/tests/integrations/cloud_resource_context/test_cloud_resource_context.py
+++ b/tests/integrations/cloud_resource_context/test_cloud_resource_context.py
@@ -352,6 +352,7 @@ def test_get_cloud_resource_context_supported_providers(cloud_provider):
     assert CloudResourceContextIntegration._get_cloud_resource_context() != {}
 
 
+@pytest.mark.forked
 @pytest.mark.parametrize(
     "cloud_provider, cloud_resource_context, warning_called, set_context_called",
     [


### PR DESCRIPTION
This test is flaky. Seems to be because of a concurrency issue because it fails nondeterministically with different call counts on reruns against the same code (e.g. [here](https://github.com/getsentry/sentry-python/actions/runs/8327184318/job/22784714862?pr=2454)). 

Let's add `pytest.mark.forked` to see if it fixes the flakiness!