### PR TITLE
feat(logs): Make the `logging` integration send Sentry logs

### DIFF
--- a/sentry_sdk/_experimental_logger.py
+++ b/sentry_sdk/_experimental_logger.py
@@ -1,6 +1,6 @@
 # NOTE: this is the logger sentry exposes to users, not some generic logger.
 import functools
-from time import time_ns
+import time
 from typing import Any
 
 from sentry_sdk import get_client, get_current_scope
@@ -25,7 +25,7 @@ def _capture_log(severity_text, severity_number, template, **kwargs):
             "severity_number": severity_number,
             "attributes": attrs,
             "body": template.format(**kwargs),
-            "time_unix_nano": time_ns(),
+            "time_unix_nano": time.time_ns(),
             "trace_id": None,
         },
     )

--- a/sentry_sdk/_experimental_logger.py
+++ b/sentry_sdk/_experimental_logger.py
@@ -13,7 +13,7 @@ def _capture_log(severity_text, severity_number, template, **kwargs):
 
     attrs = {
         "sentry.message.template": template,
-    }
+    }  # type: dict[str, str | bool | float | int]
     for k, v in kwargs.items():
         attrs[f"sentry.message.parameters.{k}"] = v
 

--- a/sentry_sdk/_experimental_logger.py
+++ b/sentry_sdk/_experimental_logger.py
@@ -14,6 +14,8 @@ def _capture_log(severity_text, severity_number, template, **kwargs):
     attrs = {
         "sentry.message.template": template,
     }  # type: dict[str, str | bool | float | int]
+    if "attributes" in kwargs:
+        attrs.update(kwargs.pop("attributes"))
     for k, v in kwargs.items():
         attrs[f"sentry.message.parameters.{k}"] = v
 

--- a/sentry_sdk/_experimental_logger.py
+++ b/sentry_sdk/_experimental_logger.py
@@ -1,5 +1,6 @@
 # NOTE: this is the logger sentry exposes to users, not some generic logger.
 import functools
+from time import time_ns
 from typing import Any
 
 from sentry_sdk import get_client, get_current_scope
@@ -9,9 +10,24 @@ def _capture_log(severity_text, severity_number, template, **kwargs):
     # type: (str, int, str, **Any) -> None
     client = get_client()
     scope = get_current_scope()
-    kwargs["sentry.message.template"] = template
-    client.capture_log(
-        scope, severity_text, severity_number, template.format(**kwargs), **kwargs
+
+    attrs = {
+        "sentry.message.template": template,
+    }
+    for k, v in kwargs.items():
+        attrs[f"sentry.message.parameters.{k}"] = v
+
+    # noinspection PyProtectedMember
+    client._capture_experimental_log(
+        scope,
+        {
+            "severity_text": severity_text,
+            "severity_number": severity_number,
+            "attributes": attrs,
+            "body": template.format(**kwargs),
+            "time_unix_nano": time_ns(),
+            "trace_id": None,
+        },
     )
 
 

--- a/sentry_sdk/_experimental_logger.py
+++ b/sentry_sdk/_experimental_logger.py
@@ -9,7 +9,10 @@ def _capture_log(severity_text, severity_number, template, **kwargs):
     # type: (str, int, str, **Any) -> None
     client = get_client()
     scope = get_current_scope()
-    client.capture_log(scope, severity_text, severity_number, template, **kwargs)
+    kwargs["sentry.message.template"] = template
+    client.capture_log(
+        scope, severity_text, severity_number, template.format(**kwargs), **kwargs
+    )
 
 
 trace = functools.partial(_capture_log, "trace", 1)

--- a/sentry_sdk/client.py
+++ b/sentry_sdk/client.py
@@ -901,7 +901,6 @@ class _Client(BaseClient):
                 "error": logging.ERROR,
                 "fatal": logging.CRITICAL,
             }
