### PR TITLE
Add http_methods_to_capture to ASGI Django

### DIFF
--- a/sentry_sdk/integrations/django/asgi.py
+++ b/sentry_sdk/integrations/django/asgi.py
@@ -90,13 +90,15 @@ def patch_django_asgi_handler_impl(cls):
 
     async def sentry_patched_asgi_handler(self, scope, receive, send):
         # type: (Any, Any, Any, Any) -> Any
-        if sentry_sdk.get_client().get_integration(DjangoIntegration) is None:
+        integration = sentry_sdk.get_client().get_integration(DjangoIntegration)
+        if integration is None:
             return await old_app(self, scope, receive, send)
 
         middleware = SentryAsgiMiddleware(
             old_app.__get__(self, cls),
             unsafe_context_data=True,
             span_origin=DjangoIntegration.origin,
+            http_methods_to_capture=integration.http_methods_to_capture,
         )._run_asgi3
 
         return await middleware(scope, receive, send)
@@ -142,13 +144,15 @@ def patch_channels_asgi_handler_impl(cls):
 
         async def sentry_patched_asgi_handler(self, receive, send):
             # type: (Any, Any, Any) -> Any
-            if sentry_sdk.get_client().get_integration(DjangoIntegration) is None:
+            integration = sentry_sdk.get_client().get_integration(DjangoIntegration)
+            if integration is None:
                 return await old_app(self, receive, send)
 
             middleware = SentryAsgiMiddleware(
                 lambda _scope: old_app.__get__(self, cls),
                 unsafe_context_data=True,
                 span_origin=DjangoIntegration.origin,
+                http_methods_to_capture=integration.http_methods_to_capture,
             )
 
             return await middleware(self.scope)(receive, send)


### PR DESCRIPTION
The ASGI middleware already supports this, we just weren't passing the option in.