### PR TITLE
fix(ourlogs): Use repr instead of json for message and arguments

### DIFF
--- a/sentry_sdk/integrations/logging.py
+++ b/sentry_sdk/integrations/logging.py
@@ -5,6 +5,7 @@ from fnmatch import fnmatch
 import sentry_sdk
 from sentry_sdk.client import BaseClient
 from sentry_sdk.utils import (
+    safe_repr,
     to_string,
     event_from_exception,
     current_stacktrace,
@@ -364,7 +365,7 @@ class SentryLogsHandler(_BaseHandler):
             if isinstance(record.args, tuple):
                 for i, arg in enumerate(record.args):
                     attrs[f"sentry.message.parameters.{i}"] = (
-                        arg if isinstance(arg, str) else repr(arg)
+                        arg if isinstance(arg, str) else safe_repr(arg)
                     )
         if record.lineno:
             attrs["code.line.number"] = record.lineno

--- a/sentry_sdk/integrations/logging.py
+++ b/sentry_sdk/integrations/logging.py
@@ -357,11 +357,9 @@ class SentryLogsHandler(_BaseHandler):
         # type: (BaseClient, LogRecord) -> None
         scope = sentry_sdk.get_current_scope()
         otel_severity_number, otel_severity_text = _python_level_to_otel(record.levelno)
-        attrs = {
-            "sentry.message.template": (
-                record.msg if isinstance(record.msg, str) else repr(record.msg)
-            ),
-        }  # type: dict[str, str | bool | float | int]
+        attrs = {}  # type: dict[str, str | bool | float | int]
+        if isinstance(record.msg, str):
+            attrs["sentry.message.template"] = record.msg
         if record.args is not None:
             if isinstance(record.args, tuple):
                 for i, arg in enumerate(record.args):

--- a/sentry_sdk/integrations/logging.py
+++ b/sentry_sdk/integrations/logging.py
@@ -1,4 +1,3 @@
-import json
 import logging
 from datetime import datetime, timezone
 from fnmatch import fnmatch
@@ -360,14 +359,14 @@ class SentryLogsHandler(_BaseHandler):
         otel_severity_number, otel_severity_text = _python_level_to_otel(record.levelno)
         attrs = {
             "sentry.message.template": (
-                record.msg if isinstance(record.msg, str) else json.dumps(record.msg)
+                record.msg if isinstance(record.msg, str) else repr(record.msg)
             ),
         }  # type: dict[str, str | bool | float | int]
         if record.args is not None:
             if isinstance(record.args, tuple):
                 for i, arg in enumerate(record.args):
                     attrs[f"sentry.message.parameters.{i}"] = (
-                        arg if isinstance(arg, str) else json.dumps(arg)
+                        arg if isinstance(arg, str) else repr(arg)
                     )
         if record.lineno:
             attrs["code.line.number"] = record.lineno

--- a/tests/test_logs.py
+++ b/tests/test_logs.py
@@ -293,5 +293,6 @@ def test_logging_errors(sentry_init, capture_envelopes):
 
     python_logger = logging.Logger("test-logger")
     python_logger.error(Exception("test exc"))
+    python_logger.error("error is %s", Exception("test exc"))
 
-    assert len(envelopes) == 2
+    assert len(envelopes) == 4

--- a/tests/test_logs.py
+++ b/tests/test_logs.py
@@ -300,7 +300,7 @@ def test_logging_errors(sentry_init, capture_envelopes):
 
     log_event_1 = envelopes[1].items[0].payload.json
     assert log_event_1["severityText"] == "error"
-    # If only logging an exception, there is no "sentry.message.template" or "sentry.message.parameters.0"
+    # When only logging an exception, there is no "sentry.message.template" or "sentry.message.parameters.0"
     assert len(log_event_1["attributes"]) == 10
     assert log_event_1["attributes"][0]["key"] == "code.line.number"
 

--- a/tests/test_logs.py
+++ b/tests/test_logs.py
@@ -281,3 +281,17 @@ def test_no_log_infinite_loop(sentry_init, capture_envelopes):
     python_logger.debug("this is %s a template %s", "1", "2")
 
     assert len(envelopes) == 1
+
+
+@minimum_python_37
+def test_logging_errors(sentry_init, capture_envelopes):
+    """
+    The python logger module should be able to log errors without erroring
+    """
+    sentry_init(_experiments={"enable_sentry_logs": True})
+    envelopes = capture_envelopes()
+
+    python_logger = logging.Logger("test-logger")
+    python_logger.error(Exception("test exc"))
+
+    assert len(envelopes) == 2


### PR DESCRIPTION
Currently if you do something like

```
    python_logger = logging.Logger("test-logger")
    python_logger.error(Exception("test exc"))
```

It will error, because Exception is not JSON serializable.