-            # Be careful editing this line, you can add infinite logging loops with the logger integration
             logger.log(
                 severity_text_to_logging_level.get(log["severity_text"], logging.DEBUG),
                 f'[Sentry Logs] {log["body"]}',

--- a/sentry_sdk/client.py
+++ b/sentry_sdk/client.py
@@ -886,7 +886,9 @@ class _Client(BaseClient):
 
         propagation_context = scope.get_active_propagation_context()
         if propagation_context is not None:
-            headers["trace_id"] = propagation_context.trace_id
+            if propagation_context.dynamic_sampling_context is not None:
+                headers["trace"] = propagation_context.dynamic_sampling_context
+
             if log["trace_id"] is None:
                 log["trace_id"] = propagation_context.trace_id
 

--- a/sentry_sdk/client.py
+++ b/sentry_sdk/client.py
@@ -1,6 +1,5 @@
 import json
 import os
-import time
 import uuid
 import random
 import socket
@@ -210,10 +209,8 @@ class BaseClient:
         # type: (*Any, **Any) -> Optional[str]
         return None
 
-    def _capture_experimental_log(
-        self, scope, severity_text, severity_number, body, time_unix_nano=None, **kwargs
-    ):
-        # type: (Scope, str, int, str, Optional[int], **Any) -> None
+    def _capture_experimental_log(self, scope, log):
+        # type: (Scope, Log) -> None
         pass
 
     def capture_session(self, *args, **kwargs):
@@ -865,50 +862,33 @@ class _Client(BaseClient):
 
         return return_value
 
-    def _capture_experimental_log(
-        self, scope, severity_text, severity_number, body, time_unix_nano=None, **kwargs
-    ):
-        # type: (Scope, str, int, str, Optional[int], **Any) -> None
+    def _capture_experimental_log(self, scope, log):
+        # type: (Scope, Log) -> None
         logs_enabled = self.options["_experiments"].get("enable_sentry_logs", False)
         if not logs_enabled:
             return
-
-        if time_unix_nano is None:
-            time_unix_nano = time.time_ns()
 
         headers = {
             "sent_at": format_timestamp(datetime.now(timezone.utc)),
         }  # type: dict[str, object]
 
-        attrs = {}  # type: dict[str, str | bool | float | int]
-
-        kwargs_attributes = kwargs.get("attributes")
-        if kwargs_attributes is not None:
-            attrs.update(kwargs_attributes)
-
         environment = self.options.get("environment")
-        if environment is not None:
-            attrs["sentry.environment"] = environment
+        if environment is not None and "sentry.environment" not in log["attributes"]:
+            log["attributes"]["sentry.environment"] = environment
 
         release = self.options.get("release")
-        if release is not None:
-            attrs["sentry.release"] = release
+        if release is not None and "sentry.release" not in log["attributes"]:
+            log["attributes"]["sentry.release"] = release
 
         span = scope.span
-        if span is not None:
-            attrs["sentry.trace.parent_span_id"] = span.span_id
+        if span is not None and "sentry.trace.parent_span_id" not in log["attributes"]:
+            log["attributes"]["sentry.trace.parent_span_id"] = span.span_id
 
-        for k, v in kwargs.items():
-            attrs[f"sentry.message.parameters.{k}"] = v
-
-        log = {
-            "severity_text": severity_text,
-            "severity_number": severity_number,
-            "body": body,
-            "attributes": attrs,
-            "time_unix_nano": time_unix_nano,
-            "trace_id": None,
-        }  # type: Log
+        propagation_context = scope.get_active_propagation_context()
+        if propagation_context is not None:
+            headers["trace_id"] = propagation_context.trace_id
+            if log["trace_id"] is None:
+                log["trace_id"] = propagation_context.trace_id
 
         # If debug is enabled, log the log to the console
         debug = self.options.get("debug", False)
@@ -923,14 +903,9 @@ class _Client(BaseClient):
             }
             # Be careful editing this line, you can add infinite logging loops with the logger integration
             logger.log(
-                severity_text_to_logging_level.get(severity_text, logging.DEBUG),
+                severity_text_to_logging_level.get(log["severity_text"], logging.DEBUG),
                 f'[Sentry Logs] {log["body"]}',
             )
