### PR TITLE
feat: Add optional `keep_alive`

### DIFF
--- a/sentry_sdk/consts.py
+++ b/sentry_sdk/consts.py
@@ -264,6 +264,7 @@ class ClientConstructor(object):
         ignore_errors=[],  # type: Sequence[Union[type, str]]  # noqa: B006
         max_request_body_size="medium",  # type: str
         socket_options=None,  # type: Optional[List[Tuple[int, int, int | bytes]]]
+        keep_alive=False,  # type: bool
         before_send=None,  # type: Optional[EventProcessor]
         before_breadcrumb=None,  # type: Optional[BreadcrumbProcessor]
         debug=None,  # type: Optional[bool]

--- a/sentry_sdk/transport.py
+++ b/sentry_sdk/transport.py
@@ -43,10 +43,10 @@ except ImportError:
 
 KEEP_ALIVE_SOCKET_OPTIONS = []
 for option in [
-    (socket.SOL_SOCKET, lambda: getattr(socket, "SO_KEEPALIVE"), 1),
-    (socket.SOL_TCP, lambda: getattr(socket, "TCP_KEEPIDLE"), 45),
-    (socket.SOL_TCP, lambda: getattr(socket, "TCP_KEEPINTVL"), 10),
-    (socket.SOL_TCP, lambda: getattr(socket, "TCP_KEEPCNT"), 6),
+    (socket.SOL_SOCKET, lambda: getattr(socket, "SO_KEEPALIVE"), 1),  # noqa: B009
+    (socket.SOL_TCP, lambda: getattr(socket, "TCP_KEEPIDLE"), 45),  # noqa: B009
+    (socket.SOL_TCP, lambda: getattr(socket, "TCP_KEEPINTVL"), 10),  # noqa: B009
+    (socket.SOL_TCP, lambda: getattr(socket, "TCP_KEEPCNT"), 6),  # noqa: B009
 ]:
     try:
         KEEP_ALIVE_SOCKET_OPTIONS.append((option[0], option[1](), option[2]))

--- a/sentry_sdk/transport.py
+++ b/sentry_sdk/transport.py
@@ -462,11 +462,13 @@ class HttpTransport(Transport):
             "ca_certs": ca_certs or certifi.where(),
         }
 
-        if self.options["socket_options"]:
-            socket_options = self.options["socket_options"]
-            options["socket_options"] = socket_options
+        if self.options["socket_options"] is not None:
+            options["socket_options"] = self.options["socket_options"]
 
         if self.options["keep_alive"]:
+            if not options.get("socket_options"):
+                options["socket_options"] = []
+
             used_options = {(o[0], o[1]) for o in options.get("socket_options") or []}
             for default_option in KEEP_ALIVE_SOCKET_OPTIONS:
                 if (default_option[0], default_option[1]) not in used_options:

--- a/sentry_sdk/transport.py
+++ b/sentry_sdk/transport.py
@@ -41,16 +41,19 @@ except ImportError:
     from urllib import getproxies  # type: ignore
 
 
-KEEP_ALIVE_SOCKET_OPTIONS = [
+KEEP_ALIVE_SOCKET_OPTIONS = []
+for option in [
     (socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1),
+    (socket.SOL_TCP, socket.TCP_KEEPIDLE, 45),
     (socket.SOL_TCP, socket.TCP_KEEPINTVL, 10),
     (socket.SOL_TCP, socket.TCP_KEEPCNT, 6),
-]
-try:
-    KEEP_ALIVE_SOCKET_OPTIONS.append((socket.SOL_TCP, socket.TCP_KEEPIDLE, 45))
-except AttributeError:
-    # socket.TCP_KEEPIDLE doesn't exist on all systems (e.g. MacOS)
-    pass
+]:
+    try:
+        KEEP_ALIVE_SOCKET_OPTIONS.append(option)
+    except AttributeError:
+        # a specific option might not be available on specific systems,
+        # e.g. TCP_KEEPIDLE doesn't exist on macOS
+        pass
 
 
 class Transport(object):

--- a/sentry_sdk/transport.py
+++ b/sentry_sdk/transport.py
@@ -467,7 +467,7 @@ class HttpTransport(Transport):
             options["socket_options"] = socket_options
 
         if self.options["keep_alive"]:
