### PR TITLE
fix(ci): Various errors on master

### DIFF
--- a/sentry_sdk/_queue.py
+++ b/sentry_sdk/_queue.py
@@ -86,11 +86,13 @@ __all__ = ["EmptyError", "FullError", "Queue"]
 
 class EmptyError(Exception):
     "Exception raised by Queue.get(block=0)/get_nowait()."
+
     pass
 
 
 class FullError(Exception):
     "Exception raised by Queue.put(block=0)/put_nowait()."
+
     pass
 
 

--- a/tests/integrations/aiohttp/test_aiohttp.py
+++ b/tests/integrations/aiohttp/test_aiohttp.py
@@ -474,22 +474,17 @@ async def test_trace_from_headers_if_performance_disabled(
     assert error_event["contexts"]["trace"]["trace_id"] == trace_id
 
 
-if sys.version_info >= (3, 12):
-
+if sys.version_info < (3, 12):
+    # `loop` was deprecated in `pytest-aiohttp`
+    # in favor of `event_loop` from `pytest-asyncio`
     @pytest.fixture
-    def asyncio_loop(event_loop):
-        yield event_loop
-
-else:
-
-    @pytest.fixture
-    def asyncio_loop(loop):
+    def event_loop(loop):
         yield loop
 
 
 @pytest.mark.asyncio
 async def test_crumb_capture(
-    sentry_init, aiohttp_raw_server, aiohttp_client, asyncio_loop, capture_events
+    sentry_init, aiohttp_raw_server, aiohttp_client, event_loop, capture_events
 ):
     def before_breadcrumb(crumb, hint):
         crumb["data"]["extra"] = "foo"

--- a/tests/integrations/aiohttp/test_aiohttp.py
+++ b/tests/integrations/aiohttp/test_aiohttp.py
@@ -475,7 +475,7 @@ async def test_trace_from_headers_if_performance_disabled(
 
 @pytest.mark.asyncio
 async def test_crumb_capture(
-    sentry_init, aiohttp_raw_server, aiohttp_client, loop, capture_events
+    sentry_init, aiohttp_raw_server, aiohttp_client, event_loop, capture_events
 ):
     def before_breadcrumb(crumb, hint):
         crumb["data"]["extra"] = "foo"

--- a/tests/integrations/aiohttp/test_aiohttp.py
+++ b/tests/integrations/aiohttp/test_aiohttp.py
@@ -1,5 +1,6 @@
 import asyncio
 import json
+import sys
 from contextlib import suppress
 from unittest import mock
 
@@ -473,9 +474,22 @@ async def test_trace_from_headers_if_performance_disabled(
     assert error_event["contexts"]["trace"]["trace_id"] == trace_id
 
 
+if sys.version_info >= (3, 12):
+
+    @pytest.fixture
+    def asyncio_loop(event_loop):
+        yield event_loop
+
+else:
+
+    @pytest.fixture
+    def asyncio_loop(loop):
+        yield loop
+
+
 @pytest.mark.asyncio
 async def test_crumb_capture(
-    sentry_init, aiohttp_raw_server, aiohttp_client, event_loop, capture_events
+    sentry_init, aiohttp_raw_server, aiohttp_client, asyncio_loop, capture_events
 ):
     def before_breadcrumb(crumb, hint):
         crumb["data"]["extra"] = "foo"

--- a/tests/integrations/pymongo/test_pymongo.py
+++ b/tests/integrations/pymongo/test_pymongo.py
@@ -10,7 +10,7 @@ import pytest
 @pytest.fixture(scope="session")
 def mongo_server():
     server = MockupDB(verbose=True)
-    server.autoresponds("ismaster", maxWireVersion=6)
+    server.autoresponds("ismaster", maxWireVersion=7)
     server.run()
     server.autoresponds(
         {"find": "test_collection"}, cursor={"id": 123, "firstBatch": []}


### PR DESCRIPTION
- `black==25.1.0` changed some default styles
- `pytest-aiohttp==1.1.0` removed the `loop` fixture
- `huggingface-hub==0.28.0` deprecated `InferenceClient.post` to `InferenceClient._inner_post`
- `pymongo==4.11.0` required `maxWireVersion` to be `7`