### PR TITLE
Set level based on status code for HTTP client breadcrumbs

### DIFF
--- a/sentry_sdk/tracing_utils.py
+++ b/sentry_sdk/tracing_utils.py
@@ -156,14 +156,13 @@ def record_sql_queries(
 
 def maybe_create_breadcrumbs_from_span(scope, span):
     # type: (sentry_sdk.Scope, sentry_sdk.tracing.Span) -> None
-
     if span.op == OP.DB_REDIS:
         scope.add_breadcrumb(
             message=span.description, type="redis", category="redis", data=span._tags
         )
 
     elif span.op == OP.HTTP_CLIENT:
-        level = "info"  # XXX is this correct?
+        level = None
         status_code = span._data.get(SPANDATA.HTTP_STATUS_CODE)
         if status_code:
             if 500 <= status_code <= 599:
@@ -171,9 +170,12 @@ def maybe_create_breadcrumbs_from_span(scope, span):
             elif 400 <= status_code <= 499:
                 level = "warning"
 
-        scope.add_breadcrumb(
-            type="http", category="httplib", data=span._data, level=level
-        )
+        if level:
+            scope.add_breadcrumb(
+                type="http", category="httplib", data=span._data, level=level
+            )
+        else:
+            scope.add_breadcrumb(type="http", category="httplib", data=span._data)
 
     elif span.op == "subprocess":
         scope.add_breadcrumb(

--- a/sentry_sdk/tracing_utils.py
+++ b/sentry_sdk/tracing_utils.py
@@ -161,8 +161,20 @@ def maybe_create_breadcrumbs_from_span(scope, span):
         scope.add_breadcrumb(
             message=span.description, type="redis", category="redis", data=span._tags
         )
+
     elif span.op == OP.HTTP_CLIENT:
-        scope.add_breadcrumb(type="http", category="httplib", data=span._data)
+        level = "info"  # XXX is this correct?
+        status_code = span._data.get(SPANDATA.HTTP_STATUS_CODE)
+        if status_code:
+            if 500 <= status_code <= 599:
+                level = "error"
+            elif 400 <= status_code <= 499:
+                level = "warning"
+
+        scope.add_breadcrumb(
+            type="http", category="httplib", data=span._data, level=level
+        )
+
     elif span.op == "subprocess":
         scope.add_breadcrumb(
             type="subprocess",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -587,8 +587,14 @@ def suppress_deprecation_warnings():
 
 class MockServerRequestHandler(BaseHTTPRequestHandler):
     def do_GET(self):  # noqa: N802
-        # Process an HTTP GET request and return a response with an HTTP 200 status.
-        self.send_response(200)
+        # Process an HTTP GET request and return a response.
+        # If the path ends with /status/<number>, return status code <number>.
+        # Otherwise return a 200 response.
+        code = 200
+        if "/status/" in self.path:
+            code = int(self.path[-3:])
+
+        self.send_response(code)
         self.end_headers()
         return
 

--- a/tests/integrations/aiohttp/test_aiohttp.py
+++ b/tests/integrations/aiohttp/test_aiohttp.py
@@ -475,7 +475,7 @@ async def test_trace_from_headers_if_performance_disabled(
 
 @pytest.mark.asyncio
 async def test_crumb_capture(
-    sentry_init, aiohttp_raw_server, aiohttp_client, loop, capture_events
+    sentry_init, aiohttp_raw_server, aiohttp_client, capture_events
 ):
     def before_breadcrumb(crumb, hint):
         crumb["data"]["extra"] = "foo"
@@ -512,6 +512,60 @@ async def test_crumb_capture(
                 "http.response.status_code": 200,
                 "reason": "OK",
                 "extra": "foo",
+            }
+        )
+
+
+@pytest.mark.parametrize(
+    "status_code,level",
+    [
+        (200, None),
+        (301, None),
+        (403, "warning"),
+        (405, "warning"),
+        (500, "error"),
+    ],
+)
+@pytest.mark.asyncio
+async def test_crumb_capture_client_error(
+    sentry_init,
+    aiohttp_raw_server,
+    aiohttp_client,
+    capture_events,
+    status_code,
+    level,
+):
+    sentry_init(integrations=[AioHttpIntegration()])
+
+    async def handler(request):
+        return web.Response(status=status_code)
+
+    raw_server = await aiohttp_raw_server(handler)
+
+    with start_transaction():
+        events = capture_events()
+
+        client = await aiohttp_client(raw_server)
+        resp = await client.get("/")
+        assert resp.status == status_code
+        capture_message("Testing!")
+
+        (event,) = events
+
+        crumb = event["breadcrumbs"]["values"][0]
+        assert crumb["type"] == "http"
+        if level is None:
+            assert "level" not in crumb
+        else:
+            assert crumb["level"] == level
+        assert crumb["category"] == "httplib"
+        assert crumb["data"] == ApproxDict(
+            {
+                "url": "http://127.0.0.1:{}/".format(raw_server.port),
+                "http.fragment": "",
+                "http.method": "GET",
+                "http.query": "",
+                "http.response.status_code": status_code,
             }
         )
 

--- a/tests/integrations/httpx/test_httpx.py
+++ b/tests/integrations/httpx/test_httpx.py
@@ -61,6 +61,66 @@ def test_crumb_capture_and_hint(sentry_init, capture_events, httpx_client, httpx
     "httpx_client",
     (httpx.Client(), httpx.AsyncClient()),
 )
+@pytest.mark.parametrize(
+    "status_code,level",
+    [
+        (200, None),
+        (301, None),
+        (403, "warning"),
+        (405, "warning"),
+        (500, "error"),
+    ],
+)
+def test_crumb_capture_client_error(
+    sentry_init, capture_events, httpx_client, httpx_mock, status_code, level
+):
+    httpx_mock.add_response(status_code=status_code)
+
+    sentry_init(integrations=[HttpxIntegration()])
+
+    url = "http://example.com/"
+
+    with start_transaction():
+        events = capture_events()
+
+        if asyncio.iscoroutinefunction(httpx_client.get):
+            response = asyncio.get_event_loop().run_until_complete(
+                httpx_client.get(url)
+            )
+        else:
+            response = httpx_client.get(url)
+
+        assert response.status_code == status_code
+        capture_message("Testing!")
+
+        (event,) = events
+
+        crumb = event["breadcrumbs"]["values"][0]
+        assert crumb["type"] == "http"
+        assert crumb["category"] == "httplib"
+
+        if level is None:
+            assert "level" not in crumb
+        else:
+            assert crumb["level"] == level
+
+        assert crumb["data"] == ApproxDict(
+            {
+                "url": url,
+                SPANDATA.HTTP_METHOD: "GET",
+                SPANDATA.HTTP_FRAGMENT: "",
+                SPANDATA.HTTP_QUERY: "",
+                SPANDATA.HTTP_STATUS_CODE: status_code,
+                "reason": "OK",
+                "extra": "foo",
+            }
+        )
+
+
+@pytest.mark.parametrize(
+    "httpx_client",
+    (httpx.Client(), httpx.AsyncClient()),
+)
 def test_outgoing_trace_headers(sentry_init, httpx_client, httpx_mock):
     httpx_mock.add_response()
 

--- a/tests/integrations/httpx/test_httpx.py
+++ b/tests/integrations/httpx/test_httpx.py
@@ -111,8 +111,6 @@ def test_crumb_capture_client_error(
                 SPANDATA.HTTP_FRAGMENT: "",
                 SPANDATA.HTTP_QUERY: "",
                 SPANDATA.HTTP_STATUS_CODE: status_code,
-                "reason": "OK",
-                "extra": "foo",
             }
         )
 

--- a/tests/integrations/requests/test_requests.py
+++ b/tests/integrations/requests/test_requests.py
@@ -2,22 +2,20 @@ from unittest import mock
 
 import pytest
 import requests
-import responses
 
 from sentry_sdk import capture_message
 from sentry_sdk.consts import SPANDATA
 from sentry_sdk.integrations.stdlib import StdlibIntegration
-from tests.conftest import ApproxDict
+from tests.conftest import ApproxDict, create_mock_http_server
+
+PORT = create_mock_http_server()
 
 
 def test_crumb_capture(sentry_init, capture_events):
     sentry_init(integrations=[StdlibIntegration()])
-
-    url = "http://example.com/"
-    responses.add(responses.GET, url, status=200)
-
     events = capture_events()
 
+    url = f"http://localhost:{PORT}/hello-world"  # noqa:E231
     response = requests.get(url)
     capture_message("Testing!")
 
@@ -37,14 +35,55 @@ def test_crumb_capture(sentry_init, capture_events):
     )
 
 
+@pytest.mark.parametrize(
+    "status_code,level",
+    [
+        (200, None),
+        (301, None),
+        (403, "warning"),
+        (405, "warning"),
+        (500, "error"),
+    ],
+)
+def test_crumb_capture_warning(sentry_init, capture_events, status_code, level):
+    sentry_init(integrations=[StdlibIntegration()])
+
+    events = capture_events()
+
+    url = f"http://localhost:{PORT}/status/{status_code}"  # noqa:E231
+    response = requests.get(url)
+
+    capture_message("Testing!")
+
+    (event,) = events
+    (crumb,) = event["breadcrumbs"]["values"]
+    assert crumb["type"] == "http"
+    assert crumb["category"] == "httplib"
+
+    if level is None:
+        assert "level" not in crumb
+    else:
+        assert crumb["level"] == level
+
+    assert crumb["data"] == ApproxDict(
+        {
+            "url": url,
+            SPANDATA.HTTP_METHOD: "GET",
+            SPANDATA.HTTP_FRAGMENT: "",
+            SPANDATA.HTTP_QUERY: "",
+            SPANDATA.HTTP_STATUS_CODE: response.status_code,
+            "reason": response.reason,
+        }
+    )
+
+
 @pytest.mark.tests_internal_exceptions
 def test_omit_url_data_if_parsing_fails(sentry_init, capture_events):
     sentry_init(integrations=[StdlibIntegration()])
 
-    url = "https://example.com"
-    responses.add(responses.GET, url, status=200)
-
     events = capture_events()
+
+    url = f"http://localhost:{PORT}/ok"  # noqa:E231
 
     with mock.patch(
         "sentry_sdk.integrations.stdlib.parse_url",
@@ -63,7 +102,6 @@ def test_omit_url_data_if_parsing_fails(sentry_init, capture_events):
             # no url related data
         }
     )
