### PR TITLE
Set HTTP client breadcrumb level based on status code

### DIFF
--- a/sentry_sdk/integrations/aiohttp.py
+++ b/sentry_sdk/integrations/aiohttp.py
@@ -27,6 +27,7 @@ from sentry_sdk.utils import (
     capture_internal_exceptions,
     ensure_integration_enabled,
     event_from_exception,
+    http_client_status_to_breadcrumb_level,
     logger,
     parse_url,
     parse_version,
@@ -277,13 +278,15 @@ def create_trace_config():
             return
 
         span_data = trace_config_ctx.span_data or {}
-        span_data[SPANDATA.HTTP_STATUS_CODE] = int(params.response.status)
+        status_code = int(params.response.status)
+        span_data[SPANDATA.HTTP_STATUS_CODE] = status_code
         span_data["reason"] = params.response.reason
 
         sentry_sdk.add_breadcrumb(
             type="http",
             category="httplib",
             data=span_data,
+            level=http_client_status_to_breadcrumb_level(status_code),
         )
 
         span = trace_config_ctx.span

--- a/sentry_sdk/integrations/httpx.py
+++ b/sentry_sdk/integrations/httpx.py
@@ -7,6 +7,7 @@ from sentry_sdk.utils import (
     SENSITIVE_DATA_SUBSTITUTE,
     capture_internal_exceptions,
     ensure_integration_enabled,
+    http_client_status_to_breadcrumb_level,
     logger,
     parse_url,
 )
@@ -101,6 +102,7 @@ def _install_httpx_client():
                 type="http",
                 category="httplib",
                 data=data,
+                level=http_client_status_to_breadcrumb_level(rv.status_code),
             )
 
             return rv

--- a/sentry_sdk/integrations/stdlib.py
+++ b/sentry_sdk/integrations/stdlib.py
@@ -14,6 +14,7 @@ from sentry_sdk.utils import (
     capture_internal_exceptions,
     ensure_integration_enabled,
     get_current_thread_meta,
+    http_client_status_to_breadcrumb_level,
     is_sentry_url,
     logger,
     safe_repr,
@@ -144,14 +145,16 @@ def _install_httplib():
             span_data[SPANDATA.HTTP_STATUS_CODE] = int(rv.status)
             span_data["reason"] = rv.reason
 
+            status_code = int(rv.status)
+            span.set_http_status(status_code)
+            span.set_data("reason", rv.reason)
+
             sentry_sdk.add_breadcrumb(
                 type="http",
                 category="httplib",
                 data=span_data,
+                level=http_client_status_to_breadcrumb_level(status_code),
             )
-
-            span.set_http_status(int(rv.status))
-            span.set_data("reason", rv.reason)
         finally:
             span.__exit__(None, None, None)
 

--- a/sentry_sdk/utils.py
+++ b/sentry_sdk/utils.py
@@ -1887,3 +1887,14 @@ def should_be_treated_as_error(ty, value):
         return False
 
     return True
+
+
+def http_client_status_to_breadcrumb_level(status_code):
+    # type: (Optional[int]) -> str
+    if status_code is not None:
+        if 500 <= status_code <= 599:
+            return "error"
+        elif 400 <= status_code <= 499:
+            return "warning"
+
+    return "info"

--- a/tests/integrations/aiohttp/test_aiohttp.py
+++ b/tests/integrations/aiohttp/test_aiohttp.py
@@ -534,8 +534,8 @@ async def test_crumb_capture(
 @pytest.mark.parametrize(
     "status_code,level",
     [
-        (200, None),
-        (301, None),
+        (200, "info"),
+        (301, "info"),
         (403, "warning"),
         (405, "warning"),
         (500, "error"),
@@ -570,10 +570,7 @@ async def test_crumb_capture_client_error(
 
         crumb = event["breadcrumbs"]["values"][0]
         assert crumb["type"] == "http"
-        if level is None:
-            assert "level" not in crumb
-        else:
-            assert crumb["level"] == level
+        assert crumb["level"] == level
         assert crumb["category"] == "httplib"
         assert crumb["data"] == ApproxDict(
             {

--- a/tests/integrations/httpx/test_httpx.py
+++ b/tests/integrations/httpx/test_httpx.py
@@ -64,8 +64,8 @@ def test_crumb_capture_and_hint(sentry_init, capture_events, httpx_client, httpx
 @pytest.mark.parametrize(
     "status_code,level",
     [
-        (200, None),
-        (301, None),
+        (200, "info"),
+        (301, "info"),
         (403, "warning"),
         (405, "warning"),
         (500, "error"),
@@ -98,12 +98,7 @@ def test_crumb_capture_client_error(
         crumb = event["breadcrumbs"]["values"][0]
         assert crumb["type"] == "http"
         assert crumb["category"] == "httplib"
-
-        if level is None:
-            assert "level" not in crumb
-        else:
-            assert crumb["level"] == level
-
+        assert crumb["level"] == level
         assert crumb["data"] == ApproxDict(
             {
                 "url": url,

--- a/tests/integrations/requests/test_requests.py
+++ b/tests/integrations/requests/test_requests.py
@@ -43,8 +43,8 @@ def test_crumb_capture(sentry_init, capture_events):
 @pytest.mark.parametrize(
     "status_code,level",
     [
-        (200, None),
-        (301, None),
+        (200, "info"),
+        (301, "info"),
         (403, "warning"),
         (405, "warning"),
         (500, "error"),
@@ -66,12 +66,7 @@ def test_crumb_capture_client_error(sentry_init, capture_events, status_code, le
     (crumb,) = event["breadcrumbs"]["values"]
     assert crumb["type"] == "http"
     assert crumb["category"] == "httplib"
-
-    if level is None:
-        assert "level" not in crumb
-    else:
-        assert crumb["level"] == level
-
+    assert crumb["level"] == level
     assert crumb["data"] == ApproxDict(
         {
             "url": url,

--- a/tests/integrations/stdlib/test_httplib.py
+++ b/tests/integrations/stdlib/test_httplib.py
@@ -70,8 +70,8 @@ def test_crumb_capture(sentry_init, capture_events):
 @pytest.mark.parametrize(
     "status_code,level",
     [
-        (200, None),
-        (301, None),
+        (200, "info"),
+        (301, "info"),
         (403, "warning"),
         (405, "warning"),
         (500, "error"),
@@ -94,12 +94,7 @@ def test_crumb_capture_client_error(sentry_init, capture_events, status_code, le
 
     assert crumb["type"] == "http"
     assert crumb["category"] == "httplib"
-
-    if level is None:
-        assert "level" not in crumb
-    else:
-        assert crumb["level"] == level
-
+    assert crumb["level"] == level
     assert crumb["data"] == ApproxDict(
         {
             "url": url,


### PR DESCRIPTION
On potel-base, we got rid of the `maybe_create_breadcrumbs` function in favor of creating breadcrumbs manually, so the new breadcrumb level logic needs to go directly in the affected integrations.

Closes https://github.com/getsentry/sentry-python/issues/4066