### PR TITLE
Fix some methods in POTelSpan

### DIFF
--- a/MIGRATION_GUIDE.md
+++ b/MIGRATION_GUIDE.md
@@ -29,6 +29,8 @@ Looking to upgrade from Sentry SDK 2.x to 3.x? Here's a comprehensive list of wh
 - Utility function `is_auto_session_tracking_enabled()` has been removed. There is no public replacement. There is a private `_is_auto_session_tracking_enabled()` (if you absolutely need this function) It accepts a `scope` parameter instead of the previously used `hub` parameter.
 - Utility function `is_auto_session_tracking_enabled_scope()` has been removed. There is no public replacement. There is a private `_is_auto_session_tracking_enabled()` (if you absolutely need this function)
 - Setting `scope.level` has been removed. Use `scope.set_level` instead.
+- `span.containing_transaction` has been removed. Use `span.root_span` instead.
+- `continue_from_headers`, `continue_from_environ` and `from_traceparent` have been removed, please use top-level API `sentry_sdk.continue_trace` instead.`
 
 
 ### Deprecated

--- a/sentry_sdk/integrations/grpc/aio/server.py
+++ b/sentry_sdk/integrations/grpc/aio/server.py
@@ -2,7 +2,7 @@ import sentry_sdk
 from sentry_sdk.consts import OP
 from sentry_sdk.integrations import DidNotEnable
 from sentry_sdk.integrations.grpc.consts import SPAN_ORIGIN
-from sentry_sdk.tracing import Transaction, TRANSACTION_SOURCE_CUSTOM
+from sentry_sdk.tracing import TRANSACTION_SOURCE_CUSTOM
 from sentry_sdk.utils import event_from_exception
 
 from typing import TYPE_CHECKING
@@ -44,26 +44,24 @@ class ServerInterceptor(grpc.aio.ServerInterceptor):  # type: ignore
                     return await handler(request, context)
 
                 # What if the headers are empty?
-                transaction = Transaction.continue_from_headers(
-                    dict(context.invocation_metadata()),
-                    op=OP.GRPC_SERVER,
-                    name=name,
-                    source=TRANSACTION_SOURCE_CUSTOM,
-                    origin=SPAN_ORIGIN,
-                )
-
-                with sentry_sdk.start_transaction(transaction=transaction):
-                    try:
-                        return await handler.unary_unary(request, context)
-                    except AbortError:
-                        raise
-                    except Exception as exc:
-                        event, hint = event_from_exception(
-                            exc,
-                            mechanism={"type": "grpc", "handled": False},
-                        )
-                        sentry_sdk.capture_event(event, hint=hint)
-                        raise
+                with sentry_sdk.continue_trace(dict(context.invocation_metadata())):
+                    with sentry_sdk.start_transaction(
+                        op=OP.GRPC_SERVER,
+                        name=name,
+                        source=TRANSACTION_SOURCE_CUSTOM,
+                        origin=SPAN_ORIGIN,
+                    ):
+                        try:
+                            return await handler.unary_unary(request, context)
+                        except AbortError:
+                            raise
+                        except Exception as exc:
+                            event, hint = event_from_exception(
+                                exc,
+                                mechanism={"type": "grpc", "handled": False},
+                            )
+                            sentry_sdk.capture_event(event, hint=hint)
+                            raise
 
         elif not handler.request_streaming and handler.response_streaming:
             handler_factory = grpc.unary_stream_rpc_method_handler

--- a/sentry_sdk/tracing.py
+++ b/sentry_sdk/tracing.py
@@ -1269,7 +1269,7 @@ class POTelSpan:
         # type: (str) -> Optional[Any]
         if not isinstance(self._otel_span, ReadableSpan):
             return None
-        self._otel_span.attributes.get(name)
+        return self._otel_span.attributes.get(name)
 
     @property
     def description(self):

--- a/sentry_sdk/tracing.py
+++ b/sentry_sdk/tracing.py
@@ -1380,7 +1380,7 @@ class POTelSpan:
         # type: () -> Optional[str]
         from sentry_sdk.integrations.opentelemetry.consts import SentrySpanAttribute
 
-        self._get_attribute(SentrySpanAttribute.NAME)
+        return self._get_attribute(SentrySpanAttribute.NAME)
 
     @name.setter
     def name(self, value):

--- a/sentry_sdk/tracing.py
+++ b/sentry_sdk/tracing.py
@@ -1365,7 +1365,7 @@ class POTelSpan:
         # type: () -> Optional[str]
         from sentry_sdk.integrations.opentelemetry.consts import SentrySpanAttribute
 
-        self._get_attribute(SentrySpanAttribute.OP)
+        return self._get_attribute(SentrySpanAttribute.OP)
 
     @op.setter
     def op(self, value):


### PR DESCRIPTION
 * use `ReadableSpan` checks for attribute and parent access (handles the `NonRecordingSpan` case as a result)
 * deleted methods `continue_from_environ`, `continue_from_headers` and `from_traceparent` from `POTelSpan`, the new interface will not support them, but we might shim them later to not break code from outside the otel stuff
      * replaced `continue_from_headers` with `continue_trace` in grpc