### PR TITLE
fix: Handle JSONDecodeError gracefully in StarletteRequestExtractor

### DIFF
--- a/sentry_sdk/integrations/starlette.py
+++ b/sentry_sdk/integrations/starlette.py
@@ -3,6 +3,7 @@ import functools
 import warnings
 from collections.abc import Set
 from copy import deepcopy
+from json import JSONDecodeError
 
 import sentry_sdk
 from sentry_sdk.consts import OP
@@ -680,8 +681,10 @@ class StarletteRequestExtractor:
         # type: (StarletteRequestExtractor) -> Optional[Dict[str, Any]]
         if not self.is_json():
             return None
-
-        return await self.request.json()
+        try:
+            return await self.request.json()
+        except JSONDecodeError:
+            return None
 
 
 def _transaction_name_from_router(scope):

--- a/tests/integrations/starlette/test_starlette.py
+++ b/tests/integrations/starlette/test_starlette.py
@@ -1354,3 +1354,28 @@ def test_configurable_status_codes(
     client.get("/error")
 
     assert len(events) == int(expected_error)
+
+
+@pytest.mark.asyncio
+async def test_starletterequestextractor_malformed_json_error_handling(sentry_init):
+    scope = SCOPE.copy()
+    scope["headers"] = [
+        [b"content-type", b"application/json"],
+    ]
+    starlette_request = starlette.requests.Request(scope)
+
+    malformed_json = "{invalid json"
+    malformed_messages = [
+        {"type": "http.request", "body": malformed_json.encode("utf-8")},
+        {"type": "http.disconnect"},
+    ]
+
+    side_effect = [_mock_receive(msg) for msg in malformed_messages]
+    starlette_request._receive = mock.Mock(side_effect=side_effect)
+
+    extractor = StarletteRequestExtractor(starlette_request)
+
+    assert extractor.is_json()
+
+    result = await extractor.json()
+    assert result is None


### PR DESCRIPTION
Previously, when encountering malformed JSON in request bodies, the json() method would raise a JSONDecodeError. This change updates the method to catch the exception and return None instead, providing more consistent behavior and preventing unexpected crashes.

Added a test case to verify this error handling behavior.