### PR TITLE
feat(openai): Make tiktoken encoding name configurable + tiktoken usage opt-in

### DIFF
--- a/sentry_sdk/integrations/langchain.py
+++ b/sentry_sdk/integrations/langchain.py
@@ -27,28 +27,6 @@ except ImportError:
     raise DidNotEnable("langchain not installed")
 
 
-try:
-    import tiktoken  # type: ignore
-
-    enc = tiktoken.get_encoding("cl100k_base")
-
-    def count_tokens(s):
-        # type: (str) -> int
-        return len(enc.encode_ordinary(s))
-
-    logger.debug("[langchain] using tiktoken to count tokens")
-except ImportError:
-    logger.info(
-        "The Sentry Python SDK requires 'tiktoken' in order to measure token usage from streaming langchain calls."
-        "Please install 'tiktoken' if you aren't receiving accurate token usage in Sentry."
-        "See https://docs.sentry.io/platforms/python/integrations/langchain/ for more information."
-    )
-
-    def count_tokens(s):
-        # type: (str) -> int
-        return 1
-
-
 DATA_FIELDS = {
     "temperature": SPANDATA.AI_TEMPERATURE,
     "top_p": SPANDATA.AI_TOP_P,
@@ -78,10 +56,13 @@ class LangchainIntegration(Integration):
     # The most number of spans (e.g., LLM calls) that can be processed at the same time.
     max_spans = 1024
 
-    def __init__(self, include_prompts=True, max_spans=1024):
-        # type: (LangchainIntegration, bool, int) -> None
+    def __init__(
+        self, include_prompts=True, max_spans=1024, tiktoken_encoding_name=None
+    ):
+        # type: (LangchainIntegration, bool, int, Optional[str]) -> None
         self.include_prompts = include_prompts
         self.max_spans = max_spans
+        self.tiktoken_encoding_name = tiktoken_encoding_name
 
     @staticmethod
     def setup_once():
@@ -109,10 +90,22 @@ class SentryLangchainCallback(BaseCallbackHandler):  # type: ignore[misc]
 
     max_span_map_size = 0
 
-    def __init__(self, max_span_map_size, include_prompts):
-        # type: (int, bool) -> None
+    def __init__(self, max_span_map_size, include_prompts, tiktoken_encoding_name=None):
+        # type: (int, bool, Optional[str]) -> None
         self.max_span_map_size = max_span_map_size
         self.include_prompts = include_prompts
+
+        self.tiktoken_encoding = None
+        if tiktoken_encoding_name is not None:
+            import tiktoken  # type: ignore
+
+            self.tiktoken_encoding = tiktoken.get_encoding(tiktoken_encoding_name)
+
+    def count_tokens(self, s):
+        # type: (str) -> int
+        if self.tiktoken_encoding is not None:
+            return len(self.tiktoken_encoding.encode_ordinary(s))
+        return 0
 
     def gc_span_map(self):
         # type: () -> None
@@ -244,9 +237,9 @@ class SentryLangchainCallback(BaseCallbackHandler):  # type: ignore[misc]
             if not watched_span.no_collect_tokens:
                 for list_ in messages:
                     for message in list_:
-                        self.span_map[run_id].num_prompt_tokens += count_tokens(
+                        self.span_map[run_id].num_prompt_tokens += self.count_tokens(
                             message.content
-                        ) + count_tokens(message.type)
+                        ) + self.count_tokens(message.type)
 
     def on_llm_new_token(self, token, *, run_id, **kwargs):
         # type: (SentryLangchainCallback, str, UUID, Any) -> Any
@@ -257,7 +250,7 @@ class SentryLangchainCallback(BaseCallbackHandler):  # type: ignore[misc]
             span_data = self.span_map[run_id]
             if not span_data or span_data.no_collect_tokens:
                 return
-            span_data.num_completion_tokens += count_tokens(token)
+            span_data.num_completion_tokens += self.count_tokens(token)
 
     def on_llm_end(self, response, *, run_id, **kwargs):
         # type: (SentryLangchainCallback, LLMResult, UUID, Any) -> Any
@@ -461,7 +454,9 @@ def _wrap_configure(f):
             if not already_added:
                 new_callbacks.append(
                     SentryLangchainCallback(
-                        integration.max_spans, integration.include_prompts
+                        integration.max_spans,
+                        integration.include_prompts,
+                        integration.tiktoken_encoding_name,
                     )
                 )
         return f(*args, **kwargs)

--- a/sentry_sdk/integrations/openai.py
+++ b/sentry_sdk/integrations/openai.py
@@ -197,7 +197,11 @@ def _wrap_chat_completion_create(f):
                                     span, SPANDATA.AI_RESPONSES, all_responses
                                 )
                             _calculate_chat_completion_usage(
-                                messages, res, span, all_responses
+                                messages,
+                                res,
+                                span,
+                                all_responses,
+                                integration.count_tokens,
                             )
                     span.__exit__(None, None, None)
 

