### PR TITLE
ref(scope): Remove apparently unnecessary `if`

### DIFF
--- a/sentry_sdk/scope.py
+++ b/sentry_sdk/scope.py
@@ -1031,9 +1031,8 @@ class Scope(object):
 
             transaction._profile = profile
 
-        # we don't bother to keep spans if we already know we're not going to
-        # send the transaction
-        if transaction.sampled:
+            # we don't bother to keep spans if we already know we're not going to
+            # send the transaction
             max_spans = (client.options["_experiments"].get("max_spans")) or 1000
             transaction.init_span_recorder(maxlen=max_spans)
 


### PR DESCRIPTION
The removed `if` statement is identical to the `if` statement immediately before. It does not seem that the code before the second `if` can modify `transaction.sampled`, so it should be safe to combine the two `if` blocks into a single block under the first `if` statement.