### PR TITLE
[do not merge] Only mark frame as `in_app` if explicitly set by user

### DIFF
--- a/sentry_sdk/utils.py
+++ b/sentry_sdk/utils.py
@@ -1076,19 +1076,6 @@ def set_in_app_in_frames(frames, in_app_exclude, in_app_include, project_root=No
             frame["in_app"] = False
             continue
 
-        # if frame has no abs_path, skip further checks
-        abs_path = frame.get("abs_path")
-        if abs_path is None:
-            continue
-
-        if _is_external_source(abs_path):
-            frame["in_app"] = False
-            continue
-
-        if _is_in_project_root(abs_path, project_root):
-            frame["in_app"] = True
-            continue
-
     return frames
 
 

--- a/tests/integrations/aws_lambda/test_aws.py
+++ b/tests/integrations/aws_lambda/test_aws.py
@@ -219,7 +219,7 @@ def test_basic(run_lambda_function):
     assert frame1["abs_path"] == "/var/task/test_lambda.py"
     assert frame1["function"] == "test_handler"
 
-    assert frame1["in_app"] is True
+    assert "in_app" not in frame1
 
     assert exception["mechanism"]["type"] == "aws_lambda"
     assert not exception["mechanism"]["handled"]

--- a/tests/new_scopes_compat/test_new_scopes_compat_event.py
+++ b/tests/new_scopes_compat/test_new_scopes_compat_event.py
@@ -66,7 +66,6 @@ def expected_error(integrations):
                                     "vars": {
                                         "ex": mock.ANY,
                                     },
-                                    "in_app": True,
                                 }
                             ]
                         },

