### PR TITLE
Fix flaky transport test

### DIFF
--- a/sentry_sdk/_compat.py
+++ b/sentry_sdk/_compat.py
@@ -10,6 +10,7 @@ if TYPE_CHECKING:
 
 
 PY37 = sys.version_info[0] == 3 and sys.version_info[1] >= 7
+PY38 = sys.version_info[0] == 3 and sys.version_info[1] >= 8
 PY310 = sys.version_info[0] == 3 and sys.version_info[1] >= 10
 PY311 = sys.version_info[0] == 3 and sys.version_info[1] >= 11
 

--- a/tests/test_transport.py
+++ b/tests/test_transport.py
@@ -23,6 +23,7 @@ from sentry_sdk import (
     get_isolation_scope,
     Hub,
 )
+from sentry_sdk._compat import PY37, PY38
 from sentry_sdk.envelope import Envelope, Item, parse_json
 from sentry_sdk.transport import (
     KEEP_ALIVE_SOCKET_OPTIONS,
@@ -123,10 +124,11 @@ def mock_transaction_envelope(span_count):
 @pytest.mark.parametrize("client_flush_method", ["close", "flush"])
 @pytest.mark.parametrize("use_pickle", (True, False))
 @pytest.mark.parametrize("compression_level", (0, 9, None))
-@pytest.mark.parametrize("compression_algo", ("gzip", "br", "<invalid>", None))
 @pytest.mark.parametrize(
-    "http2", [True, False] if sys.version_info >= (3, 8) else [False]
+    "compression_algo",
+    ("gzip", "br", "<invalid>", None) if PY37 else ("gzip", "<invalid>", None),
 )
+@pytest.mark.parametrize("http2", [True, False] if PY38 else [False])
 def test_transport_works(
     capturing_server,
     request,

--- a/tests/test_transport.py
+++ b/tests/test_transport.py
@@ -14,6 +14,11 @@ import pytest
 from pytest_localserver.http import WSGIServer
 from werkzeug.wrappers import Request, Response
 
+try:
+    import gevent
+except ImportError:
+    gevent = None
+
 import sentry_sdk
 from sentry_sdk import (
     Client,
@@ -126,7 +131,11 @@ def mock_transaction_envelope(span_count):
 @pytest.mark.parametrize("compression_level", (0, 9, None))
 @pytest.mark.parametrize(
     "compression_algo",
-    ("gzip", "br", "<invalid>", None) if PY37 else ("gzip", "<invalid>", None),
+    (
+        ("gzip", "br", "<invalid>", None)
+        if PY37 or gevent is None
+        else ("gzip", "<invalid>", None)
+    ),
 )
 @pytest.mark.parametrize("http2", [True, False] if PY38 else [False])
 def test_transport_works(


### PR DESCRIPTION
The `test_transport_works` test is flaking ~7 our of 10 times after adding brotli, but only on 3.6 with gevent and only in CI.