### PR TITLE
ref: Explicit reexport of types (backport to 1.x)

### DIFF
--- a/sentry_sdk/types.py
+++ b/sentry_sdk/types.py
@@ -12,3 +12,5 @@ from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from sentry_sdk._types import Event, Hint  # noqa: F401
+
+    __all__ = ["Event", "Hint"]


### PR DESCRIPTION
Explicitly reexport types to make strict mypy setups happy. This backports #2866 to 1.x.

Fixes GH-2910