### PR TITLE
fix(integrations): Don't capture StopIteration in SentryWsgiMiddleware

### DIFF
--- a/sentry_sdk/integrations/wsgi.py
+++ b/sentry_sdk/integrations/wsgi.py
@@ -134,6 +134,11 @@ class SentryWsgiMiddleware:
                                     _sentry_start_response, start_response, transaction
                                 ),
                             )
+                        except StopIteration:
+                            if "gunicorn" in environ.get("SERVER_SOFTWARE", ""):
+                                raise
+                            else:
+                                reraise(*_capture_exception())
                         except BaseException:
                             reraise(*_capture_exception())
         finally:


### PR DESCRIPTION
Currently Sentry will emit an unhandled exception for StopIteration. However,
when running certain combinations of libraries with gunicorn and sync workers
(eg: python-socketio) the StopIteration exception is actually expected. To
workaround this issue, don't capture this exception when using this middleware
with gunicorn and just reraise it.

See discussion about StopIteration here: https://github.com/miguelgrinberg/python-engineio/discussions/335 and https://github.com/miguelgrinberg/flask-sock/issues/64
