### PR TITLE
Fix WSGI tests

### DIFF
--- a/sentry_sdk/integrations/opentelemetry/utils.py
+++ b/sentry_sdk/integrations/opentelemetry/utils.py
@@ -234,7 +234,7 @@ def extract_span_status(span):
         return (inferred_status, http_status)
 
     if status and status.status_code == StatusCode.UNSET:
-        return (SPANSTATUS.OK, None)
+        return (None, None)
     else:
         return (SPANSTATUS.UNKNOWN_ERROR, None)
 
@@ -308,8 +308,10 @@ def get_trace_context(span, span_data=None):
         "parent_span_id": parent_span_id,
         "op": op,
         "origin": origin or DEFAULT_SPAN_ORIGIN,
-        "status": status,
     }  # type: dict[str, Any]
+
+    if status:
+        trace_context["status"] = status
 
     if span.attributes:
         trace_context["data"] = dict(span.attributes)

--- a/tests/integrations/opentelemetry/test_utils.py
+++ b/tests/integrations/opentelemetry/test_utils.py
@@ -16,54 +16,54 @@ from sentry_sdk.integrations.opentelemetry.utils import (
     [
         (
             "OTel Span Blank",
-            Status(StatusCode.UNSET),  # Unset defaults to OK
+            Status(StatusCode.UNSET),
             {},
             {
                 "op": "OTel Span Blank",
                 "description": "OTel Span Blank",
-                "status": "ok",
+                "status": None,
                 "http_status_code": None,
                 "origin": None,
             },
         ),
         (
             "OTel Span RPC",
-            Status(StatusCode.UNSET),  # Unset defaults to OK
+            Status(StatusCode.UNSET),
             {
                 "rpc.service": "myservice.EchoService",
             },
             {
                 "op": "rpc",
                 "description": "OTel Span RPC",
-                "status": "ok",
+                "status": None,
                 "http_status_code": None,
                 "origin": None,
             },
         ),
         (
             "OTel Span Messaging",
-            Status(StatusCode.UNSET),  # Unset defaults to OK
+            Status(StatusCode.UNSET),
             {
                 "messaging.system": "rabbitmq",
             },
             {
                 "op": "message",
                 "description": "OTel Span Messaging",
-                "status": "ok",
+                "status": None,
                 "http_status_code": None,
                 "origin": None,
             },
         ),
         (
             "OTel Span FaaS",
-            Status(StatusCode.UNSET),  # Unset defaults to OK
+            Status(StatusCode.UNSET),
             {
                 "faas.trigger": "pubsub",
             },
             {
                 "op": "pubsub",
                 "description": "OTel Span FaaS",
-                "status": "ok",
+                "status": None,
                 "http_status_code": None,
                 "origin": None,
             },
@@ -241,13 +241,13 @@ def test_span_data_for_db_query():
         ),
         (
             SpanKind.SERVER,
-            Status(StatusCode.UNSET),  # Unset defaults to OK
+            Status(StatusCode.UNSET),
             {
                 "http.method": "POST",
                 "http.route": "/some/route",
             },
             {
-                "status": "ok",
+                "status": None,
                 "http_status_code": None,
             },
         ),
@@ -336,15 +336,15 @@ def test_span_data_for_db_query():
             SpanKind.SERVER,
             Status(
                 StatusCode.ERROR, "I'm a teapot"
-            ),  # Error status with unknown description is an unknown error
+            ),
             {
                 "http.method": "POST",
                 "http.route": "/some/route",
                 "http.response.status_code": 418,
             },
             {
-                "status": "unknown_error",
-                "http_status_code": None,
+                "status": "invalid_argument",
+                "http_status_code": 418,
             },
         ),
         (


### PR DESCRIPTION
* Don't default to OK span status for UNSET, this breaks older behavior
* Set transaction name manually on scope after isolation (we should generally do this everywhere)
  * This is necessary because now *unsampled* spans are `NonRecordingSpan`s and therefore have no attributes - this is completely different behavior than our older tracing spans since we have active spans but they carry NO DATA. 
