### PR TITLE
Szokeasaurusrex/test psycopg fix

### DIFF
--- a/sentry_sdk/integrations/django/__init__.py
+++ b/sentry_sdk/integrations/django/__init__.py
@@ -695,15 +695,10 @@ def _set_db_data(span, cursor_or_db):
     if is_psycopg2:
         connection_params = cursor_or_db.connection.get_dsn_parameters()
     else:
-        is_psycopg3 = (
-            hasattr(cursor_or_db, "connection")
-            and hasattr(cursor_or_db.connection, "info")
-            and hasattr(cursor_or_db.connection.info, "get_parameters")
-            and inspect.isroutine(cursor_or_db.connection.info.get_parameters)
-        )
-        if is_psycopg3:
+        try:
+            # psycopg3
             connection_params = cursor_or_db.connection.info.get_parameters()
-        else:
+        except Exception:
             connection_params = db.get_connection_params()
 
     db_name = connection_params.get("dbname") or connection_params.get("database")

--- a/tests/integrations/django/myapp/settings.py
+++ b/tests/integrations/django/myapp/settings.py
@@ -111,7 +111,7 @@ WSGI_APPLICATION = "tests.integrations.django.myapp.wsgi.application"
 DATABASES = {"default": {"ENGINE": "django.db.backends.sqlite3", "NAME": ":memory:"}}
 
 try:
-    import psycopg2  # noqa
+    import psycopg  # noqa
 
     db_engine = "django.db.backends.postgresql"
     try:

--- a/tests/integrations/django/test_basic.py
+++ b/tests/integrations/django/test_basic.py
@@ -647,6 +647,8 @@ def test_set_db_data_custom_backend():
         pytest.fail("A TypeError was raised")
 
 
+@pytest.mark.forked
+@pytest_mark_django_db_decorator()
 def test_connection_reconnect_does_not_error(sentry_init):
     sentry_init(integrations=[DjangoIntegration()])
 

--- a/tests/integrations/django/test_basic.py
+++ b/tests/integrations/django/test_basic.py
@@ -647,6 +647,18 @@ def test_set_db_data_custom_backend():
         pytest.fail("A TypeError was raised")
 
 
+def test_connection_reconnect_does_not_error(sentry_init):
+    sentry_init(integrations=[DjangoIntegration()])
+
+    from django.db import connections
+
+    if "postgres" not in connections:
+        pytest.skip("postgres tests disabled")
+
+    connections["postgres"].close()
+    connections["postgres"].connect()
+
+
 @pytest.mark.parametrize(
     "transaction_style,client_url,expected_transaction,expected_source,expected_response",
     [

--- a/tox.ini
+++ b/tox.ini
@@ -358,7 +358,7 @@ deps =
     cohere-latest: cohere
 
     # Django
-    django: psycopg2-binary
+    django: psycopg[binary]
     django-v{1.11,2.0,2.1,2.2,3.0,3.1,3.2}: djangorestframework>=3.0.0,<4.0.0
     django-v{2.0,2.2,3.0,3.2,4.0,4.1,4.2,5.0}: channels[daphne]
     django-v{1.11,2.0,2.2,3.0,3.2}: Werkzeug<2.1.0


### PR DESCRIPTION
Draft PR containing a test for #3111. In order to implement this change, we first would need to modify our test suite to allow running tests against both psycopg2 and 3. For testing purposes, this change modifies our test suite to only run against psycopg3; we would undo this change before merging

The main challenge preventing this change from working is an error occurring during test teardown. The test itself passes; the teardown error is the only problem. The test also tests the feature as intended: if we undo the change from #3111, the test fails.

Adding `transaction=True` to the Pytest-Django decorator eliminates the teardown error allowing the test to pass; however, if we undo #3111, the test still passes, indicating that running with `transaction=True` does not properly test the functionality we wish to verify. 