### PR TITLE
Deprecate `enable_tracing` option

### DIFF
--- a/sentry_sdk/client.py
+++ b/sentry_sdk/client.py
@@ -6,6 +6,7 @@ from collections.abc import Mapping
 from datetime import datetime, timezone
 from importlib import import_module
 from typing import cast, overload
+import warnings
 
 from sentry_sdk._compat import PY37, check_uwsgi_thread_support
 from sentry_sdk.utils import (
@@ -139,6 +140,13 @@ def _get_options(*args, **kwargs):
             "Ignoring socket_options because of unexpected format. See urllib3.HTTPConnection.socket_options for the expected format."
         )
         rv["socket_options"] = None
+
+    if rv["enable_tracing"] is not None:
+        warnings.warn(
+            "The `enable_tracing` parameter is deprecated. Please use `traces_sample_rate` instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
 
     return rv
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1490,3 +1490,9 @@ class TestSpanClientReports:
 )
 def test_dropped_transaction(sentry_init, capture_record_lost_event_calls, test_config):
     test_config.run(sentry_init, capture_record_lost_event_calls)
+
+
+@pytest.mark.parametrize("enable_tracing", [True, False])
+def test_enable_tracing_deprecated(sentry_init, enable_tracing):
+    with pytest.warns(DeprecationWarning):
+        sentry_init(enable_tracing=enable_tracing)


### PR DESCRIPTION
The option `enable_tracing` is deprecated in favor of using `traces_sample_rate`. 

Fixes #3918