### PR TITLE
meta: Allow blank GitHub issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,4 +1,4 @@
-blank_issues_enabled: false
+blank_issues_enabled: true
 contact_links:
   - name: Support Request
     url: https://sentry.io/support


### PR DESCRIPTION
With the sub-issues beta, it appears that I am no longer able to open blank issues by manually editing the URL to https://github.com/getsentry/sentry-python/issues/new.

While users should, of course, be encouraged to use one of the templates, blank issues are often quite helpful for internal purposes. For example, in my experience with the Sentry CLI repo where blank issues are enabled, very few (perhaps none) of the issues from external users that I have triaged have been blank issues.