### PR TITLE
fix: preserve ARQ enqueue_job __kwdefaults__ after patching

### DIFF
--- a/sentry_sdk/integrations/arq.py
+++ b/sentry_sdk/integrations/arq.py
@@ -71,6 +71,7 @@ class ArqIntegration(Integration):
 def patch_enqueue_job():
     # type: () -> None
     old_enqueue_job = ArqRedis.enqueue_job
+    original_kwdefaults = old_enqueue_job.__kwdefaults__
 
     async def _sentry_enqueue_job(self, function, *args, **kwargs):
         # type: (ArqRedis, str, *Any, **Any) -> Optional[Job]
@@ -83,6 +84,7 @@ def patch_enqueue_job():
         ):
             return await old_enqueue_job(self, function, *args, **kwargs)
 
+    _sentry_enqueue_job.__kwdefaults__ = original_kwdefaults
     ArqRedis.enqueue_job = _sentry_enqueue_job
 
 


### PR DESCRIPTION
Problem:
- The ARQ integration loses `__kwdefaults__` when patching the `enqueue_job` method
- This causes issues when filtering kwargs in custom implementations

Solution:
- Save original `__kwdefaults__` before patching
- Restore them in the patched function

---

Thank you for contributing to `sentry-python`! Please add tests to validate your changes, and lint your code using `tox -e linters`.

Running the test suite on your PR might require maintainer approval. The AWS Lambda tests additionally require a maintainer to add a special label, and they will fail until this label is added.
