### PR TITLE
ref(flags): allow OpenFeature integration to track a single client

### DIFF
--- a/sentry_sdk/integrations/launchdarkly.py
+++ b/sentry_sdk/integrations/launchdarkly.py
@@ -4,39 +4,37 @@ import sentry_sdk
 from sentry_sdk.integrations import DidNotEnable, Integration
 from sentry_sdk.flag_utils import flag_error_processor
 
+if TYPE_CHECKING:
+    from typing import Any, Optional
+
 try:
-    import ldclient
     from ldclient.hook import Hook, Metadata
 
     if TYPE_CHECKING:
         from ldclient import LDClient
         from ldclient.hook import EvaluationSeriesContext
         from ldclient.evaluation import EvaluationDetail
-
-        from typing import Any
 except ImportError:
     raise DidNotEnable("LaunchDarkly is not installed")
 
 
 class LaunchDarklyIntegration(Integration):
     identifier = "launchdarkly"
-    _ld_client = None  # type: LDClient | None
+    _client = None  # type: Optional[LDClient]
 
-    def __init__(self, ld_client=None):
-        # type: (LDClient | None) -> None
+    def __init__(self, client):
+        # type: (LDClient) -> None
         """
-        :param client: An initialized LDClient instance. If a client is not provided, this
-            integration will attempt to use the shared global instance.
+        :param client: An initialized LDClient instance.
         """
-        self.__class__._ld_client = ld_client
+        self.__class__._client = client
 
     @staticmethod
     def setup_once():
         # type: () -> None
-        try:
-            client = LaunchDarklyIntegration._ld_client or ldclient.get()
-        except Exception as exc:
-            raise DidNotEnable("Error getting LaunchDarkly client. " + repr(exc))
+        client = LaunchDarklyIntegration._client
+        if not client:
+            raise DidNotEnable("Error getting LDClient instance")
 
         # Register the flag collection hook with the LD client.
         client.add_hook(LaunchDarklyHook())

--- a/sentry_sdk/integrations/launchdarkly.py
+++ b/sentry_sdk/integrations/launchdarkly.py
@@ -4,37 +4,39 @@ import sentry_sdk
 from sentry_sdk.integrations import DidNotEnable, Integration
 from sentry_sdk.flag_utils import flag_error_processor
 
-if TYPE_CHECKING:
-    from typing import Any, Optional
-
 try:
+    import ldclient
     from ldclient.hook import Hook, Metadata
 
     if TYPE_CHECKING:
         from ldclient import LDClient
         from ldclient.hook import EvaluationSeriesContext
         from ldclient.evaluation import EvaluationDetail
+
+        from typing import Any
 except ImportError:
     raise DidNotEnable("LaunchDarkly is not installed")
 
 
 class LaunchDarklyIntegration(Integration):
     identifier = "launchdarkly"
-    _client = None  # type: Optional[LDClient]
+    _ld_client = None  # type: LDClient | None
 
-    def __init__(self, client):
-        # type: (LDClient) -> None
+    def __init__(self, ld_client=None):
+        # type: (LDClient | None) -> None
         """
-        :param client: An initialized LDClient instance.
+        :param client: An initialized LDClient instance. If a client is not provided, this
+            integration will attempt to use the shared global instance.
         """
-        self.__class__._client = client
+        self.__class__._ld_client = ld_client
 
     @staticmethod
     def setup_once():
         # type: () -> None
-        client = LaunchDarklyIntegration._client
-        if not client:
-            raise DidNotEnable("Error getting LDClient instance")
+        try:
+            client = LaunchDarklyIntegration._ld_client or ldclient.get()
+        except Exception as exc:
+            raise DidNotEnable("Error getting LaunchDarkly client. " + repr(exc))
 
         # Register the flag collection hook with the LD client.
         client.add_hook(LaunchDarklyHook())

--- a/sentry_sdk/integrations/openfeature.py
+++ b/sentry_sdk/integrations/openfeature.py
@@ -35,6 +35,7 @@ class OpenFeatureIntegration(Integration):
         if client:
             # Register the hook within the openfeature client.
             client.add_hooks(hooks=[OpenFeatureHook()])
+            print("added hook to", client)
         else:
             # Register the hook within the global openfeature hooks list.
             api.add_hooks(hooks=[OpenFeatureHook()])

--- a/sentry_sdk/integrations/openfeature.py
+++ b/sentry_sdk/integrations/openfeature.py
@@ -8,6 +8,7 @@ if TYPE_CHECKING:
     from typing import Optional
 
 try:
+    from openfeature import api
     from openfeature.hook import Hook
 
     if TYPE_CHECKING:
@@ -22,8 +23,8 @@ class OpenFeatureIntegration(Integration):
     identifier = "openfeature"
     _client = None  # type: Optional[OpenFeatureClient]
 
