### PR TITLE
Add `OpenTelemetryIntegration` to `DEFAULT_INTEGRATIONS`

### DIFF
--- a/sentry_sdk/client.py
+++ b/sentry_sdk/client.py
@@ -30,7 +30,7 @@ from sentry_sdk.consts import (
     VERSION,
     ClientConstructor,
 )
-from sentry_sdk.integrations import _DEFAULT_INTEGRATIONS, setup_integrations
+from sentry_sdk.integrations import setup_integrations
 from sentry_sdk.sessions import SessionFlusher
 from sentry_sdk.envelope import Envelope
 from sentry_sdk.profiler.continuous_profiler import setup_continuous_profiler
@@ -344,18 +344,6 @@ class _Client(BaseClient):
                         max_request_body_size
                     )
                 )
-
-            if self.options["_experiments"].get("otel_powered_performance", False):
-                logger.debug(
-                    "[OTel] Enabling experimental OTel-powered performance monitoring."
-                )
-                if (
-                    "sentry_sdk.integrations.opentelemetry.integration.OpenTelemetryIntegration"
-                    not in _DEFAULT_INTEGRATIONS
-                ):
-                    _DEFAULT_INTEGRATIONS.append(
-                        "sentry_sdk.integrations.opentelemetry.integration.OpenTelemetryIntegration",
-                    )
 
             self.integrations = setup_integrations(
                 self.options["integrations"],

--- a/sentry_sdk/integrations/__init__.py
+++ b/sentry_sdk/integrations/__init__.py
@@ -65,6 +65,7 @@ _DEFAULT_INTEGRATIONS = [
     "sentry_sdk.integrations.excepthook.ExcepthookIntegration",
     "sentry_sdk.integrations.logging.LoggingIntegration",
     "sentry_sdk.integrations.modules.ModulesIntegration",
+    "sentry_sdk.integrations.opentelemetry.integration.OpenTelemetryIntegration",
     "sentry_sdk.integrations.stdlib.StdlibIntegration",
     "sentry_sdk.integrations.threading.ThreadingIntegration",
 ]


### PR DESCRIPTION
Previously, it was only added if the experimental `otel_powered_performance` flag was on.

We need the integration to be active to set up basic things like the tracer.