### PR TITLE
docs(init): Fix `sentry_sdk.init` type hint

### DIFF
--- a/sentry_sdk/consts.py
+++ b/sentry_sdk/consts.py
@@ -1,3 +1,5 @@
+import itertools
+
 from enum import Enum
 from sentry_sdk._types import TYPE_CHECKING
 
@@ -479,6 +481,7 @@ class ClientConstructor:
     def __init__(
         self,
         dsn=None,  # type: Optional[str]
+        *,
         max_breadcrumbs=DEFAULT_MAX_BREADCRUMBS,  # type: int
         release=None,  # type: Optional[str]
         environment=None,  # type: Optional[str]
@@ -540,7 +543,7 @@ class ClientConstructor:
 
 
 def _get_default_options():
-    # type: () -> Dict[str, Any]
+    # type: () -> dict[str, Any]
     import inspect
 
     if hasattr(inspect, "getfullargspec"):
@@ -550,7 +553,14 @@ def _get_default_options():
 
     a = getargspec(ClientConstructor.__init__)
     defaults = a.defaults or ()
-    return dict(zip(a.args[-len(defaults) :], defaults))
+    kwonlydefaults = a.kwonlydefaults or {}
+
+    return dict(
+        itertools.chain(
+            zip(a.args[-len(defaults) :], defaults),
+            kwonlydefaults.items(),
+        )
+    )
 
 
 DEFAULT_OPTIONS = _get_default_options()

--- a/sentry_sdk/hub.py
+++ b/sentry_sdk/hub.py
@@ -89,7 +89,7 @@ def _init(*args, **kwargs):
 
     This takes the same arguments as the client constructor.
     """
-    client = Client(*args, **kwargs)  # type: ignore
+    client = Client(*args, **kwargs)
     Scope.get_global_scope().set_client(client)
     _check_python_deprecations()
     rv = _InitGuard(client)


### PR DESCRIPTION
The current type hint suggests that all the parameters can be passed as positional arguments, when this is not the case. Only the `dsn` can be passed as a positional argument; the rest must be passed as keyword arguments.

This PR makes the type hint reflect the reality of what parameters can be passed to `sentry_sdk.init`.
