### PR TITLE
ref(types): Correct `ExcInfo` type

### DIFF
--- a/sentry_sdk/_types.py
+++ b/sentry_sdk/_types.py
@@ -121,8 +121,9 @@ if TYPE_CHECKING:
         total=False,
     )
 
-    ExcInfo = Tuple[
-        Optional[Type[BaseException]], Optional[BaseException], Optional[TracebackType]
+    ExcInfo = Union[
+        tuple[Type[BaseException], BaseException, Optional[TracebackType]],
+        tuple[None, None, None],
     ]
 
     Hint = Dict[str, Any]

--- a/sentry_sdk/integrations/sanic.py
+++ b/sentry_sdk/integrations/sanic.py
@@ -28,13 +28,12 @@ if TYPE_CHECKING:
     from typing import Callable
     from typing import Optional
     from typing import Union
-    from typing import Tuple
     from typing import Dict
 
     from sanic.request import Request, RequestParameters
     from sanic.response import BaseHTTPResponse
 
-    from sentry_sdk._types import Event, EventProcessor, Hint
+    from sentry_sdk._types import Event, EventProcessor, ExcInfo, Hint
     from sanic.router import Route
 
 try:
@@ -325,7 +324,7 @@ def _legacy_router_get(self, *args):
 
 @ensure_integration_enabled(SanicIntegration)
 def _capture_exception(exception):
-    # type: (Union[Tuple[Optional[type], Optional[BaseException], Any], BaseException]) -> None
+    # type: (Union[ExcInfo, BaseException]) -> None
     with capture_internal_exceptions():
         event, hint = event_from_exception(
             exception,

--- a/sentry_sdk/utils.py
+++ b/sentry_sdk/utils.py
@@ -1019,7 +1019,14 @@ def exc_info_from_error(error):
     else:
         raise ValueError("Expected Exception object to report, got %s!" % type(error))
 
-    return exc_type, exc_value, tb
+    exc_info = (exc_type, exc_value, tb)
+
+    if TYPE_CHECKING:
+        # This cast is safe because exc_type and exc_value are either both
+        # None or both not None.
+        exc_info = cast(ExcInfo, exc_info)
+
+    return exc_info
 
 
 def event_from_exception(


### PR DESCRIPTION
Previously, we defined `ExcInfo` as `tuple[Type[BaseException] | None, BaseException | None, TracebackType | None]`, when in fact, the correct type is the narrower `tuple[Type[BaseException], BaseException, TracebackType | None] | tuple[None, None, None]`.

This change makes [b0b5ecc](https://github.com/getsentry/sentry-python/pull/3264/commits/b0b5ecc28a10f43eac970a322ae314f5e898881b)  (included in #3264) possible; previously, we would have gotten a mypy error when passing the ExcInfo tuple to `logger.error`