### PR TITLE
ref: `ensure_integration_enabled` without original function

### DIFF
--- a/sentry_sdk/utils.py
+++ b/sentry_sdk/utils.py
@@ -1713,7 +1713,8 @@ def ensure_integration_enabled(
 
 if TYPE_CHECKING:
 
-    @overload
+    # mypy has some trouble with the overloads, hence the ignore[no-overload-impl]
+    @overload  # type: ignore[no-overload-impl]
     def ensure_integration_enabled_async(
         integration,  # type: type[sentry_sdk.integrations.Integration]
         original_function,  # type: Callable[P, Awaitable[R]]
@@ -1729,7 +1730,8 @@ if TYPE_CHECKING:
         ...
 
 
-def ensure_integration_enabled_async(
+# The ignore[no-redef] also needed because mypy is struggling with these overloads.
+def ensure_integration_enabled_async(  # type: ignore[no-redef]
     integration,  # type: type[sentry_sdk.integrations.Integration]
     original_function=_no_op_async,  # type: Union[Callable[P, Awaitable[R]], Callable[P, Awaitable[None]]]
 ):

--- a/sentry_sdk/utils.py
+++ b/sentry_sdk/utils.py
@@ -1704,7 +1704,7 @@ def ensure_integration_enabled(
             return sentry_patched_function(*args, **kwargs)
 
         if original_function is _no_op:
-            return runner
+            return wraps(sentry_patched_function)(runner)
 
         return wraps(original_function)(runner)
 
@@ -1755,7 +1755,7 @@ def ensure_integration_enabled_async(
             return await sentry_patched_function(*args, **kwargs)
 
         if original_function is _no_op_async:
-            return runner
+            return wraps(sentry_patched_function)(runner)
 
         return wraps(original_function)(runner)
 

--- a/sentry_sdk/utils.py
+++ b/sentry_sdk/utils.py
@@ -1741,7 +1741,7 @@ def ensure_integration_enabled_async(
     """
 
     if TYPE_CHECKING:
-        # Type hint to ensure the default funciton has the write typing. The overloads
+        # Type hint to ensure the default function has the right typing. The overloads
         # ensure the default _no_op function is only used when R is None.
         original_function = cast(Callable[P, Awaitable[R]], original_function)
 

--- a/sentry_sdk/utils.py
+++ b/sentry_sdk/utils.py
@@ -1690,7 +1690,7 @@ def ensure_integration_enabled(
     ```
     """
     if TYPE_CHECKING:
-        # Type hint to ensure the default funciton has the write typing. The overloads
+        # Type hint to ensure the default function has the right typing. The overloads
         # ensure the default _no_op function is only used when R is None.
         original_function = cast(Callable[P, R], original_function)
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -597,6 +597,7 @@ def test_ensure_integration_enabled_integration_enabled(sentry_init):
     )
 
     assert patched_function() == "patched"
+    assert patched_function.__name__ == "original_function"
 
 
 def test_ensure_integration_enabled_integration_disabled(sentry_init):
@@ -614,6 +615,41 @@ def test_ensure_integration_enabled_integration_disabled(sentry_init):
     )
 
     assert patched_function() == "original"
+    assert patched_function.__name__ == "original_function"
+
+
+def test_ensure_integration_enabled_no_original_function_enabled(sentry_init):
+    shared_variable = "original"
+
+    def function_to_patch():
+        nonlocal shared_variable
+        shared_variable = "patched"
+
+    sentry_init(integrations=[TestIntegration])
+
+    # Test the decorator by applying to function_to_patch
+    patched_function = ensure_integration_enabled(TestIntegration)(function_to_patch)
+    patched_function()
+
+    assert shared_variable == "patched"
+    assert patched_function.__name__ == "function_to_patch"
+
+
+def test_ensure_integration_enabled_no_original_function_disabled(sentry_init):
+    shared_variable = "original"
+
+    def function_to_patch():
+        nonlocal shared_variable
+        shared_variable = "patched"
+
+    sentry_init(integrations=[])
+
+    # Test the decorator by applying to function_to_patch
+    patched_function = ensure_integration_enabled(TestIntegration)(function_to_patch)
+    patched_function()
+
+    assert shared_variable == "original"
+    assert patched_function.__name__ == "function_to_patch"
 
 
 @pytest.mark.asyncio
@@ -633,6 +669,7 @@ async def test_ensure_integration_enabled_async_integration_enabled(sentry_init)
     )(function_to_patch)
 
     assert await patched_function() == "patched"
+    assert patched_function.__name__ == "original_function"
 
 
 @pytest.mark.asyncio
@@ -652,3 +689,48 @@ async def test_ensure_integration_enabled_async_integration_disabled(sentry_init
     )(function_to_patch)
 
     assert await patched_function() == "original"
+    assert patched_function.__name__ == "original_function"
+
+
+@pytest.mark.asyncio
+async def test_ensure_integration_enabled_async_no_original_function_enabled(
+    sentry_init,
+):
+    shared_variable = "original"
+
+    async def function_to_patch():
+        nonlocal shared_variable
+        shared_variable = "patched"
+
+    sentry_init(integrations=[TestIntegration])
+
+    # Test the decorator by applying to function_to_patch
+    patched_function = ensure_integration_enabled_async(TestIntegration)(
+        function_to_patch
+    )
+    await patched_function()
+
+    assert shared_variable == "patched"
+    assert patched_function.__name__ == "function_to_patch"
+
+
+@pytest.mark.asyncio
+async def test_ensure_integration_enabled_async_no_original_function_disabled(
+    sentry_init,
+):
+    shared_variable = "original"
+
+    async def function_to_patch():
+        nonlocal shared_variable
+        shared_variable = "patched"
+
+    sentry_init(integrations=[])
+
+    # Test the decorator by applying to function_to_patch
+    patched_function = ensure_integration_enabled_async(TestIntegration)(
+        function_to_patch
+    )
+    await patched_function()
+
+    assert shared_variable == "original"
+    assert patched_function.__name__ == "function_to_patch"

--- a/tests/tracing/test_decorator.py
+++ b/tests/tracing/test_decorator.py
@@ -15,6 +15,7 @@ async def my_async_example_function():
     return "return_of_async_function"
 
 
+@pytest.mark.forked
 def test_trace_decorator():
     with patch_start_tracing_child() as fake_start_child:
         result = my_example_function()


### PR DESCRIPTION
`ensure_integration_enabled` and `ensure_integration_enabled_async` can now decorate functions that return `None` without an original function.