### PR TITLE
feat(typing): Make monitor_config a TypedDict

### DIFF
--- a/sentry_sdk/_types.py
+++ b/sentry_sdk/_types.py
@@ -181,7 +181,14 @@ if TYPE_CHECKING:
 
     MonitorConfigScheduleType = Literal["crontab", "interval"]
     MonitorConfigScheduleUnit = Literal[
-        "year", "month", "week", "day", "hour", "minute"
+        "year",
+        "month",
+        "week",
+        "day",
+        "hour",
+        "minute",
+        "second",
+        # "second" is not supported in Sentry and will result in a warning
     ]
 
     MonitorConfigSchedule = TypedDict(

--- a/sentry_sdk/_types.py
+++ b/sentry_sdk/_types.py
@@ -178,3 +178,26 @@ if TYPE_CHECKING:
 
     BucketKey = Tuple[MetricType, str, MeasurementUnit, MetricTagsInternal]
     MetricMetaKey = Tuple[MetricType, str, MeasurementUnit]
+
+    MonitorConfigSchedule = TypedDict(
+        "MonitorConfigSchedule",
+        {
+            "type": Literal["crontab", "interval"],
+            "value": Union[int, str],
+            "unit": str,
+        },
+        total=False,
+    )
+
+    MonitorConfig = TypedDict(
+        "MonitorConfig",
+        {
+            "schedule": MonitorConfigSchedule,
+            "timezone": str,
+            "checkin_margin": int,
+            "max_runtime": int,
+            "failure_issue_threshold": int,
+            "recovery_threshold": int,
+        },
+        total=False,
+    )

--- a/sentry_sdk/_types.py
+++ b/sentry_sdk/_types.py
@@ -187,8 +187,7 @@ if TYPE_CHECKING:
         "day",
         "hour",
         "minute",
-        "second",
-        # "second" is not supported in Sentry and will result in a warning
+        "second",  # not supported in Sentry and will result in a warning
     ]
 
     MonitorConfigSchedule = TypedDict(

--- a/sentry_sdk/_types.py
+++ b/sentry_sdk/_types.py
@@ -179,12 +179,17 @@ if TYPE_CHECKING:
     BucketKey = Tuple[MetricType, str, MeasurementUnit, MetricTagsInternal]
     MetricMetaKey = Tuple[MetricType, str, MeasurementUnit]
 
+    MonitorConfigScheduleType = Literal["crontab", "interval"]
+    MonitorConfigScheduleUnit = Literal[
+        "year", "month", "week", "day", "hour", "minute"
+    ]
+
     MonitorConfigSchedule = TypedDict(
         "MonitorConfigSchedule",
         {
-            "type": Literal["crontab", "interval"],
+            "type": MonitorConfigScheduleType,
             "value": Union[int, str],
-            "unit": Literal["year", "month", "week", "day", "hour", "minute"],
+            "unit": MonitorConfigScheduleUnit,
         },
         total=False,
     )

--- a/sentry_sdk/_types.py
+++ b/sentry_sdk/_types.py
@@ -184,7 +184,7 @@ if TYPE_CHECKING:
         {
             "type": Literal["crontab", "interval"],
             "value": Union[int, str],
-            "unit": str,
+            "unit": Literal["year", "month", "week", "day", "hour", "minute"],
         },
         total=False,
     )

--- a/sentry_sdk/crons/api.py
+++ b/sentry_sdk/crons/api.py
@@ -5,18 +5,18 @@ from sentry_sdk._types import TYPE_CHECKING
 
 
 if TYPE_CHECKING:
-    from typing import Any, Dict, Optional
-    from sentry_sdk._types import Event
+    from typing import Optional
+    from sentry_sdk._types import Event, MonitorConfig
 
 
 def _create_check_in_event(
-    monitor_slug=None,
-    check_in_id=None,
-    status=None,
-    duration_s=None,
-    monitor_config=None,
+    monitor_slug=None,  # type: Optional[str]
+    check_in_id=None,  # type: Optional[str]
+    status=None,  # type: Optional[str]
+    duration_s=None,  # type: Optional[float]
+    monitor_config=None,  # type: Optional[MonitorConfig]
 ):
-    # type: (Optional[str], Optional[str], Optional[str], Optional[float], Optional[Dict[str, Any]]) -> Event
+    # type: (...) -> Event
     options = Hub.current.client.options if Hub.current.client else {}
     check_in_id = check_in_id or uuid.uuid4().hex  # type: str
 
