### PR TITLE
meta: Slim down PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,8 +2,6 @@
 
 ---
 
-Thank you for contributing to `sentry-python`!
-
-Please add tests to validate your changes, and lint your code using `tox -e linters`.
+Thank you for contributing to `sentry-python`! Please add tests to validate your changes, and lint your code using `tox -e linters`.
 
 Running the test suite on your PR might require maintainer approval. Some tests (AWS Lambda) additionally require a maintainer to add a special label to run and will fail if the label is not present.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,4 +4,4 @@
 
 Thank you for contributing to `sentry-python`! Please add tests to validate your changes, and lint your code using `tox -e linters`.
 
-Running the test suite on your PR might require maintainer approval. Some tests (AWS Lambda) additionally require a maintainer to add a special label to run and will fail if the label is not present.
+Running the test suite on your PR might require maintainer approval. The AWS Lambda tests additionally require a maintainer to add a special label, and they will fail until this label is added.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,16 +2,8 @@
 
 ---
 
-## General Notes
-
 Thank you for contributing to `sentry-python`!
 
 Please add tests to validate your changes, and lint your code using `tox -e linters`.
 
 Running the test suite on your PR might require maintainer approval. Some tests (AWS Lambda) additionally require a maintainer to add a special label to run and will fail if the label is not present.
-
-#### For maintainers
-
-Sensitive test suites require maintainer review to ensure that tests do not compromise our secrets. This review must be repeated after any code revisions.
-
-Before running sensitive test suites, please carefully check the PR. Then, apply the `Trigger: tests using secrets` label. The label will be removed after any code changes to enforce our policy requiring maintainers to review all code revisions before running sensitive tests.


### PR DESCRIPTION
Moved the maintainer part to the [wiki](https://github.com/getsentry/sentry-python/wiki/AWS-Lambda-test-suite).
