### PR TITLE
Fix breadcrumbs in redis

### DIFF
--- a/sentry_sdk/integrations/redis/_async_common.py
+++ b/sentry_sdk/integrations/redis/_async_common.py
@@ -7,6 +7,7 @@ from sentry_sdk.integrations.redis.modules.caches import (
 )
 from sentry_sdk.integrations.redis.modules.queries import _compile_db_span_properties
 from sentry_sdk.integrations.redis.utils import (
+    _create_breadcrumb,
     _get_client_data,
     _get_pipeline_data,
     _update_span,
@@ -52,6 +53,7 @@ def patch_redis_async_pipeline(
                     ),
                 )
                 _update_span(span, span_data, pipeline_data)
+                _create_breadcrumb("redis.pipeline.execute", span_data, pipeline_data)
 
             return await old_execute(self, *args, **kwargs)
 
@@ -98,6 +100,7 @@ def patch_redis_async_client(cls, is_cluster, get_db_data_fn):
         db_span_data = get_db_data_fn(self)
         db_client_span_data = _get_client_data(is_cluster, name, *args)
         _update_span(db_span, db_span_data, db_client_span_data)
+        _create_breadcrumb(db_properties["op"], db_span_data, db_client_span_data)
 
         value = await old_execute_command(self, name, *args, **kwargs)
 

--- a/sentry_sdk/integrations/redis/_async_common.py
+++ b/sentry_sdk/integrations/redis/_async_common.py
@@ -100,7 +100,9 @@ def patch_redis_async_client(cls, is_cluster, get_db_data_fn):
         db_span_data = get_db_data_fn(self)
         db_client_span_data = _get_client_data(is_cluster, name, *args)
         _update_span(db_span, db_span_data, db_client_span_data)
-        _create_breadcrumb(db_properties["op"], db_span_data, db_client_span_data)
+        _create_breadcrumb(
+            db_properties["description"], db_span_data, db_client_span_data
+        )
 
         value = await old_execute_command(self, name, *args, **kwargs)
 

--- a/sentry_sdk/integrations/redis/_async_common.py
+++ b/sentry_sdk/integrations/redis/_async_common.py
@@ -26,7 +26,7 @@ if TYPE_CHECKING:
 def patch_redis_async_pipeline(
     pipeline_cls, is_cluster, get_command_args_fn, get_db_data_fn
 ):
-    # type: (Union[type[Pipeline[Any]], type[ClusterPipeline[Any]]], bool, Any, Callable[[Span, Any], None]) -> None
+    # type: (Union[type[Pipeline[Any]], type[ClusterPipeline[Any]]], bool, Any, Callable[[Any], dict[str, Any]]) -> None
     old_execute = pipeline_cls.execute
 
     from sentry_sdk.integrations.redis import RedisIntegration
@@ -47,7 +47,9 @@ def patch_redis_async_pipeline(
                     is_cluster=is_cluster,
                     get_command_args_fn=get_command_args_fn,
                     is_transaction=False if is_cluster else self.is_transaction,
-                    command_stack=self._command_stack if is_cluster else self.command_stack,
+                    command_stack=(
+                        self._command_stack if is_cluster else self.command_stack
+                    ),
                 )
                 _update_span(span, span_data, pipeline_data)
 
