### PR TITLE
Refactored the Celery Beat integration.

### DIFF
--- a/sentry_sdk/integrations/celery/__init__.py
+++ b/sentry_sdk/integrations/celery/__init__.py
@@ -70,10 +70,9 @@ class CeleryIntegration(Integration):
         self.monitor_beat_tasks = monitor_beat_tasks
         self.exclude_beat_tasks = exclude_beat_tasks
 
-        if monitor_beat_tasks:
-            _patch_beat_apply_entry()
-            _patch_redbeat_maybe_due()
-            _setup_celery_beat_signals()
+        _patch_beat_apply_entry()
+        _patch_redbeat_maybe_due()
+        _setup_celery_beat_signals()
 
     @staticmethod
     def setup_once():
@@ -167,11 +166,11 @@ def _update_celery_task_headers(original_headers, span, monitor_beat_tasks):
     """
     updated_headers = original_headers.copy()
     with capture_internal_exceptions():
-        headers = {}
-        if span is not None:
-            headers = dict(
-                Scope.get_current_scope().iter_trace_propagation_headers(span=span)
-            )
+        # if span is None (when the task was started by Celery Beat)
+        # this will return the trace headers from the scope.
+        headers = dict(
+            Scope.get_isolation_scope().iter_trace_propagation_headers(span=span)
+        )
 
         if monitor_beat_tasks:
             headers.update(

--- a/sentry_sdk/scope.py
+++ b/sentry_sdk/scope.py
@@ -604,9 +604,10 @@ class Scope(object):
     def iter_trace_propagation_headers(self, *args, **kwargs):
         # type: (Any, Any) -> Generator[Tuple[str, str], None, None]
         """
-        Return HTTP headers which allow propagation of trace data. Data taken
-        from the span representing the request, if available, or the current
-        span on the scope if not.
+        Return HTTP headers which allow propagation of trace data.
+
+        If a span is given, the trace data will taken from the span.
+        If no span is given, the trace data is taken from the scope.
         """
         client = Scope.get_client()
         if not client.options.get("propagate_traces"):

--- a/tests/integrations/celery/test_update_celery_task_headers.py
+++ b/tests/integrations/celery/test_update_celery_task_headers.py
@@ -28,12 +28,13 @@ def test_monitor_beat_tasks(monitor_beat_tasks):
     assert headers == {}  # left unchanged
 
     if monitor_beat_tasks:
-        assert updated_headers == {
-            "headers": {"sentry-monitor-start-timestamp-s": mock.ANY},
-            "sentry-monitor-start-timestamp-s": mock.ANY,
-        }
+        assert updated_headers["sentry-monitor-start-timestamp-s"] == mock.ANY
+        assert (
+            updated_headers["headers"]["sentry-monitor-start-timestamp-s"] == mock.ANY
+        )
     else:
-        assert updated_headers == headers
+        assert "sentry-monitor-start-timestamp-s" not in updated_headers
+        assert "sentry-monitor-start-timestamp-s" not in updated_headers["headers"]
 
 
 @pytest.mark.parametrize("monitor_beat_tasks", [True, False, None, "", "bla", 1, 0])
@@ -46,18 +47,24 @@ def test_monitor_beat_tasks_with_headers(monitor_beat_tasks):
 
     updated_headers = _update_celery_task_headers(headers, span, monitor_beat_tasks)
 
+    assert headers == {
+        "blub": "foo",
+        "sentry-something": "bar",
+    }  # left unchanged
+
     if monitor_beat_tasks:
-        assert updated_headers == {
-            "blub": "foo",
-            "sentry-something": "bar",
-            "headers": {
-                "sentry-monitor-start-timestamp-s": mock.ANY,
-                "sentry-something": "bar",
-            },
-            "sentry-monitor-start-timestamp-s": mock.ANY,
-        }
+        assert updated_headers["blub"] == "foo"
+        assert updated_headers["sentry-something"] == "bar"
+        assert updated_headers["sentry-monitor-start-timestamp-s"] == mock.ANY
+        assert updated_headers["headers"]["sentry-something"] == "bar"
+        assert (
+            updated_headers["headers"]["sentry-monitor-start-timestamp-s"] == mock.ANY
+        )
     else:
-        assert updated_headers == headers
+        assert updated_headers["blub"] == "foo"
+        assert updated_headers["sentry-something"] == "bar"
+        assert "sentry-monitor-start-timestamp-s" not in updated_headers
+        assert "sentry-monitor-start-timestamp-s" not in updated_headers["headers"]
 
 
 def test_span_with_transaction(sentry_init):

--- a/tests/integrations/celery/test_update_celery_task_headers.py
+++ b/tests/integrations/celery/test_update_celery_task_headers.py
@@ -154,8 +154,13 @@ def test_celery_trace_propagation_default(sentry_init, monitor_beat_tasks):
         assert "sentry-monitor-start-timestamp-s" not in outgoing_headers["headers"]
 
 
-@pytest.mark.parametrize("traces_sample_rate,monitor_beat_tasks", list(itertools.product([None, 0, 0.0, 0.5, 1.0, 1, 2], [True, False])))
-def test_celery_trace_propagation_traces_sample_rate(sentry_init, traces_sample_rate, monitor_beat_tasks):
+@pytest.mark.parametrize(
+    "traces_sample_rate,monitor_beat_tasks",
+    list(itertools.product([None, 0, 0.0, 0.5, 1.0, 1, 2], [True, False])),
+)
+def test_celery_trace_propagation_traces_sample_rate(
+    sentry_init, traces_sample_rate, monitor_beat_tasks
+):
     """
     The celery integration does not check the traces_sample_rate.
     By default traces_sample_rate is None which means "do not propagate traces".
