### PR TITLE
test(sessions): Replace `push_scope`

### DIFF
--- a/sentry_sdk/api.py
+++ b/sentry_sdk/api.py
@@ -1,4 +1,5 @@
 import inspect
+import warnings
 from contextlib import contextmanager
 
 from sentry_sdk import tracing_utils, Client
@@ -185,6 +186,14 @@ def configure_scope(  # noqa: F811
 
     :returns: If no callback is provided, returns a context manager that returns the scope.
     """
+    warnings.warn(
+        "sentry_sdk.configure_scope is deprecated and will be removed in the next major version. "
+        "Please consult our migration guide to learn how to migrate to the new API: "
+        "https://docs.sentry.io/platforms/python/migration/1.x-to-2.x#scope-configuring",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+
     scope = Scope.get_isolation_scope()
     scope.generate_propagation_context()
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -11,6 +11,7 @@ from sentry_sdk import (
     is_initialized,
     start_transaction,
     set_tags,
+    configure_scope,
 )
 
 from sentry_sdk.client import Client, NonRecordingClient
@@ -179,3 +180,9 @@ def test_set_tags(sentry_init, capture_events):
         "tag2": "updated",
         "tag3": "new",
     }, "Updating tags with empty dict changed tags"
+
+
+def test_configure_scope_deprecation():
+    with pytest.warns(DeprecationWarning):
+        with configure_scope():
+            ...

--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -22,6 +22,7 @@ from sentry_sdk import (
     last_event_id,
     add_breadcrumb,
     isolation_scope,
+    new_scope,
     Hub,
     Scope,
 )
@@ -606,14 +607,14 @@ def test_scope_event_processor_order(sentry_init, capture_events):
     sentry_init(debug=True, before_send=before_send)
     events = capture_events()
 
-    with push_scope() as scope:
+    with new_scope() as scope:
 
         @scope.add_event_processor
         def foo(event, hint):
             event["message"] += "foo"
             return event
 
-        with push_scope() as scope:
+        with new_scope() as scope:
 
             @scope.add_event_processor
             def bar(event, hint):

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -570,7 +570,9 @@ def test_atexit(tmpdir, monkeypatch, num_messages):
     assert output.count(b"HI") == num_messages
 
 
-def test_configure_scope_available(sentry_init, request, monkeypatch):
+def test_configure_scope_available(
+    sentry_init, request, monkeypatch, suppress_deprecation_warnings
+):
     """
     Test that scope is configured if client is configured
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -686,14 +686,13 @@ def test_cyclic_data(sentry_init, capture_events):
     sentry_init()
     events = capture_events()
 
-    with configure_scope() as scope:
-        data = {}
-        data["is_cyclic"] = data
+    data = {}
+    data["is_cyclic"] = data
 
-        other_data = ""
-        data["not_cyclic"] = other_data
-        data["not_cyclic2"] = other_data
-        scope.set_extra("foo", data)
+    other_data = ""
+    data["not_cyclic"] = other_data
+    data["not_cyclic2"] = other_data
+    sentry_sdk.Scope.get_isolation_scope().set_extra("foo", data)
 
     capture_message("hi")
     (event,) = events

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -51,9 +51,8 @@ def test_aggregates(sentry_init, capture_envelopes):
     envelopes = capture_envelopes()
 
     with auto_session_tracking(session_mode="request"):
-        with sentry_sdk.push_scope():
+        with sentry_sdk.new_scope() as scope:
             try:
-                scope = sentry_sdk.Scope.get_current_scope()
                 scope.set_user({"id": "42"})
                 raise Exception("all is wrong")
             except Exception:
@@ -92,7 +91,7 @@ def test_aggregates_explicitly_disabled_session_tracking_request_mode(
     envelopes = capture_envelopes()
 
     with auto_session_tracking(session_mode="request"):
-        with sentry_sdk.push_scope():
+        with sentry_sdk.new_scope():
             try:
                 raise Exception("all is wrong")
             except Exception:
@@ -127,7 +126,7 @@ def test_no_thread_on_shutdown_no_errors(sentry_init):
         side_effect=RuntimeError("can't create new thread at interpreter shutdown"),
     ):
         with auto_session_tracking(session_mode="request"):
-            with sentry_sdk.push_scope():
+            with sentry_sdk.new_scope():
                 try:
                     raise Exception("all is wrong")
                 except Exception:


### PR DESCRIPTION
All usages of `sentry_sdk.push_scope` in `test_sessions.py` can be
replaced with `new_scope`.

Closes: #3345
