### PR TITLE
ref(pymongo): Remove redundant command name in query description

### DIFF
--- a/sentry_sdk/integrations/pymongo.py
+++ b/sentry_sdk/integrations/pymongo.py
@@ -155,7 +155,7 @@ class CommandTracer(monitoring.CommandListener):
             if not should_send_default_pii():
                 command = _strip_pii(command)
 
-            query = "{} {}".format(event.command_name, command)
+            query = "{}".format(command)
             span = sentry_sdk.start_span(op=op, description=query)
 
             for tag, value in tags.items():

--- a/tests/integrations/pymongo/test_pymongo.py
+++ b/tests/integrations/pymongo/test_pymongo.py
@@ -71,9 +71,9 @@ def test_transactions(sentry_init, capture_events, mongo_server, with_pii):
     assert insert_success["tags"]["db.operation"] == "insert"
     assert insert_fail["tags"]["db.operation"] == "insert"
 
-    assert find["description"].startswith("find {")
-    assert insert_success["description"].startswith("insert {")
-    assert insert_fail["description"].startswith("insert {")
+    assert find["description"].startswith("{'find")
+    assert insert_success["description"].startswith("{'insert")
+    assert insert_fail["description"].startswith("{'insert")
     if with_pii:
         assert "1" in find["description"]
         assert "2" in insert_success["description"]
@@ -113,7 +113,7 @@ def test_breadcrumbs(sentry_init, capture_events, mongo_server, with_pii):
     (crumb,) = event["breadcrumbs"]["values"]
 
     assert crumb["category"] == "query"
-    assert crumb["message"].startswith("find {")
+    assert crumb["message"].startswith("{'find")
     if with_pii:
         assert "1" in crumb["message"]
     else:


### PR DESCRIPTION
The query command is already included as the first key within the command JSON, so query spans would end up looking like this:

![image](https://github.com/getsentry/sentry-python/assets/16740047/1684ed2f-36a7-4c21-b110-021c41bf3be8)

Our Node SDK, which uses OTel under the hood now, formats queries differently; it doesn't include the command name at the front, example:

![image](https://github.com/getsentry/sentry-python/assets/16740047/e73135ce-5f4f-477f-9836-0d4440359c5c)

We also already include the command within the `db.operation` tag, so there's no confusion or loss of details here. This change will ensure consistent behaviour between our other SDKs!