### PR TITLE
Reapply "Refactor the Celery Beat integration (#3105)" (#3144)

### DIFF
--- a/.github/workflows/test-integrations-data-processing.yml
+++ b/.github/workflows/test-integrations-data-processing.yml
@@ -36,6 +36,8 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
+      - name: Start Redis
+        uses: supercharge/redis-github-action@1.7.0
       - name: Setup Test Env
         run: |
           pip install coverage tox
@@ -108,6 +110,8 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
+      - name: Start Redis
+        uses: supercharge/redis-github-action@1.7.0
       - name: Setup Test Env
         run: |
           pip install coverage tox

--- a/scripts/split-tox-gh-actions/split-tox-gh-actions.py
+++ b/scripts/split-tox-gh-actions/split-tox-gh-actions.py
@@ -35,6 +35,10 @@ FRAMEWORKS_NEEDING_POSTGRES = {
     "asyncpg",
 }
 
+FRAMEWORKS_NEEDING_REDIS = {
+    "celery",
+}
+
 FRAMEWORKS_NEEDING_CLICKHOUSE = {
     "clickhouse_driver",
 }
@@ -275,6 +279,7 @@ def render_template(group, frameworks, py_versions_pinned, py_versions_latest):
         "needs_aws_credentials": bool(set(frameworks) & FRAMEWORKS_NEEDING_AWS),
         "needs_clickhouse": bool(set(frameworks) & FRAMEWORKS_NEEDING_CLICKHOUSE),
         "needs_postgres": bool(set(frameworks) & FRAMEWORKS_NEEDING_POSTGRES),
+        "needs_redis": bool(set(frameworks) & FRAMEWORKS_NEEDING_REDIS),
         "needs_github_secrets": bool(
             set(frameworks) & FRAMEWORKS_NEEDING_GITHUB_SECRETS
         ),

--- a/scripts/split-tox-gh-actions/templates/test_group.jinja
+++ b/scripts/split-tox-gh-actions/templates/test_group.jinja
@@ -53,6 +53,11 @@
       - uses: getsentry/action-clickhouse-in-ci@v1
       {% endif %}
 
+      {% if needs_redis %}
+      - name: Start Redis
+        uses: supercharge/redis-github-action@1.7.0
+      {% endif %}
+
       - name: Setup Test Env
         run: |
           pip install coverage tox

--- a/sentry_sdk/integrations/celery/__init__.py
+++ b/sentry_sdk/integrations/celery/__init__.py
@@ -72,7 +72,7 @@ class CeleryIntegration(Integration):
 
         _patch_beat_apply_entry()
         _patch_redbeat_maybe_due()
-        _setup_celery_beat_signals()
+        _setup_celery_beat_signals(monitor_beat_tasks)
 
     @staticmethod
     def setup_once():

--- a/sentry_sdk/integrations/celery/__init__.py
+++ b/sentry_sdk/integrations/celery/__init__.py
@@ -70,10 +70,9 @@ class CeleryIntegration(Integration):
         self.monitor_beat_tasks = monitor_beat_tasks
         self.exclude_beat_tasks = exclude_beat_tasks
 
-        if monitor_beat_tasks:
-            _patch_beat_apply_entry()
-            _patch_redbeat_maybe_due()
-            _setup_celery_beat_signals()
+        _patch_beat_apply_entry()
+        _patch_redbeat_maybe_due()
+        _setup_celery_beat_signals()
 
     @staticmethod
     def setup_once():
@@ -167,11 +166,11 @@ def _update_celery_task_headers(original_headers, span, monitor_beat_tasks):
     """
     updated_headers = original_headers.copy()
     with capture_internal_exceptions():
-        headers = {}
-        if span is not None:
-            headers = dict(
-                Scope.get_current_scope().iter_trace_propagation_headers(span=span)
-            )
+        # if span is None (when the task was started by Celery Beat)
+        # this will return the trace headers from the scope.
+        headers = dict(
+            Scope.get_isolation_scope().iter_trace_propagation_headers(span=span)
+        )
 
         if monitor_beat_tasks:
             headers.update(

--- a/sentry_sdk/integrations/celery/beat.py
+++ b/sentry_sdk/integrations/celery/beat.py
@@ -1,4 +1,3 @@
-from functools import wraps
 import sentry_sdk
 from sentry_sdk.crons import capture_checkin, MonitorStatus
 from sentry_sdk.integrations import DidNotEnable
@@ -159,7 +158,7 @@ def _apply_crons_data_to_schedule_entry(scheduler, schedule_entry, integration):
     schedule_entry.options["headers"] = headers
 
 
-def _wrap_beat_scheduler(f):
+def _wrap_beat_scheduler(original_function):
     # type: (Callable[..., Any]) -> Callable[..., Any]
     """
     Makes sure that:
@@ -171,14 +170,19 @@ def _wrap_beat_scheduler(f):
     After the patched function is called,
     Celery Beat will call apply_async to put the task in the queue.
     """
+    # Patch only once
+    # Can't use __name__ here, because some of our tests mock original_apply_entry
+    already_patched = "sentry_patched_scheduler" in str(original_function)
+    if already_patched:
+        return original_function
+
     from sentry_sdk.integrations.celery import CeleryIntegration
 
-    @wraps(f)
     def sentry_patched_scheduler(*args, **kwargs):
         # type: (*Any, **Any) -> None
         integration = sentry_sdk.get_client().get_integration(CeleryIntegration)
         if integration is None:
-            return f(*args, **kwargs)
+            return original_function(*args, **kwargs)
 
         # Tasks started by Celery Beat start a new Trace
         scope = Scope.get_isolation_scope()
@@ -188,7 +192,7 @@ def _wrap_beat_scheduler(f):
         scheduler, schedule_entry = args
         _apply_crons_data_to_schedule_entry(scheduler, schedule_entry, integration)
 
-        return f(*args, **kwargs)
+        return original_function(*args, **kwargs)
 
     return sentry_patched_scheduler
 
@@ -206,13 +210,9 @@ def _patch_redbeat_maybe_due():
     RedBeatScheduler.maybe_due = _wrap_beat_scheduler(RedBeatScheduler.maybe_due)
 
 
-def _setup_celery_beat_signals():
-    # type: () -> None
-    from sentry_sdk.integrations.celery import CeleryIntegration
-
-    integration = sentry_sdk.get_client().get_integration(CeleryIntegration)
-
-    if integration is not None and integration.monitor_beat_tasks:
+def _setup_celery_beat_signals(monitor_beat_tasks):
+    # type: (bool) -> None
+    if monitor_beat_tasks:
         task_success.connect(crons_task_success)
         task_failure.connect(crons_task_failure)
         task_retry.connect(crons_task_retry)

--- a/sentry_sdk/scope.py
+++ b/sentry_sdk/scope.py
@@ -604,9 +604,10 @@ class Scope(object):
     def iter_trace_propagation_headers(self, *args, **kwargs):
         # type: (Any, Any) -> Generator[Tuple[str, str], None, None]
         """
-        Return HTTP headers which allow propagation of trace data. Data taken
-        from the span representing the request, if available, or the current
-        span on the scope if not.
+        Return HTTP headers which allow propagation of trace data.
+
+        If a span is given, the trace data will taken from the span.
+        If no span is given, the trace data is taken from the scope.
         """
         client = Scope.get_client()
         if not client.options.get("propagate_traces"):

--- a/tests/integrations/celery/integration_tests/__init__.py
+++ b/tests/integrations/celery/integration_tests/__init__.py
@@ -1,0 +1,58 @@
+import os
+import signal
+import tempfile
+import threading
+import time
+
+from celery.beat import Scheduler
+
+from sentry_sdk.utils import logger
+
+
+class ImmediateScheduler(Scheduler):
+    """
+    A custom scheduler that starts tasks immediately after starting Celery beat.
+    """
+
+    def setup_schedule(self):
+        super().setup_schedule()
+        for _, entry in self.schedule.items():
+            self.apply_entry(entry)
+
+    def tick(self):
+        # Override tick to prevent the normal schedule cycle
+        return 1
+
+
+def kill_beat(beat_pid_file, delay_seconds=1):
+    """
+    Terminates Celery Beat after the given `delay_seconds`.
+    """
+    logger.info("Starting Celery Beat killer...")
+    time.sleep(delay_seconds)
+    pid = int(open(beat_pid_file, "r").read())
+    logger.info("Terminating Celery Beat...")
+    os.kill(pid, signal.SIGTERM)
+
+
+def run_beat(celery_app, runtime_seconds=1, loglevel="warning", quiet=True):
+    """
+    Run Celery Beat that immediately starts tasks.
+    The Celery Beat instance is automatically terminated after `runtime_seconds`.
+    """
+    logger.info("Starting Celery Beat...")
+    pid_file = os.path.join(tempfile.mkdtemp(), f"celery-beat-{os.getpid()}.pid")
+
+    t = threading.Thread(
+        target=kill_beat,
+        args=(pid_file,),
+        kwargs={"delay_seconds": runtime_seconds},
+    )
+    t.start()
+
+    beat_instance = celery_app.Beat(
+        loglevel=loglevel,
+        quiet=quiet,
+        pidfile=pid_file,
+    )
+    beat_instance.run()

--- a/tests/integrations/celery/integration_tests/test_celery_beat_cron_monitoring.py
+++ b/tests/integrations/celery/integration_tests/test_celery_beat_cron_monitoring.py
@@ -1,0 +1,153 @@
+import os
+import pytest
+
+from celery.contrib.testing.worker import start_worker
+
+from sentry_sdk.utils import logger
+
+from tests.integrations.celery.integration_tests import run_beat
+
+
+REDIS_SERVER = "redis://127.0.0.1:6379"
+REDIS_DB = 15
+
+
+@pytest.fixture()
+def celery_config():
+    return {
+        "worker_concurrency": 1,
+        "broker_url": f"{REDIS_SERVER}/{REDIS_DB}",
+        "result_backend": f"{REDIS_SERVER}/{REDIS_DB}",
+        "beat_scheduler": "tests.integrations.celery.integration_tests:ImmediateScheduler",
+        "task_always_eager": False,
+        "task_create_missing_queues": True,
+        "task_default_queue": f"queue_{os.getpid()}",
+    }
+
+
+@pytest.fixture
+def celery_init(sentry_init, celery_config):
+    """
+    Create a Sentry instrumented Celery app.
+    """
+    from celery import Celery
+
+    from sentry_sdk.integrations.celery import CeleryIntegration
+
+    def inner(propagate_traces=True, monitor_beat_tasks=False, **kwargs):
+        sentry_init(
+            integrations=[
+                CeleryIntegration(
+                    propagate_traces=propagate_traces,
+                    monitor_beat_tasks=monitor_beat_tasks,
+                )
+            ],
+            **kwargs,
+        )
+        app = Celery("tasks")
+        app.conf.update(celery_config)
+
+        return app
+
+    return inner
+
+
+@pytest.mark.forked
+def test_explanation(celery_init, capture_envelopes):
+    """
+    This is a dummy test for explaining how to test using Celery Beat
+    """
+
+    # First initialize a Celery app.
+    # You can give the options of CeleryIntegrations
+    # and the options for `sentry_dks.init` as keyword arguments.
+    # See the celery_init fixture for details.
+    app = celery_init(
+        monitor_beat_tasks=True,
+    )
+
+    # Capture envelopes.
+    envelopes = capture_envelopes()
+
+    # Define the task you want to run
+    @app.task
+    def test_task():
+        logger.info("Running test_task")
+
+    # Add the task to the beat schedule
+    app.add_periodic_task(60.0, test_task.s(), name="success_from_beat")
+
+    # Start a Celery worker
+    with start_worker(app, perform_ping_check=False):
+        # And start a Celery Beat instance
+        # This Celery Beat will start the task above immediately
+        # after start for the first time
+        # By default Celery Beat is terminated after 1 second.
+        # See `run_beat` function on how to change this.
+        run_beat(app)
+
+    # After the Celery Beat is terminated, you can check the envelopes
+    assert len(envelopes) >= 0
+
+
+@pytest.mark.forked
+def test_beat_task_crons_success(celery_init, capture_envelopes):
+    app = celery_init(
+        monitor_beat_tasks=True,
+    )
+    envelopes = capture_envelopes()
+
+    @app.task
+    def test_task():
+        logger.info("Running test_task")
+
+    app.add_periodic_task(60.0, test_task.s(), name="success_from_beat")
+
+    with start_worker(app, perform_ping_check=False):
+        run_beat(app)
+
+    assert len(envelopes) == 2
+    (envelop_in_progress, envelope_ok) = envelopes
+
+    assert envelop_in_progress.items[0].headers["type"] == "check_in"
+    check_in = envelop_in_progress.items[0].payload.json
+    assert check_in["type"] == "check_in"
+    assert check_in["monitor_slug"] == "success_from_beat"
+    assert check_in["status"] == "in_progress"
+
+    assert envelope_ok.items[0].headers["type"] == "check_in"
+    check_in = envelope_ok.items[0].payload.json
+    assert check_in["type"] == "check_in"
+    assert check_in["monitor_slug"] == "success_from_beat"
+    assert check_in["status"] == "ok"
+
+
+@pytest.mark.forked
+def test_beat_task_crons_error(celery_init, capture_envelopes):
+    app = celery_init(
+        monitor_beat_tasks=True,
+    )
+    envelopes = capture_envelopes()
+
+    @app.task
+    def test_task():
+        logger.info("Running test_task")
+        1 / 0
+
+    app.add_periodic_task(60.0, test_task.s(), name="failure_from_beat")
+
+    with start_worker(app, perform_ping_check=False):
+        run_beat(app)
+
+    envelop_in_progress = envelopes[0]
+    envelope_error = envelopes[-1]
+
+    check_in = envelop_in_progress.items[0].payload.json
+    assert check_in["type"] == "check_in"
+    assert check_in["monitor_slug"] == "failure_from_beat"
+    assert check_in["status"] == "in_progress"
+
+    check_in = envelope_error.items[0].payload.json
+    assert check_in["type"] == "check_in"
+    assert check_in["monitor_slug"] == "failure_from_beat"
+    assert check_in["status"] == "error"

--- a/tests/integrations/celery/test_celery.py
+++ b/tests/integrations/celery/test_celery.py
@@ -26,9 +26,19 @@ def connect_signal(request):
 
 @pytest.fixture
 def init_celery(sentry_init, request):
-    def inner(propagate_traces=True, backend="always_eager", **kwargs):
+    def inner(
+        propagate_traces=True,
+        backend="always_eager",
+        monitor_beat_tasks=False,
+        **kwargs,
+    ):
         sentry_init(
-            integrations=[CeleryIntegration(propagate_traces=propagate_traces)],
+            integrations=[
+                CeleryIntegration(
+                    propagate_traces=propagate_traces,
+                    monitor_beat_tasks=monitor_beat_tasks,
+                )
+            ],
             **kwargs,
         )
         celery = Celery(__name__)

--- a/tests/integrations/celery/test_update_celery_task_headers.py
+++ b/tests/integrations/celery/test_update_celery_task_headers.py
@@ -1,4 +1,5 @@
 from copy import copy
+import itertools
 import pytest
 
 from unittest import mock
@@ -23,23 +24,18 @@ def test_monitor_beat_tasks(monitor_beat_tasks):
     headers = {}
     span = None
 
-    updated_headers = _update_celery_task_headers(headers, span, monitor_beat_tasks)
+    outgoing_headers = _update_celery_task_headers(headers, span, monitor_beat_tasks)
 
     assert headers == {}  # left unchanged
 
     if monitor_beat_tasks:
-        assert updated_headers == {
-            "headers": {
-                "sentry-monitor-start-timestamp-s": mock.ANY,
-                "sentry-task-enqueued-time": mock.ANY,
-            },
-            "sentry-monitor-start-timestamp-s": mock.ANY,
-            "sentry-task-enqueued-time": mock.ANY,
-        }
+        assert outgoing_headers["sentry-monitor-start-timestamp-s"] == mock.ANY
+        assert (
+            outgoing_headers["headers"]["sentry-monitor-start-timestamp-s"] == mock.ANY
+        )
     else:
-        assert updated_headers == {
-            "sentry-task-enqueued-time": mock.ANY,
-        }
+        assert "sentry-monitor-start-timestamp-s" not in outgoing_headers
+        assert "sentry-monitor-start-timestamp-s" not in outgoing_headers["headers"]
 
 
 @pytest.mark.parametrize("monitor_beat_tasks", [True, False, None, "", "bla", 1, 0])
@@ -51,37 +47,44 @@ def test_monitor_beat_tasks_with_headers(monitor_beat_tasks):
     }
     span = None
 
-    updated_headers = _update_celery_task_headers(headers, span, monitor_beat_tasks)
+    outgoing_headers = _update_celery_task_headers(headers, span, monitor_beat_tasks)
+
+    assert headers == {
+        "blub": "foo",
+        "sentry-something": "bar",
+    }  # left unchanged
 
     if monitor_beat_tasks:
-        assert updated_headers == {
-            "blub": "foo",
-            "sentry-something": "bar",
-            "headers": {
-                "sentry-monitor-start-timestamp-s": mock.ANY,
-                "sentry-something": "bar",
-                "sentry-task-enqueued-time": mock.ANY,
-            },
-            "sentry-monitor-start-timestamp-s": mock.ANY,
-            "sentry-task-enqueued-time": mock.ANY,
-        }
+        assert outgoing_headers["blub"] == "foo"
+        assert outgoing_headers["sentry-something"] == "bar"
+        assert outgoing_headers["sentry-monitor-start-timestamp-s"] == mock.ANY
+        assert outgoing_headers["headers"]["sentry-something"] == "bar"
+        assert (
+            outgoing_headers["headers"]["sentry-monitor-start-timestamp-s"] == mock.ANY
+        )
     else:
-        assert updated_headers == headers
+        assert outgoing_headers["blub"] == "foo"
+        assert outgoing_headers["sentry-something"] == "bar"
+        assert "sentry-monitor-start-timestamp-s" not in outgoing_headers
+        assert "sentry-monitor-start-timestamp-s" not in outgoing_headers["headers"]
 
 
 def test_span_with_transaction(sentry_init):
     sentry_init(enable_tracing=True)
     headers = {}
+    monitor_beat_tasks = False
 
     with sentry_sdk.start_transaction(name="test_transaction") as transaction:
         with sentry_sdk.start_span(op="test_span") as span:
-            updated_headers = _update_celery_task_headers(headers, span, False)
+            outgoing_headers = _update_celery_task_headers(
+                headers, span, monitor_beat_tasks
+            )
 
-            assert updated_headers["sentry-trace"] == span.to_traceparent()
-            assert updated_headers["headers"]["sentry-trace"] == span.to_traceparent()
-            assert updated_headers["baggage"] == transaction.get_baggage().serialize()
+            assert outgoing_headers["sentry-trace"] == span.to_traceparent()
+            assert outgoing_headers["headers"]["sentry-trace"] == span.to_traceparent()
+            assert outgoing_headers["baggage"] == transaction.get_baggage().serialize()
             assert (
-                updated_headers["headers"]["baggage"]
+                outgoing_headers["headers"]["baggage"]
                 == transaction.get_baggage().serialize()
             )
 
@@ -95,10 +98,10 @@ def test_span_with_transaction_custom_headers(sentry_init):
 
     with sentry_sdk.start_transaction(name="test_transaction") as transaction:
         with sentry_sdk.start_span(op="test_span") as span:
-            updated_headers = _update_celery_task_headers(headers, span, False)
+            outgoing_headers = _update_celery_task_headers(headers, span, False)
 
-            assert updated_headers["sentry-trace"] == span.to_traceparent()
-            assert updated_headers["headers"]["sentry-trace"] == span.to_traceparent()
+            assert outgoing_headers["sentry-trace"] == span.to_traceparent()
+            assert outgoing_headers["headers"]["sentry-trace"] == span.to_traceparent()
 
             incoming_baggage = Baggage.from_incoming_header(headers["baggage"])
             combined_baggage = copy(transaction.get_baggage())
@@ -113,9 +116,112 @@ def test_span_with_transaction_custom_headers(sentry_init):
                     if x is not None and x != ""
                 ]
             )
-            assert updated_headers["baggage"] == combined_baggage.serialize(
+            assert outgoing_headers["baggage"] == combined_baggage.serialize(
                 include_third_party=True
             )
-            assert updated_headers["headers"]["baggage"] == combined_baggage.serialize(
+            assert outgoing_headers["headers"]["baggage"] == combined_baggage.serialize(
                 include_third_party=True
             )
+
+
+@pytest.mark.parametrize("monitor_beat_tasks", [True, False])
+def test_celery_trace_propagation_default(sentry_init, monitor_beat_tasks):
+    """
+    The celery integration does not check the traces_sample_rate.
+    By default traces_sample_rate is None which means "do not propagate traces".
+    But the celery integration does not check this value.
+    The Celery integration has its own mechanism to propagate traces:
+    https://docs.sentry.io/platforms/python/integrations/celery/#distributed-traces
+    """
+    sentry_init()
+
+    headers = {}
+    span = None
+
+    scope = sentry_sdk.Scope.get_isolation_scope()
+
+    outgoing_headers = _update_celery_task_headers(headers, span, monitor_beat_tasks)
+
+    assert outgoing_headers["sentry-trace"] == scope.get_traceparent()
+    assert outgoing_headers["headers"]["sentry-trace"] == scope.get_traceparent()
+    assert outgoing_headers["baggage"] == scope.get_baggage().serialize()
+    assert outgoing_headers["headers"]["baggage"] == scope.get_baggage().serialize()
+
+    if monitor_beat_tasks:
+        assert "sentry-monitor-start-timestamp-s" in outgoing_headers
+        assert "sentry-monitor-start-timestamp-s" in outgoing_headers["headers"]
+    else:
+        assert "sentry-monitor-start-timestamp-s" not in outgoing_headers
+        assert "sentry-monitor-start-timestamp-s" not in outgoing_headers["headers"]
+
+
+@pytest.mark.parametrize(
+    "traces_sample_rate,monitor_beat_tasks",
+    list(itertools.product([None, 0, 0.0, 0.5, 1.0, 1, 2], [True, False])),
+)
+def test_celery_trace_propagation_traces_sample_rate(
+    sentry_init, traces_sample_rate, monitor_beat_tasks
+):
+    """
+    The celery integration does not check the traces_sample_rate.
+    By default traces_sample_rate is None which means "do not propagate traces".
+    But the celery integration does not check this value.
+    The Celery integration has its own mechanism to propagate traces:
+    https://docs.sentry.io/platforms/python/integrations/celery/#distributed-traces
+    """
+    sentry_init(traces_sample_rate=traces_sample_rate)
+
+    headers = {}
+    span = None
+
+    scope = sentry_sdk.Scope.get_isolation_scope()
+
+    outgoing_headers = _update_celery_task_headers(headers, span, monitor_beat_tasks)
+
+    assert outgoing_headers["sentry-trace"] == scope.get_traceparent()
+    assert outgoing_headers["headers"]["sentry-trace"] == scope.get_traceparent()
+    assert outgoing_headers["baggage"] == scope.get_baggage().serialize()
+    assert outgoing_headers["headers"]["baggage"] == scope.get_baggage().serialize()
+
+    if monitor_beat_tasks:
+        assert "sentry-monitor-start-timestamp-s" in outgoing_headers
+        assert "sentry-monitor-start-timestamp-s" in outgoing_headers["headers"]
+    else:
+        assert "sentry-monitor-start-timestamp-s" not in outgoing_headers
+        assert "sentry-monitor-start-timestamp-s" not in outgoing_headers["headers"]
+
+
+@pytest.mark.parametrize(
+    "enable_tracing,monitor_beat_tasks",
+    list(itertools.product([None, True, False], [True, False])),
+)
+def test_celery_trace_propagation_enable_tracing(
+    sentry_init, enable_tracing, monitor_beat_tasks
+):
+    """
+    The celery integration does not check the traces_sample_rate.
+    By default traces_sample_rate is None which means "do not propagate traces".
+    But the celery integration does not check this value.
+    The Celery integration has its own mechanism to propagate traces:
+    https://docs.sentry.io/platforms/python/integrations/celery/#distributed-traces
+    """
+    sentry_init(enable_tracing=enable_tracing)
+
+    headers = {}
+    span = None
+
+    scope = sentry_sdk.Scope.get_isolation_scope()
+
+    outgoing_headers = _update_celery_task_headers(headers, span, monitor_beat_tasks)
+
+    assert outgoing_headers["sentry-trace"] == scope.get_traceparent()
+    assert outgoing_headers["headers"]["sentry-trace"] == scope.get_traceparent()
+    assert outgoing_headers["baggage"] == scope.get_baggage().serialize()
+    assert outgoing_headers["headers"]["baggage"] == scope.get_baggage().serialize()
+
+    if monitor_beat_tasks:
+        assert "sentry-monitor-start-timestamp-s" in outgoing_headers
+        assert "sentry-monitor-start-timestamp-s" in outgoing_headers["headers"]
+    else:
+        assert "sentry-monitor-start-timestamp-s" not in outgoing_headers
+        assert "sentry-monitor-start-timestamp-s" not in outgoing_headers["headers"]

--- a/tests/integrations/celery/test_update_celery_task_headers.py
+++ b/tests/integrations/celery/test_update_celery_task_headers.py
@@ -52,6 +52,7 @@ def test_monitor_beat_tasks_with_headers(monitor_beat_tasks):
     assert headers == {
         "blub": "foo",
         "sentry-something": "bar",
+        "sentry-task-enqueued-time": mock.ANY,
     }  # left unchanged
 
     if monitor_beat_tasks:


### PR DESCRIPTION
This reverts commit d818e8f08625dbc44bac95598293e86cfac9e8a1.

This reverts the revert that was done to mitigate the regression error with Crons not being sending ok/error checkins.

We have a fix ready in https://github.com/getsentry/sentry-python/pull/3155 that fixes that regression that will be merge into this PR.


<!-- Describe your PR here -->

---

## General Notes

Thank you for contributing to `sentry-python`!

Please add tests to validate your changes, and lint your code using `tox -e linters`.

Running the test suite on your PR might require maintainer approval. Some tests (AWS Lambda) additionally require a maintainer to add a special label to run and will fail if the label is not present.

#### For maintainers

Sensitive test suites require maintainer review to ensure that tests do not compromise our secrets. This review must be repeated after any code revisions.

Before running sensitive test suites, please carefully check the PR. Then, apply the `Trigger: tests using secrets` label. The label will be removed after any code changes to enforce our policy requiring maintainers to review all code revisions before running sensitive tests.