@@ -185,8 +190,13 @@ def test_celery_trace_propagation_traces_sample_rate(sentry_init, traces_sample_
         assert "sentry-monitor-start-timestamp-s" not in outgoing_headers["headers"]
 
 
-@pytest.mark.parametrize("enable_tracing,monitor_beat_tasks", list(itertools.product([None, True, False], [True, False])))
-def test_celery_trace_propagation_enable_tracing(sentry_init, enable_tracing, monitor_beat_tasks):
+@pytest.mark.parametrize(
+    "enable_tracing,monitor_beat_tasks",
+    list(itertools.product([None, True, False], [True, False])),
+)
+def test_celery_trace_propagation_enable_tracing(
+    sentry_init, enable_tracing, monitor_beat_tasks
+):
     """
     The celery integration does not check the traces_sample_rate.
     By default traces_sample_rate is None which means "do not propagate traces".

--- a/tests/integrations/celery/test_update_celery_task_headers.py
+++ b/tests/integrations/celery/test_update_celery_task_headers.py
@@ -23,18 +23,18 @@ def test_monitor_beat_tasks(monitor_beat_tasks):
     headers = {}
     span = None
 
-    updated_headers = _update_celery_task_headers(headers, span, monitor_beat_tasks)
+    outgoing_headers = _update_celery_task_headers(headers, span, monitor_beat_tasks)
 
     assert headers == {}  # left unchanged
 
     if monitor_beat_tasks:
-        assert updated_headers["sentry-monitor-start-timestamp-s"] == mock.ANY
+        assert outgoing_headers["sentry-monitor-start-timestamp-s"] == mock.ANY
         assert (
-            updated_headers["headers"]["sentry-monitor-start-timestamp-s"] == mock.ANY
+            outgoing_headers["headers"]["sentry-monitor-start-timestamp-s"] == mock.ANY
         )
     else:
-        assert "sentry-monitor-start-timestamp-s" not in updated_headers
-        assert "sentry-monitor-start-timestamp-s" not in updated_headers["headers"]
+        assert "sentry-monitor-start-timestamp-s" not in outgoing_headers
+        assert "sentry-monitor-start-timestamp-s" not in outgoing_headers["headers"]
 
 
 @pytest.mark.parametrize("monitor_beat_tasks", [True, False, None, "", "bla", 1, 0])
@@ -45,7 +45,7 @@ def test_monitor_beat_tasks_with_headers(monitor_beat_tasks):
     }
     span = None
 
-    updated_headers = _update_celery_task_headers(headers, span, monitor_beat_tasks)
+    outgoing_headers = _update_celery_task_headers(headers, span, monitor_beat_tasks)
 
     assert headers == {
         "blub": "foo",
@@ -53,33 +53,36 @@ def test_monitor_beat_tasks_with_headers(monitor_beat_tasks):
     }  # left unchanged
 
     if monitor_beat_tasks:
-        assert updated_headers["blub"] == "foo"
-        assert updated_headers["sentry-something"] == "bar"
-        assert updated_headers["sentry-monitor-start-timestamp-s"] == mock.ANY
-        assert updated_headers["headers"]["sentry-something"] == "bar"
+        assert outgoing_headers["blub"] == "foo"
+        assert outgoing_headers["sentry-something"] == "bar"
+        assert outgoing_headers["sentry-monitor-start-timestamp-s"] == mock.ANY
+        assert outgoing_headers["headers"]["sentry-something"] == "bar"
         assert (
-            updated_headers["headers"]["sentry-monitor-start-timestamp-s"] == mock.ANY
+            outgoing_headers["headers"]["sentry-monitor-start-timestamp-s"] == mock.ANY
         )
     else:
-        assert updated_headers["blub"] == "foo"
-        assert updated_headers["sentry-something"] == "bar"
-        assert "sentry-monitor-start-timestamp-s" not in updated_headers
-        assert "sentry-monitor-start-timestamp-s" not in updated_headers["headers"]
+        assert outgoing_headers["blub"] == "foo"
+        assert outgoing_headers["sentry-something"] == "bar"
+        assert "sentry-monitor-start-timestamp-s" not in outgoing_headers
+        assert "sentry-monitor-start-timestamp-s" not in outgoing_headers["headers"]
 
 
 def test_span_with_transaction(sentry_init):
     sentry_init(enable_tracing=True)
     headers = {}
+    monitor_beat_tasks = False
 
     with sentry_sdk.start_transaction(name="test_transaction") as transaction:
         with sentry_sdk.start_span(op="test_span") as span:
-            updated_headers = _update_celery_task_headers(headers, span, False)
+            outgoing_headers = _update_celery_task_headers(
+                headers, span, monitor_beat_tasks
+            )
 
-            assert updated_headers["sentry-trace"] == span.to_traceparent()
-            assert updated_headers["headers"]["sentry-trace"] == span.to_traceparent()
-            assert updated_headers["baggage"] == transaction.get_baggage().serialize()
+            assert outgoing_headers["sentry-trace"] == span.to_traceparent()
+            assert outgoing_headers["headers"]["sentry-trace"] == span.to_traceparent()
+            assert outgoing_headers["baggage"] == transaction.get_baggage().serialize()
             assert (
-                updated_headers["headers"]["baggage"]
+                outgoing_headers["headers"]["baggage"]
                 == transaction.get_baggage().serialize()
             )
 
@@ -93,10 +96,10 @@ def test_span_with_transaction_custom_headers(sentry_init):
 
     with sentry_sdk.start_transaction(name="test_transaction") as transaction:
         with sentry_sdk.start_span(op="test_span") as span:
-            updated_headers = _update_celery_task_headers(headers, span, False)
+            outgoing_headers = _update_celery_task_headers(headers, span, False)
 
-            assert updated_headers["sentry-trace"] == span.to_traceparent()
-            assert updated_headers["headers"]["sentry-trace"] == span.to_traceparent()
+            assert outgoing_headers["sentry-trace"] == span.to_traceparent()
+            assert outgoing_headers["headers"]["sentry-trace"] == span.to_traceparent()
 
             incoming_baggage = Baggage.from_incoming_header(headers["baggage"])
             combined_baggage = copy(transaction.get_baggage())
@@ -111,9 +114,83 @@ def test_span_with_transaction_custom_headers(sentry_init):
                     if x is not None and x != ""
                 ]
             )
-            assert updated_headers["baggage"] == combined_baggage.serialize(
+            assert outgoing_headers["baggage"] == combined_baggage.serialize(
                 include_third_party=True
             )
-            assert updated_headers["headers"]["baggage"] == combined_baggage.serialize(
+            assert outgoing_headers["headers"]["baggage"] == combined_baggage.serialize(
                 include_third_party=True
             )
+
+
+def test_celery_trace_propagation_default(sentry_init):
+    """
+    The celery integration does not check the traces_sample_rate.
+    By default traces_sample_rate is None which means "do not propagate traces".
+    But the celery integration does not check this value.
+    The Celery integration has its own mechanism to propagate traces:
+    https://docs.sentry.io/platforms/python/integrations/celery/#distributed-traces
+    """
+    sentry_init()
+
+    headers = {}
+    span = None
+    monitor_beat_tasks = False
+
+    scope = sentry_sdk.Scope.get_isolation_scope()
+
+    outgoing_headers = _update_celery_task_headers(headers, span, monitor_beat_tasks)
+
+    assert outgoing_headers["sentry-trace"] == scope.get_traceparent()
+    assert outgoing_headers["headers"]["sentry-trace"] == scope.get_traceparent()
+    assert outgoing_headers["baggage"] == scope.get_baggage().serialize()
+    assert outgoing_headers["headers"]["baggage"] == scope.get_baggage().serialize()
+
+
+@pytest.mark.parametrize("traces_sample_rate", [None, 0, 0.0, 0.5, 1.0, 1, 2])
+def test_celery_trace_propagation_traces_sample_rate(sentry_init, traces_sample_rate):
+    """
+    The celery integration does not check the traces_sample_rate.
+    By default traces_sample_rate is None which means "do not propagate traces".
+    But the celery integration does not check this value.
+    The Celery integration has its own mechanism to propagate traces:
+    https://docs.sentry.io/platforms/python/integrations/celery/#distributed-traces
+    """
+    sentry_init(traces_sample_rate=traces_sample_rate)
+
+    headers = {}
+    span = None
+    monitor_beat_tasks = False
+
+    scope = sentry_sdk.Scope.get_isolation_scope()
+
+    outgoing_headers = _update_celery_task_headers(headers, span, monitor_beat_tasks)
+
+    assert outgoing_headers["sentry-trace"] == scope.get_traceparent()
+    assert outgoing_headers["headers"]["sentry-trace"] == scope.get_traceparent()
+    assert outgoing_headers["baggage"] == scope.get_baggage().serialize()
+    assert outgoing_headers["headers"]["baggage"] == scope.get_baggage().serialize()
+
+
+@pytest.mark.parametrize("enable_tracing", [None, True, False])
+def test_celery_trace_propagation_enable_tracing(sentry_init, enable_tracing):
+    """
+    The celery integration does not check the traces_sample_rate.
+    By default traces_sample_rate is None which means "do not propagate traces".
+    But the celery integration does not check this value.
+    The Celery integration has its own mechanism to propagate traces:
+    https://docs.sentry.io/platforms/python/integrations/celery/#distributed-traces
+    """
+    sentry_init(enable_tracing=enable_tracing)
+
+    headers = {}
+    span = None
+    monitor_beat_tasks = False
+
+    scope = sentry_sdk.Scope.get_isolation_scope()
+
+    outgoing_headers = _update_celery_task_headers(headers, span, monitor_beat_tasks)
+
+    assert outgoing_headers["sentry-trace"] == scope.get_traceparent()
+    assert outgoing_headers["headers"]["sentry-trace"] == scope.get_traceparent()
+    assert outgoing_headers["baggage"] == scope.get_baggage().serialize()
+    assert outgoing_headers["headers"]["baggage"] == scope.get_baggage().serialize()


### PR DESCRIPTION
Making it:
- to be less error prone
- correctly propagate trace information to Celery tasks started by Celery beat.

Small docs update to make it clear how trace propagation in Celery works:
https://github.com/getsentry/sentry-docs/pull/10161