@@ -37,13 +37,13 @@ def _create_check_in_event(
 
 
 def capture_checkin(
-    monitor_slug=None,
-    check_in_id=None,
-    status=None,
-    duration=None,
-    monitor_config=None,
+    monitor_slug=None,  # type: Optional[str]
+    check_in_id=None,  # type: Optional[str]
+    status=None,  # type: Optional[str]
+    duration=None,  # type: Optional[float]
+    monitor_config=None,  # type: Optional[MonitorConfig]
 ):
-    # type: (Optional[str], Optional[str], Optional[str], Optional[float], Optional[Dict[str, Any]]) -> str
+    # type: (...) -> str
     check_in_event = _create_check_in_event(
         monitor_slug=monitor_slug,
         check_in_id=check_in_id,

--- a/sentry_sdk/crons/decorator.py
+++ b/sentry_sdk/crons/decorator.py
@@ -5,8 +5,9 @@ from sentry_sdk.crons.consts import MonitorStatus
 from sentry_sdk.utils import now
 
 if TYPE_CHECKING:
-    from typing import Any, Optional, Type
+    from typing import Optional, Type
     from types import TracebackType
+    from sentry_sdk._types import MonitorConfig
 
 if PY2:
     from sentry_sdk.crons._decorator_py2 import MonitorMixin
@@ -48,7 +49,7 @@ class monitor(MonitorMixin):  # noqa: N801
     """
 
     def __init__(self, monitor_slug=None, monitor_config=None):
-        # type: (Optional[str], Optional[dict[str, Any]]) -> None
+        # type: (Optional[str], Optional[MonitorConfig]) -> None
         self.monitor_slug = monitor_slug
         self.monitor_config = monitor_config
 

--- a/sentry_sdk/integrations/celery.py
+++ b/sentry_sdk/integrations/celery.py
@@ -31,7 +31,7 @@ if TYPE_CHECKING:
     from typing import Union
 
     from sentry_sdk.tracing import Span
-    from sentry_sdk._types import EventProcessor, Event, Hint, ExcInfo
+    from sentry_sdk._types import EventProcessor, Event, Hint, ExcInfo, MonitorConfig
 
     F = TypeVar("F", bound=Callable[..., Any])
 
@@ -433,8 +433,8 @@ def _get_humanized_interval(seconds):
 
 
 def _get_monitor_config(celery_schedule, app, monitor_name):
-    # type: (Any, Celery, str) -> Dict[str, Any]
-    monitor_config = {}  # type: Dict[str, Any]
+    # type: (Any, Celery, str) -> MonitorConfig
+    monitor_config = {}  # type: MonitorConfig
     schedule_type = None  # type: Optional[str]
     schedule_value = None  # type: Optional[Union[str, int]]
     schedule_unit = None  # type: Optional[str]

--- a/sentry_sdk/integrations/celery.py
+++ b/sentry_sdk/integrations/celery.py
@@ -29,6 +29,7 @@ if TYPE_CHECKING:
     from typing import Tuple
     from typing import TypeVar
     from typing import Union
+    from typing import cast
 
     from sentry_sdk.tracing import Span
     from sentry_sdk._types import (
@@ -424,7 +425,7 @@ def _get_headers(task):
 
 
 def _get_humanized_interval(seconds):
-    # type: (float) -> Tuple[int, str]
+    # type: (float) -> Tuple[int, MonitorConfigScheduleUnit]
     TIME_UNITS = (  # noqa: N806
         ("day", 60 * 60 * 24.0),
         ("hour", 60 * 60.0),
@@ -435,7 +436,7 @@ def _get_humanized_interval(seconds):
     for unit, divider in TIME_UNITS:
         if seconds >= divider:
             interval = int(seconds / divider)
-            return (interval, unit)
+            return (interval, cast(MonitorConfigScheduleUnit, unit))
 
     return (int(seconds), "second")
 

--- a/sentry_sdk/integrations/celery.py
+++ b/sentry_sdk/integrations/celery.py
@@ -3,6 +3,11 @@ from __future__ import absolute_import
 import sys
 import time
 
+try:
+    from typing import cast
+except ImportError:
+    cast = lambda _, o: o
+
 from sentry_sdk.api import continue_trace
 from sentry_sdk.consts import OP
 from sentry_sdk._compat import reraise
@@ -429,13 +434,13 @@ def _get_humanized_interval(seconds):
         ("day", 60 * 60 * 24.0),
         ("hour", 60 * 60.0),
         ("minute", 60.0),
-    )  # type: tuple[tuple[MonitorConfigScheduleUnit, float]]
+    )
 
     seconds = float(seconds)
     for unit, divider in TIME_UNITS:
         if seconds >= divider:
             interval = int(seconds / divider)
-            return (interval, unit)
+            return (interval, cast("MonitorConfigScheduleUnit", unit))
 
     return (int(seconds), "second")
 

--- a/sentry_sdk/integrations/celery.py
+++ b/sentry_sdk/integrations/celery.py
@@ -3,6 +3,11 @@ from __future__ import absolute_import
 import sys
 import time
 
+try:
+    from typing import cast
+except ImportError:
+    cast = lambda _, obj: obj
+
 from sentry_sdk.api import continue_trace
 from sentry_sdk.consts import OP
 from sentry_sdk._compat import reraise
@@ -29,7 +34,6 @@ if TYPE_CHECKING:
     from typing import Tuple
     from typing import TypeVar
     from typing import Union
-    from typing import cast
 
     from sentry_sdk.tracing import Span
     from sentry_sdk._types import (

--- a/sentry_sdk/integrations/celery.py
+++ b/sentry_sdk/integrations/celery.py
@@ -3,11 +3,6 @@ from __future__ import absolute_import
 import sys
 import time
 
-try:
-    from typing import cast
-except ImportError:
-    cast = lambda _, obj: obj
-
 from sentry_sdk.api import continue_trace
 from sentry_sdk.consts import OP
 from sentry_sdk._compat import reraise
@@ -434,13 +429,13 @@ def _get_humanized_interval(seconds):
         ("day", 60 * 60 * 24.0),
         ("hour", 60 * 60.0),
         ("minute", 60.0),
-    )
+    )  # type: tuple[tuple[MonitorConfigScheduleUnit, float]]
 
     seconds = float(seconds)
     for unit, divider in TIME_UNITS:
         if seconds >= divider:
             interval = int(seconds / divider)
-            return (interval, cast(MonitorConfigScheduleUnit, unit))
+            return (interval, unit)
 
     return (int(seconds), "second")
 

--- a/sentry_sdk/integrations/celery.py
+++ b/sentry_sdk/integrations/celery.py
@@ -31,7 +31,15 @@ if TYPE_CHECKING:
     from typing import Union
 
     from sentry_sdk.tracing import Span
-    from sentry_sdk._types import EventProcessor, Event, Hint, ExcInfo, MonitorConfig
+    from sentry_sdk._types import (
+        EventProcessor,
+        Event,
+        Hint,
+        ExcInfo,
+        MonitorConfig,
+        MonitorConfigScheduleType,
+        MonitorConfigScheduleUnit,
+    )
 
     F = TypeVar("F", bound=Callable[..., Any])
 
@@ -435,9 +443,9 @@ def _get_humanized_interval(seconds):
 def _get_monitor_config(celery_schedule, app, monitor_name):
     # type: (Any, Celery, str) -> MonitorConfig
     monitor_config = {}  # type: MonitorConfig
-    schedule_type = None  # type: Optional[str]
+    schedule_type = None  # type: Optional[MonitorConfigScheduleType]
     schedule_value = None  # type: Optional[Union[str, int]]
-    schedule_unit = None  # type: Optional[str]
+    schedule_unit = None  # type: Optional[MonitorConfigScheduleUnit]
 
     if isinstance(celery_schedule, crontab):
         schedule_type = "crontab"


### PR DESCRIPTION
Better type hinting for monitor configs.

Closes https://github.com/getsentry/sentry-python/issues/2930

---

## General Notes

Thank you for contributing to `sentry-python`!

Please add tests to validate your changes, and lint your code using `tox -e linters`.

Running the test suite on your PR might require maintainer approval. Some tests (AWS Lambda) additionally require a maintainer to add a special label to run and will fail if the label is not present.

#### For maintainers

Sensitive test suites require maintainer review to ensure that tests do not compromise our secrets. This review must be repeated after any code revisions.

Before running sensitive test suites, please carefully check the PR. Then, apply the `Trigger: tests using secrets` label. The label will be removed after any code changes to enforce our policy requiring maintainers to review all code revisions before running sensitive tests.