-            used_options = {(o[0], o[1]) for o in options["socket_options"] or []}
+            used_options = {(o[0], o[1]) for o in options.get("socket_options") or []}
             for default_option in KEEP_ALIVE_SOCKET_OPTIONS:
                 if (default_option[0], default_option[1]) not in used_options:
                     options["socket_options"].append(default_option)

--- a/sentry_sdk/transport.py
+++ b/sentry_sdk/transport.py
@@ -22,6 +22,7 @@ if TYPE_CHECKING:
     from typing import Callable
     from typing import Dict
     from typing import Iterable
+    from typing import List
     from typing import Optional
     from typing import Tuple
     from typing import Type
@@ -462,17 +463,22 @@ class HttpTransport(Transport):
             "ca_certs": ca_certs or certifi.where(),
         }
 
+        socket_options = None  # type: Optional[List[Tuple[int, int, int | bytes]]]
+
         if self.options["socket_options"] is not None:
-            options["socket_options"] = self.options["socket_options"]
+            socket_options = self.options["socket_options"]
 
         if self.options["keep_alive"]:
-            if not options.get("socket_options"):
-                options["socket_options"] = []
+            if socket_options is None:
+                socket_options = []
 
-            used_options = {(o[0], o[1]) for o in options["socket_options"]}
+            used_options = {(o[0], o[1]) for o in socket_options}
             for default_option in KEEP_ALIVE_SOCKET_OPTIONS:
                 if (default_option[0], default_option[1]) not in used_options:
-                    options["socket_options"].append(default_option)
+                    socket_options.append(default_option)
+
+        if socket_options is not None:
+            options["socket_options"] = socket_options
 
         return options
 

--- a/sentry_sdk/transport.py
+++ b/sentry_sdk/transport.py
@@ -469,7 +469,7 @@ class HttpTransport(Transport):
             if not options.get("socket_options"):
                 options["socket_options"] = []
 
-            used_options = {(o[0], o[1]) for o in options.get("socket_options") or []}
+            used_options = {(o[0], o[1]) for o in options["socket_options"]}
             for default_option in KEEP_ALIVE_SOCKET_OPTIONS:
                 if (default_option[0], default_option[1]) not in used_options:
                     options["socket_options"].append(default_option)

--- a/sentry_sdk/transport.py
+++ b/sentry_sdk/transport.py
@@ -462,10 +462,19 @@ class HttpTransport(Transport):
             "ca_certs": ca_certs or certifi.where(),
         }
 
+        socket_options = []
+
         if self.options["socket_options"]:
-            options["socket_options"] = self.options["socket_options"]
-        elif self.options["keep_alive"]:
-            options["socket_options"] = KEEP_ALIVE_SOCKET_OPTIONS
+            socket_options = self.options["socket_options"]
+
+        if self.options["keep_alive"]:
+            used_options = {(o[0], o[1]) for o in socket_options}
+            for default_option in KEEP_ALIVE_SOCKET_OPTIONS:
+                if (default_option[0], default_option[1]) not in used_options:
+                    socket_options.append(default_option)
+
+        if socket_options:
+            options["socket_options"] = socket_options
 
         return options
 

--- a/sentry_sdk/transport.py
+++ b/sentry_sdk/transport.py
@@ -43,13 +43,13 @@ except ImportError:
 
 KEEP_ALIVE_SOCKET_OPTIONS = []
 for option in [
-    (socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1),
-    (socket.SOL_TCP, socket.TCP_KEEPIDLE, 45),
-    (socket.SOL_TCP, socket.TCP_KEEPINTVL, 10),
-    (socket.SOL_TCP, socket.TCP_KEEPCNT, 6),
+    (socket.SOL_SOCKET, lambda: getattr(socket, "SO_KEEPALIVE"), 1),
+    (socket.SOL_TCP, lambda: getattr(socket, "TCP_KEEPIDLE"), 45),
+    (socket.SOL_TCP, lambda: getattr(socket, "TCP_KEEPINTVL"), 10),
+    (socket.SOL_TCP, lambda: getattr(socket, "TCP_KEEPCNT"), 6),
 ]:
     try:
