### PR TITLE
Remove custom_sampling_context

### DIFF
--- a/MIGRATION_GUIDE.md
+++ b/MIGRATION_GUIDE.md
@@ -19,7 +19,7 @@ Looking to upgrade from Sentry SDK 2.x to 3.x? Here's a comprehensive list of wh
 - Redis integration: In Redis pipeline spans there is no `span["data"]["redis.commands"]` that contains a dict `{"count": 3, "first_ten": ["cmd1", "cmd2", ...]}` but instead `span["data"]["redis.commands.count"]` (containing `3`) and `span["data"]["redis.commands.first_ten"]` (containing `["cmd1", "cmd2", ...]`).
 - clickhouse-driver integration: The query is now available under the `db.query.text` span attribute (only if `send_default_pii` is `True`).
 - `sentry_sdk.init` now returns `None` instead of a context manager.
-- The sampling context accessible in `traces_sampler` has changed. It now contains all span attributes. The original `sampling_context["transaction_context"]["name"]` and `sampling_context["transaction_context"]["op"]` are now accessible as `sampling_context["sentry_name"]` and `sampling_context["sentry_op"]`, respectively.
+- The sampling context accessible in `traces_sampler` has changed. The original `sampling_context["transaction_context"]["name"]` and `sampling_context["transaction_context"]["op"]` are now accessible as `sampling_context["sentry_name"]` and `sampling_context["sentry_op"]`, respectively.
 
 ### Removed
 

--- a/MIGRATION_GUIDE.md
+++ b/MIGRATION_GUIDE.md
@@ -25,7 +25,7 @@ Looking to upgrade from Sentry SDK 2.x to 3.x? Here's a comprehensive list of wh
 
 - Spans no longer have a `description`. Use `name` instead.
 - Dropped support for Python 3.6.
