### PR TITLE
ci: Remove Django `setuptools` pin

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -1,3 +1,0 @@
-# Workaround for https://github.com/pypa/setuptools/issues/4519.
-# Applies only for Django tests.
-setuptools<72.0.0

--- a/tox.ini
+++ b/tox.ini
@@ -646,7 +646,6 @@ setenv =
     OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES
     COVERAGE_FILE=.coverage-{envname}
     django: DJANGO_SETTINGS_MODULE=tests.integrations.django.myapp.settings
-    py3.12-django: PIP_CONSTRAINT=constraints.txt
 
     common: TESTPATH=tests
     gevent: TESTPATH=tests


### PR DESCRIPTION
Revert getsentry/sentry-python#3371, which was needed to work around https://github.com/pypa/setuptools/issues/4519 and allow our Django tests to run on Python 3.12. https://github.com/pypa/setuptools/issues/4519 has been resolved upstream, so the workaround should no longer be needed.