### PR TITLE
fix(tests): Adapt to new Anthropic version

### DIFF
--- a/tests/integrations/anthropic/test_anthropic.py
+++ b/tests/integrations/anthropic/test_anthropic.py
@@ -8,7 +8,6 @@ from anthropic.types.message_start_event import MessageStartEvent
 from anthropic.types.content_block_start_event import ContentBlockStartEvent
 from anthropic.types.content_block_delta_event import ContentBlockDeltaEvent
 from anthropic.types.content_block_stop_event import ContentBlockStopEvent
-from anthropic.types.text_block import TextBlock
 
 try:
     # 0.27+
@@ -16,6 +15,11 @@ try:
 except ImportError:
     # pre 0.27
     from anthropic.types.message_delta_event import Delta
+
+try:
+    from anthropic.types.text_block import TextBlock
+except ImportError:
+    from anthropic.types.content_block import ContentBlock as TextBlock
 
 from sentry_sdk import start_transaction
 from sentry_sdk.consts import OP, SPANDATA

--- a/tests/integrations/anthropic/test_anthropic.py
+++ b/tests/integrations/anthropic/test_anthropic.py
@@ -1,13 +1,21 @@
 import pytest
 from unittest import mock
 from anthropic import Anthropic, Stream, AnthropicError
-from anthropic.types import Usage, ContentBlock, MessageDeltaUsage, TextDelta
+from anthropic.types import Usage, MessageDeltaUsage, TextDelta
 from anthropic.types.message import Message
+from anthropic.types.message_delta_event import MessageDeltaEvent
 from anthropic.types.message_start_event import MessageStartEvent
 from anthropic.types.content_block_start_event import ContentBlockStartEvent
 from anthropic.types.content_block_delta_event import ContentBlockDeltaEvent
 from anthropic.types.content_block_stop_event import ContentBlockStopEvent
-from anthropic.types.message_delta_event import MessageDeltaEvent, Delta
+from anthropic.types.text_block import TextBlock
+
+try:
+    # 0.27+
+    from anthropic.types.raw_message_delta_event import Delta
+except ImportError:
+    # pre 0.27
+    from anthropic.types.message_delta_event import Delta
 
 from sentry_sdk import start_transaction
 from sentry_sdk.consts import OP, SPANDATA
@@ -18,7 +26,7 @@ EXAMPLE_MESSAGE = Message(
     id="id",
     model="model",
     role="assistant",
-    content=[ContentBlock(type="text", text="Hi, I'm Claude.")],
+    content=[TextBlock(type="text", text="Hi, I'm Claude.")],
     type="message",
     usage=Usage(input_tokens=10, output_tokens=20),
 )
@@ -113,7 +121,7 @@ def test_streaming_create_message(
         ContentBlockStartEvent(
             type="content_block_start",
             index=0,
-            content_block=ContentBlock(type="text", text=""),
+            content_block=TextBlock(type="text", text=""),
         ),
         ContentBlockDeltaEvent(
             delta=TextDelta(text="Hi", type="text_delta"),


### PR DESCRIPTION
[Anthropic 0.27.0](https://github.com/anthropics/anthropic-sdk-python/compare/v0.26.2...v0.27.0) contains two changes that broke our tests:
* `Delta` is now in a different module
* `ContentBlock` is now a `Union`. Prior to 0.27 it was an alias for `TextBlock`, so now we use `TextBlock` directly.

---

## General Notes

Thank you for contributing to `sentry-python`!

Please add tests to validate your changes, and lint your code using `tox -e linters`.

Running the test suite on your PR might require maintainer approval. Some tests (AWS Lambda) additionally require a maintainer to add a special label to run and will fail if the label is not present.

#### For maintainers

Sensitive test suites require maintainer review to ensure that tests do not compromise our secrets. This review must be repeated after any code revisions.

Before running sensitive test suites, please carefully check the PR. Then, apply the `Trigger: tests using secrets` label. The label will be removed after any code changes to enforce our policy requiring maintainers to review all code revisions before running sensitive tests.
