### PR TITLE
Fix breadcrumb level for HTTP client breadcrumbs in POTel

### DIFF
--- a/sentry_sdk/integrations/httpx.py
+++ b/sentry_sdk/integrations/httpx.py
@@ -174,6 +174,7 @@ def _install_httpx_async_client():
                 type="http",
                 category="httplib",
                 data=data,
+                level=http_client_status_to_breadcrumb_level(rv.status_code),
             )
 
             return rv


### PR DESCRIPTION
Oversight from https://github.com/getsentry/sentry-python/pull/4090 -- forgot to update the breadcrumb level created by the async httpx client

Makes all Network tests green.