-
-        propagation_context = scope.get_active_propagation_context()
-        if propagation_context is not None:
-            headers["trace_id"] = propagation_context.trace_id
-            log["trace_id"] = propagation_context.trace_id
 
         envelope = Envelope(headers=headers)
 

--- a/sentry_sdk/client.py
+++ b/sentry_sdk/client.py
@@ -211,9 +211,9 @@ class BaseClient:
         return None
 
     def _capture_experimental_log(
-        self, scope, severity_text, severity_number, body, **kwargs
+        self, scope, severity_text, severity_number, body, time_unix_nano=None, **kwargs
     ):
-        # type: (Scope, str, int, str, **Any) -> None
+        # type: (Scope, str, int, str, Optional[int], **Any) -> None
         pass
 
     def capture_session(self, *args, **kwargs):
@@ -866,12 +866,15 @@ class _Client(BaseClient):
         return return_value
 
     def _capture_experimental_log(
-        self, scope, severity_text, severity_number, body, **kwargs
+        self, scope, severity_text, severity_number, body, time_unix_nano=None, **kwargs
     ):
-        # type: (Scope, str, int, str, **Any) -> None
+        # type: (Scope, str, int, str, Optional[int], **Any) -> None
         logs_enabled = self.options["_experiments"].get("enable_sentry_logs", False)
         if not logs_enabled:
             return
+
+        if time_unix_nano is None:
+            time_unix_nano = time.time_ns()
 
         headers = {
             "sent_at": format_timestamp(datetime.now(timezone.utc)),
@@ -903,7 +906,7 @@ class _Client(BaseClient):
             "severity_number": severity_number,
             "body": body,
             "attributes": attrs,
-            "time_unix_nano": kwargs.pop("time_unix_nano", time.time_ns()),
+            "time_unix_nano": time_unix_nano,
             "trace_id": None,
         }  # type: Log
 

--- a/sentry_sdk/consts.py
+++ b/sentry_sdk/consts.py
@@ -78,6 +78,7 @@ if TYPE_CHECKING:
                 Callable[[str, MetricValue, MeasurementUnit, MetricTags], bool]
             ],
             "metric_code_locations": Optional[bool],
+            "enable_sentry_logs": Optional[bool],
         },
         total=False,
     )

--- a/sentry_sdk/integrations/logging.py
+++ b/sentry_sdk/integrations/logging.py
@@ -66,8 +66,8 @@ class LoggingIntegration(Integration):
     def __init__(
         self,
         level=DEFAULT_LEVEL,
-        sentry_logs_level=DEFAULT_LEVEL,
         event_level=DEFAULT_EVENT_LEVEL,
+        sentry_logs_level=DEFAULT_LEVEL,
     ):
         # type: (Optional[int], Optional[int], Optional[int]) -> None
         self._handler = None

--- a/sentry_sdk/integrations/logging.py
+++ b/sentry_sdk/integrations/logging.py
@@ -321,6 +321,7 @@ def _python_level_to_otel(record_level):
     ]:
         if max(record_level, 0) >= py_level:
             return otel_severity_number, otel_severity_text
+    raise AssertionError("this shouldn't happen")
 
 
 class SentryLogsHandler(_BaseHandler):

--- a/sentry_sdk/integrations/logging.py
+++ b/sentry_sdk/integrations/logging.py
@@ -317,11 +317,10 @@ def _python_level_to_otel(record_level):
         (20, 9, "info"),
         (10, 5, "debug"),
         (5, 1, "trace"),
-        (0, 0, "default"),
     ]:
-        if max(record_level, 0) >= py_level:
+        if record_level >= py_level:
             return otel_severity_number, otel_severity_text
-    raise AssertionError("this shouldn't happen")
+    return 0, "default"
 
 
 class SentryLogsHandler(_BaseHandler):

--- a/sentry_sdk/integrations/logging.py
+++ b/sentry_sdk/integrations/logging.py
@@ -13,7 +13,7 @@ from sentry_sdk.utils import (
 )
 from sentry_sdk.integrations import Integration
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Tuple
 
 if TYPE_CHECKING:
     from collections.abc import MutableMapping
@@ -309,7 +309,7 @@ class BreadcrumbHandler(_BaseHandler):
 
 
 def _python_level_to_otel(record_level):
