### PR TITLE
fix(profiling): profiler_id uses underscore

### DIFF
--- a/sentry_sdk/consts.py
+++ b/sentry_sdk/consts.py
@@ -379,7 +379,7 @@ class SPANDATA:
     Example: "MainThread"
     """
 
-    PROFILER_ID = "profiler.id"
+    PROFILER_ID = "profiler_id"
     """
     Label identifying the profiler id that the span occurred in. This should be a string.
     Example: "5249fbada8d5416482c2f6e47e337372"

--- a/sentry_sdk/tracing.py
+++ b/sentry_sdk/tracing.py
@@ -115,7 +115,7 @@ if TYPE_CHECKING:
     ProfileContext = TypedDict(
         "ProfileContext",
         {
-            "profiler.id": str,
+            "profiler_id": str,
         },
     )
 
@@ -693,7 +693,7 @@ class Span:
             return None
 
         return {
-            "profiler.id": profiler_id,
+            "profiler_id": profiler_id,
         }
 
 

--- a/tests/profiler/test_continuous_profiler.py
+++ b/tests/profiler/test_continuous_profiler.py
@@ -101,16 +101,16 @@ def assert_single_transaction_with_profile_chunks(envelopes, thread):
     )
 
     profile_context = transaction["contexts"]["profile"]
-    profiler_id = profile_context["profiler.id"]
+    profiler_id = profile_context["profiler_id"]
 
-    assert profile_context == ApproxDict({"profiler.id": profiler_id})
+    assert profile_context == ApproxDict({"profiler_id": profiler_id})
 
     spans = transaction["spans"]
     assert len(spans) > 0
     for span in spans:
         assert span["data"] == ApproxDict(
             {
-                "profiler.id": profiler_id,
+                "profiler_id": profiler_id,
                 "thread.id": str(thread.ident),
                 "thread.name": thread.name,
             }


### PR DESCRIPTION
Relay expects this with an underscore instead of a dot.