### PR TITLE
test(tox): Unpin `pytest` for `celery` tests

### DIFF
--- a/tests/integrations/celery/test_celery.py
+++ b/tests/integrations/celery/test_celery.py
@@ -831,3 +831,11 @@ def test_send_task_wrapped(
     assert span["description"] == "very_creative_task_name"
     assert span["op"] == "queue.submit.celery"
     assert span["trace_id"] == kwargs["headers"]["sentry-trace"].split("-")[0]
+
+
+@pytest.mark.skip(reason="placeholder so that forked test does not come last")
+def test_placeholder():
+    """Forked tests must not come last in the module.
+    See https://github.com/pytest-dev/pytest-forked/issues/67#issuecomment-1964718720.
+    """
+    pass

--- a/tox.ini
+++ b/tox.ini
@@ -374,7 +374,6 @@ deps =
     celery-latest: Celery
 
     celery: newrelic
-    celery: pytest<7
     {py3.7}-celery: importlib-metadata<5.0
 
     # Chalice


### PR DESCRIPTION
Unpin `pytest` for Celery tests. This requires adding a placeholder test to workaround a [bug with `pytest-forked`](https://github.com/pytest-dev/pytest-forked/issues/67#issuecomment-1964718720).

ref #3035 