### PR TITLE
Add `only_if_parent` option to POTelSpan and use it in integrations

### DIFF
--- a/sentry_sdk/ai/monitoring.py
+++ b/sentry_sdk/ai/monitoring.py
@@ -33,7 +33,9 @@ def ai_track(description, **span_kwargs):
             curr_pipeline = _ai_pipeline_name.get()
             op = span_kwargs.get("op", "ai.run" if curr_pipeline else "ai.pipeline")
 
-            with start_span(name=description, op=op, **span_kwargs) as span:
+            with start_span(
+                name=description, op=op, only_if_parent=True, **span_kwargs
+            ) as span:
                 for k, v in kwargs.pop("sentry_tags", {}).items():
                     span.set_tag(k, v)
                 for k, v in kwargs.pop("sentry_data", {}).items():
@@ -62,7 +64,9 @@ def ai_track(description, **span_kwargs):
             curr_pipeline = _ai_pipeline_name.get()
             op = span_kwargs.get("op", "ai.run" if curr_pipeline else "ai.pipeline")
 
-            with start_span(name=description, op=op, **span_kwargs) as span:
+            with start_span(
+                name=description, op=op, only_if_parent=True, **span_kwargs
+            ) as span:
                 for k, v in kwargs.pop("sentry_tags", {}).items():
                     span.set_tag(k, v)
                 for k, v in kwargs.pop("sentry_data", {}).items():

--- a/sentry_sdk/integrations/aiohttp.py
+++ b/sentry_sdk/integrations/aiohttp.py
@@ -228,6 +228,7 @@ def create_trace_config():
             name="%s %s"
             % (method, parsed_url.url if parsed_url else SENSITIVE_DATA_SUBSTITUTE),
             origin=AioHttpIntegration.origin,
+            only_if_parent=True,
         )
 
         data = {

--- a/sentry_sdk/integrations/anthropic.py
+++ b/sentry_sdk/integrations/anthropic.py
@@ -151,6 +151,7 @@ def _sentry_patched_create_common(f, *args, **kwargs):
         op=OP.ANTHROPIC_MESSAGES_CREATE,
         description="Anthropic messages create",
         origin=AnthropicIntegration.origin,
+        only_if_parent=True,
     )
     span.__enter__()
 

--- a/sentry_sdk/integrations/arq.py
+++ b/sentry_sdk/integrations/arq.py
@@ -79,7 +79,10 @@ def patch_enqueue_job():
             return await old_enqueue_job(self, function, *args, **kwargs)
 
         with sentry_sdk.start_span(
-            op=OP.QUEUE_SUBMIT_ARQ, name=function, origin=ArqIntegration.origin
+            op=OP.QUEUE_SUBMIT_ARQ,
+            name=function,
+            origin=ArqIntegration.origin,
+            only_if_parent=True,
         ):
             return await old_enqueue_job(self, function, *args, **kwargs)
 

--- a/sentry_sdk/integrations/asyncio.py
+++ b/sentry_sdk/integrations/asyncio.py
@@ -48,6 +48,7 @@ def patch_asyncio():
                         op=OP.FUNCTION,
                         name=get_name(coro),
                         origin=AsyncioIntegration.origin,
+                        only_if_parent=True,
                     ):
                         try:
                             result = await coro

--- a/sentry_sdk/integrations/asyncpg.py
+++ b/sentry_sdk/integrations/asyncpg.py
@@ -169,6 +169,7 @@ def _wrap_connect_addr(f: Callable[..., Awaitable[T]]) -> Callable[..., Awaitabl
             op=OP.DB,
             name="connect",
             origin=AsyncPGIntegration.origin,
+            only_if_parent=True,
         ) as span:
             data = _get_db_data(
                 addr=kwargs.get("addr"),

--- a/sentry_sdk/integrations/boto3.py
+++ b/sentry_sdk/integrations/boto3.py
@@ -72,6 +72,7 @@ def _sentry_request_created(service_id, request, operation_name, **kwargs):
         op=OP.HTTP_CLIENT,
         name=description,
         origin=Boto3Integration.origin,
+        only_if_parent=True,
     )
 
     data = {

--- a/sentry_sdk/integrations/celery/__init__.py
+++ b/sentry_sdk/integrations/celery/__init__.py
@@ -495,6 +495,7 @@ def _patch_producer_publish():
             op=OP.QUEUE_PUBLISH,
             name=task_name,
             origin=CeleryIntegration.origin,
+            only_if_parent=True,
         ) as span:
             if task_id is not None:
                 span.set_data(SPANDATA.MESSAGING_MESSAGE_ID, task_id)

