### PR TITLE
Simplify tox version spec

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -289,7 +289,7 @@ deps =
 
     # === Common ===
     py3.8-common: hypothesis
-    {py3.6,py3.7,py3.8,py3.9,py3.10,py3.11,py3.12,py3.13}-common: pytest-asyncio
+    common: pytest-asyncio
     # See https://github.com/pytest-dev/pytest/issues/9621
     # and https://github.com/pytest-dev/pytest-forked/issues/67
     # for justification of the upper bound on pytest


### PR DESCRIPTION
No need to specify the versions for a target one by one if it's literally all the versions we support.