### PR TITLE
fix(spotlight): Make Django middleware init even more defensive

### DIFF
--- a/sentry_sdk/spotlight.py
+++ b/sentry_sdk/spotlight.py
@@ -210,13 +210,13 @@ def setup_spotlight(options):
     if not isinstance(url, str):
         return None
 
-    if (
-        settings is not None
-        and settings.DEBUG
-        and env_to_bool(os.environ.get("SENTRY_SPOTLIGHT_ON_ERROR", "1"))
-        and env_to_bool(os.environ.get("SENTRY_SPOTLIGHT_MIDDLEWARE", "1"))
-    ):
-        with capture_internal_exceptions():
+    with capture_internal_exceptions():
+        if (
+            settings is not None
+            and settings.DEBUG
+            and env_to_bool(os.environ.get("SENTRY_SPOTLIGHT_ON_ERROR", "1"))
+            and env_to_bool(os.environ.get("SENTRY_SPOTLIGHT_MIDDLEWARE", "1"))
+        ):
             middleware = settings.MIDDLEWARE
             if DJANGO_SPOTLIGHT_MIDDLEWARE_PATH not in middleware:
                 settings.MIDDLEWARE = type(middleware)(


### PR DESCRIPTION
I just got faced with a situation where even trying to do `settings.DEBUG` may trigger a Django exception if the settings are not loaded yet, hence widening the `capture_internal_exceptions()` scope for this.
