### PR TITLE
Test more integrations on 3.13

### DIFF
--- a/.github/workflows/test-integrations-ai.yml
+++ b/.github/workflows/test-integrations-ai.yml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.7","3.9","3.11","3.12"]
+        python-version: ["3.7","3.9","3.11","3.12","3.13"]
         # python3.6 reached EOL and is no longer being supported on
         # new versions of hosted runners on Github Actions
         # ubuntu-20.04 is the last version that supported python3.6
@@ -99,7 +99,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.7","3.9","3.11","3.12"]
+        python-version: ["3.7","3.9","3.11","3.12","3.13"]
         # python3.6 reached EOL and is no longer being supported on
         # new versions of hosted runners on Github Actions
         # ubuntu-20.04 is the last version that supported python3.6

--- a/.github/workflows/test-integrations-cloud-computing.yml
+++ b/.github/workflows/test-integrations-cloud-computing.yml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8","3.11","3.12"]
+        python-version: ["3.8","3.11","3.12","3.13"]
         # python3.6 reached EOL and is no longer being supported on
         # new versions of hosted runners on Github Actions
         # ubuntu-20.04 is the last version that supported python3.6

--- a/.github/workflows/test-integrations-cloud-computing.yml
+++ b/.github/workflows/test-integrations-cloud-computing.yml
@@ -95,7 +95,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.6","3.7","3.9","3.11","3.12"]
+        python-version: ["3.6","3.7","3.9","3.11","3.12","3.13"]
         # python3.6 reached EOL and is no longer being supported on
         # new versions of hosted runners on Github Actions
         # ubuntu-20.04 is the last version that supported python3.6

--- a/.github/workflows/test-integrations-data-processing.yml
+++ b/.github/workflows/test-integrations-data-processing.yml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.6","3.7","3.8","3.10","3.11","3.12"]
+        python-version: ["3.6","3.7","3.8","3.10","3.11","3.12","3.13"]
         # python3.6 reached EOL and is no longer being supported on
         # new versions of hosted runners on Github Actions
         # ubuntu-20.04 is the last version that supported python3.6

--- a/.github/workflows/test-integrations-databases.yml
+++ b/.github/workflows/test-integrations-databases.yml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.7","3.8","3.11","3.12"]
+        python-version: ["3.7","3.8","3.11","3.12","3.13"]
         # python3.6 reached EOL and is no longer being supported on
         # new versions of hosted runners on Github Actions
         # ubuntu-20.04 is the last version that supported python3.6

--- a/.github/workflows/test-integrations-graphql.yml
+++ b/.github/workflows/test-integrations-graphql.yml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.7","3.8","3.11","3.12"]
+        python-version: ["3.7","3.8","3.11","3.12","3.13"]
         # python3.6 reached EOL and is no longer being supported on
         # new versions of hosted runners on Github Actions
         # ubuntu-20.04 is the last version that supported python3.6

--- a/.github/workflows/test-integrations-graphql.yml
+++ b/.github/workflows/test-integrations-graphql.yml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.7","3.8","3.11","3.12","3.13"]
+        python-version: ["3.7","3.8","3.12","3.13"]
         # python3.6 reached EOL and is no longer being supported on
         # new versions of hosted runners on Github Actions
         # ubuntu-20.04 is the last version that supported python3.6

--- a/.github/workflows/test-integrations-miscellaneous.yml
+++ b/.github/workflows/test-integrations-miscellaneous.yml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.6","3.8","3.11","3.12"]
+        python-version: ["3.6","3.8","3.11","3.12","3.13"]
         # python3.6 reached EOL and is no longer being supported on
         # new versions of hosted runners on Github Actions
         # ubuntu-20.04 is the last version that supported python3.6
