### PR TITLE
Tread `SystemExit(0)` not as a span status of 'internal_error'

### DIFF
--- a/sentry_sdk/integrations/opentelemetry/span_processor.py
+++ b/sentry_sdk/integrations/opentelemetry/span_processor.py
@@ -261,9 +261,6 @@ class SentrySpanProcessor(SpanProcessor):
             }
         )
 
-        if status:
-            span_json.setdefault("tags", {})["status"] = status
-
         if parent_span_id:
             span_json["parent_span_id"] = parent_span_id
 

--- a/sentry_sdk/tracing.py
+++ b/sentry_sdk/tracing.py
@@ -20,6 +20,7 @@ from sentry_sdk.utils import (
     _serialize_span_attribute,
     get_current_thread_meta,
     logger,
+    should_be_treated_as_error,
 )
 
 from typing import TYPE_CHECKING, cast
@@ -424,7 +425,7 @@ class Span:
 
     def __exit__(self, ty, value, tb):
         # type: (Optional[Any], Optional[Any], Optional[Any]) -> None
-        if value is not None:
+        if value is not None and should_be_treated_as_error(ty, value):
             self.set_status(SPANSTATUS.INTERNAL_ERROR)
         else:
             status_unset = (

--- a/sentry_sdk/utils.py
+++ b/sentry_sdk/utils.py
@@ -1879,7 +1879,6 @@ def datetime_from_isoformat(value):
     return result.astimezone(timezone.utc)
 
 
-# TODO-neel-potel use in span status
 def should_be_treated_as_error(ty, value):
     # type: (Any, Any) -> bool
     if ty == SystemExit and hasattr(value, "code") and value.code in (0, None):

--- a/tests/tracing/test_integration_tests.py
+++ b/tests/tracing/test_integration_tests.py
@@ -37,11 +37,10 @@ def test_basic(sentry_init, capture_events, sample_rate):
 
         span1, span2 = event["spans"]
         parent_span = event
-        assert span1["tags"]["status"] == "internal_error"
         assert span1["status"] == "internal_error"
         assert span1["op"] == "foo"
         assert span1["description"] == "foodesc"
-        assert span2["tags"]["status"] == "ok"
+        assert span2["status"] == "ok"
         assert span2["op"] == "bar"
         assert span2["description"] == "bardesc"
         assert parent_span["transaction"] == "hi"
@@ -253,8 +252,8 @@ def test_non_error_exceptions(
     sentry_init(traces_sample_rate=1.0)
     events = capture_events()
 
-    with start_span(name="hi") as span:
-        span.set_status(SPANSTATUS.OK)
+    with start_span(name="hi") as root_span:
+        root_span.set_status(SPANSTATUS.OK)
         with pytest.raises(exception_cls):
             with start_span(op="foo", name="foodesc"):
                 raise exception_cls(exception_value)
@@ -264,7 +263,7 @@ def test_non_error_exceptions(
 
     span = event["spans"][0]
     assert "status" not in span.get("tags", {})
-    assert "status" not in event["tags"]
+    assert "status" not in event.get("tags", {})
     assert event["contexts"]["trace"]["status"] == "ok"
 
 
@@ -289,5 +288,5 @@ def test_good_sysexit_doesnt_fail_transaction(
 
     span = event["spans"][0]
     assert "status" not in span.get("tags", {})
-    assert "status" not in event["tags"]
+    assert "status" not in event.get("tags", {})
     assert event["contexts"]["trace"]["status"] == "ok"


### PR DESCRIPTION
Also make sure, that the span status is not set as a tag on the span. SDKs should not set tags at all by default (only users are allowed to set tags)

Fixes #4065