### PR TITLE
Fix last_event_id() in nested scopes

### DIFF
--- a/sentry_sdk/scope.py
+++ b/sentry_sdk/scope.py
@@ -208,9 +208,6 @@ class Scope(object):
         incoming_trace_information = self._load_trace_data_from_env()
         self.generate_propagation_context(incoming_data=incoming_trace_information)
 
-        # self._last_event_id is only applicable to isolation scopes
-        self._last_event_id = None  # type: Optional[str]
-
     def __copy__(self):
         # type: () -> Scope
         """
@@ -243,6 +240,8 @@ class Scope(object):
         rv._attachments = list(self._attachments)
 
         rv._profile = self._profile
+
+        rv._last_event_id = self._last_event_id
 
         return rv
 
@@ -676,6 +675,9 @@ class Scope(object):
         self._profile = None  # type: Optional[Profile]
 
         self._propagation_context = None
+
+        # self._last_event_id is only applicable to isolation scopes
+        self._last_event_id = None  # type: Optional[str]
 
     @_attr_setter
     def level(self, value):

--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -800,3 +800,11 @@ def test_last_event_id_transaction(sentry_init):
         pass
 
     assert last_event_id() is None, "Transaction should not set last_event_id"
+
+
+def test_last_event_id_scope(sentry_init):
+    sentry_init(enable_tracing=True)
+
+    # Should not crash
+    with push_scope() as scope:
+        assert scope.last_event_id() is None

--- a/tests/test_scope.py
+++ b/tests/test_scope.py
@@ -25,6 +25,10 @@ def test_copying():
     s1.set_tag("foo", "bar")
 
     s2 = copy.copy(s1)
+    # Check all attributes are copied
+    for name in set(Scope.__slots__) - {"client"}:
+        getattr(s2, name)
+
     assert "foo" in s2._tags
 
     s1.set_tag("bam", "baz")


### PR DESCRIPTION
Fixes #3113.

I added two tests, one that generally checks `Scope.__copy__()` copies everything that it should, and one top-level one that reproduces the bug seen. On `master`, both fail with:

```
AttributeError: 'Scope' object has no attribute '_last_event_id'. Did you mean: 'last_event_id'?
```

@szokeasaurusrex please take a look :)