### PR TITLE
feat(profiling): Continuous profiling lifecycle

### DIFF
--- a/sentry_sdk/consts.py
+++ b/sentry_sdk/consts.py
@@ -38,6 +38,7 @@ if TYPE_CHECKING:
     from typing import Any
     from typing import Sequence
     from typing import Tuple
+    from typing_extensions import Literal
     from typing_extensions import TypedDict
 
     from sentry_sdk._types import (
@@ -528,6 +529,7 @@ class ClientConstructor:
         profiles_sample_rate=None,  # type: Optional[float]
         profiles_sampler=None,  # type: Optional[TracesSampler]
         profiler_mode=None,  # type: Optional[ProfilerMode]
+        profile_lifecycle="manual",  # type: Literal["manual", "auto"]
         profile_session_sample_rate=None,  # type: Optional[float]
         auto_enabling_integrations=True,  # type: bool
         disabled_integrations=None,  # type: Optional[Sequence[sentry_sdk.integrations.Integration]]

--- a/sentry_sdk/profiler/continuous_profiler.py
+++ b/sentry_sdk/profiler/continuous_profiler.py
@@ -5,6 +5,7 @@ import sys
 import threading
 import time
 import uuid
+from collections import deque
 from datetime import datetime, timezone
 
 from sentry_sdk.consts import VERSION
@@ -27,6 +28,7 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from typing import Any
     from typing import Callable
+    from typing import Deque
     from typing import Dict
     from typing import List
     from typing import Optional
@@ -120,6 +122,9 @@ def setup_continuous_profiler(options, sdk_info, capture_func):
 
 def try_autostart_continuous_profiler():
     # type: () -> None
+
+    # TODO: deprecate this as it'll be replaced by the auto lifecycle option
+
     if _scheduler is None:
         return
 
@@ -127,6 +132,22 @@ def try_autostart_continuous_profiler():
         return
 
     _scheduler.manual_start()
+
+
+def try_profile_lifecycle_auto_start():
+    # type: () -> bool
+    if _scheduler is None:
+        return False
+
+    return _scheduler.auto_start()
+
+
+def try_profile_lifecycle_auto_stop():
+    # type: () -> None
+    if _scheduler is None:
+        return
+
+    _scheduler.auto_stop()
 
 
 def start_profiler():
@@ -179,16 +200,22 @@ class ContinuousScheduler:
         self.options = options
         self.sdk_info = sdk_info
         self.capture_func = capture_func
+
+        self.lifecycle = self.options.get("profile_lifecycle")
+        profile_session_sample_rate = self.options.get("profile_session_sample_rate")
+        self.sampled = determine_profile_session_sampling_decision(
+            profile_session_sample_rate
+        )
+
         self.sampler = self.make_sampler()
         self.buffer = None  # type: Optional[ProfileBuffer]
         self.pid = None  # type: Optional[int]
 
         self.running = False
 
-        profile_session_sample_rate = self.options.get("profile_session_sample_rate")
-        self.sampled = determine_profile_session_sampling_decision(
-            profile_session_sample_rate
-        )
+        self.active_spans = 0
+        self.started_spans = deque(maxlen=128)  # type: Deque[None]
+        self.finished_spans = deque(maxlen=128)  # type: Deque[None]
 
     def is_auto_start_enabled(self):
         # type: () -> bool
@@ -207,15 +234,45 @@ class ContinuousScheduler:
 
         return experiments.get("continuous_profiling_auto_start")
 
+    def auto_start(self):
+        # type: () -> bool
+        if not self.sampled:
+            return False
+
+        if self.lifecycle != "auto":
+            return False
+
+        logger.debug("[Profiling] Auto starting profiler")
+
+        self.started_spans.append(None)
+        self.ensure_running()
+
+        return True
+
+    def auto_stop(self):
+        # type: () -> None
+        if self.lifecycle != "auto":
+            return
+
+        logger.debug("[Profiling] Auto stopping profiler")
+
+        self.finished_spans.append(None)
+
     def manual_start(self):
         # type: () -> None
         if not self.sampled:
+            return
+
+        if self.lifecycle != "manual":
             return
 
         self.ensure_running()
 
     def manual_stop(self):
         # type: () -> None
+        if self.lifecycle != "manual":
+            return
+
         self.teardown()
 
     def ensure_running(self):
@@ -249,28 +306,77 @@ class ContinuousScheduler:
 
         cache = LRUCache(max_size=256)
 
-        def _sample_stack(*args, **kwargs):
-            # type: (*Any, **Any) -> None
-            """
-            Take a sample of the stack on all the threads in the process.
-            This should be called at a regular interval to collect samples.
-            """
+        if self.lifecycle == "auto":
 
-            ts = now()
+            def _sample_stack(*args, **kwargs):
+                # type: (*Any, **Any) -> None
+                """
+                Take a sample of the stack on all the threads in the process.
+                This should be called at a regular interval to collect samples.
+                """
 
-            try:
-                sample = [
-                    (str(tid), extract_stack(frame, cache, cwd))
-                    for tid, frame in sys._current_frames().items()
-                ]
-            except AttributeError:
-                # For some reason, the frame we get doesn't have certain attributes.
-                # When this happens, we abandon the current sample as it's bad.
-                capture_internal_exception(sys.exc_info())
-                return
+                if (
+                    not self.active_spans
+                    and not self.started_spans
+                    and not self.finished_spans
+                ):
+                    self.running = False
+                    return
 
-            if self.buffer is not None:
-                self.buffer.write(ts, sample)
+                started_spans = len(self.started_spans)
+                finished_spans = len(self.finished_spans)
+
+                ts = now()
+
+                try:
+                    sample = [
+                        (str(tid), extract_stack(frame, cache, cwd))
+                        for tid, frame in sys._current_frames().items()
+                    ]
+                except AttributeError:
+                    # For some reason, the frame we get doesn't have certain attributes.
+                    # When this happens, we abandon the current sample as it's bad.
+                    capture_internal_exception(sys.exc_info())
+                    return
+
+                for _ in range(started_spans):
+                    self.started_spans.popleft()
+
+                for _ in range(finished_spans):
+                    self.finished_spans.popleft()
+
+                self.active_spans = self.active_spans + started_spans - finished_spans
+
+                if self.buffer is None:
+                    self.reset_buffer()
+
+                if self.buffer is not None:
+                    self.buffer.write(ts, sample)
+
+        else:
+
+            def _sample_stack(*args, **kwargs):
+                # type: (*Any, **Any) -> None
+                """
+                Take a sample of the stack on all the threads in the process.
+                This should be called at a regular interval to collect samples.
+                """
+
+                ts = now()
+
+                try:
+                    sample = [
+                        (str(tid), extract_stack(frame, cache, cwd))
+                        for tid, frame in sys._current_frames().items()
+                    ]
+                except AttributeError:
+                    # For some reason, the frame we get doesn't have certain attributes.
+                    # When this happens, we abandon the current sample as it's bad.
+                    capture_internal_exception(sys.exc_info())
+                    return
+
+                if self.buffer is not None:
+                    self.buffer.write(ts, sample)
 
         return _sample_stack
 
@@ -294,6 +400,7 @@ class ContinuousScheduler:
 
         if self.buffer is not None:
             self.buffer.flush()
+            self.buffer = None
 
 
 class ThreadContinuousScheduler(ContinuousScheduler):

--- a/sentry_sdk/scope.py
+++ b/sentry_sdk/scope.py
@@ -12,7 +12,11 @@ from itertools import chain
 from sentry_sdk.attachments import Attachment
 from sentry_sdk.consts import DEFAULT_MAX_BREADCRUMBS, FALSE_VALUES, INSTRUMENTER
 from sentry_sdk.feature_flags import FlagBuffer, DEFAULT_FLAG_CAPACITY
-from sentry_sdk.profiler.continuous_profiler import try_autostart_continuous_profiler
+from sentry_sdk.profiler.continuous_profiler import (
+    get_profiler_id,
+    try_autostart_continuous_profiler,
+    try_profile_lifecycle_auto_start,
+)
 from sentry_sdk.profiler.transaction_profiler import Profile
 from sentry_sdk.session import Session
 from sentry_sdk.tracing_utils import (
@@ -1050,6 +1054,14 @@ class Scope:
             profile._set_initial_sampling_decision(sampling_context=sampling_context)
 
             transaction._profile = profile
+
+            transaction._started_profile_lifecycle = try_profile_lifecycle_auto_start()
+
+            # Typically, the profiler is set when the transaction is created. But when
+            # using the auto lifecycle, the profiler isn't running when the first
+            # transaction is started. So make sure we update the profiler id on it.
+            if transaction._started_profile_lifecycle:
+                transaction.set_profiler_id(get_profiler_id())
 
             # we don't bother to keep spans if we already know we're not going to
             # send the transaction

--- a/tests/profiler/test_continuous_profiler.py
+++ b/tests/profiler/test_continuous_profiler.py
@@ -8,6 +8,7 @@ import pytest
 import sentry_sdk
 from sentry_sdk.consts import VERSION
 from sentry_sdk.profiler.continuous_profiler import (
+    get_profiler_id,
     setup_continuous_profiler,
     start_profiler,
     stop_profiler,
@@ -24,9 +25,12 @@ requires_gevent = pytest.mark.skipif(gevent is None, reason="gevent not enabled"
 
 
 def get_client_options(use_top_level_profiler_mode):
-    def client_options(mode=None, auto_start=None, profile_session_sample_rate=1.0):
+    def client_options(
+        mode=None, auto_start=None, profile_session_sample_rate=1.0, lifecycle="manual"
+    ):
         if use_top_level_profiler_mode:
             return {
+                "profile_lifecycle": lifecycle,
                 "profiler_mode": mode,
                 "profile_session_sample_rate": profile_session_sample_rate,
                 "_experiments": {
@@ -34,6 +38,7 @@ def get_client_options(use_top_level_profiler_mode):
                 },
             }
         return {
+            "profile_lifecycle": lifecycle,
             "profile_session_sample_rate": profile_session_sample_rate,
             "_experiments": {
                 "continuous_profiling_auto_start": auto_start,
@@ -224,7 +229,7 @@ def test_continuous_profiler_auto_start_and_manual_stop(
 
     with sentry_sdk.start_transaction(name="profiling"):
         with sentry_sdk.start_span(op="op"):
-            time.sleep(0.1)
+            time.sleep(0.05)
 
     assert_single_transaction_with_profile_chunks(envelopes, thread)
 
@@ -235,7 +240,7 @@ def test_continuous_profiler_auto_start_and_manual_stop(
 
         with sentry_sdk.start_transaction(name="profiling"):
             with sentry_sdk.start_span(op="op"):
-                time.sleep(0.1)
+                time.sleep(0.05)
 
         assert_single_transaction_without_profile_chunks(envelopes)
 
@@ -245,7 +250,7 @@ def test_continuous_profiler_auto_start_and_manual_stop(
 
         with sentry_sdk.start_transaction(name="profiling"):
             with sentry_sdk.start_span(op="op"):
-                time.sleep(0.1)
+                time.sleep(0.05)
 
         assert_single_transaction_with_profile_chunks(envelopes, thread)
 
@@ -272,7 +277,9 @@ def test_continuous_profiler_manual_start_and_stop_sampled(
     make_options,
     teardown_profiling,
 ):
-    options = make_options(mode=mode)
+    options = make_options(
+        mode=mode, profile_session_sample_rate=1.0, lifecycle="manual"
+    )
     sentry_init(
         traces_sample_rate=1.0,
         **options,
@@ -325,7 +332,9 @@ def test_continuous_profiler_manual_start_and_stop_unsampled(
     make_options,
     teardown_profiling,
 ):
-    options = make_options(mode=mode, profile_session_sample_rate=0.0)
+    options = make_options(
+        mode=mode, profile_session_sample_rate=0.0, lifecycle="manual"
+    )
     sentry_init(
         traces_sample_rate=1.0,
         **options,
@@ -342,3 +351,93 @@ def test_continuous_profiler_manual_start_and_stop_unsampled(
     assert_single_transaction_without_profile_chunks(envelopes)
 
     stop_profiler()
+
+
+@pytest.mark.parametrize(
+    "mode",
+    [
+        pytest.param("thread"),
+        pytest.param("gevent", marks=requires_gevent),
+    ],
+)
+@pytest.mark.parametrize(
+    "make_options",
+    [
+        pytest.param(get_client_options(True), id="non-experiment"),
+        pytest.param(get_client_options(False), id="experiment"),
+    ],
+)
+@mock.patch("sentry_sdk.profiler.continuous_profiler.PROFILE_BUFFER_SECONDS", 0.01)
+def test_continuous_profiler_auto_start_and_stop_sampled(
+    sentry_init,
+    capture_envelopes,
+    mode,
+    make_options,
+    teardown_profiling,
+):
+    options = make_options(mode=mode, profile_session_sample_rate=1.0, lifecycle="auto")
+    sentry_init(
+        traces_sample_rate=1.0,
+        **options,
+    )
+
+    envelopes = capture_envelopes()
+
+    thread = threading.current_thread()
+
+    for _ in range(3):
+        envelopes.clear()
+
+        with sentry_sdk.start_transaction(name="profiling"):
+            assert get_profiler_id() is not None, "profiler should be running"
+            with sentry_sdk.start_span(op="op"):
+                time.sleep(0.05)
+            assert get_profiler_id() is not None, "profiler should be running"
+
+        # wait at least 1 cycle for the profiler to stop
+        time.sleep(0.05)
+        assert get_profiler_id() is None, "profiler should not be running"
+        assert_single_transaction_with_profile_chunks(envelopes, thread)
+
+
+@pytest.mark.parametrize(
+    "mode",
+    [
+        pytest.param("thread"),
+        pytest.param("gevent", marks=requires_gevent),
+    ],
+)
+@pytest.mark.parametrize(
+    "make_options",
+    [
+        pytest.param(get_client_options(True), id="non-experiment"),
+        pytest.param(get_client_options(False), id="experiment"),
+    ],
+)
+@mock.patch("sentry_sdk.profiler.continuous_profiler.PROFILE_BUFFER_SECONDS", 0.01)
+def test_continuous_profiler_auto_start_and_stop_unsampled(
+    sentry_init,
+    capture_envelopes,
+    mode,
+    make_options,
+    teardown_profiling,
+):
+    options = make_options(mode=mode, profile_session_sample_rate=0.0, lifecycle="auto")
+    sentry_init(
+        traces_sample_rate=1.0,
+        **options,
+    )
+
+    envelopes = capture_envelopes()
+
+    for _ in range(3):
+        envelopes.clear()
+
+        with sentry_sdk.start_transaction(name="profiling"):
+            assert get_profiler_id() is None, "profiler should not be running"
+            with sentry_sdk.start_span(op="op"):
+                time.sleep(0.05)
+            assert get_profiler_id() is None, "profiler should not be running"
+
+        assert get_profiler_id() is None, "profiler should not be running"
+        assert_single_transaction_without_profile_chunks(envelopes)


### PR DESCRIPTION
This introduces auto lifecycle setting for continuous profiling to only profile while there is an active transaction. This replaces the experimental auto start setting.