-
     assert "url" not in event["breadcrumbs"]["values"][0]["data"]
     assert SPANDATA.HTTP_FRAGMENT not in event["breadcrumbs"]["values"][0]["data"]
     assert SPANDATA.HTTP_QUERY not in event["breadcrumbs"]["values"][0]["data"]

--- a/tests/integrations/requests/test_requests.py
+++ b/tests/integrations/requests/test_requests.py
@@ -1,3 +1,4 @@
+import sys
 from unittest import mock
 
 import pytest
@@ -35,6 +36,10 @@ def test_crumb_capture(sentry_init, capture_events):
     )
 
 
+@pytest.mark.skipif(
+    sys.version_info < (3, 7),
+    reason="The response status is not set on the span early enough in 3.6",
+)
 @pytest.mark.parametrize(
     "status_code,level",
     [
@@ -52,6 +57,8 @@ def test_crumb_capture_client_error(sentry_init, capture_events, status_code, le
 
     url = f"http://localhost:{PORT}/status/{status_code}"  # noqa:E231
     response = requests.get(url)
+
+    assert response.status_code == status_code
 
     capture_message("Testing!")
 

--- a/tests/integrations/requests/test_requests.py
+++ b/tests/integrations/requests/test_requests.py
@@ -45,7 +45,7 @@ def test_crumb_capture(sentry_init, capture_events):
         (500, "error"),
     ],
 )
-def test_crumb_capture_warning(sentry_init, capture_events, status_code, level):
+def test_crumb_capture_client_error(sentry_init, capture_events, status_code, level):
     sentry_init(integrations=[StdlibIntegration()])
 
     events = capture_events()

--- a/tests/integrations/stdlib/test_httplib.py
+++ b/tests/integrations/stdlib/test_httplib.py
@@ -42,6 +42,48 @@ def test_crumb_capture(sentry_init, capture_events):
     )
 
 
