### PR TITLE
Use stdlib pathlib in script

### DIFF
--- a/scripts/ready_yet/requirements.txt
+++ b/scripts/ready_yet/requirements.txt
@@ -1,3 +1,2 @@
 requests
-pathlib
 tox


### PR DESCRIPTION
`pathlib` has been part of the standard library for a long time, no need to use the pypi package.

Thanks @Tenzer for [spotting this](https://github.com/getsentry/sentry-python/pull/3425#discussion_r1872767671)!