### PR TITLE
fix: Fix breadcrumb timestamp casting and its tests

### DIFF
--- a/sentry_sdk/integrations/cohere.py
+++ b/sentry_sdk/integrations/cohere.py
@@ -26,13 +26,18 @@ try:
     from cohere import (
         ChatStreamEndEvent,
         NonStreamedChatResponse,
-        StreamedChatResponse_StreamEnd,
     )
 
     if TYPE_CHECKING:
         from cohere import StreamedChatResponse
 except ImportError:
     raise DidNotEnable("Cohere not installed")
+
+try:
+    # cohere 5.9.3+
+    from cohere import StreamEndStreamedChatResponse
+except ImportError:
+    from cohere import StreamedChatResponse_StreamEnd as StreamEndStreamedChatResponse  # type: ignore
 
 
 COLLECTED_CHAT_PARAMS = {
@@ -189,7 +194,7 @@ def _wrap_chat(f, streaming):
                     with capture_internal_exceptions():
                         for x in old_iterator:
                             if isinstance(x, ChatStreamEndEvent) or isinstance(
-                                x, StreamedChatResponse_StreamEnd
+                                x, StreamEndStreamedChatResponse
                             ):
                                 collect_chat_response_fields(
                                     span,

--- a/sentry_sdk/integrations/cohere.py
+++ b/sentry_sdk/integrations/cohere.py
@@ -37,7 +37,7 @@ try:
     # cohere 5.9.3+
     from cohere import StreamEndStreamedChatResponse
 except ImportError:
-    from cohere import StreamedChatResponse_StreamEnd as StreamEndStreamedChatResponse  # type: ignore
+    from cohere import StreamedChatResponse_StreamEnd as StreamEndStreamedChatResponse
 
 
 COLLECTED_CHAT_PARAMS = {

--- a/sentry_sdk/integrations/cohere.py
+++ b/sentry_sdk/integrations/cohere.py
@@ -26,18 +26,13 @@ try:
     from cohere import (
         ChatStreamEndEvent,
         NonStreamedChatResponse,
+        StreamedChatResponse_StreamEnd,
     )
 
     if TYPE_CHECKING:
         from cohere import StreamedChatResponse
 except ImportError:
     raise DidNotEnable("Cohere not installed")
-
-try:
-    # cohere 5.9.3+
-    from cohere import StreamEndStreamedChatResponse
-except ImportError:
-    from cohere import StreamedChatResponse_StreamEnd as StreamEndStreamedChatResponse
 
 
 COLLECTED_CHAT_PARAMS = {
@@ -194,7 +189,7 @@ def _wrap_chat(f, streaming):
                     with capture_internal_exceptions():
                         for x in old_iterator:
                             if isinstance(x, ChatStreamEndEvent) or isinstance(
-                                x, StreamEndStreamedChatResponse
+                                x, StreamedChatResponse_StreamEnd
                             ):
                                 collect_chat_response_fields(
                                     span,

--- a/sentry_sdk/scope.py
+++ b/sentry_sdk/scope.py
@@ -968,7 +968,7 @@ class Scope:
         transaction=None,
         instrumenter=INSTRUMENTER.SENTRY,
         custom_sampling_context=None,
-        **kwargs
+        **kwargs,
     ):
         # type: (Optional[Transaction], str, Optional[SamplingContext], Unpack[TransactionKwargs]) -> Union[Transaction, NoOpSpan]
         """
@@ -1324,7 +1324,8 @@ class Scope:
                     crumb["timestamp"] = datetime_from_isoformat(crumb["timestamp"])
 
             event["breadcrumbs"]["values"].sort(key=lambda crumb: crumb["timestamp"])
-        except Exception:
+        except Exception as err:
+            logger.debug("Error when sorting breadcrumbs", exc_info=err)
             pass
 
     def _apply_user_to_event(self, event, hint, options):

--- a/sentry_sdk/scope.py
+++ b/sentry_sdk/scope.py
@@ -1325,7 +1325,7 @@ class Scope:
 
             event["breadcrumbs"]["values"].sort(key=lambda crumb: crumb["timestamp"])
         except Exception as err:
-            logger.debug("Error when sorting breadcrumbs", exc_info=err)
+            logger.warning("Error when sorting breadcrumbs", exc_info=err)
             pass
 
     def _apply_user_to_event(self, event, hint, options):

--- a/sentry_sdk/scope.py
+++ b/sentry_sdk/scope.py
@@ -1325,7 +1325,7 @@ class Scope:
 
             event["breadcrumbs"]["values"].sort(key=lambda crumb: crumb["timestamp"])
         except Exception as err:
-            logger.warning("Error when sorting breadcrumbs", exc_info=err)
+            logger.debug("Error when sorting breadcrumbs", exc_info=err)
             pass
 
     def _apply_user_to_event(self, event, hint, options):

--- a/sentry_sdk/scope.py
+++ b/sentry_sdk/scope.py
@@ -1325,6 +1325,7 @@ class Scope:
 
             event["breadcrumbs"]["values"].sort(key=lambda crumb: crumb["timestamp"])
         except Exception as err:
+            print(err)
             logger.warning("Error when sorting breadcrumbs", exc_info=err)
             pass
 

--- a/sentry_sdk/scope.py
+++ b/sentry_sdk/scope.py
@@ -1325,7 +1325,6 @@ class Scope:
 
             event["breadcrumbs"]["values"].sort(key=lambda crumb: crumb["timestamp"])
         except Exception as err:
-            print(err)
             logger.warning("Error when sorting breadcrumbs", exc_info=err)
             pass
 

--- a/sentry_sdk/utils.py
+++ b/sentry_sdk/utils.py
@@ -243,15 +243,20 @@ def datetime_from_isoformat(value):
     # type: (str) -> datetime
     try:
         return datetime.fromisoformat(value)
-    except AttributeError:
+    except (AttributeError, ValueError):
         # py 3.6
         timestamp_format = (
             "%Y-%m-%dT%H:%M:%S.%f" if "." in value else "%Y-%m-%dT%H:%M:%S"
         )
         if value.endswith("Z"):
             value = value[:-1]
-        elif "+" in value:
-            timestamp_format += "%z"
+        else:
+            plus_idx = value.rfind("+")
+            if plus_idx != -1:
+                tz_colon_index = value.rfind(":", plus_idx)
+                if tz_colon_index != -1:
+                    value = value[:tz_colon_index] + value[tz_colon_index + 1 :]
+                timestamp_format += "%z"
 
         return datetime.strptime(value, timestamp_format)
 

--- a/sentry_sdk/utils.py
+++ b/sentry_sdk/utils.py
@@ -239,6 +239,9 @@ def format_timestamp(value):
     return utctime.strftime("%Y-%m-%dT%H:%M:%S.%fZ")
 
 
+ISO_TZ_SEPARATORS = frozenset(("+", "-"))
+
+
 def datetime_from_isoformat(value):
     # type: (str) -> datetime
     try:
@@ -251,11 +254,10 @@ def datetime_from_isoformat(value):
         if value.endswith("Z"):
             value = value[:-1]
         else:
-            plus_idx = value.rfind("+")
-            if plus_idx != -1:
-                tz_colon_index = value.rfind(":", plus_idx)
-                if tz_colon_index != -1:
-                    value = value[:tz_colon_index] + value[tz_colon_index + 1 :]
+            if value[-6] in ISO_TZ_SEPARATORS:
+                timestamp_format += "%z"
+                value = value[:-3] + value[-2:]
+            elif value[-5] in ISO_TZ_SEPARATORS:
                 timestamp_format += "%z"
 
         return datetime.strptime(value, timestamp_format).astimezone(timezone.utc)

--- a/sentry_sdk/utils.py
+++ b/sentry_sdk/utils.py
@@ -245,7 +245,8 @@ def datetime_from_isoformat(value):
         return datetime.fromisoformat(value)
     except AttributeError:
         # py 3.6
-        return datetime.strptime(value, "%Y-%m-%dT%H:%M:%S.%f")
+        iso_format = "%Y-%m-%dT%H:%M:%S.%f" if "." in value else "%Y-%m-%dT%H:%M:%S"
+        return datetime.strptime(value, iso_format)
 
 
 def event_hint_with_exc_info(exc_info=None):

--- a/sentry_sdk/utils.py
+++ b/sentry_sdk/utils.py
@@ -258,7 +258,7 @@ def datetime_from_isoformat(value):
                     value = value[:tz_colon_index] + value[tz_colon_index + 1 :]
                 timestamp_format += "%z"
 
-        return datetime.strptime(value, timestamp_format)
+        return datetime.strptime(value, timestamp_format).astimezone(timezone.utc)
 
 
 def event_hint_with_exc_info(exc_info=None):

--- a/sentry_sdk/utils.py
+++ b/sentry_sdk/utils.py
@@ -245,8 +245,15 @@ def datetime_from_isoformat(value):
         return datetime.fromisoformat(value)
     except AttributeError:
         # py 3.6
-        iso_format = "%Y-%m-%dT%H:%M:%S.%f" if "." in value else "%Y-%m-%dT%H:%M:%S"
-        return datetime.strptime(value, iso_format)
+        timestamp_format = (
+            "%Y-%m-%dT%H:%M:%S.%f" if "." in value else "%Y-%m-%dT%H:%M:%S"
+        )
+        if value.endswith("Z"):
+            value = value[:-1]
+        elif "+" in value:
+            timestamp_format += "%z"
+
+        return datetime.strptime(value, timestamp_format)
 
 
 def event_hint_with_exc_info(exc_info=None):

--- a/sentry_sdk/utils.py
+++ b/sentry_sdk/utils.py
@@ -245,22 +245,23 @@ ISO_TZ_SEPARATORS = frozenset(("+", "-"))
 def datetime_from_isoformat(value):
     # type: (str) -> datetime
     try:
-        return datetime.fromisoformat(value)
+        result = datetime.fromisoformat(value)
     except (AttributeError, ValueError):
         # py 3.6
         timestamp_format = (
             "%Y-%m-%dT%H:%M:%S.%f" if "." in value else "%Y-%m-%dT%H:%M:%S"
         )
         if value.endswith("Z"):
-            value = value[:-1]
-        else:
-            if value[-6] in ISO_TZ_SEPARATORS:
-                timestamp_format += "%z"
-                value = value[:-3] + value[-2:]
-            elif value[-5] in ISO_TZ_SEPARATORS:
-                timestamp_format += "%z"
+            value = value[:-1] + "+0000"
 
-        return datetime.strptime(value, timestamp_format).astimezone(timezone.utc)
+        if value[-6] in ISO_TZ_SEPARATORS:
+            timestamp_format += "%z"
+            value = value[:-3] + value[-2:]
+        elif value[-5] in ISO_TZ_SEPARATORS:
+            timestamp_format += "%z"
+
+        result = datetime.strptime(value, timestamp_format)
+    return result.astimezone(timezone.utc)
 
 
 def event_hint_with_exc_info(exc_info=None):

--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -419,7 +419,13 @@ def test_breadcrumb_ordering(sentry_init, capture_events):
     assert len(event["breadcrumbs"]["values"]) == len(timestamps)
     timestamps_from_event = [
         datetime.datetime.strptime(
-            x["timestamp"].replace("Z", ""), "%Y-%m-%dT%H:%M:%S.%f"
+            # We do the `.replace("Z", "")` monstrosity to support Python 3.6
+            # Otherwise we could have used `%z` or just `Z` in strptime
+            # but it cannot handle both `Z` and `+00:00` (only one) so
+            # this is why we cannot have nice things.
+            # TODO: Move to `%z` once we drop Py 3.6 support
+            x["timestamp"].replace("Z", ""),
+            "%Y-%m-%dT%H:%M:%S.%f",
         ).replace(tzinfo=datetime.timezone.utc)
         for x in event["breadcrumbs"]["values"]
     ]
@@ -451,7 +457,13 @@ def test_breadcrumb_ordering_different_types(sentry_init, capture_events):
     assert len(event["breadcrumbs"]["values"]) == len(timestamps)
     timestamps_from_event = [
         datetime.datetime.strptime(
-            x["timestamp"].replace("Z", ""), "%Y-%m-%dT%H:%M:%S.%f"
+            # We do the `.replace("Z", "")` monstrosity to support Python 3.6
+            # Otherwise we could have used `%z` or just `Z` in strptime
+            # but it cannot handle both `Z` and `+00:00` (only one) so
+            # this is why we cannot have nice things.
+            # TODO: Move to `%z` once we drop Py 3.6 support
+            x["timestamp"].replace("Z", ""),
+            "%Y-%m-%dT%H:%M:%S.%f",
         ).replace(tzinfo=datetime.timezone.utc)
         for x in event["breadcrumbs"]["values"]
     ]

--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -397,7 +397,7 @@ def test_breadcrumbs(sentry_init, capture_events):
 def test_breadcrumb_ordering(sentry_init, capture_events):
     sentry_init()
     events = capture_events()
-    now = datetime.datetime.now(datetime.timezone.utc)
+    now = datetime.datetime.now(datetime.timezone.utc).replace(microsecond=0)
 
     timestamps = [
         now - datetime.timedelta(days=10),
@@ -419,13 +419,11 @@ def test_breadcrumb_ordering(sentry_init, capture_events):
     assert len(event["breadcrumbs"]["values"]) == len(timestamps)
     timestamps_from_event = [
         datetime.datetime.strptime(
-            # We do the `.replace("Z", "")` monstrosity to support Python 3.6
-            # Otherwise we could have used `%z` or just `Z` in strptime
-            # but it cannot handle both `Z` and `+00:00` (only one) so
-            # this is why we cannot have nice things.
-            # TODO: Move to `%z` once we drop Py 3.6 support
-            x["timestamp"].replace("Z", ""),
-            "%Y-%m-%dT%H:%M:%S.%f",
+            # Because Python doesn't know how to parse ISO timestamps until 3.11
+            # And Python 3.6 randomly uses +00:00 or Z as UTC timezone
+            # TODO: Replace this with the format "%Y-%m-%dT%H:%M:%S.%f%z" once 3.6 is gone
+            x["timestamp"][0:19],
+            "%Y-%m-%dT%H:%M:%S",
         ).replace(tzinfo=datetime.timezone.utc)
         for x in event["breadcrumbs"]["values"]
     ]
@@ -435,7 +433,7 @@ def test_breadcrumb_ordering(sentry_init, capture_events):
 def test_breadcrumb_ordering_different_types(sentry_init, capture_events):
     sentry_init()
     events = capture_events()
-    now = datetime.datetime.now(datetime.timezone.utc)
+    now = datetime.datetime.now(datetime.timezone.utc).replace(microsecond=0)
 
     timestamps = [
         now - datetime.timedelta(days=10),
@@ -457,13 +455,11 @@ def test_breadcrumb_ordering_different_types(sentry_init, capture_events):
     assert len(event["breadcrumbs"]["values"]) == len(timestamps)
     timestamps_from_event = [
         datetime.datetime.strptime(
-            # We do the `.replace("Z", "")` monstrosity to support Python 3.6
-            # Otherwise we could have used `%z` or just `Z` in strptime
-            # but it cannot handle both `Z` and `+00:00` (only one) so
-            # this is why we cannot have nice things.
-            # TODO: Move to `%z` once we drop Py 3.6 support
-            x["timestamp"].replace("Z", ""),
-            "%Y-%m-%dT%H:%M:%S.%f",
+            # Because Python doesn't know how to parse ISO timestamps until 3.11
+            # And Python 3.6 randomly uses +00:00 or Z as UTC timezone
+            # TODO: Replace this with the format "%Y-%m-%dT%H:%M:%S.%f%z" once 3.6 is gone
+            x["timestamp"][0:19],
+            "%Y-%m-%dT%H:%M:%S",
         ).replace(tzinfo=datetime.timezone.utc)
         for x in event["breadcrumbs"]["values"]
     ]

--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -418,7 +418,7 @@ def test_breadcrumb_ordering(sentry_init, capture_events):
 
     assert len(event["breadcrumbs"]["values"]) == len(timestamps)
     timestamps_from_event = [
-        datetime.datetime.strptime(x["timestamp"], "%Y-%m-%dT%H:%M:%S.%f%z").replace(
+        datetime.datetime.strptime(x["timestamp"], "%Y-%m-%dT%H:%M:%S.%fZ").replace(
             tzinfo=datetime.timezone.utc
         )
         for x in event["breadcrumbs"]["values"]
@@ -450,7 +450,7 @@ def test_breadcrumb_ordering_different_types(sentry_init, capture_events):
 
     assert len(event["breadcrumbs"]["values"]) == len(timestamps)
     timestamps_from_event = [
-        datetime.datetime.strptime(x["timestamp"], "%Y-%m-%dT%H:%M:%S.%f%z").replace(
+        datetime.datetime.strptime(x["timestamp"], "%Y-%m-%dT%H:%M:%S.%fZ").replace(
             tzinfo=datetime.timezone.utc
         )
         for x in event["breadcrumbs"]["values"]

--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -446,7 +446,6 @@ def test_breadcrumb_ordering_different_types(sentry_init, capture_events):
         datetime.datetime.strftime(timestamps[4], "%Y-%m-%dT%H:%M:%S.%f") + "+0000",
         datetime.datetime.strftime(timestamps[5], "%Y-%m-%dT%H:%M:%S.%f") + "+0000",
     ]
-    print(breadcrumb_timestamps)
 
     for i, timestamp in enumerate(timestamps):
         add_breadcrumb(

--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -419,7 +419,7 @@ def test_breadcrumb_ordering(sentry_init, capture_events):
     assert len(event["breadcrumbs"]["values"]) == len(timestamps)
     timestamps_from_event = [
         datetime.datetime.strptime(
-            x["timestamp"], "%Y-%m-%dT%H:%M:%S.%fZ"
+            x["timestamp"].replace("Z", ""), "%Y-%m-%dT%H:%M:%S.%f"
         ).replace(tzinfo=datetime.timezone.utc)
         for x in event["breadcrumbs"]["values"]
     ]
@@ -451,7 +451,7 @@ def test_breadcrumb_ordering_different_types(sentry_init, capture_events):
     assert len(event["breadcrumbs"]["values"]) == len(timestamps)
     timestamps_from_event = [
         datetime.datetime.strptime(
-            x["timestamp"], "%Y-%m-%dT%H:%M:%S.%fZ"
+            x["timestamp"].replace("Z", ""), "%Y-%m-%dT%H:%M:%S.%f"
         ).replace(tzinfo=datetime.timezone.utc)
         for x in event["breadcrumbs"]["values"]
     ]

--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -419,7 +419,7 @@ def test_breadcrumb_ordering(sentry_init, capture_events):
     assert len(event["breadcrumbs"]["values"]) == len(timestamps)
     timestamps_from_event = [
         datetime.datetime.strptime(
-            x["timestamp"].replace("Z", ""), "%Y-%m-%dT%H:%M:%S.%f"
+            x["timestamp"], "%Y-%m-%dT%H:%M:%S.%fZ"
         ).replace(tzinfo=datetime.timezone.utc)
         for x in event["breadcrumbs"]["values"]
     ]
@@ -451,7 +451,7 @@ def test_breadcrumb_ordering_different_types(sentry_init, capture_events):
     assert len(event["breadcrumbs"]["values"]) == len(timestamps)
     timestamps_from_event = [
         datetime.datetime.strptime(
-            x["timestamp"].replace("Z", ""), "%Y-%m-%dT%H:%M:%S.%f"
+            x["timestamp"], "%Y-%m-%dT%H:%M:%S.%fZ"
         ).replace(tzinfo=datetime.timezone.utc)
         for x in event["breadcrumbs"]["values"]
     ]

--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -431,7 +431,6 @@ def test_breadcrumb_ordering(sentry_init, capture_events):
 
 
 def test_breadcrumb_ordering_different_types(sentry_init, capture_events):
-    sentry_sdk.set_level("warning")
     sentry_init()
     events = capture_events()
     now = datetime.datetime.now(datetime.timezone.utc).replace(microsecond=0)

--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -444,7 +444,7 @@ def test_breadcrumb_ordering_different_types(sentry_init, capture_events):
         datetime.datetime.strftime(timestamps[2], "%Y-%m-%dT%H:%M:%S") + "Z",
         datetime.datetime.strftime(timestamps[3], "%Y-%m-%dT%H:%M:%S.%f") + "+00:00",
         datetime.datetime.strftime(timestamps[4], "%Y-%m-%dT%H:%M:%S.%f") + "+0000",
-        datetime.datetime.strftime(timestamps[5], "%Y-%m-%dT%H:%M:%S.%f") + "+0000",
+        datetime.datetime.strftime(timestamps[5], "%Y-%m-%dT%H:%M:%S.%f") + "-0000",
     ]
 
     for i, timestamp in enumerate(timestamps):

--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -418,9 +418,9 @@ def test_breadcrumb_ordering(sentry_init, capture_events):
 
     assert len(event["breadcrumbs"]["values"]) == len(timestamps)
     timestamps_from_event = [
-        datetime.datetime.strptime(x["timestamp"], "%Y-%m-%dT%H:%M:%S.%fZ").replace(
-            tzinfo=datetime.timezone.utc
-        )
+        datetime.datetime.strptime(
+            x["timestamp"], "%Y-%m-%dT%H:%M:%S.%fZ"
+        ).replace(tzinfo=datetime.timezone.utc)
         for x in event["breadcrumbs"]["values"]
     ]
     assert timestamps_from_event == sorted(timestamps)
@@ -450,9 +450,9 @@ def test_breadcrumb_ordering_different_types(sentry_init, capture_events):
 
     assert len(event["breadcrumbs"]["values"]) == len(timestamps)
     timestamps_from_event = [
-        datetime.datetime.strptime(x["timestamp"], "%Y-%m-%dT%H:%M:%S.%fZ").replace(
-            tzinfo=datetime.timezone.utc
-        )
+        datetime.datetime.strptime(
+            x["timestamp"], "%Y-%m-%dT%H:%M:%S.%fZ"
+        ).replace(tzinfo=datetime.timezone.utc)
         for x in event["breadcrumbs"]["values"]
     ]
     assert timestamps_from_event == sorted(timestamps)

--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -431,6 +431,7 @@ def test_breadcrumb_ordering(sentry_init, capture_events):
 
 
 def test_breadcrumb_ordering_different_types(sentry_init, capture_events):
+    sentry_sdk.set_level("warning")
     sentry_init()
     events = capture_events()
     now = datetime.datetime.now(datetime.timezone.utc).replace(microsecond=0)

--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -418,7 +418,7 @@ def test_breadcrumb_ordering(sentry_init, capture_events):
 
     assert len(event["breadcrumbs"]["values"]) == len(timestamps)
     timestamps_from_event = [
-        datetime.datetime.strptime(x["timestamp"], "%Y-%m-%dT%H:%M:%S.%fZ").replace(
+        datetime.datetime.strptime(x["timestamp"], "%Y-%m-%dT%H:%M:%S.%f%z").replace(
             tzinfo=datetime.timezone.utc
         )
         for x in event["breadcrumbs"]["values"]
@@ -450,7 +450,7 @@ def test_breadcrumb_ordering_different_types(sentry_init, capture_events):
 
     assert len(event["breadcrumbs"]["values"]) == len(timestamps)
     timestamps_from_event = [
-        datetime.datetime.strptime(x["timestamp"], "%Y-%m-%dT%H:%M:%S.%fZ").replace(
+        datetime.datetime.strptime(x["timestamp"], "%Y-%m-%dT%H:%M:%S.%f%z").replace(
             tzinfo=datetime.timezone.utc
         )
         for x in event["breadcrumbs"]["values"]

--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -418,9 +418,9 @@ def test_breadcrumb_ordering(sentry_init, capture_events):
 
     assert len(event["breadcrumbs"]["values"]) == len(timestamps)
     timestamps_from_event = [
-        datetime.datetime.strptime(
-            x["timestamp"], "%Y-%m-%dT%H:%M:%S.%fZ"
-        ).replace(tzinfo=datetime.timezone.utc)
+        datetime.datetime.strptime(x["timestamp"], "%Y-%m-%dT%H:%M:%S.%fZ").replace(
+            tzinfo=datetime.timezone.utc
+        )
         for x in event["breadcrumbs"]["values"]
     ]
     assert timestamps_from_event == sorted(timestamps)
@@ -450,9 +450,9 @@ def test_breadcrumb_ordering_different_types(sentry_init, capture_events):
 
     assert len(event["breadcrumbs"]["values"]) == len(timestamps)
     timestamps_from_event = [
-        datetime.datetime.strptime(
-            x["timestamp"], "%Y-%m-%dT%H:%M:%S.%fZ"
-        ).replace(tzinfo=datetime.timezone.utc)
+        datetime.datetime.strptime(x["timestamp"], "%Y-%m-%dT%H:%M:%S.%fZ").replace(
+            tzinfo=datetime.timezone.utc
+        )
         for x in event["breadcrumbs"]["values"]
     ]
     assert timestamps_from_event == sorted(timestamps)

--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -397,11 +397,12 @@ def test_breadcrumbs(sentry_init, capture_events):
 def test_breadcrumb_ordering(sentry_init, capture_events):
     sentry_init()
     events = capture_events()
+    now = datetime.datetime.now(datetime.timezone.utc)
 
     timestamps = [
-        datetime.datetime.now() - datetime.timedelta(days=10),
-        datetime.datetime.now() - datetime.timedelta(days=8),
-        datetime.datetime.now() - datetime.timedelta(days=12),
+        now - datetime.timedelta(days=10),
+        now - datetime.timedelta(days=8),
+        now - datetime.timedelta(days=12),
     ]
 
     for timestamp in timestamps:
@@ -419,7 +420,7 @@ def test_breadcrumb_ordering(sentry_init, capture_events):
     timestamps_from_event = [
         datetime.datetime.strptime(
             x["timestamp"].replace("Z", ""), "%Y-%m-%dT%H:%M:%S.%f"
-        )
+        ).replace(tzinfo=datetime.timezone.utc)
         for x in event["breadcrumbs"]["values"]
     ]
     assert timestamps_from_event == sorted(timestamps)
@@ -428,11 +429,12 @@ def test_breadcrumb_ordering(sentry_init, capture_events):
 def test_breadcrumb_ordering_different_types(sentry_init, capture_events):
     sentry_init()
     events = capture_events()
+    now = datetime.datetime.now(datetime.timezone.utc)
 
     timestamps = [
-        datetime.datetime.now() - datetime.timedelta(days=10),
-        datetime.datetime.now() - datetime.timedelta(days=8),
-        datetime.datetime.now() - datetime.timedelta(days=12),
+        now - datetime.timedelta(days=10),
+        now - datetime.timedelta(days=8),
+        now - datetime.timedelta(days=12),
     ]
 
     for i, timestamp in enumerate(timestamps):
@@ -450,7 +452,7 @@ def test_breadcrumb_ordering_different_types(sentry_init, capture_events):
     timestamps_from_event = [
         datetime.datetime.strptime(
             x["timestamp"].replace("Z", ""), "%Y-%m-%dT%H:%M:%S.%f"
-        )
+        ).replace(tzinfo=datetime.timezone.utc)
         for x in event["breadcrumbs"]["values"]
     ]
     assert timestamps_from_event == sorted(timestamps)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -12,6 +12,7 @@ from sentry_sdk._queue import Queue
 from sentry_sdk.utils import (
     Components,
     Dsn,
+    datetime_from_isoformat,
     env_to_bool,
     format_timestamp,
     get_current_thread_meta,
@@ -59,6 +60,55 @@ def _normalize_distribution_name(name):
     for more details.
     """
     return re.sub(r"[-_.]+", "-", name).lower()
+
+
+@pytest.mark.parametrize(
+    ("input_str", "expected_output"),
+    (
+        (
+            "2021-01-01T00:00:00.000000Z",
+            datetime(2021, 1, 1, tzinfo=timezone.utc),
+        ),  # UTC time
+        (
+            "2021-01-01T00:00:00.000000",
+            datetime(2021, 1, 1, tzinfo=datetime.now().astimezone().tzinfo),
+        ),  # No TZ -- assume UTC
+        (
+            "2021-01-01T00:00:00Z",
+            datetime(2021, 1, 1, tzinfo=timezone.utc),
+        ),  # UTC - No milliseconds
+        (
+            "2021-01-01T00:00:00.000000+00:00",
+            datetime(2021, 1, 1, tzinfo=timezone.utc),
+        ),
+        (
+            "2021-01-01T00:00:00.000000-00:00",
+            datetime(2021, 1, 1, tzinfo=timezone.utc),
+        ),
+        (
+            "2021-01-01T00:00:00.000000+0000",
+            datetime(2021, 1, 1, tzinfo=timezone.utc),
+        ),
+        (
+            "2021-01-01T00:00:00.000000-0000",
+            datetime(2021, 1, 1, tzinfo=timezone.utc),
+        ),
+        (
+            "2020-12-31T00:00:00.000000+02:00",
+            datetime(2020, 12, 31, tzinfo=timezone(timedelta(hours=2))),
+        ),  # UTC+2 time
+        (
+            "2020-12-31T00:00:00.000000-0200",
+            datetime(2020, 12, 31, tzinfo=timezone(timedelta(hours=-2))),
+        ),  # UTC-2 time
+        (
+            "2020-12-31T00:00:00-0200",
+            datetime(2020, 12, 31, tzinfo=timezone(timedelta(hours=-2))),
+        ),  # UTC-2 time - no milliseconds
+    ),
+)
+def test_datetime_from_isoformat(input_str, expected_output):
+    assert datetime_from_isoformat(input_str) == expected_output, input_str
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
These tests were failing for me locally as the timestamps were without `tzinfo` and all were assumed UTC whereas my local timezone is BST at the moment.

This patch fixes the tests along with faulty/incomplete breadcrumb timestamp parsing logic on py3.7 and py3.8.
