### PR TITLE
ref(consts): Remove Python 2 compatibility code

### DIFF
--- a/sentry_sdk/consts.py
+++ b/sentry_sdk/consts.py
@@ -546,12 +546,7 @@ def _get_default_options():
     # type: () -> dict[str, Any]
     import inspect
 
-    if hasattr(inspect, "getfullargspec"):
-        getargspec = inspect.getfullargspec
-    else:
-        getargspec = inspect.getargspec  # type: ignore
-
-    a = getargspec(ClientConstructor.__init__)
+    a = inspect.getfullargspec(ClientConstructor.__init__)
     defaults = a.defaults or ()
     kwonlydefaults = a.kwonlydefaults or {}
 


### PR DESCRIPTION
All the versions we now support include `inspect.getfullargspec`, so we no longer need the backwards-compatible fallback.
