### PR TITLE
✨ Add Typer integration

### DIFF
--- a/.github/workflows/test-integrations-misc.yml
+++ b/.github/workflows/test-integrations-misc.yml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.6","3.8","3.12","3.13"]
+        python-version: ["3.6","3.7","3.8","3.12","3.13"]
         # python3.6 reached EOL and is no longer being supported on
         # new versions of hosted runners on Github Actions
         # ubuntu-20.04 is the last version that supported python3.6
@@ -73,6 +73,10 @@ jobs:
         run: |
           set -x # print commands that are executed
           ./scripts/runtox.sh "py${{ matrix.python-version }}-trytond-latest"
+      - name: Test typer latest
+        run: |
+          set -x # print commands that are executed
+          ./scripts/runtox.sh "py${{ matrix.python-version }}-typer-latest"
       - name: Generate coverage XML (Python 3.6)
         if: ${{ !cancelled() && matrix.python-version == '3.6' }}
         run: |
@@ -153,6 +157,10 @@ jobs:
         run: |
           set -x # print commands that are executed
           ./scripts/runtox.sh --exclude-latest "py${{ matrix.python-version }}-trytond"
+      - name: Test typer pinned
+        run: |
+          set -x # print commands that are executed
+          ./scripts/runtox.sh --exclude-latest "py${{ matrix.python-version }}-typer"
       - name: Generate coverage XML (Python 3.6)
         if: ${{ !cancelled() && matrix.python-version == '3.6' }}
         run: |

--- a/requirements-linting.txt
+++ b/requirements-linting.txt
@@ -17,3 +17,4 @@ pre-commit # local linting
 httpcore
 openfeature-sdk
 launchdarkly-server-sdk
+typer

--- a/scripts/split-tox-gh-actions/split-tox-gh-actions.py
+++ b/scripts/split-tox-gh-actions/split-tox-gh-actions.py
@@ -132,6 +132,7 @@ GROUPS = {
         "potel",
         "pure_eval",
         "trytond",
+        "typer",
     ],
 }
 

--- a/sentry_sdk/integrations/typer.py
+++ b/sentry_sdk/integrations/typer.py
@@ -32,7 +32,7 @@ class TyperIntegration(Integration):
     @staticmethod
     def setup_once():
         # type: () -> None
-        typer.main.except_hook = _make_excepthook(typer.main.except_hook)
+        typer.main.except_hook = _make_excepthook(typer.main.except_hook)  # type: ignore
 
 
 def _make_excepthook(old_excepthook):

--- a/sentry_sdk/integrations/typer.py
+++ b/sentry_sdk/integrations/typer.py
@@ -41,7 +41,7 @@ def _make_excepthook(old_excepthook):
         # type: (Type[BaseException], BaseException, Optional[TracebackType]) -> None
         integration = sentry_sdk.get_client().get_integration(TyperIntegration)
 
-        # Note: If  we replace this with ensure_integration_enabled then
+        # Note: If we replace this with ensure_integration_enabled then
         # we break the exceptiongroup backport;
         # See: https://github.com/getsentry/sentry-python/issues/3097
         if integration is None:

--- a/sentry_sdk/integrations/typer.py
+++ b/sentry_sdk/integrations/typer.py
@@ -51,7 +51,7 @@ def _make_excepthook(old_excepthook):
             event, hint = event_from_exception(
                 (type_, value, traceback),
                 client_options=sentry_sdk.get_client().options,
-                mechanism={"type": "excepthook", "handled": False},
+                mechanism={"type": "typer", "handled": False},
             )
             sentry_sdk.capture_event(event, hint=hint)
 

--- a/sentry_sdk/integrations/typer.py
+++ b/sentry_sdk/integrations/typer.py
@@ -1,0 +1,60 @@
+import sentry_sdk
+from sentry_sdk.utils import (
+    capture_internal_exceptions,
+    event_from_exception,
+)
+from sentry_sdk.integrations import Integration, DidNotEnable
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from typing import Callable
+    from typing import Any
+    from typing import Type
+    from typing import Optional
+
+    from types import TracebackType
+
+    Excepthook = Callable[
+        [Type[BaseException], BaseException, Optional[TracebackType]],
+        Any,
+    ]
+
+try:
+    import typer
+except ImportError:
+    raise DidNotEnable("Typer not installed")
+
+
+class TyperIntegration(Integration):
+    identifier = "typer"
+
+    @staticmethod
+    def setup_once():
+        # type: () -> None
+        typer.main.except_hook = _make_excepthook(typer.main.except_hook)
+
+
+def _make_excepthook(old_excepthook):
+    # type: (Excepthook) -> Excepthook
+    def sentry_sdk_excepthook(type_, value, traceback):
+        # type: (Type[BaseException], BaseException, Optional[TracebackType]) -> None
+        integration = sentry_sdk.get_client().get_integration(TyperIntegration)
+
+        # Note: If  we replace this with ensure_integration_enabled then
+        # we break the exceptiongroup backport;
+        # See: https://github.com/getsentry/sentry-python/issues/3097
+        if integration is None:
+            return old_excepthook(type_, value, traceback)
+
+        with capture_internal_exceptions():
+            event, hint = event_from_exception(
+                (type_, value, traceback),
+                client_options=sentry_sdk.get_client().options,
+                mechanism={"type": "excepthook", "handled": False},
+            )
+            sentry_sdk.capture_event(event, hint=hint)
+
+        return old_excepthook(type_, value, traceback)
+
+    return sentry_sdk_excepthook

