### PR TITLE
feat(scope): Emit `buffer_overflow` discard reason when popping breadcrumbs

### DIFF
--- a/sentry_sdk/_types.py
+++ b/sentry_sdk/_types.py
@@ -159,6 +159,7 @@ if TYPE_CHECKING:
         "metric_bucket",
         "monitor",
         "span",
+        "log_item",
     ]
     SessionStatus = Literal["ok", "exited", "crashed", "abnormal"]
 

--- a/sentry_sdk/scope.py
+++ b/sentry_sdk/scope.py
@@ -972,6 +972,8 @@ class Scope:
             logger.info("before breadcrumb dropped breadcrumb (%s)", crumb)
 
         while len(self._breadcrumbs) > max_breadcrumbs:
+            if client.transport is not None:
+                client.transport.record_lost_event("buffer_overflow", "log_item")
             self._breadcrumbs.popleft()
 
     def start_transaction(


### PR DESCRIPTION
ref https://github.com/getsentry/team-sdks/issues/116

This PR implements a new client discard reason for `buffer_overflow`. This will be used to track when the internal breadcrumbs buffer overflows for the new logs product that we are working on.

`log_item` is the new data category for logs, which we are basing out of breadcrumbs. Eventually we will be sending standalone envelope items that only contain breadcrumbs.