### PR TITLE
Create spans on scope

### DIFF
--- a/MIGRATION_GUIDE.md
+++ b/MIGRATION_GUIDE.md
@@ -9,10 +9,13 @@ Looking to upgrade from Sentry SDK 2.x to 3.x? Here's a comprehensive list of wh
 
 ### Changed
 
+- `sentry_sdk.start_span` now only takes keyword arguments.
+
 ### Removed
 
 ### Deprecated
 
+- `sentry_sdk.start_transaction` is deprecated. Use `sentry_sdk.start_span` instead.
 
 ## Upgrading to 2.0
 

--- a/sentry_sdk/api.py
+++ b/sentry_sdk/api.py
@@ -234,16 +234,25 @@ def flush(
 
 def start_span(
     *,
-    root_span=None,
+    span=None,
     custom_sampling_context=None,
     **kwargs,  # type: Any
 ):
     # type: (...) -> POTelSpan
     """
     Start and return a span.
+
+    This is the entry point to manual tracing instrumentation.
+
+    A tree structure can be built by adding child spans to the span.
+    To start a new child span within the span, call the `start_child()` method.
+
+    When used as a context manager, spans are automatically finished at the end
+    of the `with` block. If not using context managers, call the `finish()`
+    method.
     """
     # TODO: Consider adding type hints to the method signature.
-    return get_current_scope().start_span(root_span, custom_sampling_context, **kwargs)
+    return get_current_scope().start_span(span, custom_sampling_context, **kwargs)
 
 
 def start_transaction(

--- a/sentry_sdk/api.py
+++ b/sentry_sdk/api.py
@@ -295,7 +295,7 @@ def start_transaction(
         available arguments.
     """
     return start_span(
-        root_span=transaction,
+        span=transaction,
         custom_sampling_context=custom_sampling_context,
         **kwargs,
     )

--- a/sentry_sdk/api.py
+++ b/sentry_sdk/api.py
@@ -285,7 +285,7 @@ def start_transaction(
         constructor. See :py:class:`sentry_sdk.tracing.Transaction` for
         available arguments.
     """
-    return get_current_scope().start_span(
+    return start_span(
         root_span=transaction,
         custom_sampling_context=custom_sampling_context,
         **kwargs,

--- a/sentry_sdk/api.py
+++ b/sentry_sdk/api.py
@@ -1,6 +1,6 @@
 import inspect
 
-from sentry_sdk import tracing, tracing_utils, Client
+from sentry_sdk import tracing_utils, Client
 from sentry_sdk._init_implementation import init
 from sentry_sdk.tracing import POTelSpan, Transaction, trace
 from sentry_sdk.crons import monitor
@@ -233,14 +233,17 @@ def flush(
 
 
 def start_span(
+    *,
+    root_span=None,
+    custom_sampling_context=None,
     **kwargs,  # type: Any
 ):
     # type: (...) -> POTelSpan
     """
-    Alias for tracing.POTelSpan constructor. The method signature is the same.
+    Start and return a span.
     """
     # TODO: Consider adding type hints to the method signature.
-    return tracing.POTelSpan(**kwargs)
+    return get_current_scope().start_span(root_span, custom_sampling_context, **kwargs)
 
 
 def start_transaction(
@@ -282,7 +285,11 @@ def start_transaction(
         constructor. See :py:class:`sentry_sdk.tracing.Transaction` for
         available arguments.
     """
-    return start_span(**kwargs)
+    return get_current_scope().start_span(
+        root_span=transaction,
+        custom_sampling_context=custom_sampling_context,
+        **kwargs,
+    )
 
 
 def set_measurement(name, value, unit=""):

--- a/sentry_sdk/scope.py
+++ b/sentry_sdk/scope.py
@@ -1024,7 +1024,7 @@ class Scope(object):
 
         return transaction
 
-    def start_span(self, root_span=None, custom_sampling_context=None, **kwargs):
+    def start_span(self, span=None, custom_sampling_context=None, **kwargs):
         # type: (Optional[Span], Optional[SamplingContext], Any) -> Span
         """
         Start a span whose parent is the currently active span, if any.
@@ -1039,7 +1039,7 @@ class Scope(object):
             kwargs.setdefault("scope", self)
 
             # get current span or transaction
-            span = self.span or self.get_isolation_scope().span
+            span = span or self.span or self.get_isolation_scope().span
 
             if span is None:
                 # New spans get the `trace_id` from the scope

--- a/sentry_sdk/scope.py
+++ b/sentry_sdk/scope.py
@@ -998,15 +998,12 @@ class Scope(object):
         """
         kwargs.setdefault("scope", self)
 
-        client = self.get_client()
-
         try_autostart_continuous_profiler()
 
         custom_sampling_context = custom_sampling_context or {}
 
         # if we haven't been given a transaction, make one
-        if transaction is None:
-            transaction = POTelSpan(**kwargs)
+        transaction = transaction or POTelSpan(**kwargs)
 
         # use traces_sample_rate, traces_sampler, and/or inheritance to make a
         # sampling decision
@@ -1024,11 +1021,6 @@ class Scope(object):
             profile._set_initial_sampling_decision(sampling_context=sampling_context)
 
             transaction._profile = profile
-
-            # we don't bother to keep spans if we already know we're not going to
-            # send the transaction
-            max_spans = (client.options["_experiments"].get("max_spans")) or 1000
-            transaction.init_span_recorder(maxlen=max_spans)
 
         return transaction
 

--- a/sentry_sdk/tracing.py
+++ b/sentry_sdk/tracing.py
@@ -1310,7 +1310,8 @@ class POTelSpan:
         # type: (str, **Any) -> POTelSpan
         kwargs.setdefault("sampled", self.sampled)
 
-        return POTelSpan(**kwargs)
+        span = POTelSpan(**kwargs)
+        return span
 
     @classmethod
     def continue_from_environ(
@@ -1319,7 +1320,9 @@ class POTelSpan:
         **kwargs,  # type: Any
     ):
         # type: (...) -> POTelSpan
-        pass
+        # XXX actually propagate
+        span = POTelSpan(**kwargs)
+        return span
 
     @classmethod
     def continue_from_headers(
@@ -1328,7 +1331,9 @@ class POTelSpan:
         **kwargs,  # type: Any
     ):
         # type: (...) -> POTelSpan
-        pass
+        # XXX actually propagate
+        span = POTelSpan(**kwargs)
+        return span
 
     def iter_headers(self):
         # type: () -> Iterator[Tuple[str, str]]
@@ -1341,7 +1346,9 @@ class POTelSpan:
         **kwargs,  # type: Any
     ):
         # type: (...) -> Optional[Transaction]
-        pass
+        # XXX actually propagate
+        span = POTelSpan(**kwargs)
+        return span
 
     def to_traceparent(self):
         # type: () -> str

--- a/sentry_sdk/tracing.py
+++ b/sentry_sdk/tracing.py
@@ -1308,7 +1308,9 @@ class POTelSpan:
 
     def start_child(self, **kwargs):
         # type: (str, **Any) -> POTelSpan
-        pass
+        kwargs.setdefault("sampled", self.sampled)
+
+        return POTelSpan(**kwargs)
 
     @classmethod
     def continue_from_environ(


### PR DESCRIPTION
Move span instantiation to the scope, as it was before.

This is pretty broken atm because it expects a bunch of things to be on `POTelSpan`s that are not there (yet).