### PR TITLE
test(redis): Install `pytest-asyncio` for `redis` tests (Python 3.12-13)

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -584,7 +584,7 @@ deps =
     redis: fakeredis!=1.7.4
     redis: pytest<8.0.0
     {py3.6,py3.7}-redis: fakeredis!=2.26.0  # https://github.com/cunla/fakeredis-py/issues/341
-    {py3.7,py3.8,py3.9,py3.10,py3.11}-redis: pytest-asyncio
+    {py3.7,py3.8,py3.9,py3.10,py3.11,py3.12,py3.13}-redis: pytest-asyncio
     redis-v3: redis~=3.0
     redis-v4: redis~=4.0
     redis-v5: redis~=5.0


### PR DESCRIPTION
Although we run the `redis` tests on Python 3.12 and 3.13, we don't install `pytest-asyncio` on these versions. We likely should.

