### PR TITLE
fix(scopes): Add more typing info to Scope.update_from_kwargs's "contexts"

### DIFF
--- a/sentry_sdk/scope.py
+++ b/sentry_sdk/scope.py
@@ -1568,7 +1568,7 @@ class Scope:
         user=None,  # type: Optional[Any]
         level=None,  # type: Optional[LogLevelStr]
         extras=None,  # type: Optional[Dict[str, Any]]
-        contexts=None,  # type: Optional[Dict[str, Any]]
+        contexts=None,  # type: Optional[Dict[str, Dict[str, Any]]]
         tags=None,  # type: Optional[Dict[str, str]]
         fingerprint=None,  # type: Optional[List[str]]
     ):


### PR DESCRIPTION
The original type hint could be understood as a one-level `dict` of `str` to `Any`, when in fact, it's a two-level dict.
