### PR TITLE
Make DSC and trace_context work for outgoing traces

### DIFF
--- a/sentry_sdk/_types.py
+++ b/sentry_sdk/_types.py
@@ -197,3 +197,5 @@ if TYPE_CHECKING:
     )
 
     HttpStatusCodeRange = Union[int, Container[int]]
+
+    OtelExtractedSpanData = tuple[str, str, Optional[str], Optional[int], Optional[str]]

--- a/sentry_sdk/integrations/opentelemetry/scope.py
+++ b/sentry_sdk/integrations/opentelemetry/scope.py
@@ -4,7 +4,7 @@ from typing import cast
 from contextlib import contextmanager
 
 from opentelemetry.context import get_value, set_value, attach, detach, get_current
-from opentelemetry.trace import SpanContext, NonRecordingSpan, TraceFlags, use_span
+from opentelemetry.trace import SpanContext, NonRecordingSpan, TraceFlags, TraceState, use_span
 
 from sentry_sdk.integrations.opentelemetry.consts import (
     SENTRY_SCOPES_KEY,
@@ -12,6 +12,7 @@ from sentry_sdk.integrations.opentelemetry.consts import (
     SENTRY_USE_CURRENT_SCOPE_KEY,
     SENTRY_USE_ISOLATION_SCOPE_KEY,
 )
+from sentry_sdk.integrations.opentelemetry.utils import trace_state_from_baggage
 from sentry_sdk.scope import Scope, ScopeType
 from sentry_sdk.tracing import POTelSpan
 from sentry_sdk._types import TYPE_CHECKING
@@ -93,15 +94,17 @@ class PotelScope(Scope):
             else TraceFlags.DEFAULT
         )
 
-        # TODO-neel-potel tracestate
+        # TODO-neel-potel do we need parent and sampled like JS?
+        trace_state = None
+        if self._propagation_context.baggage:
+            trace_state = trace_state_from_baggage(self._propagation_context.baggage)
+
         span_context = SpanContext(
             trace_id=int(self._propagation_context.trace_id, 16),  # type: ignore
             span_id=int(self._propagation_context.parent_span_id, 16),  # type: ignore
             is_remote=True,
             trace_flags=trace_flags,
-            # TODO-anton: add trace_state (mapping[str,str]) with the parentSpanId, dsc and sampled from self._propagation_context
-            # trace_state={
-            # }
+            trace_state=trace_state,
         )
 
         return span_context


### PR DESCRIPTION
* Add parsed baggage sentry items as items on the `sampling_context.trace_state` in `continue_trace`
* Fix sampler to propagate the `trace_state` to children in both sampled and dropped cases
* make `iter_headers` work
* make `get_trace_context` work
* add `dynamic_sampling_context` in `trace_context` so that it can be picked up by the client and added in the envelope header

closes #3478, #3565

---

[Example trace using JS -> Python -> Rails](https://sentry-sdks.sentry.io/performance/trace/bdf2c2df328c4254b233270740696c0a/?node=txn-49f5b05bea31490cabc29ecde1df4d49&node=txn-2c8f4dd512364e5fae14071594b14d81&node=txn-22a631acda6f46718bde8a528d597059&project=5434472&query=http.method%3AGET&referrer=performance-transaction-summary&showTransactions=recent&source=performance_transaction_summary&statsPeriod=1h&timestamp=1727120986&transaction=PaymentsController%23success&unselectedSeries=p100%28%29&unselectedSeries=avg%28%29)

![image](https://github.com/user-attachments/assets/3da2a57f-cdad-4280-9412-230776b44fb3)

django headers
![image](https://github.com/user-attachments/assets/485b3705-d79a-41d1-988b-c1fce4662603)

rails headers
![image](https://github.com/user-attachments/assets/0ebc76f3-1476-4701-94ff-c2456d54c429)

dsc on envelope in django transaction
![image](https://github.com/user-attachments/assets/af326535-60ea-4752-99c4-8ea5818137f9)
