### PR TITLE
test(sessions): Remove unnecessary line

### DIFF
--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -53,7 +53,6 @@ def test_aggregates(sentry_init, capture_envelopes):
     with auto_session_tracking(session_mode="request"):
         with sentry_sdk.new_scope() as scope:
             try:
-                scope = sentry_sdk.get_current_scope()
                 scope.set_user({"id": "42"})
                 raise Exception("all is wrong")
             except Exception:


### PR DESCRIPTION
We removed this line in #3354 since it is no longer needed, but it was apparently accidentally added back in #3357.