-        KEEP_ALIVE_SOCKET_OPTIONS.append(option)
+        KEEP_ALIVE_SOCKET_OPTIONS.append((option[0], option[1](), option[2]))
     except AttributeError:
         # a specific option might not be available on specific systems,
         # e.g. TCP_KEEPIDLE doesn't exist on macOS

--- a/sentry_sdk/transport.py
+++ b/sentry_sdk/transport.py
@@ -462,19 +462,15 @@ class HttpTransport(Transport):
             "ca_certs": ca_certs or certifi.where(),
         }
 
-        socket_options = []
-
         if self.options["socket_options"]:
             socket_options = self.options["socket_options"]
+            options["socket_options"] = socket_options
 
         if self.options["keep_alive"]:
-            used_options = {(o[0], o[1]) for o in socket_options}
+            used_options = {(o[0], o[1]) for o in options["socket_options"] or []}
             for default_option in KEEP_ALIVE_SOCKET_OPTIONS:
                 if (default_option[0], default_option[1]) not in used_options:
-                    socket_options.append(default_option)
-
-        if socket_options:
-            options["socket_options"] = socket_options
+                    options["socket_options"].append(default_option)
 
         return options
 

--- a/tests/test_transport.py
+++ b/tests/test_transport.py
@@ -167,11 +167,17 @@ def test_socket_options(make_client):
     assert options["socket_options"] == socket_options
 
 
-def test_keep_alive(make_client):
+def test_keep_alive_true(make_client):
     client = make_client(keep_alive=True)
 
     options = client.transport._get_pool_options([])
     assert options["socket_options"] == KEEP_ALIVE_SOCKET_OPTIONS
+
+
+def test_keep_alive_off_by_default(make_client):
+    client = make_client()
+    options = client.transport._get_pool_options([])
+    assert "socket_options" not in options
 
 
 def test_socket_options_override_keep_alive(make_client):
@@ -207,19 +213,10 @@ def test_socket_options_override_defaults(make_client):
     # If socket_options are set to [], this doesn't mean the user doesn't want
     # any custom socket_options, but rather that they want to disable the urllib3
     # socket option defaults, so we need to set this and not ignore it.
-    socket_options = []
-
-    client = make_client(socket_options=socket_options, keep_alive=True)
+    client = make_client(socket_options=[])
 
     options = client.transport._get_pool_options([])
     assert options["socket_options"] == []
-
-
-def test_keep_alive_off_by_default(make_client):
-    client = make_client()
-
-    options = client.transport._get_pool_options([])
-    assert "socket_options" not in options
 
 
 def test_transport_infinite_loop(capturing_server, request, make_client):

--- a/tests/test_transport.py
+++ b/tests/test_transport.py
@@ -187,7 +187,7 @@ def test_socket_options_override_keep_alive(make_client):
     assert options["socket_options"] == socket_options
 
 
-def test_socket_options_merge_keep_alive_with_socket_options(make_client):
+def test_socket_options_merge_with_keep_alive(make_client):
     socket_options = [
         (socket.SOL_SOCKET, socket.SO_KEEPALIVE, 42),
         (socket.SOL_TCP, socket.TCP_KEEPINTVL, 42),
@@ -201,6 +201,18 @@ def test_socket_options_merge_keep_alive_with_socket_options(make_client):
         (socket.SOL_TCP, socket.TCP_KEEPINTVL, 42),
         (socket.SOL_TCP, socket.TCP_KEEPCNT, 6),
     ]
+
+
+def test_socket_options_override_defaults(make_client):
+    # If socket_options are set to [], this doesn't mean the user doesn't want
+    # any custom socket_options, but rather that they want to disable the urllib3
+    # socket option defaults, so we need to set this and not ignore it.
+    socket_options = []
+
+    client = make_client(socket_options=socket_options, keep_alive=True)
+
+    options = client.transport._get_pool_options([])
+    assert options["socket_options"] == []
 
 
 def test_keep_alive_off_by_default(make_client):

--- a/tests/test_transport.py
+++ b/tests/test_transport.py
@@ -191,7 +191,7 @@ def test_keep_alive_off_by_default(make_client):
     client = make_client()
 
     options = client.transport._get_pool_options([])
-    assert options["socket_options"] != KEEP_ALIVE_SOCKET_OPTIONS
+    assert "socket_options" not in options
 
 
 def test_transport_infinite_loop(capturing_server, request, make_client):

