### PR TITLE
feat(django): Use `functools.wraps` in more places

### DIFF
--- a/sentry_sdk/integrations/django/__init__.py
+++ b/sentry_sdk/integrations/django/__init__.py
@@ -168,7 +168,6 @@ class DjangoIntegration(Integration):
 
         old_app = WSGIHandler.__call__
 
-        @functools.wraps(old_app)
         @ensure_integration_enabled(DjangoIntegration, old_app)
         def sentry_patched_wsgi_handler(self, environ, start_response):
             # type: (Any, Dict[str, str], Callable[..., Any]) -> _ScopedResponse
@@ -640,7 +639,6 @@ def install_sql_hook():
         # This won't work on Django versions < 1.6
         return
 
-    @functools.wraps(real_execute)
     @ensure_integration_enabled(DjangoIntegration, real_execute)
     def execute(self, sql, params=None):
         # type: (CursorWrapper, Any, Optional[Any]) -> Any
@@ -660,7 +658,6 @@ def install_sql_hook():
 
         return result
 
-    @functools.wraps(real_executemany)
     @ensure_integration_enabled(DjangoIntegration, real_executemany)
     def executemany(self, sql, param_list):
         # type: (CursorWrapper, Any, List[Any]) -> Any
@@ -681,7 +678,6 @@ def install_sql_hook():
 
         return result
 
-    @functools.wraps(real_connect)
     @ensure_integration_enabled(DjangoIntegration, real_connect)
     def connect(self):
         # type: (BaseDatabaseWrapper) -> None

--- a/sentry_sdk/integrations/django/__init__.py
+++ b/sentry_sdk/integrations/django/__init__.py
@@ -168,8 +168,8 @@ class DjangoIntegration(Integration):
 
         old_app = WSGIHandler.__call__
 
-        @ensure_integration_enabled(DjangoIntegration, old_app)
         @functools.wraps(old_app)
+        @ensure_integration_enabled(DjangoIntegration, old_app)
         def sentry_patched_wsgi_handler(self, environ, start_response):
             # type: (Any, Dict[str, str], Callable[..., Any]) -> _ScopedResponse
             bound_old_app = old_app.__get__(self, WSGIHandler)
@@ -640,8 +640,8 @@ def install_sql_hook():
         # This won't work on Django versions < 1.6
         return
 
-    @ensure_integration_enabled(DjangoIntegration, real_execute)
     @functools.wraps(real_execute)
