### PR TITLE
Use POTel `use_scope`, `use_isolation_scope`

### DIFF
--- a/sentry_sdk/api.py
+++ b/sentry_sdk/api.py
@@ -11,6 +11,8 @@ from sentry_sdk.integrations.opentelemetry.scope import (
     PotelScope as Scope,
     new_scope,
     isolation_scope,
+    use_scope,
+    use_isolation_scope,
 )
 
 
@@ -77,6 +79,8 @@ __all__ = [
     "start_transaction",
     "trace",
     "monitor",
+    "use_scope",
+    "use_isolation_scope",
 ]
 
 

--- a/sentry_sdk/integrations/threading.py
+++ b/sentry_sdk/integrations/threading.py
@@ -4,7 +4,7 @@ from threading import Thread, current_thread
 
 import sentry_sdk
 from sentry_sdk.integrations import Integration
-from sentry_sdk.scope import use_isolation_scope, use_scope
+from sentry_sdk.integrations.opentelemetry.scope import use_isolation_scope, use_scope
 from sentry_sdk.utils import (
     ensure_integration_enabled,
     event_from_exception,

--- a/sentry_sdk/integrations/threading.py
+++ b/sentry_sdk/integrations/threading.py
@@ -4,7 +4,6 @@ from threading import Thread, current_thread
 
 import sentry_sdk
 from sentry_sdk.integrations import Integration
-from sentry_sdk.integrations.opentelemetry.scope import use_isolation_scope, use_scope
 from sentry_sdk.utils import (
     ensure_integration_enabled,
     event_from_exception,
@@ -95,8 +94,8 @@ def _wrap_run(isolation_scope_to_use, current_scope_to_use, old_run_func):
                 reraise(*_capture_exception())
 
         if isolation_scope_to_use is not None and current_scope_to_use is not None:
-            with use_isolation_scope(isolation_scope_to_use):
-                with use_scope(current_scope_to_use):
+            with sentry_sdk.use_isolation_scope(isolation_scope_to_use):
+                with sentry_sdk.use_scope(current_scope_to_use):
                     return _run_old_run_func()
         else:
             return _run_old_run_func()

--- a/sentry_sdk/integrations/wsgi.py
+++ b/sentry_sdk/integrations/wsgi.py
@@ -6,7 +6,6 @@ from sentry_sdk._werkzeug import get_host, _get_headers
 from sentry_sdk.consts import OP
 from sentry_sdk.scope import should_send_default_pii
 from sentry_sdk.integrations._wsgi_common import _filter_headers
-from sentry_sdk.integrations.opentelemetry.scope import use_isolation_scope
 from sentry_sdk.sessions import track_session
 from sentry_sdk.tracing import Transaction, TRANSACTION_SOURCE_ROUTE
 from sentry_sdk.utils import (
@@ -219,7 +218,7 @@ class _ScopedResponse:
         iterator = iter(self._response)
 
         while True:
-            with use_isolation_scope(self._scope):
+            with sentry_sdk.use_isolation_scope(self._scope):
                 try:
                     chunk = next(iterator)
                 except StopIteration:
@@ -231,7 +230,7 @@ class _ScopedResponse:
 
     def close(self):
         # type: () -> None
-        with use_isolation_scope(self._scope):
+        with sentry_sdk.use_isolation_scope(self._scope):
             try:
                 self._response.close()  # type: ignore
             except AttributeError:

--- a/sentry_sdk/integrations/wsgi.py
+++ b/sentry_sdk/integrations/wsgi.py
@@ -6,8 +6,8 @@ from sentry_sdk._werkzeug import get_host, _get_headers
 from sentry_sdk.consts import OP
 from sentry_sdk.scope import should_send_default_pii
 from sentry_sdk.integrations._wsgi_common import _filter_headers
+from sentry_sdk.integrations.opentelemetry.scope import use_isolation_scope
 from sentry_sdk.sessions import track_session
-from sentry_sdk.scope import use_isolation_scope
 from sentry_sdk.tracing import Transaction, TRANSACTION_SOURCE_ROUTE
 from sentry_sdk.utils import (
     ContextVar,


### PR DESCRIPTION
Replace usages of `use_scope`, `use_isolation_scope` with the POTel-friendly variant.