### PR TITLE
Explicitly export cron symbols for typecheckers

### DIFF
--- a/sentry_sdk/crons/__init__.py
+++ b/sentry_sdk/crons/__init__.py
@@ -1,3 +1,10 @@
-from sentry_sdk.crons.api import capture_checkin  # noqa
-from sentry_sdk.crons.consts import MonitorStatus  # noqa
-from sentry_sdk.crons.decorator import monitor  # noqa
+from sentry_sdk.crons.api import capture_checkin
+from sentry_sdk.crons.consts import MonitorStatus
+from sentry_sdk.crons.decorator import monitor
+
+
+__all__ = [
+    "capture_checkin",
+    "MonitorStatus",
+    "monitor",
+]


### PR DESCRIPTION
Mypy with `no_implicit_reexport = true` does not see the symbols in `sentry_sdk.crons` as exported.

```
my_file.py:10: error: Module "sentry_sdk.crons" does not explicitly export attribute "monitor"  [attr-defined]
```

Adding the `X as X` to the imports marks the symbol as exported and silences the error.

An alternative approach would be to list the symbols in `__all__`. I'm happy to rework this if you'd prefer that.

https://mypy.readthedocs.io/en/stable/command_line.html#cmdoption-mypy-no-implicit-reexport

I've not audited other parts of the library for this; this just fixes the one module that I'm hitting issues with.