### PR TITLE
build: Remove Pytest pin

### DIFF
--- a/requirements-devenv.txt
+++ b/requirements-devenv.txt
@@ -1,5 +1,5 @@
 -r requirements-linting.txt
 -r requirements-testing.txt
 mockupdb # required by `pymongo` tests that are enabled by `pymongo` from linter requirements
-pytest<7.0.0 # https://github.com/pytest-dev/pytest/issues/9621; see tox.ini
+pytest
 pytest-asyncio

--- a/tests/integrations/celery/integration_tests/test_celery_beat_cron_monitoring.py
+++ b/tests/integrations/celery/integration_tests/test_celery_beat_cron_monitoring.py
@@ -151,3 +151,10 @@ def test_beat_task_crons_error(celery_init, capture_envelopes):
     assert check_in["type"] == "check_in"
     assert check_in["monitor_slug"] == "failure_from_beat"
     assert check_in["status"] == "error"
+
+
+def test_placeholder():
+    """Forked test cannot be last in a module.
+    See https://github.com/pytest-dev/pytest-forked/issues/67#issuecomment-1964718720.
+    """
+    assert True

--- a/tests/integrations/celery/test_celery.py
+++ b/tests/integrations/celery/test_celery.py
@@ -831,3 +831,10 @@ def test_send_task_wrapped(
     assert span["description"] == "very_creative_task_name"
     assert span["op"] == "queue.submit.celery"
     assert span["trace_id"] == kwargs["headers"]["sentry-trace"].split("-")[0]
+
+
+def test_placeholder():
+    """Forked test cannot be last in a module.
+    See https://github.com/pytest-dev/pytest-forked/issues/67#issuecomment-1964718720.
+    """
+    assert True

--- a/tests/integrations/django/test_cache_module.py
+++ b/tests/integrations/django/test_cache_module.py
@@ -626,3 +626,10 @@ def test_span_origin_cache(sentry_init, client, capture_events, use_django_cachi
             cache_span_found = True
 
     assert cache_span_found
+
+
+def test_placeholder():
+    """Forked test cannot be last in a module.
+    See https://github.com/pytest-dev/pytest-forked/issues/67#issuecomment-1964718720.
+    """
+    assert True

--- a/tests/integrations/django/test_data_scrubbing.py
+++ b/tests/integrations/django/test_data_scrubbing.py
@@ -82,3 +82,10 @@ def test_scrub_django_custom_session_cookies_filtered(
         "csrf_secret": "[Filtered]",
         "foo": "bar",
     }
+
+
+def test_placeholder():
+    """Forked test cannot be last in a module.
+    See https://github.com/pytest-dev/pytest-forked/issues/67#issuecomment-1964718720.
+    """
+    assert True

--- a/tests/integrations/django/test_db_query_data.py
+++ b/tests/integrations/django/test_db_query_data.py
@@ -524,3 +524,10 @@ def test_db_span_origin_executemany(sentry_init, client, capture_events):
 
     assert event["contexts"]["trace"]["origin"] == "manual"
     assert event["spans"][0]["origin"] == "auto.db.django"
+
+
+def test_placeholder():
+    """Forked test cannot be last in a module.
+    See https://github.com/pytest-dev/pytest-forked/issues/67#issuecomment-1964718720.
+    """
+    assert True

--- a/tests/integrations/opentelemetry/test_experimental.py
+++ b/tests/integrations/opentelemetry/test_experimental.py
@@ -45,3 +45,10 @@ def test_integration_not_enabled_if_option_is_missing(sentry_init, reset_integra
     ):
         sentry_init()
         mocked_setup_once.assert_not_called()
+
+
+def test_placeholder():
+    """Forked test cannot be last in a module.
+    See https://github.com/pytest-dev/pytest-forked/issues/67#issuecomment-1964718720.
+    """
+    assert True

--- a/tests/integrations/ray/test_ray.py
+++ b/tests/integrations/ray/test_ray.py
@@ -203,3 +203,10 @@ def test_ray_actor():
             == client_transaction["contexts"]["trace"]["trace_id"]
             == client_transaction["contexts"]["trace"]["trace_id"]
         )
+
+
+def test_placeholder():
+    """Forked test cannot be last in a module.
+    See https://github.com/pytest-dev/pytest-forked/issues/67#issuecomment-1964718720.
+    """
+    assert True

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -969,3 +969,10 @@ def test_disable_metrics_for_old_python_with_gevent(
 
     assert sentry_sdk.get_client().metrics_aggregator is None
     assert not envelopes
+
+
+def test_placeholder():
+    """Forked test cannot be last in a module.
+    See https://github.com/pytest-dev/pytest-forked/issues/67#issuecomment-1964718720.
+    """
+    assert True


### PR DESCRIPTION
Remove Pytest pin. This requires ensuring that any test modules which contain both forked and non-forked tests do not have a forked test as the last test in the module. See [here](https://github.com/pytest-dev/pytest-forked/issues/67#issuecomment-1964718720).

Closes #3035

