### PR TITLE
docs: Move transaction __init__ doc comment content

### DIFF
--- a/sentry_sdk/tracing.py
+++ b/sentry_sdk/tracing.py
@@ -558,6 +558,8 @@ class Transaction(Span):
         This will be used to determine the transaction's type.
         See https://develop.sentry.dev/sdk/event-payloads/transaction/#transaction-annotations
         for more information. Default "custom".
+    :param kwargs: Additional arguments to be passed to the Span constructor.
+        See :py:class:`sentry_sdk.tracing.Span` for available arguments.
     """
 
     __slots__ = (

--- a/sentry_sdk/tracing.py
+++ b/sentry_sdk/tracing.py
@@ -546,7 +546,19 @@ class Span:
 
 class Transaction(Span):
     """The Transaction is the root element that holds all the spans
-    for Sentry performance instrumentation."""
+    for Sentry performance instrumentation.
+
+    :param name: Identifier of the transaction.
+        Will show up in the Sentry UI.
+    :param parent_sampled: Whether the parent transaction was sampled.
+        If True this transaction will be kept, if False it will be discarded.
+    :param baggage: The W3C baggage header value.
+        (see https://www.w3.org/TR/baggage/)
+    :param source: A string describing the source of the transaction name.
+        This will be used to determine the transaction's type.
+        See https://develop.sentry.dev/sdk/event-payloads/transaction/#transaction-annotations
+        for more information. Default "custom".
+    """
 
     __slots__ = (
         "name",
@@ -569,19 +581,6 @@ class Transaction(Span):
         **kwargs,  # type: Unpack[SpanKwargs]
     ):
         # type: (...) -> None
-        """Constructs a new Transaction.
-
-        :param name: Identifier of the transaction.
-            Will show up in the Sentry UI.
-        :param parent_sampled: Whether the parent transaction was sampled.
-            If True this transaction will be kept, if False it will be discarded.
-        :param baggage: The W3C baggage header value.
-            (see https://www.w3.org/TR/baggage/)
-        :param source: A string describing the source of the transaction name.
-            This will be used to determine the transaction's type.
-            See https://develop.sentry.dev/sdk/event-payloads/transaction/#transaction-annotations
-            for more information. Default "custom".
-        """
 
         super().__init__(**kwargs)
 


### PR DESCRIPTION
This change moves the `Transaction` constructor's parameter doctsring from the `__init__` method to the class's docstring. This way, the API docs display the parameter descriptions under the class. When the docstring is defined on `__init__`, the parameter descriptions are missing from the API docs.

This change also documents the `kwargs` parameter in the API docs.

Before the change:
![Screenshot 2024-03-28 at 13 28 29](https://github.com/getsentry/sentry-python/assets/7881302/074eef71-3475-4618-8db5-5a2617367b97)

After the change:
![Screenshot 2024-03-28 at 13 54 36](https://github.com/getsentry/sentry-python/assets/7881302/e05b58f2-7d02-4982-8292-fbadea63ec93)

Partially addresses https://github.com/getsentry/sentry-docs/issues/5082