### PR TITLE
Do not raise error when channels is not installed

### DIFF
--- a/sentry_sdk/integrations/django/__init__.py
+++ b/sentry_sdk/integrations/django/__init__.py
@@ -325,14 +325,10 @@ def _patch_drf():
 def _patch_channels():
     # type: () -> None
     try:
-        # Django < 3.0
         from channels.http import AsgiHandler  # type: ignore
     except ImportError:
-        try:
-            # DJango 3.0+
-            from django.core.handlers.asgi import ASGIHandler as AsgiHandler
-        except ImportError:
-            return
+        return
+
     if not HAS_REAL_CONTEXTVARS:
         # We better have contextvars or we're going to leak state between
         # requests.

--- a/sentry_sdk/integrations/django/asgi.py
+++ b/sentry_sdk/integrations/django/asgi.py
@@ -135,10 +135,14 @@ def patch_get_response_async(cls, _before_get_response):
 def patch_channels_asgi_handler_impl(cls):
     # type: (Any) -> None
 
-    import channels  # type: ignore
+    try:
+        import channels  # type: ignore
+    except ImportError:
+        channels = None
+
     from sentry_sdk.integrations.django import DjangoIntegration
 
-    if channels.__version__ < "3.0.0":
+    if channels is not None and channels.__version__ < "3.0.0":
         old_app = cls.__call__
 
         async def sentry_patched_asgi_handler(self, receive, send):

--- a/sentry_sdk/integrations/django/asgi.py
+++ b/sentry_sdk/integrations/django/asgi.py
@@ -134,15 +134,11 @@ def patch_get_response_async(cls, _before_get_response):
 
 def patch_channels_asgi_handler_impl(cls):
     # type: (Any) -> None
-
-    try:
-        import channels  # type: ignore
-    except ImportError:
-        channels = None
+    import channels  # type: ignore
 
     from sentry_sdk.integrations.django import DjangoIntegration
 
-    if channels is not None and channels.__version__ < "3.0.0":
+    if channels.__version__ < "3.0.0":
         old_app = cls.__call__
 
         async def sentry_patched_asgi_handler(self, receive, send):


### PR DESCRIPTION
Small bugfix that can occur if you have a modern Django installation without channels installed. 


<!-- Describe your PR here -->

---

## General Notes

Thank you for contributing to `sentry-python`!

Please add tests to validate your changes, and lint your code using `tox -e linters`.

Running the test suite on your PR might require maintainer approval. Some tests (AWS Lambda) additionally require a maintainer to add a special label to run and will fail if the label is not present.

#### For maintainers

Sensitive test suites require maintainer review to ensure that tests do not compromise our secrets. This review must be repeated after any code revisions.

Before running sensitive test suites, please carefully check the PR. Then, apply the `Trigger: tests using secrets` label. The label will be removed after any code changes to enforce our policy requiring maintainers to review all code revisions before running sensitive tests.
