### PR TITLE
Bring back `last_event_id`

### DIFF
--- a/sentry_sdk/__init__.py
+++ b/sentry_sdk/__init__.py
@@ -34,6 +34,7 @@ __all__ = [  # noqa
     "is_initialized",
     "isolation_scope",
     "new_scope",
+    "last_event_id",
     "push_scope",
     "set_context",
     "set_extra",

--- a/sentry_sdk/api.py
+++ b/sentry_sdk/api.py
@@ -60,6 +60,7 @@ __all__ = [
     "is_initialized",
     "isolation_scope",
     "new_scope",
+    "last_event_id",
     "push_scope",
     "set_context",
     "set_extra",
@@ -375,3 +376,9 @@ def continue_trace(environ_or_headers, op=None, name=None, source=None):
     return Scope.get_isolation_scope().continue_trace(
         environ_or_headers, op, name, source
     )
+
+
+@clientmethod
+def last_event_id():
+    # type: () -> Optional[str]
+    return get_client().last_event_id()

--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -18,6 +18,7 @@ from sentry_sdk import (
     add_breadcrumb,
     Hub,
     Scope,
+    last_event_id,
 )
 from sentry_sdk.integrations import (
     _AUTO_ENABLING_INTEGRATIONS,
@@ -778,3 +779,24 @@ def test_classmethod_tracing(sentry_init):
         with patch_start_tracing_child() as fake_start_child:
             assert instance_or_class.class_(1) == (TracingTestClass, 1)
             assert fake_start_child.call_count == 1
+
+
+def test_last_event_id(sentry_init):
+    sentry_init()
+
+    assert last_event_id() is None
+
+    capture_exception(ValueError("foo"))
+
+    assert last_event_id() is not None
+
+
+def test_last_event_id_transaction(sentry_init):
+    sentry_init()
+
+    assert last_event_id() is None
+
+    with start_transaction():
+        pass
+
+    assert last_event_id() is None


### PR DESCRIPTION
`last_event_id` will return the ID of the most recently captured error event

Closes #3049 
