### PR TITLE
feat(tracing): Propagate sample_rand to transaction's baggage 

### DIFF
--- a/sentry_sdk/scope.py
+++ b/sentry_sdk/scope.py
@@ -43,6 +43,7 @@ from sentry_sdk.utils import (
     logger,
 )
 
+import typing
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -1146,8 +1147,20 @@ class Scope:
         """
         self.generate_propagation_context(environ_or_headers)
 
+        # When we generate the propagation context, the sample_rand value is set
+        # if missing or invalid (we use the original value if it's valid).
+        # We want the transaction to use the same sample_rand value. Due to duplicated
+        # propagation logic in the transaction, we pass it in to avoid recomputing it
+        # in the transaction.
+        # TYPE SAFETY: self.generate_propagation_context() ensures that self._propagation_context
+        # is not None.
+        sample_rand = typing.cast(
+            PropagationContext, self._propagation_context
+        )._sample_rand()
+
         transaction = Transaction.continue_from_headers(
             normalize_incoming_data(environ_or_headers),
+            _sample_rand=sample_rand,
             op=op,
             origin=origin,
             name=name,

--- a/sentry_sdk/tracing.py
+++ b/sentry_sdk/tracing.py
@@ -477,6 +477,8 @@ class Span:
     def continue_from_headers(
         cls,
         headers,  # type: Mapping[str, str]
+        *,
+        _sample_rand=None,  # type: Optional[str]
         **kwargs,  # type: Any
     ):
         # type: (...) -> Transaction
@@ -485,6 +487,8 @@ class Span:
         the ``sentry-trace`` and ``baggage`` headers).
 
         :param headers: The dictionary with the HTTP headers to pull information from.
+        :param _sample_rand: If provided, we override the sample_rand value from the
+            incoming headers with this value. (internal use only)
         """
         # TODO move this to the Transaction class
         if cls is Span:
@@ -495,7 +499,9 @@ class Span:
 
         # TODO-neel move away from this kwargs stuff, it's confusing and opaque
         # make more explicit
-        baggage = Baggage.from_incoming_header(headers.get(BAGGAGE_HEADER_NAME))
+        baggage = Baggage.from_incoming_header(
+            headers.get(BAGGAGE_HEADER_NAME), _sample_rand=_sample_rand
+        )
         kwargs.update({BAGGAGE_HEADER_NAME: baggage})
 
         sentrytrace_kwargs = extract_sentrytrace_data(

--- a/sentry_sdk/tracing_utils.py
+++ b/sentry_sdk/tracing_utils.py
@@ -531,6 +531,14 @@ class PropagationContext:
             f"{sample_rand:.6f}"  # noqa: E231
         )
 
