### PR TITLE
ref(scope): Properly type `Scope.root_span`

### DIFF
--- a/sentry_sdk/scope.py
+++ b/sentry_sdk/scope.py
@@ -689,8 +689,7 @@ class Scope:
 
     @property
     def root_span(self):
-        # type: () -> Any
-        # would be type: () -> Optional[Span], see https://github.com/python/mypy/issues/3004
+        # type: () -> Optional[Span]
         """Return the root span in the scope, if any."""
 
         # there is no span/transaction on the scope


### PR DESCRIPTION
Currently, this property has type `Any`, but it can now be changed to `Optional[Span]`

Depends on:
  - #4263