### PR TITLE
Added `name` parameter to `start_span()` and deprecated `description` parameter.

### DIFF
--- a/sentry_sdk/scope.py
+++ b/sentry_sdk/scope.py
@@ -1,5 +1,6 @@
 import os
 import sys
+import warnings
 from copy import copy
 from collections import deque
 from contextlib import contextmanager
@@ -1067,6 +1068,13 @@ class Scope:
         be removed in the next major version. Going forward, it should only
         be used by the SDK itself.
         """
+        if kwargs.get("description") is not None:
+            warnings.warn(
+                "The `description` parameter is deprecated. Please use `name` instead.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+
         with new_scope():
             kwargs.setdefault("scope", self)
 

--- a/tests/tracing/test_misc.py
+++ b/tests/tracing/test_misc.py
@@ -36,11 +36,6 @@ def test_transaction_naming(sentry_init, capture_events):
     sentry_init(traces_sample_rate=1.0)
     events = capture_events()
 
-    # only transactions have names - spans don't
-    with pytest.raises(TypeError):
-        start_span(name="foo")
-    assert len(events) == 0
-
     # default name in event if no name is passed
     with start_transaction() as transaction:
         pass

--- a/tests/tracing/test_span_name.py
+++ b/tests/tracing/test_span_name.py
@@ -1,0 +1,59 @@
+import pytest
+
+import sentry_sdk
+
+
+def test_start_span_description(sentry_init, capture_events):
+    sentry_init(traces_sample_rate=1.0)
+    events = capture_events()
+
+    with sentry_sdk.start_transaction(name="hi"):
+        with pytest.deprecated_call():
+            with sentry_sdk.start_span(op="foo", description="span-desc"):
+                ...
+
+    (event,) = events
+
+    assert event["spans"][0]["description"] == "span-desc"
+
+
+def test_start_span_name(sentry_init, capture_events):
+    sentry_init(traces_sample_rate=1.0)
+    events = capture_events()
+
+    with sentry_sdk.start_transaction(name="hi"):
+        with sentry_sdk.start_span(op="foo", name="span-name"):
+            ...
+
+    (event,) = events
+
+    assert event["spans"][0]["description"] == "span-name"
+
+
+def test_start_child_description(sentry_init, capture_events):
+    sentry_init(traces_sample_rate=1.0)
+    events = capture_events()
+
+    with sentry_sdk.start_transaction(name="hi"):
+        with pytest.deprecated_call():
+            with sentry_sdk.start_span(op="foo", description="span-desc") as span:
+                with span.start_child(op="bar", description="child-desc"):
+                    ...
+
+    (event,) = events
+
+    assert event["spans"][-1]["description"] == "child-desc"
+
+
+def test_start_child_name(sentry_init, capture_events):
+    sentry_init(traces_sample_rate=1.0)
+    events = capture_events()
+
+    with sentry_sdk.start_transaction(name="hi"):
+        with sentry_sdk.start_span(op="foo", name="span-name") as span:
+            with span.start_child(op="bar", name="child-name"):
+                ...
+
+    (event,) = events
+
+    assert event["spans"][-1]["description"] == "child-name"


### PR DESCRIPTION
To align our API with OpenTelementry. In OTel a span has no `description` but a `name`.

This only changes to user facing API, under the hood there is still everything using the `description`. (This will then be changed with OTel)

Docs PR: https://github.com/getsentry/sentry-docs/pull/11332

Follow up PR that should be released at the same time: https://github.com/getsentry/sentry-python/pull/3525

Fixes #3520