-    # type: (int) -> (int, str)
+    # type: (int) -> Tuple[int, str]
     for py_level, otel_severity_number, otel_severity_text in [
         (50, 21, "fatal"),
         (40, 17, "error"),
@@ -358,7 +358,7 @@ class SentryLogsHandler(_BaseHandler):
             "sentry.message.template": (
                 record.msg if isinstance(record.msg, str) else json.dumps(record.msg)
             ),
-        }
+        }  # type: dict[str, str | bool | float | int]
         if record.args is not None:
             if isinstance(record.args, tuple):
                 for i, arg in enumerate(record.args):

--- a/sentry_sdk/integrations/logging.py
+++ b/sentry_sdk/integrations/logging.py
@@ -63,7 +63,12 @@ def ignore_logger(
 class LoggingIntegration(Integration):
     identifier = "logging"
 
-    def __init__(self, level=DEFAULT_LEVEL, event_level=DEFAULT_EVENT_LEVEL):
+    def __init__(
+        self,
+        level=DEFAULT_LEVEL,
+        sentry_logs_level=DEFAULT_LEVEL,
+        event_level=DEFAULT_EVENT_LEVEL,
+    ):
         # type: (Optional[int], Optional[int]) -> None
         self._handler = None
         self._breadcrumb_handler = None
@@ -71,6 +76,8 @@ class LoggingIntegration(Integration):
 
         if level is not None:
             self._breadcrumb_handler = BreadcrumbHandler(level=level)
+
+        if sentry_logs_level is not None:
             self._sentry_logs_handler = SentryLogsHandler(level=level)
 
         if event_level is not None:

--- a/sentry_sdk/integrations/logging.py
+++ b/sentry_sdk/integrations/logging.py
@@ -345,9 +345,6 @@ class SentryLogsHandler(_BaseHandler):
             if not client.options["_experiments"].get("enable_sentry_logs", False):
                 return
 
-            if record.msg.startswith("[Sentry Logs]"):
-                return  # avoid infinite loop when debug is true
-
             SentryLogsHandler._capture_log_from_record(client, record)
 
     @staticmethod

--- a/sentry_sdk/integrations/logging.py
+++ b/sentry_sdk/integrations/logging.py
@@ -69,7 +69,7 @@ class LoggingIntegration(Integration):
         sentry_logs_level=DEFAULT_LEVEL,
         event_level=DEFAULT_EVENT_LEVEL,
     ):
-        # type: (Optional[int], Optional[int]) -> None
+        # type: (Optional[int], Optional[int], Optional[int]) -> None
         self._handler = None
         self._breadcrumb_handler = None
         self._sentry_logs_handler = None
@@ -78,7 +78,7 @@ class LoggingIntegration(Integration):
             self._breadcrumb_handler = BreadcrumbHandler(level=level)
 
         if sentry_logs_level is not None:
-            self._sentry_logs_handler = SentryLogsHandler(level=level)
+            self._sentry_logs_handler = SentryLogsHandler(level=sentry_logs_level)
 
         if event_level is not None:
             self._handler = EventHandler(level=event_level)

--- a/tests/test_logs.py
+++ b/tests/test_logs.py
@@ -74,14 +74,14 @@ def test_logs_basics(sentry_init, capture_envelopes):
 @minimum_python_37
 def test_logs_before_emit_log(sentry_init, capture_envelopes):
     def _before_log(record, hint):
-        assert list(record.keys()) == [
+        assert set(record.keys()) == {
             "severity_text",
             "severity_number",
             "body",
             "attributes",
             "time_unix_nano",
             "trace_id",
-        ]
+        }
 
         if record["severity_text"] in ["fatal", "error"]:
             return None

