### PR TITLE
Fix sqlalchemy spans

### DIFF
--- a/tests/integrations/sqlalchemy/test_sqlalchemy.py
+++ b/tests/integrations/sqlalchemy/test_sqlalchemy.py
@@ -1,5 +1,5 @@
 import os
-from datetime import datetime
+from datetime import datetime, timezone
 from unittest import mock
 
 import pytest
@@ -554,13 +554,9 @@ def test_no_query_source_if_duration_too_short(sentry_init, capture_events):
 
         class fake_record_sql_queries:  # noqa: N801
             def __init__(self, *args, **kwargs):
-                with freeze_time(datetime(2024, 1, 1, microsecond=0)):
+                with freeze_time(datetime(2024, 1, 1, microsecond=99999)):
                     with record_sql_queries(*args, **kwargs) as span:
                         self.span = span
-                        freezer = freeze_time(datetime(2024, 1, 1, microsecond=99999))
-                        freezer.start()
-
-                    freezer.stop()
 
             def __enter__(self):
                 return self.span
@@ -569,10 +565,14 @@ def test_no_query_source_if_duration_too_short(sentry_init, capture_events):
                 pass
 
         with mock.patch(
-            "sentry_sdk.integrations.sqlalchemy.record_sql_queries",
-            fake_record_sql_queries,
+            "sentry_sdk.tracing.POTelSpan.start_timestamp",
+            datetime(2024, 1, 1, microsecond=0, tzinfo=timezone.utc),
         ):
-            assert session.query(Person).first() == bob
+            with mock.patch(
+                "sentry_sdk.integrations.sqlalchemy.record_sql_queries",
+                fake_record_sql_queries,
+            ):
+                assert session.query(Person).first() == bob
 
     (event,) = events
 
@@ -622,13 +622,9 @@ def test_query_source_if_duration_over_threshold(sentry_init, capture_events):
 
         class fake_record_sql_queries:  # noqa: N801
             def __init__(self, *args, **kwargs):
-                with freeze_time(datetime(2024, 1, 1, microsecond=0)):
+                with freeze_time(datetime(2024, 1, 1, microsecond=100001)):
                     with record_sql_queries(*args, **kwargs) as span:
                         self.span = span
-                        freezer = freeze_time(datetime(2024, 1, 1, microsecond=99999))
-                        freezer.start()
-
-                    freezer.stop()
 
             def __enter__(self):
                 return self.span
@@ -637,10 +633,14 @@ def test_query_source_if_duration_over_threshold(sentry_init, capture_events):
                 pass
 
         with mock.patch(
-            "sentry_sdk.integrations.sqlalchemy.record_sql_queries",
-            fake_record_sql_queries,
+            "sentry_sdk.tracing.POTelSpan.start_timestamp",
+            datetime(2024, 1, 1, microsecond=0, tzinfo=timezone.utc),
         ):
-            assert session.query(Person).first() == bob
+            with mock.patch(
+                "sentry_sdk.integrations.sqlalchemy.record_sql_queries",
+                fake_record_sql_queries,
+            ):
+                assert session.query(Person).first() == bob
 
     (event,) = events
 


### PR DESCRIPTION
- query source moved to before the span finishes