### PR TITLE
Handle MultiPartParserError to avoid internal sentry crash

### DIFF
--- a/sentry_sdk/integrations/_wsgi_common.py
+++ b/sentry_sdk/integrations/_wsgi_common.py
@@ -149,8 +149,15 @@ class RequestExtractor:
 
     def parsed_body(self):
         # type: () -> Optional[Dict[str, Any]]
-        form = self.form()
-        files = self.files()
+        try:
+            form = self.form()
+        except Exception:
+            form = None
+        try:
+            files = self.files()
+        except Exception:
+            files = None
+
         if form or files:
             data = {}
             if form:


### PR DESCRIPTION
Handles an internal error in sentry_sdk if there is an issue with parsing request.POST. See attached stack trace of this internal error that we experienced in production.

It would be better to handle this exception without request data instead of crashing and not reporting anything.

```
 [sentry] ERROR: Internal error in sentry_sdk
Traceback (most recent call last):
  File "/usr/src/app/.venv/lib/python3.13/site-packages/sentry_sdk/integrations/django/__init__.py", line 588, in parsed_body
    return self.request.data
           ^^^^^^^^^^^^^^^^^
AttributeError: 'WSGIRequest' object has no attribute 'data'
During handling of the above exception, another exception occurred:
Traceback (most recent call last):
  File "/usr/src/app/.venv/lib/python3.13/site-packages/sentry_sdk/integrations/django/__init__.py", line 508, in wsgi_request_event_processor
    DjangoRequestExtractor(request).extract_into_event(event)
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^
  File "/usr/src/app/.venv/lib/python3.13/site-packages/sentry_sdk/integrations/_wsgi_common.py", line 118, in extract_into_event
    parsed_body = self.parsed_body()
  File "/usr/src/app/.venv/lib/python3.13/site-packages/sentry_sdk/integrations/django/__init__.py", line 590, in parsed_body
    return RequestExtractor.parsed_body(self)
           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^
  File "/usr/src/app/.venv/lib/python3.13/site-packages/sentry_sdk/integrations/_wsgi_common.py", line 152, in parsed_body
    form = self.form()
  File "/usr/src/app/.venv/lib/python3.13/site-packages/sentry_sdk/integrations/django/__init__.py", line 575, in form
    return self.request.POST
           ^^^^^^^^^^^^^^^^^
  File "/usr/src/app/.venv/lib/python3.13/site-packages/django/core/handlers/wsgi.py", line 93, in _get_post
    self._load_post_and_files()
    ~~~~~~~~~~~~~~~~~~~~~~~~~^^
  File "/usr/src/app/.venv/lib/python3.13/site-packages/django/http/request.py", line 374, in _load_post_and_files
    self._post, self._files = self.parse_file_upload(self.META, data)
                              ~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^
  File "/usr/src/app/.venv/lib/python3.13/site-packages/django/http/request.py", line 321, in parse_file_upload
    parser = MultiPartParser(META, post_data, self.upload_handlers, self.encoding)
  File "/usr/src/app/.venv/lib/python3.13/site-packages/django/http/multipartparser.py", line 89, in __init__
    raise MultiPartParserError(
        "Invalid boundary in multipart: %s" % force_str(boundary)
    )
django.http.multipartparser.MultiPartParserError: Invalid boundary in multipart: None
```

<!-- Describe your PR here -->

---

Thank you for contributing to `sentry-python`! Please add tests to validate your changes, and lint your code using `tox -e linters`.

Running the test suite on your PR might require maintainer approval. The AWS Lambda tests additionally require a maintainer to add a special label, and they will fail until this label is added.
