### PR TITLE
Add support for Python 3.12 and 3.13 to AWS Lambda integration.

### DIFF
--- a/.craft.yml
+++ b/.craft.yml
@@ -25,6 +25,8 @@ targets:
           - python3.9
           - python3.10
           - python3.11
+          - python3.12
+          - python3.13
     license: MIT
   - name: sentry-pypi
     internalPypiRepo: getsentry/pypi

--- a/tests/integrations/aws_lambda/test_aws.py
+++ b/tests/integrations/aws_lambda/test_aws.py
@@ -38,10 +38,9 @@ import pytest
 
 RUNTIMES_TO_TEST = [
     "python3.8",
-    "python3.9",
     "python3.10",
-    "python3.11",
     "python3.12",
+    "python3.13",
 ]
 
 LAMBDA_PRELUDE = """


### PR DESCRIPTION
Its time to add support for newer versions of Python to our AWS Lambda integration. 

Fixes #3946