### PR TITLE
fix: Always set _spotlight_url

### DIFF
--- a/sentry_sdk/spotlight.py
+++ b/sentry_sdk/spotlight.py
@@ -104,7 +104,7 @@ try:
         @property
         def spotlight_script(self):
             # type: (Self) -> Optional[str]
-            if self._spotlight_script is None:
+            if self._spotlight_url is not None and self._spotlight_script is None:
                 try:
                     spotlight_js_url = urllib.parse.urljoin(
                         self._spotlight_url, SPOTLIGHT_JS_ENTRY_PATH
@@ -174,7 +174,7 @@ try:
 
         def process_exception(self, _request, exception):
             # type: (Self, HttpRequest, Exception) -> Optional[HttpResponseServerError]
-            if not settings.DEBUG:
+            if not settings.DEBUG or not self._spotlight_url:
                 return None
 
             try:

--- a/sentry_sdk/spotlight.py
+++ b/sentry_sdk/spotlight.py
@@ -82,11 +82,11 @@ try:
 
     class SpotlightMiddleware(MiddlewareMixin):  # type: ignore[misc]
         _spotlight_script = None  # type: Optional[str]
+        _spotlight_url = None  # type: Optional[str]
 
         def __init__(self, get_response):
             # type: (Self, Callable[..., HttpResponse]) -> None
             super().__init__(get_response)
-            self._spotlight_script = None
 
             import sentry_sdk.api
 

--- a/sentry_sdk/spotlight.py
+++ b/sentry_sdk/spotlight.py
@@ -86,7 +86,7 @@ try:
         def __init__(self, get_response):
             # type: (Self, Callable[..., HttpResponse]) -> None
             super().__init__(get_response)
-            _spotlight_script = None
+            self._spotlight_script = None
 
             import sentry_sdk.api
 

--- a/sentry_sdk/spotlight.py
+++ b/sentry_sdk/spotlight.py
@@ -86,6 +86,7 @@ try:
         def __init__(self, get_response):
             # type: (Self, Callable[..., HttpResponse]) -> None
             super().__init__(get_response)
+            _spotlight_script = None
 
             import sentry_sdk.api
 


### PR DESCRIPTION
The conditional early exit in `SpotlightMiddleware` may cause attribute access errors when trying to check if `_spotlight_url` is set or not. This patch sets it to `None` explicitly at class level.
