### PR TITLE
ref: Define types at runtime

### DIFF
--- a/sentry_sdk/types.py
+++ b/sentry_sdk/types.py
@@ -11,7 +11,7 @@ releases.
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from sentry_sdk._types import Event, Hint  # noqa: F401
+    from sentry_sdk._types import Event, Hint
 else:
     # The lines below allow the types to be imported from outside `if TYPE_CHECKING`
     # guards. The types in this module are only intended to be used for type hints.

--- a/sentry_sdk/types.py
+++ b/sentry_sdk/types.py
@@ -18,4 +18,4 @@ else:
     Event = None
     Hint = None
 
-__all__ = ["Event", "Hint"]
+__all__ = ("Event", "Hint")

--- a/sentry_sdk/types.py
+++ b/sentry_sdk/types.py
@@ -12,5 +12,10 @@ from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from sentry_sdk._types import Event, Hint  # noqa: F401
+else:
+    # The lines below allow the types to be imported from outside `if TYPE_CHECKING`
+    # guards. The types in this module are only intended to be used for type hints.
+    Event = None
+    Hint = None
 
-    __all__ = ["Event", "Hint"]
+__all__ = ["Event", "Hint"]

--- a/sentry_sdk/types.py
+++ b/sentry_sdk/types.py
@@ -12,3 +12,5 @@ from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from sentry_sdk._types import Event, Hint  # noqa: F401
+
+    __all__ = ["Event", "Hint"]


### PR DESCRIPTION
Set types in `sentry_sdk.types` to `None` at runtime. This allows the types to be imported from outside `if TYPE_CHECKING` guards.

Fixes GH-2909
