### PR TITLE
Fix `make aws lambda layer`

### DIFF
--- a/requirements-aws-lambda-layer.txt
+++ b/requirements-aws-lambda-layer.txt
@@ -5,3 +5,5 @@ certifi
 # So we pin this here to make our Lambda layer work with
 # Lambda Function using Python 3.7+
 urllib3<1.27
+
+opentelemetry-distro>=0.35b0


### PR DESCRIPTION
For generating the lambda layer we have a separate requirements file (Because Lambda layers for Python 3.7 do not support modern `urllib3`)

So we need to add the new dependency of `opentelemetry-distro` to this file.