### PR TITLE
docs(attachment): Document attachment parameters

### DIFF
--- a/sentry_sdk/attachments.py
+++ b/sentry_sdk/attachments.py
@@ -9,6 +9,25 @@ if TYPE_CHECKING:
 
 
 class Attachment:
+    """Additional files/data to send along with an event.
+
+    This class stores attachments that can be sent along with an event. Attachments are files or other data, e.g.
+    config or log files, that are relevant to an event. Attachments are set on the ``Scope``, and are sent along with
+    all non-transaction events (or all events including transactions if ``add_to_transactions`` is ``True``) that are
+    captured within the ``Scope``.
+
+    To add an attachment to a ``Scope``, use :py:meth:`sentry_sdk.Scope.add_attachment`. The parameters for
+    ``add_attachment`` are the same as the parameters for this class's constructor.
+
+    :param bytes: Raw bytes of the attachment, or a function that returns the raw bytes. Must be provided unless
+                  ``path`` is provided.
+    :param filename: The filename of the attachment. Must be provided unless ``path`` is provided.
+    :param path: Path to a file to attach. Must be provided unless ``bytes`` is provided.
+    :param content_type: The content type of the attachment. If not provided, it will be guessed from the ``filename``
+                         parameter, if available, or the ``path`` parameter if ``filename`` is ``None``.
+    :param add_to_transactions: Whether to add this attachment to transactions. Defaults to ``False``.
+    """
+
     def __init__(
         self,
         bytes=None,  # type: Union[None, bytes, Callable[[], bytes]]

--- a/sentry_sdk/scope.py
+++ b/sentry_sdk/scope.py
@@ -893,7 +893,7 @@ class Scope(object):
 
     def add_attachment(
         self,
-        bytes=None,  # type: Optional[bytes]
+        bytes=None,  # type: Union[None, bytes, Callable[[], bytes]]
         filename=None,  # type: Optional[str]
         path=None,  # type: Optional[str]
         content_type=None,  # type: Optional[str]

--- a/sentry_sdk/scope.py
+++ b/sentry_sdk/scope.py
@@ -900,7 +900,10 @@ class Scope(object):
         add_to_transactions=False,  # type: bool
     ):
         # type: (...) -> None
-        """Adds an attachment to future events sent."""
+        """Adds an attachment to future events sent from this scope.
+
+        The parameters are the same as for the :py:class:`sentry_sdk.attachments.Attachment` constructor.
+        """
         self._attachments.append(
             Attachment(
                 bytes=bytes,


### PR DESCRIPTION
Document parameters to `sentry_sdk.Scope.add_attachment` and `sentry_sdk.attachments.Attachment`.

Also, update `add_attachment`'s type hint to match the `Attachment` constructor's hint.

Fixes: #3340
Related: getsentry/sentry-docs#10844