### PR TITLE
fix(types): Replace custom TYPE_CHECKING with stdlib typing.TYPE_CHECKING

### DIFF
--- a/scripts/init_serverless_sdk.py
+++ b/scripts/init_serverless_sdk.py
@@ -11,7 +11,7 @@ import sys
 import re
 
 import sentry_sdk
-from sentry_sdk._types import TYPE_CHECKING
+from typing import TYPE_CHECKING
 from sentry_sdk.integrations.aws_lambda import AwsLambdaIntegration
 
 if TYPE_CHECKING:

--- a/scripts/init_serverless_sdk.py
+++ b/scripts/init_serverless_sdk.py
@@ -11,8 +11,9 @@ import sys
 import re
 
 import sentry_sdk
-from typing import TYPE_CHECKING
 from sentry_sdk.integrations.aws_lambda import AwsLambdaIntegration
+
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from typing import Any

--- a/sentry_sdk/_compat.py
+++ b/sentry_sdk/_compat.py
@@ -1,6 +1,6 @@
 import sys
 
-from sentry_sdk._types import TYPE_CHECKING
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from typing import Any

--- a/sentry_sdk/_queue.py
+++ b/sentry_sdk/_queue.py
@@ -76,7 +76,7 @@ import threading
 from collections import deque
 from time import time
 
-from sentry_sdk._types import TYPE_CHECKING
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from typing import Any

--- a/sentry_sdk/_types.py
+++ b/sentry_sdk/_types.py
@@ -1,7 +1,4 @@
-try:
-    from typing import TYPE_CHECKING
-except ImportError:
-    TYPE_CHECKING = False
+from typing import TYPE_CHECKING
 
 
 # Re-exported for compat, since code out there in the wild might use this variable.

