### PR TITLE
fix(langchain): handle case when parent span wasn't traced

### DIFF
--- a/sentry_sdk/integrations/langchain.py
+++ b/sentry_sdk/integrations/langchain.py
@@ -138,7 +138,7 @@ class SentryLangchainCallback(BaseCallbackHandler):  # type: ignore[misc]
 
         watched_span = None  # type: Optional[WatchedSpan]
         if parent_id:
-            parent_span = self.span_map[parent_id]  # type: Optional[WatchedSpan]
+            parent_span = self.span_map.get(parent_id)  # type: Optional[WatchedSpan]
             if parent_span:
                 watched_span = WatchedSpan(parent_span.span.start_child(**kwargs))
                 parent_span.children.append(watched_span)


### PR DESCRIPTION
It's possible for the parent span to not have been traced (or have been GCd) so a KeyError would be raised when trying to fetch the span for the parent run_id. Now we defensively `.get()` the parent span instead of subscripting it.