### PR TITLE
ref(tests): Remove `debug=True` from tests

### DIFF
--- a/tests/integrations/asgi/test_asgi.py
+++ b/tests/integrations/asgi/test_asgi.py
@@ -322,7 +322,7 @@ async def test_trace_from_headers_if_performance_disabled(
 
 @pytest.mark.asyncio
 async def test_websocket(sentry_init, asgi3_ws_app, capture_events, request):
-    sentry_init(debug=True, send_default_pii=True)
+    sentry_init(send_default_pii=True)
 
     events = capture_events()
 
@@ -612,7 +612,6 @@ async def test_transaction_name(
     """
     sentry_init(
         traces_sample_rate=1.0,
-        debug=True,
     )
 
     envelopes = capture_envelopes()
@@ -674,7 +673,6 @@ async def test_transaction_name_in_traces_sampler(
     sentry_init(
         traces_sampler=dummy_traces_sampler,
         traces_sample_rate=1.0,
-        debug=True,
     )
 
     app = SentryAsgiMiddleware(asgi3_app, transaction_style=transaction_style)

--- a/tests/integrations/asyncio/test_asyncio.py
+++ b/tests/integrations/asyncio/test_asyncio.py
@@ -67,7 +67,6 @@ async def test_create_task(
     sentry_init(
         traces_sample_rate=1.0,
         send_default_pii=True,
-        debug=True,
         integrations=[
             AsyncioIntegration(),
         ],
@@ -111,7 +110,6 @@ async def test_gather(
     sentry_init(
         traces_sample_rate=1.0,
         send_default_pii=True,
-        debug=True,
         integrations=[
             AsyncioIntegration(),
         ],
@@ -155,7 +153,6 @@ async def test_exception(
     sentry_init(
         traces_sample_rate=1.0,
         send_default_pii=True,
-        debug=True,
         integrations=[
             AsyncioIntegration(),
         ],

--- a/tests/integrations/celery/test_celery.py
+++ b/tests/integrations/celery/test_celery.py
@@ -361,7 +361,7 @@ def test_retry(celery, capture_events):
 )
 @pytest.mark.forked
 def test_redis_backend_trace_propagation(init_celery, capture_events_forksafe):
-    celery = init_celery(traces_sample_rate=1.0, backend="redis", debug=True)
+    celery = init_celery(traces_sample_rate=1.0, backend="redis")
 
     events = capture_events_forksafe()
 

--- a/tests/integrations/falcon/test_falcon.py
+++ b/tests/integrations/falcon/test_falcon.py
@@ -112,7 +112,7 @@ def test_transaction_style(
 
 
 def test_unhandled_errors(sentry_init, capture_exceptions, capture_events):
-    sentry_init(integrations=[FalconIntegration()], debug=True)
+    sentry_init(integrations=[FalconIntegration()])
 
     class Resource:
         def on_get(self, req, resp):
@@ -140,7 +140,7 @@ def test_unhandled_errors(sentry_init, capture_exceptions, capture_events):
 
 
 def test_raised_5xx_errors(sentry_init, capture_exceptions, capture_events):
-    sentry_init(integrations=[FalconIntegration()], debug=True)
+    sentry_init(integrations=[FalconIntegration()])
 
     class Resource:
         def on_get(self, req, resp):
@@ -164,7 +164,7 @@ def test_raised_5xx_errors(sentry_init, capture_exceptions, capture_events):
 
 
 def test_raised_4xx_errors(sentry_init, capture_exceptions, capture_events):
-    sentry_init(integrations=[FalconIntegration()], debug=True)
+    sentry_init(integrations=[FalconIntegration()])
 
     class Resource:
         def on_get(self, req, resp):
@@ -188,7 +188,7 @@ def test_http_status(sentry_init, capture_exceptions, capture_events):
     This just demonstrates, that if Falcon raises a HTTPStatus with code 500
     (instead of a HTTPError with code 500) Sentry will not capture it.
     """
-    sentry_init(integrations=[FalconIntegration()], debug=True)
+    sentry_init(integrations=[FalconIntegration()])
 
     class Resource:
         def on_get(self, req, resp):

--- a/tests/integrations/fastapi/test_fastapi.py
+++ b/tests/integrations/fastapi/test_fastapi.py
@@ -59,7 +59,6 @@ async def test_response(sentry_init, capture_events):
         integrations=[StarletteIntegration(), FastApiIntegration()],
         traces_sample_rate=1.0,
         send_default_pii=True,
-        debug=True,
     )
 
     app = fastapi_app_factory()
@@ -196,7 +195,6 @@ async def test_original_request_not_scrubbed(sentry_init, capture_events):
     sentry_init(
         integrations=[StarletteIntegration(), FastApiIntegration()],
         traces_sample_rate=1.0,
-        debug=True,
     )
 
     app = FastAPI()
@@ -354,7 +352,6 @@ def test_transaction_name(
             FastApiIntegration(transaction_style=transaction_style),
         ],
         traces_sample_rate=1.0,
-        debug=True,
     )
 
     envelopes = capture_envelopes()