--- a/sentry_sdk/_werkzeug.py
+++ b/sentry_sdk/_werkzeug.py
@@ -32,7 +32,7 @@ THIS SOFTWARE AND DOCUMENTATION, EVEN IF ADVISED OF THE POSSIBILITY OF
 SUCH DAMAGE.
 """
 
-from sentry_sdk._types import TYPE_CHECKING
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from typing import Dict

--- a/sentry_sdk/ai/monitoring.py
+++ b/sentry_sdk/ai/monitoring.py
@@ -5,7 +5,7 @@ import sentry_sdk.utils
 from sentry_sdk import start_span
 from sentry_sdk.tracing import Span
 from sentry_sdk.utils import ContextVar
-from sentry_sdk._types import TYPE_CHECKING
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from typing import Optional, Callable, Any

--- a/sentry_sdk/ai/monitoring.py
+++ b/sentry_sdk/ai/monitoring.py
@@ -5,6 +5,7 @@ import sentry_sdk.utils
 from sentry_sdk import start_span
 from sentry_sdk.tracing import Span
 from sentry_sdk.utils import ContextVar
+
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:

--- a/sentry_sdk/ai/utils.py
+++ b/sentry_sdk/ai/utils.py
@@ -1,4 +1,4 @@
-from sentry_sdk._types import TYPE_CHECKING
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from typing import Any

--- a/sentry_sdk/api.py
+++ b/sentry_sdk/api.py
@@ -10,7 +10,7 @@ from sentry_sdk.tracing import NoOpSpan, Transaction, trace
 from sentry_sdk.crons import monitor
 
 
-from sentry_sdk._types import TYPE_CHECKING
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from collections.abc import Mapping

--- a/sentry_sdk/api.py
+++ b/sentry_sdk/api.py
@@ -9,7 +9,6 @@ from sentry_sdk.scope import Scope, _ScopeManager, new_scope, isolation_scope
 from sentry_sdk.tracing import NoOpSpan, Transaction, trace
 from sentry_sdk.crons import monitor
 
-
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:

--- a/sentry_sdk/attachments.py
+++ b/sentry_sdk/attachments.py
@@ -1,8 +1,9 @@
 import os
 import mimetypes
 
-from typing import TYPE_CHECKING
 from sentry_sdk.envelope import Item, PayloadRef
+
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from typing import Optional, Union, Callable

--- a/sentry_sdk/attachments.py
+++ b/sentry_sdk/attachments.py
@@ -1,7 +1,7 @@
 import os
 import mimetypes
 
-from sentry_sdk._types import TYPE_CHECKING
+from typing import TYPE_CHECKING
 from sentry_sdk.envelope import Item, PayloadRef
 
 if TYPE_CHECKING:

--- a/sentry_sdk/client.py
+++ b/sentry_sdk/client.py
@@ -44,7 +44,7 @@ from sentry_sdk.scrubber import EventScrubber
 from sentry_sdk.monitor import Monitor
 from sentry_sdk.spotlight import setup_spotlight
 
-from sentry_sdk._types import TYPE_CHECKING
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from typing import Any
@@ -881,7 +881,7 @@ class _Client(BaseClient):
         self.close()
 
 
-from sentry_sdk._types import TYPE_CHECKING
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     # Make mypy, PyCharm and other static analyzers think `get_options` is a

--- a/sentry_sdk/consts.py
+++ b/sentry_sdk/consts.py
@@ -1,7 +1,7 @@
 import itertools
 
 from enum import Enum
-from sentry_sdk._types import TYPE_CHECKING
+from typing import TYPE_CHECKING
 
 # up top to prevent circular import due to integration import
 DEFAULT_MAX_VALUE_LENGTH = 1024

--- a/sentry_sdk/crons/api.py
+++ b/sentry_sdk/crons/api.py
@@ -1,8 +1,8 @@
 import uuid
 
 import sentry_sdk
-from typing import TYPE_CHECKING
 
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from typing import Optional

--- a/sentry_sdk/crons/api.py
+++ b/sentry_sdk/crons/api.py
@@ -1,7 +1,7 @@
 import uuid
 
 import sentry_sdk
-from sentry_sdk._types import TYPE_CHECKING
+from typing import TYPE_CHECKING
 
 
 if TYPE_CHECKING:

--- a/sentry_sdk/crons/decorator.py
+++ b/sentry_sdk/crons/decorator.py
@@ -1,10 +1,11 @@
 from functools import wraps
 from inspect import iscoroutinefunction
 
-from typing import TYPE_CHECKING
 from sentry_sdk.crons import capture_checkin
 from sentry_sdk.crons.consts import MonitorStatus
 from sentry_sdk.utils import now
+
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from collections.abc import Awaitable, Callable

--- a/sentry_sdk/crons/decorator.py
+++ b/sentry_sdk/crons/decorator.py
@@ -1,7 +1,7 @@
 from functools import wraps
 from inspect import iscoroutinefunction
 
-from sentry_sdk._types import TYPE_CHECKING
+from typing import TYPE_CHECKING
 from sentry_sdk.crons import capture_checkin
 from sentry_sdk.crons.consts import MonitorStatus
 from sentry_sdk.utils import now

--- a/sentry_sdk/db/explain_plan/__init__.py
+++ b/sentry_sdk/db/explain_plan/__init__.py
@@ -1,6 +1,5 @@
 from datetime import datetime, timedelta, timezone
-
-from sentry_sdk.consts import TYPE_CHECKING
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from typing import Any

--- a/sentry_sdk/db/explain_plan/django.py
+++ b/sentry_sdk/db/explain_plan/django.py
@@ -1,4 +1,5 @@
-from sentry_sdk.consts import TYPE_CHECKING
+from typing import TYPE_CHECKING
+
 from sentry_sdk.db.explain_plan import cache_statement, should_run_explain_plan
 
 if TYPE_CHECKING:

--- a/sentry_sdk/db/explain_plan/sqlalchemy.py
+++ b/sentry_sdk/db/explain_plan/sqlalchemy.py
@@ -1,4 +1,5 @@
-from sentry_sdk.consts import TYPE_CHECKING
+from typing import TYPE_CHECKING
+
 from sentry_sdk.db.explain_plan import cache_statement, should_run_explain_plan
 from sentry_sdk.integrations import DidNotEnable
 

--- a/sentry_sdk/envelope.py
+++ b/sentry_sdk/envelope.py
@@ -2,9 +2,10 @@ import io
 import json
 import mimetypes
 
-from typing import TYPE_CHECKING
 from sentry_sdk.session import Session
 from sentry_sdk.utils import json_dumps, capture_internal_exceptions
+
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from typing import Any

--- a/sentry_sdk/envelope.py
+++ b/sentry_sdk/envelope.py
@@ -2,7 +2,7 @@ import io
 import json
 import mimetypes
 
-from sentry_sdk._types import TYPE_CHECKING
+from typing import TYPE_CHECKING
 from sentry_sdk.session import Session
 from sentry_sdk.utils import json_dumps, capture_internal_exceptions
 

--- a/sentry_sdk/hub.py
+++ b/sentry_sdk/hub.py
@@ -22,7 +22,7 @@ from sentry_sdk.utils import (
     ContextVar,
 )
 
-from sentry_sdk._types import TYPE_CHECKING
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from typing import Any

--- a/sentry_sdk/integrations/__init__.py
+++ b/sentry_sdk/integrations/__init__.py
@@ -1,7 +1,7 @@
 from abc import ABC, abstractmethod
 from threading import Lock
 
-from sentry_sdk._types import TYPE_CHECKING
+from typing import TYPE_CHECKING
 from sentry_sdk.utils import logger
 
 

--- a/sentry_sdk/integrations/__init__.py
+++ b/sentry_sdk/integrations/__init__.py
@@ -1,9 +1,9 @@
 from abc import ABC, abstractmethod
 from threading import Lock
 
-from typing import TYPE_CHECKING
 from sentry_sdk.utils import logger
 
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from collections.abc import Sequence

--- a/sentry_sdk/integrations/_asgi_common.py
+++ b/sentry_sdk/integrations/_asgi_common.py
@@ -2,7 +2,7 @@ import urllib
 
 from sentry_sdk.scope import should_send_default_pii
 from sentry_sdk.integrations._wsgi_common import _filter_headers
-from sentry_sdk._types import TYPE_CHECKING
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from typing import Any

--- a/sentry_sdk/integrations/_asgi_common.py
+++ b/sentry_sdk/integrations/_asgi_common.py
@@ -2,6 +2,7 @@ import urllib
 
 from sentry_sdk.scope import should_send_default_pii
 from sentry_sdk.integrations._wsgi_common import _filter_headers
+
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:

--- a/sentry_sdk/integrations/_wsgi_common.py
+++ b/sentry_sdk/integrations/_wsgi_common.py
@@ -4,7 +4,7 @@ from copy import deepcopy
 import sentry_sdk
 from sentry_sdk.scope import should_send_default_pii
 from sentry_sdk.utils import AnnotatedValue, logger
-from sentry_sdk._types import TYPE_CHECKING
+from typing import TYPE_CHECKING
 
 try:
     from django.http.request import RawPostDataException

--- a/sentry_sdk/integrations/_wsgi_common.py
+++ b/sentry_sdk/integrations/_wsgi_common.py
@@ -4,13 +4,13 @@ from copy import deepcopy
 import sentry_sdk
 from sentry_sdk.scope import should_send_default_pii
 from sentry_sdk.utils import AnnotatedValue, logger
-from typing import TYPE_CHECKING
 
 try:
     from django.http.request import RawPostDataException
 except ImportError:
     RawPostDataException = None
 
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from typing import Any

--- a/sentry_sdk/integrations/aiohttp.py
+++ b/sentry_sdk/integrations/aiohttp.py
@@ -41,7 +41,7 @@ try:
 except ImportError:
     raise DidNotEnable("AIOHTTP not installed")
 
-from sentry_sdk._types import TYPE_CHECKING
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from aiohttp.web_request import Request

--- a/sentry_sdk/integrations/argv.py
+++ b/sentry_sdk/integrations/argv.py
@@ -4,7 +4,7 @@ import sentry_sdk
 from sentry_sdk.integrations import Integration
 from sentry_sdk.scope import add_global_event_processor
 
-from sentry_sdk._types import TYPE_CHECKING
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from typing import Optional

--- a/sentry_sdk/integrations/ariadne.py
+++ b/sentry_sdk/integrations/ariadne.py
@@ -12,7 +12,6 @@ from sentry_sdk.utils import (
     event_from_exception,
     package_version,
 )
-from typing import TYPE_CHECKING
 
 try:
     # importing like this is necessary due to name shadowing in ariadne
@@ -21,6 +20,7 @@ try:
 except ImportError:
     raise DidNotEnable("ariadne is not installed")
 
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from typing import Any, Dict, List, Optional

--- a/sentry_sdk/integrations/ariadne.py
+++ b/sentry_sdk/integrations/ariadne.py
@@ -12,7 +12,7 @@ from sentry_sdk.utils import (
     event_from_exception,
     package_version,
 )
-from sentry_sdk._types import TYPE_CHECKING
+from typing import TYPE_CHECKING
 
 try:
     # importing like this is necessary due to name shadowing in ariadne

--- a/sentry_sdk/integrations/arq.py
+++ b/sentry_sdk/integrations/arq.py
@@ -1,7 +1,7 @@
 import sys
 
 import sentry_sdk
-from sentry_sdk._types import TYPE_CHECKING
+from typing import TYPE_CHECKING
 from sentry_sdk.consts import OP, SPANSTATUS
 from sentry_sdk.integrations import DidNotEnable, Integration
 from sentry_sdk.integrations.logging import ignore_logger

--- a/sentry_sdk/integrations/arq.py
+++ b/sentry_sdk/integrations/arq.py
@@ -1,7 +1,6 @@
 import sys
 
 import sentry_sdk
-from typing import TYPE_CHECKING
 from sentry_sdk.consts import OP, SPANSTATUS
 from sentry_sdk.integrations import DidNotEnable, Integration
 from sentry_sdk.integrations.logging import ignore_logger
@@ -23,6 +22,8 @@ try:
     from arq.worker import JobExecutionFailed, Retry, RetryJob, Worker
 except ImportError:
     raise DidNotEnable("Arq is not installed")
+
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from typing import Any, Dict, Optional, Union

--- a/sentry_sdk/integrations/asgi.py
+++ b/sentry_sdk/integrations/asgi.py
@@ -10,7 +10,7 @@ from copy import deepcopy
 from functools import partial
 
 import sentry_sdk
-from sentry_sdk._types import TYPE_CHECKING
+from typing import TYPE_CHECKING
 from sentry_sdk.api import continue_trace
 from sentry_sdk.consts import OP
 

--- a/sentry_sdk/integrations/asgi.py
+++ b/sentry_sdk/integrations/asgi.py
@@ -10,7 +10,6 @@ from copy import deepcopy
 from functools import partial
 
 import sentry_sdk
-from typing import TYPE_CHECKING
 from sentry_sdk.api import continue_trace
 from sentry_sdk.consts import OP
 
@@ -36,6 +35,8 @@ from sentry_sdk.utils import (
     _get_installed_modules,
 )
 from sentry_sdk.tracing import Transaction
+
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from typing import Any

--- a/sentry_sdk/integrations/asyncio.py
+++ b/sentry_sdk/integrations/asyncio.py
@@ -3,7 +3,6 @@ import sys
 import sentry_sdk
 from sentry_sdk.consts import OP
 from sentry_sdk.integrations import Integration, DidNotEnable
-from typing import TYPE_CHECKING
 from sentry_sdk.utils import event_from_exception, reraise
 
 try:
@@ -12,6 +11,7 @@ try:
 except ImportError:
     raise DidNotEnable("asyncio not available")
 
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from typing import Any

--- a/sentry_sdk/integrations/asyncio.py
+++ b/sentry_sdk/integrations/asyncio.py
@@ -3,7 +3,7 @@ import sys
 import sentry_sdk
 from sentry_sdk.consts import OP
 from sentry_sdk.integrations import Integration, DidNotEnable
-from sentry_sdk._types import TYPE_CHECKING
+from typing import TYPE_CHECKING
 from sentry_sdk.utils import event_from_exception, reraise
 
 try:

--- a/sentry_sdk/integrations/atexit.py
+++ b/sentry_sdk/integrations/atexit.py
@@ -6,7 +6,7 @@ import sentry_sdk
 from sentry_sdk.utils import logger
 from sentry_sdk.integrations import Integration
 from sentry_sdk.utils import ensure_integration_enabled
-from sentry_sdk._types import TYPE_CHECKING
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from typing import Any

--- a/sentry_sdk/integrations/atexit.py
+++ b/sentry_sdk/integrations/atexit.py
@@ -6,6 +6,7 @@ import sentry_sdk
 from sentry_sdk.utils import logger
 from sentry_sdk.integrations import Integration
 from sentry_sdk.utils import ensure_integration_enabled
+
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:

--- a/sentry_sdk/integrations/aws_lambda.py
+++ b/sentry_sdk/integrations/aws_lambda.py
@@ -19,6 +19,7 @@ from sentry_sdk.utils import (
 )
 from sentry_sdk.integrations import Integration
 from sentry_sdk.integrations._wsgi_common import _filter_headers
+
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:

--- a/sentry_sdk/integrations/aws_lambda.py
+++ b/sentry_sdk/integrations/aws_lambda.py
@@ -19,7 +19,7 @@ from sentry_sdk.utils import (
 )
 from sentry_sdk.integrations import Integration
 from sentry_sdk.integrations._wsgi_common import _filter_headers
-from sentry_sdk._types import TYPE_CHECKING
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from typing import Any

--- a/sentry_sdk/integrations/beam.py
+++ b/sentry_sdk/integrations/beam.py
@@ -11,7 +11,7 @@ from sentry_sdk.utils import (
     event_from_exception,
     reraise,
 )
-from sentry_sdk._types import TYPE_CHECKING
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from typing import Any

--- a/sentry_sdk/integrations/beam.py
+++ b/sentry_sdk/integrations/beam.py
@@ -11,6 +11,7 @@ from sentry_sdk.utils import (
     event_from_exception,
     reraise,
 )
+
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:

--- a/sentry_sdk/integrations/boto3.py
+++ b/sentry_sdk/integrations/boto3.py
@@ -5,7 +5,7 @@ from sentry_sdk.consts import OP, SPANDATA
 from sentry_sdk.integrations import Integration, DidNotEnable
 from sentry_sdk.tracing import Span
 
-from sentry_sdk._types import TYPE_CHECKING
+from typing import TYPE_CHECKING
 from sentry_sdk.utils import (
     capture_internal_exceptions,
     ensure_integration_enabled,

--- a/sentry_sdk/integrations/boto3.py
+++ b/sentry_sdk/integrations/boto3.py
@@ -4,14 +4,14 @@ import sentry_sdk
 from sentry_sdk.consts import OP, SPANDATA
 from sentry_sdk.integrations import Integration, DidNotEnable
 from sentry_sdk.tracing import Span
-
-from typing import TYPE_CHECKING
 from sentry_sdk.utils import (
     capture_internal_exceptions,
     ensure_integration_enabled,
     parse_url,
     parse_version,
 )
+
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from typing import Any

--- a/sentry_sdk/integrations/bottle.py
+++ b/sentry_sdk/integrations/bottle.py
@@ -10,6 +10,7 @@ from sentry_sdk.utils import (
 from sentry_sdk.integrations import Integration, DidNotEnable
 from sentry_sdk.integrations.wsgi import SentryWsgiMiddleware
 from sentry_sdk.integrations._wsgi_common import RequestExtractor
+
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:

--- a/sentry_sdk/integrations/bottle.py
+++ b/sentry_sdk/integrations/bottle.py
@@ -10,7 +10,7 @@ from sentry_sdk.utils import (
 from sentry_sdk.integrations import Integration, DidNotEnable
 from sentry_sdk.integrations.wsgi import SentryWsgiMiddleware
 from sentry_sdk.integrations._wsgi_common import RequestExtractor
-from sentry_sdk._types import TYPE_CHECKING
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from sentry_sdk.integrations.wsgi import _ScopedResponse

--- a/sentry_sdk/integrations/celery/__init__.py
+++ b/sentry_sdk/integrations/celery/__init__.py
@@ -15,7 +15,7 @@ from sentry_sdk.integrations.celery.beat import (
 from sentry_sdk.integrations.celery.utils import _now_seconds_since_epoch
 from sentry_sdk.integrations.logging import ignore_logger
 from sentry_sdk.tracing import BAGGAGE_HEADER_NAME, TRANSACTION_SOURCE_TASK
-from sentry_sdk._types import TYPE_CHECKING
+from typing import TYPE_CHECKING
 from sentry_sdk.tracing_utils import Baggage
 from sentry_sdk.utils import (
     capture_internal_exceptions,

--- a/sentry_sdk/integrations/celery/__init__.py
+++ b/sentry_sdk/integrations/celery/__init__.py
@@ -15,7 +15,6 @@ from sentry_sdk.integrations.celery.beat import (
 from sentry_sdk.integrations.celery.utils import _now_seconds_since_epoch
 from sentry_sdk.integrations.logging import ignore_logger
 from sentry_sdk.tracing import BAGGAGE_HEADER_NAME, TRANSACTION_SOURCE_TASK
-from typing import TYPE_CHECKING
 from sentry_sdk.tracing_utils import Baggage
 from sentry_sdk.utils import (
     capture_internal_exceptions,
@@ -23,6 +22,8 @@ from sentry_sdk.utils import (
     event_from_exception,
     reraise,
 )
+
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from typing import Any

--- a/sentry_sdk/integrations/celery/beat.py
+++ b/sentry_sdk/integrations/celery/beat.py
@@ -5,11 +5,12 @@ from sentry_sdk.integrations.celery.utils import (
     _get_humanized_interval,
     _now_seconds_since_epoch,
 )
-from typing import TYPE_CHECKING
 from sentry_sdk.utils import (
     logger,
     match_regex_list,
 )
+
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from collections.abc import Callable

--- a/sentry_sdk/integrations/celery/beat.py
+++ b/sentry_sdk/integrations/celery/beat.py
@@ -5,7 +5,7 @@ from sentry_sdk.integrations.celery.utils import (
     _get_humanized_interval,
     _now_seconds_since_epoch,
 )
-from sentry_sdk._types import TYPE_CHECKING
+from typing import TYPE_CHECKING
 from sentry_sdk.utils import (
     logger,
     match_regex_list,

--- a/sentry_sdk/integrations/celery/utils.py
+++ b/sentry_sdk/integrations/celery/utils.py
@@ -1,7 +1,5 @@
 import time
-from typing import cast
-
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
 if TYPE_CHECKING:
     from typing import Any, Tuple

--- a/sentry_sdk/integrations/celery/utils.py
+++ b/sentry_sdk/integrations/celery/utils.py
@@ -1,7 +1,7 @@
 import time
 from typing import cast
 
-from sentry_sdk._types import TYPE_CHECKING
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from typing import Any, Tuple

--- a/sentry_sdk/integrations/chalice.py
+++ b/sentry_sdk/integrations/chalice.py
@@ -11,7 +11,7 @@ from sentry_sdk.utils import (
     parse_version,
     reraise,
 )
-from sentry_sdk._types import TYPE_CHECKING
+from typing import TYPE_CHECKING
 
 try:
     import chalice  # type: ignore

--- a/sentry_sdk/integrations/chalice.py
+++ b/sentry_sdk/integrations/chalice.py
@@ -11,7 +11,6 @@ from sentry_sdk.utils import (
     parse_version,
     reraise,
 )
-from typing import TYPE_CHECKING
 
 try:
     import chalice  # type: ignore
@@ -20,6 +19,8 @@ try:
     from chalice.app import EventSourceHandler as ChaliceEventSourceHandler  # type: ignore
 except ImportError:
     raise DidNotEnable("Chalice is not installed")
+
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from typing import Any

--- a/sentry_sdk/integrations/clickhouse_driver.py
+++ b/sentry_sdk/integrations/clickhouse_driver.py
@@ -2,11 +2,10 @@ import sentry_sdk
 from sentry_sdk.consts import OP, SPANDATA
 from sentry_sdk.integrations import Integration, DidNotEnable
 from sentry_sdk.tracing import Span
-from typing import TYPE_CHECKING
 from sentry_sdk.scope import should_send_default_pii
 from sentry_sdk.utils import capture_internal_exceptions, ensure_integration_enabled
 
-from typing import TypeVar
+from typing import TYPE_CHECKING, TypeVar
 
 # Hack to get new Python features working in older versions
 # without introducing a hard dependency on `typing_extensions`

--- a/sentry_sdk/integrations/clickhouse_driver.py
+++ b/sentry_sdk/integrations/clickhouse_driver.py
@@ -2,7 +2,7 @@ import sentry_sdk
 from sentry_sdk.consts import OP, SPANDATA
 from sentry_sdk.integrations import Integration, DidNotEnable
 from sentry_sdk.tracing import Span
-from sentry_sdk._types import TYPE_CHECKING
+from typing import TYPE_CHECKING
 from sentry_sdk.scope import should_send_default_pii
 from sentry_sdk.utils import capture_internal_exceptions, ensure_integration_enabled
 

--- a/sentry_sdk/integrations/cloud_resource_context.py
+++ b/sentry_sdk/integrations/cloud_resource_context.py
@@ -5,7 +5,7 @@ from sentry_sdk.integrations import Integration
 from sentry_sdk.api import set_context
 from sentry_sdk.utils import logger
 
-from sentry_sdk._types import TYPE_CHECKING
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from typing import Dict

--- a/sentry_sdk/integrations/cohere.py
+++ b/sentry_sdk/integrations/cohere.py
@@ -1,10 +1,11 @@
 from functools import wraps
 
 from sentry_sdk import consts
-from typing import TYPE_CHECKING
 from sentry_sdk.ai.monitoring import record_token_usage
 from sentry_sdk.consts import SPANDATA
 from sentry_sdk.ai.utils import set_data_normalized
+
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from typing import Any, Callable, Iterator

--- a/sentry_sdk/integrations/cohere.py
+++ b/sentry_sdk/integrations/cohere.py
@@ -1,7 +1,7 @@
 from functools import wraps
 
 from sentry_sdk import consts
-from sentry_sdk._types import TYPE_CHECKING
+from typing import TYPE_CHECKING
 from sentry_sdk.ai.monitoring import record_token_usage
 from sentry_sdk.consts import SPANDATA
 from sentry_sdk.ai.utils import set_data_normalized

--- a/sentry_sdk/integrations/dedupe.py
+++ b/sentry_sdk/integrations/dedupe.py
@@ -3,7 +3,7 @@ from sentry_sdk.utils import ContextVar
 from sentry_sdk.integrations import Integration
 from sentry_sdk.scope import add_global_event_processor
 
-from sentry_sdk._types import TYPE_CHECKING
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from typing import Optional

--- a/sentry_sdk/integrations/django/__init__.py
+++ b/sentry_sdk/integrations/django/__init__.py
@@ -5,7 +5,6 @@ import weakref
 from importlib import import_module
 
 import sentry_sdk
-from typing import TYPE_CHECKING
 from sentry_sdk.consts import OP, SPANDATA
 from sentry_sdk.db.explain_plan.django import attach_explain_plan_to_span
 from sentry_sdk.scope import add_global_event_processor, should_send_default_pii
@@ -68,6 +67,7 @@ if DJANGO_VERSION[:2] > (1, 8):
 else:
     patch_caching = None  # type: ignore
 
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from typing import Any

--- a/sentry_sdk/integrations/django/__init__.py
+++ b/sentry_sdk/integrations/django/__init__.py
@@ -5,7 +5,7 @@ import weakref
 from importlib import import_module
 
 import sentry_sdk
-from sentry_sdk._types import TYPE_CHECKING
+from typing import TYPE_CHECKING
 from sentry_sdk.consts import OP, SPANDATA
 from sentry_sdk.db.explain_plan.django import attach_explain_plan_to_span
 from sentry_sdk.scope import add_global_event_processor, should_send_default_pii

--- a/sentry_sdk/integrations/django/asgi.py
+++ b/sentry_sdk/integrations/django/asgi.py
@@ -13,7 +13,6 @@ import inspect
 from django.core.handlers.wsgi import WSGIRequest
 
 import sentry_sdk
-from typing import TYPE_CHECKING
 from sentry_sdk.consts import OP
 
 from sentry_sdk.integrations.asgi import SentryAsgiMiddleware
@@ -23,6 +22,7 @@ from sentry_sdk.utils import (
     ensure_integration_enabled,
 )
 
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from typing import Any, Callable, Union, TypeVar

--- a/sentry_sdk/integrations/django/asgi.py
+++ b/sentry_sdk/integrations/django/asgi.py
@@ -13,7 +13,7 @@ import inspect
 from django.core.handlers.wsgi import WSGIRequest
 
 import sentry_sdk
-from sentry_sdk._types import TYPE_CHECKING
+from typing import TYPE_CHECKING
 from sentry_sdk.consts import OP
 
 from sentry_sdk.integrations.asgi import SentryAsgiMiddleware

--- a/sentry_sdk/integrations/django/middleware.py
+++ b/sentry_sdk/integrations/django/middleware.py
@@ -7,7 +7,7 @@ from functools import wraps
 from django import VERSION as DJANGO_VERSION
 
 import sentry_sdk
-from sentry_sdk._types import TYPE_CHECKING
+from typing import TYPE_CHECKING
 from sentry_sdk.consts import OP
 from sentry_sdk.utils import (
     ContextVar,

--- a/sentry_sdk/integrations/django/middleware.py
+++ b/sentry_sdk/integrations/django/middleware.py
@@ -7,13 +7,14 @@ from functools import wraps
 from django import VERSION as DJANGO_VERSION
 
 import sentry_sdk
-from typing import TYPE_CHECKING
 from sentry_sdk.consts import OP
 from sentry_sdk.utils import (
     ContextVar,
     transaction_from_function,
     capture_internal_exceptions,
 )
+
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from typing import Any

--- a/sentry_sdk/integrations/django/signals_handlers.py
+++ b/sentry_sdk/integrations/django/signals_handlers.py
@@ -3,7 +3,7 @@ from functools import wraps
 from django.dispatch import Signal
 
 import sentry_sdk
-from sentry_sdk._types import TYPE_CHECKING
+from typing import TYPE_CHECKING
 from sentry_sdk.consts import OP
 from sentry_sdk.integrations.django import DJANGO_VERSION
 

--- a/sentry_sdk/integrations/django/signals_handlers.py
+++ b/sentry_sdk/integrations/django/signals_handlers.py
@@ -3,10 +3,10 @@ from functools import wraps
 from django.dispatch import Signal
 
 import sentry_sdk
-from typing import TYPE_CHECKING
 from sentry_sdk.consts import OP
 from sentry_sdk.integrations.django import DJANGO_VERSION
 
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from collections.abc import Callable

--- a/sentry_sdk/integrations/django/templates.py
+++ b/sentry_sdk/integrations/django/templates.py
@@ -5,7 +5,7 @@ from django.utils.safestring import mark_safe
 from django import VERSION as DJANGO_VERSION
 
 import sentry_sdk
-from sentry_sdk._types import TYPE_CHECKING
+from typing import TYPE_CHECKING
 from sentry_sdk.consts import OP
 from sentry_sdk.utils import ensure_integration_enabled
 

--- a/sentry_sdk/integrations/django/templates.py
+++ b/sentry_sdk/integrations/django/templates.py
@@ -5,9 +5,10 @@ from django.utils.safestring import mark_safe
 from django import VERSION as DJANGO_VERSION
 
 import sentry_sdk
-from typing import TYPE_CHECKING
 from sentry_sdk.consts import OP
 from sentry_sdk.utils import ensure_integration_enabled
+
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from typing import Any

--- a/sentry_sdk/integrations/django/transactions.py
+++ b/sentry_sdk/integrations/django/transactions.py
@@ -7,7 +7,7 @@ in use.
 
 import re
 
-from sentry_sdk._types import TYPE_CHECKING
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from django.urls.resolvers import URLResolver

--- a/sentry_sdk/integrations/django/views.py
+++ b/sentry_sdk/integrations/django/views.py
@@ -2,7 +2,7 @@ import functools
 
 import sentry_sdk
 from sentry_sdk.consts import OP
-from sentry_sdk._types import TYPE_CHECKING
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from typing import Any

--- a/sentry_sdk/integrations/django/views.py
+++ b/sentry_sdk/integrations/django/views.py
@@ -2,6 +2,7 @@ import functools
 
 import sentry_sdk
 from sentry_sdk.consts import OP
+
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:

--- a/sentry_sdk/integrations/dramatiq.py
+++ b/sentry_sdk/integrations/dramatiq.py
@@ -2,7 +2,6 @@ import json
 
 import sentry_sdk
 from sentry_sdk.integrations import Integration
-from typing import TYPE_CHECKING
 from sentry_sdk.integrations._wsgi_common import request_body_within_bounds
 from sentry_sdk.utils import (
     AnnotatedValue,
@@ -14,6 +13,8 @@ from dramatiq.broker import Broker  # type: ignore
 from dramatiq.message import Message  # type: ignore
 from dramatiq.middleware import Middleware, default_middleware  # type: ignore
 from dramatiq.errors import Retry  # type: ignore
+
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from typing import Any, Callable, Dict, Optional, Union

--- a/sentry_sdk/integrations/dramatiq.py
+++ b/sentry_sdk/integrations/dramatiq.py
@@ -2,7 +2,7 @@ import json
 
 import sentry_sdk
 from sentry_sdk.integrations import Integration
-from sentry_sdk._types import TYPE_CHECKING
+from typing import TYPE_CHECKING
 from sentry_sdk.integrations._wsgi_common import request_body_within_bounds
 from sentry_sdk.utils import (
     AnnotatedValue,

--- a/sentry_sdk/integrations/excepthook.py
+++ b/sentry_sdk/integrations/excepthook.py
@@ -7,7 +7,7 @@ from sentry_sdk.utils import (
 )
 from sentry_sdk.integrations import Integration
 
-from sentry_sdk._types import TYPE_CHECKING
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from typing import Callable

--- a/sentry_sdk/integrations/executing.py
+++ b/sentry_sdk/integrations/executing.py
@@ -1,5 +1,5 @@
 import sentry_sdk
-from sentry_sdk._types import TYPE_CHECKING
+from typing import TYPE_CHECKING
 from sentry_sdk.integrations import Integration, DidNotEnable
 from sentry_sdk.scope import add_global_event_processor
 from sentry_sdk.utils import walk_exception_chain, iter_stacks

--- a/sentry_sdk/integrations/executing.py
+++ b/sentry_sdk/integrations/executing.py
@@ -1,8 +1,9 @@
 import sentry_sdk
-from typing import TYPE_CHECKING
 from sentry_sdk.integrations import Integration, DidNotEnable
 from sentry_sdk.scope import add_global_event_processor
 from sentry_sdk.utils import walk_exception_chain, iter_stacks
+
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from typing import Optional

--- a/sentry_sdk/integrations/falcon.py
+++ b/sentry_sdk/integrations/falcon.py
@@ -10,7 +10,7 @@ from sentry_sdk.utils import (
     parse_version,
 )
 
-from sentry_sdk._types import TYPE_CHECKING
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from typing import Any

--- a/sentry_sdk/integrations/fastapi.py
+++ b/sentry_sdk/integrations/fastapi.py
@@ -3,7 +3,7 @@ from copy import deepcopy
 from functools import wraps
 
 import sentry_sdk
-from sentry_sdk._types import TYPE_CHECKING
+from typing import TYPE_CHECKING
 from sentry_sdk.integrations import DidNotEnable
 from sentry_sdk.scope import should_send_default_pii
 from sentry_sdk.tracing import SOURCE_FOR_STYLE, TRANSACTION_SOURCE_ROUTE

--- a/sentry_sdk/integrations/fastapi.py
+++ b/sentry_sdk/integrations/fastapi.py
@@ -3,7 +3,6 @@ from copy import deepcopy
 from functools import wraps
 
 import sentry_sdk
-from typing import TYPE_CHECKING
 from sentry_sdk.integrations import DidNotEnable
 from sentry_sdk.scope import should_send_default_pii
 from sentry_sdk.tracing import SOURCE_FOR_STYLE, TRANSACTION_SOURCE_ROUTE
@@ -11,6 +10,8 @@ from sentry_sdk.utils import (
     transaction_from_function,
     logger,
 )
+
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from typing import Any, Callable, Dict

--- a/sentry_sdk/integrations/flask.py
+++ b/sentry_sdk/integrations/flask.py
@@ -1,5 +1,5 @@
 import sentry_sdk
-from sentry_sdk._types import TYPE_CHECKING
+from typing import TYPE_CHECKING
 from sentry_sdk.integrations import DidNotEnable, Integration
 from sentry_sdk.integrations._wsgi_common import RequestExtractor
 from sentry_sdk.integrations.wsgi import SentryWsgiMiddleware

--- a/sentry_sdk/integrations/flask.py
+++ b/sentry_sdk/integrations/flask.py
@@ -1,5 +1,4 @@
 import sentry_sdk
-from typing import TYPE_CHECKING
 from sentry_sdk.integrations import DidNotEnable, Integration
 from sentry_sdk.integrations._wsgi_common import RequestExtractor
 from sentry_sdk.integrations.wsgi import SentryWsgiMiddleware
@@ -11,6 +10,8 @@ from sentry_sdk.utils import (
     event_from_exception,
     package_version,
 )
+
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from typing import Any, Callable, Dict, Union

--- a/sentry_sdk/integrations/gcp.py
+++ b/sentry_sdk/integrations/gcp.py
@@ -20,7 +20,7 @@ from sentry_sdk.utils import (
     reraise,
 )
 
-from sentry_sdk._types import TYPE_CHECKING
+from typing import TYPE_CHECKING
 
 # Constants
 TIMEOUT_WARNING_BUFFER = 1.5  # Buffer time required to send timeout warning to Sentry

--- a/sentry_sdk/integrations/gnu_backtrace.py
+++ b/sentry_sdk/integrations/gnu_backtrace.py
@@ -5,7 +5,7 @@ from sentry_sdk.integrations import Integration
 from sentry_sdk.scope import add_global_event_processor
 from sentry_sdk.utils import capture_internal_exceptions
 
-from sentry_sdk._types import TYPE_CHECKING
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from typing import Any

--- a/sentry_sdk/integrations/gql.py
+++ b/sentry_sdk/integrations/gql.py
@@ -16,7 +16,7 @@ try:
 except ImportError:
     raise DidNotEnable("gql is not installed")
 
-from sentry_sdk._types import TYPE_CHECKING
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from typing import Any, Dict, Tuple, Union

--- a/sentry_sdk/integrations/graphene.py
+++ b/sentry_sdk/integrations/graphene.py
@@ -10,7 +10,7 @@ from sentry_sdk.utils import (
     event_from_exception,
     package_version,
 )
-from sentry_sdk._types import TYPE_CHECKING
+from typing import TYPE_CHECKING
 
 
 try:

--- a/sentry_sdk/integrations/graphene.py
+++ b/sentry_sdk/integrations/graphene.py
@@ -10,14 +10,13 @@ from sentry_sdk.utils import (
     event_from_exception,
     package_version,
 )
-from typing import TYPE_CHECKING
-
 
 try:
     from graphene.types import schema as graphene_schema  # type: ignore
 except ImportError:
     raise DidNotEnable("graphene is not installed")
 
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from collections.abc import Generator

--- a/sentry_sdk/integrations/grpc/__init__.py
+++ b/sentry_sdk/integrations/grpc/__init__.py
@@ -6,7 +6,6 @@ from grpc.aio import Channel as AsyncChannel
 from grpc.aio import Server as AsyncServer
 
 from sentry_sdk.integrations import Integration
-from typing import TYPE_CHECKING
 
 from .client import ClientInterceptor
 from .server import ServerInterceptor
@@ -18,7 +17,7 @@ from .aio.client import (
     SentryUnaryStreamClientInterceptor as AsyncUnaryStreamClientIntercetor,
 )
 
-from typing import Any, Optional, Sequence
+from typing import TYPE_CHECKING, Any, Optional, Sequence
 
 # Hack to get new Python features working in older versions
 # without introducing a hard dependency on `typing_extensions`

--- a/sentry_sdk/integrations/grpc/__init__.py
+++ b/sentry_sdk/integrations/grpc/__init__.py
@@ -6,7 +6,7 @@ from grpc.aio import Channel as AsyncChannel
 from grpc.aio import Server as AsyncServer
 
 from sentry_sdk.integrations import Integration
-from sentry_sdk._types import TYPE_CHECKING
+from typing import TYPE_CHECKING
 
 from .client import ClientInterceptor
 from .server import ServerInterceptor

--- a/sentry_sdk/integrations/grpc/aio/server.py
+++ b/sentry_sdk/integrations/grpc/aio/server.py
@@ -1,5 +1,5 @@
 import sentry_sdk
-from sentry_sdk._types import TYPE_CHECKING
+from typing import TYPE_CHECKING
 from sentry_sdk.consts import OP
 from sentry_sdk.integrations import DidNotEnable
 from sentry_sdk.integrations.grpc.consts import SPAN_ORIGIN

--- a/sentry_sdk/integrations/grpc/aio/server.py
+++ b/sentry_sdk/integrations/grpc/aio/server.py
@@ -1,10 +1,11 @@
 import sentry_sdk
-from typing import TYPE_CHECKING
 from sentry_sdk.consts import OP
 from sentry_sdk.integrations import DidNotEnable
 from sentry_sdk.integrations.grpc.consts import SPAN_ORIGIN
 from sentry_sdk.tracing import Transaction, TRANSACTION_SOURCE_CUSTOM
 from sentry_sdk.utils import event_from_exception
+
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from collections.abc import Awaitable, Callable

--- a/sentry_sdk/integrations/grpc/client.py
+++ b/sentry_sdk/integrations/grpc/client.py
@@ -1,8 +1,9 @@
 import sentry_sdk
-from typing import TYPE_CHECKING
 from sentry_sdk.consts import OP
 from sentry_sdk.integrations import DidNotEnable
 from sentry_sdk.integrations.grpc.consts import SPAN_ORIGIN
+
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from typing import Any, Callable, Iterator, Iterable, Union

--- a/sentry_sdk/integrations/grpc/client.py
+++ b/sentry_sdk/integrations/grpc/client.py
@@ -1,5 +1,5 @@
 import sentry_sdk
-from sentry_sdk._types import TYPE_CHECKING
+from typing import TYPE_CHECKING
 from sentry_sdk.consts import OP
 from sentry_sdk.integrations import DidNotEnable
 from sentry_sdk.integrations.grpc.consts import SPAN_ORIGIN

--- a/sentry_sdk/integrations/grpc/server.py
+++ b/sentry_sdk/integrations/grpc/server.py
@@ -1,9 +1,10 @@
 import sentry_sdk
-from typing import TYPE_CHECKING
 from sentry_sdk.consts import OP
 from sentry_sdk.integrations import DidNotEnable
 from sentry_sdk.integrations.grpc.consts import SPAN_ORIGIN
 from sentry_sdk.tracing import Transaction, TRANSACTION_SOURCE_CUSTOM
+
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from typing import Callable, Optional

--- a/sentry_sdk/integrations/grpc/server.py
+++ b/sentry_sdk/integrations/grpc/server.py
@@ -1,5 +1,5 @@
 import sentry_sdk
-from sentry_sdk._types import TYPE_CHECKING
+from typing import TYPE_CHECKING
 from sentry_sdk.consts import OP
 from sentry_sdk.integrations import DidNotEnable
 from sentry_sdk.integrations.grpc.consts import SPAN_ORIGIN

--- a/sentry_sdk/integrations/httpx.py
+++ b/sentry_sdk/integrations/httpx.py
@@ -11,7 +11,7 @@ from sentry_sdk.utils import (
     parse_url,
 )
 
-from sentry_sdk._types import TYPE_CHECKING
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from typing import Any

--- a/sentry_sdk/integrations/huey.py
+++ b/sentry_sdk/integrations/huey.py
@@ -2,7 +2,6 @@ import sys
 from datetime import datetime
 
 import sentry_sdk
-from typing import TYPE_CHECKING
 from sentry_sdk.api import continue_trace, get_baggage, get_traceparent
 from sentry_sdk.consts import OP, SPANSTATUS
 from sentry_sdk.integrations import DidNotEnable, Integration
@@ -19,6 +18,8 @@ from sentry_sdk.utils import (
     SENSITIVE_DATA_SUBSTITUTE,
     reraise,
 )
+
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from typing import Any, Callable, Optional, Union, TypeVar

--- a/sentry_sdk/integrations/huey.py
+++ b/sentry_sdk/integrations/huey.py
@@ -2,7 +2,7 @@ import sys
 from datetime import datetime
 
 import sentry_sdk
-from sentry_sdk._types import TYPE_CHECKING
+from typing import TYPE_CHECKING
 from sentry_sdk.api import continue_trace, get_baggage, get_traceparent
 from sentry_sdk.consts import OP, SPANSTATUS
 from sentry_sdk.integrations import DidNotEnable, Integration

--- a/sentry_sdk/integrations/langchain.py
+++ b/sentry_sdk/integrations/langchain.py
@@ -2,18 +2,19 @@ from collections import OrderedDict
 from functools import wraps
 
 import sentry_sdk
-from typing import TYPE_CHECKING
 from sentry_sdk.ai.monitoring import set_ai_pipeline_name, record_token_usage
 from sentry_sdk.consts import OP, SPANDATA
 from sentry_sdk.ai.utils import set_data_normalized
 from sentry_sdk.scope import should_send_default_pii
 from sentry_sdk.tracing import Span
+from sentry_sdk.integrations import DidNotEnable, Integration
+from sentry_sdk.utils import logger, capture_internal_exceptions
+
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from typing import Any, List, Callable, Dict, Union, Optional
     from uuid import UUID
-from sentry_sdk.integrations import DidNotEnable, Integration
-from sentry_sdk.utils import logger, capture_internal_exceptions
 
 try:
     from langchain_core.messages import BaseMessage

--- a/sentry_sdk/integrations/langchain.py
+++ b/sentry_sdk/integrations/langchain.py
@@ -2,7 +2,7 @@ from collections import OrderedDict
 from functools import wraps
 
 import sentry_sdk
-from sentry_sdk._types import TYPE_CHECKING
+from typing import TYPE_CHECKING
 from sentry_sdk.ai.monitoring import set_ai_pipeline_name, record_token_usage
 from sentry_sdk.consts import OP, SPANDATA
 from sentry_sdk.ai.utils import set_data_normalized

--- a/sentry_sdk/integrations/litestar.py
+++ b/sentry_sdk/integrations/litestar.py
@@ -1,5 +1,5 @@
 import sentry_sdk
-from sentry_sdk._types import TYPE_CHECKING
+from typing import TYPE_CHECKING
 from sentry_sdk.consts import OP
 from sentry_sdk.integrations import DidNotEnable, Integration
 from sentry_sdk.integrations.asgi import SentryAsgiMiddleware

--- a/sentry_sdk/integrations/litestar.py
+++ b/sentry_sdk/integrations/litestar.py
@@ -1,5 +1,4 @@
 import sentry_sdk
-from typing import TYPE_CHECKING
 from sentry_sdk.consts import OP
 from sentry_sdk.integrations import DidNotEnable, Integration
 from sentry_sdk.integrations.asgi import SentryAsgiMiddleware
@@ -20,6 +19,9 @@ try:
     from litestar.data_extractors import ConnectionDataExtractor  # type: ignore
 except ImportError:
     raise DidNotEnable("Litestar is not installed")
+
+from typing import TYPE_CHECKING
+
 if TYPE_CHECKING:
     from typing import Any, Optional, Union
     from litestar.types.asgi_types import ASGIApp  # type: ignore

--- a/sentry_sdk/integrations/logging.py
+++ b/sentry_sdk/integrations/logging.py
@@ -10,7 +10,7 @@ from sentry_sdk.utils import (
     capture_internal_exceptions,
 )
 from sentry_sdk.integrations import Integration
-from sentry_sdk._types import TYPE_CHECKING
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from collections.abc import MutableMapping

--- a/sentry_sdk/integrations/logging.py
+++ b/sentry_sdk/integrations/logging.py
@@ -10,6 +10,7 @@ from sentry_sdk.utils import (
     capture_internal_exceptions,
 )
 from sentry_sdk.integrations import Integration
+
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:

--- a/sentry_sdk/integrations/loguru.py
+++ b/sentry_sdk/integrations/loguru.py
@@ -1,6 +1,6 @@
 import enum
 
-from sentry_sdk._types import TYPE_CHECKING
+from typing import TYPE_CHECKING
 from sentry_sdk.integrations import Integration, DidNotEnable
 from sentry_sdk.integrations.logging import (
     BreadcrumbHandler,

--- a/sentry_sdk/integrations/loguru.py
+++ b/sentry_sdk/integrations/loguru.py
@@ -1,12 +1,13 @@
 import enum
 
-from typing import TYPE_CHECKING
 from sentry_sdk.integrations import Integration, DidNotEnable
 from sentry_sdk.integrations.logging import (
     BreadcrumbHandler,
     EventHandler,
     _BaseHandler,
 )
+
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from logging import LogRecord

--- a/sentry_sdk/integrations/modules.py
+++ b/sentry_sdk/integrations/modules.py
@@ -3,7 +3,7 @@ from sentry_sdk.integrations import Integration
 from sentry_sdk.scope import add_global_event_processor
 from sentry_sdk.utils import _get_installed_modules
 
-from sentry_sdk._types import TYPE_CHECKING
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from typing import Any

--- a/sentry_sdk/integrations/openai.py
+++ b/sentry_sdk/integrations/openai.py
@@ -1,7 +1,7 @@
 from functools import wraps
 
 from sentry_sdk import consts
-from sentry_sdk._types import TYPE_CHECKING
+from typing import TYPE_CHECKING
 from sentry_sdk.ai.monitoring import record_token_usage
 from sentry_sdk.consts import SPANDATA
 from sentry_sdk.ai.utils import set_data_normalized

--- a/sentry_sdk/integrations/openai.py
+++ b/sentry_sdk/integrations/openai.py
@@ -1,23 +1,23 @@
 from functools import wraps
 
-from sentry_sdk import consts
-from typing import TYPE_CHECKING
-from sentry_sdk.ai.monitoring import record_token_usage
-from sentry_sdk.consts import SPANDATA
-from sentry_sdk.ai.utils import set_data_normalized
-
-if TYPE_CHECKING:
-    from typing import Any, Iterable, List, Optional, Callable, Iterator
-    from sentry_sdk.tracing import Span
-
 import sentry_sdk
-from sentry_sdk.scope import should_send_default_pii
+from sentry_sdk import consts
+from sentry_sdk.ai.monitoring import record_token_usage
+from sentry_sdk.ai.utils import set_data_normalized
+from sentry_sdk.consts import SPANDATA
 from sentry_sdk.integrations import DidNotEnable, Integration
+from sentry_sdk.scope import should_send_default_pii
 from sentry_sdk.utils import (
     capture_internal_exceptions,
     event_from_exception,
     ensure_integration_enabled,
 )
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from typing import Any, Iterable, List, Optional, Callable, Iterator
+    from sentry_sdk.tracing import Span
 
 try:
     from openai.resources.chat.completions import Completions

--- a/sentry_sdk/integrations/opentelemetry/propagator.py
+++ b/sentry_sdk/integrations/opentelemetry/propagator.py
@@ -18,7 +18,7 @@ from opentelemetry.trace import (
     TraceFlags,
 )
 
-from sentry_sdk._types import TYPE_CHECKING
+from typing import TYPE_CHECKING
 from sentry_sdk.integrations.opentelemetry.consts import (
     SENTRY_BAGGAGE_KEY,
     SENTRY_TRACE_KEY,

--- a/sentry_sdk/integrations/opentelemetry/propagator.py
+++ b/sentry_sdk/integrations/opentelemetry/propagator.py
@@ -18,7 +18,6 @@ from opentelemetry.trace import (
     TraceFlags,
 )
 
-from typing import TYPE_CHECKING
 from sentry_sdk.integrations.opentelemetry.consts import (
     SENTRY_BAGGAGE_KEY,
     SENTRY_TRACE_KEY,
@@ -31,6 +30,8 @@ from sentry_sdk.tracing import (
     SENTRY_TRACE_HEADER_NAME,
 )
 from sentry_sdk.tracing_utils import Baggage, extract_sentrytrace_data
+
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from typing import Optional, Set

--- a/sentry_sdk/integrations/opentelemetry/span_processor.py
+++ b/sentry_sdk/integrations/opentelemetry/span_processor.py
@@ -24,7 +24,7 @@ from sentry_sdk.integrations.opentelemetry.consts import (
 from sentry_sdk.scope import add_global_event_processor
 from sentry_sdk.tracing import Transaction, Span as SentrySpan
 from sentry_sdk.utils import Dsn
-from sentry_sdk._types import TYPE_CHECKING
+from typing import TYPE_CHECKING
 
 from urllib3.util import parse_url as urlparse
 

--- a/sentry_sdk/integrations/opentelemetry/span_processor.py
+++ b/sentry_sdk/integrations/opentelemetry/span_processor.py
@@ -1,6 +1,6 @@
 from datetime import datetime, timezone
 from time import time
-from typing import cast
+from typing import TYPE_CHECKING, cast
 
 from opentelemetry.context import get_value
 from opentelemetry.sdk.trace import SpanProcessor, ReadableSpan as OTelSpan
@@ -24,7 +24,6 @@ from sentry_sdk.integrations.opentelemetry.consts import (
 from sentry_sdk.scope import add_global_event_processor
 from sentry_sdk.tracing import Transaction, Span as SentrySpan
 from sentry_sdk.utils import Dsn
-from typing import TYPE_CHECKING
 
 from urllib3.util import parse_url as urlparse
 

--- a/sentry_sdk/integrations/pure_eval.py
+++ b/sentry_sdk/integrations/pure_eval.py
@@ -2,10 +2,11 @@ import ast
 
 import sentry_sdk
 from sentry_sdk import serializer
-from typing import TYPE_CHECKING
 from sentry_sdk.integrations import Integration, DidNotEnable
 from sentry_sdk.scope import add_global_event_processor
 from sentry_sdk.utils import walk_exception_chain, iter_stacks
+
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from typing import Optional, Dict, Any, Tuple, List

--- a/sentry_sdk/integrations/pure_eval.py
+++ b/sentry_sdk/integrations/pure_eval.py
@@ -2,7 +2,7 @@ import ast
 
 import sentry_sdk
 from sentry_sdk import serializer
-from sentry_sdk._types import TYPE_CHECKING
+from typing import TYPE_CHECKING
 from sentry_sdk.integrations import Integration, DidNotEnable
 from sentry_sdk.scope import add_global_event_processor
 from sentry_sdk.utils import walk_exception_chain, iter_stacks

--- a/sentry_sdk/integrations/pymongo.py
+++ b/sentry_sdk/integrations/pymongo.py
@@ -8,12 +8,12 @@ from sentry_sdk.scope import should_send_default_pii
 from sentry_sdk.tracing import Span
 from sentry_sdk.utils import capture_internal_exceptions
 
-from typing import TYPE_CHECKING
-
 try:
     from pymongo import monitoring
 except ImportError:
     raise DidNotEnable("Pymongo not installed")
+
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from typing import Any, Dict, Union

--- a/sentry_sdk/integrations/pymongo.py
+++ b/sentry_sdk/integrations/pymongo.py
@@ -8,7 +8,7 @@ from sentry_sdk.scope import should_send_default_pii
 from sentry_sdk.tracing import Span
 from sentry_sdk.utils import capture_internal_exceptions
 
-from sentry_sdk._types import TYPE_CHECKING
+from typing import TYPE_CHECKING
 
 try:
     from pymongo import monitoring

--- a/sentry_sdk/integrations/pyramid.py
+++ b/sentry_sdk/integrations/pyramid.py
@@ -14,7 +14,7 @@ from sentry_sdk.utils import (
     event_from_exception,
     reraise,
 )
-from sentry_sdk._types import TYPE_CHECKING
+from typing import TYPE_CHECKING
 
 try:
     from pyramid.httpexceptions import HTTPException

--- a/sentry_sdk/integrations/pyramid.py
+++ b/sentry_sdk/integrations/pyramid.py
@@ -14,7 +14,6 @@ from sentry_sdk.utils import (
     event_from_exception,
     reraise,
 )
-from typing import TYPE_CHECKING
 
 try:
     from pyramid.httpexceptions import HTTPException
@@ -22,6 +21,7 @@ try:
 except ImportError:
     raise DidNotEnable("Pyramid not installed")
 
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from pyramid.response import Response

--- a/sentry_sdk/integrations/quart.py
+++ b/sentry_sdk/integrations/quart.py
@@ -14,7 +14,7 @@ from sentry_sdk.utils import (
     ensure_integration_enabled,
     event_from_exception,
 )
-from sentry_sdk._types import TYPE_CHECKING
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from typing import Any

--- a/sentry_sdk/integrations/redis/__init__.py
+++ b/sentry_sdk/integrations/redis/__init__.py
@@ -1,4 +1,3 @@
-from typing import TYPE_CHECKING
 from sentry_sdk.integrations import Integration, DidNotEnable
 from sentry_sdk.integrations.redis.consts import _DEFAULT_MAX_DATA_SIZE
 from sentry_sdk.integrations.redis.rb import _patch_rb
@@ -6,6 +5,8 @@ from sentry_sdk.integrations.redis.redis import _patch_redis
 from sentry_sdk.integrations.redis.redis_cluster import _patch_redis_cluster
 from sentry_sdk.integrations.redis.redis_py_cluster_legacy import _patch_rediscluster
 from sentry_sdk.utils import logger
+
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from typing import Optional

--- a/sentry_sdk/integrations/redis/__init__.py
+++ b/sentry_sdk/integrations/redis/__init__.py
@@ -1,4 +1,4 @@
-from sentry_sdk._types import TYPE_CHECKING
+from typing import TYPE_CHECKING
 from sentry_sdk.integrations import Integration, DidNotEnable
 from sentry_sdk.integrations.redis.consts import _DEFAULT_MAX_DATA_SIZE
 from sentry_sdk.integrations.redis.rb import _patch_rb

--- a/sentry_sdk/integrations/redis/_async_common.py
+++ b/sentry_sdk/integrations/redis/_async_common.py
@@ -1,4 +1,4 @@
-from sentry_sdk._types import TYPE_CHECKING
+from typing import TYPE_CHECKING
 from sentry_sdk.consts import OP
 from sentry_sdk.integrations.redis.consts import SPAN_ORIGIN
 from sentry_sdk.integrations.redis.modules.caches import (

--- a/sentry_sdk/integrations/redis/_async_common.py
+++ b/sentry_sdk/integrations/redis/_async_common.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING
+import sentry_sdk
 from sentry_sdk.consts import OP
 from sentry_sdk.integrations.redis.consts import SPAN_ORIGIN
 from sentry_sdk.integrations.redis.modules.caches import (
@@ -12,8 +12,8 @@ from sentry_sdk.integrations.redis.utils import (
 )
 from sentry_sdk.tracing import Span
 from sentry_sdk.utils import capture_internal_exceptions
-import sentry_sdk
 
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from collections.abc import Callable

--- a/sentry_sdk/integrations/redis/_sync_common.py
+++ b/sentry_sdk/integrations/redis/_sync_common.py
@@ -1,4 +1,4 @@
-from sentry_sdk._types import TYPE_CHECKING
+from typing import TYPE_CHECKING
 from sentry_sdk.consts import OP
 from sentry_sdk.integrations.redis.consts import SPAN_ORIGIN
 from sentry_sdk.integrations.redis.modules.caches import (

--- a/sentry_sdk/integrations/redis/_sync_common.py
+++ b/sentry_sdk/integrations/redis/_sync_common.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING
+import sentry_sdk
 from sentry_sdk.consts import OP
 from sentry_sdk.integrations.redis.consts import SPAN_ORIGIN
 from sentry_sdk.integrations.redis.modules.caches import (
@@ -12,8 +12,8 @@ from sentry_sdk.integrations.redis.utils import (
 )
 from sentry_sdk.tracing import Span
 from sentry_sdk.utils import capture_internal_exceptions
-import sentry_sdk
 
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from collections.abc import Callable

--- a/sentry_sdk/integrations/redis/modules/caches.py
+++ b/sentry_sdk/integrations/redis/modules/caches.py
@@ -2,7 +2,7 @@
 Code used for the Caches module in Sentry
 """
 
