### PR TITLE
fix(crons): Make `monitor` async friendly

### DIFF
--- a/sentry_sdk/crons/_decorator.py
+++ b/sentry_sdk/crons/_decorator.py
@@ -1,0 +1,90 @@
+from functools import wraps
+
+try:
+    from inspect import iscoroutinefunction
+except ImportError:
+    iscoroutinefunction = lambda f: False
+
+from sentry_sdk._types import TYPE_CHECKING
+from sentry_sdk.crons import capture_checkin
+from sentry_sdk.crons.consts import MonitorStatus
+from sentry_sdk.utils import now
+
+if TYPE_CHECKING:
+    from typing import Callable, Optional, Type
+    from types import TracebackType
+
+
+class monitor:  # noqa: N801
+    """
+    Decorator/context manager to capture checkin events for a monitor.
+
+    Usage (as decorator):
+    ```
+    import sentry_sdk
+
+    app = Celery()
+
+    @app.task
+    @sentry_sdk.monitor(monitor_slug='my-fancy-slug')
+    def test(arg):
+        print(arg)
+    ```
+
+    This does not have to be used with Celery, but if you do use it with celery,
+    put the `@sentry_sdk.monitor` decorator below Celery's `@app.task` decorator.
+
+    Usage (as context manager):
+    ```
+    import sentry_sdk
+
+    def test(arg):
+        with sentry_sdk.monitor(monitor_slug='my-fancy-slug'):
+            print(arg)
+    ```
+    """
+
+    def __init__(self, monitor_slug=None):
+        # type: (str) -> None
+        self.monitor_slug = monitor_slug
+
+    def __enter__(self):
+        # type: () -> None
+        self.start_timestamp = now()
+        self.check_in_id = capture_checkin(
+            monitor_slug=self.monitor_slug, status=MonitorStatus.IN_PROGRESS
+        )
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        # type: (Optional[Type[BaseException]], Optional[BaseException], Optional[TracebackType]) -> None
+        duration_s = now() - self.start_timestamp
+
+        if exc_type is None and exc_value is None and traceback is None:
+            status = MonitorStatus.OK
+        else:
+            status = MonitorStatus.ERROR
+
+        capture_checkin(
+            monitor_slug=self.monitor_slug,
+            check_in_id=self.check_in_id,
+            status=status,
+            duration=duration_s,
+        )
+
+    def __call__(self, fn):
+        # type: (Callable) -> Callable
+        if iscoroutinefunction(fn):
+
+            @wraps(fn)
+            async def inner(*args, **kwargs):
+                with self:
+                    return await fn(*args, **kwargs)
+
+        else:
+
+            @wraps(fn)
+            def inner(*args, **kwargs):
+                with self:
+                    return fn(*args, **kwargs)
+
+        return inner

--- a/sentry_sdk/crons/_decorator.py
+++ b/sentry_sdk/crons/_decorator.py
@@ -4,12 +4,15 @@ from inspect import iscoroutinefunction
 from sentry_sdk._types import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from typing import Any, Callable
+    from typing import Any, Callable, ParamSpec, TypeVar
+
+    P = ParamSpec("P")
+    R = TypeVar("R")
 
 
-class _MonitorMixin:
+class MonitorMixin:
     def __call__(self, fn):
-        # type: (Callable[..., Any]) -> Callable[..., Any]
+        # type: (Callable[P, R]) -> Callable[P, R]
         if iscoroutinefunction(fn):
 
             @wraps(fn)

--- a/sentry_sdk/crons/_decorator.py
+++ b/sentry_sdk/crons/_decorator.py
@@ -4,7 +4,13 @@ from inspect import iscoroutinefunction
 from sentry_sdk._types import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from typing import Any, Callable, ParamSpec, TypeVar
+    from typing import (
+        Awaitable,
+        Callable,
+        ParamSpec,
+        TypeVar,
+        Union,
+    )
 
     P = ParamSpec("P")
     R = TypeVar("R")
@@ -12,20 +18,18 @@ if TYPE_CHECKING:
 
 class MonitorMixin:
     def __call__(self, fn):
-        # type: (Callable[P, R]) -> Callable[P, R]
+        # type: (Callable[P, R]) -> Callable[P, Union[R, Awaitable[R]]]
         if iscoroutinefunction(fn):
 
             @wraps(fn)
