### PR TITLE
fix(pyspark): Grab `attemptId` more defensively

### DIFF
--- a/sentry_sdk/integrations/spark/spark_driver.py
+++ b/sentry_sdk/integrations/spark/spark_driver.py
@@ -295,6 +295,7 @@ class SentryListener(SparkListener):
 
 
 def _get_attempt_id(stage_info):
+    # type: (Any) -> Optional[int]
     from py4j.protocol import Py4JJavaError  # type: ignore
 
     try:

--- a/sentry_sdk/integrations/spark/spark_driver.py
+++ b/sentry_sdk/integrations/spark/spark_driver.py
@@ -296,7 +296,7 @@ class SentryListener(SparkListener):
 
 def _get_attempt_id(stage_info):
     # type: (Any) -> Optional[int]
-    from py4j.protocol import Py4JJavaError  # type: ignore
+    from py4j.protocol import Py4JJavaError
 
     try:
         return stage_info.attemptId()
@@ -305,11 +305,6 @@ def _get_attempt_id(stage_info):
 
     try:
         return stage_info.attemptNumber()
-    except Py4JJavaError:
-        pass
-
-    try:
-        return stage_info.currentAttemptId()
     except Py4JJavaError:
         pass
 

--- a/sentry_sdk/integrations/spark/spark_driver.py
+++ b/sentry_sdk/integrations/spark/spark_driver.py
@@ -296,16 +296,14 @@ class SentryListener(SparkListener):
 
 def _get_attempt_id(stage_info):
     # type: (Any) -> Optional[int]
-    from py4j.protocol import Py4JJavaError
-
     try:
         return stage_info.attemptId()
-    except Py4JJavaError:
+    except Exception:
         pass
 
     try:
         return stage_info.attemptNumber()
-    except Py4JJavaError:
+    except Exception:
         pass
 
     return None

--- a/sentry_sdk/integrations/spark/spark_driver.py
+++ b/sentry_sdk/integrations/spark/spark_driver.py
@@ -260,7 +260,12 @@ class SentryListener(SparkListener):
         # type: (Any) -> None
         stage_info = stageSubmitted.stageInfo()
         message = "Stage {} Submitted".format(stage_info.stageId())
-        data = {"attemptId": stage_info.attemptId(), "name": stage_info.name()}
+
+        data = {"name": stage_info.name()}
+        attempt_id = _get_attempt_id(stage_info)
+        if attempt_id is not None:
+            data["attemptId"] = attempt_id
+
         self._add_breadcrumb(level="info", message=message, data=data)
         _set_app_properties()
 
@@ -271,7 +276,11 @@ class SentryListener(SparkListener):
         stage_info = stageCompleted.stageInfo()
         message = ""
         level = ""
-        data = {"attemptId": stage_info.attemptId(), "name": stage_info.name()}
+
+        data = {"name": stage_info.name()}
+        attempt_id = _get_attempt_id(stage_info)
+        if attempt_id is not None:
+            data["attemptId"] = attempt_id
 
         # Have to Try Except because stageInfo.failureReason() is typed with Scala Option
         try:
@@ -283,3 +292,24 @@ class SentryListener(SparkListener):
             level = "info"
 
         self._add_breadcrumb(level=level, message=message, data=data)
+
+
+def _get_attempt_id(stage_info):
+    from py4j.protocol import Py4JJavaError  # type: ignore
+
+    try:
+        return stage_info.attemptId()
+    except Py4JJavaError:
+        pass
+
+    try:
+        return stage_info.attemptNumber()
+    except Py4JJavaError:
+        pass
+
+    try:
+        return stage_info.currentAttemptId()
+    except Py4JJavaError:
+        pass
+
+    return None

--- a/tests/integrations/spark/test_spark.py
+++ b/tests/integrations/spark/test_spark.py
@@ -295,6 +295,9 @@ def test_sentry_listener_on_stage_submitted_no_attempt_id(sentry_listener):
             def name(self):
                 return "run-job"
 
+            def attemptId(self):
+                raise Py4JJavaError
+
             def attemptNumber(self):  # noqa: N802
                 return 14
 
