### PR TITLE
Remove obsolete object as superclass

### DIFF
--- a/sentry_sdk/integrations/dramatiq.py
+++ b/sentry_sdk/integrations/dramatiq.py
@@ -140,7 +140,7 @@ def _make_message_event_processor(message, integration):
     return inner
 
 
-class DramatiqMessageExtractor(object):
+class DramatiqMessageExtractor:
     def __init__(self, message):
         # type: (Message) -> None
         self.message_data = dict(message.asdict())

--- a/sentry_sdk/integrations/logging.py
+++ b/sentry_sdk/integrations/logging.py
@@ -111,7 +111,7 @@ class LoggingIntegration(Integration):
         logging.Logger.callHandlers = sentry_patched_callhandlers  # type: ignore
 
 
-class _BaseHandler(logging.Handler, object):
+class _BaseHandler(logging.Handler):
     COMMON_RECORD_ATTRS = frozenset(
         (
             "args",

--- a/sentry_sdk/profiler/continuous_profiler.py
+++ b/sentry_sdk/profiler/continuous_profiler.py
@@ -164,7 +164,7 @@ def get_profiler_id():
     return _scheduler.profiler_id
 
 
-class ContinuousScheduler(object):
+class ContinuousScheduler:
     mode = "unknown"  # type: ContinuousProfilerMode
 
     def __init__(self, frequency, options, sdk_info, capture_func):
@@ -410,7 +410,7 @@ class GeventContinuousScheduler(ContinuousScheduler):
 PROFILE_BUFFER_SECONDS = 10
 
 
-class ProfileBuffer(object):
+class ProfileBuffer:
     def __init__(self, options, sdk_info, buffer_size, capture_func):
         # type: (Dict[str, Any], SDKInfo, int, Callable[[Envelope], None]) -> None
         self.options = options
@@ -458,7 +458,7 @@ class ProfileBuffer(object):
         self.capture_func(envelope)
 
 
-class ProfileChunk(object):
+class ProfileChunk:
     def __init__(self):
         # type: () -> None
         self.chunk_id = uuid.uuid4().hex

--- a/sentry_sdk/scope.py
+++ b/sentry_sdk/scope.py
@@ -154,7 +154,7 @@ def _disable_capture(fn):
     return wrapper  # type: ignore
 
 
-class Scope(object):
+class Scope:
     """The scope holds extra information that should be sent with all
     events that belong to it.
     """

--- a/sentry_sdk/scrubber.py
+++ b/sentry_sdk/scrubber.py
@@ -59,7 +59,7 @@ DEFAULT_PII_DENYLIST = [
 ]
 
 
-class EventScrubber(object):
+class EventScrubber:
     def __init__(
         self, denylist=None, recursive=False, send_default_pii=False, pii_denylist=None
     ):

--- a/tests/integrations/beam/test_beam.py
+++ b/tests/integrations/beam/test_beam.py
@@ -45,7 +45,7 @@ class A:
         return self.fn()
 
 
-class B(A, object):
+class B(A):
     def fa(self, x, element=False, another_element=False):
         if x or (element and not another_element):
             # print(self.r)

--- a/tests/integrations/ray/test_ray.py
+++ b/tests/integrations/ray/test_ray.py
@@ -172,7 +172,7 @@ def test_ray_actor():
     )
 
     @ray.remote
-    class Counter(object):
+    class Counter:
         def __init__(self):
             self.n = 0
 


### PR DESCRIPTION
More `object`s have popped up since we last cleaned this up when we dropped Python 2.7.