### PR TITLE
fix(aiohttp): Handle invalid responses

### DIFF
--- a/sentry_sdk/integrations/aiohttp.py
+++ b/sentry_sdk/integrations/aiohttp.py
@@ -139,7 +139,17 @@ class AioHttpIntegration(Integration):
                             # have no way to tell. Do not set span status.
                             reraise(*_capture_exception())
 
-                        transaction.set_http_status(response.status)
+                        try:
+                            # A valid response handler will return a valid response with a status. But, if the handler
+                            # returns an invalid response (e.g. None), the line below will raise an AttributeError.
+                            # Even though this is likely invalid, we need to handle this case to ensure we don't break
+                            # the application.
+                            response_status = response.status
+                        except AttributeError:
+                            pass
+                        else:
+                            transaction.set_http_status(response_status)
+
                         return response
 
         Application._handle = sentry_app_handle


### PR DESCRIPTION
If the request handler returns an invalid response (e.g. `None`), our SDK triggers an error because we try to access the invalid response's `status` attribute. Wrap this with a `try` block to handle the `AttributeError` and ensure the SDK does not break the app.