### PR TITLE
ref: Remove `SpanKwargs` and `TransactionKwargs`

### DIFF
--- a/sentry_sdk/api.py
+++ b/sentry_sdk/api.py
@@ -30,8 +30,6 @@ if TYPE_CHECKING:
     from typing import Union
     from typing import Generator
 
-    from typing_extensions import Unpack
-
     from sentry_sdk.client import BaseClient
     from sentry_sdk._types import (
         Event,
@@ -42,7 +40,7 @@ if TYPE_CHECKING:
         MeasurementUnit,
         LogLevelStr,
     )
-    from sentry_sdk.tracing import Span, TransactionKwargs
+    from sentry_sdk.tracing import Span
 
     T = TypeVar("T")
     F = TypeVar("F", bound=Callable[..., Any])
@@ -258,7 +256,7 @@ def start_span(**kwargs):
 
 def start_transaction(
     transaction=None,  # type: Optional[Span]
-    **kwargs,  # type: Unpack[TransactionKwargs]
+    **kwargs,  # type: Any
 ):
     # type: (...) -> Span
     """

--- a/sentry_sdk/integrations/opentelemetry/scope.py
+++ b/sentry_sdk/integrations/opentelemetry/scope.py
@@ -34,9 +34,6 @@ from sentry_sdk._types import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from typing import Tuple, Optional, Generator, Dict, Any
-    from typing_extensions import Unpack
-
-    from sentry_sdk.tracing import TransactionKwargs
 
 
 class PotelScope(Scope):
@@ -136,7 +133,7 @@ class PotelScope(Scope):
         return span_context
 
     def start_transaction(self, **kwargs):
-        # type: (Unpack[TransactionKwargs]) -> Span
+        # type: (Any) -> Span
         """
         .. deprecated:: 3.0.0
             This function is deprecated and will be removed in a future release.

--- a/sentry_sdk/scope.py
+++ b/sentry_sdk/scope.py
@@ -56,8 +56,6 @@ if TYPE_CHECKING:
     from typing import Union
     from typing import Self
 
-    from typing_extensions import Unpack
-
     from sentry_sdk._types import (
         Breadcrumb,
         BreadcrumbHint,
@@ -69,8 +67,6 @@ if TYPE_CHECKING:
         LogLevelStr,
         Type,
     )
-
-    from sentry_sdk.tracing import TransactionKwargs
 
     import sentry_sdk
 
@@ -910,7 +906,7 @@ class Scope:
             self._n_breadcrumbs_truncated += 1
 
     def start_transaction(self, **kwargs):
-        # type: (Unpack[TransactionKwargs]) -> Union[NoOpSpan, Span]
+        # type: (Any) -> Union[NoOpSpan, Span]
         """
         .. deprecated:: 3.0.0
             This function is deprecated and will be removed in a future release.

--- a/sentry_sdk/tracing.py
+++ b/sentry_sdk/tracing.py
@@ -38,8 +38,6 @@ if TYPE_CHECKING:
     from typing import Union
     from typing import TypeVar
 
-    from typing_extensions import TypedDict
-
     P = ParamSpec("P")
     R = TypeVar("R")
 
@@ -49,83 +47,6 @@ if TYPE_CHECKING:
     )
 
     from sentry_sdk.tracing_utils import Baggage
-
-    class SpanKwargs(TypedDict, total=False):
-        trace_id: str
-        """
-        The trace ID of the root span. If this new span is to be the root span,
-        omit this parameter, and a new trace ID will be generated.
-        """
-
-        span_id: str
-        """The span ID of this span. If omitted, a new span ID will be generated."""
-
-        parent_span_id: str
-        """The span ID of the parent span, if applicable."""
-
-        same_process_as_parent: bool
-        """Whether this span is in the same process as the parent span."""
-
-        sampled: bool
-        """
-        Whether the span should be sampled. Overrides the default sampling decision
-        for this span when provided.
-        """
-
-        op: str
-        """
-        The span's operation. A list of recommended values is available here:
-        https://develop.sentry.dev/sdk/performance/span-operations/
-        """
-
-        description: str
-        """A description of what operation is being performed within the span. This argument is DEPRECATED. Please use the `name` parameter, instead."""
-
-        status: str
-        """The span's status. Possible values are listed at https://develop.sentry.dev/sdk/event-payloads/span/"""
-
-        containing_transaction: Optional["Span"]
-        """The transaction that this span belongs to."""
-
-        start_timestamp: Optional[Union[datetime, float]]
-        """
-        The timestamp when the span started. If omitted, the current time
-        will be used.
-        """
-
-        scope: "sentry_sdk.Scope"
-        """The scope to use for this span. If not provided, we use the current scope."""
-
-        origin: Optional[str]
-        """
-        The origin of the span.
-        See https://develop.sentry.dev/sdk/performance/trace-origin/
-        Default "manual".
-        """
-
-        name: str
-        """A string describing what operation is being performed within the span/transaction."""
-
-    class TransactionKwargs(SpanKwargs, total=False):
-        source: str
-        """
-        A string describing the source of the transaction name. This will be used to determine the transaction's type.
-        See https://develop.sentry.dev/sdk/event-payloads/transaction/#transaction-annotations for more information.
-        Default "custom".
-        """
-
-        parent_sampled: bool
-        """Whether the parent transaction was sampled. If True this transaction will be kept, if False it will be discarded."""
-
-        baggage: "Baggage"
-        """The W3C baggage header value. (see https://www.w3.org/TR/baggage/)"""
-
-    ProfileContext = TypedDict(
-        "ProfileContext",
-        {
-            "profiler_id": str,
-        },
-    )
 
 BAGGAGE_HEADER_NAME = "baggage"
 SENTRY_TRACE_HEADER_NAME = "sentry-trace"


### PR DESCRIPTION
These classes were added so that `start_transaction`'s `kwargs` would be typed.

Now that that function is deprecated, these classes are no longer needed. The types have also now diverged from the actual signature of `Span.__init__`, making their continued presence confusing

<!-- Describe your PR here -->

---

Thank you for contributing to `sentry-python`! Please add tests to validate your changes, and lint your code using `tox -e linters`.

Running the test suite on your PR might require maintainer approval.