### PR TITLE
Tweak OTel timestamp utils

### DIFF
--- a/sentry_sdk/integrations/opentelemetry/potel_span_processor.py
+++ b/sentry_sdk/integrations/opentelemetry/potel_span_processor.py
@@ -7,7 +7,7 @@ from opentelemetry.sdk.trace import Span, ReadableSpan, SpanProcessor
 from sentry_sdk import capture_event
 from sentry_sdk.integrations.opentelemetry.utils import (
     is_sentry_span,
-    convert_otel_timestamp,
+    convert_from_otel_timestamp,
     extract_span_data,
 )
 from sentry_sdk.integrations.opentelemetry.consts import (
@@ -141,8 +141,8 @@ class PotelSentrySpanProcessor(SpanProcessor):
             # TODO-neel-potel tx source based on integration
             "transaction_info": {"source": "custom"},
             "contexts": contexts,
-            "start_timestamp": convert_otel_timestamp(span.start_time),
-            "timestamp": convert_otel_timestamp(span.end_time),
+            "start_timestamp": convert_from_otel_timestamp(span.start_time),
+            "timestamp": convert_from_otel_timestamp(span.end_time),
         }  # type: Event
 
         return event
@@ -169,8 +169,8 @@ class PotelSentrySpanProcessor(SpanProcessor):
             "op": op,
             "description": description,
             "status": status,
-            "start_timestamp": convert_otel_timestamp(span.start_time),
-            "timestamp": convert_otel_timestamp(span.end_time),
+            "start_timestamp": convert_from_otel_timestamp(span.start_time),
+            "timestamp": convert_from_otel_timestamp(span.end_time),
         }  # type: dict[str, Any]
 
         if parent_span_id:

--- a/sentry_sdk/integrations/opentelemetry/utils.py
+++ b/sentry_sdk/integrations/opentelemetry/utils.py
@@ -73,13 +73,13 @@ def is_sentry_span(span):
 
 def convert_from_otel_timestamp(time):
     # type: (int) -> datetime
-    """Convert an OTel ns-level timestamp to a datetime."""
+    """Convert an OTel nanosecond-level timestamp to a datetime."""
     return datetime.fromtimestamp(time / 1e9, timezone.utc)
 
 
 def convert_to_otel_timestamp(time):
     # type: (Union[datetime.datetime, float]) -> int
-    """Convert a datetime to an OTel timestamp (with ns precision)."""
+    """Convert a datetime to an OTel timestamp (with nanosecond precision)."""
     if isinstance(time, datetime):
         return int(time.timestamp() * 1e9)
     return int(time * 1e9)

--- a/sentry_sdk/integrations/opentelemetry/utils.py
+++ b/sentry_sdk/integrations/opentelemetry/utils.py
@@ -13,7 +13,7 @@ from sentry_sdk.utils import Dsn
 from sentry_sdk._types import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from typing import Optional, Mapping, Sequence
+    from typing import Optional, Mapping, Sequence, Union
 
 
 GRPC_ERROR_MAP = {
@@ -71,9 +71,18 @@ def is_sentry_span(span):
     return False
 
 
-def convert_otel_timestamp(time):
+def convert_from_otel_timestamp(time):
     # type: (int) -> datetime
+    """Convert an OTel ns-level timestamp to a datetime."""
     return datetime.fromtimestamp(time / 1e9, timezone.utc)
+
+
+def convert_to_otel_timestamp(time):
+    # type: (Union[datetime.datetime, float]) -> int
+    """Convert a datetime to an OTel timestamp (with ns precision)."""
+    if isinstance(time, datetime):
+        return int(time.timestamp() * 1e9)
+    return int(time * 1e9)
 
 
 def extract_span_data(span):


### PR DESCRIPTION
The `convert_to_otel_timestamp` func will be used in follow up PRs