### PR TITLE
fix(tracing): Keep original function signature when decorated

### DIFF
--- a/sentry_sdk/tracing_utils.py
+++ b/sentry_sdk/tracing_utils.py
@@ -646,7 +646,7 @@ def start_child_span_decorator(func):
                 return await func(*args, **kwargs)
 
         try:
-            func_with_tracing.__signature__ = inspect.signature(func)
+            func_with_tracing.__signature__ = inspect.signature(func)  # type: ignore[attr-defined]
         except Exception:
             pass
 
@@ -674,7 +674,7 @@ def start_child_span_decorator(func):
                 return func(*args, **kwargs)
 
         try:
-            func_with_tracing.__signature__ = inspect.signature(func)
+            func_with_tracing.__signature__ = inspect.signature(func)  # type: ignore[attr-defined]
         except Exception:
             pass
 

--- a/sentry_sdk/tracing_utils.py
+++ b/sentry_sdk/tracing_utils.py
@@ -645,7 +645,10 @@ def start_child_span_decorator(func):
             ):
                 return await func(*args, **kwargs)
 
-        func_with_tracing.__signature__ = inspect.signature(func)
+        try:
+            func_with_tracing.__signature__ = inspect.signature(func)
+        except Exception:
+            pass
 
     # Synchronous case
     else:
@@ -670,7 +673,10 @@ def start_child_span_decorator(func):
             ):
                 return func(*args, **kwargs)
 
-        func_with_tracing.__signature__ = inspect.signature(func)
+        try:
+            func_with_tracing.__signature__ = inspect.signature(func)
+        except Exception:
+            pass
 
     return func_with_tracing
 

--- a/sentry_sdk/tracing_utils.py
+++ b/sentry_sdk/tracing_utils.py
@@ -645,7 +645,7 @@ def start_child_span_decorator(func):
             ):
                 return await func(*args, **kwargs)
 
-        func_with_tracing.__signature__ = func.__signature__
+        func_with_tracing.__signature__ = inspect.signature(func)
 
     # Synchronous case
     else:
@@ -670,7 +670,7 @@ def start_child_span_decorator(func):
             ):
                 return func(*args, **kwargs)
 
-        func_with_tracing.__signature__ = func.__signature__
+        func_with_tracing.__signature__ = inspect.signature(func)
 
     return func_with_tracing
 

--- a/sentry_sdk/tracing_utils.py
+++ b/sentry_sdk/tracing_utils.py
@@ -645,6 +645,8 @@ def start_child_span_decorator(func):
             ):
                 return await func(*args, **kwargs)
 
+        func_with_tracing.__signature__ = func.__signature__
+
     # Synchronous case
     else:
 
@@ -667,6 +669,8 @@ def start_child_span_decorator(func):
                 description=qualname_from_function(func),
             ):
                 return func(*args, **kwargs)
+
+        func_with_tracing.__signature__ = func.__signature__
 
     return func_with_tracing
 

--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -1,4 +1,3 @@
-import inspect
 import logging
 import os
 import sys
@@ -19,7 +18,6 @@ from sentry_sdk import (
     last_event_id,
     add_breadcrumb,
     isolation_scope,
-    tracing,
     Hub,
     Scope,
 )
@@ -681,23 +679,6 @@ def test_functions_to_trace(sentry_init, capture_events):
     assert event["spans"][0]["description"] == "time.sleep"
     assert event["spans"][1]["description"] == "tests.test_basics._hello_world"
     assert event["spans"][2]["description"] == "tests.test_basics._hello_world"
-
-
-def test_functions_to_trace_signature_unchanged(sentry_init):
-    sentry_init(
-        traces_sample_rate=1.0,
-    )
-
-    def _some_function(a, b, c):
-        pass
-
-    @tracing.trace
-    def _some_function_traced(a, b, c):
-        pass
-
-    assert inspect.getcallargs(_some_function, 1, 2, 3) == inspect.getcallargs(
-        _some_function_traced, 1, 2, 3
-    )
 
 
 class WorldGreeter:

