### PR TITLE
ref(metrics): Deprecate `sentry_sdk.metrics`

### DIFF
--- a/sentry_sdk/metrics.py
+++ b/sentry_sdk/metrics.py
@@ -5,6 +5,7 @@ import re
 import sys
 import threading
 import time
+import warnings
 import zlib
 from abc import ABC, abstractmethod
 from contextlib import contextmanager
@@ -53,6 +54,14 @@ if TYPE_CHECKING:
     from sentry_sdk._types import MetricType
     from sentry_sdk._types import MetricValue
 
+
+warnings.warn(
+    "The sentry_sdk.metrics module is deprecated and will be removed in the next major release. "
+    "Sentry will reject all metrics sent after October 7, 2024. "
+    "Learn more: https://sentry.zendesk.com/hc/en-us/articles/26369339769883-Upcoming-API-Changes-to-Metrics",
+    DeprecationWarning,
+    stacklevel=2,
+)
 
 _in_metrics = ContextVar("in_metrics", default=False)
 _set = set  # set is shadowed below

--- a/sentry_sdk/tracing.py
+++ b/sentry_sdk/tracing.py
@@ -1298,4 +1298,8 @@ from sentry_sdk.tracing_utils import (
     has_tracing_enabled,
     maybe_create_breadcrumbs_from_span,
 )
-from sentry_sdk.metrics import LocalAggregator
+
+with warnings.catch_warnings():
+    # The code in this file which uses `LocalAggregator` is only called from the deprecated `metrics` module.
+    warnings.simplefilter("ignore", DeprecationWarning)
+    from sentry_sdk.metrics import LocalAggregator


### PR DESCRIPTION
Raise a `DeprecationWarning` on import of the `sentry_sdk.metrics` module.

Closes #3502
