### PR TITLE
feat(django): Do not error if post body cannot be read

### DIFF
--- a/sentry_sdk/integrations/django/__init__.py
+++ b/sentry_sdk/integrations/django/__init__.py
@@ -79,7 +79,7 @@ if TYPE_CHECKING:
 
     from django.core.handlers.wsgi import WSGIRequest
     from django.http.response import HttpResponse
-    from django.http.request import QueryDict
+    from django.http.request import QueryDict, RawPostDataException
     from django.utils.datastructures import MultiValueDict
 
     from sentry_sdk.tracing import Span
@@ -554,7 +554,10 @@ class DjangoRequestExtractor(RequestExtractor):
         try:
             return self.request.data
         except AttributeError:
-            return RequestExtractor.parsed_body(self)
+            try:
+                return RequestExtractor.parsed_body(self)
+            except RawPostDataException:
+                return None  # something has already read the POST data
 
 
 def _set_user_info(request, event):


### PR DESCRIPTION
[See example logs in sentry production here](https://console.cloud.google.com/logs/query;query=resource.type%3D%22k8s_container%22%0A-resource.labels.container_name%3D%22envoy%22%0Alabels.name%3D%22sentry_sdk.errors%22;summaryFields=:true:32:beginning;cursorTimestamp=2024-05-08T23:37:16.845492734Z;startTime=2024-05-08T23:36:38.096Z;endTime=2024-05-08T23:37:38.096Z?project=internal-sentry&rapt=AEjHL4OTmaiNGLf_dIkLRBFUkgdfXC7Dodjv0k8BMjvzySo-ejqxRZN0sqYGm7paUHsEAqDTt2Ftvtx7jT4apsBs3KcYEv1-rQU2ILDPWVB1Bxn3TFlthzo)