--- a/tests/utils/test_general.py
+++ b/tests/utils/test_general.py
@@ -121,13 +121,12 @@ def test_parse_invalid_dsn(dsn):
 
 
 @pytest.mark.parametrize(
-    "frame,in_app_include,in_app_exclude,project_root,resulting_frame",
+    "frame,in_app_include,in_app_exclude,resulting_frame",
     [
         [
             {
                 "abs_path": "/home/ubuntu/fastapi/.venv/lib/python3.10/site-packages/fastapi/routing.py",
             },
-            None,
             None,
             None,
             {
@@ -140,7 +139,6 @@ def test_parse_invalid_dsn(dsn):
                 "module": "fastapi.routing",
                 "abs_path": "/home/ubuntu/fastapi/.venv/lib/python3.10/site-packages/fastapi/routing.py",
             },
-            None,
             None,
             None,
             {
@@ -155,7 +153,6 @@ def test_parse_invalid_dsn(dsn):
                 "abs_path": "/home/ubuntu/fastapi/.venv/lib/python3.10/site-packages/fastapi/routing.py",
                 "in_app": True,
             },
-            None,
             None,
             None,
             {
@@ -168,7 +165,6 @@ def test_parse_invalid_dsn(dsn):
             {
                 "abs_path": "C:\\Users\\winuser\\AppData\\Roaming\\Python\\Python35\\site-packages\\fastapi\\routing.py",
             },
-            None,
             None,
             None,
             {
@@ -181,7 +177,6 @@ def test_parse_invalid_dsn(dsn):
                 "module": "fastapi.routing",
                 "abs_path": "/usr/lib/python2.7/dist-packages/fastapi/routing.py",
             },
-            None,
             None,
             None,
             {
@@ -194,7 +189,6 @@ def test_parse_invalid_dsn(dsn):
             {
                 "abs_path": "/home/ubuntu/fastapi/main.py",
             },
-            None,
             None,
             None,
             {
@@ -206,7 +200,6 @@ def test_parse_invalid_dsn(dsn):
                 "module": "main",
                 "abs_path": "/home/ubuntu/fastapi/main.py",
             },
-            None,
             None,
             None,
             {
@@ -221,7 +214,6 @@ def test_parse_invalid_dsn(dsn):
             },
             ["fastapi"],
             None,
-            None,
             {
                 "abs_path": "/home/ubuntu/fastapi/.venv/lib/python3.10/site-packages/fastapi/routing.py",
                 "in_app": False,  # because there is no module set
@@ -233,7 +225,6 @@ def test_parse_invalid_dsn(dsn):
                 "abs_path": "/home/ubuntu/fastapi/.venv/lib/python3.10/site-packages/fastapi/routing.py",
             },
             ["fastapi"],
-            None,
             None,
             {
                 "module": "fastapi.routing",
@@ -249,7 +240,6 @@ def test_parse_invalid_dsn(dsn):
             },
             ["fastapi"],
             None,
-            None,
             {
                 "module": "fastapi.routing",
                 "abs_path": "/home/ubuntu/fastapi/.venv/lib/python3.10/site-packages/fastapi/routing.py",
@@ -262,7 +252,6 @@ def test_parse_invalid_dsn(dsn):
             },
             ["fastapi"],
             None,
-            None,
             {
                 "abs_path": "C:\\Users\\winuser\\AppData\\Roaming\\Python\\Python35\\site-packages\\fastapi\\routing.py",
                 "in_app": False,  # because there is no module set
@@ -274,7 +263,6 @@ def test_parse_invalid_dsn(dsn):
                 "abs_path": "/usr/lib/python2.7/dist-packages/fastapi/routing.py",
             },
             ["fastapi"],
-            None,
             None,
             {
                 "module": "fastapi.routing",
@@ -287,7 +275,6 @@ def test_parse_invalid_dsn(dsn):
                 "abs_path": "/home/ubuntu/fastapi/main.py",
             },
             ["fastapi"],
-            None,
             None,
             {
                 "abs_path": "/home/ubuntu/fastapi/main.py",
@@ -299,7 +286,6 @@ def test_parse_invalid_dsn(dsn):
                 "abs_path": "/home/ubuntu/fastapi/main.py",
             },
             ["fastapi"],
-            None,
             None,
             {
                 "module": "main",
@@ -313,7 +299,6 @@ def test_parse_invalid_dsn(dsn):
             },
             None,
             ["main"],
-            None,
             {
                 "abs_path": "/home/ubuntu/fastapi/.venv/lib/python3.10/site-packages/fastapi/routing.py",
                 "in_app": False,
@@ -326,7 +311,6 @@ def test_parse_invalid_dsn(dsn):
             },
             None,
             ["main"],
-            None,
             {
                 "module": "fastapi.routing",
                 "abs_path": "/home/ubuntu/fastapi/.venv/lib/python3.10/site-packages/fastapi/routing.py",
@@ -341,7 +325,6 @@ def test_parse_invalid_dsn(dsn):
             },
             None,
             ["main"],
-            None,
             {
                 "module": "fastapi.routing",
                 "abs_path": "/home/ubuntu/fastapi/.venv/lib/python3.10/site-packages/fastapi/routing.py",
@@ -354,7 +337,6 @@ def test_parse_invalid_dsn(dsn):
             },
             None,
             ["main"],
-            None,
             {
                 "abs_path": "C:\\Users\\winuser\\AppData\\Roaming\\Python\\Python35\\site-packages\\fastapi\\routing.py",
                 "in_app": False,
@@ -367,7 +349,6 @@ def test_parse_invalid_dsn(dsn):
             },
             None,
             ["main"],
-            None,
             {
                 "module": "fastapi.routing",
                 "abs_path": "/usr/lib/python2.7/dist-packages/fastapi/routing.py",
@@ -380,7 +361,6 @@ def test_parse_invalid_dsn(dsn):
             },
             None,
             ["main"],
-            None,
             {
                 "abs_path": "/home/ubuntu/fastapi/main.py",
             },
@@ -392,7 +372,6 @@ def test_parse_invalid_dsn(dsn):
             },
             None,
             ["main"],
-            None,
             {
                 "module": "main",
                 "abs_path": "/home/ubuntu/fastapi/main.py",
@@ -405,7 +384,6 @@ def test_parse_invalid_dsn(dsn):
             },
             None,
             None,
-            None,
             {
                 "module": "fastapi.routing",
             },
@@ -415,7 +393,6 @@ def test_parse_invalid_dsn(dsn):
                 "module": "fastapi.routing",
             },
             ["fastapi"],
-            None,
             None,
             {
                 "module": "fastapi.routing",
@@ -428,65 +405,18 @@ def test_parse_invalid_dsn(dsn):
             },
             None,
             ["fastapi"],
-            None,
             {
                 "module": "fastapi.routing",
-                "in_app": False,
-            },
-        ],
-        # with project_root set
-        [
-            {
-                "module": "main",
-                "abs_path": "/home/ubuntu/fastapi/main.py",
-            },
-            None,
-            None,
-            "/home/ubuntu/fastapi",
-            {
-                "module": "main",
-                "abs_path": "/home/ubuntu/fastapi/main.py",
-                "in_app": True,
-            },
-        ],
-        [
-            {
-                "module": "main",
-                "abs_path": "/home/ubuntu/fastapi/main.py",
-            },
-            ["main"],
-            None,
-            "/home/ubuntu/fastapi",
-            {
-                "module": "main",
-                "abs_path": "/home/ubuntu/fastapi/main.py",
-                "in_app": True,
-            },
-        ],
-        [
-            {
-                "module": "main",
-                "abs_path": "/home/ubuntu/fastapi/main.py",
-            },
-            None,
-            ["main"],
-            "/home/ubuntu/fastapi",
-            {
-                "module": "main",
-                "abs_path": "/home/ubuntu/fastapi/main.py",
                 "in_app": False,
             },
         ],
     ],
 )
