### PR TITLE
[issue-2804] Handle the parameter `stack_info` for the `LoggingIntegration`

### DIFF
--- a/sentry_sdk/integrations/logging.py
+++ b/sentry_sdk/integrations/logging.py
@@ -202,7 +202,7 @@ class EventHandler(_BaseHandler):
                 client_options=client_options,
                 mechanism={"type": "logging", "handled": True},
             )
-        elif record.exc_info and record.exc_info[0] is None:
+        elif (record.exc_info and record.exc_info[0] is None) or record.stack_info:
             event = {}
             hint = {}
             with capture_internal_exceptions():

--- a/tests/integrations/logging/test_logging.py
+++ b/tests/integrations/logging/test_logging.py
@@ -77,11 +77,18 @@ def test_logging_extra_data_integer_keys(sentry_init, capture_events):
     assert event["extra"] == {"1": 1}
 
 
-def test_logging_stack(sentry_init, capture_events):
+@pytest.mark.parametrize(
+    "enable_stack_trace_kwarg",
+    (
+        pytest.param({"exc_info": True}, id="exc_info"),
+        pytest.param({"stack_info": True}, id="stack_info"),
+    ),
+)
+def test_logging_stack_trace(sentry_init, capture_events, enable_stack_trace_kwarg):
     sentry_init(integrations=[LoggingIntegration()], default_integrations=False)
     events = capture_events()
 
-    logger.error("first", exc_info=True)
+    logger.error("first", **enable_stack_trace_kwarg)
     logger.error("second")
 
     (


### PR DESCRIPTION
add capability for the logging integration to use the parameter 'stack_info' (added in Python 3.2). When set to True the stack trace will be retrieved and properly handled.

This feature is mapped in this [issue](https://github.com/getsentry/sentry-python/issues/2804).

---

Thank you for contributing to `sentry-python`! Please add tests to validate your changes, and lint your code using `tox -e linters`.

Running the test suite on your PR might require maintainer approval. The AWS Lambda tests additionally require a maintainer to add a special label, and they will fail until this label is added.
