### PR TITLE
ci: update actions/upload-artifact to v4 with merge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,7 +102,7 @@ jobs:
     needs: [build_lambda_layer, docs]
     steps:
       - name: Merge Artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/merge@v4
         with:
           # Craft expects release assets to be a single artifact named after the sha.
           name: ${{ github.sha }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,13 +104,13 @@ jobs:
           compression-level: '0'
 
   merge:
+    name: Create Release Artifact
     runs-on: ubuntu-latest
     needs: [build_lambda_layer, docs]
     steps:
-      - name: Merge Artifacts
-        uses: actions/upload-artifact/merge@v4
+      - uses: actions/upload-artifact/merge@v4
         with:
-          # Craft expects release assets to be a single artifact named after the sha.
+          # Craft expects release assets from github to be a single artifact named after the sha.
           name: ${{ github.sha }}
           pattern: artifact-*
           delete-merged: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,9 +70,9 @@ jobs:
           # This will also trigger "make dist" that creates the Python packages
           make aws-lambda-layer
       - name: Upload Python Packages
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: ${{ github.sha }}
+          name: artifact-build_lambda_layer
           path: |
             dist/*
 
@@ -91,7 +91,20 @@ jobs:
           make apidocs
           cd docs/_build && zip -r gh-pages ./
 
-      - uses: actions/upload-artifact@v3.1.1
+      - uses: actions/upload-artifact@v4
         with:
-          name: ${{ github.sha }}
+          name: artifact-docs
           path: docs/_build/gh-pages.zip
+            dist/*
+
+  merge:
+    runs-on: ubuntu-latest
+    needs: [build_lambda_layer, docs]
+    steps:
+      - name: Merge Artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          # Craft expects release assets to be a single artifact named after the sha.
+          name: ${{ github.sha }}
+          pattern: artifact-*
+          delete-merged: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,7 +102,7 @@ jobs:
     needs: [build_lambda_layer, docs]
     steps:
       - name: Merge Artifacts
-        uses: actions/merge@v4
+        uses: actions/upload-artifact/merge@v4
         with:
           # Craft expects release assets to be a single artifact named after the sha.
           name: ${{ github.sha }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,6 +75,9 @@ jobs:
           name: artifact-build_lambda_layer
           path: |
             dist/*
+          if-no-files-found: 'error'
+          # since this artifact will be merged, compression is not necessary
+          compression-level: '0'
 
   docs:
     name: Build SDK API Doc
@@ -94,8 +97,11 @@ jobs:
       - uses: actions/upload-artifact@v4
         with:
           name: artifact-docs
-          path: docs/_build/gh-pages.zip
-            dist/*
+          path: |
+            docs/_build/gh-pages.zip
+          if-no-files-found: 'error'
+          # since this artifact will be merged, compression is not necessary
+          compression-level: '0'
 
   merge:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Supersedes https://github.com/getsentry/sentry-python/pull/3381 using artifacts/merge to merge together multiple artifacts from different jobs into the single one named github.sha that craft expects.

Summarily, upload-artifact v3 is deprecated but v4 doesn't support mutating an artifact with the name name by uploading different filepaths to the same artifact. Because we need a single artifact "github.sha", we have to use actions/merge to create it. Alternatively craft could be modified but this is the easiest way forward and I like the idea of a unified artifact, it makes craft simpler.

ref: https://github.com/getsentry/craft/issues/552