### PR TITLE
fix(django): Fix errors when instrumenting Django cache

### DIFF
--- a/sentry_sdk/integrations/django/caching.py
+++ b/sentry_sdk/integrations/django/caching.py
@@ -75,11 +75,12 @@ def _patch_cache_method(cache, method_name, address, port):
                         span.set_data(SPANDATA.CACHE_HIT, True)
                     else:
                         span.set_data(SPANDATA.CACHE_HIT, False)
-                else:
-                    try:
+                else:  # TODO: We don't handle `get_or_set` which we should
+                    arg_count = len(args)
+                    if arg_count >= 2:
                         # 'set' command
                         item_size = len(str(args[1]))
-                    except IndexError:
+                    elif arg_count == 1:
                         # 'set_many' command
                         item_size = len(str(args[0]))
 


### PR DESCRIPTION
I was testing Spotlight with Sentry and realized things started to get slow and crashy. It looks like sometimes `args` is just an empty array on cache's `_instruments_call` causing lots of exceptions being thrown. This patch fixes that with explicit length checks and also adds a note for the missing instrumentation for `get_or_set` method. This might be related to #2122 and #3300.
