### PR TITLE
Use new scopes API in Django, SQLAlchemy, and asyncpg integration.

### DIFF
--- a/sentry_sdk/integrations/asyncpg.py
+++ b/sentry_sdk/integrations/asyncpg.py
@@ -2,12 +2,17 @@ from __future__ import annotations
 import contextlib
 from typing import Any, TypeVar, Callable, Awaitable, Iterator
 
-from sentry_sdk import Hub
+import sentry_sdk
 from sentry_sdk.consts import OP, SPANDATA
 from sentry_sdk.integrations import Integration, DidNotEnable
 from sentry_sdk.tracing import Span
 from sentry_sdk.tracing_utils import add_query_source, record_sql_queries
-from sentry_sdk.utils import parse_version, capture_internal_exceptions
+from sentry_sdk.utils import (
+    ensure_integration_enabled,
+    ensure_integration_enabled_async,
+    parse_version,
+    capture_internal_exceptions,
+)
 
 try:
     import asyncpg  # type: ignore[import-not-found]
@@ -54,8 +59,7 @@ T = TypeVar("T")
 
 def _wrap_execute(f: Callable[..., Awaitable[T]]) -> Callable[..., Awaitable[T]]:
     async def _inner(*args: Any, **kwargs: Any) -> T:
-        hub = Hub.current
-        integration = hub.get_integration(AsyncPGIntegration)
+        integration = sentry_sdk.get_client().get_integration(AsyncPGIntegration)
 
         # Avoid recording calls to _execute twice.
         # Calls to Connection.execute with args also call
@@ -65,13 +69,11 @@ def _wrap_execute(f: Callable[..., Awaitable[T]]) -> Callable[..., Awaitable[T]]
             return await f(*args, **kwargs)
 
         query = args[1]
-        with record_sql_queries(
-            hub, None, query, None, None, executemany=False
-        ) as span:
+        with record_sql_queries(None, query, None, None, executemany=False) as span:
             res = await f(*args, **kwargs)
 
         with capture_internal_exceptions():
-            add_query_source(hub, span)
+            add_query_source(span)
 
         return res
 
@@ -83,21 +85,19 @@ SubCursor = TypeVar("SubCursor", bound=BaseCursor)
 
 @contextlib.contextmanager
 def _record(
-    hub: Hub,
     cursor: SubCursor | None,
     query: str,
     params_list: tuple[Any, ...] | None,
     *,
     executemany: bool = False,
 ) -> Iterator[Span]:
