### PR TITLE
feat: Add SENTRY_SPOTLIGHT env variable support

### DIFF
--- a/sentry_sdk/client.py
+++ b/sentry_sdk/client.py
@@ -105,7 +105,7 @@ def _get_options(*args, **kwargs):
         rv["environment"] = os.environ.get("SENTRY_ENVIRONMENT") or "production"
 
     if rv["debug"] is None:
-        rv["debug"] = env_to_bool(os.environ.get("SENTRY_DEBUG", "False"))
+        rv["debug"] = env_to_bool(os.environ.get("SENTRY_DEBUG", "False"), strict=True)
 
     if rv["server_name"] is None and hasattr(socket, "gethostname"):
         rv["server_name"] = socket.gethostname()

--- a/sentry_sdk/client.py
+++ b/sentry_sdk/client.py
@@ -373,8 +373,8 @@ class _Client(BaseClient):
 
             self.spotlight = None
             spotlight_config = self.options.get("spotlight")
-            if spotlight_config is None:
-                spotlight_env_value = os.environ.get("SENTRY_SPOTLIGHT", "0")
+            if spotlight_config is None and "SENTRY_SPOTLIGHT" in os.environ:
+                spotlight_env_value = os.environ["SENTRY_SPOTLIGHT"]
                 spotlight_config = env_to_bool(spotlight_env_value, strict=True)
                 self.options["spotlight"] = (
                     spotlight_config

--- a/sentry_sdk/client.py
+++ b/sentry_sdk/client.py
@@ -375,6 +375,16 @@ class _Client(BaseClient):
             )
 
             self.spotlight = None
+            spotlight_config = self.options.get("spotlight")
+            if spotlight_config == None:
+                spotlight_config = os.environ["SENTRY_SPOTLIGHT"].lower() if "SENTRY_SPOTLIGHT" in os.environ else None
+                if spotlight_config in ('1', 'true', 'yes'):
+                    self.options["spotlight"] = True
+                elif spotlight_config in ('0', 'false', 'no', ''):
+                    self.options["spotlight"] = False
+                else:
+                    self.options["spotlight"] = spotlight_config
+
             if self.options.get("spotlight"):
                 self.spotlight = setup_spotlight(self.options)
 

--- a/sentry_sdk/spotlight.py
+++ b/sentry_sdk/spotlight.py
@@ -12,6 +12,9 @@ from sentry_sdk.utils import logger
 from sentry_sdk.envelope import Envelope
 
 
+DEFAULT_SPOTLIGHT_URL = "http://localhost:8969/stream"
+
+
 class SpotlightClient:
     def __init__(self, url):
         # type: (str) -> None
@@ -51,7 +54,7 @@ def setup_spotlight(options):
     if isinstance(url, str):
         pass
     elif url is True:
-        url = "http://localhost:8969/stream"
+        url = DEFAULT_SPOTLIGHT_URL
     else:
         return None
 

--- a/sentry_sdk/utils.py
+++ b/sentry_sdk/utils.py
@@ -80,7 +80,7 @@ def env_to_bool(value, *, strict=False):
     """Casts an ENV variable value to boolean using the constants defined above.
     In strict mode, it may return None if the value doesn't match any of the predefined values.
     """
-    normalized = str(value).lower()
+    normalized = str(value).lower() if value is not None else None
 
     if normalized in FALSY_ENV_VALUES:
         return False

--- a/sentry_sdk/utils.py
+++ b/sentry_sdk/utils.py
@@ -71,6 +71,25 @@ BASE64_ALPHABET = re.compile(r"^[a-zA-Z0-9/+=]*$")
 
 SENSITIVE_DATA_SUBSTITUTE = "[Filtered]"
 
+FALSY_ENV_VALUES = frozenset(("false", "n", "no", "off", "0"))
+TRUTHY_ENV_VALUES = frozenset(("true", "y", "yes", "on", "1"))
+
+
+def env_to_bool(value, *, strict=False):
+    # type: (Any, Optional[bool]) -> bool | None
+    """Casts an ENV variable value to boolean using the constants defined above.
+    In strict mode, it may return None if the value doesn't match any of the predefined values.
+    """
+    normalized = str(value).lower()
+
+    if normalized in FALSY_ENV_VALUES:
+        return False
+
+    if normalized in TRUTHY_ENV_VALUES:
+        return True
+
+    return None if strict else bool(value)
+
 
 def json_dumps(data):
     # type: (Any) -> bytes