--- a/sentry_sdk/integrations/clickhouse_driver.py
+++ b/sentry_sdk/integrations/clickhouse_driver.py
@@ -89,6 +89,7 @@ def _wrap_start(f: Callable[P, T]) -> Callable[P, T]:
             op=OP.DB,
             name=query,
             origin=ClickhouseDriverIntegration.origin,
+            only_if_parent=True,
         )
 
         connection._sentry_span = span  # type: ignore[attr-defined]

--- a/sentry_sdk/integrations/cohere.py
+++ b/sentry_sdk/integrations/cohere.py
@@ -147,6 +147,7 @@ def _wrap_chat(f, streaming):
             op=consts.OP.COHERE_CHAT_COMPLETIONS_CREATE,
             name="cohere.client.Chat",
             origin=CohereIntegration.origin,
+            only_if_parent=True,
         )
         span.__enter__()
         try:
@@ -233,6 +234,7 @@ def _wrap_embed(f):
             op=consts.OP.COHERE_EMBEDDINGS_CREATE,
             name="Cohere Embedding Creation",
             origin=CohereIntegration.origin,
+            only_if_parent=True,
         ) as span:
             if "texts" in kwargs and (
                 should_send_default_pii() and integration.include_prompts

--- a/sentry_sdk/integrations/django/__init__.py
+++ b/sentry_sdk/integrations/django/__init__.py
@@ -687,6 +687,7 @@ def install_sql_hook():
             op=OP.DB,
             name="connect",
             origin=DjangoIntegration.origin_db,
+            only_if_parent=True,
         ) as span:
             _set_db_data(span, self)
             return real_connect(self)

--- a/sentry_sdk/integrations/django/asgi.py
+++ b/sentry_sdk/integrations/django/asgi.py
@@ -184,6 +184,7 @@ def wrap_async_view(callback):
             op=OP.VIEW_RENDER,
             name=request.resolver_match.view_name,
             origin=DjangoIntegration.origin,
+            only_if_parent=True,
         ):
             return await callback(request, *args, **kwargs)
 

--- a/sentry_sdk/integrations/django/caching.py
+++ b/sentry_sdk/integrations/django/caching.py
@@ -54,6 +54,7 @@ def _patch_cache_method(cache, method_name, address, port):
             op=op,
             name=description,
             origin=DjangoIntegration.origin,
+            only_if_parent=True,
         ) as span:
             value = original_method(*args, **kwargs)
 

--- a/sentry_sdk/integrations/django/middleware.py
+++ b/sentry_sdk/integrations/django/middleware.py
@@ -89,6 +89,7 @@ def _wrap_middleware(middleware, middleware_name):
             op=OP.MIDDLEWARE_DJANGO,
             name=description,
             origin=DjangoIntegration.origin,
+            only_if_parent=True,
         )
         middleware_span.set_tag("django.function_name", function_name)
         middleware_span.set_tag("django.middleware_name", middleware_name)

--- a/sentry_sdk/integrations/django/signals_handlers.py
+++ b/sentry_sdk/integrations/django/signals_handlers.py
@@ -68,6 +68,7 @@ def patch_signals():
                     op=OP.EVENT_DJANGO,
                     name=signal_name,
                     origin=DjangoIntegration.origin,
+                    only_if_parent=True,
                 ) as span:
                     span.set_data("signal", signal_name)
                     return receiver(*args, **kwargs)

