### PR TITLE
chore: Deprecate Scope.user

### DIFF
--- a/sentry_sdk/scope.py
+++ b/sentry_sdk/scope.py
@@ -794,6 +794,11 @@ class Scope:
     def user(self, value):
         # type: (Optional[Dict[str, Any]]) -> None
         """When set a specific user is bound to the scope. Deprecated in favor of set_user."""
+        warnings.warn(
+            "Setting `Scope.user` directly is deprecated. Please use `Scope.set_user()` instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         self.set_user(value)
 
     def set_user(self, value):

--- a/sentry_sdk/scope.py
+++ b/sentry_sdk/scope.py
@@ -795,7 +795,7 @@ class Scope:
         # type: (Optional[Dict[str, Any]]) -> None
         """When set a specific user is bound to the scope. Deprecated in favor of set_user."""
         warnings.warn(
-            "Setting `Scope.user` directly is deprecated. Please use `Scope.set_user()` instead.",
+            "The `Scope.user` setter is deprecated in favor of `Scope.set_user()`.",
             DeprecationWarning,
             stacklevel=2,
         )


### PR DESCRIPTION
The docstring for `Scope.user` says it's deprecated in favor of `Scope.set_user()`, but there is no user-facing warning. Add one so that we can [drop the property](https://github.com/getsentry/sentry-python/pull/4193) in the next major.