### PR TITLE
Set the correct SpanContext in continue_trace 

### DIFF
--- a/sentry_sdk/api.py
+++ b/sentry_sdk/api.py
@@ -237,7 +237,6 @@ def flush(
 
 def start_span(
     *,
-    span=None,
     custom_sampling_context=None,
     **kwargs,  # type: Any
 ):
@@ -255,7 +254,7 @@ def start_span(
     method.
     """
     # TODO: Consider adding type hints to the method signature.
-    return get_current_scope().start_span(span, custom_sampling_context, **kwargs)
+    return get_current_scope().start_span(custom_sampling_context, **kwargs)
 
 
 def start_transaction(

--- a/sentry_sdk/integrations/opentelemetry/potel_span_processor.py
+++ b/sentry_sdk/integrations/opentelemetry/potel_span_processor.py
@@ -51,8 +51,7 @@ class PotelSentrySpanProcessor(SpanProcessor):
         if is_sentry_span(span):
             return
 
-        # TODO-neel-potel-remote only take parent if not remote
-        if span.parent:
+        if span.parent and not span.parent.is_remote:
             self._children_spans[span.parent.span_id].append(span)
         else:
             # if have a root span ending, we build a transaction and send it

--- a/sentry_sdk/tracing.py
+++ b/sentry_sdk/tracing.py
@@ -3,6 +3,7 @@ import random
 from datetime import datetime, timedelta, timezone
 
 from opentelemetry import trace as otel_trace, context
+from opentelemetry.trace import format_trace_id, format_span_id
 from opentelemetry.trace.status import StatusCode
 
 import sentry_sdk
@@ -1346,13 +1347,13 @@ class POTelSpan:
 
     @property
     def trace_id(self):
-        # type: () -> Optional[str]
-        return self._otel_span.get_span_context().trace_id
+        # type: () -> str
+        return format_trace_id(self._otel_span.get_span_context().trace_id)
 
     @property
     def span_id(self):
-        # type: () -> Optional[str]
-        return self._otel_span.get_span_context().span_id
+        # type: () -> str
+        return format_span_id(self._otel_span.get_span_context().span_id)
 
     @property
     def sampled(self):


### PR DESCRIPTION
This commit makes incoming distributed tracing work and finishes implementing `continue_trace`

* Updates the span processor to consider remote parents as root spans
* Adds a simpler `start_span` to `POTelScope` for now that is a simplified version of the original that just creates a `POTelSpan`
* `continue_trace` now adds a fake remote `NonRecordingSpan` with the correct `trace_id`, `parent_span_id` and `parent_sampled` fields taken from the `PropagationContext`
* fix the `trace_id` and `span_id` properties on `POTelSpan`

closes #3476 