### PR TITLE
feat(pymongo): Set MongoDB tags directly on span data

### DIFF
--- a/sentry_sdk/integrations/pymongo.py
+++ b/sentry_sdk/integrations/pymongo.py
@@ -162,7 +162,7 @@ class CommandTracer(monitoring.CommandListener):
             )
 
             for tag, value in tags.items():
-                span.set_tag(tag, value)
+                span.set_data(tag, value)
 
             for key, value in data.items():
                 span.set_data(key, value)

--- a/sentry_sdk/integrations/pymongo.py
+++ b/sentry_sdk/integrations/pymongo.py
@@ -162,6 +162,7 @@ class CommandTracer(monitoring.CommandListener):
             )
 
             for tag, value in tags.items():
+                span.set_tag(tag, value)
                 span.set_data(tag, value)
 
             for key, value in data.items():

--- a/sentry_sdk/integrations/pymongo.py
+++ b/sentry_sdk/integrations/pymongo.py
@@ -162,7 +162,10 @@ class CommandTracer(monitoring.CommandListener):
             )
 
             for tag, value in tags.items():
+                # set the tag for backwards-compatibility.
+                # TODO: remove the set_tag call in the next major release!
                 span.set_tag(tag, value)
+
                 span.set_data(tag, value)
 
             for key, value in data.items():

--- a/tests/integrations/pymongo/test_pymongo.py
+++ b/tests/integrations/pymongo/test_pymongo.py
@@ -61,23 +61,23 @@ def test_transactions(sentry_init, capture_events, mongo_server, with_pii):
         assert span["data"][SPANDATA.SERVER_ADDRESS] == "localhost"
         assert span["data"][SPANDATA.SERVER_PORT] == mongo_server.port
         for field, value in common_tags.items():
-            assert span["tags"][field] == value
+            assert span["data"][field] == value
 
     assert find["op"] == "db"
     assert insert_success["op"] == "db"
     assert insert_fail["op"] == "db"
 
-    assert find["tags"]["db.operation"] == "find"
-    assert insert_success["tags"]["db.operation"] == "insert"
-    assert insert_fail["tags"]["db.operation"] == "insert"
+    assert find["data"]["db.operation"] == "find"
+    assert insert_success["data"]["db.operation"] == "insert"
+    assert insert_fail["data"]["db.operation"] == "insert"
 
     assert find["description"].startswith("{'find")
     assert insert_success["description"].startswith("{'insert")
     assert insert_fail["description"].startswith("{'insert")
 
-    assert find["tags"][SPANDATA.DB_MONGODB_COLLECTION] == "test_collection"
-    assert insert_success["tags"][SPANDATA.DB_MONGODB_COLLECTION] == "test_collection"
-    assert insert_fail["tags"][SPANDATA.DB_MONGODB_COLLECTION] == "erroneous"
+    assert find["data"][SPANDATA.DB_MONGODB_COLLECTION] == "test_collection"
+    assert insert_success["data"][SPANDATA.DB_MONGODB_COLLECTION] == "test_collection"
+    assert insert_fail["data"][SPANDATA.DB_MONGODB_COLLECTION] == "erroneous"
     if with_pii:
         assert "1" in find["description"]
         assert "2" in insert_success["description"]

--- a/tests/integrations/pymongo/test_pymongo.py
+++ b/tests/integrations/pymongo/test_pymongo.py
@@ -49,7 +49,7 @@ def test_transactions(sentry_init, capture_events, mongo_server, with_pii):
     (event,) = events
     (find, insert_success, insert_fail) = event["spans"]
 
-    common_tags = {
+    common_data = {
         "db.name": "test_db",
         "db.system": "mongodb",
         "net.peer.name": mongo_server.host,
@@ -60,7 +60,7 @@ def test_transactions(sentry_init, capture_events, mongo_server, with_pii):
         assert span["data"][SPANDATA.DB_NAME] == "test_db"
         assert span["data"][SPANDATA.SERVER_ADDRESS] == "localhost"
         assert span["data"][SPANDATA.SERVER_PORT] == mongo_server.port
-        for field, value in common_tags.items():
+        for field, value in common_data.items():
             assert span["data"][field] == value
 
     assert find["op"] == "db"

--- a/tests/integrations/pymongo/test_pymongo.py
+++ b/tests/integrations/pymongo/test_pymongo.py
@@ -49,7 +49,7 @@ def test_transactions(sentry_init, capture_events, mongo_server, with_pii):
     (event,) = events
     (find, insert_success, insert_fail) = event["spans"]
 
-    common_data = {
+    common_tags = {
         "db.name": "test_db",
         "db.system": "mongodb",
         "net.peer.name": mongo_server.host,
@@ -60,7 +60,8 @@ def test_transactions(sentry_init, capture_events, mongo_server, with_pii):
         assert span["data"][SPANDATA.DB_NAME] == "test_db"
         assert span["data"][SPANDATA.SERVER_ADDRESS] == "localhost"
         assert span["data"][SPANDATA.SERVER_PORT] == mongo_server.port
-        for field, value in common_data.items():
+        for field, value in common_tags.items():
+            assert span["tags"][field] == value
             assert span["data"][field] == value
 
     assert find["op"] == "db"

--- a/tests/integrations/pymongo/test_pymongo.py
+++ b/tests/integrations/pymongo/test_pymongo.py
@@ -69,16 +69,22 @@ def test_transactions(sentry_init, capture_events, mongo_server, with_pii):
     assert insert_fail["op"] == "db"
 
     assert find["data"]["db.operation"] == "find"
+    assert find["tags"]["db.operation"] == "find"
     assert insert_success["data"]["db.operation"] == "insert"
+    assert insert_success["tags"]["db.operation"] == "insert"
     assert insert_fail["data"]["db.operation"] == "insert"
+    assert insert_fail["tags"]["db.operation"] == "insert"
 
     assert find["description"].startswith("{'find")
     assert insert_success["description"].startswith("{'insert")
     assert insert_fail["description"].startswith("{'insert")
 
     assert find["data"][SPANDATA.DB_MONGODB_COLLECTION] == "test_collection"
+    assert find["tags"][SPANDATA.DB_MONGODB_COLLECTION] == "test_collection"
     assert insert_success["data"][SPANDATA.DB_MONGODB_COLLECTION] == "test_collection"
+    assert insert_success["tags"][SPANDATA.DB_MONGODB_COLLECTION] == "test_collection"
     assert insert_fail["data"][SPANDATA.DB_MONGODB_COLLECTION] == "erroneous"
+    assert insert_fail["tags"][SPANDATA.DB_MONGODB_COLLECTION] == "erroneous"
     if with_pii:
         assert "1" in find["description"]
         assert "2" in insert_success["description"]


### PR DESCRIPTION
Another PR to iron out some inconsistencies between the Python and Node SDKs. OTel attaches MongoDB tags directly on the span data, rather than in the `tags` databag. This change is necessary so that Relay can parse MongoDB spans in Python for metrics extraction.

### Node SDK Spans:
Relevant MongoDB data is set directly as span data
![image](https://github.com/user-attachments/assets/9f066e02-d31f-41be-99c8-957c39847c8d)

### Python SDK Spans:
Relevant MongoDB data is set in the `tags` databag
![image](https://github.com/user-attachments/assets/212b51bc-8c53-4ecd-89dc-80f70c7dc51c)
