### PR TITLE
Restore original scope

### DIFF
--- a/sentry_sdk/integrations/opentelemetry/scope.py
+++ b/sentry_sdk/integrations/opentelemetry/scope.py
@@ -106,7 +106,7 @@ class PotelScope(Scope):
             This function is deprecated and will be removed in a future release.
             Use :py:meth:`sentry_sdk.start_span` instead.
         """
-        return self.start_span(custom_sampling_context)
+        return self.start_span(custom_sampling_context=custom_sampling_context)
 
     def start_span(self, custom_sampling_context=None, **kwargs):
         # type: (Optional[SamplingContext], Any) -> POTelSpan

--- a/sentry_sdk/integrations/opentelemetry/scope.py
+++ b/sentry_sdk/integrations/opentelemetry/scope.py
@@ -63,19 +63,6 @@ class PotelScope(Scope):
         scopes = cls._get_scopes()
         return scopes[1] if scopes else None
 
-    def start_transaction(self, custom_sampling_context=None, **kwargs):
-        # type: (Optional[SamplingContext], Unpack[TransactionKwargs]) -> POTelSpan
-        """
-        .. deprecated:: 3.0.0
-            This function is deprecated and will be removed in a future release.
-            Use :py:meth:`sentry_sdk.start_span` instead.
-        """
-        return self.start_span(custom_sampling_context)
-
-    def start_span(self, custom_sampling_context=None, **kwargs):
-        # type: (Optional[SamplingContext], Any) -> POTelSpan
-        return POTelSpan(**kwargs, scope=self)
-
     @contextmanager
     def continue_trace(self, environ_or_headers):
         # type: (Dict[str, Any]) -> Generator[None, None, None]
@@ -112,26 +99,18 @@ class PotelScope(Scope):
 
         return span_context
 
+    def start_transaction(self, custom_sampling_context=None, **kwargs):
+        # type: (Optional[SamplingContext], Unpack[TransactionKwargs]) -> POTelSpan
+        """
+        .. deprecated:: 3.0.0
+            This function is deprecated and will be removed in a future release.
+            Use :py:meth:`sentry_sdk.start_span` instead.
+        """
+        return self.start_span(custom_sampling_context)
+
     def start_span(self, custom_sampling_context=None, **kwargs):
         # type: (Optional[SamplingContext], Any) -> POTelSpan
-        # TODO-neel-potel ideally want to remove the span argument, discuss with ivana
         return POTelSpan(**kwargs, scope=self)
-
-    @property
-    def root_span(self):
-        # type: () -> POTelSpan
-        """Return the root span in the scope, if any."""
-
-        # there is no span on the scope
-        if self._span is None:
-            return None
-
-        # this is a root span
-        if self._span.root_span is None:
-            return self._span
-
-        # get the topmost parent
-        return self._span.root_span
 
 
 _INITIAL_CURRENT_SCOPE = PotelScope(ty=ScopeType.CURRENT)


### PR DESCRIPTION
- Restore previous `tracing.Scope` to keep it free from OTel
- Add basic `start_transaction` to `PotelScope`