--- a/sentry_sdk/integrations/django/templates.py
+++ b/sentry_sdk/integrations/django/templates.py
@@ -72,6 +72,7 @@ def patch_templates():
             op=OP.TEMPLATE_RENDER,
             name=_get_template_name_description(self.template_name),
             origin=DjangoIntegration.origin,
+            only_if_parent=True,
         ) as span:
             if isinstance(self.context_data, dict):
                 for k, v in self.context_data.items():
@@ -102,6 +103,7 @@ def patch_templates():
             op=OP.TEMPLATE_RENDER,
             name=_get_template_name_description(template_name),
             origin=DjangoIntegration.origin,
+            only_if_parent=True,
         ) as span:
             for k, v in context.items():
                 span.set_data(f"context.{k}", v)

--- a/sentry_sdk/integrations/django/views.py
+++ b/sentry_sdk/integrations/django/views.py
@@ -37,6 +37,7 @@ def patch_views():
             op=OP.VIEW_RESPONSE_RENDER,
             name="serialize response",
             origin=DjangoIntegration.origin,
+            only_if_parent=True,
         ):
             return old_render(self)
 
@@ -90,6 +91,7 @@ def _wrap_sync_view(callback):
             op=OP.VIEW_RENDER,
             name=request.resolver_match.view_name,
             origin=DjangoIntegration.origin,
+            only_if_parent=True,
         ):
             return callback(request, *args, **kwargs)
 

--- a/sentry_sdk/integrations/graphene.py
+++ b/sentry_sdk/integrations/graphene.py
@@ -144,7 +144,9 @@ def graphql_span(schema, source, kwargs):
     if scope.span:
         _graphql_span = scope.span.start_child(op=op, name=operation_name)
     else:
-        _graphql_span = sentry_sdk.start_span(op=op, name=operation_name)
+        _graphql_span = sentry_sdk.start_span(
+            op=op, name=operation_name, only_if_parent=True
+        )
 
     _graphql_span.set_data("graphql.document", source)
     _graphql_span.set_data("graphql.operation.name", operation_name)

--- a/sentry_sdk/integrations/grpc/aio/client.py
+++ b/sentry_sdk/integrations/grpc/aio/client.py
@@ -52,6 +52,7 @@ class SentryUnaryUnaryClientInterceptor(ClientInterceptor, UnaryUnaryClientInter
             op=OP.GRPC_CLIENT,
             name="unary unary call to %s" % method.decode(),
             origin=SPAN_ORIGIN,
+            only_if_parent=True,
         ) as span:
             span.set_data("type", "unary unary")
             span.set_data("method", method)
@@ -82,6 +83,7 @@ class SentryUnaryStreamClientInterceptor(
             op=OP.GRPC_CLIENT,
             name="unary stream call to %s" % method.decode(),
             origin=SPAN_ORIGIN,
+            only_if_parent=True,
         ) as span:
             span.set_data("type", "unary stream")
             span.set_data("method", method)

--- a/sentry_sdk/integrations/grpc/client.py
+++ b/sentry_sdk/integrations/grpc/client.py
@@ -31,6 +31,7 @@ class ClientInterceptor(
             op=OP.GRPC_CLIENT,
             name="unary unary call to %s" % method,
             origin=SPAN_ORIGIN,
+            only_if_parent=True,
         ) as span:
             span.set_data("type", "unary unary")
             span.set_data("method", method)
@@ -52,6 +53,7 @@ class ClientInterceptor(
             op=OP.GRPC_CLIENT,
             name="unary stream call to %s" % method,
             origin=SPAN_ORIGIN,
+            only_if_parent=True,
         ) as span:
             span.set_data("type", "unary stream")
             span.set_data("method", method)

--- a/sentry_sdk/integrations/httpx.py
+++ b/sentry_sdk/integrations/httpx.py
@@ -59,6 +59,7 @@ def _install_httpx_client():
                 parsed_url.url if parsed_url else SENSITIVE_DATA_SUBSTITUTE,
             ),
             origin=HttpxIntegration.origin,