-            async def inner(*args, **kwargs):
-                # type: (Any, Any) -> Any
+            async def inner(*args: "P.args", **kwargs: "P.kwargs") -> R:
                 with self:  # type: ignore[attr-defined]
                     return await fn(*args, **kwargs)
 
         else:
 
             @wraps(fn)
-            def inner(*args, **kwargs):
-                # type: (Any, Any) -> Any
+            def inner(*args: "P.args", **kwargs: "P.kwargs") -> R:
                 with self:  # type: ignore[attr-defined]
                     return fn(*args, **kwargs)
 

--- a/sentry_sdk/crons/_decorator.py
+++ b/sentry_sdk/crons/_decorator.py
@@ -14,14 +14,16 @@ class _MonitorMixin:
 
             @wraps(fn)
             async def inner(*args, **kwargs):
-                with self:
+                # type: (Any, Any) -> Any
+                with self:  # type: ignore[attr-defined]
                     return await fn(*args, **kwargs)
 
         else:
 
             @wraps(fn)
             def inner(*args, **kwargs):
-                with self:
+                # type: (Any, Any) -> Any
+                with self:  # type: ignore[attr-defined]
                     return fn(*args, **kwargs)
 
         return inner

--- a/sentry_sdk/crons/_decorator.py
+++ b/sentry_sdk/crons/_decorator.py
@@ -22,14 +22,16 @@ class MonitorMixin:
         if iscoroutinefunction(fn):
 
             @wraps(fn)
-            async def inner(*args: "P.args", **kwargs: "P.kwargs") -> R:
+            async def inner(*args: "P.args", **kwargs: "P.kwargs"):
+                # type: (...) -> R
                 with self:  # type: ignore[attr-defined]
                     return await fn(*args, **kwargs)
 
         else:
 
             @wraps(fn)
-            def inner(*args: "P.args", **kwargs: "P.kwargs") -> R:
+            def inner(*args: "P.args", **kwargs: "P.kwargs"):
+                # type: (...) -> R
                 with self:  # type: ignore[attr-defined]
                     return fn(*args, **kwargs)
 

--- a/sentry_sdk/crons/_decorator.py
+++ b/sentry_sdk/crons/_decorator.py
@@ -1,78 +1,15 @@
 from functools import wraps
-
-try:
-    from inspect import iscoroutinefunction
-except ImportError:
-    iscoroutinefunction = lambda f: False
+from inspect import iscoroutinefunction
 
 from sentry_sdk._types import TYPE_CHECKING
-from sentry_sdk.crons import capture_checkin
-from sentry_sdk.crons.consts import MonitorStatus
-from sentry_sdk.utils import now
 
 if TYPE_CHECKING:
-    from typing import Callable, Optional, Type
-    from types import TracebackType
+    from typing import Any, Callable
 
 
-class monitor:  # noqa: N801
-    """
-    Decorator/context manager to capture checkin events for a monitor.
-
-    Usage (as decorator):
-    ```
-    import sentry_sdk
-
-    app = Celery()
-
-    @app.task
-    @sentry_sdk.monitor(monitor_slug='my-fancy-slug')
-    def test(arg):
-        print(arg)
-    ```
-
-    This does not have to be used with Celery, but if you do use it with celery,
-    put the `@sentry_sdk.monitor` decorator below Celery's `@app.task` decorator.
-
-    Usage (as context manager):
-    ```
-    import sentry_sdk
-
-    def test(arg):
-        with sentry_sdk.monitor(monitor_slug='my-fancy-slug'):
-            print(arg)
-    ```
-    """
-
-    def __init__(self, monitor_slug=None):
-        # type: (str) -> None
-        self.monitor_slug = monitor_slug
-
-    def __enter__(self):
-        # type: () -> None
-        self.start_timestamp = now()
-        self.check_in_id = capture_checkin(
-            monitor_slug=self.monitor_slug, status=MonitorStatus.IN_PROGRESS
-        )
-
-    def __exit__(self, exc_type, exc_value, traceback):
-        # type: (Optional[Type[BaseException]], Optional[BaseException], Optional[TracebackType]) -> None
-        duration_s = now() - self.start_timestamp
-
-        if exc_type is None and exc_value is None and traceback is None:
-            status = MonitorStatus.OK
-        else:
-            status = MonitorStatus.ERROR
-
-        capture_checkin(
-            monitor_slug=self.monitor_slug,
-            check_in_id=self.check_in_id,
-            status=status,
-            duration=duration_s,
-        )
-
+class _MonitorMixin:
     def __call__(self, fn):
