### PR TITLE
feat: Add opportunistic Brotli compression

### DIFF
--- a/requirements-testing.txt
+++ b/requirements-testing.txt
@@ -13,3 +13,4 @@ pysocks
 socksio
 httpcore[http2]
 setuptools
+Brotli

--- a/sentry_sdk/consts.py
+++ b/sentry_sdk/consts.py
@@ -18,6 +18,11 @@ class EndpointType(Enum):
     ENVELOPE = "envelope"
 
 
+class CompressionAlgo(Enum):
+    GZIP = "gzip"
+    BROTLI = "br"
+
+
 if TYPE_CHECKING:
     import sentry_sdk
 
@@ -59,6 +64,8 @@ if TYPE_CHECKING:
             "continuous_profiling_mode": Optional[ContinuousProfilerMode],
             "otel_powered_performance": Optional[bool],
             "transport_zlib_compression_level": Optional[int],
+            "transport_compression_level": Optional[int],
+            "transport_compression_algo": Optional[CompressionAlgo],
             "transport_num_pools": Optional[int],
             "transport_http2": Optional[bool],
             "enable_metrics": Optional[bool],

--- a/sentry_sdk/transport.py
+++ b/sentry_sdk/transport.py
@@ -19,13 +19,12 @@ import urllib3
 import certifi
 
 import sentry_sdk
-from sentry_sdk._types import EventDataCategory
 from sentry_sdk.consts import EndpointType
 from sentry_sdk.utils import Dsn, logger, capture_internal_exceptions
 from sentry_sdk.worker import BackgroundWorker
 from sentry_sdk.envelope import Envelope, Item, PayloadRef
 
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from typing import Any
@@ -44,7 +43,7 @@ if TYPE_CHECKING:
     from urllib3.poolmanager import PoolManager
     from urllib3.poolmanager import ProxyManager
 
-    from sentry_sdk._types import Event
+    from sentry_sdk._types import Event, EventDataCategory
 
 KEEP_ALIVE_SOCKET_OPTIONS = []
 for option in [
@@ -181,7 +180,6 @@ def _parse_rate_limits(header, now=None):
 
             retry_after = now + timedelta(seconds=int(retry_after_val))
             for category in categories and categories.split(";") or (None,):
-                category = cast(EventDataCategory, category)
                 if category == "metric_bucket":
                     try:
                         namespaces = parameters[4].split(";")
@@ -189,10 +187,10 @@ def _parse_rate_limits(header, now=None):
                         namespaces = []
 
                     if not namespaces or "custom" in namespaces:
-                        yield category, retry_after
+                        yield category, retry_after  # type: ignore
 
                 else:
-                    yield category, retry_after
+                    yield category, retry_after  # type: ignore
         except (LookupError, ValueError):
             continue
 

--- a/sentry_sdk/transport.py
+++ b/sentry_sdk/transport.py
@@ -19,6 +19,7 @@ import urllib3
 import certifi
 
 import sentry_sdk
+from sentry_sdk._types import EventDataCategory
 from sentry_sdk.consts import EndpointType
 from sentry_sdk.utils import Dsn, logger, capture_internal_exceptions
 from sentry_sdk.worker import BackgroundWorker
@@ -43,7 +44,7 @@ if TYPE_CHECKING:
     from urllib3.poolmanager import PoolManager
     from urllib3.poolmanager import ProxyManager
 
-    from sentry_sdk._types import Event, EventDataCategory
+    from sentry_sdk._types import Event
 
 KEEP_ALIVE_SOCKET_OPTIONS = []
 for option in [

--- a/tests/integrations/aiohttp/test_aiohttp.py
+++ b/tests/integrations/aiohttp/test_aiohttp.py
@@ -55,7 +55,7 @@ async def test_basic(sentry_init, aiohttp_client, capture_events):
     assert request["url"] == "http://{host}/".format(host=host)
     assert request["headers"] == {
         "Accept": "*/*",
-        "Accept-Encoding": "gzip, deflate",
+        "Accept-Encoding": "gzip, deflate, br",
         "Host": host,
         "User-Agent": request["headers"]["User-Agent"],
         "baggage": mock.ANY,

--- a/tests/integrations/aiohttp/test_aiohttp.py
+++ b/tests/integrations/aiohttp/test_aiohttp.py
@@ -55,7 +55,7 @@ async def test_basic(sentry_init, aiohttp_client, capture_events):
     assert request["url"] == "http://{host}/".format(host=host)
     assert request["headers"] == {
         "Accept": "*/*",
-        "Accept-Encoding": "gzip, deflate, br",
+        "Accept-Encoding": mock.ANY,
         "Host": host,
         "User-Agent": request["headers"]["User-Agent"],
         "baggage": mock.ANY,

--- a/tests/test_transport.py
+++ b/tests/test_transport.py
@@ -174,11 +174,18 @@ def test_transport_works(
     out, err = capsys.readouterr()
     assert not err and not out
     assert capturing_server.captured
-    assert (
-        capturing_server.captured[0].compressed == (compression_level is None)
-        or (compression_level > 0)
-        or (compression_algo is None)
+    should_compress = (
+        (
+            compression_level is None
+        )  # default is to compress with bortli if available, gzip otherwise
+        or (
+            compression_level > 0
+        )  # setting compression level to 0 means don't compress
+        or (
+            compression_algo is None
+        )  # if we couldn't resolve to a known algo, we don't compress
     )
+    assert capturing_server.captured[0].compressed == should_compress
 
     assert any("Sending envelope" in record.msg for record in caplog.records) == debug
 


### PR DESCRIPTION
Brotli level 4 and 5 offer comparable or better compression to GZip
level 9 (which is our default) with better performance. This patch
adds opportunistic Brotli compression at level 4 (to be conservative)
when it detects the `brotli` module is available. It also provides some
escape hatches through `transport_compression_level` and
`transport_compression_algo` experiment configs to fine tune the behavior.

In the future, we may want to bump the default level from 4 to 5 for better
compression.
