### PR TITLE
Pin `fakeredis` until `rq` can work with the new version

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*   @getsentry/product-owners-sdks-web-backend
+*   @getsentry/team-web-sdk-backend

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*   @getsentry/owners-python-sdk
+*   @getsentry/product-owners-sdks-web-backend

--- a/scripts/populate_tox/tox.jinja
+++ b/scripts/populate_tox/tox.jinja
@@ -400,9 +400,9 @@ deps =
     rq-v{0.6}: fakeredis<1.0
     rq-v{0.6}: redis<3.2.2
     rq-v{0.13,1.0,1.5,1.10}: fakeredis>=1.0,<1.7.4
-    rq-v{1.15,1.16}: fakeredis
+    rq-v{1.15,1.16}: fakeredis<2.28.0
     {py3.6,py3.7}-rq-v{1.15,1.16}: fakeredis!=2.26.0  # https://github.com/cunla/fakeredis-py/issues/341
-    rq-latest: fakeredis
+    rq-latest: fakeredis<2.28.0
     {py3.6,py3.7}-rq-latest: fakeredis!=2.26.0  # https://github.com/cunla/fakeredis-py/issues/341
     rq-v0.6: rq~=0.6.0
     rq-v0.13: rq~=0.13.0

--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,7 @@
 # The file (and all resulting CI YAMLs) then need to be regenerated via
 # "scripts/generate-test-files.sh".
 #
-# Last generated: 2025-03-28T08:54:21.617802+00:00
+# Last generated: 2025-03-31T10:49:05.789167+00:00
 
 [tox]
 requires =
@@ -217,7 +217,7 @@ envlist =
     {py3.8,py3.10,py3.11}-strawberry-v0.209.8
     {py3.8,py3.11,py3.12}-strawberry-v0.227.7
     {py3.8,py3.11,py3.12}-strawberry-v0.245.0
-    {py3.9,py3.12,py3.13}-strawberry-v0.262.5
+    {py3.9,py3.12,py3.13}-strawberry-v0.262.6
 
 
     # ~~~ Network ~~~
@@ -522,9 +522,9 @@ deps =
     rq-v{0.6}: fakeredis<1.0
     rq-v{0.6}: redis<3.2.2
     rq-v{0.13,1.0,1.5,1.10}: fakeredis>=1.0,<1.7.4
-    rq-v{1.15,1.16}: fakeredis
+    rq-v{1.15,1.16}: fakeredis<2.28.0
     {py3.6,py3.7}-rq-v{1.15,1.16}: fakeredis!=2.26.0  # https://github.com/cunla/fakeredis-py/issues/341
-    rq-latest: fakeredis
+    rq-latest: fakeredis<2.28.0
     {py3.6,py3.7}-rq-latest: fakeredis!=2.26.0  # https://github.com/cunla/fakeredis-py/issues/341
     rq-v0.6: rq~=0.6.0
     rq-v0.13: rq~=0.13.0
@@ -611,12 +611,11 @@ deps =
     strawberry-v0.209.8: strawberry-graphql[fastapi,flask]==0.209.8
     strawberry-v0.227.7: strawberry-graphql[fastapi,flask]==0.227.7
     strawberry-v0.245.0: strawberry-graphql[fastapi,flask]==0.245.0
-    strawberry-v0.262.5: strawberry-graphql[fastapi,flask]==0.262.5
+    strawberry-v0.262.6: strawberry-graphql[fastapi,flask]==0.262.6
     strawberry: httpx
     strawberry-v0.209.8: pydantic<2.11
     strawberry-v0.227.7: pydantic<2.11
     strawberry-v0.245.0: pydantic<2.11
-    strawberry-v0.262.5: pydantic<2.11
 
 
     # ~~~ Network ~~~


### PR DESCRIPTION
This is breaking our test suite right now. The eco system should stabilize in the next couple of days/weeks, then we can remove the pin.