### PR TITLE
Make it work with old and new newrelic versions

### DIFF
--- a/tests/integrations/celery/test_celery.py
+++ b/tests/integrations/celery/test_celery.py
@@ -414,15 +414,28 @@ def test_redis_backend_trace_propagation(init_celery, capture_events_forksafe):
     assert not runs
 
 
-@pytest.mark.forked
+# @pytest.mark.forked
 @pytest.mark.parametrize("newrelic_order", ["sentry_first", "sentry_last"])
 def test_newrelic_interference(init_celery, newrelic_order, celery_invocation):
     def instrument_newrelic():
-        import celery.app.trace as celery_mod
-        from newrelic.hooks.application_celery import instrument_celery_execute_trace
+        try:
+            # older newrelic versions
+            from newrelic.hooks.application_celery import (
+                instrument_celery_execute_trace,
+            )
+            import celery.app.trace as celery_trace_module
 
-        assert hasattr(celery_mod, "build_tracer")
-        instrument_celery_execute_trace(celery_mod)
+            assert hasattr(celery_trace_module, "build_tracer")
+            instrument_celery_execute_trace(celery_trace_module)
+
+        except ImportError:
+            # newer newrelic versions
+            from newrelic.hooks.application_celery import instrument_celery_app_base
+            import celery.app as celery_app_module
+
+            assert hasattr(celery_app_module, "Celery")
+            assert hasattr(celery_app_module.Celery, "send_task")
+            instrument_celery_app_base(celery_app_module)
 
     if newrelic_order == "sentry_first":
         celery = init_celery()

--- a/tests/integrations/celery/test_celery.py
+++ b/tests/integrations/celery/test_celery.py
@@ -414,7 +414,7 @@ def test_redis_backend_trace_propagation(init_celery, capture_events_forksafe):
     assert not runs
 
 
-# @pytest.mark.forked
+@pytest.mark.forked
 @pytest.mark.parametrize("newrelic_order", ["sentry_first", "sentry_last"])
 def test_newrelic_interference(init_celery, newrelic_order, celery_invocation):
     def instrument_newrelic():


### PR DESCRIPTION
This fixes our tests that rely on the `newrelic` package. In their version `v9.9.0` they removed a function that we called so we had to update our tests.