### PR TITLE
docs: Document Transaction and Span kwargs typed dicts

### DIFF
--- a/sentry_sdk/api.py
+++ b/sentry_sdk/api.py
@@ -29,9 +29,9 @@ if TYPE_CHECKING:
         ExcInfo,
         MeasurementUnit,
         LogLevelStr,
+        SamplingContext,
     )
-    from sentry_sdk.scope import StartTransactionKwargs
-    from sentry_sdk.tracing import Span
+    from sentry_sdk.tracing import Span, TransactionKwargs
 
     T = TypeVar("T")
     F = TypeVar("F", bound=Callable[..., Any])
@@ -284,11 +284,12 @@ def start_span(
 def start_transaction(
     transaction=None,  # type: Optional[Transaction]
     instrumenter=INSTRUMENTER.SENTRY,  # type: str
-    **kwargs,  # type: Unpack[StartTransactionKwargs]
+    custom_sampling_context=None,  # type: Optional[SamplingContext]
+    **kwargs,  # type: Unpack[TransactionKwargs]
 ):
     # type: (...) -> Union[Transaction, NoOpSpan]
     return Scope.get_current_scope().start_transaction(
-        transaction, instrumenter, **kwargs
+        transaction, instrumenter, custom_sampling_context, **kwargs
     )
 
 

--- a/sentry_sdk/hub.py
+++ b/sentry_sdk/hub.py
@@ -42,9 +42,10 @@ if TYPE_CHECKING:
         BreadcrumbHint,
         ExcInfo,
         LogLevelStr,
+        SamplingContext,
     )
     from sentry_sdk.consts import ClientConstructor
-    from sentry_sdk.scope import StartTransactionKwargs
+    from sentry_sdk.tracing import TransactionKwargs
 
     T = TypeVar("T")
 
@@ -472,9 +473,13 @@ class Hub(with_metaclass(HubMeta)):  # type: ignore
         return scope.start_span(instrumenter=instrumenter, **kwargs)
 
     def start_transaction(
-        self, transaction=None, instrumenter=INSTRUMENTER.SENTRY, **kwargs
+        self,
+        transaction=None,
+        instrumenter=INSTRUMENTER.SENTRY,
+        custom_sampling_context=None,
+        **kwargs
     ):
-        # type: (Optional[Transaction], str, Unpack[StartTransactionKwargs]) -> Union[Transaction, NoOpSpan]
+        # type: (Optional[Transaction], str, Optional[SamplingContext], Unpack[TransactionKwargs]) -> Union[Transaction, NoOpSpan]
         """
         .. deprecated:: 2.0.0
             This function is deprecated and will be removed in a future release.
@@ -511,7 +516,7 @@ class Hub(with_metaclass(HubMeta)):  # type: ignore
         kwargs["hub"] = scope  # type: ignore
 
         return scope.start_transaction(
-            transaction=transaction, instrumenter=instrumenter, **kwargs
+            transaction, instrumenter, custom_sampling_context, **kwargs
         )
 
     def continue_trace(self, environ_or_headers, op=None, name=None, source=None):

--- a/sentry_sdk/tracing.py
+++ b/sentry_sdk/tracing.py
@@ -32,23 +32,69 @@ if TYPE_CHECKING:
 
     class SpanKwargs(TypedDict, total=False):
         trace_id: str
+        """
+        The trace ID of the root span. If this new span is to be the root span,
+        omit this parameter, and a new trace ID will be generated.
+        """
+
         span_id: str
+        """The span ID of this span. If omitted, a new span ID will be generated."""
+
         parent_span_id: str
+        """The span ID of the parent span, if applicable."""
+
         same_process_as_parent: bool
+        """Whether this span is in the same process as the parent span."""
+
         sampled: bool
+        """
+        Whether the span should be sampled. Overrides the default sampling decision
+        for this span when provided.
+        """
+
         op: str
+        """
+        The span's operation. A list of recommended values is available here:
+        https://develop.sentry.dev/sdk/performance/span-operations/
+        """
+
         description: str
-        # hub: Optional[sentry_sdk.Hub] is deprecated, and therefore omitted here!
+        """A description of what operation is being performed within the span."""
+
+        hub: Optional["sentry_sdk.Hub"]
+        """The hub to use for this span. This argument is DEPRECATED. Please use the `scope` parameter, instead."""
+
         status: str
+        """The span's status. Possible values are listed at https://develop.sentry.dev/sdk/event-payloads/span/"""
+
         containing_transaction: Optional["Transaction"]
