### PR TITLE
feat(profiling): reverse profile_session start/stop methods deprecation

### DIFF
--- a/sentry_sdk/profiler/__init__.py
+++ b/sentry_sdk/profiler/__init__.py
@@ -25,10 +25,10 @@ from sentry_sdk.profiler.utils import (
 )
 
 __all__ = [
-    "start_profile_session",
-    "start_profiler",  # TODO: Deprecate this in favor of `start_profile_session`
-    "stop_profile_session",
-    "stop_profiler",  # TODO: Deprecate this in favor of `stop_profile_session`
+    "start_profile_session", # TODO: Deprecate this in favor of `start_profiler`
+    "start_profiler",  
+    "stop_profile_session", # TODO: Deprecate this in favor of `stop_profiler`
+    "stop_profiler",  
     # DEPRECATED: The following was re-exported for backwards compatibility. It
     # will be removed from sentry_sdk.profiler in a future release.
     "MAX_PROFILE_DURATION_NS",

--- a/sentry_sdk/profiler/__init__.py
+++ b/sentry_sdk/profiler/__init__.py
@@ -25,10 +25,10 @@ from sentry_sdk.profiler.utils import (
 )
 
 __all__ = [
-    "start_profile_session", # TODO: Deprecate this in favor of `start_profiler`
-    "start_profiler",  
-    "stop_profile_session", # TODO: Deprecate this in favor of `stop_profiler`
-    "stop_profiler",  
+    "start_profile_session",  # TODO: Deprecate this in favor of `start_profiler`
+    "start_profiler",
+    "stop_profile_session",  # TODO: Deprecate this in favor of `stop_profiler`
+    "stop_profiler",
     # DEPRECATED: The following was re-exported for backwards compatibility. It
     # will be removed from sentry_sdk.profiler in a future release.
     "MAX_PROFILE_DURATION_NS",

--- a/sentry_sdk/profiler/continuous_profiler.py
+++ b/sentry_sdk/profiler/continuous_profiler.py
@@ -145,32 +145,34 @@ def try_profile_lifecycle_trace_start():
 
 def start_profiler():
     # type: () -> None
-
-    # TODO: deprecate this as it'll be replaced by `start_profile_session`
-    start_profile_session()
-
-
-def start_profile_session():
-    # type: () -> None
     if _scheduler is None:
         return
 
     _scheduler.manual_start()
 
 
-def stop_profiler():
+
+def start_profile_session():
     # type: () -> None
 
-    # TODO: deprecate this as it'll be replaced by `stop_profile_session`
-    stop_profile_session()
+    # TODO: deprecate this as it'll be replaced by `start_profiler`
+    start_profiler()
 
 
-def stop_profile_session():
+def stop_profiler():
     # type: () -> None
     if _scheduler is None:
         return
 
     _scheduler.manual_stop()
+
+
+def stop_profile_session():
+    # type: () -> None
+
+    # TODO: deprecate this as it'll be replaced by `stop_profiler`
+    stop_profiler()
+
 
 
 def teardown_continuous_profiler():

--- a/sentry_sdk/profiler/continuous_profiler.py
+++ b/sentry_sdk/profiler/continuous_profiler.py
@@ -151,7 +151,6 @@ def start_profiler():
     _scheduler.manual_start()
 
 
-
 def start_profile_session():
     # type: () -> None
 
@@ -172,7 +171,6 @@ def stop_profile_session():
 
     # TODO: deprecate this as it'll be replaced by `stop_profiler`
     stop_profiler()
-
 
 
 def teardown_continuous_profiler():


### PR DESCRIPTION
Revert back to using `start_profiler` and `stop_profiler` function names and deprecate the `*_session` ones instead.

Prior PR that introduced the change we're undoing: https://github.com/getsentry/sentry-python/pull/4056 