--- a/tests/integrations/langchain/test_langchain.py
+++ b/tests/integrations/langchain/test_langchain.py
@@ -46,6 +46,15 @@ class MockOpenAI(ChatOpenAI):
         return llm_type
 
 
+def tiktoken_encoding_if_installed():
+    try:
+        import tiktoken  # type: ignore # noqa # pylint: disable=unused-import
+
+        return "cl100k_base"
+    except ImportError:
+        return None
+
+
 @pytest.mark.parametrize(
     "send_default_pii, include_prompts, use_unknown_llm_type",
     [
@@ -62,7 +71,12 @@ def test_langchain_agent(
     llm_type = "acme-llm" if use_unknown_llm_type else "openai-chat"
 
     sentry_init(
-        integrations=[LangchainIntegration(include_prompts=include_prompts)],
+        integrations=[
+            LangchainIntegration(
+                include_prompts=include_prompts,
+                tiktoken_encoding_name=tiktoken_encoding_if_installed(),
+            )
+        ],
         traces_sample_rate=1.0,
         send_default_pii=send_default_pii,
     )

--- a/tests/integrations/openai/test_openai.py
+++ b/tests/integrations/openai/test_openai.py
@@ -78,6 +78,15 @@ def test_nonstreaming_chat_completion(
     assert span["measurements"]["ai_total_tokens_used"]["value"] == 30
 
 
+def tiktoken_encoding_if_installed():
+    try:
+        import tiktoken  # type: ignore # noqa # pylint: disable=unused-import
+
+        return "cl100k_base"
+    except ImportError:
+        return None
+
+
 # noinspection PyTypeChecker
 @pytest.mark.parametrize(
     "send_default_pii, include_prompts",
@@ -87,7 +96,12 @@ def test_streaming_chat_completion(
     sentry_init, capture_events, send_default_pii, include_prompts
 ):
     sentry_init(
-        integrations=[OpenAIIntegration(include_prompts=include_prompts)],
+        integrations=[
+            OpenAIIntegration(
+                include_prompts=include_prompts,
+                tiktoken_encoding_name=tiktoken_encoding_if_installed(),
+            )
+        ],
         traces_sample_rate=1.0,
         send_default_pii=send_default_pii,
     )


### PR DESCRIPTION
Tiktoken encodings sometimes make network requests, or do other stateful things. We can't guarantee what happens when you call tiktoken, so let's make it explicitly opt-in to users.

---

## General Notes

Thank you for contributing to `sentry-python`!

Please add tests to validate your changes, and lint your code using `tox -e linters`.

Running the test suite on your PR might require maintainer approval. Some tests (AWS Lambda) additionally require a maintainer to add a special label to run and will fail if the label is not present.

#### For maintainers

Sensitive test suites require maintainer review to ensure that tests do not compromise our secrets. This review must be repeated after any code revisions.

Before running sensitive test suites, please carefully check the PR. Then, apply the `Trigger: tests using secrets` label. The label will be removed after any code changes to enforce our policy requiring maintainers to review all code revisions before running sensitive tests.