--- a/sentry_sdk/utils.py
+++ b/sentry_sdk/utils.py
@@ -71,8 +71,8 @@ BASE64_ALPHABET = re.compile(r"^[a-zA-Z0-9/+=]*$")
 
 SENSITIVE_DATA_SUBSTITUTE = "[Filtered]"
 
-FALSY_ENV_VALUES = frozenset(("false", "n", "no", "off", "0"))
-TRUTHY_ENV_VALUES = frozenset(("true", "y", "yes", "on", "1"))
+FALSY_ENV_VALUES = frozenset(("false", "f", "n", "no", "off", "0"))
+TRUTHY_ENV_VALUES = frozenset(("true", "t", "y", "yes", "on", "1"))
 
 
 def env_to_bool(value, *, strict=False):

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -21,6 +21,7 @@ from sentry_sdk import (
     capture_event,
     set_tag,
 )
+from sentry_sdk.spotlight import DEFAULT_SPOTLIGHT_URL
 from sentry_sdk.utils import capture_internal_exception
 from sentry_sdk.integrations.executing import ExecutingIntegration
 from sentry_sdk.transport import Transport
@@ -1095,6 +1096,43 @@ def test_debug_option(
         assert "something is wrong" in caplog.text
     else:
         assert "something is wrong" not in caplog.text
+
+
+@pytest.mark.parametrize(
+    "client_option,env_var_value,spotlight_url_expected",
+    [
+        (None, None, None),
+        (None, "", None),
+        (None, "F", None),
+        (False, None, None),
+        (False, "", None),
+        (False, "t", None),
+        (None, "t", DEFAULT_SPOTLIGHT_URL),
+        (None, "1", DEFAULT_SPOTLIGHT_URL),
+        (True, None, DEFAULT_SPOTLIGHT_URL),
+        (True, "http://localhost:8080/slurp", DEFAULT_SPOTLIGHT_URL),
+        ("http://localhost:8080/slurp", "f", "http://localhost:8080/slurp"),
+        (None, "http://localhost:8080/slurp", "http://localhost:8080/slurp"),
+    ],
+)
+def test_spotlight_option(
+    sentry_init,
+    monkeypatch,
+    client_option,
+    env_var_value,
+    spotlight_url_expected,
+):
+    monkeypatch.setenv("SENTRY_SPOTLIGHT", env_var_value)
+
+    if client_option is None:
+        client = sentry_init()
+    else:
+        client = sentry_init(debug=client_option)
+
+    url = client.spotlight.url if client.spotlight else None
+    assert (
+        url == spotlight_url_expected
+    ), f"With config {client_option} and env {env_var_value}"
 
 
 class IssuesSamplerTestConfig:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1125,10 +1125,11 @@ def test_spotlight_option(
     monkeypatch.setenv("SENTRY_SPOTLIGHT", env_var_value)
 
     if client_option is None:
-        client = sentry_init()
+        sentry_init()
     else:
-        client = sentry_init(debug=client_option)
+        sentry_init(debug=client_option)
 
+    client = sentry_sdk.get_client()
     url = client.spotlight.url if client.spotlight else None
     assert (
         url == spotlight_url_expected

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1127,7 +1127,7 @@ def test_spotlight_option(
     if client_option is None:
         sentry_init()
     else:
-        sentry_init(debug=client_option)
+        sentry_init(spotlight=client_option)
 
     client = sentry_sdk.get_client()
     url = client.spotlight.url if client.spotlight else None

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1122,7 +1122,10 @@ def test_spotlight_option(
     env_var_value,
     spotlight_url_expected,
 ):
-    monkeypatch.setenv("SENTRY_SPOTLIGHT", env_var_value)
+    if env_var_value is None:
+        monkeypatch.delenv("SENTRY_SPOTLIGHT", raising=False)
+    else:
+        monkeypatch.setenv("SENTRY_SPOTLIGHT", env_var_value)
 
     if client_option is None:
         sentry_init()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -63,12 +63,16 @@ def _normalize_distribution_name(name):
 @pytest.mark.parametrize(
     "env_var_value,strict,expected",
     [
-        ("", True, False),
+        ("", True, None),
         ("", False, False),
         ("t", True, True),
+        ("T", True, True),
         ("t", False, True),
+        ("T", False, True),
         ("y", True, True),
+        ("Y", True, True),
         ("y", False, True),
+        ("Y", False, True),
         ("1", True, True),
         ("1", False, True),
         ("True", True, True),
@@ -83,10 +87,18 @@ def _normalize_distribution_name(name):
         ("yes", False, True),
         ("yEs", True, True),
         ("yEs", False, True),
+        ("On", True, True),
+        ("On", False, True),
+        ("on", True, True),
+        ("on", False, True),
+        ("oN", True, True),
+        ("oN", False, True),
         ("f", True, False),
         ("f", False, False),
         ("n", True, False),
+        ("N", True, False),
         ("n", False, False),
+        ("N", False, False),
         ("0", True, False),
         ("0", False, False),
         ("False", True, False),
@@ -101,12 +113,20 @@ def _normalize_distribution_name(name):
         ("no", False, False),
         ("nO", True, False),
         ("nO", False, False),
+        ("Off", True, False),
+        ("Off", False, False),
+        ("off", True, False),
+        ("off", False, False),
+        ("oFf", True, False),
+        ("oFf", False, False),
         ("xxx", True, None),
         ("xxx", False, True),
     ],
 )
 def test_env_to_bool(env_var_value, strict, expected):
-    assert env_to_bool(env_var_value, strict=strict) == expected
+    assert (
+        env_to_bool(env_var_value, strict=strict) == expected
+    ), f"Value: {env_var_value}, strict: {strict}"
 
 
 @pytest.mark.parametrize(

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -12,6 +12,7 @@ from sentry_sdk._queue import Queue
 from sentry_sdk.utils import (
     Components,
     Dsn,
+    env_to_bool,
     get_current_thread_meta,
     get_default_release,
     get_error_message,
@@ -57,6 +58,55 @@ def _normalize_distribution_name(name):
     for more details.
     """
     return re.sub(r"[-_.]+", "-", name).lower()
+
+
+@pytest.mark.parametrize(
+    "env_var_value,strict,expected",
+    [
+        ("", True, False),
+        ("", False, False),
+        ("t", True, True),
+        ("t", False, True),
+        ("y", True, True),
+        ("y", False, True),
+        ("1", True, True),
+        ("1", False, True),
+        ("True", True, True),
+        ("True", False, True),
+        ("true", True, True),
+        ("true", False, True),
+        ("tRuE", True, True),
+        ("tRuE", False, True),
+        ("Yes", True, True),
+        ("Yes", False, True),
+        ("yes", True, True),
+        ("yes", False, True),
+        ("yEs", True, True),
+        ("yEs", False, True),
+        ("f", True, False),
+        ("f", False, False),
+        ("n", True, False),
+        ("n", False, False),
+        ("0", True, False),
+        ("0", False, False),
+        ("False", True, False),
+        ("False", False, False),
+        ("false", True, False),
+        ("false", False, False),
+        ("FaLsE", True, False),
+        ("FaLsE", False, False),
+        ("No", True, False),
+        ("No", False, False),
+        ("no", True, False),
+        ("no", False, False),
+        ("nO", True, False),
+        ("nO", False, False),
+        ("xxx", True, None),
+        ("xxx", False, True),
+    ],
+)
+def test_env_to_bool(env_var_value, strict, expected):
+    assert env_to_bool(env_var_value, strict=strict) == expected
 
 
 @pytest.mark.parametrize(

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -63,6 +63,8 @@ def _normalize_distribution_name(name):
 @pytest.mark.parametrize(
     "env_var_value,strict,expected",
     [
+        (None, True, None),
+        (None, False, False),
         ("", True, None),
         ("", False, False),
         ("t", True, True),


### PR DESCRIPTION
Allows setting Spotlight through `$SENTRY_SPOTLIGHT` env variable.

Part of getsentry/spotlight#482
