### PR TITLE
meta: Change CODEOWNERS back to Python SDK owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*   @getsentry/team-web-sdk-backend
+*   @getsentry/owners-python-sdk


### PR DESCRIPTION
Don't spam the whole backend SDK team on each PR.