### PR TITLE
test(tox): Unpin pytest for Python 3.8+ common tests

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -294,8 +294,8 @@ deps =
     # See https://github.com/pytest-dev/pytest/issues/9621
     # and https://github.com/pytest-dev/pytest-forked/issues/67
     # for justification of the upper bound on pytest
-    {py3.6,py3.7,py3.8,py3.9,py3.10,py3.11,py3.12}-common: pytest<7.0.0
-    py3.13-common: pytest
+    {py3.6,py3.7}-common: pytest<7.0.0
+    {py3.8,py3.9,py3.10,py3.11,py3.12,py3.13}-common: pytest
 
     # === Gevent ===
     {py3.6,py3.7,py3.8,py3.9,py3.10,py3.11}-gevent: gevent>=22.10.0, <22.11.0


### PR DESCRIPTION
This pin appears to be unnecessary on Python 3.8+.

ref #3035 