### PR TITLE
test: Allow passing of PostgreSQL port

### DIFF
--- a/tests/integrations/asyncpg/test_asyncpg.py
+++ b/tests/integrations/asyncpg/test_asyncpg.py
@@ -13,7 +13,7 @@ import os
 
 
 PG_HOST = os.getenv("SENTRY_PYTHON_TEST_POSTGRES_HOST", "localhost")
-PG_PORT = 5432
+PG_PORT = int(os.getenv("SENTRY_PYTHON_TEST_POSTGRES_PORT", "5432"))
 PG_USER = os.getenv("SENTRY_PYTHON_TEST_POSTGRES_USER", "postgres")
 PG_PASSWORD = os.getenv("SENTRY_PYTHON_TEST_POSTGRES_PASSWORD", "sentry")
 PG_NAME = os.getenv("SENTRY_PYTHON_TEST_POSTGRES_NAME", "postgres")

--- a/tests/integrations/django/myapp/settings.py
+++ b/tests/integrations/django/myapp/settings.py
@@ -122,7 +122,7 @@ try:
     DATABASES["postgres"] = {
         "ENGINE": db_engine,
         "HOST": os.environ.get("SENTRY_PYTHON_TEST_POSTGRES_HOST", "localhost"),
-        "PORT": 5432,
+        "PORT": int(os.environ.get("SENTRY_PYTHON_TEST_POSTGRES_PORT", "5432")),
         "USER": os.environ.get("SENTRY_PYTHON_TEST_POSTGRES_USER", "postgres"),
         "PASSWORD": os.environ.get("SENTRY_PYTHON_TEST_POSTGRES_PASSWORD", "sentry"),
         "NAME": os.environ.get(

--- a/tests/integrations/django/test_basic.py
+++ b/tests/integrations/django/test_basic.py
@@ -626,7 +626,9 @@ def test_db_connection_span_data(sentry_init, client, capture_events):
             assert data.get(SPANDATA.SERVER_ADDRESS) == os.environ.get(
                 "SENTRY_PYTHON_TEST_POSTGRES_HOST", "localhost"
             )
-            assert data.get(SPANDATA.SERVER_PORT) == "5432"
+            assert data.get(SPANDATA.SERVER_PORT) == os.environ.get(
+                "SENTRY_PYTHON_TEST_POSTGRES_PORT", "5432"
+            )
 
 
 def test_set_db_data_custom_backend():


### PR DESCRIPTION
Allow passing an arbitrary port via the `SENTPY_PYTHON_TEST_POSTGRES_PORT` environmental variable.

Fedora's RPM macro `%postgresql_tests_run` which starts PostgreSQL dynamically selects PostgreSQL port to prevent start failures when running multiple PostgreSQL servers on the same default port [1].

This issue is not specific to Fedora. In case there is some application running on the same machine with port `5432` opened, such as PostgreSQL instance with the default port, this will result in failure to start the PostgreSQL server, resulting in an inability to run these tests.

This change allows running these tests in environments where PostgreSQL has a non-default port and where other applications (including a PostgreSQL instance with the default port) have opened port `5432`, while at the same time keeping the old behavior as the default.

[1] The macro is provided by https://packages.fedoraproject.org/pkgs/postgresql15/postgresql15-test-rpm-macros/,
which packages https://github.com/devexp-db/postgresql-setup. Dynamic selection of the port was added in 2018:
https://github.com/devexp-db/postgresql-setup/pull/16, for the reasoningsee `NEWS` file changes: https://github.com/devexp-db/postgresql-setup/pull/16/files#diff-7ee66c4f1536ac84dc5bbff1b8312e2eef24b974b3e48a5c5c2bcfdf2eb8f3ce).

<!-- Describe your PR here -->

---

## General Notes

Thank you for contributing to `sentry-python`!

Please add tests to validate your changes, and lint your code using `tox -e linters`.

Running the test suite on your PR might require maintainer approval. Some tests (AWS Lambda) additionally require a maintainer to add a special label to run and will fail if the label is not present.

#### For maintainers

Sensitive test suites require maintainer review to ensure that tests do not compromise our secrets. This review must be repeated after any code revisions.

Before running sensitive test suites, please carefully check the PR. Then, apply the `Trigger: tests using secrets` label. The label will be removed after any code changes to enforce our policy requiring maintainers to review all code revisions before running sensitive tests.
