### PR TITLE
ref(grouping): Add `project_root` to `debug_meta` in event

### DIFF
--- a/sentry_sdk/_types.py
+++ b/sentry_sdk/_types.py
@@ -77,6 +77,7 @@ if TYPE_CHECKING:
             ],  # TODO: We can expand on this type
             "check_in_id": str,
             "contexts": dict[str, dict[str, object]],
+            "debug_meta": dict[str, Any],
             "dist": str,
             "duration": Optional[float],
             "environment": str,

--- a/tests/new_scopes_compat/test_new_scopes_compat_event.py
+++ b/tests/new_scopes_compat/test_new_scopes_compat_event.py
@@ -136,6 +136,7 @@ def expected_error(integrations):
                 "integrations": integrations,
             },
             "platform": "python",
+            "debug_meta": {"project_root": mock.ANY},
             "_meta": {
                 "user": {"ip_address": {"": {"rem": [["!config", "s"]]}}},
                 "extra": {


### PR DESCRIPTION
As part of the "Incorporate any internal logic from the SDK in the server-side grouping config" task from https://github.com/getsentry/sentry/issues/83603, this sends the `project_root` value in the outgoing payload, under `debug_meta`. This will allow the sentry server to replicate the logic [here](https://github.com/getsentry/sentry-python/blob/3f57299d1addff54a2d218c069e466a371edc8c4/sentry_sdk/utils.py#L1088-L1089). 

Note to reviewers: If there's a better place to put it, please let me know. If `debug_meta` is a good spot, we'll need to also make a PR to Relay to add `project_root` as a recognized entry. (I have the change in a branch, but won't push it until we decide.)