### PR TITLE
Fix litestar tests

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -530,6 +530,7 @@ deps =
     litestar: python-multipart
     litestar: requests
     litestar: cryptography
+    litestar: httpx<0.27.2
     litestar-v2.0: litestar~=2.0.0
     litestar-v2.3: litestar~=2.3.0
     litestar-v2.5: litestar~=2.5.0


### PR DESCRIPTION
The latest release of `httpx` seems to have broken Litestar's `TestClient`.