### PR TITLE
Bring all span data under pii control in rust_tracing integration

### DIFF
--- a/sentry_sdk/integrations/rust_tracing.py
+++ b/sentry_sdk/integrations/rust_tracing.py
@@ -205,9 +205,18 @@ class RustTracingLayer:
         else:
             sentry_span = scope.start_span(**kwargs)
 
+        send_sensitive_data = (
+            should_send_default_pii()
+            if self.send_sensitive_data is None
+            else self.send_sensitive_data
+        )
+
         fields = metadata.get("fields", [])
         for field in fields:
-            sentry_span.set_data(field, attrs.get(field))
+            if send_sensitive_data:
+                sentry_span.set_data(field, attrs.get(field))
+            else:
+                sentry_span.set_data(field, SENSITIVE_DATA_SUBSTITUTE)
 
         scope.span = sentry_span
         return (parent_sentry_span, sentry_span)


### PR DESCRIPTION
Before only data that was set in `on_record` was protected by our PII controls. Now also the span data that is add in `on_new_span` is prtected by PII controls. 

<!-- Describe your PR here -->

---

Thank you for contributing to `sentry-python`! Please add tests to validate your changes, and lint your code using `tox -e linters`.

Running the test suite on your PR might require maintainer approval. The AWS Lambda tests additionally require a maintainer to add a special label, and they will fail until this label is added.
