### PR TITLE
feat(profiling): add platform header to the chunk item-type in the envelope

### DIFF
--- a/sentry_sdk/envelope.py
+++ b/sentry_sdk/envelope.py
@@ -82,7 +82,7 @@ class Envelope:
             Item(
                 payload=PayloadRef(json=profile_chunk),
                 type="profile_chunk",
-                headers={"platform": profile_chunk.get("platform")},
+                headers={"platform": profile_chunk.get("platform", "python")},
             )
         )
 

--- a/sentry_sdk/envelope.py
+++ b/sentry_sdk/envelope.py
@@ -79,7 +79,7 @@ class Envelope:
     ):
         # type: (...) -> None
         self.add_item(
-            Item(payload=PayloadRef(json=profile_chunk), type="profile_chunk")
+            Item(payload=PayloadRef(json=profile_chunk), type="profile_chunk", headers={"platform": profile_chunk.get("platform")})
         )
 
     def add_checkin(

--- a/sentry_sdk/envelope.py
+++ b/sentry_sdk/envelope.py
@@ -79,7 +79,11 @@ class Envelope:
     ):
         # type: (...) -> None
         self.add_item(
-            Item(payload=PayloadRef(json=profile_chunk), type="profile_chunk", headers={"platform": profile_chunk.get("platform")})
+            Item(
+                payload=PayloadRef(json=profile_chunk),
+                type="profile_chunk",
+                headers={"platform": profile_chunk.get("platform")},
+            )
         )
 
     def add_checkin(

--- a/tests/profiler/test_continuous_profiler.py
+++ b/tests/profiler/test_continuous_profiler.py
@@ -141,6 +141,11 @@ def assert_single_transaction_with_profile_chunks(
     if max_chunks is not None:
         assert len(items["profile_chunk"]) <= max_chunks
 
+    for chunk_item in items["profile_chunk"]:
+        chunk = chunk_item.payload.json
+        headers = chunk_item.headers
+        assert chunk["platform"]==headers["platform"]
+
     transaction = items["transaction"][0].payload.json
 
     trace_context = transaction["contexts"]["trace"]
@@ -215,12 +220,12 @@ def assert_single_transaction_without_profile_chunks(envelopes):
         pytest.param(
             start_profile_session,
             stop_profile_session,
-            id="start_profile_session/stop_profile_session",
+            id="start_profile_session/stop_profile_session (deprecated)",
         ),
         pytest.param(
             start_profiler,
             stop_profiler,
-            id="start_profiler/stop_profiler (deprecated)",
+            id="start_profiler/stop_profiler",
         ),
     ],
 )
@@ -292,12 +297,12 @@ def test_continuous_profiler_auto_start_and_manual_stop(
         pytest.param(
             start_profile_session,
             stop_profile_session,
-            id="start_profile_session/stop_profile_session",
+            id="start_profile_session/stop_profile_session  (deprecated)",
         ),
         pytest.param(
             start_profiler,
             stop_profiler,
-            id="start_profiler/stop_profiler (deprecated)",
+            id="start_profiler/stop_profiler",
         ),
     ],
 )
@@ -374,12 +379,12 @@ def test_continuous_profiler_manual_start_and_stop_sampled(
         pytest.param(
             start_profile_session,
             stop_profile_session,
-            id="start_profile_session/stop_profile_session",
+            id="start_profile_session/stop_profile_session (deprecated)",
         ),
         pytest.param(
             start_profiler,
             stop_profiler,
-            id="start_profiler/stop_profiler (deprecated)",
+            id="start_profiler/stop_profiler",
         ),
     ],
 )
@@ -544,12 +549,12 @@ def test_continuous_profiler_auto_start_and_stop_unsampled(
         pytest.param(
             start_profile_session,
             stop_profile_session,
-            id="start_profile_session/stop_profile_session",
+            id="start_profile_session/stop_profile_session (deprecated)",
         ),
         pytest.param(
             start_profiler,
             stop_profiler,
-            id="start_profiler/stop_profiler (deprecated)",
+            id="start_profiler/stop_profiler",
         ),
     ],
 )

--- a/tests/profiler/test_continuous_profiler.py
+++ b/tests/profiler/test_continuous_profiler.py
@@ -144,7 +144,7 @@ def assert_single_transaction_with_profile_chunks(
     for chunk_item in items["profile_chunk"]:
         chunk = chunk_item.payload.json
         headers = chunk_item.headers
-        assert chunk["platform"]==headers["platform"]
+        assert chunk["platform"] == headers["platform"]
 
     transaction = items["transaction"][0].payload.json
 


### PR DESCRIPTION
We need to send the platform as part of the headers in the chunk item-type as this is the header that relay is checking to manage rate limiting.