### PR TITLE
feat(tracing): Remove `containing_transaction`

### DIFF
--- a/sentry_sdk/api.py
+++ b/sentry_sdk/api.py
@@ -30,8 +30,6 @@ if TYPE_CHECKING:
     from typing import Union
     from typing import Generator
 
-    from typing_extensions import Unpack
-
     from sentry_sdk.client import BaseClient
     from sentry_sdk._types import (
         Event,
@@ -42,7 +40,7 @@ if TYPE_CHECKING:
         MeasurementUnit,
         LogLevelStr,
     )
-    from sentry_sdk.tracing import Span, TransactionKwargs
+    from sentry_sdk.tracing import Span
 
     T = TypeVar("T")
     F = TypeVar("F", bound=Callable[..., Any])
@@ -258,7 +256,7 @@ def start_span(**kwargs):
 
 def start_transaction(
     transaction=None,  # type: Optional[Span]
-    **kwargs,  # type: Unpack[TransactionKwargs]
+    **kwargs,  # type: Any
 ):
     # type: (...) -> Span
     """

--- a/sentry_sdk/integrations/opentelemetry/scope.py
+++ b/sentry_sdk/integrations/opentelemetry/scope.py
@@ -34,9 +34,6 @@ from sentry_sdk._types import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from typing import Tuple, Optional, Generator, Dict, Any
-    from typing_extensions import Unpack
-
-    from sentry_sdk.tracing import TransactionKwargs
 
 
 class PotelScope(Scope):
@@ -136,7 +133,7 @@ class PotelScope(Scope):
         return span_context
 
     def start_transaction(self, **kwargs):
-        # type: (Unpack[TransactionKwargs]) -> Span
+        # type: (Any) -> Span
         """
         .. deprecated:: 3.0.0
             This function is deprecated and will be removed in a future release.

--- a/sentry_sdk/scope.py
+++ b/sentry_sdk/scope.py
@@ -56,8 +56,6 @@ if TYPE_CHECKING:
     from typing import Union
     from typing import Self
 
-    from typing_extensions import Unpack
-
     from sentry_sdk._types import (
         Breadcrumb,
         BreadcrumbHint,
@@ -69,8 +67,6 @@ if TYPE_CHECKING:
         LogLevelStr,
         Type,
     )
-
-    from sentry_sdk.tracing import TransactionKwargs
 
     import sentry_sdk
 
@@ -910,7 +906,7 @@ class Scope:
             self._n_breadcrumbs_truncated += 1
 
     def start_transaction(self, **kwargs):
