### PR TITLE
Drop Python 3.6

### DIFF
--- a/.github/workflows/test-integrations-cloud-computing.yml
+++ b/.github/workflows/test-integrations-cloud-computing.yml
@@ -85,7 +85,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.6","3.7","3.9","3.11","3.12"]
+        python-version: ["3.7","3.9","3.11","3.12"]
         # python3.6 reached EOL and is no longer being supported on
         # new versions of hosted runners on Github Actions
         # ubuntu-20.04 is the last version that supported python3.6

--- a/.github/workflows/test-integrations-common.yml
+++ b/.github/workflows/test-integrations-common.yml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.6","3.7","3.8","3.9","3.10","3.11","3.12","3.13"]
+        python-version: ["3.7","3.8","3.9","3.10","3.11","3.12","3.13"]
         # python3.6 reached EOL and is no longer being supported on
         # new versions of hosted runners on Github Actions
         # ubuntu-20.04 is the last version that supported python3.6

--- a/.github/workflows/test-integrations-data-processing.yml
+++ b/.github/workflows/test-integrations-data-processing.yml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.6","3.7","3.8","3.10","3.11","3.12"]
+        python-version: ["3.7","3.8","3.10","3.11","3.12"]
         # python3.6 reached EOL and is no longer being supported on
         # new versions of hosted runners on Github Actions
         # ubuntu-20.04 is the last version that supported python3.6
@@ -99,7 +99,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.6","3.7","3.8","3.9","3.10","3.11","3.12"]
+        python-version: ["3.7","3.8","3.9","3.10","3.11","3.12"]
         # python3.6 reached EOL and is no longer being supported on
         # new versions of hosted runners on Github Actions
         # ubuntu-20.04 is the last version that supported python3.6

--- a/.github/workflows/test-integrations-databases.yml
+++ b/.github/workflows/test-integrations-databases.yml
@@ -112,7 +112,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.6","3.7","3.8","3.9","3.10","3.11","3.12"]
+        python-version: ["3.7","3.8","3.9","3.10","3.11","3.12"]
         # python3.6 reached EOL and is no longer being supported on
         # new versions of hosted runners on Github Actions
         # ubuntu-20.04 is the last version that supported python3.6

--- a/.github/workflows/test-integrations-miscellaneous.yml
+++ b/.github/workflows/test-integrations-miscellaneous.yml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.6","3.8","3.11","3.12"]
+        python-version: ["3.7","3.8","3.11","3.12"]
         # python3.6 reached EOL and is no longer being supported on
         # new versions of hosted runners on Github Actions
         # ubuntu-20.04 is the last version that supported python3.6
@@ -89,7 +89,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.6","3.7","3.8","3.9","3.10","3.11","3.12"]
+        python-version: ["3.7","3.8","3.9","3.10","3.11","3.12"]
         # python3.6 reached EOL and is no longer being supported on
         # new versions of hosted runners on Github Actions
         # ubuntu-20.04 is the last version that supported python3.6

--- a/.github/workflows/test-integrations-networking.yml
+++ b/.github/workflows/test-integrations-networking.yml
@@ -85,7 +85,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.6","3.7","3.8","3.9","3.10","3.11","3.12"]
+        python-version: ["3.7","3.8","3.9","3.10","3.11","3.12"]
         # python3.6 reached EOL and is no longer being supported on
         # new versions of hosted runners on Github Actions
         # ubuntu-20.04 is the last version that supported python3.6

--- a/.github/workflows/test-integrations-web-frameworks-1.yml
+++ b/.github/workflows/test-integrations-web-frameworks-1.yml
@@ -103,7 +103,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.6","3.7","3.8","3.9","3.10","3.11","3.12"]
+        python-version: ["3.7","3.8","3.9","3.10","3.11","3.12"]
         # python3.6 reached EOL and is no longer being supported on
         # new versions of hosted runners on Github Actions
         # ubuntu-20.04 is the last version that supported python3.6

