### PR TITLE
fix(spotlight): Use the spotlight_url passed into the SDK when loading Spotlight

### DIFF
--- a/sentry_sdk/spotlight.py
+++ b/sentry_sdk/spotlight.py
@@ -66,7 +66,7 @@ try:
 
     SPOTLIGHT_JS_ENTRY_PATH = "/assets/main.js"
     SPOTLIGHT_JS_SNIPPET_PATTERN = (
-        '<script>window.__spotlight = {{ initOptions: {{ sidecarUrl: '{spotlight_url}', fullPage: false }} }};</script>\n'
+        "<script>window.__spotlight = {{ initOptions: {{ sidecarUrl: '{spotlight_url}', fullPage: false }} }};</script>\n"
         '<script type="module" crossorigin src="{spotlight_js_url}"></script>\n'
     )
     SPOTLIGHT_ERROR_PAGE_SNIPPET = (

--- a/sentry_sdk/spotlight.py
+++ b/sentry_sdk/spotlight.py
@@ -66,7 +66,8 @@ try:
 
     SPOTLIGHT_JS_ENTRY_PATH = "/assets/main.js"
     SPOTLIGHT_JS_SNIPPET_PATTERN = (
-        '<script type="module" crossorigin src="{}"></script>'
+        '<script>window.__spotlight = {{ initOptions: {{ sidecarUrl: '{spotlight_url}', fullPage: false }} }};</script>\n'
+        '<script type="module" crossorigin src="{spotlight_js_url}"></script>\n'
     )
     SPOTLIGHT_ERROR_PAGE_SNIPPET = (
         '<html><base href="{spotlight_url}">\n'
@@ -113,7 +114,7 @@ try:
                     )
                     urllib.request.urlopen(req)
                     self._spotlight_script = SPOTLIGHT_JS_SNIPPET_PATTERN.format(
-                        spotlight_js_url
+                        spotlight_url=self._spotlight_url, spotlight_js_url=spotlight_js_url
                     )
                 except urllib.error.URLError as err:
                     sentry_logger.debug(

--- a/sentry_sdk/spotlight.py
+++ b/sentry_sdk/spotlight.py
@@ -114,7 +114,8 @@ try:
                     )
                     urllib.request.urlopen(req)
                     self._spotlight_script = SPOTLIGHT_JS_SNIPPET_PATTERN.format(
-                        spotlight_url=self._spotlight_url, spotlight_js_url=spotlight_js_url
+                        spotlight_url=self._spotlight_url,
+                        spotlight_js_url=spotlight_js_url,
                     )
                 except urllib.error.URLError as err:
                     sentry_logger.debug(


### PR DESCRIPTION
When we inject spotlight, we don't set the correct sidecar URL. This is an issue when a user defines a custom sidecar URL where we are able to load Spotlight UI from the correct URL but don't tell it the correct sidecar URL, making it non-functional.
