### PR TITLE
fix(integrations/dramatiq): use set_transaction_name

### DIFF
--- a/sentry_sdk/integrations/dramatiq.py
+++ b/sentry_sdk/integrations/dramatiq.py
@@ -95,7 +95,7 @@ class SentryMiddleware(Middleware):  # type: ignore[misc]
         message._scope_manager.__enter__()
 
         scope = sentry_sdk.get_current_scope()
-        scope.transaction = message.actor_name
+        scope.set_transaction_name(message.actor_name)
         scope.set_extra("dramatiq_message_id", message.message_id)
         scope.add_event_processor(_make_message_event_processor(message, integration))
 


### PR DESCRIPTION
The Dramatiq integration is using a deprecated method to set the scope's transaction name, use set_transaction_name instead.

"Assigning to scope.transaction directly is deprecated: use scope.set_transaction_name() instead."

<!-- Describe your PR here -->

---

Thank you for contributing to `sentry-python`! Please add tests to validate your changes, and lint your code using `tox -e linters`.

Running the test suite on your PR might require maintainer approval.