### PR TITLE
test(starlette): Refactor shared test parametrization

### DIFF
--- a/tests/integrations/fastapi/test_fastapi.py
+++ b/tests/integrations/fastapi/test_fastapi.py
@@ -13,6 +13,8 @@ from sentry_sdk.integrations.asgi import SentryAsgiMiddleware
 from sentry_sdk.integrations.fastapi import FastApiIntegration
 from sentry_sdk.integrations.starlette import StarletteIntegration
 
+from tests.integrations.starlette import test_starlette
+
 
 def fastapi_app_factory():
     app = FastAPI()
@@ -503,25 +505,7 @@ def test_transaction_name_in_middleware(
     )
 
 
-@pytest.mark.parametrize(
-    "failed_request_status_codes,status_code,expected_error",
-    [
-        (None, 500, True),
-        (None, 400, False),
-        ([500, 501], 500, True),
-        ([500, 501], 401, False),
-        ([range(400, 499)], 401, True),
-        ([range(400, 499)], 500, False),
-        ([range(400, 499), range(500, 599)], 300, False),
-        ([range(400, 499), range(500, 599)], 403, True),
-        ([range(400, 499), range(500, 599)], 503, True),
-        ([range(400, 403), 500, 501], 401, True),
-        ([range(400, 403), 500, 501], 405, False),
-        ([range(400, 403), 500, 501], 501, True),
-        ([range(400, 403), 500, 501], 503, False),
-        ([None], 500, False),
-    ],
-)
+@test_starlette.parametrize_test_configurable_status_codes
 def test_configurable_status_codes(
     sentry_init,
     capture_events,

--- a/tests/integrations/starlette/test_starlette.py
+++ b/tests/integrations/starlette/test_starlette.py
@@ -1133,7 +1133,7 @@ def test_span_origin(sentry_init, capture_events):
         assert span["origin"] == "auto.http.starlette"
 
 
-@pytest.mark.parametrize(
+parametrize_test_configurable_status_codes = pytest.mark.parametrize(
     "failed_request_status_codes,status_code,expected_error",
     [
         (None, 500, True),
@@ -1152,6 +1152,12 @@ def test_span_origin(sentry_init, capture_events):
         ([None], 500, False),
     ],
 )
+"""Test cases for configurable status codes.
+Also used by the FastAPI tests.
+"""
+
+
+@parametrize_test_configurable_status_codes
 def test_configurable_status_codes(
     sentry_init,
     capture_events,


### PR DESCRIPTION
We use the same parametrization for testing FastAPI's and Starlette's `failed_request_status_codes` because the `FastApiIntegration`'s constructor is the same as `StarletteIntegration`'s constructor (the former is a subclass of the latter).

Here, we refactor the test cases to define the parametrization once, then use it in both tests. This change will make some future changes simpler, since we only need to change the parameters in one place to affect the test for both frameworks.