-    integration = hub.get_integration(AsyncPGIntegration)
-    if not integration._record_params:
+    integration = sentry_sdk.get_client().get_integration(AsyncPGIntegration)
+    if integration is not None and not integration._record_params:
         params_list = None
 
     param_style = "pyformat" if params_list else None
 
     with record_sql_queries(
-        hub,
         cursor,
         query,
         params_list,
@@ -111,16 +111,11 @@ def _record(
 def _wrap_connection_method(
     f: Callable[..., Awaitable[T]], *, executemany: bool = False
 ) -> Callable[..., Awaitable[T]]:
+    @ensure_integration_enabled_async(AsyncPGIntegration, f)
     async def _inner(*args: Any, **kwargs: Any) -> T:
-        hub = Hub.current
-        integration = hub.get_integration(AsyncPGIntegration)
-
-        if integration is None:
-            return await f(*args, **kwargs)
-
         query = args[1]
         params_list = args[2] if len(args) > 2 else None
-        with _record(hub, None, query, params_list, executemany=executemany) as span:
+        with _record(None, query, params_list, executemany=executemany) as span:
             _set_db_data(span, args[0])
             res = await f(*args, **kwargs)
 
@@ -130,18 +125,12 @@ def _wrap_connection_method(
 
 
 def _wrap_cursor_creation(f: Callable[..., T]) -> Callable[..., T]:
+    @ensure_integration_enabled(AsyncPGIntegration, f)
     def _inner(*args: Any, **kwargs: Any) -> T:  # noqa: N807
-        hub = Hub.current
-        integration = hub.get_integration(AsyncPGIntegration)
-
-        if integration is None:
-            return f(*args, **kwargs)
-
         query = args[1]
         params_list = args[2] if len(args) > 2 else None
 
         with _record(
-            hub,
             None,
             query,
             params_list,
@@ -157,17 +146,12 @@ def _wrap_cursor_creation(f: Callable[..., T]) -> Callable[..., T]:
 
 
 def _wrap_connect_addr(f: Callable[..., Awaitable[T]]) -> Callable[..., Awaitable[T]]:
+    @ensure_integration_enabled_async(AsyncPGIntegration, f)
     async def _inner(*args: Any, **kwargs: Any) -> T:
-        hub = Hub.current
-        integration = hub.get_integration(AsyncPGIntegration)
-
-        if integration is None:
-            return await f(*args, **kwargs)
-
         user = kwargs["params"].user
         database = kwargs["params"].database
 
-        with hub.start_span(op=OP.DB, description="connect") as span:
+        with sentry_sdk.start_span(op=OP.DB, description="connect") as span:
             span.set_data(SPANDATA.DB_SYSTEM, "postgresql")
             addr = kwargs.get("addr")
             if addr:
@@ -180,7 +164,9 @@ def _wrap_connect_addr(f: Callable[..., Awaitable[T]]) -> Callable[..., Awaitabl
             span.set_data(SPANDATA.DB_USER, user)
 
             with capture_internal_exceptions():
-                hub.add_breadcrumb(message="connect", category="query", data=span._data)
+                sentry_sdk.add_breadcrumb(
+                    message="connect", category="query", data=span._data
+                )
             res = await f(*args, **kwargs)
 
         return res

--- a/sentry_sdk/integrations/django/__init__.py
+++ b/sentry_sdk/integrations/django/__init__.py
@@ -8,7 +8,7 @@ import sentry_sdk
 from sentry_sdk._types import TYPE_CHECKING
 from sentry_sdk.consts import OP, SPANDATA
 from sentry_sdk.db.explain_plan.django import attach_explain_plan_to_span
-from sentry_sdk.scope import Scope, add_global_event_processor
+from sentry_sdk.scope import Scope, add_global_event_processor, should_send_default_pii
 from sentry_sdk.serializer import add_global_repr_processor
 from sentry_sdk.tracing import SOURCE_FOR_STYLE, TRANSACTION_SOURCE_URL
 from sentry_sdk.tracing_utils import add_query_source, record_sql_queries
@@ -483,7 +483,7 @@ def _make_wsgi_request_event_processor(weak_request, integration):
         with capture_internal_exceptions():
             DjangoRequestExtractor(request).extract_into_event(event)
 
-        if sentry_sdk.get_client().should_send_default_pii():
+        if should_send_default_pii():
             with capture_internal_exceptions():
                 _set_user_info(request, event)
 

--- a/sentry_sdk/integrations/django/asgi.py
+++ b/sentry_sdk/integrations/django/asgi.py
@@ -17,6 +17,7 @@ from sentry_sdk._types import TYPE_CHECKING
 from sentry_sdk.consts import OP
 
 from sentry_sdk.integrations.asgi import SentryAsgiMiddleware
+from sentry_sdk.scope import should_send_default_pii
 from sentry_sdk.utils import (
     capture_internal_exceptions,
     ensure_integration_enabled,
@@ -55,7 +56,7 @@ def _make_asgi_request_event_processor(request):
         with capture_internal_exceptions():
             DjangoRequestExtractor(request).extract_into_event(event)
 
-        if sentry_sdk.get_client().should_send_default_pii():
+        if should_send_default_pii():
             with capture_internal_exceptions():
                 _set_user_info(request, event)
 

--- a/sentry_sdk/integrations/django/asgi.py
+++ b/sentry_sdk/integrations/django/asgi.py
@@ -11,13 +11,17 @@ import functools
 
 from django.core.handlers.wsgi import WSGIRequest
 
-from sentry_sdk import Hub
+import sentry_sdk
+from sentry_sdk import Scope
 from sentry_sdk._types import TYPE_CHECKING
 from sentry_sdk.consts import OP
-from sentry_sdk.hub import _should_send_default_pii
 
 from sentry_sdk.integrations.asgi import SentryAsgiMiddleware
-from sentry_sdk.utils import capture_internal_exceptions
+from sentry_sdk.utils import (
+    capture_internal_exceptions,
+    ensure_integration_enabled,
+    ensure_integration_enabled_async,
+)
 
 
 if TYPE_CHECKING:
@@ -51,7 +55,7 @@ def _make_asgi_request_event_processor(request):
         with capture_internal_exceptions():
             DjangoRequestExtractor(request).extract_into_event(event)
 
-        if _should_send_default_pii():
+        if sentry_sdk.get_client().should_send_default_pii():
             with capture_internal_exceptions():
                 _set_user_info(request, event)
 
@@ -67,13 +71,9 @@ def patch_django_asgi_handler_impl(cls):
 
     old_app = cls.__call__
 
+    @ensure_integration_enabled_async(DjangoIntegration, old_app)
     async def sentry_patched_asgi_handler(self, scope, receive, send):
         # type: (Any, Any, Any, Any) -> Any
-        hub = Hub.current
-        integration = hub.get_integration(DjangoIntegration)
-        if integration is None:
-            return await old_app(self, scope, receive, send)
-
         middleware = SentryAsgiMiddleware(
             old_app.__get__(self, cls), unsafe_context_data=True
         )._run_asgi3
@@ -86,18 +86,14 @@ def patch_django_asgi_handler_impl(cls):
     if modern_django_asgi_support:
         old_create_request = cls.create_request
 
+        @ensure_integration_enabled(DjangoIntegration, old_create_request)
         def sentry_patched_create_request(self, *args, **kwargs):
             # type: (Any, *Any, **Any) -> Any
-            hub = Hub.current
-            integration = hub.get_integration(DjangoIntegration)
-            if integration is None:
-                return old_create_request(self, *args, **kwargs)
+            request, error_response = old_create_request(self, *args, **kwargs)
+            scope = Scope.get_isolation_scope()
+            scope.add_event_processor(_make_asgi_request_event_processor(request))
 
-            with hub.configure_scope() as scope:
-                request, error_response = old_create_request(self, *args, **kwargs)
-                scope.add_event_processor(_make_asgi_request_event_processor(request))
-
-                return request, error_response
+            return request, error_response
 
         cls.create_request = sentry_patched_create_request
 
@@ -123,11 +119,9 @@ def patch_channels_asgi_handler_impl(cls):
     if channels.__version__ < "3.0.0":
         old_app = cls.__call__
 
+        @ensure_integration_enabled_async(DjangoIntegration, old_app)
         async def sentry_patched_asgi_handler(self, receive, send):
             # type: (Any, Any, Any) -> Any
-            if Hub.current.get_integration(DjangoIntegration) is None:
-                return await old_app(self, receive, send)
-
             middleware = SentryAsgiMiddleware(
                 lambda _scope: old_app.__get__(self, cls), unsafe_context_data=True
             )
@@ -142,20 +136,19 @@ def patch_channels_asgi_handler_impl(cls):
         patch_django_asgi_handler_impl(cls)
 
 
-def wrap_async_view(hub, callback):
-    # type: (Hub, Any) -> Any
+def wrap_async_view(callback):
+    # type: (Any) -> Any
     @functools.wraps(callback)
     async def sentry_wrapped_callback(request, *args, **kwargs):
         # type: (Any, *Any, **Any) -> Any
+        sentry_scope = Scope.get_isolation_scope()
+        if sentry_scope.profile is not None:
+            sentry_scope.profile.update_active_thread_id()
 
-        with hub.configure_scope() as sentry_scope:
-            if sentry_scope.profile is not None:
-                sentry_scope.profile.update_active_thread_id()
-
-            with hub.start_span(
-                op=OP.VIEW_RENDER, description=request.resolver_match.view_name
-            ):
-                return await callback(request, *args, **kwargs)
+        with sentry_sdk.start_span(
+            op=OP.VIEW_RENDER, description=request.resolver_match.view_name
+        ):
+            return await callback(request, *args, **kwargs)
 
     return sentry_wrapped_callback
 

--- a/sentry_sdk/integrations/django/caching.py
+++ b/sentry_sdk/integrations/django/caching.py
@@ -89,7 +89,7 @@ def patch_caching():
                 cache = original_get_item(self, alias)
 
                 integration = sentry_sdk.get_client().get_integration(DjangoIntegration)
-                if integration and integration.cache_spans:
+                if integration is not None and integration.cache_spans:
                     _patch_cache(cache)
 
                 return cache
@@ -106,7 +106,7 @@ def patch_caching():
                 cache = original_create_connection(self, alias)
 
                 integration = sentry_sdk.get_client().get_integration(DjangoIntegration)
-                if integration and integration.cache_spans:
+                if integration is not None and integration.cache_spans:
                     _patch_cache(cache)
 
                 return cache

--- a/sentry_sdk/integrations/django/caching.py
+++ b/sentry_sdk/integrations/django/caching.py
@@ -4,8 +4,9 @@ from typing import TYPE_CHECKING
 from django import VERSION as DJANGO_VERSION
 from django.core.cache import CacheHandler
 
-from sentry_sdk import Hub
+import sentry_sdk
 from sentry_sdk.consts import OP, SPANDATA
+from sentry_sdk.utils import ensure_integration_enabled
 
 
 if TYPE_CHECKING:
@@ -35,16 +36,16 @@ def _patch_cache_method(cache, method_name):
     # type: (CacheHandler, str) -> None
     from sentry_sdk.integrations.django import DjangoIntegration
 
+    original_method = getattr(cache, method_name)
+
+    @ensure_integration_enabled(DjangoIntegration, original_method)
     def _instrument_call(cache, method_name, original_method, args, kwargs):
         # type: (CacheHandler, str, Callable[..., Any], Any, Any) -> Any
-        hub = Hub.current
-        integration = hub.get_integration(DjangoIntegration)
-        if integration is None or not integration.cache_spans:
-            return original_method(*args, **kwargs)
-
         description = _get_span_description(method_name, args, kwargs)
 
-        with hub.start_span(op=OP.CACHE_GET_ITEM, description=description) as span:
+        with sentry_sdk.start_span(
+            op=OP.CACHE_GET_ITEM, description=description
+        ) as span:
             value = original_method(*args, **kwargs)
 
             if value:
@@ -57,8 +58,6 @@ def _patch_cache_method(cache, method_name):
                 span.set_data(SPANDATA.CACHE_HIT, False)
 
             return value
-
-    original_method = getattr(cache, method_name)
 
     @functools.wraps(original_method)
     def sentry_method(*args, **kwargs):
@@ -89,7 +88,7 @@ def patch_caching():
                 # type: (CacheHandler, str) -> Any
                 cache = original_get_item(self, alias)
 
-                integration = Hub.current.get_integration(DjangoIntegration)
+                integration = sentry_sdk.get_client().get_integration(DjangoIntegration)
                 if integration and integration.cache_spans:
                     _patch_cache(cache)
 
@@ -106,7 +105,7 @@ def patch_caching():
                 # type: (CacheHandler, str) -> Any
                 cache = original_create_connection(self, alias)
 
-                integration = Hub.current.get_integration(DjangoIntegration)
+                integration = sentry_sdk.get_client().get_integration(DjangoIntegration)
                 if integration and integration.cache_spans:
                     _patch_cache(cache)
 

--- a/sentry_sdk/integrations/django/middleware.py
+++ b/sentry_sdk/integrations/django/middleware.py
@@ -6,7 +6,7 @@ from functools import wraps
 
 from django import VERSION as DJANGO_VERSION
 
-from sentry_sdk import Hub
+import sentry_sdk
 from sentry_sdk._types import TYPE_CHECKING
 from sentry_sdk.consts import OP
 from sentry_sdk.utils import (
@@ -71,8 +71,7 @@ def _wrap_middleware(middleware, middleware_name):
 
     def _check_middleware_span(old_method):
         # type: (Callable[..., Any]) -> Optional[Span]
-        hub = Hub.current
-        integration = hub.get_integration(DjangoIntegration)
+        integration = sentry_sdk.get_client().get_integration(DjangoIntegration)
         if integration is None or not integration.middleware_spans:
             return None
 
@@ -83,7 +82,7 @@ def _wrap_middleware(middleware, middleware_name):
         if function_basename:
             description = "{}.{}".format(description, function_basename)
 
-        middleware_span = hub.start_span(
+        middleware_span = sentry_sdk.start_span(
             op=OP.MIDDLEWARE_DJANGO, description=description
         )
         middleware_span.set_tag("django.function_name", function_name)

--- a/sentry_sdk/integrations/django/templates.py
+++ b/sentry_sdk/integrations/django/templates.py
@@ -85,8 +85,8 @@ def patch_templates():
 
     real_render = django.shortcuts.render
 
-    @ensure_integration_enabled(DjangoIntegration, real_render)
     @functools.wraps(real_render)
+    @ensure_integration_enabled(DjangoIntegration, real_render)
     def render(request, template_name, context=None, *args, **kwargs):
         # type: (django.http.HttpRequest, str, Optional[Dict[str, Any]], *Any, **Any) -> django.http.HttpResponse
 

--- a/sentry_sdk/integrations/django/templates.py
+++ b/sentry_sdk/integrations/django/templates.py
@@ -4,9 +4,11 @@ from django.template import TemplateSyntaxError
 from django.utils.safestring import mark_safe
 from django import VERSION as DJANGO_VERSION
 
-from sentry_sdk import Hub
+import sentry_sdk
+from sentry_sdk import Scope
 from sentry_sdk._types import TYPE_CHECKING
 from sentry_sdk.consts import OP
+from sentry_sdk.utils import ensure_integration_enabled
 
 if TYPE_CHECKING:
     from typing import Any
@@ -65,11 +67,10 @@ def patch_templates():
     @property  # type: ignore
     def rendered_content(self):
         # type: (SimpleTemplateResponse) -> str
-        hub = Hub.current
-        if hub.get_integration(DjangoIntegration) is None:
+        if sentry_sdk.get_client().get_integration(DjangoIntegration) is None:
             return real_rendered_content.fget(self)
 
-        with hub.start_span(
+        with sentry_sdk.start_span(
             op=OP.TEMPLATE_RENDER,
             description=_get_template_name_description(self.template_name),
         ) as span:
@@ -84,19 +85,19 @@ def patch_templates():
 
     real_render = django.shortcuts.render
 
+    @ensure_integration_enabled(DjangoIntegration, real_render)
     @functools.wraps(real_render)
     def render(request, template_name, context=None, *args, **kwargs):
         # type: (django.http.HttpRequest, str, Optional[Dict[str, Any]], *Any, **Any) -> django.http.HttpResponse
-        hub = Hub.current
-        if hub.get_integration(DjangoIntegration) is None:
-            return real_render(request, template_name, context, *args, **kwargs)
 
         # Inject trace meta tags into template context
         context = context or {}
         if "sentry_trace_meta" not in context:
-            context["sentry_trace_meta"] = mark_safe(hub.trace_propagation_meta())
+            context["sentry_trace_meta"] = mark_safe(
+                Scope.get_current_scope().trace_propagation_meta()
+            )
 
-        with hub.start_span(
+        with sentry_sdk.start_span(
             op=OP.TEMPLATE_RENDER,
             description=_get_template_name_description(template_name),
         ) as span:

--- a/sentry_sdk/integrations/django/views.py
+++ b/sentry_sdk/integrations/django/views.py
@@ -1,7 +1,8 @@
 import functools
 
+import sentry_sdk
+from sentry_sdk import Scope
 from sentry_sdk.consts import OP
-from sentry_sdk.hub import Hub
 from sentry_sdk._types import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -32,8 +33,7 @@ def patch_views():
 
     def sentry_patched_render(self):
         # type: (SimpleTemplateResponse) -> Any
-        hub = Hub.current
-        with hub.start_span(
+        with sentry_sdk.start_span(
             op=OP.VIEW_RESPONSE_RENDER, description="serialize response"
         ):
             return old_render(self)
@@ -46,8 +46,7 @@ def patch_views():
         # XXX: The wrapper function is created for every request. Find more
         # efficient way to wrap views (or build a cache?)
 
-        hub = Hub.current
-        integration = hub.get_integration(DjangoIntegration)
+        integration = sentry_sdk.get_client().get_integration(DjangoIntegration)
         if integration is not None and integration.middleware_spans:
             is_async_view = (
                 iscoroutinefunction is not None
@@ -55,9 +54,9 @@ def patch_views():
                 and iscoroutinefunction(callback)
             )
             if is_async_view:
-                sentry_wrapped_callback = wrap_async_view(hub, callback)
+                sentry_wrapped_callback = wrap_async_view(callback)
             else:
-                sentry_wrapped_callback = _wrap_sync_view(hub, callback)
+                sentry_wrapped_callback = _wrap_sync_view(callback)
 
         else:
             sentry_wrapped_callback = callback
@@ -68,20 +67,20 @@ def patch_views():
     BaseHandler.make_view_atomic = sentry_patched_make_view_atomic
 
 
-def _wrap_sync_view(hub, callback):
-    # type: (Hub, Any) -> Any
+def _wrap_sync_view(callback):
+    # type: (Any) -> Any
     @functools.wraps(callback)
     def sentry_wrapped_callback(request, *args, **kwargs):
         # type: (Any, *Any, **Any) -> Any
-        with hub.configure_scope() as sentry_scope:
-            # set the active thread id to the handler thread for sync views
-            # this isn't necessary for async views since that runs on main
-            if sentry_scope.profile is not None:
-                sentry_scope.profile.update_active_thread_id()
+        sentry_scope = Scope.get_isolation_scope()
+        # set the active thread id to the handler thread for sync views
+        # this isn't necessary for async views since that runs on main
+        if sentry_scope.profile is not None:
+            sentry_scope.profile.update_active_thread_id()
 
-            with hub.start_span(
-                op=OP.VIEW_RENDER, description=request.resolver_match.view_name
-            ):
-                return callback(request, *args, **kwargs)
+        with sentry_sdk.start_span(
+            op=OP.VIEW_RENDER, description=request.resolver_match.view_name
+        ):
+            return callback(request, *args, **kwargs)
 
     return sentry_wrapped_callback

--- a/tests/integrations/django/myapp/views.py
+++ b/tests/integrations/django/myapp/views.py
@@ -177,10 +177,18 @@ def template_test2(request, *args, **kwargs):
 
 @csrf_exempt
 def template_test3(request, *args, **kwargs):
-    from sentry_sdk import Hub
+    from sentry_sdk import Scope
 
-    hub = Hub.current
-    capture_message(hub.get_traceparent() + "\n" + hub.get_baggage())
+    traceparent = Scope.get_current_scope().get_traceparent()
+    if traceparent is None:
+        traceparent = Scope.get_isolation_scope().get_traceparent() 
+
+    baggage = Scope.get_current_scope().get_baggage()
+    if baggage is None:
+        baggage = Scope.get_isolation_scope().get_baggage() 
+
+
+    capture_message(traceparent + "\n" + baggage.serialize())
     return render(request, "trace_meta.html", {})
 
 

--- a/tests/integrations/django/myapp/views.py
+++ b/tests/integrations/django/myapp/views.py
@@ -181,12 +181,11 @@ def template_test3(request, *args, **kwargs):
 
     traceparent = Scope.get_current_scope().get_traceparent()
     if traceparent is None:
-        traceparent = Scope.get_isolation_scope().get_traceparent() 
+        traceparent = Scope.get_isolation_scope().get_traceparent()
 
     baggage = Scope.get_current_scope().get_baggage()
     if baggage is None:
-        baggage = Scope.get_isolation_scope().get_baggage() 
-
+        baggage = Scope.get_isolation_scope().get_baggage()
 
     capture_message(traceparent + "\n" + baggage.serialize())
     return render(request, "trace_meta.html", {})


### PR DESCRIPTION
Needed to change all three of those integrations at the same time, because they use the same helper functions that had a `hub` as a parameter.

Fixes #2809 (Django)

Relates to #2815 (Database integrations)