@@ -99,7 +99,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.6","3.7","3.8","3.9","3.10","3.11","3.12"]
+        python-version: ["3.6","3.7","3.8","3.9","3.10","3.11","3.12","3.13"]
         # python3.6 reached EOL and is no longer being supported on
         # new versions of hosted runners on Github Actions
         # ubuntu-20.04 is the last version that supported python3.6

--- a/.github/workflows/test-integrations-miscellaneous.yml
+++ b/.github/workflows/test-integrations-miscellaneous.yml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.6","3.8","3.11","3.12","3.13"]
+        python-version: ["3.6","3.8","3.12","3.13"]
         # python3.6 reached EOL and is no longer being supported on
         # new versions of hosted runners on Github Actions
         # ubuntu-20.04 is the last version that supported python3.6

--- a/.github/workflows/test-integrations-networking.yml
+++ b/.github/workflows/test-integrations-networking.yml
@@ -95,7 +95,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.6","3.7","3.8","3.9","3.10","3.11","3.12"]
+        python-version: ["3.6","3.7","3.8","3.9","3.10","3.11","3.12","3.13"]
         # python3.6 reached EOL and is no longer being supported on
         # new versions of hosted runners on Github Actions
         # ubuntu-20.04 is the last version that supported python3.6

--- a/.github/workflows/test-integrations-networking.yml
+++ b/.github/workflows/test-integrations-networking.yml
@@ -95,7 +95,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.6","3.7","3.8","3.9","3.10","3.11","3.12","3.13"]
+        python-version: ["3.6","3.7","3.8","3.9","3.10","3.11","3.12"]
         # python3.6 reached EOL and is no longer being supported on
         # new versions of hosted runners on Github Actions
         # ubuntu-20.04 is the last version that supported python3.6

--- a/.github/workflows/test-integrations-networking.yml
+++ b/.github/workflows/test-integrations-networking.yml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8","3.9","3.11","3.12"]
+        python-version: ["3.8","3.9","3.11","3.12","3.13"]
         # python3.6 reached EOL and is no longer being supported on
         # new versions of hosted runners on Github Actions
         # ubuntu-20.04 is the last version that supported python3.6

--- a/.github/workflows/test-integrations-web-frameworks-1.yml
+++ b/.github/workflows/test-integrations-web-frameworks-1.yml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8","3.10","3.11","3.12","3.13"]
+        python-version: ["3.8","3.10","3.12","3.13"]
         # python3.6 reached EOL and is no longer being supported on
         # new versions of hosted runners on Github Actions
         # ubuntu-20.04 is the last version that supported python3.6

--- a/.github/workflows/test-integrations-web-frameworks-1.yml
+++ b/.github/workflows/test-integrations-web-frameworks-1.yml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8","3.10","3.11","3.12"]
+        python-version: ["3.8","3.10","3.11","3.12","3.13"]
         # python3.6 reached EOL and is no longer being supported on
         # new versions of hosted runners on Github Actions
         # ubuntu-20.04 is the last version that supported python3.6

--- a/.github/workflows/test-integrations-web-frameworks-2.yml
+++ b/.github/workflows/test-integrations-web-frameworks-2.yml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.6","3.7","3.8","3.11","3.12"]
+        python-version: ["3.6","3.7","3.8","3.11","3.12","3.13"]
         # python3.6 reached EOL and is no longer being supported on
         # new versions of hosted runners on Github Actions
         # ubuntu-20.04 is the last version that supported python3.6

--- a/.github/workflows/test-integrations-web-frameworks-2.yml
+++ b/.github/workflows/test-integrations-web-frameworks-2.yml
@@ -119,7 +119,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.6","3.7","3.8","3.9","3.11","3.12"]
+        python-version: ["3.6","3.7","3.8","3.9","3.11","3.12","3.13"]
         # python3.6 reached EOL and is no longer being supported on
         # new versions of hosted runners on Github Actions
         # ubuntu-20.04 is the last version that supported python3.6

