### PR TITLE
Ignore opentelemetry logger in logging integration

### DIFF
--- a/sentry_sdk/integrations/logging.py
+++ b/sentry_sdk/integrations/logging.py
@@ -40,7 +40,7 @@ LOGGING_TO_EVENT_LEVEL = {
 # Note: Ignoring by logger name here is better than mucking with thread-locals.
 # We do not necessarily know whether thread-locals work 100% correctly in the user's environment.
 _IGNORED_LOGGERS = set(
-    ["sentry_sdk.errors", "urllib3.connectionpool", "urllib3.connection"]
+    ["sentry_sdk.errors", "urllib3.connectionpool", "urllib3.connection", "opentelemetry.*"]
 )
 
 


### PR DESCRIPTION
Without this, internal otel logs (especially `logger.exception`s) will show up as events / breadcrumbs in the payload.