### PR TITLE
tests: Add `fail_on_changes` to toxgen

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,8 @@ jobs:
         with:
           python-version: 3.12
 
-      - run: |
+      - name: Detect unexpected changes to tox.ini or CI
+        run: |
           pip install -e .
           pip install -r scripts/populate_tox/requirements.txt
           python scripts/populate_tox/populate_tox.py --fail-on-changes

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,8 @@ jobs:
           python-version: 3.12
 
       - run: |
+          pip install -r scripts/populate_tox/requirements.txt
+          python scripts/populate_tox/populate_tox.py --fail-on-changes
           pip install -r scripts/split_tox_gh_actions/requirements.txt
           python scripts/split_tox_gh_actions/split_tox_gh_actions.py --fail-on-changes
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,7 @@ jobs:
           python-version: 3.12
 
       - run: |
+          pip install -e .
           pip install -r scripts/populate_tox/requirements.txt
           python scripts/populate_tox/populate_tox.py --fail-on-changes
           pip install -r scripts/split_tox_gh_actions/requirements.txt

--- a/scripts/populate_tox/populate_tox.py
+++ b/scripts/populate_tox/populate_tox.py
@@ -14,6 +14,7 @@ from importlib.metadata import metadata
 from packaging.specifiers import SpecifierSet
 from packaging.version import Version
 from pathlib import Path
+from textwrap import dedent
 from typing import Optional, Union
 
 # Adding the scripts directory to PATH. This is necessary in order to be able
@@ -594,16 +595,27 @@ def main(fail_on_changes: bool = False) -> None:
         new_file_hash = get_file_hash()
         if old_file_hash != new_file_hash:
             raise RuntimeError(
-                "The yaml configuration files have changed. This means that either `tox.ini` "
-                "or one of the constants in `split_tox_gh_actions.py` has changed "
-                "but the changes have not been propagated to the GitHub actions config files. "
-                "Please run `python scripts/split_tox_gh_actions/split_tox_gh_actions.py` "
-                "locally and commit the changes of the yaml configuration files to continue. "
-            )
+                dedent(
+                    """
+                Detected an unexpected change in `tox.ini` that is not reflected
+                in `tox.jinja` and/or `populate_tox.py`.
 
-    print(
-        "Done generating tox.ini. Make sure to also update the CI YAML files to reflect the new test targets."
-    )
+                Please make sure to not make manual changes to `tox.ini`. The file
+                is generated from a template in `scripts/populate_tox/tox.jinja`
+                by the `scripts/populate_tox/populate_tox.py` script. Any changes
+                should be made to the template or the script directly and the
+                resulting `tox.ini` file should be generated with:
+
+                pip install -r scripts/populate_tox/requirements.txt
+                python scripts/populate_tox/populate_tox.py
+                """
+                )
+            )
+        print("Done checking tox.ini. Looking good!")
+    else:
+        print(
+            "Done generating tox.ini. Make sure to also update the CI YAML files to reflect the new test targets."
+        )
 
 
 if __name__ == "__main__":