--- a/tests/test_logs.py
+++ b/tests/test_logs.py
@@ -272,7 +272,7 @@ def test_no_log_infinite_loop(sentry_init, capture_envelopes):
     """
     sentry_init(
         _experiments={"enable_sentry_logs": True},
-        integrations=[LoggingIntegration(level=logging.DEBUG)],
+        integrations=[LoggingIntegration(sentry_logs_level=logging.DEBUG)],
         debug=True,
     )
     envelopes = capture_envelopes()

--- a/tests/test_logs.py
+++ b/tests/test_logs.py
@@ -1,5 +1,6 @@
 import logging
 import sys
+from typing import List, Any
 from unittest import mock
 import pytest
 
@@ -12,9 +13,16 @@ minimum_python_37 = pytest.mark.skipif(
 )
 
 
+def otel_attributes_to_dict(otel_attrs: List[Any]):
+    return {item["key"]: item["value"] for item in otel_attrs}
+
+
 @minimum_python_37
 def test_logs_disabled_by_default(sentry_init, capture_envelopes):
     sentry_init()
+
+    python_logger = logging.Logger("some-logger")
+
     envelopes = capture_envelopes()
 
     sentry_logger.trace("This is a 'trace' log.")
@@ -23,6 +31,7 @@ def test_logs_disabled_by_default(sentry_init, capture_envelopes):
     sentry_logger.warn("This is a 'warn' log...")
     sentry_logger.error("This is a 'error' log...")
     sentry_logger.fatal("This is a 'fatal' log...")
+    python_logger.warning("sad")
 
     assert len(envelopes) == 0
 
@@ -124,34 +133,14 @@ def test_logs_attributes(sentry_init, capture_envelopes):
     log_item = envelopes[0].items[0].payload.json
     assert log_item["body"]["stringValue"] == "The recorded value was 'some value'"
 
-    assert log_item["attributes"][1] == {
-        "key": "attr_int",
-        "value": {"intValue": "1"},
-    }  # TODO: this is strange.
-    assert log_item["attributes"][2] == {
-        "key": "attr_float",
-        "value": {"doubleValue": 2.0},
-    }
-    assert log_item["attributes"][3] == {
-        "key": "attr_bool",
-        "value": {"boolValue": True},
-    }
-    assert log_item["attributes"][4] == {
-        "key": "attr_string",
-        "value": {"stringValue": "string attribute"},
-    }
-    assert log_item["attributes"][5] == {
-        "key": "sentry.environment",
-        "value": {"stringValue": "production"},
-    }
-    assert log_item["attributes"][6] == {
-        "key": "sentry.release",
-        "value": {"stringValue": mock.ANY},
-    }
-    assert log_item["attributes"][7] == {
-        "key": "sentry.message.parameters.my_var",
-        "value": {"stringValue": "some value"},
-    }
+    attrs = otel_attributes_to_dict(log_item["attributes"])
+    assert attrs["attr_int"] == {"intValue": "1"}
+    assert attrs["attr_float"] == {"doubleValue": 2.0}
+    assert attrs["attr_bool"] == {"boolValue": True}
+    assert attrs["attr_string"] == {"stringValue": "string attribute"}
+    assert attrs["sentry.environment"] == {"stringValue": "production"}
+    assert attrs["sentry.release"] == {"stringValue": mock.ANY}
+    assert attrs["sentry.message.parameters.my_var"] == {"stringValue": "some value"}
 
 
 @minimum_python_37
@@ -173,37 +162,33 @@ def test_logs_message_params(sentry_init, capture_envelopes):
         envelopes[0].items[0].payload.json["body"]["stringValue"]
         == "The recorded value was '1'"
     )
-    assert envelopes[0].items[0].payload.json["attributes"][-1] == {
-        "key": "sentry.message.parameters.int_var",
-        "value": {"intValue": "1"},
-    }  # TODO: this is strange.
+    assert otel_attributes_to_dict(envelopes[0].items[0].payload.json["attributes"])[
+        "sentry.message.parameters.int_var"
+    ] == {"intValue": "1"}
 
     assert (
         envelopes[1].items[0].payload.json["body"]["stringValue"]
         == "The recorded value was '2.0'"
     )
-    assert envelopes[1].items[0].payload.json["attributes"][-1] == {
-        "key": "sentry.message.parameters.float_var",
-        "value": {"doubleValue": 2.0},
-    }
+    assert otel_attributes_to_dict(envelopes[1].items[0].payload.json["attributes"])[
+        "sentry.message.parameters.float_var"
+    ] == {"doubleValue": 2.0}
 
     assert (
         envelopes[2].items[0].payload.json["body"]["stringValue"]
         == "The recorded value was 'False'"
     )
-    assert envelopes[2].items[0].payload.json["attributes"][-1] == {
-        "key": "sentry.message.parameters.bool_var",
-        "value": {"boolValue": False},
-    }
+    assert otel_attributes_to_dict(envelopes[2].items[0].payload.json["attributes"])[
+        "sentry.message.parameters.bool_var"
+    ] == {"boolValue": False}
 
     assert (
         envelopes[3].items[0].payload.json["body"]["stringValue"]
         == "The recorded value was 'some string value'"
     )
-    assert envelopes[3].items[0].payload.json["attributes"][-1] == {
-        "key": "sentry.message.parameters.string_var",
-        "value": {"stringValue": "some string value"},
-    }
+    assert otel_attributes_to_dict(envelopes[2].items[0].payload.json["attributes"])[
+        "sentry.message.parameters.string_var"
+    ] == {"stringValue": "some string value"}
 
 
 @minimum_python_37
@@ -236,11 +221,8 @@ def test_logs_tied_to_spans(sentry_init, capture_envelopes):
         with sentry_sdk.start_span(description="test-span") as span:
             sentry_logger.warn("This is a log tied to a span")
 
-    log_entry = envelopes[0].items[0].payload.json
-    assert log_entry["attributes"][-1] == {
-        "key": "sentry.trace.parent_span_id",
-        "value": {"stringValue": span.span_id},
-    }
+    attrs = otel_attributes_to_dict(envelopes[0].items[0].payload.json["attributes"])
+    assert attrs["sentry.trace.parent_span_id"] == {"stringValue": span.span_id}
 
 
 @minimum_python_37
@@ -255,10 +237,16 @@ def test_logger_integration_warning(sentry_init, capture_envelopes):
     python_logger.warning("this is %s a template %s", "1", "2")
 
     log_entry = envelopes[0].items[0].payload.json
-    assert log_entry["attributes"][0] == {
-        "key": "sentry.message.template",
-        "value": {"stringValue": "this is %s a template %s"},
+    attrs = otel_attributes_to_dict(log_entry["attributes"])
+    assert attrs["sentry.message.template"] == {
+        "stringValue": "this is %s a template %s"
     }
+    assert "code.file.path" in attrs
+    assert "code.line.number" in attrs
+    assert attrs["logger.name"] == {"stringValue": "test-logger"}
+    assert attrs["sentry.environment"] == {"stringValue": "production"}
+    assert attrs["sentry.message.parameters.0"] == {"stringValue": "1"}
+    assert attrs["sentry.message.parameters.1"]
     assert log_entry["severityNumber"] == 13
     assert log_entry["severityText"] == "warn"
 

--- a/tests/test_logs.py
+++ b/tests/test_logs.py
@@ -186,7 +186,7 @@ def test_logs_message_params(sentry_init, capture_envelopes):
         envelopes[3].items[0].payload.json["body"]["stringValue"]
         == "The recorded value was 'some string value'"
     )
-    assert otel_attributes_to_dict(envelopes[2].items[0].payload.json["attributes"])[
+    assert otel_attributes_to_dict(envelopes[3].items[0].payload.json["attributes"])[
         "sentry.message.parameters.string_var"
     ] == {"stringValue": "some string value"}
 


### PR DESCRIPTION
We have integrations that make the python logger create breadcrumbs and issues. This adds a third handler which creates Sentry logs on `logger.log` statements.

Enable the logger with:
```python
sentry_sdk.init(
    ...
    _experiments={
        "enable_sentry_logs": True
    }
)

some_logger = logging.Logger("some-logger")
some_logger.info('Finished sending answer! #chunks=%s', chunks)
```

![Screenshot 2025-03-17 at 4 12 27 PM](https://github.com/user-attachments/assets/0e8dcd46-6361-47c0-8662-389fcb924969)

Refs #4150