### PR TITLE
feat(logs): Add sdk name and version as log attributes

### DIFF
--- a/sentry_sdk/client.py
+++ b/sentry_sdk/client.py
@@ -895,6 +895,9 @@ class _Client(BaseClient):
             return
         isolation_scope = current_scope.get_isolation_scope()
 
+        log["attributes"]["sentry.sdk.name"] = SDK_INFO["name"]
+        log["attributes"]["sentry.sdk.version"] = SDK_INFO["version"]
+
         server_name = self.options.get("server_name")
         if server_name is not None and SPANDATA.SERVER_ADDRESS not in log["attributes"]:
             log["attributes"][SPANDATA.SERVER_ADDRESS] = server_name

--- a/tests/test_logs.py
+++ b/tests/test_logs.py
@@ -11,7 +11,7 @@ from sentry_sdk import get_client
 from sentry_sdk.envelope import Envelope
 from sentry_sdk.integrations.logging import LoggingIntegration
 from sentry_sdk.types import Log
-from sentry_sdk.consts import SPANDATA
+from sentry_sdk.consts import SPANDATA, VERSION
 
 minimum_python_37 = pytest.mark.skipif(
     sys.version_info < (3, 7), reason="Asyncio tests need Python >= 3.7"
@@ -186,6 +186,8 @@ def test_logs_attributes(sentry_init, capture_envelopes):
     assert "sentry.release" in logs[0]["attributes"]
     assert logs[0]["attributes"]["sentry.message.parameters.my_var"] == "some value"
     assert logs[0]["attributes"][SPANDATA.SERVER_ADDRESS] == "test-server"
+    assert logs[0]["attributes"]["sentry.sdk.name"] == "sentry.python"
+    assert logs[0]["attributes"]["sentry.sdk.version"] == VERSION
 
 
 @minimum_python_37


### PR DESCRIPTION
Docs: https://develop-docs-git-abhi-logs-sdk-developer-documentation.sentry.dev/sdk/telemetry/logs/#default-attributes

> sentry.sdk.name: The name of the SDK that sent the log
> sentry.sdk.version: The version of the SDK that sent the log

convention docs:
- `sentry.sdk.name`: https://getsentry.github.io/sentry-conventions/generated/attributes/sentry.html#sentrysdkname
- `sentry.sdk.version`: https://getsentry.github.io/sentry-conventions/generated/attributes/sentry.html#sentrysdkversion

resolves https://linear.app/getsentry/issue/PY-1/