### PR TITLE
Make transaction names work

### DIFF
--- a/sentry_sdk/integrations/opentelemetry/consts.py
+++ b/sentry_sdk/integrations/opentelemetry/consts.py
@@ -28,4 +28,5 @@ class SentrySpanAttribute:
     MEASUREMENT = "sentry.measurement"
     TAG = "sentry.tag"
     NAME = "sentry.name"
+    SOURCE = "sentry.source"
     CONTEXT = "sentry.context"

--- a/sentry_sdk/integrations/opentelemetry/potel_span_processor.py
+++ b/sentry_sdk/integrations/opentelemetry/potel_span_processor.py
@@ -18,6 +18,7 @@ from sentry_sdk.integrations.opentelemetry.utils import (
     convert_from_otel_timestamp,
     extract_span_attributes,
     extract_span_data,
+    extract_transaction_name_source,
     get_trace_context,
 )
 from sentry_sdk.integrations.opentelemetry.consts import (
@@ -137,6 +138,7 @@ class PotelSentrySpanProcessor(SpanProcessor):
         if event is None:
             return None
 
+        transaction_name, transaction_source = extract_transaction_name_source(span)
         span_data = extract_span_data(span)
         (_, description, _, http_status, _) = span_data
 
@@ -152,9 +154,8 @@ class PotelSentrySpanProcessor(SpanProcessor):
         event.update(
             {
                 "type": "transaction",
-                "transaction": description,
-                # TODO-neel-potel tx source based on integration
-                "transaction_info": {"source": "custom"},
+                "transaction": transaction_name or description,
+                "transaction_info": {"source": transaction_source or "custom"},
                 "contexts": contexts,
             }
         )

--- a/sentry_sdk/scope.py
+++ b/sentry_sdk/scope.py
@@ -741,6 +741,16 @@ class Scope:
         if source:
             self._transaction_info["source"] = source
 
+    @property
+    def transaction_name(self):
+        # type: () -> Optional[str]
+        return self._transaction
+
+    @property
+    def transaction_source(self):
+        # type: () -> Optional[str]
+        return self._transaction_info.get("source")
+
     @_attr_setter
     def user(self, value):
         # type: (Optional[Dict[str, Any]]) -> None

--- a/sentry_sdk/tracing.py
+++ b/sentry_sdk/tracing.py
@@ -1292,7 +1292,7 @@ class POTelSpan:
         from sentry_sdk.integrations.opentelemetry.consts import SentrySpanAttribute
 
         if value is not None:
-            self._otel_span.set_attribute(SentrySpanAttribute.DESCRIPTION, value)
+            self.set_attribute(SentrySpanAttribute.DESCRIPTION, value)
 
     @property
     def origin(self):
@@ -1307,7 +1307,7 @@ class POTelSpan:
         from sentry_sdk.integrations.opentelemetry.consts import SentrySpanAttribute
 
         if value is not None:
-            self._otel_span.set_attribute(SentrySpanAttribute.ORIGIN, value)
+            self.set_attribute(SentrySpanAttribute.ORIGIN, value)
 
     @property
     def containing_transaction(self):
@@ -1380,7 +1380,7 @@ class POTelSpan:
         from sentry_sdk.integrations.opentelemetry.consts import SentrySpanAttribute
 
         if value is not None:
-            self._otel_span.set_attribute(SentrySpanAttribute.OP, value)
+            self.set_attribute(SentrySpanAttribute.OP, value)
 
     @property
     def name(self):
@@ -1395,17 +1395,23 @@ class POTelSpan:
         from sentry_sdk.integrations.opentelemetry.consts import SentrySpanAttribute
 
         if value is not None:
-            self._otel_span.set_attribute(SentrySpanAttribute.NAME, value)
+            self.set_attribute(SentrySpanAttribute.NAME, value)
 
     @property
     def source(self):
         # type: () -> str
-        pass
+        from sentry_sdk.integrations.opentelemetry.consts import SentrySpanAttribute
+
+        return (
+            self.get_attribute(SentrySpanAttribute.SOURCE) or TRANSACTION_SOURCE_CUSTOM
+        )
 
     @source.setter
     def source(self, value):
         # type: (str) -> None
-        pass
+        from sentry_sdk.integrations.opentelemetry.consts import SentrySpanAttribute
+
+        self.set_attribute(SentrySpanAttribute.SOURCE, value)
 
     @property
     def start_timestamp(self):

--- a/tests/integrations/flask/test_flask.py
+++ b/tests/integrations/flask/test_flask.py
@@ -751,12 +751,14 @@ def test_tracing_success(sentry_init, capture_events, app):
 
     assert transaction_event["type"] == "transaction"
     assert transaction_event["transaction"] == "hi_tx"
+    assert transaction_event["transaction_info"] == {"source": "component"}
     assert transaction_event["contexts"]["trace"]["status"] == "ok"
     assert transaction_event["tags"]["view"] == "yes"
     assert transaction_event["tags"]["before_request"] == "yes"
 
     assert message_event["message"] == "hi"
     assert message_event["transaction"] == "hi_tx"
+    assert message_event["transaction_info"] == {"source": "component"}
     assert message_event["tags"]["view"] == "yes"
     assert message_event["tags"]["before_request"] == "yes"
 


### PR DESCRIPTION
* while sending the event in the final payload, the transaction name will be picked up from the attributes `sentry.name` or fallback to the `description` when we only have otel instrumentation
* for populating DSC in the head case, we are doing a best attempt solution and fetching the transaction name/source from the current and isolation scopes
    * NOTE that there are cases where this will be inaccurate if we never set the transaction name on the scope in some integration, so we will go through and fix those cases separately.

