### PR TITLE
Remove `ensure_integration_enabled_async`

### DIFF
--- a/sentry_sdk/utils.py
+++ b/sentry_sdk/utils.py
@@ -31,8 +31,6 @@ from sentry_sdk.consts import DEFAULT_MAX_VALUE_LENGTH, EndpointType
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from collections.abc import Awaitable
-
     from types import FrameType, TracebackType
     from typing import (
         Any,
@@ -1731,12 +1729,6 @@ def _no_op(*_a, **_k):
     pass
 
 
-async def _no_op_async(*_a, **_k):
-    # type: (*Any, **Any) -> None
-    """No-op function for ensure_integration_enabled_async."""
-    pass
-
-
 if TYPE_CHECKING:
 
     @overload
@@ -1796,59 +1788,6 @@ def ensure_integration_enabled(
             return sentry_patched_function(*args, **kwargs)
 
         if original_function is _no_op:
-            return wraps(sentry_patched_function)(runner)
-
-        return wraps(original_function)(runner)
-
-    return patcher
-
-
-if TYPE_CHECKING:
-
-    # mypy has some trouble with the overloads, hence the ignore[no-overload-impl]
-    @overload  # type: ignore[no-overload-impl]
-    def ensure_integration_enabled_async(
-        integration,  # type: type[sentry_sdk.integrations.Integration]
-        original_function,  # type: Callable[P, Awaitable[R]]
-    ):
-        # type: (...) -> Callable[[Callable[P, Awaitable[R]]], Callable[P, Awaitable[R]]]
-        ...
-
-    @overload
-    def ensure_integration_enabled_async(
-        integration,  # type: type[sentry_sdk.integrations.Integration]
-    ):
-        # type: (...) -> Callable[[Callable[P, Awaitable[None]]], Callable[P, Awaitable[None]]]
-        ...
-
-
-# The ignore[no-redef] also needed because mypy is struggling with these overloads.
-def ensure_integration_enabled_async(  # type: ignore[no-redef]
-    integration,  # type: type[sentry_sdk.integrations.Integration]
-    original_function=_no_op_async,  # type: Union[Callable[P, Awaitable[R]], Callable[P, Awaitable[None]]]
-):
-    # type: (...) -> Callable[[Callable[P, Awaitable[R]]], Callable[P, Awaitable[R]]]
-    """
-    Version of `ensure_integration_enabled` for decorating async functions.
-
-    Please refer to the `ensure_integration_enabled` documentation for more information.
-    """
-
-    if TYPE_CHECKING:
-        # Type hint to ensure the default function has the right typing. The overloads
-        # ensure the default _no_op function is only used when R is None.
-        original_function = cast(Callable[P, Awaitable[R]], original_function)
-
-    def patcher(sentry_patched_function):
-        # type: (Callable[P, Awaitable[R]]) -> Callable[P, Awaitable[R]]
-        async def runner(*args: "P.args", **kwargs: "P.kwargs"):
-            # type: (...) -> R
-            if sentry_sdk.get_client().get_integration(integration) is None:
-                return await original_function(*args, **kwargs)
-
-            return await sentry_patched_function(*args, **kwargs)
-
-        if original_function is _no_op_async:
             return wraps(sentry_patched_function)(runner)
 
         return wraps(original_function)(runner)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -31,14 +31,12 @@ from sentry_sdk.utils import (
     _get_installed_modules,
     _generate_installed_modules,
     ensure_integration_enabled,
-    ensure_integration_enabled_async,
 )
 
 
 class TestIntegration(Integration):
     """
-    Test integration for testing ensure_integration_enabled and
-    ensure_integration_enabled_async decorators.
+    Test integration for testing ensure_integration_enabled decorator.
     """
 
     identifier = "test"
@@ -778,90 +776,6 @@ def test_ensure_integration_enabled_no_original_function_disabled(sentry_init):
     # Test the decorator by applying to function_to_patch
     patched_function = ensure_integration_enabled(TestIntegration)(function_to_patch)
     patched_function()
-
-    assert shared_variable == "original"
-    assert patched_function.__name__ == "function_to_patch"
-
-
-@pytest.mark.asyncio
-async def test_ensure_integration_enabled_async_integration_enabled(sentry_init):
-    # Setup variables and functions for the test
-    async def original_function():
-        return "original"
-
-    async def function_to_patch():
-        return "patched"
-
-    sentry_init(integrations=[TestIntegration()])
-
-    # Test the decorator by applying to function_to_patch
-    patched_function = ensure_integration_enabled_async(
-        TestIntegration, original_function
-    )(function_to_patch)
-
-    assert await patched_function() == "patched"
-    assert patched_function.__name__ == "original_function"
-
-
-@pytest.mark.asyncio
-async def test_ensure_integration_enabled_async_integration_disabled(sentry_init):
-    # Setup variables and functions for the test
-    async def original_function():
-        return "original"
-
-    async def function_to_patch():
-        return "patched"
-
-    sentry_init(integrations=[])  # TestIntegration is disabled
-
-    # Test the decorator by applying to function_to_patch
-    patched_function = ensure_integration_enabled_async(
-        TestIntegration, original_function
-    )(function_to_patch)
-
-    assert await patched_function() == "original"
-    assert patched_function.__name__ == "original_function"
-
-
-@pytest.mark.asyncio
-async def test_ensure_integration_enabled_async_no_original_function_enabled(
-    sentry_init,
-):
-    shared_variable = "original"
-
-    async def function_to_patch():
-        nonlocal shared_variable
-        shared_variable = "patched"
-
-    sentry_init(integrations=[TestIntegration])
-
-    # Test the decorator by applying to function_to_patch
-    patched_function = ensure_integration_enabled_async(TestIntegration)(
-        function_to_patch
-    )
-    await patched_function()
-
-    assert shared_variable == "patched"
-    assert patched_function.__name__ == "function_to_patch"
-
-
-@pytest.mark.asyncio
-async def test_ensure_integration_enabled_async_no_original_function_disabled(
-    sentry_init,
-):
-    shared_variable = "original"
-
-    async def function_to_patch():
-        nonlocal shared_variable
-        shared_variable = "patched"
-
-    sentry_init(integrations=[])
-
-    # Test the decorator by applying to function_to_patch
-    patched_function = ensure_integration_enabled_async(TestIntegration)(
-        function_to_patch
-    )
-    await patched_function()
 
     assert shared_variable == "original"
     assert patched_function.__name__ == "function_to_patch"


### PR DESCRIPTION
Removing `ensure_integration_enabled_async` since there are some unresolved issues with it.

This should be ok to just remove (as opposed to deprecate) since it's only meant to be used internally.

Closes https://github.com/getsentry/sentry-python/issues/2892