+            only_if_parent=True,
         ) as span:
             data = {
                 SPANDATA.HTTP_METHOD: request.method,
@@ -129,6 +130,7 @@ def _install_httpx_async_client():
                 parsed_url.url if parsed_url else SENSITIVE_DATA_SUBSTITUTE,
             ),
             origin=HttpxIntegration.origin,
+            only_if_parent=True,
         ) as span:
             data = {
                 SPANDATA.HTTP_METHOD: request.method,

--- a/sentry_sdk/integrations/huey.py
+++ b/sentry_sdk/integrations/huey.py
@@ -61,6 +61,7 @@ def patch_enqueue():
             op=OP.QUEUE_SUBMIT_HUEY,
             name=task.name,
             origin=HueyIntegration.origin,
+            only_if_parent=True,
         ):
             if not isinstance(task, PeriodicTask):
                 # Attach trace propagation data to task kwargs. We do

--- a/sentry_sdk/integrations/huggingface_hub.py
+++ b/sentry_sdk/integrations/huggingface_hub.py
@@ -77,6 +77,7 @@ def _wrap_text_generation(f):
             op=consts.OP.HUGGINGFACE_HUB_CHAT_COMPLETIONS_CREATE,
             name="Text Generation",
             origin=HuggingfaceHubIntegration.origin,
+            only_if_parent=True,
         )
         span.__enter__()
         try:

--- a/sentry_sdk/integrations/langchain.py
+++ b/sentry_sdk/integrations/langchain.py
@@ -143,7 +143,9 @@ class SentryLangchainCallback(BaseCallbackHandler):  # type: ignore[misc]
                 watched_span = WatchedSpan(parent_span.span.start_child(**kwargs))
                 parent_span.children.append(watched_span)
         if watched_span is None:
-            watched_span = WatchedSpan(sentry_sdk.start_span(**kwargs))
+            watched_span = WatchedSpan(
+                sentry_sdk.start_span(only_if_parent=True, **kwargs)
+            )
 
         if kwargs.get("op", "").startswith("ai.pipeline."):
             if kwargs.get("name"):

--- a/sentry_sdk/integrations/litestar.py
+++ b/sentry_sdk/integrations/litestar.py
@@ -141,6 +141,7 @@ def enable_span_for_middleware(middleware):
             op=OP.MIDDLEWARE_LITESTAR,
             name=middleware_name,
             origin=LitestarIntegration.origin,
+            only_if_parent=True,
         ) as middleware_span:
             middleware_span.set_tag("litestar.middleware_name", middleware_name)
 
@@ -153,6 +154,7 @@ def enable_span_for_middleware(middleware):
                     op=OP.MIDDLEWARE_LITESTAR_RECEIVE,
                     name=getattr(receive, "__qualname__", str(receive)),
                     origin=LitestarIntegration.origin,
+                    only_if_parent=True,
                 ) as span:
                     span.set_tag("litestar.middleware_name", middleware_name)
                     return await receive(*args, **kwargs)
@@ -170,6 +172,7 @@ def enable_span_for_middleware(middleware):
                     op=OP.MIDDLEWARE_LITESTAR_SEND,
                     name=getattr(send, "__qualname__", str(send)),
                     origin=LitestarIntegration.origin,
+                    only_if_parent=True,
                 ) as span:
                     span.set_tag("litestar.middleware_name", middleware_name)
                     return await send(message)

--- a/sentry_sdk/integrations/openai.py
+++ b/sentry_sdk/integrations/openai.py
@@ -139,6 +139,7 @@ def _new_chat_completion_common(f, *args, **kwargs):
         op=consts.OP.OPENAI_CHAT_COMPLETIONS_CREATE,
         description="Chat Completion",
         origin=OpenAIIntegration.origin,
+        only_if_parent=True,
     )
     span.__enter__()
 
@@ -324,6 +325,7 @@ def _new_embeddings_create_common(f, *args, **kwargs):
         op=consts.OP.OPENAI_EMBEDDINGS_CREATE,
         description="OpenAI Embedding Creation",
         origin=OpenAIIntegration.origin,
