### PR TITLE
feat: Add reason for in_app to frames

### DIFF
--- a/sentry_sdk/tracing_utils.py
+++ b/sentry_sdk/tracing_utils.py
@@ -191,11 +191,12 @@ def _should_be_included(
     # type: (...) -> bool
     # in_app_include takes precedence over in_app_exclude
     should_be_included = _module_in_list(namespace, in_app_include)
-    should_be_excluded = _is_external_source(abs_path) or _module_in_list(
-        namespace, in_app_exclude
+    should_be_excluded = (
+        _is_external_source(abs_path)
+        or _module_in_list(namespace, in_app_exclude) is not None
     )
     return not is_sentry_sdk_frame and (
-        should_be_included
+        should_be_included is not None
         or (_is_in_project_root(abs_path, project_root) and not should_be_excluded)
     )
 

--- a/sentry_sdk/utils.py
+++ b/sentry_sdk/utils.py
@@ -1042,12 +1042,14 @@ def set_in_app_in_frames(frames, in_app_exclude, in_app_include, project_root=No
         module = frame.get("module")
 
         # check if module in frame is in the list of modules to include
-        if _module_in_list(module, in_app_include):
+        include_pattern_matched = _module_in_list(module, in_app_include)
+        if include_pattern_matched:
             frame["in_app"] = True
+            frame["in_app_include_used"] = include_pattern_matched
             continue
 
         # check if module in frame is in the list of modules to exclude
-        if _module_in_list(module, in_app_exclude):
+        if _module_in_list(module, in_app_exclude) is not None:
             frame["in_app"] = False
             continue
 
@@ -1118,18 +1120,18 @@ def event_from_exception(
 
 
 def _module_in_list(name, items):
-    # type: (Optional[str], Optional[List[str]]) -> bool
+    # type: (Optional[str], Optional[List[str]]) -> Optional[str]
     if name is None:
-        return False
+        return None
 
     if not items:
-        return False
+        return None
 
     for item in items:
         if item == name or name.startswith(item + "."):
-            return True
+            return item
 
-    return False
+    return None
 
 
 def _is_external_source(abs_path):

--- a/tests/utils/test_general.py
+++ b/tests/utils/test_general.py
@@ -239,6 +239,7 @@ def test_parse_invalid_dsn(dsn):
                 "module": "fastapi.routing",
                 "abs_path": "/home/ubuntu/fastapi/.venv/lib/python3.10/site-packages/fastapi/routing.py",
                 "in_app": True,
+                "in_app_include_used": "fastapi",
             },
         ],
         [
@@ -280,6 +281,7 @@ def test_parse_invalid_dsn(dsn):
                 "module": "fastapi.routing",
                 "abs_path": "/usr/lib/python2.7/dist-packages/fastapi/routing.py",
                 "in_app": True,
+                "in_app_include_used": "fastapi",
             },
         ],
         [
@@ -420,6 +422,7 @@ def test_parse_invalid_dsn(dsn):
             {
                 "module": "fastapi.routing",
                 "in_app": True,
+                "in_app_include_used": "fastapi",
             },
         ],
         [
@@ -461,6 +464,7 @@ def test_parse_invalid_dsn(dsn):
                 "module": "main",
                 "abs_path": "/home/ubuntu/fastapi/main.py",
                 "in_app": True,
+                "in_app_include_used": "main",
             },
         ],
         [


### PR DESCRIPTION
Sentry enhances the `in_app` decision from the SDK, sometimes overriding it.

In case the decision to set `in_app` to `True` comes from the user themselves (by setting `in_app_include`), we don't want Sentry to override it.

Currently there's no way for Sentry to know what led to the decision in the SDK. Changing that here.

Draft: To be clarified whether `in_app_include_used` should contain the actual prefix from the user's `in_app_include` or a general category like `in_project_root`, `in_app_include` outlining the general reason for marking it as in app.

Closes https://github.com/getsentry/sentry-python/issues/3671