### PR TITLE
feat(logging): Do not capture errors from `LoggingIntegration` to Sentry by default

### DIFF
--- a/MIGRATION_GUIDE.md
+++ b/MIGRATION_GUIDE.md
@@ -26,6 +26,7 @@ Looking to upgrade from Sentry SDK 2.x to 3.x? Here's a comprehensive list of wh
 - `sentry_sdk.init` now returns `None` instead of a context manager.
 - The `sampling_context` argument of `traces_sampler` and `profiles_sampler` now additionally contains all span attributes known at span start.
 - We updated how we handle `ExceptionGroup`s. You will now get more data if ExceptionGroups are appearing in chained exceptions. It could happen that after updating the SDK the grouping of issues change because of this. So eventually you will see the same exception in two Sentry issues (one from before the update, one from after the update)
+- The integration for Python `logging` module does not send Sentry issues by default anymore when calling `logging.error()`, `logging.critical()` or `logging.exception()`. If you want to preserve the old behavior use `sentry_sdk.init(integrations=[LoggingIntegration(event_level="ERROR")])`.
 - The integration-specific content of the `sampling_context` argument of `traces_sampler` and `profiles_sampler` now looks different.
   - The Celery integration doesn't add the `celery_job` dictionary anymore. Instead, the individual keys are now available as:
 

--- a/sentry_sdk/integrations/logging.py
+++ b/sentry_sdk/integrations/logging.py
@@ -23,7 +23,7 @@ if TYPE_CHECKING:
     from typing import Optional
 
 DEFAULT_LEVEL = logging.INFO
-DEFAULT_EVENT_LEVEL = logging.ERROR
+DEFAULT_EVENT_LEVEL = None  # None means no events are captured
 LOGGING_TO_EVENT_LEVEL = {
     logging.NOTSET: "notset",
     logging.DEBUG: "debug",

--- a/tests/integrations/flask/test_flask.py
+++ b/tests/integrations/flask/test_flask.py
@@ -285,7 +285,7 @@ def test_flask_session_tracking(sentry_init, capture_envelopes, app):
         try:
             raise ValueError("stuff")
         except Exception:
-            logging.exception("stuff happened")
+            sentry_sdk.capture_exception()
         1 / 0
 
     envelopes = capture_envelopes()
@@ -875,7 +875,12 @@ def test_dont_override_sentry_trace_context(sentry_init, app):
 
 
 def test_request_not_modified_by_reference(sentry_init, capture_events, app):
-    sentry_init(integrations=[flask_sentry.FlaskIntegration()])
+    sentry_init(
+        integrations=[
+            flask_sentry.FlaskIntegration(),
+            LoggingIntegration(event_level="ERROR"),
+        ]
+    )
 
     @app.route("/", methods=["POST"])
     def index():

--- a/tests/integrations/starlette/test_starlette.py
+++ b/tests/integrations/starlette/test_starlette.py
@@ -13,6 +13,7 @@ import pytest
 
 from sentry_sdk import capture_message, get_baggage, get_traceparent
 from sentry_sdk.integrations.asgi import SentryAsgiMiddleware
+from sentry_sdk.integrations.logging import LoggingIntegration
 from sentry_sdk.integrations.starlette import (
     StarletteIntegration,
     StarletteRequestExtractor,
@@ -943,7 +944,9 @@ def test_active_thread_id(sentry_init, capture_envelopes, teardown_profiling, en
 
 
 def test_original_request_not_scrubbed(sentry_init, capture_events):
-    sentry_init(integrations=[StarletteIntegration()])
+    sentry_init(
+        integrations=[StarletteIntegration(), LoggingIntegration(event_level="ERROR")]
+    )
 
     events = capture_events()
 

--- a/tests/test_logs.py
+++ b/tests/test_logs.py
@@ -331,7 +331,10 @@ def test_logging_errors(sentry_init, capture_envelopes):
     """
     The python logger module should be able to log errors without erroring
     """
-    sentry_init(_experiments={"enable_logs": True})
+    sentry_init(
+        _experiments={"enable_logs": True},
+        integrations=[LoggingIntegration(event_level="ERROR")],
+    )
     envelopes = capture_envelopes()
 
     python_logger = logging.Logger("test-logger")

--- a/tests/test_scrubber.py
+++ b/tests/test_scrubber.py
@@ -2,6 +2,7 @@ import sys
 import logging
 
 from sentry_sdk import capture_exception, capture_event, start_span
+from sentry_sdk.integrations.logging import LoggingIntegration
 from sentry_sdk.utils import event_from_exception
 from sentry_sdk.scrubber import EventScrubber
 from tests.conftest import ApproxDict
@@ -119,7 +120,10 @@ def test_stack_var_scrubbing(sentry_init, capture_events):
 
 
 def test_breadcrumb_extra_scrubbing(sentry_init, capture_events):
-    sentry_init(max_breadcrumbs=2)
+    sentry_init(
+        max_breadcrumbs=2,
+        integrations=[LoggingIntegration(event_level="ERROR")],
+    )
     events = capture_events()
     logger.info("breadcrumb 1", extra=dict(foo=1, password="secret"))
     logger.info("breadcrumb 2", extra=dict(bar=2, auth="secret"))


### PR DESCRIPTION
Fixes #4187 