+        only_if_parent=True,
     ) as span:
         if "input" in kwargs and (
             should_send_default_pii() and integration.include_prompts

--- a/sentry_sdk/integrations/pymongo.py
+++ b/sentry_sdk/integrations/pymongo.py
@@ -153,6 +153,7 @@ class CommandTracer(monitoring.CommandListener):
                 op=OP.DB,
                 name=query,
                 origin=PyMongoIntegration.origin,
+                only_if_parent=True,
             )
 
             with capture_internal_exceptions():

--- a/sentry_sdk/integrations/ray.py
+++ b/sentry_sdk/integrations/ray.py
@@ -88,6 +88,7 @@ def _patch_ray_remote():
                 op=OP.QUEUE_SUBMIT_RAY,
                 name=qualname_from_function(f),
                 origin=RayIntegration.origin,
+                only_if_parent=True,
             ) as span:
                 tracing = {
                     k: v

--- a/sentry_sdk/integrations/redis/_async_common.py
+++ b/sentry_sdk/integrations/redis/_async_common.py
@@ -40,6 +40,7 @@ def patch_redis_async_pipeline(
             op=OP.DB_REDIS,
             name="redis.pipeline.execute",
             origin=SPAN_ORIGIN,
+            only_if_parent=True,
         ) as span:
             with capture_internal_exceptions():
                 span_data = get_db_data_fn(self)
@@ -84,6 +85,7 @@ def patch_redis_async_client(cls, is_cluster, get_db_data_fn):
                 op=cache_properties["op"],
                 name=cache_properties["description"],
                 origin=SPAN_ORIGIN,
+                only_if_parent=True,
             )
             cache_span.__enter__()
 
@@ -93,6 +95,7 @@ def patch_redis_async_client(cls, is_cluster, get_db_data_fn):
             op=db_properties["op"],
             name=db_properties["description"],
             origin=SPAN_ORIGIN,
+            only_if_parent=True,
         )
         db_span.__enter__()
 

--- a/sentry_sdk/integrations/redis/_sync_common.py
+++ b/sentry_sdk/integrations/redis/_sync_common.py
@@ -41,6 +41,7 @@ def patch_redis_pipeline(
             op=OP.DB_REDIS,
             name="redis.pipeline.execute",
             origin=SPAN_ORIGIN,
+            only_if_parent=True,
         ) as span:
             with capture_internal_exceptions():
                 span_data = get_db_data_fn(self)

--- a/sentry_sdk/integrations/socket.py
+++ b/sentry_sdk/integrations/socket.py
@@ -57,6 +57,7 @@ def _patch_create_connection():
             op=OP.SOCKET_CONNECTION,
             name=_get_span_description(address[0], address[1]),
             origin=SocketIntegration.origin,
+            only_if_parent=True,
         ) as span:
             span.set_data("address", address)
             span.set_data("timeout", timeout)
@@ -83,6 +84,7 @@ def _patch_getaddrinfo():
             op=OP.SOCKET_DNS,
             name=_get_span_description(host, port),
             origin=SocketIntegration.origin,
+            only_if_parent=True,
         ) as span:
             span.set_data("host", host)
             span.set_data("port", port)

--- a/sentry_sdk/integrations/starlette.py
+++ b/sentry_sdk/integrations/starlette.py
@@ -164,6 +164,7 @@ def _enable_span_for_middleware(middleware_class):
             op=OP.MIDDLEWARE_STARLETTE,
             name=middleware_name,
             origin=StarletteIntegration.origin,
+            only_if_parent=True,
         ) as middleware_span:
             middleware_span.set_tag("starlette.middleware_name", middleware_name)
 
@@ -174,6 +175,7 @@ def _enable_span_for_middleware(middleware_class):
                     op=OP.MIDDLEWARE_STARLETTE_RECEIVE,
                     name=getattr(receive, "__qualname__", str(receive)),
                     origin=StarletteIntegration.origin,
