### PR TITLE
feat(transport): Remove `HttpTransport` `hub_cls` attribute

### DIFF
--- a/sentry_sdk/transport.py
+++ b/sentry_sdk/transport.py
@@ -12,7 +12,6 @@ from urllib.request import getproxies
 import urllib3
 import certifi
 
-import sentry_sdk
 from sentry_sdk.consts import EndpointType
 from sentry_sdk.utils import Dsn, logger, capture_internal_exceptions
 from sentry_sdk.worker import BackgroundWorker
@@ -230,9 +229,6 @@ class HttpTransport(Transport):
             key_file=options["key_file"],
             proxy_headers=options["proxy_headers"],
         )
-
-        # Backwards compatibility for deprecated `self.hub_class` attribute
-        self._hub_cls = sentry_sdk.Hub
 
     def record_lost_event(
         self,
@@ -603,30 +599,6 @@ class HttpTransport(Transport):
         # type: () -> None
         logger.debug("Killing HTTP transport")
         self._worker.kill()
-
-    @staticmethod
-    def _warn_hub_cls():
-        # type: () -> None
-        """Convenience method to warn users about the deprecation of the `hub_cls` attribute."""
-        warnings.warn(
-            "The `hub_cls` attribute is deprecated and will be removed in a future release.",
-            DeprecationWarning,
-            stacklevel=3,
-        )
-
-    @property
-    def hub_cls(self):
-        # type: () -> type[sentry_sdk.Hub]
-        """DEPRECATED: This attribute is deprecated and will be removed in a future release."""
-        HttpTransport._warn_hub_cls()
-        return self._hub_cls
-
-    @hub_cls.setter
-    def hub_cls(self, value):
-        # type: (type[sentry_sdk.Hub]) -> None
-        """DEPRECATED: This attribute is deprecated and will be removed in a future release."""
-        HttpTransport._warn_hub_cls()
-        self._hub_cls = value
 
 
 class _FunctionTransport(Transport):

--- a/tests/test_transport.py
+++ b/tests/test_transport.py
@@ -18,13 +18,11 @@ from sentry_sdk import (
     capture_message,
     isolation_scope,
     get_isolation_scope,
-    Hub,
 )
 from sentry_sdk.envelope import Envelope, Item, parse_json
 from sentry_sdk.transport import (
     KEEP_ALIVE_SOCKET_OPTIONS,
     _parse_rate_limits,
-    HttpTransport,
 )
 from sentry_sdk.integrations.logging import LoggingIntegration, ignore_logger
 
@@ -647,24 +645,6 @@ def test_metric_bucket_limits_with_all_namespaces(
     assert report["discarded_events"] == [
         {"category": "metric_bucket", "reason": "ratelimit_backoff", "quantity": 1},
     ]
-
-
-def test_hub_cls_backwards_compat():
-    class TestCustomHubClass(Hub):
-        pass
-
-    transport = HttpTransport(
-        defaultdict(lambda: None, {"dsn": "https://123abc@example.com/123"})
-    )
-
-    with pytest.deprecated_call():
-        assert transport.hub_cls is Hub
-
-    with pytest.deprecated_call():
-        transport.hub_cls = TestCustomHubClass
-
-    with pytest.deprecated_call():
-        assert transport.hub_cls is TestCustomHubClass
 
 
 @pytest.mark.parametrize("quantity", (1, 2, 10))


### PR DESCRIPTION
This change is a prerequisite for #3404.

BREAKING CHANGE: Remove `sentry_sdk.transport.HttpTransport`'s `hub_cls` attribute.