### PR TITLE
ref(docs): Deprecate old hub API in migration guide

### DIFF
--- a/MIGRATION_GUIDE.md
+++ b/MIGRATION_GUIDE.md
@@ -111,6 +111,7 @@ Looking to upgrade from Sentry SDK 1.x to 2.x? Here's a comprehensive list of wh
 
   with sentry_sdk.isolation_scope() as scope:
       # do something with the forked scope
+  ```
 
 - `configure_scope` is deprecated. Use the new isolation scope directly via `Scope.get_isolation_scope()` instead.
 

--- a/MIGRATION_GUIDE.md
+++ b/MIGRATION_GUIDE.md
@@ -76,6 +76,76 @@ Looking to upgrade from Sentry SDK 1.x to 2.x? Here's a comprehensive list of wh
 
 ## Deprecated
 
+- Using the `Hub` directly as well as using hub-based APIs has been deprecated. Where available, use [the top-level API instead](sentry_sdk/api.py); otherwise use the [scope API](sentry_sdk/scope.py) or the [client API](sentry_sdk/client.py).
+
+  Before:
+
+  ```python
+  with hub.start_span(...):
+      # do something
+  ```
+
+  After:
+
+  ```python
+  import sentry_sdk
+
+  with sentry_sdk.start_span(...):
+      # do something
+  ```
+
+- Hub cloning is deprecated.
+
+  Before:
+
+  ```python
+  with Hub(Hub.current) as hub:
+      # do something with the cloned hub
+  ```
+
+  After:
+
+  ```python
+  with isolation_scope() as scope:
+      # do something with the forked scope
+
+- `configure_scope` is deprecated. Use the new isolation scope directly via `Scope.get_isolation_scope()` instead.
+
+  Before:
+
+  ```python
+  with configure_scope() as scope:
+      # do something with `scope`
+  ```
+
+  After:
+
+  ```python
+  from sentry_sdk.scope import Scope
+
+  scope = Scope.get_isolation_scope()
+  # do something with `scope`
+  ```
+
+- `push_scope` is deprecated. Use the new `new_scope` context manager to fork the necessary scopes.
+
+  Before:
+
+  ```python
+  with push_scope() as scope:
+      # do something with `scope`
+  ```
+
+  After:
+
+  ```python
+  from sentry_sdk.scope import Scope
+
+  with new_scope() as scope:
+      # do something with `scope`
+  ```
+
+- Accessing the client via the hub has been deprecated. Use the top-level `sentry_sdk.get_client()` to get the current client.
 - `profiler_mode` and `profiles_sample_rate` have been deprecated as `_experiments` options. Use them as top level options instead:
   ```python
   sentry_sdk.init(

--- a/MIGRATION_GUIDE.md
+++ b/MIGRATION_GUIDE.md
@@ -5,6 +5,7 @@ Looking to upgrade from Sentry SDK 1.x to 2.x? Here's a comprehensive list of wh
 ## New Features
 
 - Additional integrations will now be activated automatically if the SDK detects the respective package is installed: Ariadne, ARQ, asyncpg, Chalice, clickhouse-driver, GQL, Graphene, huey, Loguru, PyMongo, Quart, Starlite, Strawberry.
+- Added new API for custom instrumentation: `new_scope`, `isolation_scope`. See the [Deprecated](#deprecated) section to see how they map to the existing APIs.
 
 ## Changed
 
@@ -106,7 +107,9 @@ Looking to upgrade from Sentry SDK 1.x to 2.x? Here's a comprehensive list of wh
   After:
 
   ```python
-  with isolation_scope() as scope:
+  import sentry_sdk
+
+  with sentry_sdk.isolation_scope() as scope:
       # do something with the forked scope
 
 - `configure_scope` is deprecated. Use the new isolation scope directly via `Scope.get_isolation_scope()` instead.
@@ -139,9 +142,9 @@ Looking to upgrade from Sentry SDK 1.x to 2.x? Here's a comprehensive list of wh
   After:
 
   ```python
-  from sentry_sdk.scope import Scope
+  import sentry_sdk
 
-  with new_scope() as scope:
+  with sentry_sdk.new_scope() as scope:
       # do something with `scope`
   ```
 


### PR DESCRIPTION
We're deprecating hub-based API with 2.0. Add this to the migration guide.

---

## General Notes

Thank you for contributing to `sentry-python`!

Please add tests to validate your changes, and lint your code using `tox -e linters`.

Running the test suite on your PR might require maintainer approval. Some tests (AWS Lambda) additionally require a maintainer to add a special label to run and will fail if the label is not present.

#### For maintainers

Sensitive test suites require maintainer review to ensure that tests do not compromise our secrets. This review must be repeated after any code revisions.

Before running sensitive test suites, please carefully check the PR. Then, apply the `Trigger: tests using secrets` label. The label will be removed after any code changes to enforce our policy requiring maintainers to review all code revisions before running sensitive tests.
