### PR TITLE
Fix Cohere tests in potel

### DIFF
--- a/tests/integrations/cohere/test_cohere.py
+++ b/tests/integrations/cohere/test_cohere.py
@@ -152,7 +152,7 @@ def test_bad_chat(sentry_init, capture_events):
     with pytest.raises(httpx.HTTPError):
         client.chat(model="some-model", message="hello")
 
-    (event, _) = events
+    (event,) = events
     assert event["level"] == "error"
 
 


### PR DESCRIPTION
A few weeks ago I changed this tests to assume the second event. We since have fixed the thing that was creating this event, so we can change the test back. 