### PR TITLE
Added timeout to HTTP requests in CloudResourceContextIntegration

### DIFF
--- a/sentry_sdk/integrations/cloud_resource_context.py
+++ b/sentry_sdk/integrations/cloud_resource_context.py
@@ -86,7 +86,9 @@ class CloudResourceContextIntegration(Integration):
             return True
 
         except urllib3.exceptions.TimeoutError:
-            logger.debug("AWS metadata service timed out after %s seconds", HTTP_TIMEOUT)
+            logger.debug(
+                "AWS metadata service timed out after %s seconds", HTTP_TIMEOUT
+            )
             return False
         except Exception as e:
             logger.debug("Error checking AWS metadata service: %s", str(e))
@@ -138,7 +140,9 @@ class CloudResourceContextIntegration(Integration):
                 pass
 
         except urllib3.exceptions.TimeoutError:
-            logger.debug("AWS metadata service timed out after %s seconds", HTTP_TIMEOUT)
+            logger.debug(
+                "AWS metadata service timed out after %s seconds", HTTP_TIMEOUT
+            )
         except Exception as e:
             logger.debug("Error fetching AWS metadata: %s", str(e))
 
@@ -161,7 +165,9 @@ class CloudResourceContextIntegration(Integration):
             return True
 
         except urllib3.exceptions.TimeoutError:
-            logger.debug("GCP metadata service timed out after %s seconds", HTTP_TIMEOUT)
+            logger.debug(
+                "GCP metadata service timed out after %s seconds", HTTP_TIMEOUT
+            )
             return False
         except Exception as e:
             logger.debug("Error checking GCP metadata service: %s", str(e))
@@ -214,7 +220,9 @@ class CloudResourceContextIntegration(Integration):
                 pass
 
         except urllib3.exceptions.TimeoutError:
-            logger.debug("GCP metadata service timed out after %s seconds", HTTP_TIMEOUT)
+            logger.debug(
+                "GCP metadata service timed out after %s seconds", HTTP_TIMEOUT
+            )
         except Exception as e:
             logger.debug("Error fetching GCP metadata: %s", str(e))
 

--- a/sentry_sdk/integrations/cloud_resource_context.py
+++ b/sentry_sdk/integrations/cloud_resource_context.py
@@ -13,6 +13,8 @@ if TYPE_CHECKING:
 
 CONTEXT_TYPE = "cloud_resource"
 
+HTTP_TIMEOUT = 2.0
+
 AWS_METADATA_HOST = "169.254.169.254"
 AWS_TOKEN_URL = "http://{}/latest/api/token".format(AWS_METADATA_HOST)
 AWS_METADATA_URL = "http://{}/latest/dynamic/instance-identity/document".format(
@@ -59,7 +61,7 @@ class CloudResourceContextIntegration(Integration):
     cloud_provider = ""
 
     aws_token = ""
-    http = urllib3.PoolManager()
+    http = urllib3.PoolManager(timeout=HTTP_TIMEOUT)
 
     gcp_metadata = None
 
@@ -83,7 +85,11 @@ class CloudResourceContextIntegration(Integration):
             cls.aws_token = r.data.decode()
             return True
 
-        except Exception:
+        except urllib3.exceptions.TimeoutError:
+            logger.debug("AWS metadata service timed out after %s seconds", HTTP_TIMEOUT)
+            return False
+        except Exception as e:
+            logger.debug("Error checking AWS metadata service: %s", str(e))
             return False
 
     @classmethod
@@ -131,8 +137,10 @@ class CloudResourceContextIntegration(Integration):
             except Exception:
                 pass
 
-        except Exception:
-            pass
+        except urllib3.exceptions.TimeoutError:
+            logger.debug("AWS metadata service timed out after %s seconds", HTTP_TIMEOUT)
+        except Exception as e:
+            logger.debug("Error fetching AWS metadata: %s", str(e))
 
         return ctx
 
@@ -152,7 +160,11 @@ class CloudResourceContextIntegration(Integration):
             cls.gcp_metadata = json.loads(r.data.decode("utf-8"))
             return True
 
-        except Exception:
+        except urllib3.exceptions.TimeoutError:
+            logger.debug("GCP metadata service timed out after %s seconds", HTTP_TIMEOUT)
+            return False
+        except Exception as e:
+            logger.debug("Error checking GCP metadata service: %s", str(e))
             return False
 
     @classmethod
@@ -201,8 +213,10 @@ class CloudResourceContextIntegration(Integration):
             except Exception:
                 pass
 
-        except Exception:
-            pass
+        except urllib3.exceptions.TimeoutError:
+            logger.debug("GCP metadata service timed out after %s seconds", HTTP_TIMEOUT)
+        except Exception as e:
+            logger.debug("Error fetching GCP metadata: %s", str(e))
 
         return ctx
 


### PR DESCRIPTION
The URL that works in EC2 does not work in ECS, this can lead to the HTTP request getting stuck. 

Fixes #2376