### PR TITLE
ref(client): Improve `get_integration` typing

### DIFF
--- a/sentry_sdk/client.py
+++ b/sentry_sdk/client.py
@@ -5,7 +5,7 @@ import socket
 from collections.abc import Mapping
 from datetime import datetime, timezone
 from importlib import import_module
-from typing import cast
+from typing import cast, overload
 
 from sentry_sdk._compat import PY37, check_uwsgi_thread_support
 from sentry_sdk.utils import (
@@ -54,6 +54,7 @@ if TYPE_CHECKING:
     from typing import Sequence
     from typing import Type
     from typing import Union
+    from typing import TypeVar
 
     from sentry_sdk._types import Event, Hint, SDKInfo
     from sentry_sdk.integrations import Integration
@@ -62,6 +63,7 @@ if TYPE_CHECKING:
     from sentry_sdk.session import Session
     from sentry_sdk.transport import Transport
 
+    I = TypeVar("I", bound=Integration)  # noqa: E741
 
 _client_init_debug = ContextVar("client_init_debug")
 
@@ -195,8 +197,20 @@ class BaseClient:
         # type: (*Any, **Any) -> None
         return None
 
-    def get_integration(self, *args, **kwargs):
-        # type: (*Any, **Any) -> Any
+    if TYPE_CHECKING:
+
+        @overload
+        def get_integration(self, name_or_class):
+            # type: (str) -> Optional[Integration]
+            ...
+
+        @overload
+        def get_integration(self, name_or_class):
+            # type: (type[I]) -> Optional[I]
+            ...
+
+    def get_integration(self, name_or_class):
+        # type: (Union[str, type[Integration]]) -> Optional[Integration]
         return None
 
     def close(self, *args, **kwargs):
@@ -815,10 +829,22 @@ class _Client(BaseClient):
         else:
             self.session_flusher.add_session(session)
 
+    if TYPE_CHECKING:
+
+        @overload
+        def get_integration(self, name_or_class):
+            # type: (str) -> Optional[Integration]
+            ...
+
+        @overload
+        def get_integration(self, name_or_class):
+            # type: (type[I]) -> Optional[I]
+            ...
+
     def get_integration(
         self, name_or_class  # type: Union[str, Type[Integration]]
     ):
-        # type: (...) -> Any
+        # type: (...) -> Optional[Integration]
         """Returns the integration for this client by name or class.
         If the client does not have that integration then `None` is returned.
         """

--- a/sentry_sdk/integrations/aiohttp.py
+++ b/sentry_sdk/integrations/aiohttp.py
@@ -1,5 +1,6 @@
 import sys
 import weakref
+from functools import wraps
 
 import sentry_sdk
 from sentry_sdk.api import continue_trace
@@ -146,11 +147,14 @@ class AioHttpIntegration(Integration):
 
         old_urldispatcher_resolve = UrlDispatcher.resolve
 
+        @wraps(old_urldispatcher_resolve)
         async def sentry_urldispatcher_resolve(self, request):
             # type: (UrlDispatcher, Request) -> UrlMappingMatchInfo
             rv = await old_urldispatcher_resolve(self, request)
 
             integration = sentry_sdk.get_client().get_integration(AioHttpIntegration)
+            if integration is None:
+                return rv
 
             name = None
 

--- a/sentry_sdk/integrations/anthropic.py
+++ b/sentry_sdk/integrations/anthropic.py
@@ -7,7 +7,6 @@ from sentry_sdk.integrations import DidNotEnable, Integration
 from sentry_sdk.scope import should_send_default_pii
 from sentry_sdk.utils import (
     capture_internal_exceptions,
-    ensure_integration_enabled,
     event_from_exception,
     package_version,
 )
@@ -78,10 +77,11 @@ def _calculate_token_usage(result, span):
 def _wrap_message_create(f):
     # type: (Any) -> Any
     @wraps(f)
-    @ensure_integration_enabled(AnthropicIntegration, f)
     def _sentry_patched_create(*args, **kwargs):
         # type: (*Any, **Any) -> Any
-        if "messages" not in kwargs:
+        integration = sentry_sdk.get_client().get_integration(AnthropicIntegration)
+
+        if integration is None or "messages" not in kwargs:
             return f(*args, **kwargs)
 
         try:
@@ -105,8 +105,6 @@ def _wrap_message_create(f):
             _capture_exception(exc)
             span.__exit__(None, None, None)
             raise exc from None
-
-        integration = sentry_sdk.get_client().get_integration(AnthropicIntegration)
 
         with capture_internal_exceptions():
             span.set_data(SPANDATA.AI_MODEL_ID, model)

--- a/sentry_sdk/integrations/atexit.py
+++ b/sentry_sdk/integrations/atexit.py
@@ -5,8 +5,6 @@ import atexit
 import sentry_sdk
 from sentry_sdk.utils import logger
 from sentry_sdk.integrations import Integration
-from sentry_sdk.utils import ensure_integration_enabled
-
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -44,13 +42,16 @@ class AtexitIntegration(Integration):
     def setup_once():
         # type: () -> None
         @atexit.register
-        @ensure_integration_enabled(AtexitIntegration)
         def _shutdown():
             # type: () -> None
-            logger.debug("atexit: got shutdown signal")
             client = sentry_sdk.get_client()
             integration = client.get_integration(AtexitIntegration)
 
+            if integration is None:
+                return
+
+            logger.debug("atexit: got shutdown signal")
             logger.debug("atexit: shutting down client")
             sentry_sdk.get_isolation_scope().end_session()
+
             client.close(callback=integration.callback)

--- a/sentry_sdk/integrations/bottle.py
+++ b/sentry_sdk/integrations/bottle.py
@@ -1,3 +1,5 @@
+import functools
+
 import sentry_sdk
 from sentry_sdk.tracing import SOURCE_FOR_STYLE
 from sentry_sdk.utils import (
@@ -81,10 +83,12 @@ class BottleIntegration(Integration):
 
         old_handle = Bottle._handle
 
-        @ensure_integration_enabled(BottleIntegration, old_handle)
+        @functools.wraps(old_handle)
         def _patched_handle(self, environ):
             # type: (Bottle, Dict[str, Any]) -> Any
             integration = sentry_sdk.get_client().get_integration(BottleIntegration)
+            if integration is None:
+                return old_handle(self, environ)
 
             scope = sentry_sdk.get_isolation_scope()
             scope._name = "bottle"

--- a/sentry_sdk/integrations/celery/__init__.py
+++ b/sentry_sdk/integrations/celery/__init__.py
@@ -248,13 +248,15 @@ class NoOpMgr:
 def _wrap_task_run(f):
     # type: (F) -> F
     @wraps(f)
-    @ensure_integration_enabled(CeleryIntegration, f)
     def apply_async(*args, **kwargs):
         # type: (*Any, **Any) -> Any
         # Note: kwargs can contain headers=None, so no setdefault!
         # Unsure which backend though.
-        kwarg_headers = kwargs.get("headers") or {}
         integration = sentry_sdk.get_client().get_integration(CeleryIntegration)
+        if integration is None:
+            return f(*args, **kwargs)
+
+        kwarg_headers = kwargs.get("headers") or {}
         propagate_traces = kwarg_headers.pop(
             "sentry-propagate-traces", integration.propagate_traces
         )

--- a/sentry_sdk/integrations/django/__init__.py
+++ b/sentry_sdk/integrations/django/__init__.py
@@ -411,10 +411,11 @@ def _set_transaction_name_and_source(scope, transaction_style, request):
         pass
 
 
-@ensure_integration_enabled(DjangoIntegration)
 def _before_get_response(request):
     # type: (WSGIRequest) -> None
     integration = sentry_sdk.get_client().get_integration(DjangoIntegration)
+    if integration is None:
+        return
 
     _patch_drf()
 
@@ -440,11 +441,10 @@ def _attempt_resolve_again(request, scope, transaction_style):
     _set_transaction_name_and_source(scope, transaction_style, request)
 
 
-@ensure_integration_enabled(DjangoIntegration)
 def _after_get_response(request):
     # type: (WSGIRequest) -> None
     integration = sentry_sdk.get_client().get_integration(DjangoIntegration)
-    if integration.transaction_style != "url":
+    if integration is None or integration.transaction_style != "url":
         return
 
     scope = sentry_sdk.get_current_scope()
@@ -510,11 +510,12 @@ def _make_wsgi_request_event_processor(weak_request, integration):
     return wsgi_request_event_processor
 
 
-@ensure_integration_enabled(DjangoIntegration)
 def _got_request_exception(request=None, **kwargs):
     # type: (WSGIRequest, **Any) -> None
     client = sentry_sdk.get_client()
     integration = client.get_integration(DjangoIntegration)
+    if integration is None:
+        return
 
     if request is not None and integration.transaction_style == "url":
         scope = sentry_sdk.get_current_scope()

--- a/sentry_sdk/integrations/fastapi.py
+++ b/sentry_sdk/integrations/fastapi.py
@@ -99,10 +99,10 @@ def patch_get_request_handler():
 
         async def _sentry_app(*args, **kwargs):
             # type: (*Any, **Any) -> Any
-            if sentry_sdk.get_client().get_integration(FastApiIntegration) is None:
+            integration = sentry_sdk.get_client().get_integration(FastApiIntegration)
+            if integration is None:
                 return await old_app(*args, **kwargs)
 
-            integration = sentry_sdk.get_client().get_integration(FastApiIntegration)
             request = args[0]
 
             _set_transaction_name_and_source(

--- a/sentry_sdk/integrations/flask.py
+++ b/sentry_sdk/integrations/flask.py
@@ -118,10 +118,12 @@ def _set_transaction_name_and_source(scope, transaction_style, request):
         pass
 
 
-@ensure_integration_enabled(FlaskIntegration)
 def _request_started(app, **kwargs):
     # type: (Flask, **Any) -> None
     integration = sentry_sdk.get_client().get_integration(FlaskIntegration)
+    if integration is None:
+        return
+
     request = flask_request._get_current_object()
 
     # Set the transaction name and source here,

--- a/sentry_sdk/integrations/gcp.py
+++ b/sentry_sdk/integrations/gcp.py
@@ -1,3 +1,4 @@
+import functools
 import sys
 from copy import deepcopy
 from datetime import datetime, timedelta, timezone
@@ -13,7 +14,6 @@ from sentry_sdk.tracing import TRANSACTION_SOURCE_COMPONENT
 from sentry_sdk.utils import (
     AnnotatedValue,
     capture_internal_exceptions,
-    ensure_integration_enabled,
     event_from_exception,
     logger,
     TimeoutThread,
@@ -39,12 +39,14 @@ if TYPE_CHECKING:
 
 def _wrap_func(func):
     # type: (F) -> F
-    @ensure_integration_enabled(GcpIntegration, func)
+    @functools.wraps(func)
     def sentry_func(functionhandler, gcp_event, *args, **kwargs):
         # type: (Any, Any, *Any, **Any) -> Any
         client = sentry_sdk.get_client()
 
         integration = client.get_integration(GcpIntegration)
+        if integration is None:
+            return func(functionhandler, gcp_event, *args, **kwargs)
 
         configured_time = environ.get("FUNCTION_TIMEOUT_SEC")
         if not configured_time:

--- a/sentry_sdk/integrations/huggingface_hub.py
+++ b/sentry_sdk/integrations/huggingface_hub.py
@@ -13,7 +13,6 @@ from sentry_sdk.integrations import DidNotEnable, Integration
 from sentry_sdk.utils import (
     capture_internal_exceptions,
     event_from_exception,
-    ensure_integration_enabled,
 )
 
 try:
@@ -55,9 +54,12 @@ def _capture_exception(exc):
 def _wrap_text_generation(f):
     # type: (Callable[..., Any]) -> Callable[..., Any]
     @wraps(f)
-    @ensure_integration_enabled(HuggingfaceHubIntegration, f)
     def new_text_generation(*args, **kwargs):
         # type: (*Any, **Any) -> Any
+        integration = sentry_sdk.get_client().get_integration(HuggingfaceHubIntegration)
+        if integration is None:
+            return f(*args, **kwargs)
+
         if "prompt" in kwargs:
             prompt = kwargs["prompt"]
         elif len(args) >= 2:
@@ -83,8 +85,6 @@ def _wrap_text_generation(f):
             _capture_exception(e)
             span.__exit__(None, None, None)
             raise e from None
-
-        integration = sentry_sdk.get_client().get_integration(HuggingfaceHubIntegration)
 
         with capture_internal_exceptions():
             if should_send_default_pii() and integration.include_prompts:

--- a/sentry_sdk/integrations/langchain.py
+++ b/sentry_sdk/integrations/langchain.py
@@ -420,6 +420,8 @@ def _wrap_configure(f):
         # type: (Any, Any) -> Any
 
         integration = sentry_sdk.get_client().get_integration(LangchainIntegration)
+        if integration is None:
+            return f(*args, **kwargs)
 
         with capture_internal_exceptions():
             new_callbacks = []  # type: List[BaseCallbackHandler]

--- a/sentry_sdk/integrations/pyramid.py
+++ b/sentry_sdk/integrations/pyramid.py
@@ -1,3 +1,4 @@
+import functools
 import os
 import sys
 import weakref
@@ -73,10 +74,12 @@ class PyramidIntegration(Integration):
 
         old_call_view = router._call_view
 
-        @ensure_integration_enabled(PyramidIntegration, old_call_view)
+        @functools.wraps(old_call_view)
         def sentry_patched_call_view(registry, request, *args, **kwargs):
             # type: (Any, Request, *Any, **Any) -> Response
             integration = sentry_sdk.get_client().get_integration(PyramidIntegration)
+            if integration is None:
+                return old_call_view(registry, request, *args, **kwargs)
 
             _set_transaction_name_and_source(
                 sentry_sdk.get_current_scope(), integration.transaction_style, request

--- a/sentry_sdk/integrations/sanic.py
+++ b/sentry_sdk/integrations/sanic.py
@@ -212,9 +212,7 @@ async def _context_exit(request, response=None):
         if not request.ctx._sentry_do_integration:
             return
 
-        integration = sentry_sdk.get_client().get_integration(
-            SanicIntegration
-        )  # type: Integration
+        integration = sentry_sdk.get_client().get_integration(SanicIntegration)
 
         response_status = None if response is None else response.status
 

--- a/sentry_sdk/integrations/threading.py
+++ b/sentry_sdk/integrations/threading.py
@@ -6,7 +6,6 @@ import sentry_sdk
 from sentry_sdk.integrations import Integration
 from sentry_sdk.scope import use_isolation_scope, use_scope
 from sentry_sdk.utils import (
-    ensure_integration_enabled,
     event_from_exception,
     capture_internal_exceptions,
     logger,
@@ -51,10 +50,12 @@ class ThreadingIntegration(Integration):
         old_start = Thread.start
 
         @wraps(old_start)
-        @ensure_integration_enabled(ThreadingIntegration, old_start)
         def sentry_start(self, *a, **kw):
             # type: (Thread, *Any, **Any) -> Any
             integration = sentry_sdk.get_client().get_integration(ThreadingIntegration)
+            if integration is None:
+                return old_start(self, *a, **kw)
+
             if integration.propagate_scope:
                 isolation_scope = sentry_sdk.get_isolation_scope()
                 current_scope = sentry_sdk.get_current_scope()

--- a/tests/profiler/test_continuous_profiler.py
+++ b/tests/profiler/test_continuous_profiler.py
@@ -168,6 +168,7 @@ def assert_single_transaction_without_profile_chunks(envelopes):
     assert "profile" not in transaction["contexts"]
 
 
+@pytest.mark.forked
 @pytest.mark.parametrize(
     "mode",
     [


### PR DESCRIPTION
Improve `get_integration` typing to make it clear that we return an `Optional[Integration]`. Further, add overloads to specify that when called with some integration type `I` (i.e. `I` is a subclass of `Integration`), then `get_integration` guarantees a return value of `Optional[I]`.

These changes should enhance type safety by explicitly guaranteeing the existing behavior of `get_integration`.
