### PR TITLE
ci: Workaround bug preventing Django test runs

### DIFF
--- a/.github/workflows/test-integrations-web-frameworks-1.yml
+++ b/.github/workflows/test-integrations-web-frameworks-1.yml
@@ -64,7 +64,6 @@ jobs:
       - name: Test django latest
         run: |
           set -x # print commands that are executed
-          export PIP_CONSTRAINT=constraints.txt
           ./scripts/runtox.sh "py${{ matrix.python-version }}-django-latest"
       - name: Test flask latest
         run: |
@@ -141,7 +140,6 @@ jobs:
       - name: Test django pinned
         run: |
           set -x # print commands that are executed
-          export PIP_CONSTRAINT=constraints.txt
           ./scripts/runtox.sh --exclude-latest "py${{ matrix.python-version }}-django"
       - name: Test flask pinned
         run: |

--- a/.github/workflows/test-integrations-web-frameworks-1.yml
+++ b/.github/workflows/test-integrations-web-frameworks-1.yml
@@ -64,6 +64,7 @@ jobs:
       - name: Test django latest
         run: |
           set -x # print commands that are executed
+          export PIP_CONSTRAINT=constraints.txt
           ./scripts/runtox.sh "py${{ matrix.python-version }}-django-latest"
       - name: Test flask latest
         run: |
@@ -140,6 +141,7 @@ jobs:
       - name: Test django pinned
         run: |
           set -x # print commands that are executed
+          export PIP_CONSTRAINT=constraints.txt
           ./scripts/runtox.sh --exclude-latest "py${{ matrix.python-version }}-django"
       - name: Test flask pinned
         run: |

--- a/constraints.txt
+++ b/constraints.txt
@@ -1,0 +1,3 @@
+# Workaround for https://github.com/pypa/setuptools/issues/4519.
+# Applies only for Django tests.
+setuptools<72.0.0

--- a/tox.ini
+++ b/tox.ini
@@ -648,6 +648,7 @@ setenv =
     OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES
     COVERAGE_FILE=.coverage-{envname}
     django: DJANGO_SETTINGS_MODULE=tests.integrations.django.myapp.settings
+    py3.12-django: PIP_CONSTRAINT=constraints.txt
 
     common: TESTPATH=tests
     gevent: TESTPATH=tests


### PR DESCRIPTION
Workaround https://github.com/pypa/setuptools/issues/4519 by constraining `setuptools72.0.0` when installing dependencies for Django tests.