--- a/tox.ini
+++ b/tox.ini
@@ -69,7 +69,7 @@ envlist =
 
     # Bottle
     {py3.6,py3.9}-bottle-v{0.12}
-    {py3.6,py3.11,py3.12}-bottle-latest
+    {py3.6,py3.11,py3.12,py3.13}-bottle-latest
 
     # Celery
     {py3.6,py3.8}-celery-v{4}

--- a/tox.ini
+++ b/tox.ini
@@ -30,7 +30,7 @@ envlist =
     # AIOHTTP
     {py3.7}-aiohttp-v{3.4}
     {py3.7,py3.9,py3.11}-aiohttp-v{3.8}
-    {py3.8,py3.11,py3.12}-aiohttp-latest
+    {py3.8,py3.11,py3.12,py3.13}-aiohttp-latest
 
     # Anthropic
     {py3.7,py3.11,py3.12}-anthropic-v{0.16,0.25}

--- a/tox.ini
+++ b/tox.ini
@@ -30,7 +30,7 @@ envlist =
     # AIOHTTP
     {py3.7}-aiohttp-v{3.4}
     {py3.7,py3.9,py3.11}-aiohttp-v{3.8}
-    {py3.8,py3.11,py3.12,py3.13}-aiohttp-latest
+    {py3.8,py3.12,py3.13}-aiohttp-latest
 
     # Anthropic
     {py3.7,py3.11,py3.12}-anthropic-v{0.16,0.25}
@@ -38,14 +38,14 @@ envlist =
 
     # Ariadne
     {py3.8,py3.11}-ariadne-v{0.20}
-    {py3.8,py3.11,py3.12,py3.13}-ariadne-latest
+    {py3.8,py3.12,py3.13}-ariadne-latest
 
     # Arq
     {py3.7,py3.11}-arq-v{0.23}
-    {py3.7,py3.11,py3.12,py3.13}-arq-latest
+    {py3.7,py3.12,py3.13}-arq-latest
 
     # Asgi
-    {py3.7,py3.11,py3.12,py3.13}-asgi
+    {py3.7,py3.12,py3.13}-asgi
 
     # asyncpg
     {py3.7,py3.10}-asyncpg-v{0.23}
@@ -69,7 +69,7 @@ envlist =
 
     # Bottle
     {py3.6,py3.9}-bottle-v{0.12}
-    {py3.6,py3.11,py3.12,py3.13}-bottle-latest
+    {py3.6,py3.12,py3.13}-bottle-latest
 
     # Celery
     {py3.6,py3.8}-celery-v{4}
@@ -84,7 +84,7 @@ envlist =
 
     # Clickhouse Driver
     {py3.8,py3.11}-clickhouse_driver-v{0.2.0}
-    {py3.8,py3.11,py3.12,py3.13}-clickhouse_driver-latest
+    {py3.8,py3.12,py3.13}-clickhouse_driver-latest
 
     # Cloud Resource Context
     {py3.6,py3.11,py3.12}-cloud_resource_context
@@ -106,13 +106,13 @@ envlist =
     {py3.8,py3.11,py3.12}-django-v{4.0,4.1,4.2}
     # - Django 5.x
     {py3.10,py3.11,py3.12}-django-v{5.0,5.1}
-    {py3.10,py3.11,py3.12,py3.13}-django-latest
+    {py3.10,py3.12,py3.13}-django-latest
 
     # dramatiq
     {py3.6,py3.9}-dramatiq-v{1.13}
     {py3.7,py3.10,py3.11}-dramatiq-v{1.15}
     {py3.8,py3.11,py3.12}-dramatiq-v{1.17}
-    {py3.8,py3.11,py3.12,py3.13}-dramatiq-latest
+    {py3.8,py3.12,py3.13}-dramatiq-latest
 
     # Falcon
     {py3.6,py3.7}-falcon-v{1,1.4,2}
