### PR TITLE
Add None check for grpc.aio interceptor

### DIFF
--- a/sentry_sdk/integrations/grpc/aio/server.py
+++ b/sentry_sdk/integrations/grpc/aio/server.py
@@ -29,6 +29,8 @@ class ServerInterceptor(grpc.aio.ServerInterceptor):  # type: ignore
         # type: (ServerInterceptor, Callable[[HandlerCallDetails], Awaitable[RpcMethodHandler]], HandlerCallDetails) -> Awaitable[RpcMethodHandler]
         self._handler_call_details = handler_call_details
         handler = await continuation(handler_call_details)
+        if handler is None:
+            return
 
         if not handler.request_streaming and not handler.response_streaming:
             handler_factory = grpc.unary_unary_rpc_method_handler

--- a/sentry_sdk/integrations/grpc/aio/server.py
+++ b/sentry_sdk/integrations/grpc/aio/server.py
@@ -7,7 +7,7 @@ from sentry_sdk.utils import event_from_exception
 
 if TYPE_CHECKING:
     from collections.abc import Awaitable, Callable
-    from typing import Any
+    from typing import Any, Optional
 
 
 try:
@@ -26,11 +26,11 @@ class ServerInterceptor(grpc.aio.ServerInterceptor):  # type: ignore
         super().__init__()
 
     async def intercept_service(self, continuation, handler_call_details):
-        # type: (ServerInterceptor, Callable[[HandlerCallDetails], Awaitable[RpcMethodHandler]], HandlerCallDetails) -> Awaitable[RpcMethodHandler]
+        # type: (ServerInterceptor, Callable[[HandlerCallDetails], Awaitable[RpcMethodHandler]], HandlerCallDetails) -> Optional[Awaitable[RpcMethodHandler]]
         self._handler_call_details = handler_call_details
         handler = await continuation(handler_call_details)
         if handler is None:
-            return
+            return None
 
         if not handler.request_streaming and not handler.response_streaming:
             handler_factory = grpc.unary_unary_rpc_method_handler


### PR DESCRIPTION
Add a `None` check in gRPC AIO interceptor.

Address issue: https://github.com/getsentry/sentry-python/issues/3108

`grpc.aio.ServerInterceptor` should expect the continuation to return `None` if the RPC isn't handled. Checking the return of continuation is not `None` before getting the `handler_factory` prevents an `AttributeError`

References

1. gRPC Python Docs on return types for interceptors, https://grpc.github.io/grpc/python/grpc_asyncio.html#grpc.aio.ServerInterceptor
2. Example implementation: https://github.com/d5h-foss/grpc-interceptor/blob/master/src/grpc_interceptor/server.py#L48-L57

---

## General Notes

Thank you for contributing to `sentry-python`!

Please add tests to validate your changes, and lint your code using `tox -e linters`.

Running the test suite on your PR might require maintainer approval. Some tests (AWS Lambda) additionally require a maintainer to add a special label to run and will fail if the label is not present.

#### For maintainers

Sensitive test suites require maintainer review to ensure that tests do not compromise our secrets. This review must be repeated after any code revisions.

Before running sensitive test suites, please carefully check the PR. Then, apply the `Trigger: tests using secrets` label. The label will be removed after any code changes to enforce our policy requiring maintainers to review all code revisions before running sensitive tests.