+    @ensure_integration_enabled(DjangoIntegration, real_execute)
     def execute(self, sql, params=None):
         # type: (CursorWrapper, Any, Optional[Any]) -> Any
         with record_sql_queries(
@@ -660,8 +660,8 @@ def install_sql_hook():
 
         return result
 
-    @ensure_integration_enabled(DjangoIntegration, real_executemany)
     @functools.wraps(real_executemany)
+    @ensure_integration_enabled(DjangoIntegration, real_executemany)
     def executemany(self, sql, param_list):
         # type: (CursorWrapper, Any, List[Any]) -> Any
         with record_sql_queries(
@@ -681,8 +681,8 @@ def install_sql_hook():
 
         return result
 
-    @ensure_integration_enabled(DjangoIntegration, real_connect)
     @functools.wraps(real_connect)
+    @ensure_integration_enabled(DjangoIntegration, real_connect)
     def connect(self):
         # type: (BaseDatabaseWrapper) -> None
         with capture_internal_exceptions():

--- a/sentry_sdk/integrations/django/asgi.py
+++ b/sentry_sdk/integrations/django/asgi.py
@@ -110,7 +110,7 @@ def patch_django_asgi_handler_impl(cls):
     if modern_django_asgi_support:
         old_create_request = cls.create_request
 
-        @functools.wrap(old_create_request)
+        @functools.wraps(old_create_request)
         @ensure_integration_enabled(DjangoIntegration, old_create_request)
         def sentry_patched_create_request(self, *args, **kwargs):
             # type: (Any, *Any, **Any) -> Any

--- a/sentry_sdk/integrations/django/asgi.py
+++ b/sentry_sdk/integrations/django/asgi.py
@@ -88,6 +88,7 @@ def patch_django_asgi_handler_impl(cls):
 
     old_app = cls.__call__
 
+    @functools.wraps(old_app)
     async def sentry_patched_asgi_handler(self, scope, receive, send):
         # type: (Any, Any, Any, Any) -> Any
         integration = sentry_sdk.get_client().get_integration(DjangoIntegration)
@@ -109,6 +110,7 @@ def patch_django_asgi_handler_impl(cls):
     if modern_django_asgi_support:
         old_create_request = cls.create_request
 
+        @functools.wrap(old_create_request)
         @ensure_integration_enabled(DjangoIntegration, old_create_request)
         def sentry_patched_create_request(self, *args, **kwargs):
             # type: (Any, *Any, **Any) -> Any
@@ -125,6 +127,7 @@ def patch_get_response_async(cls, _before_get_response):
     # type: (Any, Any) -> None
     old_get_response_async = cls.get_response_async
 
+    @functools.wraps(old_get_response_async)
     async def sentry_patched_get_response_async(self, request):
         # type: (Any, Any) -> Union[HttpResponse, BaseException]
         _before_get_response(request)
@@ -142,6 +145,7 @@ def patch_channels_asgi_handler_impl(cls):
     if channels.__version__ < "3.0.0":
         old_app = cls.__call__
 
+        @functools.wraps(old_app)
         async def sentry_patched_asgi_handler(self, receive, send):
             # type: (Any, Any, Any) -> Any
             integration = sentry_sdk.get_client().get_integration(DjangoIntegration)

--- a/sentry_sdk/integrations/django/asgi.py
+++ b/sentry_sdk/integrations/django/asgi.py
@@ -110,7 +110,6 @@ def patch_django_asgi_handler_impl(cls):
     if modern_django_asgi_support:
         old_create_request = cls.create_request
 
-        @functools.wraps(old_create_request)
         @ensure_integration_enabled(DjangoIntegration, old_create_request)
         def sentry_patched_create_request(self, *args, **kwargs):
             # type: (Any, *Any, **Any) -> Any

--- a/sentry_sdk/integrations/django/signals_handlers.py
+++ b/sentry_sdk/integrations/django/signals_handlers.py
@@ -50,6 +50,7 @@ def patch_signals():
 
     old_live_receivers = Signal._live_receivers
 
+    @wraps(old_live_receivers)
     def _sentry_live_receivers(self, sender):
         # type: (Signal, Any) -> Union[tuple[list[Callable[..., Any]], list[Callable[..., Any]]], list[Callable[..., Any]]]
         if DJANGO_VERSION >= (5, 0):

--- a/sentry_sdk/integrations/django/templates.py
+++ b/sentry_sdk/integrations/django/templates.py
@@ -64,7 +64,6 @@ def patch_templates():
 
     real_rendered_content = SimpleTemplateResponse.rendered_content
 
-    @functools.wraps(real_rendered_content)
     @property  # type: ignore
     @ensure_integration_enabled(DjangoIntegration, real_rendered_content.fget)
     def rendered_content(self):

--- a/sentry_sdk/integrations/django/templates.py
+++ b/sentry_sdk/integrations/django/templates.py
@@ -64,6 +64,7 @@ def patch_templates():
 
     real_rendered_content = SimpleTemplateResponse.rendered_content
 
+    @functools.wraps(real_rendered_content)
     @property  # type: ignore
     @ensure_integration_enabled(DjangoIntegration, real_rendered_content.fget)
     def rendered_content(self):

--- a/sentry_sdk/integrations/django/views.py
+++ b/sentry_sdk/integrations/django/views.py
@@ -31,6 +31,7 @@ def patch_views():
     old_make_view_atomic = BaseHandler.make_view_atomic
     old_render = SimpleTemplateResponse.render
 
+    @functools.wraps(old_render)
     def sentry_patched_render(self):
         # type: (SimpleTemplateResponse) -> Any
         with sentry_sdk.start_span(


### PR DESCRIPTION
We're not using `@functools.wraps` in a handful of places in the Django integration, leading to the wrapped functions reporting wrong (i.e., Sentry wrapper) names when inspected.

Closes https://github.com/getsentry/sentry-python/issues/4138