### PR TITLE
Setup scopes before client

### DIFF
--- a/sentry_sdk/_init_implementation.py
+++ b/sentry_sdk/_init_implementation.py
@@ -23,9 +23,9 @@ def _init(*args, **kwargs):
 
     This takes the same arguments as the client constructor.
     """
+    setup_scope_context_management()
     client = sentry_sdk.Client(*args, **kwargs)
     sentry_sdk.get_global_scope().set_client(client)
-    setup_scope_context_management()
     _check_python_deprecations()
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -199,10 +199,10 @@ def uninstall_integration():
 @pytest.fixture
 def sentry_init(request):
     def inner(*a, **kw):
+        setup_scope_context_management()
         kw.setdefault("transport", TestTransport())
         client = sentry_sdk.Client(*a, **kw)
         sentry_sdk.get_global_scope().set_client(client)
-        setup_scope_context_management()
 
     if request.node.get_closest_marker("forked"):
         # Do not run isolation if the test is already running in


### PR DESCRIPTION
The newly added feature flags add an error processor to `current_scope` in their `setup_once`. This is actually an antipattern and shouldn't be encouraged.
Either way, this PR sets up the scopes first since the integrations get setup in the `Client` and require that scope to be correct.