### PR TITLE
fix: Deepcopy flag buffer on scope fork

### DIFF
--- a/sentry_sdk/_lru_cache.py
+++ b/sentry_sdk/_lru_cache.py
@@ -62,7 +62,7 @@ Agreement.
 
 """
 
-from copy import copy, deepcopy
+from copy import deepcopy
 
 SENTINEL = object()
 
@@ -94,7 +94,7 @@ class LRUCache:
     def __copy__(self):
         cache = LRUCache(self.max_size)
         cache.full = self.full
-        cache.cache = copy(self.cache)
+        cache.cache = deepcopy(self.cache)
         cache.root = deepcopy(self.root)
         return cache
 

--- a/sentry_sdk/_lru_cache.py
+++ b/sentry_sdk/_lru_cache.py
@@ -62,8 +62,6 @@ Agreement.
 
 """
 
-from copy import deepcopy
-
 SENTINEL = object()
 
 
@@ -90,13 +88,6 @@ class LRUCache:
         self.root[:] = [self.root, self.root, None, None]
 
         self.hits = self.misses = 0
-
-    def __copy__(self):
-        cache = LRUCache(self.max_size)
-        cache.full = self.full
-        cache.cache = deepcopy(self.cache)
-        cache.root = deepcopy(self.root)
-        return cache
 
     def set(self, key, value):
         link = self.cache.get(key, SENTINEL)

--- a/sentry_sdk/flag_utils.py
+++ b/sentry_sdk/flag_utils.py
@@ -1,4 +1,3 @@
-from copy import copy
 from typing import TYPE_CHECKING
 
 import sentry_sdk
@@ -24,12 +23,6 @@ class FlagBuffer:
     def clear(self):
         # type: () -> None
         self.buffer = LRUCache(self.capacity)
-
-    def __copy__(self):
-        # type: () -> FlagBuffer
-        buffer = FlagBuffer(capacity=self.capacity)
-        buffer.buffer = copy(self.buffer)
-        return buffer
 
     def get(self):
         # type: () -> list[FlagData]

--- a/sentry_sdk/scope.py
+++ b/sentry_sdk/scope.py
@@ -1,7 +1,7 @@
 import os
 import sys
 import warnings
-from copy import copy
+from copy import copy, deepcopy
 from collections import deque
 from contextlib import contextmanager
 from enum import Enum
@@ -252,7 +252,7 @@ class Scope:
 
         rv._last_event_id = self._last_event_id
 
-        rv._flags = copy(self._flags)
+        rv._flags = deepcopy(self._flags)
 
         return rv
 

--- a/tests/test_lru_cache.py
+++ b/tests/test_lru_cache.py
@@ -1,5 +1,7 @@
 import pytest
 
+from copy import deepcopy
+
 from sentry_sdk._lru_cache import LRUCache
 
 
@@ -58,3 +60,29 @@ def test_cache_get_all():
     assert cache.get_all() == [(1, 1), (2, 2), (3, 3)]
     cache.get(1)
     assert cache.get_all() == [(2, 2), (3, 3), (1, 1)]
+
+
+def test_cache_copy():
+    cache = LRUCache(3)
+    cache.set(0, 0)
+    cache.set(1, 1)
+
+    copied = deepcopy(cache)
+    cache.set(2, 2)
+    cache.set(3, 3)
+    assert copied.get_all() == [(0, 0), (1, 1)]
+    assert cache.get_all() == [(1, 1), (2, 2), (3, 3)]
+
+    copied = deepcopy(cache)
+    cache.get(1)
+    assert copied.get_all() == [(1, 1), (2, 2), (3, 3)]
+    assert cache.get_all() == [(2, 2), (3, 3), (1, 1)]
+
+
+def test_cache_pollution():
+    cache1 = LRUCache(max_size=2)
+    cache1.set(1, True)
+    cache2 = deepcopy(cache1)
+    cache2.set(1, False)
+    assert cache1.get(1) is True
+    assert cache2.get(1) is False

--- a/tests/test_lru_cache.py
+++ b/tests/test_lru_cache.py
@@ -1,5 +1,4 @@
 import pytest
-
 from copy import deepcopy
 
 from sentry_sdk._lru_cache import LRUCache

--- a/tests/test_lru_cache.py
+++ b/tests/test_lru_cache.py
@@ -76,3 +76,12 @@ def test_cache_copy():
     cache.get(1)
     assert copied.get_all() == [(1, 1), (2, 2), (3, 3)]
     assert cache.get_all() == [(2, 2), (3, 3), (1, 1)]
+
+
+def test_cache_no_overwrites_to_parent():
+    cache1 = LRUCache(max_size=2)
+    cache1.set(1, True)
+    cache2 = cache1.__copy__()
+    cache2.set(1, False)
+    assert cache1.get(1) is True
+    assert cache2.get(1) is False

--- a/tests/test_lru_cache.py
+++ b/tests/test_lru_cache.py
@@ -1,5 +1,4 @@
 import pytest
-from copy import copy
 
 from sentry_sdk._lru_cache import LRUCache
 
