### PR TITLE
feat: Sample everything 100% w/ Spotlight & no DSN set

### DIFF
--- a/sentry_sdk/client.py
+++ b/sentry_sdk/client.py
@@ -418,7 +418,7 @@ class _Client(BaseClient):
             if self.options.get("spotlight"):
                 self.spotlight = setup_spotlight(self.options)
                 if not self.options["dsn"]:
-                    sample_all = lambda *_args: 1.0
+                    sample_all = lambda *_args, **_kwargs: 1.0
                     self.options["send_default_pii"] = True
                     self.options["error_sampler"] = sample_all
                     self.options["traces_sampler"] = sample_all

--- a/sentry_sdk/client.py
+++ b/sentry_sdk/client.py
@@ -418,7 +418,7 @@ class _Client(BaseClient):
             if self.options.get("spotlight"):
                 self.spotlight = setup_spotlight(self.options)
                 if not self.options["dsn"]:
-                    sample_all = lambda c: 1
+                    sample_all = lambda *_args: 1.0
                     self.options["send_default_pii"] = True
                     self.options["error_sampler"] = sample_all
                     self.options["traces_sampler"] = sample_all
@@ -474,7 +474,7 @@ class _Client(BaseClient):
 
         Returns whether the client should send default PII (Personally Identifiable Information) data to Sentry.
         """
-        return self.options.get("send_default_pii", False)
+        return self.options.get("send_default_pii") or False
 
     @property
     def dsn(self):

--- a/sentry_sdk/client.py
+++ b/sentry_sdk/client.py
@@ -417,6 +417,12 @@ class _Client(BaseClient):
 
             if self.options.get("spotlight"):
                 self.spotlight = setup_spotlight(self.options)
+                if not self.options["dsn"]:
+                    sample_all = lambda c: 1
+                    self.options["send_default_pii"] = True
+                    self.options["error_sampler"] = sample_all
+                    self.options["traces_sampler"] = sample_all
+                    self.options["profiles_sampler"] = sample_all
 
             sdk_name = get_sdk_name(list(self.integrations.keys()))
             SDK_INFO["name"] = sdk_name
@@ -468,11 +474,7 @@ class _Client(BaseClient):
 
         Returns whether the client should send default PII (Personally Identifiable Information) data to Sentry.
         """
-        result = self.options.get("send_default_pii")
-        if result is None:
-            result = not self.options["dsn"] and self.spotlight is not None
-
-        return result
+        return self.options.get("send_default_pii", False)
 
     @property
     def dsn(self):


### PR DESCRIPTION
This patch makes Spotlight easier to setup by turning all sampling to 100% when no DSN is set and Spotlight is enabled. I consider this a non-breaking and a safe change as these only apply when no DSN is set so it should have no production or billing implications.