-        # type: (Callable) -> Callable
+        # type: (Callable[..., Any]) -> Callable[..., Any]
         if iscoroutinefunction(fn):
 
             @wraps(fn)

--- a/sentry_sdk/crons/_decorator_py2.py
+++ b/sentry_sdk/crons/_decorator_py2.py
@@ -1,0 +1,70 @@
+import sys
+
+from sentry_sdk._compat import contextmanager, reraise
+from sentry_sdk._types import TYPE_CHECKING
+from sentry_sdk.crons import capture_checkin
+from sentry_sdk.crons.consts import MonitorStatus
+from sentry_sdk.utils import now
+
+if TYPE_CHECKING:
+    from typing import Generator, Optional
+
+
+@contextmanager
+def monitor(monitor_slug=None):
+    # type: (Optional[str]) -> Generator[None, None, None]
+    """
+    Decorator/context manager to capture checkin events for a monitor.
+
+    Usage (as decorator):
+    ```
+    import sentry_sdk
+
+    app = Celery()
+
+    @app.task
+    @sentry_sdk.monitor(monitor_slug='my-fancy-slug')
+    def test(arg):
+        print(arg)
+    ```
+
+    This does not have to be used with Celery, but if you do use it with celery,
+    put the `@sentry_sdk.monitor` decorator below Celery's `@app.task` decorator.
+
+    Usage (as context manager):
+    ```
+    import sentry_sdk
+
+    def test(arg):
+        with sentry_sdk.monitor(monitor_slug='my-fancy-slug'):
+            print(arg)
+    ```
+
+
+    """
+
+    start_timestamp = now()
+    check_in_id = capture_checkin(
+        monitor_slug=monitor_slug, status=MonitorStatus.IN_PROGRESS
+    )
+
+    try:
+        yield
+    except Exception:
+        duration_s = now() - start_timestamp
+        capture_checkin(
+            monitor_slug=monitor_slug,
+            check_in_id=check_in_id,
+            status=MonitorStatus.ERROR,
+            duration=duration_s,
+        )
+        exc_info = sys.exc_info()
+        reraise(*exc_info)
+
+    duration_s = now() - start_timestamp
+    capture_checkin(
+        monitor_slug=monitor_slug,
+        check_in_id=check_in_id,
+        status=MonitorStatus.OK,
+        duration=duration_s,
+    )

--- a/sentry_sdk/crons/_decorator_py2.py
+++ b/sentry_sdk/crons/_decorator_py2.py
@@ -1,70 +1,17 @@
-import sys
+from functools import wraps
 
-from sentry_sdk._compat import contextmanager, reraise
 from sentry_sdk._types import TYPE_CHECKING
-from sentry_sdk.crons import capture_checkin
-from sentry_sdk.crons.consts import MonitorStatus
-from sentry_sdk.utils import now
 
 if TYPE_CHECKING:
-    from typing import Generator, Optional
+    from typing import Any, Callable
 
 
-@contextmanager
-def monitor(monitor_slug=None):
-    # type: (Optional[str]) -> Generator[None, None, None]
-    """
-    Decorator/context manager to capture checkin events for a monitor.
+class _MonitorMixin:
+    def __call__(self, fn):
+        # type: (Callable[..., Any]) -> Callable[..., Any]
+        @wraps(fn)
+        def inner(*args, **kwargs):
+            with self:
+                return fn(*args, **kwargs)
 
-    Usage (as decorator):
-    ```
-    import sentry_sdk
-
-    app = Celery()
-
-    @app.task
-    @sentry_sdk.monitor(monitor_slug='my-fancy-slug')
-    def test(arg):
-        print(arg)
-    ```
-
-    This does not have to be used with Celery, but if you do use it with celery,
-    put the `@sentry_sdk.monitor` decorator below Celery's `@app.task` decorator.
-
-    Usage (as context manager):
-    ```
-    import sentry_sdk
-
-    def test(arg):
-        with sentry_sdk.monitor(monitor_slug='my-fancy-slug'):
-            print(arg)
-    ```
-
-
-    """
-
-    start_timestamp = now()
-    check_in_id = capture_checkin(
-        monitor_slug=monitor_slug, status=MonitorStatus.IN_PROGRESS
-    )
-
-    try:
-        yield
-    except Exception:
-        duration_s = now() - start_timestamp
-        capture_checkin(
-            monitor_slug=monitor_slug,
-            check_in_id=check_in_id,
-            status=MonitorStatus.ERROR,
-            duration=duration_s,
-        )
-        exc_info = sys.exc_info()
-        reraise(*exc_info)
-
-    duration_s = now() - start_timestamp
-    capture_checkin(
-        monitor_slug=monitor_slug,
-        check_in_id=check_in_id,
-        status=MonitorStatus.OK,
-        duration=duration_s,
-    )
+        return inner

