### PR TITLE
feat(pymongo): Send query description as valid JSON

### DIFF
--- a/sentry_sdk/integrations/pymongo.py
+++ b/sentry_sdk/integrations/pymongo.py
@@ -155,7 +155,7 @@ class CommandTracer(monitoring.CommandListener):
             if not should_send_default_pii():
                 command = _strip_pii(command)
 
-            query = json.dumps(command)
+            query = json.dumps(command, default=str)
             span = sentry_sdk.start_span(
                 op=OP.DB,
                 description=query,

--- a/sentry_sdk/integrations/pymongo.py
+++ b/sentry_sdk/integrations/pymongo.py
@@ -1,4 +1,5 @@
 import copy
+import json
 
 import sentry_sdk
 from sentry_sdk.consts import SPANSTATUS, SPANDATA, OP
@@ -154,7 +155,7 @@ class CommandTracer(monitoring.CommandListener):
             if not should_send_default_pii():
                 command = _strip_pii(command)
 
-            query = "{}".format(command)
+            query = json.dumps(command)
             span = sentry_sdk.start_span(
                 op=OP.DB,
                 description=query,

--- a/tests/integrations/pymongo/test_pymongo.py
+++ b/tests/integrations/pymongo/test_pymongo.py
@@ -71,9 +71,9 @@ def test_transactions(sentry_init, capture_events, mongo_server, with_pii):
     assert insert_success["tags"]["db.operation"] == "insert"
     assert insert_fail["tags"]["db.operation"] == "insert"
 
-    assert find["description"].startswith("{'find")
-    assert insert_success["description"].startswith("{'insert")
-    assert insert_fail["description"].startswith("{'insert")
+    assert find["description"].startswith('{"find')
+    assert insert_success["description"].startswith('{"insert')
+    assert insert_fail["description"].startswith('{"insert')
 
     assert find["tags"][SPANDATA.DB_MONGODB_COLLECTION] == "test_collection"
     assert insert_success["tags"][SPANDATA.DB_MONGODB_COLLECTION] == "test_collection"
@@ -117,7 +117,7 @@ def test_breadcrumbs(sentry_init, capture_events, mongo_server, with_pii):
     (crumb,) = event["breadcrumbs"]["values"]
 
     assert crumb["category"] == "query"
-    assert crumb["message"].startswith("{'find")
+    assert crumb["message"].startswith('{"find')
     if with_pii:
         assert "1" in crumb["message"]
     else:


### PR DESCRIPTION
MongoDB queries were being sent as invalid JSON, since the keys and values were surrounded by single quotes instead of double quotes. Relay cannot parse the queries unless they are sent as valid JSON. This PR converts MongoDB queries into a JSON string before sending it on the span, so that Relay may properly parse it and extract metrics.


### Before
<img width="922" alt="image" src="https://github.com/user-attachments/assets/e6d7154b-91ab-4f8d-b27b-97602e665f0b">

### After
<img width="918" alt="image" src="https://github.com/user-attachments/assets/070f2d1f-e929-45c9-a9c2-a2075d1e2a02">
