### PR TITLE
fix(integrations): Check retries_left before capturing exception

### DIFF
--- a/sentry_sdk/integrations/rq.py
+++ b/sentry_sdk/integrations/rq.py
@@ -90,9 +90,9 @@ class RqIntegration(Integration):
 
         def sentry_patched_handle_exception(self, job, *exc_info, **kwargs):
             # type: (Worker, Any, *Any, **Any) -> Any
-            # Note, the order of the `or` here is important,
-            # because calling `job.is_failed` will change `_status`.
-            if job._status == JobStatus.FAILED or job.is_failed:
+            retry = hasattr(job, 'retries_left') and job.retries_left and job.retries_left > 0
+            failed = job._status == JobStatus.FAILED or job.is_failed
+            if failed and not retry:
                 _capture_exception(exc_info)
 
             return old_handle_exception(self, job, *exc_info, **kwargs)

--- a/sentry_sdk/integrations/rq.py
+++ b/sentry_sdk/integrations/rq.py
@@ -90,7 +90,11 @@ class RqIntegration(Integration):
 
         def sentry_patched_handle_exception(self, job, *exc_info, **kwargs):
             # type: (Worker, Any, *Any, **Any) -> Any
-            retry = hasattr(job, 'retries_left') and job.retries_left and job.retries_left > 0
+            retry = (
+                hasattr(job, "retries_left")
+                and job.retries_left
+                and job.retries_left > 0
+            )
             failed = job._status == JobStatus.FAILED or job.is_failed
             if failed and not retry:
                 _capture_exception(exc_info)

--- a/tests/integrations/rq/test_rq.py
+++ b/tests/integrations/rq/test_rq.py
@@ -254,11 +254,6 @@ def test_traces_sampler_gets_correct_values_in_sampling_context(
 @pytest.mark.skipif(
     parse_version(rq.__version__) < (1, 5), reason="At least rq-1.5 required"
 )
-@pytest.mark.skipif(
-    parse_version(rq.__version__) >= (2,),
-    reason="Test broke in RQ 2.0. Investigate and fix. "
-    "See https://github.com/getsentry/sentry-python/issues/3707.",
-)
 def test_job_with_retries(sentry_init, capture_events):
     sentry_init(integrations=[RqIntegration()])
     events = capture_events()


### PR DESCRIPTION
Since https://github.com/rq/rq/pull/1964 the job status is set to Failed before the handler decides whether to capture or not the exception while `handle_job_failure ` has not yet been called so the job is not yet re-scheduled leading to all exceptions getting captured in RQ version >= 2.0.

Related to #1076
Fixes #3707