--- a/sentry_sdk/crons/_decorator_py2.py
+++ b/sentry_sdk/crons/_decorator_py2.py
@@ -3,12 +3,15 @@ from functools import wraps
 from sentry_sdk._types import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from typing import Any, Callable
+    from typing import Any, Callable, ParamSpec, TypeVar
+
+    P = ParamSpec("P")
+    R = TypeVar("R")
 
 
-class _MonitorMixin:
+class MonitorMixin:
     def __call__(self, fn):
-        # type: (Callable[..., Any]) -> Callable[..., Any]
+        # type: (Callable[P, R]) -> Callable[P, R]
         @wraps(fn)
         def inner(*args, **kwargs):
             # type: (Any, Any) -> Any

--- a/sentry_sdk/crons/_decorator_py2.py
+++ b/sentry_sdk/crons/_decorator_py2.py
@@ -11,7 +11,8 @@ class _MonitorMixin:
         # type: (Callable[..., Any]) -> Callable[..., Any]
         @wraps(fn)
         def inner(*args, **kwargs):
-            with self:
+            # type: (Any, Any) -> Any
+            with self:  # type: ignore[attr-defined]
                 return fn(*args, **kwargs)
 
         return inner

--- a/sentry_sdk/crons/decorator.py
+++ b/sentry_sdk/crons/decorator.py
@@ -1,11 +1,75 @@
 from sentry_sdk._compat import PY2
+from sentry_sdk._types import TYPE_CHECKING
+from sentry_sdk.crons import capture_checkin
+from sentry_sdk.crons.consts import MonitorStatus
+from sentry_sdk.utils import now
+
+if TYPE_CHECKING:
+    from typing import Optional, Type
+    from types import TracebackType
 
 if PY2:
-    from sentry_sdk.crons._decorator_py2 import monitor
+    from sentry_sdk.crons._decorator_py2 import _MonitorMixin
 else:
-    from sentry_sdk.crons._decorator import monitor
+    # This is in its own module so that we don't trigger
+    # `async def` SyntaxErrors on Python 2.
+    # Once we drop Python 2, remove the mixin and merge it
+    # into the main monitor class.
+    from sentry_sdk.crons._decorator import _MonitorMixin
 
 
-__all__ = [
-    monitor,
-]
+class monitor(_MonitorMixin):
+    """
+    Decorator/context manager to capture checkin events for a monitor.
+
+    Usage (as decorator):
+    ```
+    import sentry_sdk
+
+    app = Celery()
+
+    @app.task
+    @sentry_sdk.monitor(monitor_slug='my-fancy-slug')
+    def test(arg):
+        print(arg)
+    ```
+
+    This does not have to be used with Celery, but if you do use it with celery,
+    put the `@sentry_sdk.monitor` decorator below Celery's `@app.task` decorator.
+
+    Usage (as context manager):
+    ```
+    import sentry_sdk
+
+    def test(arg):
+        with sentry_sdk.monitor(monitor_slug='my-fancy-slug'):
+            print(arg)
+    ```
+    """
+
+    def __init__(self, monitor_slug=None):
+        # type: (Optional[str]) -> None
+        self.monitor_slug = monitor_slug
+
+    def __enter__(self):
+        # type: () -> None
+        self.start_timestamp = now()
+        self.check_in_id = capture_checkin(
+            monitor_slug=self.monitor_slug, status=MonitorStatus.IN_PROGRESS
+        )
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        # type: (Optional[Type[BaseException]], Optional[BaseException], Optional[TracebackType]) -> None
+        duration_s = now() - self.start_timestamp
+
+        if exc_type is None and exc_value is None and traceback is None:
+            status = MonitorStatus.OK
+        else:
+            status = MonitorStatus.ERROR
+
+        capture_checkin(
+            monitor_slug=self.monitor_slug,
+            check_in_id=self.check_in_id,
+            status=status,
+            duration=duration_s,
+        )

