### PR TITLE
Make all relevant types public

### DIFF
--- a/sentry_sdk/_types.py
+++ b/sentry_sdk/_types.py
@@ -220,7 +220,9 @@ if TYPE_CHECKING:
         tuple[None, None, None],
     ]
 
+    # TODO: Make a proper type definition for this
     Hint = Dict[str, Any]
+
     Log = TypedDict(
         "Log",
         {
@@ -233,9 +235,13 @@ if TYPE_CHECKING:
         },
     )
 
+    # TODO: Make a proper type definition for this
     Breadcrumb = Dict[str, Any]
+
+    # TODO: Make a proper type definition for this
     BreadcrumbHint = Dict[str, Any]
 
+    # TODO: Make a proper type definition for this
     SamplingContext = Dict[str, Any]
 
     EventProcessor = Callable[[Event, Hint], Optional[Event]]

--- a/sentry_sdk/_types.py
+++ b/sentry_sdk/_types.py
@@ -220,7 +220,7 @@ if TYPE_CHECKING:
         tuple[None, None, None],
     ]
 
-    # TODO: Make a proper type definition for this
+    # TODO: Make a proper type definition for this (PRs welcome!)
     Hint = Dict[str, Any]
 
     Log = TypedDict(
@@ -235,13 +235,13 @@ if TYPE_CHECKING:
         },
     )
 
-    # TODO: Make a proper type definition for this
+    # TODO: Make a proper type definition for this (PRs welcome!)
     Breadcrumb = Dict[str, Any]
 
-    # TODO: Make a proper type definition for this
+    # TODO: Make a proper type definition for this (PRs welcome!)
     BreadcrumbHint = Dict[str, Any]
 
-    # TODO: Make a proper type definition for this
+    # TODO: Make a proper type definition for this (PRs welcome!)
     SamplingContext = Dict[str, Any]
 
     EventProcessor = Callable[[Event, Hint], Optional[Event]]

--- a/sentry_sdk/types.py
+++ b/sentry_sdk/types.py
@@ -11,15 +11,39 @@ releases.
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from sentry_sdk._types import Event, EventDataCategory, Hint, Log
+    # Re-export types to make them available in the public API
+    from sentry_sdk._types import (
+        Breadcrumb,
+        BreadcrumbHint,
+        Event,
+        EventDataCategory,
+        Hint,
+        Log,
+        MonitorConfig,
+        SamplingContext,
+    )
 else:
     from typing import Any
 
     # The lines below allow the types to be imported from outside `if TYPE_CHECKING`
     # guards. The types in this module are only intended to be used for type hints.
+    Breadcrumb = Any
+    BreadcrumbHint = Any
     Event = Any
     EventDataCategory = Any
     Hint = Any
     Log = Any
+    MonitorConfig = Any
+    SamplingContext = Any
 
-__all__ = ("Event", "EventDataCategory", "Hint", "Log")
+
+__all__ = (
+    "Breadcrumb",
+    "BreadcrumbHint",
+    "Event",
+    "EventDataCategory",
+    "Hint",
+    "Log",
+    "MonitorConfig",
+    "SamplingContext",
+)


### PR DESCRIPTION
Make types that users can use when configuring the SDK public. 

Accompaniyng docs update: https://github.com/getsentry/sentry-docs/pull/13437

Fixes #4127