### PR TITLE
fix(profiler): Accessing `__class__` might throw a `ValueError`

### DIFF
--- a/sentry_sdk/profiler.py
+++ b/sentry_sdk/profiler.py
@@ -347,7 +347,7 @@ else:
                 for cls in frame.f_locals["self"].__class__.__mro__:
                     if name in cls.__dict__:
                         return "{}.{}".format(cls.__name__, name)
-        except AttributeError:
+        except (AttributeError, ValueError):
             pass
 
         # if it was a class method, (decorated with `@classmethod`)
@@ -363,7 +363,7 @@ else:
                 for cls in frame.f_locals["cls"].__mro__:
                     if name in cls.__dict__:
                         return "{}.{}".format(cls.__name__, name)
-        except AttributeError:
+        except (AttributeError, ValueError):
             pass
 
         # nothing we can do if it is a staticmethod (decorated with @staticmethod)


### PR DESCRIPTION
Closes https://github.com/getsentry/sentry-python/issues/2948

---

## General Notes

Thank you for contributing to `sentry-python`!

Please add tests to validate your changes, and lint your code using `tox -e linters`.

Running the test suite on your PR might require maintainer approval. Some tests (AWS Lambda) additionally require a maintainer to add a special label to run and will fail if the label is not present.

#### For maintainers

Sensitive test suites require maintainer review to ensure that tests do not compromise our secrets. This review must be repeated after any code revisions.

Before running sensitive test suites, please carefully check the PR. Then, apply the `Trigger: tests using secrets` label. The label will be removed after any code changes to enforce our policy requiring maintainers to review all code revisions before running sensitive tests.
