### PR TITLE
Fix breadcrumb sorting

### DIFF
--- a/sentry_sdk/scope.py
+++ b/sentry_sdk/scope.py
@@ -30,6 +30,7 @@ from sentry_sdk.utils import (
     capture_internal_exception,
     capture_internal_exceptions,
     ContextVar,
+    datetime_from_isoformat,
     disable_capture_event,
     event_from_exception,
     exc_info_from_error,
@@ -1312,7 +1313,7 @@ class Scope:
         try:
             for crumb in event["breadcrumbs"]["values"]:
                 if isinstance(crumb["timestamp"], str):
-                    crumb["timestamp"] = datetime.fromisoformat(crumb["timestamp"])
+                    crumb["timestamp"] = datetime_from_isoformat(crumb["timestamp"])
 
             event["breadcrumbs"]["values"].sort(key=lambda crumb: crumb["timestamp"])
         except Exception:

--- a/sentry_sdk/scope.py
+++ b/sentry_sdk/scope.py
@@ -1311,11 +1311,11 @@ class Scope:
         # Attempt to sort timestamps
         try:
             for crumb in event["breadcrumbs"]["values"]:
-                if isinstance(crumb, str):
+                if isinstance(crumb["timestamp"], str):
                     crumb["timestamp"] = datetime.fromisoformat(crumb["timestamp"])
 
             event["breadcrumbs"]["values"].sort(key=lambda crumb: crumb["timestamp"])
-        except Exception:  # noqa: E722
+        except Exception:
             pass
 
     def _apply_user_to_event(self, event, hint, options):

--- a/sentry_sdk/scope.py
+++ b/sentry_sdk/scope.py
@@ -1315,7 +1315,7 @@ class Scope:
                     crumb["timestamp"] = datetime.fromisoformat(crumb["timestamp"])
 
             event["breadcrumbs"]["values"].sort(key=lambda crumb: crumb["timestamp"])
-        except:  # noqa: E722
+        except Exception:  # noqa: E722
             pass
 
     def _apply_user_to_event(self, event, hint, options):

--- a/sentry_sdk/scope.py
+++ b/sentry_sdk/scope.py
@@ -1307,7 +1307,16 @@ class Scope:
         event.setdefault("breadcrumbs", {}).setdefault("values", []).extend(
             self._breadcrumbs
         )
-        event["breadcrumbs"]["values"].sort(key=lambda crumb: crumb["timestamp"])
+
+        # Attempt to sort timestamps
+        try:
+            for crumb in event["breadcrumbs"]["values"]:
+                if isinstance(crumb, str):
+                    crumb["timestamp"] = datetime.fromisoformat(crumb["timestamp"])
+
+            event["breadcrumbs"]["values"].sort(key=lambda crumb: crumb["timestamp"])
+        except:  # noqa: E722
+            pass
 
     def _apply_user_to_event(self, event, hint, options):
         # type: (Event, Hint, Optional[Dict[str, Any]]) -> None

--- a/sentry_sdk/utils.py
+++ b/sentry_sdk/utils.py
@@ -239,6 +239,15 @@ def format_timestamp(value):
     return utctime.strftime("%Y-%m-%dT%H:%M:%S.%fZ")
 
 
+def datetime_from_isoformat(value):
+    # type: (str) -> datetime.datetime
+    try:
+        return datetime.fromisoformat(value)
+    except AttributeError:
+        # py 3.6
+        return datetime.strptime("%Y-%m-%dT%H:%M:%S.%f")
+
+
 def event_hint_with_exc_info(exc_info=None):
     # type: (Optional[ExcInfo]) -> Dict[str, Optional[ExcInfo]]
     """Creates a hint with the exc info filled in."""

--- a/sentry_sdk/utils.py
+++ b/sentry_sdk/utils.py
@@ -240,12 +240,12 @@ def format_timestamp(value):
 
 
 def datetime_from_isoformat(value):
-    # type: (str) -> datetime.datetime
+    # type: (str) -> datetime
     try:
         return datetime.fromisoformat(value)
     except AttributeError:
         # py 3.6
-        return datetime.strptime("%Y-%m-%dT%H:%M:%S.%f")
+        return datetime.strptime(value, "%Y-%m-%dT%H:%M:%S.%f")
 
 
 def event_hint_with_exc_info(exc_info=None):


### PR DESCRIPTION
- ignore errors while breadcrumb sorting
- best-effort coerce string timestamps into datetimes before sorting

Fixes https://github.com/getsentry/sentry-python/issues/3508