### PR TITLE
fix(scope): Copy `_last_event_id` in `Scope.__copy__`

### DIFF
--- a/sentry_sdk/scope.py
+++ b/sentry_sdk/scope.py
@@ -244,6 +244,8 @@ class Scope(object):
 
         rv._profile = self._profile
 
+        rv._last_event_id = self._last_event_id
+
         return rv
 
     @classmethod

--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -17,6 +17,7 @@ from sentry_sdk import (
     start_transaction,
     last_event_id,
     add_breadcrumb,
+    isolation_scope,
     Hub,
     Scope,
 )
@@ -800,3 +801,11 @@ def test_last_event_id_transaction(sentry_init):
         pass
 
     assert last_event_id() is None, "Transaction should not set last_event_id"
+
+
+def test_last_event_id_scope(sentry_init):
+    sentry_init(enable_tracing=True)
+
+    # Should not crash
+    with isolation_scope() as scope:
+        assert scope.last_event_id() is None

--- a/tests/test_scope.py
+++ b/tests/test_scope.py
@@ -19,6 +19,10 @@ from sentry_sdk.scope import (
 )
 
 
+SLOTS_NOT_COPIED = {"client"}
+"""__slots__ that are not copied when copying a Scope object."""
+
+
 def test_copying():
     s1 = Scope()
     s1.fingerprint = {}
@@ -32,6 +36,15 @@ def test_copying():
     assert "bam" not in s2._tags
 
     assert s1._fingerprint is s2._fingerprint
+
+
+def test_all_slots_copied():
+    scope = Scope()
+    scope_copy = copy.copy(scope)
+
+    # Check all attributes are copied
+    for attr in set(Scope.__slots__) - SLOTS_NOT_COPIED:
+        assert getattr(scope_copy, attr) == getattr(scope, attr)
 
 
 def test_merging(sentry_init, capture_events):


### PR DESCRIPTION
This PR supersedes #3114; it is based on #3114, but includes the changes requested during review of #3114.

Fixes GH-3113