### PR TITLE
ci: Run license compliance action on all PRs

### DIFF
--- a/.github/workflows/enforce-license-compliance.yml
+++ b/.github/workflows/enforce-license-compliance.yml
@@ -8,10 +8,11 @@ on:
       - release/*
       - sentry-sdk-2.0
   pull_request:
-    branches:
-      - master
-      - main
-      - sentry-sdk-2.0
+
+# Cancel in progress workflows on pull_requests.
+# https://docs.github.com/en/actions/using-jobs/using-concurrency#example-using-a-fallback-value
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
 
 jobs:
   enforce-license-compliance:


### PR DESCRIPTION
This action only is triggered on PRs to master, but the action is required. This becomes a problem when a PR is opened against a branch other than master (e.g. as part of a PR tree). When the parent branch is merged to master, the PR's base automatically changes to master, but this action does not get triggered. Instead, it blocks on "Expected" and can only be run by adding commits to the branch.

Running the action on PRs against any branch should fix this.

Also, add logic to cancel in-progress workflows on pull requests (logic taken from our other actions)

<!-- Describe your PR here -->

---

Thank you for contributing to `sentry-python`! Please add tests to validate your changes, and lint your code using `tox -e linters`.

Running the test suite on your PR might require maintainer approval. The AWS Lambda tests additionally require a maintainer to add a special label, and they will fail until this label is added.
