### PR TITLE
fix(integrations): Do not use convenience decorator

### DIFF
--- a/sentry_sdk/integrations/fastapi.py
+++ b/sentry_sdk/integrations/fastapi.py
@@ -10,7 +10,6 @@ from sentry_sdk.tracing import SOURCE_FOR_STYLE, TRANSACTION_SOURCE_ROUTE
 from sentry_sdk.utils import (
     transaction_from_function,
     logger,
-    ensure_integration_enabled_async,
 )
 
 if TYPE_CHECKING:
@@ -97,9 +96,11 @@ def patch_get_request_handler():
 
         old_app = old_get_request_handler(*args, **kwargs)
 
-        @ensure_integration_enabled_async(FastApiIntegration, old_app)
         async def _sentry_app(*args, **kwargs):
             # type: (*Any, **Any) -> Any
+            if sentry_sdk.get_client().get_integration(FastApiIntegration) is None:
+                return await old_app(*args, **kwargs)
+
             integration = sentry_sdk.get_client().get_integration(FastApiIntegration)
             request = args[0]
 

--- a/sentry_sdk/integrations/graphene.py
+++ b/sentry_sdk/integrations/graphene.py
@@ -4,7 +4,6 @@ from sentry_sdk.scope import Scope, should_send_default_pii
 from sentry_sdk.utils import (
     capture_internal_exceptions,
     ensure_integration_enabled,
-    ensure_integration_enabled_async,
     event_from_exception,
     package_version,
 )
@@ -69,9 +68,11 @@ def _patch_graphql():
 
         return result
 
-    @ensure_integration_enabled_async(GrapheneIntegration, old_graphql_async)
     async def _sentry_patched_graphql_async(schema, source, *args, **kwargs):
         # type: (GraphQLSchema, Union[str, Source], Any, Any) -> ExecutionResult
+        if sentry_sdk.get_client().get_integration(GrapheneIntegration) is None:
+            return await old_graphql_async(schema, source, *args, **kwargs)
+
         scope = Scope.get_isolation_scope()
         scope.add_event_processor(_event_processor)
 

--- a/sentry_sdk/integrations/quart.py
+++ b/sentry_sdk/integrations/quart.py
@@ -12,7 +12,6 @@ from sentry_sdk.tracing import SOURCE_FOR_STYLE
 from sentry_sdk.utils import (
     capture_internal_exceptions,
     ensure_integration_enabled,
-    ensure_integration_enabled_async,
     event_from_exception,
 )
 from sentry_sdk._types import TYPE_CHECKING
@@ -150,10 +149,11 @@ def _set_transaction_name_and_source(scope, transaction_style, request):
         pass
 
 
-@ensure_integration_enabled_async(QuartIntegration)
 async def _request_websocket_started(app, **kwargs):
     # type: (Quart, **Any) -> None
     integration = sentry_sdk.get_client().get_integration(QuartIntegration)
+    if integration is None:
+        return
 
     if has_request_context():
         request_websocket = request._get_current_object()
@@ -200,9 +200,12 @@ def _make_request_event_processor(app, request, integration):
     return inner
 
 
-@ensure_integration_enabled_async(QuartIntegration)
 async def _capture_exception(sender, exception, **kwargs):
     # type: (Quart, Union[ValueError, BaseException], **Any) -> None
+    integration = sentry_sdk.get_client().get_integration(QuartIntegration)
+    if integration is None:
+        return
+
     event, hint = event_from_exception(
         exception,
         client_options=sentry_sdk.get_client().options,

--- a/sentry_sdk/integrations/sanic.py
+++ b/sentry_sdk/integrations/sanic.py
@@ -14,7 +14,6 @@ from sentry_sdk.scope import Scope
 from sentry_sdk.utils import (
     capture_internal_exceptions,
     ensure_integration_enabled,
-    ensure_integration_enabled_async,
     event_from_exception,
     HAS_REAL_CONTEXTVARS,
     CONTEXTVARS_ERROR_MESSAGE,
@@ -274,9 +273,11 @@ def _sentry_error_handler_lookup(self, exception, *args, **kwargs):
     return sentry_wrapped_error_handler
 
 
-@ensure_integration_enabled_async(SanicIntegration, old_handle_request)
 async def _legacy_handle_request(self, request, *args, **kwargs):
     # type: (Any, Request, *Any, **Any) -> Any
+    if sentry_sdk.get_client().get_integration(SanicIntegration) is None:
+        return await old_handle_request(self, request, *args, **kwargs)
+
     weak_request = weakref.ref(request)
 
     with sentry_sdk.isolation_scope() as scope:

--- a/sentry_sdk/integrations/starlette.py
+++ b/sentry_sdk/integrations/starlette.py
@@ -21,7 +21,6 @@ from sentry_sdk.utils import (
     AnnotatedValue,
     capture_internal_exceptions,
     ensure_integration_enabled,
-    ensure_integration_enabled_async,
     event_from_exception,
     logger,
     parse_version,
@@ -337,10 +336,11 @@ def patch_asgi_app():
     """
     old_app = Starlette.__call__
 
-    @ensure_integration_enabled_async(StarletteIntegration, old_app)
     async def _sentry_patched_asgi_app(self, scope, receive, send):
         # type: (Starlette, StarletteScope, Receive, Send) -> None
         integration = sentry_sdk.get_client().get_integration(StarletteIntegration)
+        if integration is None:
+            return await old_app(self, scope, receive, send)
 
         middleware = SentryAsgiMiddleware(
             lambda *a, **kw: old_app(self, *a, **kw),
@@ -377,12 +377,13 @@ def patch_request_response():
         is_coroutine = _is_async_callable(old_func)
         if is_coroutine:
 
-            @ensure_integration_enabled_async(StarletteIntegration, old_func)
             async def _sentry_async_func(*args, **kwargs):
                 # type: (*Any, **Any) -> Any
                 integration = sentry_sdk.get_client().get_integration(
                     StarletteIntegration
                 )
+                if integration is None:
+                    return await old_func(*args, **kwargs)
 
                 request = args[0]
 


### PR DESCRIPTION
Quick fix for https://github.com/getsentry/sentry-python/issues/3021. Removing the decorator gets rid of the issue.

We should follow up and fix the decorator later, e.g. here: https://github.com/getsentry/sentry-python/issues/2892

Closes https://github.com/getsentry/sentry-python/issues/3021

---

## General Notes

Thank you for contributing to `sentry-python`!

Please add tests to validate your changes, and lint your code using `tox -e linters`.

Running the test suite on your PR might require maintainer approval. Some tests (AWS Lambda) additionally require a maintainer to add a special label to run and will fail if the label is not present.

#### For maintainers

Sensitive test suites require maintainer review to ensure that tests do not compromise our secrets. This review must be repeated after any code revisions.

Before running sensitive test suites, please carefully check the PR. Then, apply the `Trigger: tests using secrets` label. The label will be removed after any code changes to enforce our policy requiring maintainers to review all code revisions before running sensitive tests.
