### PR TITLE
Use new clickhouse gh action

### DIFF
--- a/.github/workflows/test-integrations-dbs.yml
+++ b/.github/workflows/test-integrations-dbs.yml
@@ -57,7 +57,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           allow-prereleases: true
-      - uses: getsentry/action-clickhouse-in-ci@v1
+      - uses: getsentry/action-clickhouse-in-ci@v1.1
       - name: Setup Test Env
         run: |
           pip install "coverage[toml]" tox
@@ -152,7 +152,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           allow-prereleases: true
-      - uses: getsentry/action-clickhouse-in-ci@v1
+      - uses: getsentry/action-clickhouse-in-ci@v1.1
       - name: Setup Test Env
         run: |
           pip install "coverage[toml]" tox

--- a/scripts/split-tox-gh-actions/templates/test_group.jinja
+++ b/scripts/split-tox-gh-actions/templates/test_group.jinja
@@ -51,7 +51,7 @@
           python-version: {% raw %}${{ matrix.python-version }}{% endraw %}
           allow-prereleases: true
       {% if needs_clickhouse %}
-      - uses: getsentry/action-clickhouse-in-ci@v1
+      - uses: getsentry/action-clickhouse-in-ci@v1.1
       {% endif %}
 
       {% if needs_redis %}


### PR DESCRIPTION
The docker image name of the official Clickhouse docker image changed, so I updated our GH action that starts that docker container and reference the new version here.

<!-- Describe your PR here -->

---

Thank you for contributing to `sentry-python`! Please add tests to validate your changes, and lint your code using `tox -e linters`.

Running the test suite on your PR might require maintainer approval. The AWS Lambda tests additionally require a maintainer to add a special label, and they will fail until this label is added.
