### PR TITLE
Update integrations with new continue_trace callback usage

### DIFF
--- a/sentry_sdk/integrations/_asgi_common.py
+++ b/sentry_sdk/integrations/_asgi_common.py
@@ -21,7 +21,7 @@ def _get_headers(asgi_scope):
     Extract headers from the ASGI scope, in the format that the Sentry protocol expects.
     """
     headers = {}  # type: Dict[str, str]
-    for raw_key, raw_value in asgi_scope["headers"]:
+    for raw_key, raw_value in asgi_scope.get("headers", {}):
         key = raw_key.decode("latin-1")
         value = raw_value.decode("latin-1")
         if key in headers:

--- a/sentry_sdk/integrations/gcp.py
+++ b/sentry_sdk/integrations/gcp.py
@@ -4,7 +4,6 @@ from datetime import datetime, timedelta, timezone
 from os import environ
 
 import sentry_sdk
-from sentry_sdk.api import continue_trace
 from sentry_sdk.consts import OP
 from sentry_sdk.integrations import Integration
 from sentry_sdk.integrations._wsgi_common import _filter_headers
@@ -82,42 +81,40 @@ def _wrap_func(func):
             if hasattr(gcp_event, "headers"):
                 headers = gcp_event.headers
 
-            transaction = continue_trace(
-                headers,
-                op=OP.FUNCTION_GCP,
-                name=environ.get("FUNCTION_NAME", ""),
-                source=TRANSACTION_SOURCE_COMPONENT,
-                origin=GcpIntegration.origin,
-            )
-            sampling_context = {
-                "gcp_env": {
-                    "function_name": environ.get("FUNCTION_NAME"),
-                    "function_entry_point": environ.get("ENTRY_POINT"),
-                    "function_identity": environ.get("FUNCTION_IDENTITY"),
-                    "function_region": environ.get("FUNCTION_REGION"),
-                    "function_project": environ.get("GCP_PROJECT"),
-                },
-                "gcp_event": gcp_event,
-            }
-            with sentry_sdk.start_transaction(
-                transaction, custom_sampling_context=sampling_context
-            ):
-                try:
-                    return func(functionhandler, gcp_event, *args, **kwargs)
-                except Exception:
-                    exc_info = sys.exc_info()
-                    sentry_event, hint = event_from_exception(
-                        exc_info,
-                        client_options=client.options,
-                        mechanism={"type": "gcp", "handled": False},
-                    )
-                    sentry_sdk.capture_event(sentry_event, hint=hint)
-                    reraise(*exc_info)
-                finally:
-                    if timeout_thread:
-                        timeout_thread.stop()
-                    # Flush out the event queue
-                    client.flush()
+            with sentry_sdk.continue_trace(headers):
+                sampling_context = {
+                    "gcp_env": {
+                        "function_name": environ.get("FUNCTION_NAME"),
+                        "function_entry_point": environ.get("ENTRY_POINT"),
+                        "function_identity": environ.get("FUNCTION_IDENTITY"),
+                        "function_region": environ.get("FUNCTION_REGION"),
+                        "function_project": environ.get("GCP_PROJECT"),
+                    },
+                    "gcp_event": gcp_event,
+                }
+                with sentry_sdk.start_transaction(
+                    op=OP.FUNCTION_GCP,
+                    name=environ.get("FUNCTION_NAME", ""),
+                    source=TRANSACTION_SOURCE_COMPONENT,
+                    origin=GcpIntegration.origin,
+                    custom_sampling_context=sampling_context,
+                ):
+                    try:
+                        return func(functionhandler, gcp_event, *args, **kwargs)
+                    except Exception:
+                        exc_info = sys.exc_info()
+                        sentry_event, hint = event_from_exception(
+                            exc_info,
+                            client_options=client.options,
+                            mechanism={"type": "gcp", "handled": False},
+                        )
+                        sentry_sdk.capture_event(sentry_event, hint=hint)
+                        reraise(*exc_info)
+                    finally:
+                        if timeout_thread:
+                            timeout_thread.stop()
+                        # Flush out the event queue
+                        client.flush()
 
     return sentry_func  # type: ignore
 

--- a/sentry_sdk/integrations/ray.py
+++ b/sentry_sdk/integrations/ray.py
@@ -58,25 +58,23 @@ def _patch_ray_remote():
             """
             _check_sentry_initialized()
 
-            transaction = sentry_sdk.continue_trace(
-                _tracing or {},
-                op=OP.QUEUE_TASK_RAY,
-                name=qualname_from_function(f),
-                origin=RayIntegration.origin,
-                source=TRANSACTION_SOURCE_TASK,
-            )
+            with sentry_sdk.continue_trace(_tracing or {}):
+                with sentry_sdk.start_transaction(
+                    op=OP.QUEUE_TASK_RAY,
+                    name=qualname_from_function(f) or "unknown Ray function",
+                    origin=RayIntegration.origin,
+                    source=TRANSACTION_SOURCE_TASK,
+                ) as transaction:
+                    try:
+                        result = f(*f_args, **f_kwargs)
+                        transaction.set_status(SPANSTATUS.OK)
+                    except Exception:
+                        transaction.set_status(SPANSTATUS.INTERNAL_ERROR)
+                        exc_info = sys.exc_info()
+                        _capture_exception(exc_info)
+                        reraise(*exc_info)
 
-            with sentry_sdk.start_transaction(transaction) as transaction:
-                try:
-                    result = f(*f_args, **f_kwargs)
-                    transaction.set_status(SPANSTATUS.OK)
-                except Exception:
-                    transaction.set_status(SPANSTATUS.INTERNAL_ERROR)
-                    exc_info = sys.exc_info()
-                    _capture_exception(exc_info)
-                    reraise(*exc_info)
-
-                return result
+                    return result
 
         rv = old_remote(_f, *args, *kwargs)
         old_remote_method = rv.remote

--- a/sentry_sdk/integrations/wsgi.py
+++ b/sentry_sdk/integrations/wsgi.py
@@ -3,7 +3,6 @@ from functools import partial
 
 import sentry_sdk
 from sentry_sdk._werkzeug import get_host, _get_headers
-from sentry_sdk.api import continue_trace
 from sentry_sdk.consts import OP
 from sentry_sdk.scope import should_send_default_pii
 from sentry_sdk.integrations._wsgi_common import _filter_headers
@@ -92,7 +91,7 @@ class SentryWsgiMiddleware:
                             )
                         )
 
-                    with continue_trace(environ):
+                    with sentry_sdk.continue_trace(environ):
                         with sentry_sdk.start_transaction(
                             op=OP.HTTP_SERVER,
                             name="generic WSGI request",


### PR DESCRIPTION
* aiohttp
* asgi
* aws_lambda
* celery
* gcp
* huey
* rq
* sanic - this uses manual enter/exit on the contextmanager so we'll have to test properly
* tornado
* ray

closes #3484 