### PR TITLE
ref(aiohttp): Make `DEFUALT_FAILED_REQUEST_STATUS_CODES` private

### DIFF
--- a/sentry_sdk/integrations/aiohttp.py
+++ b/sentry_sdk/integrations/aiohttp.py
@@ -61,7 +61,7 @@ if TYPE_CHECKING:
 
 
 TRANSACTION_STYLE_VALUES = ("handler_name", "method_and_path_pattern")
-DEFAULT_FAILED_REQUEST_STATUS_CODES = frozenset(range(500, 600))
+_DEFAULT_FAILED_REQUEST_STATUS_CODES = frozenset(range(500, 600))
 
 
 class AioHttpIntegration(Integration):
@@ -72,7 +72,7 @@ class AioHttpIntegration(Integration):
         self,
         transaction_style="handler_name",  # type: str
         *,
-        failed_request_status_codes=DEFAULT_FAILED_REQUEST_STATUS_CODES,  # type: Set[int]
+        failed_request_status_codes=_DEFAULT_FAILED_REQUEST_STATUS_CODES,  # type: Set[int]
     ):
         # type: (...) -> None
         if transaction_style not in TRANSACTION_STYLE_VALUES:


### PR DESCRIPTION
There is no reason this constant should be part of the public API. Since no release has included this constant yet, making this constant private does not require a major version bump.
