### PR TITLE
fix: Import `warnings` in `tracing`

### DIFF
--- a/sentry_sdk/tracing.py
+++ b/sentry_sdk/tracing.py
@@ -1,6 +1,7 @@
 from datetime import datetime
 from enum import Enum
 import json
+import warnings
 
 from opentelemetry import trace as otel_trace, context
 from opentelemetry.trace import (


### PR DESCRIPTION
A missing `import warnings` in `tracing` is causing our linter action to fail