### PR TITLE
fix(profiling): Move thread data to trace context

### DIFF
--- a/sentry_sdk/tracing.py
+++ b/sentry_sdk/tracing.py
@@ -668,8 +668,8 @@ class Span:
         if thread_name is not None:
             data["thread.name"] = thread_name
 
-        # if data:
-        #     rv["data"] = data
+        if data:
+            rv["data"] = data
 
         return rv
 

--- a/sentry_sdk/tracing.py
+++ b/sentry_sdk/tracing.py
@@ -668,8 +668,8 @@ class Span:
         if thread_name is not None:
             data["thread.name"] = thread_name
 
-        if data:
-            rv["data"] = data
+        # if data:
+        #     rv["data"] = data
 
         return rv
 

--- a/sentry_sdk/tracing.py
+++ b/sentry_sdk/tracing.py
@@ -109,10 +109,7 @@ if TYPE_CHECKING:
         "ProfileContext",
         {
             "profiler.id": str,
-            "thread.id": str,
-            "thread.name": str,
         },
-        total=False,
     )
 
 
@@ -661,6 +658,19 @@ class Span:
                 self.containing_transaction.get_baggage().dynamic_sampling_context()
             )
 
+        data = {}
+
+        thread_id = self._data.get(SPANDATA.THREAD_ID)
+        if thread_id is not None:
+            data["thread.id"] = thread_id
+
+        thread_name = self._data.get(SPANDATA.THREAD_NAME)
+        if thread_name is not None:
+            data["thread.name"] = thread_name
+
+        if data:
+            rv["data"] = data
+
         return rv
 
     def get_profile_context(self):
@@ -669,19 +679,9 @@ class Span:
         if profiler_id is None:
             return None
 
-        rv = {
+        return {
             "profiler.id": profiler_id,
-        }  # type: ProfileContext
-
-        thread_id = self._data.get(SPANDATA.THREAD_ID)
-        if thread_id is not None:
-            rv["thread.id"] = thread_id
-
-        thread_name = self._data.get(SPANDATA.THREAD_NAME)
-        if thread_name is not None:
-            rv["thread.name"] = thread_name
-
-        return rv
+        }
 
 
 class Transaction(Span):

--- a/tests/profiler/test_continuous_profiler.py
+++ b/tests/profiler/test_continuous_profiler.py
@@ -86,17 +86,24 @@ def assert_single_transaction_with_profile_chunks(envelopes, thread):
     assert len(items["profile_chunk"]) > 0
 
     transaction = items["transaction"][0].payload.json
-    profile_context = transaction["contexts"]["profile"]
 
-    profiler_id = profile_context["profiler.id"]
+    trace_context = transaction["contexts"]["trace"]
 
