### PR TITLE
fix(django): Proper transaction names for i18n routes

### DIFF
--- a/sentry_sdk/integrations/django/transactions.py
+++ b/sentry_sdk/integrations/django/transactions.py
@@ -74,7 +74,7 @@ class RavenResolver:
             and isinstance(pattern.pattern, RoutePattern)
         ):
             return self._new_style_group_matcher.sub(
-                lambda m: "{%s}" % m.group(2), pattern.pattern._route
+                lambda m: "{%s}" % m.group(2), str(pattern.pattern._route)
             )
 
         result = get_regex(pattern).pattern

--- a/tests/integrations/django/test_transactions.py
+++ b/tests/integrations/django/test_transactions.py
@@ -120,7 +120,7 @@ def test_resolver_path_no_converter():
 
 
 def test_resolver_path_with_i18n():
-    url_conf = (path(pgettext_lazy("url", "pgettext"), lambda x: ""),)
+    url_conf = (re_path(pgettext_lazy("url", "pgettext"), lambda x: ""),)
     resolver = RavenResolver()
     result = resolver.resolve("/pgettext", url_conf)
     assert result == "/pgettext"

--- a/tests/integrations/django/test_transactions.py
+++ b/tests/integrations/django/test_transactions.py
@@ -2,6 +2,7 @@ from unittest import mock
 
 import pytest
 import django
+from django.utils.translation import pgettext_lazy
 
 
 # django<2.0 has only `url` with regex based patterns.
@@ -116,3 +117,10 @@ def test_resolver_path_no_converter():
     resolver = RavenResolver()
     result = resolver.resolve("/api/v4/myproject", url_conf)
     assert result == "/api/v4/{project_id}"
+
+
+def test_resolver_path_with_i18n():
+    url_conf = (path(pgettext_lazy("url", "pgettext"), lambda x: ""),)
+    resolver = RavenResolver()
+    result = resolver.resolve("/pgettext", url_conf)
+    assert result == "/pgettext"

--- a/tests/integrations/django/test_transactions.py
+++ b/tests/integrations/django/test_transactions.py
@@ -119,8 +119,12 @@ def test_resolver_path_no_converter():
     assert result == "/api/v4/{project_id}"
 
 
+@pytest.mark.skipif(
+    django.VERSION < (2, 0),
+    reason="Django>=2.0 required for path patterns",
+)
 def test_resolver_path_with_i18n():
-    url_conf = (re_path(pgettext_lazy("url", "pgettext"), lambda x: ""),)
+    url_conf = (path(pgettext_lazy("url", "pgettext"), lambda x: ""),)
     resolver = RavenResolver()
     result = resolver.resolve("/pgettext", url_conf)
     assert result == "/pgettext"


### PR DESCRIPTION
`pattern.pattern._route` for i18n'd Django routes is a proxy object rather than a string. This causes an exception in the resolver, leading to the transaction not getting a proper name but rather falling back to the default `Generic WSGI request`.

The string representation of the proxy object is the actual desired endpoint route, so let's use that.

Closes https://github.com/getsentry/sentry-python/issues/3094

---

## General Notes

Thank you for contributing to `sentry-python`!

Please add tests to validate your changes, and lint your code using `tox -e linters`.

Running the test suite on your PR might require maintainer approval. Some tests (AWS Lambda) additionally require a maintainer to add a special label to run and will fail if the label is not present.

#### For maintainers

Sensitive test suites require maintainer review to ensure that tests do not compromise our secrets. This review must be repeated after any code revisions.

Before running sensitive test suites, please carefully check the PR. Then, apply the `Trigger: tests using secrets` label. The label will be removed after any code changes to enforce our policy requiring maintainers to review all code revisions before running sensitive tests.
