### PR TITLE
Tracing without performance out of the box and deprecated `Span.set_data()`

### DIFF
--- a/sentry_sdk/consts.py
+++ b/sentry_sdk/consts.py
@@ -511,7 +511,7 @@ class ClientConstructor:
         debug=None,  # type: Optional[bool]
         attach_stacktrace=False,  # type: bool
         ca_certs=None,  # type: Optional[str]
-        traces_sample_rate=None,  # type: Optional[float]
+        traces_sample_rate=0,  # type: Optional[float]
         traces_sampler=None,  # type: Optional[TracesSampler]
         profiles_sample_rate=None,  # type: Optional[float]
         profiles_sampler=None,  # type: Optional[TracesSampler]

--- a/sentry_sdk/tracing.py
+++ b/sentry_sdk/tracing.py
@@ -678,6 +678,12 @@ class Span:
 
     def set_data(self, key, value):
         # type: (str, Any) -> None
+        warnings.warn(
+            "`Span.set_data` is deprecated. Please use `Span.set_attribute` instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+
         # TODO-neel-potel we cannot add dicts here
         self.set_attribute(key, value)
 

--- a/tests/integrations/aiohttp/test_aiohttp.py
+++ b/tests/integrations/aiohttp/test_aiohttp.py
@@ -448,7 +448,10 @@ async def test_trace_from_headers_if_performance_enabled(
 async def test_trace_from_headers_if_performance_disabled(
     sentry_init, aiohttp_client, capture_events
 ):
-    sentry_init(integrations=[AioHttpIntegration()])
+    sentry_init(
+        traces_sample_rate=None,  # disable all performance monitoring
+        integrations=[AioHttpIntegration()],
+    )
 
     async def hello(request):
         capture_message("It's a good day to try dividing by 0")

--- a/tests/integrations/asgi/test_asgi.py
+++ b/tests/integrations/asgi/test_asgi.py
@@ -325,7 +325,9 @@ async def test_trace_from_headers_if_performance_disabled(
     asgi3_app_with_error_and_msg,
     capture_events,
 ):
-    sentry_init()
+    sentry_init(
+        traces_sample_rate=None,  # disable all performance monitoring
+    )
     app = SentryAsgiMiddleware(asgi3_app_with_error_and_msg)
 
     trace_id = "582b43a4192642f0b136d5159a501701"

--- a/tests/integrations/django/asgi/test_asgi.py
+++ b/tests/integrations/django/asgi/test_asgi.py
@@ -385,6 +385,7 @@ async def test_trace_from_headers_if_performance_enabled(sentry_init, capture_ev
 )
 async def test_trace_from_headers_if_performance_disabled(sentry_init, capture_events):
     sentry_init(
+        traces_sample_rate=None,  # disable all performance monitoring
         integrations=[DjangoIntegration()],
     )
 

--- a/tests/integrations/django/test_basic.py
+++ b/tests/integrations/django/test_basic.py
@@ -236,6 +236,7 @@ def test_trace_from_headers_if_performance_disabled(
     sentry_init, client, capture_events
 ):
     sentry_init(
+        traces_sample_rate=None,  # disable all performance monitoring
         integrations=[
             DjangoIntegration(
                 http_methods_to_capture=("HEAD",),

--- a/tests/integrations/opentelemetry/test_sampler.py
+++ b/tests/integrations/opentelemetry/test_sampler.py
@@ -176,8 +176,8 @@ def test_sampling_traces_sampler_boolean(sentry_init, capture_envelopes):
 @pytest.mark.parametrize(
     "traces_sample_rate, expected_num_of_envelopes",
     [
-        # special case for testing, do not pass any traces_sample_rate to init() (the default traces_sample_rate=None will be used)
-        (-1, 0),
+        # special case for testing, do not pass any traces_sample_rate to init() (the default traces_sample_rate=0 will be used)
+        (-1, 1),
         # traces_sample_rate=None means do not create new traces, and also do not continue incoming traces. So, no envelopes at all.
         (None, 0),
         # traces_sample_rate=0 means do not create new traces (0% of the requests), but continue incoming traces. So envelopes will be created only if there is an incoming trace.

--- a/tests/integrations/wsgi/test_wsgi.py
+++ b/tests/integrations/wsgi/test_wsgi.py
@@ -238,7 +238,7 @@ def test_has_trace_if_performance_disabled(
         capture_message("Attempting to fetch the ball")
         raise ValueError("Fetch aborted. The ball was not returned.")
 
-    sentry_init()
+    sentry_init(traces_sample_rate=None)
     app = SentryWsgiMiddleware(dogpark)
     client = Client(app)
     events = capture_events()

--- a/tests/integrations/wsgi/test_wsgi.py
+++ b/tests/integrations/wsgi/test_wsgi.py
@@ -301,7 +301,9 @@ def test_trace_from_headers_if_performance_disabled(
         capture_message("Attempting to fetch the ball")
         raise ValueError("Fetch aborted. The ball was not returned.")
 
-    sentry_init()
+    sentry_init(
+        traces_sample_rate=None,  # disable all performance monitoring
+    )
     app = SentryWsgiMiddleware(dogpark)
     client = Client(app)
     events = capture_events()

--- a/tests/test_dsc.py
+++ b/tests/test_dsc.py
@@ -302,7 +302,7 @@ def test_dsc_continuation_of_trace_sample_rate_changed_in_traces_sampler(
             0.5,  # expected_sample_rate
             "true",  # expected_sampled (traces sampler overrides the traces_sample_rate setting, so transactions are created)
         ),
-        (  # 7 not forwarding incoming (traces_sample_rate not set) (incoming not sampled)
+        (  # 7 not forwarding incoming (traces_sample_rate set to None) (incoming not sampled)
             {
                 "incoming_sample_rate": 1.0,
                 "incoming_sampled": "false",

--- a/tests/test_dsc.py
+++ b/tests/test_dsc.py
@@ -229,7 +229,7 @@ def test_dsc_continuation_of_trace_sample_rate_changed_in_traces_sampler(
         # "local_traces_sampler_result":
         #       The result of the local traces sampler.
         # "local_traces_sample_rate":
-        #       The `traces_sample_rate` setting in the local `sentry_init` call.
+        #       The `traces_sample_rate` setting in the local `sentry_init` call. If -1, then it will not be set and the default traces_sample_rate will be used.
         (  # 1 traces_sample_rate does not override incoming
             {
                 "incoming_sample_rate": 1.0,
@@ -278,7 +278,7 @@ def test_dsc_continuation_of_trace_sample_rate_changed_in_traces_sampler(
             0.25,  # expected_sample_rate
             "false",  # expected_sampled (traces sampler can override parent sampled)
         ),
-        (  # 5 forwarding incoming (traces_sample_rate not set)
+        (  # 5 not forwarding incoming (traces_sample_rate set to None)
             {
                 "incoming_sample_rate": 1.0,
                 "incoming_sampled": "true",
@@ -297,12 +297,12 @@ def test_dsc_continuation_of_trace_sample_rate_changed_in_traces_sampler(
                 "sentry_trace_header_parent_sampled": 1,
                 "use_local_traces_sampler": True,
                 "local_traces_sampler_result": 0.5,
-                "local_traces_sample_rate": None,
+                "local_traces_sample_rate": -1,
             },
             0.5,  # expected_sample_rate
             "true",  # expected_sampled (traces sampler overrides the traces_sample_rate setting, so transactions are created)
         ),
-        (  # 7 forwarding incoming (traces_sample_rate not set) (incoming not sampled)
+        (  # 7 not forwarding incoming (traces_sample_rate not set) (incoming not sampled)
             {
                 "incoming_sample_rate": 1.0,
                 "incoming_sampled": "false",
@@ -321,7 +321,7 @@ def test_dsc_continuation_of_trace_sample_rate_changed_in_traces_sampler(
                 "sentry_trace_header_parent_sampled": 0,
                 "use_local_traces_sampler": True,
                 "local_traces_sampler_result": 0.25,
-                "local_traces_sample_rate": None,
+                "local_traces_sample_rate": -1,
             },
             0.25,  # expected_sample_rate
             "false",  # expected_sampled
@@ -344,9 +344,9 @@ def test_dsc_continuation_of_trace_sample_rate_changed_in_traces_sampler(
         "2 traces_sampler overrides incoming",
         "3 traces_sample_rate does not overrides incoming sample rate or parent (incoming not sampled)",
         "4 traces_sampler overrides incoming (incoming not sampled)",
-        "5 forwarding incoming (traces_sample_rate not set)",
+        "5 not forwarding incoming (traces_sample_rate set to None)",
         "6 traces_sampler overrides incoming  (traces_sample_rate not set)",
-        "7 forwarding incoming (traces_sample_rate not set) (incoming not sampled)",
+        "7 not forwarding incoming (traces_sample_rate set to None) (incoming not sampled)",
         "8 traces_sampler overrides incoming  (traces_sample_rate not set) (incoming not sampled)",
         "9 traces_sample_rate overrides incoming (upstream deferred sampling decision)",
     ),
@@ -373,7 +373,7 @@ def test_dsc_sample_rate_change(
         "environment": "canary",
     }
 
-    if test_data["local_traces_sample_rate"]:
+    if test_data["local_traces_sample_rate"] != -1:
         init_kwargs["traces_sample_rate"] = test_data["local_traces_sample_rate"]
 
     if test_data["use_local_traces_sampler"]:

--- a/tests/tracing/test_sample_rand_propagation.py
+++ b/tests/tracing/test_sample_rand_propagation.py
@@ -15,7 +15,9 @@ def test_continue_trace_with_sample_rand(sentry_init):
     """
     Test that an incoming sample_rand is propagated onto the transaction's baggage.
     """
-    sentry_init()
+    sentry_init(
+        traces_sample_rate=None,
+    )
 
     headers = {
         "sentry-trace": "00000000000000000000000000000000-0000000000000000-0",
@@ -31,7 +33,9 @@ def test_continue_trace_missing_sample_rand(sentry_init):
     """
     Test that a missing sample_rand is filled in onto the transaction's baggage.
     """
-    sentry_init()
+    sentry_init(
+        traces_sample_rate=None,
+    )
 
     headers = {
         "sentry-trace": "00000000000000000000000000000000-0000000000000000",


### PR DESCRIPTION
Second part of #4102