### PR TITLE
Random tweaks

### DIFF
--- a/sentry_sdk/integrations/boto3.py
+++ b/sentry_sdk/integrations/boto3.py
@@ -3,7 +3,6 @@ from functools import partial
 import sentry_sdk
 from sentry_sdk.consts import OP, SPANDATA
 from sentry_sdk.integrations import Integration, DidNotEnable
-from sentry_sdk.tracing import Span
 
 from sentry_sdk._types import TYPE_CHECKING
 from sentry_sdk.utils import (
@@ -18,6 +17,8 @@ if TYPE_CHECKING:
     from typing import Dict
     from typing import Optional
     from typing import Type
+
+    from sentry_sdk.tracing import Span
 
 try:
     from botocore import __version__ as BOTOCORE_VERSION  # type: ignore

--- a/sentry_sdk/scope.py
+++ b/sentry_sdk/scope.py
@@ -697,23 +697,6 @@ class Scope(object):
         # self._last_event_id is only applicable to isolation scopes
         self._last_event_id = None  # type: Optional[str]
 
-    @_attr_setter
-    def level(self, value):
-        # type: (LogLevelStr) -> None
-        """
-        When set this overrides the level.
-
-        .. deprecated:: 1.0.0
-            Use :func:`set_level` instead.
-
-        :param value: The level to set.
-        """
-        logger.warning(
-            "Deprecated: use .set_level() instead. This will be removed in the future."
-        )
-
-        self._level = value
-
     def set_level(self, value):
         # type: (LogLevelStr) -> None
         """
@@ -802,11 +785,12 @@ class Scope(object):
     @property
     def span(self):
         # type: () -> Optional[Span]
-        """Get/set current tracing span or transaction."""
+        """Get current tracing span."""
         return self._span
 
     @span.setter
     def span(self, span):
+        """Set current tracing span."""
         # type: (Optional[Span]) -> None
         self._span = span
         # XXX: this differs from the implementation in JS, there Scope.setSpan

--- a/sentry_sdk/tracing_utils.py
+++ b/sentry_sdk/tracing_utils.py
@@ -687,7 +687,7 @@ def start_child_span_decorator(func):
 
 
 def get_current_span(scope=None):
-    # type: (Optional[sentry_sdk.Scope]) -> Optional[Span]
+    # type: (Optional[sentry_sdk.Scope]) -> Optional[sentry_sdk.tracing.Span]
     """
     Returns the currently active span if there is one running, otherwise `None`
     """
@@ -702,6 +702,3 @@ from sentry_sdk.tracing import (
     LOW_QUALITY_TRANSACTION_SOURCES,
     SENTRY_TRACE_HEADER_NAME,
 )
-
-if TYPE_CHECKING:
-    from sentry_sdk.tracing import Span

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -30,7 +30,7 @@ def test_get_current_span():
 
 
 @pytest.mark.forked
-def test_get_current_span_default_hub(sentry_init):
+def test_get_current_span_current_scope(sentry_init):
     sentry_init()
 
     assert get_current_span() is None
@@ -43,7 +43,7 @@ def test_get_current_span_default_hub(sentry_init):
 
 
 @pytest.mark.forked
-def test_get_current_span_default_hub_with_transaction(sentry_init):
+def test_get_current_span_current_scope_with_transaction(sentry_init):
     sentry_init()
 
     assert get_current_span() is None

--- a/tests/tracing/test_misc.py
+++ b/tests/tracing/test_misc.py
@@ -258,7 +258,7 @@ def test_circular_references(monkeypatch, sentry_init, request):
     assert gc.collect() == 0
 
 
-def test_set_meaurement(sentry_init, capture_events):
+def test_set_measurement(sentry_init, capture_events):
     sentry_init(traces_sample_rate=1.0)
 
     events = capture_events()
@@ -286,7 +286,7 @@ def test_set_meaurement(sentry_init, capture_events):
     assert event["measurements"]["metric.foobar"] == {"value": 17.99, "unit": "percent"}
 
 
-def test_set_meaurement_public_api(sentry_init, capture_events):
+def test_set_measurement_public_api(sentry_init, capture_events):
     sentry_init(traces_sample_rate=1.0)
 
     events = capture_events()
@@ -412,7 +412,7 @@ def test_transaction_dropped_debug_not_started(sentry_init, sampled):
         )
 
 
-def test_transaction_dropeed_sampled_false(sentry_init):
+def test_transaction_dropped_sampled_false(sentry_init):
     sentry_init(enable_tracing=True)
 
     tx = Transaction(sampled=False)


### PR DESCRIPTION
Some random small things taken out of the monster PR to make it more readable.
* remove attribute deprecated in 1.0
* split docstring
* get rid of extra import
* fix some typos