### PR TITLE
test(client): Avoid `configure_scope`

### DIFF
--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -686,14 +686,13 @@ def test_cyclic_data(sentry_init, capture_events):
     sentry_init()
     events = capture_events()
 
-    with configure_scope() as scope:
-        data = {}
-        data["is_cyclic"] = data
+    data = {}
+    data["is_cyclic"] = data
 
-        other_data = ""
-        data["not_cyclic"] = other_data
-        data["not_cyclic2"] = other_data
-        scope.set_extra("foo", data)
+    other_data = ""
+    data["not_cyclic"] = other_data
+    data["not_cyclic2"] = other_data
+    sentry_sdk.Scope.get_isolation_scope().set_extra("foo", data)
 
     capture_message("hi")
     (event,) = events


### PR DESCRIPTION
Replace the only `configure_scope` usage in `test_client.py`, which
can be replaced without defeating the test's purpose, with
`Scope.get_isolation_scope`. The other `configure_scope` calls are
made either from a test which specifically tests `configure_scope`
or from a test which is always skipped.

Closes: #3344
