### PR TITLE
fix(spotlight): Don't give up on Spotlight on 3 errors

### DIFF
--- a/sentry_sdk/spotlight.py
+++ b/sentry_sdk/spotlight.py
@@ -42,11 +42,6 @@ class SpotlightClient:
 
     def capture_envelope(self, envelope):
         # type: (Envelope) -> None
-        if self.tries > 3:
-            sentry_logger.warning(
-                "Too many errors sending to Spotlight, stop sending events there."
-            )
-            return
         body = io.BytesIO()
         envelope.serialize_into(body)
         try:
@@ -60,7 +55,7 @@ class SpotlightClient:
             )
             req.close()
         except Exception as e:
-            self.tries += 1
+            # TODO: Implement buffering and retrying with exponential backoff
             sentry_logger.warning(str(e))
 
 


### PR DESCRIPTION
Current Spotlight error handling logic gives up sending events to Spotlight after 3 errors. This doesn't make much sense because:

1. Since there is no back off or retry mechanism, even a very brief server hiccup or restart turns off Spotlight reporting
2. Once this shut off kicks in, there is no way to turn it back on except for a server restart

I added a note for future work for retries and some short buffer.
