### PR TITLE
feat(profiling): Add new functions to start/stop continuous profiler

### DIFF
--- a/sentry_sdk/profiler/continuous_profiler.py
+++ b/sentry_sdk/profiler/continuous_profiler.py
@@ -145,6 +145,13 @@ def try_profile_lifecycle_trace_start():
 
 def start_profiler():
     # type: () -> None
+
+    # TODO: deprecate this as it'll be replaced by `start_profile_session`
+    start_profile_session()
+
+
+def start_profile_session():
+    # type: () -> None
     if _scheduler is None:
         return
 
@@ -152,6 +159,13 @@ def start_profiler():
 
 
 def stop_profiler():
+    # type: () -> None
+
+    # TODO: deprecate this as it'll be replaced by `stop_profile_session`
+    stop_profile_session()
+
+
+def stop_profile_session():
     # type: () -> None
     if _scheduler is None:
         return

--- a/tests/profiler/test_continuous_profiler.py
+++ b/tests/profiler/test_continuous_profiler.py
@@ -11,7 +11,9 @@ from sentry_sdk.profiler.continuous_profiler import (
     get_profiler_id,
     setup_continuous_profiler,
     start_profiler,
+    start_profile_session,
     stop_profiler,
+    stop_profile_session,
 )
 from tests.conftest import ApproxDict
 
@@ -208,6 +210,21 @@ def assert_single_transaction_without_profile_chunks(envelopes):
     ],
 )
 @pytest.mark.parametrize(
+    ["start_profiler_func", "stop_profiler_func"],
+    [
+        pytest.param(
+            start_profile_session,
+            stop_profile_session,
+            id="start_profile_session/stop_profile_session",
+        ),
+        pytest.param(
+            start_profiler,
+            stop_profiler,
+            id="start_profiler/stop_profiler (deprecated)",
+        ),
+    ],
+)
+@pytest.mark.parametrize(
     "make_options",
     [
         pytest.param(get_client_options(True), id="non-experiment"),
@@ -219,6 +236,8 @@ def test_continuous_profiler_auto_start_and_manual_stop(
     sentry_init,
     capture_envelopes,
     mode,
+    start_profiler_func,
+    stop_profiler_func,
     make_options,
     teardown_profiling,
 ):
@@ -239,7 +258,7 @@ def test_continuous_profiler_auto_start_and_manual_stop(
     assert_single_transaction_with_profile_chunks(envelopes, thread)
 
     for _ in range(3):
-        stop_profiler()
+        stop_profiler_func()
 
         envelopes.clear()
 
@@ -249,7 +268,7 @@ def test_continuous_profiler_auto_start_and_manual_stop(
 
         assert_single_transaction_without_profile_chunks(envelopes)
 
-        start_profiler()
+        start_profiler_func()
 
         envelopes.clear()
 
@@ -268,6 +287,21 @@ def test_continuous_profiler_auto_start_and_manual_stop(
     ],
 )
 @pytest.mark.parametrize(
+    ["start_profiler_func", "stop_profiler_func"],
+    [
+        pytest.param(
+            start_profile_session,
+            stop_profile_session,
+            id="start_profile_session/stop_profile_session",
+        ),
+        pytest.param(
+            start_profiler,
+            stop_profiler,
+            id="start_profiler/stop_profiler (deprecated)",
+        ),
+    ],
+)
+@pytest.mark.parametrize(
     "make_options",
     [
         pytest.param(get_client_options(True), id="non-experiment"),
@@ -279,6 +313,8 @@ def test_continuous_profiler_manual_start_and_stop_sampled(
     sentry_init,
     capture_envelopes,
     mode,
+    start_profiler_func,
+    stop_profiler_func,
     make_options,
     teardown_profiling,
 ):
@@ -295,7 +331,7 @@ def test_continuous_profiler_manual_start_and_stop_sampled(
     thread = threading.current_thread()
 
     for _ in range(3):
-        start_profiler()
+        start_profiler_func()
 
         envelopes.clear()
 
@@ -309,7 +345,7 @@ def test_continuous_profiler_manual_start_and_stop_sampled(
 
         assert get_profiler_id() is not None, "profiler should be running"
 
-        stop_profiler()
+        stop_profiler_func()
 
         # the profiler stops immediately in manual mode
         assert get_profiler_id() is None, "profiler should not be running"
@@ -333,6 +369,21 @@ def test_continuous_profiler_manual_start_and_stop_sampled(
     ],
 )
 @pytest.mark.parametrize(
+    ["start_profiler_func", "stop_profiler_func"],
+    [
+        pytest.param(
+            start_profile_session,
+            stop_profile_session,
+            id="start_profile_session/stop_profile_session",
+        ),
+        pytest.param(
+            start_profiler,
+            stop_profiler,
+            id="start_profiler/stop_profiler (deprecated)",
+        ),
+    ],
+)
+@pytest.mark.parametrize(
     "make_options",
     [
         pytest.param(get_client_options(True), id="non-experiment"),
@@ -343,6 +394,8 @@ def test_continuous_profiler_manual_start_and_stop_unsampled(
     sentry_init,
     capture_envelopes,
     mode,
+    start_profiler_func,
+    stop_profiler_func,
     make_options,
     teardown_profiling,
 ):
@@ -356,7 +409,7 @@ def test_continuous_profiler_manual_start_and_stop_unsampled(
 
     envelopes = capture_envelopes()
 
-    start_profiler()
+    start_profiler_func()
 
     with sentry_sdk.start_transaction(name="profiling"):
         with sentry_sdk.start_span(op="op"):
@@ -364,7 +417,7 @@ def test_continuous_profiler_manual_start_and_stop_unsampled(
 
     assert_single_transaction_without_profile_chunks(envelopes)
 
-    stop_profiler()
+    stop_profiler_func()
 
 
 @pytest.mark.parametrize(
@@ -486,6 +539,21 @@ def test_continuous_profiler_auto_start_and_stop_unsampled(
     ],
 )
 @pytest.mark.parametrize(
+    ["start_profiler_func", "stop_profiler_func"],
+    [
+        pytest.param(
+            start_profile_session,
+            stop_profile_session,
+            id="start_profile_session/stop_profile_session",
+        ),
+        pytest.param(
+            start_profiler,
+            stop_profiler,
+            id="start_profiler/stop_profiler (deprecated)",
+        ),
+    ],
+)
+@pytest.mark.parametrize(
     "make_options",
     [
         pytest.param(get_client_options(True), id="non-experiment"),
@@ -495,6 +563,8 @@ def test_continuous_profiler_auto_start_and_stop_unsampled(
 def test_continuous_profiler_manual_start_and_stop_noop_when_using_trace_lifecyle(
     sentry_init,
     mode,
+    start_profiler_func,
+    stop_profiler_func,
     class_name,
     make_options,
     teardown_profiling,
@@ -510,11 +580,11 @@ def test_continuous_profiler_manual_start_and_stop_noop_when_using_trace_lifecyl
     with mock.patch(
         f"sentry_sdk.profiler.continuous_profiler.{class_name}.ensure_running"
     ) as mock_ensure_running:
-        start_profiler()
+        start_profiler_func()
         mock_ensure_running.assert_not_called()
 
     with mock.patch(
         f"sentry_sdk.profiler.continuous_profiler.{class_name}.teardown"
     ) as mock_teardown:
-        stop_profiler()
+        stop_profiler_func()
         mock_teardown.assert_not_called()


### PR DESCRIPTION
The `start_profiler` and `stop_profiler` functions were renamed to `start_profile_session` and `stop_profile_session` respectively.