### PR TITLE
feat(logs): Add sentry.origin attribute for log handler

### DIFF
--- a/sentry_sdk/integrations/logging.py
+++ b/sentry_sdk/integrations/logging.py
@@ -358,7 +358,9 @@ class SentryLogsHandler(_BaseHandler):
         # type: (BaseClient, LogRecord) -> None
         scope = sentry_sdk.get_current_scope()
         otel_severity_number, otel_severity_text = _python_level_to_otel(record.levelno)
-        attrs = {}  # type: dict[str, str | bool | float | int]
+        attrs = {
+            "sentry.origin": "auto.logger.log",
+        }  # type: dict[str, str | bool | float | int]
         if isinstance(record.msg, str):
             attrs["sentry.message.template"] = record.msg
         if record.args is not None:

--- a/tests/test_logs.py
+++ b/tests/test_logs.py
@@ -283,6 +283,7 @@ def test_logger_integration_warning(sentry_init, capture_envelopes):
     assert attrs["sentry.environment"] == "production"
     assert attrs["sentry.message.parameters.0"] == "1"
     assert attrs["sentry.message.parameters.1"] == "2"
+    assert attrs["sentry.origin"] == "auto.logger.log"
     assert logs[0]["severity_number"] == 13
     assert logs[0]["severity_text"] == "warn"
 


### PR DESCRIPTION
resolves https://linear.app/getsentry/issue/LOGS-13

Docs: https://develop-docs-git-abhi-logs-sdk-developer-documentation.sentry.dev/sdk/telemetry/logs/#default-attributes

> If a log is generated by an SDK integration, the SDK should also set the sentry.origin attribute, as per the [Trace Origin](https://develop-docs-git-abhi-logs-sdk-developer-documentation.sentry.dev/sdk/telemetry/logs/traces/trace-origin/) documentation. It is assumed that logs without a sentry.origin attribute are manually created by the user.