### PR TITLE
Add deprecation comment for profiler internals

### DIFF
--- a/sentry_sdk/profiler/__init__.py
+++ b/sentry_sdk/profiler/__init__.py
@@ -23,7 +23,7 @@ __all__ = [
     "start_profiler",
     "stop_profiler",
     # DEPRECATED: The following was re-exported for backwards compatibility. It
-    # will be removed from the public profiler API in a future release.
+    # will be removed from sentry_sdk.profiler in a future release.
     "MAX_PROFILE_DURATION_NS",
     "PROFILE_MINIMUM_SAMPLES",
     "Profile",

--- a/sentry_sdk/profiler/__init__.py
+++ b/sentry_sdk/profiler/__init__.py
@@ -22,7 +22,8 @@ from sentry_sdk.profiler.utils import (
 __all__ = [
     "start_profiler",
     "stop_profiler",
-    # Re-exported for backwards compatibility
+    # DEPRECATED: The following was re-exported for backwards compatibility. It
+    # will be removed from the public profiler API in a future release.
     "MAX_PROFILE_DURATION_NS",
     "PROFILE_MINIMUM_SAMPLES",
     "Profile",


### PR DESCRIPTION
These symbols were never explicitly part of the public API, but they were also not explicitly marked as private, so out of abundance of caution we kept them around as importable straight from `sentry_sdk.profiler` when reorganizing modules in the scope of https://github.com/getsentry/sentry-python/pull/2830. However, since they were never meant to be public, we want to remove them from the implicitly public API, so we deprecate them here.

This also needs to be called out in the changelog.