### PR TITLE
fix: remove inconsistent PII filtering from rust_tracing integration

### DIFF
--- a/tests/integrations/rust_tracing/test_rust_tracing.py
+++ b/tests/integrations/rust_tracing/test_rust_tracing.py
@@ -1,5 +1,3 @@
-import pytest
-
 from string import Template
 from typing import Dict
 
@@ -365,7 +363,6 @@ def test_record(sentry_init):
     integration = RustTracingIntegration(
         "test_record",
         initializer=rust_tracing.set_layer_impl,
-        send_sensitive_data=True,
     )
     sentry_init(integrations=[integration], traces_sample_rate=1.0)
 
@@ -406,45 +403,3 @@ def test_record_in_ignored_span(sentry_init):
         # `on_record()` should not do anything to the current Sentry span if the associated Rust span was ignored
         span_after_record = sentry_sdk.get_current_span().to_json()
         assert span_after_record["data"]["version"] is None
-
-
-@pytest.mark.parametrize(
-    "send_default_pii, send_sensitive_data, sensitive_data_expected",
-    [
-        (True, True, True),
-        (True, False, False),
-        (True, None, True),
-        (False, True, True),
-        (False, False, False),
-        (False, None, False),
-    ],
-)
-def test_sensitive_data(
-    sentry_init, send_default_pii, send_sensitive_data, sensitive_data_expected
-):
-    rust_tracing = FakeRustTracing()
-    integration = RustTracingIntegration(
-        "test_record",
-        initializer=rust_tracing.set_layer_impl,
-        send_sensitive_data=send_sensitive_data,
-    )
-
-    sentry_init(
-        integrations=[integration],
-        traces_sample_rate=1.0,
-        send_default_pii=send_default_pii,
-    )
-    with start_transaction():
-        rust_tracing.new_span(RustTracingLevel.Info, 3)
-
-        span_before_record = sentry_sdk.get_current_span().to_json()
-        assert span_before_record["data"]["version"] is None
-
-        rust_tracing.record(3)
-
-        span_after_record = sentry_sdk.get_current_span().to_json()
-
-        if sensitive_data_expected:
-            assert span_after_record["data"]["version"] == "memoized"
-        else:
-            assert span_after_record["data"]["version"] == "[Filtered]"


### PR DESCRIPTION
the PII filtering in the merged version treats span data set in `on_new_span()` as safe but span data set in `on_record()` as sensitive. in actuality, they're two different ways to set the same thing, so they should be treated the same

below i lay out my reasoning for removing this PII filtering. there is a tiny bit more work to do either way:
- if that approach is accepted, i will update my docs branch to direct the user at [the "Scrubbing Sensitive Data" page](https://docs.sentry.io/platforms/python/data-management/sensitive-data/) and i can update [the docs for `pyo3-python-tracing-subscriber`](https://docs.rs/pyo3-python-tracing-subscriber/0.1.0/pyo3_python_tracing_subscriber/) to call out the `tracing` docs for excluding specific fields that the developer knows are sensitive
- if we instead _do_ want all-or-nothing PII filtering on by default to be conservative, i will update this PR to apply the filtering to both `on_new_span()` and `on_record()` and then update my docs branch to document the `send_sensitive_data` argument and filtering behavior

([the aforementioned docs branch](https://github.com/matt-codecov/sentry-docs/tree/matt/python-rust-tracing-integration))

### the full scoop

<details><summary>some detail on `tracing` behavior</summary>

the `#[tracing::instrument(fields(extra1=5, extra2)]` attribute at the top of a function adds all of the function's arguments + extra fields listed in the attribute arguments as span data. when `on_new_span()` is called it will include all of the function arguments and fields, with one exception: fields without default values are not "recorded", so `extra2` in this example will be omitted.

during the span, `Span::current().record(field, val)` can be called to set a value for `extra2` after the function starts. it can also overwrite a value for an already-assigned field. `on_record()` will be called with the recorded fields/values.

to summarize, `on_new_span()` and `on_record()` are setting the same data, but `on_new_span()` sets the data to its default value at the beginning of the function and `on_record()` can set the data to new values after the function has begun.
</details>

the data we get from `tracing` amounts to stack-local variables and log statements which [the Python "Scrubbing Sensitive Data" page](https://docs.sentry.io/platforms/python/data-management/sensitive-data/) list in the section for `before_send` / `before_send_transaction`. the python SDK also has `event_scrubber` for this.

additionally, this integration is basically a port of [the Rust SDK's `tracing` integration](https://github.com/getsentry/sentry-rust/tree/master/sentry-tracing/src) which does not use the Rust SDK's version of `should_send_default_pii()` in this way ([`on_record()` link](https://github.com/getsentry/sentry-rust/blob/1b65b5c99af975496880e7325218479e0037d097/sentry-tracing/src/layer.rs#L302)). [the Rust "Scrubbing Sensitive Data" page](https://docs.sentry.io/platforms/rust/data-management/sensitive-data/) also describes tracing data in the section for `before_send` / `before_send_transaction`

it seems our SDKs typically don't use all-or-nothing filtering for data like this. instead they allow the user to provide targeted filtering at the SDK level with `before_send`/`before_send_transaction`/`event_scrubber`. this PR takes that approach for this integration