### PR TITLE
allowing ASGI to use drf_request in DjangoRequestExtractor

### DIFF
--- a/sentry_sdk/integrations/django/__init__.py
+++ b/sentry_sdk/integrations/django/__init__.py
@@ -529,9 +529,9 @@ class DjangoRequestExtractor(RequestExtractor):
             if drf_request is not None:
                 request = drf_request
         except AttributeError:
-            pass            
+            pass
         self.request = request
-            
+
     def env(self):
         # type: () -> Dict[str, str]
         return self.request.META

--- a/sentry_sdk/integrations/django/__init__.py
+++ b/sentry_sdk/integrations/django/__init__.py
@@ -491,13 +491,6 @@ def _make_wsgi_request_event_processor(weak_request, integration):
             # We have a `asgi_request_event_processor` for this.
             return event
 
-        try:
-            drf_request = request._sentry_drf_request_backref()
-            if drf_request is not None:
-                request = drf_request
-        except AttributeError:
-            pass
-
         with capture_internal_exceptions():
             DjangoRequestExtractor(request).extract_into_event(event)
 
@@ -530,6 +523,15 @@ def _got_request_exception(request=None, **kwargs):
 
 
 class DjangoRequestExtractor(RequestExtractor):
+    def __init__(self, request):
+        try:
+            drf_request = request._sentry_drf_request_backref()
+            if drf_request is not None:
+                request = drf_request
+        except AttributeError:
+            pass            
+        self.request = request
+            
     def env(self):
         # type: () -> Dict[str, str]
         return self.request.META

--- a/sentry_sdk/integrations/django/__init__.py
+++ b/sentry_sdk/integrations/django/__init__.py
@@ -524,6 +524,7 @@ def _got_request_exception(request=None, **kwargs):
 
 class DjangoRequestExtractor(RequestExtractor):
     def __init__(self, request):
+        # type: (Union[WSGIRequest, ASGIRequest]) -> None
         try:
             drf_request = request._sentry_drf_request_backref()
             if drf_request is not None:


### PR DESCRIPTION
since we already have patched a request object (both ASGI/WSGI) before arriving, we should move patched-using logic closer to where it actually being used. for minimize impact and allow ASGI functionality.

---

Thank you for contributing to `sentry-python`! Please add tests to validate your changes, and lint your code using `tox -e linters`.

Running the test suite on your PR might require maintainer approval. The AWS Lambda tests additionally require a maintainer to add a special label, and they will fail until this label is added.
