### PR TITLE
Use root span transaction name in populated head DSC

### DIFF
--- a/sentry_sdk/integrations/opentelemetry/integration.py
+++ b/sentry_sdk/integrations/opentelemetry/integration.py
@@ -18,7 +18,6 @@ from sentry_sdk.utils import logger
 try:
     from opentelemetry import trace
     from opentelemetry.propagate import set_global_textmap
-    from opentelemetry.trace import Span as AbstractSpan
     from opentelemetry.sdk.trace import TracerProvider, Span, ReadableSpan
 except ImportError:
     raise DidNotEnable("opentelemetry not installed")
@@ -27,11 +26,6 @@ try:
     from opentelemetry.instrumentation.django import DjangoInstrumentor  # type: ignore[import-not-found]
 except ImportError:
     DjangoInstrumentor = None
-
-from sentry_sdk._types import TYPE_CHECKING
-
-if TYPE_CHECKING:
-    from typing import Union, Any
 
 
 CONFIGURABLE_INSTRUMENTATIONS = {
@@ -63,23 +57,12 @@ def _patch_readable_span():
     We need to pass through sentry specific metadata/objects from Span to ReadableSpan
     to work with them consistently in the SpanProcessor.
     """
-
-    @property
-    def sentry_meta(self):
-        # type: (Union[AbstractSpan, Span, ReadableSpan]) -> dict[str, Any]
-        if not getattr(self, "_sentry_meta", None):
-            self._sentry_meta = {}
-        return self._sentry_meta
-
-    AbstractSpan.sentry_meta = sentry_meta
-    ReadableSpan.sentry_meta = sentry_meta
-
     old_readable_span = Span._readable_span
 
     def sentry_patched_readable_span(self):
         # type: (Span) -> ReadableSpan
         readable_span = old_readable_span(self)
-        readable_span._sentry_meta = self._sentry_meta
+        readable_span._sentry_meta = getattr(self, "_sentry_meta", {})
         return readable_span
 
     Span._readable_span = sentry_patched_readable_span

--- a/sentry_sdk/integrations/opentelemetry/potel_span_processor.py
+++ b/sentry_sdk/integrations/opentelemetry/potel_span_processor.py
@@ -20,6 +20,8 @@ from sentry_sdk.integrations.opentelemetry.utils import (
     extract_span_data,
     extract_transaction_name_source,
     get_trace_context,
+    get_sentry_meta,
+    set_sentry_meta,
 )
 from sentry_sdk.integrations.opentelemetry.consts import (
     OTEL_SENTRY_CONTEXT,
@@ -85,12 +87,11 @@ class PotelSentrySpanProcessor(SpanProcessor):
         """
         if parent_span != INVALID_SPAN and not parent_span.get_span_context().is_remote:
             # child span points to parent's root or parent
-            span.sentry_meta["root_span"] = parent_span.sentry_meta.get(
-                "root_span", parent_span
-            )
+            parent_root_span = get_sentry_meta(parent_span, "root_span")
+            set_sentry_meta(span, "root_span", parent_root_span or parent_span)
         else:
             # root span points to itself
-            span.sentry_meta["root_span"] = span
+            set_sentry_meta(span, "root_span", span)
 
     def _flush_root_span(self, span):
         # type: (ReadableSpan) -> None

--- a/sentry_sdk/tracing.py
+++ b/sentry_sdk/tracing.py
@@ -1326,8 +1326,12 @@ class POTelSpan:
     @property
     def root_span(self):
         # type: () -> Optional[POTelSpan]
+        from sentry_sdk.integrations.opentelemetry.utils import (
+            get_sentry_meta,
+        )
+
         root_otel_span = cast(
-            "Optional[OtelSpan]", self._otel_span.sentry_meta.get("root_span", None)
+            "Optional[OtelSpan]", get_sentry_meta(self._otel_span, "root_span")
         )
         return POTelSpan(otel_span=root_otel_span) if root_otel_span else None
 


### PR DESCRIPTION
also removed the `sentry_meta` property patching and added explicit helper methods since that broke a bunch of typing