### PR TITLE
Fix threading by carrying forward span reference in `use_scope`

### DIFF
--- a/MIGRATION_GUIDE.md
+++ b/MIGRATION_GUIDE.md
@@ -138,6 +138,7 @@ Looking to upgrade from Sentry SDK 2.x to 3.x? Here's a comprehensive list of wh
 - `span.containing_transaction` has been removed. Use `span.root_span` instead.
 - `continue_from_headers`, `continue_from_environ` and `from_traceparent` have been removed, please use top-level API `sentry_sdk.continue_trace` instead.
 - `PropagationContext` constructor no longer takes a `dynamic_sampling_context` but takes a `baggage` object instead.
+- `ThreadingIntegration` no longer takes the `propagate_hub` argument.
 
 ### Deprecated
 

--- a/sentry_sdk/scope.py
+++ b/sentry_sdk/scope.py
@@ -26,6 +26,7 @@ from sentry_sdk.tracing import (
     SENTRY_TRACE_HEADER_NAME,
     NoOpSpan,
     Span,
+    POTelSpan,
     Transaction,
 )
 from sentry_sdk.utils import (
@@ -669,7 +670,7 @@ class Scope:
         self.clear_breadcrumbs()
         self._should_capture = True  # type: bool
 
-        self._span = None  # type: Optional[Span]
+        self._span = None  # type: Optional[POTelSpan]
         self._session = None  # type: Optional[Session]
         self._force_auto_session_tracking = None  # type: Optional[bool]
 
@@ -777,13 +778,13 @@ class Scope:
 
     @property
     def span(self):
-        # type: () -> Optional[Span]
+        # type: () -> Optional[POTelSpan]
         """Get current tracing span."""
         return self._span
 
     @span.setter
     def span(self, span):
-        # type: (Optional[Span]) -> None
+        # type: (Optional[POTelSpan]) -> None
         """Set current tracing span."""
         self._span = span
 

--- a/sentry_sdk/tracing.py
+++ b/sentry_sdk/tracing.py
@@ -1280,11 +1280,11 @@ class POTelSpan:
     def __repr__(self):
         # type: () -> str
         return (
-            "<%s(op=%r, description:%r, trace_id=%r, span_id=%r, parent_span_id=%r, sampled=%r, origin=%r)>"
+            "<%s(op=%r, name:%r, trace_id=%r, span_id=%r, parent_span_id=%r, sampled=%r, origin=%r)>"
             % (
                 self.__class__.__name__,
                 self.op,
-                self.description,
+                self.name,
                 self.trace_id,
                 self.span_id,
                 self.parent_span_id,


### PR DESCRIPTION
Since the otel context span reference is the source of truth for the current active span, we need to explicitly pass the span reference on the scope through when we use `use_scope` since we are changing context variables in the other thread.

Also,

* remove deprecated `propagate_hub` completely
* fixes some typing in the original scope
* adds more types to the `contextvars_context` manager