### PR TITLE
ref: Remove deprecated `Transaction` creation method

### DIFF
--- a/MIGRATION_GUIDE.md
+++ b/MIGRATION_GUIDE.md
@@ -71,6 +71,7 @@ Looking to upgrade from Sentry SDK 1.x to 2.x? Here's a comprehensive list of wh
 - Removed support for the `install` method for custom integrations. Please use `setup_once` instead.
 - Removed `sentry_sdk.tracing.Span.new_span`. Use `sentry_sdk.tracing.Span.start_child` instead.
 - Removed `sentry_sdk.tracing.Transaction.new_span`. Use `sentry_sdk.tracing.Transaction.start_child` instead.
+- Removed support for creating transactions via `sentry_sdk.tracing.Span(transaction=...)`. To create a transaction, please use `sentry_sdk.tracing.Transaction(name=...)`.
 - Removed `sentry_sdk.utils.Auth.store_api_url`.
 - `sentry_sdk.utils.Auth.get_api_url`'s now accepts a `sentry_sdk.consts.EndpointType` enum instead of a string as its only parameter. We recommend omitting this argument when calling the function, since the parameter's default value is the only possible `sentry_sdk.consts.EndpointType` value. The parameter exists for future compatibility.
 - Removed `tracing_utils_py2.py`. The `start_child_span_decorator` is now in `sentry_sdk.tracing_utils`.

--- a/sentry_sdk/tracing.py
+++ b/sentry_sdk/tracing.py
@@ -40,7 +40,6 @@ if TYPE_CHECKING:
         description: str
         # hub: Optional[sentry_sdk.Hub] is deprecated, and therefore omitted here!
         status: str
-        # transaction: str is deprecated, and therefore omitted here!
         containing_transaction: Optional["Transaction"]
         start_timestamp: Optional[Union[datetime, float]]
         scope: "sentry_sdk.Scope"
@@ -132,20 +131,6 @@ class Span:
         "scope",
     )
 
-    def __new__(cls, **kwargs):
-        # type: (**Any) -> Any
-        """
-        Backwards-compatible implementation of Span and Transaction
-        creation.
-        """
-
-        # TODO: consider removing this in a future release.
-        # This is for backwards compatibility with releases before Transaction
-        # existed, to allow for a smoother transition.
-        if "transaction" in kwargs:
-            return object.__new__(Transaction)
-        return object.__new__(cls)
-
     def __init__(
         self,
         trace_id=None,  # type: Optional[str]
@@ -157,7 +142,6 @@ class Span:
         description=None,  # type: Optional[str]
         hub=None,  # type: Optional[sentry_sdk.Hub]  # deprecated
         status=None,  # type: Optional[str]
-        transaction=None,  # type: Optional[str] # deprecated
         containing_transaction=None,  # type: Optional[Transaction]
         start_timestamp=None,  # type: Optional[Union[datetime, float]]
         scope=None,  # type: Optional[sentry_sdk.Scope]
@@ -598,15 +582,6 @@ class Transaction(Span):
             See https://develop.sentry.dev/sdk/event-payloads/transaction/#transaction-annotations
             for more information. Default "custom".
         """
-        # TODO: consider removing this in a future release.
-        # This is for backwards compatibility with releases before Transaction
-        # existed, to allow for a smoother transition.
-        if not name and "transaction" in kwargs:
-            logger.warning(
-                "Deprecated: use Transaction(name=...) to create transactions "
-                "instead of Span(transaction=...)."
-            )
-            name = kwargs.pop("transaction")  # type: ignore
 
         super().__init__(**kwargs)
 


### PR DESCRIPTION
This has been deprecated for 4 years, so I suppose we can remove it now in `2.0`.

Removing the `__new__` method also fixes our API docs for the `Span` and `Transaction` constructors. The `__new__` method causes the API docs to show both classes as only taking opaque `**kwargs`, like so:

![image](https://github.com/getsentry/sentry-python/assets/7881302/0a15ad5c-62c6-4b24-9c55-4a225cbb2433)

Following this change, the arguments are displayed correctly in the API docs:

![image](https://github.com/getsentry/sentry-python/assets/7881302/86f12fe4-aa0d-4f22-b3c5-6d958ebbd1b2)

Partially addresses https://github.com/getsentry/sentry-docs/issues/5082