### PR TITLE
ref(crons): Remove deprecated `typing` imports

### DIFF
--- a/sentry_sdk/crons/_decorator.py
+++ b/sentry_sdk/crons/_decorator.py
@@ -4,16 +4,8 @@ from inspect import iscoroutinefunction
 from sentry_sdk._types import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from typing import (
-        Any,
-        Awaitable,
-        Callable,
-        cast,
-        overload,
-        ParamSpec,
-        TypeVar,
-        Union,
-    )
+    from collections.abc import Awaitable, Callable
+    from typing import Any, cast, overload, ParamSpec, TypeVar, Union
 
     P = ParamSpec("P")
     R = TypeVar("R")

--- a/sentry_sdk/crons/_decorator.py
+++ b/sentry_sdk/crons/_decorator.py
@@ -17,6 +17,9 @@ class MonitorMixin:
         @overload
         def __call__(self, fn):
             # type: (Callable[P, Awaitable[Any]]) -> Callable[P, Awaitable[Any]]
+            # Unfortunately, mypy does not give us any reliable way to type check the
+            # return value of an Awaitable (i.e. async function) for this overload,
+            # since calling iscouroutinefunction narrows the type to Callable[P, Awaitable[Any]].
             ...
 
         @overload

--- a/sentry_sdk/crons/_decorator.py
+++ b/sentry_sdk/crons/_decorator.py
@@ -4,8 +4,16 @@ from inspect import iscoroutinefunction
 from sentry_sdk._types import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from collections.abc import Awaitable, Callable
-    from typing import Any, cast, overload, ParamSpec, TypeVar, Union
+    from typing import (
+        Any,
+        Awaitable,
+        Callable,
+        cast,
+        overload,
+        ParamSpec,
+        TypeVar,
+        Union,
+    )
 
     P = ParamSpec("P")
     R = TypeVar("R")


### PR DESCRIPTION
Instead, these should be imported from `collections.abc`

Depends on #2944