### PR TITLE
Pin httpx till upstream gets resolved

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -629,7 +629,7 @@ deps =
     starlette: pytest-asyncio
     starlette: python-multipart
     starlette: requests
-    starlette: httpx
+    starlette: httpx<0.27.1
     # (this is a dependency of httpx)
     starlette: anyio<4.0.0
     starlette: jinja2


### PR DESCRIPTION
starlette CI is broken with
```
 module 'httpx._types' has no attribute 'URLTypes' 
```

caused by this change 
github.com/encode/httpx/pull/3245

upstream discussion: https://github.com/encode/httpx/discussions/3287