### PR TITLE
Broader except in django parsed_body

### DIFF
--- a/sentry_sdk/integrations/django/__init__.py
+++ b/sentry_sdk/integrations/django/__init__.py
@@ -584,7 +584,7 @@ class DjangoRequestExtractor(RequestExtractor):
         # type: () -> Optional[Dict[str, Any]]
         try:
             return self.request.data
-        except AttributeError:
+        except Exception:
             return RequestExtractor.parsed_body(self)
 
 


### PR DESCRIPTION
We are seeing internal errors in the Sentry SDK if `self.request.data` fails. Specifically, it recently failed with `rest_framework.exceptions.UnsupportedMediaType: Unsupported media type "" in request.`.

This exception should not prevent sentry from reporting the original error. 

Similar to a previous fix I made https://github.com/getsentry/sentry-python/pull/4001