### PR TITLE
feat(transport): Add a timeout

### DIFF
--- a/sentry_sdk/transport.py
+++ b/sentry_sdk/transport.py
@@ -196,6 +196,8 @@ def _parse_rate_limits(header, now=None):
 class BaseHttpTransport(Transport):
     """The base HTTP transport."""
 
+    TIMEOUT = 10  # seconds
+
     def __init__(self, options):
         # type: (Self, Dict[str, Any]) -> None
         from sentry_sdk.consts import VERSION
@@ -621,7 +623,7 @@ class HttpTransport(BaseHttpTransport):
         options = {
             "num_pools": 2 if num_pools is None else int(num_pools),
             "cert_reqs": "CERT_REQUIRED",
-            "timeout": urllib3.Timeout(connect=5, read=5),
+            "timeout": urllib3.Timeout(connect=self.TIMEOUT, read=self.TIMEOUT),
         }
 
         socket_options = None  # type: Optional[List[Tuple[int, int, int | bytes]]]
@@ -766,6 +768,14 @@ else:
                 self._auth.get_api_url(endpoint_type),
                 content=body,
                 headers=headers,  # type: ignore
+                extensions={
+                    "timeout": {
+                        "connect": self.TIMEOUT,
+                        "read": self.TIMEOUT,
+                        "write": self.TIMEOUT,
+                        "pool": self.TIMEOUT,
+                    }
+                },
             )
             return response
 

--- a/sentry_sdk/transport.py
+++ b/sentry_sdk/transport.py
@@ -621,6 +621,7 @@ class HttpTransport(BaseHttpTransport):
         options = {
             "num_pools": 2 if num_pools is None else int(num_pools),
             "cert_reqs": "CERT_REQUIRED",
+            "timeout": urllib3.Timeout(connect=5, read=5),
         }
 
         socket_options = None  # type: Optional[List[Tuple[int, int, int | bytes]]]

--- a/sentry_sdk/transport.py
+++ b/sentry_sdk/transport.py
@@ -196,7 +196,7 @@ def _parse_rate_limits(header, now=None):
 class BaseHttpTransport(Transport):
     """The base HTTP transport."""
 
-    TIMEOUT = 10  # seconds
+    TIMEOUT = 30  # seconds
 
     def __init__(self, options):
         # type: (Self, Dict[str, Any]) -> None
@@ -623,7 +623,7 @@ class HttpTransport(BaseHttpTransport):
         options = {
             "num_pools": 2 if num_pools is None else int(num_pools),
             "cert_reqs": "CERT_REQUIRED",
-            "timeout": urllib3.Timeout(connect=self.TIMEOUT, read=self.TIMEOUT),
+            "timeout": urllib3.Timeout(total=self.TIMEOUT),
         }
 
         socket_options = None  # type: Optional[List[Tuple[int, int, int | bytes]]]
@@ -739,6 +739,8 @@ else:
     class Http2Transport(BaseHttpTransport):  # type: ignore
         """The HTTP2 transport based on httpcore."""
 
+        TIMEOUT = 15
+
         if TYPE_CHECKING:
             _pool: Union[
                 httpcore.SOCKSProxy, httpcore.HTTPProxy, httpcore.ConnectionPool
@@ -770,10 +772,10 @@ else:
                 headers=headers,  # type: ignore
                 extensions={
                     "timeout": {
-                        "connect": self.TIMEOUT,
-                        "read": self.TIMEOUT,
-                        "write": self.TIMEOUT,
                         "pool": self.TIMEOUT,
+                        "connect": self.TIMEOUT,
+                        "write": self.TIMEOUT,
+                        "read": self.TIMEOUT,
                     }
                 },
             )

--- a/tests/test_transport.py
+++ b/tests/test_transport.py
@@ -10,10 +10,14 @@ from datetime import datetime, timedelta, timezone
 from unittest import mock
 
 import brotli
-import httpcore
 import pytest
 from pytest_localserver.http import WSGIServer
 from werkzeug.wrappers import Request, Response
+
+try:
+    import httpcore
+except (ImportError, ModuleNotFoundError):
+    httpcore = None
 
 try:
     import gevent

--- a/tests/test_transport.py
+++ b/tests/test_transport.py
@@ -279,8 +279,7 @@ def test_default_timeout(make_client):
 
     options = client.transport._get_pool_options()
     assert "timeout" in options
-    assert options["timeout"].connect_timeout == client.transport.TIMEOUT
-    assert options["timeout"].read_timeout == client.transport.TIMEOUT
+    assert options["timeout"].total == client.transport.TIMEOUT
 
 
 @pytest.mark.skipif(not PY38, reason="HTTP2 libraries are only available in py3.8+")

--- a/tests/test_transport.py
+++ b/tests/test_transport.py
@@ -304,7 +304,6 @@ def test_default_timeout_http2(make_client):
             "read": client.transport.TIMEOUT,
         }
     }
-    sentry_sdk.get_global_scope().set_client(None)
 
 
 @pytest.mark.skipif(not PY38, reason="HTTP2 libraries are only available in py3.8+")

--- a/tests/test_transport.py
+++ b/tests/test_transport.py
@@ -274,6 +274,15 @@ def test_keep_alive_on_by_default(make_client):
     assert "socket_options" not in options
 
 
+def test_default_timeout(make_client):
+    client = make_client()
+
+    options = client.transport._get_pool_options()
+    assert "timeout" in options
+    assert options["timeout"].connect_timeout == 5
+    assert options["timeout"].read_timeout == 5
+
+
 @pytest.mark.skipif(not PY38, reason="HTTP2 libraries are only available in py3.8+")
 def test_http2_with_https_dsn(make_client):
     client = make_client(_experiments={"transport_http2": True})

--- a/tests/test_transport.py
+++ b/tests/test_transport.py
@@ -279,8 +279,8 @@ def test_default_timeout(make_client):
 
     options = client.transport._get_pool_options()
     assert "timeout" in options
-    assert options["timeout"].connect_timeout == 5
-    assert options["timeout"].read_timeout == 5
+    assert options["timeout"].connect_timeout == client.transport.TIMEOUT
+    assert options["timeout"].read_timeout == client.transport.TIMEOUT
 
 
 @pytest.mark.skipif(not PY38, reason="HTTP2 libraries are only available in py3.8+")


### PR DESCRIPTION
For some reason, we don't define any timeouts in our default transport(s).

With this change:
- We add a 30s total timeout for the whole connect+read cycle in the default HTTP transport
- In the experimental HTTP/2 httpcore-based transport there is no way to set a single timeout, so we set 15s each for getting a connection from the pool, connecting, writing, and reading

Backend SDKs in general set wildly different timeouts, from 30s in Go to <5s in Ruby or PHP. I went for the higher end of the range here since this is mainly meant to prevent the SDK preventing process shutdown like described in https://github.com/getsentry/sentry-python/issues/4247 -- we don't want to cut off legitimate requests that are just taking a long time. (I was considering going even higher, maybe to 60s -- but I think 30s is a good first shot at this and we can always change it later.)