### PR TITLE
ref(debug): Rename debug logging filter

### DIFF
--- a/sentry_sdk/debug.py
+++ b/sentry_sdk/debug.py
@@ -9,7 +9,7 @@ from sentry_sdk.utils import logger
 from logging import LogRecord
 
 
-class _HubBasedClientFilter(logging.Filter):
+class _DebugFilter(logging.Filter):
     def filter(self, record):
         # type: (LogRecord) -> bool
         if _client_init_debug.get(False):
@@ -31,7 +31,7 @@ def configure_logger():
     _handler.setFormatter(logging.Formatter(" [sentry] %(levelname)s: %(message)s"))
     logger.addHandler(_handler)
     logger.setLevel(logging.DEBUG)
-    logger.addFilter(_HubBasedClientFilter())
+    logger.addFilter(_DebugFilter())
 
 
 def configure_debug_hub():


### PR DESCRIPTION
Previous name said that this filter was "hub-based," when the logic in reality is not related to hubs. So, we should rename the filter to something more sensible.
