### PR TITLE
fix(integrations): don't send full env to subprocess

### DIFF
--- a/sentry_sdk/integrations/stdlib.py
+++ b/sentry_sdk/integrations/stdlib.py
@@ -207,7 +207,11 @@ def _install_subprocess():
             ):
                 if env is None:
                     env = _init_argument(
-                        a, kw, "env", 10, lambda x: dict(x or os.environ)
+                        a,
+                        kw,
+                        "env",
+                        10,
+                        lambda x: dict(x if x is not None else os.environ),
                     )
                 env["SUBPROCESS_" + k.upper().replace("-", "_")] = v
 

--- a/tests/integrations/stdlib/test_subprocess.py
+++ b/tests/integrations/stdlib/test_subprocess.py
@@ -174,6 +174,19 @@ def test_subprocess_basic(
         assert sys.executable + " -c" in subprocess_init_span["description"]
 
 
+def test_subprocess_empty_env(sentry_init, monkeypatch):
+    monkeypatch.setenv("TEST_MARKER", "should_not_be_seen")
+    sentry_init(integrations=[StdlibIntegration()], traces_sample_rate=1.0)
+    with start_transaction(name="foo"):
+        args = [
+            sys.executable,
+            "-c",
+            "import os; print(os.environ.get('TEST_MARKER', None))",
+        ]
+        output = subprocess.check_output(args, env={}, text=True)
+    assert "should_not_be_seen" not in output
+
+
 def test_subprocess_invalid_args(sentry_init):
     sentry_init(integrations=[StdlibIntegration()])
 

--- a/tests/integrations/stdlib/test_subprocess.py
+++ b/tests/integrations/stdlib/test_subprocess.py
@@ -183,7 +183,7 @@ def test_subprocess_empty_env(sentry_init, monkeypatch):
             "-c",
             "import os; print(os.environ.get('TEST_MARKER', None))",
         ]
-        output = subprocess.check_output(args, env={}, text=True)
+        output = subprocess.check_output(args, env={}, universal_newlines=True)
     assert "should_not_be_seen" not in output
 
 


### PR DESCRIPTION
During the arguments modification to `subprocess.Popen.__init__`, an explicitly empty environment of `{}` is incorrectly confused with a `None` environment. This causes sentry to pass the entire environment of the parent process instead of sending just the injected environment variables.

Fix it by only replacing the environment with `os.environ` if the variable is None, and not just falsy.
