### PR TITLE
Fix DSC in celery tasks started by Celery Beat.

### DIFF
--- a/scripts/aws_lambda_functions/sentryPythonDeleteTestFunctions/lambda_function.py
+++ b/scripts/aws_lambda_functions/sentryPythonDeleteTestFunctions/lambda_function.py
@@ -1,12 +1,12 @@
 import boto3
-import sentry_sdk 
+import sentry_sdk
 
 
 monitor_slug = "python-sdk-aws-lambda-tests-cleanup"
 monitor_config = {
     "schedule": {
         "type": "crontab",
-        "value": "0 12 * * 0", # 12 o'clock on Sunday
+        "value": "0 12 * * 0",  # 12 o'clock on Sunday
     },
     "timezone": "UTC",
     "checkin_margin": 2,
@@ -24,7 +24,7 @@ def delete_lambda_functions(prefix="test_"):
     """
     client = boto3.client("lambda", region_name="us-east-1")
     functions_deleted = 0
-    
+
     functions_paginator = client.get_paginator("list_functions")
     for functions_page in functions_paginator.paginate():
         for func in functions_page["Functions"]:
@@ -39,17 +39,17 @@ def delete_lambda_functions(prefix="test_"):
                     print(f"Got exception: {ex}")
 
     return functions_deleted
-    
+
 
 def lambda_handler(event, context):
     functions_deleted = delete_lambda_functions()
-    
+
     sentry_sdk.metrics.gauge(
-        key="num_aws_functions_deleted", 
+        key="num_aws_functions_deleted",
         value=functions_deleted,
     )
-    
+
     return {
-        'statusCode': 200,
-        'body': f"{functions_deleted} AWS Lambda functions deleted successfully."
+        "statusCode": 200,
+        "body": f"{functions_deleted} AWS Lambda functions deleted successfully.",
     }

--- a/sentry_sdk/tracing_utils.py
+++ b/sentry_sdk/tracing_utils.py
@@ -421,6 +421,16 @@ class PropagationContext:
             except AttributeError:
                 pass
 
+    def __repr__(self):
+        # type: (...) -> str
+        return "<PropagationContext _trace_id={} _span_id={} parent_span_id={} parent_sampled={} dynamic_sampling_context={}>".format(
+            self._trace_id,
+            self._span_id,
+            self.parent_span_id,
+            self.parent_sampled,
+            self.dynamic_sampling_context,
+        )
+
 
 class Baggage:
     """


### PR DESCRIPTION
Only create the span for enqueuing the task when we are not currently running in a celery beat task. (because then there is only the span without a transaction and thus the baggage header can not be given to the child celery task.) Without the span the child celery task creates its own trace, this is what we want.


<!-- Describe your PR here -->

---

## General Notes

Thank you for contributing to `sentry-python`!

Please add tests to validate your changes, and lint your code using `tox -e linters`.

Running the test suite on your PR might require maintainer approval. Some tests (AWS Lambda) additionally require a maintainer to add a special label to run and will fail if the label is not present.

#### For maintainers

Sensitive test suites require maintainer review to ensure that tests do not compromise our secrets. This review must be repeated after any code revisions.

Before running sensitive test suites, please carefully check the PR. Then, apply the `Trigger: tests using secrets` label. The label will be removed after any code changes to enforce our policy requiring maintainers to review all code revisions before running sensitive tests.
