### PR TITLE
meta(license): Bump copyright year

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2018 Functional Software, Inc. dba Sentry
+Copyright (c) 2024 Functional Software, Inc. dba Sentry
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
The copyright year should be 2024, not 2018. Would be nice if we could automate the updating of the copyright year somehow.