-    assert profile_context == ApproxDict(
+    assert trace_context == ApproxDict(
         {
-            "profiler.id": profiler_id,
-            "thread.id": str(thread.ident),
-            "thread.name": thread.name,
+            "data": ApproxDict(
+                {
+                    "thread.id": str(thread.ident),
+                    "thread.name": thread.name,
+                }
+            ),
         }
     )
+
+    profile_context = transaction["contexts"]["profile"]
+    profiler_id = profile_context["profiler.id"]
+
+    assert profile_context == ApproxDict({"profiler.id": profiler_id})
 
     spans = transaction["spans"]
     assert len(spans) > 0

--- a/tests/test_new_scopes_compat_event.py
+++ b/tests/test_new_scopes_compat_event.py
@@ -492,6 +492,7 @@ def test_event5(sentry_init, capture_envelopes, expected_error, expected_transac
     transaction = transaction_envelope.get_transaction_event()
     attachment = error_envelope.items[-1]
 
+    assert error["contexts"] == expected_error(trx, span)["contexts"]
     assert error == expected_error(trx, span)
     assert transaction == expected_transaction(trx, span)
     assert attachment.headers == {

--- a/tests/test_new_scopes_compat_event.py
+++ b/tests/test_new_scopes_compat_event.py
@@ -76,10 +76,10 @@ def expected_error():
                     "parent_span_id": span.parent_span_id,
                     "op": "test_span",
                     "description": None,
-                    # "data": {
-                    #     "thread.id": mock.ANY,
-                    #     "thread.name": mock.ANY,
-                    # },
+                    "data": {
+                        "thread.id": mock.ANY,
+                        "thread.name": mock.ANY,
+                    },
                 },
                 "runtime": {
                     "name": "CPython",

--- a/tests/test_new_scopes_compat_event.py
+++ b/tests/test_new_scopes_compat_event.py
@@ -492,7 +492,6 @@ def test_event5(sentry_init, capture_envelopes, expected_error, expected_transac
     transaction = transaction_envelope.get_transaction_event()
     attachment = error_envelope.items[-1]
 
-    assert error["contexts"] == expected_error(trx, span)["contexts"]
     assert error == expected_error(trx, span)
     assert transaction == expected_transaction(trx, span)
     assert attachment.headers == {

--- a/tests/test_new_scopes_compat_event.py
+++ b/tests/test_new_scopes_compat_event.py
@@ -36,7 +36,7 @@ def expected_error():
                                     "abs_path": mock.ANY,
                                     "function": "_faulty_function",
                                     "module": "tests.test_new_scopes_compat_event",
-                                    "lineno": 240,
+                                    "lineno": 244,
                                     "pre_context": [
                                         "    return create_expected_transaction_event",
                                         "",

--- a/tests/test_new_scopes_compat_event.py
+++ b/tests/test_new_scopes_compat_event.py
@@ -36,7 +36,7 @@ def expected_error():
                                     "abs_path": mock.ANY,
                                     "function": "_faulty_function",
                                     "module": "tests.test_new_scopes_compat_event",
-                                    "lineno": 244,
+                                    "lineno": 248,
                                     "pre_context": [
                                         "    return create_expected_transaction_event",
                                         "",
@@ -78,7 +78,7 @@ def expected_error():
                     "description": None,
                     "data": {
                         "thread.id": mock.ANY,
-                        "thread.name": mock.ANY,
+                        "thread.name": "MainThread",
                     },
                 },
                 "runtime": {
@@ -161,6 +161,10 @@ def expected_transaction():
                     "parent_span_id": None,
                     "op": "test_transaction_op",
                     "description": None,
+                    "data": {
+                        "thread.id": mock.ANY,
+                        "thread.name": "MainThread",
+                    },
                 },
                 "character": {
                     "name": "Mighty Fighter changed by before_send_transaction",

--- a/tests/test_new_scopes_compat_event.py
+++ b/tests/test_new_scopes_compat_event.py
@@ -76,6 +76,10 @@ def expected_error():
                     "parent_span_id": span.parent_span_id,
                     "op": "test_span",
                     "description": None,
+                    "data": {
+                        "thread.id": mock.ANY,
+                        "thread.name": mock.ANY,
+                    },
                 },
                 "runtime": {
                     "name": "CPython",

--- a/tests/test_new_scopes_compat_event.py
+++ b/tests/test_new_scopes_compat_event.py
@@ -76,10 +76,10 @@ def expected_error():
                     "parent_span_id": span.parent_span_id,
                     "op": "test_span",
                     "description": None,
-                    "data": {
-                        "thread.id": mock.ANY,
-                        "thread.name": mock.ANY,
-                    },
+                    # "data": {
+                    #     "thread.id": mock.ANY,
+                    #     "thread.name": mock.ANY,
+                    # },
                 },
                 "runtime": {
                     "name": "CPython",


### PR DESCRIPTION
The thread data was added to the profile context in #2830. It should live in the trace context to align with other SDKs.

---

## General Notes

Thank you for contributing to `sentry-python`!

Please add tests to validate your changes, and lint your code using `tox -e linters`.

Running the test suite on your PR might require maintainer approval. Some tests (AWS Lambda) additionally require a maintainer to add a special label to run and will fail if the label is not present.

#### For maintainers

Sensitive test suites require maintainer review to ensure that tests do not compromise our secrets. This review must be repeated after any code revisions.

Before running sensitive test suites, please carefully check the PR. Then, apply the `Trigger: tests using secrets` label. The label will be removed after any code changes to enforce our policy requiring maintainers to review all code revisions before running sensitive tests.
