### PR TITLE
Tell `tox` to use `uv` to create virtual envs

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -14,8 +14,9 @@
 
 [tox]
 requires =
-    # This version introduced using pip 24.1 which does not work with older Celery and HTTPX versions.
-    virtualenv<20.26.3
+    # Changed to be compatible with tox-uv
+    virtualenv>=20.27.1
+    tox-uv>=1.25.0
 envlist =
     # === Common ===
     {py3.6,py3.7,py3.8,py3.9,py3.10,py3.11,py3.12,py3.13}-common


### PR DESCRIPTION
This is an experiment to try how much faster this makes CI.