### PR TITLE
test(tox): Unpin `pytest` on Python 3.8+ `gevent` tests

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -303,7 +303,8 @@ deps =
     # See https://github.com/pytest-dev/pytest/issues/9621
     # and https://github.com/pytest-dev/pytest-forked/issues/67
     # for justification of the upper bound on pytest
-    {py3.6,py3.7,py3.8,py3.9,py3.10,py3.11,py3.12}-gevent: pytest<7.0.0
+    {py3.6,py3.7}-gevent: pytest<7.0.0
+    {py3.8,py3.9,py3.10,py3.11,py3.12}-gevent: pytest
 
     # === Integrations ===
 


### PR DESCRIPTION
The pin appears to be unnecessary in Python 3.8+.

ref #3035