@@ -121,13 +121,13 @@ envlist =
 
     # FastAPI
     {py3.7,py3.10}-fastapi-v{0.79}
-    {py3.8,py3.11,py3.12,py3.13}-fastapi-latest
+    {py3.8,py3.12,py3.13}-fastapi-latest
 
     # Flask
     {py3.6,py3.8}-flask-v{1}
     {py3.8,py3.11,py3.12}-flask-v{2}
     {py3.10,py3.11,py3.12}-flask-v{3}
-    {py3.10,py3.11,py3.12,py3.13}-flask-latest
+    {py3.10,py3.12,py3.13}-flask-latest
 
     # GCP
     {py3.7}-gcp
@@ -138,7 +138,7 @@ envlist =
 
     # Graphene
     {py3.7,py3.11}-graphene-v{3.3}
-    {py3.7,py3.11,py3.12,py3.13}-graphene-latest
+    {py3.7,py3.12,py3.13}-graphene-latest
 
     # gRPC
     {py3.7,py3.9}-grpc-v{1.39}
@@ -151,14 +151,15 @@ envlist =
     {py3.6,py3.10}-httpx-v{0.20,0.22}
     {py3.7,py3.11,py3.12}-httpx-v{0.23,0.24}
     {py3.9,py3.11,py3.12}-httpx-v{0.25,0.27}
-    {py3.9,py3.11,py3.12}-httpx-latest
+    {py3.9,py3.12,py3.13}-httpx-latest
 
     # Huey
     {py3.6,py3.11,py3.12}-huey-v{2.0}
-    {py3.6,py3.11,py3.12}-huey-latest
+    {py3.6,py3.12,py3.13}-huey-latest
 
     # Huggingface Hub
-    {py3.9,py3.11,py3.12}-huggingface_hub-{v0.22,latest}
+    {py3.9,py3.12,py3.13}-huggingface_hub-{v0.22}
+    {py3.9,py3.12,py3.13}-huggingface_hub-latest
 
     # Langchain
     {py3.9,py3.11,py3.12}-langchain-v0.1
@@ -175,7 +176,7 @@ envlist =
 
     # Loguru
     {py3.6,py3.11,py3.12}-loguru-v{0.5}
-    {py3.6,py3.11,py3.12}-loguru-latest
+    {py3.6,py3.12,py3.13}-loguru-latest
 
     # OpenAI
     {py3.9,py3.11,py3.12}-openai-v1
@@ -183,32 +184,31 @@ envlist =
     {py3.9,py3.11,py3.12}-openai-notiktoken
 
     # OpenTelemetry (OTel)
-    {py3.7,py3.9,py3.11,py3.12}-opentelemetry
+    {py3.7,py3.9,py3.11,py3.12,py3.13}-opentelemetry
 
     # OpenTelemetry Experimental (POTel)
-    # XXX add 3.12 when officially supported
-    {py3.8,py3.9,py3.10,py3.11}-potel
+    {py3.8,py3.9,py3.10,py3.11,py3.12,py3.13}-potel
 
     # pure_eval
-    {py3.6,py3.11,py3.12}-pure_eval
+    {py3.6,py3.12,py3.13}-pure_eval
 
     # PyMongo (Mongo DB)
     {py3.6}-pymongo-v{3.1}
     {py3.6,py3.9}-pymongo-v{3.12}
     {py3.6,py3.11}-pymongo-v{4.0}
     {py3.7,py3.11,py3.12}-pymongo-v{4.3,4.7}
-    {py3.7,py3.11,py3.12}-pymongo-latest
+    {py3.7,py3.12,py3.13}-pymongo-latest
 
     # Pyramid
     {py3.6,py3.11}-pyramid-v{1.6}
     {py3.6,py3.11,py3.12}-pyramid-v{1.10}
     {py3.6,py3.11,py3.12}-pyramid-v{2.0}