-- The `custom_sampling_context` parameter of `start_transaction` has been removed. Use `attributes` instead to set key-value pairs of data that should be accessible in the traces sampler.
+- The `custom_sampling_context` parameter of `start_transaction` has been removed. Use `attributes` instead to set key-value pairs of data that should be accessible in the traces sampler. Note that span attributes need to conform to the [OpenTelemetry specification](https://opentelemetry.io/docs/concepts/signals/traces/#attributes), meaning only certain types can be set as values.
 - The PyMongo integration no longer sets tags. The data is still accessible via span attributes.
 - The PyMongo integration doesn't set `operation_ids` anymore. The individual IDs (`operation_id`, `request_id`, `session_id`) are now accessible as separate span attributes.
 - `sentry_sdk.metrics` and associated metrics APIs have been removed as Sentry no longer accepts metrics data in this form. See https://sentry.zendesk.com/hc/en-us/articles/26369339769883-Upcoming-API-Changes-to-Metrics

--- a/MIGRATION_GUIDE.md
+++ b/MIGRATION_GUIDE.md
@@ -19,12 +19,13 @@ Looking to upgrade from Sentry SDK 2.x to 3.x? Here's a comprehensive list of wh
 - Redis integration: In Redis pipeline spans there is no `span["data"]["redis.commands"]` that contains a dict `{"count": 3, "first_ten": ["cmd1", "cmd2", ...]}` but instead `span["data"]["redis.commands.count"]` (containing `3`) and `span["data"]["redis.commands.first_ten"]` (containing `["cmd1", "cmd2", ...]`).
 - clickhouse-driver integration: The query is now available under the `db.query.text` span attribute (only if `send_default_pii` is `True`).
 - `sentry_sdk.init` now returns `None` instead of a context manager.
+- The `sampling_context` argument of `traces_sampler` now additionally contains all span attributes known at span start.
 
 ### Removed
 
 - Spans no longer have a `description`. Use `name` instead.
 - Dropped support for Python 3.6.
-- The `custom_sampling_context` parameter of `start_transaction` has been removed.
+- The `custom_sampling_context` parameter of `start_transaction` has been removed. Use `attributes` instead to set key-value pairs of data that should be accessible in the traces sampler.
 - The PyMongo integration no longer sets tags. The data is still accessible via span attributes.
 - The PyMongo integration doesn't set `operation_ids` anymore. The individual IDs (`operation_id`, `request_id`, `session_id`) are now accessible as separate span attributes.
 - `sentry_sdk.metrics` and associated metrics APIs have been removed as Sentry no longer accepts metrics data in this form. See https://sentry.zendesk.com/hc/en-us/articles/26369339769883-Upcoming-API-Changes-to-Metrics

--- a/MIGRATION_GUIDE.md
+++ b/MIGRATION_GUIDE.md
@@ -19,7 +19,6 @@ Looking to upgrade from Sentry SDK 2.x to 3.x? Here's a comprehensive list of wh
 - Redis integration: In Redis pipeline spans there is no `span["data"]["redis.commands"]` that contains a dict `{"count": 3, "first_ten": ["cmd1", "cmd2", ...]}` but instead `span["data"]["redis.commands.count"]` (containing `3`) and `span["data"]["redis.commands.first_ten"]` (containing `["cmd1", "cmd2", ...]`).
 - clickhouse-driver integration: The query is now available under the `db.query.text` span attribute (only if `send_default_pii` is `True`).
 - `sentry_sdk.init` now returns `None` instead of a context manager.
-- The sampling context accessible in `traces_sampler` has changed. The original `sampling_context["transaction_context"]["name"]` and `sampling_context["transaction_context"]["op"]` are now accessible as `sampling_context["sentry_name"]` and `sampling_context["sentry_op"]`, respectively.
 
 ### Removed
 

--- a/MIGRATION_GUIDE.md
+++ b/MIGRATION_GUIDE.md
@@ -19,11 +19,13 @@ Looking to upgrade from Sentry SDK 2.x to 3.x? Here's a comprehensive list of wh
 - Redis integration: In Redis pipeline spans there is no `span["data"]["redis.commands"]` that contains a dict `{"count": 3, "first_ten": ["cmd1", "cmd2", ...]}` but instead `span["data"]["redis.commands.count"]` (containing `3`) and `span["data"]["redis.commands.first_ten"]` (containing `["cmd1", "cmd2", ...]`).
 - clickhouse-driver integration: The query is now available under the `db.query.text` span attribute (only if `send_default_pii` is `True`).
 - `sentry_sdk.init` now returns `None` instead of a context manager.
+- The sampling context accessible in `traces_sampler` has changed. It now contains all span attributes. The original `sampling_context["transaction_context"]["name"]` and `sampling_context["transaction_context"]["op"]` are now accessible as `sampling_context["sentry_name"]` and `sampling_context["sentry_op"]`, respectively.
 
 ### Removed
 
 - Spans no longer have a `description`. Use `name` instead.
 - Dropped support for Python 3.6.
+- The `custom_sampling_context` parameter of `start_transaction` has been removed.
 - The PyMongo integration no longer sets tags. The data is still accessible via span attributes.
 - The PyMongo integration doesn't set `operation_ids` anymore. The individual IDs (`operation_id`, `request_id`, `session_id`) are now accessible as separate span attributes.
 - `sentry_sdk.metrics` and associated metrics APIs have been removed as Sentry no longer accepts metrics data in this form. See https://sentry.zendesk.com/hc/en-us/articles/26369339769883-Upcoming-API-Changes-to-Metrics

--- a/sentry_sdk/api.py
+++ b/sentry_sdk/api.py
@@ -40,7 +40,6 @@ if TYPE_CHECKING:
         ExcInfo,
         MeasurementUnit,
         LogLevelStr,
-        SamplingContext,
     )
     from sentry_sdk.tracing import Span, TransactionKwargs
 
