### PR TITLE
Fix flake8

### DIFF
--- a/sentry_sdk/_init_implementation.py
+++ b/sentry_sdk/_init_implementation.py
@@ -1,5 +1,3 @@
-import warnings
-
 from typing import TYPE_CHECKING
 
 import sentry_sdk

--- a/sentry_sdk/integrations/aiohttp.py
+++ b/sentry_sdk/integrations/aiohttp.py
@@ -390,7 +390,7 @@ def _prepopulate_attributes(request):
             attributes["server.address"] = request.host
 
     try:
-        url = f"{request.scheme}://{request.host}{request.path}"
+        url = f"{request.scheme}://{request.host}{request.path}"  # noqa: E231
         if request.query_string:
             attributes["url.full"] = f"{url}?{request.query_string}"
     except Exception:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,7 +1,6 @@
 import pytest
 from unittest import mock
 
-import sentry_sdk
 from sentry_sdk import (
     capture_exception,
     continue_trace,

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -61,55 +61,6 @@ def _normalize_distribution_name(name):
 
 
 @pytest.mark.parametrize(
-    ("input_str", "expected_output"),
-    (
-        (
-            "2021-01-01T00:00:00.000000Z",
-            datetime(2021, 1, 1, tzinfo=timezone.utc),
-        ),  # UTC time
-        (
-            "2021-01-01T00:00:00.000000",
-            datetime(2021, 1, 1).astimezone(timezone.utc),
-        ),  # No TZ -- assume local but convert to UTC
-        (
-            "2021-01-01T00:00:00Z",
-            datetime(2021, 1, 1, tzinfo=timezone.utc),
-        ),  # UTC - No milliseconds
-        (
-            "2021-01-01T00:00:00.000000+00:00",
-            datetime(2021, 1, 1, tzinfo=timezone.utc),
-        ),
-        (
-            "2021-01-01T00:00:00.000000-00:00",
-            datetime(2021, 1, 1, tzinfo=timezone.utc),
-        ),
-        (
-            "2021-01-01T00:00:00.000000+0000",
-            datetime(2021, 1, 1, tzinfo=timezone.utc),
-        ),
-        (
-            "2021-01-01T00:00:00.000000-0000",
-            datetime(2021, 1, 1, tzinfo=timezone.utc),
-        ),
-        (
-            "2020-12-31T00:00:00.000000+02:00",
-            datetime(2020, 12, 31, tzinfo=timezone(timedelta(hours=2))),
-        ),  # UTC+2 time
-        (
-            "2020-12-31T00:00:00.000000-0200",
-            datetime(2020, 12, 31, tzinfo=timezone(timedelta(hours=-2))),
-        ),  # UTC-2 time
-        (
-            "2020-12-31T00:00:00-0200",
-            datetime(2020, 12, 31, tzinfo=timezone(timedelta(hours=-2))),
-        ),  # UTC-2 time - no milliseconds
-    ),
-)
-def test_datetime_from_isoformat(input_str, expected_output):
-    assert datetime_from_isoformat(input_str) == expected_output, input_str
-
-
-@pytest.mark.parametrize(
     "env_var_value,strict,expected",
     [
         (None, True, None),


### PR DESCRIPTION
Tiny PR with some flake8 fixes:
- some extra imports
- testing a removed util
- ignoring `sentry_sdk/integrations/aiohttp.py:393:33: E231 missing whitespace after ':'` on this line

  ```python
  url = f"{request.scheme}://{request.host}{request.path}"
  ```
  🙄 
 
 
Original output:
```
linters: commands[0]> flake8 tests sentry_sdk
tests/test_utils.py:109:12: F821 undefined name 'datetime_from_isoformat'
tests/test_api.py:4:1: F401 'sentry_sdk' imported but unused
sentry_sdk/_init_implementation.py:1:1: F401 'warnings' imported but unused
sentry_sdk/integrations/aiohttp.py:393:33: E231 missing whitespace after ':'
```