### PR TITLE
fix(logging): Send raw logging parameters

### DIFF
--- a/sentry_sdk/integrations/logging.py
+++ b/sentry_sdk/integrations/logging.py
@@ -265,11 +265,7 @@ class EventHandler(_BaseHandler):
         else:
             event["logentry"] = {
                 "message": to_string(record.msg),
-                "params": (
-                    tuple(str(arg) if arg is None else arg for arg in record.args)
-                    if record.args
-                    else ()
-                ),
+                "params": record.args,
             }
 
         event["extra"] = self._extra_from_record(record)

--- a/tests/integrations/logging/test_logging.py
+++ b/tests/integrations/logging/test_logging.py
@@ -234,3 +234,33 @@ def test_ignore_logger_wildcard(sentry_init, capture_events):
 
     (event,) = events
     assert event["logentry"]["message"] == "hi"
+
+
+def test_logging_dictionary_interpolation(sentry_init, capture_events):
+    """Here we test an entire dictionary being interpolated into the log message."""
+    sentry_init(integrations=[LoggingIntegration()], default_integrations=False)
+    events = capture_events()
+
+    logger.error("this is a log with a dictionary %s", {"foo": "bar"})
+
+    (event,) = events
+    assert event["logentry"]["message"] == "this is a log with a dictionary %s"
+    assert event["logentry"]["params"] == {"foo": "bar"}
+
+
+def test_logging_dictionary_args(sentry_init, capture_events):
+    """Here we test items from a dictionary being interpolated into the log message."""
+    sentry_init(integrations=[LoggingIntegration()], default_integrations=False)
+    events = capture_events()
+
+    logger.error(
+        "the value of foo is %(foo)s, and the value of bar is %(bar)s",
+        {"foo": "bar", "bar": "baz"},
+    )
+
+    (event,) = events
+    assert (
+        event["logentry"]["message"]
+        == "the value of foo is %(foo)s, and the value of bar is %(bar)s"
+    )
+    assert event["logentry"]["params"] == {"foo": "bar", "bar": "baz"}


### PR DESCRIPTION
This reverts commit 4c9731bbe68b6523cccec73fb764e04e61e441cb, adding tests to ensure the correct behavior going forward.

That commit caused a regression when `record.args` contains a dictionary. Because we iterate over `record.args`, that change caused us to only send the dictionary's keys, not the values.

A more robust fix for #3660 will be to send the formatted message in the [`formatted` field](https://develop.sentry.dev/sdk/data-model/event-payloads/message/) (which we have not been doing yet). I will open a follow-up PR to do this.

Fixes #4267