--- a/scripts/populate_tox/populate_tox.py
+++ b/scripts/populate_tox/populate_tox.py
@@ -598,15 +598,19 @@ def main(fail_on_changes: bool = False) -> None:
             raise RuntimeError(
                 dedent(
                     """
-                Detected an unexpected change in `tox.ini` that is not reflected
-                in `tox.jinja` and/or `populate_tox.py`.
+                Detected that `tox.ini` is out of sync with
+                `scripts/populate_tox/tox.jinja` and/or
+                `scripts/populate_tox/populate_tox.py`. This might either mean
+                that `tox.ini` was changed manually, or the `tox.jinja`
+                template and/or the `populate_tox.py` script were changed without
+                regenerating `tox.ini`.
 
-                Please make sure to not make manual changes to `tox.ini`. The file
-                is generated from a template in `scripts/populate_tox/tox.jinja`
-                by the `scripts/populate_tox/populate_tox.py` script. Any changes
-                should be made to the template or the script directly and the
-                resulting `tox.ini` file should be generated with:
+                Please don't make manual changes to `tox.ini`. Instead, make the
+                changes to the `tox.jinja` template and/or the `populate_tox.py`
+                script (as applicable) and regenerate the `tox.ini` file with:
 
+                python -m venv toxgen.env
+                . toxgen.env/bin/activate
                 pip install -r scripts/populate_tox/requirements.txt
                 python scripts/populate_tox/populate_tox.py
                 """

--- a/scripts/populate_tox/populate_tox.py
+++ b/scripts/populate_tox/populate_tox.py
@@ -490,7 +490,7 @@ def get_last_updated() -> Optional[datetime]:
     with open(TOX_FILE, "r") as f:
         for line in f:
             if line.startswith("# Last generated:"):
-                timestamp = datetime.fromisoformat(line.strip().split[-1])
+                timestamp = datetime.fromisoformat(line.strip().split()[-1])
                 break
 
     if timestamp is None:

--- a/scripts/populate_tox/tox.jinja
+++ b/scripts/populate_tox/tox.jinja
@@ -9,6 +9,8 @@
 # or in the script (if you want to change the auto-generated part).
 # The file (and all resulting CI YAMLs) then need to be regenerated via
 # "scripts/generate-test-files.sh".
+#
+# Last generated: {{ updated }}
 
 [tox]
 requires =

--- a/tox.ini
+++ b/tox.ini
@@ -9,6 +9,8 @@
 # or in the script (if you want to change the auto-generated part).
 # The file (and all resulting CI YAMLs) then need to be regenerated via
 # "scripts/generate-test-files.sh".
+#
+# Last generated: 2025-02-18T12:26:42.990713+00:00
 
 [tox]
 requires =
@@ -176,17 +178,16 @@ envlist =
     # ~~~ DBs ~~~
     {py3.7,py3.11,py3.12}-clickhouse_driver-v0.2.9
 
-    {py3.6}-pymongo-v3.5.1
-    {py3.6,py3.10,py3.11}-pymongo-v3.13.0
-    {py3.6,py3.9,py3.10}-pymongo-v4.0.2
+    {py3.7}-pymongo-v3.7.2
+    {py3.7,py3.10,py3.11}-pymongo-v3.13.0
+    {py3.7,py3.9,py3.10}-pymongo-v4.0.2
     {py3.9,py3.12,py3.13}-pymongo-v4.11.1
 
-    {py3.6}-redis_py_cluster_legacy-v1.3.6
-    {py3.6,py3.7}-redis_py_cluster_legacy-v2.0.0
-    {py3.6,py3.7,py3.8}-redis_py_cluster_legacy-v2.1.3
+    {py3.7}-redis_py_cluster_legacy-v2.0.0
+    {py3.7,py3.8}-redis_py_cluster_legacy-v2.1.3
 
-    {py3.6,py3.7}-sqlalchemy-v1.3.9
-    {py3.6,py3.11,py3.12}-sqlalchemy-v1.4.54
+    {py3.7}-sqlalchemy-v1.3.9
+    {py3.7,py3.11,py3.12}-sqlalchemy-v1.4.54
     {py3.7,py3.10,py3.11}-sqlalchemy-v2.0.9
     {py3.7,py3.12,py3.13}-sqlalchemy-v2.0.38
 
@@ -211,10 +212,10 @@ envlist =
     {py3.8,py3.11,py3.12}-ariadne-v0.24.0
     {py3.8,py3.11,py3.12}-ariadne-v0.25.2
 
-    {py3.6,py3.9,py3.10}-gql-v3.4.1
+    {py3.7,py3.9,py3.10}-gql-v3.4.1
     {py3.7,py3.11,py3.12}-gql-v3.5.0
 
-    {py3.6,py3.9,py3.10}-graphene-v3.3
+    {py3.7,py3.9,py3.10}-graphene-v3.3
     {py3.8,py3.12,py3.13}-graphene-v3.4.3
 
     {py3.8,py3.10,py3.11}-strawberry-v0.209.8
@@ -231,12 +232,12 @@ envlist =
 
 
     # ~~~ Tasks ~~~
-    {py3.6,py3.7,py3.8}-celery-v4.4.7
-    {py3.6,py3.7,py3.8}-celery-v5.0.5
+    {py3.7,py3.8}-celery-v4.4.7
+    {py3.7,py3.8}-celery-v5.0.5
     {py3.8,py3.11,py3.12}-celery-v5.4.0
 
-    {py3.6,py3.7}-dramatiq-v1.9.0
-    {py3.6,py3.8,py3.9}-dramatiq-v1.12.3
+    {py3.7}-dramatiq-v1.9.0
+    {py3.7,py3.8,py3.9}-dramatiq-v1.12.3
     {py3.7,py3.10,py3.11}-dramatiq-v1.15.0
     {py3.8,py3.12,py3.13}-dramatiq-v1.17.1
 
@@ -247,50 +248,47 @@ envlist =
 
 
     # ~~~ Web 1 ~~~
-    {py3.6,py3.7,py3.8}-flask-v1.1.4
+    {py3.7,py3.8}-flask-v1.1.4
     {py3.8,py3.12,py3.13}-flask-v2.3.3
     {py3.8,py3.12,py3.13}-flask-v3.0.3
     {py3.9,py3.12,py3.13}-flask-v3.1.0
 
-    {py3.6,py3.9,py3.10}-starlette-v0.16.0
+    {py3.7,py3.9,py3.10}-starlette-v0.16.0
     {py3.7,py3.10,py3.11}-starlette-v0.26.1
     {py3.8,py3.11,py3.12}-starlette-v0.36.3
     {py3.9,py3.12,py3.13}-starlette-v0.45.3
 
 
     # ~~~ Web 2 ~~~
-    {py3.6,py3.7}-bottle-v0.12.25
-    {py3.6,py3.8,py3.9}-bottle-v0.13.2
+    {py3.7}-bottle-v0.12.25
+    {py3.7,py3.8,py3.9}-bottle-v0.13.2
 
-    {py3.6}-falcon-v1.4.1
-    {py3.6,py3.7}-falcon-v2.0.0
-    {py3.6,py3.11,py3.12}-falcon-v3.1.3
+    {py3.7}-falcon-v2.0.0
+    {py3.7,py3.11,py3.12}-falcon-v3.1.3
     {py3.8,py3.11,py3.12}-falcon-v4.0.2
 
-    {py3.6}-pyramid-v1.8.6
-    {py3.6,py3.8,py3.9}-pyramid-v1.10.8
-    {py3.6,py3.10,py3.11}-pyramid-v2.0.2
+    {py3.7,py3.8,py3.9}-pyramid-v1.10.8
+    {py3.7,py3.10,py3.11}-pyramid-v2.0.2
 
     {py3.8,py3.10,py3.11}-starlite-v1.48.1
     {py3.8,py3.10,py3.11}-starlite-v1.49.0
     {py3.8,py3.10,py3.11}-starlite-v1.50.2
     {py3.8,py3.10,py3.11}-starlite-v1.51.16
 
-    {py3.6,py3.7,py3.8}-tornado-v6.0.4
-    {py3.6,py3.8,py3.9}-tornado-v6.1
+    {py3.7,py3.8}-tornado-v6.0.4
+    {py3.7,py3.8,py3.9}-tornado-v6.1
     {py3.7,py3.9,py3.10}-tornado-v6.2
     {py3.8,py3.10,py3.11}-tornado-v6.4.2
 
 
     # ~~~ Misc ~~~
-    {py3.6,py3.12,py3.13}-loguru-v0.7.3
+    {py3.7,py3.12,py3.13}-loguru-v0.7.3
 
-    {py3.6}-trytond-v4.6.9
-    {py3.6}-trytond-v4.8.18
-    {py3.6,py3.7,py3.8}-trytond-v5.8.16
+    {py3.7}-trytond-v5.0.9
+    {py3.7,py3.8}-trytond-v5.8.16
     {py3.8,py3.10,py3.11}-trytond-v6.8.17
     {py3.8,py3.11,py3.12}-trytond-v7.0.9
-    {py3.8,py3.11,py3.12}-trytond-v7.4.5
+    {py3.8,py3.11,py3.12}-trytond-v7.4.6
 
     {py3.7,py3.11,py3.12}-typer-v0.15.1
 
@@ -555,13 +553,12 @@ deps =
     # ~~~ DBs ~~~
     clickhouse_driver-v0.2.9: clickhouse-driver==0.2.9
 
-    pymongo-v3.5.1: pymongo==3.5.1
+    pymongo-v3.7.2: pymongo==3.7.2
     pymongo-v3.13.0: pymongo==3.13.0
     pymongo-v4.0.2: pymongo==4.0.2
     pymongo-v4.11.1: pymongo==4.11.1
     pymongo: mockupdb
 
-    redis_py_cluster_legacy-v1.3.6: redis-py-cluster==1.3.6
     redis_py_cluster_legacy-v2.0.0: redis-py-cluster==2.0.0
     redis_py_cluster_legacy-v2.1.3: redis-py-cluster==2.1.3
 
@@ -674,12 +671,10 @@ deps =
     bottle-v0.13.2: bottle==0.13.2
     bottle: werkzeug<2.1.0
 
-    falcon-v1.4.1: falcon==1.4.1
     falcon-v2.0.0: falcon==2.0.0
     falcon-v3.1.3: falcon==3.1.3
     falcon-v4.0.2: falcon==4.0.2
 
-    pyramid-v1.8.6: pyramid==1.8.6
     pyramid-v1.10.8: pyramid==1.10.8
     pyramid-v2.0.2: pyramid==2.0.2
     pyramid: werkzeug<2.1.0
@@ -709,15 +704,12 @@ deps =
     # ~~~ Misc ~~~
     loguru-v0.7.3: loguru==0.7.3
 
-    trytond-v4.6.9: trytond==4.6.9
-    trytond-v4.8.18: trytond==4.8.18
+    trytond-v5.0.9: trytond==5.0.9
     trytond-v5.8.16: trytond==5.8.16
     trytond-v6.8.17: trytond==6.8.17
     trytond-v7.0.9: trytond==7.0.9
-    trytond-v7.4.5: trytond==7.4.5
+    trytond-v7.4.6: trytond==7.4.6
     trytond: werkzeug
-    trytond-v4.6.9: werkzeug<1.0
-    trytond-v4.8.18: werkzeug<1.0
 
     typer-v0.15.1: typer==0.15.1
 

--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,7 @@
 # The file (and all resulting CI YAMLs) then need to be regenerated via
 # "scripts/generate-test-files.sh".
 #
-# Last generated: 2025-02-18T12:26:42.990713+00:00
+# Last generated: 2025-02-18T12:44:30.669986+00:00
 
 [tox]
 requires =
@@ -178,16 +178,17 @@ envlist =
     # ~~~ DBs ~~~
     {py3.7,py3.11,py3.12}-clickhouse_driver-v0.2.9
 
-    {py3.7}-pymongo-v3.7.2
-    {py3.7,py3.10,py3.11}-pymongo-v3.13.0
-    {py3.7,py3.9,py3.10}-pymongo-v4.0.2
+    {py3.6}-pymongo-v3.5.1
+    {py3.6,py3.10,py3.11}-pymongo-v3.13.0
+    {py3.6,py3.9,py3.10}-pymongo-v4.0.2
     {py3.9,py3.12,py3.13}-pymongo-v4.11.1
 
-    {py3.7}-redis_py_cluster_legacy-v2.0.0
-    {py3.7,py3.8}-redis_py_cluster_legacy-v2.1.3
+    {py3.6}-redis_py_cluster_legacy-v1.3.6
+    {py3.6,py3.7}-redis_py_cluster_legacy-v2.0.0
+    {py3.6,py3.7,py3.8}-redis_py_cluster_legacy-v2.1.3
 
-    {py3.7}-sqlalchemy-v1.3.9
-    {py3.7,py3.11,py3.12}-sqlalchemy-v1.4.54
+    {py3.6,py3.7}-sqlalchemy-v1.3.9
+    {py3.6,py3.11,py3.12}-sqlalchemy-v1.4.54
     {py3.7,py3.10,py3.11}-sqlalchemy-v2.0.9
     {py3.7,py3.12,py3.13}-sqlalchemy-v2.0.38
 
@@ -212,10 +213,10 @@ envlist =
     {py3.8,py3.11,py3.12}-ariadne-v0.24.0
     {py3.8,py3.11,py3.12}-ariadne-v0.25.2
 
-    {py3.7,py3.9,py3.10}-gql-v3.4.1
+    {py3.6,py3.9,py3.10}-gql-v3.4.1
     {py3.7,py3.11,py3.12}-gql-v3.5.0
 
-    {py3.7,py3.9,py3.10}-graphene-v3.3
+    {py3.6,py3.9,py3.10}-graphene-v3.3
     {py3.8,py3.12,py3.13}-graphene-v3.4.3
 
     {py3.8,py3.10,py3.11}-strawberry-v0.209.8
@@ -232,12 +233,12 @@ envlist =
 
 
     # ~~~ Tasks ~~~
-    {py3.7,py3.8}-celery-v4.4.7
-    {py3.7,py3.8}-celery-v5.0.5
+    {py3.6,py3.7,py3.8}-celery-v4.4.7
+    {py3.6,py3.7,py3.8}-celery-v5.0.5
     {py3.8,py3.11,py3.12}-celery-v5.4.0
 
-    {py3.7}-dramatiq-v1.9.0
-    {py3.7,py3.8,py3.9}-dramatiq-v1.12.3
+    {py3.6,py3.7}-dramatiq-v1.9.0
+    {py3.6,py3.8,py3.9}-dramatiq-v1.12.3
     {py3.7,py3.10,py3.11}-dramatiq-v1.15.0
     {py3.8,py3.12,py3.13}-dramatiq-v1.17.1
 
@@ -248,44 +249,47 @@ envlist =
 
 
     # ~~~ Web 1 ~~~
-    {py3.7,py3.8}-flask-v1.1.4
+    {py3.6,py3.7,py3.8}-flask-v1.1.4
     {py3.8,py3.12,py3.13}-flask-v2.3.3
     {py3.8,py3.12,py3.13}-flask-v3.0.3
     {py3.9,py3.12,py3.13}-flask-v3.1.0
 
-    {py3.7,py3.9,py3.10}-starlette-v0.16.0
+    {py3.6,py3.9,py3.10}-starlette-v0.16.0
     {py3.7,py3.10,py3.11}-starlette-v0.26.1
     {py3.8,py3.11,py3.12}-starlette-v0.36.3
     {py3.9,py3.12,py3.13}-starlette-v0.45.3
 
 
     # ~~~ Web 2 ~~~
-    {py3.7}-bottle-v0.12.25
-    {py3.7,py3.8,py3.9}-bottle-v0.13.2
+    {py3.6,py3.7}-bottle-v0.12.25
+    {py3.6,py3.8,py3.9}-bottle-v0.13.2
 
-    {py3.7}-falcon-v2.0.0
-    {py3.7,py3.11,py3.12}-falcon-v3.1.3
+    {py3.6}-falcon-v1.4.1
+    {py3.6,py3.7}-falcon-v2.0.0
+    {py3.6,py3.11,py3.12}-falcon-v3.1.3
     {py3.8,py3.11,py3.12}-falcon-v4.0.2
 
-    {py3.7,py3.8,py3.9}-pyramid-v1.10.8
-    {py3.7,py3.10,py3.11}-pyramid-v2.0.2
+    {py3.6}-pyramid-v1.8.6
+    {py3.6,py3.8,py3.9}-pyramid-v1.10.8
+    {py3.6,py3.10,py3.11}-pyramid-v2.0.2
 
     {py3.8,py3.10,py3.11}-starlite-v1.48.1
     {py3.8,py3.10,py3.11}-starlite-v1.49.0
     {py3.8,py3.10,py3.11}-starlite-v1.50.2
     {py3.8,py3.10,py3.11}-starlite-v1.51.16
 
-    {py3.7,py3.8}-tornado-v6.0.4
-    {py3.7,py3.8,py3.9}-tornado-v6.1
+    {py3.6,py3.7,py3.8}-tornado-v6.0.4
+    {py3.6,py3.8,py3.9}-tornado-v6.1
     {py3.7,py3.9,py3.10}-tornado-v6.2
     {py3.8,py3.10,py3.11}-tornado-v6.4.2
 
 
     # ~~~ Misc ~~~
-    {py3.7,py3.12,py3.13}-loguru-v0.7.3
+    {py3.6,py3.12,py3.13}-loguru-v0.7.3
 
-    {py3.7}-trytond-v5.0.9
-    {py3.7,py3.8}-trytond-v5.8.16
+    {py3.6}-trytond-v4.6.9
+    {py3.6}-trytond-v4.8.18
+    {py3.6,py3.7,py3.8}-trytond-v5.8.16
     {py3.8,py3.10,py3.11}-trytond-v6.8.17
     {py3.8,py3.11,py3.12}-trytond-v7.0.9
     {py3.8,py3.11,py3.12}-trytond-v7.4.6
@@ -553,12 +557,13 @@ deps =
     # ~~~ DBs ~~~
     clickhouse_driver-v0.2.9: clickhouse-driver==0.2.9
 
-    pymongo-v3.7.2: pymongo==3.7.2
+    pymongo-v3.5.1: pymongo==3.5.1
     pymongo-v3.13.0: pymongo==3.13.0
     pymongo-v4.0.2: pymongo==4.0.2
     pymongo-v4.11.1: pymongo==4.11.1
     pymongo: mockupdb
 
+    redis_py_cluster_legacy-v1.3.6: redis-py-cluster==1.3.6
     redis_py_cluster_legacy-v2.0.0: redis-py-cluster==2.0.0
     redis_py_cluster_legacy-v2.1.3: redis-py-cluster==2.1.3
 
@@ -671,10 +676,12 @@ deps =
     bottle-v0.13.2: bottle==0.13.2
     bottle: werkzeug<2.1.0
 
+    falcon-v1.4.1: falcon==1.4.1
     falcon-v2.0.0: falcon==2.0.0
     falcon-v3.1.3: falcon==3.1.3
     falcon-v4.0.2: falcon==4.0.2
 
+    pyramid-v1.8.6: pyramid==1.8.6
     pyramid-v1.10.8: pyramid==1.10.8
     pyramid-v2.0.2: pyramid==2.0.2
     pyramid: werkzeug<2.1.0
@@ -704,12 +711,15 @@ deps =
     # ~~~ Misc ~~~
     loguru-v0.7.3: loguru==0.7.3
 
-    trytond-v5.0.9: trytond==5.0.9
+    trytond-v4.6.9: trytond==4.6.9
+    trytond-v4.8.18: trytond==4.8.18
     trytond-v5.8.16: trytond==5.8.16
     trytond-v6.8.17: trytond==6.8.17
     trytond-v7.0.9: trytond==7.0.9
     trytond-v7.4.6: trytond==7.4.6
     trytond: werkzeug
+    trytond-v4.6.9: werkzeug<1.0
+    trytond-v4.8.18: werkzeug<1.0
 
     typer-v0.15.1: typer==0.15.1
 

--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,7 @@
 # The file (and all resulting CI YAMLs) then need to be regenerated via
 # "scripts/generate-test-files.sh".
 #
-# Last generated: 2025-02-18T12:44:30.669986+00:00
+# Last generated: 2025-02-18T12:57:32.874168+00:00
 
 [tox]
 requires =


### PR DESCRIPTION
Add `fail_on_changes` to toxgen. The idea is that the script will now have two modes:

- **Normal mode** (when `fail_on_changes` is `False`) that is used to actually generate the `tox.ini` file. This [will be](https://github.com/getsentry/sentry-python/issues/4050) run in a cron job in CI and create a PR with the updated test setup.
- The newly added **fail-on-changes mode** (when `fail_on_changes` is `True`) that is used to detect manual changes to one of the affected files without updating the rest (e.g. making a manual change to `tox.ini` without updating the `tox.jinja` template). This will be run in CI similar to the `fail_on_changes` check of `split-tox-gh-actions`.

The problem with detecting manual changes is that if we just reran the script on each PR, chances are it would pull in new releases that are not part of the `tox.ini` on master, making the file look different from what was committed as if it had unrelated manual changes.

To counteract this, we now store the timestamp when the file was last generated in `tox.ini`. We use this in fail-on-changes mode to filter out releases that popped up after the file was last generated. This way, the package versions should be the same and if there is anything different in `tox.ini`, it's likely to be the manual changes that we want to detect. 

Closes https://github.com/getsentry/sentry-python/issues/4051