--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -683,19 +683,17 @@ def test_functions_to_trace(sentry_init, capture_events):
     assert event["spans"][2]["description"] == "tests.test_basics._hello_world"
 
 
-def _some_function(a, b, c):
-    pass
-
-
-@tracing.trace
-def _some_function_traced(a, b, c):
-    pass
-
-
 def test_functions_to_trace_signature_unchanged(sentry_init):
     sentry_init(
         traces_sample_rate=1.0,
     )
+
+    def _some_function(a, b, c):
+        pass
+
+    @tracing.trace
+    def _some_function_traced(a, b, c):
+        pass
 
     assert inspect.getcallargs(_some_function, 1, 2, 3) == inspect.getcallargs(
         _some_function_traced, 1, 2, 3

--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -1,3 +1,4 @@
+import inspect
 import logging
 import os
 import sys
@@ -18,6 +19,7 @@ from sentry_sdk import (
     last_event_id,
     add_breadcrumb,
     isolation_scope,
+    tracing,
     Hub,
     Scope,
 )
@@ -679,6 +681,25 @@ def test_functions_to_trace(sentry_init, capture_events):
     assert event["spans"][0]["description"] == "time.sleep"
     assert event["spans"][1]["description"] == "tests.test_basics._hello_world"
     assert event["spans"][2]["description"] == "tests.test_basics._hello_world"
+
+
+def _some_function(a, b, c):
+    pass
+
+
+@tracing.trace
+def _some_function_traced(a, b, c):
+    pass
+
+
+def test_functions_to_trace_signature_unchanged(sentry_init):
+    sentry_init(
+        traces_sample_rate=1.0,
+    )
+
+    assert inspect.getcallargs(_some_function, 1, 2, 3) == inspect.getcallargs(
+        _some_function_traced, 1, 2, 3
+    )
 
 
 class WorldGreeter:

--- a/tests/tracing/test_decorator.py
+++ b/tests/tracing/test_decorator.py
@@ -1,7 +1,9 @@
+import inspect
 from unittest import mock
 
 import pytest
 
+from sentry_sdk.tracing import trace
 from sentry_sdk.tracing_utils import start_child_span_decorator
 from sentry_sdk.utils import logger
 from tests.conftest import patch_start_tracing_child
@@ -76,3 +78,38 @@ async def test_trace_decorator_async_no_trx():
                 "test_decorator.my_async_example_function",
             )
             assert result2 == "return_of_async_function"
+
+
+def test_functions_to_trace_signature_unchanged_sync(sentry_init):
+    sentry_init(
+        traces_sample_rate=1.0,
+    )
+
+    def _some_function(a, b, c):
+        pass
+
+    @trace
+    def _some_function_traced(a, b, c):
+        pass
+
+    assert inspect.getcallargs(_some_function, 1, 2, 3) == inspect.getcallargs(
+        _some_function_traced, 1, 2, 3
+    )
+
+
+@pytest.mark.asyncio
+async def test_functions_to_trace_signature_unchanged_async(sentry_init):
+    sentry_init(
+        traces_sample_rate=1.0,
+    )
+
+    async def _some_function(a, b, c):
+        pass
+
+    @trace
+    async def _some_function_traced(a, b, c):
+        pass
+
+    assert inspect.getcallargs(_some_function, 1, 2, 3) == inspect.getcallargs(
+        _some_function_traced, 1, 2, 3
+    )


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry-python/issues/3177

---

## General Notes

Thank you for contributing to `sentry-python`!

Please add tests to validate your changes, and lint your code using `tox -e linters`.

Running the test suite on your PR might require maintainer approval. Some tests (AWS Lambda) additionally require a maintainer to add a special label to run and will fail if the label is not present.

#### For maintainers

Sensitive test suites require maintainer review to ensure that tests do not compromise our secrets. This review must be repeated after any code revisions.

Before running sensitive test suites, please carefully check the PR. Then, apply the `Trigger: tests using secrets` label. The label will be removed after any code changes to enforce our policy requiring maintainers to review all code revisions before running sensitive tests.
