### PR TITLE
Implement new continue_trace and make WSGI work

### DIFF
--- a/sentry_sdk/api.py
+++ b/sentry_sdk/api.py
@@ -1,4 +1,5 @@
 import inspect
+from contextlib import contextmanager
 
 from sentry_sdk import tracing_utils, Client
 from sentry_sdk._init_implementation import init
@@ -23,6 +24,7 @@ if TYPE_CHECKING:
     from typing import Callable
     from typing import TypeVar
     from typing import Union
+    from typing import Generator
 
     from typing_extensions import Unpack
 
@@ -336,11 +338,10 @@ def get_baggage():
     return None
 
 
-def continue_trace(environ_or_headers, op=None, name=None, source=None, origin=None):
-    # type: (Dict[str, Any], Optional[str], Optional[str], Optional[str], Optional[str]) -> Transaction
+@contextmanager
+def continue_trace(environ_or_headers):
+    # type: (Dict[str, Any]) -> Generator[None, None, None]
     """
-    Sets the propagation context from environment or headers and returns a transaction.
+    Sets the propagation context from environment or headers to continue an incoming trace.
     """
-    return get_isolation_scope().continue_trace(
-        environ_or_headers, op, name, source, origin
-    )
+    yield get_isolation_scope().continue_trace(environ_or_headers)

--- a/sentry_sdk/api.py
+++ b/sentry_sdk/api.py
@@ -344,4 +344,5 @@ def continue_trace(environ_or_headers):
     """
     Sets the propagation context from environment or headers to continue an incoming trace.
     """
-    yield get_isolation_scope().continue_trace(environ_or_headers)
+    with get_isolation_scope().continue_trace(environ_or_headers):
+        yield

--- a/sentry_sdk/integrations/opentelemetry/scope.py
+++ b/sentry_sdk/integrations/opentelemetry/scope.py
@@ -12,7 +12,7 @@ from sentry_sdk.integrations.opentelemetry.consts import (
 from sentry_sdk._types import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from typing import Tuple, Optional, Generator
+    from typing import Tuple, Optional, Generator, Dict, Any
 
 
 class PotelScope(Scope):
@@ -57,6 +57,14 @@ class PotelScope(Scope):
         """
         scopes = cls._get_scopes()
         return scopes[1] if scopes else None
+
+    @contextmanager
+    def continue_trace(self, environ_or_headers):
+        # type: (Dict[str, Any]) -> Generator[None, None, None]
+        with new_scope() as scope:
+            scope.generate_propagation_context(environ_or_headers)
+            # TODO-neel-potel add remote span on context
+            yield
 
 
 _INITIAL_CURRENT_SCOPE = PotelScope(ty=ScopeType.CURRENT)

--- a/sentry_sdk/tracing.py
+++ b/sentry_sdk/tracing.py
@@ -89,7 +89,7 @@ if TYPE_CHECKING:
         scope: "sentry_sdk.Scope"
         """The scope to use for this span. If not provided, we use the current scope."""
 
-        origin: str
+        origin: Optional[str]
         """
         The origin of the span.
         See https://develop.sentry.dev/sdk/performance/trace-origin/
@@ -1401,6 +1401,32 @@ class POTelSpan:
         # type: (str) -> None
         pass
 
+    @property
+    def start_timestamp(self):
+        # type: () -> Optional[datetime]
+        start_time = self._otel_span.start_time
+        if start_time is None:
+            return None
+
+        from sentry_sdk.integrations.opentelemetry.utils import (
+            convert_from_otel_timestamp,
+        )
+
+        return convert_from_otel_timestamp(start_time)
+
+    @property
+    def timestamp(self):
+        # type: () -> Optional[datetime]
+        end_time = self._otel_span.end_time
+        if end_time is None:
+            return None
+
+        from sentry_sdk.integrations.opentelemetry.utils import (
+            convert_from_otel_timestamp,
+        )
+
+        return convert_from_otel_timestamp(end_time)
+
     def start_child(self, **kwargs):
         # type: (str, **Any) -> POTelSpan
         kwargs.setdefault("sampled", self.sampled)
@@ -1485,7 +1511,7 @@ class POTelSpan:
             otel_description = None
         else:
             otel_status = StatusCode.ERROR
-            otel_description = status.value
+            otel_description = status
 
         self._otel_span.set_status(otel_status, otel_description)
 


### PR DESCRIPTION
The new `continue_trace` API will no longer return a `Transaction` entity. Instead, it will simply update the propagation context and run as a contextmanager.

(TODO) It will set a remote span on the OTEL context so that it can be picked up by `start_span` later.

closes #3458

---

working flask + sqlalchemy trace

<img width="1324" alt="image" src="https://github.com/user-attachments/assets/b62f9b52-a8dd-450b-b882-6ed6164b32e7">
