### PR TITLE
Add context-friendly `use_scope`, `use_isolation_scope`

### DIFF
--- a/sentry_sdk/integrations/opentelemetry/consts.py
+++ b/sentry_sdk/integrations/opentelemetry/consts.py
@@ -7,7 +7,10 @@ SENTRY_BAGGAGE_KEY = create_key("sentry-baggage")
 
 # scope management keys
 SENTRY_SCOPES_KEY = create_key("sentry_scopes")
+SENTRY_FORK_CURRENT_SCOPE_KEY = create_key("sentry_fork_isolation_scope")
 SENTRY_FORK_ISOLATION_SCOPE_KEY = create_key("sentry_fork_isolation_scope")
+SENTRY_USE_CURRENT_SCOPE_KEY = create_key("sentry_use_current_scope")
+SENTRY_USE_ISOLATION_SCOPE_KEY = create_key("sentry_use_isolation_scope")
 
 OTEL_SENTRY_CONTEXT = "otel"
 SPAN_ORIGIN = "auto.otel"

--- a/sentry_sdk/integrations/opentelemetry/contextvars_context.py
+++ b/sentry_sdk/integrations/opentelemetry/contextvars_context.py
@@ -17,8 +17,8 @@ class SentryContextVarsRuntimeContext(ContextVarsRuntimeContext):
         should_fork_isolation_scope = context.pop(
             SENTRY_FORK_ISOLATION_SCOPE_KEY, False
         )
-        should_use_isolation_scope = context.pop(SENTRY_USE_ISOLATION_SCOPE_KEY, False)
-        should_use_current_scope = context.pop(SENTRY_USE_CURRENT_SCOPE_KEY, False)
+        should_use_isolation_scope = context.pop(SENTRY_USE_ISOLATION_SCOPE_KEY, None)
+        should_use_current_scope = context.pop(SENTRY_USE_CURRENT_SCOPE_KEY, None)
 
         if scopes and isinstance(scopes, tuple):
             (current_scope, isolation_scope) = scopes

--- a/sentry_sdk/integrations/opentelemetry/scope.py
+++ b/sentry_sdk/integrations/opentelemetry/scope.py
@@ -7,6 +7,8 @@ from opentelemetry.trace import SpanContext, NonRecordingSpan, TraceFlags, use_s
 from sentry_sdk.integrations.opentelemetry.consts import (
     SENTRY_SCOPES_KEY,
     SENTRY_FORK_ISOLATION_SCOPE_KEY,
+    SENTRY_USE_CURRENT_SCOPE_KEY,
+    SENTRY_USE_ISOLATION_SCOPE_KEY,
 )
 from sentry_sdk.scope import Scope, ScopeType
 from sentry_sdk.tracing import POTelSpan
@@ -134,5 +136,29 @@ def new_scope():
     token = attach(get_current())
     try:
         yield PotelScope.get_current_scope()
+    finally:
+        detach(token)
+
+
+@contextmanager
+def use_scope(scope):
+    # type: (Scope) -> Generator[Scope, None, None]
+    context = set_value(SENTRY_USE_CURRENT_SCOPE_KEY, scope)
+    token = attach(context)
+
+    try:
+        yield scope
+    finally:
+        detach(token)
+
+
+@contextmanager
+def use_isolation_scope(isolation_scope):
+    # type: (Scope) -> Generator[Scope, None, None]
+    context = set_value(SENTRY_USE_ISOLATION_SCOPE_KEY, isolation_scope)
+    token = attach(context)
+
+    try:
+        yield isolation_scope
     finally:
         detach(token)


### PR DESCRIPTION
`use_scope` and `use_isolation_scope` don't have POTel-friendly versions that work correctly with the OTel context yet. Adding them.