### PR TITLE
feat(misc): Implement the span.origin field

### DIFF
--- a/sentry_sdk/tracing.py
+++ b/sentry_sdk/tracing.py
@@ -188,6 +188,7 @@ class Span:
         "same_process_as_parent",
         "sampled",
         "op",
+        "origin",
         "description",
         "start_timestamp",
         "_start_timestamp_monotonic_ns",
@@ -211,6 +212,7 @@ class Span:
         same_process_as_parent=True,  # type: bool
         sampled=None,  # type: Optional[bool]
         op=None,  # type: Optional[str]
+        origin=None,  # type: Optional[str]
         description=None,  # type: Optional[str]
         hub=None,  # type: Optional[sentry_sdk.Hub]  # deprecated
         status=None,  # type: Optional[str]
@@ -225,6 +227,7 @@ class Span:
         self.same_process_as_parent = same_process_as_parent
         self.sampled = sampled
         self.op = op
+        self.origin = origin
         self.description = description
         self.status = status
         self.hub = hub
@@ -585,6 +588,7 @@ class Span:
             "parent_span_id": self.parent_span_id,
             "same_process_as_parent": self.same_process_as_parent,
             "op": self.op,
+            "origin": self.origin,
             "description": self.description,
             "start_timestamp": self.start_timestamp,
             "timestamp": self.timestamp,


### PR DESCRIPTION
Add support for the "span.origin" field

---

## General Notes

Thank you for contributing to `sentry-python`!

Please add tests to validate your changes, and lint your code using `tox -e linters`.

Running the test suite on your PR might require maintainer approval. Some tests (AWS Lambda) additionally require a maintainer to add a special label to run and will fail if the label is not present.

#### For maintainers

Sensitive test suites require maintainer review to ensure that tests do not compromise our secrets. This review must be repeated after any code revisions.

Before running sensitive test suites, please carefully check the PR. Then, apply the `Trigger: tests using secrets` label. The label will be removed after any code changes to enforce our policy requiring maintainers to review all code revisions before running sensitive tests.
