### PR TITLE
fix(strawberry): prepare for upstream extension removal

### DIFF
--- a/sentry_sdk/integrations/strawberry.py
+++ b/sentry_sdk/integrations/strawberry.py
@@ -31,13 +31,18 @@ try:
     from strawberry import Schema
     from strawberry.extensions import SchemaExtension  # type: ignore
     from strawberry.extensions.tracing.utils import should_skip_tracing as strawberry_should_skip_tracing  # type: ignore
+    from strawberry.http import async_base_view, sync_base_view  # type: ignore
+except ImportError:
+    raise DidNotEnable("strawberry-graphql is not installed")
+
+try:
     from strawberry.extensions.tracing import (  # type: ignore
         SentryTracingExtension as StrawberrySentryAsyncExtension,
         SentryTracingExtensionSync as StrawberrySentrySyncExtension,
     )
-    from strawberry.http import async_base_view, sync_base_view  # type: ignore
 except ImportError:
-    raise DidNotEnable("strawberry-graphql is not installed")
+    StrawberrySentryAsyncExtension = None
+    StrawberrySentrySyncExtension = None
 
 from typing import TYPE_CHECKING
 

--- a/tests/integrations/strawberry/test_strawberry.py
+++ b/tests/integrations/strawberry/test_strawberry.py
@@ -10,10 +10,6 @@ from unittest import mock
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 from flask import Flask
-from strawberry.extensions.tracing import (
-    SentryTracingExtension,
-    SentryTracingExtensionSync,
-)
 from strawberry.fastapi import GraphQLRouter
 from strawberry.flask.views import GraphQLView
 
@@ -27,6 +23,15 @@ from sentry_sdk.integrations.strawberry import (
     SentrySyncExtension,
 )
 from tests.conftest import ApproxDict
+
+try:
+    from strawberry.extensions.tracing import (
+        SentryTracingExtension,
+        SentryTracingExtensionSync,
+    )
+except ImportError:
+    SentryTracingExtension = None
+    SentryTracingExtensionSync = None
 
 parameterize_strawberry_test = pytest.mark.parametrize(
     "client_factory,async_execution,framework_integrations",
@@ -143,6 +148,10 @@ def test_infer_execution_type_from_installed_packages_sync(sentry_init):
         assert SentrySyncExtension in schema.extensions
 
 
+@pytest.mark.skipif(
+    SentryTracingExtension is None,
+    reason="SentryTracingExtension no longer available in this Strawberry version",
+)
 def test_replace_existing_sentry_async_extension(sentry_init):
     sentry_init(integrations=[StrawberryIntegration()])
 
@@ -152,6 +161,10 @@ def test_replace_existing_sentry_async_extension(sentry_init):
     assert SentryAsyncExtension in schema.extensions
 
 
+@pytest.mark.skipif(
+    SentryTracingExtensionSync is None,
+    reason="SentryTracingExtensionSync no longer available in this Strawberry version",
+)
 def test_replace_existing_sentry_sync_extension(sentry_init):
     sentry_init(integrations=[StrawberryIntegration()])
 


### PR DESCRIPTION
As suggested by @szokeasaurusrex in https://github.com/strawberry-graphql/strawberry/issues/3590, Strawberry is preparing to fully remove its deprecated `SentryTracingExtension` in favor of the integration provided by the Sentry SDK.

This PR prepares the Sentry Strawberry integration for that removal by:
- fixing that the integration would assume Strawberry is not installed if the extension cannot be imported
- making sure tests with Strawberry versions before and after the removal still work

I also checked that removing the extension does not otherwise affect the integration: The extension's sync and async variants are imported to replace them and to guess whether sync or async code is used. Both still works if the imports are defaulted to `None`.
