### PR TITLE
Improve scope-span management

### DIFF
--- a/sentry_sdk/tracing.py
+++ b/sentry_sdk/tracing.py
@@ -1252,6 +1252,10 @@ class POTelSpan:
         # set as the implicit current context
         self._ctx_token = context.attach(ctx)
 
+        # get the new scope that was forked on context.attach
+        self.scope = sentry_sdk.get_current_scope()
+        self.scope.span = self
+
         return self
 
     def __exit__(self, ty, value, tb):
@@ -1319,7 +1323,6 @@ class POTelSpan:
 
         parent = None
         while True:
-            # XXX test if this actually works
             if self._otel_span.parent:
                 parent = self._otel_span.parent
             else:


### PR DESCRIPTION
* Do not explicitly create a `new_scope` on `start_span` -- we already do this via the OTel context hook
* Deprecate `Scope.transaction` and add `Scope.root_span` instead
* Save `span` on `scope` -- a lot of code depends on the scope having a span set