### PR TITLE
test(aiohttp): Delete test which depends on AIOHTTP behavior

### DIFF
--- a/tests/integrations/aiohttp/test_aiohttp.py
+++ b/tests/integrations/aiohttp/test_aiohttp.py
@@ -605,27 +605,6 @@ async def test_span_origin(
     assert event["spans"][0]["origin"] == "auto.http.aiohttp"
 
 
-@pytest.mark.asyncio
-@pytest.mark.parametrize("invalid_response", (None, "invalid"))
-async def test_invalid_response(
-    sentry_init, aiohttp_client, capture_events, invalid_response
-):
-    sentry_init(integrations=[AioHttpIntegration()])
-
-    async def handler(_):
-        return invalid_response
-
-    app = web.Application()
-    app.router.add_get("/", handler)
-
-    client = await aiohttp_client(app)
-
-    # Invalid response should result on a ServerDisconnectedError in the client side, not an internal server error.
-    # Important to note that the ServerDisconnectedError indicates we have no error server-side.
-    with pytest.raises(ServerDisconnectedError):
-        await client.get("/")
-
-
 @pytest.mark.parametrize(
     ("integration_kwargs", "exception_to_raise", "should_capture"),
     (


### PR DESCRIPTION
This test was added in #3554 to ensure that we don't break people's AIOHTTP apps when a request handler returns an invalid response. However, the test broke with a recent AIOHTTP release. After investigating, I believe the test broke because it depends on internal AIOHTTP implementation details which changed in the recent AIOHTTP release.

This test likely does not add too much value anyways, since the change in #3554 includes a comment, which explains why handling the AttributeError is important, so I think we can safely remove it.

Fixes #3567
