### PR TITLE
Cleaning up types

### DIFF
--- a/scripts/populate_tox/config.py
+++ b/scripts/populate_tox/config.py
@@ -159,9 +159,6 @@ TEST_SUITE_CONFIG = {
     },
     "statsig": {
         "package": "statsig",
-        "deps": {
-            "*": ["typing_extensions"],
-        },
     },
     "strawberry": {
         "package": "strawberry-graphql[fastapi,flask]",

--- a/sentry_sdk/_types.py
+++ b/sentry_sdk/_types.py
@@ -129,6 +129,22 @@ Log = TypedDict(
 # "critical" is an alias of "fatal" recognized by Relay
 LogLevelStr = Literal["fatal", "critical", "error", "warning", "info", "debug"]
 
+EventDataCategory = Literal[
+    "default",
+    "error",
+    "crash",
+    "transaction",
+    "security",
+    "attachment",
+    "session",
+    "internal",
+    "profile",
+    "profile_chunk",
+    "monitor",
+    "span",
+    "log",
+]
+
 DurationUnit = Literal[
     "nanosecond",
     "microsecond",
@@ -249,21 +265,6 @@ if TYPE_CHECKING:
     # https://github.com/python/mypy/issues/5710
     NotImplementedType = Any
 
-    EventDataCategory = Literal[
-        "default",
-        "error",
-        "crash",
-        "transaction",
-        "security",
-        "attachment",
-        "session",
-        "internal",
-        "profile",
-        "profile_chunk",
-        "monitor",
-        "span",
-        "log",
-    ]
     SessionStatus = Literal["ok", "exited", "crashed", "abnormal"]
 
     ContinuousProfilerMode = Literal["thread", "gevent", "unknown"]

--- a/sentry_sdk/consts.py
+++ b/sentry_sdk/consts.py
@@ -32,14 +32,14 @@ if TYPE_CHECKING:
     from typing import Optional
     from typing import Callable
     from typing import Union
+    from typing import Literal
     from typing import List
     from typing import Type
     from typing import Dict
     from typing import Any
     from typing import Sequence
     from typing import Tuple
-    from typing_extensions import Literal
-    from typing_extensions import TypedDict
+    from typing import TypedDict
 
     from sentry_sdk._types import (
         BreadcrumbProcessor,

--- a/sentry_sdk/integrations/_asgi_common.py
+++ b/sentry_sdk/integrations/_asgi_common.py
@@ -8,9 +8,9 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from typing import Any
     from typing import Dict
+    from typing import Literal
     from typing import Optional
     from typing import Union
-    from typing_extensions import Literal
 
     from sentry_sdk.utils import AnnotatedValue
 

--- a/sentry_sdk/profiler/continuous_profiler.py
+++ b/sentry_sdk/profiler/continuous_profiler.py
@@ -34,8 +34,9 @@ if TYPE_CHECKING:
     from typing import Optional
     from typing import Set
     from typing import Type
+    from typing import TypedDict
     from typing import Union
-    from typing_extensions import TypedDict
+
     from sentry_sdk._types import ContinuousProfilerMode, SDKInfo
     from sentry_sdk.profiler.utils import (
         ExtractedSample,

--- a/sentry_sdk/profiler/transaction_profiler.py
+++ b/sentry_sdk/profiler/transaction_profiler.py
@@ -62,7 +62,7 @@ if TYPE_CHECKING:
     from typing import Optional
     from typing import Set
     from typing import Type
-    from typing_extensions import TypedDict
+    from typing import TypedDict
 
     from sentry_sdk.profiler.utils import (
         ProcessedStack,

--- a/sentry_sdk/profiler/utils.py
+++ b/sentry_sdk/profiler/utils.py
@@ -14,7 +14,7 @@ if TYPE_CHECKING:
     from typing import Optional
     from typing import Sequence
     from typing import Tuple
-    from typing_extensions import TypedDict
+    from typing import TypedDict
 
     ThreadId = str
 

--- a/sentry_sdk/types.py
+++ b/sentry_sdk/types.py
@@ -1,25 +1,20 @@
-"""
-This module contains type definitions for the Sentry SDK's public API.
-The types are re-exported from the internal module `sentry_sdk._types`.
+# Re-exported from sentry_sdk._types to make those types public
+from sentry_sdk._types import (
+    Event,
+    EventDataCategory,
+    Hint,
+    Log,
+    Breadcrumb,
+    BreadcrumbHint,
+    SamplingContext,
+)
 
-Disclaimer: Since types are a form of documentation, type definitions
-may change in minor releases. Removing a type would be considered a
-breaking change, and so we will only remove type definitions in major
-releases.
-"""
-
-from typing import TYPE_CHECKING
-
-if TYPE_CHECKING:
-    from sentry_sdk._types import Event, EventDataCategory, Hint, Log
-else:
-    from typing import Any
-
-    # The lines below allow the types to be imported from outside `if TYPE_CHECKING`
-    # guards. The types in this module are only intended to be used for type hints.
-    Event = Any
-    EventDataCategory = Any
-    Hint = Any
-    Log = Any
-
-__all__ = ("Event", "EventDataCategory", "Hint", "Log")
+__all__ = (
+    "Event",
+    "EventDataCategory",
+    "Hint",
+    "Log",
+    "Breadcrumb",
+    "BreadcrumbHint",
+    "SamplingContext",
+)


### PR DESCRIPTION
Reorganize our types so they are easy for humans and IDEs to find and use.

As we will support Python 3.8+ we can refrain from using `typing_extension` 

Fixes #4127