### PR TITLE
fix(integrations): Do not patch `execute`

### DIFF
--- a/requirements-linting.txt
+++ b/requirements-linting.txt
@@ -19,3 +19,4 @@ openfeature-sdk
 launchdarkly-server-sdk
 UnleashClient
 typer
+strawberry-graphql

--- a/sentry_sdk/integrations/ariadne.py
+++ b/sentry_sdk/integrations/ariadne.py
@@ -25,7 +25,7 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from typing import Any, Dict, List, Optional
     from ariadne.types import GraphQLError, GraphQLResult, GraphQLSchema, QueryParser  # type: ignore
-    from graphql.language.ast import DocumentNode  # type: ignore
+    from graphql.language.ast import DocumentNode
     from sentry_sdk._types import Event, EventProcessor
 
 

--- a/sentry_sdk/integrations/gql.py
+++ b/sentry_sdk/integrations/gql.py
@@ -10,7 +10,12 @@ from sentry_sdk.scope import should_send_default_pii
 
 try:
     import gql  # type: ignore[import-not-found]
-    from graphql import print_ast, get_operation_ast, DocumentNode, VariableDefinitionNode  # type: ignore[import-not-found]
+    from graphql import (
+        print_ast,
+        get_operation_ast,
+        DocumentNode,
+        VariableDefinitionNode,
+    )
     from gql.transport import Transport, AsyncTransport  # type: ignore[import-not-found]
     from gql.transport.exceptions import TransportQueryError  # type: ignore[import-not-found]
 except ImportError:

--- a/sentry_sdk/integrations/graphene.py
+++ b/sentry_sdk/integrations/graphene.py
@@ -22,8 +22,8 @@ if TYPE_CHECKING:
     from collections.abc import Generator
     from typing import Any, Dict, Union
     from graphene.language.source import Source  # type: ignore
-    from graphql.execution import ExecutionResult  # type: ignore
-    from graphql.type import GraphQLSchema  # type: ignore
+    from graphql.execution import ExecutionResult
+    from graphql.type import GraphQLSchema
     from sentry_sdk._types import Event
 
 

--- a/sentry_sdk/integrations/strawberry.py
+++ b/sentry_sdk/integrations/strawberry.py
@@ -322,6 +322,20 @@ def _patch_execute():
     strawberry_schema.execute_sync = _sentry_patched_execute_sync
 
 
+def _patch_execute_new():
+    old_execute_sync = strawberry_schema.Schema.execute_sync
+    old_execute_async = strawberry_schema.Schema.execute
+
+    def _sentry_patched_execute_sync(self, query, variable_values, context_value, root_value, operation_name, *args, **kwargs):
+        # type: (strawberry_schema.Schema, Optional[str], Optional[dict[str, Any]], Optional[Any], Optional[Any], Optional[str]) -> ExecutionResult
+        pass
+
+    def _sentry_patched_execute_async(...):
+        pass
+
+    strawberry_schema.Schema.execute_sync = _sentry_patched_execute_sync
+    strawberry_schema.Schema.execute = _sentry_patched_execute_async
+
 def _patch_views():
     # type: () -> None
     old_async_view_handle_errors = async_base_view.AsyncBaseHTTPView._handle_errors

--- a/sentry_sdk/integrations/strawberry.py
+++ b/sentry_sdk/integrations/strawberry.py
@@ -140,7 +140,7 @@ class SentryAsyncExtension(SchemaExtension):
     @cached_property
     def _resource_name(self):
         # type: () -> str
-        query_hash = self.hash_query(self.execution_context.query)
+        query_hash = self.hash_query(self.execution_context.query)  # type: ignore
 
         if self.execution_context.operation_name:
             return "{}:{}".format(self.execution_context.operation_name, query_hash)
@@ -347,7 +347,7 @@ def _make_request_event_processor(execution_context):
                 request_data["api_target"] = "graphql"
 
                 if not request_data.get("data"):
-                    data = {"query": execution_context.query}
+                    data = {"query": execution_context.query}  # type: dict[str, Any]
                     if execution_context.variables:
                         data["variables"] = execution_context.variables
                     if execution_context.operation_name:

--- a/sentry_sdk/integrations/strawberry.py
+++ b/sentry_sdk/integrations/strawberry.py
@@ -28,14 +28,16 @@ except ImportError:
 
 try:
     from strawberry import Schema
-    from strawberry.extensions import SchemaExtension  # type: ignore
-    from strawberry.extensions.tracing.utils import should_skip_tracing as strawberry_should_skip_tracing  # type: ignore
-    from strawberry.http import async_base_view, sync_base_view  # type: ignore
+    from strawberry.extensions import SchemaExtension
+    from strawberry.extensions.tracing.utils import (
+        should_skip_tracing as strawberry_should_skip_tracing,
+    )
+    from strawberry.http import async_base_view, sync_base_view
 except ImportError:
     raise DidNotEnable("strawberry-graphql is not installed")
 
 try:
-    from strawberry.extensions.tracing import (  # type: ignore
+    from strawberry.extensions.tracing import (
         SentryTracingExtension as StrawberrySentryAsyncExtension,
         SentryTracingExtensionSync as StrawberrySentrySyncExtension,
     )
@@ -47,9 +49,9 @@ from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from typing import Any, Callable, Generator, List, Optional
-    from graphql import GraphQLError, GraphQLResolveInfo  # type: ignore
+    from graphql import GraphQLError, GraphQLResolveInfo
     from strawberry.http import GraphQLHTTPResponse
-    from strawberry.types import ExecutionContext  # type: ignore
+    from strawberry.types import ExecutionContext
     from sentry_sdk._types import Event, EventProcessor
 
 
@@ -122,10 +124,10 @@ def _patch_schema_init():
 
         return old_schema_init(self, *args, **kwargs)
 
-    Schema.__init__ = _sentry_patched_schema_init
+    Schema.__init__ = _sentry_patched_schema_init  # type: ignore[method-assign]
 
 
-class SentryAsyncExtension(SchemaExtension):  # type: ignore
+class SentryAsyncExtension(SchemaExtension):
     def __init__(
         self,
         *,
@@ -326,10 +328,10 @@ def _patch_views():
                 )
                 sentry_sdk.capture_event(event, hint=hint)
 
-    async_base_view.AsyncBaseHTTPView._handle_errors = (
+    async_base_view.AsyncBaseHTTPView._handle_errors = (  # type: ignore[method-assign]
         _sentry_patched_async_view_handle_errors
     )
-    sync_base_view.SyncBaseHTTPView._handle_errors = (
+    sync_base_view.SyncBaseHTTPView._handle_errors = (  # type: ignore[method-assign]
         _sentry_patched_sync_view_handle_errors
     )
 


### PR DESCRIPTION
Looks like the new release of strawberry (0.259.0) is not compatible with our integration. Fix it.

## Context

New Strawberry version removes the `execute` and `execute_sync` functions that we were monkeypatching in favor of integrating the code directly in `Schema.execute` and `Schema.execute_sync`.

We were previously patching `execute` instead of `Schema.execute` that's calling it because that way we had access to a populated `execution_context` which contains data that we wanted to put on the event via an event processor.

We have access to the `execution_context` directly in the extension hooks Strawberry provides, so we now add the event processor there instead of monkeypatching anything.

This should also work for older Strawberry versions, so shouldn't be necessary to keep the old implementation around for compat.

Closes https://github.com/getsentry/sentry-python/issues/4037