### PR TITLE
fix(flags): fix/refactor flaky launchdarkly tests

### DIFF
--- a/tests/integrations/launchdarkly/test_launchdarkly.py
+++ b/tests/integrations/launchdarkly/test_launchdarkly.py
@@ -22,7 +22,12 @@ def test_launchdarkly_integration(
     sentry_init, use_global_client, capture_events, uninstall_integration
 ):
     td = TestData.data_source()
-    config = Config("sdk-key", update_processor_class=td)
+    # Disable background requests as we aren't using a server.
+    config = Config(
+        "sdk-key", update_processor_class=td, diagnostic_opt_out=True, send_events=False
+    )
+    td.update(td.flag("hello").variation_for_all(True))
+    td.update(td.flag("world").variation_for_all(True))
 
     uninstall_integration(LaunchDarklyIntegration.identifier)
     if use_global_client:
@@ -32,10 +37,6 @@ def test_launchdarkly_integration(
     else:
         client = LDClient(config=config)
         sentry_init(integrations=[LaunchDarklyIntegration(ld_client=client)])
-
-    # Set test values
-    td.update(td.flag("hello").variation_for_all(True))
-    td.update(td.flag("world").variation_for_all(True))
 
     # Evaluate
     client.variation("hello", Context.create("my-org", "organization"), False)
@@ -59,7 +60,16 @@ def test_launchdarkly_integration_threaded(
     sentry_init, capture_events, uninstall_integration
 ):
     td = TestData.data_source()
-    client = LDClient(config=Config("sdk-key", update_processor_class=td))
+    td.update(td.flag("hello").variation_for_all(True))
+    td.update(td.flag("world").variation_for_all(True))
+    client = LDClient(
+        config=Config(
+            "sdk-key",
+            update_processor_class=td,
+            diagnostic_opt_out=True,  # Disable background requests as we aren't using a server.
+            send_events=False,
+        )
+    )
     context = Context.create("user1")
 
     uninstall_integration(LaunchDarklyIntegration.identifier)
@@ -75,8 +85,6 @@ def test_launchdarkly_integration_threaded(
             sentry_sdk.set_tag("task_id", flag_key)
             sentry_sdk.capture_exception(Exception("something wrong!"))
 
-    td.update(td.flag("hello").variation_for_all(True))
-    td.update(td.flag("world").variation_for_all(False))
     # Capture an eval before we split isolation scopes.
     client.variation("hello", context, False)
 
@@ -104,7 +112,7 @@ def test_launchdarkly_integration_threaded(
     assert events[2]["contexts"]["flags"] == {
         "values": [
             {"flag": "hello", "result": True},
-            {"flag": "world", "result": False},
+            {"flag": "world", "result": True},
         ]
     }
 
@@ -118,7 +126,16 @@ def test_launchdarkly_integration_asyncio(
     asyncio = pytest.importorskip("asyncio")
 
     td = TestData.data_source()
-    client = LDClient(config=Config("sdk-key", update_processor_class=td))
+    td.update(td.flag("hello").variation_for_all(True))
+    td.update(td.flag("world").variation_for_all(True))
+    client = LDClient(
+        config=Config(
+            "sdk-key",
+            update_processor_class=td,
+            diagnostic_opt_out=True,  # Disable background requests as we aren't using a server.
+            send_events=False,
+        )
+    )
     context = Context.create("user1")
 
     uninstall_integration(LaunchDarklyIntegration.identifier)
@@ -135,8 +152,6 @@ def test_launchdarkly_integration_asyncio(
     async def runner():
         return asyncio.gather(task("world"), task("other"))
 
-    td.update(td.flag("hello").variation_for_all(True))
-    td.update(td.flag("world").variation_for_all(False))
     # Capture an eval before we split isolation scopes.
     client.variation("hello", context, False)
 
@@ -163,7 +178,7 @@ def test_launchdarkly_integration_asyncio(
     assert events[2]["contexts"]["flags"] == {
         "values": [
             {"flag": "hello", "result": True},
-            {"flag": "world", "result": False},
+            {"flag": "world", "result": True},
         ]
     }
 

--- a/tests/integrations/launchdarkly/test_launchdarkly.py
+++ b/tests/integrations/launchdarkly/test_launchdarkly.py
@@ -22,12 +22,12 @@ def test_launchdarkly_integration(
     sentry_init, use_global_client, capture_events, uninstall_integration
 ):
     td = TestData.data_source()
+    td.update(td.flag("hello").variation_for_all(True))
+    td.update(td.flag("world").variation_for_all(True))
     # Disable background requests as we aren't using a server.
     config = Config(
         "sdk-key", update_processor_class=td, diagnostic_opt_out=True, send_events=False
     )
-    td.update(td.flag("hello").variation_for_all(True))
-    td.update(td.flag("world").variation_for_all(True))
 
     uninstall_integration(LaunchDarklyIntegration.identifier)
     if use_global_client:


### PR DESCRIPTION
Fixes flakes ([example](https://github.com/getsentry/sentry-python/actions/runs/12465223145/job/34790658871?pr=3887)) caused by background processes in `LDClient` trying to connect to a non-existent server (we're mocking the flag data through `TestData`).