### PR TITLE
tests: Move Litestar under toxgen

### DIFF
--- a/.github/workflows/test-integrations-web-2.yml
+++ b/.github/workflows/test-integrations-web-2.yml
@@ -29,7 +29,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8","3.9","3.11","3.12","3.13"]
+        python-version: ["3.8","3.9","3.12","3.13"]
         # python3.6 reached EOL and is no longer being supported on
         # new versions of hosted runners on Github Actions
         # ubuntu-20.04 is the last version that supported python3.6

--- a/scripts/populate_tox/config.py
+++ b/scripts/populate_tox/config.py
@@ -69,6 +69,13 @@ TEST_SUITE_CONFIG = {
     "launchdarkly": {
         "package": "launchdarkly-server-sdk",
     },
+    "litestar": {
+        "package": "litestar",
+        "deps": {
+            "*": ["pytest-asyncio", "python-multipart", "requests", "cryptography"],
+            "<2.7": ["httpx<0.28"],
+        },
+    },
     "loguru": {
         "package": "loguru",
     },

--- a/scripts/populate_tox/populate_tox.py
+++ b/scripts/populate_tox/populate_tox.py
@@ -73,7 +73,6 @@ IGNORE = {
     "huggingface_hub",
     "langchain",
     "langchain_notiktoken",
-    "litestar",
     "openai",
     "openai_notiktoken",
     "pure_eval",

--- a/scripts/populate_tox/tox.jinja
+++ b/scripts/populate_tox/tox.jinja
@@ -115,12 +115,6 @@ envlist =
     {py3.9,py3.11,py3.12}-langchain-latest
     {py3.9,py3.11,py3.12}-langchain-notiktoken
 
-    # Litestar
-    {py3.8,py3.11}-litestar-v{2.0}
-    {py3.8,py3.11,py3.12}-litestar-v{2.6}
-    {py3.8,py3.11,py3.12}-litestar-v{2.12}
-    {py3.8,py3.11,py3.12}-litestar-latest
-
     # OpenAI
     {py3.9,py3.11,py3.12}-openai-v1.0
     {py3.9,py3.11,py3.12}-openai-v1.22
@@ -346,17 +340,6 @@ deps =
     langchain-{latest,notiktoken}: langchain-openai
     langchain-{latest,notiktoken}: openai>=1.6.1
     langchain-latest: tiktoken~=0.6.0
-
-    # Litestar
-    litestar: pytest-asyncio
-    litestar: python-multipart
-    litestar: requests
-    litestar: cryptography
-    litestar-v{2.0,2.6}: httpx<0.28
-    litestar-v2.0: litestar~=2.0.0
-    litestar-v2.6: litestar~=2.6.0
-    litestar-v2.12: litestar~=2.12.0
-    litestar-latest: litestar
 
     # OpenAI
     openai: pytest-asyncio

--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,7 @@
 # The file (and all resulting CI YAMLs) then need to be regenerated via
 # "scripts/generate-test-files.sh".
 #
-# Last generated: 2025-03-18T10:29:17.585636+00:00
+# Last generated: 2025-03-25T13:14:20.133361+00:00
 
 [tox]
 requires =
@@ -115,12 +115,6 @@ envlist =
     {py3.9,py3.11,py3.12}-langchain-latest
     {py3.9,py3.11,py3.12}-langchain-notiktoken
 
-    # Litestar
-    {py3.8,py3.11}-litestar-v{2.0}
-    {py3.8,py3.11,py3.12}-litestar-v{2.6}
-    {py3.8,py3.11,py3.12}-litestar-v{2.12}
-    {py3.8,py3.11,py3.12}-litestar-latest
-
     # OpenAI
     {py3.9,py3.11,py3.12}-openai-v1.0
     {py3.9,py3.11,py3.12}-openai-v1.22
@@ -178,7 +172,7 @@ envlist =
     {py3.6}-pymongo-v3.5.1
     {py3.6,py3.10,py3.11}-pymongo-v3.13.0
     {py3.6,py3.9,py3.10}-pymongo-v4.0.2
-    {py3.9,py3.12,py3.13}-pymongo-v4.11.2
+    {py3.9,py3.12,py3.13}-pymongo-v4.11.3
 
     {py3.6}-redis_py_cluster_legacy-v1.3.6
     {py3.6,py3.7}-redis_py_cluster_legacy-v2.0.0
@@ -270,6 +264,11 @@ envlist =
     {py3.6,py3.7}-falcon-v2.0.0
     {py3.6,py3.11,py3.12}-falcon-v3.1.3
     {py3.8,py3.11,py3.12}-falcon-v4.0.2
+
+    {py3.8,py3.10,py3.11}-litestar-v2.0.1
+    {py3.8,py3.11,py3.12}-litestar-v2.5.5
+    {py3.8,py3.11,py3.12}-litestar-v2.10.0
+    {py3.8,py3.12,py3.13}-litestar-v2.15.1
 
     {py3.6}-pyramid-v1.8.6
     {py3.6,py3.8,py3.9}-pyramid-v1.10.8
@@ -464,17 +463,6 @@ deps =
     langchain-{latest,notiktoken}: openai>=1.6.1
     langchain-latest: tiktoken~=0.6.0
 
-    # Litestar
-    litestar: pytest-asyncio
-    litestar: python-multipart
-    litestar: requests
-    litestar: cryptography
-    litestar-v{2.0,2.6}: httpx<0.28
-    litestar-v2.0: litestar~=2.0.0
-    litestar-v2.6: litestar~=2.6.0
-    litestar-v2.12: litestar~=2.12.0
-    litestar-latest: litestar
-
     # OpenAI
     openai: pytest-asyncio
     openai-v1.0: openai~=1.0.0
@@ -568,7 +556,7 @@ deps =
     pymongo-v3.5.1: pymongo==3.5.1
     pymongo-v3.13.0: pymongo==3.13.0
     pymongo-v4.0.2: pymongo==4.0.2
-    pymongo-v4.11.2: pymongo==4.11.2
+    pymongo-v4.11.3: pymongo==4.11.3
     pymongo: mockupdb
 
     redis_py_cluster_legacy-v1.3.6: redis-py-cluster==1.3.6
@@ -693,6 +681,17 @@ deps =
     falcon-v2.0.0: falcon==2.0.0
     falcon-v3.1.3: falcon==3.1.3
     falcon-v4.0.2: falcon==4.0.2
+
+    litestar-v2.0.1: litestar==2.0.1
+    litestar-v2.5.5: litestar==2.5.5
+    litestar-v2.10.0: litestar==2.10.0
+    litestar-v2.15.1: litestar==2.15.1
+    litestar: pytest-asyncio
+    litestar: python-multipart
+    litestar: requests
+    litestar: cryptography
+    litestar-v2.0.1: httpx<0.28
+    litestar-v2.5.5: httpx<0.28
 
     pyramid-v1.8.6: pyramid==1.8.6
     pyramid-v1.10.8: pyramid==1.10.8


### PR DESCRIPTION
Remove hardcoded Litestar entries from `tox.ini`/`tox.jinja` and let `toxgen` handle it.

(the pymongo update was pulled in by rerunning the script)