### PR TITLE
ref(integrations): Use new scopes API in web framework tests

### DIFF
--- a/tests/integrations/django/test_basic.py
+++ b/tests/integrations/django/test_basic.py
@@ -18,12 +18,13 @@ except ImportError:
     from django.core.urlresolvers import reverse
 
 from sentry_sdk._compat import PY310
-from sentry_sdk import capture_message, capture_exception, configure_scope
+from sentry_sdk import capture_message, capture_exception
 from sentry_sdk.consts import SPANDATA
 from sentry_sdk.integrations.django import DjangoIntegration, _set_db_data
 from sentry_sdk.integrations.django.signals_handlers import _get_receiver_name
 from sentry_sdk.integrations.django.caching import _get_span_description
 from sentry_sdk.integrations.executing import ExecutingIntegration
+from sentry_sdk.scope import Scope
 from sentry_sdk.tracing import Span
 from tests.conftest import unpack_werkzeug_response
 from tests.integrations.django.myapp.wsgi import application
@@ -372,8 +373,7 @@ def test_sql_queries(sentry_init, capture_events, with_integration):
 
     sql = connection.cursor()
 
-    with configure_scope() as scope:
-        scope.clear_breadcrumbs()
+    Scope.get_isolation_scope().clear_breadcrumbs()
 
     with pytest.raises(OperationalError):
         # table doesn't even exist
@@ -407,8 +407,7 @@ def test_sql_dict_query_params(sentry_init, capture_events):
     sql = connections["postgres"].cursor()
 
     events = capture_events()
