### PR TITLE
Fix timezones in breadcrumb sorting

### DIFF
--- a/sentry_sdk/tracing.py
+++ b/sentry_sdk/tracing.py
@@ -1,7 +1,7 @@
 import uuid
 import random
 import time
-import warnings 
+import warnings
 from datetime import datetime, timedelta, timezone
 
 from opentelemetry import trace as otel_trace, context

--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -326,9 +326,9 @@ def test_breadcrumb_ordering(sentry_init, capture_events):
     events = capture_events()
 
     timestamps = [
-        datetime.datetime.now() - datetime.timedelta(days=10),
-        datetime.datetime.now() - datetime.timedelta(days=8),
-        datetime.datetime.now() - datetime.timedelta(days=12),
+        datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(days=10),
+        datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(days=8),
+        datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(days=12),
     ]
 
     for timestamp in timestamps:
@@ -344,8 +344,8 @@ def test_breadcrumb_ordering(sentry_init, capture_events):
 
     assert len(event["breadcrumbs"]["values"]) == len(timestamps)
     timestamps_from_event = [
-        datetime.datetime.strptime(
-            x["timestamp"].replace("Z", ""), "%Y-%m-%dT%H:%M:%S.%f"
+        datetime.datetime.strptime(x["timestamp"], "%Y-%m-%dT%H:%M:%S.%fZ").replace(
+            tzinfo=datetime.timezone.utc
         )
         for x in event["breadcrumbs"]["values"]
     ]

--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -357,9 +357,9 @@ def test_breadcrumb_ordering_different_types(sentry_init, capture_events):
     events = capture_events()
 
     timestamps = [
-        datetime.datetime.now() - datetime.timedelta(days=10),
-        datetime.datetime.now() - datetime.timedelta(days=8),
-        datetime.datetime.now() - datetime.timedelta(days=12),
+        datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(days=10),
+        datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(days=8),
+        datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(days=12),
     ]
 
     for i, timestamp in enumerate(timestamps):
@@ -375,8 +375,8 @@ def test_breadcrumb_ordering_different_types(sentry_init, capture_events):
 
     assert len(event["breadcrumbs"]["values"]) == len(timestamps)
     timestamps_from_event = [
-        datetime.datetime.strptime(
-            x["timestamp"].replace("Z", ""), "%Y-%m-%dT%H:%M:%S.%f"
+        datetime.datetime.strptime(x["timestamp"], "%Y-%m-%dT%H:%M:%S.%fZ").replace(
+            tzinfo=datetime.timezone.utc
         )
         for x in event["breadcrumbs"]["values"]
     ]


### PR DESCRIPTION
Just always use UTC.