-from sentry_sdk._types import TYPE_CHECKING
+from typing import TYPE_CHECKING
 from sentry_sdk.consts import OP, SPANDATA
 from sentry_sdk.integrations.redis.utils import _get_safe_key, _key_as_string
 from sentry_sdk.utils import capture_internal_exceptions

--- a/sentry_sdk/integrations/redis/modules/caches.py
+++ b/sentry_sdk/integrations/redis/modules/caches.py
@@ -2,13 +2,14 @@
 Code used for the Caches module in Sentry
 """
 
-from typing import TYPE_CHECKING
 from sentry_sdk.consts import OP, SPANDATA
 from sentry_sdk.integrations.redis.utils import _get_safe_key, _key_as_string
 from sentry_sdk.utils import capture_internal_exceptions
 
 GET_COMMANDS = ("get", "mget")
 SET_COMMANDS = ("set", "setex")
+
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from sentry_sdk.integrations.redis import RedisIntegration

--- a/sentry_sdk/integrations/redis/modules/queries.py
+++ b/sentry_sdk/integrations/redis/modules/queries.py
@@ -2,7 +2,7 @@
 Code used for the Queries module in Sentry
 """
 
-from sentry_sdk._types import TYPE_CHECKING
+from typing import TYPE_CHECKING
 from sentry_sdk.consts import OP, SPANDATA
 from sentry_sdk.integrations.redis.utils import _get_safe_command
 from sentry_sdk.utils import capture_internal_exceptions

