### PR TITLE
ci: Fix API doc failure in CI

### DIFF
--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,5 +1,5 @@
 gevent
 shibuya
-sphinx
-sphinx-autodoc-typehints[type_comments]>=1.8.0,<3.0
+sphinx<8.2
+sphinx-autodoc-typehints[type_comments]>=1.8.0
 typing-extensions

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,5 +1,5 @@
 gevent
 shibuya
 sphinx
-sphinx-autodoc-typehints[type_comments]>=1.8.0
+sphinx-autodoc-typehints[type_comments]>=1.8.0,<3.0
 typing-extensions


### PR DESCRIPTION
Sphinx 8.2 (see [changelog](https://www.sphinx-doc.org/en/master/changes/index.html#release-8-2-0-released-feb-18-2025)) seems to have broken our CI. Looks like an incompatibility between it and the autodoc-typehints extension, so hopefully the two catch up with one another -- I'll pin sphinx to <8.2 for now.