### PR TITLE
Serialize span attrs properly

### DIFF
--- a/sentry_sdk/integrations/asyncpg.py
+++ b/sentry_sdk/integrations/asyncpg.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 import contextlib
+import json
 from typing import Any, TypeVar, Callable, Awaitable, Iterator
 
 import sentry_sdk
@@ -147,7 +148,7 @@ def _wrap_cursor_creation(f: Callable[..., T]) -> Callable[..., T]:
         ) as span:
             _set_db_data(span, args[0])
             res = f(*args, **kwargs)
-            span.set_attribute("db.cursor", str(res))
+            span.set_attribute("db.cursor", json.dumps(res))
 
         return res
 

--- a/sentry_sdk/integrations/clickhouse_driver.py
+++ b/sentry_sdk/integrations/clickhouse_driver.py
@@ -1,3 +1,5 @@
+import json
+
 import sentry_sdk
 from sentry_sdk.consts import OP, SPANDATA
 from sentry_sdk.integrations import Integration, DidNotEnable
@@ -99,7 +101,7 @@ def _wrap_start(f: Callable[P, T]) -> Callable[P, T]:
 
         if params and should_send_default_pii():
             connection._sentry_db_params = params
-            span.set_attribute("db.params", str(params))
+            span.set_attribute("db.params", json.dumps(params))
 
         # run the original code
         ret = f(*args, **kwargs)
@@ -117,7 +119,7 @@ def _wrap_end(f: Callable[P, T]) -> Callable[P, T]:
 
         if span is not None:
             if res is not None and should_send_default_pii():
-                span.set_attribute("db.result", str(res))
+                span.set_attribute("db.result", json.dumps(res))
 
             with capture_internal_exceptions():
                 query = span.get_attribute("db.query.text")
@@ -159,7 +161,7 @@ def _wrap_send_data(f: Callable[P, T]) -> Callable[P, T]:
                     getattr(instance.connection, "_sentry_db_params", None) or []
                 )
                 db_params.extend(data)
-                span.set_attribute("db.params", str(db_params))
+                span.set_attribute("db.params", json.dumps(db_params))
                 try:
                     del instance.connection._sentry_db_params
                 except AttributeError:

--- a/sentry_sdk/tracing_utils.py
+++ b/sentry_sdk/tracing_utils.py
@@ -1,13 +1,14 @@
 import contextlib
 import inspect
+import json
 import os
 import re
 import sys
+import uuid
 from collections.abc import Mapping
 from datetime import datetime, timedelta, timezone
 from functools import wraps
 from urllib.parse import quote, unquote
-import uuid
 
 import sentry_sdk
 from sentry_sdk.consts import OP, SPANDATA
@@ -133,13 +134,13 @@ def record_sql_queries(
 
     data = {}
     if params_list is not None:
-        data["db.params"] = str(params_list)
+        data["db.params"] = json.dumps(params_list)
     if paramstyle is not None:
-        data["db.paramstyle"] = str(paramstyle)
+        data["db.paramstyle"] = json.dumps(paramstyle)
     if executemany:
         data["db.executemany"] = True
     if record_cursor_repr and cursor is not None:
-        data["db.cursor"] = str(cursor)
+        data["db.cursor"] = json.dumps(cursor)
 
     with capture_internal_exceptions():
         sentry_sdk.add_breadcrumb(message=query, category="query", data=data)

--- a/tests/integrations/clickhouse_driver/test_clickhouse_driver.py
+++ b/tests/integrations/clickhouse_driver/test_clickhouse_driver.py
@@ -5,6 +5,8 @@ docker run -d -p 18123:8123 -p9000:9000 --name clickhouse-test --ulimit nofile=2
 ```
 """
 
+import json
+
 import clickhouse_driver
 from clickhouse_driver import Client, connect
 
@@ -16,7 +18,7 @@ EXPECT_PARAMS_IN_SELECT = True
 if clickhouse_driver.VERSION < (0, 2, 6):
     EXPECT_PARAMS_IN_SELECT = False
 
-PARAMS_SERIALIZER = str
+PARAMS_SERIALIZER = json.dumps
 
 
 def test_clickhouse_client_breadcrumbs(sentry_init, capture_events) -> None:


### PR DESCRIPTION
Add a util function for best-effort early serialization.

OTel is quite restrictive in what types it allows as span attributes.

We often set arbitrary Python objects as span attributes. This needs to change.