### PR TITLE
Move scope context init outside integration

### DIFF
--- a/MIGRATION_GUIDE.md
+++ b/MIGRATION_GUIDE.md
@@ -138,6 +138,7 @@ Looking to upgrade from Sentry SDK 2.x to 3.x? Here's a comprehensive list of wh
 - `span.containing_transaction` has been removed. Use `span.root_span` instead.
 - `continue_from_headers`, `continue_from_environ` and `from_traceparent` have been removed, please use top-level API `sentry_sdk.continue_trace` instead.
 - `PropagationContext` constructor no longer takes a `dynamic_sampling_context` but takes a `baggage` object instead.
+- `ThreadingIntegration` no longer takes the `propagate_hub` argument.
 
 ### Deprecated
 

--- a/sentry_sdk/_init_implementation.py
+++ b/sentry_sdk/_init_implementation.py
@@ -1,6 +1,7 @@
 from typing import TYPE_CHECKING
 
 import sentry_sdk
+from sentry_sdk.integrations.opentelemetry.scope import setup_scope_context_management
 
 if TYPE_CHECKING:
     from typing import Any, Optional
@@ -24,6 +25,7 @@ def _init(*args, **kwargs):
     """
     client = sentry_sdk.Client(*args, **kwargs)
     sentry_sdk.get_global_scope().set_client(client)
+    setup_scope_context_management()
     _check_python_deprecations()
 
 

--- a/sentry_sdk/integrations/opentelemetry/integration.py
+++ b/sentry_sdk/integrations/opentelemetry/integration.py
@@ -5,13 +5,9 @@ removed at any time without prior notice.
 """
 
 from sentry_sdk.integrations import DidNotEnable, Integration
-from sentry_sdk.integrations.opentelemetry.scope import setup_initial_scopes
 from sentry_sdk.integrations.opentelemetry.propagator import SentryPropagator
 from sentry_sdk.integrations.opentelemetry.span_processor import (
     SentrySpanProcessor,
-)
-from sentry_sdk.integrations.opentelemetry.contextvars_context import (
-    SentryContextVarsRuntimeContext,
 )
 from sentry_sdk.integrations.opentelemetry.sampler import SentrySampler
 from sentry_sdk.utils import logger
@@ -45,7 +41,6 @@ class OpenTelemetryIntegration(Integration):
             "Use at your own risk."
         )
 
-        _setup_scope_context_management()
         _setup_sentry_tracing()
         _patch_readable_span()
         # _setup_instrumentors()
@@ -68,14 +63,6 @@ def _patch_readable_span():
         return readable_span
 
     Span._readable_span = sentry_patched_readable_span
-
-
-def _setup_scope_context_management():
-    # type: () -> None
-    import opentelemetry.context
-
-    opentelemetry.context._RUNTIME_CONTEXT = SentryContextVarsRuntimeContext()
-    setup_initial_scopes()
 
 
 def _setup_sentry_tracing():

