### PR TITLE
test: Disable broken RQ test in newly-released RQ 2.0

### DIFF
--- a/tests/integrations/rq/test_rq.py
+++ b/tests/integrations/rq/test_rq.py
@@ -35,6 +35,7 @@ def _patch_rq_get_server_version(monkeypatch):
 
 
 def crashing_job(foo):
+    print("RUNNING CRASHING JOB")
     1 / 0
 
 
@@ -253,6 +254,11 @@ def test_traces_sampler_gets_correct_values_in_sampling_context(
 
 @pytest.mark.skipif(
     parse_version(rq.__version__) < (1, 5), reason="At least rq-1.5 required"
+)
+@pytest.mark.skipif(
+    parse_version(rq.__version__) >= (2,),
+    reason="Test broke in RQ 2.0. Investigate and fix. "
+    "See https://github.com/getsentry/sentry-python/issues/3707.",
 )
 def test_job_with_retries(sentry_init, capture_events):
     sentry_init(integrations=[RqIntegration()])


### PR DESCRIPTION
See #3707
