### PR TITLE
chore: Drop more deprecated stuff

### DIFF
--- a/MIGRATION_GUIDE.md
+++ b/MIGRATION_GUIDE.md
@@ -17,6 +17,8 @@ Looking to upgrade from Sentry SDK 2.x to 3.x? Here's a comprehensive list of wh
 - `Span.finish()` no longer returns the `event_id` if the event is sent to sentry.
 - The `Profile()` constructor does not accept a `hub` parameter anymore.
 - A `Profile` object does not have a `.hub` property anymore.
+- `MAX_PROFILE_DURATION_NS`, `PROFILE_MINIMUM_SAMPLES`, `Profile`, `Scheduler`, `ThreadScheduler`, `GeventScheduler`, `has_profiling_enabled`, `setup_profiler`, `teardown_profiler` are no longer accessible from `sentry_sdk.profiler`. They're still accessible from `sentry_sdk.profiler.transaction_profiler`.
+- `DEFAULT_SAMPLING_FREQUENCY`, `MAX_STACK_DEPTH`, `get_frame_name`, `extract_frame`, `extract_stack`, `frame_id` are no longer accessible from `sentry_sdk.profiler`. They're still accessible from `sentry_sdk.profiler.utils`.
 - `sentry_sdk.continue_trace` no longer returns a `Transaction` and is now a context manager.
 - Redis integration: In Redis pipeline spans there is no `span["data"]["redis.commands"]` that contains a dict `{"count": 3, "first_ten": ["cmd1", "cmd2", ...]}` but instead `span["data"]["redis.commands.count"]` (containing `3`) and `span["data"]["redis.commands.first_ten"]` (containing `["cmd1", "cmd2", ...]`).
 - clickhouse-driver integration: The query is now available under the `db.query.text` span attribute (only if `send_default_pii` is `True`).
@@ -130,6 +132,7 @@ Looking to upgrade from Sentry SDK 2.x to 3.x? Here's a comprehensive list of wh
 
 - Spans no longer have a `description`. Use `name` instead.
 - Dropped support for Python 3.6.
