### PR TITLE
Head SDK DSC population

### DIFF
--- a/sentry_sdk/integrations/opentelemetry/consts.py
+++ b/sentry_sdk/integrations/opentelemetry/consts.py
@@ -1,4 +1,5 @@
 from opentelemetry.context import create_key
+from sentry_sdk.tracing_utils import Baggage
 
 
 # propagation keys
@@ -11,7 +12,8 @@ SENTRY_FORK_ISOLATION_SCOPE_KEY = create_key("sentry_fork_isolation_scope")
 SENTRY_USE_CURRENT_SCOPE_KEY = create_key("sentry_use_current_scope")
 SENTRY_USE_ISOLATION_SCOPE_KEY = create_key("sentry_use_isolation_scope")
 
-SENTRY_TRACE_STATE_DROPPED = "sentry_dropped"
+TRACESTATE_SAMPLED_KEY = Baggage.SENTRY_PREFIX + "sampled"
+TRACESTATE_SAMPLE_RATE_KEY = Baggage.SENTRY_PREFIX + "sample_rate"
 
 OTEL_SENTRY_CONTEXT = "otel"
 SPAN_ORIGIN = "auto.otel"

--- a/sentry_sdk/integrations/opentelemetry/sampler.py
+++ b/sentry_sdk/integrations/opentelemetry/sampler.py
@@ -1,3 +1,4 @@
+from typing import cast
 from random import random
 
 from opentelemetry import trace
@@ -6,13 +7,17 @@ from opentelemetry.sdk.trace.sampling import Sampler, SamplingResult, Decision
 from opentelemetry.trace.span import TraceState
 
 import sentry_sdk
-from sentry_sdk.integrations.opentelemetry.consts import SENTRY_TRACE_STATE_DROPPED
 from sentry_sdk.tracing_utils import has_tracing_enabled
 from sentry_sdk.utils import is_valid_sample_rate, logger
+from sentry_sdk.integrations.opentelemetry.consts import (
+    TRACESTATE_SAMPLED_KEY,
+    TRACESTATE_SAMPLE_RATE_KEY,
+)
 
-from typing import TYPE_CHECKING, Optional, Sequence
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
+    from typing import Optional, Sequence, Union
     from opentelemetry.context import Context
     from opentelemetry.trace import Link, SpanKind
     from opentelemetry.trace.span import SpanContext
@@ -32,30 +37,42 @@ def get_parent_sampled(parent_context, trace_id):
         if parent_context.trace_flags.sampled:
             return True
 
-        dropped = parent_context.trace_state.get(SENTRY_TRACE_STATE_DROPPED) == "true"
-        if dropped:
+        dsc_sampled = parent_context.trace_state.get(TRACESTATE_SAMPLED_KEY)
+        if dsc_sampled == "true":
+            return True
+        elif dsc_sampled == "false":
             return False
-
-        # TODO-anton: fall back to sampling decision in DSC (for this die DSC needs to be set in the trace_state)
 
     return None
 
 
-def dropped_result(span_context):
-    # type: (SpanContext) -> SamplingResult
-    trace_state = span_context.trace_state.update(SENTRY_TRACE_STATE_DROPPED, "true")
+def dropped_result(span_context, attributes, sample_rate=None):
+    # type: (SpanContext, Attributes, Optional[float]) -> SamplingResult
+    # note that trace_state.add will NOT overwrite existing entries
+    # so these will only be added the first time in a root span sampling decision
+    trace_state = span_context.trace_state.add(TRACESTATE_SAMPLED_KEY, "false")
+    if sample_rate:
+        trace_state = trace_state.add(TRACESTATE_SAMPLE_RATE_KEY, str(sample_rate))
 
     return SamplingResult(
         Decision.DROP,
+        attributes=attributes,
         trace_state=trace_state,
     )
 
 
-def sampled_result(span_context):
-    # type: (SpanContext) -> SamplingResult
+def sampled_result(span_context, attributes, sample_rate):
+    # type: (SpanContext, Attributes, float) -> SamplingResult
+    # note that trace_state.add will NOT overwrite existing entries
+    # so these will only be added the first time in a root span sampling decision
+    trace_state = span_context.trace_state.add(TRACESTATE_SAMPLED_KEY, "true").add(
+        TRACESTATE_SAMPLE_RATE_KEY, str(sample_rate)
+    )
+
     return SamplingResult(
         Decision.RECORD_AND_SAMPLE,
-        trace_state=span_context.trace_state,
+        attributes=attributes,
+        trace_state=trace_state,
     )
 
 
@@ -77,7 +94,7 @@ class SentrySampler(Sampler):
 
         # No tracing enabled, thus no sampling
         if not has_tracing_enabled(client.options):
-            return dropped_result(parent_span_context)
+            return dropped_result(parent_span_context, attributes)
 
         sample_rate = None
 
@@ -112,16 +129,16 @@ class SentrySampler(Sampler):
             logger.warning(
                 f"[Tracing] Discarding {name} because of invalid sample rate."
             )
-            return dropped_result(parent_span_context)
+            return dropped_result(parent_span_context, attributes)
 
         # Roll the dice on sample rate
-        sampled = random() < float(sample_rate)
+        sample_rate = float(cast("Union[bool, float, int]", sample_rate))
+        sampled = random() < sample_rate
 
-        # TODO-neel-potel set sample rate as attribute for DSC
         if sampled:
-            return sampled_result(parent_span_context)
+            return sampled_result(parent_span_context, attributes, sample_rate)
         else:
-            return dropped_result(parent_span_context)
+            return dropped_result(parent_span_context, attributes, sample_rate)
 
     def get_description(self) -> str:
         return self.__class__.__name__

--- a/sentry_sdk/integrations/opentelemetry/scope.py
+++ b/sentry_sdk/integrations/opentelemetry/scope.py
@@ -8,7 +8,6 @@ from opentelemetry.trace import (
     SpanContext,
     NonRecordingSpan,
     TraceFlags,
-    TraceState,
     use_span,
 )
 


### PR DESCRIPTION
* Populates a DSC with correct values when we don't have an incoming trace.
* We rely on `trace_state.add` only adding new keys to the tracestate so these values will be populated in the first samplign decision on the root and just be propagated further.

Note that transaction name is missing here for now and will be dealt with separately as part of the transaction name PRs.


closes #3479 