### PR TITLE
Update openai.py

### DIFF
--- a/sentry_sdk/integrations/openai.py
+++ b/sentry_sdk/integrations/openai.py
@@ -137,7 +137,7 @@ def _new_chat_completion_common(f, *args, **kwargs):
 
     span = sentry_sdk.start_span(
         op=consts.OP.OPENAI_CHAT_COMPLETIONS_CREATE,
-        description="Chat Completion",
+        name="Chat Completion",
         origin=OpenAIIntegration.origin,
     )
     span.__enter__()


### PR DESCRIPTION
Update the arguments in the start_span function. pecifically, changing the deprecated "description" to "name". This was causing a deprecation warning when running tests.

<!-- Describe your PR here -->

---

Thank you for contributing to `sentry-python`! Please add tests to validate your changes, and lint your code using `tox -e linters`.

Running the test suite on your PR might require maintainer approval. The AWS Lambda tests additionally require a maintainer to add a special label, and they will fail until this label is added.
