### PR TITLE
ref(socket): Use new scopes API

### DIFF
--- a/sentry_sdk/integrations/socket.py
+++ b/sentry_sdk/integrations/socket.py
@@ -1,8 +1,10 @@
 import socket
-from sentry_sdk import Hub
+
+import sentry_sdk
 from sentry_sdk._types import MYPY
 from sentry_sdk.consts import OP
 from sentry_sdk.integrations import Integration
+from sentry_sdk.utils import ensure_integration_enabled
 
 if MYPY:
     from socket import AddressFamily, SocketKind
@@ -41,19 +43,15 @@ def _patch_create_connection():
     # type: () -> None
     real_create_connection = socket.create_connection
 
+    @ensure_integration_enabled(SocketIntegration, real_create_connection)
     def create_connection(
         address,
         timeout=socket._GLOBAL_DEFAULT_TIMEOUT,  # type: ignore
         source_address=None,
     ):
         # type: (Tuple[Optional[str], int], Optional[float], Optional[Tuple[Union[bytearray, bytes, str], int]])-> socket.socket
-        hub = Hub.current
-        if hub.get_integration(SocketIntegration) is None:
-            return real_create_connection(
-                address=address, timeout=timeout, source_address=source_address
-            )
 
-        with hub.start_span(
+        with sentry_sdk.start_span(
             op=OP.SOCKET_CONNECTION,
             description=_get_span_description(address[0], address[1]),
         ) as span:
@@ -72,13 +70,10 @@ def _patch_getaddrinfo():
     # type: () -> None
     real_getaddrinfo = socket.getaddrinfo
 
+    @ensure_integration_enabled(real_getaddrinfo)
     def getaddrinfo(host, port, family=0, type=0, proto=0, flags=0):
         # type: (Union[bytes, str, None], Union[str, int, None], int, int, int, int) -> List[Tuple[AddressFamily, SocketKind, int, str, Union[Tuple[str, int], Tuple[str, int, int, int]]]]
-        hub = Hub.current
-        if hub.get_integration(SocketIntegration) is None:
-            return real_getaddrinfo(host, port, family, type, proto, flags)
-
-        with hub.start_span(
+        with sentry_sdk.start_span(
             op=OP.SOCKET_DNS, description=_get_span_description(host, port)
         ) as span:
             span.set_data("host", host)

--- a/sentry_sdk/integrations/socket.py
+++ b/sentry_sdk/integrations/socket.py
@@ -70,7 +70,7 @@ def _patch_getaddrinfo():
     # type: () -> None
     real_getaddrinfo = socket.getaddrinfo
 
-    @ensure_integration_enabled(real_getaddrinfo)
+    @ensure_integration_enabled(SocketIntegration, real_getaddrinfo)
     def getaddrinfo(host, port, family=0, type=0, proto=0, flags=0):
         # type: (Union[bytes, str, None], Union[str, int, None], int, int, int, int) -> List[Tuple[AddressFamily, SocketKind, int, str, Union[Tuple[str, int], Tuple[str, int, int, int]]]]
         with sentry_sdk.start_span(


### PR DESCRIPTION
Another forgotten integration.

Not using the `ensure_integration_enabled` decorator here by choice as it leads to some pretty intimidating mypy errors. 😬 

---

## General Notes

Thank you for contributing to `sentry-python`!

Please add tests to validate your changes, and lint your code using `tox -e linters`.

Running the test suite on your PR might require maintainer approval. Some tests (AWS Lambda) additionally require a maintainer to add a special label to run and will fail if the label is not present.

#### For maintainers

Sensitive test suites require maintainer review to ensure that tests do not compromise our secrets. This review must be repeated after any code revisions.

Before running sensitive test suites, please carefully check the PR. Then, apply the `Trigger: tests using secrets` label. The label will be removed after any code changes to enforce our policy requiring maintainers to review all code revisions before running sensitive tests.