--- a/sentry_sdk/crons/decorator.py
+++ b/sentry_sdk/crons/decorator.py
@@ -9,16 +9,16 @@ if TYPE_CHECKING:
     from types import TracebackType
 
 if PY2:
-    from sentry_sdk.crons._decorator_py2 import _MonitorMixin
+    from sentry_sdk.crons._decorator_py2 import MonitorMixin
 else:
     # This is in its own module so that we don't make Python 2
     # angery over `async def`s.
     # Once we drop Python 2, remove the mixin and merge it
     # into the main monitor class.
-    from sentry_sdk.crons._decorator import _MonitorMixin
+    from sentry_sdk.crons._decorator import MonitorMixin
 
 
-class monitor(_MonitorMixin):  # noqa: N801
+class monitor(MonitorMixin):  # noqa: N801
     """
     Decorator/context manager to capture checkin events for a monitor.
 

--- a/sentry_sdk/crons/decorator.py
+++ b/sentry_sdk/crons/decorator.py
@@ -48,16 +48,10 @@ class monitor:
         # type: (Callable) -> Callable
         if iscoroutinefunction(fn):
 
-            # No async def in Python 2...
-            # XXX get rid of this in SDK 2.0
-            exec(
-                """
             @wraps(fn)
             async def inner(*args, **kwargs):
                 with self:
                     return await fn(*args, **kwargs)
-            """
-            )
 
         else:
 

--- a/sentry_sdk/crons/decorator.py
+++ b/sentry_sdk/crons/decorator.py
@@ -11,14 +11,14 @@ if TYPE_CHECKING:
 if PY2:
     from sentry_sdk.crons._decorator_py2 import _MonitorMixin
 else:
-    # This is in its own module so that we don't trigger
-    # `async def` SyntaxErrors on Python 2.
+    # This is in its own module so that we don't make Python 2
+    # angery over `async def` SyntaxErrors.
     # Once we drop Python 2, remove the mixin and merge it
     # into the main monitor class.
     from sentry_sdk.crons._decorator import _MonitorMixin
 
 
-class monitor(_MonitorMixin):
+class monitor(_MonitorMixin):  # noqa: N801
     """
     Decorator/context manager to capture checkin events for a monitor.
 

--- a/sentry_sdk/crons/decorator.py
+++ b/sentry_sdk/crons/decorator.py
@@ -12,7 +12,7 @@ if PY2:
     from sentry_sdk.crons._decorator_py2 import _MonitorMixin
 else:
     # This is in its own module so that we don't make Python 2
-    # angery over `async def` SyntaxErrors.
+    # angery over `async def`s.
     # Once we drop Python 2, remove the mixin and merge it
     # into the main monitor class.
     from sentry_sdk.crons._decorator import _MonitorMixin

--- a/sentry_sdk/crons/decorator.py
+++ b/sentry_sdk/crons/decorator.py
@@ -1,63 +1,11 @@
-from functools import wraps
+from sentry_sdk._compat import PY2
 
-try:
-    from inspect import iscoroutinefunction
-except ImportError:
-    iscoroutinefunction = lambda f: False
-
-from sentry_sdk._types import TYPE_CHECKING
-from sentry_sdk.crons import capture_checkin
-from sentry_sdk.crons.consts import MonitorStatus
-from sentry_sdk.utils import now
+if PY2:
+    from sentry_sdk.crons._decorator_py2 import monitor
+else:
+    from sentry_sdk.crons._decorator import monitor
 
 
-if TYPE_CHECKING:
-    from typing import Callable, Optional, Type
-    from types import TracebackType
-
-
-class monitor:  # noqa: N801
-    def __init__(self, monitor_slug=None):
-        # type: (str) -> None
-        self.monitor_slug = monitor_slug
-
-    def __enter__(self):
-        # type: () -> None
-        self.start_timestamp = now()
-        self.check_in_id = capture_checkin(
-            monitor_slug=self.monitor_slug, status=MonitorStatus.IN_PROGRESS
-        )
-
-    def __exit__(self, exc_type, exc_value, traceback):
-        # type: (Optional[Type[BaseException]], Optional[BaseException], Optional[TracebackType]) -> None
-        duration_s = now() - self.start_timestamp
-
-        if exc_type is None and exc_value is None and traceback is None:
-            status = MonitorStatus.OK
-        else:
-            status = MonitorStatus.ERROR
-
-        capture_checkin(
-            monitor_slug=self.monitor_slug,
-            check_in_id=self.check_in_id,
-            status=status,
-            duration=duration_s,
-        )
-
-    def __call__(self, fn):
-        # type: (Callable) -> Callable
-        if iscoroutinefunction(fn):
-
-            @wraps(fn)
-            async def inner(*args, **kwargs):
-                with self:
-                    return await fn(*args, **kwargs)
-
-        else:
-
-            @wraps(fn)
-            def inner(*args, **kwargs):
-                with self:
-                    return fn(*args, **kwargs)
-
-        return inner
+__all__ = [
+    monitor,
+]

