### PR TITLE
Cleanup `span is not None` checks for TWP

### DIFF
--- a/sentry_sdk/integrations/opentelemetry/scope.py
+++ b/sentry_sdk/integrations/opentelemetry/scope.py
@@ -125,8 +125,17 @@ class PotelScope(Scope):
         return POTelSpan(**kwargs, scope=self)
 
 
-_INITIAL_CURRENT_SCOPE = PotelScope(ty=ScopeType.CURRENT)
-_INITIAL_ISOLATION_SCOPE = PotelScope(ty=ScopeType.ISOLATION)
+_INITIAL_CURRENT_SCOPE = None
+_INITIAL_ISOLATION_SCOPE = None
+
+
+def _setup_initial_scopes():
+    global _INITIAL_CURRENT_SCOPE, _INITIAL_ISOLATION_SCOPE
+    _INITIAL_CURRENT_SCOPE = PotelScope(ty=ScopeType.CURRENT)
+    _INITIAL_ISOLATION_SCOPE = PotelScope(ty=ScopeType.ISOLATION)
+
+
+_setup_initial_scopes()
 
 
 @contextmanager

--- a/sentry_sdk/integrations/rq.py
+++ b/sentry_sdk/integrations/rq.py
@@ -108,11 +108,9 @@ class RqIntegration(Integration):
         @ensure_integration_enabled(RqIntegration, old_enqueue_job)
         def sentry_patched_enqueue_job(self, job, **kwargs):
             # type: (Queue, Any, **Any) -> Any
-            scope = sentry_sdk.get_current_scope()
-            if scope.span is not None:
-                job.meta["_sentry_trace_headers"] = dict(
-                    scope.iter_trace_propagation_headers()
-                )
+            job.meta["_sentry_trace_headers"] = dict(
+                sentry_sdk.get_current_scope().iter_trace_propagation_headers()
+            )
 
             return old_enqueue_job(self, job, **kwargs)
 

--- a/sentry_sdk/scope.py
+++ b/sentry_sdk/scope.py
@@ -497,7 +497,11 @@ class Scope:
         client = self.get_client()
 
         # If we have an active span, return traceparent from there
-        if has_tracing_enabled(client.options) and self.span is not None:
+        if (
+            has_tracing_enabled(client.options)
+            and self.span is not None
+            and self.span.is_valid
+        ):
             return self.span.to_traceparent()
 
         # If this scope has a propagation context, return traceparent from there
@@ -521,7 +525,11 @@ class Scope:
         client = self.get_client()
 
         # If we have an active span, return baggage from there
-        if has_tracing_enabled(client.options) and self.span is not None:
+        if (
+            has_tracing_enabled(client.options)
+            and self.span is not None
+            and self.span.is_valid
+        ):
             return self.span.to_baggage()
 
         # If this scope has a propagation context, return baggage from there
@@ -610,7 +618,7 @@ class Scope:
         span = kwargs.pop("span", None)
         span = span or self.span
 
-        if has_tracing_enabled(client.options) and span is not None:
+        if has_tracing_enabled(client.options) and span is not None and span.is_valid:
             for header in span.iter_headers():
                 yield header
         else:
@@ -1311,7 +1319,11 @@ class Scope:
 
         # Add "trace" context
         if contexts.get("trace") is None:
-            if has_tracing_enabled(options) and self._span is not None:
+            if (
+                has_tracing_enabled(options)
+                and self._span is not None
+                and self._span.is_valid
+            ):
                 contexts["trace"] = self._span.get_trace_context()
             else:
                 contexts["trace"] = self.get_trace_context()

--- a/sentry_sdk/tracing.py
+++ b/sentry_sdk/tracing.py
@@ -1390,6 +1390,11 @@ class POTelSpan:
         return format_span_id(self._otel_span.get_span_context().span_id)
 
     @property
+    def is_valid(self):
+        # type: () -> bool
+        return self._otel_span.get_span_context().is_valid
+
+    @property
     def sampled(self):
         # type: () -> Optional[bool]
         return self._otel_span.get_span_context().trace_flags.sampled

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -74,8 +74,7 @@ def clean_scopes():
     scope._isolation_scope.set(None)
     scope._current_scope.set(None)
 
-    potel_scope._INITIAL_CURRENT_SCOPE.clear()
-    potel_scope._INITIAL_ISOLATION_SCOPE.clear()
+    potel_scope._setup_initial_scopes()
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
because of #3748  span can now be an `INVALID_SPAN` we have to cleanup the fallback cases for TWP to work properly.

also:
* better potel scope cleanup for tests
* rq was propagating only for the span case and not twp, fix this