### PR TITLE
fix(integrations): ASGI integration not capture transactions in Websocket

### DIFF
--- a/sentry_sdk/integrations/asgi.py
+++ b/sentry_sdk/integrations/asgi.py
@@ -192,8 +192,8 @@ class SentryAsgiMiddleware:
 
                     method = scope.get("method", "").upper()
                     transaction = None
-                    if method in self.http_methods_to_capture:
-                        if ty in ("http", "websocket"):
+                    if ty in ("http", "websocket"):
+                        if ty == "websocket" or method in self.http_methods_to_capture:
                             transaction = continue_trace(
                                 _get_headers(scope),
                                 op="{}.server".format(ty),
@@ -205,17 +205,18 @@ class SentryAsgiMiddleware:
                                 "[ASGI] Created transaction (continuing trace): %s",
                                 transaction,
                             )
-                        else:
-                            transaction = Transaction(
-                                op=OP.HTTP_SERVER,
-                                name=transaction_name,
-                                source=transaction_source,
-                                origin=self.span_origin,
-                            )
-                            logger.debug(
-                                "[ASGI] Created transaction (new): %s", transaction
-                            )
+                    else:
+                        transaction = Transaction(
+                            op=OP.HTTP_SERVER,
+                            name=transaction_name,
+                            source=transaction_source,
+                            origin=self.span_origin,
+                        )
+                        logger.debug(
+                            "[ASGI] Created transaction (new): %s", transaction
+                        )
 
+                    if transaction:
                         transaction.set_tag("asgi.type", ty)
                         logger.debug(
                             "[ASGI] Set transaction name and source on transaction: '%s' / '%s'",

--- a/tests/integrations/asgi/test_asgi.py
+++ b/tests/integrations/asgi/test_asgi.py
@@ -355,23 +355,17 @@ async def test_websocket(sentry_init, asgi3_ws_app, capture_events, request):
 
     asgi3_ws_app = SentryAsgiMiddleware(asgi3_ws_app)
 
-    scope = {
-        "type": "websocket",
-        "endpoint": asgi3_app,
-        "client": ("127.0.0.1", 60457),
-        "route": "some_url",
-        "headers": [
-            ("accept", "*/*"),
-        ],
-    }
+    request_url = "/ws"
 
     with pytest.raises(ValueError):
-        async with TestClient(asgi3_ws_app, scope=scope) as client:
-            async with client.websocket_connect("/ws") as ws:
-                await ws.receive_text()
+        client = TestClient(asgi3_ws_app)
+        async with client.websocket_connect(request_url) as ws:
+            await ws.receive_text()
 
     msg_event, error_event = events
 
+    assert msg_event["transaction"] == request_url
+    assert msg_event["transaction_info"]["source"] == "url"
     assert msg_event["message"] == "Some message to the world!"
 
     (exc,) = error_event["exception"]["values"]


### PR DESCRIPTION
fix(integrations): ASGI integration not capture transactions in Websocket

In [ASGI Specs](https://github.com/django/asgiref/blob/main/specs/www.rst#websocket-connection-scope), `method` is not in Websocket Connection Scope. 