### PR TITLE
Skip one of the Lambda tests

### DIFF
--- a/tests/integrations/aws_lambda/test_aws.py
+++ b/tests/integrations/aws_lambda/test_aws.py
@@ -317,6 +317,9 @@ def test_request_data(run_lambda_function):
     }
 
 
+@pytest.mark.xfail(
+    reason="Amazon changed something (2024-10-01) and on Python 3.9+ our SDK can not capture events in the init phase of the Lambda function anymore. We need to fix this somehow."
+)
 def test_init_error(run_lambda_function, lambda_runtime):
     envelope_items, _ = run_lambda_function(
         LAMBDA_PRELUDE


### PR DESCRIPTION
AWS Lambda has changed something in their environment and now our tests can not capture events in the init phase of the Lambda function.

Will skip the test for now.