### PR TITLE
Refactoring propagation context

### DIFF
--- a/sentry_sdk/scope.py
+++ b/sentry_sdk/scope.py
@@ -14,7 +14,6 @@ from sentry_sdk.profiler import Profile
 from sentry_sdk.session import Session
 from sentry_sdk.tracing_utils import (
     Baggage,
-    extract_sentrytrace_data,
     has_tracing_enabled,
     normalize_incoming_data,
     PropagationContext,

--- a/sentry_sdk/scope.py
+++ b/sentry_sdk/scope.py
@@ -433,13 +433,13 @@ class Scope(object):
 
     def _extract_propagation_context(self, incoming_data):
         # type: (Dict[str, Any]) -> Optional[PropagationContext]
-        context = None
+        propagation_context = None
 
         normalized_data = normalize_incoming_data(incoming_data)
         baggage_header = normalized_data.get(BAGGAGE_HEADER_NAME)
         if baggage_header:
-            context = PropagationContext()
-            context.dynamic_sampling_context = Baggage.from_incoming_header(
+            propagation_context = PropagationContext()
+            propagation_context.dynamic_sampling_context = Baggage.from_incoming_header(
                 baggage_header
             ).dynamic_sampling_context()
 
@@ -447,11 +447,11 @@ class Scope(object):
         if sentry_trace_header:
             sentrytrace_data = extract_sentrytrace_data(sentry_trace_header)
             if sentrytrace_data is not None:
-                if context is None:
-                    context = PropagationContext()
-                context.update(sentrytrace_data)
+                if propagation_context is None:
+                    propagation_context = PropagationContext()
+                propagation_context.update(sentrytrace_data)
 
-        return context
+        return propagation_context
 
     def set_new_propagation_context(self):
         # type: () -> None
@@ -469,10 +469,9 @@ class Scope(object):
         if there is no `incoming_data` create new `_propagation_context`, but do NOT overwrite if already existing.
         """
         if incoming_data:
-            context = self._extract_propagation_context(incoming_data)
-
-            if context is not None:
-                self._propagation_context = context
+            propagation_context = self._extract_propagation_context(incoming_data)
+            if propagation_context is not None:
+                self._propagation_context = propagation_context
 
         if self._propagation_context is None and self._type != ScopeType.CURRENT:
             self.set_new_propagation_context()

--- a/sentry_sdk/tracing_utils.py
+++ b/sentry_sdk/tracing_utils.py
@@ -348,10 +348,13 @@ class PropagationContext:
         """The span id of the currently executing span."""
 
         self.parent_span_id = parent_span_id
-        """The id of the parent span that started this span. The parent span could also be a span in an upstream service."""
+        """The id of the parent span that started this span.
+        The parent span could also be a span in an upstream service."""
 
         self.parent_sampled = parent_sampled
-        """Boolean indicator if the parent span was sampled. Important when the parent span originated in an upstream service, because we watn to sample the whole trace, or nothing from the trace."""
+        """Boolean indicator if the parent span was sampled.
+        Important when the parent span originated in an upstream service,
+        because we watn to sample the whole trace, or nothing from the trace."""
 
         self.dynamic_sampling_context = dynamic_sampling_context
         """Data that is used for dynamic sampling decisions."""

--- a/sentry_sdk/tracing_utils.py
+++ b/sentry_sdk/tracing_utils.py
@@ -11,10 +11,6 @@ import uuid
 
 import sentry_sdk
 from sentry_sdk.consts import OP, SPANDATA
-from sentry_sdk.tracing import (
-    BAGGAGE_HEADER_NAME,
-    SENTRY_TRACE_HEADER_NAME,
-)
 from sentry_sdk.utils import (
     capture_internal_exceptions,
     filename_for_module,
@@ -676,7 +672,11 @@ def get_current_span(scope=None):
 
 
 # Circular imports
-from sentry_sdk.tracing import LOW_QUALITY_TRANSACTION_SOURCES
+from sentry_sdk.tracing import (
+    BAGGAGE_HEADER_NAME,
+    LOW_QUALITY_TRANSACTION_SOURCES,
+    SENTRY_TRACE_HEADER_NAME,
+)
 
 if TYPE_CHECKING:
     from sentry_sdk.tracing import Span

--- a/sentry_sdk/tracing_utils.py
+++ b/sentry_sdk/tracing_utils.py
@@ -393,7 +393,10 @@ class PropagationContext:
         Updates the PropagationContext with data from the given dictionary.
         """
         for key, value in other_dict.items():
-            setattr(self, key, value)
+            try:
+                setattr(self, key, value)
+            except AttributeError:
+                pass
 
 
 class Baggage:

--- a/sentry_sdk/tracing_utils.py
+++ b/sentry_sdk/tracing_utils.py
@@ -332,17 +332,34 @@ class PropagationContext:
         "dynamic_sampling_context",
     )
 
-    def __init__(self):
-        # type: () -> None
-        self._trace_id = None  # type: Optional[str]
-        self._span_id = None  # type: Optional[str]
-        self.parent_span_id = None  # type: Optional[str]
-        self.parent_sampled = None  # type: Optional[bool]
-        self.dynamic_sampling_context = None  # type: Optional[Dict[str, str]]
+    def __init__(
+        self,
+        trace_id=None,  # type: Optional[str]
+        span_id=None,  # type: Optional[str]
+        parent_span_id=None,  # type: Optional[str]
+        parent_sampled=None,  # type: Optional[bool]
+        dynamic_sampling_context=None,  # type: Optional[Dict[str, str]]
+    ):
+        # type: (...) -> None
+        self._trace_id = trace_id
+        """The trace id of the Sentry trace."""
+
+        self._span_id = span_id
+        """The span id of the currently executing span."""
+
+        self.parent_span_id = parent_span_id
+        """The id of the parent span that started this span. The parent span could also be a span in an upstream service."""
+
+        self.parent_sampled = parent_sampled
+        """Boolean indicator if the parent span was sampled. Important when the parent span originated in an upstream service, because we watn to sample the whole trace, or nothing from the trace."""
+
+        self.dynamic_sampling_context = dynamic_sampling_context
+        """Data that is used for dynamic sampling decisions."""
 
     @property
     def trace_id(self):
         # type: () -> str
+        """The trace id of the Sentry trace."""
         if not self._trace_id:
             self._trace_id = uuid.uuid4().hex
 
@@ -356,6 +373,7 @@ class PropagationContext:
     @property
     def span_id(self):
         # type: () -> str
+        """The span id of the currently executed span."""
         if not self._span_id:
             self._span_id = uuid.uuid4().hex[16:]
 
@@ -368,6 +386,9 @@ class PropagationContext:
 
     def update(self, other_dict):
         # type: (Dict[str, Any]) -> None
+        """
+        Updates the PropagationContext with data from the given dictionary.
+        """
         for key, value in other_dict.items():
             setattr(self, key, value)
 

--- a/sentry_sdk/tracing_utils.py
+++ b/sentry_sdk/tracing_utils.py
@@ -11,6 +11,10 @@ import uuid
 
 import sentry_sdk
 from sentry_sdk.consts import OP, SPANDATA
+from sentry_sdk.tracing import (
+    BAGGAGE_HEADER_NAME,
+    SENTRY_TRACE_HEADER_NAME,
+)
 from sentry_sdk.utils import (
     capture_internal_exceptions,
     filename_for_module,
@@ -358,6 +362,29 @@ class PropagationContext:
 
         self.dynamic_sampling_context = dynamic_sampling_context
         """Data that is used for dynamic sampling decisions."""
+
+    @classmethod
+    def from_incoming_data(cls, incoming_data):
+        # type: (Dict[str, Any]) -> Optional[PropagationContext]
+        propagation_context = None
+
+        normalized_data = normalize_incoming_data(incoming_data)
+        baggage_header = normalized_data.get(BAGGAGE_HEADER_NAME)
+        if baggage_header:
+            propagation_context = PropagationContext()
+            propagation_context.dynamic_sampling_context = Baggage.from_incoming_header(
+                baggage_header
+            ).dynamic_sampling_context()
+
+        sentry_trace_header = normalized_data.get(SENTRY_TRACE_HEADER_NAME)
+        if sentry_trace_header:
+            sentrytrace_data = extract_sentrytrace_data(sentry_trace_header)
+            if sentrytrace_data is not None:
+                if propagation_context is None:
+                    propagation_context = PropagationContext()
+                propagation_context.update(sentrytrace_data)
+
+        return propagation_context
 
     @property
     def trace_id(self):

--- a/tests/integrations/celery/test_celery.py
+++ b/tests/integrations/celery/test_celery.py
@@ -154,11 +154,11 @@ def test_simple_without_performance(capture_events, init_celery, celery_invocati
 
         assert (
             error_event["contexts"]["trace"]["trace_id"]
-            == scope._propagation_context["trace_id"]
+            == scope._propagation_context.trace_id
         )
         assert (
             error_event["contexts"]["trace"]["span_id"]
-            != scope._propagation_context["span_id"]
+            != scope._propagation_context.span_id
         )
         assert error_event["transaction"] == "dummy_task"
         assert "celery_task_id" in error_event["tags"]

--- a/tests/integrations/rq/test_rq.py
+++ b/tests/integrations/rq/test_rq.py
@@ -190,7 +190,7 @@ def test_tracing_disabled(
     assert error_event["transaction"] == "tests.integrations.rq.test_rq.crashing_job"
     assert (
         error_event["contexts"]["trace"]["trace_id"]
-        == scope._propagation_context["trace_id"]
+        == scope._propagation_context.trace_id
     )
 
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -66,8 +66,8 @@ def test_traceparent_with_tracing_disabled(sentry_init):
 
     propagation_context = Scope.get_isolation_scope()._propagation_context
     expected_traceparent = "%s-%s" % (
-        propagation_context["trace_id"],
-        propagation_context["span_id"],
+        propagation_context.trace_id,
+        propagation_context.span_id,
     )
     assert get_traceparent() == expected_traceparent
 
@@ -78,7 +78,7 @@ def test_baggage_with_tracing_disabled(sentry_init):
     propagation_context = Scope.get_isolation_scope()._propagation_context
     expected_baggage = (
         "sentry-trace_id={},sentry-environment=dev,sentry-release=1.0.0".format(
-            propagation_context["trace_id"]
+            propagation_context.trace_id
         )
     )
     assert get_baggage() == expected_baggage
@@ -112,10 +112,10 @@ def test_continue_trace(sentry_init):
         assert transaction.name == "some name"
 
         propagation_context = Scope.get_isolation_scope()._propagation_context
-        assert propagation_context["trace_id"] == transaction.trace_id == trace_id
-        assert propagation_context["parent_span_id"] == parent_span_id
-        assert propagation_context["parent_sampled"] == parent_sampled
-        assert propagation_context["dynamic_sampling_context"] == {
+        assert propagation_context.trace_id == transaction.trace_id == trace_id
+        assert propagation_context.parent_span_id == parent_span_id
+        assert propagation_context.parent_sampled == parent_sampled
+        assert propagation_context.dynamic_sampling_context == {
             "trace_id": "566e3688a61d4bc888951642d6f14a19"
         }
 

--- a/tests/test_propagationcontext.py
+++ b/tests/test_propagationcontext.py
@@ -29,7 +29,7 @@ def test_context_with_values():
     assert ctx.trace_id == "1234567890abcdef1234567890abcdef"
     assert ctx.span_id == "1234567890abcdef"
     assert ctx.parent_span_id == "abcdef1234567890"
-    assert ctx.parent_sampled == True
+    assert ctx.parent_sampled
     assert ctx.dynamic_sampling_context == {
         "foo": "bar",
     }
@@ -77,7 +77,7 @@ def test_update():
     assert ctx.span_id is not None  # this sets _span_id
     assert ctx._span_id is not None
     assert ctx.parent_span_id == "Z234567890abcdef"
-    assert ctx.parent_sampled == False
+    assert not ctx.parent_sampled
     assert ctx.dynamic_sampling_context is None
 
     assert not hasattr(ctx, "foo")

--- a/tests/test_propagationcontext.py
+++ b/tests/test_propagationcontext.py
@@ -1,0 +1,83 @@
+from sentry_sdk.tracing_utils import PropagationContext
+
+
+def test_empty_context():
+    ctx = PropagationContext()
+
+    assert ctx.trace_id is not None
+    assert len(ctx.trace_id) == 32
+
+    assert ctx.span_id is not None
+    assert len(ctx.span_id) == 16
+
+    assert ctx.parent_span_id is None
+    assert ctx.parent_sampled is None
+    assert ctx.dynamic_sampling_context is None
+
+
+def test_context_with_values():
+    ctx = PropagationContext(
+        trace_id="1234567890abcdef1234567890abcdef",
+        span_id="1234567890abcdef",
+        parent_span_id="abcdef1234567890",
+        parent_sampled=True,
+        dynamic_sampling_context={
+            "foo": "bar",
+        },
+    )
+
+    assert ctx.trace_id == "1234567890abcdef1234567890abcdef"
+    assert ctx.span_id == "1234567890abcdef"
+    assert ctx.parent_span_id == "abcdef1234567890"
+    assert ctx.parent_sampled == True
+    assert ctx.dynamic_sampling_context == {
+        "foo": "bar",
+    }
+
+
+def test_lacy_uuids():
+    ctx = PropagationContext()
+    assert ctx._trace_id is None
+    assert ctx._span_id is None
+
+    assert ctx.trace_id is not None  # this sets _trace_id
+    assert ctx._trace_id is not None
+    assert ctx._span_id is None
+
+    assert ctx.span_id is not None  # this sets _span_id
+    assert ctx._trace_id is not None
+    assert ctx._span_id is not None
+
+
+def test_property_setters():
+    ctx = PropagationContext()
+    ctx.trace_id = "X234567890abcdef1234567890abcdef"
+    ctx.span_id = "X234567890abcdef"
+
+    assert ctx._trace_id == "X234567890abcdef1234567890abcdef"
+    assert ctx.trace_id == "X234567890abcdef1234567890abcdef"
+    assert ctx._span_id == "X234567890abcdef"
+    assert ctx.span_id == "X234567890abcdef"
+
+
+def test_update():
+    ctx = PropagationContext()
+
+    other_data = {
+        "trace_id": "Z234567890abcdef1234567890abcdef",
+        "parent_span_id": "Z234567890abcdef",
+        "parent_sampled": False,
+        "foo": "bar",
+    }
+    ctx.update(other_data)
+
+    assert ctx._trace_id == "Z234567890abcdef1234567890abcdef"
+    assert ctx.trace_id == "Z234567890abcdef1234567890abcdef"
+    assert ctx._span_id is None  # this will be set lazily
+    assert ctx.span_id is not None  # this sets _span_id
+    assert ctx._span_id is not None
+    assert ctx.parent_span_id == "Z234567890abcdef"
+    assert ctx.parent_sampled == False
+    assert ctx.dynamic_sampling_context is None
+
+    assert not hasattr(ctx, "foo")


### PR DESCRIPTION
Create a class for the `PropagationContext`. Make the class generate the UUIDs lazily.

Fixes https://github.com/getsentry/sentry-python/issues/2827