### PR TITLE
Handle also byte arrays keys

### DIFF
--- a/sentry_sdk/integrations/redis/utils.py
+++ b/sentry_sdk/integrations/redis/utils.py
@@ -53,21 +53,27 @@ def _get_safe_key(method_name, args, kwargs):
     key = ""
     if args is not None and method_name.lower() in _MULTI_KEY_COMMANDS:
         # for example redis "mget"
-        key = ", ".join(args)
+        key = ", ".join(x.decode() if isinstance(x, bytes) else x for x in args)
+
     elif args is not None and len(args) >= 1:
         # for example django "set_many/get_many" or redis "get"
-        key = args[0]
+        key = args[0].decode() if isinstance(args[0], bytes) else args[0]
+
     elif kwargs is not None and "key" in kwargs:
         # this is a legacy case for older versions of django (I guess)
-        key = kwargs["key"]
+        key = (
+            kwargs["key"].decode()
+            if isinstance(kwargs["key"], bytes)
+            else kwargs["key"]
+        )
 
     if isinstance(key, dict):
         # Django caching set_many() has a dictionary {"key": "data", "key2": "data2"}
         # as argument. In this case only return the keys of the dictionary (to not leak data)
-        key = ", ".join(key.keys())
+        key = ", ".join(x.decode() if isinstance(x, bytes) else x for x in key.keys())
 
     if isinstance(key, list):
-        key = ", ".join(key)
+        key = ", ".join(x.decode() if isinstance(x, bytes) else x for x in key)
 
     return str(key)
 


### PR DESCRIPTION
In some cases it can happen that the array of redis keys to get can be byte arrays and not string. Make sure we can deal with all kinds of keys, no matter if byte array or string.

Fixes: #3100

<!-- Describe your PR here -->

---

## General Notes

Thank you for contributing to `sentry-python`!

Please add tests to validate your changes, and lint your code using `tox -e linters`.

Running the test suite on your PR might require maintainer approval. Some tests (AWS Lambda) additionally require a maintainer to add a special label to run and will fail if the label is not present.

#### For maintainers

Sensitive test suites require maintainer review to ensure that tests do not compromise our secrets. This review must be repeated after any code revisions.

Before running sensitive test suites, please carefully check the PR. Then, apply the `Trigger: tests using secrets` label. The label will be removed after any code changes to enforce our policy requiring maintainers to review all code revisions before running sensitive tests.
