### PR TITLE
tests(httplib): Fix flakey https test

### DIFF
--- a/tests/integrations/stdlib/test_httplib.py
+++ b/tests/integrations/stdlib/test_httplib.py
@@ -380,7 +380,7 @@ def test_span_origin(sentry_init, capture_events):
     events = capture_events()
 
     with start_transaction(name="foo"):
-        conn = HTTPSConnection("example.com")
+        conn = HTTPConnection("example.com")
         conn.request("GET", "/foo")
         conn.getresponse()
 


### PR DESCRIPTION
Ideally this test shouldn't even make a request anywhere but this should make it a little more stable.

This test failed 3 times on the same PR
- https://github.com/getsentry/sentry-python/actions/runs/13337072005/job/37254546574?pr=4056
- https://github.com/getsentry/sentry-python/actions/runs/13337072005/job/37254551103?pr=4056
- https://github.com/getsentry/sentry-python/actions/runs/13337072011/job/37254546356?pr=4056