### PR TITLE
Make sentry-sdk[pure-eval] installable with pip==24.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -70,7 +70,7 @@ setup(
         "openfeature": ["openfeature-sdk>=0.7.1"],
         "opentelemetry": ["opentelemetry-distro>=0.35b0"],
         "opentelemetry-experimental": ["opentelemetry-distro"],
-        "pure_eval": ["pure_eval", "executing", "asttokens"],
+        "pure-eval": ["pure_eval", "executing", "asttokens"],
         "pymongo": ["pymongo>=3.1"],
         "pyspark": ["pyspark>=2.4.4"],
         "quart": ["quart>=0.16.1", "blinker>=1.1"],


### PR DESCRIPTION
There's an issue with `pip==24.0` where extras with an underscore in the name can't be installed, so e.g. `pip install sentry-sdk[pure_eval]` will claim there is no `pure_eval` extra.

The issue is fixed in `pip>=24.1`. Some folks are stuck using older versions though. We can fix it for them by renaming the extra to `pure-eval` instead, which makes `pip install sentry-sdk[pure-eval]` work correctly in 24.0 too. 

(The underscore version `sentry-sdk[pure_eval]` will continue to work after this change. Tested with pip and uv.)

Closes https://github.com/getsentry/sentry-python/issues/3754