-    {py3.6,py3.11,py3.12}-pyramid-latest
+    {py3.6,py3.12,py3.13}-pyramid-latest
 
     # Quart
     {py3.7,py3.11}-quart-v{0.16}
     {py3.8,py3.11,py3.12}-quart-v{0.19}
-    {py3.8,py3.11,py3.12}-quart-latest
+    {py3.8,py3.12,py3.13}-quart-latest
 
     # Ray
     {py3.10,py3.11}-ray-v{2.34}

--- a/tox.ini
+++ b/tox.ini
@@ -76,7 +76,7 @@ envlist =
     {py3.6,py3.8}-celery-v{5.0}
     {py3.7,py3.10}-celery-v{5.1,5.2}
     {py3.8,py3.11,py3.12}-celery-v{5.3,5.4}
-    {py3.8,py3.11,py3.12,py3.13}-celery-latest
+    {py3.8,py3.11,py3.12}-celery-latest
 
     # Chalice
     {py3.6,py3.9}-chalice-v{1.16}
@@ -106,13 +106,13 @@ envlist =
     {py3.8,py3.11,py3.12}-django-v{4.0,4.1,4.2}
     # - Django 5.x
     {py3.10,py3.11,py3.12}-django-v{5.0,5.1}
-    {py3.10,py3.11,py3.12}-django-latest
+    {py3.10,py3.11,py3.12,py3.13}-django-latest
 
     # dramatiq
     {py3.6,py3.9}-dramatiq-v{1.13}
     {py3.7,py3.10,py3.11}-dramatiq-v{1.15}
     {py3.8,py3.11,py3.12}-dramatiq-v{1.17}
-    {py3.8,py3.11,py3.12}-dramatiq-latest
+    {py3.8,py3.11,py3.12,py3.13}-dramatiq-latest
 
     # Falcon
     {py3.6,py3.7}-falcon-v{1,1.4,2}
@@ -121,24 +121,24 @@ envlist =
 
     # FastAPI
     {py3.7,py3.10}-fastapi-v{0.79}
-    {py3.8,py3.11,py3.12}-fastapi-latest
+    {py3.8,py3.11,py3.12,py3.13}-fastapi-latest
 
     # Flask
     {py3.6,py3.8}-flask-v{1}
     {py3.8,py3.11,py3.12}-flask-v{2}
     {py3.10,py3.11,py3.12}-flask-v{3}
-    {py3.10,py3.11,py3.12}-flask-latest
+    {py3.10,py3.11,py3.12,py3.13}-flask-latest
 
     # GCP
     {py3.7}-gcp
 
     # GQL
     {py3.7,py3.11}-gql-v{3.4}
-    {py3.7,py3.11,py3.12}-gql-latest
+    {py3.7,py3.11,py3.12,py3.13}-gql-latest
 
     # Graphene
     {py3.7,py3.11}-graphene-v{3.3}
-    {py3.7,py3.11,py3.12}-graphene-latest
+    {py3.7,py3.11,py3.12,py3.13}-graphene-latest
 
     # gRPC
     {py3.7,py3.9}-grpc-v{1.39}

--- a/tox.ini
+++ b/tox.ini
@@ -218,28 +218,28 @@ envlist =
     {py3.6,py3.8}-redis-v{3}
     {py3.7,py3.8,py3.11}-redis-v{4}
     {py3.7,py3.11,py3.12}-redis-v{5}
-    {py3.7,py3.11,py3.12}-redis-latest
+    {py3.7,py3.12,py3.13}-redis-latest
 
     # Redis Cluster
     {py3.6,py3.8}-redis_py_cluster_legacy-v{1,2}
     # no -latest, not developed anymore
 
     # Requests
-    {py3.6,py3.8,py3.11,py3.12}-requests
+    {py3.6,py3.8,py3.12,py3.13}-requests
 
     # RQ (Redis Queue)
     {py3.6}-rq-v{0.6}
     {py3.6,py3.9}-rq-v{0.13,1.0}
     {py3.6,py3.11}-rq-v{1.5,1.10}
     {py3.7,py3.11,py3.12}-rq-v{1.15,1.16}
