### PR TITLE
[2] Add tox gen check to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,10 @@ jobs:
           python-version: 3.12
 
       - run: |
+          pip install -e .
+          pip install -r scripts/populate_tox/requirements.txt
           pip install -r scripts/split_tox_gh_actions/requirements.txt
+          python scripts/populate_tox/populate_tox.py --fail-on-changes
           python scripts/split_tox_gh_actions/split_tox_gh_actions.py --fail-on-changes
 
   build_lambda_layer:


### PR DESCRIPTION
Similar to `split_tox_gh_actions`, run the tox generation script in CI and compare the resulting `tox.ini` to the committed one. If there are changes, this most likely means someone edited `tox.ini` directly instead of the template. Make the check fail in that case.