--- a/sentry_sdk/integrations/opentelemetry/scope.py
+++ b/sentry_sdk/integrations/opentelemetry/scope.py
@@ -2,7 +2,6 @@ from typing import cast
 from contextlib import contextmanager
 
 from opentelemetry.context import (
-    Context,
     get_value,
     set_value,
     attach,
@@ -23,6 +22,9 @@ from sentry_sdk.integrations.opentelemetry.consts import (
     SENTRY_USE_CURRENT_SCOPE_KEY,
     SENTRY_USE_ISOLATION_SCOPE_KEY,
     TRACESTATE_SAMPLED_KEY,
+)
+from sentry_sdk.integrations.opentelemetry.contextvars_context import (
+    SentryContextVarsRuntimeContext,
 )
 from sentry_sdk.integrations.opentelemetry.utils import trace_state_from_baggage
 from sentry_sdk.scope import Scope, ScopeType
@@ -150,6 +152,14 @@ def setup_initial_scopes():
 
     scopes = (_INITIAL_CURRENT_SCOPE, _INITIAL_ISOLATION_SCOPE)
     attach(set_value(SENTRY_SCOPES_KEY, scopes))
+
+
+def setup_scope_context_management():
+    # type: () -> None
+    import opentelemetry.context
+
+    opentelemetry.context._RUNTIME_CONTEXT = SentryContextVarsRuntimeContext()
+    setup_initial_scopes()
 
 
 @contextmanager

--- a/sentry_sdk/scope.py
+++ b/sentry_sdk/scope.py
@@ -26,6 +26,7 @@ from sentry_sdk.tracing import (
     SENTRY_TRACE_HEADER_NAME,
     NoOpSpan,
     Span,
+    POTelSpan,
     Transaction,
 )
 from sentry_sdk.utils import (
@@ -669,7 +670,7 @@ class Scope:
         self.clear_breadcrumbs()
         self._should_capture = True  # type: bool
 
-        self._span = None  # type: Optional[Span]
+        self._span = None  # type: Optional[POTelSpan]
         self._session = None  # type: Optional[Session]
         self._force_auto_session_tracking = None  # type: Optional[bool]
 
@@ -777,13 +778,13 @@ class Scope:
 
     @property
     def span(self):
-        # type: () -> Optional[Span]
+        # type: () -> Optional[POTelSpan]
         """Get current tracing span."""
         return self._span
 
     @span.setter
     def span(self, span):
-        # type: (Optional[Span]) -> None
+        # type: (Optional[POTelSpan]) -> None
         """Set current tracing span."""
         self._span = span
 

--- a/sentry_sdk/tracing.py
+++ b/sentry_sdk/tracing.py
@@ -1280,11 +1280,11 @@ class POTelSpan:
     def __repr__(self):
         # type: () -> str
         return (
-            "<%s(op=%r, description:%r, trace_id=%r, span_id=%r, parent_span_id=%r, sampled=%r, origin=%r)>"
+            "<%s(op=%r, name:%r, trace_id=%r, span_id=%r, parent_span_id=%r, sampled=%r, origin=%r)>"
             % (
                 self.__class__.__name__,
                 self.op,
-                self.description,
+                self.name,
                 self.trace_id,
                 self.span_id,
                 self.parent_span_id,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -62,7 +62,10 @@ else:
 
 
 from sentry_sdk import scope
-import sentry_sdk.integrations.opentelemetry.scope as potel_scope
+from sentry_sdk.integrations.opentelemetry.scope import (
+    setup_scope_context_management,
+    setup_initial_scopes,
+)
 
 
 @pytest.fixture(autouse=True)
@@ -74,7 +77,7 @@ def clean_scopes():
     scope._isolation_scope.set(None)
     scope._current_scope.set(None)
 
-    potel_scope.setup_initial_scopes()
+    setup_initial_scopes()
 
 
 @pytest.fixture(autouse=True)
@@ -187,6 +190,7 @@ def sentry_init(request):
         kw.setdefault("transport", TestTransport())
         client = sentry_sdk.Client(*a, **kw)
         sentry_sdk.get_global_scope().set_client(client)
+        setup_scope_context_management()
 
     if request.node.get_closest_marker("forked"):
         # Do not run isolation if the test is already running in

--- a/tests/test_scope.py
+++ b/tests/test_scope.py
@@ -15,13 +15,11 @@ from sentry_sdk.scope import (
     ScopeType,
     should_send_default_pii,
 )
-from sentry_sdk.integrations.opentelemetry.integration import (
-    _setup_scope_context_management,
-)
 from sentry_sdk.integrations.opentelemetry.scope import (
     PotelScope as Scope,
     use_scope,
     use_isolation_scope,
+    setup_scope_context_management,
 )
 
 
@@ -31,7 +29,7 @@ SLOTS_NOT_COPIED = {"client"}
 
 @pytest.fixture(autouse=True)
 def setup_otel_scope_management():
-    _setup_scope_context_management()
+    setup_scope_context_management()
 
 
 def test_copying():


### PR DESCRIPTION
The scope context management init cannot be inside the integration since that would not work when we use `default_integrations=False` and other such cases.