### PR TITLE
test(tox): Unpin `pytest` on Redis tests

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -582,7 +582,6 @@ deps =
 
     # Redis
     redis: fakeredis!=1.7.4
-    redis: pytest<8.0.0
     {py3.6,py3.7}-redis: fakeredis!=2.26.0  # https://github.com/cunla/fakeredis-py/issues/341
     {py3.7,py3.8,py3.9,py3.10,py3.11,py3.12,py3.13}-redis: pytest-asyncio
     redis-v3: redis~=3.0


### PR DESCRIPTION
<!-- Describe your PR here -->

---

Thank you for contributing to `sentry-python`! Please add tests to validate your changes, and lint your code using `tox -e linters`.

Running the test suite on your PR might require maintainer approval. The AWS Lambda tests additionally require a maintainer to add a special label, and they will fail until this label is added.
