### PR TITLE
Implement span limits on span processor

### DIFF
--- a/sentry_sdk/integrations/arq.py
+++ b/sentry_sdk/integrations/arq.py
@@ -1,7 +1,5 @@
 import sys
 
-from opentelemetry.trace.status import StatusCode
-
 import sentry_sdk
 from sentry_sdk.consts import OP, SPANSTATUS
 from sentry_sdk.integrations import DidNotEnable, Integration

--- a/sentry_sdk/integrations/logging.py
+++ b/sentry_sdk/integrations/logging.py
@@ -40,7 +40,12 @@ LOGGING_TO_EVENT_LEVEL = {
 # Note: Ignoring by logger name here is better than mucking with thread-locals.
 # We do not necessarily know whether thread-locals work 100% correctly in the user's environment.
 _IGNORED_LOGGERS = set(
-    ["sentry_sdk.errors", "urllib3.connectionpool", "urllib3.connection", "opentelemetry.*"]
+    [
+        "sentry_sdk.errors",
+        "urllib3.connectionpool",
+        "urllib3.connection",
+        "opentelemetry.*",
+    ]
 )
 
 


### PR DESCRIPTION
These limits are slightly different than before because they hold on each level of the span tree rather than on the whole transaction but I think that's fine since the main purpose of these limits are avoiding unbounded memory blowup.