### PR TITLE
meta: Use new image in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
-<p align="center">
-  <a href="https://sentry.io/?utm_source=github&utm_medium=logo" target="_blank">
-    <img src="https://github.com/user-attachments/assets/d5bf9fe3-dd0a-4485-8191-8076eb3d9bc4" alt="Sentry">
-  </a>
-</p>
+<a href="https://sentry.io/?utm_source=github&utm_medium=logo" target="_blank">
+  <img src="https://github.com/user-attachments/assets/d5bf9fe3-dd0a-4485-8191-8076eb3d9bc4" alt="Sentry">
+</a>
 
 _Bad software is everywhere, and we're tired of it. Sentry is on a mission to help developers write better software faster, so we can get back to enjoying technology. If you want to join us [<kbd>**Check out our open positions**</kbd>](https://sentry.io/careers/)_
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <p align="center">
   <a href="https://sentry.io/?utm_source=github&utm_medium=logo" target="_blank">
-    <img src="https://sentry-brand.storage.googleapis.com/sentry-wordmark-dark-280x84.png" alt="Sentry" width="280" height="84">
+    <img src="https://github.com/user-attachments/assets/d5bf9fe3-dd0a-4485-8191-8076eb3d9bc4" alt="Sentry">
   </a>
 </p>
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <a href="https://sentry.io/?utm_source=github&utm_medium=logo" target="_blank">
-  <img src="https://github.com/user-attachments/assets/d5bf9fe3-dd0a-4485-8191-8076eb3d9bc4" alt="Sentry">
+  <img src="https://github.com/user-attachments/assets/d5bf9fe3-dd0a-4485-8191-8076eb3d9bc4" alt="Sentry for Python">
 </a>
 
 _Bad software is everywhere, and we're tired of it. Sentry is on a mission to help developers write better software faster, so we can get back to enjoying technology. If you want to join us [<kbd>**Check out our open positions**</kbd>](https://sentry.io/careers/)_


### PR DESCRIPTION
See preview at https://github.com/getsentry/sentry-python/tree/ivana/readme-image (scroll down to the readme) or here:

![Screenshot 2024-08-02 at 11 26 11](https://github.com/user-attachments/assets/dc25c815-00e8-40cb-9450-5a2cf08187cd)