-    {py3.7,py3.11,py3.12}-rq-latest
+    {py3.7,py3.12,py3.13}-rq-latest
 
     # Sanic
     {py3.6,py3.7}-sanic-v{0.8}
     {py3.6,py3.8}-sanic-v{20}
     {py3.7,py3.11}-sanic-v{22}
     {py3.7,py3.11}-sanic-v{23}
-    {py3.8,py3.11}-sanic-latest
+    {py3.8,py3.11,py3.12}-sanic-latest
 
     # Spark
     {py3.8,py3.10,py3.11}-spark-v{3.1,3.3,3.5}
@@ -249,7 +249,7 @@ envlist =
     {py3.7,py3.10}-starlette-v{0.19}
     {py3.7,py3.11}-starlette-v{0.20,0.24,0.28}
     {py3.8,py3.11,py3.12}-starlette-v{0.32,0.36}
-    {py3.8,py3.11,py3.12}-starlette-latest
+    {py3.8,py3.12,py3.13}-starlette-latest
 
     # Starlite
     {py3.8,py3.11}-starlite-v{1.48,1.51}
@@ -258,12 +258,12 @@ envlist =
     # SQL Alchemy
     {py3.6,py3.9}-sqlalchemy-v{1.2,1.4}
     {py3.7,py3.11}-sqlalchemy-v{2.0}
-    {py3.7,py3.11,py3.12}-sqlalchemy-latest
+    {py3.7,py3.12,py3.13}-sqlalchemy-latest
 
     # Strawberry
     {py3.8,py3.11}-strawberry-v{0.209}
     {py3.8,py3.11,py3.12}-strawberry-v{0.222}
-    {py3.8,py3.11,py3.12}-strawberry-latest
+    {py3.8,py3.12,py3.13}-strawberry-latest
 
     # Tornado
     {py3.8,py3.11,py3.12}-tornado-v{6.0}
@@ -275,7 +275,7 @@ envlist =
     {py3.6,py3.8}-trytond-v{5}
     {py3.6,py3.11}-trytond-v{6}
     {py3.8,py3.11,py3.12}-trytond-v{7}
-    {py3.8,py3.11,py3.12}-trytond-latest
+    {py3.8,py3.12,py3.13}-trytond-latest
 
 [testenv]
 deps =
@@ -560,10 +560,6 @@ deps =
     pyramid-v2.0: pyramid~=2.0.0
     pyramid-latest: pyramid
 
-    # Ray
-    ray-v2.34: ray~=2.34.0
-    ray-latest: ray
-
     # Quart
     quart: quart-auth
     quart: pytest-asyncio
@@ -575,6 +571,10 @@ deps =
     quart-v0.19: Werkzeug>=3.0.0
     quart-v0.19: quart~=0.19.0
     quart-latest: quart
+
+    # Ray
+    ray-v2.34: ray~=2.34.0
+    ray-latest: ray
 
     # Redis
     redis: fakeredis!=1.7.4

--- a/tox.ini
+++ b/tox.ini
@@ -12,7 +12,7 @@ envlist =
     {py3.6,py3.7,py3.8,py3.9,py3.10,py3.11,py3.12,py3.13}-common
 
     # === Gevent ===
-    {py3.6,py3.8,py3.10,py3.11,py3.12,py3.13}-gevent
+    {py3.6,py3.8,py3.10,py3.11,py3.12}-gevent
 
     # === Integrations ===
     # General format is {pythonversion}-{integrationname}-v{frameworkversion}
@@ -298,12 +298,11 @@ deps =
 
     # === Gevent ===
     {py3.6,py3.7,py3.8,py3.9,py3.10,py3.11}-gevent: gevent>=22.10.0, <22.11.0
