### PR TITLE
Don't set transaction status to error on sys.exit(0)

### DIFF
--- a/sentry_sdk/tracing.py
+++ b/sentry_sdk/tracing.py
@@ -11,6 +11,7 @@ from sentry_sdk.utils import (
     is_valid_sample_rate,
     logger,
     nanosecond_time,
+    should_be_treated_as_error,
 )
 
 from typing import TYPE_CHECKING
@@ -374,7 +375,7 @@ class Span:
 
     def __exit__(self, ty, value, tb):
         # type: (Optional[Any], Optional[Any], Optional[Any]) -> None
-        if value is not None:
+        if value is not None and should_be_treated_as_error(ty, value):
             self.set_status(SPANSTATUS.INTERNAL_ERROR)
 
         scope, old_span = self._context_manager_state

--- a/sentry_sdk/utils.py
+++ b/sentry_sdk/utils.py
@@ -1879,3 +1879,11 @@ def get_current_thread_meta(thread=None):
 
     # we've tried everything, time to give up
     return None, None
+
+
+def should_be_treated_as_error(ty, value):
+    # (Any, Any) -> bool
+    if ty == SystemExit and value == 0:
+        return False
+
+    return True

--- a/sentry_sdk/utils.py
+++ b/sentry_sdk/utils.py
@@ -1883,7 +1883,8 @@ def get_current_thread_meta(thread=None):
 
 def should_be_treated_as_error(ty, value):
     # (Any, Any) -> bool
-    if ty == SystemExit and value == 0:
+    if ty == SystemExit and hasattr(value, "code") and value.code in (0, None):
+        # https://docs.python.org/3/library/exceptions.html#SystemExit
         return False
 
     return True

--- a/sentry_sdk/utils.py
+++ b/sentry_sdk/utils.py
@@ -1882,7 +1882,7 @@ def get_current_thread_meta(thread=None):
 
 
 def should_be_treated_as_error(ty, value):
-    # (Any, Any) -> bool
+    # type: (Any, Any) -> bool
     if ty == SystemExit and hasattr(value, "code") and value.code in (0, None):
         # https://docs.python.org/3/library/exceptions.html#SystemExit
         return False

--- a/tests/tracing/test_integration_tests.py
+++ b/tests/tracing/test_integration_tests.py
@@ -1,8 +1,10 @@
-import weakref
 import gc
-import re
-import pytest
 import random
+import re
+import sys
+import weakref
+
+import pytest
 
 import sentry_sdk
 from sentry_sdk import (
@@ -297,3 +299,55 @@ def test_trace_propagation_meta_head_sdk(sentry_init):
     assert 'meta name="baggage"' in baggage
     baggage_content = re.findall('content="([^"]*)"', baggage)[0]
     assert baggage_content == transaction.get_baggage().serialize()
+
+
+@pytest.mark.parametrize(
+    "exception_cls,exception_value",
+    [
+        (SystemExit, 0),
+    ],
+)
+def test_non_error_exceptions(
+    sentry_init, capture_events, exception_cls, exception_value
+):
+    sentry_init(traces_sample_rate=1.0)
+    events = capture_events()
+
+    with start_transaction(name="hi") as transaction:
+        transaction.set_status(SPANSTATUS.OK)
+        with pytest.raises(exception_cls):
+            with start_span(op="foo", name="foodesc"):
+                raise exception_cls(exception_value)
+
+    assert len(events) == 1
+    event = events[0]
+
+    span = event["spans"][0]
+    assert "status" not in span.get("tags", {})
+    assert "status" not in event["tags"]
+    assert event["contexts"]["trace"]["status"] == "ok"
+
+
+@pytest.mark.parametrize("exception_value", [None, 0, False])
+def test_good_sysexit_doesnt_fail_transaction(
+    sentry_init, capture_events, exception_value
+):
+    sentry_init(traces_sample_rate=1.0)
+    events = capture_events()
+
+    with start_transaction(name="hi") as transaction:
+        transaction.set_status(SPANSTATUS.OK)
+        with pytest.raises(SystemExit):
+            with start_span(op="foo", name="foodesc"):
+                if exception_value is not False:
+                    sys.exit(exception_value)
+                else:
+                    sys.exit()
+
+    assert len(events) == 1
+    event = events[0]
+
+    span = event["spans"][0]
+    assert "status" not in span.get("tags", {})
+    assert "status" not in event["tags"]
+    assert event["contexts"]["trace"]["status"] == "ok"


### PR DESCRIPTION
We set transaction status to `internal_error` if there is an exception exiting the `start_transaction` context manager. We don't check what kind of exception it was.

Some exceptions aren't a sign of anything wrong, like `SystemExit` with a value of 0, so we shouldn't mark the transaction as failed in that case.

Closes https://github.com/getsentry/sentry-python/issues/4024