### PR TITLE
Fix ClickHouse in test suite

### DIFF
--- a/.github/workflows/test-integrations-dbs.yml
+++ b/.github/workflows/test-integrations-dbs.yml
@@ -60,7 +60,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
           allow-prereleases: true
       - name: "Setup ClickHouse Server"
-        uses: getsentry/action-clickhouse-in-ci@v1.4
+        uses: getsentry/action-clickhouse-in-ci@v1.5
       - name: Setup Test Env
         run: |
           pip install "coverage[toml]" tox
@@ -156,7 +156,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
           allow-prereleases: true
       - name: "Setup ClickHouse Server"
-        uses: getsentry/action-clickhouse-in-ci@v1.4
+        uses: getsentry/action-clickhouse-in-ci@v1.5
       - name: Setup Test Env
         run: |
           pip install "coverage[toml]" tox

--- a/.github/workflows/test-integrations-dbs.yml
+++ b/.github/workflows/test-integrations-dbs.yml
@@ -59,7 +59,15 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           allow-prereleases: true
-      - uses: getsentry/action-clickhouse-in-ci@v1.1
+      - name: "Setup ClickHouse Server"
+        uses: getsentry/action-clickhouse-in-ci@v1.2
+      - name: Ensure ClickHouse Ready
+        run: |
+          set -x
+          sleep 3
+          docker ps
+          docker logs clickhouse-test
+          curl -i 'http://localhost:8123/' --data-binary 'SELECT * FROM system.build_options'
       - name: Setup Test Env
         run: |
           pip install "coverage[toml]" tox
@@ -154,7 +162,15 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           allow-prereleases: true
-      - uses: getsentry/action-clickhouse-in-ci@v1.1
+      - name: "Setup ClickHouse Server"
+        uses: getsentry/action-clickhouse-in-ci@v1.2
+      - name: Ensure ClickHouse Ready
+        run: |
+          set -x
+          sleep 3
+          docker ps
+          docker logs clickhouse-test
+          curl -i 'http://localhost:8123/' --data-binary 'SELECT * FROM system.build_options'
       - name: Setup Test Env
         run: |
           pip install "coverage[toml]" tox

--- a/.github/workflows/test-integrations-dbs.yml
+++ b/.github/workflows/test-integrations-dbs.yml
@@ -60,14 +60,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
           allow-prereleases: true
       - name: "Setup ClickHouse Server"
-        uses: getsentry/action-clickhouse-in-ci@v1.2
-      - name: Ensure ClickHouse Ready
-        run: |
-          set -x
-          sleep 3
-          docker ps
-          docker logs clickhouse-test
-          curl -i 'http://localhost:8123/' --data-binary 'SELECT * FROM system.build_options'
+        uses: getsentry/action-clickhouse-in-ci@v1.3
       - name: Setup Test Env
         run: |
           pip install "coverage[toml]" tox
@@ -163,14 +156,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
           allow-prereleases: true
       - name: "Setup ClickHouse Server"
-        uses: getsentry/action-clickhouse-in-ci@v1.2
-      - name: Ensure ClickHouse Ready
-        run: |
-          set -x
-          sleep 3
-          docker ps
-          docker logs clickhouse-test
-          curl -i 'http://localhost:8123/' --data-binary 'SELECT * FROM system.build_options'
+        uses: getsentry/action-clickhouse-in-ci@v1.3
       - name: Setup Test Env
         run: |
           pip install "coverage[toml]" tox

--- a/.github/workflows/test-integrations-dbs.yml
+++ b/.github/workflows/test-integrations-dbs.yml
@@ -60,7 +60,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
           allow-prereleases: true
       - name: "Setup ClickHouse Server"
-        uses: getsentry/action-clickhouse-in-ci@v1.3
+        uses: getsentry/action-clickhouse-in-ci@v1.4
       - name: Setup Test Env
         run: |
           pip install "coverage[toml]" tox
@@ -156,7 +156,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
           allow-prereleases: true
       - name: "Setup ClickHouse Server"
-        uses: getsentry/action-clickhouse-in-ci@v1.3
+        uses: getsentry/action-clickhouse-in-ci@v1.4
       - name: Setup Test Env
         run: |
           pip install "coverage[toml]" tox

--- a/scripts/split_tox_gh_actions/templates/test_group.jinja
+++ b/scripts/split_tox_gh_actions/templates/test_group.jinja
@@ -52,7 +52,7 @@
           allow-prereleases: true
       {% if needs_clickhouse %}
       - name: "Setup ClickHouse Server"
-        uses: getsentry/action-clickhouse-in-ci@v1.4
+        uses: getsentry/action-clickhouse-in-ci@v1.5
       {% endif %}
 
       {% if needs_redis %}

--- a/scripts/split_tox_gh_actions/templates/test_group.jinja
+++ b/scripts/split_tox_gh_actions/templates/test_group.jinja
@@ -52,7 +52,7 @@
           allow-prereleases: true
       {% if needs_clickhouse %}
       - name: "Setup ClickHouse Server"
-        uses: getsentry/action-clickhouse-in-ci@v1.3
+        uses: getsentry/action-clickhouse-in-ci@v1.4
       {% endif %}
 
       {% if needs_redis %}

--- a/scripts/split_tox_gh_actions/templates/test_group.jinja
+++ b/scripts/split_tox_gh_actions/templates/test_group.jinja
@@ -51,7 +51,15 @@
           python-version: {% raw %}${{ matrix.python-version }}{% endraw %}
           allow-prereleases: true
       {% if needs_clickhouse %}
-      - uses: getsentry/action-clickhouse-in-ci@v1.1
+      - name: "Setup ClickHouse Server"
+        uses: getsentry/action-clickhouse-in-ci@v1.2
+      - name: Ensure ClickHouse Ready
+        run: |
+          set -x
+          sleep 3
+          docker ps
+          docker logs clickhouse-test
+          curl -i 'http://localhost:8123/' --data-binary 'SELECT * FROM system.build_options'
       {% endif %}
 
       {% if needs_redis %}

--- a/scripts/split_tox_gh_actions/templates/test_group.jinja
+++ b/scripts/split_tox_gh_actions/templates/test_group.jinja
@@ -52,14 +52,7 @@
           allow-prereleases: true
       {% if needs_clickhouse %}
       - name: "Setup ClickHouse Server"
-        uses: getsentry/action-clickhouse-in-ci@v1.2
-      - name: Ensure ClickHouse Ready
-        run: |
-          set -x
-          sleep 3
-          docker ps
-          docker logs clickhouse-test
-          curl -i 'http://localhost:8123/' --data-binary 'SELECT * FROM system.build_options'
+        uses: getsentry/action-clickhouse-in-ci@v1.3
       {% endif %}
 
       {% if needs_redis %}


### PR DESCRIPTION
Use new version of the ClickHouse Github action. This works with newest ClickHouse and also now prints ClickHouse details.