### PR TITLE
Fix arq tests in POTel

### DIFF
--- a/sentry_sdk/integrations/arq.py
+++ b/sentry_sdk/integrations/arq.py
@@ -119,11 +119,7 @@ def patch_run_job():
             ) as span:
                 return_value = await old_run_job(self, job_id, score)
 
-                status_unset = (
-                    hasattr(span._otel_span, "status")
-                    and span._otel_span.status.status_code == StatusCode.UNSET
-                )
-                if status_unset:
+                if span.status is None:
                     span.set_status(SPANSTATUS.OK)
 
                 return return_value

--- a/sentry_sdk/tracing.py
+++ b/sentry_sdk/tracing.py
@@ -1583,6 +1583,22 @@ class POTelSpan:
 
         self._otel_span.set_attribute(key, _serialize_span_attribute(value))
 
+    @property
+    def status(self):
+        # type: () -> Optional[str]
+        if not hasattr(self._otel_span, "status"):
+            return None
+
+        if self._otel_span.status.status_code == StatusCode.OK:
+            return SPANSTATUS.OK
+        else:
+            return SPANSTATUS.UNKNOWN_ERROR
+
+    @status.setter
+    def status(self, value):
+        # type: (Optional[Any]) -> None
+        raise NotImplementedError("Use set_status instead")
+
     def set_status(self, status):
         # type: (str) -> None
         if status == SPANSTATUS.OK:

--- a/sentry_sdk/tracing.py
+++ b/sentry_sdk/tracing.py
@@ -1586,6 +1586,12 @@ class POTelSpan:
     @property
     def status(self):
         # type: () -> Optional[str]
+        """
+        Return the Sentry `SPANSTATUS` corresponding to the underlying OTel status.
+        Because differences in possible values in OTel `StatusCode` and
+        Sentry `SPANSTATUS` it can not be guaranteed that the status
+        set in `set_status()` will be the same as the one returned here.
+        """
         if not hasattr(self._otel_span, "status"):
             return None
 

--- a/sentry_sdk/tracing.py
+++ b/sentry_sdk/tracing.py
@@ -1602,11 +1602,6 @@ class POTelSpan:
         else:
             return SPANSTATUS.UNKNOWN_ERROR
 
-    @status.setter
-    def status(self, value):
-        # type: (Optional[Any]) -> None
-        raise NotImplementedError("Use set_status instead")
-
     def set_status(self, status):
         # type: (str) -> None
         if status == SPANSTATUS.OK:

--- a/sentry_sdk/tracing.py
+++ b/sentry_sdk/tracing.py
@@ -1595,7 +1595,9 @@ class POTelSpan:
         if not hasattr(self._otel_span, "status"):
             return None
 
-        if self._otel_span.status.status_code == StatusCode.OK:
+        if self._otel_span.status.status_code == StatusCode.UNSET:
+            return None
+        elif self._otel_span.status.status_code == StatusCode.OK:
             return SPANSTATUS.OK
         else:
             return SPANSTATUS.UNKNOWN_ERROR

--- a/tests/integrations/opentelemetry/test_potel.py
+++ b/tests/integrations/opentelemetry/test_potel.py
@@ -2,6 +2,7 @@ import pytest
 from opentelemetry import trace
 
 import sentry_sdk
+from sentry_sdk.consts import SPANSTATUS
 from tests.conftest import ApproxDict
 
 
@@ -331,3 +332,35 @@ def test_potel_span_root_span_references():
         with sentry_sdk.start_span(description="http") as http_span:
             assert not http_span.is_root_span
             assert http_span.root_span == request_span
+
+
+@pytest.mark.parametrize(
+    "status_in,status_out",
+    [
+        (None, None),
+        ("", SPANSTATUS.UNKNOWN_ERROR),
+        (SPANSTATUS.OK, SPANSTATUS.OK),
+        (SPANSTATUS.ABORTED, SPANSTATUS.UNKNOWN_ERROR),
+        (SPANSTATUS.ALREADY_EXISTS, SPANSTATUS.UNKNOWN_ERROR),
+        (SPANSTATUS.CANCELLED, SPANSTATUS.UNKNOWN_ERROR),
+        (SPANSTATUS.DATA_LOSS, SPANSTATUS.UNKNOWN_ERROR),
+        (SPANSTATUS.DEADLINE_EXCEEDED, SPANSTATUS.UNKNOWN_ERROR),
+        (SPANSTATUS.FAILED_PRECONDITION, SPANSTATUS.UNKNOWN_ERROR),
+        (SPANSTATUS.INTERNAL_ERROR, SPANSTATUS.UNKNOWN_ERROR),
+        (SPANSTATUS.INVALID_ARGUMENT, SPANSTATUS.UNKNOWN_ERROR),
+        (SPANSTATUS.NOT_FOUND, SPANSTATUS.UNKNOWN_ERROR),
+        (SPANSTATUS.OUT_OF_RANGE, SPANSTATUS.UNKNOWN_ERROR),
+        (SPANSTATUS.PERMISSION_DENIED, SPANSTATUS.UNKNOWN_ERROR),
+        (SPANSTATUS.RESOURCE_EXHAUSTED, SPANSTATUS.UNKNOWN_ERROR),
+        (SPANSTATUS.UNAUTHENTICATED, SPANSTATUS.UNKNOWN_ERROR),
+        (SPANSTATUS.UNAVAILABLE, SPANSTATUS.UNKNOWN_ERROR),
+        (SPANSTATUS.UNIMPLEMENTED, SPANSTATUS.UNKNOWN_ERROR),
+        (SPANSTATUS.UNKNOWN_ERROR, SPANSTATUS.UNKNOWN_ERROR),
+    ],
+)
+def test_potel_span_status(status_in, status_out):
+    span = sentry_sdk.start_span(name="test")
+    if status_in is not None:
+        span.set_status(status_in)
+
+    assert span.status == status_out


### PR DESCRIPTION
Make sure OK status is set, only when there has not been a error status set before. 