### PR TITLE
Prefer python_multipart import over multipart

### DIFF
--- a/tests/integrations/starlette/test_starlette.py
+++ b/tests/integrations/starlette/test_starlette.py
@@ -13,16 +13,10 @@ import pytest
 
 from sentry_sdk import capture_message, get_baggage, get_traceparent
 from sentry_sdk.integrations.asgi import SentryAsgiMiddleware
-with warnings.catch_warnings():
-    # Error on deprecation-type warnings related to python_multipart, which are
-    # probably about migrating from "import multipart" to "import
-    # python_multipart".
-    for w in (PendingDeprecationWarning, DeprecationWarning):
-        warnings.filterwarnings("error", ".*python_multipart.*", category=w)
-    from sentry_sdk.integrations.starlette import (
-        StarletteIntegration,
-        StarletteRequestExtractor,
-    )
+from sentry_sdk.integrations.starlette import (
+    StarletteIntegration,
+    StarletteRequestExtractor,
+)
 from sentry_sdk.utils import parse_version
 
 import starlette


### PR DESCRIPTION
See: https://github.com/Kludex/python-multipart/issues/16

See also releases 0.0.13 through 0.0.16 at
https://github.com/Kludex/python-multipart/releases.

<!-- Describe your PR here -->

This prefers the new `python_multipart` import name for https://pypi.org/project/python-multipart/ introduced in release 0.0.13 to resolve conflicts with https://pypi.org/project/multipart/. A fallback to the original `multipart` import name remains for compatibility with older versions.

Starlette itself now does something similar:

https://github.com/encode/starlette/compare/0.41.0...0.41.2 

---

I tried `tox -e linters`, `tox -e py3.13-starlette-latest`, `tox -e py3.13-starlette-0.36`, and `tox -e py3.13-starlette-0.32` locally. I don’t expect any trouble with the rest of the test matrix.