### PR TITLE
Make DSC work for outgoing traces

### DIFF
--- a/sentry_sdk/tracing.py
+++ b/sentry_sdk/tracing.py
@@ -1447,7 +1447,10 @@ class POTelSpan:
 
     def iter_headers(self):
         # type: () -> Iterator[Tuple[str, str]]
-        pass
+        yield SENTRY_TRACE_HEADER_NAME, self.to_traceparent()
+
+        trace_state  = self._otel_span.get_span_context().trace_state
+        yield BAGGAGE_HEADER_NAME, Baggage.serialize_trace_state_items(trace_state.items())
 
     def to_traceparent(self):
         # type: () -> str
@@ -1466,6 +1469,7 @@ class POTelSpan:
 
     def to_baggage(self):
         # type: () -> Optional[Baggage]
+        # TODO-neel-potel head SDK populate baggage mess
         pass
 
     def set_tag(self, key, value):

--- a/sentry_sdk/tracing_utils.py
+++ b/sentry_sdk/tracing_utils.py
@@ -30,6 +30,7 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from typing import Any
     from typing import Dict
+    from typing import ItemsView
     from typing import Generator
     from typing import Optional
     from typing import Union
@@ -596,6 +597,17 @@ class Baggage:
             items.append(self.third_party_items)
 
         return ",".join(items)
+
+    @property
+    def trace_state_items(self):
+        # type: () -> list[tuple[str, str]]
+        return [(Baggage.SENTRY_PREFIX + quote(k), quote(str(v))) for k, v in self.sentry_items.items()]
+
+    @classmethod
+    def serialize_trace_state_items(cls, trace_state_items):
+        # type: (ItemsView[str, str]) -> str
+        sentry_items = [(k, v) for k, v in trace_state_items if Baggage.SENTRY_PREFIX_REGEX.match(k)]
+        return ",".join(key + "=" + value for key, value in sentry_items)
 
 
 def should_propagate_trace(client, url):


### PR DESCRIPTION
* Add parsed baggage sentry items as items on the `sampling_context.trace_state` in `continue_trace`
* Fix sampler to propagate the `trace_state` to children in both sampled and dropped cases
* make `iter_headers` work

closes #3478 

---

[Example trace using JS -> Python -> Rails](https://sentry-sdks.sentry.io/performance/trace/bdf2c2df328c4254b233270740696c0a/?node=txn-49f5b05bea31490cabc29ecde1df4d49&node=txn-2c8f4dd512364e5fae14071594b14d81&node=txn-22a631acda6f46718bde8a528d597059&project=5434472&query=http.method%3AGET&referrer=performance-transaction-summary&showTransactions=recent&source=performance_transaction_summary&statsPeriod=1h&timestamp=1727120986&transaction=PaymentsController%23success&unselectedSeries=p100%28%29&unselectedSeries=avg%28%29)

![image](https://github.com/user-attachments/assets/3da2a57f-cdad-4280-9412-230776b44fb3)

django headers
![image](https://github.com/user-attachments/assets/485b3705-d79a-41d1-988b-c1fce4662603)

rails headers
![image](https://github.com/user-attachments/assets/0ebc76f3-1476-4701-94ff-c2456d54c429)