+@pytest.mark.parametrize(
+    "status_code,level",
+    [
+        (200, None),
+        (301, None),
+        (403, "warning"),
+        (405, "warning"),
+        (500, "error"),
+    ],
+)
+def test_crumb_capture_client_error(sentry_init, capture_events, status_code, level):
+    sentry_init(integrations=[StdlibIntegration()])
+    events = capture_events()
+
+    url = f"http://localhost:{PORT}/status/{status_code}"  # noqa:E231
+    urlopen(url)
+
+    capture_message("Testing!")
+
+    (event,) = events
+    (crumb,) = event["breadcrumbs"]["values"]
+
+    assert crumb["type"] == "http"
+    assert crumb["category"] == "httplib"
+
+    if level is None:
+        assert "level" not in crumb
+    else:
+        assert crumb["level"] == level
+
+    assert crumb["data"] == ApproxDict(
+        {
+            "url": url,
+            SPANDATA.HTTP_METHOD: "GET",
+            SPANDATA.HTTP_STATUS_CODE: status_code,
+            "reason": "OK",
+            SPANDATA.HTTP_FRAGMENT: "",
+            SPANDATA.HTTP_QUERY: "",
+        }
+    )
+
+
 def test_crumb_capture_hint(sentry_init, capture_events):
     def before_breadcrumb(crumb, hint):
         crumb["data"]["extra"] = "foo"

