### PR TITLE
feat(crons): Allow to upsert monitors

### DIFF
--- a/sentry_sdk/crons/decorator.py
+++ b/sentry_sdk/crons/decorator.py
@@ -5,7 +5,7 @@ from sentry_sdk.crons.consts import MonitorStatus
 from sentry_sdk.utils import now
 
 if TYPE_CHECKING:
-    from typing import Optional, Type
+    from typing import Any, Dict, Optional, Type
     from types import TracebackType
 
 if PY2:
@@ -47,15 +47,18 @@ class monitor(MonitorMixin):  # noqa: N801
     ```
     """
 
-    def __init__(self, monitor_slug=None):
-        # type: (Optional[str]) -> None
+    def __init__(self, monitor_slug=None, monitor_config=None):
+        # type: (Optional[str], Optional[Dict[str, Any]]) -> None
         self.monitor_slug = monitor_slug
+        self.monitor_config = monitor_config
 
     def __enter__(self):
         # type: () -> None
         self.start_timestamp = now()
         self.check_in_id = capture_checkin(
-            monitor_slug=self.monitor_slug, status=MonitorStatus.IN_PROGRESS
+            monitor_slug=self.monitor_slug,
+            status=MonitorStatus.IN_PROGRESS,
+            monitor_config=self.monitor_config,
         )
 
     def __exit__(self, exc_type, exc_value, traceback):
@@ -72,4 +75,5 @@ class monitor(MonitorMixin):  # noqa: N801
             check_in_id=self.check_in_id,
             status=status,
             duration=duration_s,
+            monitor_config=self.monitor_config,
         )

--- a/sentry_sdk/crons/decorator.py
+++ b/sentry_sdk/crons/decorator.py
@@ -5,7 +5,7 @@ from sentry_sdk.crons.consts import MonitorStatus
 from sentry_sdk.utils import now
 
 if TYPE_CHECKING:
-    from typing import Any, Dict, Optional, Type
+    from typing import Any, Optional, Type
     from types import TracebackType
 
 if PY2:
@@ -48,7 +48,7 @@ class monitor(MonitorMixin):  # noqa: N801
     """
 
     def __init__(self, monitor_slug=None, monitor_config=None):
-        # type: (Optional[str], Optional[Dict[str, Any]]) -> None
+        # type: (Optional[str], Optional[dict[str, Any]]) -> None
         self.monitor_slug = monitor_slug
         self.monitor_config = monitor_config
 

--- a/tests/crons/test_crons.py
+++ b/tests/crons/test_crons.py
@@ -33,6 +33,22 @@ def _break_world_contextmanager(name):
         return "Hello, {}".format(name)
 
 
+@sentry_sdk.monitor(monitor_slug="ghi789", monitor_config=None)
+def _no_monitor_config():
+    return
+
+
+@sentry_sdk.monitor(
+    monitor_slug="ghi789",
+    monitor_config={
+        "schedule": {"type": "crontab", "value": "0 0 * * *"},
+        "failure_issue_threshold": 5,
+    },
+)
+def _with_monitor_config():
+    return
+
+
 def test_decorator(sentry_init):
     sentry_init()
 
@@ -45,7 +61,9 @@ def test_decorator(sentry_init):
         # Check for initial checkin
         fake_capture_checkin.assert_has_calls(
             [
-                mock.call(monitor_slug="abc123", status="in_progress"),
+                mock.call(
+                    monitor_slug="abc123", status="in_progress", monitor_config=None
+                ),
             ]
         )
 
@@ -70,7 +88,9 @@ def test_decorator_error(sentry_init):
         # Check for initial checkin
         fake_capture_checkin.assert_has_calls(
             [
-                mock.call(monitor_slug="def456", status="in_progress"),
+                mock.call(
+                    monitor_slug="def456", status="in_progress", monitor_config=None
+                ),
             ]
         )
 
@@ -93,7 +113,9 @@ def test_contextmanager(sentry_init):
         # Check for initial checkin
         fake_capture_checkin.assert_has_calls(
             [
-                mock.call(monitor_slug="abc123", status="in_progress"),
+                mock.call(
+                    monitor_slug="abc123", status="in_progress", monitor_config=None
+                ),
             ]
         )
 
@@ -118,7 +140,9 @@ def test_contextmanager_error(sentry_init):
         # Check for initial checkin
         fake_capture_checkin.assert_has_calls(
             [
-                mock.call(monitor_slug="def456", status="in_progress"),
+                mock.call(
+                    monitor_slug="def456", status="in_progress", monitor_config=None
+                ),
             ]
         )
 
@@ -194,6 +218,8 @@ def test_monitor_config(sentry_init, capture_envelopes):
 
     monitor_config = {
         "schedule": {"type": "crontab", "value": "0 0 * * *"},
+        "failure_issue_threshold": 5,
+        "recovery_threshold": 5,
     }
 
     capture_checkin(monitor_slug="abc123", monitor_config=monitor_config)
@@ -209,6 +235,41 @@ def test_monitor_config(sentry_init, capture_envelopes):
 
     assert check_in["monitor_slug"] == "abc123"
     assert "monitor_config" not in check_in
+
+
+def test_decorator_monitor_config(sentry_init, capture_envelopes):
+    sentry_init()
+    envelopes = capture_envelopes()
+
+    _with_monitor_config()
+
+    assert len(envelopes) == 2
+
+    for check_in_envelope in envelopes:
+        assert len(check_in_envelope.items) == 1
+        check_in = check_in_envelope.items[0].payload.json
+
+        assert check_in["monitor_slug"] == "ghi789"
+        assert check_in["monitor_config"] == {
+            "schedule": {"type": "crontab", "value": "0 0 * * *"},
+            "failure_issue_threshold": 5,
+        }
+
+
+def test_decorator_no_monitor_config(sentry_init, capture_envelopes):
+    sentry_init()
+    envelopes = capture_envelopes()
+
+    _no_monitor_config()
+
+    assert len(envelopes) == 2
+
+    for check_in_envelope in envelopes:
+        assert len(check_in_envelope.items) == 1
+        check_in = check_in_envelope.items[0].payload.json
+
+        assert check_in["monitor_slug"] == "ghi789"
+        assert "monitor_config" not in check_in
 
 
 def test_capture_checkin_sdk_not_initialized():

--- a/tests/crons/test_crons_async_py3.py
+++ b/tests/crons/test_crons_async_py3.py
@@ -49,7 +49,9 @@ async def test_decorator(sentry_init):
         # Check for initial checkin
         fake_capture_checkin.assert_has_calls(
             [
-                mock.call(monitor_slug="abc123", status="in_progress"),
+                mock.call(
+                    monitor_slug="abc123", status="in_progress", monitor_config=None
+                ),
             ]
         )
 
@@ -75,7 +77,9 @@ async def test_decorator_error(sentry_init):
         # Check for initial checkin
         fake_capture_checkin.assert_has_calls(
             [
-                mock.call(monitor_slug="def456", status="in_progress"),
+                mock.call(
+                    monitor_slug="def456", status="in_progress", monitor_config=None
+                ),
             ]
         )
 
@@ -99,7 +103,9 @@ async def test_contextmanager(sentry_init):
         # Check for initial checkin
         fake_capture_checkin.assert_has_calls(
             [
-                mock.call(monitor_slug="abc123", status="in_progress"),
+                mock.call(
+                    monitor_slug="abc123", status="in_progress", monitor_config=None
+                ),
             ]
         )
 
@@ -125,7 +131,9 @@ async def test_contextmanager_error(sentry_init):
         # Check for initial checkin
         fake_capture_checkin.assert_has_calls(
             [
-                mock.call(monitor_slug="def456", status="in_progress"),
+                mock.call(
+                    monitor_slug="def456", status="in_progress", monitor_config=None
+                ),
             ]
         )
 


### PR DESCRIPTION
Allow to pass `monitor_config` to the `monitor` decorator/context manager.

Also adds some tests for https://github.com/getsentry/sentry-python/issues/2927 -- it was already possible to pass the new params since we just take the `monitor_config` as is.

Docs PR: https://github.com/getsentry/sentry-docs/pull/9597

Relates https://github.com/getsentry/sentry-python/issues/2927
Closes https://github.com/getsentry/sentry-python/issues/2925
Closes https://github.com/getsentry/sentry-python/issues/2770

---

## General Notes

Thank you for contributing to `sentry-python`!

Please add tests to validate your changes, and lint your code using `tox -e linters`.

Running the test suite on your PR might require maintainer approval. Some tests (AWS Lambda) additionally require a maintainer to add a special label to run and will fail if the label is not present.

#### For maintainers

Sensitive test suites require maintainer review to ensure that tests do not compromise our secrets. This review must be repeated after any code revisions.

Before running sensitive test suites, please carefully check the PR. Then, apply the `Trigger: tests using secrets` label. The label will be removed after any code changes to enforce our policy requiring maintainers to review all code revisions before running sensitive tests.
