### PR TITLE
Handle loguru msg levels that are not supported by Sentry

### DIFF
--- a/sentry_sdk/integrations/loguru.py
+++ b/sentry_sdk/integrations/loguru.py
@@ -31,6 +31,16 @@ class LoggingLevels(enum.IntEnum):
     CRITICAL = 50
 
 
+SENTRY_LEVEL_FROM_LOGURU_LEVEL = {
+    "TRACE": "DEBUG",
+    "DEBUG": "DEBUG",
+    "INFO": "INFO",
+    "SUCCESS": "INFO",
+    "WARNING": "WARNING",
+    "ERROR": "ERROR",
+    "CRITICAL": "CRITICAL",
+}
+
 DEFAULT_LEVEL = LoggingLevels.INFO.value
 DEFAULT_EVENT_LEVEL = LoggingLevels.ERROR.value
 # We need to save the handlers to be able to remove them later
@@ -87,14 +97,32 @@ class _LoguruBaseHandler(_BaseHandler):
     def _logging_to_event_level(self, record):
         # type: (LogRecord) -> str
         try:
-            return LoggingLevels(record.levelno).name.lower()
-        except ValueError:
+            return SENTRY_LEVEL_FROM_LOGURU_LEVEL[
+                LoggingLevels(record.levelno).name
+            ].lower()
+        except (ValueError, KeyError):
             return record.levelname.lower() if record.levelname else ""
 
 
 class LoguruEventHandler(_LoguruBaseHandler, EventHandler):
     """Modified version of :class:`sentry_sdk.integrations.logging.EventHandler` to use loguru's level names."""
 
+    def __init__(self, *args, **kwargs):
+        if kwargs.get("level"):
+            kwargs["level"] = SENTRY_LEVEL_FROM_LOGURU_LEVEL.get(
+                kwargs.get("level"), DEFAULT_LEVEL
+            )
+
+        super().__init__(*args, **kwargs)
+
 
 class LoguruBreadcrumbHandler(_LoguruBaseHandler, BreadcrumbHandler):
     """Modified version of :class:`sentry_sdk.integrations.logging.BreadcrumbHandler` to use loguru's level names."""
+
+    def __init__(self, *args, **kwargs):
+        if kwargs.get("level"):
+            kwargs["level"] = SENTRY_LEVEL_FROM_LOGURU_LEVEL.get(
+                kwargs.get("level"), DEFAULT_LEVEL
+            )
+
+        super().__init__(*args, **kwargs)

--- a/sentry_sdk/integrations/loguru.py
+++ b/sentry_sdk/integrations/loguru.py
@@ -11,7 +11,7 @@ from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from logging import LogRecord
-    from typing import Optional, Tuple
+    from typing import Optional, Tuple, Any
 
 try:
     import loguru
@@ -108,9 +108,10 @@ class LoguruEventHandler(_LoguruBaseHandler, EventHandler):
     """Modified version of :class:`sentry_sdk.integrations.logging.EventHandler` to use loguru's level names."""
 
     def __init__(self, *args, **kwargs):
+        # type: (*Any, **Any) -> None
         if kwargs.get("level"):
             kwargs["level"] = SENTRY_LEVEL_FROM_LOGURU_LEVEL.get(
-                kwargs.get("level"), DEFAULT_LEVEL
+                kwargs.get("level", ""), DEFAULT_LEVEL
             )
 
         super().__init__(*args, **kwargs)
@@ -120,9 +121,10 @@ class LoguruBreadcrumbHandler(_LoguruBaseHandler, BreadcrumbHandler):
     """Modified version of :class:`sentry_sdk.integrations.logging.BreadcrumbHandler` to use loguru's level names."""
 
     def __init__(self, *args, **kwargs):
+        # type: (*Any, **Any) -> None
         if kwargs.get("level"):
             kwargs["level"] = SENTRY_LEVEL_FROM_LOGURU_LEVEL.get(
-                kwargs.get("level"), DEFAULT_LEVEL
+                kwargs.get("level", ""), DEFAULT_LEVEL
             )
 
         super().__init__(*args, **kwargs)


### PR DESCRIPTION
Loguru has two message levels `TRACE` and `SUCCESS` that are not available in Sentry breadcrumbs. This PR maps `TRACE` to `debug` and `SUCCESS` to `info` in Sentry so those breadcrumbs do not show a confusing error message in the Sentry UI.

Fixes #2759