@@ -384,7 +381,6 @@ def test_route_endpoint_equal_dependant_call(sentry_init):
             FastApiIntegration(),
         ],
         traces_sample_rate=1.0,
-        debug=True,
     )
 
     app = fastapi_app_factory()
@@ -438,7 +434,6 @@ def test_transaction_name_in_traces_sampler(
         integrations=[StarletteIntegration(transaction_style=transaction_style)],
         traces_sampler=dummy_traces_sampler,
         traces_sample_rate=1.0,
-        debug=True,
     )
 
     app = fastapi_app_factory()
@@ -482,7 +477,6 @@ def test_transaction_name_in_middleware(
             FastApiIntegration(transaction_style=transaction_style),
         ],
         traces_sample_rate=1.0,
-        debug=True,
     )
 
     envelopes = capture_envelopes()

--- a/tests/integrations/flask/test_flask.py
+++ b/tests/integrations/flask/test_flask.py
@@ -125,7 +125,7 @@ def test_errors(
     testing,
     integration_enabled_params,
 ):
-    sentry_init(debug=True, **integration_enabled_params)
+    sentry_init(**integration_enabled_params)
 
     app.debug = debug
     app.testing = testing

--- a/tests/integrations/huey/test_huey.py
+++ b/tests/integrations/huey/test_huey.py
@@ -20,7 +20,6 @@ def init_huey(sentry_init):
             integrations=[HueyIntegration()],
             traces_sample_rate=1.0,
             send_default_pii=True,
-            debug=True,
         )
 
         return MemoryHuey(name="sentry_sdk")

--- a/tests/integrations/quart/test_quart.py
+++ b/tests/integrations/quart/test_quart.py
@@ -129,7 +129,7 @@ async def test_errors(
     app,
     integration_enabled_params,
 ):
-    sentry_init(debug=True, **integration_enabled_params)
+    sentry_init(**integration_enabled_params)
 
     @app.route("/")
     async def index():

--- a/tests/integrations/starlette/test_starlette.py
+++ b/tests/integrations/starlette/test_starlette.py
@@ -954,7 +954,6 @@ def test_transaction_name(
         auto_enabling_integrations=False,  # Make sure that httpx integration is not added, because it adds tracing information to the starlette test clients request.
         integrations=[StarletteIntegration(transaction_style=transaction_style)],
         traces_sample_rate=1.0,
-        debug=True,
     )
 
     envelopes = capture_envelopes()
@@ -1015,7 +1014,6 @@ def test_transaction_name_in_traces_sampler(
         integrations=[StarletteIntegration(transaction_style=transaction_style)],
         traces_sampler=dummy_traces_sampler,
         traces_sample_rate=1.0,
-        debug=True,
     )
 
     app = starlette_app_factory()
@@ -1057,7 +1055,6 @@ def test_transaction_name_in_middleware(
             StarletteIntegration(transaction_style=transaction_style),
         ],
         traces_sample_rate=1.0,
-        debug=True,
     )
 
     envelopes = capture_envelopes()

--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -92,7 +92,7 @@ def test_auto_enabling_integrations_catches_import_error(sentry_init, caplog):
         "sentry_sdk.integrations.redis.RedisIntegration"
     )  # noqa: N806
 
-    sentry_init(auto_enabling_integrations=True, debug=True)
+    sentry_init(auto_enabling_integrations=True)
 
     for import_string in _AUTO_ENABLING_INTEGRATIONS:
         # Ignore redis in the test case, because it does not raise a DidNotEnable