--- a/sentry_sdk/integrations/redis/modules/queries.py
+++ b/sentry_sdk/integrations/redis/modules/queries.py
@@ -2,11 +2,11 @@
 Code used for the Queries module in Sentry
 """
 
-from typing import TYPE_CHECKING
 from sentry_sdk.consts import OP, SPANDATA
 from sentry_sdk.integrations.redis.utils import _get_safe_command
 from sentry_sdk.utils import capture_internal_exceptions
 
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from redis import Redis

--- a/sentry_sdk/integrations/redis/redis.py
+++ b/sentry_sdk/integrations/redis/redis.py
@@ -4,7 +4,7 @@ Instrumentation for Redis
 https://github.com/redis/redis-py
 """
 
-from sentry_sdk._types import TYPE_CHECKING
+from typing import TYPE_CHECKING
 from sentry_sdk.integrations.redis._sync_common import (
     patch_redis_client,
     patch_redis_pipeline,

--- a/sentry_sdk/integrations/redis/redis.py
+++ b/sentry_sdk/integrations/redis/redis.py
@@ -4,13 +4,13 @@ Instrumentation for Redis
 https://github.com/redis/redis-py
 """
 
-from typing import TYPE_CHECKING
 from sentry_sdk.integrations.redis._sync_common import (
     patch_redis_client,
     patch_redis_pipeline,
 )
 from sentry_sdk.integrations.redis.modules.queries import _set_db_data
 
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from typing import Any, Sequence

--- a/sentry_sdk/integrations/redis/redis_cluster.py
+++ b/sentry_sdk/integrations/redis/redis_cluster.py
@@ -5,7 +5,6 @@ This is part of the main redis-py client.
 https://github.com/redis/redis-py/blob/master/redis/cluster.py
 """
 
-from typing import TYPE_CHECKING
 from sentry_sdk.integrations.redis._sync_common import (
     patch_redis_client,
     patch_redis_pipeline,
@@ -14,6 +13,8 @@ from sentry_sdk.integrations.redis.modules.queries import _set_db_data_on_span
 from sentry_sdk.integrations.redis.utils import _parse_rediscluster_command
 
 from sentry_sdk.utils import capture_internal_exceptions
+
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from typing import Any

--- a/sentry_sdk/integrations/redis/redis_cluster.py
+++ b/sentry_sdk/integrations/redis/redis_cluster.py
@@ -5,7 +5,7 @@ This is part of the main redis-py client.
 https://github.com/redis/redis-py/blob/master/redis/cluster.py
 """
 
-from sentry_sdk._types import TYPE_CHECKING
+from typing import TYPE_CHECKING
 from sentry_sdk.integrations.redis._sync_common import (
     patch_redis_client,
     patch_redis_pipeline,

--- a/sentry_sdk/integrations/redis/utils.py
+++ b/sentry_sdk/integrations/redis/utils.py
@@ -1,4 +1,3 @@
-from typing import TYPE_CHECKING
 from sentry_sdk.consts import SPANDATA
 from sentry_sdk.integrations.redis.consts import (
     _COMMANDS_INCLUDING_SENSITIVE_DATA,
@@ -10,6 +9,7 @@ from sentry_sdk.integrations.redis.consts import (
 from sentry_sdk.scope import should_send_default_pii
 from sentry_sdk.utils import SENSITIVE_DATA_SUBSTITUTE
 
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from typing import Any, Optional, Sequence

--- a/sentry_sdk/integrations/redis/utils.py
+++ b/sentry_sdk/integrations/redis/utils.py
@@ -1,4 +1,4 @@
-from sentry_sdk._types import TYPE_CHECKING
+from typing import TYPE_CHECKING
 from sentry_sdk.consts import SPANDATA
 from sentry_sdk.integrations.redis.consts import (
     _COMMANDS_INCLUDING_SENSITIVE_DATA,

--- a/sentry_sdk/integrations/rq.py
+++ b/sentry_sdk/integrations/rq.py
@@ -23,7 +23,7 @@ try:
 except ImportError:
     raise DidNotEnable("RQ not installed")
 
-from sentry_sdk._types import TYPE_CHECKING
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from typing import Any, Callable

--- a/sentry_sdk/integrations/sanic.py
+++ b/sentry_sdk/integrations/sanic.py
@@ -19,6 +19,7 @@ from sentry_sdk.utils import (
     parse_version,
     reraise,
 )
+
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:

--- a/sentry_sdk/integrations/sanic.py
+++ b/sentry_sdk/integrations/sanic.py
@@ -19,7 +19,7 @@ from sentry_sdk.utils import (
     parse_version,
     reraise,
 )
-from sentry_sdk._types import TYPE_CHECKING
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from collections.abc import Container

--- a/sentry_sdk/integrations/serverless.py
+++ b/sentry_sdk/integrations/serverless.py
@@ -3,6 +3,7 @@ from functools import wraps
 
 import sentry_sdk
 from sentry_sdk.utils import event_from_exception, reraise
+
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -11,7 +12,6 @@ if TYPE_CHECKING:
     from typing import TypeVar
     from typing import Union
     from typing import Optional
-
     from typing import overload
 
     F = TypeVar("F", bound=Callable[..., Any])

--- a/sentry_sdk/integrations/serverless.py
+++ b/sentry_sdk/integrations/serverless.py
@@ -3,7 +3,7 @@ from functools import wraps
 
 import sentry_sdk
 from sentry_sdk.utils import event_from_exception, reraise
-from sentry_sdk._types import TYPE_CHECKING
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from typing import Any

--- a/sentry_sdk/integrations/spark/spark_driver.py
+++ b/sentry_sdk/integrations/spark/spark_driver.py
@@ -2,7 +2,7 @@ import sentry_sdk
 from sentry_sdk.integrations import Integration
 from sentry_sdk.utils import capture_internal_exceptions, ensure_integration_enabled
 
-from sentry_sdk._types import TYPE_CHECKING
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from typing import Any

--- a/sentry_sdk/integrations/spark/spark_worker.py
+++ b/sentry_sdk/integrations/spark/spark_worker.py
@@ -10,7 +10,7 @@ from sentry_sdk.utils import (
     event_hint_with_exc_info,
 )
 
-from sentry_sdk._types import TYPE_CHECKING
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from typing import Any

--- a/sentry_sdk/integrations/sqlalchemy.py
+++ b/sentry_sdk/integrations/sqlalchemy.py
@@ -1,5 +1,5 @@
 import sentry_sdk
-from sentry_sdk._types import TYPE_CHECKING
+from typing import TYPE_CHECKING
 from sentry_sdk.consts import SPANSTATUS, SPANDATA
 from sentry_sdk.db.explain_plan.sqlalchemy import attach_explain_plan_to_span
 from sentry_sdk.integrations import Integration, DidNotEnable

--- a/sentry_sdk/integrations/sqlalchemy.py
+++ b/sentry_sdk/integrations/sqlalchemy.py
@@ -1,5 +1,4 @@
 import sentry_sdk
-from typing import TYPE_CHECKING
 from sentry_sdk.consts import SPANSTATUS, SPANDATA
 from sentry_sdk.db.explain_plan.sqlalchemy import attach_explain_plan_to_span
 from sentry_sdk.integrations import Integration, DidNotEnable
@@ -16,6 +15,8 @@ try:
     from sqlalchemy import __version__ as SQLALCHEMY_VERSION  # type: ignore
 except ImportError:
     raise DidNotEnable("SQLAlchemy not installed.")
+
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from typing import Any

--- a/sentry_sdk/integrations/starlette.py
+++ b/sentry_sdk/integrations/starlette.py
@@ -3,7 +3,7 @@ import functools
 from copy import deepcopy
 
 import sentry_sdk
-from sentry_sdk._types import TYPE_CHECKING
+from typing import TYPE_CHECKING
 from sentry_sdk.consts import OP
 from sentry_sdk.integrations import DidNotEnable, Integration
 from sentry_sdk.integrations._wsgi_common import (

--- a/sentry_sdk/integrations/starlette.py
+++ b/sentry_sdk/integrations/starlette.py
@@ -3,7 +3,6 @@ import functools
 from copy import deepcopy
 
 import sentry_sdk
-from typing import TYPE_CHECKING
 from sentry_sdk.consts import OP
 from sentry_sdk.integrations import DidNotEnable, Integration
 from sentry_sdk.integrations._wsgi_common import (
@@ -27,6 +26,8 @@ from sentry_sdk.utils import (
     parse_version,
     transaction_from_function,
 )
+
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from typing import Any, Awaitable, Callable, Dict, Optional, Tuple

--- a/sentry_sdk/integrations/starlite.py
+++ b/sentry_sdk/integrations/starlite.py
@@ -1,5 +1,5 @@
 import sentry_sdk
-from sentry_sdk._types import TYPE_CHECKING
+from typing import TYPE_CHECKING
 from sentry_sdk.consts import OP
 from sentry_sdk.integrations import DidNotEnable, Integration
 from sentry_sdk.integrations.asgi import SentryAsgiMiddleware

--- a/sentry_sdk/integrations/starlite.py
+++ b/sentry_sdk/integrations/starlite.py
@@ -1,5 +1,4 @@
 import sentry_sdk
-from typing import TYPE_CHECKING
 from sentry_sdk.consts import OP
 from sentry_sdk.integrations import DidNotEnable, Integration
 from sentry_sdk.integrations.asgi import SentryAsgiMiddleware
@@ -21,6 +20,8 @@ try:
     from pydantic import BaseModel  # type: ignore
 except ImportError:
     raise DidNotEnable("Starlite is not installed")
+
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from typing import Any, Optional, Union

--- a/sentry_sdk/integrations/stdlib.py
+++ b/sentry_sdk/integrations/stdlib.py
@@ -18,7 +18,7 @@ from sentry_sdk.utils import (
     safe_repr,
     parse_url,
 )
-from sentry_sdk._types import TYPE_CHECKING
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from typing import Any

--- a/sentry_sdk/integrations/stdlib.py
+++ b/sentry_sdk/integrations/stdlib.py
@@ -18,6 +18,7 @@ from sentry_sdk.utils import (
     safe_repr,
     parse_url,
 )
+
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:

--- a/sentry_sdk/integrations/strawberry.py
+++ b/sentry_sdk/integrations/strawberry.py
@@ -15,7 +15,7 @@ from sentry_sdk.utils import (
     package_version,
     _get_installed_modules,
 )
-from sentry_sdk._types import TYPE_CHECKING
+from typing import TYPE_CHECKING
 
 try:
     from functools import cached_property

--- a/sentry_sdk/integrations/strawberry.py
+++ b/sentry_sdk/integrations/strawberry.py
@@ -15,7 +15,6 @@ from sentry_sdk.utils import (
     package_version,
     _get_installed_modules,
 )
-from typing import TYPE_CHECKING
 
 try:
     from functools import cached_property
@@ -38,6 +37,8 @@ try:
     from strawberry.http import async_base_view, sync_base_view  # type: ignore
 except ImportError:
     raise DidNotEnable("strawberry-graphql is not installed")
+
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from typing import Any, Callable, Generator, List, Optional

--- a/sentry_sdk/integrations/threading.py
+++ b/sentry_sdk/integrations/threading.py
@@ -3,7 +3,7 @@ from functools import wraps
 from threading import Thread, current_thread
 
 import sentry_sdk
-from sentry_sdk._types import TYPE_CHECKING
+from typing import TYPE_CHECKING
 from sentry_sdk.integrations import Integration
 from sentry_sdk.scope import use_isolation_scope, use_scope
 from sentry_sdk.utils import (

--- a/sentry_sdk/integrations/threading.py
+++ b/sentry_sdk/integrations/threading.py
@@ -3,7 +3,6 @@ from functools import wraps
 from threading import Thread, current_thread
 
 import sentry_sdk
-from typing import TYPE_CHECKING
 from sentry_sdk.integrations import Integration
 from sentry_sdk.scope import use_isolation_scope, use_scope
 from sentry_sdk.utils import (
@@ -13,6 +12,8 @@ from sentry_sdk.utils import (
     logger,
     reraise,
 )
+
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from typing import Any

--- a/sentry_sdk/integrations/tornado.py
+++ b/sentry_sdk/integrations/tornado.py
@@ -33,7 +33,7 @@ try:
 except ImportError:
     raise DidNotEnable("Tornado not installed")
 
-from sentry_sdk._types import TYPE_CHECKING
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from typing import Any

--- a/sentry_sdk/integrations/wsgi.py
+++ b/sentry_sdk/integrations/wsgi.py
@@ -2,7 +2,7 @@ import sys
 from functools import partial
 
 import sentry_sdk
-from sentry_sdk._types import TYPE_CHECKING
+from typing import TYPE_CHECKING
 from sentry_sdk._werkzeug import get_host, _get_headers
 from sentry_sdk.api import continue_trace
 from sentry_sdk.consts import OP

--- a/sentry_sdk/integrations/wsgi.py
+++ b/sentry_sdk/integrations/wsgi.py
@@ -2,7 +2,6 @@ import sys
 from functools import partial
 
 import sentry_sdk
-from typing import TYPE_CHECKING
 from sentry_sdk._werkzeug import get_host, _get_headers
 from sentry_sdk.api import continue_trace
 from sentry_sdk.consts import OP
@@ -17,6 +16,8 @@ from sentry_sdk.utils import (
     event_from_exception,
     reraise,
 )
+
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from typing import Callable

--- a/sentry_sdk/metrics.py
+++ b/sentry_sdk/metrics.py
@@ -27,6 +27,7 @@ from sentry_sdk.tracing import (
     TRANSACTION_SOURCE_COMPONENT,
     TRANSACTION_SOURCE_TASK,
 )
+
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:

--- a/sentry_sdk/metrics.py
+++ b/sentry_sdk/metrics.py
@@ -27,7 +27,7 @@ from sentry_sdk.tracing import (
     TRANSACTION_SOURCE_COMPONENT,
     TRANSACTION_SOURCE_TASK,
 )
-from sentry_sdk._types import TYPE_CHECKING
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from typing import Any

--- a/sentry_sdk/monitor.py
+++ b/sentry_sdk/monitor.py
@@ -4,6 +4,7 @@ from threading import Thread, Lock
 
 import sentry_sdk
 from sentry_sdk.utils import logger
+
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:

--- a/sentry_sdk/monitor.py
+++ b/sentry_sdk/monitor.py
@@ -4,7 +4,7 @@ from threading import Thread, Lock
 
 import sentry_sdk
 from sentry_sdk.utils import logger
-from sentry_sdk._types import TYPE_CHECKING
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from typing import Optional

--- a/sentry_sdk/profiler/continuous_profiler.py
+++ b/sentry_sdk/profiler/continuous_profiler.py
@@ -9,7 +9,6 @@ from datetime import datetime, timezone
 from sentry_sdk.consts import VERSION
 from sentry_sdk.envelope import Envelope
 from sentry_sdk._lru_cache import LRUCache
-from typing import TYPE_CHECKING
 from sentry_sdk.profiler.utils import (
     DEFAULT_SAMPLING_FREQUENCY,
     extract_stack,
@@ -22,6 +21,7 @@ from sentry_sdk.utils import (
     set_in_app_in_frames,
 )
 
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from typing import Any

--- a/sentry_sdk/profiler/continuous_profiler.py
+++ b/sentry_sdk/profiler/continuous_profiler.py
@@ -9,7 +9,7 @@ from datetime import datetime, timezone
 from sentry_sdk.consts import VERSION
 from sentry_sdk.envelope import Envelope
 from sentry_sdk._lru_cache import LRUCache
-from sentry_sdk._types import TYPE_CHECKING
+from typing import TYPE_CHECKING
 from sentry_sdk.profiler.utils import (
     DEFAULT_SAMPLING_FREQUENCY,
     extract_stack,

--- a/sentry_sdk/profiler/transaction_profiler.py
+++ b/sentry_sdk/profiler/transaction_profiler.py
@@ -39,7 +39,6 @@ from collections import deque
 
 import sentry_sdk
 from sentry_sdk._lru_cache import LRUCache
-from typing import TYPE_CHECKING
 from sentry_sdk.profiler.utils import (
     DEFAULT_SAMPLING_FREQUENCY,
     extract_stack,
@@ -53,6 +52,8 @@ from sentry_sdk.utils import (
     nanosecond_time,
     set_in_app_in_frames,
 )
+
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from typing import Any

--- a/sentry_sdk/profiler/transaction_profiler.py
+++ b/sentry_sdk/profiler/transaction_profiler.py
@@ -39,7 +39,7 @@ from collections import deque
 
 import sentry_sdk
 from sentry_sdk._lru_cache import LRUCache
-from sentry_sdk._types import TYPE_CHECKING
+from typing import TYPE_CHECKING
 from sentry_sdk.profiler.utils import (
     DEFAULT_SAMPLING_FREQUENCY,
     extract_stack,

--- a/sentry_sdk/profiler/utils.py
+++ b/sentry_sdk/profiler/utils.py
@@ -2,8 +2,9 @@ import os
 from collections import deque
 
 from sentry_sdk._compat import PY311
-from typing import TYPE_CHECKING
 from sentry_sdk.utils import filename_for_module
+
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from sentry_sdk._lru_cache import LRUCache

--- a/sentry_sdk/profiler/utils.py
+++ b/sentry_sdk/profiler/utils.py
@@ -2,7 +2,7 @@ import os
 from collections import deque
 
 from sentry_sdk._compat import PY311
-from sentry_sdk._types import TYPE_CHECKING
+from typing import TYPE_CHECKING
 from sentry_sdk.utils import filename_for_module
 
 if TYPE_CHECKING:

--- a/sentry_sdk/scope.py
+++ b/sentry_sdk/scope.py
@@ -26,7 +26,6 @@ from sentry_sdk.tracing import (
     Span,
     Transaction,
 )
-from typing import TYPE_CHECKING
 from sentry_sdk.utils import (
     capture_internal_exception,
     capture_internal_exceptions,
@@ -36,6 +35,8 @@ from sentry_sdk.utils import (
     exc_info_from_error,
     logger,
 )
+
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from collections.abc import Mapping, MutableMapping

--- a/sentry_sdk/scope.py
+++ b/sentry_sdk/scope.py
@@ -26,7 +26,7 @@ from sentry_sdk.tracing import (
     Span,
     Transaction,
 )
-from sentry_sdk._types import TYPE_CHECKING
+from typing import TYPE_CHECKING
 from sentry_sdk.utils import (
     capture_internal_exception,
     capture_internal_exceptions,

--- a/sentry_sdk/scrubber.py
+++ b/sentry_sdk/scrubber.py
@@ -3,7 +3,7 @@ from sentry_sdk.utils import (
     AnnotatedValue,
     iter_event_frames,
 )
-from sentry_sdk._types import TYPE_CHECKING
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from sentry_sdk._types import Event

--- a/sentry_sdk/scrubber.py
+++ b/sentry_sdk/scrubber.py
@@ -3,6 +3,7 @@ from sentry_sdk.utils import (
     AnnotatedValue,
     iter_event_frames,
 )
+
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:

--- a/sentry_sdk/serializer.py
+++ b/sentry_sdk/serializer.py
@@ -11,7 +11,7 @@ from sentry_sdk.utils import (
     safe_repr,
     strip_string,
 )
-from sentry_sdk._types import TYPE_CHECKING
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from types import TracebackType

--- a/sentry_sdk/serializer.py
+++ b/sentry_sdk/serializer.py
@@ -11,6 +11,7 @@ from sentry_sdk.utils import (
     safe_repr,
     strip_string,
 )
+
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:

--- a/sentry_sdk/session.py
+++ b/sentry_sdk/session.py
@@ -1,7 +1,7 @@
 import uuid
 from datetime import datetime, timezone
 
-from sentry_sdk._types import TYPE_CHECKING
+from typing import TYPE_CHECKING
 from sentry_sdk.utils import format_timestamp
 
 if TYPE_CHECKING:

--- a/sentry_sdk/session.py
+++ b/sentry_sdk/session.py
@@ -1,8 +1,9 @@
 import uuid
 from datetime import datetime, timezone
 
-from typing import TYPE_CHECKING
 from sentry_sdk.utils import format_timestamp
+
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from typing import Optional

--- a/sentry_sdk/sessions.py
+++ b/sentry_sdk/sessions.py
@@ -7,8 +7,9 @@ from contextlib import contextmanager
 import sentry_sdk
 from sentry_sdk.envelope import Envelope
 from sentry_sdk.session import Session
-from typing import TYPE_CHECKING
 from sentry_sdk.utils import format_timestamp
+
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from typing import Any

--- a/sentry_sdk/sessions.py
+++ b/sentry_sdk/sessions.py
@@ -7,7 +7,7 @@ from contextlib import contextmanager
 import sentry_sdk
 from sentry_sdk.envelope import Envelope
 from sentry_sdk.session import Session
-from sentry_sdk._types import TYPE_CHECKING
+from typing import TYPE_CHECKING
 from sentry_sdk.utils import format_timestamp
 
 if TYPE_CHECKING:

--- a/sentry_sdk/spotlight.py
+++ b/sentry_sdk/spotlight.py
@@ -1,7 +1,7 @@
 import io
 import urllib3
 
-from sentry_sdk._types import TYPE_CHECKING
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from typing import Any

--- a/sentry_sdk/tracing.py
+++ b/sentry_sdk/tracing.py
@@ -12,7 +12,7 @@ from sentry_sdk.utils import (
     logger,
     nanosecond_time,
 )
-from sentry_sdk._types import TYPE_CHECKING
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Mapping, MutableMapping

--- a/sentry_sdk/tracing.py
+++ b/sentry_sdk/tracing.py
@@ -12,6 +12,7 @@ from sentry_sdk.utils import (
     logger,
     nanosecond_time,
 )
+
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:

--- a/sentry_sdk/tracing_utils.py
+++ b/sentry_sdk/tracing_utils.py
@@ -23,7 +23,7 @@ from sentry_sdk.utils import (
     _is_external_source,
     _module_in_list,
 )
-from sentry_sdk._types import TYPE_CHECKING
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from typing import Any

--- a/sentry_sdk/tracing_utils.py
+++ b/sentry_sdk/tracing_utils.py
@@ -23,6 +23,7 @@ from sentry_sdk.utils import (
     _is_external_source,
     _module_in_list,
 )
+
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:

--- a/sentry_sdk/transport.py
+++ b/sentry_sdk/transport.py
@@ -17,7 +17,7 @@ from sentry_sdk.consts import EndpointType
 from sentry_sdk.utils import Dsn, logger, capture_internal_exceptions
 from sentry_sdk.worker import BackgroundWorker
 from sentry_sdk.envelope import Envelope, Item, PayloadRef
-from sentry_sdk._types import TYPE_CHECKING
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from typing import Any

--- a/sentry_sdk/transport.py
+++ b/sentry_sdk/transport.py
@@ -17,6 +17,7 @@ from sentry_sdk.consts import EndpointType
 from sentry_sdk.utils import Dsn, logger, capture_internal_exceptions
 from sentry_sdk.worker import BackgroundWorker
 from sentry_sdk.envelope import Envelope, Item, PayloadRef
+
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:

--- a/sentry_sdk/utils.py
+++ b/sentry_sdk/utils.py
@@ -26,7 +26,7 @@ except ImportError:
 
 import sentry_sdk
 from sentry_sdk._compat import PY37
-from sentry_sdk._types import TYPE_CHECKING
+from typing import TYPE_CHECKING
 from sentry_sdk.consts import DEFAULT_MAX_VALUE_LENGTH, EndpointType
 
 if TYPE_CHECKING:

--- a/sentry_sdk/utils.py
+++ b/sentry_sdk/utils.py
@@ -26,8 +26,9 @@ except ImportError:
 
 import sentry_sdk
 from sentry_sdk._compat import PY37
-from typing import TYPE_CHECKING
 from sentry_sdk.consts import DEFAULT_MAX_VALUE_LENGTH, EndpointType
+
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from collections.abc import Awaitable

--- a/sentry_sdk/worker.py
+++ b/sentry_sdk/worker.py
@@ -6,7 +6,7 @@ from sentry_sdk._queue import Queue, FullError
 from sentry_sdk.utils import logger
 from sentry_sdk.consts import DEFAULT_QUEUE_SIZE
 
-from sentry_sdk._types import TYPE_CHECKING
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from typing import Any

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -35,7 +35,7 @@ from sentry_sdk.utils import reraise
 
 from tests import _warning_recorder, _warning_recorder_mgr
 
-from sentry_sdk._types import TYPE_CHECKING
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from typing import Optional

--- a/tests/integrations/sanic/test_sanic.py
+++ b/tests/integrations/sanic/test_sanic.py
@@ -26,7 +26,7 @@ try:
 except ImportError:
     ReusableClient = None
 
-from sentry_sdk._types import TYPE_CHECKING
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from collections.abc import Iterable, Container

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -27,6 +27,7 @@ from sentry_sdk.integrations.executing import ExecutingIntegration
 from sentry_sdk.transport import Transport
 from sentry_sdk.serializer import MAX_DATABAG_BREADTH
 from sentry_sdk.consts import DEFAULT_MAX_BREADCRUMBS, DEFAULT_MAX_VALUE_LENGTH
+
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -27,7 +27,7 @@ from sentry_sdk.integrations.executing import ExecutingIntegration
 from sentry_sdk.transport import Transport
 from sentry_sdk.serializer import MAX_DATABAG_BREADTH
 from sentry_sdk.consts import DEFAULT_MAX_BREADCRUMBS, DEFAULT_MAX_VALUE_LENGTH
-from sentry_sdk._types import TYPE_CHECKING
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from collections.abc import Callable


### PR DESCRIPTION
This commit replaces the custom TYPE_CHECKING constant in _types.py with the standard library's typing.TYPE_CHECKING. This change simplifies the code and removes unnecessary backward compatibility for Python versions below 3.6. Since the _types module is private, this update does not introduce any breaking changes.

Closes #3426