### PR TITLE
test(rq): Remove accidentally-committed print

### DIFF
--- a/tests/integrations/rq/test_rq.py
+++ b/tests/integrations/rq/test_rq.py
@@ -35,7 +35,6 @@ def _patch_rq_get_server_version(monkeypatch):
 
 
 def crashing_job(foo):
-    print("RUNNING CRASHING JOB")
     1 / 0
 
 


### PR DESCRIPTION
#3708 got auto-merged before I had the chance to remove this print statement.
