### PR TITLE
ref(tracing): Remove `Hub` in `Transaction.finish`

### DIFF
--- a/sentry_sdk/tracing.py
+++ b/sentry_sdk/tracing.py
@@ -1205,8 +1205,17 @@ class NoOpSpan(Span):
         # type: () -> Any
         return {}
 
-    def finish(self, hub=None, end_timestamp=None):
-        # type: (Optional[Union[sentry_sdk.Hub, sentry_sdk.Scope]], Optional[Union[float, datetime]]) -> Optional[str]
+    def finish(
+        self,
+        scope=None,  # type: Optional[sentry_sdk.Scope]
+        end_timestamp=None,  # type: Optional[Union[float, datetime]]
+        *,
+        hub=None,  # type: Optional[sentry_sdk.Hub]
+    ):
+        # type: (...) -> Optional[str]
+        """
+        The `hub` parameter is deprecated. Please use the `scope` parameter, instead.
+        """
         pass
 
     def set_measurement(self, name, value, unit=""):

--- a/tests/tracing/test_deprecated.py
+++ b/tests/tracing/test_deprecated.py
@@ -1,4 +1,9 @@
+import warnings
+
 import pytest
+
+import sentry_sdk
+import sentry_sdk.tracing
 from sentry_sdk import start_span
 
 from sentry_sdk.tracing import Span
@@ -20,3 +25,23 @@ def test_start_span_to_start_transaction(sentry_init, capture_events):
     assert len(events) == 2
     assert events[0]["transaction"] == "/1/"
     assert events[1]["transaction"] == "/2/"
+
+
+@pytest.mark.parametrize("parameter_value", (sentry_sdk.Hub(), sentry_sdk.Scope()))
+def test_passing_hub_parameter_to_transaction_finish(parameter_value):
+    transaction = sentry_sdk.tracing.Transaction()
+    with pytest.warns(DeprecationWarning):
+        transaction.finish(hub=parameter_value)
+
+
+def test_passing_hub_object_to_scope_transaction_finish():
+    transaction = sentry_sdk.tracing.Transaction()
+    with pytest.warns(DeprecationWarning):
+        transaction.finish(sentry_sdk.Hub())
+
+
+def test_no_warnings_scope_to_transaction_finish():
+    transaction = sentry_sdk.tracing.Transaction()
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        transaction.finish(sentry_sdk.Scope())


### PR DESCRIPTION
Rename `Transaction.finish` method's `hub` parameter to `scope` (in a backwards-compatible manner), and update the method so that it is using `Scope` API under the hood as much as possible.

Prerequisite for #3265
