### PR TITLE
Fix initial scope handling

### DIFF
--- a/sentry_sdk/integrations/opentelemetry/integration.py
+++ b/sentry_sdk/integrations/opentelemetry/integration.py
@@ -5,6 +5,7 @@ removed at any time without prior notice.
 """
 
 from sentry_sdk.integrations import DidNotEnable, Integration
+from sentry_sdk.integrations.opentelemetry.scope import setup_initial_scopes
 from sentry_sdk.integrations.opentelemetry.propagator import SentryPropagator
 from sentry_sdk.integrations.opentelemetry.span_processor import (
     SentrySpanProcessor,
@@ -74,6 +75,7 @@ def _setup_scope_context_management():
     import opentelemetry.context
 
     opentelemetry.context._RUNTIME_CONTEXT = SentryContextVarsRuntimeContext()
+    setup_initial_scopes()
 
 
 def _setup_sentry_tracing():

--- a/sentry_sdk/integrations/opentelemetry/propagator.py
+++ b/sentry_sdk/integrations/opentelemetry/propagator.py
@@ -99,7 +99,7 @@ class SentryPropagator(TextMapPropagator):
 
             # TODO-neel-potel check trace_propagation_targets
             # TODO-neel-potel test propagator works with twp
-            for (key, value) in current_scope.iter_trace_propagation_headers():
+            for key, value in current_scope.iter_trace_propagation_headers():
                 setter.set(carrier, key, value)
 
     @property

--- a/sentry_sdk/integrations/opentelemetry/scope.py
+++ b/sentry_sdk/integrations/opentelemetry/scope.py
@@ -1,7 +1,14 @@
 from typing import cast
 from contextlib import contextmanager
 
-from opentelemetry.context import get_value, set_value, attach, detach, get_current
+from opentelemetry.context import (
+    Context,
+    get_value,
+    set_value,
+    attach,
+    detach,
+    get_current,
+)
 from opentelemetry.trace import (
     SpanContext,
     NonRecordingSpan,
@@ -136,13 +143,13 @@ _INITIAL_CURRENT_SCOPE = None
 _INITIAL_ISOLATION_SCOPE = None
 
 
-def _setup_initial_scopes():
+def setup_initial_scopes():
     global _INITIAL_CURRENT_SCOPE, _INITIAL_ISOLATION_SCOPE
     _INITIAL_CURRENT_SCOPE = PotelScope(ty=ScopeType.CURRENT)
     _INITIAL_ISOLATION_SCOPE = PotelScope(ty=ScopeType.ISOLATION)
 
-
-_setup_initial_scopes()
+    scopes = (_INITIAL_CURRENT_SCOPE, _INITIAL_ISOLATION_SCOPE)
+    attach(set_value(SENTRY_SCOPES_KEY, scopes))
 
 
 @contextmanager

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -74,7 +74,7 @@ def clean_scopes():
     scope._isolation_scope.set(None)
     scope._current_scope.set(None)
 
-    potel_scope._setup_initial_scopes()
+    potel_scope.setup_initial_scopes()
 
 
 @pytest.fixture(autouse=True)

--- a/tests/integrations/stdlib/test_subprocess.py
+++ b/tests/integrations/stdlib/test_subprocess.py
@@ -7,7 +7,7 @@ from unittest import mock
 
 import pytest
 
-from sentry_sdk import capture_exception, capture_message, start_transaction
+from sentry_sdk import capture_exception, capture_message, start_span
 from sentry_sdk.integrations.stdlib import StdlibIntegration
 from tests.conftest import ApproxDict
 
@@ -59,7 +59,7 @@ def test_subprocess_basic(
     sentry_init(integrations=[StdlibIntegration()], traces_sample_rate=1.0)
     events = capture_events()
 
-    with start_transaction(name="foo") as transaction:
+    with start_span(name="foo") as span:
         args = [
             sys.executable,
             "-c",
@@ -110,7 +110,7 @@ def test_subprocess_basic(
 
     assert os.environ == old_environ
 
-    assert transaction.trace_id in str(output)
+    assert span.trace_id in str(output)
 
     capture_message("hi")
 
@@ -178,7 +178,7 @@ def test_subprocess_basic(
 def test_subprocess_empty_env(sentry_init, monkeypatch):
     monkeypatch.setenv("TEST_MARKER", "should_not_be_seen")
     sentry_init(integrations=[StdlibIntegration()], traces_sample_rate=1.0)
-    with start_transaction(name="foo"):
+    with start_span(name="foo"):
         args = [
             sys.executable,
             "-c",
@@ -201,7 +201,7 @@ def test_subprocess_span_origin(sentry_init, capture_events):
     sentry_init(integrations=[StdlibIntegration()], traces_sample_rate=1.0)
     events = capture_events()
 
-    with start_transaction(name="foo"):
+    with start_span(name="foo"):
         args = [
             sys.executable,
             "-c",


### PR DESCRIPTION
Instead of relying on fallback behaviour, it makes sense to populate the scopes on the first context during init.

This also fixes breadcrumb leakage between httplib and subprocess tests.