### PR TITLE
feat(scope): New `set_tags` function

### DIFF
--- a/sentry_sdk/__init__.py
+++ b/sentry_sdk/__init__.py
@@ -40,6 +40,7 @@ __all__ = [  # noqa
     "set_level",
     "set_measurement",
     "set_tag",
+    "set_tags",
     "set_user",
     "start_span",
     "start_transaction",

--- a/sentry_sdk/api.py
+++ b/sentry_sdk/api.py
@@ -8,6 +8,8 @@ from sentry_sdk.scope import Scope, _ScopeManager, new_scope, isolation_scope
 from sentry_sdk.tracing import NoOpSpan, Transaction
 
 if TYPE_CHECKING:
+    from collections.abc import Mapping
+
     from typing import Any
     from typing import Dict
     from typing import Generator
@@ -64,6 +66,7 @@ __all__ = [
     "set_level",
     "set_measurement",
     "set_tag",
+    "set_tags",
     "set_user",
     "start_span",
     "start_transaction",
@@ -237,6 +240,12 @@ def push_scope(  # noqa: F811
 def set_tag(key, value):
     # type: (str, Any) -> None
     return Scope.get_isolation_scope().set_tag(key, value)
+
+
+@scopemethod
+def set_tags(tags):
+    # type: (Mapping[str, object]) -> None
+    Scope.get_isolation_scope().set_tags(tags)
 
 
 @scopemethod

--- a/sentry_sdk/scope.py
+++ b/sentry_sdk/scope.py
@@ -801,6 +801,21 @@ class Scope(object):
 
     def set_tags(self, tags):
         # type: (Mapping[str, object]) -> None
+        """Sets multiple tags at once.
+
+        This method updates multiple tags at once. The tags are passed as a dictionary
+        or other mapping type.
+
+        Calling this method is equivalent to calling `set_tag` on each key-value pair
+        in the mapping. If a tag key already exists in the scope, its value will be
+        updated. If the tag key does not exist in the scope, the key-value pair will
+        be added to the scope.
+
+        This method only modifies tag keys in the `tags` mapping passed to the method.
+        `scope.set_tags({})` is, therefore, a no-op.
+
+        :param tags: A mapping of tag keys to tag values to set.
+        """
         self._tags.update(tags)
 
     def remove_tag(self, key):

--- a/sentry_sdk/scope.py
+++ b/sentry_sdk/scope.py
@@ -35,7 +35,7 @@ from sentry_sdk.utils import (
 )
 
 if TYPE_CHECKING:
-    from collections.abc import MutableMapping
+    from collections.abc import Mapping, MutableMapping
 
     from typing import Any
     from typing import Callable
@@ -798,6 +798,10 @@ class Scope(object):
         :param value: Value of the tag to set.
         """
         self._tags[key] = value
+
+    def set_tags(self, tags):
+        # type: (Mapping[str, object]) -> None
+        self._tags.update(tags)
 
     def remove_tag(self, key):
         # type: (str) -> None

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -178,4 +178,4 @@ def test_set_tags(sentry_init, capture_events):
         "tag1": "value1",
         "tag2": "updated",
         "tag3": "new",
-    }, "Upating tags with empty dict changed tags"
+    }, "Updating tags with empty dict changed tags"

--- a/tests/test_scope.py
+++ b/tests/test_scope.py
@@ -821,4 +821,4 @@ def test_set_tags():
         "tag1": "value1",
         "tag2": "updated",
         "tag3": "new",
-    }, "Upating tags with empty dict changed tags"
+    }, "Updating tags with empty dict changed tags"

--- a/tests/test_scope.py
+++ b/tests/test_scope.py
@@ -796,3 +796,29 @@ def test_should_send_default_pii_false(sentry_init):
     sentry_init(send_default_pii=False)
 
     assert should_send_default_pii() is False
+
+
+def test_set_tags():
+    scope = Scope()
+    scope.set_tags({"tag1": "value1", "tag2": "value2"})
+    event = scope.apply_to_event({}, {})
+
+    assert event["tags"] == {"tag1": "value1", "tag2": "value2"}, "Setting tags failed"
+
+    scope.set_tags({"tag2": "updated", "tag3": "new"})
+    event = scope.apply_to_event({}, {})
+
+    assert event["tags"] == {
+        "tag1": "value1",
+        "tag2": "updated",
+        "tag3": "new",
+    }, "Updating tags failed"
+
+    scope.set_tags({})
+    event = scope.apply_to_event({}, {})
+
+    assert event["tags"] == {
+        "tag1": "value1",
+        "tag2": "updated",
+        "tag3": "new",
+    }, "Upating tags with empty dict changed tags"


### PR DESCRIPTION
`Scope.set_tags` allows multiple tags to be set at the same time by passing the tags to update as a dictionary (or other `Mapping` type).

Closes GH-1344