--- a/tests/integrations/stdlib/test_httplib.py
+++ b/tests/integrations/stdlib/test_httplib.py
@@ -1,6 +1,7 @@
 import random
 from http.client import HTTPConnection, HTTPSConnection
 from socket import SocketIO
+from urllib.error import HTTPError
 from urllib.request import urlopen
 from unittest import mock
 
@@ -57,7 +58,10 @@ def test_crumb_capture_client_error(sentry_init, capture_events, status_code, le
     events = capture_events()
 
     url = f"http://localhost:{PORT}/status/{status_code}"  # noqa:E231
-    urlopen(url)
+    try:
+        urlopen(url)
+    except HTTPError:
+        pass
 
     capture_message("Testing!")
 
@@ -77,7 +81,6 @@ def test_crumb_capture_client_error(sentry_init, capture_events, status_code, le
             "url": url,
             SPANDATA.HTTP_METHOD: "GET",
             SPANDATA.HTTP_STATUS_CODE: status_code,
-            "reason": "OK",
             SPANDATA.HTTP_FRAGMENT: "",
             SPANDATA.HTTP_QUERY: "",
         }


### PR DESCRIPTION
- add logic to `maybe_create_breadcrumbs_from_span` to set the `level` of the breadcrumb to `warning` for the client error range (4xx) and to `error` for server errors (5xx)
- add functionality to the simple HTTP server that we use in some tests to respond with a specific error code
  - we were (and are) still "using" `responses` in multiple places, but they're not actually active (the `activate` decorator is missing) and we're making actual requests outside -- we should clean this up
  - we also can't use `responses` for stdlib/requests tests since they patch something that we patch
- add `httpx`, `stdlib`, `requests`, `aiohttp` tests for the new behavior
  - restrict the `requests` tests to 3.7+ since in 3.6, the span is finished before the HTTP status is set for some reason...

Closes https://github.com/getsentry/sentry-python/issues/4000