+- The `enable_tracing` `init` option has been removed. Configure `traces_sample_rate` directly.
 - The `custom_sampling_context` parameter of `start_transaction` has been removed. Use `attributes` instead to set key-value pairs of data that should be accessible in the traces sampler. Note that span attributes need to conform to the [OpenTelemetry specification](https://opentelemetry.io/docs/concepts/signals/traces/#attributes), meaning only certain types can be set as values.
 - The PyMongo integration no longer sets tags. The data is still accessible via span attributes.
 - The PyMongo integration doesn't set `operation_ids` anymore. The individual IDs (`operation_id`, `request_id`, `session_id`) are now accessible as separate span attributes.
@@ -141,13 +144,17 @@ Looking to upgrade from Sentry SDK 2.x to 3.x? Here's a comprehensive list of wh
 - The context manager `auto_session_tracking()` has been removed. Use `track_session()` instead.
 - The context manager `auto_session_tracking_scope()` has been removed. Use `track_session()` instead.
 - Utility function `is_auto_session_tracking_enabled()` has been removed. There is no public replacement. There is a private `_is_auto_session_tracking_enabled()` (if you absolutely need this function) It accepts a `scope` parameter instead of the previously used `hub` parameter.
-- Utility function `is_auto_session_tracking_enabled_scope()` has been removed. There is no public replacement. There is a private `_is_auto_session_tracking_enabled()` (if you absolutely need this function)
+- Utility function `is_auto_session_tracking_enabled_scope()` has been removed. There is no public replacement. There is a private `_is_auto_session_tracking_enabled()` (if you absolutely need this function).
 - Setting `scope.level` has been removed. Use `scope.set_level` instead.
 - `span.containing_transaction` has been removed. Use `span.root_span` instead.
 - `continue_from_headers`, `continue_from_environ` and `from_traceparent` have been removed, please use top-level API `sentry_sdk.continue_trace` instead.
 - `PropagationContext` constructor no longer takes a `dynamic_sampling_context` but takes a `baggage` object instead.
 - `ThreadingIntegration` no longer takes the `propagate_hub` argument.
 - `Baggage.populate_from_transaction` has been removed.
+- `debug.configure_debug_hub` was removed.
+- `profiles_sample_rate` and `profiler_mode` were removed from options available via `_experiments`. Use the top-level `profiles_sample_rate` and `profiler_mode` options instead.
+- `Transport.capture_event` has been removed. Use `Transport.capture_envelope` instead.
+- Function transports are no longer supported. Subclass the `Transport` instead.
 
 ### Deprecated
 

--- a/sentry_sdk/client.py
+++ b/sentry_sdk/client.py
@@ -9,7 +9,6 @@ from collections.abc import Mapping
 from datetime import datetime, timezone
 from importlib import import_module
 from typing import TYPE_CHECKING, List, Dict, cast, overload
-import warnings
 
 from sentry_sdk._compat import check_uwsgi_thread_support
 from sentry_sdk.utils import (
@@ -121,9 +120,6 @@ def _get_options(*args, **kwargs):
 
         rv["project_root"] = project_root
 
-    if rv["enable_tracing"] is True and rv["traces_sample_rate"] is None:
-        rv["traces_sample_rate"] = 1.0
-
     if rv["event_scrubber"] is None:
         rv["event_scrubber"] = EventScrubber(
             send_default_pii=(
@@ -136,13 +132,6 @@ def _get_options(*args, **kwargs):
             "Ignoring socket_options because of unexpected format. See urllib3.HTTPConnection.socket_options for the expected format."
         )
         rv["socket_options"] = None
-
-    if rv["enable_tracing"] is not None:
-        warnings.warn(
-            "The `enable_tracing` parameter is deprecated. Please use `traces_sample_rate` instead.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
 
     return rv
 

--- a/sentry_sdk/consts.py
+++ b/sentry_sdk/consts.py
@@ -526,7 +526,6 @@ class ClientConstructor:
         proxy_headers=None,  # type: Optional[Dict[str, str]]
         before_send_transaction=None,  # type: Optional[TransactionProcessor]
         project_root=None,  # type: Optional[str]
-        enable_tracing=None,  # type: Optional[bool]
         include_local_variables=True,  # type: Optional[bool]
         include_source_context=True,  # type: Optional[bool]
         trace_propagation_targets=[  # noqa: B006
@@ -914,9 +913,6 @@ class ClientConstructor:
         :param profile_lifecycle:
 
         :param profile_session_sample_rate:
-
-
-        :param enable_tracing:
 
         :param propagate_traces:
 

--- a/sentry_sdk/debug.py
+++ b/sentry_sdk/debug.py
@@ -1,6 +1,5 @@
 import sys
 import logging
-import warnings
 
 from sentry_sdk import get_client
 from sentry_sdk.client import _client_init_debug
@@ -30,12 +29,3 @@ def configure_logger():
     logger.addHandler(_handler)
     logger.setLevel(logging.DEBUG)
     logger.addFilter(_DebugFilter())
-
-
-def configure_debug_hub():
-    # type: () -> None
-    warnings.warn(
-        "configure_debug_hub is deprecated. Please remove calls to it, as it is a no-op.",
-        DeprecationWarning,
-        stacklevel=2,
-    )

--- a/sentry_sdk/profiler/__init__.py
+++ b/sentry_sdk/profiler/__init__.py
@@ -2,38 +2,8 @@ from sentry_sdk.profiler.continuous_profiler import (
     start_profiler,
     stop_profiler,
 )
-from sentry_sdk.profiler.transaction_profiler import (
-    Profile,
-    Scheduler,
-    ThreadScheduler,
-    GeventScheduler,
-    has_profiling_enabled,
-    setup_profiler,
-    teardown_profiler,
-)
-from sentry_sdk.profiler.utils import (
-    DEFAULT_SAMPLING_FREQUENCY,
-    MAX_STACK_DEPTH,
-    get_frame_name,
-    extract_frame,
-    extract_stack,
-    frame_id,
-)
 
 __all__ = [
     "start_profiler",
     "stop_profiler",
-    "Profile",
-    "Scheduler",
-    "ThreadScheduler",
-    "GeventScheduler",
-    "has_profiling_enabled",
-    "setup_profiler",
-    "teardown_profiler",
-    "DEFAULT_SAMPLING_FREQUENCY",
-    "MAX_STACK_DEPTH",
-    "get_frame_name",
-    "extract_frame",
-    "extract_stack",
-    "frame_id",
 ]

--- a/sentry_sdk/profiler/__init__.py
+++ b/sentry_sdk/profiler/__init__.py
@@ -3,8 +3,6 @@ from sentry_sdk.profiler.continuous_profiler import (
     stop_profiler,
 )
 from sentry_sdk.profiler.transaction_profiler import (
-    MAX_PROFILE_DURATION_NS,
-    PROFILE_MINIMUM_SAMPLES,
     Profile,
     Scheduler,
     ThreadScheduler,
@@ -25,10 +23,6 @@ from sentry_sdk.profiler.utils import (
 __all__ = [
     "start_profiler",
     "stop_profiler",
-    # DEPRECATED: The following was re-exported for backwards compatibility. It
-    # will be removed from sentry_sdk.profiler in a future release.
-    "MAX_PROFILE_DURATION_NS",
-    "PROFILE_MINIMUM_SAMPLES",
     "Profile",
     "Scheduler",
     "ThreadScheduler",

--- a/sentry_sdk/profiler/continuous_profiler.py
+++ b/sentry_sdk/profiler/continuous_profiler.py
@@ -87,15 +87,9 @@ def setup_continuous_profiler(options, sdk_info, capture_func):
     else:
         default_profiler_mode = ThreadContinuousScheduler.mode
 
+    profiler_mode = default_profiler_mode
     if options.get("profiler_mode") is not None:
         profiler_mode = options["profiler_mode"]
-    else:
-        # TODO: deprecate this and just use the existing `profiler_mode`
-        experiments = options.get("_experiments", {})
-
-        profiler_mode = (
-            experiments.get("continuous_profiling_mode") or default_profiler_mode
-        )
 
     frequency = DEFAULT_SAMPLING_FREQUENCY
 

--- a/sentry_sdk/profiler/transaction_profiler.py
+++ b/sentry_sdk/profiler/transaction_profiler.py
@@ -270,8 +270,6 @@ class Profile:
             sample_rate = options["profiles_sampler"](sampling_context)
         elif options["profiles_sample_rate"] is not None:
             sample_rate = options["profiles_sample_rate"]
-        else:
-            sample_rate = options["_experiments"].get("profiles_sample_rate")
 
         # The profiles_sample_rate option was not set, so profiling
         # was never enabled.

--- a/sentry_sdk/profiler/transaction_profiler.py
+++ b/sentry_sdk/profiler/transaction_profiler.py
@@ -266,6 +266,7 @@ class Profile:
 
         options = client.options
 
+        sample_rate = None
         if callable(options.get("profiles_sampler")):
             sample_rate = options["profiles_sampler"](sampling_context)
         elif options["profiles_sample_rate"] is not None:

--- a/sentry_sdk/profiler/transaction_profiler.py
+++ b/sentry_sdk/profiler/transaction_profiler.py
@@ -125,16 +125,6 @@ def has_profiling_enabled(options):
     if profiles_sample_rate is not None and profiles_sample_rate > 0:
         return True
 
-    profiles_sample_rate = options["_experiments"].get("profiles_sample_rate")
-    if profiles_sample_rate is not None:
-        logger.warning(
-            "_experiments['profiles_sample_rate'] is deprecated. "
-            "Please use the non-experimental profiles_sample_rate option "
-            "directly."
-        )
-        if profiles_sample_rate > 0:
-            return True
-
     return False
 
 
@@ -157,16 +147,9 @@ def setup_profiler(options):
     else:
         default_profiler_mode = ThreadScheduler.mode
 
+    profiler_mode = default_profiler_mode
     if options.get("profiler_mode") is not None:
         profiler_mode = options["profiler_mode"]
-    else:
-        profiler_mode = options.get("_experiments", {}).get("profiler_mode")
-        if profiler_mode is not None:
-            logger.warning(
-                "_experiments['profiler_mode'] is deprecated. Please use the "
-                "non-experimental profiler_mode option directly."
-            )
-        profiler_mode = profiler_mode or default_profiler_mode
 
     if (
         profiler_mode == ThreadScheduler.mode

--- a/sentry_sdk/tracing_utils.py
+++ b/sentry_sdk/tracing_utils.py
@@ -93,17 +93,14 @@ def has_tracing_enabled(options):
     # type: (Optional[Dict[str, Any]]) -> bool
     """
     Returns True if either traces_sample_rate or traces_sampler is
-    defined and enable_tracing is set and not false.
+    defined.
     """
     if options is None:
         return False
 
     return bool(
-        options.get("enable_tracing") is not False
-        and (
-            options.get("traces_sample_rate") is not None
-            or options.get("traces_sampler") is not None
-        )
+        options.get("traces_sample_rate") is not None
+        or options.get("traces_sampler") is not None
     )
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -28,7 +28,7 @@ from sentry_sdk.integrations import (  # noqa: F401
     _installed_integrations,
     _processed_integrations,
 )
-from sentry_sdk.profiler import teardown_profiler
+from sentry_sdk.profiler.transaction_profiler import teardown_profiler
 from sentry_sdk.profiler.continuous_profiler import teardown_continuous_profiler
 from sentry_sdk.transport import Transport
 from sentry_sdk.utils import reraise

--- a/tests/integrations/celery/test_celery.py
+++ b/tests/integrations/celery/test_celery.py
@@ -611,7 +611,7 @@ def test_apply_async_no_args(init_celery):
 def test_messaging_destination_name_default_exchange(
     mock_request, routing_key, init_celery, capture_events
 ):
-    celery_app = init_celery(enable_tracing=True)
+    celery_app = init_celery(traces_sample_rate=1.0)
     events = capture_events()
     mock_request.delivery_info = {"routing_key": routing_key, "exchange": ""}
 
@@ -635,7 +635,7 @@ def test_messaging_destination_name_nondefault_exchange(
     that the routing key is the queue name. Other exchanges may not guarantee this
     behavior.
     """
-    celery_app = init_celery(enable_tracing=True)
+    celery_app = init_celery(traces_sample_rate=1.0)
     events = capture_events()
     mock_request.delivery_info = {"routing_key": "celery", "exchange": "custom"}
 
@@ -650,7 +650,7 @@ def test_messaging_destination_name_nondefault_exchange(
 
 
 def test_messaging_id(init_celery, capture_events):
-    celery = init_celery(enable_tracing=True)
+    celery = init_celery(traces_sample_rate=1.0)
     events = capture_events()
 
     @celery.task
@@ -664,7 +664,7 @@ def test_messaging_id(init_celery, capture_events):
 
 
 def test_retry_count_zero(init_celery, capture_events):
-    celery = init_celery(enable_tracing=True)
+    celery = init_celery(traces_sample_rate=1.0)
     events = capture_events()
 
     @celery.task()
@@ -681,7 +681,7 @@ def test_retry_count_zero(init_celery, capture_events):
 def test_retry_count_nonzero(mock_request, init_celery, capture_events):
     mock_request.retries = 3
 
-    celery = init_celery(enable_tracing=True)
+    celery = init_celery(traces_sample_rate=1.0)
     events = capture_events()
 
     @celery.task()
@@ -696,7 +696,7 @@ def test_retry_count_nonzero(mock_request, init_celery, capture_events):
 
 @pytest.mark.parametrize("system", ("redis", "amqp"))
 def test_messaging_system(system, init_celery, capture_events):
-    celery = init_celery(enable_tracing=True)
+    celery = init_celery(traces_sample_rate=1.0)
     events = capture_events()
 
     # Does not need to be a real URL, since we use always eager
@@ -721,7 +721,7 @@ def test_producer_span_data(system, monkeypatch, sentry_init, capture_events):
 
     monkeypatch.setattr(kombu.messaging.Producer, "_publish", publish)
 
-    sentry_init(integrations=[CeleryIntegration()], enable_tracing=True)
+    sentry_init(integrations=[CeleryIntegration()], traces_sample_rate=1.0)
     celery = Celery(__name__, broker=f"{system}://example.com")  # noqa: E231
     events = capture_events()
 
@@ -759,7 +759,7 @@ def test_receive_latency(init_celery, capture_events):
 
 
 def tests_span_origin_consumer(init_celery, capture_events):
-    celery = init_celery(enable_tracing=True)
+    celery = init_celery(traces_sample_rate=1.0)
     celery.conf.broker_url = "redis://example.com"  # noqa: E231
 
     events = capture_events()
@@ -783,7 +783,7 @@ def tests_span_origin_producer(monkeypatch, sentry_init, capture_events):
 
     monkeypatch.setattr(kombu.messaging.Producer, "_publish", publish)
 
-    sentry_init(integrations=[CeleryIntegration()], enable_tracing=True)
+    sentry_init(integrations=[CeleryIntegration()], traces_sample_rate=1.0)
     celery = Celery(__name__, broker="redis://example.com")  # noqa: E231
 
     events = capture_events()
@@ -812,7 +812,7 @@ def test_send_task_wrapped(
     capture_events,
     reset_integrations,
 ):
-    sentry_init(integrations=[CeleryIntegration()], enable_tracing=True)
+    sentry_init(integrations=[CeleryIntegration()], traces_sample_rate=1.0)
     celery = Celery(__name__, broker="redis://example.com")  # noqa: E231
 
     events = capture_events()

--- a/tests/integrations/celery/test_update_celery_task_headers.py
+++ b/tests/integrations/celery/test_update_celery_task_headers.py
@@ -71,7 +71,7 @@ def test_monitor_beat_tasks_with_headers(monitor_beat_tasks):
 
 
 def test_span_with_transaction(sentry_init):
-    sentry_init(enable_tracing=True)
+    sentry_init(traces_sample_rate=1.0)
     headers = {}
     monitor_beat_tasks = False
 
@@ -91,7 +91,7 @@ def test_span_with_transaction(sentry_init):
 
 
 def test_span_with_transaction_custom_headers(sentry_init):
-    sentry_init(enable_tracing=True)
+    sentry_init(traces_sample_rate=1.0)
     headers = {
         "baggage": BAGGAGE_VALUE,
         "sentry-trace": SENTRY_TRACE_VALUE,
@@ -171,42 +171,6 @@ def test_celery_trace_propagation_traces_sample_rate(
     https://docs.sentry.io/platforms/python/integrations/celery/#distributed-traces
     """
     sentry_init(traces_sample_rate=traces_sample_rate)
-
-    headers = {}
-    span = None
-
-    scope = sentry_sdk.get_isolation_scope()
-
-    outgoing_headers = _update_celery_task_headers(headers, span, monitor_beat_tasks)
-
-    assert outgoing_headers["sentry-trace"] == scope.get_traceparent()
-    assert outgoing_headers["headers"]["sentry-trace"] == scope.get_traceparent()
-    assert outgoing_headers["baggage"] == scope.get_baggage().serialize()
-    assert outgoing_headers["headers"]["baggage"] == scope.get_baggage().serialize()
-
-    if monitor_beat_tasks:
-        assert "sentry-monitor-start-timestamp-s" in outgoing_headers
-        assert "sentry-monitor-start-timestamp-s" in outgoing_headers["headers"]
-    else:
-        assert "sentry-monitor-start-timestamp-s" not in outgoing_headers
-        assert "sentry-monitor-start-timestamp-s" not in outgoing_headers["headers"]
-
-
-@pytest.mark.parametrize(
-    "enable_tracing,monitor_beat_tasks",
-    list(itertools.product([None, True, False], [True, False])),
-)
-def test_celery_trace_propagation_enable_tracing(
-    sentry_init, enable_tracing, monitor_beat_tasks
-):
-    """
-    The celery integration does not check the traces_sample_rate.
-    By default traces_sample_rate is None which means "do not propagate traces".
-    But the celery integration does not check this value.
-    The Celery integration has its own mechanism to propagate traces:
-    https://docs.sentry.io/platforms/python/integrations/celery/#distributed-traces
-    """
-    sentry_init(enable_tracing=enable_tracing)
 
     headers = {}
     span = None

--- a/tests/integrations/graphene/test_graphene.py
+++ b/tests/integrations/graphene/test_graphene.py
@@ -207,7 +207,7 @@ def test_no_event_if_no_errors_sync(sentry_init, capture_events):
 def test_graphql_span_holds_query_information(sentry_init, capture_events):
     sentry_init(
         integrations=[GrapheneIntegration(), FlaskIntegration()],
-        enable_tracing=True,
+        traces_sample_rate=1.0,
         default_integrations=False,
     )
     events = capture_events()

--- a/tests/integrations/sqlalchemy/test_sqlalchemy.py
+++ b/tests/integrations/sqlalchemy/test_sqlalchemy.py
@@ -295,14 +295,12 @@ def test_engine_name_not_string(sentry_init):
 
 
 def test_query_source_disabled(sentry_init, capture_events):
-    sentry_options = {
-        "integrations": [SqlalchemyIntegration()],
-        "enable_tracing": True,
-        "enable_db_query_source": False,
-        "db_query_source_threshold_ms": 0,
-    }
-
-    sentry_init(**sentry_options)
+    sentry_init(
+        integrations=[SqlalchemyIntegration()],
+        traces_sample_rate=1.0,
+        enable_db_query_source=False,
+        db_query_source_threshold_ms=0,
+    )
 
     events = capture_events()
 
@@ -348,7 +346,7 @@ def test_query_source_disabled(sentry_init, capture_events):
 def test_query_source_enabled(sentry_init, capture_events, enable_db_query_source):
     sentry_options = {
         "integrations": [SqlalchemyIntegration()],
-        "enable_tracing": True,
+        "traces_sample_rate": 1.0,
         "db_query_source_threshold_ms": 0,
     }
     if enable_db_query_source is not None:
@@ -399,7 +397,7 @@ def test_query_source_enabled(sentry_init, capture_events, enable_db_query_sourc
 def test_query_source(sentry_init, capture_events):
     sentry_init(
         integrations=[SqlalchemyIntegration()],
-        enable_tracing=True,
+        traces_sample_rate=1.0,
         enable_db_query_source=True,
         db_query_source_threshold_ms=0,
     )
@@ -464,7 +462,7 @@ def test_query_source_with_module_in_search_path(sentry_init, capture_events):
     """
     sentry_init(
         integrations=[SqlalchemyIntegration()],
-        enable_tracing=True,
+        traces_sample_rate=1.0,
         enable_db_query_source=True,
         db_query_source_threshold_ms=0,
     )
@@ -527,7 +525,7 @@ def test_query_source_with_module_in_search_path(sentry_init, capture_events):
 def test_no_query_source_if_duration_too_short(sentry_init, capture_events):
     sentry_init(
         integrations=[SqlalchemyIntegration()],
-        enable_tracing=True,
+        traces_sample_rate=1.0,
         enable_db_query_source=True,
         db_query_source_threshold_ms=100,
     )
@@ -595,7 +593,7 @@ def test_no_query_source_if_duration_too_short(sentry_init, capture_events):
 def test_query_source_if_duration_over_threshold(sentry_init, capture_events):
     sentry_init(
         integrations=[SqlalchemyIntegration()],
-        enable_tracing=True,
+        traces_sample_rate=1.0,
         enable_db_query_source=True,
         db_query_source_threshold_ms=100,
     )

--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -33,7 +33,6 @@ from sentry_sdk.integrations.logging import LoggingIntegration
 from sentry_sdk.integrations.stdlib import StdlibIntegration
 from sentry_sdk.scope import add_global_event_processor
 from sentry_sdk.utils import datetime_from_isoformat, get_sdk_name, reraise
-from sentry_sdk.tracing_utils import has_tracing_enabled
 
 
 class NoOpIntegration(Integration):
@@ -247,32 +246,6 @@ def test_option_before_breadcrumb(sentry_init, capture_events, monkeypatch):
     assert crumb["message"] == "Hello"
     assert crumb["data"] == {"foo": "bar"}
     assert crumb["type"] == "default"
-
-
-@pytest.mark.parametrize(
-    "enable_tracing, traces_sample_rate, tracing_enabled, updated_traces_sample_rate",
-    [
-        (None, None, False, None),
-        (False, 0.0, False, 0.0),
-        (False, 1.0, False, 1.0),
-        (None, 1.0, True, 1.0),
-        (True, 1.0, True, 1.0),
-        (None, 0.0, True, 0.0),  # We use this as - it's configured but turned off
-        (True, 0.0, True, 0.0),  # We use this as - it's configured but turned off
-        (True, None, True, 1.0),
-    ],
-)
-def test_option_enable_tracing(
-    sentry_init,
-    enable_tracing,
-    traces_sample_rate,
-    tracing_enabled,
-    updated_traces_sample_rate,
-):
-    sentry_init(enable_tracing=enable_tracing, traces_sample_rate=traces_sample_rate)
-    options = sentry_sdk.get_client().options
-    assert has_tracing_enabled(options) is tracing_enabled
-    assert options["traces_sample_rate"] == updated_traces_sample_rate
 
 
 def test_breadcrumb_arguments(sentry_init, capture_events):
@@ -839,7 +812,7 @@ def test_classmethod_tracing(sentry_init):
 
 
 def test_last_event_id(sentry_init):
-    sentry_init(enable_tracing=True)
+    sentry_init(traces_sample_rate=1.0)
 
     assert last_event_id() is None
 
@@ -849,7 +822,7 @@ def test_last_event_id(sentry_init):
 
 
 def test_last_event_id_transaction(sentry_init):
-    sentry_init(enable_tracing=True)
+    sentry_init(traces_sample_rate=1.0)
 
     assert last_event_id() is None
 
@@ -860,7 +833,7 @@ def test_last_event_id_transaction(sentry_init):
 
 
 def test_last_event_id_scope(sentry_init):
-    sentry_init(enable_tracing=True)
+    sentry_init(traces_sample_rate=1.0)
 
     # Should not crash
     with isolation_scope() as scope:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1440,9 +1440,3 @@ class TestSpanClientReports:
 )
 def test_dropped_transaction(sentry_init, capture_record_lost_event_calls, test_config):
     test_config.run(sentry_init, capture_record_lost_event_calls)
-
-
-@pytest.mark.parametrize("enable_tracing", [True, False])
-def test_enable_tracing_deprecated(sentry_init, enable_tracing):
-    with pytest.warns(DeprecationWarning):
-        sentry_init(enable_tracing=enable_tracing)

--- a/tests/test_scope.py
+++ b/tests/test_scope.py
@@ -884,7 +884,7 @@ def test_set_tags():
 
 
 def test_last_event_id(sentry_init):
-    sentry_init(enable_tracing=True)
+    sentry_init(traces_sample_rate=1.0)
 
     assert Scope.last_event_id() is None
 
@@ -894,7 +894,7 @@ def test_last_event_id(sentry_init):
 
 
 def test_last_event_id_transaction(sentry_init):
-    sentry_init(enable_tracing=True)
+    sentry_init(traces_sample_rate=1.0)
 
     assert Scope.last_event_id() is None
 
@@ -905,7 +905,7 @@ def test_last_event_id_transaction(sentry_init):
 
 
 def test_last_event_id_cleared(sentry_init):
-    sentry_init(enable_tracing=True)
+    sentry_init(traces_sample_rate=1.0)
 
     # Make sure last_event_id is set
     sentry_sdk.capture_exception(Exception("test"))


### PR DESCRIPTION
Remove the following deprecated stuff:
- `configure_debug_hub` from `debug.py`
- exported stuff in `profiler/__init__.py` that's not part of public API and was only exported for backwards compat reasons
- support for `_experiments['profiler_mode']` and `_experiments['profiles_sample_rate']` which both have non-experimental top-level options now
- `Transport.capture_event`
- `_FunctionTransport` and support for function transports in general
- `enable_tracing`