### PR TITLE
Serialize vars early to avoid living references

### DIFF
--- a/sentry_sdk/client.py
+++ b/sentry_sdk/client.py
@@ -5,12 +5,12 @@ import socket
 from collections.abc import Mapping
 from datetime import datetime, timezone
 from importlib import import_module
+from typing import cast
 
 from sentry_sdk._compat import PY37, check_uwsgi_thread_support
 from sentry_sdk.utils import (
     capture_internal_exceptions,
     current_stacktrace,
-    disable_capture_event,
     format_timestamp,
     get_sdk_name,
     get_type_name,
@@ -525,10 +525,13 @@ class _Client(BaseClient):
         # Postprocess the event here so that annotated types do
         # generally not surface in before_send
         if event is not None:
-            event = serialize(
-                event,
-                max_request_body_size=self.options.get("max_request_body_size"),
-                max_value_length=self.options.get("max_value_length"),
+            event = cast(
+                "Event",
+                serialize(
+                    cast("Dict[str, Any]", event),
+                    max_request_body_size=self.options.get("max_request_body_size"),
+                    max_value_length=self.options.get("max_value_length"),
+                ),
             )
 
         before_send = self.options["before_send"]
@@ -726,9 +729,6 @@ class _Client(BaseClient):
 
         :returns: An event ID. May be `None` if there is no DSN set or of if the SDK decided to discard the event for other reasons. In such situations setting `debug=True` on `init()` may help.
         """
-        if disable_capture_event.get(False):
-            return None
-
         if hint is None:
             hint = {}
         event_id = event.get("event_id")

--- a/sentry_sdk/integrations/pure_eval.py
+++ b/sentry_sdk/integrations/pure_eval.py
@@ -131,7 +131,8 @@ def pure_eval_frame(frame):
     atok = source.asttokens()
 
     expressions.sort(key=closeness, reverse=True)
-    return {
+    vars = {
         atok.get_text(nodes[0]): value
         for nodes, value in expressions[: serializer.MAX_DATABAG_BREADTH]
     }
+    return serializer.serialize(vars, is_vars=True)

--- a/sentry_sdk/scope.py
+++ b/sentry_sdk/scope.py
@@ -31,6 +31,7 @@ from sentry_sdk.utils import (
     capture_internal_exception,
     capture_internal_exceptions,
     ContextVar,
+    disable_capture_event,
     event_from_exception,
     exc_info_from_error,
     logger,
@@ -1130,6 +1131,9 @@ class Scope(object):
 
         :returns: An `event_id` if the SDK decided to send the event (see :py:meth:`sentry_sdk.client._Client.capture_event`).
         """
+        if disable_capture_event.get(False):
+            return None
+
         scope = self._merge_scopes(scope, scope_kwargs)
 
         event_id = self.get_client().capture_event(event=event, hint=hint, scope=scope)
@@ -1157,6 +1161,9 @@ class Scope(object):
 
         :returns: An `event_id` if the SDK decided to send the event (see :py:meth:`sentry_sdk.client._Client.capture_event`).
         """
+        if disable_capture_event.get(False):
+            return None
+
         if level is None:
             level = "info"
 
@@ -1182,6 +1189,9 @@ class Scope(object):
 
         :returns: An `event_id` if the SDK decided to send the event (see :py:meth:`sentry_sdk.client._Client.capture_event`).
         """
+        if disable_capture_event.get(False):
+            return None
+
         if error is not None:
             exc_info = exc_info_from_error(error)
         else:

--- a/sentry_sdk/utils.py
+++ b/sentry_sdk/utils.py
@@ -618,7 +618,7 @@ def serialize_frame(
     if include_local_variables:
         from sentry_sdk.serializer import serialize
 
-        rv["vars"] = serialize(frame.f_locals, is_vars=True)
+        rv["vars"] = serialize(dict(frame.f_locals), is_vars=True)
 
     return rv
 

--- a/sentry_sdk/utils.py
+++ b/sentry_sdk/utils.py
@@ -616,7 +616,9 @@ def serialize_frame(
         )
 
     if include_local_variables:
-        rv["vars"] = frame.f_locals.copy()
+        from sentry_sdk.serializer import serialize
+
+        rv["vars"] = serialize(frame.f_locals, is_vars=True)
 
     return rv
 


### PR DESCRIPTION
Since we added the `recursive` option for the `EventScrubber` in #2755, vars nested inside could be replaced with `AnnotatedValue` and potentially break userland code.

We really shouldn't be holding references to `frame.f_locals` throughout our SDK, this has all sorts of breakage potential.

This is a bit hacky, but we'll simply call `serialize` early on `vars`. I tried patching `deepcopy` in #3392  to work with our requirements, but I was simply reimplementing most of this serialize function.

Turns out @sentrivana did the same in #2117 