### PR TITLE
ci: Run CodeQL action on all PRs

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -17,12 +17,14 @@ on:
       - master
       - sentry-sdk-2.0
   pull_request:
-    # The branches below must be a subset of the branches above
-    branches:
-      - master
-      - sentry-sdk-2.0
   schedule:
     - cron: '18 18 * * 3'
+
+# Cancel in progress workflows on pull_requests.
+# https://docs.github.com/en/actions/using-jobs/using-concurrency#example-using-a-fallback-value
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
 
 permissions:
   contents: read


### PR DESCRIPTION
This action only is triggered on PRs to `master`, but the action is required. This becomes a problem when a PR is opened against a branch other than `master` (e.g. as part of a PR tree). When the parent branch is merged to `master`, the PR's base automatically changes to `master`, but this action does not get triggered. Instead, it blocks on "Expected" and can only be run by adding commits to the branch.

Running the action on PRs against any branch should fix this.

Also, add logic to cancel in-progress workflows on pull requests (logic taken from our other actions)