### PR TITLE
ref(flags): register LD hook in setup instead of init, and don't check for initialization

### DIFF
--- a/sentry_sdk/integrations/launchdarkly.py
+++ b/sentry_sdk/integrations/launchdarkly.py
@@ -35,7 +35,6 @@ class LaunchDarklyIntegration(Integration):
         # type: () -> None
         try:
             client = LaunchDarklyIntegration._ld_client or ldclient.get()
-            print("got client")
         except Exception as exc:
             raise DidNotEnable("Error getting LaunchDarkly client. " + repr(exc))
 

--- a/sentry_sdk/integrations/launchdarkly.py
+++ b/sentry_sdk/integrations/launchdarkly.py
@@ -20,6 +20,7 @@ except ImportError:
 
 class LaunchDarklyIntegration(Integration):
     identifier = "launchdarkly"
+    _ld_client = None  # type: LDClient | None
 
     def __init__(self, ld_client=None):
         # type: (LDClient | None) -> None
@@ -27,20 +28,20 @@ class LaunchDarklyIntegration(Integration):
         :param client: An initialized LDClient instance. If a client is not provided, this
             integration will attempt to use the shared global instance.
         """
-        try:
-            client = ld_client or ldclient.get()
-        except Exception as exc:
-            raise DidNotEnable("Error getting LaunchDarkly client. " + repr(exc))
-
-        if not client.is_initialized():
-            raise DidNotEnable("LaunchDarkly client is not initialized.")
-
-        # Register the flag collection hook with the LD client.
-        client.add_hook(LaunchDarklyHook())
+        self.__class__._ld_client = ld_client
 
     @staticmethod
     def setup_once():
         # type: () -> None
+        try:
+            client = LaunchDarklyIntegration._ld_client or ldclient.get()
+            print("got client")
+        except Exception as exc:
+            raise DidNotEnable("Error getting LaunchDarkly client. " + repr(exc))
+
+        # Register the flag collection hook with the LD client.
+        client.add_hook(LaunchDarklyHook())
+
         scope = sentry_sdk.get_current_scope()
         scope.add_error_processor(flag_error_processor)
 

--- a/tests/integrations/launchdarkly/test_launchdarkly.py
+++ b/tests/integrations/launchdarkly/test_launchdarkly.py
@@ -168,10 +168,8 @@ def test_launchdarkly_integration_asyncio(
     }
 
 
-def test_launchdarkly_integration_did_not_enable(monkeypatch):
-    # Client is not passed in and set_config wasn't called.
-    # TODO: Bad practice to access internals like this. We can skip this test, or remove this
-    #  case entirely (force user to pass in a client instance).
+def test_launchdarkly_integration_did_not_enable(sentry_init, uninstall_integration):
+    # Using global client and set_config wasn't called.
     ldclient._reset_client()
     try:
         ldclient.__lock.lock()
@@ -179,11 +177,6 @@ def test_launchdarkly_integration_did_not_enable(monkeypatch):
     finally:
         ldclient.__lock.unlock()
 
+    uninstall_integration(LaunchDarklyIntegration.identifier)
     with pytest.raises(DidNotEnable):
-        LaunchDarklyIntegration()
-
-    # Client not initialized.
-    client = LDClient(config=Config("sdk-key"))
-    monkeypatch.setattr(client, "is_initialized", lambda: False)
-    with pytest.raises(DidNotEnable):
-        LaunchDarklyIntegration(ld_client=client)
+        sentry_init(integrations=[LaunchDarklyIntegration()])

--- a/tests/integrations/launchdarkly/test_launchdarkly.py
+++ b/tests/integrations/launchdarkly/test_launchdarkly.py
@@ -169,7 +169,13 @@ def test_launchdarkly_integration_asyncio(
 
 
 def test_launchdarkly_integration_did_not_enable(sentry_init, uninstall_integration):
-    # Using global client and set_config wasn't called.
+    """
+    Setup should fail when using global client and ldclient.set_config wasn't called.
+
+    We're accessing ldclient internals to set up this test, so it might break if launchdarkly's
+    implementation changes.
+    """
+
     ldclient._reset_client()
     try:
         ldclient.__lock.lock()


### PR DESCRIPTION
Refactors setup code and removes an error case from the [LaunchDarkly integration](https://docs.sentry.io/platforms/python/integrations/launchdarkly/)

> register LD hook in setup instead of init

IMO we should only hook into LD once, when this integration is setup by `sentry_sdk.init`. It's rare, but this class could be instantiated more than once, from user error, tests, etc. It's reasonable to expect Sentry `init` is only called once in prod.

> don't check for initialization

We shouldn't fail if LDClient hasn't initialized yet. Initialization is the async process of connecting to the LD server, and may take a moment. With the setup code from our docs, we configure LD right before calling Sentry `init`, and don't wait for initialization to complete. **This could lead to a lot of errors / failure to start your app if you have a slow internet connection. It's ultimately the user's responsibility to ensure LD is initialized before evaluating flags**. Even if the client's never initialized, flags will default to False, so nothing's breaking on our end.