### PR TITLE
fix(http2): Check for h2 existence

### DIFF
--- a/sentry_sdk/transport.py
+++ b/sentry_sdk/transport.py
@@ -720,6 +720,7 @@ class HttpTransport(BaseHttpTransport):
 
 try:
     import httpcore
+    import h2  # type: ignore
 except ImportError:
     # Sorry, no Http2Transport for you
     class Http2Transport(HttpTransport):

--- a/sentry_sdk/transport.py
+++ b/sentry_sdk/transport.py
@@ -720,7 +720,7 @@ class HttpTransport(BaseHttpTransport):
 
 try:
     import httpcore
-    import h2  # noqa: F401
+    import h2  # type: ignore # noqa: F401
 except ImportError:
     # Sorry, no Http2Transport for you
     class Http2Transport(HttpTransport):

--- a/sentry_sdk/transport.py
+++ b/sentry_sdk/transport.py
@@ -720,7 +720,7 @@ class HttpTransport(BaseHttpTransport):
 
 try:
     import httpcore
-    import h2  # type: ignore
+    import h2  # noqa: F401
 except ImportError:
     # Sorry, no Http2Transport for you
     class Http2Transport(HttpTransport):


### PR DESCRIPTION
The new `HTTP2Transport` needs `httpcore` _and_ `h2` and we only checked for `httpcore`. This caused runtime errors and dropping of all events during testing as the test platform had `httpcore` installed but not `h2`. This patch adds both as conditions for the new transport implementation. Ideally, when we switch out the old transport, we'd silently check for `h2` existence only and set the `http2` option accordingly.
