### PR TITLE
Fix pymongo

### DIFF
--- a/MIGRATION_GUIDE.md
+++ b/MIGRATION_GUIDE.md
@@ -25,8 +25,8 @@ Looking to upgrade from Sentry SDK 2.x to 3.x? Here's a comprehensive list of wh
 
 - Spans no longer have a `description`. Use `name` instead.
 - Dropped support for Python 3.6.
-- The PyMongo integration no longer sets tags. The data is still accessible via `data`.
-- The PyMongo integration doesn't set `operation_ids` anymore. The individual IDs (`operation_id`, `request_id`, `session_id`) are now accessible on the top level.
+- The PyMongo integration no longer sets tags. The data is still accessible via span attributes.
+- The PyMongo integration doesn't set `operation_ids` anymore. The individual IDs (`operation_id`, `request_id`, `session_id`) are now accessible as separate span attributes.
 - `sentry_sdk.metrics` and associated metrics APIs have been removed as Sentry no longer accepts metrics data in this form. See https://sentry.zendesk.com/hc/en-us/articles/26369339769883-Upcoming-API-Changes-to-Metrics
 - The experimental options `enable_metrics`, `before_emit_metric` and `metric_code_locations` have been removed.
 - When setting span status, the HTTP status code is no longer automatically added as a tag.

--- a/MIGRATION_GUIDE.md
+++ b/MIGRATION_GUIDE.md
@@ -24,6 +24,7 @@ Looking to upgrade from Sentry SDK 2.x to 3.x? Here's a comprehensive list of wh
 
 - Spans no longer have a `description`. Use `name` instead.
 - Dropped support for Python 3.6.
+- The PyMongo integration no longer sets tags. The data is still accessible via `data`.
 - `sentry_sdk.metrics` and associated metrics APIs have been removed as Sentry no longer accepts metrics data in this form. See https://sentry.zendesk.com/hc/en-us/articles/26369339769883-Upcoming-API-Changes-to-Metrics
 - The experimental options `enable_metrics`, `before_emit_metric` and `metric_code_locations` have been removed.
 - When setting span status, the HTTP status code is no longer automatically added as a tag.

--- a/MIGRATION_GUIDE.md
+++ b/MIGRATION_GUIDE.md
@@ -25,6 +25,7 @@ Looking to upgrade from Sentry SDK 2.x to 3.x? Here's a comprehensive list of wh
 - Spans no longer have a `description`. Use `name` instead.
 - Dropped support for Python 3.6.
 - The PyMongo integration no longer sets tags. The data is still accessible via `data`.
+- The PyMongo integration doesn't set `operation_ids` anymore. The individual IDs (`operation_id`, `request_id`, `session_id`) are now accessible on the top level.
 - `sentry_sdk.metrics` and associated metrics APIs have been removed as Sentry no longer accepts metrics data in this form. See https://sentry.zendesk.com/hc/en-us/articles/26369339769883-Upcoming-API-Changes-to-Metrics
 - The experimental options `enable_metrics`, `before_emit_metric` and `metric_code_locations` have been removed.
 - When setting span status, the HTTP status code is no longer automatically added as a tag.

--- a/MIGRATION_GUIDE.md
+++ b/MIGRATION_GUIDE.md
@@ -10,6 +10,7 @@ Looking to upgrade from Sentry SDK 2.x to 3.x? Here's a comprehensive list of wh
 ### Changed
 
 - The SDK now supports Python 3.7 and higher.
+- Transaction names can no longer contain commas and equals signs. If present, these characters will be stripped.
 - `sentry_sdk.start_span` now only takes keyword arguments.
 - `sentry_sdk.start_span` no longer takes an explicit `span` argument.
 - The `Span()` constructor does not accept a `hub` parameter anymore.

--- a/sentry_sdk/integrations/pymongo.py
+++ b/sentry_sdk/integrations/pymongo.py
@@ -163,10 +163,6 @@ class CommandTracer(monitoring.CommandListener):
             )
 
             for tag, value in tags.items():
-                # set the tag for backwards-compatibility.
-                # TODO: remove the set_tag call in the next major release!
-                span.set_tag(tag, value)
-
                 span.set_data(tag, value)
 
             for key, value in data.items():

--- a/sentry_sdk/integrations/pymongo.py
+++ b/sentry_sdk/integrations/pymongo.py
@@ -1,12 +1,11 @@
 import copy
-import json
 
 import sentry_sdk
 from sentry_sdk.consts import SPANSTATUS, SPANDATA, OP
 from sentry_sdk.integrations import DidNotEnable, Integration
 from sentry_sdk.scope import should_send_default_pii
 from sentry_sdk.tracing import Span
-from sentry_sdk.utils import capture_internal_exceptions
+from sentry_sdk.utils import capture_internal_exceptions, _serialize_span_attribute
 
 try:
     from pymongo import monitoring
@@ -127,51 +126,48 @@ class CommandTracer(monitoring.CommandListener):
             command.pop("$clusterTime", None)
             command.pop("$signature", None)
 
