### PR TITLE
(Partially) fix POTel CI

### DIFF
--- a/sentry_sdk/tracing.py
+++ b/sentry_sdk/tracing.py
@@ -183,16 +183,22 @@ class Span:
         only_if_parent=False,  # type: bool
         parent_span=None,  # type: Optional[Span]
         otel_span=None,  # type: Optional[OtelSpan]
+        span=None,  # type: Optional[Span]
     ):
         # type: (...) -> None
         """
         If otel_span is passed explicitly, just acts as a proxy.
+
+        If span is passed explicitly, use it. The only purpose of this param
+        if backwards compatibility with start_transaction(transaction=...).
 
         If only_if_parent is True, just return an INVALID_SPAN
         and avoid instrumentation if there's no active parent span.
         """
         if otel_span is not None:
             self._otel_span = otel_span
+        elif span is not None:
+            self._otel_span = span._otel_span
         else:
             skip_span = False
             if only_if_parent and parent_span is None:

--- a/tests/integrations/logging/test_logging.py
+++ b/tests/integrations/logging/test_logging.py
@@ -296,7 +296,10 @@ def test_ignore_logger_wildcard(sentry_init, capture_events):
 
 def test_logging_dictionary_interpolation(sentry_init, capture_events):
     """Here we test an entire dictionary being interpolated into the log message."""
-    sentry_init(integrations=[LoggingIntegration()], default_integrations=False)
+    sentry_init(
+        integrations=[LoggingIntegration(event_level=logging.ERROR)],
+        default_integrations=False,
+    )
     events = capture_events()
 
     logger.error("this is a log with a dictionary %s", {"foo": "bar"})
@@ -312,7 +315,10 @@ def test_logging_dictionary_interpolation(sentry_init, capture_events):
 
 def test_logging_dictionary_args(sentry_init, capture_events):
     """Here we test items from a dictionary being interpolated into the log message."""
-    sentry_init(integrations=[LoggingIntegration()], default_integrations=False)
+    sentry_init(
+        integrations=[LoggingIntegration(event_level=logging.ERROR)],
+        default_integrations=False,
+    )
     events = capture_events()
 
     logger.error(

--- a/tests/integrations/threading/test_threading.py
+++ b/tests/integrations/threading/test_threading.py
@@ -104,7 +104,6 @@ def test_propagates_threadpool_scope(sentry_init, capture_events, propagate_scop
         assert len(event["spans"]) == 0
 
 
-@pytest.mark.skip(reason="Temporarily disable to release SDK 2.0a1.")
 def test_circular_references(sentry_init, request):
     sentry_init(default_integrations=False, integrations=[ThreadingIntegration()])
 
@@ -232,7 +231,7 @@ def test_spans_from_multiple_threads(
 
     threads = []
 
-    with sentry_sdk.start_transaction(op="outer-trx"):
+    with sentry_sdk.start_span(op="outer-trx"):
         for number in range(5):
             with sentry_sdk.start_span(
                 op=f"outer-submit-{number}", name="Thread: main"


### PR DESCRIPTION
Porting stuff from master and other fixes
* add correct `event_level` to new logging tests (on `potel-base`, we don't capture logging errors by default so this has to be set explicitly)
* add compat for `start_transaction`
* re-enable an old test

**Note:** This still leaves one failing threading test, will address that separately