### PR TITLE
Remove `propagate_scope`

### DIFF
--- a/MIGRATION_GUIDE.md
+++ b/MIGRATION_GUIDE.md
@@ -152,7 +152,7 @@ Looking to upgrade from Sentry SDK 2.x to 3.x? Here's a comprehensive list of wh
 - `span.containing_transaction` has been removed. Use `span.root_span` instead.
 - `continue_from_headers`, `continue_from_environ` and `from_traceparent` have been removed, please use top-level API `sentry_sdk.continue_trace` instead.
 - `PropagationContext` constructor no longer takes a `dynamic_sampling_context` but takes a `baggage` object instead.
-- `ThreadingIntegration` no longer takes the `propagate_hub` argument.
+- `ThreadingIntegration` no longer takes the `propagate_hub` and `propagate_scope` arguments. Scope data will be propagated by default.
 - `Baggage.populate_from_transaction` has been removed.
 - `debug.configure_debug_hub` was removed.
 - `profiles_sample_rate` and `profiler_mode` were removed from options available via `_experiments`. Use the top-level `profiles_sample_rate` and `profiler_mode` options instead.

--- a/sentry_sdk/integrations/threading.py
+++ b/sentry_sdk/integrations/threading.py
@@ -106,6 +106,9 @@ def _wrap_run(isolation_scope_to_use, current_scope_to_use, old_run_func):
             with sentry_sdk.use_isolation_scope(isolation_scope_to_use):
                 with sentry_sdk.use_scope(current_scope_to_use):
                     return _run_old_run_func()
+        else:
+            with sentry_sdk.isolation_scope():
+                return _run_old_run_func()
 
     return run  # type: ignore
 


### PR DESCRIPTION
Remove `propagate_scope` from `ThreadingIntegration`.

We added `propagate_scope` as a replacement for `propagate_hub` in the hubs & scopes refactor, but as [this comment](https://github.com/getsentry/sentry-python/blob/a8516c2e3bc27f4998eaa2500570c32211c7e8f1/sentry_sdk/integrations/threading.py#L37-L39) states:

> Note: propagate_hub did not have any effect on propagation of scope data
  scope data was always propagated no matter what the value of propagate_hub was
  This is why the default for propagate_scope is True

So this is not actually a replacement for `propagate_hub`. Unless we have a usecase in mind which `propagate_scope=False` solves, let's just remove it.

I also checked public code on GitHub and no one sets `propagate_scope` to `False`.