-        # type: (Unpack[TransactionKwargs]) -> Union[NoOpSpan, Span]
+        # type: (Any) -> Union[NoOpSpan, Span]
         """
         .. deprecated:: 3.0.0
             This function is deprecated and will be removed in a future release.

--- a/sentry_sdk/scope.py
+++ b/sentry_sdk/scope.py
@@ -698,21 +698,21 @@ class Scope:
             return None
 
         # there is an orphan span on the scope
-        if self._span.containing_transaction is None:
+        if self._span.root_span is None:
             return None
-        # there is either a transaction (which is its own containing
-        # transaction) or a non-orphan span on the scope
-        return self._span.containing_transaction
+        # there is either a root span (which is its own root
+        # span) or a non-orphan span on the scope
+        return self._span.root_span
 
     def set_transaction_name(self, name, source=None):
         # type: (str, Optional[str]) -> None
         """Set the transaction name and optionally the transaction source."""
         self._transaction = name
 
-        if self._span and self._span.containing_transaction:
-            self._span.containing_transaction.name = name
+        if self._span and self._span.root_span:
+            self._span.root_span.name = name
             if source:
-                self._span.containing_transaction.source = source
+                self._span.root_span.source = source
 
         if source:
             self._transaction_info["source"] = source

--- a/sentry_sdk/tracing.py
+++ b/sentry_sdk/tracing.py
@@ -38,8 +38,6 @@ if TYPE_CHECKING:
     from typing import Union
     from typing import TypeVar
 
-    from typing_extensions import TypedDict
-
     P = ParamSpec("P")
     R = TypeVar("R")
 
@@ -49,83 +47,6 @@ if TYPE_CHECKING:
     )
 
     from sentry_sdk.tracing_utils import Baggage
-
-    class SpanKwargs(TypedDict, total=False):
-        trace_id: str
-        """
-        The trace ID of the root span. If this new span is to be the root span,
-        omit this parameter, and a new trace ID will be generated.
-        """
-
-        span_id: str
-        """The span ID of this span. If omitted, a new span ID will be generated."""
-
-        parent_span_id: str
-        """The span ID of the parent span, if applicable."""
-
-        same_process_as_parent: bool
-        """Whether this span is in the same process as the parent span."""
-
-        sampled: bool
-        """
-        Whether the span should be sampled. Overrides the default sampling decision
-        for this span when provided.
-        """
-
-        op: str
-        """
-        The span's operation. A list of recommended values is available here:
-        https://develop.sentry.dev/sdk/performance/span-operations/
-        """
-
-        description: str
-        """A description of what operation is being performed within the span. This argument is DEPRECATED. Please use the `name` parameter, instead."""
-
-        status: str
-        """The span's status. Possible values are listed at https://develop.sentry.dev/sdk/event-payloads/span/"""
-
-        containing_transaction: Optional["Span"]
-        """The transaction that this span belongs to."""
-
-        start_timestamp: Optional[Union[datetime, float]]
-        """
-        The timestamp when the span started. If omitted, the current time
-        will be used.
-        """
-
-        scope: "sentry_sdk.Scope"
-        """The scope to use for this span. If not provided, we use the current scope."""
-
-        origin: Optional[str]
-        """
-        The origin of the span.
-        See https://develop.sentry.dev/sdk/performance/trace-origin/
-        Default "manual".
-        """
-
-        name: str
-        """A string describing what operation is being performed within the span/transaction."""
-
-    class TransactionKwargs(SpanKwargs, total=False):
-        source: str
-        """
-        A string describing the source of the transaction name. This will be used to determine the transaction's type.
-        See https://develop.sentry.dev/sdk/event-payloads/transaction/#transaction-annotations for more information.
-        Default "custom".
-        """
-
-        parent_sampled: bool
-        """Whether the parent transaction was sampled. If True this transaction will be kept, if False it will be discarded."""
-
-        baggage: "Baggage"
-        """The W3C baggage header value. (see https://www.w3.org/TR/baggage/)"""
-
-    ProfileContext = TypedDict(
-        "ProfileContext",
-        {
-            "profiler_id": str,
-        },
-    )
 
 BAGGAGE_HEADER_NAME = "baggage"
 SENTRY_TRACE_HEADER_NAME = "sentry-trace"

--- a/sentry_sdk/tracing.py
+++ b/sentry_sdk/tracing.py
@@ -1,7 +1,6 @@
 from datetime import datetime
 from enum import Enum
 import json
-import warnings
 
 from opentelemetry import trace as otel_trace, context
 from opentelemetry.trace import (
@@ -139,7 +138,7 @@ class NoOpSpan:
         return "<%s>" % self.__class__.__name__
 
     @property
-    def containing_transaction(self):
+    def root_span(self):
         # type: () -> Optional[Span]
         return None
 
@@ -387,22 +386,6 @@ class Span:
         from sentry_sdk.integrations.opentelemetry.consts import SentrySpanAttribute
 
         self.set_attribute(SentrySpanAttribute.ORIGIN, value)
-
-    @property
-    def containing_transaction(self):
-        # type: () -> Optional[Span]
-        """
-        Get the transaction this span is a child of.
-
-        .. deprecated:: 3.0.0
-            This will be removed in the future. Use :func:`root_span` instead.
-        """
-        warnings.warn(
-            "Deprecated: This will be removed in the future. Use root_span instead.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        return self.root_span
 
     @property
     def root_span(self):

--- a/tests/integrations/rust_tracing/test_rust_tracing.py
+++ b/tests/integrations/rust_tracing/test_rust_tracing.py
@@ -189,7 +189,7 @@ def test_on_new_span_without_transaction(sentry_init):
     rust_tracing.new_span(RustTracingLevel.Info, 3)
     current_span = sentry_sdk.get_current_span()
     assert current_span is not None
-    assert current_span.containing_transaction is None
+    assert current_span.root_span is None
 
 
 def test_on_event_exception(sentry_init, capture_events):


### PR DESCRIPTION
BREAKING CHANGE: Remove `Span.containing_transaction`. Use `Span.root_span` instead.

Closes #4253

<!-- Describe your PR here -->

---

Thank you for contributing to `sentry-python`! Please add tests to validate your changes, and lint your code using `tox -e linters`.

Running the test suite on your PR might require maintainer approval.