### PR TITLE
fix(types): Fixed `Event | None` runtime `TypeError`

### DIFF
--- a/sentry_sdk/types.py
+++ b/sentry_sdk/types.py
@@ -13,9 +13,11 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from sentry_sdk._types import Event, Hint
 else:
+    from typing import Any
+
     # The lines below allow the types to be imported from outside `if TYPE_CHECKING`
     # guards. The types in this module are only intended to be used for type hints.
-    Event = None
-    Hint = None
+    Event = Any
+    Hint = Any
 
 __all__ = ("Event", "Hint")

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -1,0 +1,17 @@
+from sentry_sdk.types import Event, Hint
+
+
+def test_event_or_none_runtime():
+    """
+    Ensures that the `Event` type's runtime value supports the `|` operation with `None`.
+    This test is needed to ensure that using an `Event | None` type hint (e.g. for
+    `before_send`'s return value) does not raise a TypeError at runtime.
+    """
+    Event | None
+
+
+def test_hint_or_none_runtime():
+    """
+    Analogue to `test_event_or_none_runtime`, but for the `Hint` type.
+    """
+    Hint | None

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -1,6 +1,13 @@
+import sys
+
+import pytest
 from sentry_sdk.types import Event, Hint
 
 
+@pytest.mark.skipif(
+    sys.version_info < (3, 10),
+    reason="Type hinting with `|` is available in Python 3.10+",
+)
 def test_event_or_none_runtime():
     """
     Ensures that the `Event` type's runtime value supports the `|` operation with `None`.
@@ -10,6 +17,10 @@ def test_event_or_none_runtime():
     Event | None
 
 
+@pytest.mark.skipif(
+    sys.version_info < (3, 10),
+    reason="Type hinting with `|` is available in Python 3.10+",
+)
 def test_hint_or_none_runtime():
     """
     Analogue to `test_event_or_none_runtime`, but for the `Hint` type.


### PR DESCRIPTION
Change `Event`'s runtime value to `typing.Any`, since the previous value of None caused the expression `Event | None` to result in a `TypeError` at runtime, even when the `Event | None` expression was used as a type hint. Also, add a test to make sure we don't reintroduce this bug.

Fixes GH-2926