### PR TITLE
ci(tox): Exclude fakeredis 2.26.0 on py3.6 and 3.7

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -583,6 +583,7 @@ deps =
     # Redis
     redis: fakeredis!=1.7.4
     redis: pytest<8.0.0
+    {py3.6,py3.7}-redis: fakeredis!=2.26.0  # https://github.com/cunla/fakeredis-py/issues/341
     {py3.7,py3.8,py3.9,py3.10,py3.11}-redis: pytest-asyncio
     redis-v3: redis~=3.0
     redis-v4: redis~=4.0
@@ -602,7 +603,9 @@ deps =
     rq-v{0.6}: redis<3.2.2
     rq-v{0.13,1.0,1.5,1.10}: fakeredis>=1.0,<1.7.4
     rq-v{1.15,1.16}: fakeredis
+    {py3.6,py3.7}-rq-v{1.15,1.16}: fakeredis!=2.26.0  # https://github.com/cunla/fakeredis-py/issues/341
     rq-latest: fakeredis
+    {py3.6,py3.7}-rq-latest: fakeredis!=2.26.0  # https://github.com/cunla/fakeredis-py/issues/341
     rq-v0.6: rq~=0.6.0
     rq-v0.13: rq~=0.13.0
     rq-v1.0: rq~=1.0.0


### PR DESCRIPTION
`fakeredis` `2.26.0` [broke on Python 3.6 and 3.7](https://github.com/cunla/fakeredis-py/issues/341). A fix should be available when the next version is available.
