### PR TITLE
ref(threading): Use new scopes API in tests

### DIFF
--- a/tests/integrations/threading/test_threading.py
+++ b/tests/integrations/threading/test_threading.py
@@ -5,8 +5,9 @@ from threading import Thread
 import pytest
 
 import sentry_sdk
-from sentry_sdk import configure_scope, capture_message
+from sentry_sdk import capture_message
 from sentry_sdk.integrations.threading import ThreadingIntegration
+from sentry_sdk.scope import Scope
 
 original_start = Thread.start
 original_run = Thread.run
@@ -44,8 +45,7 @@ def test_propagates_hub(sentry_init, capture_events, propagate_hub):
     events = capture_events()
 
     def stage1():
-        with configure_scope() as scope:
-            scope.set_tag("stage1", "true")
+        Scope.get_isolation_scope().set_tag("stage1", "true")
 
         t = Thread(target=stage2)
         t.start()


### PR DESCRIPTION
<!-- Describe your PR here -->

---

## General Notes

Thank you for contributing to `sentry-python`!

Please add tests to validate your changes, and lint your code using `tox -e linters`.

Running the test suite on your PR might require maintainer approval. Some tests (AWS Lambda) additionally require a maintainer to add a special label to run and will fail if the label is not present.

#### For maintainers

Sensitive test suites require maintainer review to ensure that tests do not compromise our secrets. This review must be repeated after any code revisions.

Before running sensitive test suites, please carefully check the PR. Then, apply the `Trigger: tests using secrets` label. The label will be removed after any code changes to enforce our policy requiring maintainers to review all code revisions before running sensitive tests.