--- a/sentry_sdk/crons/decorator.py
+++ b/sentry_sdk/crons/decorator.py
@@ -16,7 +16,7 @@ if TYPE_CHECKING:
     from types import TracebackType
 
 
-class monitor:
+class monitor:  # noqa: N801
     def __init__(self, monitor_slug=None):
         # type: (str) -> None
         self.monitor_slug = monitor_slug

--- a/tests/crons/test_crons.py
+++ b/tests/crons/test_crons.py
@@ -39,22 +39,22 @@ def test_decorator(sentry_init):
 
     with mock.patch(
         "sentry_sdk.crons.decorator.capture_checkin"
-    ) as fake_capture_checking:
+    ) as fake_capture_checkin:
         result = _hello_world("Grace")
         assert result == "Hello, Grace"
 
         # Check for initial checkin
-        fake_capture_checking.assert_has_calls(
+        fake_capture_checkin.assert_has_calls(
             [
                 mock.call(monitor_slug="abc123", status="in_progress"),
             ]
         )
 
         # Check for final checkin
-        assert fake_capture_checking.call_args[1]["monitor_slug"] == "abc123"
-        assert fake_capture_checking.call_args[1]["status"] == "ok"
-        assert fake_capture_checking.call_args[1]["duration"]
-        assert fake_capture_checking.call_args[1]["check_in_id"]
+        assert fake_capture_checkin.call_args[1]["monitor_slug"] == "abc123"
+        assert fake_capture_checkin.call_args[1]["status"] == "ok"
+        assert fake_capture_checkin.call_args[1]["duration"]
+        assert fake_capture_checkin.call_args[1]["check_in_id"]
 
 
 def test_decorator_error(sentry_init):
@@ -62,24 +62,24 @@ def test_decorator_error(sentry_init):
 
     with mock.patch(
         "sentry_sdk.crons.decorator.capture_checkin"
-    ) as fake_capture_checking:
+    ) as fake_capture_checkin:
         with pytest.raises(ZeroDivisionError):
             result = _break_world("Grace")
 
         assert "result" not in locals()
 
         # Check for initial checkin
-        fake_capture_checking.assert_has_calls(
+        fake_capture_checkin.assert_has_calls(
             [
                 mock.call(monitor_slug="def456", status="in_progress"),
             ]
         )
 
         # Check for final checkin
-        assert fake_capture_checking.call_args[1]["monitor_slug"] == "def456"
-        assert fake_capture_checking.call_args[1]["status"] == "error"
-        assert fake_capture_checking.call_args[1]["duration"]
-        assert fake_capture_checking.call_args[1]["check_in_id"]
+        assert fake_capture_checkin.call_args[1]["monitor_slug"] == "def456"
+        assert fake_capture_checkin.call_args[1]["status"] == "error"
+        assert fake_capture_checkin.call_args[1]["duration"]
+        assert fake_capture_checkin.call_args[1]["check_in_id"]
 
 
 def test_contextmanager(sentry_init):
@@ -87,22 +87,22 @@ def test_contextmanager(sentry_init):
 
     with mock.patch(
         "sentry_sdk.crons.decorator.capture_checkin"
-    ) as fake_capture_checking:
+    ) as fake_capture_checkin:
         result = _hello_world_contextmanager("Grace")
         assert result == "Hello, Grace"
 
         # Check for initial checkin
