### PR TITLE
Moved should_send_default_pii into client

### DIFF
--- a/sentry_sdk/client.py
+++ b/sentry_sdk/client.py
@@ -403,6 +403,15 @@ class _Client(BaseClient):
         """
         return True
 
+    def should_send_default_pii(self):
+        # type: () -> bool
+        """
+        .. versionadded:: 2.0.0
+
+        Returns whether the client should send default PII (Personally Identifiable Information) data to Sentry.
+        """
+        return self.options.get("send_default_pii", False)
+
     @property
     def dsn(self):
         # type: () -> Optional[str]

--- a/sentry_sdk/hub.py
+++ b/sentry_sdk/hub.py
@@ -63,7 +63,7 @@ def _should_send_default_pii():
     client = Hub.current.client
     if not client:
         return False
-    return client.options["send_default_pii"]
+    return client.should_send_default_pii()
 
 
 class _InitGuard:

--- a/sentry_sdk/hub.py
+++ b/sentry_sdk/hub.py
@@ -60,6 +60,8 @@ _local = ContextVar("sentry_current_hub")
 
 def _should_send_default_pii():
     # type: () -> bool
+    # TODO: Migrate existing code to client.should_send_default_pii() and remove this function.
+    # New code should not use this function!
     client = Hub.current.client
     if not client:
         return False


### PR DESCRIPTION
Moved functionality from `_should_send_default_pii()` in Hub into `should_send_default_pii` on the Client.

Fixes #2819 