### PR TITLE
Fix mypy

### DIFF
--- a/requirements-linting.txt
+++ b/requirements-linting.txt
@@ -14,3 +14,4 @@ loguru # There is no separate types module.
 flake8-bugbear
 pep8-naming
 pre-commit # local linting
+httpcore

--- a/sentry_sdk/integrations/__init__.py
+++ b/sentry_sdk/integrations/__init__.py
@@ -125,7 +125,7 @@ def setup_integrations(
     with_auto_enabling_integrations=False,
     disabled_integrations=None,
 ):
-    # type: (Sequence[Integration], bool, bool, Optional[Sequence[Union[type, Integration]]]) -> Dict[str, Integration]
+    # type: (Sequence[Integration], bool, bool, Optional[Sequence[Union[type[Integration], Integration]]]) -> Dict[str, Integration]
     """
     Given a list of integration instances, this installs them all.
 

--- a/sentry_sdk/integrations/__init__.py
+++ b/sentry_sdk/integrations/__init__.py
@@ -14,6 +14,7 @@ if TYPE_CHECKING:
     from typing import Optional
     from typing import Set
     from typing import Type
+    from typing import Union
 
 
 _DEFAULT_FAILED_REQUEST_STATUS_CODES = frozenset(range(500, 600))
@@ -124,7 +125,7 @@ def setup_integrations(
     with_auto_enabling_integrations=False,
     disabled_integrations=None,
 ):
-    # type: (Sequence[Integration], bool, bool, Optional[Sequence[Integration]]) -> Dict[str, Integration]
+    # type: (Sequence[Integration], bool, bool, Optional[Sequence[Union[type, Integration]]]) -> Dict[str, Integration]
     """
     Given a list of integration instances, this installs them all.
 


### PR DESCRIPTION
mypy updated itself and started throwing:

```
linters: commands[2]> mypy sentry_sdk
sentry_sdk/integrations/__init__.py:145: error: List comprehension has incompatible type List[sentry_sdk.integrations.<subclass of "Integration" and "type">1 | type[Integration]]; expected List[sentry_sdk.integrations.<subclass of "Integration" and "type"> | type[Integration]]  [misc]
```

Locally it's also complaining that it cannot find types for `httpcore`, so adding that to linter reqs.