+    def _sample_rand(self):
+        # type: () -> Optional[str]
+        """Convenience method to get the sample_rand value from the dynamic_sampling_context."""
+        if self.dynamic_sampling_context is None:
+            return None
+
+        return self.dynamic_sampling_context.get("sample_rand")
+
 
 class Baggage:
     """
@@ -553,8 +561,13 @@ class Baggage:
         self.mutable = mutable
 
     @classmethod
-    def from_incoming_header(cls, header):
-        # type: (Optional[str]) -> Baggage
+    def from_incoming_header(
+        cls,
+        header,  # type: Optional[str]
+        *,
+        _sample_rand=None,  # type: Optional[str]
+    ):
+        # type: (...) -> Baggage
         """
         freeze if incoming header already has sentry baggage
         """
@@ -576,6 +589,10 @@ class Baggage:
                         mutable = False
                     else:
                         third_party_items += ("," if third_party_items else "") + item
+
+        if _sample_rand is not None:
+            sentry_items["sample_rand"] = str(_sample_rand)
+            mutable = False
 
         return Baggage(sentry_items, third_party_items, mutable)
 

--- a/tests/integrations/aiohttp/test_aiohttp.py
+++ b/tests/integrations/aiohttp/test_aiohttp.py
@@ -626,18 +626,19 @@ async def test_outgoing_trace_headers_append_to_baggage(
 
     raw_server = await aiohttp_raw_server(handler)
 
-    with start_transaction(
-        name="/interactions/other-dogs/new-dog",
-        op="greeting.sniff",
-        trace_id="0123456789012345678901234567890",
-    ):
-        client = await aiohttp_client(raw_server)
-        resp = await client.get("/", headers={"bagGage": "custom=value"})
+    with mock.patch("sentry_sdk.tracing_utils.Random.uniform", return_value=0.5):
+        with start_transaction(
+            name="/interactions/other-dogs/new-dog",
+            op="greeting.sniff",
+            trace_id="0123456789012345678901234567890",
+        ):
+            client = await aiohttp_client(raw_server)
+            resp = await client.get("/", headers={"bagGage": "custom=value"})
 
-        assert (
-            resp.request_info.headers["baggage"]
-            == "custom=value,sentry-trace_id=0123456789012345678901234567890,sentry-environment=production,sentry-release=d08ebdb9309e1b004c6f52202de58a09c2268e42,sentry-transaction=/interactions/other-dogs/new-dog,sentry-sample_rate=1.0,sentry-sampled=true"
-        )
+            assert (
+                resp.request_info.headers["baggage"]
+                == "custom=value,sentry-trace_id=0123456789012345678901234567890,sentry-sample_rand=0.500000,sentry-environment=production,sentry-release=d08ebdb9309e1b004c6f52202de58a09c2268e42,sentry-transaction=/interactions/other-dogs/new-dog,sentry-sample_rate=1.0,sentry-sampled=true"
+            )
 
 
 @pytest.mark.asyncio

--- a/tests/integrations/celery/test_celery.py
+++ b/tests/integrations/celery/test_celery.py
@@ -509,22 +509,25 @@ def test_baggage_propagation(init_celery):
     def dummy_task(self, x, y):
         return _get_headers(self)
 
-    with start_transaction() as transaction:
-        result = dummy_task.apply_async(
-            args=(1, 0),
-            headers={"baggage": "custom=value"},
-        ).get()
+    # patch random.uniform to return a predictable sample_rand value
+    with mock.patch("sentry_sdk.tracing_utils.Random.uniform", return_value=0.5):
+        with start_transaction() as transaction:
+            result = dummy_task.apply_async(
+                args=(1, 0),
+                headers={"baggage": "custom=value"},
+            ).get()
 
-        assert sorted(result["baggage"].split(",")) == sorted(
-            [
-                "sentry-release=abcdef",
-                "sentry-trace_id={}".format(transaction.trace_id),
-                "sentry-environment=production",
-                "sentry-sample_rate=1.0",
-                "sentry-sampled=true",
-                "custom=value",
-            ]
-        )
+            assert sorted(result["baggage"].split(",")) == sorted(
+                [
+                    "sentry-release=abcdef",
+                    "sentry-trace_id={}".format(transaction.trace_id),
+                    "sentry-environment=production",
+                    "sentry-sample_rand=0.500000",
+                    "sentry-sample_rate=1.0",
+                    "sentry-sampled=true",
+                    "custom=value",
+                ]
+            )
 
 
 def test_sentry_propagate_traces_override(init_celery):

--- a/tests/integrations/httpx/test_httpx.py
+++ b/tests/integrations/httpx/test_httpx.py
@@ -170,30 +170,32 @@ def test_outgoing_trace_headers_append_to_baggage(
 
     url = "http://example.com/"
 
-    with start_transaction(
-        name="/interactions/other-dogs/new-dog",
-        op="greeting.sniff",
-        trace_id="01234567890123456789012345678901",
-    ) as transaction:
-        if asyncio.iscoroutinefunction(httpx_client.get):
-            response = asyncio.get_event_loop().run_until_complete(
-                httpx_client.get(url, headers={"baGGage": "custom=data"})
-            )
-        else:
-            response = httpx_client.get(url, headers={"baGGage": "custom=data"})
+    # patch random.uniform to return a predictable sample_rand value
+    with mock.patch("sentry_sdk.tracing_utils.Random.uniform", return_value=0.5):
+        with start_transaction(
+            name="/interactions/other-dogs/new-dog",
+            op="greeting.sniff",
+            trace_id="01234567890123456789012345678901",
+        ) as transaction:
+            if asyncio.iscoroutinefunction(httpx_client.get):
+                response = asyncio.get_event_loop().run_until_complete(
+                    httpx_client.get(url, headers={"baGGage": "custom=data"})
+                )
+            else:
+                response = httpx_client.get(url, headers={"baGGage": "custom=data"})
 
-        request_span = transaction._span_recorder.spans[-1]
-        assert response.request.headers[
-            "sentry-trace"
-        ] == "{trace_id}-{parent_span_id}-{sampled}".format(
-            trace_id=transaction.trace_id,
-            parent_span_id=request_span.span_id,
-            sampled=1,
-        )
-        assert (
-            response.request.headers["baggage"]
-            == "custom=data,sentry-trace_id=01234567890123456789012345678901,sentry-environment=production,sentry-release=d08ebdb9309e1b004c6f52202de58a09c2268e42,sentry-transaction=/interactions/other-dogs/new-dog,sentry-sample_rate=1.0,sentry-sampled=true"
-        )
+            request_span = transaction._span_recorder.spans[-1]
+            assert response.request.headers[
+                "sentry-trace"
+            ] == "{trace_id}-{parent_span_id}-{sampled}".format(
+                trace_id=transaction.trace_id,
+                parent_span_id=request_span.span_id,
+                sampled=1,
+            )
+            assert (
+                response.request.headers["baggage"]
+                == "custom=data,sentry-trace_id=01234567890123456789012345678901,sentry-sample_rand=0.500000,sentry-environment=production,sentry-release=d08ebdb9309e1b004c6f52202de58a09c2268e42,sentry-transaction=/interactions/other-dogs/new-dog,sentry-sample_rate=1.0,sentry-sampled=true"
+            )
 
 
 @pytest.mark.parametrize(

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,4 +1,6 @@
 import pytest
+
+import re
 from unittest import mock
 
 import sentry_sdk
@@ -95,10 +97,10 @@ def test_baggage_with_tracing_disabled(sentry_init):
 def test_baggage_with_tracing_enabled(sentry_init):
     sentry_init(traces_sample_rate=1.0, release="1.0.0", environment="dev")
     with start_transaction() as transaction:
-        expected_baggage = "sentry-trace_id={},sentry-environment=dev,sentry-release=1.0.0,sentry-sample_rate=1.0,sentry-sampled={}".format(
+        expected_baggage_re = r"^sentry-trace_id={},sentry-sample_rand=0\.\d{{6}},sentry-environment=dev,sentry-release=1\.0\.0,sentry-sample_rate=1\.0,sentry-sampled={}$".format(
             transaction.trace_id, "true" if transaction.sampled else "false"
         )
-        assert get_baggage() == expected_baggage
+        assert re.match(expected_baggage_re, get_baggage())
 
 
 @pytest.mark.forked

--- a/tests/test_dsc.py
+++ b/tests/test_dsc.py
@@ -8,7 +8,6 @@ The DSC is propagated between service using a header called "baggage".
 This is not tested in this file.
 """
 
