### PR TITLE
Turn custom_sampling_context into span attrs in Celery integration

### DIFF
--- a/MIGRATION_GUIDE.md
+++ b/MIGRATION_GUIDE.md
@@ -21,6 +21,16 @@ Looking to upgrade from Sentry SDK 2.x to 3.x? Here's a comprehensive list of wh
 - clickhouse-driver integration: The query is now available under the `db.query.text` span attribute (only if `send_default_pii` is `True`).
 - `sentry_sdk.init` now returns `None` instead of a context manager.
 - The `sampling_context` argument of `traces_sampler` now additionally contains all span attributes known at span start.
+- If you're using the Celery integration, the `sampling_context` argument of `traces_sampler` doesn't contain the `celery_job` dictionary anymore. Instead, the individual keys are now available as:
+
+  | Dictionary keys | Sampling context key         |
+  | ---------------- | ------------------------------- |
+  | `celery_job["args"]`   | `celery.job.args`                |
+  | `celery_job["kwargs"]` | `celery.job.kwargs`              |
+  | `celery_job["task"]`   | `celery.job.task`                |
+
+  Note that all of these are serialized, i.e., not the original `args` and `kwargs` but rather OpenTelemetry-friendly span attributes.
+
 - If you're using the AIOHTTP integration, the `sampling_context` argument of `traces_sampler` doesn't contain the `aiohttp_request` object anymore. Instead, some of the individual properties of the request are accessible, if available, as follows:
 
   | Request property | Sampling context key(s)         |
@@ -71,7 +81,7 @@ Looking to upgrade from Sentry SDK 2.x to 3.x? Here's a comprehensive list of wh
   | `client`       | `client.address`, `client.port` |
   | full URL       | `url.full`                      |
 
-- If you're using the RQ integration, the `sampling_context` argument of `traces_sampler` doesn't contain the `rq_job` object anymore. Instead, the individual properties of the scope, if available, are accessible as follows:
+- If you're using the RQ integration, the `sampling_context` argument of `traces_sampler` doesn't contain the `rq_job` object anymore. Instead, the individual properties of the job and the queue, if available, are accessible as follows:
 
   | RQ property     | Sampling context key(s)      |
   | --------------- | ---------------------------- |
@@ -79,7 +89,7 @@ Looking to upgrade from Sentry SDK 2.x to 3.x? Here's a comprehensive list of wh
   | `rq_job.kwargs` | `rq.job.kwargs`              |
   | `rq_job.func`   | `rq.job.func`                |
   | `queue.name`    | `messaging.destination.name` |
-  | `job.id`        | `messaging.message.id`       |
+  | `rq_job.id`     | `messaging.message.id`       |
 
   Note that `rq.job.args`, `rq.job.kwargs`, and `rq.job.func` are serialized and not the actual objects on the job.
 

--- a/sentry_sdk/integrations/celery/__init__.py
+++ b/sentry_sdk/integrations/celery/__init__.py
@@ -20,6 +20,7 @@ from sentry_sdk.utils import (
     ensure_integration_enabled,
     event_from_exception,
     reraise,
+    _serialize_span_attribute,
 )
 
 from typing import TYPE_CHECKING
@@ -318,15 +319,9 @@ def _wrap_tracer(task, f):
                     name=task.name,
                     source=TRANSACTION_SOURCE_TASK,
                     origin=CeleryIntegration.origin,
-                    custom_sampling_context={
-                        "celery_job": {
-                            "task": task.name,
-                            # for some reason, args[1] is a list if non-empty but a
-                            # tuple if empty
-                            "args": list(args[1]),
-                            "kwargs": args[2],
-                        }
-                    },
+                    # for some reason, args[1] is a list if non-empty but a
+                    # tuple if empty
+                    attributes=_prepopulate_attributes(task, list(args[1]), args[2]),
                 ) as transaction:
                     transaction.set_status(SPANSTATUS.OK)
                     return f(*args, **kwargs)
@@ -516,3 +511,12 @@ def _patch_producer_publish():
             return original_publish(self, *args, **kwargs)
 
     Producer.publish = sentry_publish
+
+
+def _prepopulate_attributes(task, args, kwargs):
+    attributes = {
+        "celery.job.task": task.name,
+        "celery.job.args": _serialize_span_attribute(args),
+        "celery.job.kwargs": _serialize_span_attribute(kwargs),
+    }
+    return attributes


### PR DESCRIPTION
* remove `custom_sampling_context` and replace the `celery_job` dict with span attrs