### PR TITLE
ref(logging): Lower logger level for some messages

### DIFF
--- a/sentry_sdk/tracing.py
+++ b/sentry_sdk/tracing.py
@@ -806,7 +806,7 @@ class Transaction(Span):
     def __enter__(self):
         # type: () -> Transaction
         if not self._possibly_started():
-            logger.warning(
+            logger.debug(
                 "Transaction was entered without being started with sentry_sdk.start_transaction."
                 "The transaction will not be sent to Sentry. To fix, start the transaction by"
                 "passing it to sentry_sdk.start_transaction."

--- a/sentry_sdk/tracing_utils.py
+++ b/sentry_sdk/tracing_utils.py
@@ -637,8 +637,8 @@ def start_child_span_decorator(func):
             span = get_current_span()
 
             if span is None:
-                logger.warning(
-                    "Can not create a child span for %s. "
+                logger.debug(
+                    "Cannot create a child span for %s. "
                     "Please start a Sentry transaction before calling this function.",
                     qualname_from_function(func),
                 )
@@ -665,8 +665,8 @@ def start_child_span_decorator(func):
             span = get_current_span()
 
             if span is None:
-                logger.warning(
-                    "Can not create a child span for %s. "
+                logger.debug(
+                    "Cannot create a child span for %s. "
                     "Please start a Sentry transaction before calling this function.",
                     qualname_from_function(func),
                 )

--- a/tests/tracing/test_decorator.py
+++ b/tests/tracing/test_decorator.py
@@ -33,13 +33,13 @@ def test_trace_decorator():
 
 def test_trace_decorator_no_trx():
     with patch_start_tracing_child(fake_transaction_is_none=True):
-        with mock.patch.object(logger, "debug", mock.Mock()) as fake_warning:
+        with mock.patch.object(logger, "debug", mock.Mock()) as fake_debug:
             result = my_example_function()
-            fake_warning.assert_not_called()
+            fake_debug.assert_not_called()
             assert result == "return_of_sync_function"
 
             result2 = start_child_span_decorator(my_example_function)()
-            fake_warning.assert_called_once_with(
+            fake_debug.assert_called_once_with(
                 "Cannot create a child span for %s. "
                 "Please start a Sentry transaction before calling this function.",
                 "test_decorator.my_example_function",
@@ -66,13 +66,13 @@ async def test_trace_decorator_async():
 @pytest.mark.asyncio
 async def test_trace_decorator_async_no_trx():
     with patch_start_tracing_child(fake_transaction_is_none=True):
-        with mock.patch.object(logger, "debug", mock.Mock()) as fake_warning:
+        with mock.patch.object(logger, "debug", mock.Mock()) as fake_debug:
             result = await my_async_example_function()
-            fake_warning.assert_not_called()
+            fake_debug.assert_not_called()
             assert result == "return_of_async_function"
 
             result2 = await start_child_span_decorator(my_async_example_function)()
-            fake_warning.assert_called_once_with(
+            fake_debug.assert_called_once_with(
                 "Cannot create a child span for %s. "
                 "Please start a Sentry transaction before calling this function.",
                 "test_decorator.my_async_example_function",

--- a/tests/tracing/test_decorator.py
+++ b/tests/tracing/test_decorator.py
@@ -33,14 +33,14 @@ def test_trace_decorator():
 
 def test_trace_decorator_no_trx():
     with patch_start_tracing_child(fake_transaction_is_none=True):
-        with mock.patch.object(logger, "warning", mock.Mock()) as fake_warning:
+        with mock.patch.object(logger, "debug", mock.Mock()) as fake_warning:
             result = my_example_function()
             fake_warning.assert_not_called()
             assert result == "return_of_sync_function"
 
             result2 = start_child_span_decorator(my_example_function)()
             fake_warning.assert_called_once_with(
-                "Can not create a child span for %s. "
+                "Cannot create a child span for %s. "
                 "Please start a Sentry transaction before calling this function.",
                 "test_decorator.my_example_function",
             )
@@ -66,14 +66,14 @@ async def test_trace_decorator_async():
 @pytest.mark.asyncio
 async def test_trace_decorator_async_no_trx():
     with patch_start_tracing_child(fake_transaction_is_none=True):
-        with mock.patch.object(logger, "warning", mock.Mock()) as fake_warning:
+        with mock.patch.object(logger, "debug", mock.Mock()) as fake_warning:
             result = await my_async_example_function()
             fake_warning.assert_not_called()
             assert result == "return_of_async_function"
 
             result2 = await start_child_span_decorator(my_async_example_function)()
             fake_warning.assert_called_once_with(
-                "Can not create a child span for %s. "
+                "Cannot create a child span for %s. "
                 "Please start a Sentry transaction before calling this function.",
                 "test_decorator.my_async_example_function",
             )

--- a/tests/tracing/test_misc.py
+++ b/tests/tracing/test_misc.py
@@ -412,7 +412,7 @@ def test_transaction_not_started_warning(sentry_init):
         with tx:
             pass
 
-    mock_logger.warning.assert_any_call(
+    mock_logger.debug.assert_any_call(
         "Transaction was entered without being started with sentry_sdk.start_transaction."
         "The transaction will not be sent to Sentry. To fix, start the transaction by"
         "passing it to sentry_sdk.start_transaction."


### PR DESCRIPTION
These messages might blow up in volume, as we've observed ourselves in Sentry. This might end up clogging up users' logs and increasing their spending.

WIP: look at if there's more cases where it makes sense to lower the log level