### PR TITLE
Fix clickhouse test

### DIFF
--- a/tests/integrations/clickhouse_driver/test_clickhouse_driver.py
+++ b/tests/integrations/clickhouse_driver/test_clickhouse_driver.py
@@ -109,7 +109,13 @@ def test_clickhouse_client_breadcrumbs(sentry_init, capture_events) -> None:
     for crumb in event["breadcrumbs"]["values"]:
         crumb.pop("timestamp", None)
 
-    assert event["breadcrumbs"]["values"] == expected_breadcrumbs
+    actual_query_breadcrumbs = [
+        breadcrumb
+        for breadcrumb in event["breadcrumbs"]["values"]
+        if breadcrumb["category"] == "query"
+    ]
+
+    assert actual_query_breadcrumbs == expected_breadcrumbs
 
 
 def test_clickhouse_client_breadcrumbs_with_pii(sentry_init, capture_events) -> None:
@@ -211,13 +217,7 @@ def test_clickhouse_client_breadcrumbs_with_pii(sentry_init, capture_events) -> 
     for crumb in event["breadcrumbs"]["values"]:
         crumb.pop("timestamp", None)
 
-    actual_query_breadcrumbs = [
-        breadcrumb
-        for breadcrumb in event["breadcrumbs"]["values"]
-        if breadcrumb["category"] == "query"
-    ]
-
-    assert actual_query_breadcrumbs == expected_breadcrumbs
+    assert event["breadcrumbs"]["values"] == expected_breadcrumbs
 
 
 def test_clickhouse_client_spans(

--- a/tests/integrations/clickhouse_driver/test_clickhouse_driver.py
+++ b/tests/integrations/clickhouse_driver/test_clickhouse_driver.py
@@ -211,7 +211,13 @@ def test_clickhouse_client_breadcrumbs_with_pii(sentry_init, capture_events) -> 
     for crumb in event["breadcrumbs"]["values"]:
         crumb.pop("timestamp", None)
 
-    assert event["breadcrumbs"]["values"] == expected_breadcrumbs
+    actual_query_breadcrumbs = [
+        breadcrumb
+        for breadcrumb in event["breadcrumbs"]["values"]
+        if breadcrumb["category"] == "query"
+    ]
+
+    assert actual_query_breadcrumbs == expected_breadcrumbs
 
 
 def test_clickhouse_client_spans(


### PR DESCRIPTION
We're not interested in random breadcrumbs from random logs like
```
  +     {
  +         'category': 'tzlocal',
  +         'data': {},
  +         'level': 'warning',
  +         'message': '/etc/timezone is deprecated on Debian, and no longer reliable. '
  +         'Ignoring.',
  +         'type': 'log',
        },
```