### PR TITLE
fix: Trim long stacktraces

### DIFF
--- a/sentry_sdk/consts.py
+++ b/sentry_sdk/consts.py
@@ -82,6 +82,18 @@ DEFAULT_QUEUE_SIZE = 100
 DEFAULT_MAX_BREADCRUMBS = 100
 MATCH_ALL = r".*"
 
+MAX_STACK_FRAMES = 300  # type: int
+"""The maximum number of stack frames to capture on error events.
+
+Relay enforces a limit of 250 frames on the stack trace. See
+https://github.com/getsentry/relay/blob/aae36669414a1f7c6ef68d5226cb2e96a28f7667/relay-event-normalization/src/trimming.rs#L286.
+We use a slightly higher value here; Relay will trim any frames
+beyond its limit.
+
+This constant is for internal use only, and it may be changed or removed
+at any time.
+"""
+
 FALSE_VALUES = [
     "false",
     "no",

--- a/sentry_sdk/utils.py
+++ b/sentry_sdk/utils.py
@@ -1,4 +1,5 @@
 import base64
+import itertools
 import json
 import linecache
 import logging
@@ -26,7 +27,7 @@ except ImportError:
 
 import sentry_sdk
 from sentry_sdk._compat import PY37
-from sentry_sdk.consts import DEFAULT_MAX_VALUE_LENGTH, EndpointType
+from sentry_sdk.consts import DEFAULT_MAX_VALUE_LENGTH, MAX_STACK_FRAMES, EndpointType
 
 from typing import TYPE_CHECKING
 
@@ -803,7 +804,7 @@ def single_exception_from_error_tuple(
             max_value_length=max_value_length,
             custom_repr=custom_repr,
         )
-        for tb in iter_stacks(tb)
+        for tb in itertools.islice(iter_stacks(tb), MAX_STACK_FRAMES)
     ]
 
     if frames:


### PR DESCRIPTION
Only process and send the first 300 stack frames for an error event. This prevents the SDK from causing the program to hang when the SDK captures an error with a very large number of stack frames. Relay anyways [trims events to 250 stack frames](https://github.com/getsentry/relay/blob/aae36669414a1f7c6ef68d5226cb2e96a28f7667/relay-event-normalization/src/trimming.rs#L286), so it is pointless for us to process much beyond that number.

Fixes #2764