### PR TITLE
test(profiler): Fork flaky test

### DIFF
--- a/tests/profiler/test_continuous_profiler.py
+++ b/tests/profiler/test_continuous_profiler.py
@@ -226,6 +226,7 @@ def test_continuous_profiler_auto_start_and_manual_stop(
         assert_single_transaction_with_profile_chunks(envelopes, thread)
 
 
+@pytest.mark.forked
 @pytest.mark.parametrize(
     "mode",
     [


### PR DESCRIPTION
This test is flaky; Codecov has even identified it as such. Let's try forking the test, maybe that will make it more stable.