--- a/tests/test_transport.py
+++ b/tests/test_transport.py
@@ -202,11 +202,19 @@ def test_socket_options_merge_with_keep_alive(make_client):
     client = make_client(socket_options=socket_options, keep_alive=True)
 
     options = client.transport._get_pool_options([])
-    assert options["socket_options"] == [
-        (socket.SOL_SOCKET, socket.SO_KEEPALIVE, 42),
-        (socket.SOL_TCP, socket.TCP_KEEPINTVL, 42),
-        (socket.SOL_TCP, socket.TCP_KEEPCNT, 6),
-    ]
+    try:
+        assert options["socket_options"] == [
+            (socket.SOL_SOCKET, socket.SO_KEEPALIVE, 42),
+            (socket.SOL_TCP, socket.TCP_KEEPINTVL, 42),
+            (socket.SOL_TCP, socket.TCP_KEEPIDLE, 45),
+            (socket.SOL_TCP, socket.TCP_KEEPCNT, 6),
+        ]
+    except AttributeError:
+        assert options["socket_options"] == [
+            (socket.SOL_SOCKET, socket.SO_KEEPALIVE, 42),
+            (socket.SOL_TCP, socket.TCP_KEEPINTVL, 42),
+            (socket.SOL_TCP, socket.TCP_KEEPCNT, 6),
+        ]
 
 
 def test_socket_options_override_defaults(make_client):

--- a/tests/test_transport.py
+++ b/tests/test_transport.py
@@ -187,6 +187,13 @@ def test_socket_options_override_keep_alive(make_client):
     assert options["socket_options"] == socket_options
 
 
+def test_keep_alive_off_by_default(make_client):
+    client = make_client()
+
+    options = client.transport._get_pool_options([])
+    assert options["socket_options"] != KEEP_ALIVE_SOCKET_OPTIONS
+
+
 def test_transport_infinite_loop(capturing_server, request, make_client):
     client = make_client(
         debug=True,

--- a/tests/test_transport.py
+++ b/tests/test_transport.py
@@ -187,6 +187,22 @@ def test_socket_options_override_keep_alive(make_client):
     assert options["socket_options"] == socket_options
 
 
+def test_socket_options_merge_keep_alive_with_socket_options(make_client):
+    socket_options = [
+        (socket.SOL_SOCKET, socket.SO_KEEPALIVE, 42),
+        (socket.SOL_TCP, socket.TCP_KEEPINTVL, 42),
+    ]
+
+    client = make_client(socket_options=socket_options, keep_alive=True)
+
+    options = client.transport._get_pool_options([])
+    assert options["socket_options"] == [
+        (socket.SOL_SOCKET, socket.SO_KEEPALIVE, 42),
+        (socket.SOL_TCP, socket.TCP_KEEPINTVL, 42),
+        (socket.SOL_TCP, socket.TCP_KEEPCNT, 6),
+    ]
+
+
 def test_keep_alive_off_by_default(make_client):
     client = make_client()
 


### PR DESCRIPTION
In case folks are experiencing network issues between the SDK and Sentry, we in general recommend tweaking socket_options directly with a predefined set of settings. This seems to alleviate the issue most of the time, but feels rather low-level and hacky.

Node has a separate [keepAlive transport option](https://docs.sentry.io/platforms/node/configuration/options/#transport-options). We could do something similar: an option that sets the socket options to [what we usually recommend](https://github.com/getsentry/sentry-python/releases/tag/1.41.0), while keeping the `socket_options` option around as well for users who need more control over things.

Docs: https://github.com/getsentry/sentry-docs/pull/9498

Closes https://github.com/getsentry/sentry-python/issues/2837

---

## General Notes

Thank you for contributing to `sentry-python`!

Please add tests to validate your changes, and lint your code using `tox -e linters`.

Running the test suite on your PR might require maintainer approval. Some tests (AWS Lambda) additionally require a maintainer to add a special label to run and will fail if the label is not present.

#### For maintainers

Sensitive test suites require maintainer review to ensure that tests do not compromise our secrets. This review must be repeated after any code revisions.

Before running sensitive test suites, please carefully check the PR. Then, apply the `Trigger: tests using secrets` label. The label will be removed after any code changes to enforce our policy requiring maintainers to review all code revisions before running sensitive tests.