-            tags = {
-                "db.name": event.database_name,
+            data = {
+                SPANDATA.DB_NAME: event.database_name,
                 SPANDATA.DB_SYSTEM: "mongodb",
                 SPANDATA.DB_OPERATION: event.command_name,
                 SPANDATA.DB_MONGODB_COLLECTION: command.get(event.command_name),
             }
 
             try:
-                tags["net.peer.name"] = event.connection_id[0]
-                tags["net.peer.port"] = str(event.connection_id[1])
+                data["net.peer.name"] = event.connection_id[0]
+                data["net.peer.port"] = str(event.connection_id[1])
             except TypeError:
                 pass
 
-            data = {"operation_ids": {}}  # type: Dict[str, Any]
-            data["operation_ids"]["operation"] = event.operation_id
-            data["operation_ids"]["request"] = event.request_id
-
-            data.update(_get_db_data(event))
-
             try:
                 lsid = command.pop("lsid")["id"]
-                data["operation_ids"]["session"] = str(lsid)
+                data["session_id"] = str(lsid)
             except KeyError:
                 pass
 
             if not should_send_default_pii():
                 command = _strip_pii(command)
 
-            query = json.dumps(command, default=str)
+            query = _serialize_span_attribute(command)
             span = sentry_sdk.start_span(
                 op=OP.DB,
                 name=query,
                 origin=PyMongoIntegration.origin,
             )
 
-            for tag, value in tags.items():
-                span.set_data(tag, value)
-
-            for key, value in data.items():
-                span.set_data(key, value)
-
             with capture_internal_exceptions():
                 sentry_sdk.add_breadcrumb(
-                    message=query, category="query", type=OP.DB, data=tags
+                    message=query, category="query", type=OP.DB, data=data
                 )
+
+            for key, value in data.items():
+                span.set_attribute(key, value)
+
+            for key, value in _get_db_data(event).items():
+                span.set_attribute(key, value)
+
+            span.set_attribute("operation_id", event.operation_id)
+            span.set_attribute("request_id", event.request_id)
 
             self._ongoing_operations[self._operation_key(event)] = span.__enter__()
 

--- a/tests/integrations/pymongo/test_pymongo.py
+++ b/tests/integrations/pymongo/test_pymongo.py
@@ -49,7 +49,7 @@ def test_transactions(sentry_init, capture_events, mongo_server, with_pii):
     (event,) = events
     (find, insert_success, insert_fail) = event["spans"]
 
-    common_tags = {
+    common_data = {
         "db.name": "test_db",
         "db.system": "mongodb",
         "net.peer.name": mongo_server.host,
@@ -60,8 +60,7 @@ def test_transactions(sentry_init, capture_events, mongo_server, with_pii):
         assert span["data"][SPANDATA.DB_NAME] == "test_db"
         assert span["data"][SPANDATA.SERVER_ADDRESS] == "localhost"
         assert span["data"][SPANDATA.SERVER_PORT] == mongo_server.port
-        for field, value in common_tags.items():
-            assert span["tags"][field] == value
+        for field, value in common_data.items():
             assert span["data"][field] == value
 
     assert find["op"] == "db"
@@ -69,22 +68,16 @@ def test_transactions(sentry_init, capture_events, mongo_server, with_pii):
     assert insert_fail["op"] == "db"
 
     assert find["data"]["db.operation"] == "find"
-    assert find["tags"]["db.operation"] == "find"
     assert insert_success["data"]["db.operation"] == "insert"
-    assert insert_success["tags"]["db.operation"] == "insert"
     assert insert_fail["data"]["db.operation"] == "insert"
-    assert insert_fail["tags"]["db.operation"] == "insert"
 
     assert find["description"].startswith('{"find')
     assert insert_success["description"].startswith('{"insert')
     assert insert_fail["description"].startswith('{"insert')
 
     assert find["data"][SPANDATA.DB_MONGODB_COLLECTION] == "test_collection"
-    assert find["tags"][SPANDATA.DB_MONGODB_COLLECTION] == "test_collection"
     assert insert_success["data"][SPANDATA.DB_MONGODB_COLLECTION] == "test_collection"
-    assert insert_success["tags"][SPANDATA.DB_MONGODB_COLLECTION] == "test_collection"
     assert insert_fail["data"][SPANDATA.DB_MONGODB_COLLECTION] == "erroneous"
-    assert insert_fail["tags"][SPANDATA.DB_MONGODB_COLLECTION] == "erroneous"
     if with_pii:
         assert "1" in find["description"]
         assert "2" in insert_success["description"]
@@ -99,16 +92,22 @@ def test_transactions(sentry_init, capture_events, mongo_server, with_pii):
             and "4" not in insert_fail["description"]
         )
 
-    assert find["tags"]["status"] == "ok"
-    assert insert_success["tags"]["status"] == "ok"
-    assert insert_fail["tags"]["status"] == "internal_error"
 
-
-@pytest.mark.parametrize("with_pii", [False, True])
-def test_breadcrumbs(sentry_init, capture_events, mongo_server, with_pii):
+@pytest.mark.parametrize(
+    "with_pii,traces_sample_rate",
+    [
+        [False, 0.0],
+        [False, 1.0],
+        [True, 0.0],
+        [True, 1.0],
+    ],
+)
+def test_breadcrumbs(
+    sentry_init, capture_events, mongo_server, with_pii, traces_sample_rate
+):
     sentry_init(
         integrations=[PyMongoIntegration()],
-        traces_sample_rate=1.0,
+        traces_sample_rate=traces_sample_rate,
         send_default_pii=with_pii,
     )
     events = capture_events()


### PR DESCRIPTION
Fix pymongo spans/breadcrumbs.

❗ **Important:** With this PR we're now stripping commas and equals signs from all span names because they're [not supported](https://github.com/open-telemetry/opentelemetry-python/blob/5de1ccbfe296abeb79a46d3a895eaf34a758c62d/opentelemetry-api/src/opentelemetry/trace/span.py#L28-L37) in OTel tracestate values.