### PR TITLE
Only `add` to trace state if key does not exist

### DIFF
--- a/sentry_sdk/integrations/opentelemetry/sampler.py
+++ b/sentry_sdk/integrations/opentelemetry/sampler.py
@@ -51,10 +51,10 @@ def dropped_result(span_context, attributes, sample_rate=None):
     # these will only be added the first time in a root span sampling decision
     trace_state = span_context.trace_state
 
-    if TRACESTATE_SAMPLED_KEY not in span_context.trace_state.keys():
+    if TRACESTATE_SAMPLED_KEY not in span_context.trace_state:
         trace_state = span_context.trace_state.add(TRACESTATE_SAMPLED_KEY, "false")
 
-    if sample_rate and TRACESTATE_SAMPLE_RATE_KEY not in trace_state.keys():
+    if sample_rate and TRACESTATE_SAMPLE_RATE_KEY not in trace_state:
         trace_state = trace_state.add(TRACESTATE_SAMPLE_RATE_KEY, str(sample_rate))
 
     return SamplingResult(
@@ -69,9 +69,9 @@ def sampled_result(span_context, attributes, sample_rate):
     # these will only be added the first time in a root span sampling decision
     trace_state = span_context.trace_state
 
-    if TRACESTATE_SAMPLED_KEY not in trace_state.keys():
+    if TRACESTATE_SAMPLED_KEY not in trace_state:
         trace_state = span_context.trace_state.add(TRACESTATE_SAMPLED_KEY, "true")
-    if TRACESTATE_SAMPLE_RATE_KEY not in trace_state.keys():
+    if TRACESTATE_SAMPLE_RATE_KEY not in trace_state:
         trace_state = trace_state.add(TRACESTATE_SAMPLE_RATE_KEY, str(sample_rate))
 
     return SamplingResult(

--- a/sentry_sdk/integrations/opentelemetry/sampler.py
+++ b/sentry_sdk/integrations/opentelemetry/sampler.py
@@ -48,10 +48,13 @@ def get_parent_sampled(parent_context, trace_id):
 
 def dropped_result(span_context, attributes, sample_rate=None):
     # type: (SpanContext, Attributes, Optional[float]) -> SamplingResult
-    # note that trace_state.add will NOT overwrite existing entries
-    # so these will only be added the first time in a root span sampling decision
-    trace_state = span_context.trace_state.add(TRACESTATE_SAMPLED_KEY, "false")
-    if sample_rate:
+    # these will only be added the first time in a root span sampling decision
+    trace_state = span_context.trace_state
+
+    if TRACESTATE_SAMPLED_KEY not in span_context.trace_state.keys():
+        trace_state = span_context.trace_state.add(TRACESTATE_SAMPLED_KEY, "false")
+
+    if sample_rate and TRACESTATE_SAMPLE_RATE_KEY not in trace_state.keys():
         trace_state = trace_state.add(TRACESTATE_SAMPLE_RATE_KEY, str(sample_rate))
 
     return SamplingResult(
@@ -63,11 +66,13 @@ def dropped_result(span_context, attributes, sample_rate=None):
 
 def sampled_result(span_context, attributes, sample_rate):
     # type: (SpanContext, Attributes, float) -> SamplingResult
-    # note that trace_state.add will NOT overwrite existing entries
-    # so these will only be added the first time in a root span sampling decision
-    trace_state = span_context.trace_state.add(TRACESTATE_SAMPLED_KEY, "true").add(
-        TRACESTATE_SAMPLE_RATE_KEY, str(sample_rate)
-    )
+    # these will only be added the first time in a root span sampling decision
+    trace_state = span_context.trace_state
+
+    if TRACESTATE_SAMPLED_KEY not in trace_state.keys():
+        trace_state = span_context.trace_state.add(TRACESTATE_SAMPLED_KEY, "true")
+    if TRACESTATE_SAMPLE_RATE_KEY not in trace_state.keys():
+        trace_state = trace_state.add(TRACESTATE_SAMPLE_RATE_KEY, str(sample_rate))
 
     return SamplingResult(
         Decision.RECORD_AND_SAMPLE,

--- a/sentry_sdk/integrations/opentelemetry/sampler.py
+++ b/sentry_sdk/integrations/opentelemetry/sampler.py
@@ -51,8 +51,8 @@ def dropped_result(span_context, attributes, sample_rate=None):
     # these will only be added the first time in a root span sampling decision
     trace_state = span_context.trace_state
 
-    if TRACESTATE_SAMPLED_KEY not in span_context.trace_state:
-        trace_state = span_context.trace_state.add(TRACESTATE_SAMPLED_KEY, "false")
+    if TRACESTATE_SAMPLED_KEY not in trace_state:
+        trace_state = trace_state.add(TRACESTATE_SAMPLED_KEY, "false")
 
     if sample_rate and TRACESTATE_SAMPLE_RATE_KEY not in trace_state:
         trace_state = trace_state.add(TRACESTATE_SAMPLE_RATE_KEY, str(sample_rate))
@@ -70,7 +70,7 @@ def sampled_result(span_context, attributes, sample_rate):
     trace_state = span_context.trace_state
 
     if TRACESTATE_SAMPLED_KEY not in trace_state:
-        trace_state = span_context.trace_state.add(TRACESTATE_SAMPLED_KEY, "true")
+        trace_state = trace_state.add(TRACESTATE_SAMPLED_KEY, "true")
     if TRACESTATE_SAMPLE_RATE_KEY not in trace_state:
         trace_state = trace_state.add(TRACESTATE_SAMPLE_RATE_KEY, str(sample_rate))
 


### PR DESCRIPTION
`trace_state.add` will never overwrite existing entries -- this is good. However, everytime it bails, it logs a warning, which then shows up in breadcrumbs in tests. 

```
WARNING  opentelemetry.trace.span:span.py:308 The provided key sentry-sampled already exists.
WARNING  opentelemetry.trace.span:span.py:308 The provided key sentry-sample_rate already exists.
WARNING  opentelemetry.trace.span:span.py:308 The provided key sentry-sampled already exists.
WARNING  opentelemetry.trace.span:span.py:308 The provided key sentry-sample_rate already exists.
WARNING  opentelemetry.trace.span:span.py:308 The provided key sentry-sampled already exists.
...
```

In this PR we explicitly check before `add`ing.