### PR TITLE
ref(tests): remove `ApproxDict` #3380

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -633,15 +633,3 @@ def patch_start_tracing_child(fake_transaction_is_none=False):
         "sentry_sdk.tracing_utils.get_current_span", return_value=fake_transaction
     ):
         yield fake_start_child
-
-
-class ApproxDict(dict):
-    def __eq__(self, other):
-        # For an ApproxDict to equal another dict, the other dict just needs to contain
-        # all the keys from the ApproxDict with the same values.
-        #
-        # The other dict may contain additional keys with any value.
-        return all(key in other and other[key] == value for key, value in self.items())
-
-    def __ne__(self, other):
-        return not self.__eq__(other)

--- a/tests/integrations/aiohttp/test_aiohttp.py
+++ b/tests/integrations/aiohttp/test_aiohttp.py
@@ -10,7 +10,6 @@ from aiohttp.web_request import Request
 
 from sentry_sdk import capture_message, start_transaction
 from sentry_sdk.integrations.aiohttp import AioHttpIntegration
-from tests.conftest import ApproxDict
 
 
 @pytest.mark.asyncio
@@ -496,8 +495,9 @@ async def test_crumb_capture(
         crumb = event["breadcrumbs"]["values"][0]
         assert crumb["type"] == "http"
         assert crumb["category"] == "httplib"
-        assert crumb["data"] == ApproxDict(
-            {
+        assert (
+            crumb["data"].items()
+            >= {
                 "url": "http://127.0.0.1:{}/".format(raw_server.port),
                 "http.fragment": "",
                 "http.method": "GET",
@@ -505,7 +505,7 @@ async def test_crumb_capture(
                 "http.response.status_code": 200,
                 "reason": "OK",
                 "extra": "foo",
-            }
+            }.items()
         )
 
 

--- a/tests/integrations/asyncpg/test_asyncpg.py
+++ b/tests/integrations/asyncpg/test_asyncpg.py
@@ -31,7 +31,6 @@ from sentry_sdk import capture_message, start_transaction
 from sentry_sdk.integrations.asyncpg import AsyncPGIntegration
 from sentry_sdk.consts import SPANDATA
 from sentry_sdk.tracing_utils import record_sql_queries
-from tests.conftest import ApproxDict
 
 
 PG_CONNECTION_URI = "postgresql://{}:{}@{}/{}".format(
@@ -39,15 +38,13 @@ PG_CONNECTION_URI = "postgresql://{}:{}@{}/{}".format(
 )
 CRUMBS_CONNECT = {
     "category": "query",
-    "data": ApproxDict(
-        {
-            "db.name": PG_NAME,
-            "db.system": "postgresql",
-            "db.user": PG_USER,
-            "server.address": PG_HOST,
-            "server.port": PG_PORT,
-        }
-    ),
+    "data": {
+        "db.name": PG_NAME,
+        "db.system": "postgresql",
+        "db.user": PG_USER,
+        "server.address": PG_HOST,
+        "server.port": PG_PORT,
+    },
     "message": "connect",
     "type": "default",
 }

--- a/tests/integrations/boto3/test_s3.py
+++ b/tests/integrations/boto3/test_s3.py
@@ -5,7 +5,6 @@ import pytest
 
 import sentry_sdk
 from sentry_sdk.integrations.boto3 import Boto3Integration
-from tests.conftest import ApproxDict
 from tests.integrations.boto3 import read_fixture
 from tests.integrations.boto3.aws_mock import MockResponse
 
@@ -62,13 +61,14 @@ def test_streaming(sentry_init, capture_events):
     span1 = event["spans"][0]
     assert span1["op"] == "http.client"
     assert span1["description"] == "aws.s3.GetObject"
-    assert span1["data"] == ApproxDict(
-        {
+    assert (
+        span1["data"].items()
+        >= {
             "http.method": "GET",
             "aws.request.url": "https://bucket.s3.amazonaws.com/foo.pdf",
             "http.fragment": "",
             "http.query": "",
-        }
+        }.items()
     )
 
     span2 = event["spans"][1]
@@ -122,11 +122,12 @@ def test_omit_url_data_if_parsing_fails(sentry_init, capture_events):
             transaction.finish()
 
     (event,) = events
-    assert event["spans"][0]["data"] == ApproxDict(
-        {
+    assert (
+        event["spans"][0]["data"].items()
+        >= {
             "http.method": "GET",
             # no url data
-        }
+        }.items()
     )
 
     assert "aws.request.url" not in event["spans"][0]["data"]

--- a/tests/integrations/celery/test_celery.py
+++ b/tests/integrations/celery/test_celery.py
@@ -13,7 +13,6 @@ from sentry_sdk.integrations.celery import (
     _wrap_apply_async,
 )
 from sentry_sdk.integrations.celery.beat import _get_headers
-from tests.conftest import ApproxDict
 
 
 @pytest.fixture
@@ -227,12 +226,12 @@ def test_transaction_events(capture_events, init_celery, celery_invocation, task
             "same_process_as_parent": True,
             "op": "queue.process",
             "description": "dummy_task",
-            "data": ApproxDict(),
+            "data": {},
         }.items()
     )
     assert submission_event["spans"] == [
         {
-            "data": ApproxDict(),
+            "data": {},
             "description": "dummy_task",
             "op": "queue.submit.celery",
             "origin": "auto.queue.celery",

--- a/tests/integrations/clickhouse_driver/test_clickhouse_driver.py
+++ b/tests/integrations/clickhouse_driver/test_clickhouse_driver.py
@@ -10,7 +10,6 @@ from clickhouse_driver import Client, connect
 
 from sentry_sdk import start_transaction, capture_message
 from sentry_sdk.integrations.clickhouse_driver import ClickhouseDriverIntegration
-from tests.conftest import ApproxDict
 
 EXPECT_PARAMS_IN_SELECT = True
 if clickhouse_driver.VERSION < (0, 2, 6):
@@ -102,9 +101,6 @@ def test_clickhouse_client_breadcrumbs(sentry_init, capture_events) -> None:
 
     if not EXPECT_PARAMS_IN_SELECT:
         expected_breadcrumbs[-1]["data"].pop("db.params", None)
-
-    for crumb in expected_breadcrumbs:
-        crumb["data"] = ApproxDict(crumb["data"])
 
     for crumb in event["breadcrumbs"]["values"]:
         crumb.pop("timestamp", None)
@@ -204,9 +200,6 @@ def test_clickhouse_client_breadcrumbs_with_pii(sentry_init, capture_events) -> 
 
     if not EXPECT_PARAMS_IN_SELECT:
         expected_breadcrumbs[-1]["data"].pop("db.params", None)
-
-    for crumb in expected_breadcrumbs:
-        crumb["data"] = ApproxDict(crumb["data"])
 
     for crumb in event["breadcrumbs"]["values"]:
         crumb.pop("timestamp", None)
@@ -324,9 +317,6 @@ def test_clickhouse_client_spans(
 
     if not EXPECT_PARAMS_IN_SELECT:
         expected_spans[-1]["data"].pop("db.params", None)
-
-    for span in expected_spans:
-        span["data"] = ApproxDict(span["data"])
 
     for span in event["spans"]:
         span.pop("span_id", None)
@@ -454,9 +444,6 @@ def test_clickhouse_client_spans_with_pii(
     if not EXPECT_PARAMS_IN_SELECT:
         expected_spans[-1]["data"].pop("db.params", None)
 
-    for span in expected_spans:
-        span["data"] = ApproxDict(span["data"])
-
     for span in event["spans"]:
         span.pop("span_id", None)
         span.pop("start_timestamp", None)
@@ -551,9 +538,6 @@ def test_clickhouse_dbapi_breadcrumbs(sentry_init, capture_events) -> None:
 
     if not EXPECT_PARAMS_IN_SELECT:
         expected_breadcrumbs[-1]["data"].pop("db.params", None)
-
-    for crumb in expected_breadcrumbs:
-        crumb["data"] = ApproxDict(crumb["data"])
 
     for crumb in event["breadcrumbs"]["values"]:
         crumb.pop("timestamp", None)
@@ -654,9 +638,6 @@ def test_clickhouse_dbapi_breadcrumbs_with_pii(sentry_init, capture_events) -> N
 
     if not EXPECT_PARAMS_IN_SELECT:
         expected_breadcrumbs[-1]["data"].pop("db.params", None)
-
-    for crumb in expected_breadcrumbs:
-        crumb["data"] = ApproxDict(crumb["data"])
 
     for crumb in event["breadcrumbs"]["values"]:
         crumb.pop("timestamp", None)
@@ -772,9 +753,6 @@ def test_clickhouse_dbapi_spans(sentry_init, capture_events, capture_envelopes) 
 
     if not EXPECT_PARAMS_IN_SELECT:
         expected_spans[-1]["data"].pop("db.params", None)
-
-    for span in expected_spans:
-        span["data"] = ApproxDict(span["data"])
 
     for span in event["spans"]:
         span.pop("span_id", None)
@@ -901,9 +879,6 @@ def test_clickhouse_dbapi_spans_with_pii(
 
     if not EXPECT_PARAMS_IN_SELECT:
         expected_spans[-1]["data"].pop("db.params", None)
-
-    for span in expected_spans:
-        span["data"] = ApproxDict(span["data"])
 
     for span in event["spans"]:
         span.pop("span_id", None)

--- a/tests/integrations/grpc/test_grpc.py
+++ b/tests/integrations/grpc/test_grpc.py
@@ -10,7 +10,6 @@ from unittest.mock import Mock
 from sentry_sdk import start_span, start_transaction
 from sentry_sdk.consts import OP
 from sentry_sdk.integrations.grpc import GRPCIntegration
-from tests.conftest import ApproxDict
 from tests.integrations.grpc.grpc_test_service_pb2 import gRPCTestMessage
 from tests.integrations.grpc.grpc_test_service_pb2_grpc import (
     add_gRPCTestServiceServicer_to_server,
@@ -169,12 +168,13 @@ def test_grpc_client_starts_span(sentry_init, capture_events_forksafe):
         span["description"]
         == "unary unary call to /grpc_test_server.gRPCTestService/TestServe"
     )
-    assert span["data"] == ApproxDict(
-        {
+    assert (
+        span["data"].items()
+        >= {
             "type": "unary unary",
             "method": "/grpc_test_server.gRPCTestService/TestServe",
             "code": "OK",
-        }
+        }.items()
     )
 
 
@@ -203,11 +203,12 @@ def test_grpc_client_unary_stream_starts_span(sentry_init, capture_events_forksa
         span["description"]
         == "unary stream call to /grpc_test_server.gRPCTestService/TestUnaryStream"
     )
-    assert span["data"] == ApproxDict(
-        {
+    assert (
+        span["data"].items()
+        >= {
             "type": "unary stream",
             "method": "/grpc_test_server.gRPCTestService/TestUnaryStream",
-        }
+        }.items()
     )
 
 
@@ -251,12 +252,13 @@ def test_grpc_client_other_interceptor(sentry_init, capture_events_forksafe):
         span["description"]
         == "unary unary call to /grpc_test_server.gRPCTestService/TestServe"
     )
-    assert span["data"] == ApproxDict(
-        {
+    assert (
+        span["data"].items()
+        >= {
             "type": "unary unary",
             "method": "/grpc_test_server.gRPCTestService/TestServe",
             "code": "OK",
-        }
+        }.items()
     )
 
 

--- a/tests/integrations/grpc/test_grpc_aio.py
+++ b/tests/integrations/grpc/test_grpc_aio.py
@@ -9,7 +9,6 @@ import sentry_sdk
 from sentry_sdk import start_span, start_transaction
 from sentry_sdk.consts import OP
 from sentry_sdk.integrations.grpc import GRPCIntegration
-from tests.conftest import ApproxDict
 from tests.integrations.grpc.grpc_test_service_pb2 import gRPCTestMessage
 from tests.integrations.grpc.grpc_test_service_pb2_grpc import (
     add_gRPCTestServiceServicer_to_server,
@@ -181,12 +180,13 @@ async def test_grpc_client_starts_span(grpc_server, capture_events_forksafe):
         span["description"]
         == "unary unary call to /grpc_test_server.gRPCTestService/TestServe"
     )
-    assert span["data"] == ApproxDict(
-        {
+    assert (
+        span["data"].items()
+        >= {
             "type": "unary unary",
             "method": "/grpc_test_server.gRPCTestService/TestServe",
             "code": "OK",
-        }
+        }.items()
     )
 
 
@@ -212,11 +212,12 @@ async def test_grpc_client_unary_stream_starts_span(
         span["description"]
         == "unary stream call to /grpc_test_server.gRPCTestService/TestUnaryStream"
     )
-    assert span["data"] == ApproxDict(
-        {
+    assert (
+        span["data"].items()
+        >= {
             "type": "unary stream",
             "method": "/grpc_test_server.gRPCTestService/TestUnaryStream",
-        }
+        }.items()
     )
 
 

--- a/tests/integrations/httpx/test_httpx.py
+++ b/tests/integrations/httpx/test_httpx.py
@@ -9,7 +9,6 @@ import sentry_sdk
 from sentry_sdk import capture_message, start_transaction
 from sentry_sdk.consts import MATCH_ALL, SPANDATA
 from sentry_sdk.integrations.httpx import HttpxIntegration
-from tests.conftest import ApproxDict
 
 
 @pytest.mark.parametrize(
@@ -44,8 +43,9 @@ def test_crumb_capture_and_hint(sentry_init, capture_events, httpx_client):
         crumb = event["breadcrumbs"]["values"][0]
         assert crumb["type"] == "http"
         assert crumb["category"] == "httplib"
-        assert crumb["data"] == ApproxDict(
-            {
+        assert (
+            crumb["data"].items()
+            >= {
                 "url": url,
                 SPANDATA.HTTP_METHOD: "GET",
                 SPANDATA.HTTP_FRAGMENT: "",
@@ -53,7 +53,7 @@ def test_crumb_capture_and_hint(sentry_init, capture_events, httpx_client):
                 SPANDATA.HTTP_STATUS_CODE: 200,
                 "reason": "OK",
                 "extra": "foo",
-            }
+            }.items()
         )
 
 
@@ -308,13 +308,14 @@ def test_omit_url_data_if_parsing_fails(sentry_init, capture_events):
     capture_message("Testing!")
 
     (event,) = events
-    assert event["breadcrumbs"]["values"][0]["data"] == ApproxDict(
-        {
+    assert (
+        event["breadcrumbs"]["values"][0]["data"].items()
+        >= {
             SPANDATA.HTTP_METHOD: "GET",
             SPANDATA.HTTP_STATUS_CODE: 200,
             "reason": "OK",
             # no url related data
-        }
+        }.items()
     )
 
     assert "url" not in event["breadcrumbs"]["values"][0]["data"]

--- a/tests/integrations/redis/asyncio/test_redis_asyncio.py
+++ b/tests/integrations/redis/asyncio/test_redis_asyncio.py
@@ -3,7 +3,6 @@ import pytest
 from sentry_sdk import capture_message, start_transaction
 from sentry_sdk.consts import SPANDATA
 from sentry_sdk.integrations.redis import RedisIntegration
-from tests.conftest import ApproxDict
 
 from fakeredis.aioredis import FakeRedis
 
@@ -65,8 +64,9 @@ async def test_async_redis_pipeline(
     (span,) = event["spans"]
     assert span["op"] == "db.redis"
     assert span["description"] == "redis.pipeline.execute"
-    assert span["data"] == ApproxDict(
-        {
+    assert (
+        span["data"].items()
+        >= {
             "redis.commands": {
                 "count": 3,
                 "first_ten": expected_first_ten,
@@ -77,7 +77,7 @@ async def test_async_redis_pipeline(
                 "host"
             ),
             SPANDATA.SERVER_PORT: 6379,
-        }
+        }.items()
     )
     assert span["tags"] == {
         "redis.transaction": is_transaction,

--- a/tests/integrations/redis/cluster/test_redis_cluster.py
+++ b/tests/integrations/redis/cluster/test_redis_cluster.py
@@ -3,7 +3,6 @@ from sentry_sdk import capture_message
 from sentry_sdk.consts import SPANDATA
 from sentry_sdk.api import start_transaction
 from sentry_sdk.integrations.redis import RedisIntegration
-from tests.conftest import ApproxDict
 
 import redis
 
@@ -83,13 +82,14 @@ def test_rediscluster_basic(sentry_init, capture_events, send_default_pii, descr
     span = spans[-1]
     assert span["op"] == "db.redis"
     assert span["description"] == description
-    assert span["data"] == ApproxDict(
-        {
+    assert (
+        span["data"].items()
+        >= {
             SPANDATA.DB_SYSTEM: "redis",
             # ClusterNode converts localhost to 127.0.0.1
             SPANDATA.SERVER_ADDRESS: "127.0.0.1",
             SPANDATA.SERVER_PORT: 6379,
-        }
+        }.items()
     )
     assert span["tags"] == {
         "db.operation": "SET",
@@ -128,8 +128,9 @@ def test_rediscluster_pipeline(
     (span,) = event["spans"]
     assert span["op"] == "db.redis"
     assert span["description"] == "redis.pipeline.execute"
-    assert span["data"] == ApproxDict(
-        {
+    assert (
+        span["data"].items()
+        >= {
             "redis.commands": {
                 "count": 3,
                 "first_ten": expected_first_ten,
@@ -138,7 +139,7 @@ def test_rediscluster_pipeline(
             # ClusterNode converts localhost to 127.0.0.1
             SPANDATA.SERVER_ADDRESS: "127.0.0.1",
             SPANDATA.SERVER_PORT: 6379,
-        }
+        }.items()
     )
     assert span["tags"] == {
         "redis.transaction": False,  # For Cluster, this is always False

--- a/tests/integrations/requests/test_requests.py
+++ b/tests/integrations/requests/test_requests.py
@@ -7,7 +7,6 @@ import responses
 from sentry_sdk import capture_message
 from sentry_sdk.consts import SPANDATA
 from sentry_sdk.integrations.stdlib import StdlibIntegration
-from tests.conftest import ApproxDict
 
 
 def test_crumb_capture(sentry_init, capture_events):
@@ -25,15 +24,16 @@ def test_crumb_capture(sentry_init, capture_events):
     (crumb,) = event["breadcrumbs"]["values"]
     assert crumb["type"] == "http"
     assert crumb["category"] == "httplib"
-    assert crumb["data"] == ApproxDict(
-        {
+    assert (
+        crumb["data"].items()
+        >= {
             "url": url,
             SPANDATA.HTTP_METHOD: "GET",
             SPANDATA.HTTP_FRAGMENT: "",
             SPANDATA.HTTP_QUERY: "",
             SPANDATA.HTTP_STATUS_CODE: response.status_code,
             "reason": response.reason,
-        }
+        }.items()
     )
 
 
@@ -55,13 +55,14 @@ def test_omit_url_data_if_parsing_fails(sentry_init, capture_events):
     capture_message("Testing!")
 
     (event,) = events
-    assert event["breadcrumbs"]["values"][0]["data"] == ApproxDict(
-        {
+    assert (
+        event["breadcrumbs"]["values"][0]["data"].items()
+        >= {
             SPANDATA.HTTP_METHOD: "GET",
             SPANDATA.HTTP_STATUS_CODE: response.status_code,
             "reason": response.reason,
             # no url related data
-        }
+        }.items()
     )
 
     assert "url" not in event["breadcrumbs"]["values"][0]["data"]

--- a/tests/integrations/socket/test_socket.py
+++ b/tests/integrations/socket/test_socket.py
@@ -2,7 +2,6 @@ import socket
 
 from sentry_sdk import start_transaction
 from sentry_sdk.integrations.socket import SocketIntegration
-from tests.conftest import ApproxDict
 
 
 def test_getaddrinfo_trace(sentry_init, capture_events):
@@ -17,11 +16,12 @@ def test_getaddrinfo_trace(sentry_init, capture_events):
 
     assert span["op"] == "socket.dns"
     assert span["description"] == "example.com:443"
-    assert span["data"] == ApproxDict(
-        {
+    assert (
+        span["data"].items()
+        >= {
             "host": "example.com",
             "port": 443,
-        }
+        }.items()
     )
 
 
@@ -40,21 +40,23 @@ def test_create_connection_trace(sentry_init, capture_events):
 
     assert connect_span["op"] == "socket.connection"
     assert connect_span["description"] == "example.com:443"
-    assert connect_span["data"] == ApproxDict(
-        {
+    assert (
+        connect_span["data"].items()
+        >= {
             "address": ["example.com", 443],
             "timeout": timeout,
             "source_address": None,
-        }
+        }.items()
     )
 
     assert dns_span["op"] == "socket.dns"
     assert dns_span["description"] == "example.com:443"
-    assert dns_span["data"] == ApproxDict(
-        {
+    assert (
+        dns_span["data"].items()
+        >= {
             "host": "example.com",
             "port": 443,
-        }
+        }.items()
     )
 
 

--- a/tests/integrations/stdlib/test_httplib.py
+++ b/tests/integrations/stdlib/test_httplib.py
@@ -10,7 +10,7 @@ from sentry_sdk.consts import MATCH_ALL, SPANDATA
 from sentry_sdk.tracing import Transaction
 from sentry_sdk.integrations.stdlib import StdlibIntegration
 
-from tests.conftest import ApproxDict, create_mock_http_server
+from tests.conftest import create_mock_http_server
 
 PORT = create_mock_http_server()
 
@@ -29,15 +29,16 @@ def test_crumb_capture(sentry_init, capture_events):
 
     assert crumb["type"] == "http"
     assert crumb["category"] == "httplib"
-    assert crumb["data"] == ApproxDict(
-        {
+    assert (
+        crumb["data"].items()
+        >= {
             "url": url,
             SPANDATA.HTTP_METHOD: "GET",
             SPANDATA.HTTP_STATUS_CODE: 200,
             "reason": "OK",
             SPANDATA.HTTP_FRAGMENT: "",
             SPANDATA.HTTP_QUERY: "",
-        }
+        }.items()
     )
 
 
@@ -58,8 +59,9 @@ def test_crumb_capture_hint(sentry_init, capture_events):
     (crumb,) = event["breadcrumbs"]["values"]
     assert crumb["type"] == "http"
     assert crumb["category"] == "httplib"
-    assert crumb["data"] == ApproxDict(
-        {
+    assert (
+        crumb["data"].items()
+        >= {
             "url": url,
             SPANDATA.HTTP_METHOD: "GET",
             SPANDATA.HTTP_STATUS_CODE: 200,
@@ -67,7 +69,7 @@ def test_crumb_capture_hint(sentry_init, capture_events):
             "extra": "foo",
             SPANDATA.HTTP_FRAGMENT: "",
             SPANDATA.HTTP_QUERY: "",
-        }
+        }.items()
     )
 
 
@@ -118,15 +120,16 @@ def test_httplib_misuse(sentry_init, capture_events, request):
 
     assert crumb["type"] == "http"
     assert crumb["category"] == "httplib"
-    assert crumb["data"] == ApproxDict(
-        {
+    assert (
+        crumb["data"].items()
+        >= {
             "url": "http://localhost:{}/200".format(PORT),
             SPANDATA.HTTP_METHOD: "GET",
             SPANDATA.HTTP_STATUS_CODE: 200,
             "reason": "OK",
             SPANDATA.HTTP_FRAGMENT: "",
             SPANDATA.HTTP_QUERY: "",
-        }
+        }.items()
     )
 
 

--- a/tests/integrations/stdlib/test_subprocess.py
+++ b/tests/integrations/stdlib/test_subprocess.py
@@ -8,7 +8,6 @@ import pytest
 
 from sentry_sdk import capture_message, start_transaction
 from sentry_sdk.integrations.stdlib import StdlibIntegration
-from tests.conftest import ApproxDict
 
 
 class ImmutableDict(Mapping):
@@ -120,7 +119,7 @@ def test_subprocess_basic(
 
     assert message_event["message"] == "hi"
 
-    data = ApproxDict({"subprocess.cwd": os.getcwd()} if with_cwd else {})
+    data = {"subprocess.cwd": os.getcwd()} if with_cwd else {}
 
     (crumb,) = message_event["breadcrumbs"]["values"]
     assert crumb == {

--- a/tests/integrations/strawberry/test_strawberry.py
+++ b/tests/integrations/strawberry/test_strawberry.py
@@ -26,7 +26,6 @@ from sentry_sdk.integrations.strawberry import (
     SentryAsyncExtension,
     SentrySyncExtension,
 )
-from tests.conftest import ApproxDict
 
 parameterize_strawberry_test = pytest.mark.parametrize(
     "client_factory,async_execution,framework_integrations",
@@ -362,13 +361,14 @@ def test_capture_transaction_on_error(
     resolve_span = resolve_spans[0]
     assert resolve_span["parent_span_id"] == query_span["span_id"]
     assert resolve_span["description"] == "resolving Query.error"
-    assert resolve_span["data"] == ApproxDict(
-        {
+    assert (
+        resolve_span["data"].items()
+        >= {
             "graphql.field_name": "error",
             "graphql.parent_type": "Query",
             "graphql.field_path": "Query.error",
             "graphql.path": "error",
-        }
+        }.items()
     )
 
 
@@ -439,13 +439,14 @@ def test_capture_transaction_on_success(
     resolve_span = resolve_spans[0]
     assert resolve_span["parent_span_id"] == query_span["span_id"]
     assert resolve_span["description"] == "resolving Query.hello"
-    assert resolve_span["data"] == ApproxDict(
-        {
+    assert (
+        resolve_span["data"].items()
+        >= {
             "graphql.field_name": "hello",
             "graphql.parent_type": "Query",
             "graphql.field_path": "Query.hello",
             "graphql.path": "hello",
-        }
+        }.items()
     )
 
 
@@ -519,13 +520,14 @@ def test_transaction_no_operation_name(
     resolve_span = resolve_spans[0]
     assert resolve_span["parent_span_id"] == query_span["span_id"]
     assert resolve_span["description"] == "resolving Query.hello"
-    assert resolve_span["data"] == ApproxDict(
-        {
+    assert (
+        resolve_span["data"].items()
+        >= {
             "graphql.field_name": "hello",
             "graphql.parent_type": "Query",
             "graphql.field_path": "Query.hello",
             "graphql.path": "hello",
-        }
+        }.items()
     )
 
 
@@ -596,13 +598,14 @@ def test_transaction_mutation(
     resolve_span = resolve_spans[0]
     assert resolve_span["parent_span_id"] == query_span["span_id"]
     assert resolve_span["description"] == "resolving Mutation.change"
-    assert resolve_span["data"] == ApproxDict(
-        {
+    assert (
+        resolve_span["data"].items()
+        >= {
             "graphql.field_name": "change",
             "graphql.parent_type": "Mutation",
             "graphql.field_path": "Mutation.change",
             "graphql.path": "change",
-        }
+        }.items()
     )
 
 

--- a/tests/profiler/test_continuous_profiler.py
+++ b/tests/profiler/test_continuous_profiler.py
@@ -11,7 +11,6 @@ from sentry_sdk.profiler.continuous_profiler import (
     start_profiler,
     stop_profiler,
 )
-from tests.conftest import ApproxDict
 
 try:
     import gevent
@@ -89,37 +88,39 @@ def assert_single_transaction_with_profile_chunks(envelopes, thread):
 
     trace_context = transaction["contexts"]["trace"]
 
-    assert trace_context == ApproxDict(
-        {
-            "data": ApproxDict(
-                {
-                    "thread.id": str(thread.ident),
-                    "thread.name": thread.name,
-                }
-            ),
-        }
-    )
+    assert trace_context.items() >= {
+        "data": {
+            "thread.id": str(thread.ident),
+            "thread.name": thread.name,
+        }.items()
+    }
 
     profile_context = transaction["contexts"]["profile"]
     profiler_id = profile_context["profiler_id"]
 
-    assert profile_context == ApproxDict({"profiler_id": profiler_id})
+    assert profile_context.items() >= {"profiler_id": profiler_id}.items()
 
     spans = transaction["spans"]
     assert len(spans) > 0
     for span in spans:
-        assert span["data"] == ApproxDict(
-            {
+        assert (
+            span["data"].items()
+            >= {
                 "profiler_id": profiler_id,
                 "thread.id": str(thread.ident),
                 "thread.name": thread.name,
-            }
+            }.items()
         )
 
     for profile_chunk_item in items["profile_chunk"]:
         profile_chunk = profile_chunk_item.payload.json
-        assert profile_chunk == ApproxDict(
-            {"platform": "python", "profiler_id": profiler_id, "version": "2"}
+        assert (
+            profile_chunk.items()
+            >= {
+                "platform": "python",
+                "profiler_id": profiler_id,
+                "version": "2",
+            }.items()
         )
 
 

--- a/tests/test_scrubber.py
+++ b/tests/test_scrubber.py
@@ -4,7 +4,6 @@ import logging
 from sentry_sdk import capture_exception, capture_event, start_transaction, start_span
 from sentry_sdk.utils import event_from_exception
 from sentry_sdk.scrubber import EventScrubber
-from tests.conftest import ApproxDict
 
 
 logger = logging.getLogger(__name__)
@@ -122,8 +121,9 @@ def test_span_data_scrubbing(sentry_init, capture_events):
             span.set_data("datafoo", "databar")
 
     (event,) = events
-    assert event["spans"][0]["data"] == ApproxDict(
-        {"password": "[Filtered]", "datafoo": "databar"}
+    assert (
+        event["spans"][0]["data"].items()
+        >= {"password": "[Filtered]", "datafoo": "databar"}.items()
     )
     assert event["_meta"]["spans"] == {
         "0": {"data": {"password": {"": {"rem": [["!config", "s"]]}}}}


### PR DESCRIPTION
This commit removes `ApproxDict` in favour of a more explicit assertion style.

Closes #3380


---

Thank you for contributing to `sentry-python`! Please add tests to validate your changes, and lint your code using `tox -e linters`.

Running the test suite on your PR might require maintainer approval. The AWS Lambda tests additionally require a maintainer to add a special label, and they will fail until this label is added.