@@ -239,12 +238,8 @@ def flush(
     return get_client().flush(timeout=timeout, callback=callback)
 
 
-def start_span(
-    *,
-    custom_sampling_context=None,
-    **kwargs,  # type: Any
-):
-    # type: (...) -> POTelSpan
+def start_span(**kwargs):
+    # type: (type.Any) -> POTelSpan
     """
     Start and return a span.
 
@@ -257,13 +252,11 @@ def start_span(
     of the `with` block. If not using context managers, call the `finish()`
     method.
     """
-    # TODO: Consider adding type hints to the method signature.
-    return get_current_scope().start_span(custom_sampling_context, **kwargs)
+    return get_current_scope().start_span(**kwargs)
 
 
 def start_transaction(
     transaction=None,  # type: Optional[Transaction]
-    custom_sampling_context=None,  # type: Optional[SamplingContext]
     **kwargs,  # type: Unpack[TransactionKwargs]
 ):
     # type: (...) -> POTelSpan
@@ -295,14 +288,12 @@ def start_transaction(
 
     :param transaction: The transaction to start. If omitted, we create and
         start a new transaction.
-    :param custom_sampling_context: The transaction's custom sampling context.
     :param kwargs: Optional keyword arguments to be passed to the Transaction
         constructor. See :py:class:`sentry_sdk.tracing.Transaction` for
         available arguments.
     """
     return start_span(
         span=transaction,
-        custom_sampling_context=custom_sampling_context,
         **kwargs,
     )
 

--- a/sentry_sdk/integrations/opentelemetry/consts.py
+++ b/sentry_sdk/integrations/opentelemetry/consts.py
@@ -30,3 +30,5 @@ class SentrySpanAttribute:
     NAME = "sentry.name"
     SOURCE = "sentry.source"
     CONTEXT = "sentry.context"
+    CUSTOM_SAMPLED = "sentry.custom_sampled"
+    PARENT_SAMPLED = "sentry.parent_sampled"

--- a/sentry_sdk/integrations/opentelemetry/consts.py
+++ b/sentry_sdk/integrations/opentelemetry/consts.py
@@ -30,4 +30,4 @@ class SentrySpanAttribute:
     NAME = "sentry.name"
     SOURCE = "sentry.source"
     CONTEXT = "sentry.context"
-    CUSTOM_SAMPLED = "sentry.custom_sampled"
+    CUSTOM_SAMPLED = "sentry.custom_sampled"  # used for saving start_span(sampled=X)

--- a/sentry_sdk/integrations/opentelemetry/consts.py
+++ b/sentry_sdk/integrations/opentelemetry/consts.py
@@ -30,3 +30,4 @@ class SentrySpanAttribute:
     NAME = "sentry.name"
     SOURCE = "sentry.source"
     CONTEXT = "sentry.context"
+    CUSTOM_SAMPLED = "sentry.custom_sampled"

--- a/sentry_sdk/integrations/opentelemetry/consts.py
+++ b/sentry_sdk/integrations/opentelemetry/consts.py
@@ -30,5 +30,3 @@ class SentrySpanAttribute:
     NAME = "sentry.name"
     SOURCE = "sentry.source"
     CONTEXT = "sentry.context"
-    CUSTOM_SAMPLED = "sentry.custom_sampled"
-    PARENT_SAMPLED = "sentry.parent_sampled"

--- a/sentry_sdk/integrations/opentelemetry/sampler.py
+++ b/sentry_sdk/integrations/opentelemetry/sampler.py
@@ -132,7 +132,7 @@ class SentrySampler(Sampler):
             sampling_context = {
                 "transaction_context": {
                     "name": name,
-                    "op": attributes.get("op"),
+                    "op": attributes.get(SentrySpanAttribute.OP),
                 },
                 "parent_sampled": get_parent_sampled(parent_span_context, trace_id),
             }

--- a/sentry_sdk/integrations/opentelemetry/sampler.py
+++ b/sentry_sdk/integrations/opentelemetry/sampler.py
@@ -129,10 +129,14 @@ class SentrySampler(Sampler):
         # Traces_sampler is responsible to check parent sampled to have full transactions.
         has_traces_sampler = callable(client.options.get("traces_sampler"))
         if has_traces_sampler:
-            attributes[SentrySpanAttribute.PARENT_SAMPLED] = get_parent_sampled(
-                parent_span_context, trace_id
-            )
-            sample_rate = client.options["traces_sampler"](attributes)
+            sampling_context = {
+                "transaction_context": {
+                    "name": name,
+                    "op": attributes.get("op"),
+                },
+                "parent_sampled": get_parent_sampled(parent_span_context, trace_id),
+            }
+            sample_rate = client.options["traces_sampler"](sampling_context)
 
         else:
             # Check if there is a parent with a sampling decision

--- a/sentry_sdk/integrations/opentelemetry/sampler.py
+++ b/sentry_sdk/integrations/opentelemetry/sampler.py
@@ -136,6 +136,7 @@ class SentrySampler(Sampler):
                 },
                 "parent_sampled": get_parent_sampled(parent_span_context, trace_id),
             }
+            sampling_context.update(attributes)
             sample_rate = client.options["traces_sampler"](sampling_context)
 
         else:

--- a/sentry_sdk/integrations/opentelemetry/sampler.py
+++ b/sentry_sdk/integrations/opentelemetry/sampler.py
@@ -114,6 +114,8 @@ class SentrySampler(Sampler):
 
         parent_span_context = trace.get_current_span(parent_context).get_span_context()
 
+        attributes = attributes or {}
+
         # No tracing enabled, thus no sampling
         if not has_tracing_enabled(client.options):
             return dropped_result(parent_span_context, attributes)

--- a/sentry_sdk/integrations/opentelemetry/sampler.py
+++ b/sentry_sdk/integrations/opentelemetry/sampler.py
@@ -123,7 +123,10 @@ class SentrySampler(Sampler):
         # Explicit sampled value provided at start_span
         if attributes.get(SentrySpanAttribute.CUSTOM_SAMPLED) is not None:
             sample_rate = float(attributes[SentrySpanAttribute.CUSTOM_SAMPLED])
-            return sampled_result(parent_span_context, attributes, sample_rate)
+            if sample_rate > 0:
+                return sampled_result(parent_span_context, attributes, sample_rate)
+            else:
+                return dropped_result(parent_span_context, attributes)
 
         sample_rate = None
 

--- a/sentry_sdk/integrations/opentelemetry/scope.py
+++ b/sentry_sdk/integrations/opentelemetry/scope.py
@@ -24,7 +24,6 @@ if TYPE_CHECKING:
     from typing import Tuple, Optional, Generator, Dict, Any
     from typing_extensions import Unpack
 
-    from sentry_sdk._types import SamplingContext
     from sentry_sdk.tracing import TransactionKwargs
 
 
@@ -112,20 +111,18 @@ class PotelScope(Scope):
 
         return span_context
 
-    def start_transaction(self, custom_sampling_context=None, **kwargs):
-        # type: (Optional[SamplingContext], Unpack[TransactionKwargs]) -> POTelSpan
+    def start_transaction(self, **kwargs):
+        # type: (Unpack[TransactionKwargs]) -> POTelSpan
         """
         .. deprecated:: 3.0.0
             This function is deprecated and will be removed in a future release.
             Use :py:meth:`sentry_sdk.start_span` instead.
         """
-        return self.start_span(custom_sampling_context=custom_sampling_context)
+        return self.start_span(**kwargs)
 
-    def start_span(self, custom_sampling_context=None, **kwargs):
-        # type: (Optional[SamplingContext], Any) -> POTelSpan
-        return POTelSpan(
-            **kwargs, custom_sampling_context=custom_sampling_context, scope=self
-        )
+    def start_span(self, **kwargs):
+        # type: (Any) -> POTelSpan
+        return POTelSpan(**kwargs, scope=self)
 
 
 _INITIAL_CURRENT_SCOPE = PotelScope(ty=ScopeType.CURRENT)

--- a/sentry_sdk/integrations/opentelemetry/scope.py
+++ b/sentry_sdk/integrations/opentelemetry/scope.py
@@ -123,7 +123,9 @@ class PotelScope(Scope):
 
     def start_span(self, custom_sampling_context=None, **kwargs):
         # type: (Optional[SamplingContext], Any) -> POTelSpan
-        return POTelSpan(**kwargs, scope=self)
+        return POTelSpan(
+            **kwargs, custom_sampling_context=custom_sampling_context, scope=self
+        )
 
 
 _INITIAL_CURRENT_SCOPE = PotelScope(ty=ScopeType.CURRENT)

--- a/sentry_sdk/scope.py
+++ b/sentry_sdk/scope.py
@@ -946,9 +946,7 @@ class Scope:
         while len(self._breadcrumbs) > max_breadcrumbs:
             self._breadcrumbs.popleft()
 
-    def start_transaction(
-        self, transaction=None, custom_sampling_context=None, **kwargs
-    ):
+    def start_transaction(self, transaction=None, **kwargs):
         # type: (Optional[Transaction], Optional[SamplingContext], Unpack[TransactionKwargs]) -> Union[Transaction, NoOpSpan]
         """
         Start and return a transaction.
@@ -974,7 +972,6 @@ class Scope:
 
         :param transaction: The transaction to start. If omitted, we create and
             start a new transaction.
-        :param custom_sampling_context: The transaction's custom sampling context.
         :param kwargs: Optional keyword arguments to be passed to the Transaction
             constructor. See :py:class:`sentry_sdk.tracing.Transaction` for
             available arguments.
@@ -985,8 +982,6 @@ class Scope:
 
         try_autostart_continuous_profiler()
 
-        custom_sampling_context = custom_sampling_context or {}
-
         # if we haven't been given a transaction, make one
         transaction = Transaction(**kwargs)
 
@@ -996,7 +991,6 @@ class Scope:
             "transaction_context": transaction.to_json(),
             "parent_sampled": transaction.parent_sampled,
         }
-        sampling_context.update(custom_sampling_context)
         transaction._set_initial_sampling_decision(sampling_context=sampling_context)
 
         if transaction.sampled:

--- a/sentry_sdk/tracing.py
+++ b/sentry_sdk/tracing.py
@@ -1233,7 +1233,7 @@ class POTelSpan:
 
             span_name = name or description or op or ""
 
-            # Prepopulate some attrs to be accessible in traces_sampler
+            # Prepopulate some attrs so that they're accessible in traces_sampler
             attributes = attributes or {}
             attributes[SentrySpanAttribute.OP] = op
             if sampled is not None:

--- a/sentry_sdk/tracing.py
+++ b/sentry_sdk/tracing.py
@@ -1257,9 +1257,9 @@ class POTelSpan:
                     span_name, start_time=start_timestamp, attributes=attributes
                 )
 
