### PR TITLE
misc(ai-monitoring): Auto-enable Anthropic integration + gate imports

### DIFF
--- a/sentry_sdk/integrations/__init__.py
+++ b/sentry_sdk/integrations/__init__.py
@@ -69,6 +69,7 @@ _DEFAULT_INTEGRATIONS = [
 
 _AUTO_ENABLING_INTEGRATIONS = [
     "sentry_sdk.integrations.aiohttp.AioHttpIntegration",
+    "sentry_sdk.integrations.anthropic.AnthropicIntegration",
     "sentry_sdk.integrations.ariadne.AriadneIntegration",
     "sentry_sdk.integrations.arq.ArqIntegration",
     "sentry_sdk.integrations.asyncpg.AsyncPGIntegration",

--- a/sentry_sdk/integrations/anthropic.py
+++ b/sentry_sdk/integrations/anthropic.py
@@ -12,13 +12,19 @@ from sentry_sdk.utils import (
     package_version,
 )
 
-from anthropic.resources import Messages
-
 from typing import TYPE_CHECKING
+
+try:
+    from anthropic.resources import Messages
+
+    if TYPE_CHECKING:
+        from anthropic.types import MessageStreamEvent
+except ImportError:
+    raise DidNotEnable("Anthropic not installed")
+
 
 if TYPE_CHECKING:
     from typing import Any, Iterator
-    from anthropic.types import MessageStreamEvent
     from sentry_sdk.tracing import Span
 
 


### PR DESCRIPTION
Auto-enable the Anthropic integration, and put all anthropic-related imports in `try` for safety.