### PR TITLE
Support Starlette/FastAPI `app.host`

### DIFF
--- a/sentry_sdk/integrations/starlette.py
+++ b/sentry_sdk/integrations/starlette.py
@@ -693,7 +693,11 @@ def _transaction_name_from_router(scope):
     for route in router.routes:
         match = route.matches(scope)
         if match[0] == Match.FULL:
-            return getattr(route, "path", None)
+            try:
+                return route.path
+            except AttributeError:
+                # routes added via app.host() won't have a path attribute
+                return scope.get("path")
 
     return None
 

--- a/sentry_sdk/integrations/starlette.py
+++ b/sentry_sdk/integrations/starlette.py
@@ -693,7 +693,7 @@ def _transaction_name_from_router(scope):
     for route in router.routes:
         match = route.matches(scope)
         if match[0] == Match.FULL:
-            return route.path
+            return getattr(route, "path", None)
 
     return None
 


### PR DESCRIPTION
In Starlette/FastAPI you're able to create subapps. When using `transaction_style="url"` in our integration, this would throw an exception because we try to access `route.path` to determine the transaction name, but `Host` routes have no `path` attribute.

Closes https://github.com/getsentry/sentry-python/issues/2631