-import random
 from unittest import mock
 
 import pytest
@@ -176,7 +175,7 @@ def test_dsc_continuation_of_trace_sample_rate_changed_in_traces_sampler(
     }
 
     # We continue the incoming trace and start a new transaction
-    with mock.patch.object(random, "random", return_value=0.2):
+    with mock.patch("sentry_sdk.tracing_utils.Random.uniform", return_value=0.125):
         transaction = sentry_sdk.continue_trace(incoming_http_headers)
         with sentry_sdk.start_transaction(transaction, name="foo"):
             pass

--- a/tests/tracing/test_sample_rand.py
+++ b/tests/tracing/test_sample_rand.py
@@ -1,0 +1,55 @@
+from unittest import mock
+
+import pytest
+
+import sentry_sdk
+from sentry_sdk.tracing_utils import Baggage
+
+
+@pytest.mark.parametrize("sample_rand", (0.0, 0.25, 0.5, 0.75))
+@pytest.mark.parametrize("sample_rate", (0.0, 0.25, 0.5, 0.75, 1.0))
+def test_deterministic_sampled(sentry_init, capture_events, sample_rate, sample_rand):
+    """
+    Test that sample_rand is generated on new traces, that it is used to
+    make the sampling decision, and that it is included in the transaction's
+    baggage.
+    """
+    sentry_init(traces_sample_rate=sample_rate)
+    events = capture_events()
+
+    with mock.patch(
+        "sentry_sdk.tracing_utils.Random.uniform", return_value=sample_rand
+    ):
+        with sentry_sdk.start_transaction() as transaction:
+            assert (
+                transaction.get_baggage().sentry_items["sample_rand"]
+                == f"{sample_rand:.6f}"  # noqa: E231
+            )
+
+    # Transaction event captured if sample_rand < sample_rate, indicating that
+    # sample_rand is used to make the sampling decision.
+    assert len(events) == int(sample_rand < sample_rate)
+
+
+@pytest.mark.parametrize("sample_rand", (0.0, 0.25, 0.5, 0.75))
+@pytest.mark.parametrize("sample_rate", (0.0, 0.25, 0.5, 0.75, 1.0))
+def test_transaction_uses_incoming_sample_rand(
+    sentry_init, capture_events, sample_rate, sample_rand
+):
+    """
+    Test that the transaction uses the sample_rand value from the incoming baggage.
+    """
+    baggage = Baggage(sentry_items={"sample_rand": f"{sample_rand:.6f}"})  # noqa: E231
+
+    sentry_init(traces_sample_rate=sample_rate)
+    events = capture_events()
+
+    with sentry_sdk.start_transaction(baggage=baggage) as transaction:
+        assert (
+            transaction.get_baggage().sentry_items["sample_rand"]
+            == f"{sample_rand:.6f}"  # noqa: E231
+        )
+
+    # Transaction event captured if sample_rand < sample_rate, indicating that
+    # sample_rand is used to make the sampling decision.
+    assert len(events) == int(sample_rand < sample_rate)

