### PR TITLE
test(starlette): Remove invalid `failed_request_status_code` tests

### DIFF
--- a/tests/integrations/starlette/test_starlette.py
+++ b/tests/integrations/starlette/test_starlette.py
@@ -1149,7 +1149,6 @@ parametrize_test_configurable_status_codes = pytest.mark.parametrize(
         ([range(400, 403), 500, 501], 405, False),
         ([range(400, 403), 500, 501], 501, True),
         ([range(400, 403), 500, 501], 503, False),
-        ([None], 500, False),
     ],
 )
 """Test cases for configurable status codes.


### PR DESCRIPTION
The Starlette integration tests (as well as the FastAPI integration tests, which hit the same code path as the Starlette integration) include a test where the integrations' `failed_request_status_codes` parameter is set to `[None]`. However, since the parameter is typed as `Optional[list[HttpStatusCodeRange]]`, where `HttpStatusCodeRange = Union[int, Container[int]]`, passing `[None]` for this parameter should not be allowed, per the type hint. Thus, we should not test this input, since the behavior of passing `[None]` is not, and likely should not be, defined by the API.

Depends on #3562