### PR TITLE
Fix asyncpg breadcrumbs

### DIFF
--- a/sentry_sdk/integrations/asyncpg.py
+++ b/sentry_sdk/integrations/asyncpg.py
@@ -178,11 +178,6 @@ def _wrap_connect_addr(f: Callable[..., Awaitable[T]]) -> Callable[..., Awaitabl
             _set_on_span(span, data)
 
             with capture_internal_exceptions():
-                # XXX
-                #    "db.cursor",
-                #    "db.params",
-                #    "db.paramstyle",
-
                 sentry_sdk.add_breadcrumb(
                     message="connect", category="query", data=data
                 )

--- a/sentry_sdk/integrations/asyncpg.py
+++ b/sentry_sdk/integrations/asyncpg.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 import contextlib
-from typing import Any, TypeVar, Callable, Awaitable, Iterator
+from typing import Any, TypeVar, Callable, Awaitable, Iterator, Optional
 
 import sentry_sdk
 from sentry_sdk.consts import OP, SPANDATA
@@ -20,6 +20,7 @@ try:
 
 except ImportError:
     raise DidNotEnable("asyncpg not installed.")
+
 
 # asyncpg.__version__ is a string containing the semantic version in the form of "<major>.<minor>.<patch>"
 asyncpg_version = parse_version(asyncpg.__version__)
@@ -123,10 +124,13 @@ def _wrap_connection_method(
     async def _inner(*args: Any, **kwargs: Any) -> T:
         if sentry_sdk.get_client().get_integration(AsyncPGIntegration) is None:
             return await f(*args, **kwargs)
+
         query = args[1]
         params_list = args[2] if len(args) > 2 else None
+
         with _record(None, query, params_list, executemany=executemany) as span:
-            _set_db_data(span, args[0])
+            data = _get_db_data(conn=args[0])
+            _set_on_span(span, data)
             res = await f(*args, **kwargs)
 
         return res
@@ -146,7 +150,8 @@ def _wrap_cursor_creation(f: Callable[..., T]) -> Callable[..., T]:
             params_list,
             executemany=False,
         ) as span:
-            _set_db_data(span, args[0])
+            data = _get_db_data(conn=args[0])
+            _set_on_span(span, data)
             res = f(*args, **kwargs)
             span.set_attribute("db.cursor", _serialize_span_attribute(res))
 
@@ -160,40 +165,23 @@ def _wrap_connect_addr(f: Callable[..., Awaitable[T]]) -> Callable[..., Awaitabl
         if sentry_sdk.get_client().get_integration(AsyncPGIntegration) is None:
             return await f(*args, **kwargs)
 
-        user = kwargs["params"].user
-        database = kwargs["params"].database
-
         with sentry_sdk.start_span(
             op=OP.DB,
             name="connect",
             origin=AsyncPGIntegration.origin,
         ) as span:
-            span.set_attribute(SPANDATA.DB_SYSTEM, "postgresql")
-            addr = kwargs.get("addr")
-            if addr:
-                try:
-                    span.set_attribute(SPANDATA.SERVER_ADDRESS, addr[0])
-                    span.set_attribute(SPANDATA.SERVER_PORT, addr[1])
-                except IndexError:
-                    pass
-
-            span.set_attribute(SPANDATA.DB_NAME, database)
-            span.set_attribute(SPANDATA.DB_USER, user)
+            data = _get_db_data(
+                addr=kwargs.get("addr"),
+                database=kwargs["params"].database,
+                user=kwargs["params"].user,
+            )
+            _set_on_span(span, data)
 
             with capture_internal_exceptions():
-                data = {}
-                for attr in (
-                    "db.cursor",
-                    "db.params",
-                    "db.paramstyle",
-                    SPANDATA.DB_NAME,
-                    SPANDATA.DB_SYSTEM,
-                    SPANDATA.DB_USER,
-                    SPANDATA.SERVER_ADDRESS,
-                    SPANDATA.SERVER_PORT,
-                ):
-                    if span.get_attribute(attr):
-                        data[attr] = span.get_attribute(attr)
+                # XXX
+                #    "db.cursor",
+                #    "db.params",
+                #    "db.paramstyle",
 
                 sentry_sdk.add_breadcrumb(
                     message="connect", category="query", data=data
@@ -206,21 +194,37 @@ def _wrap_connect_addr(f: Callable[..., Awaitable[T]]) -> Callable[..., Awaitabl
     return _inner
 
 
-def _set_db_data(span: Span, conn: Any) -> None:
-    span.set_attribute(SPANDATA.DB_SYSTEM, "postgresql")
+def _get_db_data(
+    conn: Any = None,
+    addr: Optional[tuple[str]] = None,
+    database: Optional[str] = None,
+    user: Optional[str] = None,
+) -> dict[str, str]:
+    if conn is not None:
+        addr = conn._addr
+        database = conn._params.database
+        user = conn._params.user
 
-    addr = conn._addr
+    data = {
+        SPANDATA.DB_SYSTEM: "postgresql",
+    }
+
     if addr:
         try:
-            span.set_attribute(SPANDATA.SERVER_ADDRESS, addr[0])
-            span.set_attribute(SPANDATA.SERVER_PORT, addr[1])
+            data[SPANDATA.SERVER_ADDRESS] = addr[0]
+            data[SPANDATA.SERVER_PORT] = addr[1]
         except IndexError:
             pass
 
-    database = conn._params.database
     if database:
-        span.set_attribute(SPANDATA.DB_NAME, database)
+        data[SPANDATA.DB_NAME] = database
 
-    user = conn._params.user
     if user:
-        span.set_attribute(SPANDATA.DB_USER, user)
+        data[SPANDATA.DB_USER] = user
+
+    return data
+
+
+def _set_on_span(span: Span, data: dict[str, Any]):
+    for key, value in data.items():
+        span.set_attribute(key, value)

--- a/tests/integrations/asyncpg/test_asyncpg.py
+++ b/tests/integrations/asyncpg/test_asyncpg.py
@@ -74,7 +74,6 @@ async def _clean_pg():
 async def test_connect(sentry_init, capture_events) -> None:
     sentry_init(
         integrations=[AsyncPGIntegration()],
-        traces_sample_rate=1.0,
         _experiments={"record_sql_params": True},
     )
     events = capture_events()
@@ -97,7 +96,6 @@ async def test_connect(sentry_init, capture_events) -> None:
 async def test_execute(sentry_init, capture_events) -> None:
     sentry_init(
         integrations=[AsyncPGIntegration()],
-        traces_sample_rate=1.0,
         _experiments={"record_sql_params": True},
     )
     events = capture_events()
@@ -163,7 +161,6 @@ async def test_execute(sentry_init, capture_events) -> None:
 async def test_execute_many(sentry_init, capture_events) -> None:
     sentry_init(
         integrations=[AsyncPGIntegration()],
-        traces_sample_rate=1.0,
         _experiments={"record_sql_params": True},
     )
     events = capture_events()
@@ -202,7 +199,6 @@ async def test_execute_many(sentry_init, capture_events) -> None:
 async def test_record_params(sentry_init, capture_events) -> None:
     sentry_init(
         integrations=[AsyncPGIntegration(record_params=True)],
-        traces_sample_rate=1.0,
         _experiments={"record_sql_params": True},
     )
     events = capture_events()
@@ -243,7 +239,6 @@ async def test_record_params(sentry_init, capture_events) -> None:
 async def test_cursor(sentry_init, capture_events) -> None:
     sentry_init(
         integrations=[AsyncPGIntegration()],
-        traces_sample_rate=1.0,
         _experiments={"record_sql_params": True},
     )
     events = capture_events()
@@ -308,7 +303,6 @@ async def test_cursor(sentry_init, capture_events) -> None:
 async def test_cursor_manual(sentry_init, capture_events) -> None:
     sentry_init(
         integrations=[AsyncPGIntegration()],
-        traces_sample_rate=1.0,
         _experiments={"record_sql_params": True},
     )
     events = capture_events()
@@ -375,7 +369,6 @@ async def test_cursor_manual(sentry_init, capture_events) -> None:
 async def test_prepared_stmt(sentry_init, capture_events) -> None:
     sentry_init(
         integrations=[AsyncPGIntegration()],
-        traces_sample_rate=1.0,
         _experiments={"record_sql_params": True},
     )
     events = capture_events()
@@ -425,7 +418,6 @@ async def test_prepared_stmt(sentry_init, capture_events) -> None:
 async def test_connection_pool(sentry_init, capture_events) -> None:
     sentry_init(
         integrations=[AsyncPGIntegration()],
-        traces_sample_rate=1.0,
         _experiments={"record_sql_params": True},
     )
     events = capture_events()
@@ -497,7 +489,7 @@ async def test_connection_pool(sentry_init, capture_events) -> None:
 async def test_query_source_disabled(sentry_init, capture_events):
     sentry_options = {
         "integrations": [AsyncPGIntegration()],
-        "enable_tracing": True,
+        "traces_sample_rate": 1.0,
         "enable_db_query_source": False,
         "db_query_source_threshold_ms": 0,
     }
@@ -535,7 +527,7 @@ async def test_query_source_enabled(
 ):
     sentry_options = {
         "integrations": [AsyncPGIntegration()],
-        "enable_tracing": True,
+        "traces_sample_rate": 1.0,
         "db_query_source_threshold_ms": 0,
     }
     if enable_db_query_source is not None:
@@ -571,7 +563,7 @@ async def test_query_source_enabled(
 async def test_query_source(sentry_init, capture_events):
     sentry_init(
         integrations=[AsyncPGIntegration()],
-        enable_tracing=True,
+        traces_sample_rate=1.0,
         enable_db_query_source=True,
         db_query_source_threshold_ms=0,
     )
@@ -621,7 +613,7 @@ async def test_query_source_with_module_in_search_path(sentry_init, capture_even
     """
     sentry_init(
         integrations=[AsyncPGIntegration()],
-        enable_tracing=True,
+        traces_sample_rate=1.0,
         enable_db_query_source=True,
         db_query_source_threshold_ms=0,
     )
@@ -667,7 +659,7 @@ async def test_query_source_with_module_in_search_path(sentry_init, capture_even
 async def test_no_query_source_if_duration_too_short(sentry_init, capture_events):
     sentry_init(
         integrations=[AsyncPGIntegration()],
-        enable_tracing=True,
+        traces_sample_rate=1.0,
         enable_db_query_source=True,
         db_query_source_threshold_ms=100,
     )
@@ -714,7 +706,7 @@ async def test_no_query_source_if_duration_too_short(sentry_init, capture_events
 async def test_query_source_if_duration_over_threshold(sentry_init, capture_events):
     sentry_init(
         integrations=[AsyncPGIntegration()],
-        enable_tracing=True,
+        traces_sample_rate=1.0,
         enable_db_query_source=True,
         db_query_source_threshold_ms=100,
     )


### PR DESCRIPTION
We can't use data stored on the span because it might be a NonRecordingSpan that doesn't carry any data.

Fixes https://github.com/getsentry/sentry-python/issues/3681