### PR TITLE
feat(strawberry): Use operation name as transaction name

### DIFF
--- a/sentry_sdk/integrations/strawberry.py
+++ b/sentry_sdk/integrations/strawberry.py
@@ -182,8 +182,9 @@ class SentryAsyncExtension(SchemaExtension):  # type: ignore
         if span:
             if self._operation_name:
                 transaction = span.containing_transaction
-                transaction.name = self._operation_name
-                transaction.source = TRANSACTION_SOURCE_COMPONENT
+                if transaction:
+                    transaction.name = self._operation_name
+                    transaction.source = TRANSACTION_SOURCE_COMPONENT
 
             self.graphql_span = span.start_child(
                 op=op,

--- a/sentry_sdk/integrations/strawberry.py
+++ b/sentry_sdk/integrations/strawberry.py
@@ -199,9 +199,18 @@ class SentryAsyncExtension(SchemaExtension):  # type: ignore
         yield
 
         transaction = self.graphql_span.containing_transaction
-        if transaction and self.execution_context.operation_name:
-            transaction.name = self.execution_context.operation_name
-            transaction.source = TRANSACTION_SOURCE_COMPONENT
+        if transaction:
+            if self.execution_context.operation_name:
+                transaction.name = self.execution_context.operation_name
+                transaction.source = TRANSACTION_SOURCE_COMPONENT
+            if operation_type:
+                op = {
+                    "query": OP.GRAPHQL_QUERY,
+                    "mutation": OP.GRAPHQL_MUTATION,
+                    "subscription": OP.GRAPHQL_SUBSCRIPTION,
+                }.get(operation_type)
+                if op is not None:
+                    transaction.op = op
 
         self.graphql_span.finish()
 

--- a/sentry_sdk/integrations/strawberry.py
+++ b/sentry_sdk/integrations/strawberry.py
@@ -199,11 +199,10 @@ class SentryAsyncExtension(SchemaExtension):  # type: ignore
         yield
 
         transaction = self.graphql_span.containing_transaction
-        if transaction:
-            if self.execution_context.operation_name:
-                transaction.name = self.execution_context.operation_name
-                transaction.source = TRANSACTION_SOURCE_COMPONENT
-                transaction.op = op
+        if transaction and self.execution_context.operation_name:
+            transaction.name = self.execution_context.operation_name
+            transaction.source = TRANSACTION_SOURCE_COMPONENT
+            transaction.op = op
 
         self.graphql_span.finish()
 

--- a/sentry_sdk/integrations/strawberry.py
+++ b/sentry_sdk/integrations/strawberry.py
@@ -203,14 +203,7 @@ class SentryAsyncExtension(SchemaExtension):  # type: ignore
             if self.execution_context.operation_name:
                 transaction.name = self.execution_context.operation_name
                 transaction.source = TRANSACTION_SOURCE_COMPONENT
-            if operation_type:
-                op = {
-                    "query": OP.GRAPHQL_QUERY,
-                    "mutation": OP.GRAPHQL_MUTATION,
-                    "subscription": OP.GRAPHQL_SUBSCRIPTION,
-                }.get(operation_type)
-                if op is not None:
-                    transaction.op = op
+                transaction.op = op
 
         self.graphql_span.finish()
 

--- a/tests/integrations/strawberry/test_strawberry.py
+++ b/tests/integrations/strawberry/test_strawberry.py
@@ -325,6 +325,7 @@ def test_capture_transaction_on_error(
     (_, transaction_event) = events
 
     assert transaction_event["transaction"] == "ErrorQuery"
+    assert transaction_event["contexts"]["trace"]["op"] == OP.GRAPHQL_QUERY
     assert transaction_event["spans"]
 
     query_spans = [
@@ -401,6 +402,7 @@ def test_capture_transaction_on_success(
     (transaction_event,) = events
 
     assert transaction_event["transaction"] == "GreetingQuery"
+    assert transaction_event["contexts"]["trace"]["op"] == OP.GRAPHQL_QUERY
     assert transaction_event["spans"]
 
     query_spans = [
@@ -557,6 +559,7 @@ def test_transaction_mutation(
     (transaction_event,) = events
 
     assert transaction_event["transaction"] == "Change"
+    assert transaction_event["contexts"]["trace"]["op"] == OP.GRAPHQL_MUTATION
     assert transaction_event["spans"]
 
     query_spans = [

--- a/tests/integrations/strawberry/test_strawberry.py
+++ b/tests/integrations/strawberry/test_strawberry.py
@@ -324,11 +324,7 @@ def test_capture_transaction_on_error(
     assert len(events) == 2
     (_, transaction_event) = events
 
-    if async_execution:
-        assert transaction_event["transaction"] == "/graphql"
-    else:
-        assert transaction_event["transaction"] == "graphql_view"
-
+    assert transaction_event["transaction"] == "ErrorQuery"
     assert transaction_event["spans"]
 
     query_spans = [
@@ -404,11 +400,7 @@ def test_capture_transaction_on_success(
     assert len(events) == 1
     (transaction_event,) = events
 
-    if async_execution:
-        assert transaction_event["transaction"] == "/graphql"
-    else:
-        assert transaction_event["transaction"] == "graphql_view"
-
+    assert transaction_event["transaction"] == "GreetingQuery"
     assert transaction_event["spans"]
 
     query_spans = [
@@ -564,11 +556,7 @@ def test_transaction_mutation(
     assert len(events) == 1
     (transaction_event,) = events
 
-    if async_execution:
-        assert transaction_event["transaction"] == "/graphql"
-    else:
-        assert transaction_event["transaction"] == "graphql_view"
-
+    assert transaction_event["transaction"] == "Change"
     assert transaction_event["spans"]
 
     query_spans = [


### PR DESCRIPTION
The Strawberry integration is creating spans at the moment, but they're all grouped under the same `/graphql` transaction coming from the web framework integration. This has significant effect on the usefulness of tracing.

In this PR, we use the operation name to update the name of the transaction so that each unique operation becomes its own event group.

Closes https://github.com/getsentry/sentry-python/issues/3285