### PR TITLE
Made `cache.key` span data field a list

### DIFF
--- a/sentry_sdk/integrations/django/caching.py
+++ b/sentry_sdk/integrations/django/caching.py
@@ -1,6 +1,6 @@
 import functools
 from typing import TYPE_CHECKING
-from sentry_sdk.integrations.redis.utils import _get_safe_key
+from sentry_sdk.integrations.redis.utils import _get_safe_key, _key_as_string
 from urllib3.util import parse_url as urlparse
 
 from django import VERSION as DJANGO_VERSION
@@ -30,7 +30,7 @@ METHODS_TO_INSTRUMENT = [
 
 def _get_span_description(method_name, args, kwargs):
     # type: (str, tuple[Any], dict[str, Any]) -> str
-    return _get_safe_key(method_name, args, kwargs)
+    return _key_as_string(_get_safe_key(method_name, args, kwargs))
 
 
 def _patch_cache_method(cache, method_name, address, port):
@@ -61,7 +61,7 @@ def _patch_cache_method(cache, method_name, address, port):
                     span.set_data(SPANDATA.NETWORK_PEER_PORT, port)
 
                 key = _get_safe_key(method_name, args, kwargs)
-                if key != "":
+                if key is not None:
                     span.set_data(SPANDATA.CACHE_KEY, key)
 
                 item_size = None

--- a/sentry_sdk/integrations/redis/utils.py
+++ b/sentry_sdk/integrations/redis/utils.py
@@ -44,12 +44,23 @@ def _get_safe_command(name, args):
     return command
 
 
+def _safe_decode(key):
+    # type: (Any) -> str
+    if isinstance(key, bytes):
+        try:
+            return key.decode()
+        except UnicodeDecodeError:
+            return ""
+
+    return key
+
+
 def _key_as_string(key):
     # type: (Any) -> str
     if isinstance(key, (dict, list, tuple)):
-        key = ", ".join(x.decode() if isinstance(x, bytes) else x for x in key)
+        key = ", ".join(_safe_decode(x) for x in key)
     elif isinstance(key, bytes):
-        key = key.decode()
+        key = _safe_decode(key)
     elif key is None:
         key = ""
     else:

--- a/sentry_sdk/integrations/redis/utils.py
+++ b/sentry_sdk/integrations/redis/utils.py
@@ -46,9 +46,7 @@ def _get_safe_command(name, args):
 
 def _key_as_string(key):
     # type: (Any) -> str
-    if isinstance(key, dict):
-        key = ", ".join(x.decode() if isinstance(x, bytes) else x for x in key.keys())
-    elif isinstance(key, (list, tuple)):
+    if isinstance(key, (dict, list, tuple)):
         key = ", ".join(x.decode() if isinstance(x, bytes) else x for x in key)
     elif isinstance(key, bytes):
         key = key.decode()
@@ -74,10 +72,8 @@ def _get_safe_key(method_name, args, kwargs):
 
     elif args is not None and len(args) >= 1:
         # for example django "set_many/get_many" or redis "get"
-        if isinstance(args[0], (list, tuple)):
+        if isinstance(args[0], (dict, list, tuple)):
             key = tuple(args[0])
-        elif isinstance(args[0], (dict)):
-            key = tuple(args[0].keys())
         else:
             key = (args[0],)
 

--- a/sentry_sdk/integrations/redis/utils.py
+++ b/sentry_sdk/integrations/redis/utils.py
@@ -44,38 +44,53 @@ def _get_safe_command(name, args):
     return command
 
 
+def _key_as_string(key):
+    # type: (Any) -> str
+    if isinstance(key, dict):
+        key = ", ".join(x.decode() if isinstance(x, bytes) else x for x in key.keys())
+    elif isinstance(key, (list, tuple)):
+        key = ", ".join(x.decode() if isinstance(x, bytes) else x for x in key)
+    elif isinstance(key, bytes):
+        key = key.decode()
+    elif key is None:
+        key = ""
+    else:
+        key = str(key)
+
+    return key
+
+
 def _get_safe_key(method_name, args, kwargs):
-    # type: (str, Optional[tuple[Any, ...]], Optional[dict[str, Any]]) -> str
+    # type: (str, Optional[tuple[Any, ...]], Optional[dict[str, Any]]) -> Optional[tuple[str, ...]]
     """
-    Gets the keys (or keys) from the given method_name.
+    Gets the key (or keys) from the given method_name.
     The method_name could be a redis command or a django caching command
     """
-    key = ""
+    key = None
+
     if args is not None and method_name.lower() in _MULTI_KEY_COMMANDS:
         # for example redis "mget"
-        key = ", ".join(x.decode() if isinstance(x, bytes) else x for x in args)
+        key = tuple(args)
 
     elif args is not None and len(args) >= 1:
         # for example django "set_many/get_many" or redis "get"
-        key = args[0].decode() if isinstance(args[0], bytes) else args[0]
+        if isinstance(args[0], (list, tuple)):
+            key = tuple(args[0])
+        elif isinstance(args[0], (dict)):
+            key = tuple(args[0].keys())
+        else:
+            key = (args[0],)
 
     elif kwargs is not None and "key" in kwargs:
-        # this is a legacy case for older versions of django (I guess)
-        key = (
-            kwargs["key"].decode()
-            if isinstance(kwargs["key"], bytes)
-            else kwargs["key"]
-        )
+        # this is a legacy case for older versions of Django
+        if isinstance(kwargs["key"], (list, tuple)):
+            if len(kwargs["key"]) > 0:
+                key = tuple(kwargs["key"])
+        else:
+            if kwargs["key"] is not None:
+                key = (kwargs["key"],)
 
-    if isinstance(key, dict):
-        # Django caching set_many() has a dictionary {"key": "data", "key2": "data2"}
-        # as argument. In this case only return the keys of the dictionary (to not leak data)
-        key = ", ".join(x.decode() if isinstance(x, bytes) else x for x in key.keys())
-
-    if isinstance(key, list):
-        key = ", ".join(x.decode() if isinstance(x, bytes) else x for x in key)
-
-    return str(key)
+    return key
 
 
 def _parse_rediscluster_command(command):

--- a/tests/integrations/django/test_cache_module.py
+++ b/tests/integrations/django/test_cache_module.py
@@ -198,7 +198,7 @@ def test_cache_spans_middleware(
         "views.decorators.cache.cache_header."
     )
     assert first_event["spans"][0]["data"]["network.peer.address"] is not None
-    assert first_event["spans"][0]["data"]["cache.key"].startswith(
+    assert first_event["spans"][0]["data"]["cache.key"][0].startswith(
         "views.decorators.cache.cache_header."
     )
     assert not first_event["spans"][0]["data"]["cache.hit"]
@@ -209,7 +209,7 @@ def test_cache_spans_middleware(
         "views.decorators.cache.cache_header."
     )
     assert first_event["spans"][1]["data"]["network.peer.address"] is not None
-    assert first_event["spans"][1]["data"]["cache.key"].startswith(
+    assert first_event["spans"][1]["data"]["cache.key"][0].startswith(
         "views.decorators.cache.cache_header."
     )
     assert "cache.hit" not in first_event["spans"][1]["data"]
@@ -220,7 +220,7 @@ def test_cache_spans_middleware(
         "views.decorators.cache.cache_header."
     )
     assert second_event["spans"][0]["data"]["network.peer.address"] is not None
-    assert second_event["spans"][0]["data"]["cache.key"].startswith(
+    assert second_event["spans"][0]["data"]["cache.key"][0].startswith(
         "views.decorators.cache.cache_header."
     )
     assert not second_event["spans"][0]["data"]["cache.hit"]
@@ -231,7 +231,7 @@ def test_cache_spans_middleware(
         "views.decorators.cache.cache_page."
     )
     assert second_event["spans"][1]["data"]["network.peer.address"] is not None
-    assert second_event["spans"][1]["data"]["cache.key"].startswith(
+    assert second_event["spans"][1]["data"]["cache.key"][0].startswith(
         "views.decorators.cache.cache_page."
     )
     assert second_event["spans"][1]["data"]["cache.hit"]
@@ -264,7 +264,7 @@ def test_cache_spans_decorator(sentry_init, client, capture_events, use_django_c
         "views.decorators.cache.cache_header."
     )
     assert first_event["spans"][0]["data"]["network.peer.address"] is not None
-    assert first_event["spans"][0]["data"]["cache.key"].startswith(
+    assert first_event["spans"][0]["data"]["cache.key"][0].startswith(
         "views.decorators.cache.cache_header."
     )
     assert not first_event["spans"][0]["data"]["cache.hit"]
@@ -275,7 +275,7 @@ def test_cache_spans_decorator(sentry_init, client, capture_events, use_django_c
         "views.decorators.cache.cache_header."
     )
     assert first_event["spans"][1]["data"]["network.peer.address"] is not None
-    assert first_event["spans"][1]["data"]["cache.key"].startswith(
+    assert first_event["spans"][1]["data"]["cache.key"][0].startswith(
         "views.decorators.cache.cache_header."
     )
     assert "cache.hit" not in first_event["spans"][1]["data"]
@@ -286,7 +286,7 @@ def test_cache_spans_decorator(sentry_init, client, capture_events, use_django_c
         "views.decorators.cache.cache_page."
     )
     assert second_event["spans"][1]["data"]["network.peer.address"] is not None
-    assert second_event["spans"][1]["data"]["cache.key"].startswith(
+    assert second_event["spans"][1]["data"]["cache.key"][0].startswith(
         "views.decorators.cache.cache_page."
     )
     assert second_event["spans"][1]["data"]["cache.hit"]
@@ -322,7 +322,7 @@ def test_cache_spans_templatetag(
         "template.cache.some_identifier."
     )
     assert first_event["spans"][0]["data"]["network.peer.address"] is not None
-    assert first_event["spans"][0]["data"]["cache.key"].startswith(
+    assert first_event["spans"][0]["data"]["cache.key"][0].startswith(
         "template.cache.some_identifier."
     )
     assert not first_event["spans"][0]["data"]["cache.hit"]
@@ -333,7 +333,7 @@ def test_cache_spans_templatetag(
         "template.cache.some_identifier."
     )
     assert first_event["spans"][1]["data"]["network.peer.address"] is not None
-    assert first_event["spans"][1]["data"]["cache.key"].startswith(
+    assert first_event["spans"][1]["data"]["cache.key"][0].startswith(
         "template.cache.some_identifier."
     )
     assert "cache.hit" not in first_event["spans"][1]["data"]
@@ -344,7 +344,7 @@ def test_cache_spans_templatetag(
         "template.cache.some_identifier."
     )
     assert second_event["spans"][0]["data"]["network.peer.address"] is not None
-    assert second_event["spans"][0]["data"]["cache.key"].startswith(
+    assert second_event["spans"][0]["data"]["cache.key"][0].startswith(
         "template.cache.some_identifier."
     )
     assert second_event["spans"][0]["data"]["cache.hit"]
@@ -557,7 +557,7 @@ def test_cache_spans_get_many(sentry_init, capture_events, use_django_caching):
     assert transaction["spans"][6]["description"] == f"S{id+1}"
 
 
-@pytest.mark.forked
+# @pytest.mark.forked
 @pytest_mark_django_db_decorator()
 def test_cache_spans_set_many(sentry_init, capture_events, use_django_caching):
     sentry_init(

--- a/tests/integrations/django/test_cache_module.py
+++ b/tests/integrations/django/test_cache_module.py
@@ -1,9 +1,9 @@
-import pytest
 import os
 import random
+import uuid
 
+import pytest
 from django import VERSION as DJANGO_VERSION
-
 from werkzeug.test import Client
 
 try:
@@ -358,6 +358,7 @@ def test_cache_spans_templatetag(
         ("get", None, None, ""),
         ("get", [], {}, ""),
         ("get", ["bla", "blub", "foo"], {}, "bla"),
+        ("get", [uuid.uuid4().bytes], {}, ""),
         (
             "get_many",
             [["bla1", "bla2", "bla3"], "blub", "foo"],

--- a/tests/integrations/django/test_cache_module.py
+++ b/tests/integrations/django/test_cache_module.py
@@ -557,7 +557,7 @@ def test_cache_spans_get_many(sentry_init, capture_events, use_django_caching):
     assert transaction["spans"][6]["description"] == f"S{id+1}"
 
 
-# @pytest.mark.forked
+@pytest.mark.forked
 @pytest_mark_django_db_decorator()
 def test_cache_spans_set_many(sentry_init, capture_events, use_django_caching):
     sentry_init(

--- a/tests/integrations/redis/test_redis_cache_module.py
+++ b/tests/integrations/redis/test_redis_cache_module.py
@@ -1,3 +1,5 @@
+import uuid
+
 import pytest
 
 import fakeredis
@@ -230,6 +232,18 @@ def test_cache_data(sentry_init, capture_events):
             {"key": [b"bla", "blub", "foo"]},
             (b"bla", "blub", "foo"),
         ),
+        (
+            "not-important",
+            None,
+            {"key": b"\x00c\x0f\xeaC\xe1L\x1c\xbff\xcb\xcc\xc1\xed\xc6\t"},
+            (b"\x00c\x0f\xeaC\xe1L\x1c\xbff\xcb\xcc\xc1\xed\xc6\t",),
+        ),
+        (
+            "get",
+            [b"\x00c\x0f\xeaC\xe1L\x1c\xbff\xcb\xcc\xc1\xed\xc6\t"],
+            None,
+            (b"\x00c\x0f\xeaC\xe1L\x1c\xbff\xcb\xcc\xc1\xed\xc6\t",),
+        ),
     ],
 )
 def test_get_safe_key(method_name, args, kwargs, expected_key):
@@ -251,6 +265,7 @@ def test_get_safe_key(method_name, args, kwargs, expected_key):
             "bla",
         ),
         (["bla", "blub", "foo"], "bla, blub, foo"),
+        ([uuid.uuid4().bytes], ""),
     ],
 )
 def test_key_as_string(key, expected_key):

--- a/tests/integrations/redis/test_redis_cache_module_async.py
+++ b/tests/integrations/redis/test_redis_cache_module_async.py
@@ -128,7 +128,9 @@ async def test_cache_data(sentry_init, capture_events):
 
     assert spans[0]["op"] == "cache.get"
     assert spans[0]["description"] == "myasynccachekey"
-    assert spans[0]["data"]["cache.key"] == "myasynccachekey"
+    assert spans[0]["data"]["cache.key"] == [
+        "myasynccachekey",
+    ]
     assert spans[0]["data"]["cache.hit"] == False  # noqa: E712
     assert "cache.item_size" not in spans[0]["data"]
     # very old fakeredis can not handle port and/or host.
@@ -146,7 +148,9 @@ async def test_cache_data(sentry_init, capture_events):
 
     assert spans[2]["op"] == "cache.put"
     assert spans[2]["description"] == "myasynccachekey"
-    assert spans[2]["data"]["cache.key"] == "myasynccachekey"
+    assert spans[2]["data"]["cache.key"] == [
+        "myasynccachekey",
+    ]
     assert "cache.hit" not in spans[1]["data"]
     assert spans[2]["data"]["cache.item_size"] == 18
     # very old fakeredis can not handle port.
@@ -164,7 +168,9 @@ async def test_cache_data(sentry_init, capture_events):
 
     assert spans[4]["op"] == "cache.get"
     assert spans[4]["description"] == "myasynccachekey"
-    assert spans[4]["data"]["cache.key"] == "myasynccachekey"
+    assert spans[4]["data"]["cache.key"] == [
+        "myasynccachekey",
+    ]
     assert spans[4]["data"]["cache.hit"] == True  # noqa: E712
     assert spans[4]["data"]["cache.item_size"] == 18
     # very old fakeredis can not handle port.


### PR DESCRIPTION
Make sure the `cache.key` span data field in cache spans is always an array, with one or more fields. (Compared to the description of the cache spans that is a comma separated string of the keys.)

See spec here: https://develop.sentry.dev/sdk/performance/modules/caches/

Fixes https://github.com/getsentry/sentry-python/issues/3117