### PR TITLE
fix: Don't hang when capturing long stacktrace

### DIFF
--- a/sentry_sdk/_types.py
+++ b/sentry_sdk/_types.py
@@ -47,11 +47,14 @@ class AnnotatedValue:
         )
 
     @classmethod
-    def removed_because_over_size_limit(cls):
-        # type: () -> AnnotatedValue
-        """The actual value was removed because the size of the field exceeded the configured maximum size (specified with the max_request_body_size sdk option)"""
+    def removed_because_over_size_limit(cls, value=""):
+        # type: (Any) -> AnnotatedValue
+        """
+        The actual value was removed because the size of the field exceeded the configured maximum size,
+        for example specified with the max_request_body_size sdk option.
+        """
         return AnnotatedValue(
-            value="",
+            value=value,
             metadata={
                 "rem": [  # Remark
                     [
@@ -160,7 +163,7 @@ if TYPE_CHECKING:
             "errors": list[dict[str, Any]],  # TODO: We can expand on this type
             "event_id": str,
             "exception": dict[
-                Literal["values"], list[dict[str, Any]]
+                Literal["values"], list[Annotated[dict[str, Any]]]
             ],  # TODO: We can expand on this type
             "extra": MutableMapping[str, object],
             "fingerprint": list[str],

--- a/sentry_sdk/_types.py
+++ b/sentry_sdk/_types.py
@@ -163,7 +163,7 @@ if TYPE_CHECKING:
             "errors": list[dict[str, Any]],  # TODO: We can expand on this type
             "event_id": str,
             "exception": dict[
-                Literal["values"], list[Annotated[dict[str, Any]]]
+                Literal["values"], list[dict[str, Any]]
             ],  # TODO: We can expand on this type
             "extra": MutableMapping[str, object],
             "fingerprint": list[str],

--- a/sentry_sdk/client.py
+++ b/sentry_sdk/client.py
@@ -756,6 +756,8 @@ class _Client(BaseClient):
         if exceptions:
             errored = True
             for error in exceptions:
+                if isinstance(error, AnnotatedValue):
+                    error = error.value or {}
                 mechanism = error.get("mechanism")
                 if isinstance(mechanism, Mapping) and mechanism.get("handled") is False:
                     crashed = True

--- a/sentry_sdk/utils.py
+++ b/sentry_sdk/utils.py
@@ -676,7 +676,7 @@ def single_exception_from_error_tuple(
     source=None,  # type: Optional[str]
     full_stack=None,  # type: Optional[list[dict[str, Any]]]
 ):
-    # type: (...) -> Annotated[Dict[str, Any]]
+    # type: (...) -> Dict[str, Any]
     """
     Creates a dict that goes into the events `exception.values` list and is ingestible by Sentry.
 
@@ -812,7 +812,7 @@ def exceptions_from_error(
     source=None,  # type: Optional[str]
     full_stack=None,  # type: Optional[list[dict[str, Any]]]
 ):
-    # type: (...) -> Tuple[int, List[Annotated[Dict[str, Any]]]]
+    # type: (...) -> Tuple[int, List[Dict[str, Any]]]
     """
     Creates the list of exceptions.
     This can include chained exceptions and exceptions from an ExceptionGroup.
@@ -908,7 +908,7 @@ def exceptions_from_error_tuple(
     mechanism=None,  # type: Optional[Dict[str, Any]]
     full_stack=None,  # type: Optional[list[dict[str, Any]]]
 ):
-    # type: (...) -> List[Annotated[Dict[str, Any]]]
+    # type: (...) -> List[Dict[str, Any]]
     exc_type, exc_value, tb = exc_info
 
     is_exception_group = BaseExceptionGroup is not None and isinstance(

--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -1065,3 +1065,47 @@ def test_notes_safe_str(sentry_init, capture_events):
     (event,) = events
 
     assert event["exception"]["values"][0]["value"] == "aha!\nnote 1\nnote 3"
+
+
+@pytest.mark.skipif(
+    sys.version_info < (3, 11),
+    reason="this test appears to cause a segfault on Python < 3.11",
+)
+def test_stacktrace_big_recursion(sentry_init, capture_events):
+    """
+    Ensure that if the recursion limit is increased, the full stacktrace is not captured,
+    as it would take too long to process the entire stack trace.
+    Also, ensure that the capturing does not take too long.
+    """
+    sentry_init()
+    events = capture_events()
+
+    def recurse():
+        recurse()
+
+    old_recursion_limit = sys.getrecursionlimit()
+
+    try:
+        sys.setrecursionlimit(100_000)
+        recurse()
+    except RecursionError as e:
+        capture_start_time = time.perf_counter_ns()
+        sentry_sdk.capture_exception(e)
+        capture_end_time = time.perf_counter_ns()
+    finally:
+        sys.setrecursionlimit(old_recursion_limit)
+
+    (event,) = events
+
+    assert event["exception"]["values"][0]["stacktrace"] is None
+    assert event["_meta"] == {
+        "exception": {
+            "values": {"0": {"stacktrace": {"": {"rem": [["!config", "x"]]}}}}
+        }
+    }
+
+    # On my machine, it takes about 100-200ms to capture the exception,
+    # so this limit should be generous enough.
+    assert (
+        capture_end_time - capture_start_time < 10**9
+    ), "stacktrace capture took too long, check that frame limit is set correctly"


### PR DESCRIPTION
Fixes #2764