### PR TITLE
feat(tracing): Add `__repr__` to `Baggage`

### DIFF
--- a/sentry_sdk/tracing_utils.py
+++ b/sentry_sdk/tracing_utils.py
@@ -638,6 +638,10 @@ class Baggage:
             )
         )
 
+    def __repr__(self):
+        # type: () -> str
+        return f'<Baggage "{self.serialize(include_third_party=True)}", mutable={self.mutable}>'
+
 
 def should_propagate_trace(client, url):
     # type: (sentry_sdk.client.BaseClient, str) -> bool

--- a/tests/test_tracing_utils.py
+++ b/tests/test_tracing_utils.py
@@ -115,3 +115,34 @@ def test_should_be_included(test_case, expected):
 )
 def test_strip_sentry_baggage(header, expected):
     assert Baggage.strip_sentry_baggage(header) == expected
+
+
+@pytest.mark.parametrize(
+    ("baggage", "expected_repr"),
+    (
+        (Baggage(sentry_items={}), '<Baggage "", mutable=True>'),
+        (Baggage(sentry_items={}, mutable=False), '<Baggage "", mutable=False>'),
+        (
+            Baggage(sentry_items={"foo": "bar"}),
+            '<Baggage "sentry-foo=bar,", mutable=True>',
+        ),
+        (
+            Baggage(sentry_items={"foo": "bar"}, mutable=False),
+            '<Baggage "sentry-foo=bar,", mutable=False>',
+        ),
+        (
+            Baggage(sentry_items={"foo": "bar"}, third_party_items="asdf=1234,"),
+            '<Baggage "sentry-foo=bar,asdf=1234,", mutable=True>',
+        ),
+        (
+            Baggage(
+                sentry_items={"foo": "bar"},
+                third_party_items="asdf=1234,",
+                mutable=False,
+            ),
+            '<Baggage "sentry-foo=bar,asdf=1234,", mutable=False>',
+        ),
+    ),
+)
+def test_baggage_repr(baggage, expected_repr):
+    assert repr(baggage) == expected_repr


### PR DESCRIPTION
The default `__repr__` does not show what is in the `Baggage`, making it extremely difficult to debug code involving `Baggage` objects. Add a `__repr__` which includes the serialized `Baggage` to improve debuggability.

<!-- Describe your PR here -->

---

Thank you for contributing to `sentry-python`! Please add tests to validate your changes, and lint your code using `tox -e linters`.

Running the test suite on your PR might require maintainer approval. The AWS Lambda tests additionally require a maintainer to add a special label, and they will fail until this label is added.