@@ -57,7 +59,7 @@ def patch_redis_async_pipeline(
 
 
 def patch_redis_async_client(cls, is_cluster, get_db_data_fn):
-    # type: (Union[type[StrictRedis[Any]], type[RedisCluster[Any]]], bool, Callable[[Span, Any], None]) -> None
+    # type: (Union[type[StrictRedis[Any]], type[RedisCluster[Any]]], bool, Callable[[Any], dict[str, Any]]) -> None
     old_execute_command = cls.execute_command
 
     from sentry_sdk.integrations.redis import RedisIntegration

--- a/sentry_sdk/integrations/redis/_async_common.py
+++ b/sentry_sdk/integrations/redis/_async_common.py
@@ -7,7 +7,7 @@ from sentry_sdk.integrations.redis.modules.caches import (
 )
 from sentry_sdk.integrations.redis.modules.queries import _compile_db_span_properties
 from sentry_sdk.integrations.redis.utils import (
-    _set_client_data,
+    _get_client_data,
     _get_pipeline_data,
 )
 from sentry_sdk.tracing import Span
@@ -92,7 +92,7 @@ def patch_redis_async_client(cls, is_cluster, get_db_data_fn):
         db_span.__enter__()
 
         db_span_data = get_db_data_fn(self)
-        _set_client_data(db_span, is_cluster, name, *args)
+        db_client_span_data = _get_client_data(db_span, is_cluster, name, *args)
 
         value = await old_execute_command(self, name, *args, **kwargs)
 

--- a/sentry_sdk/integrations/redis/_async_common.py
+++ b/sentry_sdk/integrations/redis/_async_common.py
@@ -3,7 +3,7 @@ from sentry_sdk.consts import OP
 from sentry_sdk.integrations.redis.consts import SPAN_ORIGIN
 from sentry_sdk.integrations.redis.modules.caches import (
     _compile_cache_span_properties,
-    _set_cache_data,
+    _get_cache_data,
 )
 from sentry_sdk.integrations.redis.modules.queries import _compile_db_span_properties
 from sentry_sdk.integrations.redis.utils import (
@@ -99,7 +99,7 @@ def patch_redis_async_client(cls, is_cluster, get_db_data_fn):
         db_span.__exit__(None, None, None)
 
         if cache_span:
-            _set_cache_data(cache_span, self, cache_properties, value)
+            cache_span_data = _get_cache_data(self, cache_properties, value)
             cache_span.__exit__(None, None, None)
 
         return value

--- a/sentry_sdk/integrations/redis/_async_common.py
+++ b/sentry_sdk/integrations/redis/_async_common.py
@@ -8,7 +8,7 @@ from sentry_sdk.integrations.redis.modules.caches import (
 from sentry_sdk.integrations.redis.modules.queries import _compile_db_span_properties
 from sentry_sdk.integrations.redis.utils import (
     _set_client_data,
-    _set_pipeline_data,
+    _get_pipeline_data,
 )
 from sentry_sdk.tracing import Span
 from sentry_sdk.utils import capture_internal_exceptions
@@ -42,12 +42,11 @@ def patch_redis_async_pipeline(
         ) as span:
             with capture_internal_exceptions():
                 span_data = get_db_data_fn(self)
-                _set_pipeline_data(
-                    span,
-                    is_cluster,
-                    get_command_args_fn,
-                    False if is_cluster else self.is_transaction,
-                    self._command_stack if is_cluster else self.command_stack,
+                pipeline_data = _get_pipeline_data(
+                    is_cluster=is_cluster,
+                    get_command_args_fn=get_command_args_fn,
+                    is_transaction=False if is_cluster else self.is_transaction,
+                    command_stack=self._command_stack if is_cluster else self.command_stack,
                 )
 
             return await old_execute(self, *args, **kwargs)

--- a/sentry_sdk/integrations/redis/_async_common.py
+++ b/sentry_sdk/integrations/redis/_async_common.py
@@ -9,6 +9,7 @@ from sentry_sdk.integrations.redis.modules.queries import _compile_db_span_prope
 from sentry_sdk.integrations.redis.utils import (
     _get_client_data,
     _get_pipeline_data,
+    _update_span,
 )
 from sentry_sdk.tracing import Span
 from sentry_sdk.utils import capture_internal_exceptions
@@ -48,6 +49,7 @@ def patch_redis_async_pipeline(
                     is_transaction=False if is_cluster else self.is_transaction,
                     command_stack=self._command_stack if is_cluster else self.command_stack,
                 )
+                _update_span(span, span_data, pipeline_data)
 
             return await old_execute(self, *args, **kwargs)
 
@@ -92,7 +94,8 @@ def patch_redis_async_client(cls, is_cluster, get_db_data_fn):
         db_span.__enter__()
 
         db_span_data = get_db_data_fn(self)
-        db_client_span_data = _get_client_data(db_span, is_cluster, name, *args)
+        db_client_span_data = _get_client_data(is_cluster, name, *args)
+        _update_span(db_span, db_span_data, db_client_span_data)
 
         value = await old_execute_command(self, name, *args, **kwargs)
 
@@ -100,6 +103,7 @@ def patch_redis_async_client(cls, is_cluster, get_db_data_fn):
 
         if cache_span:
             cache_span_data = _get_cache_data(self, cache_properties, value)
+            _update_span(cache_span, cache_span_data)
             cache_span.__exit__(None, None, None)
 
         return value

--- a/sentry_sdk/integrations/redis/_async_common.py
+++ b/sentry_sdk/integrations/redis/_async_common.py
@@ -23,7 +23,7 @@ if TYPE_CHECKING:
 
 
 def patch_redis_async_pipeline(
-    pipeline_cls, is_cluster, get_command_args_fn, set_db_data_fn
+    pipeline_cls, is_cluster, get_command_args_fn, get_db_data_fn
 ):
     # type: (Union[type[Pipeline[Any]], type[ClusterPipeline[Any]]], bool, Any, Callable[[Span, Any], None]) -> None
     old_execute = pipeline_cls.execute
@@ -41,7 +41,7 @@ def patch_redis_async_pipeline(
             origin=SPAN_ORIGIN,
         ) as span:
             with capture_internal_exceptions():
-                set_db_data_fn(span, self)
+                span_data = get_db_data_fn(self)
                 _set_pipeline_data(
                     span,
                     is_cluster,
@@ -55,7 +55,7 @@ def patch_redis_async_pipeline(
     pipeline_cls.execute = _sentry_execute  # type: ignore
 
 
-def patch_redis_async_client(cls, is_cluster, set_db_data_fn):
+def patch_redis_async_client(cls, is_cluster, get_db_data_fn):
     # type: (Union[type[StrictRedis[Any]], type[RedisCluster[Any]]], bool, Callable[[Span, Any], None]) -> None
     old_execute_command = cls.execute_command
 
@@ -92,7 +92,7 @@ def patch_redis_async_client(cls, is_cluster, set_db_data_fn):
         )
         db_span.__enter__()
 
-        set_db_data_fn(db_span, self)
+        db_span_data = get_db_data_fn(self)
         _set_client_data(db_span, is_cluster, name, *args)
 
         value = await old_execute_command(self, name, *args, **kwargs)

--- a/sentry_sdk/integrations/redis/_sync_common.py
+++ b/sentry_sdk/integrations/redis/_sync_common.py
@@ -8,7 +8,7 @@ from sentry_sdk.integrations.redis.modules.caches import (
 from sentry_sdk.integrations.redis.modules.queries import _compile_db_span_properties
 from sentry_sdk.integrations.redis.utils import (
     _set_client_data,
-    _set_pipeline_data,
+    _get_pipeline_data,
 )
 from sentry_sdk.tracing import Span
 from sentry_sdk.utils import capture_internal_exceptions
@@ -44,12 +44,11 @@ def patch_redis_pipeline(
         ) as span:
             with capture_internal_exceptions():
                 span_data = get_db_data_fn(self)
-                _set_pipeline_data(
-                    span,
-                    is_cluster,
-                    get_command_args_fn,
-                    False if is_cluster else self.transaction,
-                    self.command_stack,
+                pipeline_data = _get_pipeline_data(
+                    is_cluster=is_cluster,
+                    get_command_args_fn=get_command_args_fn,
+                    is_transaction=False if is_cluster else self.transaction,
+                    command_stack=self.command_stack,
                 )
 
             return old_execute(self, *args, **kwargs)

--- a/sentry_sdk/integrations/redis/_sync_common.py
+++ b/sentry_sdk/integrations/redis/_sync_common.py
@@ -103,7 +103,9 @@ def patch_redis_client(cls, is_cluster, get_db_data_fn):
         db_span_data = get_db_data_fn(self)
         db_client_span_data = _get_client_data(is_cluster, name, *args)
         _update_span(db_span, db_span_data, db_client_span_data)
-        _create_breadcrumb(db_properties["op"], db_span_data, db_client_span_data)
+        _create_breadcrumb(
+            db_properties["description"], db_span_data, db_client_span_data
+        )
 
         value = old_execute_command(self, name, *args, **kwargs)
 

--- a/sentry_sdk/integrations/redis/_sync_common.py
+++ b/sentry_sdk/integrations/redis/_sync_common.py
@@ -3,7 +3,7 @@ from sentry_sdk.consts import OP
 from sentry_sdk.integrations.redis.consts import SPAN_ORIGIN
 from sentry_sdk.integrations.redis.modules.caches import (
     _compile_cache_span_properties,
-    _set_cache_data,
+    _get_cache_data,
 )
 from sentry_sdk.integrations.redis.modules.queries import _compile_db_span_properties
 from sentry_sdk.integrations.redis.utils import (
@@ -105,7 +105,7 @@ def patch_redis_client(cls, is_cluster, get_db_data_fn):
         db_span.__exit__(None, None, None)
 
         if cache_span:
-            _set_cache_data(cache_span, self, cache_properties, value)
+            cache_span_data = _get_cache_data(self, cache_properties, value)
             cache_span.__exit__(None, None, None)
 
         return value

--- a/sentry_sdk/integrations/redis/_sync_common.py
+++ b/sentry_sdk/integrations/redis/_sync_common.py
@@ -7,6 +7,7 @@ from sentry_sdk.integrations.redis.modules.caches import (
 )
 from sentry_sdk.integrations.redis.modules.queries import _compile_db_span_properties
 from sentry_sdk.integrations.redis.utils import (
+    _create_breadcrumb,
     _get_client_data,
     _get_pipeline_data,
     _update_span,
@@ -51,6 +52,7 @@ def patch_redis_pipeline(
                     command_stack=self.command_stack,
                 )
                 _update_span(span, span_data, pipeline_data)
+                _create_breadcrumb("redis.pipeline.execute", span_data, pipeline_data)
 
             return old_execute(self, *args, **kwargs)
 
@@ -101,6 +103,7 @@ def patch_redis_client(cls, is_cluster, get_db_data_fn):
         db_span_data = get_db_data_fn(self)
         db_client_span_data = _get_client_data(is_cluster, name, *args)
         _update_span(db_span, db_span_data, db_client_span_data)
+        _create_breadcrumb(db_properties["op"], db_span_data, db_client_span_data)
 
         value = old_execute_command(self, name, *args, **kwargs)
 

--- a/sentry_sdk/integrations/redis/_sync_common.py
+++ b/sentry_sdk/integrations/redis/_sync_common.py
@@ -7,7 +7,7 @@ from sentry_sdk.integrations.redis.modules.caches import (
 )
 from sentry_sdk.integrations.redis.modules.queries import _compile_db_span_properties
 from sentry_sdk.integrations.redis.utils import (
-    _set_client_data,
+    _get_client_data,
     _get_pipeline_data,
 )
 from sentry_sdk.tracing import Span
@@ -98,7 +98,7 @@ def patch_redis_client(cls, is_cluster, get_db_data_fn):
         db_span.__enter__()
 
         db_span_data = get_db_data_fn(self)
-        _set_client_data(db_span, is_cluster, name, *args)
+        db_client_span_data = _get_client_data(db_span, is_cluster, name, *args)
 
         value = old_execute_command(self, name, *args, **kwargs)
 

--- a/sentry_sdk/integrations/redis/modules/caches.py
+++ b/sentry_sdk/integrations/redis/modules/caches.py
@@ -75,22 +75,24 @@ def _get_cache_span_description(redis_command, args, kwargs, integration):
     return description
 
 
-def _set_cache_data(span, redis_client, properties, return_value):
-    # type: (Span, Any, dict[str, Any], Optional[Any]) -> None
+def _get_cache_data(redis_client, properties, return_value):
+    # type: (Any, dict[str, Any], Optional[Any]) -> dict[str, Any]
+    data = {}
+
     with capture_internal_exceptions():
-        span.set_data(SPANDATA.CACHE_KEY, properties["key"])
+        data[SPANDATA.CACHE_KEY] = properties["key"]
 
         if properties["redis_command"] in GET_COMMANDS:
             if return_value is not None:
-                span.set_data(SPANDATA.CACHE_HIT, True)
+                data[SPANDATA.CACHE_HIT] = True
                 size = (
                     len(str(return_value).encode("utf-8"))
                     if not isinstance(return_value, bytes)
                     else len(return_value)
                 )
-                span.set_data(SPANDATA.CACHE_ITEM_SIZE, size)
+                data[SPANDATA.CACHE_ITEM_SIZE] = size
             else:
-                span.set_data(SPANDATA.CACHE_HIT, False)
+                data[SPANDATA.CACHE_HIT] = False
 
         elif properties["redis_command"] in SET_COMMANDS:
             if properties["value"] is not None:
@@ -99,7 +101,7 @@ def _set_cache_data(span, redis_client, properties, return_value):
                     if not isinstance(properties["value"], bytes)
                     else len(properties["value"])
                 )
-                span.set_data(SPANDATA.CACHE_ITEM_SIZE, size)
+                data[SPANDATA.CACHE_ITEM_SIZE] = size
 
         try:
             connection_params = redis_client.connection_pool.connection_kwargs
@@ -114,8 +116,10 @@ def _set_cache_data(span, redis_client, properties, return_value):
 
         host = connection_params.get("host")
         if host is not None:
-            span.set_data(SPANDATA.NETWORK_PEER_ADDRESS, host)
+            data[SPANDATA.NETWORK_PEER_ADDRESS] = host
 
         port = connection_params.get("port")
         if port is not None:
-            span.set_data(SPANDATA.NETWORK_PEER_PORT, port)
+            data[SPANDATA.NETWORK_PEER_PORT] = port
+
+    return data

--- a/sentry_sdk/integrations/redis/modules/queries.py
+++ b/sentry_sdk/integrations/redis/modules/queries.py
@@ -43,8 +43,8 @@ def _get_db_span_description(integration, command_name, args):
     return description
 
 
-def _get_connection_data(span, connection_params):
-    # type: (Span, dict[str, Any]) -> None
+def _get_connection_data(connection_params):
+    # type: (dict[str, Any]) -> dict[str, Any]
     data = {
         SPANDATA.DB_SYSTEM: "redis",
     }
@@ -64,9 +64,9 @@ def _get_connection_data(span, connection_params):
     return data
 
 
-def _set_db_data(span, redis_instance):
-    # type: (Span, Redis[Any]) -> None
+def _get_db_data(redis_instance):
+    # type: (Redis[Any]) -> dict[str, Any]
     try:
-        _get_connection_data(span, redis_instance.connection_pool.connection_kwargs)
+        return _get_connection_data(redis_instance.connection_pool.connection_kwargs)
     except AttributeError:
-        pass  # connections_kwargs may be missing in some cases
+        return {}  # connections_kwargs may be missing in some cases

--- a/sentry_sdk/integrations/redis/modules/queries.py
+++ b/sentry_sdk/integrations/redis/modules/queries.py
@@ -43,26 +43,30 @@ def _get_db_span_description(integration, command_name, args):
     return description
 
 
-def _set_db_data_on_span(span, connection_params):
+def _get_connection_data(span, connection_params):
     # type: (Span, dict[str, Any]) -> None
-    span.set_data(SPANDATA.DB_SYSTEM, "redis")
+    data = {
+        SPANDATA.DB_SYSTEM: "redis",
+    }
 
     db = connection_params.get("db")
     if db is not None:
-        span.set_data(SPANDATA.DB_NAME, str(db))
+        data[SPANDATA.DB_NAME] = str(db)
 
     host = connection_params.get("host")
     if host is not None:
-        span.set_data(SPANDATA.SERVER_ADDRESS, host)
+        data[SPANDATA.SERVER_ADDRESS] = host
 
     port = connection_params.get("port")
     if port is not None:
-        span.set_data(SPANDATA.SERVER_PORT, port)
+        data[SPANDATA.SERVER_PORT] = port
+
+    return data
 
 
 def _set_db_data(span, redis_instance):
     # type: (Span, Redis[Any]) -> None
     try:
-        _set_db_data_on_span(span, redis_instance.connection_pool.connection_kwargs)
+        _get_connection_data(span, redis_instance.connection_pool.connection_kwargs)
     except AttributeError:
         pass  # connections_kwargs may be missing in some cases

--- a/sentry_sdk/integrations/redis/rb.py
+++ b/sentry_sdk/integrations/redis/rb.py
@@ -5,7 +5,7 @@ https://github.com/getsentry/rb
 """
 
 from sentry_sdk.integrations.redis._sync_common import patch_redis_client
-from sentry_sdk.integrations.redis.modules.queries import _set_db_data
+from sentry_sdk.integrations.redis.modules.queries import _get_db_data
 
 
 def _patch_rb():
@@ -18,15 +18,15 @@ def _patch_rb():
         patch_redis_client(
             rb.clients.FanoutClient,
             is_cluster=False,
-            set_db_data_fn=_set_db_data,
+            get_db_data_fn=_get_db_data,
         )
         patch_redis_client(
             rb.clients.MappingClient,
             is_cluster=False,
-            set_db_data_fn=_set_db_data,
+            get_db_data_fn=_get_db_data,
         )
         patch_redis_client(
             rb.clients.RoutingClient,
             is_cluster=False,
-            set_db_data_fn=_set_db_data,
+            get_db_data_fn=_get_db_data,
         )

--- a/sentry_sdk/integrations/redis/redis.py
+++ b/sentry_sdk/integrations/redis/redis.py
@@ -8,7 +8,7 @@ from sentry_sdk.integrations.redis._sync_common import (
     patch_redis_client,
     patch_redis_pipeline,
 )
-from sentry_sdk.integrations.redis.modules.queries import _set_db_data
+from sentry_sdk.integrations.redis.modules.queries import _get_db_data
 
 from typing import TYPE_CHECKING
 
@@ -26,13 +26,13 @@ def _patch_redis(StrictRedis, client):  # noqa: N803
     patch_redis_client(
         StrictRedis,
         is_cluster=False,
-        set_db_data_fn=_set_db_data,
+        get_db_data_fn=_get_db_data,
     )
     patch_redis_pipeline(
         client.Pipeline,
         is_cluster=False,
         get_command_args_fn=_get_redis_command_args,
-        set_db_data_fn=_set_db_data,
+        get_db_data_fn=_get_db_data,
     )
     try:
         strict_pipeline = client.StrictPipeline
@@ -43,7 +43,7 @@ def _patch_redis(StrictRedis, client):  # noqa: N803
             strict_pipeline,
             is_cluster=False,
             get_command_args_fn=_get_redis_command_args,
-            set_db_data_fn=_set_db_data,
+            get_db_data_fn=_get_db_data,
         )
 
     try:
@@ -59,11 +59,11 @@ def _patch_redis(StrictRedis, client):  # noqa: N803
         patch_redis_async_client(
             redis.asyncio.client.StrictRedis,
             is_cluster=False,
-            set_db_data_fn=_set_db_data,
+            get_db_data_fn=_get_db_data,
         )
         patch_redis_async_pipeline(
             redis.asyncio.client.Pipeline,
             False,
             _get_redis_command_args,
-            set_db_data_fn=_set_db_data,
+            get_db_data_fn=_get_db_data,
         )

--- a/sentry_sdk/integrations/redis/redis_cluster.py
+++ b/sentry_sdk/integrations/redis/redis_cluster.py
@@ -9,7 +9,7 @@ from sentry_sdk.integrations.redis._sync_common import (
     patch_redis_client,
     patch_redis_pipeline,
 )
-from sentry_sdk.integrations.redis.modules.queries import _set_db_data_on_span
+from sentry_sdk.integrations.redis.modules.queries import _get_connection_data
 from sentry_sdk.integrations.redis.utils import _parse_rediscluster_command
 
 from sentry_sdk.utils import capture_internal_exceptions
@@ -30,7 +30,7 @@ def _set_async_cluster_db_data(span, async_redis_cluster_instance):
     # type: (Span, AsyncRedisCluster[Any]) -> None
     default_node = async_redis_cluster_instance.get_default_node()
     if default_node is not None and default_node.connection_kwargs is not None:
-        _set_db_data_on_span(span, default_node.connection_kwargs)
+        _get_connection_data(span, default_node.connection_kwargs)
 
 
 def _set_async_cluster_pipeline_db_data(span, async_redis_cluster_pipeline_instance):
@@ -53,7 +53,7 @@ def _set_cluster_db_data(span, redis_cluster_instance):
             "host": default_node.host,
             "port": default_node.port,
         }
-        _set_db_data_on_span(span, connection_params)
+        _get_connection_data(span, connection_params)
 
 
 def _patch_redis_cluster():

--- a/sentry_sdk/integrations/redis/redis_cluster.py
+++ b/sentry_sdk/integrations/redis/redis_cluster.py
@@ -67,13 +67,13 @@ def _patch_redis_cluster():
         patch_redis_client(
             RedisCluster,
             is_cluster=True,
-            set_db_data_fn=_set_cluster_db_data,
+            get_db_data_fn=_set_cluster_db_data,
         )
         patch_redis_pipeline(
             cluster.ClusterPipeline,
             is_cluster=True,
             get_command_args_fn=_parse_rediscluster_command,
-            set_db_data_fn=_set_cluster_db_data,
+            get_db_data_fn=_set_cluster_db_data,
         )
 
     try:
@@ -89,11 +89,11 @@ def _patch_redis_cluster():
         patch_redis_async_client(
             async_cluster.RedisCluster,
             is_cluster=True,
-            set_db_data_fn=_set_async_cluster_db_data,
+            get_db_data_fn=_set_async_cluster_db_data,
         )
         patch_redis_async_pipeline(
             async_cluster.ClusterPipeline,
             is_cluster=True,
             get_command_args_fn=_parse_rediscluster_command,
-            set_db_data_fn=_set_async_cluster_pipeline_db_data,
+            get_db_data_fn=_set_async_cluster_pipeline_db_data,
         )

--- a/sentry_sdk/integrations/redis/redis_cluster.py
+++ b/sentry_sdk/integrations/redis/redis_cluster.py
@@ -44,8 +44,8 @@ def _set_async_cluster_pipeline_db_data(span, async_redis_cluster_pipeline_insta
         )
 
 
-def _set_cluster_db_data(span, redis_cluster_instance):
-    # type: (Span, RedisCluster[Any]) -> None
+def _get_cluster_db_data(redis_cluster_instance):
+    # type: (RedisCluster[Any]) -> dict[str, Any]
     default_node = redis_cluster_instance.get_default_node()
 
     if default_node is not None:
@@ -53,7 +53,9 @@ def _set_cluster_db_data(span, redis_cluster_instance):
             "host": default_node.host,
             "port": default_node.port,
         }
-        _get_connection_data(span, connection_params)
+        return _get_connection_data(connection_params)
+    else:
+        return {}
 
 
 def _patch_redis_cluster():
@@ -67,13 +69,13 @@ def _patch_redis_cluster():
         patch_redis_client(
             RedisCluster,
             is_cluster=True,
-            get_db_data_fn=_set_cluster_db_data,
+            get_db_data_fn=_get_cluster_db_data,
         )
         patch_redis_pipeline(
             cluster.ClusterPipeline,
             is_cluster=True,
             get_command_args_fn=_parse_rediscluster_command,
-            get_db_data_fn=_set_cluster_db_data,
+            get_db_data_fn=_get_cluster_db_data,
         )
 
     try:

--- a/sentry_sdk/integrations/redis/redis_cluster.py
+++ b/sentry_sdk/integrations/redis/redis_cluster.py
@@ -35,8 +35,8 @@ def _get_async_cluster_db_data(async_redis_cluster_instance):
         return {}
 
 
-def _set_async_cluster_pipeline_db_data(span, async_redis_cluster_pipeline_instance):
-    # type: (Span, AsyncClusterPipeline[Any]) -> dict[str, Any]
+def _get_async_cluster_pipeline_db_data(async_redis_cluster_pipeline_instance):
+    # type: (AsyncClusterPipeline[Any]) -> dict[str, Any]
     with capture_internal_exceptions():
         return _get_async_cluster_db_data(
             # the AsyncClusterPipeline has always had a `_client` attr but it is private so potentially problematic and mypy
@@ -98,5 +98,5 @@ def _patch_redis_cluster():
             async_cluster.ClusterPipeline,
             is_cluster=True,
             get_command_args_fn=_parse_rediscluster_command,
-            get_db_data_fn=_set_async_cluster_pipeline_db_data,
+            get_db_data_fn=_get_async_cluster_pipeline_db_data,
         )

--- a/sentry_sdk/integrations/redis/redis_py_cluster_legacy.py
+++ b/sentry_sdk/integrations/redis/redis_py_cluster_legacy.py
@@ -9,7 +9,7 @@ from sentry_sdk.integrations.redis._sync_common import (
     patch_redis_client,
     patch_redis_pipeline,
 )
-from sentry_sdk.integrations.redis.modules.queries import _set_db_data
+from sentry_sdk.integrations.redis.modules.queries import _get_db_data
 from sentry_sdk.integrations.redis.utils import _parse_rediscluster_command
 
 
@@ -23,7 +23,7 @@ def _patch_rediscluster():
     patch_redis_client(
         rediscluster.RedisCluster,
         is_cluster=True,
-        set_db_data_fn=_set_db_data,
+        get_db_data_fn=_get_db_data,
     )
 
     # up to v1.3.6, __version__ attribute is a tuple
@@ -37,7 +37,7 @@ def _patch_rediscluster():
         patch_redis_client(
             rediscluster.StrictRedisCluster,
             is_cluster=True,
-            set_db_data_fn=_set_db_data,
+            get_db_data_fn=_get_db_data,
         )
     else:
         pipeline_cls = rediscluster.pipeline.ClusterPipeline
@@ -46,5 +46,5 @@ def _patch_rediscluster():
         pipeline_cls,
         is_cluster=True,
         get_command_args_fn=_parse_rediscluster_command,
-        set_db_data_fn=_set_db_data,
+        get_db_data_fn=_get_db_data,
     )

--- a/sentry_sdk/integrations/redis/utils.py
+++ b/sentry_sdk/integrations/redis/utils.py
@@ -124,14 +124,12 @@ def _parse_rediscluster_command(command):
     return command.args
 
 
-def _get_pipeline_data(
-    is_cluster, get_command_args_fn, is_transaction, command_stack
-):
+def _get_pipeline_data(is_cluster, get_command_args_fn, is_transaction, command_stack):
     # type: (bool, Any, bool, Sequence[Any]) -> dict[str, Any]
     data = {
         "redis.is_cluster": is_cluster,
         "redis.transaction": is_transaction,
-    }
+    }  # type: dict[str, Any]
 
     commands = []
     for i, arg in enumerate(command_stack):
@@ -151,7 +149,8 @@ def _get_client_data(is_cluster, name, *args):
     # type: (bool, str, *Any) -> dict[str, Any]
     data = {
         "redis.is_cluster": is_cluster,
-    }
+    }  # type: dict[str, Any]
+
     if name:
         data["redis.command"] = name
         data[SPANDATA.DB_OPERATION] = name

--- a/sentry_sdk/integrations/redis/utils.py
+++ b/sentry_sdk/integrations/redis/utils.py
@@ -128,16 +128,20 @@ def _get_pipeline_data(
     return data
 
 
-def _set_client_data(span, is_cluster, name, *args):
-    # type: (Span, bool, str, *Any) -> None
-    span.set_tag("redis.is_cluster", is_cluster)
+def _get_client_data(is_cluster, name, *args):
+    # type: (bool, str, *Any) -> dict[str, Any]
+    data = {
+        "redis.is_cluster": is_cluster,
+    }
     if name:
-        span.set_tag("redis.command", name)
-        span.set_tag(SPANDATA.DB_OPERATION, name)
+        data["redis.command"] = name
+        data[SPANDATA.DB_OPERATION] = name
 
     if name and args:
         name_low = name.lower()
         if (name_low in _SINGLE_KEY_COMMANDS) or (
             name_low in _MULTI_KEY_COMMANDS and len(args) == 1
         ):
-            span.set_tag("redis.key", args[0])
+            data["redis.key"] = args[0]
+
+    return data

--- a/sentry_sdk/integrations/redis/utils.py
+++ b/sentry_sdk/integrations/redis/utils.py
@@ -18,7 +18,7 @@ if TYPE_CHECKING:
 
 
 TAG_KEYS = [
-    "redis.commands",
+    "redis.command",
     "redis.is_cluster",
     "redis.key",
     "redis.transaction",
@@ -42,17 +42,19 @@ def _update_span(span, *data_bags):
 def _create_breadcrumb(message, *data_bags):
     # type: (str, *dict[str, Any]) -> None
     """
-    Create a breadcrumb containing the data from the given data bags.
+    Create a breadcrumb containing the tags data from the given data bags.
     """
-    combined_data = {}
+    data = {}
     for data in data_bags:
-        combined_data.update(data)
+        for key, value in data.items():
+            if key in TAG_KEYS:
+                data[key] = value
 
     sentry_sdk.add_breadcrumb(
         message=message,
         type="redis",
         category="redis",
-        data=combined_data,
+        data=data,
     )
 
 

--- a/sentry_sdk/integrations/redis/utils.py
+++ b/sentry_sdk/integrations/redis/utils.py
@@ -16,6 +16,25 @@ if TYPE_CHECKING:
     from sentry_sdk.tracing import Span
 
 
+TAG_KEYS = [
+    "redis.commands",
+    "redis.is_cluster",
+    "redis.key",
+    "redis.transaction",
+    SPANDATA.DB_OPERATION,
+]
+
+
+def _update_span(span, *data_bags):
+    # type: (Span, *dict[str, Any]) -> None
+    for data in data_bags:
+        for key, value in data.items():
+            if key in TAG_KEYS:
+                span.set_tag(key, value)
+            else:
+                span.set_data(key, value)
+
+
 def _get_safe_command(name, args):
     # type: (str, Sequence[Any]) -> str
     command_parts = [name]

--- a/sentry_sdk/tracing_utils.py
+++ b/sentry_sdk/tracing_utils.py
@@ -157,14 +157,7 @@ def record_sql_queries(
 
 def maybe_create_breadcrumbs_from_span(scope, span):
     # type: (sentry_sdk.Scope, sentry_sdk.tracing.Span) -> None
-    if span.op == OP.DB_REDIS:
-        scope.add_breadcrumb(
-            message=span.description,
-            type="redis",
-            category="redis",
-            data=span._tags,
-        )
-    elif span.op == OP.HTTP_CLIENT:
+    if span.op == OP.HTTP_CLIENT:
         scope.add_breadcrumb(
             type="http",
             category="httplib",

--- a/tests/integrations/redis/test_redis.py
+++ b/tests/integrations/redis/test_redis.py
@@ -80,7 +80,7 @@ def test_redis_pipeline(
     }
 
 
-def test_sensitive_data(sentry_init, capture_events):
+def test_sensitive_data(sentry_init, capture_events, render_span_tree):
     # fakeredis does not support the AUTH command, so we need to mock it
     with mock.patch(
         "sentry_sdk.integrations.redis.utils._COMMANDS_INCLUDING_SENSITIVE_DATA",
@@ -100,12 +100,16 @@ def test_sensitive_data(sentry_init, capture_events):
             )  # because fakeredis does not support AUTH we use GET instead
 
         (event,) = events
-        spans = event["spans"]
-        assert spans[0]["op"] == "db.redis"
-        assert spans[0]["description"] == "GET [Filtered]"
+        assert (
+            render_span_tree(event)
+            == """\
+- op="": description=null
+  - op="db.redis": description="GET [Filtered]"\
+"""
+        )
 
 
-def test_pii_data_redacted(sentry_init, capture_events):
+def test_pii_data_redacted(sentry_init, capture_events, render_span_tree):
     sentry_init(
         integrations=[RedisIntegration()],
         traces_sample_rate=1.0,
@@ -120,15 +124,19 @@ def test_pii_data_redacted(sentry_init, capture_events):
         connection.delete("somekey1", "somekey2")
 
     (event,) = events
-    spans = event["spans"]
-    assert spans[0]["op"] == "db.redis"
-    assert spans[0]["description"] == "SET 'somekey1' [Filtered]"
-    assert spans[1]["description"] == "SET 'somekey2' [Filtered]"
-    assert spans[2]["description"] == "GET 'somekey2'"
-    assert spans[3]["description"] == "DEL 'somekey1' [Filtered]"
+    assert (
+        render_span_tree(event)
+        == """\
+- op="": description=null
+  - op="db.redis": description="SET 'somekey1' [Filtered]"
+  - op="db.redis": description="SET 'somekey2' [Filtered]"
+  - op="db.redis": description="GET 'somekey2'"
+  - op="db.redis": description="DEL 'somekey1' [Filtered]"\
+"""
+    )
 
 
-def test_pii_data_sent(sentry_init, capture_events):
+def test_pii_data_sent(sentry_init, capture_events, render_span_tree):
     sentry_init(
         integrations=[RedisIntegration()],
         traces_sample_rate=1.0,
@@ -144,15 +152,19 @@ def test_pii_data_sent(sentry_init, capture_events):
         connection.delete("somekey1", "somekey2")
 
     (event,) = events
-    spans = event["spans"]
-    assert spans[0]["op"] == "db.redis"
-    assert spans[0]["description"] == "SET 'somekey1' 'my secret string1'"
-    assert spans[1]["description"] == "SET 'somekey2' 'my secret string2'"
-    assert spans[2]["description"] == "GET 'somekey2'"
-    assert spans[3]["description"] == "DEL 'somekey1' 'somekey2'"
+    assert (
+        render_span_tree(event)
+        == """\
+- op="": description=null
+  - op="db.redis": description="SET 'somekey1' 'my secret string1'"
+  - op="db.redis": description="SET 'somekey2' 'my secret string2'"
+  - op="db.redis": description="GET 'somekey2'"
+  - op="db.redis": description="DEL 'somekey1' 'somekey2'"\
+"""
+    )
 
 
-def test_data_truncation(sentry_init, capture_events):
+def test_data_truncation(sentry_init, capture_events, render_span_tree):
     sentry_init(
         integrations=[RedisIntegration()],
         traces_sample_rate=1.0,
@@ -168,15 +180,17 @@ def test_data_truncation(sentry_init, capture_events):
         connection.set("somekey2", short_string)
 
     (event,) = events
-    spans = event["spans"]
-    assert spans[0]["op"] == "db.redis"
-    assert spans[0]["description"] == "SET 'somekey1' '%s..." % (
-        long_string[: 1024 - len("...") - len("SET 'somekey1' '")],
+    assert (
+        render_span_tree(event)
+        == f"""\
+- op="": description=null
+  - op="db.redis": description="SET 'somekey1' '{long_string[: 1024 - len("...") - len("SET 'somekey1' '")]}..."
+  - op="db.redis": description="SET 'somekey2' 'bbbbbbbbbb'"\
+"""
     )
-    assert spans[1]["description"] == "SET 'somekey2' '%s'" % (short_string,)
 
 
-def test_data_truncation_custom(sentry_init, capture_events):
+def test_data_truncation_custom(sentry_init, capture_events, render_span_tree):
     sentry_init(
         integrations=[RedisIntegration(max_data_size=30)],
         traces_sample_rate=1.0,
@@ -192,12 +206,14 @@ def test_data_truncation_custom(sentry_init, capture_events):
         connection.set("somekey2", short_string)
 
     (event,) = events
-    spans = event["spans"]
-    assert spans[0]["op"] == "db.redis"
-    assert spans[0]["description"] == "SET 'somekey1' '%s..." % (
-        long_string[: 30 - len("...") - len("SET 'somekey1' '")],
+    assert (
+        render_span_tree(event)
+        == f"""\
+- op="": description=null
+  - op="db.redis": description="SET 'somekey1' '{long_string[: 30 - len("...") - len("SET 'somekey1' '")]}..."
+  - op="db.redis": description="SET 'somekey2' '{short_string}'"\
+"""
     )
-    assert spans[1]["description"] == "SET 'somekey2' '%s'" % (short_string,)
 
 
 def test_breadcrumbs(sentry_init, capture_events):

--- a/tests/integrations/redis/test_redis_cache_module.py
+++ b/tests/integrations/redis/test_redis_cache_module.py
@@ -28,7 +28,7 @@ def test_no_cache_basic(sentry_init, capture_events):
         connection.get("mycachekey")
 
     (event,) = events
-    spans = event["spans"]
+    spans = sorted(event["spans"], key=lambda x: x["start_timestamp"])
     assert len(spans) == 1
     assert spans[0]["op"] == "db.redis"
 
@@ -53,7 +53,7 @@ def test_cache_basic(sentry_init, capture_events):
         connection.mget("mycachekey1", "mycachekey2")
 
     (event,) = events
-    spans = event["spans"]
+    spans = sorted(event["spans"], key=lambda x: x["start_timestamp"])
     assert len(spans) == 9
 
     # no cache support for hget command
@@ -96,7 +96,8 @@ def test_cache_keys(sentry_init, capture_events):
         connection.get("bl")
 
     (event,) = events
-    spans = event["spans"]
+    spans = sorted(event["spans"], key=lambda x: x["start_timestamp"])
+
     assert len(spans) == 6
     assert spans[0]["op"] == "db.redis"
     assert spans[0]["description"] == "GET 'somethingelse'"
@@ -133,7 +134,7 @@ def test_cache_data(sentry_init, capture_events):
         connection.get("mycachekey")
 
     (event,) = events
-    spans = event["spans"]
+    spans = sorted(event["spans"], key=lambda x: x["start_timestamp"])
 
     assert len(spans) == 6
 
@@ -222,7 +223,7 @@ def test_cache_prefixes(sentry_init, capture_events):
 
     (event,) = events
 
-    spans = event["spans"]
+    spans = sorted(event["spans"], key=lambda x: x["start_timestamp"])
     assert len(spans) == 13  # 8 db spans + 5 cache spans
 
     cache_spans = [span for span in spans if span["op"] == "cache.get"]

--- a/tests/integrations/redis/test_redis_cache_module.py
+++ b/tests/integrations/redis/test_redis_cache_module.py
@@ -14,7 +14,7 @@ import sentry_sdk
 FAKEREDIS_VERSION = parse_version(fakeredis.__version__)
 
 
-def test_no_cache_basic(sentry_init, capture_events):
+def test_no_cache_basic(sentry_init, capture_events, render_span_tree):
     sentry_init(
         integrations=[
             RedisIntegration(),
@@ -28,12 +28,16 @@ def test_no_cache_basic(sentry_init, capture_events):
         connection.get("mycachekey")
 
     (event,) = events
-    spans = sorted(event["spans"], key=lambda x: x["start_timestamp"])
-    assert len(spans) == 1
-    assert spans[0]["op"] == "db.redis"
+    assert (
+        render_span_tree(event)
+        == """\
+- op="": description=null
+  - op="db.redis": description="GET 'mycachekey'"\
+"""
+    )
 
 
-def test_cache_basic(sentry_init, capture_events):
+def test_cache_basic(sentry_init, capture_events, render_span_tree):
     sentry_init(
         integrations=[
             RedisIntegration(
@@ -53,31 +57,25 @@ def test_cache_basic(sentry_init, capture_events):
         connection.mget("mycachekey1", "mycachekey2")
 
     (event,) = events
-    spans = sorted(event["spans"], key=lambda x: x["start_timestamp"])
-    assert len(spans) == 9
-
-    # no cache support for hget command
-    assert spans[0]["op"] == "db.redis"
-    assert spans[0]["tags"]["redis.command"] == "HGET"
-
-    assert spans[1]["op"] == "cache.get"
-    assert spans[2]["op"] == "db.redis"
-    assert spans[2]["tags"]["redis.command"] == "GET"
-
-    assert spans[3]["op"] == "cache.put"
-    assert spans[4]["op"] == "db.redis"
-    assert spans[4]["tags"]["redis.command"] == "SET"
-
-    assert spans[5]["op"] == "cache.put"
-    assert spans[6]["op"] == "db.redis"
-    assert spans[6]["tags"]["redis.command"] == "SETEX"
-
-    assert spans[7]["op"] == "cache.get"
-    assert spans[8]["op"] == "db.redis"
-    assert spans[8]["tags"]["redis.command"] == "MGET"
+    # no cache support for HGET command
+    assert (
+        render_span_tree(event)
+        == """\
+- op="": description=null
+  - op="db.redis": description="HGET 'mycachekey' [Filtered]"
+  - op="cache.get": description="mycachekey"
+    - op="db.redis": description="GET 'mycachekey'"
+  - op="cache.put": description="mycachekey1"
+    - op="db.redis": description="SET 'mycachekey1' [Filtered]"
+  - op="cache.put": description="mycachekey2"
+    - op="db.redis": description="SETEX 'mycachekey2' [Filtered] [Filtered]"
+  - op="cache.get": description="mycachekey1, mycachekey2"
+    - op="db.redis": description="MGET 'mycachekey1' [Filtered]"\
+"""
+    )
 
 
-def test_cache_keys(sentry_init, capture_events):
+def test_cache_keys(sentry_init, capture_events, render_span_tree):
     sentry_init(
         integrations=[
             RedisIntegration(
@@ -96,24 +94,18 @@ def test_cache_keys(sentry_init, capture_events):
         connection.get("bl")
 
     (event,) = events
-    spans = sorted(event["spans"], key=lambda x: x["start_timestamp"])
-
-    assert len(spans) == 6
-    assert spans[0]["op"] == "db.redis"
-    assert spans[0]["description"] == "GET 'somethingelse'"
-
-    assert spans[1]["op"] == "cache.get"
-    assert spans[1]["description"] == "blub"
-    assert spans[2]["op"] == "db.redis"
-    assert spans[2]["description"] == "GET 'blub'"
-
-    assert spans[3]["op"] == "cache.get"
-    assert spans[3]["description"] == "blubkeything"
-    assert spans[4]["op"] == "db.redis"
-    assert spans[4]["description"] == "GET 'blubkeything'"
-
-    assert spans[5]["op"] == "db.redis"
-    assert spans[5]["description"] == "GET 'bl'"
+    assert (
+        render_span_tree(event)
+        == """\
+- op="": description=null
+  - op="db.redis": description="GET 'somethingelse'"
+  - op="cache.get": description="blub"
+    - op="db.redis": description="GET 'blub'"
+  - op="cache.get": description="blubkeything"
+    - op="db.redis": description="GET 'blubkeything'"
+  - op="db.redis": description="GET 'bl'"\
+"""
+    )
 
 
 def test_cache_data(sentry_init, capture_events):


### PR DESCRIPTION
This moves the creation of `redis` breadcrumbs from the `maybe_create_breadcrumbs_from_span` into the integrations. And as well fixes some span related tests by using `render_span_tree`.