### PR TITLE
fix(ai): Do not consume anthropic streaming stop

### DIFF
--- a/sentry_sdk/integrations/anthropic.py
+++ b/sentry_sdk/integrations/anthropic.py
@@ -184,8 +184,7 @@ def _sentry_patched_create_common(f, *args, **kwargs):
                     input_tokens, output_tokens, content_blocks = _collect_ai_data(
                         event, input_tokens, output_tokens, content_blocks
                     )
-                    if event.type != "message_stop":
-                        yield event
+                    yield event
 
                 _add_ai_data_to_span(
                     span, integration, input_tokens, output_tokens, content_blocks
@@ -202,8 +201,7 @@ def _sentry_patched_create_common(f, *args, **kwargs):
                     input_tokens, output_tokens, content_blocks = _collect_ai_data(
                         event, input_tokens, output_tokens, content_blocks
                     )
-                    if event.type != "message_stop":
-                        yield event
+                    yield event
 
                 _add_ai_data_to_span(
                     span, integration, input_tokens, output_tokens, content_blocks


### PR DESCRIPTION
The old functionality wouldn't re-emit the `stop` message for streaming Anthropic calls.