### PR TITLE
fix: Don't use deprecated logger.warn

### DIFF
--- a/sentry_sdk/integrations/langchain.py
+++ b/sentry_sdk/integrations/langchain.py
@@ -443,7 +443,7 @@ def _wrap_configure(f):
                 elif isinstance(existing_callbacks, BaseCallbackHandler):
                     new_callbacks.append(existing_callbacks)
                 else:
-                    logger.warn("Unknown callback type: %s", existing_callbacks)
+                    logger.debug("Unknown callback type: %s", existing_callbacks)
 
             already_added = False
             for callback in new_callbacks:

--- a/tests/integrations/django/myapp/settings.py
+++ b/tests/integrations/django/myapp/settings.py
@@ -132,7 +132,7 @@ try:
 except (ImportError, KeyError):
     from sentry_sdk.utils import logger
 
-    logger.warn("No psycopg2 found, testing with SQLite.")
+    logger.warning("No psycopg2 found, testing with SQLite.")
 
 
 # Password validation


### PR DESCRIPTION
`logger.warn()` is deprecated in favor of `logger.warning()`.

We were using `logger.warn()` in two places. I changed one to `debug` to not pollute folks' logs and the other one to `logger.warning()` since it's in the tests.