### PR TITLE
Update anthropic dependencies

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -324,6 +324,7 @@ deps =
 
     # Anthropic
     anthropic: pytest-asyncio
+    anthropic: httpx<0.28.0  # because deprecated "proxies" arg has been removed in 0.28.0 that is used by anthropic client
     anthropic-v0.25: anthropic~=0.25.0
     anthropic-v0.16: anthropic~=0.16.0
     anthropic-latest: anthropic


### PR DESCRIPTION
New version of HTTPX breaks Anthropic tests. Pinning