### PR TITLE
ci: dependency review action

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,19 @@
+name: 'Dependency Review'
+on:
+  pull_request:
+    branches: ['master']
+
+permissions:
+  contents: read
+
+jobs:
+  dependency-review:
+    runs-on: ubuntu-latest
+    steps:
+      - name: 'Checkout Repository'
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+      - name: Dependency Review
+        uses: actions/dependency-review-action@5a2ce3f5b92ee19cbb1541a4984c76d921601d7c # v4.3.4
+        with:
+          # Possible values: "critical", "high", "moderate", "low"
+          fail-on-severity: high


### PR DESCRIPTION
Add dependency review action. 

Any new dependencies added that have a known high or critical vulnerability will fail CI.