### PR TITLE
Coerce None values into strings in logentry params.

### DIFF
--- a/sentry_sdk/integrations/logging.py
+++ b/sentry_sdk/integrations/logging.py
@@ -248,7 +248,9 @@ class EventHandler(_BaseHandler):
         else:
             event["logentry"] = {
                 "message": to_string(record.msg),
-                "params": record.args,
+                "params": (
+                    tuple(to_string(arg) for arg in record.args) if record.args else ()
+                ),
             }
 
         event["extra"] = self._extra_from_record(record)


### PR DESCRIPTION
Nice rendering of log messages containing parameters that are `None` values does not work. There we coerce `None` values into strings to have nicer messages in Sentry UI.

Fixes #3660