-def test_set_in_app_in_frames(
-    frame, in_app_include, in_app_exclude, project_root, resulting_frame
-):
+def test_set_in_app_in_frames(frame, in_app_include, in_app_exclude, resulting_frame):
     new_frames = set_in_app_in_frames(
         [frame],
         in_app_include=in_app_include,
         in_app_exclude=in_app_exclude,
-        project_root=project_root,
     )
 
     assert new_frames[0] == resulting_frame

--- a/tests/utils/test_general.py
+++ b/tests/utils/test_general.py
@@ -131,7 +131,6 @@ def test_parse_invalid_dsn(dsn):
             None,
             {
                 "abs_path": "/home/ubuntu/fastapi/.venv/lib/python3.10/site-packages/fastapi/routing.py",
-                "in_app": False,
             },
         ],
         [
@@ -144,7 +143,6 @@ def test_parse_invalid_dsn(dsn):
             {
                 "module": "fastapi.routing",
                 "abs_path": "/home/ubuntu/fastapi/.venv/lib/python3.10/site-packages/fastapi/routing.py",
-                "in_app": False,
             },
         ],
         [
@@ -169,7 +167,6 @@ def test_parse_invalid_dsn(dsn):
             None,
             {
                 "abs_path": "C:\\Users\\winuser\\AppData\\Roaming\\Python\\Python35\\site-packages\\fastapi\\routing.py",
-                "in_app": False,
             },
         ],
         [
@@ -182,7 +179,6 @@ def test_parse_invalid_dsn(dsn):
             {
                 "module": "fastapi.routing",
                 "abs_path": "/usr/lib/python2.7/dist-packages/fastapi/routing.py",
-                "in_app": False,
             },
         ],
         [
@@ -216,7 +212,6 @@ def test_parse_invalid_dsn(dsn):
             None,
             {
                 "abs_path": "/home/ubuntu/fastapi/.venv/lib/python3.10/site-packages/fastapi/routing.py",
-                "in_app": False,  # because there is no module set
             },
         ],
         [
@@ -254,7 +249,6 @@ def test_parse_invalid_dsn(dsn):
             None,
             {
                 "abs_path": "C:\\Users\\winuser\\AppData\\Roaming\\Python\\Python35\\site-packages\\fastapi\\routing.py",
-                "in_app": False,  # because there is no module set
             },
         ],
         [
@@ -301,7 +295,6 @@ def test_parse_invalid_dsn(dsn):
             ["main"],
             {
                 "abs_path": "/home/ubuntu/fastapi/.venv/lib/python3.10/site-packages/fastapi/routing.py",
-                "in_app": False,
             },
         ],
         [
@@ -314,7 +307,6 @@ def test_parse_invalid_dsn(dsn):
             {
                 "module": "fastapi.routing",
                 "abs_path": "/home/ubuntu/fastapi/.venv/lib/python3.10/site-packages/fastapi/routing.py",
-                "in_app": False,
             },
         ],
         [
@@ -339,7 +331,6 @@ def test_parse_invalid_dsn(dsn):
             ["main"],
             {
                 "abs_path": "C:\\Users\\winuser\\AppData\\Roaming\\Python\\Python35\\site-packages\\fastapi\\routing.py",
-                "in_app": False,
             },
         ],
         [
@@ -352,7 +343,6 @@ def test_parse_invalid_dsn(dsn):
             {
                 "module": "fastapi.routing",
                 "abs_path": "/usr/lib/python2.7/dist-packages/fastapi/routing.py",
-                "in_app": False,
             },
         ],
         [


### PR DESCRIPTION
❗ This is ready for review, but **not ready to be merged**. Releasing this needs to be coordinated with (1) the SDK sending `project_root` (https://github.com/getsentry/sentry-python/pull/3941) and (2) the logic actually being moved to the server.

Only take `in_app_include` and `in_app_exclude` into account when marking a frame `in_app`, nothing else. The existing logic will be moving to the server. We will not merge this before that happens.

See https://github.com/getsentry/sentry/issues/83603 for the big picture

Closes https://github.com/getsentry/sentry-python/issues/3945