-    {py3.12,py3.13}-gevent: gevent
+    {py3.12}-gevent: gevent
     # See https://github.com/pytest-dev/pytest/issues/9621
     # and https://github.com/pytest-dev/pytest-forked/issues/67
     # for justification of the upper bound on pytest
     {py3.6,py3.7,py3.8,py3.9,py3.10,py3.11,py3.12}-gevent: pytest<7.0.0
-    py3.13-gevent: pytest
 
     # === Integrations ===
 

--- a/tox.ini
+++ b/tox.ini
@@ -12,7 +12,7 @@ envlist =
     {py3.6,py3.7,py3.8,py3.9,py3.10,py3.11,py3.12,py3.13}-common
 
     # === Gevent ===
-    {py3.6,py3.8,py3.10,py3.11,py3.12}-gevent
+    {py3.6,py3.8,py3.10,py3.11,py3.12,py3.13}-gevent
 
     # === Integrations ===
     # General format is {pythonversion}-{integrationname}-v{frameworkversion}
@@ -38,14 +38,14 @@ envlist =
 
     # Ariadne
     {py3.8,py3.11}-ariadne-v{0.20}
-    {py3.8,py3.11,py3.12}-ariadne-latest
+    {py3.8,py3.11,py3.12,py3.13}-ariadne-latest
 
     # Arq
     {py3.7,py3.11}-arq-v{0.23}
-    {py3.7,py3.11,py3.12}-arq-latest
+    {py3.7,py3.11,py3.12,py3.13}-arq-latest
 
     # Asgi
-    {py3.7,py3.11,py3.12}-asgi
+    {py3.7,py3.11,py3.12,py3.13}-asgi
 
     # asyncpg
     {py3.7,py3.10}-asyncpg-v{0.23}
@@ -65,7 +65,7 @@ envlist =
     {py3.6,py3.7}-boto3-v{1.12}
     {py3.7,py3.11,py3.12}-boto3-v{1.23}
     {py3.11,py3.12}-boto3-v{1.34}
-    {py3.11,py3.12}-boto3-latest
+    {py3.11,py3.12,py3.13}-boto3-latest
 
     # Bottle
     {py3.6,py3.9}-bottle-v{0.12}
@@ -76,15 +76,15 @@ envlist =
     {py3.6,py3.8}-celery-v{5.0}
     {py3.7,py3.10}-celery-v{5.1,5.2}
     {py3.8,py3.11,py3.12}-celery-v{5.3,5.4}
-    {py3.8,py3.11,py3.12}-celery-latest
+    {py3.8,py3.11,py3.12,py3.13}-celery-latest
 
     # Chalice
     {py3.6,py3.9}-chalice-v{1.16}
-    {py3.8,py3.12}-chalice-latest
+    {py3.8,py3.12,py3.13}-chalice-latest
 
     # Clickhouse Driver
     {py3.8,py3.11}-clickhouse_driver-v{0.2.0}
-    {py3.8,py3.11,py3.12}-clickhouse_driver-latest
+    {py3.8,py3.11,py3.12,py3.13}-clickhouse_driver-latest
 
     # Cloud Resource Context
     {py3.6,py3.11,py3.12}-cloud_resource_context

--- a/tox.ini
+++ b/tox.ini
@@ -87,7 +87,7 @@ envlist =
     {py3.8,py3.12,py3.13}-clickhouse_driver-latest
 
     # Cloud Resource Context
-    {py3.6,py3.11,py3.12}-cloud_resource_context
+    {py3.6,py3.11,py3.12,py3.13}-cloud_resource_context
 
     # Cohere
     {py3.9,py3.11,py3.12}-cohere-v5
@@ -112,7 +112,7 @@ envlist =
     {py3.6,py3.9}-dramatiq-v{1.13}
     {py3.7,py3.10,py3.11}-dramatiq-v{1.15}
     {py3.8,py3.11,py3.12}-dramatiq-v{1.17}
