### PR TITLE
fix(redis): Support multiple keys with cache_prefixes

### DIFF
--- a/sentry_sdk/integrations/redis/modules/caches.py
+++ b/sentry_sdk/integrations/redis/modules/caches.py
@@ -39,6 +39,8 @@ def _compile_cache_span_properties(redis_command, args, kwargs, integration):
             if kee.startswith(prefix):
                 is_cache_key = True
                 break
+        if is_cache_key:
+            break
 
     value = None
     if redis_command.lower() in SET_COMMANDS:

--- a/sentry_sdk/integrations/redis/modules/caches.py
+++ b/sentry_sdk/integrations/redis/modules/caches.py
@@ -31,12 +31,14 @@ def _compile_cache_span_properties(redis_command, args, kwargs, integration):
     # type: (str, tuple[Any, ...], dict[str, Any], RedisIntegration) -> dict[str, Any]
     key = _get_safe_key(redis_command, args, kwargs)
     key_as_string = _key_as_string(key)
+    keys_as_string = key_as_string.split(", ")
 
     is_cache_key = False
     for prefix in integration.cache_prefixes:
-        if key_as_string.startswith(prefix):
-            is_cache_key = True
-            break
+        for kee in keys_as_string:
+            if kee.startswith(prefix):
+                is_cache_key = True
+                break
 
     value = None
     if redis_command.lower() in SET_COMMANDS:

--- a/tests/integrations/redis/test_redis_cache_module.py
+++ b/tests/integrations/redis/test_redis_cache_module.py
@@ -218,19 +218,21 @@ def test_cache_prefixes(sentry_init, capture_events):
         connection.mget("no.1", "no.2", "no.actually.yes")
         connection.mget(b"no.3", b"yes.5")
         connection.mget(uuid.uuid4().bytes)
+        connection.mget(uuid.uuid4().bytes, "yes")
 
     (event,) = events
 
     spans = event["spans"]
-    assert len(spans) == 11  # 7 db spans + 4 cache spans
+    assert len(spans) == 13  # 8 db spans + 5 cache spans
 
     cache_spans = [span for span in spans if span["op"] == "cache.get"]
-    assert len(cache_spans) == 4
+    assert len(cache_spans) == 5
 
     assert cache_spans[0]["description"] == "yes, no"
     assert cache_spans[1]["description"] == "no, 1, yes"
     assert cache_spans[2]["description"] == "no, yes.1, yes.2"
     assert cache_spans[3]["description"] == "no.3, yes.5"
+    assert cache_spans[4]["description"] == ", yes"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
When multiple keys are used, cache_prefixes should kick in if any of the keys is prefixed with any of the prefixes.

Fixes https://github.com/getsentry/sentry-python/issues/3127

---

## General Notes

Thank you for contributing to `sentry-python`!

Please add tests to validate your changes, and lint your code using `tox -e linters`.

Running the test suite on your PR might require maintainer approval. Some tests (AWS Lambda) additionally require a maintainer to add a special label to run and will fail if the label is not present.

#### For maintainers

Sensitive test suites require maintainer review to ensure that tests do not compromise our secrets. This review must be repeated after any code revisions.

Before running sensitive test suites, please carefully check the PR. Then, apply the `Trigger: tests using secrets` label. The label will be removed after any code changes to enforce our policy requiring maintainers to review all code revisions before running sensitive tests.
