### PR TITLE
tests: Test relevant prereleases and allow to ignore releases

### DIFF
--- a/scripts/populate_tox/README.md
+++ b/scripts/populate_tox/README.md
@@ -52,7 +52,7 @@ integration_name: {
 When talking about version specifiers, we mean
 [version specifiers as defined](https://packaging.python.org/en/latest/specifications/version-specifiers/#id5)
 by the Python Packaging Authority. See also the actual implementation
-in `[packaging.specifiers](https://packaging.pypa.io/en/stable/specifiers.html)`.
+in [packaging.specifiers](https://packaging.pypa.io/en/stable/specifiers.html).
 
 ### `package`
 

--- a/scripts/populate_tox/README.md
+++ b/scripts/populate_tox/README.md
@@ -45,7 +45,7 @@ integration_name: {
          rule2: [package3, package4, ...],
      },
      "python": python_version_specifier,
-     "ignore": package_version_specifier,
+     "include": package_version_specifier,
 }
 ```
 
@@ -124,19 +124,19 @@ metadata or the SDK is explicitly not supporting some packages on specific
 Python versions (because of, for example, broken context vars), the `python`
 key can be used.
 
-### `ignore`
+### `include`
 
 Sometimes there are versions of packages that we explicitly don't want to test.
 One example is Starlite, which has two alpha prereleases of version 2.0.0, but
 there will never will be a stable 2.0 release, since development on Starlite
 has stopped and Starlite 2.0 eventually became Litestar.
 
-The value of the `ignore` key expects a version specifier defining which
-versions should not be considered for testing.
+The value of the `include` key expects a version specifier defining which
+versions should be considered for testing.
 
 ```python
 "starlite": {
-    "ignore": "==2.*",
+    "include": "!=2.0.0a1,!=2.0.0a2",
     ...
 }
 ```

--- a/scripts/populate_tox/README.md
+++ b/scripts/populate_tox/README.md
@@ -44,8 +44,8 @@ integration_name: {
          rule1: [package1, package2, ...],
          rule2: [package3, package4, ...],
      },
-     "python": version_specifier,
-     "ignore": version_specifier,
+     "python": python_version_specifier,
+     "ignore": package_version_specifier,
 }
 ```
 

--- a/scripts/populate_tox/README.md
+++ b/scripts/populate_tox/README.md
@@ -126,13 +126,25 @@ key can be used.
 
 ### `include`
 
-Sometimes there are versions of packages that we explicitly don't want to test.
-One example is Starlite, which has two alpha prereleases of version 2.0.0, but
-there will never will be a stable 2.0 release, since development on Starlite
-has stopped and Starlite 2.0 eventually became Litestar.
+Sometimes we only want to consider testing some specific versions of packages.
+For example, the Starlite package has two alpha prereleases of version 2.0.0, but
+we do not want to test these, since Starlite 2.0 was renamed to Litestar.
 
 The value of the `include` key expects a version specifier defining which
-versions should be considered for testing.
+versions should be considered for testing. For example, since we only want to test
+versions below 2.x in Starlite, we can use
+
+```python
+"starlite": {
+    "include": "<2",
+    ...
+}
+```
+
+The `include` key can also be used to exclude a set of specific versions by using
+`!=` version specifiers. For example, the Starlite restriction above could equivalently
+be expressed like so:
+
 
 ```python
 "starlite": {
@@ -140,6 +152,7 @@ versions should be considered for testing.
     ...
 }
 ```
+
 
 ## How-Tos
 

--- a/scripts/populate_tox/README.md
+++ b/scripts/populate_tox/README.md
@@ -136,7 +136,7 @@ versions should not be considered for testing.
 
 ```python
 "starlite": {
-    "ignore": ">=2.0",
+    "ignore": "==2.*",
     ...
 }
 ```

--- a/scripts/populate_tox/README.md
+++ b/scripts/populate_tox/README.md
@@ -44,9 +44,15 @@ integration_name: {
          rule1: [package1, package2, ...],
          rule2: [package3, package4, ...],
      },
-     "python": python_version_specifier,
+     "python": version_specifier,
+     "ignore": version_specifier,
 }
 ```
+
+When talking about version specifiers, we mean
+[version specifiers as defined](https://packaging.python.org/en/latest/specifications/version-specifiers/#id5)
+by the Python Packaging Authority. See also the actual implementation
+in `[packaging.specifiers](https://packaging.pypa.io/en/stable/specifiers.html)`.
 
 ### `package`
 
@@ -118,6 +124,22 @@ metadata or the SDK is explicitly not supporting some packages on specific
 Python versions (because of, for example, broken context vars), the `python`
 key can be used.
 
+### `ignore`
+
+Sometimes there are versions of packages that we explicitly don't want to test.
+One example is Starlite, which has two alpha prereleases of version 2.0.0, but
+there will never will be a stable 2.0 release, since development on Starlite
+has stopped and Starlite 2.0 eventually became Litestar.
+
+The value of the `ignore` key expects a version specifier defining which
+versions should not be considered for testing.
+
+```python
+"starlite": {
+    "ignore": ">=2.0",
+    ...
+}
+```
 
 ## How-Tos
 

--- a/scripts/populate_tox/config.py
+++ b/scripts/populate_tox/config.py
@@ -129,6 +129,7 @@ TEST_SUITE_CONFIG = {
             ],
         },
         "python": "<=3.11",
+        "ignore": "==2.0.0a1,==2.0.0a2",  # the project ultimately renamed itself to litestar and these are not relevant as there will never be a stable 2.0 release
     },
     "statsig": {
         "package": "statsig",

--- a/scripts/populate_tox/config.py
+++ b/scripts/populate_tox/config.py
@@ -129,7 +129,7 @@ TEST_SUITE_CONFIG = {
             ],
         },
         "python": "<=3.11",