-        fake_capture_checking.assert_has_calls(
+        fake_capture_checkin.assert_has_calls(
             [
                 mock.call(monitor_slug="abc123", status="in_progress"),
             ]
         )
 
         # Check for final checkin
-        assert fake_capture_checking.call_args[1]["monitor_slug"] == "abc123"
-        assert fake_capture_checking.call_args[1]["status"] == "ok"
-        assert fake_capture_checking.call_args[1]["duration"]
-        assert fake_capture_checking.call_args[1]["check_in_id"]
+        assert fake_capture_checkin.call_args[1]["monitor_slug"] == "abc123"
+        assert fake_capture_checkin.call_args[1]["status"] == "ok"
+        assert fake_capture_checkin.call_args[1]["duration"]
+        assert fake_capture_checkin.call_args[1]["check_in_id"]
 
 
 def test_contextmanager_error(sentry_init):
@@ -110,24 +110,24 @@ def test_contextmanager_error(sentry_init):
 
     with mock.patch(
         "sentry_sdk.crons.decorator.capture_checkin"
-    ) as fake_capture_checking:
+    ) as fake_capture_checkin:
         with pytest.raises(ZeroDivisionError):
             result = _break_world_contextmanager("Grace")
 
         assert "result" not in locals()
 
         # Check for initial checkin
