### PR TITLE
feat(logs): Add server.address to logs

### DIFF
--- a/sentry_sdk/client.py
+++ b/sentry_sdk/client.py
@@ -27,6 +27,7 @@ from sentry_sdk.serializer import serialize
 from sentry_sdk.tracing import trace
 from sentry_sdk.transport import BaseHttpTransport, make_transport
 from sentry_sdk.consts import (
+    SPANDATA,
     DEFAULT_MAX_VALUE_LENGTH,
     DEFAULT_OPTIONS,
     INSTRUMENTER,
@@ -893,6 +894,10 @@ class _Client(BaseClient):
         if not logs_enabled:
             return
         isolation_scope = current_scope.get_isolation_scope()
+
+        server_name = self.options.get("server_name")
+        if server_name is not None and SPANDATA.SERVER_ADDRESS not in log["attributes"]:
+            log["attributes"][SPANDATA.SERVER_ADDRESS] = server_name
 
         environment = self.options.get("environment")
         if environment is not None and "sentry.environment" not in log["attributes"]:

--- a/tests/test_logs.py
+++ b/tests/test_logs.py
@@ -11,6 +11,7 @@ from sentry_sdk import get_client
 from sentry_sdk.envelope import Envelope
 from sentry_sdk.integrations.logging import LoggingIntegration
 from sentry_sdk.types import Log
+from sentry_sdk.consts import SPANDATA
 
 minimum_python_37 = pytest.mark.skipif(
     sys.version_info < (3, 7), reason="Asyncio tests need Python >= 3.7"
@@ -184,6 +185,7 @@ def test_logs_attributes(sentry_init, capture_envelopes):
     assert logs[0]["attributes"]["sentry.environment"] == "production"
     assert "sentry.release" in logs[0]["attributes"]
     assert logs[0]["attributes"]["sentry.message.parameters.my_var"] == "some value"
+    assert logs[0]["attributes"][SPANDATA.SERVER_ADDRESS]
 
 
 @minimum_python_37

--- a/tests/test_logs.py
+++ b/tests/test_logs.py
@@ -162,7 +162,7 @@ def test_logs_attributes(sentry_init, capture_envelopes):
     """
     Passing arbitrary attributes to log messages.
     """
-    sentry_init(_experiments={"enable_logs": True})
+    sentry_init(_experiments={"enable_logs": True}, server_name="test-server")
     envelopes = capture_envelopes()
 
     attrs = {
@@ -185,7 +185,7 @@ def test_logs_attributes(sentry_init, capture_envelopes):
     assert logs[0]["attributes"]["sentry.environment"] == "production"
     assert "sentry.release" in logs[0]["attributes"]
     assert logs[0]["attributes"]["sentry.message.parameters.my_var"] == "some value"
-    assert logs[0]["attributes"][SPANDATA.SERVER_ADDRESS]
+    assert logs[0]["attributes"][SPANDATA.SERVER_ADDRESS] == "test-server"
 
 
 @minimum_python_37


### PR DESCRIPTION
Docs: https://develop-docs-git-abhi-logs-sdk-developer-documentation.sentry.dev/sdk/telemetry/logs/#default-attributes

> [BACKEND SDKS ONLY] `server.address`: The address of the server that sent the log. Equivalent to server_name we attach to errors and transactions.

`server.address` convention docs: https://getsentry.github.io/sentry-conventions/generated/attributes/server.html#serveraddress

resolves https://linear.app/getsentry/issue/LOGS-33