--- a/tests/tracing/test_sample_rand_propagation.py
+++ b/tests/tracing/test_sample_rand_propagation.py
@@ -1,0 +1,43 @@
+"""
+These tests exist to verify that Scope.continue_trace() correctly propagates the
+sample_rand value onto the transaction's baggage.
+
+We check both the case where there is an incoming sample_rand, as well as the case
+where we need to compute it because it is missing.
+"""
+
+from unittest import mock
+from unittest.mock import Mock
+
+import sentry_sdk
+
+
+def test_continue_trace_with_sample_rand():
+    """
+    Test that an incoming sample_rand is propagated onto the transaction's baggage.
+    """
+    headers = {
+        "sentry-trace": "00000000000000000000000000000000-0000000000000000-0",
+        "baggage": "sentry-sample_rand=0.1,sentry-sample_rate=0.5",
+    }
+
+    transaction = sentry_sdk.continue_trace(headers)
+    assert transaction.get_baggage().sentry_items["sample_rand"] == "0.1"
+
+
+def test_continue_trace_missing_sample_rand():
+    """
+    Test that a missing sample_rand is filled in onto the transaction's baggage.
+    """
+
+    headers = {
+        "sentry-trace": "00000000000000000000000000000000-0000000000000000",
+        "baggage": "sentry-placeholder=asdf",
+    }
+
+    mock_uniform = Mock(return_value=0.5)
+
+    with mock.patch("sentry_sdk.tracing_utils.Random.uniform", mock_uniform):
+        transaction = sentry_sdk.continue_trace(headers)
+
+    assert transaction.get_baggage().sentry_items["sample_rand"] == "0.500000"

--- a/tests/tracing/test_sampling.py
+++ b/tests/tracing/test_sampling.py
@@ -7,6 +7,7 @@ import pytest
 import sentry_sdk
 from sentry_sdk import start_span, start_transaction, capture_exception
 from sentry_sdk.tracing import Transaction
+from sentry_sdk.tracing_utils import Baggage
 from sentry_sdk.utils import logger
 
 
@@ -73,9 +74,9 @@ def test_uses_traces_sample_rate_correctly(
 ):
     sentry_init(traces_sample_rate=traces_sample_rate)
 
-    with mock.patch.object(random, "random", return_value=0.5):
-        transaction = start_transaction(name="dogpark")
-        assert transaction.sampled is expected_decision
+    baggage = Baggage(sentry_items={"sample_rand": "0.500000"})
+    transaction = start_transaction(name="dogpark", baggage=baggage)
+    assert transaction.sampled is expected_decision
 
 
 @pytest.mark.parametrize(
@@ -89,9 +90,9 @@ def test_uses_traces_sampler_return_value_correctly(
 ):
     sentry_init(traces_sampler=mock.Mock(return_value=traces_sampler_return_value))
 
-    with mock.patch.object(random, "random", return_value=0.5):
-        transaction = start_transaction(name="dogpark")
-        assert transaction.sampled is expected_decision
+    baggage = Baggage(sentry_items={"sample_rand": "0.500000"})
+    transaction = start_transaction(name="dogpark", baggage=baggage)
+    assert transaction.sampled is expected_decision
 
 
 @pytest.mark.parametrize("traces_sampler_return_value", [True, False])


### PR DESCRIPTION
`continue_trace` now propagates incoming `sample_rand` values to the transaction's baggage. Also, in the case where `sample_rand` is missing from the incoming trace and needs to be backfilled, this change introduces a mechanism for the backfilled value from the scope's propagation context to be propagated to the transaction's baggage.

The transaction still does not use the `sample_rand` for making sampling decisions; this PR only enables propagation. A future PR will add support for reading the incoming/backfilled `sample_rand` and for using this value to make sampling decisions.

Depends on:
  - #4038 

Ref #3998

<!-- Describe your PR here -->

---

Thank you for contributing to `sentry-python`! Please add tests to validate your changes, and lint your code using `tox -e linters`.

Running the test suite on your PR might require maintainer approval. The AWS Lambda tests additionally require a maintainer to add a special label, and they will fail until this label is added.