-    with configure_scope() as scope:
-        scope.clear_breadcrumbs()
+    Scope.get_isolation_scope().clear_breadcrumbs()
 
     with pytest.raises(ProgrammingError):
         sql.execute(
@@ -473,8 +472,7 @@ def test_sql_psycopg2_string_composition(sentry_init, capture_events, query):
 
     sql = connections["postgres"].cursor()
 
-    with configure_scope() as scope:
-        scope.clear_breadcrumbs()
+    Scope.get_isolation_scope().clear_breadcrumbs()
 
     events = capture_events()
 
@@ -507,8 +505,7 @@ def test_sql_psycopg2_placeholders(sentry_init, capture_events):
     sql = connections["postgres"].cursor()
 
     events = capture_events()
-    with configure_scope() as scope:
-        scope.clear_breadcrumbs()
+    Scope.get_isolation_scope().clear_breadcrumbs()
 
     with pytest.raises(DataError):
         names = ["foo", "bar"]

--- a/tests/integrations/falcon/test_falcon.py
+++ b/tests/integrations/falcon/test_falcon.py
@@ -380,17 +380,20 @@ def test_does_not_leak_scope(sentry_init, capture_events):
     sentry_init(integrations=[FalconIntegration()])
     events = capture_events()
 
-    Scope.get_isolation_scope().set_tag("request_data", False)
+    scope = Scope.get_isolation_scope()
+    scope.set_tag("request_data", False)
 
     app = falcon.API()
 
     class Resource:
         def on_get(self, req, resp):
-            Scope.get_isolation_scope().set_tag("request_data", True)
+            scope = Scope.get_isolation_scope()
+            scope.set_tag("request_data", True)
 
             def generator():
                 for row in range(1000):
-                    assert Scope.get_isolation_scope()._tags["request_data"]
+                    scope = Scope.get_isolation_scope()
+                    assert scope._tags["request_data"]
 
                     yield (str(row) + "\n").encode()
 
@@ -405,7 +408,8 @@ def test_does_not_leak_scope(sentry_init, capture_events):
     assert response.text == expected_response
     assert not events
 
-    not Scope.get_isolation_scope()._tags["request_data"]
+    scope = Scope.get_isolation_scope()
+    assert not scope._tags["request_data"]
 
 
 @pytest.mark.skipif(

--- a/tests/integrations/falcon/test_falcon.py
+++ b/tests/integrations/falcon/test_falcon.py
@@ -380,20 +380,17 @@ def test_does_not_leak_scope(sentry_init, capture_events):
     sentry_init(integrations=[FalconIntegration()])
     events = capture_events()
 
-    scope = Scope.get_isolation_scope()
-    scope.set_tag("request_data", False)
+    Scope.get_isolation_scope().set_tag("request_data", False)
 
     app = falcon.API()
 
     class Resource:
         def on_get(self, req, resp):
-            scope = Scope.get_isolation_scope()
-            scope.set_tag("request_data", True)
+            Scope.get_isolation_scope().set_tag("request_data", True)
 
             def generator():
                 for row in range(1000):
-                    scope = Scope.get_isolation_scope()
-                    assert scope._tags["request_data"]
+                    assert Scope.get_isolation_scope()._tags["request_data"]
 
                     yield (str(row) + "\n").encode()
 
@@ -407,9 +404,7 @@ def test_does_not_leak_scope(sentry_init, capture_events):
     expected_response = "".join(str(row) + "\n" for row in range(1000))
     assert response.text == expected_response
     assert not events
-
-    scope = Scope.get_isolation_scope()
-    assert not scope._tags["request_data"]
+    assert not Scope.get_isolation_scope()._tags["request_data"]
 
 
 @pytest.mark.skipif(

--- a/tests/integrations/tornado/test_tornado.py
+++ b/tests/integrations/tornado/test_tornado.py
@@ -2,8 +2,9 @@ import json
 
 import pytest
 
-from sentry_sdk import configure_scope, start_transaction, capture_message
+from sentry_sdk import start_transaction, capture_message
 from sentry_sdk.integrations.tornado import TornadoIntegration
+from sentry_sdk.scope import Scope
 
 from tornado.web import RequestHandler, Application, HTTPError
 from tornado.testing import AsyncHTTPTestCase
@@ -36,13 +37,11 @@ def tornado_testcase(request):
 
 class CrashingHandler(RequestHandler):
     def get(self):
-        with configure_scope() as scope:
-            scope.set_tag("foo", "42")
+        Scope.get_isolation_scope().set_tag("foo", "42")
         1 / 0
 
     def post(self):
-        with configure_scope() as scope:
-            scope.set_tag("foo", "43")
+        Scope.get_isolation_scope().set_tag("foo", "43")
         1 / 0
 
 
@@ -54,14 +53,12 @@ class CrashingWithMessageHandler(RequestHandler):
 
 class HelloHandler(RequestHandler):
     async def get(self):
-        with configure_scope() as scope:
-            scope.set_tag("foo", "42")
+        Scope.get_isolation_scope().set_tag("foo", "42")
 
         return b"hello"
 
     async def post(self):
-        with configure_scope() as scope:
-            scope.set_tag("foo", "43")
+        Scope.get_isolation_scope().set_tag("foo", "43")
 
         return b"hello"
 
@@ -104,8 +101,7 @@ def test_basic(tornado_testcase, sentry_init, capture_events):
     )
     assert event["transaction_info"] == {"source": "component"}
 
-    with configure_scope() as scope:
-        assert not scope._tags
+    assert not Scope.get_isolation_scope()._tags
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Putting these in one PR because even though it spans different integrations, it's the same changes.

---

## General Notes

Thank you for contributing to `sentry-python`!

Please add tests to validate your changes, and lint your code using `tox -e linters`.

Running the test suite on your PR might require maintainer approval. Some tests (AWS Lambda) additionally require a maintainer to add a special label to run and will fail if the label is not present.

#### For maintainers

Sensitive test suites require maintainer review to ensure that tests do not compromise our secrets. This review must be repeated after any code revisions.

Before running sensitive test suites, please carefully check the PR. Then, apply the `Trigger: tests using secrets` label. The label will be removed after any code changes to enforce our policy requiring maintainers to review all code revisions before running sensitive tests.
