### PR TITLE
fix(tests): Fix trytond tests

### DIFF
--- a/tests/integrations/trytond/test_trytond.py
+++ b/tests/integrations/trytond/test_trytond.py
@@ -11,7 +11,9 @@ from trytond.exceptions import LoginException
 from trytond.wsgi import app as trytond_app
 
 from werkzeug.test import Client
+
 from sentry_sdk.integrations.trytond import TrytondWSGIIntegration
+from tests.conftest import unpack_werkzeug_response
 
 
 @pytest.fixture(scope="function")
@@ -118,8 +120,8 @@ def test_rpc_error_page(sentry_init, app, get_client):
         "/rpcerror", content_type="application/json", data=json.dumps(_data)
     )
 
-    (content, status, headers) = response
-    data = json.loads(next(content))
+    (content, status, headers) = unpack_werkzeug_response(response)
+    data = json.loads(content)
     assert status == "200 OK"
     assert headers.get("Content-Type") == "application/json"
     assert data == dict(id=42, error=["UserError", ["Sentry error.", "foo", None]])

--- a/tox.ini
+++ b/tox.ini
@@ -570,6 +570,7 @@ deps =
 
     # Trytond
     trytond: werkzeug
+    trytond-v4: werkzeug<1.0
     trytond-v4: trytond~=4.0
     trytond-v5: trytond~=5.0
     trytond-v6: trytond~=6.0

--- a/tox.ini
+++ b/tox.ini
@@ -569,15 +569,12 @@ deps =
     tornado-latest: tornado
 
     # Trytond
+    trytond: werkzeug
     trytond-v4: trytond~=4.0
     trytond-v5: trytond~=5.0
     trytond-v6: trytond~=6.0
     trytond-v7: trytond~=7.0
     trytond-latest: trytond
-
-    trytond-v{4}: werkzeug<1.0
-    trytond-v{5,6,7}: werkzeug<2.0
-    trytond-latest: werkzeug<2.0
 
 setenv =
     PYTHONDONTWRITEBYTECODE=1


### PR DESCRIPTION
Remove the pin on super old `werkzeug` versions. Latest `trytond` release doesn't work with `werkzeug` that old.

---

## General Notes

Thank you for contributing to `sentry-python`!

Please add tests to validate your changes, and lint your code using `tox -e linters`.

Running the test suite on your PR might require maintainer approval. Some tests (AWS Lambda) additionally require a maintainer to add a special label to run and will fail if the label is not present.

#### For maintainers

Sensitive test suites require maintainer review to ensure that tests do not compromise our secrets. This review must be repeated after any code revisions.

Before running sensitive test suites, please carefully check the PR. Then, apply the `Trigger: tests using secrets` label. The label will be removed after any code changes to enforce our policy requiring maintainers to review all code revisions before running sensitive tests.
