### PR TITLE
ref(hub): Delete `_should_send_default_pii`

### DIFF
--- a/sentry_sdk/hub.py
+++ b/sentry_sdk/hub.py
@@ -59,16 +59,6 @@ else:
 _local = ContextVar("sentry_current_hub")
 
 
-def _should_send_default_pii():
-    # type: () -> bool
-    # TODO: Migrate existing code to `scope.should_send_default_pii()` and remove this function.
-    # New code should not use this function!
-    client = Hub.current.client
-    if not client:
-        return False
-    return client.should_send_default_pii()
-
-
 class _InitGuard:
     def __init__(self, client):
         # type: (Client) -> None


### PR DESCRIPTION
We don't use this function, and since it is marked as a private method, that means we can delete it.
