### PR TITLE
fix(tracing): Only propagate headers from spans within transactions

### DIFF
--- a/tests/integrations/aiohttp/test_aiohttp.py
+++ b/tests/integrations/aiohttp/test_aiohttp.py
@@ -404,13 +404,17 @@ async def test_trace_from_headers_if_performance_enabled(
     # The aiohttp_client is instrumented so will generate the sentry-trace header and add request.
     # Get the sentry-trace header from the request so we can later compare with transaction events.
     client = await aiohttp_client(app)
-    resp = await client.get("/")
+    with start_transaction():
+        # Headers are only added to the span if there is an active transaction
+        resp = await client.get("/")
+
     sentry_trace_header = resp.request_info.headers.get("sentry-trace")
     trace_id = sentry_trace_header.split("-")[0]
 
     assert resp.status == 500
 
-    msg_event, error_event, transaction_event = events
+    # Last item is the custom transaction event wrapping `client.get("/")`
+    msg_event, error_event, transaction_event, _ = events
 
     assert msg_event["contexts"]["trace"]
     assert "trace_id" in msg_event["contexts"]["trace"]

--- a/tests/integrations/celery/test_update_celery_task_headers.py
+++ b/tests/integrations/celery/test_update_celery_task_headers.py
@@ -77,33 +77,6 @@ def test_span_with_transaction(sentry_init):
             )
 
 
-def test_span_with_no_transaction(sentry_init):
-    sentry_init(enable_tracing=True)
-    headers = {}
-
-    with sentry_sdk.start_span(op="test_span") as span:
-        updated_headers = _update_celery_task_headers(headers, span, False)
-
-        assert updated_headers["sentry-trace"] == span.to_traceparent()
-        assert updated_headers["headers"]["sentry-trace"] == span.to_traceparent()
-        assert "baggage" not in updated_headers.keys()
-        assert "baggage" not in updated_headers["headers"].keys()
-
-
-def test_custom_span(sentry_init):
-    sentry_init(enable_tracing=True)
-    span = sentry_sdk.tracing.Span()
-    headers = {}
-
-    with sentry_sdk.start_transaction(name="test_transaction"):
-        updated_headers = _update_celery_task_headers(headers, span, False)
-
-        assert updated_headers["sentry-trace"] == span.to_traceparent()
-        assert updated_headers["headers"]["sentry-trace"] == span.to_traceparent()
-        assert "baggage" not in updated_headers.keys()
-        assert "baggage" not in updated_headers["headers"].keys()
-
-
 def test_span_with_transaction_custom_headers(sentry_init):
     sentry_init(enable_tracing=True)
     headers = {
@@ -137,36 +110,3 @@ def test_span_with_transaction_custom_headers(sentry_init):
             assert updated_headers["headers"]["baggage"] == combined_baggage.serialize(
                 include_third_party=True
             )
-
-
-def test_span_with_no_transaction_custom_headers(sentry_init):
-    sentry_init(enable_tracing=True)
-    headers = {
-        "baggage": BAGGAGE_VALUE,
-        "sentry-trace": SENTRY_TRACE_VALUE,
-    }
-
-    with sentry_sdk.start_span(op="test_span") as span:
-        updated_headers = _update_celery_task_headers(headers, span, False)
-
-        assert updated_headers["sentry-trace"] == span.to_traceparent()
-        assert updated_headers["headers"]["sentry-trace"] == span.to_traceparent()
-        assert updated_headers["baggage"] == headers["baggage"]
-        assert updated_headers["headers"]["baggage"] == headers["baggage"]
-
-
-def test_custom_span_custom_headers(sentry_init):
-    sentry_init(enable_tracing=True)
-    span = sentry_sdk.tracing.Span()
-    headers = {
-        "baggage": BAGGAGE_VALUE,
-        "sentry-trace": SENTRY_TRACE_VALUE,
-    }
-
-    with sentry_sdk.start_transaction(name="test_transaction"):
-        updated_headers = _update_celery_task_headers(headers, span, False)
-
-        assert updated_headers["sentry-trace"] == span.to_traceparent()
-        assert updated_headers["headers"]["sentry-trace"] == span.to_traceparent()
-        assert updated_headers["baggage"] == headers["baggage"]
-        assert updated_headers["headers"]["baggage"] == headers["baggage"]

--- a/tests/tracing/test_propagation.py
+++ b/tests/tracing/test_propagation.py
@@ -1,0 +1,40 @@
+import sentry_sdk
+import pytest
+
+
+def test_standalone_span_iter_headers(sentry_init):
+    sentry_init(enable_tracing=True)
+
+    with sentry_sdk.start_span(op="test") as span:
+        with pytest.raises(StopIteration):
+            # We should not have any propagation headers
+            next(span.iter_headers())
+
+
+def test_span_in_span_iter_headers(sentry_init):
+    sentry_init(enable_tracing=True)
+
+    with sentry_sdk.start_span(op="test"):
+        with sentry_sdk.start_span(op="test2") as span_inner:
+            with pytest.raises(StopIteration):
+                # We should not have any propagation headers
+                next(span_inner.iter_headers())
+
+
+def test_span_in_transaction(sentry_init):
+    sentry_init(enable_tracing=True)
+
+    with sentry_sdk.start_transaction(op="test"):
+        with sentry_sdk.start_span(op="test2") as span:
+            # Ensure the headers are there
+            next(span.iter_headers())
+
+
+def test_span_in_span_in_transaction(sentry_init):
+    sentry_init(enable_tracing=True)
+
+    with sentry_sdk.start_transaction(op="test"):
+        with sentry_sdk.start_span(op="test2"):
+            with sentry_sdk.start_span(op="test3") as span_inner:
+                # Ensure the headers are there
+                next(span_inner.iter_headers())


### PR DESCRIPTION
This change ensures that we only propagate trace headers from spans that are within a transaction. This fixes a bug where any child transactions of a span created outside a transaction are missing a dynamic sampling context and are part of a trace missing a root transaction (because the root is the span).

Fixes #3068