### PR TITLE
ref(redis): Use new scopes API

### DIFF
--- a/sentry_sdk/integrations/redis/__init__.py
+++ b/sentry_sdk/integrations/redis/__init__.py
@@ -1,4 +1,4 @@
-from sentry_sdk import Hub
+import sentry_sdk
 from sentry_sdk.consts import OP, SPANDATA
 from sentry_sdk.hub import _should_send_default_pii
 from sentry_sdk.integrations import Integration, DidNotEnable
@@ -6,6 +6,7 @@ from sentry_sdk._types import TYPE_CHECKING
 from sentry_sdk.utils import (
     SENSITIVE_DATA_SUBSTITUTE,
     capture_internal_exceptions,
+    ensure_integration_enabled,
     logger,
 )
 
@@ -176,14 +177,10 @@ def patch_redis_pipeline(pipeline_cls, is_cluster, get_command_args_fn, set_db_d
     # type: (Any, bool, Any, Callable[[Span, Any], None]) -> None
     old_execute = pipeline_cls.execute
 
+    @ensure_integration_enabled(RedisIntegration, old_execute)
     def sentry_patched_execute(self, *args, **kwargs):
         # type: (Any, *Any, **Any) -> Any
-        hub = Hub.current
-
-        if hub.get_integration(RedisIntegration) is None:
-            return old_execute(self, *args, **kwargs)
-
-        with hub.start_span(
+        with sentry_sdk.start_span(
             op=OP.DB_REDIS, description="redis.pipeline.execute"
         ) as span:
             with capture_internal_exceptions():
@@ -209,14 +206,10 @@ def patch_redis_client(cls, is_cluster, set_db_data_fn):
     """
     old_execute_command = cls.execute_command
 
+    @ensure_integration_enabled(RedisIntegration, old_execute_command)
     def sentry_patched_execute_command(self, name, *args, **kwargs):
         # type: (Any, str, *Any, **Any) -> Any
-        hub = Hub.current
-        integration = hub.get_integration(RedisIntegration)
-
-        if integration is None:
-            return old_execute_command(self, name, *args, **kwargs)
-
+        integration = sentry_sdk.get_client().get_integration(RedisIntegration)
         description = _get_span_description(name, *args)
 
         data_should_be_truncated = (
@@ -225,7 +218,7 @@ def patch_redis_client(cls, is_cluster, set_db_data_fn):
         if data_should_be_truncated:
             description = description[: integration.max_data_size - len("...")] + "..."
 
-        with hub.start_span(op=OP.DB_REDIS, description=description) as span:
+        with sentry_sdk.start_span(op=OP.DB_REDIS, description=description) as span:
             set_db_data_fn(span, self)
             _set_client_data(span, is_cluster, name, *args)
 

--- a/sentry_sdk/integrations/redis/asyncio.py
+++ b/sentry_sdk/integrations/redis/asyncio.py
@@ -44,14 +44,14 @@ def patch_redis_async_pipeline(
 
             return await old_execute(self, *args, **kwargs)
 
-    pipeline_cls.execute = _sentry_execute  # type: ignore[method-assign]
+    pipeline_cls.execute = _sentry_execute  # type: ignore
 
 
 def patch_redis_async_client(cls, is_cluster, set_db_data_fn):
     # type: (Union[type[StrictRedis[Any]], type[RedisCluster[Any]]], bool, Callable[[Span, Any], None]) -> None
     old_execute_command = cls.execute_command
 
-    @ensure_integration_enabled_async(RedisIntegration, old_execute_command)
+    @ensure_integration_enabled_async(RedisIntegration, old_execute_command)  # type: ignore
     async def _sentry_execute_command(self, name, *args, **kwargs):
         # type: (Any, str, *Any, **Any) -> Any
         description = _get_span_description(name, *args)
@@ -62,4 +62,4 @@ def patch_redis_async_client(cls, is_cluster, set_db_data_fn):
 
             return await old_execute_command(self, name, *args, **kwargs)
 
-    cls.execute_command = _sentry_execute_command  # type: ignore[method-assign]
+    cls.execute_command = _sentry_execute_command  # type: ignore


### PR DESCRIPTION
Update our redis integration to use the new scopes API.

---

## General Notes

Thank you for contributing to `sentry-python`!

Please add tests to validate your changes, and lint your code using `tox -e linters`.

Running the test suite on your PR might require maintainer approval. Some tests (AWS Lambda) additionally require a maintainer to add a special label to run and will fail if the label is not present.

#### For maintainers

Sensitive test suites require maintainer review to ensure that tests do not compromise our secrets. This review must be repeated after any code revisions.

Before running sensitive test suites, please carefully check the PR. Then, apply the `Trigger: tests using secrets` label. The label will be removed after any code changes to enforce our policy requiring maintainers to review all code revisions before running sensitive tests.
