### PR TITLE
feat(spotlight): Auto enable cache_spans for Spotlight on DEBUG

### DIFF
--- a/sentry_sdk/integrations/django/caching.py
+++ b/sentry_sdk/integrations/django/caching.py
@@ -132,10 +132,21 @@ def _get_address_port(settings):
     return address, int(port) if port is not None else None
 
 
-def patch_caching():
-    # type: () -> None
+def should_enable_cache_spans():
+    # type: () -> bool
     from sentry_sdk.integrations.django import DjangoIntegration
 
+    client = sentry_sdk.get_client()
+    integration = client.get_integration(DjangoIntegration)
+    from django.conf import settings
+
+    return integration is not None and (
+        (client.spotlight is not None and settings.DEBUG is True)
+        or integration.cache_spans is True
+    )
+
+def patch_caching():
+    # type: () -> None
     if not hasattr(CacheHandler, "_sentry_patched"):
         if DJANGO_VERSION < (3, 2):
             original_get_item = CacheHandler.__getitem__
@@ -145,8 +156,7 @@ def patch_caching():
                 # type: (CacheHandler, str) -> Any
                 cache = original_get_item(self, alias)
 
-                integration = sentry_sdk.get_client().get_integration(DjangoIntegration)
-                if integration is not None and integration.cache_spans:
+                if should_enable_cache_spans():
                     from django.conf import settings
 
                     address, port = _get_address_port(
@@ -168,8 +178,7 @@ def patch_caching():
                 # type: (CacheHandler, str) -> Any
                 cache = original_create_connection(self, alias)
 
-                integration = sentry_sdk.get_client().get_integration(DjangoIntegration)
-                if integration is not None and integration.cache_spans:
+                if should_enable_cache_spans():
                     address, port = _get_address_port(self.settings[alias or "default"])
 
                     _patch_cache(cache, address, port)

--- a/sentry_sdk/integrations/django/caching.py
+++ b/sentry_sdk/integrations/django/caching.py
@@ -145,6 +145,7 @@ def should_enable_cache_spans():
         or integration.cache_spans is True
     )
 
+
 def patch_caching():
     # type: () -> None
     if not hasattr(CacheHandler, "_sentry_patched"):


### PR DESCRIPTION
This patch enables `cache_spans` in Django integration automatically when Spotlight is enabled and `DEBUG` is set in Django settings.
