### PR TITLE
test: Introduce `capture_record_lost_event_calls` fixture

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -248,20 +248,18 @@ def capture_envelopes(monkeypatch):
 
 
 @pytest.fixture
-def capture_client_reports(monkeypatch):
+def capture_record_lost_event_calls(monkeypatch):
     def inner():
-        reports = []
-        test_client = sentry_sdk.Hub.current.client
+        calls = []
+        test_client = sentry_sdk.get_client()
 
         def record_lost_event(reason, data_category=None, item=None):
-            if data_category is None:
-                data_category = item.data_category
-            return reports.append((reason, data_category))
+            calls.append((reason, data_category, item))
 
         monkeypatch.setattr(
             test_client.transport, "record_lost_event", record_lost_event
         )
-        return reports
+        return calls
 
     return inner
 

--- a/tests/profiler/test_transaction_profiler.py
+++ b/tests/profiler/test_transaction_profiler.py
@@ -126,7 +126,7 @@ def test_profiler_setup_twice(make_options, teardown_profiling):
 def test_profiles_sample_rate(
     sentry_init,
     capture_envelopes,
-    capture_client_reports,
+    capture_record_lost_event_calls,
     teardown_profiling,
     profiles_sample_rate,
     profile_count,
@@ -142,7 +142,7 @@ def test_profiles_sample_rate(
     )
 
     envelopes = capture_envelopes()
-    reports = capture_client_reports()
+    record_lost_event_calls = capture_record_lost_event_calls()
 
     with mock.patch(
         "sentry_sdk.profiler.transaction_profiler.random.random", return_value=0.5
@@ -158,11 +158,11 @@ def test_profiles_sample_rate(
     assert len(items["transaction"]) == 1
     assert len(items["profile"]) == profile_count
     if profiles_sample_rate is None or profiles_sample_rate == 0:
-        assert reports == []
+        assert record_lost_event_calls == []
     elif profile_count:
-        assert reports == []
+        assert record_lost_event_calls == []
     else:
-        assert reports == [("sample_rate", "profile")]
+        assert record_lost_event_calls == [("sample_rate", "profile", None)]
 
 
 @pytest.mark.parametrize(
@@ -201,7 +201,7 @@ def test_profiles_sample_rate(
 def test_profiles_sampler(
     sentry_init,
     capture_envelopes,
-    capture_client_reports,
+    capture_record_lost_event_calls,
     teardown_profiling,
     profiles_sampler,
     profile_count,
@@ -213,7 +213,7 @@ def test_profiles_sampler(
     )
 
     envelopes = capture_envelopes()
-    reports = capture_client_reports()
+    record_lost_event_calls = capture_record_lost_event_calls()
 
     with mock.patch(
         "sentry_sdk.profiler.transaction_profiler.random.random", return_value=0.5
@@ -229,15 +229,15 @@ def test_profiles_sampler(
     assert len(items["transaction"]) == 1
     assert len(items["profile"]) == profile_count
     if profile_count:
-        assert reports == []
+        assert record_lost_event_calls == []
     else:
-        assert reports == [("sample_rate", "profile")]
+        assert record_lost_event_calls == [("sample_rate", "profile", None)]
 
 
 def test_minimum_unique_samples_required(
     sentry_init,
     capture_envelopes,
-    capture_client_reports,
+    capture_record_lost_event_calls,
     teardown_profiling,
 ):
     sentry_init(
@@ -246,7 +246,7 @@ def test_minimum_unique_samples_required(
     )
 
     envelopes = capture_envelopes()
-    reports = capture_client_reports()
+    record_lost_event_calls = capture_record_lost_event_calls()
 
     with start_transaction(name="profiling"):
         pass
@@ -260,7 +260,7 @@ def test_minimum_unique_samples_required(
     # because we dont leave any time for the profiler to
     # take any samples, it should be not be sent
     assert len(items["profile"]) == 0
-    assert reports == [("insufficient_data", "profile")]
+    assert record_lost_event_calls == [("insufficient_data", "profile", None)]
 
 
 @pytest.mark.forked

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -55,14 +55,14 @@ def test_monitor_unhealthy(sentry_init):
 
 
 def test_transaction_uses_downsampled_rate(
-    sentry_init, capture_client_reports, monkeypatch
+    sentry_init, capture_record_lost_event_calls, monkeypatch
 ):
     sentry_init(
         traces_sample_rate=1.0,
         transport=UnhealthyTestTransport(),
     )
 
-    reports = capture_client_reports()
+    record_lost_event_calls = capture_record_lost_event_calls()
 
     monitor = sentry_sdk.get_client().monitor
     monitor.interval = 0.1
@@ -79,7 +79,7 @@ def test_transaction_uses_downsampled_rate(
         assert transaction.sampled is False
         assert transaction.sample_rate == 0.5
 
-    assert reports == [("backpressure", "transaction")]
+    assert record_lost_event_calls == [("backpressure", "transaction", None)]
 
 
 def test_monitor_no_thread_on_shutdown_no_errors(sentry_init):


### PR DESCRIPTION
`capture_record_lost_event_calls` replaces the `capture_client_reports` fixture. The fixture records calls to `Transport.record_lost_event` by noting the arguments passed to each call.

This change is being introduced in preparation for #3244, which changes `Transport.record_lost_event`'s signature and behavior.
