### PR TITLE
Revert "chore: Deprecate `same_process_as_parent` (#4244)"

### DIFF
--- a/sentry_sdk/tracing.py
+++ b/sentry_sdk/tracing.py
@@ -323,13 +323,6 @@ class Span:
 
             self.scope = self.scope or hub.scope
 
-        if same_process_as_parent is not None:
-            warnings.warn(
-                "The `same_process_as_parent` parameter is deprecated.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
-
         if start_timestamp is None:
             start_timestamp = datetime.now(timezone.utc)
         elif isinstance(start_timestamp, float):


### PR DESCRIPTION
This reverts commit e05ed0aa62cfe2c992b26b07c64c3148f837a609.

`same_process_as_parent` is `True` by default, so we actually don't have a way of detecting whether this was set explicitly by the user or not.

Removing the deprecation altogether -- no one's using this.

Closes https://github.com/getsentry/sentry-python/issues/4289