### PR TITLE
Support new failed request status codes API in Starlette

### DIFF
--- a/sentry_sdk/integrations/__init__.py
+++ b/sentry_sdk/integrations/__init__.py
@@ -16,6 +16,9 @@ if TYPE_CHECKING:
     from typing import Type
 
 
+_DEFAULT_FAILED_REQUEST_STATUS_CODES = frozenset(range(500, 600))
+
+
 _installer_lock = Lock()
 
 # Set of all integration identifiers we have attempted to install

--- a/sentry_sdk/integrations/_wsgi_common.py
+++ b/sentry_sdk/integrations/_wsgi_common.py
@@ -210,7 +210,7 @@ def _filter_headers(headers):
 
 
 def _in_http_status_code_range(code, code_ranges):
-    # type: (int, list[HttpStatusCodeRange]) -> bool
+    # type: (object, list[HttpStatusCodeRange]) -> bool
     for target in code_ranges:
         if isinstance(target, int):
             if code == target:
@@ -226,3 +226,18 @@ def _in_http_status_code_range(code, code_ranges):
             )
 
     return False
+
+
+class HttpCodeRangeContainer:
+    """
+    Wrapper to make it possible to use list[HttpStatusCodeRange] as a Container[int].
+    Used for backwards compatibility with the old `failed_request_status_codes` option.
+    """
+
+    def __init__(self, code_ranges):
+        # type: (list[HttpStatusCodeRange]) -> None
+        self._code_ranges = code_ranges
+
+    def __contains__(self, item):
+        # type: (object) -> bool
+        return _in_http_status_code_range(item, self._code_ranges)

--- a/sentry_sdk/integrations/aiohttp.py
+++ b/sentry_sdk/integrations/aiohttp.py
@@ -5,7 +5,11 @@ from functools import wraps
 import sentry_sdk
 from sentry_sdk.api import continue_trace
 from sentry_sdk.consts import OP, SPANSTATUS, SPANDATA
-from sentry_sdk.integrations import Integration, DidNotEnable
+from sentry_sdk.integrations import (
+    _DEFAULT_FAILED_REQUEST_STATUS_CODES,
+    Integration,
+    DidNotEnable,
+)
 from sentry_sdk.integrations.logging import ignore_logger
 from sentry_sdk.sessions import track_session
 from sentry_sdk.integrations._wsgi_common import (
@@ -61,7 +65,6 @@ if TYPE_CHECKING:
 
 
 TRANSACTION_STYLE_VALUES = ("handler_name", "method_and_path_pattern")
-_DEFAULT_FAILED_REQUEST_STATUS_CODES = frozenset(range(500, 600))
 
 
 class AioHttpIntegration(Integration):

--- a/tests/integrations/starlette/test_starlette.py
+++ b/tests/integrations/starlette/test_starlette.py
@@ -6,6 +6,7 @@ import logging
 import os
 import re
 import threading
+import warnings
 from unittest import mock
 
 import pytest
@@ -1133,7 +1134,22 @@ def test_span_origin(sentry_init, capture_events):
         assert span["origin"] == "auto.http.starlette"
 
 
-parametrize_test_configurable_status_codes = pytest.mark.parametrize(
+class NonIterableContainer:
+    """Wraps any container and makes it non-iterable.
+
+    Used to test backwards compatibility with our old way of defining failed_request_status_codes, which allowed
+    passing in a list of (possibly non-iterable) containers. The Python standard library does not provide any built-in
+    non-iterable containers, so we have to define our own.
+    """
+
+    def __init__(self, inner):
+        self.inner = inner
+
+    def __contains__(self, item):
+        return item in self.inner
+
+
+parametrize_test_configurable_status_codes_deprecated = pytest.mark.parametrize(
     "failed_request_status_codes,status_code,expected_error",
     [
         (None, 500, True),
@@ -1150,28 +1166,29 @@ parametrize_test_configurable_status_codes = pytest.mark.parametrize(
         ([range(400, 403), 500, 501], 501, True),
         ([range(400, 403), 500, 501], 503, False),
         ([], 500, False),
+        ([NonIterableContainer(range(500, 600))], 500, True),
+        ([NonIterableContainer(range(500, 600))], 404, False),
     ],
 )
-"""Test cases for configurable status codes.
+"""Test cases for configurable status codes (deprecated API).
 Also used by the FastAPI tests.
 """
 
 
-@parametrize_test_configurable_status_codes
-def test_configurable_status_codes(
+@parametrize_test_configurable_status_codes_deprecated
+def test_configurable_status_codes_deprecated(
     sentry_init,
     capture_events,
     failed_request_status_codes,
     status_code,
     expected_error,
 ):
-    sentry_init(
-        integrations=[
-            StarletteIntegration(
-                failed_request_status_codes=failed_request_status_codes
-            )
-        ]
-    )
+    with pytest.warns(DeprecationWarning):
+        starlette_integration = StarletteIntegration(
+            failed_request_status_codes=failed_request_status_codes
+        )
+
+    sentry_init(integrations=[starlette_integration])
 
     events = capture_events()
 
@@ -1191,3 +1208,59 @@ def test_configurable_status_codes(
         assert len(events) == 1
     else:
         assert not events
+
+
+parametrize_test_configurable_status_codes = pytest.mark.parametrize(
+    ("failed_request_status_codes", "status_code", "expected_error"),
+    (
+        (None, 500, True),
+        (None, 400, False),
+        ({500, 501}, 500, True),
+        ({500, 501}, 401, False),
+        ({*range(400, 500)}, 401, True),
+        ({*range(400, 500)}, 500, False),
+        ({*range(400, 600)}, 300, False),
+        ({*range(400, 600)}, 403, True),
+        ({*range(400, 600)}, 503, True),
+        ({*range(400, 403), 500, 501}, 401, True),
+        ({*range(400, 403), 500, 501}, 405, False),
+        ({*range(400, 403), 500, 501}, 501, True),
+        ({*range(400, 403), 500, 501}, 503, False),
+        (set(), 500, False),
+    ),
+)
+
+
+@parametrize_test_configurable_status_codes
+def test_configurable_status_codes(
+    sentry_init,
+    capture_events,
+    failed_request_status_codes,
+    status_code,
+    expected_error,
+):
+    integration_kwargs = {}
+    if failed_request_status_codes is not None:
+        integration_kwargs["failed_request_status_codes"] = failed_request_status_codes
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", DeprecationWarning)
+        starlette_integration = StarletteIntegration(**integration_kwargs)
+
+    sentry_init(integrations=[starlette_integration])
+
+    events = capture_events()
+
+    async def _error(_):
+        raise HTTPException(status_code)
+
+    app = starlette.applications.Starlette(
+        routes=[
+            starlette.routing.Route("/error", _error, methods=["GET"]),
+        ],
+    )
+
+    client = TestClient(app)
+    client.get("/error")
+
+    assert len(events) == int(expected_error)


### PR DESCRIPTION
Add support to Starlette and FastApi for the new `Set[int]` API for `failed_request_status_codes` that we are using in the AIOHttp integration