### PR TITLE
Remove usages of deprecated `description` and replace by `name` in `start_span()` calls.

### DIFF
--- a/sentry_sdk/ai/monitoring.py
+++ b/sentry_sdk/ai/monitoring.py
@@ -33,7 +33,7 @@ def ai_track(description, **span_kwargs):
             curr_pipeline = _ai_pipeline_name.get()
             op = span_kwargs.get("op", "ai.run" if curr_pipeline else "ai.pipeline")
 
-            with start_span(description=description, op=op, **span_kwargs) as span:
+            with start_span(name=description, op=op, **span_kwargs) as span:
                 for k, v in kwargs.pop("sentry_tags", {}).items():
                     span.set_tag(k, v)
                 for k, v in kwargs.pop("sentry_data", {}).items():
@@ -62,7 +62,7 @@ def ai_track(description, **span_kwargs):
             curr_pipeline = _ai_pipeline_name.get()
             op = span_kwargs.get("op", "ai.run" if curr_pipeline else "ai.pipeline")
 
-            with start_span(description=description, op=op, **span_kwargs) as span:
+            with start_span(name=description, op=op, **span_kwargs) as span:
                 for k, v in kwargs.pop("sentry_tags", {}).items():
                     span.set_tag(k, v)
                 for k, v in kwargs.pop("sentry_data", {}).items():

--- a/sentry_sdk/integrations/aiohttp.py
+++ b/sentry_sdk/integrations/aiohttp.py
@@ -205,7 +205,7 @@ def create_trace_config():
 
         span = sentry_sdk.start_span(
             op=OP.HTTP_CLIENT,
-            description="%s %s"
+            name="%s %s"
             % (method, parsed_url.url if parsed_url else SENSITIVE_DATA_SUBSTITUTE),
             origin=AioHttpIntegration.origin,
         )

--- a/sentry_sdk/integrations/anthropic.py
+++ b/sentry_sdk/integrations/anthropic.py
@@ -94,7 +94,7 @@ def _wrap_message_create(f):
 
         span = sentry_sdk.start_span(
             op=OP.ANTHROPIC_MESSAGES_CREATE,
-            description="Anthropic messages create",
+            name="Anthropic messages create",
             origin=AnthropicIntegration.origin,
         )
         span.__enter__()

--- a/sentry_sdk/integrations/arq.py
+++ b/sentry_sdk/integrations/arq.py
@@ -79,7 +79,7 @@ def patch_enqueue_job():
             return await old_enqueue_job(self, function, *args, **kwargs)
 
         with sentry_sdk.start_span(
-            op=OP.QUEUE_SUBMIT_ARQ, description=function, origin=ArqIntegration.origin
+            op=OP.QUEUE_SUBMIT_ARQ, name=function, origin=ArqIntegration.origin
         ):
             return await old_enqueue_job(self, function, *args, **kwargs)
 

--- a/sentry_sdk/integrations/asyncio.py
+++ b/sentry_sdk/integrations/asyncio.py
@@ -46,7 +46,7 @@ def patch_asyncio():
                 with sentry_sdk.isolation_scope():
                     with sentry_sdk.start_span(
                         op=OP.FUNCTION,
-                        description=get_name(coro),
+                        name=get_name(coro),
                         origin=AsyncioIntegration.origin,
                     ):
                         try:

--- a/sentry_sdk/integrations/asyncpg.py
+++ b/sentry_sdk/integrations/asyncpg.py
@@ -165,7 +165,7 @@ def _wrap_connect_addr(f: Callable[..., Awaitable[T]]) -> Callable[..., Awaitabl
 
         with sentry_sdk.start_span(
             op=OP.DB,
-            description="connect",
+            name="connect",
             origin=AsyncPGIntegration.origin,
         ) as span:
             span.set_data(SPANDATA.DB_SYSTEM, "postgresql")

--- a/sentry_sdk/integrations/boto3.py
+++ b/sentry_sdk/integrations/boto3.py
@@ -69,7 +69,7 @@ def _sentry_request_created(service_id, request, operation_name, **kwargs):
     description = "aws.%s.%s" % (service_id, operation_name)
     span = sentry_sdk.start_span(
         op=OP.HTTP_CLIENT,
-        description=description,
+        name=description,
         origin=Boto3Integration.origin,
     )
 
@@ -107,7 +107,7 @@ def _sentry_after_call(context, parsed, **kwargs):
 
     streaming_span = span.start_child(
         op=OP.HTTP_CLIENT_STREAM,
-        description=span.description,
+        name=span.description,
         origin=Boto3Integration.origin,
     )
 

--- a/sentry_sdk/integrations/celery/__init__.py
+++ b/sentry_sdk/integrations/celery/__init__.py
@@ -274,7 +274,7 @@ def _wrap_task_run(f):
         span_mgr = (
             sentry_sdk.start_span(
                 op=OP.QUEUE_SUBMIT_CELERY,
-                description=task_name,
+                name=task_name,
                 origin=CeleryIntegration.origin,
             )
             if not task_started_from_beat
@@ -374,7 +374,7 @@ def _wrap_task_call(task, f):
         try:
             with sentry_sdk.start_span(
                 op=OP.QUEUE_PROCESS,
-                description=task.name,
+                name=task.name,
                 origin=CeleryIntegration.origin,
             ) as span:
                 _set_messaging_destination_name(task, span)
@@ -503,7 +503,7 @@ def _patch_producer_publish():
 
         with sentry_sdk.start_span(
             op=OP.QUEUE_PUBLISH,
-            description=task_name,
+            name=task_name,
             origin=CeleryIntegration.origin,
         ) as span:
             if task_id is not None:

--- a/sentry_sdk/integrations/clickhouse_driver.py
+++ b/sentry_sdk/integrations/clickhouse_driver.py
@@ -83,7 +83,7 @@ def _wrap_start(f: Callable[P, T]) -> Callable[P, T]:
 
         span = sentry_sdk.start_span(
             op=OP.DB,
-            description=query,
+            name=query,
             origin=ClickhouseDriverIntegration.origin,
         )
 

--- a/sentry_sdk/integrations/cohere.py
+++ b/sentry_sdk/integrations/cohere.py
@@ -142,7 +142,7 @@ def _wrap_chat(f, streaming):
 
         span = sentry_sdk.start_span(
             op=consts.OP.COHERE_CHAT_COMPLETIONS_CREATE,
-            description="cohere.client.Chat",
+            name="cohere.client.Chat",
             origin=CohereIntegration.origin,
         )
         span.__enter__()
@@ -227,7 +227,7 @@ def _wrap_embed(f):
         # type: (*Any, **Any) -> Any
         with sentry_sdk.start_span(
             op=consts.OP.COHERE_EMBEDDINGS_CREATE,
-            description="Cohere Embedding Creation",
+            name="Cohere Embedding Creation",
             origin=CohereIntegration.origin,
         ) as span:
             integration = sentry_sdk.get_client().get_integration(CohereIntegration)

--- a/sentry_sdk/integrations/django/__init__.py
+++ b/sentry_sdk/integrations/django/__init__.py
@@ -683,7 +683,7 @@ def install_sql_hook():
 
         with sentry_sdk.start_span(
             op=OP.DB,
-            description="connect",
+            name="connect",
             origin=DjangoIntegration.origin_db,
         ) as span:
             _set_db_data(span, self)

--- a/sentry_sdk/integrations/django/asgi.py
+++ b/sentry_sdk/integrations/django/asgi.py
@@ -174,7 +174,7 @@ def wrap_async_view(callback):
 
         with sentry_sdk.start_span(
             op=OP.VIEW_RENDER,
-            description=request.resolver_match.view_name,
+            name=request.resolver_match.view_name,
             origin=DjangoIntegration.origin,
         ):
             return await callback(request, *args, **kwargs)

--- a/sentry_sdk/integrations/django/caching.py
+++ b/sentry_sdk/integrations/django/caching.py
@@ -52,7 +52,7 @@ def _patch_cache_method(cache, method_name, address, port):
 
         with sentry_sdk.start_span(
             op=op,
-            description=description,
+            name=description,
             origin=DjangoIntegration.origin,
         ) as span:
             value = original_method(*args, **kwargs)

--- a/sentry_sdk/integrations/django/middleware.py
+++ b/sentry_sdk/integrations/django/middleware.py
@@ -87,7 +87,7 @@ def _wrap_middleware(middleware, middleware_name):
 
         middleware_span = sentry_sdk.start_span(
             op=OP.MIDDLEWARE_DJANGO,
-            description=description,
+            name=description,
             origin=DjangoIntegration.origin,
         )
         middleware_span.set_tag("django.function_name", function_name)

--- a/sentry_sdk/integrations/django/signals_handlers.py
+++ b/sentry_sdk/integrations/django/signals_handlers.py
@@ -66,7 +66,7 @@ def patch_signals():
                 signal_name = _get_receiver_name(receiver)
                 with sentry_sdk.start_span(
                     op=OP.EVENT_DJANGO,
-                    description=signal_name,
+                    name=signal_name,
                     origin=DjangoIntegration.origin,
                 ) as span:
                     span.set_data("signal", signal_name)

--- a/sentry_sdk/integrations/django/templates.py
+++ b/sentry_sdk/integrations/django/templates.py
@@ -70,7 +70,7 @@ def patch_templates():
         # type: (SimpleTemplateResponse) -> str
         with sentry_sdk.start_span(
             op=OP.TEMPLATE_RENDER,
-            description=_get_template_name_description(self.template_name),
+            name=_get_template_name_description(self.template_name),
             origin=DjangoIntegration.origin,
         ) as span:
             span.set_data("context", self.context_data)
@@ -98,7 +98,7 @@ def patch_templates():
 
         with sentry_sdk.start_span(
             op=OP.TEMPLATE_RENDER,
-            description=_get_template_name_description(template_name),
+            name=_get_template_name_description(template_name),
             origin=DjangoIntegration.origin,
         ) as span:
             span.set_data("context", context)

--- a/sentry_sdk/integrations/django/views.py
+++ b/sentry_sdk/integrations/django/views.py
@@ -35,7 +35,7 @@ def patch_views():
         # type: (SimpleTemplateResponse) -> Any
         with sentry_sdk.start_span(
             op=OP.VIEW_RESPONSE_RENDER,
-            description="serialize response",
+            name="serialize response",
             origin=DjangoIntegration.origin,
         ):
             return old_render(self)
@@ -84,7 +84,7 @@ def _wrap_sync_view(callback):
 
         with sentry_sdk.start_span(
             op=OP.VIEW_RENDER,
-            description=request.resolver_match.view_name,
+            name=request.resolver_match.view_name,
             origin=DjangoIntegration.origin,
         ):
             return callback(request, *args, **kwargs)

--- a/sentry_sdk/integrations/graphene.py
+++ b/sentry_sdk/integrations/graphene.py
@@ -142,9 +142,9 @@ def graphql_span(schema, source, kwargs):
 
     scope = sentry_sdk.get_current_scope()
     if scope.span:
-        _graphql_span = scope.span.start_child(op=op, description=operation_name)
+        _graphql_span = scope.span.start_child(op=op, name=operation_name)
     else:
-        _graphql_span = sentry_sdk.start_span(op=op, description=operation_name)
+        _graphql_span = sentry_sdk.start_span(op=op, name=operation_name)
 
     _graphql_span.set_data("graphql.document", source)
     _graphql_span.set_data("graphql.operation.name", operation_name)

--- a/sentry_sdk/integrations/grpc/aio/client.py
+++ b/sentry_sdk/integrations/grpc/aio/client.py
@@ -50,7 +50,7 @@ class SentryUnaryUnaryClientInterceptor(ClientInterceptor, UnaryUnaryClientInter
 
         with sentry_sdk.start_span(
             op=OP.GRPC_CLIENT,
-            description="unary unary call to %s" % method.decode(),
+            name="unary unary call to %s" % method.decode(),
             origin=SPAN_ORIGIN,
         ) as span:
             span.set_data("type", "unary unary")
@@ -80,7 +80,7 @@ class SentryUnaryStreamClientInterceptor(
 
         with sentry_sdk.start_span(
             op=OP.GRPC_CLIENT,
-            description="unary stream call to %s" % method.decode(),
+            name="unary stream call to %s" % method.decode(),
             origin=SPAN_ORIGIN,
         ) as span:
             span.set_data("type", "unary stream")

--- a/sentry_sdk/integrations/grpc/client.py
+++ b/sentry_sdk/integrations/grpc/client.py
@@ -29,7 +29,7 @@ class ClientInterceptor(
 
         with sentry_sdk.start_span(
             op=OP.GRPC_CLIENT,
-            description="unary unary call to %s" % method,
+            name="unary unary call to %s" % method,
             origin=SPAN_ORIGIN,
         ) as span:
             span.set_data("type", "unary unary")
@@ -50,7 +50,7 @@ class ClientInterceptor(
 
         with sentry_sdk.start_span(
             op=OP.GRPC_CLIENT,
-            description="unary stream call to %s" % method,
+            name="unary stream call to %s" % method,
             origin=SPAN_ORIGIN,
         ) as span:
             span.set_data("type", "unary stream")

--- a/sentry_sdk/integrations/httpx.py
+++ b/sentry_sdk/integrations/httpx.py
@@ -53,7 +53,7 @@ def _install_httpx_client():
 
         with sentry_sdk.start_span(
             op=OP.HTTP_CLIENT,
-            description="%s %s"
+            name="%s %s"
             % (
                 request.method,
                 parsed_url.url if parsed_url else SENSITIVE_DATA_SUBSTITUTE,
@@ -109,7 +109,7 @@ def _install_httpx_async_client():
 
         with sentry_sdk.start_span(
             op=OP.HTTP_CLIENT,
-            description="%s %s"
+            name="%s %s"
             % (
                 request.method,
                 parsed_url.url if parsed_url else SENSITIVE_DATA_SUBSTITUTE,

--- a/sentry_sdk/integrations/huey.py
+++ b/sentry_sdk/integrations/huey.py
@@ -59,7 +59,7 @@ def patch_enqueue():
         # type: (Huey, Task) -> Optional[Union[Result, ResultGroup]]
         with sentry_sdk.start_span(
             op=OP.QUEUE_SUBMIT_HUEY,
-            description=task.name,
+            name=task.name,
             origin=HueyIntegration.origin,
         ):
             if not isinstance(task, PeriodicTask):

--- a/sentry_sdk/integrations/huggingface_hub.py
+++ b/sentry_sdk/integrations/huggingface_hub.py
@@ -73,7 +73,7 @@ def _wrap_text_generation(f):
 
         span = sentry_sdk.start_span(
             op=consts.OP.HUGGINGFACE_HUB_CHAT_COMPLETIONS_CREATE,
-            description="Text Generation",
+            name="Text Generation",
             origin=HuggingfaceHubIntegration.origin,
         )
         span.__enter__()

--- a/sentry_sdk/integrations/langchain.py
+++ b/sentry_sdk/integrations/langchain.py
@@ -146,8 +146,8 @@ class SentryLangchainCallback(BaseCallbackHandler):  # type: ignore[misc]
             watched_span = WatchedSpan(sentry_sdk.start_span(**kwargs))
 
         if kwargs.get("op", "").startswith("ai.pipeline."):
-            if kwargs.get("description"):
-                set_ai_pipeline_name(kwargs.get("description"))
+            if kwargs.get("name"):
+                set_ai_pipeline_name(kwargs.get("name"))
             watched_span.is_pipeline = True
 
         watched_span.span.__enter__()
@@ -186,7 +186,7 @@ class SentryLangchainCallback(BaseCallbackHandler):  # type: ignore[misc]
                 run_id,
                 kwargs.get("parent_run_id"),
                 op=OP.LANGCHAIN_RUN,
-                description=kwargs.get("name") or "Langchain LLM call",
+                name=kwargs.get("name") or "Langchain LLM call",
                 origin=LangchainIntegration.origin,
             )
             span = watched_span.span
@@ -208,7 +208,7 @@ class SentryLangchainCallback(BaseCallbackHandler):  # type: ignore[misc]
                 run_id,
                 kwargs.get("parent_run_id"),
                 op=OP.LANGCHAIN_CHAT_COMPLETIONS_CREATE,
-                description=kwargs.get("name") or "Langchain Chat Model",
+                name=kwargs.get("name") or "Langchain Chat Model",
                 origin=LangchainIntegration.origin,
             )
             span = watched_span.span
@@ -312,7 +312,7 @@ class SentryLangchainCallback(BaseCallbackHandler):  # type: ignore[misc]
                     if kwargs.get("parent_run_id") is not None
                     else OP.LANGCHAIN_PIPELINE
                 ),
-                description=kwargs.get("name") or "Chain execution",
+                name=kwargs.get("name") or "Chain execution",
                 origin=LangchainIntegration.origin,
             )
             metadata = kwargs.get("metadata")
@@ -345,7 +345,7 @@ class SentryLangchainCallback(BaseCallbackHandler):  # type: ignore[misc]
                 run_id,
                 kwargs.get("parent_run_id"),
                 op=OP.LANGCHAIN_AGENT,
-                description=action.tool or "AI tool usage",
+                name=action.tool or "AI tool usage",
                 origin=LangchainIntegration.origin,
             )
             if action.tool_input and should_send_default_pii() and self.include_prompts:
@@ -378,9 +378,7 @@ class SentryLangchainCallback(BaseCallbackHandler):  # type: ignore[misc]
                 run_id,
                 kwargs.get("parent_run_id"),
                 op=OP.LANGCHAIN_TOOL,
-                description=serialized.get("name")
-                or kwargs.get("name")
-                or "AI tool usage",
+                name=serialized.get("name") or kwargs.get("name") or "AI tool usage",
                 origin=LangchainIntegration.origin,
             )
             if should_send_default_pii() and self.include_prompts:

--- a/sentry_sdk/integrations/litestar.py
+++ b/sentry_sdk/integrations/litestar.py
@@ -139,7 +139,7 @@ def enable_span_for_middleware(middleware):
         middleware_name = self.__class__.__name__
         with sentry_sdk.start_span(
             op=OP.MIDDLEWARE_LITESTAR,
-            description=middleware_name,
+            name=middleware_name,
             origin=LitestarIntegration.origin,
         ) as middleware_span:
             middleware_span.set_tag("litestar.middleware_name", middleware_name)
@@ -151,7 +151,7 @@ def enable_span_for_middleware(middleware):
                     return await receive(*args, **kwargs)
                 with sentry_sdk.start_span(
                     op=OP.MIDDLEWARE_LITESTAR_RECEIVE,
-                    description=getattr(receive, "__qualname__", str(receive)),
+                    name=getattr(receive, "__qualname__", str(receive)),
                     origin=LitestarIntegration.origin,
                 ) as span:
                     span.set_tag("litestar.middleware_name", middleware_name)
@@ -168,7 +168,7 @@ def enable_span_for_middleware(middleware):
                     return await send(message)
                 with sentry_sdk.start_span(
                     op=OP.MIDDLEWARE_LITESTAR_SEND,
-                    description=getattr(send, "__qualname__", str(send)),
+                    name=getattr(send, "__qualname__", str(send)),
                     origin=LitestarIntegration.origin,
                 ) as span:
                     span.set_tag("litestar.middleware_name", middleware_name)

--- a/sentry_sdk/integrations/openai.py
+++ b/sentry_sdk/integrations/openai.py
@@ -133,7 +133,7 @@ def _wrap_chat_completion_create(f):
 
         span = sentry_sdk.start_span(
             op=consts.OP.OPENAI_CHAT_COMPLETIONS_CREATE,
-            description="Chat Completion",
+            name="Chat Completion",
             origin=OpenAIIntegration.origin,
         )
         span.__enter__()
@@ -223,7 +223,7 @@ def _wrap_embeddings_create(f):
         # type: (*Any, **Any) -> Any
         with sentry_sdk.start_span(
             op=consts.OP.OPENAI_EMBEDDINGS_CREATE,
-            description="OpenAI Embedding Creation",
+            name="OpenAI Embedding Creation",
             origin=OpenAIIntegration.origin,
         ) as span:
             integration = sentry_sdk.get_client().get_integration(OpenAIIntegration)

--- a/sentry_sdk/integrations/opentelemetry/span_processor.py
+++ b/sentry_sdk/integrations/opentelemetry/span_processor.py
@@ -147,7 +147,7 @@ class SentrySpanProcessor(SpanProcessor):
         if sentry_parent_span:
             sentry_span = sentry_parent_span.start_child(
                 span_id=trace_data["span_id"],
-                description=otel_span.name,
+                name=otel_span.name,
                 start_timestamp=start_timestamp,
                 instrumenter=INSTRUMENTER.OTEL,
                 origin=SPAN_ORIGIN,

--- a/sentry_sdk/integrations/pymongo.py
+++ b/sentry_sdk/integrations/pymongo.py
@@ -158,7 +158,7 @@ class CommandTracer(monitoring.CommandListener):
             query = json.dumps(command, default=str)
             span = sentry_sdk.start_span(
                 op=OP.DB,
-                description=query,
+                name=query,
                 origin=PyMongoIntegration.origin,
             )
 

--- a/sentry_sdk/integrations/ray.py
+++ b/sentry_sdk/integrations/ray.py
@@ -88,7 +88,7 @@ def _patch_ray_remote():
             """
             with sentry_sdk.start_span(
                 op=OP.QUEUE_SUBMIT_RAY,
-                description=qualname_from_function(f),
+                name=qualname_from_function(f),
                 origin=RayIntegration.origin,
             ) as span:
                 tracing = {

--- a/sentry_sdk/integrations/redis/_async_common.py
+++ b/sentry_sdk/integrations/redis/_async_common.py
@@ -37,7 +37,7 @@ def patch_redis_async_pipeline(
 
         with sentry_sdk.start_span(
             op=OP.DB_REDIS,
-            description="redis.pipeline.execute",
+            name="redis.pipeline.execute",
             origin=SPAN_ORIGIN,
         ) as span:
             with capture_internal_exceptions():
@@ -78,7 +78,7 @@ def patch_redis_async_client(cls, is_cluster, set_db_data_fn):
         if cache_properties["is_cache_key"] and cache_properties["op"] is not None:
             cache_span = sentry_sdk.start_span(
                 op=cache_properties["op"],
-                description=cache_properties["description"],
+                name=cache_properties["description"],
                 origin=SPAN_ORIGIN,
             )
             cache_span.__enter__()
@@ -87,7 +87,7 @@ def patch_redis_async_client(cls, is_cluster, set_db_data_fn):
 
         db_span = sentry_sdk.start_span(
             op=db_properties["op"],
-            description=db_properties["description"],
+            name=db_properties["description"],
             origin=SPAN_ORIGIN,
         )
         db_span.__enter__()

--- a/sentry_sdk/integrations/redis/_sync_common.py
+++ b/sentry_sdk/integrations/redis/_sync_common.py
@@ -38,7 +38,7 @@ def patch_redis_pipeline(
 
         with sentry_sdk.start_span(
             op=OP.DB_REDIS,
-            description="redis.pipeline.execute",
+            name="redis.pipeline.execute",
             origin=SPAN_ORIGIN,
         ) as span:
             with capture_internal_exceptions():
@@ -83,7 +83,7 @@ def patch_redis_client(cls, is_cluster, set_db_data_fn):
         if cache_properties["is_cache_key"] and cache_properties["op"] is not None:
             cache_span = sentry_sdk.start_span(
                 op=cache_properties["op"],
-                description=cache_properties["description"],
+                name=cache_properties["description"],
                 origin=SPAN_ORIGIN,
             )
             cache_span.__enter__()
@@ -92,7 +92,7 @@ def patch_redis_client(cls, is_cluster, set_db_data_fn):
 
         db_span = sentry_sdk.start_span(
             op=db_properties["op"],
-            description=db_properties["description"],
+            name=db_properties["description"],
             origin=SPAN_ORIGIN,
         )
         db_span.__enter__()

--- a/sentry_sdk/integrations/socket.py
+++ b/sentry_sdk/integrations/socket.py
@@ -55,7 +55,7 @@ def _patch_create_connection():
 
         with sentry_sdk.start_span(
             op=OP.SOCKET_CONNECTION,
-            description=_get_span_description(address[0], address[1]),
+            name=_get_span_description(address[0], address[1]),
             origin=SocketIntegration.origin,
         ) as span:
             span.set_data("address", address)
@@ -81,7 +81,7 @@ def _patch_getaddrinfo():
 
         with sentry_sdk.start_span(
             op=OP.SOCKET_DNS,
-            description=_get_span_description(host, port),
+            name=_get_span_description(host, port),
             origin=SocketIntegration.origin,
         ) as span:
             span.set_data("host", host)

--- a/sentry_sdk/integrations/starlette.py
+++ b/sentry_sdk/integrations/starlette.py
@@ -132,7 +132,7 @@ def _enable_span_for_middleware(middleware_class):
 
         with sentry_sdk.start_span(
             op=OP.MIDDLEWARE_STARLETTE,
-            description=middleware_name,
+            name=middleware_name,
             origin=StarletteIntegration.origin,
         ) as middleware_span:
             middleware_span.set_tag("starlette.middleware_name", middleware_name)
@@ -142,7 +142,7 @@ def _enable_span_for_middleware(middleware_class):
                 # type: (*Any, **Any) -> Any
                 with sentry_sdk.start_span(
                     op=OP.MIDDLEWARE_STARLETTE_RECEIVE,
-                    description=getattr(receive, "__qualname__", str(receive)),
+                    name=getattr(receive, "__qualname__", str(receive)),
                     origin=StarletteIntegration.origin,
                 ) as span:
                     span.set_tag("starlette.middleware_name", middleware_name)
@@ -157,7 +157,7 @@ def _enable_span_for_middleware(middleware_class):
                 # type: (*Any, **Any) -> Any
                 with sentry_sdk.start_span(
                     op=OP.MIDDLEWARE_STARLETTE_SEND,
-                    description=getattr(send, "__qualname__", str(send)),
+                    name=getattr(send, "__qualname__", str(send)),
                     origin=StarletteIntegration.origin,
                 ) as span:
                     span.set_tag("starlette.middleware_name", middleware_name)

--- a/sentry_sdk/integrations/starlite.py
+++ b/sentry_sdk/integrations/starlite.py
@@ -138,7 +138,7 @@ def enable_span_for_middleware(middleware):
         middleware_name = self.__class__.__name__
         with sentry_sdk.start_span(
             op=OP.MIDDLEWARE_STARLITE,
-            description=middleware_name,
+            name=middleware_name,
             origin=StarliteIntegration.origin,
         ) as middleware_span:
             middleware_span.set_tag("starlite.middleware_name", middleware_name)
@@ -150,7 +150,7 @@ def enable_span_for_middleware(middleware):
                     return await receive(*args, **kwargs)
                 with sentry_sdk.start_span(
                     op=OP.MIDDLEWARE_STARLITE_RECEIVE,
-                    description=getattr(receive, "__qualname__", str(receive)),
+                    name=getattr(receive, "__qualname__", str(receive)),
                     origin=StarliteIntegration.origin,
                 ) as span:
                     span.set_tag("starlite.middleware_name", middleware_name)
@@ -167,7 +167,7 @@ def enable_span_for_middleware(middleware):
                     return await send(message)
                 with sentry_sdk.start_span(
                     op=OP.MIDDLEWARE_STARLITE_SEND,
-                    description=getattr(send, "__qualname__", str(send)),
+                    name=getattr(send, "__qualname__", str(send)),
                     origin=StarliteIntegration.origin,
                 ) as span:
                     span.set_tag("starlite.middleware_name", middleware_name)

--- a/sentry_sdk/integrations/stdlib.py
+++ b/sentry_sdk/integrations/stdlib.py
@@ -90,7 +90,7 @@ def _install_httplib():
 
         span = sentry_sdk.start_span(
             op=OP.HTTP_CLIENT,
-            description="%s %s"
+            name="%s %s"
             % (method, parsed_url.url if parsed_url else SENSITIVE_DATA_SUBSTITUTE),
             origin="auto.http.stdlib.httplib",
         )
@@ -203,7 +203,7 @@ def _install_subprocess():
 
         with sentry_sdk.start_span(
             op=OP.SUBPROCESS,
-            description=description,
+            name=description,
             origin="auto.subprocess.stdlib.subprocess",
         ) as span:
             for k, v in sentry_sdk.get_current_scope().iter_trace_propagation_headers(

--- a/sentry_sdk/integrations/strawberry.py
+++ b/sentry_sdk/integrations/strawberry.py
@@ -182,13 +182,13 @@ class SentryAsyncExtension(SchemaExtension):  # type: ignore
         if span:
             self.graphql_span = span.start_child(
                 op=op,
-                description=description,
+                name=description,
                 origin=StrawberryIntegration.origin,
             )
         else:
             self.graphql_span = sentry_sdk.start_span(
                 op=op,
-                description=description,
+                name=description,
                 origin=StrawberryIntegration.origin,
             )
 
@@ -211,7 +211,7 @@ class SentryAsyncExtension(SchemaExtension):  # type: ignore
         # type: () -> Generator[None, None, None]
         self.validation_span = self.graphql_span.start_child(
             op=OP.GRAPHQL_VALIDATE,
-            description="validation",
+            name="validation",
             origin=StrawberryIntegration.origin,
         )
 
@@ -223,7 +223,7 @@ class SentryAsyncExtension(SchemaExtension):  # type: ignore
         # type: () -> Generator[None, None, None]
         self.parsing_span = self.graphql_span.start_child(
             op=OP.GRAPHQL_PARSE,
-            description="parsing",
+            name="parsing",
             origin=StrawberryIntegration.origin,
         )
 
@@ -253,7 +253,7 @@ class SentryAsyncExtension(SchemaExtension):  # type: ignore
 
         with self.graphql_span.start_child(
             op=OP.GRAPHQL_RESOLVE,
-            description="resolving {}".format(field_path),
+            name="resolving {}".format(field_path),
             origin=StrawberryIntegration.origin,
         ) as span:
             span.set_data("graphql.field_name", info.field_name)
@@ -274,7 +274,7 @@ class SentrySyncExtension(SentryAsyncExtension):
 
         with self.graphql_span.start_child(
             op=OP.GRAPHQL_RESOLVE,
-            description="resolving {}".format(field_path),
+            name="resolving {}".format(field_path),
             origin=StrawberryIntegration.origin,
         ) as span:
             span.set_data("graphql.field_name", info.field_name)

--- a/sentry_sdk/metrics.py
+++ b/sentry_sdk/metrics.py
@@ -826,7 +826,7 @@ class _Timing:
         # type: (...) -> _Timing
         self.entered = TIMING_FUNCTIONS[self.unit]()
         self._validate_invocation("context-manager")
-        self._span = sentry_sdk.start_span(op="metric.timing", description=self.key)
+        self._span = sentry_sdk.start_span(op="metric.timing", name=self.key)
         if self.tags:
             for key, value in self.tags.items():
                 if isinstance(value, (tuple, list)):

--- a/sentry_sdk/scope.py
+++ b/sentry_sdk/scope.py
@@ -1,5 +1,6 @@
 import os
 import sys
+import warnings
 from copy import copy
 from collections import deque
 from contextlib import contextmanager
@@ -1067,6 +1068,13 @@ class Scope:
         be removed in the next major version. Going forward, it should only
         be used by the SDK itself.
         """
+        if kwargs.get("description") is not None:
+            warnings.warn(
+                "The `description` parameter is deprecated. Please use `name` instead.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+
         with new_scope():
             kwargs.setdefault("scope", self)
 

--- a/sentry_sdk/tracing_utils.py
+++ b/sentry_sdk/tracing_utils.py
@@ -146,7 +146,7 @@ def record_sql_queries(
 
     with sentry_sdk.start_span(
         op=OP.DB,
-        description=query,
+        name=query,
         origin=span_origin,
     ) as span:
         for k, v in data.items():
@@ -649,7 +649,7 @@ def start_child_span_decorator(func):
 
             with span.start_child(
                 op=OP.FUNCTION,
-                description=qualname_from_function(func),
+                name=qualname_from_function(func),
             ):
                 return await func(*args, **kwargs)
 
@@ -677,7 +677,7 @@ def start_child_span_decorator(func):
 
             with span.start_child(
                 op=OP.FUNCTION,
-                description=qualname_from_function(func),
+                name=qualname_from_function(func),
             ):
                 return func(*args, **kwargs)
 

--- a/tests/integrations/asyncio/test_asyncio.py
+++ b/tests/integrations/asyncio/test_asyncio.py
@@ -75,7 +75,7 @@ async def test_create_task(
     events = capture_events()
 
     with sentry_sdk.start_transaction(name="test_transaction_for_create_task"):
-        with sentry_sdk.start_span(op="root", description="not so important"):
+        with sentry_sdk.start_span(op="root", name="not so important"):
             tasks = [event_loop.create_task(foo()), event_loop.create_task(bar())]
             await asyncio.wait(tasks, return_when=asyncio.FIRST_EXCEPTION)
 
@@ -118,7 +118,7 @@ async def test_gather(
     events = capture_events()
 
     with sentry_sdk.start_transaction(name="test_transaction_for_gather"):
-        with sentry_sdk.start_span(op="root", description="not so important"):
+        with sentry_sdk.start_span(op="root", name="not so important"):
             await asyncio.gather(foo(), bar(), return_exceptions=True)
 
         sentry_sdk.flush()
@@ -161,7 +161,7 @@ async def test_exception(
     events = capture_events()
 
     with sentry_sdk.start_transaction(name="test_exception"):
-        with sentry_sdk.start_span(op="root", description="not so important"):
+        with sentry_sdk.start_span(op="root", name="not so important"):
             tasks = [event_loop.create_task(boom()), event_loop.create_task(bar())]
             await asyncio.wait(tasks, return_when=asyncio.FIRST_EXCEPTION)
 

--- a/tests/integrations/grpc/test_grpc.py
+++ b/tests/integrations/grpc/test_grpc.py
@@ -357,7 +357,7 @@ class TestService(gRPCTestServiceServicer):
     def TestServe(request, context):  # noqa: N802
         with start_span(
             op="test",
-            description="test",
+            name="test",
             origin="auto.grpc.grpc.TestService",
         ):
             pass

--- a/tests/integrations/grpc/test_grpc_aio.py
+++ b/tests/integrations/grpc/test_grpc_aio.py
@@ -282,7 +282,7 @@ class TestService(gRPCTestServiceServicer):
     async def TestServe(cls, request, context):  # noqa: N802
         with start_span(
             op="test",
-            description="test",
+            name="test",
             origin="auto.grpc.grpc.TestService.aio",
         ):
             pass

--- a/tests/integrations/opentelemetry/test_span_processor.py
+++ b/tests/integrations/opentelemetry/test_span_processor.py
@@ -361,7 +361,7 @@ def test_on_start_child():
 
     fake_span.start_child.assert_called_once_with(
         span_id="1234567890abcdef",
-        description="Sample OTel Span",
+        name="Sample OTel Span",
         start_timestamp=datetime.fromtimestamp(
             otel_span.start_time / 1e9, timezone.utc
         ),

--- a/tests/integrations/ray/test_ray.py
+++ b/tests/integrations/ray/test_ray.py
@@ -52,7 +52,7 @@ def test_ray_tracing():
 
     @ray.remote
     def example_task():
-        with sentry_sdk.start_span(op="task", description="example task step"):
+        with sentry_sdk.start_span(op="task", name="example task step"):
             ...
 
         return sentry_sdk.get_client().transport.envelopes
@@ -177,7 +177,7 @@ def test_ray_actor():
             self.n = 0
 
         def increment(self):
-            with sentry_sdk.start_span(op="task", description="example task step"):
+            with sentry_sdk.start_span(op="task", name="example task step"):
                 self.n += 1
 
             return sentry_sdk.get_client().transport.envelopes

--- a/tests/integrations/threading/test_threading.py
+++ b/tests/integrations/threading/test_threading.py
@@ -80,7 +80,7 @@ def test_propagates_threadpool_hub(sentry_init, capture_events, propagate_hub):
     events = capture_events()
 
     def double(number):
-        with sentry_sdk.start_span(op="task", description=str(number)):
+        with sentry_sdk.start_span(op="task", name=str(number)):
             return number * 2
 
     with sentry_sdk.start_transaction(name="test_handles_threadpool"):

--- a/tests/test_scrubber.py
+++ b/tests/test_scrubber.py
@@ -146,7 +146,7 @@ def test_span_data_scrubbing(sentry_init, capture_events):
     events = capture_events()
 
     with start_transaction(name="hi"):
-        with start_span(op="foo", description="bar") as span:
+        with start_span(op="foo", name="bar") as span:
             span.set_data("password", "secret")
             span.set_data("datafoo", "databar")
 

--- a/tests/tracing/test_decorator.py
+++ b/tests/tracing/test_decorator.py
@@ -26,7 +26,7 @@ def test_trace_decorator():
 
         result2 = start_child_span_decorator(my_example_function)()
         fake_start_child.assert_called_once_with(
-            op="function", description="test_decorator.my_example_function"
+            op="function", name="test_decorator.my_example_function"
         )
         assert result2 == "return_of_sync_function"
 
@@ -58,7 +58,7 @@ async def test_trace_decorator_async():
         result2 = await start_child_span_decorator(my_async_example_function)()
         fake_start_child.assert_called_once_with(
             op="function",
-            description="test_decorator.my_async_example_function",
+            name="test_decorator.my_async_example_function",
         )
         assert result2 == "return_of_async_function"
 

--- a/tests/tracing/test_integration_tests.py
+++ b/tests/tracing/test_integration_tests.py
@@ -23,10 +23,10 @@ def test_basic(sentry_init, capture_events, sample_rate):
     with start_transaction(name="hi") as transaction:
         transaction.set_status(SPANSTATUS.OK)
         with pytest.raises(ZeroDivisionError):
-            with start_span(op="foo", description="foodesc"):
+            with start_span(op="foo", name="foodesc"):
                 1 / 0
 
-        with start_span(op="bar", description="bardesc"):
+        with start_span(op="bar", name="bardesc"):
             pass
 
     if sample_rate:
@@ -158,7 +158,7 @@ def test_dynamic_sampling_head_sdk_creates_dsc(
     assert baggage.third_party_items == ""
 
     with start_transaction(transaction):
-        with start_span(op="foo", description="foodesc"):
+        with start_span(op="foo", name="foodesc"):
             pass
 
     # finish will create a new baggage entry
@@ -211,7 +211,7 @@ def test_memory_usage(sentry_init, capture_events, args, expected_refcount):
 
     with start_transaction(name="hi"):
         for i in range(100):
-            with start_span(op="helloworld", description="hi {}".format(i)) as span:
+            with start_span(op="helloworld", name="hi {}".format(i)) as span:
 
                 def foo():
                     pass
@@ -248,14 +248,14 @@ def test_start_span_after_finish(sentry_init, capture_events):
             pass
 
         def capture_event(self, event):
-            start_span(op="toolate", description="justdont")
+            start_span(op="toolate", name="justdont")
             pass
 
     sentry_init(traces_sample_rate=1, transport=CustomTransport())
     events = capture_events()
 
     with start_transaction(name="hi"):
-        with start_span(op="bar", description="bardesc"):
+        with start_span(op="bar", name="bardesc"):
             pass
 
     assert len(events) == 1
@@ -269,7 +269,7 @@ def test_trace_propagation_meta_head_sdk(sentry_init):
     span = None
 
     with start_transaction(transaction):
-        with start_span(op="foo", description="foodesc") as current_span:
+        with start_span(op="foo", name="foodesc") as current_span:
             span = current_span
             meta = sentry_sdk.get_current_scope().trace_propagation_meta()
 

--- a/tests/tracing/test_misc.py
+++ b/tests/tracing/test_misc.py
@@ -36,11 +36,6 @@ def test_transaction_naming(sentry_init, capture_events):
     sentry_init(traces_sample_rate=1.0)
     events = capture_events()
 
-    # only transactions have names - spans don't
-    with pytest.raises(TypeError):
-        start_span(name="foo")
-    assert len(events) == 0
-
     # default name in event if no name is passed
     with start_transaction() as transaction:
         pass

--- a/tests/tracing/test_noop_span.py
+++ b/tests/tracing/test_noop_span.py
@@ -23,7 +23,7 @@ def test_noop_start_transaction(sentry_init):
 def test_noop_start_span(sentry_init):
     sentry_init(instrumenter="otel")
 
-    with sentry_sdk.start_span(op="http", description="GET /") as span:
+    with sentry_sdk.start_span(op="http", name="GET /") as span:
         assert isinstance(span, NoOpSpan)
         assert sentry_sdk.get_current_scope().span is span
 

--- a/tests/tracing/test_span_name.py
+++ b/tests/tracing/test_span_name.py
@@ -1,0 +1,59 @@
+import pytest
+
+import sentry_sdk
+
+
+def test_start_span_description(sentry_init, capture_events):
+    sentry_init(traces_sample_rate=1.0)
+    events = capture_events()
+
+    with sentry_sdk.start_transaction(name="hi"):
+        with pytest.deprecated_call():
+            with sentry_sdk.start_span(op="foo", description="span-desc"):
+                ...
+
+    (event,) = events
+
+    assert event["spans"][0]["description"] == "span-desc"
+
+
+def test_start_span_name(sentry_init, capture_events):
+    sentry_init(traces_sample_rate=1.0)
+    events = capture_events()
+
+    with sentry_sdk.start_transaction(name="hi"):
+        with sentry_sdk.start_span(op="foo", name="span-name"):
+            ...
+
+    (event,) = events
+
+    assert event["spans"][0]["description"] == "span-name"
+
+
+def test_start_child_description(sentry_init, capture_events):
+    sentry_init(traces_sample_rate=1.0)
+    events = capture_events()
+
+    with sentry_sdk.start_transaction(name="hi"):
+        with pytest.deprecated_call():
+            with sentry_sdk.start_span(op="foo", description="span-desc") as span:
+                with span.start_child(op="bar", description="child-desc"):
+                    ...
+
+    (event,) = events
+
+    assert event["spans"][-1]["description"] == "child-desc"
+
+
+def test_start_child_name(sentry_init, capture_events):
+    sentry_init(traces_sample_rate=1.0)
+    events = capture_events()
+
+    with sentry_sdk.start_transaction(name="hi"):
+        with sentry_sdk.start_span(op="foo", name="span-name") as span:
+            with span.start_child(op="bar", name="child-name"):
+                ...
+
+    (event,) = events
+
+    assert event["spans"][-1]["description"] == "child-name"

--- a/tests/tracing/test_span_name.py
+++ b/tests/tracing/test_span_name.py
@@ -9,7 +9,7 @@ def test_start_span_description(sentry_init, capture_events):
 
     with sentry_sdk.start_transaction(name="hi"):
         with pytest.deprecated_call():
-            with sentry_sdk.start_span(op="foo", name="span-desc"):
+            with sentry_sdk.start_span(op="foo", description="span-desc"):
                 ...
 
     (event,) = events
@@ -36,8 +36,8 @@ def test_start_child_description(sentry_init, capture_events):
 
     with sentry_sdk.start_transaction(name="hi"):
         with pytest.deprecated_call():
-            with sentry_sdk.start_span(op="foo", name="span-desc") as span:
-                with span.start_child(op="bar", name="child-desc"):
+            with sentry_sdk.start_span(op="foo", description="span-desc") as span:
+                with span.start_child(op="bar", description="child-desc"):
                     ...
 
     (event,) = events

--- a/tests/tracing/test_span_name.py
+++ b/tests/tracing/test_span_name.py
@@ -9,7 +9,7 @@ def test_start_span_description(sentry_init, capture_events):
 
     with sentry_sdk.start_transaction(name="hi"):
         with pytest.deprecated_call():
-            with sentry_sdk.start_span(op="foo", description="span-desc"):
+            with sentry_sdk.start_span(op="foo", name="span-desc"):
                 ...
 
     (event,) = events
@@ -36,8 +36,8 @@ def test_start_child_description(sentry_init, capture_events):
 
     with sentry_sdk.start_transaction(name="hi"):
         with pytest.deprecated_call():
-            with sentry_sdk.start_span(op="foo", description="span-desc") as span:
-                with span.start_child(op="bar", description="child-desc"):
+            with sentry_sdk.start_span(op="foo", name="span-desc") as span:
+                with span.start_child(op="bar", name="child-desc"):
                     ...
 
     (event,) = events

--- a/tests/tracing/test_span_origin.py
+++ b/tests/tracing/test_span_origin.py
@@ -6,7 +6,7 @@ def test_span_origin_manual(sentry_init, capture_events):
     events = capture_events()
 
     with start_transaction(name="hi"):
-        with start_span(op="foo", description="bar"):
+        with start_span(op="foo", name="bar"):
             pass
 
     (event,) = events
@@ -21,11 +21,11 @@ def test_span_origin_custom(sentry_init, capture_events):
     events = capture_events()
 
     with start_transaction(name="hi"):
-        with start_span(op="foo", description="bar", origin="foo.foo2.foo3"):
+        with start_span(op="foo", name="bar", origin="foo.foo2.foo3"):
             pass
 
     with start_transaction(name="ho", origin="ho.ho2.ho3"):
-        with start_span(op="baz", description="qux", origin="baz.baz2.baz3"):
+        with start_span(op="baz", name="qux", origin="baz.baz2.baz3"):
             pass
 
     (first_transaction, second_transaction) = events


### PR DESCRIPTION
Replace the deprecated `description` parameter in all calls to `start_span()` and `start_child` and replace it with the new `name` parameter. 

This PR is blocked by this one that deprecates `description`: https://github.com/getsentry/sentry-python/pull/3524

Fixes #3521