+        """The transaction that this span belongs to."""
+
         start_timestamp: Optional[Union[datetime, float]]
+        """
+        The timestamp when the span started. If omitted, the current time
+        will be used.
+        """
+
         scope: "sentry_sdk.Scope"
+        """The scope to use for this span. If not provided, we use the current scope."""
 
     class TransactionKwargs(SpanKwargs, total=False):
         name: str
+        """Identifier of the transaction. Will show up in the Sentry UI."""
+
         source: str
+        """
+        A string describing the source of the transaction name. This will be used to determine the transaction's type.
+        See https://develop.sentry.dev/sdk/event-payloads/transaction/#transaction-annotations for more information.
+        Default "custom".
+        """
+
         parent_sampled: bool
+        """Whether the parent transaction was sampled. If True this transaction will be kept, if False it will be discarded."""
+
         baggage: "Baggage"
+        """The W3C baggage header value. (see https://www.w3.org/TR/baggage/)"""
 
 
 BAGGAGE_HEADER_NAME = "baggage"

--- a/sentry_sdk/tracing.py
+++ b/sentry_sdk/tracing.py
@@ -107,7 +107,29 @@ class _SpanRecorder:
 
 class Span:
     """A span holds timing information of a block of code.
-    Spans can have multiple child spans thus forming a span tree."""
+    Spans can have multiple child spans thus forming a span tree.
+
+    :param trace_id: The trace ID of the root span. If this new span is to be the root span,
+        omit this parameter, and a new trace ID will be generated.
+    :param span_id: The span ID of this span. If omitted, a new span ID will be generated.
+    :param parent_span_id: The span ID of the parent span, if applicable.
+    :param same_process_as_parent: Whether this span is in the same process as the parent span.
+    :param sampled: Whether the span should be sampled. Overrides the default sampling decision
+        for this span when provided.
+    :param op: The span's operation. A list of recommended values is available here:
+        https://develop.sentry.dev/sdk/performance/span-operations/
+    :param description: A description of what operation is being performed within the span.
+    :param hub: The hub to use for this span.
+
+        .. deprecated:: 2.0.0
+            Please use the `scope` parameter, instead.
+    :param status: The span's status. Possible values are listed at
+        https://develop.sentry.dev/sdk/event-payloads/span/
+    :param containing_transaction: The transaction that this span belongs to.
+    :param start_timestamp: The timestamp when the span started. If omitted, the current time
+        will be used.
+    :param scope: The scope to use for this span. If not provided, we use the current scope.
+    """
 
     __slots__ = (
         "trace_id",


### PR DESCRIPTION
Repeating the doc comments also on the kwargs typed dicts enables better hinting in VSCode. See example below.

Before:
![Screenshot 2024-03-28 at 15 16 08](https://github.com/getsentry/sentry-python/assets/7881302/00d6da79-efac-4bb6-a012-93c8b5f9f954)

After:
![Screenshot 2024-03-28 at 15 14 44](https://github.com/getsentry/sentry-python/assets/7881302/fd0fca1c-955e-4c59-b4c5-9d59b72c8ad8)

I wish there was a way to do this without simply repeating the documentation both on the classes and in the Kwargs typeddicts, but this is the best way I found.

ref: https://github.com/getsentry/sentry-docs/issues/5082