### PR TITLE
fix(openai): Lazy initialize tiktoken to avoid http at import time

### DIFF
--- a/sentry_sdk/integrations/openai.py
+++ b/sentry_sdk/integrations/openai.py
@@ -32,10 +32,13 @@ except ImportError:
 try:
     import tiktoken  # type: ignore
 
-    enc = tiktoken.get_encoding("cl100k_base")
+    enc = None  # lazy initialize
 
     def count_tokens(s):
         # type: (str) -> int
+        global enc
+        if enc is None:
+            enc = tiktoken.get_encoding("cl100k_base")
         return len(enc.encode_ordinary(s))
 
     logger.debug("[OpenAI] using tiktoken to count tokens")


### PR DESCRIPTION
`tiktoken.get_encoding` makes a HTTP connection if the encoding doesn't already exist.

If a user has OpenAI, sentry, and tiktoken all installed, this line would make a HTTP request at import time.

