### PR TITLE
breakpoints/debug printing for Django ASGI investigation

### DIFF
--- a/sentry_sdk/client.py
+++ b/sentry_sdk/client.py
@@ -763,6 +763,9 @@ class _Client(BaseClient):
         if self.transport is None:
             return None
 
+        if is_transaction:
+            breakpoint()
+
         self.transport.capture_envelope(envelope)
 
         return event_id

--- a/sentry_sdk/tracing.py
+++ b/sentry_sdk/tracing.py
@@ -310,6 +310,7 @@ class Span:
 
     def __exit__(self, ty, value, tb):
         # type: (Optional[Any], Optional[Any], Optional[Any]) -> None
+        breakpoint()
         if value is not None:
             self.set_status("internal_error")
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -210,6 +210,7 @@ def capture_events(monkeypatch):
         def append_event(envelope):
             for item in envelope:
                 if item.headers.get("type") in ("event", "transaction"):
+                    print(f"append_event: {item}")
                     events.append(item.payload.json)
             return old_capture_envelope(envelope)
 

--- a/tests/integrations/django/asgi/test_asgi.py
+++ b/tests/integrations/django/asgi/test_asgi.py
@@ -317,7 +317,7 @@ async def test_has_trace_if_performance_disabled(sentry_init, capture_events):
 
 
 @pytest.mark.asyncio
-@pytest.mark.forked
+# @pytest.mark.forked
 @pytest.mark.skipif(
     django.VERSION < (3, 1), reason="async views have been introduced in Django 3.1"
 )
@@ -338,18 +338,20 @@ async def test_trace_from_headers_if_performance_enabled(sentry_init, capture_ev
     response = await comm.get_response()
     assert response["status"] == 500
 
+    assert len(events) == 3
+
     # ASGI Django does not create transactions per default,
     # so we do not have a transaction_event here.
-    (msg_event, error_event) = events
+    # (msg_event, error_event) = events
 
-    assert msg_event["contexts"]["trace"]
-    assert "trace_id" in msg_event["contexts"]["trace"]
+    # assert msg_event["contexts"]["trace"]
+    # assert "trace_id" in msg_event["contexts"]["trace"]
 
-    assert error_event["contexts"]["trace"]
-    assert "trace_id" in error_event["contexts"]["trace"]
+    # assert error_event["contexts"]["trace"]
+    # assert "trace_id" in error_event["contexts"]["trace"]
 
-    assert msg_event["contexts"]["trace"]["trace_id"] == trace_id
-    assert error_event["contexts"]["trace"]["trace_id"] == trace_id
+    # assert msg_event["contexts"]["trace"]["trace_id"] == trace_id
+    # assert error_event["contexts"]["trace"]["trace_id"] == trace_id
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
The problem (see #3142) is as follows: We expect there to be three events in the test, but right now (in master), the test verifies only that we have two events, with the transaction missing. So, we want to find out what happens with the transaction. 

The lack of transaction seems unique to the testing environment – when I [tried to reproduce](https://github.com/szokeasaurusrex/issue-reproductions/tree/main/getsentry/sentry-python/3142) with a similar setup outside of a testing environment, I saw transactions as expected in Sentry. Therefore, it appears that either no transaction is created during testing, or we somehow fail to capture the transaction in the TestTransport that we use for the `capture_events` fixture.

I have tried placing breakpoints in many different places, but have still struggled to figure out the root cause for the strange behavior. In this PR, I have included two breakpoints that cause unexpected behavior. The first breakpoint we have is one in the `__exit__` of a span; if the code is run as is with `tox -e py3.12-django-latest -- tests/integrations/django/asgi/test_asgi.py::test_trace_from_headers_if_performance_enabled`, we hit that breakpoint three times (perhaps, because we have spans as well as a transaction). Then, we will end up inside the second breakpoint in `capture_event`. Since this breakpoint is inside an `if is_transaction` block, we know that we are about to capture the transaction. If we step through the transport `capture_envelope` call, we see that we correctly add the transaction event to the events list. However, when we continue from this last breakpoint, the test fails with an asyncio `TimeoutError`. 

If we comment out the breakpoint in `Span.__exit__`, however, we do not hit the breakpoint in `capture_event` at all, suggesting that for whatever reason the transaction does not get captured in this case. We end up failing with the assertion error, since there are only two, rather than three, events in the test. No asyncio TimeoutError in this case.

I am not really sure yet what to make of all this strange behavior, but I guess asyncio somehow prevents the transaction from being captured in our tests
