### PR TITLE
ci: Clarify that only pinned tests are required

### DIFF
--- a/.github/workflows/test-integrations-ai.yml
+++ b/.github/workflows/test-integrations-ai.yml
@@ -165,7 +165,7 @@ jobs:
           files: .junitxml
           verbose: true
   check_required_tests:
-    name: All AI tests passed
+    name: All pinned AI tests passed
     needs: test-ai-pinned
     # Always run this, even if a dependent job failed
     if: always()

--- a/.github/workflows/test-integrations-aws-lambda.yml
+++ b/.github/workflows/test-integrations-aws-lambda.yml
@@ -112,7 +112,7 @@ jobs:
           files: .junitxml
           verbose: true
   check_required_tests:
-    name: All AWS Lambda tests passed
+    name: All pinned AWS Lambda tests passed
     needs: test-aws_lambda-pinned
     # Always run this, even if a dependent job failed
     if: always()

--- a/.github/workflows/test-integrations-cloud-computing.yml
+++ b/.github/workflows/test-integrations-cloud-computing.yml
@@ -157,7 +157,7 @@ jobs:
           files: .junitxml
           verbose: true
   check_required_tests:
-    name: All Cloud Computing tests passed
+    name: All pinned Cloud Computing tests passed
     needs: test-cloud_computing-pinned
     # Always run this, even if a dependent job failed
     if: always()

--- a/.github/workflows/test-integrations-common.yml
+++ b/.github/workflows/test-integrations-common.yml
@@ -77,7 +77,7 @@ jobs:
           files: .junitxml
           verbose: true
   check_required_tests:
-    name: All Common tests passed
+    name: All pinned Common tests passed
     needs: test-common-pinned
     # Always run this, even if a dependent job failed
     if: always()

--- a/.github/workflows/test-integrations-data-processing.yml
+++ b/.github/workflows/test-integrations-data-processing.yml
@@ -193,7 +193,7 @@ jobs:
           files: .junitxml
           verbose: true
   check_required_tests:
-    name: All Data Processing tests passed
+    name: All pinned Data Processing tests passed
     needs: test-data_processing-pinned
     # Always run this, even if a dependent job failed
     if: always()

--- a/.github/workflows/test-integrations-databases.yml
+++ b/.github/workflows/test-integrations-databases.yml
@@ -211,7 +211,7 @@ jobs:
           files: .junitxml
           verbose: true
   check_required_tests:
-    name: All Databases tests passed
+    name: All pinned Databases tests passed
     needs: test-databases-pinned
     # Always run this, even if a dependent job failed
     if: always()

--- a/.github/workflows/test-integrations-graphql.yml
+++ b/.github/workflows/test-integrations-graphql.yml
@@ -157,7 +157,7 @@ jobs:
           files: .junitxml
           verbose: true
   check_required_tests:
-    name: All GraphQL tests passed
+    name: All pinned GraphQL tests passed
     needs: test-graphql-pinned
     # Always run this, even if a dependent job failed
     if: always()

--- a/.github/workflows/test-integrations-miscellaneous.yml
+++ b/.github/workflows/test-integrations-miscellaneous.yml
@@ -165,7 +165,7 @@ jobs:
           files: .junitxml
           verbose: true
   check_required_tests:
-    name: All Miscellaneous tests passed
+    name: All pinned Miscellaneous tests passed
     needs: test-miscellaneous-pinned
     # Always run this, even if a dependent job failed
     if: always()

--- a/.github/workflows/test-integrations-networking.yml
+++ b/.github/workflows/test-integrations-networking.yml
@@ -157,7 +157,7 @@ jobs:
           files: .junitxml
           verbose: true
   check_required_tests:
-    name: All Networking tests passed
+    name: All pinned Networking tests passed
     needs: test-networking-pinned
     # Always run this, even if a dependent job failed
     if: always()

--- a/.github/workflows/test-integrations-web-frameworks-1.yml
+++ b/.github/workflows/test-integrations-web-frameworks-1.yml
@@ -193,7 +193,7 @@ jobs:
           files: .junitxml
           verbose: true
   check_required_tests:
-    name: All Web Frameworks 1 tests passed
+    name: All pinned Web Frameworks 1 tests passed
     needs: test-web_frameworks_1-pinned
     # Always run this, even if a dependent job failed
     if: always()

--- a/.github/workflows/test-integrations-web-frameworks-2.yml
+++ b/.github/workflows/test-integrations-web-frameworks-2.yml
@@ -205,7 +205,7 @@ jobs:
           files: .junitxml
           verbose: true
   check_required_tests:
-    name: All Web Frameworks 2 tests passed
+    name: All pinned Web Frameworks 2 tests passed
     needs: test-web_frameworks_2-pinned
     # Always run this, even if a dependent job failed
     if: always()

--- a/scripts/split-tox-gh-actions/templates/check_required.jinja
+++ b/scripts/split-tox-gh-actions/templates/check_required.jinja
@@ -1,5 +1,5 @@
   check_required_tests:
-    name: All {{ group }} tests passed
+    name: All pinned {{ group }} tests passed
     {% if "pinned" in categories %}
     needs: test-{{ group | replace(" ", "_") | lower }}-pinned
     {% endif %}


### PR DESCRIPTION
Rename the action that checks that all our pinned-version tests for our integrations are named "All pinned XXX tests passed" rather than just "All XXX tests passed." The old name was confusing because the action only checks that the pinned tests have passed.