-    def __init__(self, client):
-        # type: (OpenFeatureClient) -> None
+    def __init__(self, client=None):
+        # type: (Optional[OpenFeatureClient]) -> None
         self.__class__._client = client
 
     @staticmethod
@@ -31,11 +32,12 @@ class OpenFeatureIntegration(Integration):
         # type: () -> None
 
         client = OpenFeatureIntegration._client
-        if not client:
-            raise DidNotEnable("Error getting OpenFeatureClient instance")
-
-        # Register the hook within the openfeature client.
-        client.add_hooks(hooks=[OpenFeatureHook()])
+        if client:
+            # Register the hook within the openfeature client.
+            client.add_hooks(hooks=[OpenFeatureHook()])
+        else:
+            # Register the hook within the global openfeature hooks list.
+            api.add_hooks(hooks=[OpenFeatureHook()])
 
         scope = sentry_sdk.get_current_scope()
         scope.add_error_processor(flag_error_processor)

--- a/tests/integrations/launchdarkly/test_launchdarkly.py
+++ b/tests/integrations/launchdarkly/test_launchdarkly.py
@@ -18,9 +18,10 @@ from sentry_sdk.integrations.launchdarkly import LaunchDarklyIntegration
 def reset_launchdarkly(uninstall_integration):
     yield
 
-    # Teardown. We're using ldclient internals here, so this might break if their implementation
-    # changes.
     uninstall_integration(LaunchDarklyIntegration.identifier)
+
+    # Resets global client and config only. We're using ldclient internals here, so this might
+    # break if their implementation changes.
     ldclient._reset_client()
     try:
         ldclient.__lock.lock()

--- a/tests/integrations/launchdarkly/test_launchdarkly.py
+++ b/tests/integrations/launchdarkly/test_launchdarkly.py
@@ -10,6 +10,7 @@ from ldclient.context import Context
 from ldclient.integrations.test_data import TestData
 
 import sentry_sdk
+from sentry_sdk.integrations import DidNotEnable
 from sentry_sdk.integrations.launchdarkly import LaunchDarklyIntegration
 
 
@@ -26,10 +27,11 @@ def test_launchdarkly_integration(
     uninstall_integration(LaunchDarklyIntegration.identifier)
     if use_global_client:
         ldclient.set_config(config)
+        sentry_init(integrations=[LaunchDarklyIntegration()])
         client = ldclient.get()
     else:
         client = LDClient(config=config)
-    sentry_init(integrations=[LaunchDarklyIntegration(client)])
+        sentry_init(integrations=[LaunchDarklyIntegration(ld_client=client)])
 
     # Set test values
     td.update(td.flag("hello").variation_for_all(True))
@@ -61,7 +63,7 @@ def test_launchdarkly_integration_threaded(
     context = Context.create("user1")
 
     uninstall_integration(LaunchDarklyIntegration.identifier)
-    sentry_init(integrations=[LaunchDarklyIntegration(client)])
+    sentry_init(integrations=[LaunchDarklyIntegration(ld_client=client)])
     events = capture_events()
 
     def task(flag_key):
@@ -120,7 +122,7 @@ def test_launchdarkly_integration_asyncio(
     context = Context.create("user1")
 
     uninstall_integration(LaunchDarklyIntegration.identifier)
-    sentry_init(integrations=[LaunchDarklyIntegration(client)])
+    sentry_init(integrations=[LaunchDarklyIntegration(ld_client=client)])
     events = capture_events()
 
     async def task(flag_key):
@@ -164,3 +166,23 @@ def test_launchdarkly_integration_asyncio(
             {"flag": "world", "result": False},
         ]
     }
+
+
+def test_launchdarkly_integration_did_not_enable(sentry_init, uninstall_integration):
+    """
+    Setup should fail when using global client and ldclient.set_config wasn't called.
+
+    We're accessing ldclient internals to set up this test, so it might break if launchdarkly's
+    implementation changes.
+    """
+
+    ldclient._reset_client()
+    try:
+        ldclient.__lock.lock()
+        ldclient.__config = None
+    finally:
+        ldclient.__lock.unlock()
+
+    uninstall_integration(LaunchDarklyIntegration.identifier)
+    with pytest.raises(DidNotEnable):
+        sentry_init(integrations=[LaunchDarklyIntegration()])


### PR DESCRIPTION
All provider SDKs so far have the concept of a "client" class, which is used to connect to the server and query flags. Since clients can query multiple projects/environments by specifying a `context`, it is rare for an app to use >1 client. 

I discussed with @billyvg and we want to stay consistent for all FF integrations, and focus on tracking one client. This means users should pass a client to the Integration, and we'll register hooks on that client, rather than globally.

Update 12/26:
For backwards compatibility, I think it's best to
- keep LD as-is: optionally takes a client. If one is not given, then hook into the global singleton.
- mirror this in OF, optionally taking in a client.

Updated setup code can be seen at: https://github.com/getsentry/sentry-docs/pull/12222/files