### PR TITLE
Use pythons venv instead of virtualenv to create virtual envs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,6 @@ jobs:
       - name: Build Packages
         run: |
           echo "Creating directory containing Python SDK Lambda Layer"
-          pip install virtualenv
           # This will also trigger "make dist" that creates the Python packages
           make aws-lambda-layer
       - name: Upload Python Packages
@@ -89,7 +88,6 @@ jobs:
           python-version: 3.12
 
       - run: |
-          pip install virtualenv
           make apidocs
           cd docs/_build && zip -r gh-pages ./
 

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ help:
 	@false
 
 .venv:
-	virtualenv -ppython3 $(VENV_PATH)
+	python -m venv $(VENV_PATH)
 	$(VENV_PATH)/bin/pip install tox
 
 dist: .venv


### PR DESCRIPTION
We used a very old verison of `virtualenv` to create virtual environments for apidocs generation. Switching to pythons `venv` module because it can do everything we wand and it can create virtual environments running Python 3.11+ (which the old version of virtualenv could not)

Fixes #3076
