### PR TITLE
fix(LRUCache): copy using deepcopy, and ensure the get_all function always terminates

### DIFF
--- a/sentry_sdk/_lru_cache.py
+++ b/sentry_sdk/_lru_cache.py
@@ -62,7 +62,7 @@ Agreement.
 
 """
 
-from copy import copy
+from copy import copy, deepcopy
 
 SENTINEL = object()
 
@@ -95,7 +95,7 @@ class LRUCache:
         cache = LRUCache(self.max_size)
         cache.full = self.full
         cache.cache = copy(self.cache)
-        cache.root = copy(self.root)
+        cache.root = deepcopy(self.root)
         return cache
 
     def set(self, key, value):
@@ -167,7 +167,15 @@ class LRUCache:
     def get_all(self):
         nodes = []
         node = self.root[NEXT]
-        while node is not self.root:
+
+        # To ensure the loop always terminates we iterate to the maximum
+        # size of the LRU cache.
+        for _ in range(self.max_size):
+            # The cache may not be full. We exit early if we've wrapped
+            # around to the head.
+            if node is self.root:
+                break
             nodes.append((node[KEY], node[VALUE]))
             node = node[NEXT]
+
         return nodes

--- a/tests/test_lru_cache.py
+++ b/tests/test_lru_cache.py
@@ -1,4 +1,5 @@
 import pytest
+from copy import copy
 
 from sentry_sdk._lru_cache import LRUCache
 
@@ -57,4 +58,21 @@ def test_cache_get_all():
     cache.set(3, 3)
     assert cache.get_all() == [(1, 1), (2, 2), (3, 3)]
     cache.get(1)
+    assert cache.get_all() == [(2, 2), (3, 3), (1, 1)]
+
+
+def test_cache_copy():
+    cache = LRUCache(3)
+    cache.set(0, 0)
+    cache.set(1, 1)
+
+    copied = copy(cache)
+    cache.set(2, 2)
+    cache.set(3, 3)
+    assert copied.get_all() == [(0, 0), (1, 1)]
+    assert cache.get_all() == [(1, 1), (2, 2), (3, 3)]
+
+    copied = copy(cache)
+    cache.get(1)
+    assert copied.get_all() == [(1, 1), (2, 2), (3, 3)]
     assert cache.get_all() == [(2, 2), (3, 3), (1, 1)]


### PR DESCRIPTION
@aliu39 discovered that under certain circumstances a process can get stuck in an infinite loop.  Andrew fixed this by using `deepcopy` which prevents the infinite loop and fixes a bug where the LRU returns incorrect results.  Additionally, I've added a terminating loop in case there are any future bugs we've missed.

Closes: https://github.com/getsentry/sentry-python/issues/3862

Out of precaution, we disabled flagpole evaluation tracking Sentry while we wait for this to be merged.