-        "ignore": "==2.0.0a1,==2.0.0a2",  # the project ultimately renamed itself to litestar and these are not relevant as there will never be a stable 2.0 release
+        "ignore": "==2.*",  # the project ultimately renamed itself to litestar and these are not relevant as there will never be a stable 2.0 release
     },
     "statsig": {
         "package": "statsig",

--- a/scripts/populate_tox/config.py
+++ b/scripts/populate_tox/config.py
@@ -129,7 +129,7 @@ TEST_SUITE_CONFIG = {
             ],
         },
         "python": "<=3.11",
-        "ignore": "==2.*",  # these are not relevant as there will never be a stable 2.0 release (starlite continues as litestar)
+        "include": "!=2.0.0a1,!=2.0.0a2",  # these are not relevant as there will never be a stable 2.0 release (starlite continues as litestar)
     },
     "statsig": {
         "package": "statsig",

--- a/scripts/populate_tox/config.py
+++ b/scripts/populate_tox/config.py
@@ -129,7 +129,7 @@ TEST_SUITE_CONFIG = {
             ],
         },
         "python": "<=3.11",
-        "ignore": "==2.*",  # the project ultimately renamed itself to litestar and these are not relevant as there will never be a stable 2.0 release
+        "ignore": "==2.*",  # these are not relevant as there will never be a stable 2.0 release (starlite continues as litestar)
     },
     "statsig": {
         "package": "statsig",

--- a/scripts/populate_tox/populate_tox.py
+++ b/scripts/populate_tox/populate_tox.py
@@ -515,9 +515,11 @@ def main() -> None:
             _compare_min_version_with_defined(integration, releases)
 
             # Pick a handful of the supported releases to actually test against
-            # and fetch the PYPI data for each to determine which Python versions
+            # and fetch the PyPI data for each to determine which Python versions
             # to test it on
             test_releases = pick_releases_to_test(releases)
+            if latest_prerelease is not None:
+                test_releases.append(latest_prerelease)
 
             for release in test_releases:
                 _add_python_versions_to_release(integration, package, release)

--- a/scripts/populate_tox/populate_tox.py
+++ b/scripts/populate_tox/populate_tox.py
@@ -133,10 +133,10 @@ def _prefilter_releases(
             f"  {integration} doesn't have a minimum version defined in sentry_sdk/integrations/__init__.py. Consider defining one"
         )
 
-    ignored_versions = set()
-    if TEST_SUITE_CONFIG[integration].get("ignore") is not None:
-        ignored_versions = SpecifierSet(
-            TEST_SUITE_CONFIG[integration]["ignore"], prereleases=True
+    include_versions = None
+    if TEST_SUITE_CONFIG[integration].get("include") is not None:
+        include_versions = SpecifierSet(
+            TEST_SUITE_CONFIG[integration]["include"], prereleases=True
         )
 
     filtered_releases = []
@@ -163,7 +163,7 @@ def _prefilter_releases(
         if version.is_postrelease or version.is_devrelease:
             continue
 
-        if version in ignored_versions:
+        if include_versions is not None and version not in include_versions:
             continue
 
         if version.is_prerelease:

--- a/tox.ini
+++ b/tox.ini
@@ -179,16 +179,16 @@ envlist =
     {py3.6}-pymongo-v3.5.1
     {py3.6,py3.10,py3.11}-pymongo-v3.13.0
     {py3.6,py3.9,py3.10}-pymongo-v4.0.2
-    {py3.9,py3.12,py3.13}-pymongo-v4.11.1
+    {py3.8,py3.12,py3.13}-pymongo-v4.10.1
 
     {py3.6}-redis_py_cluster_legacy-v1.3.6
     {py3.6,py3.7}-redis_py_cluster_legacy-v2.0.0
-    {py3.6,py3.7,py3.8}-redis_py_cluster_legacy-v2.1.3
+    {py3.6,py3.7,py3.8}-redis_py_cluster_legacy-v2.0.99rc2
 
     {py3.6,py3.7}-sqlalchemy-v1.3.9
     {py3.6,py3.11,py3.12}-sqlalchemy-v1.4.54
+    {py3.7,py3.10,py3.11}-sqlalchemy-v2.0.0rc3
     {py3.7,py3.10,py3.11}-sqlalchemy-v2.0.9
-    {py3.7,py3.12,py3.13}-sqlalchemy-v2.0.38
 
 
     # ~~~ Flags ~~~
@@ -209,10 +209,11 @@ envlist =
     {py3.8,py3.10,py3.11}-ariadne-v0.20.1
     {py3.8,py3.11,py3.12}-ariadne-v0.22
     {py3.8,py3.11,py3.12}-ariadne-v0.24.0
-    {py3.8,py3.11,py3.12}-ariadne-v0.25.2
+    {py3.9,py3.12,py3.13}-ariadne-v0.26.0.dev1
 
     {py3.6,py3.9,py3.10}-gql-v3.4.1
     {py3.7,py3.11,py3.12}-gql-v3.5.0
+    {py3.9,py3.12,py3.13}-gql-v3.6.0b4
 
     {py3.6,py3.9,py3.10}-graphene-v3.3
     {py3.8,py3.12,py3.13}-graphene-v3.4.3
@@ -220,20 +221,20 @@ envlist =
     {py3.8,py3.10,py3.11}-strawberry-v0.209.8
     {py3.8,py3.11,py3.12}-strawberry-v0.226.2
     {py3.8,py3.11,py3.12}-strawberry-v0.243.1
-    {py3.9,py3.12,py3.13}-strawberry-v0.260.2
+    {py3.9,py3.12,py3.13}-strawberry-v0.259.1
 
 
     # ~~~ Network ~~~
     {py3.7,py3.8}-grpc-v1.32.0
     {py3.7,py3.9,py3.10}-grpc-v1.44.0
     {py3.7,py3.10,py3.11}-grpc-v1.58.3
-    {py3.8,py3.12,py3.13}-grpc-v1.70.0
+    {py3.8,py3.12,py3.13}-grpc-v1.70.0rc1
 
 
     # ~~~ Tasks ~~~
     {py3.6,py3.7,py3.8}-celery-v4.4.7
     {py3.6,py3.7,py3.8}-celery-v5.0.5
-    {py3.8,py3.11,py3.12}-celery-v5.4.0
+    {py3.8,py3.12,py3.13}-celery-v5.5.0rc4
 
     {py3.6,py3.7}-dramatiq-v1.9.0
     {py3.6,py3.8,py3.9}-dramatiq-v1.12.3
@@ -241,16 +242,14 @@ envlist =
     {py3.8,py3.12,py3.13}-dramatiq-v1.17.1
 
     {py3.8,py3.9}-spark-v3.0.3
-    {py3.8,py3.9}-spark-v3.2.4
-    {py3.8,py3.10,py3.11}-spark-v3.4.4
     {py3.8,py3.10,py3.11}-spark-v3.5.4
+    {py3.9,py3.11,py3.12}-spark-v4.0.0.dev2
 
 
     # ~~~ Web 1 ~~~
     {py3.6,py3.7,py3.8}-flask-v1.1.4
     {py3.8,py3.12,py3.13}-flask-v2.3.3
     {py3.8,py3.12,py3.13}-flask-v3.0.3
-    {py3.9,py3.12,py3.13}-flask-v3.1.0
 
     {py3.6,py3.9,py3.10}-starlette-v0.16.0
     {py3.7,py3.10,py3.11}-starlette-v0.26.1
@@ -265,21 +264,20 @@ envlist =
     {py3.6}-falcon-v1.4.1
     {py3.6,py3.7}-falcon-v2.0.0
     {py3.6,py3.11,py3.12}-falcon-v3.1.3
-    {py3.8,py3.11,py3.12}-falcon-v4.0.2
+    {py3.8,py3.11,py3.12}-falcon-v4.0.0rc1
 
     {py3.6}-pyramid-v1.8.6
     {py3.6,py3.8,py3.9}-pyramid-v1.10.8
-    {py3.6,py3.10,py3.11}-pyramid-v2.0.2
+    {py3.6,py3.8,py3.9}-pyramid-v2.0b1
 
     {py3.8,py3.10,py3.11}-starlite-v1.48.1
-    {py3.8,py3.10,py3.11}-starlite-v1.49.0
-    {py3.8,py3.10,py3.11}-starlite-v1.50.2
     {py3.8,py3.10,py3.11}-starlite-v1.51.16
+    {py3.8,py3.10,py3.11}-starlite-v2.0.0a2
 
     {py3.6,py3.7,py3.8}-tornado-v6.0.4
     {py3.6,py3.8,py3.9}-tornado-v6.1
     {py3.7,py3.9,py3.10}-tornado-v6.2
-    {py3.8,py3.10,py3.11}-tornado-v6.4.2
+    {py3.8,py3.10,py3.11}-tornado-v6.4b1
 
 
     # ~~~ Misc ~~~
@@ -290,7 +288,7 @@ envlist =
     {py3.6,py3.7,py3.8}-trytond-v5.8.16
     {py3.8,py3.10,py3.11}-trytond-v6.8.17
     {py3.8,py3.11,py3.12}-trytond-v7.0.9
-    {py3.8,py3.11,py3.12}-trytond-v7.4.5
+    {py3.8,py3.11,py3.12}-trytond-v7.4.6
 
     {py3.7,py3.11,py3.12}-typer-v0.15.1
 
@@ -558,17 +556,17 @@ deps =
     pymongo-v3.5.1: pymongo==3.5.1
     pymongo-v3.13.0: pymongo==3.13.0
     pymongo-v4.0.2: pymongo==4.0.2
-    pymongo-v4.11.1: pymongo==4.11.1
+    pymongo-v4.10.1: pymongo==4.10.1
     pymongo: mockupdb
 
     redis_py_cluster_legacy-v1.3.6: redis-py-cluster==1.3.6
     redis_py_cluster_legacy-v2.0.0: redis-py-cluster==2.0.0
-    redis_py_cluster_legacy-v2.1.3: redis-py-cluster==2.1.3
+    redis_py_cluster_legacy-v2.0.99rc2: redis-py-cluster==2.0.99rc2
 
     sqlalchemy-v1.3.9: sqlalchemy==1.3.9
     sqlalchemy-v1.4.54: sqlalchemy==1.4.54
+    sqlalchemy-v2.0.0rc3: sqlalchemy==2.0.0rc3
     sqlalchemy-v2.0.9: sqlalchemy==2.0.9
-    sqlalchemy-v2.0.38: sqlalchemy==2.0.38
 
 
     # ~~~ Flags ~~~
@@ -590,13 +588,14 @@ deps =
     ariadne-v0.20.1: ariadne==0.20.1
     ariadne-v0.22: ariadne==0.22
     ariadne-v0.24.0: ariadne==0.24.0
-    ariadne-v0.25.2: ariadne==0.25.2
+    ariadne-v0.26.0.dev1: ariadne==0.26.0.dev1
     ariadne: fastapi
     ariadne: flask
     ariadne: httpx
 
     gql-v3.4.1: gql[all]==3.4.1
     gql-v3.5.0: gql[all]==3.5.0
+    gql-v3.6.0b4: gql[all]==3.6.0b4
 
     graphene-v3.3: graphene==3.3
     graphene-v3.4.3: graphene==3.4.3
@@ -609,7 +608,7 @@ deps =
     strawberry-v0.209.8: strawberry-graphql[fastapi,flask]==0.209.8
     strawberry-v0.226.2: strawberry-graphql[fastapi,flask]==0.226.2
     strawberry-v0.243.1: strawberry-graphql[fastapi,flask]==0.243.1
-    strawberry-v0.260.2: strawberry-graphql[fastapi,flask]==0.260.2
+    strawberry-v0.259.1: strawberry-graphql[fastapi,flask]==0.259.1
     strawberry: httpx
 
 
@@ -617,7 +616,7 @@ deps =
     grpc-v1.32.0: grpcio==1.32.0
     grpc-v1.44.0: grpcio==1.44.0
     grpc-v1.58.3: grpcio==1.58.3
-    grpc-v1.70.0: grpcio==1.70.0
+    grpc-v1.70.0rc1: grpcio==1.70.0rc1
     grpc: protobuf
     grpc: mypy-protobuf
     grpc: types-protobuf
@@ -627,7 +626,7 @@ deps =
     # ~~~ Tasks ~~~
     celery-v4.4.7: celery==4.4.7
     celery-v5.0.5: celery==5.0.5
-    celery-v5.4.0: celery==5.4.0
+    celery-v5.5.0rc4: celery==5.5.0rc4
     celery: newrelic
     celery: redis
     py3.7-celery: importlib-metadata<5.0
@@ -638,16 +637,14 @@ deps =
     dramatiq-v1.17.1: dramatiq==1.17.1
 
     spark-v3.0.3: pyspark==3.0.3
-    spark-v3.2.4: pyspark==3.2.4
-    spark-v3.4.4: pyspark==3.4.4
     spark-v3.5.4: pyspark==3.5.4
+    spark-v4.0.0.dev2: pyspark==4.0.0.dev2
 
 
     # ~~~ Web 1 ~~~
     flask-v1.1.4: flask==1.1.4
     flask-v2.3.3: flask==2.3.3
     flask-v3.0.3: flask==3.0.3
-    flask-v3.1.0: flask==3.1.0
     flask: flask-login
     flask: werkzeug
     flask-v1.1.4: werkzeug<2.1.0
@@ -677,17 +674,16 @@ deps =
     falcon-v1.4.1: falcon==1.4.1
     falcon-v2.0.0: falcon==2.0.0
     falcon-v3.1.3: falcon==3.1.3
-    falcon-v4.0.2: falcon==4.0.2
+    falcon-v4.0.0rc1: falcon==4.0.0rc1
 
     pyramid-v1.8.6: pyramid==1.8.6
     pyramid-v1.10.8: pyramid==1.10.8
-    pyramid-v2.0.2: pyramid==2.0.2
+    pyramid-v2.0b1: pyramid==2.0b1
     pyramid: werkzeug<2.1.0
 
     starlite-v1.48.1: starlite==1.48.1
-    starlite-v1.49.0: starlite==1.49.0
-    starlite-v1.50.2: starlite==1.50.2
     starlite-v1.51.16: starlite==1.51.16
+    starlite-v2.0.0a2: starlite==2.0.0a2
     starlite: pytest-asyncio
     starlite: python-multipart
     starlite: requests
@@ -698,7 +694,7 @@ deps =
     tornado-v6.0.4: tornado==6.0.4
     tornado-v6.1: tornado==6.1
     tornado-v6.2: tornado==6.2
-    tornado-v6.4.2: tornado==6.4.2
+    tornado-v6.4b1: tornado==6.4b1
     tornado: pytest
     tornado-v6.0.4: pytest<8.2
     tornado-v6.1: pytest<8.2
@@ -714,7 +710,7 @@ deps =
     trytond-v5.8.16: trytond==5.8.16
     trytond-v6.8.17: trytond==6.8.17
     trytond-v7.0.9: trytond==7.0.9
-    trytond-v7.4.5: trytond==7.4.5
+    trytond-v7.4.6: trytond==7.4.6
     trytond: werkzeug
     trytond-v4.6.9: werkzeug<1.0
     trytond-v4.8.18: werkzeug<1.0

--- a/tox.ini
+++ b/tox.ini
@@ -246,7 +246,6 @@ envlist =
     {py3.8,py3.9}-spark-v3.2.4
     {py3.8,py3.10,py3.11}-spark-v3.4.4
     {py3.8,py3.10,py3.11}-spark-v3.5.4
-    {py3.9,py3.11,py3.12}-spark-v4.0.0.dev2
 
 
     # ~~~ Web 1 ~~~
@@ -647,7 +646,6 @@ deps =
     spark-v3.2.4: pyspark==3.2.4
     spark-v3.4.4: pyspark==3.4.4
     spark-v3.5.4: pyspark==3.5.4
-    spark-v4.0.0.dev2: pyspark==4.0.0.dev2
 
 
     # ~~~ Web 1 ~~~

--- a/tox.ini
+++ b/tox.ini
@@ -179,16 +179,16 @@ envlist =
     {py3.6}-pymongo-v3.5.1
     {py3.6,py3.10,py3.11}-pymongo-v3.13.0
     {py3.6,py3.9,py3.10}-pymongo-v4.0.2
-    {py3.8,py3.12,py3.13}-pymongo-v4.10.1
+    {py3.9,py3.12,py3.13}-pymongo-v4.11.1
 
     {py3.6}-redis_py_cluster_legacy-v1.3.6
     {py3.6,py3.7}-redis_py_cluster_legacy-v2.0.0
-    {py3.6,py3.7,py3.8}-redis_py_cluster_legacy-v2.0.99rc2
+    {py3.6,py3.7,py3.8}-redis_py_cluster_legacy-v2.1.3
 
     {py3.6,py3.7}-sqlalchemy-v1.3.9
     {py3.6,py3.11,py3.12}-sqlalchemy-v1.4.54
-    {py3.7,py3.10,py3.11}-sqlalchemy-v2.0.0rc3
     {py3.7,py3.10,py3.11}-sqlalchemy-v2.0.9
+    {py3.7,py3.12,py3.13}-sqlalchemy-v2.0.38
 
 
     # ~~~ Flags ~~~
@@ -209,7 +209,7 @@ envlist =
     {py3.8,py3.10,py3.11}-ariadne-v0.20.1
     {py3.8,py3.11,py3.12}-ariadne-v0.22
     {py3.8,py3.11,py3.12}-ariadne-v0.24.0
-    {py3.9,py3.12,py3.13}-ariadne-v0.26.0.dev1
+    {py3.9,py3.12,py3.13}-ariadne-v0.26.0
 
     {py3.6,py3.9,py3.10}-gql-v3.4.1
     {py3.7,py3.11,py3.12}-gql-v3.5.0
@@ -221,19 +221,20 @@ envlist =
     {py3.8,py3.10,py3.11}-strawberry-v0.209.8
     {py3.8,py3.11,py3.12}-strawberry-v0.226.2
     {py3.8,py3.11,py3.12}-strawberry-v0.243.1
-    {py3.9,py3.12,py3.13}-strawberry-v0.259.1
+    {py3.9,py3.12,py3.13}-strawberry-v0.260.2
 
 
     # ~~~ Network ~~~
     {py3.7,py3.8}-grpc-v1.32.0
     {py3.7,py3.9,py3.10}-grpc-v1.44.0
     {py3.7,py3.10,py3.11}-grpc-v1.58.3
-    {py3.8,py3.12,py3.13}-grpc-v1.70.0rc1
+    {py3.8,py3.12,py3.13}-grpc-v1.70.0
 
 
     # ~~~ Tasks ~~~
     {py3.6,py3.7,py3.8}-celery-v4.4.7
     {py3.6,py3.7,py3.8}-celery-v5.0.5
+    {py3.8,py3.11,py3.12}-celery-v5.4.0
     {py3.8,py3.12,py3.13}-celery-v5.5.0rc4
 
     {py3.6,py3.7}-dramatiq-v1.9.0
@@ -242,6 +243,8 @@ envlist =
     {py3.8,py3.12,py3.13}-dramatiq-v1.17.1
 
     {py3.8,py3.9}-spark-v3.0.3
+    {py3.8,py3.9}-spark-v3.2.4
+    {py3.8,py3.10,py3.11}-spark-v3.4.4
     {py3.8,py3.10,py3.11}-spark-v3.5.4
     {py3.9,py3.11,py3.12}-spark-v4.0.0.dev2
 
@@ -250,6 +253,7 @@ envlist =
     {py3.6,py3.7,py3.8}-flask-v1.1.4
     {py3.8,py3.12,py3.13}-flask-v2.3.3
     {py3.8,py3.12,py3.13}-flask-v3.0.3
+    {py3.9,py3.12,py3.13}-flask-v3.1.0
 
     {py3.6,py3.9,py3.10}-starlette-v0.16.0
     {py3.7,py3.10,py3.11}-starlette-v0.26.1
@@ -264,20 +268,22 @@ envlist =
     {py3.6}-falcon-v1.4.1
     {py3.6,py3.7}-falcon-v2.0.0
     {py3.6,py3.11,py3.12}-falcon-v3.1.3
-    {py3.8,py3.11,py3.12}-falcon-v4.0.0rc1
+    {py3.8,py3.11,py3.12}-falcon-v4.0.2
 
     {py3.6}-pyramid-v1.8.6
     {py3.6,py3.8,py3.9}-pyramid-v1.10.8
-    {py3.6,py3.8,py3.9}-pyramid-v2.0b1
+    {py3.6,py3.10,py3.11}-pyramid-v2.0.2
 
     {py3.8,py3.10,py3.11}-starlite-v1.48.1
+    {py3.8,py3.10,py3.11}-starlite-v1.49.0
+    {py3.8,py3.10,py3.11}-starlite-v1.50.2
     {py3.8,py3.10,py3.11}-starlite-v1.51.16
     {py3.8,py3.10,py3.11}-starlite-v2.0.0a2
 
     {py3.6,py3.7,py3.8}-tornado-v6.0.4
     {py3.6,py3.8,py3.9}-tornado-v6.1
     {py3.7,py3.9,py3.10}-tornado-v6.2
-    {py3.8,py3.10,py3.11}-tornado-v6.4b1
+    {py3.8,py3.10,py3.11}-tornado-v6.4.2
 
 
     # ~~~ Misc ~~~
@@ -556,17 +562,17 @@ deps =
     pymongo-v3.5.1: pymongo==3.5.1
     pymongo-v3.13.0: pymongo==3.13.0
     pymongo-v4.0.2: pymongo==4.0.2
-    pymongo-v4.10.1: pymongo==4.10.1
+    pymongo-v4.11.1: pymongo==4.11.1
     pymongo: mockupdb
 
     redis_py_cluster_legacy-v1.3.6: redis-py-cluster==1.3.6
     redis_py_cluster_legacy-v2.0.0: redis-py-cluster==2.0.0
-    redis_py_cluster_legacy-v2.0.99rc2: redis-py-cluster==2.0.99rc2
+    redis_py_cluster_legacy-v2.1.3: redis-py-cluster==2.1.3
 
     sqlalchemy-v1.3.9: sqlalchemy==1.3.9
     sqlalchemy-v1.4.54: sqlalchemy==1.4.54
-    sqlalchemy-v2.0.0rc3: sqlalchemy==2.0.0rc3
     sqlalchemy-v2.0.9: sqlalchemy==2.0.9
+    sqlalchemy-v2.0.38: sqlalchemy==2.0.38
 
 
     # ~~~ Flags ~~~
@@ -588,7 +594,7 @@ deps =
     ariadne-v0.20.1: ariadne==0.20.1
     ariadne-v0.22: ariadne==0.22
     ariadne-v0.24.0: ariadne==0.24.0
-    ariadne-v0.26.0.dev1: ariadne==0.26.0.dev1
+    ariadne-v0.26.0: ariadne==0.26.0
     ariadne: fastapi
     ariadne: flask
     ariadne: httpx
@@ -608,7 +614,7 @@ deps =
     strawberry-v0.209.8: strawberry-graphql[fastapi,flask]==0.209.8
     strawberry-v0.226.2: strawberry-graphql[fastapi,flask]==0.226.2
     strawberry-v0.243.1: strawberry-graphql[fastapi,flask]==0.243.1
-    strawberry-v0.259.1: strawberry-graphql[fastapi,flask]==0.259.1
+    strawberry-v0.260.2: strawberry-graphql[fastapi,flask]==0.260.2
     strawberry: httpx
 
 
@@ -616,7 +622,7 @@ deps =
     grpc-v1.32.0: grpcio==1.32.0
     grpc-v1.44.0: grpcio==1.44.0
     grpc-v1.58.3: grpcio==1.58.3
-    grpc-v1.70.0rc1: grpcio==1.70.0rc1
+    grpc-v1.70.0: grpcio==1.70.0
     grpc: protobuf
     grpc: mypy-protobuf
     grpc: types-protobuf
@@ -626,6 +632,7 @@ deps =
     # ~~~ Tasks ~~~
     celery-v4.4.7: celery==4.4.7
     celery-v5.0.5: celery==5.0.5
+    celery-v5.4.0: celery==5.4.0
     celery-v5.5.0rc4: celery==5.5.0rc4
     celery: newrelic
     celery: redis
@@ -637,6 +644,8 @@ deps =
     dramatiq-v1.17.1: dramatiq==1.17.1
 
     spark-v3.0.3: pyspark==3.0.3
+    spark-v3.2.4: pyspark==3.2.4
+    spark-v3.4.4: pyspark==3.4.4
     spark-v3.5.4: pyspark==3.5.4
     spark-v4.0.0.dev2: pyspark==4.0.0.dev2
 
@@ -645,6 +654,7 @@ deps =
     flask-v1.1.4: flask==1.1.4
     flask-v2.3.3: flask==2.3.3
     flask-v3.0.3: flask==3.0.3
+    flask-v3.1.0: flask==3.1.0
     flask: flask-login
     flask: werkzeug
     flask-v1.1.4: werkzeug<2.1.0
@@ -674,14 +684,16 @@ deps =
     falcon-v1.4.1: falcon==1.4.1
     falcon-v2.0.0: falcon==2.0.0
     falcon-v3.1.3: falcon==3.1.3
-    falcon-v4.0.0rc1: falcon==4.0.0rc1
+    falcon-v4.0.2: falcon==4.0.2
 
     pyramid-v1.8.6: pyramid==1.8.6
     pyramid-v1.10.8: pyramid==1.10.8
-    pyramid-v2.0b1: pyramid==2.0b1
+    pyramid-v2.0.2: pyramid==2.0.2
     pyramid: werkzeug<2.1.0
 
     starlite-v1.48.1: starlite==1.48.1
+    starlite-v1.49.0: starlite==1.49.0
+    starlite-v1.50.2: starlite==1.50.2
     starlite-v1.51.16: starlite==1.51.16
     starlite-v2.0.0a2: starlite==2.0.0a2
     starlite: pytest-asyncio
@@ -694,7 +706,7 @@ deps =
     tornado-v6.0.4: tornado==6.0.4
     tornado-v6.1: tornado==6.1
     tornado-v6.2: tornado==6.2
-    tornado-v6.4b1: tornado==6.4b1
+    tornado-v6.4.2: tornado==6.4.2
     tornado: pytest
     tornado-v6.0.4: pytest<8.2
     tornado-v6.1: pytest<8.2

--- a/tox.ini
+++ b/tox.ini
@@ -277,7 +277,6 @@ envlist =
     {py3.8,py3.10,py3.11}-starlite-v1.49.0
     {py3.8,py3.10,py3.11}-starlite-v1.50.2
     {py3.8,py3.10,py3.11}-starlite-v1.51.16
-    {py3.8,py3.10,py3.11}-starlite-v2.0.0a2
 
     {py3.6,py3.7,py3.8}-tornado-v6.0.4
     {py3.6,py3.8,py3.9}-tornado-v6.1
@@ -693,7 +692,6 @@ deps =
     starlite-v1.49.0: starlite==1.49.0
     starlite-v1.50.2: starlite==1.50.2
     starlite-v1.51.16: starlite==1.51.16
-    starlite-v2.0.0a2: starlite==2.0.0a2
     starlite: pytest-asyncio
     starlite: python-multipart
     starlite: requests

--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,7 @@
 # The file (and all resulting CI YAMLs) then need to be regenerated via
 # "scripts/generate-test-files.sh".
 #
-# Last generated: 2025-02-19T11:15:06.395241+00:00
+# Last generated: 2025-02-19T12:41:15.689786+00:00
 
 [tox]
 requires =


### PR DESCRIPTION
If a package has a prerelease of a higher version than the highest released stable version, make sure to test it, too. We consider alpha, beta, and RC releases.

Also add an option to ignore specific releases (this is related to the above since the script now pulls in two irrelevant alpha releases of starlite).

Closes https://github.com/getsentry/sentry-python/issues/4030