### PR TITLE
Make Django db spans have origin `auto.db.django`

### DIFF
--- a/sentry_sdk/integrations/django/__init__.py
+++ b/sentry_sdk/integrations/django/__init__.py
@@ -116,6 +116,7 @@ class DjangoIntegration(Integration):
 
     identifier = "django"
     origin = f"auto.http.{identifier}"
+    origin_db = f"auto.db.{identifier}"
 
     transaction_style = ""
     middleware_spans = None
@@ -630,7 +631,7 @@ def install_sql_hook():
             params_list=params,
             paramstyle="format",
             executemany=False,
-            span_origin=DjangoIntegration.origin,
+            span_origin=DjangoIntegration.origin_db,
         ) as span:
             _set_db_data(span, self)
             options = (
@@ -663,7 +664,7 @@ def install_sql_hook():
             params_list=param_list,
             paramstyle="format",
             executemany=True,
-            span_origin=DjangoIntegration.origin,
+            span_origin=DjangoIntegration.origin_db,
         ) as span:
             _set_db_data(span, self)
 
@@ -683,7 +684,7 @@ def install_sql_hook():
         with sentry_sdk.start_span(
             op=OP.DB,
             description="connect",
-            origin=DjangoIntegration.origin,
+            origin=DjangoIntegration.origin_db,
         ) as span:
             _set_db_data(span, self)
             return real_connect(self)

--- a/tests/integrations/django/test_db_query_data.py
+++ b/tests/integrations/django/test_db_query_data.py
@@ -481,7 +481,10 @@ def test_db_span_origin_execute(sentry_init, client, capture_events):
     assert event["contexts"]["trace"]["origin"] == "auto.http.django"
 
     for span in event["spans"]:
-        assert span["origin"] == "auto.http.django"
+        if span["op"] == "db":
+            assert span["origin"] == "auto.db.django"
+        else:
+            assert span["origin"] == "auto.http.django"
 
 
 @pytest.mark.forked
@@ -520,4 +523,4 @@ def test_db_span_origin_executemany(sentry_init, client, capture_events):
     (event,) = events
 
     assert event["contexts"]["trace"]["origin"] == "manual"
-    assert event["spans"][0]["origin"] == "auto.http.django"
+    assert event["spans"][0]["origin"] == "auto.db.django"


### PR DESCRIPTION

<!-- Describe your PR here -->

---

## General Notes

Thank you for contributing to `sentry-python`!

Please add tests to validate your changes, and lint your code using `tox -e linters`.

Running the test suite on your PR might require maintainer approval. Some tests (AWS Lambda) additionally require a maintainer to add a special label to run and will fail if the label is not present.

#### For maintainers

Sensitive test suites require maintainer review to ensure that tests do not compromise our secrets. This review must be repeated after any code revisions.

Before running sensitive test suites, please carefully check the PR. Then, apply the `Trigger: tests using secrets` label. The label will be removed after any code changes to enforce our policy requiring maintainers to review all code revisions before running sensitive tests.
