### PR TITLE
fix(api): `configure_scope` deprecation warning

### DIFF
--- a/sentry_sdk/api.py
+++ b/sentry_sdk/api.py
@@ -1,4 +1,5 @@
 import inspect
+import warnings
 from contextlib import contextmanager
 
 from sentry_sdk import tracing_utils, Client
@@ -185,6 +186,14 @@ def configure_scope(  # noqa: F811
 
     :returns: If no callback is provided, returns a context manager that returns the scope.
     """
+    warnings.warn(
+        "sentry_sdk.configure_scope is deprecated and will be removed in the next major version. "
+        "Please consult our migration guide to learn how to migrate to the new API: "
+        "https://docs.sentry.io/platforms/python/migration/1.x-to-2.x#scope-configuring",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+
     scope = Scope.get_isolation_scope()
     scope.generate_propagation_context()
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -11,6 +11,7 @@ from sentry_sdk import (
     is_initialized,
     start_transaction,
     set_tags,
+    configure_scope,
 )
 
 from sentry_sdk.client import Client, NonRecordingClient
@@ -179,3 +180,9 @@ def test_set_tags(sentry_init, capture_events):
         "tag2": "updated",
         "tag3": "new",
     }, "Updating tags with empty dict changed tags"
+
+
+def test_configure_scope_deprecation():
+    with pytest.warns(DeprecationWarning):
+        with configure_scope():
+            ...

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -570,7 +570,9 @@ def test_atexit(tmpdir, monkeypatch, num_messages):
     assert output.count(b"HI") == num_messages
 
 
-def test_configure_scope_available(sentry_init, request, monkeypatch):
+def test_configure_scope_available(
+    sentry_init, request, monkeypatch, suppress_deprecation_warnings
+):
     """
     Test that scope is configured if client is configured
 


### PR DESCRIPTION
Although `configure_scope` was meant to be deprecated since Sentry
SDK 2.0.0, calling `configure_scope` did not raise a deprecation
warning. Now, it does.

Fixes #3346
