### PR TITLE
Treat potel-base as release branch in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - master
       - release/**
-      - sentry-sdk-2.0
+      - potel-base
 
   pull_request:
 

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -15,7 +15,7 @@ on:
   push:
     branches:
       - master
-      - sentry-sdk-2.0
+      - potel-base
   pull_request:
   schedule:
     - cron: '18 18 * * 3'

--- a/.github/workflows/enforce-license-compliance.yml
+++ b/.github/workflows/enforce-license-compliance.yml
@@ -6,7 +6,7 @@ on:
       - master
       - main
       - release/*
-      - sentry-sdk-2.0
+      - potel-base
   pull_request:
 
 # Cancel in progress workflows on pull_requests.

--- a/.github/workflows/test-integrations-ai.yml
+++ b/.github/workflows/test-integrations-ai.yml
@@ -8,7 +8,7 @@ on:
     branches:
       - master
       - release/**
-      - sentry-sdk-2.0
+      - potel-base
   pull_request:
 # Cancel in progress workflows on pull_requests.
 # https://docs.github.com/en/actions/using-jobs/using-concurrency#example-using-a-fallback-value

--- a/.github/workflows/test-integrations-aws.yml
+++ b/.github/workflows/test-integrations-aws.yml
@@ -8,7 +8,7 @@ on:
     branches:
       - master
       - release/**
-      - sentry-sdk-2.0
+      - potel-base
   # XXX: We are using `pull_request_target` instead of `pull_request` because we want
   # this to run on forks with access to the secrets necessary to run the test suite.
   # Prefer to use `pull_request` when possible.

--- a/.github/workflows/test-integrations-cloud.yml
+++ b/.github/workflows/test-integrations-cloud.yml
@@ -8,7 +8,7 @@ on:
     branches:
       - master
       - release/**
-      - sentry-sdk-2.0
+      - potel-base
   pull_request:
 # Cancel in progress workflows on pull_requests.
 # https://docs.github.com/en/actions/using-jobs/using-concurrency#example-using-a-fallback-value

--- a/.github/workflows/test-integrations-common.yml
+++ b/.github/workflows/test-integrations-common.yml
@@ -8,7 +8,7 @@ on:
     branches:
       - master
       - release/**
-      - sentry-sdk-2.0
+      - potel-base
   pull_request:
 # Cancel in progress workflows on pull_requests.
 # https://docs.github.com/en/actions/using-jobs/using-concurrency#example-using-a-fallback-value

--- a/.github/workflows/test-integrations-dbs.yml
+++ b/.github/workflows/test-integrations-dbs.yml
@@ -8,7 +8,7 @@ on:
     branches:
       - master
       - release/**
-      - sentry-sdk-2.0
+      - potel-base
   pull_request:
 # Cancel in progress workflows on pull_requests.
 # https://docs.github.com/en/actions/using-jobs/using-concurrency#example-using-a-fallback-value

--- a/.github/workflows/test-integrations-graphql.yml
+++ b/.github/workflows/test-integrations-graphql.yml
@@ -8,7 +8,7 @@ on:
     branches:
       - master
       - release/**
-      - sentry-sdk-2.0
+      - potel-base
   pull_request:
 # Cancel in progress workflows on pull_requests.
 # https://docs.github.com/en/actions/using-jobs/using-concurrency#example-using-a-fallback-value

--- a/.github/workflows/test-integrations-misc.yml
+++ b/.github/workflows/test-integrations-misc.yml
@@ -8,7 +8,7 @@ on:
     branches:
       - master
       - release/**
-      - sentry-sdk-2.0
+      - potel-base
   pull_request:
 # Cancel in progress workflows on pull_requests.
 # https://docs.github.com/en/actions/using-jobs/using-concurrency#example-using-a-fallback-value

--- a/.github/workflows/test-integrations-network.yml
+++ b/.github/workflows/test-integrations-network.yml
@@ -8,7 +8,7 @@ on:
     branches:
       - master
       - release/**
-      - sentry-sdk-2.0
+      - potel-base
   pull_request:
 # Cancel in progress workflows on pull_requests.
 # https://docs.github.com/en/actions/using-jobs/using-concurrency#example-using-a-fallback-value

--- a/.github/workflows/test-integrations-tasks.yml
+++ b/.github/workflows/test-integrations-tasks.yml
@@ -8,7 +8,7 @@ on:
     branches:
       - master
       - release/**
-      - sentry-sdk-2.0
+      - potel-base
   pull_request:
 # Cancel in progress workflows on pull_requests.
 # https://docs.github.com/en/actions/using-jobs/using-concurrency#example-using-a-fallback-value

--- a/.github/workflows/test-integrations-web-1.yml
+++ b/.github/workflows/test-integrations-web-1.yml
@@ -8,7 +8,7 @@ on:
     branches:
       - master
       - release/**
-      - sentry-sdk-2.0
+      - potel-base
   pull_request:
 # Cancel in progress workflows on pull_requests.
 # https://docs.github.com/en/actions/using-jobs/using-concurrency#example-using-a-fallback-value

--- a/.github/workflows/test-integrations-web-2.yml
+++ b/.github/workflows/test-integrations-web-2.yml
@@ -8,7 +8,7 @@ on:
     branches:
       - master
       - release/**
-      - sentry-sdk-2.0
+      - potel-base
   pull_request:
 # Cancel in progress workflows on pull_requests.
 # https://docs.github.com/en/actions/using-jobs/using-concurrency#example-using-a-fallback-value

--- a/scripts/split_tox_gh_actions/templates/base.jinja
+++ b/scripts/split_tox_gh_actions/templates/base.jinja
@@ -11,7 +11,7 @@ on:
     branches:
       - master
       - release/**
-      - sentry-sdk-2.0
+      - potel-base
 
   {% if needs_github_secrets %}
   # XXX: We are using `pull_request_target` instead of `pull_request` because we want


### PR DESCRIPTION
...and remove `sentry-sdk-2.0` from the CI yamls.

In the future it probably makes sense to have these long-running feature branches have a common prefix since then we can just say `common-prefix/**` in the yamls and don't have to update them for every new long-running feature branch. Maybe `major/` or `feature/`?