### PR TITLE
ref(sessions): Deprecate `is_auto_session_tracking_enabled`

### DIFF
--- a/sentry_sdk/sessions.py
+++ b/sentry_sdk/sessions.py
@@ -1,5 +1,6 @@
 import os
 import time
+import warnings
 from threading import Thread, Lock
 from contextlib import contextmanager
 
@@ -21,8 +22,15 @@ if TYPE_CHECKING:
 
 def is_auto_session_tracking_enabled(hub=None):
     # type: (Optional[sentry_sdk.Hub]) -> Union[Any, bool, None]
-    """Utility function to find out if session tracking is enabled."""
-    # TODO: add deprecation warning
+    """DEPRECATED: Utility function to find out if session tracking is enabled."""
+
+    # Internal callers should use private _is_auto_session_tracking_enabled, instead.
+    warnings.warn(
+        "This function is deprecated and will be removed in the next major release. "
+        "There is no public API replacement.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
 
     if hub is None:
         hub = sentry_sdk.Hub.current
@@ -44,7 +52,9 @@ def auto_session_tracking(hub=None, session_mode="application"):
 
     if hub is None:
         hub = sentry_sdk.Hub.current
-    should_track = is_auto_session_tracking_enabled(hub)
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+        should_track = is_auto_session_tracking_enabled(hub)
     if should_track:
         hub.start_session(session_mode=session_mode)
     try:
@@ -57,12 +67,26 @@ def auto_session_tracking(hub=None, session_mode="application"):
 def is_auto_session_tracking_enabled_scope(scope):
     # type: (sentry_sdk.Scope) -> bool
     """
-    Utility function to find out if session tracking is enabled.
-
-    TODO: This uses the new scopes. When the Hub is removed, the function
-    is_auto_session_tracking_enabled should be removed and this function
-    should be renamed to is_auto_session_tracking_enabled.
+    DEPRECATED: Utility function to find out if session tracking is enabled.
     """
+
+    warnings.warn(
+        "This function is deprecated and will be removed in the next major release. "
+        "There is no public API replacement.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+
+    # Internal callers should use private _is_auto_session_tracking_enabled, instead.
+    return _is_auto_session_tracking_enabled(scope)
+
+
+def _is_auto_session_tracking_enabled(scope):
+    # type: (sentry_sdk.Scope) -> bool
+    """
+    Utility function to find out if session tracking is enabled.
+    """
+
     should_track = scope._force_auto_session_tracking
     if should_track is None:
         client_options = sentry_sdk.get_client().options
@@ -81,7 +105,7 @@ def auto_session_tracking_scope(scope, session_mode="application"):
     auto_session_tracking should be removed and this function
     should be renamed to auto_session_tracking.
     """
-    should_track = is_auto_session_tracking_enabled_scope(scope)
+    should_track = _is_auto_session_tracking_enabled(scope)
     if should_track:
         scope.start_session(session_mode=session_mode)
     try:


### PR DESCRIPTION
Deprecate the Hub-based `is_auto_session_tracking_enabled` and the Scope-based `is_auto_session_tracking_enabled_scope`, and replace them with a new Scope-based private-API equivalent.

Partially implements #3417
