### PR TITLE
Handle span without parent_context

### DIFF
--- a/sentry_sdk/integrations/opentelemetry/span_processor.py
+++ b/sentry_sdk/integrations/opentelemetry/span_processor.py
@@ -159,7 +159,7 @@ class SentrySpanProcessor(SpanProcessor):
                 span_id=trace_data["span_id"],
                 parent_span_id=parent_span_id,
                 trace_id=trace_data["trace_id"],
-                baggage=trace_data["baggage"],
+                baggage=trace_data.get("baggage"),
                 start_timestamp=start_timestamp,
                 instrumenter=INSTRUMENTER.OTEL,
                 origin=SPAN_ORIGIN,


### PR DESCRIPTION
In Django startup it can be that there is a transaction without parent_context and thus baggage is not yet there. This PR is preventing an error when this is the case. 

<!-- Describe your PR here -->

---

## General Notes

Thank you for contributing to `sentry-python`!

Please add tests to validate your changes, and lint your code using `tox -e linters`.

Running the test suite on your PR might require maintainer approval. Some tests (AWS Lambda) additionally require a maintainer to add a special label to run and will fail if the label is not present.

#### For maintainers

Sensitive test suites require maintainer review to ensure that tests do not compromise our secrets. This review must be repeated after any code revisions.

Before running sensitive test suites, please carefully check the PR. Then, apply the `Trigger: tests using secrets` label. The label will be removed after any code changes to enforce our policy requiring maintainers to review all code revisions before running sensitive tests.
