### PR TITLE
fix(django): Add `sync_capable` to `SentryWrappingMiddleware`

### DIFF
--- a/sentry_sdk/integrations/django/middleware.py
+++ b/sentry_sdk/integrations/django/middleware.py
@@ -125,6 +125,7 @@ def _wrap_middleware(middleware, middleware_name):
     class SentryWrappingMiddleware(
         _asgi_middleware_mixin_factory(_check_middleware_span)  # type: ignore
     ):
+        sync_capable = getattr(middleware, "sync_capable", True)
         async_capable = DJANGO_SUPPORTS_ASYNC_MIDDLEWARE and getattr(
             middleware, "async_capable", False
         )

--- a/tests/integrations/django/test_middleware.py
+++ b/tests/integrations/django/test_middleware.py
@@ -1,0 +1,34 @@
+from typing import Optional
+
+import pytest
+
+from sentry_sdk.integrations.django.middleware import _wrap_middleware
+
+
+def _sync_capable_middleware_factory(sync_capable):
+    # type: (Optional[bool]) -> type
+    """Create a middleware class with a sync_capable attribute set to the value passed to the factory.
+    If the factory is called with None, the middleware class will not have a sync_capable attribute.
+    """
+    sc = sync_capable  # rename so we can set sync_capable in the class
+
+    class TestMiddleware:
+        nonlocal sc
+        if sc is not None:
+            sync_capable = sc
+
+    return TestMiddleware
+
+
+@pytest.mark.parametrize(
+    ("middleware", "sync_capable"),
+    (
+        (_sync_capable_middleware_factory(True), True),
+        (_sync_capable_middleware_factory(False), False),
+        (_sync_capable_middleware_factory(None), True),
+    ),
+)
+def test_wrap_middleware_sync_capable_attribute(middleware, sync_capable):
+    wrapped_middleware = _wrap_middleware(middleware, "test_middleware")
+
+    assert wrapped_middleware.sync_capable is sync_capable


### PR DESCRIPTION
Apparently, not having the [`sync_capable`](https://docs.djangoproject.com/en/5.1/topics/http/middleware/#asynchronous-support) on the `SentryWrappingMiddleware` sometimes breaks things when we have an async-only middleware, such as [ServeStatic](https://github.com/Archmonger/ServeStatic). 

Fixes #3506