### PR TITLE
fix(django): Don't let RawPostDataException bubble up

### DIFF
--- a/sentry_sdk/integrations/django/__init__.py
+++ b/sentry_sdk/integrations/django/__init__.py
@@ -555,9 +555,8 @@ class DjangoRequestExtractor(RequestExtractor):
         try:
             return self.request.body
         except RawPostDataException:
-            # We can't access the body anymore after the stream has been read.
-            # TODO: This is just a mitigation so that we don't break. Figure out
-            # how to prevent this from happening in the first place.
+            # We can't access the body anymore because the stream has already
+            # been read
             return None
 
     def form(self):

--- a/sentry_sdk/integrations/django/__init__.py
+++ b/sentry_sdk/integrations/django/__init__.py
@@ -32,6 +32,7 @@ try:
     from django.conf import settings as django_settings
     from django.core import signals
     from django.conf import settings
+    from django.http.request import RawPostDataException
 
     try:
         from django.urls import resolve
@@ -550,8 +551,14 @@ class DjangoRequestExtractor(RequestExtractor):
         return clean_cookies
 
     def raw_data(self):
-        # type: () -> bytes
-        return self.request.body
+        # type: () -> Optional[bytes]
+        try:
+            return self.request.body
+        except RawPostDataException:
+            # We can't access the body anymore after the stream has been read.
+            # TODO: This is just a mitigation so that we don't break. Figure out
+            # how to prevent this from happening in the first place.
+            return None
 
     def form(self):
         # type: () -> QueryDict

--- a/tests/integrations/django/test_basic.py
+++ b/tests/integrations/django/test_basic.py
@@ -756,7 +756,7 @@ def test_request_body_already_read(sentry_init, client, capture_events):
         def data(self):
             raise AttributeError
 
-    with mock.patch("django.http.request.HttpRequest", MockRequest):
+    with mock.patch("werkzeug.test.Request", MockRequest):
         response = client.post(
             reverse("post_echo"), data=b'{"hey": 42}', content_type="application/json"
         )


### PR DESCRIPTION
WIP: test

Django might raise a `RawPostDataException` when we attempt to read the body to include it in the event. We don't know what triggers this, but whatever the reason is, we shouldn't error out.

Fixes https://github.com/getsentry/sentry-python/issues/3045
Fixes https://github.com/getsentry/sentry-python/issues/3539