-                self.name = name
                 self.origin = origin or DEFAULT_SPAN_ORIGIN
                 self.description = description
+                self.name = span_name
                 self.source = source
 
                 if status is not None:

--- a/sentry_sdk/tracing.py
+++ b/sentry_sdk/tracing.py
@@ -1235,7 +1235,6 @@ class POTelSpan:
 
             # Prepopulate some attrs to be accessible in traces_sampler
             attributes = attributes or {}
-            attributes[SentrySpanAttribute.NAME] = span_name
             attributes[SentrySpanAttribute.OP] = op
             if sampled is not None:
                 attributes[SentrySpanAttribute.CUSTOM_SAMPLED] = sampled
@@ -1244,6 +1243,7 @@ class POTelSpan:
                 span_name, start_time=start_timestamp, attributes=attributes
             )
 
+            self.name = name
             self.origin = origin or DEFAULT_SPAN_ORIGIN
             self.description = description
             self.source = source

--- a/tests/tracing/test_sampling.py
+++ b/tests/tracing/test_sampling.py
@@ -211,19 +211,6 @@ def test_passes_parent_sampling_decision_in_sampling_context(
     assert sampling_context["parent_sampled"]._mock_wraps is parent_sampling_decision
 
 
-def test_passes_custom_samling_context_from_start_transaction_to_traces_sampler(
-    sentry_init, DictionaryContaining  # noqa: N803
-):
-    traces_sampler = mock.Mock()
-    sentry_init(traces_sampler=traces_sampler)
-
-    start_transaction(custom_sampling_context={"dogs": "yes", "cats": "maybe"})
-
-    traces_sampler.assert_any_call(
-        DictionaryContaining({"dogs": "yes", "cats": "maybe"})
-    )
-
-
 def test_sample_rate_affects_errors(sentry_init, capture_events):
     sentry_init(sample_rate=0)
     events = capture_events()

--- a/tests/tracing/test_sampling.py
+++ b/tests/tracing/test_sampling.py
@@ -5,7 +5,7 @@ from unittest import mock
 import pytest
 
 import sentry_sdk
-from sentry_sdk import start_span, capture_exception
+from sentry_sdk import start_span, start_transaction, capture_exception
 from sentry_sdk.tracing import Transaction
 from sentry_sdk.utils import logger
 
@@ -13,7 +13,7 @@ from sentry_sdk.utils import logger
 def test_sampling_decided_only_for_transactions(sentry_init, capture_events):
     sentry_init(traces_sample_rate=0.5)
 
-    with start_span(name="hi") as transaction:
+    with start_transaction(name="hi") as transaction:
         assert transaction.sampled is not None
 
         with start_span() as span:
@@ -24,14 +24,16 @@ def test_sampling_decided_only_for_transactions(sentry_init, capture_events):
 
 
 @pytest.mark.parametrize("sampled", [True, False])
-def test_nested_span_sampling_override(sentry_init, sampled):
+def test_nested_transaction_sampling_override(sentry_init, sampled):
     sentry_init(traces_sample_rate=1.0)
 
-    with start_span(name="outer", sampled=sampled) as outer_span:
-        assert outer_span.sampled is sampled
-        with start_span(name="inner", sampled=(not sampled)) as inner_span:
-            assert inner_span.sampled is not sampled
-        assert outer_span.sampled is sampled
+    with start_transaction(name="outer", sampled=sampled) as outer_transaction:
+        assert outer_transaction.sampled is sampled
+        with start_transaction(
+            name="inner", sampled=(not sampled)
+        ) as inner_transaction:
+            assert inner_transaction.sampled is not sampled
+        assert outer_transaction.sampled is sampled
 
 
 def test_no_double_sampling(sentry_init, capture_events):
@@ -40,19 +42,19 @@ def test_no_double_sampling(sentry_init, capture_events):
     sentry_init(traces_sample_rate=1.0, sample_rate=0.0)
     events = capture_events()
 
-    with start_span(name="/"):
+    with start_transaction(name="/"):
         pass
 
     assert len(events) == 1
 
 
 @pytest.mark.parametrize("sampling_decision", [True, False])
-def test_get_span_from_scope_regardless_of_sampling_decision(
+def test_get_transaction_and_span_from_scope_regardless_of_sampling_decision(
     sentry_init, sampling_decision
 ):
     sentry_init(traces_sample_rate=1.0)
 
-    with start_span(name="/", sampled=sampling_decision):
+    with start_transaction(name="/", sampled=sampling_decision):
         with start_span(op="child-span"):
             with start_span(op="child-child-span"):
                 scope = sentry_sdk.get_current_scope()
@@ -72,8 +74,8 @@ def test_uses_traces_sample_rate_correctly(
     sentry_init(traces_sample_rate=traces_sample_rate)
 
     with mock.patch.object(random, "random", return_value=0.5):
-        span = start_span(name="dogpark")
-        assert span.sampled is expected_decision
+        transaction = start_transaction(name="dogpark")
+        assert transaction.sampled is expected_decision
 
 
 @pytest.mark.parametrize(
@@ -88,8 +90,8 @@ def test_uses_traces_sampler_return_value_correctly(
     sentry_init(traces_sampler=mock.Mock(return_value=traces_sampler_return_value))
 
     with mock.patch.object(random, "random", return_value=0.5):
-        span = start_span(name="dogpark")
-        assert span.sampled is expected_decision
+        transaction = start_transaction(name="dogpark")
+        assert transaction.sampled is expected_decision
 
 
 @pytest.mark.parametrize("traces_sampler_return_value", [True, False])
@@ -98,19 +100,19 @@ def test_tolerates_traces_sampler_returning_a_boolean(
 ):
     sentry_init(traces_sampler=mock.Mock(return_value=traces_sampler_return_value))
 
-    span = start_span(name="dogpark")
-    assert span.sampled is traces_sampler_return_value
+    transaction = start_transaction(name="dogpark")
+    assert transaction.sampled is traces_sampler_return_value
 
 
 @pytest.mark.parametrize("sampling_decision", [True, False])
-def test_only_captures_span_when_sampled_is_true(
+def test_only_captures_transaction_when_sampled_is_true(
     sentry_init, sampling_decision, capture_events
 ):
     sentry_init(traces_sampler=mock.Mock(return_value=sampling_decision))
     events = capture_events()
 
-    span = start_span(name="dogpark")
-    span.finish()
+    transaction = start_transaction(name="dogpark")
+    transaction.finish()
 
     assert len(events) == (1 if sampling_decision else 0)
 
@@ -131,9 +133,9 @@ def test_prefers_traces_sampler_to_traces_sample_rate(
         traces_sampler=traces_sampler,
     )
 
-    span = start_span(name="dogpark")
+    transaction = start_transaction(name="dogpark")
     assert traces_sampler.called is True
-    assert span.sampled is traces_sampler_return_value
+    assert transaction.sampled is traces_sampler_return_value
 
 
 @pytest.mark.parametrize("parent_sampling_decision", [True, False])
@@ -145,8 +147,10 @@ def test_ignores_inherited_sample_decision_when_traces_sampler_defined(
     traces_sampler = mock.Mock(return_value=not parent_sampling_decision)
     sentry_init(traces_sampler=traces_sampler)
 
-    span = start_span(name="dogpark", parent_sampled=parent_sampling_decision)
-    assert span.sampled is not parent_sampling_decision
+    transaction = start_transaction(
+        name="dogpark", parent_sampled=parent_sampling_decision
+    )
+    assert transaction.sampled is not parent_sampling_decision
 
 
 @pytest.mark.parametrize("explicit_decision", [True, False])
@@ -158,8 +162,8 @@ def test_traces_sampler_doesnt_overwrite_explicitly_passed_sampling_decision(
     traces_sampler = mock.Mock(return_value=not explicit_decision)
     sentry_init(traces_sampler=traces_sampler)
 
-    span = start_span(name="dogpark", sampled=explicit_decision)
-    assert span.sampled is explicit_decision
+    transaction = start_transaction(name="dogpark", sampled=explicit_decision)
+    assert transaction.sampled is explicit_decision
 
 
 @pytest.mark.parametrize("parent_sampling_decision", [True, False])
@@ -173,8 +177,10 @@ def test_inherits_parent_sampling_decision_when_traces_sampler_undefined(
     mock_random_value = 0.25 if parent_sampling_decision is False else 0.75
 
     with mock.patch.object(random, "random", return_value=mock_random_value):
-        span = start_span(name="dogpark", parent_sampled=parent_sampling_decision)
-        assert span.sampled is parent_sampling_decision
+        transaction = start_transaction(
+            name="dogpark", parent_sampled=parent_sampling_decision
+        )
+        assert transaction.sampled is parent_sampling_decision
 
 
 @pytest.mark.parametrize("parent_sampling_decision", [True, False])
@@ -189,13 +195,11 @@ def test_passes_parent_sampling_decision_in_sampling_context(
         )
     )
 
-    # XXX
-
     transaction = Transaction.continue_from_headers(
         headers={"sentry-trace": sentry_trace_header}, name="dogpark"
     )
     spy = mock.Mock(wraps=transaction)
-    start_span(span=spy)
+    start_transaction(transaction=spy)
 
     # there's only one call (so index at 0) and kwargs are always last in a call
     # tuple (so index at -1)
@@ -205,6 +209,19 @@ def test_passes_parent_sampling_decision_in_sampling_context(
     assert "parent_sampled" in sampling_context
     # because we passed in a spy, attribute access requires unwrapping
     assert sampling_context["parent_sampled"]._mock_wraps is parent_sampling_decision
+
+
+def test_passes_attributes_from_start_span_to_traces_sampler(
+    sentry_init, DictionaryContaining  # noqa: N803
+):
+    traces_sampler = mock.Mock()
+    sentry_init(traces_sampler=traces_sampler)
+
+    start_transaction(attributes={"dogs": "yes", "cats": "maybe"})
+
+    traces_sampler.assert_any_call(
+        DictionaryContaining({"dogs": "yes", "cats": "maybe"})
+    )
 
 
 def test_sample_rate_affects_errors(sentry_init, capture_events):
@@ -217,19 +234,6 @@ def test_sample_rate_affects_errors(sentry_init, capture_events):
         capture_exception()
 
     assert len(events) == 0
-
-
-def test_passes_custom_attributes_from_start_span_to_traces_sampler(
-    sentry_init, DictionaryContaining  # noqa: N803
-):
-    traces_sampler = mock.Mock()
-    sentry_init(traces_sampler=traces_sampler)
-
-    start_span(attributes={"dogs": "yes", "cats": "maybe"})
-
-    traces_sampler.assert_any_call(
-        DictionaryContaining({"dogs": "yes", "cats": "maybe"})
-    )
 
 
 @pytest.mark.parametrize(
@@ -252,9 +256,9 @@ def test_warns_and_sets_sampled_to_false_on_invalid_traces_sampler_return_value(
     sentry_init(traces_sampler=mock.Mock(return_value=traces_sampler_return_value))
 
     with mock.patch.object(logger, "warning", mock.Mock()):
-        span = start_span(name="dogpark")
+        transaction = start_transaction(name="dogpark")
         logger.warning.assert_any_call(StringContaining("Given sample rate is invalid"))
-        assert span.sampled is False
+        assert transaction.sampled is False
 
 
 @pytest.mark.parametrize(
@@ -279,9 +283,9 @@ def test_records_lost_event_only_if_traces_sample_rate_enabled(
     sentry_init(traces_sample_rate=traces_sample_rate)
     record_lost_event_calls = capture_record_lost_event_calls()
 
-    span = start_span(name="dogpark")
-    assert span.sampled is sampled_output
-    span.finish()
+    transaction = start_transaction(name="dogpark")
+    assert transaction.sampled is sampled_output
+    transaction.finish()
 
     # Use Counter because order of calls does not matter
     assert Counter(record_lost_event_calls) == Counter(expected_record_lost_event_calls)
@@ -309,9 +313,9 @@ def test_records_lost_event_only_if_traces_sampler_enabled(
     sentry_init(traces_sampler=traces_sampler)
     record_lost_event_calls = capture_record_lost_event_calls()
 
-    span = start_span(name="dogpark")
-    assert span.sampled is sampled_output
-    span.finish()
+    transaction = start_transaction(name="dogpark")
+    assert transaction.sampled is sampled_output
+    transaction.finish()
 
     # Use Counter because order of calls does not matter
     assert Counter(record_lost_event_calls) == Counter(expected_record_lost_event_calls)


### PR DESCRIPTION
- Add support for the `sampled` flag for `start_span` and respect it when making sampling decisions.
- Rework `sampling_context` in `traces_sampler` to work with span attributes instead. Make sure we still have the same data accessible as now. 

We could go one step further and change the format of `sampling_context` to just be the actual span attributes without any postprocessing into the current format. I kept the format in line with what we have now to make it easier to update.

See https://github.com/getsentry/sentry-python/issues/3746
Closes https://github.com/getsentry/sentry-python/issues/3739

This is a breaking change since we're removing `custom_sampling_context`. It'll break multiple integrations until we fix them (see https://github.com/getsentry/sentry-python/issues/3746).