--- a/tests/integrations/typer/__init__.py
+++ b/tests/integrations/typer/__init__.py
@@ -1,0 +1,3 @@
+import pytest
+
+pytest.importorskip("typer")

--- a/tests/integrations/typer/test_typer.py
+++ b/tests/integrations/typer/test_typer.py
@@ -1,0 +1,52 @@
+import subprocess
+import sys
+from textwrap import dedent
+import pytest
+
+from typer.testing import CliRunner
+
+runner = CliRunner()
+
+
+def test_catch_exceptions(tmpdir):
+    app = tmpdir.join("app.py")
+
+    app.write(
+        dedent(
+            """
+    import typer
+    from unittest import mock
+
+    from sentry_sdk import init, transport
+    from sentry_sdk.integrations.typer import TyperIntegration
+
+    def capture_envelope(self, envelope):
+        print("capture_envelope was called")
+        event = envelope.get_event()
+        if event is not None:
+            print(event)
+
+    transport.HttpTransport.capture_envelope = capture_envelope
+
+    init("http://foobar@localhost/123", integrations=[TyperIntegration()])
+
+    app = typer.Typer()
+
+    @app.command()
+    def test():
+        print("test called")
+        raise Exception("pollo")
+
+    app()
+    """
+        )
+    )
+
+    with pytest.raises(subprocess.CalledProcessError) as excinfo:
+        subprocess.check_output([sys.executable, str(app)], stderr=subprocess.STDOUT)
+
+    output = excinfo.value.output
+
+    assert b"capture_envelope was called" in output
+    assert b"test called" in output
+    assert b"pollo" in output

--- a/tox.ini
+++ b/tox.ini
@@ -288,7 +288,8 @@ envlist =
     {py3.8,py3.12,py3.13}-trytond-latest
 
     # Typer
-    {py3.7,py3.9,py3.10,py3.11,py3.12,py3.13}-typer-lates
+    {py3.7,py3.12,py3.13}-typer-v{0.15}
+    {py3.7,py3.12,py3.13}-typer-latest
 
 [testenv]
 deps =
@@ -727,7 +728,7 @@ deps =
     trytond-latest: trytond
 
     # Typer
-    typer: typer
+    typer-v0.15: typer~=0.15.0
     typer-latest: typer
 
 setenv =
@@ -792,6 +793,7 @@ setenv =
     strawberry: TESTPATH=tests/integrations/strawberry
     tornado: TESTPATH=tests/integrations/tornado
     trytond: TESTPATH=tests/integrations/trytond
+    typer: TESTPATH=tests/integrations/typer
     socket: TESTPATH=tests/integrations/socket
 
 passenv =

--- a/tox.ini
+++ b/tox.ini
@@ -287,6 +287,9 @@ envlist =
     {py3.8,py3.11,py3.12}-trytond-v{7}
     {py3.8,py3.12,py3.13}-trytond-latest
 
+    # Typer
+    {py3.7,py3.9,py3.10,py3.11,py3.12,py3.13}-typer-lates
+
 [testenv]
 deps =
     # if you change requirements-testing.txt and your change is not being reflected
@@ -722,6 +725,10 @@ deps =
     trytond-v6: trytond~=6.0
     trytond-v7: trytond~=7.0
     trytond-latest: trytond
+
+    # Typer
+    typer: typer
+    typer-latest: typer
 
 setenv =
     PYTHONDONTWRITEBYTECODE=1


### PR DESCRIPTION
This PR adds an integration for [Typer](https://typer.tiangolo.com/)

The integration works by mocking `typer.main.except_hook`, I was chatting with Sebastian and he's willing to add a hook in typer to avoid mocking, but I think it's also fine to keep the code as is 😊

The code is inspired by the `ExcepthookIntegration`, same thing for the test, unfortunately there's no way to test a custom except_hook with pytest, so I'm running the CLI using subprocess.

Shall I add this to the default integrations? 😊

Closes #1612
Closes #1604