### PR TITLE
chore(ourlogs): Rename import to sentry_sdk.logger, export Log type

### DIFF
--- a/sentry_sdk/__init__.py
+++ b/sentry_sdk/__init__.py
@@ -45,7 +45,7 @@ __all__ = [  # noqa
     "start_transaction",
     "trace",
     "monitor",
-    "_experimental_logger",
+    "logger",
 ]
 
 # Initialize the debug support after everything is loaded

--- a/sentry_sdk/logger.py
+++ b/sentry_sdk/logger.py
@@ -17,7 +17,7 @@ def _capture_log(severity_text, severity_number, template, **kwargs):
     if "attributes" in kwargs:
         attrs.update(kwargs.pop("attributes"))
     for k, v in kwargs.items():
-        attrs[f"sentry.message.parameters.{k}"] = v
+        attrs[f"sentry.message.parameters.{k}"] = v if isinstance(v, str) else repr(v)
 
     # noinspection PyProtectedMember
     client._capture_experimental_log(
@@ -36,6 +36,6 @@ def _capture_log(severity_text, severity_number, template, **kwargs):
 trace = functools.partial(_capture_log, "trace", 1)
 debug = functools.partial(_capture_log, "debug", 5)
 info = functools.partial(_capture_log, "info", 9)
-warn = functools.partial(_capture_log, "warn", 13)
+warning = functools.partial(_capture_log, "warning", 13)
 error = functools.partial(_capture_log, "error", 17)
 fatal = functools.partial(_capture_log, "fatal", 21)

--- a/sentry_sdk/types.py
+++ b/sentry_sdk/types.py
@@ -11,7 +11,7 @@ releases.
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from sentry_sdk._types import Event, EventDataCategory, Hint
+    from sentry_sdk._types import Event, EventDataCategory, Hint, Log
 else:
     from typing import Any
 
@@ -20,5 +20,6 @@ else:
     Event = Any
     EventDataCategory = Any
     Hint = Any
+    Log = Any
 
-__all__ = ("Event", "EventDataCategory", "Hint")
+__all__ = ("Event", "EventDataCategory", "Hint", "Log")

--- a/tests/test_logs.py
+++ b/tests/test_logs.py
@@ -5,7 +5,6 @@ from unittest import mock
 import pytest
 
 import sentry_sdk
-from sentry_sdk import _experimental_logger as sentry_logger
 from sentry_sdk.integrations.logging import LoggingIntegration
 
 minimum_python_37 = pytest.mark.skipif(
@@ -25,12 +24,12 @@ def test_logs_disabled_by_default(sentry_init, capture_envelopes):
 
     envelopes = capture_envelopes()
 
-    sentry_logger.trace("This is a 'trace' log.")
-    sentry_logger.debug("This is a 'debug' log...")
-    sentry_logger.info("This is a 'info' log...")
-    sentry_logger.warn("This is a 'warn' log...")
-    sentry_logger.error("This is a 'error' log...")
-    sentry_logger.fatal("This is a 'fatal' log...")
+    sentry_sdk.logger.trace("This is a 'trace' log.")
+    sentry_sdk.logger.debug("This is a 'debug' log...")
+    sentry_sdk.logger.info("This is a 'info' log...")
+    sentry_sdk.logger.warning("This is a 'warn' log...")
+    sentry_sdk.logger.error("This is a 'error' log...")
+    sentry_sdk.logger.fatal("This is a 'fatal' log...")
     python_logger.warning("sad")
 
     assert len(envelopes) == 0
@@ -41,12 +40,12 @@ def test_logs_basics(sentry_init, capture_envelopes):
     sentry_init(_experiments={"enable_sentry_logs": True})
     envelopes = capture_envelopes()
 
-    sentry_logger.trace("This is a 'trace' log...")
-    sentry_logger.debug("This is a 'debug' log...")
-    sentry_logger.info("This is a 'info' log...")
-    sentry_logger.warn("This is a 'warn' log...")
-    sentry_logger.error("This is a 'error' log...")
-    sentry_logger.fatal("This is a 'fatal' log...")
+    sentry_sdk.logger.trace("This is a 'trace' log...")
+    sentry_sdk.logger.debug("This is a 'debug' log...")
+    sentry_sdk.logger.info("This is a 'info' log...")
+    sentry_sdk.logger.warning("This is a 'warn' log...")
+    sentry_sdk.logger.error("This is a 'error' log...")
+    sentry_sdk.logger.fatal("This is a 'fatal' log...")
 
     assert (
         len(envelopes) == 6
@@ -96,12 +95,12 @@ def test_logs_before_emit_log(sentry_init, capture_envelopes):
     )
     envelopes = capture_envelopes()
 
-    sentry_logger.trace("This is a 'trace' log...")
-    sentry_logger.debug("This is a 'debug' log...")
-    sentry_logger.info("This is a 'info' log...")
-    sentry_logger.warn("This is a 'warn' log...")
-    sentry_logger.error("This is a 'error' log...")
-    sentry_logger.fatal("This is a 'fatal' log...")
+    sentry_sdk.logger.trace("This is a 'trace' log...")
+    sentry_sdk.logger.debug("This is a 'debug' log...")
+    sentry_sdk.logger.info("This is a 'info' log...")
+    sentry_sdk.logger.warning("This is a 'warn' log...")
+    sentry_sdk.logger.error("This is a 'error' log...")
+    sentry_sdk.logger.fatal("This is a 'fatal' log...")
 
     assert len(envelopes) == 4
 
@@ -126,7 +125,7 @@ def test_logs_attributes(sentry_init, capture_envelopes):
         "attr_string": "string attribute",
     }
 
-    sentry_logger.warn(
+    sentry_sdk.logger.warning(
         "The recorded value was '{my_var}'", my_var="some value", attributes=attrs
     )
 
@@ -151,10 +150,10 @@ def test_logs_message_params(sentry_init, capture_envelopes):
     sentry_init(_experiments={"enable_sentry_logs": True})
     envelopes = capture_envelopes()
 
-    sentry_logger.warn("The recorded value was '{int_var}'", int_var=1)
-    sentry_logger.warn("The recorded value was '{float_var}'", float_var=2.0)
-    sentry_logger.warn("The recorded value was '{bool_var}'", bool_var=False)
-    sentry_logger.warn(
+    sentry_sdk.logger.warning("The recorded value was '{int_var}'", int_var=1)
+    sentry_sdk.logger.warning("The recorded value was '{float_var}'", float_var=2.0)
+    sentry_sdk.logger.warning("The recorded value was '{bool_var}'", bool_var=False)
+    sentry_sdk.logger.warning(
         "The recorded value was '{string_var}'", string_var="some string value"
     )
 
@@ -200,7 +199,7 @@ def test_logs_tied_to_transactions(sentry_init, capture_envelopes):
     envelopes = capture_envelopes()
 
     with sentry_sdk.start_transaction(name="test-transaction") as trx:
-        sentry_logger.warn("This is a log tied to a transaction")
+        sentry_sdk.logger.warning("This is a log tied to a transaction")
 
     log_entry = envelopes[0].items[0].payload.json
     assert log_entry["attributes"][-1] == {
@@ -219,7 +218,7 @@ def test_logs_tied_to_spans(sentry_init, capture_envelopes):
 
     with sentry_sdk.start_transaction(name="test-transaction"):
         with sentry_sdk.start_span(description="test-span") as span:
-            sentry_logger.warn("This is a log tied to a span")
+            sentry_sdk.logger.warning("This is a log tied to a span")
 
     attrs = otel_attributes_to_dict(envelopes[0].items[0].payload.json["attributes"])
     assert attrs["sentry.trace.parent_span_id"] == {"stringValue": span.span_id}

--- a/tests/test_logs.py
+++ b/tests/test_logs.py
@@ -27,7 +27,7 @@ def test_logs_disabled_by_default(sentry_init, capture_envelopes):
     sentry_sdk.logger.trace("This is a 'trace' log.")
     sentry_sdk.logger.debug("This is a 'debug' log...")
     sentry_sdk.logger.info("This is a 'info' log...")
-    sentry_sdk.logger.warning("This is a 'warn' log...")
+    sentry_sdk.logger.warning("This is a 'warning' log...")
     sentry_sdk.logger.error("This is a 'error' log...")
     sentry_sdk.logger.fatal("This is a 'fatal' log...")
     python_logger.warning("sad")
@@ -60,7 +60,7 @@ def test_logs_basics(sentry_init, capture_envelopes):
     assert envelopes[2].items[0].payload.json["severityText"] == "info"
     assert envelopes[2].items[0].payload.json["severityNumber"] == 9
 
-    assert envelopes[3].items[0].payload.json["severityText"] == "warn"
+    assert envelopes[3].items[0].payload.json["severityText"] == "warning"
     assert envelopes[3].items[0].payload.json["severityNumber"] == 13
 
     assert envelopes[4].items[0].payload.json["severityText"] == "error"
@@ -98,7 +98,7 @@ def test_logs_before_emit_log(sentry_init, capture_envelopes):
     sentry_sdk.logger.trace("This is a 'trace' log...")
     sentry_sdk.logger.debug("This is a 'debug' log...")
     sentry_sdk.logger.info("This is a 'info' log...")
-    sentry_sdk.logger.warning("This is a 'warn' log...")
+    sentry_sdk.logger.warning("This is a 'warning' log...")
     sentry_sdk.logger.error("This is a 'error' log...")
     sentry_sdk.logger.fatal("This is a 'fatal' log...")
 
@@ -107,7 +107,7 @@ def test_logs_before_emit_log(sentry_init, capture_envelopes):
     assert envelopes[0].items[0].payload.json["severityText"] == "trace"
     assert envelopes[1].items[0].payload.json["severityText"] == "debug"
     assert envelopes[2].items[0].payload.json["severityText"] == "info"
-    assert envelopes[3].items[0].payload.json["severityText"] == "warn"
+    assert envelopes[3].items[0].payload.json["severityText"] == "warning"
 
 
 @minimum_python_37
@@ -247,7 +247,7 @@ def test_logger_integration_warning(sentry_init, capture_envelopes):
     assert attrs["sentry.message.parameters.0"] == {"stringValue": "1"}
     assert attrs["sentry.message.parameters.1"]
     assert log_entry["severityNumber"] == 13
-    assert log_entry["severityText"] == "warn"
+    assert log_entry["severityText"] == "warning"
 
 
 @minimum_python_37


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry-python/issues/4155, https://github.com/getsentry/sentry-python/issues/4225