### PR TITLE
Updating our Celery tests

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -345,13 +345,13 @@ deps =
 
     # Celery
     celery: redis
-    celery-v4: Celery~=4.0
-    celery-v5.0: Celery~=5.0.0
-    celery-v5.1: Celery~=5.1.0
-    celery-v5.2: Celery~=5.2.0
-    celery-v5.3: Celery~=5.3.0
-    celery-v5.4: Celery~=5.4.0
-    celery-latest: Celery
+    celery-v4: Celery[pytest]~=4.0
+    celery-v5.0: Celery[pytest]~=5.0.0
+    celery-v5.1: Celery[pytest]~=5.1.0
+    celery-v5.2: Celery[pytest]~=5.2.0
+    celery-v5.3: Celery[pytest]~=5.3.0
+    celery-v5.4: Celery[pytest]~=5.4.0
+    celery-latest: Celery[pytest]
 
     {py3.7}-celery: importlib-metadata<5.0
     {py3.6,py3.7,py3.8,py3.9,py3.10,py3.11,py3.12}-celery: newrelic


### PR DESCRIPTION
Trying something to update our Celery test suite (because it is still made for Celery 3 and this is not supported anymore)

Celery 4 introduced some helpful fixtures that should be used: https://docs.celeryq.dev/en/stable/userguide/testing.html#pytest

<!-- Describe your PR here -->

---

## General Notes

Thank you for contributing to `sentry-python`!

Please add tests to validate your changes, and lint your code using `tox -e linters`.

Running the test suite on your PR might require maintainer approval. Some tests (AWS Lambda) additionally require a maintainer to add a special label to run and will fail if the label is not present.

#### For maintainers

Sensitive test suites require maintainer review to ensure that tests do not compromise our secrets. This review must be repeated after any code revisions.

Before running sensitive test suites, please carefully check the PR. Then, apply the `Trigger: tests using secrets` label. The label will be removed after any code changes to enforce our policy requiring maintainers to review all code revisions before running sensitive tests.
