### PR TITLE
Revert "ref(flags): register LD hook in setup instead of init, and don't check for initialization"

### DIFF
--- a/sentry_sdk/integrations/launchdarkly.py
+++ b/sentry_sdk/integrations/launchdarkly.py
@@ -20,7 +20,6 @@ except ImportError:
 
 class LaunchDarklyIntegration(Integration):
     identifier = "launchdarkly"
-    _ld_client = None  # type: LDClient | None
 
     def __init__(self, ld_client=None):
         # type: (LDClient | None) -> None
@@ -28,19 +27,20 @@ class LaunchDarklyIntegration(Integration):
         :param client: An initialized LDClient instance. If a client is not provided, this
             integration will attempt to use the shared global instance.
         """
-        self.__class__._ld_client = ld_client
-
-    @staticmethod
-    def setup_once():
-        # type: () -> None
         try:
-            client = LaunchDarklyIntegration._ld_client or ldclient.get()
+            client = ld_client or ldclient.get()
         except Exception as exc:
             raise DidNotEnable("Error getting LaunchDarkly client. " + repr(exc))
+
+        if not client.is_initialized():
+            raise DidNotEnable("LaunchDarkly client is not initialized.")
 
         # Register the flag collection hook with the LD client.
         client.add_hook(LaunchDarklyHook())
 
+    @staticmethod
+    def setup_once():
+        # type: () -> None
         scope = sentry_sdk.get_current_scope()
         scope.add_error_processor(flag_error_processor)
 

--- a/tests/integrations/launchdarkly/test_launchdarkly.py
+++ b/tests/integrations/launchdarkly/test_launchdarkly.py
@@ -168,14 +168,10 @@ def test_launchdarkly_integration_asyncio(
     }
 
 
-def test_launchdarkly_integration_did_not_enable(sentry_init, uninstall_integration):
-    """
-    Setup should fail when using global client and ldclient.set_config wasn't called.
-
-    We're accessing ldclient internals to set up this test, so it might break if launchdarkly's
-    implementation changes.
-    """
-
+def test_launchdarkly_integration_did_not_enable(monkeypatch):
+    # Client is not passed in and set_config wasn't called.
+    # TODO: Bad practice to access internals like this. We can skip this test, or remove this
+    #  case entirely (force user to pass in a client instance).
     ldclient._reset_client()
     try:
         ldclient.__lock.lock()
@@ -183,6 +179,11 @@ def test_launchdarkly_integration_did_not_enable(sentry_init, uninstall_integrat
     finally:
         ldclient.__lock.unlock()
 
-    uninstall_integration(LaunchDarklyIntegration.identifier)
     with pytest.raises(DidNotEnable):
-        sentry_init(integrations=[LaunchDarklyIntegration()])
+        LaunchDarklyIntegration()
+
+    # Client not initialized.
+    client = LDClient(config=Config("sdk-key"))
+    monkeypatch.setattr(client, "is_initialized", lambda: False)
+    with pytest.raises(DidNotEnable):
+        LaunchDarklyIntegration(ld_client=client)


### PR DESCRIPTION
Mutating a class attribute on `__init__` violates encapsulation and will lead to strange errors.  We need to rethink how we want to implement this before we merge any code. 

Reverts getsentry/sentry-python#3890