### PR TITLE
ref(tests): Unhardcode integration list

### DIFF
--- a/tests/new_scopes_compat/test_new_scopes_compat_event.py
+++ b/tests/new_scopes_compat/test_new_scopes_compat_event.py
@@ -4,6 +4,7 @@ from unittest import mock
 
 import sentry_sdk
 from sentry_sdk.hub import Hub
+from sentry_sdk.integrations import iter_default_integrations
 from sentry_sdk.scrubber import EventScrubber, DEFAULT_DENYLIST
 
 
@@ -18,7 +19,17 @@ This makes sure that we are backwards compatible. (on a best effort basis, there
 
 
 @pytest.fixture
-def expected_error():
+def integrations():
+    return [
+        integration.identifier
+        for integration in iter_default_integrations(
+            with_auto_enabling_integrations=False
+        )
+    ]
+
+
+@pytest.fixture
+def expected_error(integrations):
     def create_expected_error_event(trx, span):
         return {
             "level": "warning-X",
@@ -122,16 +133,7 @@ def expected_error():
                 "name": "sentry.python",
                 "version": mock.ANY,
                 "packages": [{"name": "pypi:sentry-sdk", "version": mock.ANY}],
-                "integrations": [
-                    "argv",
-                    "atexit",
-                    "dedupe",
-                    "excepthook",
-                    "logging",
-                    "modules",
-                    "stdlib",
-                    "threading",
-                ],
+                "integrations": integrations,
             },
             "platform": "python",
             "_meta": {
@@ -149,7 +151,7 @@ def expected_error():
 
 
 @pytest.fixture
-def expected_transaction():
+def expected_transaction(integrations):
     def create_expected_transaction_event(trx, span):
         return {
             "type": "transaction",
@@ -220,16 +222,7 @@ def expected_transaction():
                 "name": "sentry.python",
                 "version": mock.ANY,
                 "packages": [{"name": "pypi:sentry-sdk", "version": mock.ANY}],
-                "integrations": [
-                    "argv",
-                    "atexit",
-                    "dedupe",
-                    "excepthook",
-                    "logging",
-                    "modules",
-                    "stdlib",
-                    "threading",
-                ],
+                "integrations": integrations,
             },
             "platform": "python",
             "_meta": {
@@ -328,6 +321,7 @@ def _init_sentry_sdk(sentry_init):
         ),
         send_default_pii=False,
         traces_sample_rate=1.0,
+        auto_enabling_integrations=False,
     )
 
 


### PR DESCRIPTION
Benefits of unhardcoding integration list and disabling auto integrations:
1. It becomes possible to successfully run tests in environments where certain extra auto integrations get enabled.
2. There is no need to update hardcoded list when new default integrations are introduced.

The origin of this change is a patch that I had to apply while packaging for Fedora: https://src.fedoraproject.org/rpms/python-sentry-sdk/blob/30f00540cd30328d578dfb84625226dcc7f28969/f/python-sentry-sdk.spec#_52 (https://src.fedoraproject.org/rpms/python-sentry-sdk/blob/30f00540cd30328d578dfb84625226dcc7f28969/f/0002-tests.test_new_scopes_compat_event-compatibility.patch). The patch was necessary because all possible optional dependencies for optional integrations are pre-installed as system packages, so that as many tests as possible could be run. Unfortunately, the patch no longer applies to a new version of the Sentry SDK, so instead of redoing the patch in Fedora, I am submitting this PR.

<!-- Describe your PR here -->

---

## General Notes

Thank you for contributing to `sentry-python`!

Please add tests to validate your changes, and lint your code using `tox -e linters`.

Running the test suite on your PR might require maintainer approval. Some tests (AWS Lambda) additionally require a maintainer to add a special label to run and will fail if the label is not present.

#### For maintainers

Sensitive test suites require maintainer review to ensure that tests do not compromise our secrets. This review must be repeated after any code revisions.

Before running sensitive test suites, please carefully check the PR. Then, apply the `Trigger: tests using secrets` label. The label will be removed after any code changes to enforce our policy requiring maintainers to review all code revisions before running sensitive tests.
