### PR TITLE
ci: Fix GraphQL failures

### DIFF
--- a/scripts/populate_tox/config.py
+++ b/scripts/populate_tox/config.py
@@ -148,6 +148,7 @@ TEST_SUITE_CONFIG = {
         "package": "strawberry-graphql[fastapi,flask]",
         "deps": {
             "*": ["httpx"],
+            "<=0.262.5": ["pydantic<2.11"],
         },
     },
     "tornado": {

--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,7 @@
 # The file (and all resulting CI YAMLs) then need to be regenerated via
 # "scripts/generate-test-files.sh".
 #
-# Last generated: 2025-03-25T13:14:20.133361+00:00
+# Last generated: 2025-03-28T08:54:21.617802+00:00
 
 [tox]
 requires =
@@ -613,6 +613,10 @@ deps =
     strawberry-v0.245.0: strawberry-graphql[fastapi,flask]==0.245.0
     strawberry-v0.262.5: strawberry-graphql[fastapi,flask]==0.262.5
     strawberry: httpx
+    strawberry-v0.209.8: pydantic<2.11
+    strawberry-v0.227.7: pydantic<2.11
+    strawberry-v0.245.0: pydantic<2.11
+    strawberry-v0.262.5: pydantic<2.11
 
 
     # ~~~ Network ~~~

--- a/tox.ini
+++ b/tox.ini
@@ -181,7 +181,7 @@ envlist =
     {py3.6,py3.7}-sqlalchemy-v1.3.9
     {py3.6,py3.11,py3.12}-sqlalchemy-v1.4.54
     {py3.7,py3.10,py3.11}-sqlalchemy-v2.0.9
-    {py3.7,py3.12,py3.13}-sqlalchemy-v2.0.39
+    {py3.7,py3.12,py3.13}-sqlalchemy-v2.0.40
 
 
     # ~~~ Flags ~~~
@@ -566,7 +566,7 @@ deps =
     sqlalchemy-v1.3.9: sqlalchemy==1.3.9
     sqlalchemy-v1.4.54: sqlalchemy==1.4.54
     sqlalchemy-v2.0.9: sqlalchemy==2.0.9
-    sqlalchemy-v2.0.39: sqlalchemy==2.0.39
+    sqlalchemy-v2.0.40: sqlalchemy==2.0.40
 
 
     # ~~~ Flags ~~~


### PR DESCRIPTION
Looks like strawberry is not compatible with the latest pydantic release (2.11.0). Restrict the version of pydantic used in strawberry tests for now.

sqlalchemy apparently released a new version which made it in by rerunning toxgen.