-    {py3.8,py3.12,py3.13}-dramatiq-latest
+    {py3.8,py3.11,py3.12}-dramatiq-latest
 
     # Falcon
     {py3.6,py3.7}-falcon-v{1,1.4,2}

--- a/tox.ini
+++ b/tox.ini
@@ -298,11 +298,12 @@ deps =
 
     # === Gevent ===
     {py3.6,py3.7,py3.8,py3.9,py3.10,py3.11}-gevent: gevent>=22.10.0, <22.11.0
-    {py3.12}-gevent: gevent
+    {py3.12,py3.13}-gevent: gevent
     # See https://github.com/pytest-dev/pytest/issues/9621
     # and https://github.com/pytest-dev/pytest-forked/issues/67
     # for justification of the upper bound on pytest
     {py3.6,py3.7,py3.8,py3.9,py3.10,py3.11,py3.12}-gevent: pytest<7.0.0
+    py3.13-gevent: pytest
 
     # === Integrations ===
 
@@ -371,7 +372,7 @@ deps =
     celery-v5.4: Celery~=5.4.0
     celery-latest: Celery
 
-    {py3.6,py3.7,py3.8,py3.9,py3.10,py3.11,py3.12}-celery: newrelic
+    celery: newrelic
     celery: pytest<7
     {py3.7}-celery: importlib-metadata<5.0
 

--- a/tox.ini
+++ b/tox.ini
@@ -76,7 +76,7 @@ envlist =
     {py3.6,py3.8}-celery-v{5.0}
     {py3.7,py3.10}-celery-v{5.1,5.2}
     {py3.8,py3.11,py3.12}-celery-v{5.3,5.4}
-    {py3.8,py3.11,py3.12}-celery-latest
+    {py3.8,py3.12,py3.13}-celery-latest
 
     # Chalice
     {py3.6,py3.9}-chalice-v{1.16}
@@ -203,7 +203,7 @@ envlist =
     {py3.6,py3.11}-pyramid-v{1.6}
     {py3.6,py3.11,py3.12}-pyramid-v{1.10}
     {py3.6,py3.11,py3.12}-pyramid-v{2.0}
-    {py3.6,py3.12,py3.13}-pyramid-latest
+    {py3.6,py3.11,py3.12}-pyramid-latest
 
     # Quart
     {py3.7,py3.11}-quart-v{0.16}

--- a/tox.ini
+++ b/tox.ini
@@ -87,7 +87,7 @@ envlist =
     {py3.8,py3.12,py3.13}-clickhouse_driver-latest
 
     # Cloud Resource Context
-    {py3.6,py3.11,py3.12,py3.13}-cloud_resource_context
+    {py3.6,py3.12,py3.13}-cloud_resource_context
 
     # Cohere
     {py3.9,py3.11,py3.12}-cohere-v5
@@ -134,7 +134,7 @@ envlist =
 
     # GQL
     {py3.7,py3.11}-gql-v{3.4}
-    {py3.7,py3.11,py3.12,py3.13}-gql-latest
+    {py3.7,py3.12,py3.13}-gql-latest
 
     # Graphene
     {py3.7,py3.11}-graphene-v{3.3}
@@ -184,7 +184,7 @@ envlist =
     {py3.9,py3.11,py3.12}-openai-notiktoken
 
     # OpenTelemetry (OTel)
-    {py3.7,py3.9,py3.11,py3.12,py3.13}-opentelemetry
+    {py3.7,py3.9,py3.12,py3.13}-opentelemetry
 
     # OpenTelemetry Experimental (POTel)
     {py3.8,py3.9,py3.10,py3.11,py3.12,py3.13}-potel


### PR DESCRIPTION
Test integrations on Python 3.13 as long as the framework/library supports it.

Follow up: https://github.com/getsentry/sentry-python/issues/3582