### PR TITLE
feat: Add getter methods for Scope class

### DIFF
--- a/sentry_sdk/scope.py
+++ b/sentry_sdk/scope.py
@@ -849,14 +849,14 @@ class Scope(object):
         self._tags.pop(key, None)
 
     def get_tag(self, key):
-        # type: (str) -> Any
+        # type: (str) -> (Any | None)
         """
         Retrieves the value of a specific tag.
 
         :param key: Key of the tag to retrieve.
         :return: Value of the tag, or None if the tag does not exist.
         """
-        return self._tags.get(key, None)
+        return self._tags.get(key)
 
     def set_context(
         self,
@@ -879,14 +879,14 @@ class Scope(object):
     def get_context(
         self, key  # type: str
     ):
-        # type: (...) -> Any
+        # type: (...) -> (Any | None)
         """
         Retrieves the value of a specific context.
 
         :param key: Key of the context to retrieve.
         :return: Value of the context key, or None if the context key does not exist.
         """
-        return self._contexts.get(key, None)
+        return self._contexts.get(key)
 
     def set_extra(
         self,
@@ -907,14 +907,14 @@ class Scope(object):
     def get_extra(
         self, key  # type: str
     ):
-        # type: (...) -> Any
+        # type: (...) -> (Any | None)
         """
          Retrieves the value of a specific extra.
 
         :param key: Key of the extra to retrieve.
         :return: Value of the extra key, or None if the extra key does not exist.
         """
-        return self._extras.get(key, None)
+        return self._extras.get(key)
 
     def clear_breadcrumbs(self):
         # type: () -> None

--- a/sentry_sdk/scope.py
+++ b/sentry_sdk/scope.py
@@ -848,6 +848,16 @@ class Scope(object):
         """
         self._tags.pop(key, None)
 
+    def get_tag(self, key):
+        # type: (str) -> Any
+        """
+        Retrieves the value of a specific tag.
+
+        :param key: Key of the tag to retrieve.
+        :return: Value of the tag, or None if the tag does not exist.
+        """
+        return self._tags.get(key, None)
+
     def set_context(
         self,
         key,  # type: str
@@ -866,6 +876,18 @@ class Scope(object):
         """Removes a context."""
         self._contexts.pop(key, None)
 
+    def get_context(
+        self, key  # type: str
+    ):
+        # type: (...) -> Any
+        """
+            Retrieves the value of a specific context.
+
+            :param key: Key of the context to retrieve.
+            :return: Value of the extra key, or None if the extra key does not exist.
+        """
+        return self._contexts.get(key, None)
+
     def set_extra(
         self,
         key,  # type: str
@@ -881,6 +903,19 @@ class Scope(object):
         # type: (...) -> None
         """Removes a specific extra key."""
         self._extras.pop(key, None)
+
+    def get_extra(
+        self, key  # type: str
+    ):
+        # type: (...) -> Any
+        """
+            Retrieves the value of a specific extra.
+
+           :param key: Key of the extra to retrieve.
+           :return: Value of the extra key, or None if the extra key does not exist.
+        """
+        return self._extras.get(key, None)
+
 
     def clear_breadcrumbs(self):
         # type: () -> None

--- a/sentry_sdk/scope.py
+++ b/sentry_sdk/scope.py
@@ -736,7 +736,7 @@ class Scope(object):
         Deprecated: use set_transaction_name instead."""
 
         # XXX: the docstring above is misleading. The implementation of
-        # apply_to_event prefers an existing value of event.transaction over
+        # apply_to_event prefers an existing  of event.transaction over
         # anything set in the scope.
         # XXX: note that with the introduction of the Scope.transaction getter,
         # there is a semantic and type mismatch between getter and setter. The
@@ -884,7 +884,7 @@ class Scope(object):
         Retrieves the value of a specific context.
 
         :param key: Key of the context to retrieve.
-        :return: Value of the extra key, or None if the extra key does not exist.
+        :return: Value of the context key, or None if the context key does not exist.
         """
         return self._contexts.get(key, None)
 

--- a/sentry_sdk/scope.py
+++ b/sentry_sdk/scope.py
@@ -881,10 +881,10 @@ class Scope(object):
     ):
         # type: (...) -> Any
         """
-            Retrieves the value of a specific context.
+        Retrieves the value of a specific context.
 
-            :param key: Key of the context to retrieve.
-            :return: Value of the extra key, or None if the extra key does not exist.
+        :param key: Key of the context to retrieve.
+        :return: Value of the extra key, or None if the extra key does not exist.
         """
         return self._contexts.get(key, None)
 
@@ -909,13 +909,12 @@ class Scope(object):
     ):
         # type: (...) -> Any
         """
-            Retrieves the value of a specific extra.
+         Retrieves the value of a specific extra.
 
-           :param key: Key of the extra to retrieve.
-           :return: Value of the extra key, or None if the extra key does not exist.
+        :param key: Key of the extra to retrieve.
+        :return: Value of the extra key, or None if the extra key does not exist.
         """
         return self._extras.get(key, None)
-
 
     def clear_breadcrumbs(self):
         # type: () -> None

--- a/sentry_sdk/scope.py
+++ b/sentry_sdk/scope.py
@@ -736,7 +736,7 @@ class Scope(object):
         Deprecated: use set_transaction_name instead."""
 
         # XXX: the docstring above is misleading. The implementation of
-        # apply_to_event prefers an existing  of event.transaction over
+        # apply_to_event prefers an existing value of event.transaction over
         # anything set in the scope.
         # XXX: note that with the introduction of the Scope.transaction getter,
         # there is a semantic and type mismatch between getter and setter. The

--- a/tests/test_scope.py
+++ b/tests/test_scope.py
@@ -843,3 +843,25 @@ def test_last_event_id_transaction(sentry_init):
         pass
 
     assert Scope.last_event_id() is None, "Transaction should not set last_event_id"
+
+
+def test_get_tag():
+    scope = Scope()
+    scope.set_tags({"tag1": "value1", "tag2": "value2"})
+    assert scope.get_tag("tag1") == "value1"
+    assert scope.get_tag("tag2") == "value2"
+    assert scope.get_tag("missing") is None
+
+
+def test_get_context():
+    scope = Scope()
+    scope.set_context("device", {"a": "b"})
+    assert scope.get_context("device") == {"a": "b"}
+    assert scope.get_context("missing") is None
+
+
+def test_get_extra():
+    scope = Scope()
+    scope.set_extra("foo", "bar")
+    assert scope.get_extra("foo") == "bar"
+    assert scope.get_extra("missing") is None


### PR DESCRIPTION
<!-- Describe your PR here -->

The getter methods would allow users to check if a specific tag/context/extra is already set or not. I have a use case like this and I don't want to access the protected members of a class. This PR adds getter methods for the following variables: `_tags`, `_contexts`, and `_extras`. If adding getter methods for _contexts and _extras doesn't make sense, I can remove them; however, I think they will be useful.