@@ -325,6 +328,12 @@ def test_sentry_listener_on_stage_submitted_no_attempt_id_or_number(sentry_liste
 
             def name(self):
                 return "run-job"
+
+            def attemptId(self):
+                raise Py4JJavaError
+
+            def attemptNumber(self):
+                raise Py4JJavaError
 
         class MockStageSubmitted:
             def stageInfo(self):  # noqa: N802

--- a/tests/integrations/spark/test_spark.py
+++ b/tests/integrations/spark/test_spark.py
@@ -295,7 +295,7 @@ def test_sentry_listener_on_stage_submitted_no_attempt_id(sentry_listener):
             def name(self):
                 return "run-job"
 
-            def attemptId(self):
+            def attemptId(self):  # noqa: N802
                 raise Py4JJavaError
 
             def attemptNumber(self):  # noqa: N802
@@ -329,10 +329,10 @@ def test_sentry_listener_on_stage_submitted_no_attempt_id_or_number(sentry_liste
             def name(self):
                 return "run-job"
 
-            def attemptId(self):
+            def attemptId(self):  # noqa: N802
                 raise Py4JJavaError
 
-            def attemptNumber(self):
+            def attemptNumber(self):  # noqa: N802
                 raise Py4JJavaError
 
         class MockStageSubmitted:

--- a/tests/integrations/spark/test_spark.py
+++ b/tests/integrations/spark/test_spark.py
@@ -14,6 +14,7 @@ from pyspark import SparkContext
 
 from py4j.protocol import Py4JJavaError
 
+
 ################
 # DRIVER TESTS #
 ################
@@ -166,6 +167,65 @@ def test_sentry_listener_on_stage_submitted(sentry_listener):
         assert mock_hub.kwargs["data"]["name"] == "run-job"
 
 
+def test_sentry_listener_on_stage_submitted_no_attempt_id(sentry_listener):
+    listener = sentry_listener
+    with patch.object(listener, "_add_breadcrumb") as mock_add_breadcrumb:
+
+        class StageInfo:
+            def stageId(self):  # noqa: N802
+                return "sample-stage-id-submit"
+
+            def name(self):
+                return "run-job"
+
+            def attemptNumber(self):  # noqa: N802
+                return 14
+
+        class MockStageSubmitted:
+            def stageInfo(self):  # noqa: N802
+                stageinf = StageInfo()
+                return stageinf
+
+        mock_stage_submitted = MockStageSubmitted()
+        listener.onStageSubmitted(mock_stage_submitted)
+
+        mock_add_breadcrumb.assert_called_once()
+        mock_hub = mock_add_breadcrumb.call_args
+
+        assert mock_hub.kwargs["level"] == "info"
+        assert "sample-stage-id-submit" in mock_hub.kwargs["message"]
+        assert mock_hub.kwargs["data"]["attemptId"] == 14
+        assert mock_hub.kwargs["data"]["name"] == "run-job"
+
+
+def test_sentry_listener_on_stage_submitted_no_attempt_id_or_number(sentry_listener):
+    listener = sentry_listener
+    with patch.object(listener, "_add_breadcrumb") as mock_add_breadcrumb:
+
+        class StageInfo:
+            def stageId(self):  # noqa: N802
+                return "sample-stage-id-submit"
+
+            def name(self):
+                return "run-job"
+
+        class MockStageSubmitted:
+            def stageInfo(self):  # noqa: N802
+                stageinf = StageInfo()
+                return stageinf
+
+        mock_stage_submitted = MockStageSubmitted()
+        listener.onStageSubmitted(mock_stage_submitted)
+
+        mock_add_breadcrumb.assert_called_once()
+        mock_hub = mock_add_breadcrumb.call_args
+
+        assert mock_hub.kwargs["level"] == "info"
+        assert "sample-stage-id-submit" in mock_hub.kwargs["message"]
+        assert "attemptId" not in mock_hub.kwargs["data"]
+        assert mock_hub.kwargs["data"]["name"] == "run-job"
+
+
 @pytest.fixture
 def get_mock_stage_completed():
     def _inner(failure_reason):
@@ -282,71 +342,3 @@ def test_spark_worker(monkeypatch, sentry_init, capture_events, capture_exceptio
         "partitionId": "2",
         "taskAttemptId": "3",
     }
-
-
-def test_sentry_listener_on_stage_submitted_no_attempt_id(sentry_listener):
-    listener = sentry_listener
-    with patch.object(listener, "_add_breadcrumb") as mock_add_breadcrumb:
-
-        class StageInfo:
-            def stageId(self):  # noqa: N802
-                return "sample-stage-id-submit"
-
-            def name(self):
-                return "run-job"
-
-            def attemptId(self):  # noqa: N802
-                raise Py4JJavaError
-
-            def attemptNumber(self):  # noqa: N802
-                return 14
-
-        class MockStageSubmitted:
-            def stageInfo(self):  # noqa: N802
-                stageinf = StageInfo()
-                return stageinf
-
-        mock_stage_submitted = MockStageSubmitted()
-        listener.onStageSubmitted(mock_stage_submitted)
-
-        mock_add_breadcrumb.assert_called_once()
-        mock_hub = mock_add_breadcrumb.call_args
-
-        assert mock_hub.kwargs["level"] == "info"
-        assert "sample-stage-id-submit" in mock_hub.kwargs["message"]
-        assert mock_hub.kwargs["data"]["attemptId"] == 14
-        assert mock_hub.kwargs["data"]["name"] == "run-job"
-
-
-def test_sentry_listener_on_stage_submitted_no_attempt_id_or_number(sentry_listener):
-    listener = sentry_listener
-    with patch.object(listener, "_add_breadcrumb") as mock_add_breadcrumb:
-
-        class StageInfo:
-            def stageId(self):  # noqa: N802
-                return "sample-stage-id-submit"
-
-            def name(self):
-                return "run-job"
-
-            def attemptId(self):  # noqa: N802
-                raise Py4JJavaError
-
-            def attemptNumber(self):  # noqa: N802
-                raise Py4JJavaError
-
-        class MockStageSubmitted:
-            def stageInfo(self):  # noqa: N802
-                stageinf = StageInfo()
-                return stageinf
-
-        mock_stage_submitted = MockStageSubmitted()
-        listener.onStageSubmitted(mock_stage_submitted)
-
-        mock_add_breadcrumb.assert_called_once()
-        mock_hub = mock_add_breadcrumb.call_args
-
-        assert mock_hub.kwargs["level"] == "info"
-        assert "sample-stage-id-submit" in mock_hub.kwargs["message"]
-        assert "attemptId" not in mock_hub.kwargs["data"]
-        assert mock_hub.kwargs["data"]["name"] == "run-job"

--- a/tests/integrations/spark/test_spark.py
+++ b/tests/integrations/spark/test_spark.py
@@ -295,7 +295,7 @@ def test_sentry_listener_on_stage_submitted_no_attempt_id(sentry_listener):
             def name(self):
                 return "run-job"
 
-            def attemptName(self):  # noqa: N802
+            def attemptNumber(self):  # noqa: N802
                 return 14
 
         class MockStageSubmitted:


### PR DESCRIPTION
Closes https://github.com/getsentry/sentry-python/issues/1099