### PR TITLE
Fix circular imports

### DIFF
--- a/sentry_sdk/integrations/opentelemetry/__init__.py
+++ b/sentry_sdk/integrations/opentelemetry/__init__.py
@@ -1,8 +1,7 @@
-# TODO-neel-potel fix circular imports
-# from sentry_sdk.integrations.opentelemetry.span_processor import (  # noqa: F401
-#     SentrySpanProcessor,
-# )
+from sentry_sdk.integrations.opentelemetry.span_processor import (  # noqa: F401
+    SentrySpanProcessor,
+)
 
-# from sentry_sdk.integrations.opentelemetry.propagator import (  # noqa: F401
-#     SentryPropagator,
-# )
+from sentry_sdk.integrations.opentelemetry.propagator import (  # noqa: F401
+    SentryPropagator,
+)

--- a/sentry_sdk/integrations/opentelemetry/span_processor.py
+++ b/sentry_sdk/integrations/opentelemetry/span_processor.py
@@ -13,7 +13,6 @@ from opentelemetry.trace.span import (
     INVALID_SPAN_ID,
     INVALID_TRACE_ID,
 )
-from sentry_sdk import get_client, start_transaction
 from sentry_sdk.integrations.opentelemetry.consts import (
     SENTRY_BAGGAGE_KEY,
     SENTRY_TRACE_KEY,
@@ -106,6 +105,8 @@ class SentrySpanProcessor(SpanProcessor):
 
     def on_start(self, otel_span, parent_context=None):
         # type: (OTelSpan, Optional[context_api.Context]) -> None
+        from sentry_sdk import get_client, start_transaction
+
         client = get_client()
 
         if not client.dsn:

--- a/sentry_sdk/integrations/opentelemetry/utils.py
+++ b/sentry_sdk/integrations/opentelemetry/utils.py
@@ -8,7 +8,6 @@ from sentry_sdk.consts import SPANSTATUS
 from sentry_sdk.tracing import get_span_status_from_http_code
 from urllib3.util import parse_url as urlparse
 
-from sentry_sdk import get_client
 from sentry_sdk.utils import Dsn
 
 from sentry_sdk._types import TYPE_CHECKING
@@ -43,6 +42,8 @@ def is_sentry_span(span):
     Break infinite loop:
     HTTP requests to Sentry are caught by OTel and send again to Sentry.
     """
+    from sentry_sdk import get_client
+
     if not span.attributes:
         return False
 


### PR DESCRIPTION
"Fix" some circular imports on `ivana/potel/start-span`. This is just a quick fix. We should have a look at https://github.com/getsentry/sentry-python/issues/3407 at some point.

Picking https://github.com/getsentry/sentry-python/pull/3398 apart to have nicer reviewable PRs.