### PR TITLE
Add Github workflow to comment on issues when a fix was released

### DIFF
--- a/.github/workflows/release-comment-issues.yml
+++ b/.github/workflows/release-comment-issues.yml
@@ -1,0 +1,31 @@
+name: "Automation: Notify issues for release"
+on:
+  release:
+    types:
+      - published
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Which version to notify issues for
+        required: false
+
+# This workflow is triggered when a release is published
+jobs:
+  release-comment-issues:
+    runs-on: ubuntu-20.04
+    name: Notify issues
+    steps:
+      - name: Get version
+        id: get_version
+        run: echo "version=${{ github.event.inputs.version || github.event.release.tag_name }}" >> $GITHUB_OUTPUT
+
+      - name: Comment on linked issues that are mentioned in release
+        if: |
+          steps.get_version.outputs.version != ''
+          && !contains(steps.get_version.outputs.version, 'a')
+          && !contains(steps.get_version.outputs.version, 'b')
+          && !contains(steps.get_version.outputs.version, 'rc')
+        uses: getsentry/release-comment-issues-gh-action@v1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          version: ${{ steps.get_version.outputs.version }}


### PR DESCRIPTION
When a release is done the Changelog will be parsed for issue numbers. Then a comment will be added to those issues that a fix has been released.

This is taken from the Javascript SDK: https://github.com/getsentry/sentry-javascript/blob/develop/.github/workflows/release-comment-issues.yml