-        fake_capture_checking.assert_has_calls(
+        fake_capture_checkin.assert_has_calls(
             [
                 mock.call(monitor_slug="def456", status="in_progress"),
             ]
         )
 
         # Check for final checkin
-        assert fake_capture_checking.call_args[1]["monitor_slug"] == "def456"
-        assert fake_capture_checking.call_args[1]["status"] == "error"
-        assert fake_capture_checking.call_args[1]["duration"]
-        assert fake_capture_checking.call_args[1]["check_in_id"]
+        assert fake_capture_checkin.call_args[1]["monitor_slug"] == "def456"
+        assert fake_capture_checkin.call_args[1]["status"] == "error"
+        assert fake_capture_checkin.call_args[1]["duration"]
+        assert fake_capture_checkin.call_args[1]["check_in_id"]
 
 
 def test_capture_checkin_simple(sentry_init):

--- a/tests/crons/test_crons.py
+++ b/tests/crons/test_crons.py
@@ -2,9 +2,8 @@ import pytest
 import uuid
 
 import sentry_sdk
-from sentry_sdk.crons import capture_checkin
-
 from sentry_sdk import Hub, configure_scope, set_level
+from sentry_sdk.crons import capture_checkin
 
 try:
     from unittest import mock  # python 3.3 and above

--- a/tests/crons/test_crons_async_py3.py
+++ b/tests/crons/test_crons_async_py3.py
@@ -1,0 +1,136 @@
+import pytest
+
+import sentry_sdk
+
+try:
+    from unittest import mock  # python 3.3 and above
+except ImportError:
+    import mock  # python < 3.3
+
+
+@sentry_sdk.monitor(monitor_slug="abc123")
+async def _hello_world(name):
+    return "Hello, {}".format(name)
+
+
+@sentry_sdk.monitor(monitor_slug="def456")
+async def _break_world(name):
+    1 / 0
+    return "Hello, {}".format(name)
+
+
+async def my_coroutine():
+    return
+
+
+async def _hello_world_contextmanager(name):
+    with sentry_sdk.monitor(monitor_slug="abc123"):
+        await my_coroutine()
+        return "Hello, {}".format(name)
+
+
+async def _break_world_contextmanager(name):
+    with sentry_sdk.monitor(monitor_slug="def456"):
+        await my_coroutine()
+        1 / 0
+        return "Hello, {}".format(name)
+
+
+@pytest.mark.asyncio
+async def test_decorator(sentry_init):
+    sentry_init()
+
+    with mock.patch(
+        "sentry_sdk.crons.decorator.capture_checkin"
+    ) as fake_capture_checkin:
+        result = await _hello_world("Grace")
+        assert result == "Hello, Grace"
+
+        # Check for initial checkin
+        fake_capture_checkin.assert_has_calls(
+            [
+                mock.call(monitor_slug="abc123", status="in_progress"),
+            ]
+        )
+
+        # Check for final checkin
+        assert fake_capture_checkin.call_args[1]["monitor_slug"] == "abc123"
+        assert fake_capture_checkin.call_args[1]["status"] == "ok"
+        assert fake_capture_checkin.call_args[1]["duration"]
+        assert fake_capture_checkin.call_args[1]["check_in_id"]
+
+
+@pytest.mark.asyncio
+async def test_decorator_error(sentry_init):
+    sentry_init()
+
+    with mock.patch(
+        "sentry_sdk.crons.decorator.capture_checkin"
+    ) as fake_capture_checkin:
+        with pytest.raises(ZeroDivisionError):
+            result = await _break_world("Grace")
+
+        assert "result" not in locals()
+
+        # Check for initial checkin
+        fake_capture_checkin.assert_has_calls(
+            [
+                mock.call(monitor_slug="def456", status="in_progress"),
+            ]
+        )
+
+        # Check for final checkin
+        assert fake_capture_checkin.call_args[1]["monitor_slug"] == "def456"
+        assert fake_capture_checkin.call_args[1]["status"] == "error"
+        assert fake_capture_checkin.call_args[1]["duration"]
+        assert fake_capture_checkin.call_args[1]["check_in_id"]
+
+
+@pytest.mark.asyncio
+async def test_contextmanager(sentry_init):
+    sentry_init()
+
+    with mock.patch(
+        "sentry_sdk.crons.decorator.capture_checkin"
+    ) as fake_capture_checkin:
+        result = await _hello_world_contextmanager("Grace")
+        assert result == "Hello, Grace"
+
+        # Check for initial checkin
+        fake_capture_checkin.assert_has_calls(
+            [
+                mock.call(monitor_slug="abc123", status="in_progress"),
+            ]
+        )
+
+        # Check for final checkin
+        assert fake_capture_checkin.call_args[1]["monitor_slug"] == "abc123"
+        assert fake_capture_checkin.call_args[1]["status"] == "ok"
+        assert fake_capture_checkin.call_args[1]["duration"]
+        assert fake_capture_checkin.call_args[1]["check_in_id"]
+
+
+@pytest.mark.asyncio
+async def test_contextmanager_error(sentry_init):
+    sentry_init()
+
+    with mock.patch(
+        "sentry_sdk.crons.decorator.capture_checkin"
+    ) as fake_capture_checkin:
+        with pytest.raises(ZeroDivisionError):
+            result = await _break_world_contextmanager("Grace")
+
+        assert "result" not in locals()
+
+        # Check for initial checkin
+        fake_capture_checkin.assert_has_calls(
+            [
+                mock.call(monitor_slug="def456", status="in_progress"),
+            ]
+        )
+
+        # Check for final checkin
+        assert fake_capture_checkin.call_args[1]["monitor_slug"] == "def456"
+        assert fake_capture_checkin.call_args[1]["status"] == "error"
+        assert fake_capture_checkin.call_args[1]["duration"]
+        assert fake_capture_checkin.call_args[1]["check_in_id"]


### PR DESCRIPTION
Our `monitor` decorator/context manager is not async friendly. If you wrap an async function in it, `monitor` will only wrap the creation of the coroutine, rather than its execution, which means it'll exit early. It won't capture the actual duration of the execution of the function, and the cron run will always be reported as success.

To better illustrate, try this out:

```python
import asyncio
import sentry_sdk

sentry_sdk.init(...)

@sentry_sdk.monitor(monitor_slug='my-slug')
async def my_cron():
    print('running...')
    await asyncio.sleep(1)
    raise ValueError

asyncio.run(my_cron())
```

If you execute this, you'll see multiple fishy things:
* the cron will be green even though it throws an exception
* even if it takes >= 1s to execute, the time reported will be ~0ms
* the "running..." message will be printed _after_ the final checkin (you can see this with `debug=True`)

To fix this, we need special handling for the async case where we actually execute the coroutine and wait until it's finished before reporting.

## Implementation Notes

This is annoying to implement cleanly because of Python 2 compatibility. Python 2 will throw `SyntaxErrors` when it encounters any `async def`s. We could use an `exec` for the async part, but this is ugly.

Instead, I'm implementing the Python2+3-friendly part of the decorator in the main `monitor` class and outsourcing the problematic `__call__` definition to version-specific mixins, where the Python 3-only mixin will never get imported on Python 2.

In any case, we can get rid of this compat hack with SDK 2.0.