### PR TITLE
feat: Deprecate `instrumenter` option

### DIFF
--- a/sentry_sdk/client.py
+++ b/sentry_sdk/client.py
@@ -2,6 +2,7 @@ import os
 import uuid
 import random
 import socket
+import warnings
 from collections.abc import Mapping
 from datetime import datetime, timezone
 from importlib import import_module
@@ -115,6 +116,12 @@ def _get_options(*args, **kwargs):
 
     if rv["instrumenter"] is None:
         rv["instrumenter"] = INSTRUMENTER.SENTRY
+    else:
+        warnings.warn(
+            "The `instrumenter` option will be removed in the next major version.",
+            DeprecationWarning,
+            stacklevel=3,
+        )
 
     if rv["project_root"] is None:
         try:

--- a/sentry_sdk/consts.py
+++ b/sentry_sdk/consts.py
@@ -518,7 +518,7 @@ class ClientConstructor:
         send_client_reports=True,  # type: bool
         _experiments={},  # type: Experiments  # noqa: B006
         proxy_headers=None,  # type: Optional[Dict[str, str]]
-        instrumenter=INSTRUMENTER.SENTRY,  # type: Optional[str]
+        instrumenter=None,  # type: Optional[str]
         before_send_transaction=None,  # type: Optional[TransactionProcessor]
         project_root=None,  # type: Optional[str]
         enable_tracing=None,  # type: Optional[bool]

--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -839,3 +839,8 @@ def test_last_event_id_scope(sentry_init):
     # Should not crash
     with isolation_scope() as scope:
         assert scope.last_event_id() is None
+
+
+def test_instrumenter_deprecation_warning(sentry_init):
+    with pytest.warns(DeprecationWarning):
+        sentry_init(instrumenter="blahblahblah")


### PR DESCRIPTION
This PR deprecates the `instrumenter` option. It should be merged in the final 2.x minor/patch release, as we plan to remove the option completely in 3.0.0.

Closes [#3320](https://github.com/getsentry/sentry-python/issues/3320)