@@ -59,29 +58,3 @@ def test_cache_get_all():
     assert cache.get_all() == [(1, 1), (2, 2), (3, 3)]
     cache.get(1)
     assert cache.get_all() == [(2, 2), (3, 3), (1, 1)]
-
-
-def test_cache_copy():
-    cache = LRUCache(3)
-    cache.set(0, 0)
-    cache.set(1, 1)
-
-    copied = copy(cache)
-    cache.set(2, 2)
-    cache.set(3, 3)
-    assert copied.get_all() == [(0, 0), (1, 1)]
-    assert cache.get_all() == [(1, 1), (2, 2), (3, 3)]
-
-    copied = copy(cache)
-    cache.get(1)
-    assert copied.get_all() == [(1, 1), (2, 2), (3, 3)]
-    assert cache.get_all() == [(2, 2), (3, 3), (1, 1)]
-
-
-def test_cache_no_overwrites_to_parent():
-    cache1 = LRUCache(max_size=2)
-    cache1.set(1, True)
-    cache2 = cache1.__copy__()
-    cache2.set(1, False)
-    assert cache1.get(1) is True
-    assert cache2.get(1) is False

--- a/tests/test_scope.py
+++ b/tests/test_scope.py
@@ -43,6 +43,22 @@ def test_all_slots_copied():
         assert getattr(scope_copy, attr) == getattr(scope, attr)
 
 
+def test_scope_flags_copy():
+    # A scope exists and a flag is appended to it.
+    old_scope = Scope()
+    old_scope.flags.set("a", True)
+
+    # Scope is forked; flag buffer is copied and contains the data of
+    # the parent. The flag is overwritten.
+    new_scope = old_scope.fork()
+    new_scope.flags.set("a", False)
+
+    # New scope has the change. Old scope was not polluted by changes
+    # to the new scope.
+    old_scope.flags.get() == [{"flag": "a", "result": True}]
+    new_scope.flags.get() == [{"flag": "a", "result": False}]
+
+
 def test_merging(sentry_init, capture_events):
     sentry_init()
 

--- a/tests/test_scope.py
+++ b/tests/test_scope.py
@@ -57,11 +57,11 @@ def test_scope_flags_copy():
 
     # New scope has the change. Old scope was not polluted by changes
     # to the new scope.
-    old_scope.flags.get() == [
+    assert old_scope.flags.get() == [
         {"flag": "a", "result": True},
         {"flag": "b", "result": True},
     ]
-    new_scope.flags.get() == [{"flag": "a", "result": False}]
+    assert new_scope.flags.get() == [{"flag": "a", "result": False}]
 
 
 def test_merging(sentry_init, capture_events):

--- a/tests/test_scope.py
+++ b/tests/test_scope.py
@@ -49,13 +49,18 @@ def test_scope_flags_copy():
     old_scope.flags.set("a", True)
 
     # Scope is forked; flag buffer is copied and contains the data of
-    # the parent. The flag is overwritten.
+    # the parent. The flag is overwritten on the child. The parent
+    # scope can continue mutating without interfering with the child.
     new_scope = old_scope.fork()
     new_scope.flags.set("a", False)
+    old_scope.flags.set("b", True)
 
     # New scope has the change. Old scope was not polluted by changes
     # to the new scope.
-    old_scope.flags.get() == [{"flag": "a", "result": True}]
+    old_scope.flags.get() == [
+        {"flag": "a", "result": True},
+        {"flag": "b", "result": True},
+    ]
     new_scope.flags.get() == [{"flag": "a", "result": False}]
 
 

--- a/tests/test_scope.py
+++ b/tests/test_scope.py
@@ -44,24 +44,25 @@ def test_all_slots_copied():
 
 
 def test_scope_flags_copy():
-    # A scope exists and a flag is appended to it.
+    # Assert forking creates a deepcopy of the flag buffer. The new
+    # scope is free to mutate without consequence to the old scope. The
+    # old scope is free to mutate without consequence to the new scope.
     old_scope = Scope()
     old_scope.flags.set("a", True)
 
-    # Scope is forked; flag buffer is copied and contains the data of
-    # the parent. The flag is overwritten on the child. The parent
-    # scope can continue mutating without interfering with the child.
     new_scope = old_scope.fork()
     new_scope.flags.set("a", False)
     old_scope.flags.set("b", True)
+    new_scope.flags.set("c", True)
 
-    # New scope has the change. Old scope was not polluted by changes
-    # to the new scope.
     assert old_scope.flags.get() == [
         {"flag": "a", "result": True},
         {"flag": "b", "result": True},
     ]
-    assert new_scope.flags.get() == [{"flag": "a", "result": False}]
+    assert new_scope.flags.get() == [
+        {"flag": "a", "result": False},
+        {"flag": "c", "result": True},
+    ]
 
 
 def test_merging(sentry_init, capture_events):


### PR DESCRIPTION
A previous attempt to fix this issue focused on a related issue and assumed that it would fix this.  This PR adds a test using the reproduction steps mentioned in the bug report and fixes the issue by deep copying the buffer.

Closes: https://github.com/getsentry/sentry-python/issues/3852