### PR TITLE
ref(scope): Fix `get_client` typing

### DIFF
--- a/sentry_sdk/scope.py
+++ b/sentry_sdk/scope.py
@@ -1640,3 +1640,6 @@ def should_send_default_pii():
 
 # Circular imports
 from sentry_sdk.client import NonRecordingClient
+
+if TYPE_CHECKING:
+    import sentry_sdk.client


### PR DESCRIPTION
The `Scope.get_client` method is typed as returning `sentry_sdk.client.BaseClient`, but because `sentry_sdk.client` was not imported, the type was resolved as `Any`. This change imports `sentry_sdk.client` to fix the type hints.