### PR TITLE
Fix record sql queries tests

### DIFF
--- a/requirements-testing.txt
+++ b/requirements-testing.txt
@@ -11,3 +11,4 @@ asttokens
 responses
 pysocks
 setuptools
+freezegun

--- a/sentry_sdk/tracing.py
+++ b/sentry_sdk/tracing.py
@@ -1,7 +1,7 @@
 import uuid
 import random
 import time
-import warnings 
+import warnings
 from datetime import datetime, timedelta, timezone
 
 from opentelemetry import trace as otel_trace, context

--- a/tests/integrations/django/test_db_query_data.py
+++ b/tests/integrations/django/test_db_query_data.py
@@ -12,6 +12,7 @@ try:
 except ImportError:
     from django.core.urlresolvers import reverse
 
+from freezegun import freeze_time
 from werkzeug.test import Client
 
 from sentry_sdk import start_transaction
@@ -348,11 +349,13 @@ def test_no_query_source_if_duration_too_short(sentry_init, client, capture_even
 
     class fake_record_sql_queries:  # noqa: N801
         def __init__(self, *args, **kwargs):
-            with record_sql_queries(*args, **kwargs) as span:
-                self.span = span
+            with freeze_time(datetime(2024, 1, 1, microsecond=0)):
+                with record_sql_queries(*args, **kwargs) as span:
+                    self.span = span
+                    freezer = freeze_time(datetime(2024, 1, 1, microsecond=99999))
+                    freezer.start()
 
-            self.span.start_timestamp = datetime(2024, 1, 1, microsecond=0)
-            self.span.timestamp = datetime(2024, 1, 1, microsecond=99999)
+                freezer.stop()
 
         def __enter__(self):
             return self.span
@@ -406,11 +409,13 @@ def test_query_source_if_duration_over_threshold(sentry_init, client, capture_ev
 
     class fake_record_sql_queries:  # noqa: N801
         def __init__(self, *args, **kwargs):
-            with record_sql_queries(*args, **kwargs) as span:
-                self.span = span
+            with freeze_time(datetime(2024, 1, 1, microsecond=0)):
+                with record_sql_queries(*args, **kwargs) as span:
+                    self.span = span
+                    freezer = freeze_time(datetime(2024, 1, 1, microsecond=99999))
+                    freezer.start()
 
-            self.span.start_timestamp = datetime(2024, 1, 1, microsecond=0)
-            self.span.timestamp = datetime(2024, 1, 1, microsecond=101000)
+                freezer.stop()
 
         def __enter__(self):
             return self.span

--- a/tests/integrations/sqlalchemy/test_sqlalchemy.py
+++ b/tests/integrations/sqlalchemy/test_sqlalchemy.py
@@ -3,6 +3,7 @@ from datetime import datetime
 from unittest import mock
 
 import pytest
+from freezegun import freeze_time
 from sqlalchemy import Column, ForeignKey, Integer, String, create_engine
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.declarative import declarative_base
@@ -553,11 +554,13 @@ def test_no_query_source_if_duration_too_short(sentry_init, capture_events):
 
         class fake_record_sql_queries:  # noqa: N801
             def __init__(self, *args, **kwargs):
-                with record_sql_queries(*args, **kwargs) as span:
-                    self.span = span
+                with freeze_time(datetime(2024, 1, 1, microsecond=0)):
+                    with record_sql_queries(*args, **kwargs) as span:
+                        self.span = span
+                        freezer = freeze_time(datetime(2024, 1, 1, microsecond=99999))
+                        freezer.start()
 
-                self.span.start_timestamp = datetime(2024, 1, 1, microsecond=0)
-                self.span.timestamp = datetime(2024, 1, 1, microsecond=99999)
+                    freezer.stop()
 
             def __enter__(self):
                 return self.span
@@ -619,11 +622,13 @@ def test_query_source_if_duration_over_threshold(sentry_init, capture_events):
 
         class fake_record_sql_queries:  # noqa: N801
             def __init__(self, *args, **kwargs):
-                with record_sql_queries(*args, **kwargs) as span:
-                    self.span = span
+                with freeze_time(datetime(2024, 1, 1, microsecond=0)):
+                    with record_sql_queries(*args, **kwargs) as span:
+                        self.span = span
+                        freezer = freeze_time(datetime(2024, 1, 1, microsecond=99999))
+                        freezer.start()
 
-                self.span.start_timestamp = datetime(2024, 1, 1, microsecond=0)
-                self.span.timestamp = datetime(2024, 1, 1, microsecond=101000)
+                    freezer.stop()
 
             def __enter__(self):
                 return self.span


### PR DESCRIPTION
Use freezegun to create spans of a certain time duration. (avoids monkey patching the underlying otel span)