### PR TITLE
ref: Improve `start_transaction` docs

### DIFF
--- a/sentry_sdk/api.py
+++ b/sentry_sdk/api.py
@@ -29,9 +29,9 @@ if TYPE_CHECKING:
         ExcInfo,
         MeasurementUnit,
         LogLevelStr,
+        SamplingContext,
     )
-    from sentry_sdk.scope import StartTransactionKwargs
-    from sentry_sdk.tracing import Span
+    from sentry_sdk.tracing import Span, TransactionKwargs
 
     T = TypeVar("T")
     F = TypeVar("F", bound=Callable[..., Any])
@@ -284,11 +284,12 @@ def start_span(
 def start_transaction(
     transaction=None,  # type: Optional[Transaction]
     instrumenter=INSTRUMENTER.SENTRY,  # type: str
-    **kwargs,  # type: Unpack[StartTransactionKwargs]
+    custom_sampling_context=None,  # type: Optional[SamplingContext]
+    **kwargs,  # type: Unpack[TransactionKwargs]
 ):
     # type: (...) -> Union[Transaction, NoOpSpan]
     return Scope.get_current_scope().start_transaction(
-        transaction, instrumenter, **kwargs
+        transaction, instrumenter, custom_sampling_context, **kwargs
     )
 
 

--- a/sentry_sdk/hub.py
+++ b/sentry_sdk/hub.py
@@ -42,9 +42,10 @@ if TYPE_CHECKING:
         BreadcrumbHint,
         ExcInfo,
         LogLevelStr,
+        SamplingContext,
     )
     from sentry_sdk.consts import ClientConstructor
-    from sentry_sdk.scope import StartTransactionKwargs
+    from sentry_sdk.tracing import TransactionKwargs
 
     T = TypeVar("T")
 
@@ -472,9 +473,13 @@ class Hub(with_metaclass(HubMeta)):  # type: ignore
         return scope.start_span(instrumenter=instrumenter, **kwargs)
 
     def start_transaction(
-        self, transaction=None, instrumenter=INSTRUMENTER.SENTRY, **kwargs
+        self,
+        transaction=None,
+        instrumenter=INSTRUMENTER.SENTRY,
+        custom_sampling_context=None,
+        **kwargs
     ):
-        # type: (Optional[Transaction], str, Unpack[StartTransactionKwargs]) -> Union[Transaction, NoOpSpan]
+        # type: (Optional[Transaction], str, Optional[SamplingContext], Unpack[TransactionKwargs]) -> Union[Transaction, NoOpSpan]
         """
         .. deprecated:: 2.0.0
             This function is deprecated and will be removed in a future release.
@@ -511,7 +516,7 @@ class Hub(with_metaclass(HubMeta)):  # type: ignore
         kwargs["hub"] = scope  # type: ignore
 
         return scope.start_transaction(
-            transaction=transaction, instrumenter=instrumenter, **kwargs
+            transaction, instrumenter, custom_sampling_context, **kwargs
         )
 
     def continue_trace(self, environ_or_headers, op=None, name=None, source=None):


### PR DESCRIPTION
This PR adds documentation for all `start_transaction` parameters. It also proposes removing the `StartTransactionKwargs` typeddict, instead placing the `custom_sampling_context` parameter directly on the method and deleting the `client` parameter, which appears not to be used.

ref https://github.com/getsentry/sentry-docs/issues/5082
