### PR TITLE
fix(api): `push_scope` deprecation warning

### DIFF
--- a/sentry_sdk/api.py
+++ b/sentry_sdk/api.py
@@ -238,9 +238,19 @@ def push_scope(  # noqa: F811
     :returns: If no `callback` is provided, a context manager that should
         be used to pop the scope again.
     """
+    warnings.warn(
+        "sentry_sdk.push_scope is deprecated and will be removed in the next major version. "
+        "Please consult our migration guide to learn how to migrate to the new API: "
+        "https://docs.sentry.io/platforms/python/migration/1.x-to-2.x#scope-pushing",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+
     if callback is not None:
-        with push_scope() as scope:
-            callback(scope)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            with push_scope() as scope:
+                callback(scope)
         return None
 
     return _ScopeManager()

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -12,6 +12,7 @@ from sentry_sdk import (
     start_transaction,
     set_tags,
     configure_scope,
+    push_scope,
 )
 
 from sentry_sdk.client import Client, NonRecordingClient
@@ -185,4 +186,10 @@ def test_set_tags(sentry_init, capture_events):
 def test_configure_scope_deprecation():
     with pytest.warns(DeprecationWarning):
         with configure_scope():
+            ...
+
+
+def test_push_scope_deprecation():
+    with pytest.warns(DeprecationWarning):
+        with push_scope():
             ...

--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -295,7 +295,7 @@ def test_breadcrumb_arguments(sentry_init, capture_events):
     add_breadcrumb(crumb=dict(foo=42))
 
 
-def test_push_scope(sentry_init, capture_events):
+def test_push_scope(sentry_init, capture_events, suppress_deprecation_warnings):
     sentry_init()
     events = capture_events()
 
@@ -312,7 +312,9 @@ def test_push_scope(sentry_init, capture_events):
     assert "exception" in event
 
 
-def test_push_scope_null_client(sentry_init, capture_events):
+def test_push_scope_null_client(
+    sentry_init, capture_events, suppress_deprecation_warnings
+):
     """
     This test can be removed when we remove push_scope and the Hub from the SDK.
     """


### PR DESCRIPTION
Although `push_scope` was meant to be deprecated since Sentry
SDK 2.0.0, calling `push_scope` did not raise a deprecation
warning. Now, it does.

Fixes #3347
