### PR TITLE
ref: Correct `api.start_transaction` method signature

### DIFF
--- a/sentry_sdk/api.py
+++ b/sentry_sdk/api.py
@@ -3,6 +3,7 @@ from contextlib import contextmanager
 
 from sentry_sdk import tracing_utils, Client
 from sentry_sdk._types import TYPE_CHECKING
+from sentry_sdk.consts import INSTRUMENTER
 from sentry_sdk.scope import Scope, _ScopeManager, new_scope, isolation_scope
 from sentry_sdk.tracing import NoOpSpan, Transaction
 
@@ -282,10 +283,13 @@ def start_span(
 @scopemethod
 def start_transaction(
     transaction=None,  # type: Optional[Transaction]
+    instrumenter=INSTRUMENTER.SENTRY,  # type: str
     **kwargs,  # type: Unpack[StartTransactionKwargs]
 ):
     # type: (...) -> Union[Transaction, NoOpSpan]
-    return Scope.get_current_scope().start_transaction(transaction, **kwargs)
+    return Scope.get_current_scope().start_transaction(
+        transaction, instrumenter, **kwargs
+    )
 
 
 def set_measurement(name, value, unit=""):


### PR DESCRIPTION
Adds the `instrumenter` argument to `sentry_sdk.start_transaction`. Should unblock #2865.
