### PR TITLE
Update linting config to work with new mypy version

### DIFF
--- a/sentry_sdk/client.py
+++ b/sentry_sdk/client.py
@@ -532,7 +532,7 @@ class _Client(BaseClient):
 
         for key in "release", "environment", "server_name", "dist":
             if event.get(key) is None and self.options[key] is not None:
-                event[key] = str(self.options[key]).strip()  # type: ignore[literal-required]
+                event[key] = str(self.options[key]).strip()
         if event.get("sdk") is None:
             sdk_info = dict(SDK_INFO)
             sdk_info["integrations"] = sorted(self.integrations.keys())
@@ -581,7 +581,7 @@ class _Client(BaseClient):
                     self.transport.record_lost_event(
                         "before_send", data_category="error"
                     )
-            event = new_event  # type: ignore
+            event = new_event
 
         before_send_transaction = self.options["before_send_transaction"]
         if (
@@ -611,7 +611,7 @@ class _Client(BaseClient):
                         reason="before_send", data_category="span", quantity=spans_delta
                     )
 
-            event = new_event  # type: ignore
+            event = new_event
 
         return event
 

--- a/sentry_sdk/integrations/rust_tracing.py
+++ b/sentry_sdk/integrations/rust_tracing.py
@@ -44,11 +44,11 @@ TraceState = Optional[Tuple[Optional[SentrySpan], SentrySpan]]
 
 
 class RustTracingLevel(Enum):
-    Trace: str = "TRACE"
-    Debug: str = "DEBUG"
-    Info: str = "INFO"
-    Warn: str = "WARN"
-    Error: str = "ERROR"
+    Trace = "TRACE"
+    Debug = "DEBUG"
+    Info = "INFO"
+    Warn = "WARN"
+    Error = "ERROR"
 
 
 class EventTypeMapping(Enum):


### PR DESCRIPTION
Mypy released a [new version](https://github.com/python/mypy/blob/master/CHANGELOG.md#mypy-114) that does not allow type hints in enums anymore. 

It also made some type ignoring obsolete.