+                    only_if_parent=True,
                 ) as span:
                     span.set_tag("starlette.middleware_name", middleware_name)
                     return await receive(*args, **kwargs)
@@ -189,6 +191,7 @@ def _enable_span_for_middleware(middleware_class):
                     op=OP.MIDDLEWARE_STARLETTE_SEND,
                     name=getattr(send, "__qualname__", str(send)),
                     origin=StarletteIntegration.origin,
+                    only_if_parent=True,
                 ) as span:
                     span.set_tag("starlette.middleware_name", middleware_name)
                     return await send(*args, **kwargs)

--- a/sentry_sdk/integrations/starlite.py
+++ b/sentry_sdk/integrations/starlite.py
@@ -140,6 +140,7 @@ def enable_span_for_middleware(middleware):
             op=OP.MIDDLEWARE_STARLITE,
             name=middleware_name,
             origin=StarliteIntegration.origin,
+            only_if_parent=True,
         ) as middleware_span:
             middleware_span.set_tag("starlite.middleware_name", middleware_name)
 
@@ -152,6 +153,7 @@ def enable_span_for_middleware(middleware):
                     op=OP.MIDDLEWARE_STARLITE_RECEIVE,
                     name=getattr(receive, "__qualname__", str(receive)),
                     origin=StarliteIntegration.origin,
+                    only_if_parent=True,
                 ) as span:
                     span.set_tag("starlite.middleware_name", middleware_name)
                     return await receive(*args, **kwargs)
@@ -169,6 +171,7 @@ def enable_span_for_middleware(middleware):
                     op=OP.MIDDLEWARE_STARLITE_SEND,
                     name=getattr(send, "__qualname__", str(send)),
                     origin=StarliteIntegration.origin,
+                    only_if_parent=True,
                 ) as span:
                     span.set_tag("starlite.middleware_name", middleware_name)
                     return await send(message)

--- a/sentry_sdk/integrations/stdlib.py
+++ b/sentry_sdk/integrations/stdlib.py
@@ -94,6 +94,7 @@ def _install_httplib():
             name="%s %s"
             % (method, parsed_url.url if parsed_url else SENSITIVE_DATA_SUBSTITUTE),
             origin="auto.http.stdlib.httplib",
+            only_if_parent=True,
         )
 
         data = {
@@ -225,6 +226,7 @@ def _install_subprocess():
             op=OP.SUBPROCESS,
             name=description,
             origin="auto.subprocess.stdlib.subprocess",
+            only_if_parent=True,
         ) as span:
             for k, v in sentry_sdk.get_current_scope().iter_trace_propagation_headers(
                 span=span
@@ -275,6 +277,7 @@ def _install_subprocess():
         with sentry_sdk.start_span(
             op=OP.SUBPROCESS_WAIT,
             origin="auto.subprocess.stdlib.subprocess",
+            only_if_parent=True,
         ) as span:
             span.set_tag("subprocess.pid", self.pid)
             return old_popen_wait(self, *a, **kw)
@@ -289,6 +292,7 @@ def _install_subprocess():
         with sentry_sdk.start_span(
             op=OP.SUBPROCESS_COMMUNICATE,
             origin="auto.subprocess.stdlib.subprocess",
+            only_if_parent=True,
         ) as span:
             span.set_tag("subprocess.pid", self.pid)
             return old_popen_communicate(self, *a, **kw)

--- a/sentry_sdk/integrations/strawberry.py
+++ b/sentry_sdk/integrations/strawberry.py
@@ -191,6 +191,7 @@ class SentryAsyncExtension(SchemaExtension):  # type: ignore
                 op=op,
                 name=description,
                 origin=StrawberryIntegration.origin,
+                only_if_parent=True,
             )
 
         self.graphql_span.set_data("graphql.operation.type", operation_type)


### PR DESCRIPTION
If this option is on, we will only create a new underlying otel span if there's an active valid parent, otherwise we will just return an invalid `NonRecordingSpan` (`INVALID_SPAN`).

All internal integration child `start_span` calls have been modified so that now we will only create spans if there is an active root span (transaction) active.
