### PR TITLE
fix(cache): Fix _key_as_string

### DIFF
--- a/sentry_sdk/integrations/redis/utils.py
+++ b/sentry_sdk/integrations/redis/utils.py
@@ -52,7 +52,7 @@ def _safe_decode(key):
         except UnicodeDecodeError:
             return ""
 
-    return key
+    return str(key)
 
 
 def _key_as_string(key):

--- a/tests/integrations/redis/test_redis_cache_module.py
+++ b/tests/integrations/redis/test_redis_cache_module.py
@@ -244,6 +244,12 @@ def test_cache_data(sentry_init, capture_events):
             None,
             (b"\x00c\x0f\xeaC\xe1L\x1c\xbff\xcb\xcc\xc1\xed\xc6\t",),
         ),
+        (
+            "get",
+            [123],
+            None,
+            ("123",),
+        ),
     ],
 )
 def test_get_safe_key(method_name, args, kwargs, expected_key):

--- a/tests/integrations/redis/test_redis_cache_module.py
+++ b/tests/integrations/redis/test_redis_cache_module.py
@@ -248,7 +248,7 @@ def test_cache_data(sentry_init, capture_events):
             "get",
             [123],
             None,
-            ("123",),
+            (123,),
         ),
     ],
 )
@@ -272,6 +272,9 @@ def test_get_safe_key(method_name, args, kwargs, expected_key):
         ),
         (["bla", "blub", "foo"], "bla, blub, foo"),
         ([uuid.uuid4().bytes], ""),
+        ({"key1": 1, "key2": 2}, "key1, key2"),
+        (1, "1"),
+        ([1, 2, 3, b"hello"], "1, 2, 3, hello"),
     ],
 )
 def test_key_as_string(key, expected_key):


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry-python/issues/3130

---

## General Notes

Thank you for contributing to `sentry-python`!

Please add tests to validate your changes, and lint your code using `tox -e linters`.

Running the test suite on your PR might require maintainer approval. Some tests (AWS Lambda) additionally require a maintainer to add a special label to run and will fail if the label is not present.

#### For maintainers

Sensitive test suites require maintainer review to ensure that tests do not compromise our secrets. This review must be repeated after any code revisions.

Before running sensitive test suites, please carefully check the PR. Then, apply the `Trigger: tests using secrets` label. The label will be removed after any code changes to enforce our policy requiring maintainers to review all code revisions before running sensitive tests.
