### PR TITLE
build: Remove `pytest` pin in `requirements-devenv.txt`

### DIFF
--- a/requirements-devenv.txt
+++ b/requirements-devenv.txt
@@ -1,5 +1,5 @@
 -r requirements-linting.txt
 -r requirements-testing.txt
 mockupdb # required by `pymongo` tests that are enabled by `pymongo` from linter requirements
-pytest<7.0.0 # https://github.com/pytest-dev/pytest/issues/9621; see tox.ini
+pytest
 pytest-asyncio


### PR DESCRIPTION
The `pytest` pin in `requirements-devenv.txt` appears to be unnecessary. Our tests anyways do not seem to respect this pin; the actual pins are defined for each environment in `tox.ini`.

ref #3035 