--- a/.github/workflows/test-integrations-web-frameworks-2.yml
+++ b/.github/workflows/test-integrations-web-frameworks-2.yml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.6","3.7","3.8","3.11","3.12"]
+        python-version: ["3.7","3.8","3.11","3.12"]
         # python3.6 reached EOL and is no longer being supported on
         # new versions of hosted runners on Github Actions
         # ubuntu-20.04 is the last version that supported python3.6
@@ -109,7 +109,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.6","3.7","3.8","3.9","3.11","3.12"]
+        python-version: ["3.7","3.8","3.9","3.11","3.12"]
         # python3.6 reached EOL and is no longer being supported on
         # new versions of hosted runners on Github Actions
         # ubuntu-20.04 is the last version that supported python3.6

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setup(
     package_data={"sentry_sdk": ["py.typed"]},
     zip_safe=False,
     license="MIT",
-    python_requires=">=3.6",
+    python_requires=">=3.7",
     install_requires=[
         "urllib3>=1.26.11",
         "certifi",
@@ -91,7 +91,6 @@ setup(
         "Operating System :: OS Independent",
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",

--- a/tox.ini
+++ b/tox.ini
@@ -9,10 +9,10 @@ requires =
     virtualenv<20.26.3
 envlist =
     # === Common ===
-    {py3.6,py3.7,py3.8,py3.9,py3.10,py3.11,py3.12,py3.13}-common
+    {py3.7,py3.8,py3.9,py3.10,py3.11,py3.12,py3.13}-common
 
     # === Gevent ===
-    {py3.6,py3.8,py3.10,py3.11,py3.12}-gevent
+    {py3.8,py3.10,py3.11,py3.12}-gevent
 
     # === Integrations ===
     # General format is {pythonversion}-{integrationname}-v{frameworkversion}
@@ -62,24 +62,24 @@ envlist =
     {py3.8,py3.11}-beam-latest
 
     # Boto3
-    {py3.6,py3.7}-boto3-v{1.12}
+    {py3.7}-boto3-v{1.12}
     {py3.7,py3.11,py3.12}-boto3-v{1.23}
     {py3.11,py3.12}-boto3-v{1.34}
     {py3.11,py3.12}-boto3-latest
 
     # Bottle
-    {py3.6,py3.9}-bottle-v{0.12}
-    {py3.6,py3.11,py3.12}-bottle-latest
+    {py3.7,py3.9}-bottle-v{0.12}
+    {py3.7,py3.11,py3.12}-bottle-latest
 
     # Celery
-    {py3.6,py3.8}-celery-v{4}
-    {py3.6,py3.8}-celery-v{5.0}
+    {py3.7,py3.8}-celery-v{4}
+    {py3.7,py3.8}-celery-v{5.0}
     {py3.7,py3.10}-celery-v{5.1,5.2}
     {py3.8,py3.11,py3.12}-celery-v{5.3,5.4}
     {py3.8,py3.11,py3.12}-celery-latest
 
     # Chalice
-    {py3.6,py3.9}-chalice-v{1.16}
+    {py3.7,py3.9}-chalice-v{1.16}
     {py3.8,py3.12}-chalice-latest
 
     # Clickhouse Driver
@@ -87,7 +87,7 @@ envlist =
     {py3.8,py3.11,py3.12}-clickhouse_driver-latest
 
     # Cloud Resource Context
-    {py3.6,py3.11,py3.12}-cloud_resource_context
+    {py3.7,py3.11,py3.12}-cloud_resource_context
 
     # Cohere
     {py3.9,py3.11,py3.12}-cohere-v5
@@ -95,13 +95,13 @@ envlist =
 
     # Django
     # - Django 1.x
-    {py3.6,py3.7}-django-v{1.11}
+    {py3.7}-django-v{1.11}
     # - Django 2.x
-    {py3.6,py3.7}-django-v{2.0}
-    {py3.6,py3.9}-django-v{2.2}
+    {py3.7}-django-v{2.0}
+    {py3.7,py3.9}-django-v{2.2}
     # - Django 3.x
-    {py3.6,py3.9}-django-v{3.0}
-    {py3.6,py3.9,py3.11}-django-v{3.2}
+    {py3.7,py3.9}-django-v{3.0}
+    {py3.7,py3.9,py3.11}-django-v{3.2}
     # - Django 4.x
     {py3.8,py3.11,py3.12}-django-v{4.0,4.1,4.2}
     # - Django 5.x
@@ -109,14 +109,14 @@ envlist =
     {py3.10,py3.11,py3.12}-django-latest
 
     # dramatiq
-    {py3.6,py3.9}-dramatiq-v{1.13}
+    {py3.7,py3.9}-dramatiq-v{1.13}
     {py3.7,py3.10,py3.11}-dramatiq-v{1.15}
     {py3.8,py3.11,py3.12}-dramatiq-v{1.17}
     {py3.8,py3.11,py3.12}-dramatiq-latest
 
     # Falcon
-    {py3.6,py3.7}-falcon-v{1,1.4,2}
-    {py3.6,py3.11,py3.12}-falcon-v{3}
+    {py3.7}-falcon-v{1,1.4,2}
+    {py3.7,py3.11,py3.12}-falcon-v{3}
     {py3.7,py3.11,py3.12}-falcon-latest
 
     # FastAPI
@@ -124,7 +124,7 @@ envlist =
     {py3.8,py3.11,py3.12}-fastapi-latest
 
     # Flask
-    {py3.6,py3.8}-flask-v{1}
+    {py3.7,py3.8}-flask-v{1}
     {py3.8,py3.11,py3.12}-flask-v{2}
     {py3.10,py3.11,py3.12}-flask-v{3}
     {py3.10,py3.11,py3.12}-flask-latest
@@ -147,15 +147,15 @@ envlist =
     {py3.8,py3.11,py3.12}-grpc-latest
 
     # HTTPX
-    {py3.6,py3.9}-httpx-v{0.16,0.18}
-    {py3.6,py3.10}-httpx-v{0.20,0.22}
+    {py3.7,py3.9}-httpx-v{0.16,0.18}
+    {py3.7,py3.10}-httpx-v{0.20,0.22}
     {py3.7,py3.11,py3.12}-httpx-v{0.23,0.24}
     {py3.9,py3.11,py3.12}-httpx-v{0.25,0.27}
     {py3.9,py3.11,py3.12}-httpx-latest
 
     # Huey
-    {py3.6,py3.11,py3.12}-huey-v{2.0}
-    {py3.6,py3.11,py3.12}-huey-latest
+    {py3.7,py3.11,py3.12}-huey-v{2.0}
+    {py3.7,py3.11,py3.12}-huey-latest
 
     # Huggingface Hub
     {py3.9,py3.11,py3.12}-huggingface_hub-{v0.22,latest}
@@ -174,8 +174,8 @@ envlist =
     {py3.8,py3.11,py3.12}-litestar-latest
 
     # Loguru
-    {py3.6,py3.11,py3.12}-loguru-v{0.5}
-    {py3.6,py3.11,py3.12}-loguru-latest
+    {py3.7,py3.11,py3.12}-loguru-v{0.5}
+    {py3.7,py3.11,py3.12}-loguru-latest
 
     # OpenAI
     {py3.9,py3.11,py3.12}-openai-v1
@@ -190,20 +190,20 @@ envlist =
     {py3.8,py3.9,py3.10,py3.11}-potel
 
     # pure_eval
-    {py3.6,py3.11,py3.12}-pure_eval
+    {py3.7,py3.11,py3.12}-pure_eval
 
     # PyMongo (Mongo DB)
-    {py3.6}-pymongo-v{3.1}
-    {py3.6,py3.9}-pymongo-v{3.12}
-    {py3.6,py3.11}-pymongo-v{4.0}
+    {py3.7}-pymongo-v{3.7}
+    {py3.7,py3.9}-pymongo-v{3.12}
+    {py3.7,py3.11}-pymongo-v{4.0}
     {py3.7,py3.11,py3.12}-pymongo-v{4.3,4.7}
     {py3.7,py3.11,py3.12}-pymongo-latest
 
     # Pyramid
-    {py3.6,py3.11}-pyramid-v{1.6}
-    {py3.6,py3.11,py3.12}-pyramid-v{1.10}
-    {py3.6,py3.11,py3.12}-pyramid-v{2.0}
-    {py3.6,py3.11,py3.12}-pyramid-latest
+    {py3.7,py3.11}-pyramid-v{1.6}
+    {py3.7,py3.11,py3.12}-pyramid-v{1.10}
+    {py3.7,py3.11,py3.12}-pyramid-v{2.0}
+    {py3.7,py3.11,py3.12}-pyramid-latest
 
     # Quart
     {py3.7,py3.11}-quart-v{0.16}
@@ -211,28 +211,28 @@ envlist =
     {py3.8,py3.11,py3.12}-quart-latest
 
     # Redis
-    {py3.6,py3.8}-redis-v{3}
+    {py3.7,py3.8}-redis-v{3}
     {py3.7,py3.8,py3.11}-redis-v{4}
     {py3.7,py3.11,py3.12}-redis-v{5}
     {py3.7,py3.11,py3.12}-redis-latest
 
     # Redis Cluster
-    {py3.6,py3.8}-redis_py_cluster_legacy-v{1,2}
+    {py3.7,py3.8}-redis_py_cluster_legacy-v{1,2}
     # no -latest, not developed anymore
 
     # Requests
-    {py3.6,py3.8,py3.11,py3.12}-requests
+    {py3.7,py3.8,py3.11,py3.12}-requests
 
     # RQ (Redis Queue)
-    {py3.6}-rq-v{0.6}
-    {py3.6,py3.9}-rq-v{0.13,1.0}
-    {py3.6,py3.11}-rq-v{1.5,1.10}
+    {py3.7}-rq-v{0.6}
+    {py3.7,py3.9}-rq-v{0.13,1.0}
+    {py3.7,py3.11}-rq-v{1.5,1.10}
     {py3.7,py3.11,py3.12}-rq-v{1.15,1.16}
     {py3.7,py3.11,py3.12}-rq-latest
 
     # Sanic
-    {py3.6,py3.7}-sanic-v{0.8}
-    {py3.6,py3.8}-sanic-v{20}
+    {py3.7}-sanic-v{0.8}
+    {py3.8}-sanic-v{20}
     {py3.7,py3.11}-sanic-v{22}
     {py3.7,py3.11}-sanic-v{23}
     {py3.8,py3.11}-sanic-latest
@@ -252,7 +252,7 @@ envlist =
     # 1.51.14 is the last starlite version; the project continues as litestar
 
     # SQL Alchemy
-    {py3.6,py3.9}-sqlalchemy-v{1.2,1.4}
+    {py3.7,py3.9}-sqlalchemy-v{1.2,1.4}
     {py3.7,py3.11}-sqlalchemy-v{2.0}
     {py3.7,py3.11,py3.12}-sqlalchemy-latest
 
@@ -267,9 +267,8 @@ envlist =
     {py3.8,py3.11,py3.12}-tornado-latest
 
     # Trytond
-    {py3.6}-trytond-v{4}
-    {py3.6,py3.8}-trytond-v{5}
-    {py3.6,py3.11}-trytond-v{6}
+    {py3.7,py3.8}-trytond-v{5}
+    {py3.7,py3.11}-trytond-v{6}
     {py3.8,py3.11,py3.12}-trytond-v{7}
     {py3.8,py3.11,py3.12}-trytond-latest
 
@@ -285,20 +284,20 @@ deps =
 
     # === Common ===
     py3.8-common: hypothesis
-    {py3.6,py3.7,py3.8,py3.9,py3.10,py3.11,py3.12,py3.13}-common: pytest-asyncio
+    {py3.7,py3.8,py3.9,py3.10,py3.11,py3.12,py3.13}-common: pytest-asyncio
     # See https://github.com/pytest-dev/pytest/issues/9621
     # and https://github.com/pytest-dev/pytest-forked/issues/67
     # for justification of the upper bound on pytest
-    {py3.6,py3.7,py3.8,py3.9,py3.10,py3.11,py3.12}-common: pytest<7.0.0
+    {py3.7,py3.8,py3.9,py3.10,py3.11,py3.12}-common: pytest<7.0.0
     py3.13-common: pytest
 
     # === Gevent ===
-    {py3.6,py3.7,py3.8,py3.9,py3.10,py3.11}-gevent: gevent>=22.10.0, <22.11.0
+    {py3.7,py3.8,py3.9,py3.10,py3.11}-gevent: gevent>=22.10.0, <22.11.0
     {py3.12}-gevent: gevent
     # See https://github.com/pytest-dev/pytest/issues/9621
     # and https://github.com/pytest-dev/pytest-forked/issues/67
     # for justification of the upper bound on pytest
-    {py3.6,py3.7,py3.8,py3.9,py3.10,py3.11,py3.12}-gevent: pytest<7.0.0
+    {py3.7,py3.8,py3.9,py3.10,py3.11,py3.12}-gevent: pytest<7.0.0
 
     # === Integrations ===
 
@@ -368,7 +367,7 @@ deps =
     celery-latest: Celery
 
     {py3.7}-celery: importlib-metadata<5.0
-    {py3.6,py3.7,py3.8,py3.9,py3.10,py3.11,py3.12}-celery: newrelic
+    {py3.7,py3.8,py3.9,py3.10,py3.11,py3.12}-celery: newrelic
 
     # Chalice
     chalice-v1.16: chalice~=1.16.0
@@ -604,7 +603,6 @@ deps =
     sanic: aiohttp
     sanic-v{22,23}: sanic_testing
     sanic-latest: sanic_testing
-    {py3.6}-sanic: aiocontextvars==0.2.1
     sanic-v0.8: sanic~=0.8.0
     sanic-v20: sanic~=20.0
     sanic-v22: sanic~=22.0
@@ -748,7 +746,6 @@ extras =
     pymongo: pymongo
 
 basepython =
-    py3.6: python3.6
     py3.7: python3.7
     py3.8: python3.8
     py3.9: python3.9

--- a/tox.ini
+++ b/tox.ini
@@ -224,7 +224,6 @@ envlist =
     {py3.7,py3.8,py3.11,py3.12}-requests
 
     # RQ (Redis Queue)
-    {py3.7}-rq-v{0.6}
     {py3.7,py3.9}-rq-v{0.13,1.0}
     {py3.7,py3.11}-rq-v{1.5,1.10}
     {py3.7,py3.11,py3.12}-rq-v{1.15,1.16}
@@ -583,13 +582,9 @@ deps =
     requests: requests>=2.0
 
     # RQ (Redis Queue)
-    # https://github.com/jamesls/fakeredis/issues/245
-    rq-v{0.6}: fakeredis<1.0
-    rq-v{0.6}: redis<3.2.2
     rq-v{0.13,1.0,1.5,1.10}: fakeredis>=1.0,<1.7.4
     rq-v{1.15,1.16}: fakeredis
     rq-latest: fakeredis
-    rq-v0.6: rq~=0.6.0
     rq-v0.13: rq~=0.13.0
     rq-v1.0: rq~=1.0.0
     rq-v1.5: rq~=1.5.0
@@ -662,8 +657,6 @@ deps =
 
     # Trytond
     trytond: werkzeug
-    trytond-v4: werkzeug<1.0
-    trytond-v4: trytond~=4.0
     trytond-v5: trytond~=5.0
     trytond-v6: trytond~=6.0
     trytond-v7: trytond~=7.0


### PR DESCRIPTION
No `opentelemetry-distro` in a compatible version for Python 3.6.