### PR TITLE
ref: Fix N803 flake8 failures

### DIFF
--- a/tests/integrations/aiohttp/test_aiohttp.py
+++ b/tests/integrations/aiohttp/test_aiohttp.py
@@ -288,7 +288,7 @@ async def test_traces_sampler_gets_request_object_in_sampling_context(
     sentry_init,
     aiohttp_client,
     DictionaryContaining,  # noqa:N803
-    ObjectDescribedBy,
+    ObjectDescribedBy,  # noqa: N803
 ):
     traces_sampler = mock.Mock()
     sentry_init(

--- a/tests/integrations/aws_lambda/test_aws.py
+++ b/tests/integrations/aws_lambda/test_aws.py
@@ -555,8 +555,8 @@ def test_non_dict_event(
 def test_traces_sampler_gets_correct_values_in_sampling_context(
     run_lambda_function,
     DictionaryContaining,  # noqa:N803
-    ObjectDescribedBy,
-    StringContaining,
+    ObjectDescribedBy,  # noqa: N803
+    StringContaining,  # noqa: N803
 ):
     # TODO: This whole thing is a little hacky, specifically around the need to
     # get `conftest.py` code into the AWS runtime, which is why there's both


### PR DESCRIPTION
Recently `flake8` started to fail with `N803` errors in some places where it had previously passed. This PR adds `# noqa` comments to suppress these errors.

Unblocks #3079