@@ -439,7 +439,7 @@ def test_integration_scoping(sentry_init, capture_events):
 def test_client_initialized_within_scope(sentry_init, caplog):
     caplog.set_level(logging.WARNING)
 
-    sentry_init(debug=True)
+    sentry_init()
 
     with push_scope():
         Hub.current.bind_client(Client())
@@ -455,7 +455,7 @@ def test_client_initialized_within_scope(sentry_init, caplog):
 def test_scope_leaks_cleaned_up(sentry_init, caplog):
     caplog.set_level(logging.WARNING)
 
-    sentry_init(debug=True)
+    sentry_init()
 
     old_stack = list(Hub.current._stack)
 
@@ -475,7 +475,7 @@ def test_scope_leaks_cleaned_up(sentry_init, caplog):
 def test_scope_popped_too_soon(sentry_init, caplog):
     caplog.set_level(logging.ERROR)
 
-    sentry_init(debug=True)
+    sentry_init()
 
     old_stack = list(Hub.current._stack)
 
@@ -519,7 +519,7 @@ def test_scope_event_processor_order(sentry_init, capture_events):
 
 
 def test_capture_event_with_scope_kwargs(sentry_init, capture_events):
-    sentry_init(debug=True)
+    sentry_init()
     events = capture_events()
     capture_event({}, level="info", extras={"foo": "bar"})
     (event,) = events

--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -92,7 +92,7 @@ def test_auto_enabling_integrations_catches_import_error(sentry_init, caplog):
         "sentry_sdk.integrations.redis.RedisIntegration"
     )  # noqa: N806
 
-    sentry_init(auto_enabling_integrations=True)
+    sentry_init(auto_enabling_integrations=True, debug=True)
 
     for import_string in _AUTO_ENABLING_INTEGRATIONS:
         # Ignore redis in the test case, because it does not raise a DidNotEnable

--- a/tests/tracing/test_noop_span.py
+++ b/tests/tracing/test_noop_span.py
@@ -9,7 +9,7 @@ from sentry_sdk.tracing import NoOpSpan
 
 
 def test_noop_start_transaction(sentry_init):
-    sentry_init(instrumenter="otel", debug=True)
+    sentry_init(instrumenter="otel")
 
     with sentry_sdk.start_transaction(
         op="task", name="test_transaction_name"
@@ -21,7 +21,7 @@ def test_noop_start_transaction(sentry_init):
 
 
 def test_noop_start_span(sentry_init):
-    sentry_init(instrumenter="otel", debug=True)
+    sentry_init(instrumenter="otel")
 
     with sentry_sdk.start_span(op="http", description="GET /") as span:
         assert isinstance(span, NoOpSpan)
@@ -32,7 +32,7 @@ def test_noop_start_span(sentry_init):
 
 
 def test_noop_transaction_start_child(sentry_init):
-    sentry_init(instrumenter="otel", debug=True)
+    sentry_init(instrumenter="otel")
 
     transaction = sentry_sdk.start_transaction(name="task")
     assert isinstance(transaction, NoOpSpan)
@@ -43,7 +43,7 @@ def test_noop_transaction_start_child(sentry_init):
 
 
 def test_noop_span_start_child(sentry_init):
-    sentry_init(instrumenter="otel", debug=True)
+    sentry_init(instrumenter="otel")
     span = sentry_sdk.start_span(name="task")
     assert isinstance(span, NoOpSpan)
 


### PR DESCRIPTION
The test output is too big already -- we don't need to be debug logging on `sentry_sdk.init`s in the tests. (Unless it's actually part of the test.)

---

## General Notes

Thank you for contributing to `sentry-python`!

Please add tests to validate your changes, and lint your code using `tox -e linters`.

Running the test suite on your PR might require maintainer approval. Some tests (AWS Lambda) additionally require a maintainer to add a special label to run and will fail if the label is not present.

#### For maintainers

Sensitive test suites require maintainer review to ensure that tests do not compromise our secrets. This review must be repeated after any code revisions.

Before running sensitive test suites, please carefully check the PR. Then, apply the `Trigger: tests using secrets` label. The label will be removed after any code changes to enforce our policy requiring maintainers to review all code revisions before running sensitive tests.
