### PR TITLE
Fixed bug when `cron_jobs` is set to `None` in arq integration

### DIFF
--- a/sentry_sdk/integrations/arq.py
+++ b/sentry_sdk/integrations/arq.py
@@ -199,7 +199,8 @@ def patch_create_worker():
         if isinstance(settings_cls, dict):
             if "functions" in settings_cls:
                 settings_cls["functions"] = [
-                    _get_arq_function(func) for func in settings_cls.get("functions", [])
+                    _get_arq_function(func)
+                    for func in settings_cls.get("functions", [])
                 ]
             if "cron_jobs" in settings_cls:
                 settings_cls["cron_jobs"] = [

--- a/sentry_sdk/integrations/arq.py
+++ b/sentry_sdk/integrations/arq.py
@@ -204,7 +204,7 @@ def patch_create_worker():
             if "cron_jobs" in settings_cls:
                 settings_cls["cron_jobs"] = [
                     _get_arq_cron_job(cron_job)
-                    for cron_job in settings_cls["cron_jobs"]
+                    for cron_job in settings_cls.get("cron_jobs", [])
                 ]
 
         if hasattr(settings_cls, "functions"):

--- a/sentry_sdk/integrations/arq.py
+++ b/sentry_sdk/integrations/arq.py
@@ -199,7 +199,7 @@ def patch_create_worker():
         if isinstance(settings_cls, dict):
             if "functions" in settings_cls:
                 settings_cls["functions"] = [
-                    _get_arq_function(func) for func in settings_cls["functions"]
+                    _get_arq_function(func) for func in settings_cls.get("functions", [])
                 ]
             if "cron_jobs" in settings_cls:
                 settings_cls["cron_jobs"] = [
@@ -218,11 +218,11 @@ def patch_create_worker():
 
         if "functions" in kwargs:
             kwargs["functions"] = [
-                _get_arq_function(func) for func in kwargs["functions"]
+                _get_arq_function(func) for func in kwargs.get("functions", [])
             ]
         if "cron_jobs" in kwargs:
             kwargs["cron_jobs"] = [
-                _get_arq_cron_job(cron_job) for cron_job in kwargs["cron_jobs"]
+                _get_arq_cron_job(cron_job) for cron_job in kwargs.get("cron_jobs", [])
             ]
 
         return old_create_worker(*args, **kwargs)


### PR DESCRIPTION
Handle `None` values in arq configuration gracefully. 

Fixes #3827

Unfortunately our test setup for arq does not allow for testing `None` values in the configuration because they are changed to `[]` in the arq init code in the test suite [here](https://github.com/getsentry/sentry-python/blob/master/tests/integrations/arq/test_arq.py#L50-L51) and [here](https://github.com/getsentry/sentry-python/blob/master/tests/integrations/arq/test_arq.py#L95-L96). 

This is why I have not added additional tests for this bug fix. 

