### PR TITLE
feat(spotlight): Inject Spotlight button on Django

### DIFF
--- a/sentry_sdk/spotlight.py
+++ b/sentry_sdk/spotlight.py
@@ -85,7 +85,7 @@ try:
     )
 
     class SpotlightMiddleware(MiddlewareMixin):  # type: ignore[misc]
-        __spotlight_script = None  # type: Optional[str]
+        _spotlight_script = None  # type: Optional[str]
 
         def __init__(self, get_response):
             # type: (Self, Callable[..., HttpResponse]) -> None
@@ -107,7 +107,7 @@ try:
         @property
         def spotlight_script(self):
             # type: (Self) -> Optional[str]
-            if self.__spotlight_script is None:
+            if self._spotlight_script is None:
                 try:
                     spotlight_js_url = urllib.parse.urljoin(
                         self._spotlight_url, SPOTLIGHT_JS_ENTRY_PATH
@@ -117,7 +117,7 @@ try:
                         method="HEAD",
                     )
                     urllib.request.urlopen(req)
-                    self.__spotlight_script = SPOTLIGHT_JS_SNIPPET_PATTERN.format(
+                    self._spotlight_script = SPOTLIGHT_JS_SNIPPET_PATTERN.format(
                         spotlight_js_url
                     )
                 except urllib.error.URLError as err:
@@ -127,7 +127,7 @@ try:
                         exc_info=err,
                     )
 
-            return self.__spotlight_script
+            return self._spotlight_script
 
         def process_response(self, _request, response):
             # type: (Self, HttpRequest, HttpResponse) -> Optional[HttpResponse]

--- a/sentry_sdk/spotlight.py
+++ b/sentry_sdk/spotlight.py
@@ -81,8 +81,8 @@ try:
     CHARSET_PREFIX = "charset="
     BODY_CLOSE_TAG = "</body>"
     BODY_CLOSE_TAG_POSSIBILITIES = [
-        "".join(l)
-        for l in product(*zip(BODY_CLOSE_TAG.upper(), BODY_CLOSE_TAG.lower()))
+        "".join(chars)
+        for chars in product(*zip(BODY_CLOSE_TAG.upper(), BODY_CLOSE_TAG.lower()))
     ]
 
     class SpotlightMiddleware(MiddlewareMixin):

--- a/sentry_sdk/spotlight.py
+++ b/sentry_sdk/spotlight.py
@@ -84,7 +84,7 @@ try:
         for chars in product(*zip(BODY_CLOSE_TAG.upper(), BODY_CLOSE_TAG.lower()))
     ]
 
-    class SpotlightMiddleware(MiddlewareMixin):
+    class SpotlightMiddleware(MiddlewareMixin):  # type: ignore[misc]
         __spotlight_script: Optional[str] = None
         _spotlight_url: str
 

--- a/sentry_sdk/spotlight.py
+++ b/sentry_sdk/spotlight.py
@@ -16,6 +16,7 @@ if TYPE_CHECKING:
     from typing import Callable
     from typing import Dict
     from typing import Optional
+    from typing import Self
 
 from sentry_sdk.utils import (
     logger as sentry_logger,
@@ -64,8 +65,6 @@ class SpotlightClient:
 
 
 try:
-    from typing import Self, Optional
-
     from django.utils.deprecation import MiddlewareMixin
     from django.http import HttpResponseServerError, HttpResponse, HttpRequest
     from django.conf import settings

--- a/sentry_sdk/spotlight.py
+++ b/sentry_sdk/spotlight.py
@@ -78,11 +78,11 @@ try:
         '<script>window.__spotlight = {{ initOptions: {{ fullPage: true, startFrom: "/errors/{event_id}" }}}};</script>\n'
     )
     CHARSET_PREFIX = "charset="
-    BODY_CLOSE_TAG = "</body>"
-    BODY_CLOSE_TAG_POSSIBILITIES = [
-        "".join(chars)
-        for chars in product(*zip(BODY_CLOSE_TAG.upper(), BODY_CLOSE_TAG.lower()))
-    ]
+    BODY_TAG_NAME = "body"
+    BODY_CLOSE_TAG_POSSIBILITIES = tuple(
+        "</{}>".format("".join(chars))
+        for chars in product(*zip(BODY_TAG_NAME.upper(), BODY_TAG_NAME.lower()))
+    )
 
     class SpotlightMiddleware(MiddlewareMixin):  # type: ignore[misc]
         __spotlight_script = None  # type: Optional[str]

--- a/sentry_sdk/spotlight.py
+++ b/sentry_sdk/spotlight.py
@@ -85,8 +85,7 @@ try:
     ]
 
     class SpotlightMiddleware(MiddlewareMixin):  # type: ignore[misc]
-        __spotlight_script: Optional[str] = None
-        _spotlight_url: str
+        __spotlight_script = None  # type: Optional[str]
 
         def __init__(self, get_response):
             # type: (Self, Callable[..., HttpResponse]) -> None

--- a/sentry_sdk/spotlight.py
+++ b/sentry_sdk/spotlight.py
@@ -95,7 +95,7 @@ try:
 
             self.sentry_sdk = sentry_sdk.api
 
-            spotlight_client = sentry_sdk.api.get_client().spotlight
+            spotlight_client = self.sentry_sdk.get_client().spotlight
             if spotlight_client is None:
                 sentry_logger.warning(
                     "Cannot find Spotlight client from SpotlightMiddleware, disabling the middleware."


### PR DESCRIPTION
This patch expands the `SpotlightMiddleware` for Django and injects the Spotlight button to all HTML responses when Spotlight is enabled and running. It requires Spotlight 2.6.0 to work this way.

Ref: getsentry/spotlight#543