### PR TITLE
tests: Fix version picking in toxgen

### DIFF
--- a/scripts/populate_tox/populate_tox.py
+++ b/scripts/populate_tox/populate_tox.py
@@ -190,10 +190,10 @@ def _prefilter_releases(
             if (
                 version.major == saved_version.major
                 and version.minor == saved_version.minor
-                and version.micro > saved_version.micro
             ):
-                # Don't save all patch versions of a release, just the newest one
-                filtered_releases[i] = version
+                if version.micro > saved_version.micro:
+                    # Don't save all patch versions of a release, just the newest one
+                    filtered_releases[i] = version
                 break
         else:
             filtered_releases.append(version)

--- a/scripts/populate_tox/populate_tox.py
+++ b/scripts/populate_tox/populate_tox.py
@@ -191,8 +191,8 @@ def _prefilter_releases(
                 version.major == saved_version.major
                 and version.minor == saved_version.minor
             ):
+                # Don't save all patch versions of a release, just the newest one
                 if version.micro > saved_version.micro:
-                    # Don't save all patch versions of a release, just the newest one
                     filtered_releases[i] = version
                 break
         else:

--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,7 @@
 # The file (and all resulting CI YAMLs) then need to be regenerated via
 # "scripts/generate-test-files.sh".
 #
-# Last generated: 2025-04-17T11:01:25.976599+00:00
+# Last generated: 2025-04-23T07:46:44.042662+00:00
 
 [tox]
 requires =
@@ -145,8 +145,8 @@ envlist =
 
     # ~~~ AI ~~~
     {py3.9,py3.10,py3.11}-cohere-v5.4.0
-    {py3.9,py3.11,py3.12}-cohere-v5.9.4
-    {py3.9,py3.11,py3.12}-cohere-v5.13.9
+    {py3.9,py3.11,py3.12}-cohere-v5.8.1
+    {py3.9,py3.11,py3.12}-cohere-v5.11.4
     {py3.9,py3.11,py3.12}-cohere-v5.15.0
 
     {py3.8,py3.10,py3.11}-huggingface_hub-v0.22.2
@@ -167,9 +167,8 @@ envlist =
     {py3.6,py3.7}-redis_py_cluster_legacy-v2.0.0
     {py3.6,py3.7,py3.8}-redis_py_cluster_legacy-v2.1.3
 
-    {py3.6,py3.7}-sqlalchemy-v1.3.9
+    {py3.6,py3.8,py3.9}-sqlalchemy-v1.3.24
     {py3.6,py3.11,py3.12}-sqlalchemy-v1.4.54
-    {py3.7,py3.10,py3.11}-sqlalchemy-v2.0.9
     {py3.7,py3.12,py3.13}-sqlalchemy-v2.0.40
 
 
@@ -195,7 +194,7 @@ envlist =
     {py3.8,py3.10,py3.11}-ariadne-v0.20.1
     {py3.8,py3.11,py3.12}-ariadne-v0.22
     {py3.8,py3.11,py3.12}-ariadne-v0.24.0
-    {py3.9,py3.12,py3.13}-ariadne-v0.26.1
+    {py3.9,py3.12,py3.13}-ariadne-v0.26.2
 
     {py3.6,py3.9,py3.10}-gql-v3.4.1
     {py3.7,py3.11,py3.12}-gql-v3.5.2
@@ -207,7 +206,7 @@ envlist =
     {py3.8,py3.10,py3.11}-strawberry-v0.209.8
     {py3.8,py3.11,py3.12}-strawberry-v0.228.0
     {py3.8,py3.12,py3.13}-strawberry-v0.247.2
-    {py3.9,py3.12,py3.13}-strawberry-v0.265.1
+    {py3.9,py3.12,py3.13}-strawberry-v0.266.0
 
 
     # ~~~ Network ~~~
@@ -240,12 +239,11 @@ envlist =
 
 
     # ~~~ Web 1 ~~~
-    {py3.6}-django-v1.11.9
     {py3.6,py3.7}-django-v1.11.29
     {py3.6,py3.8,py3.9}-django-v2.2.28
     {py3.6,py3.9,py3.10}-django-v3.2.25
     {py3.8,py3.11,py3.12}-django-v4.2.20
-    {py3.10,py3.11,py3.12}-django-v5.0.9
+    {py3.10,py3.11,py3.12}-django-v5.0.14
     {py3.10,py3.12,py3.13}-django-v5.2
 
     {py3.6,py3.7,py3.8}-flask-v1.1.4
@@ -266,7 +264,7 @@ envlist =
 
     # ~~~ Web 2 ~~~
     {py3.6,py3.7}-bottle-v0.12.25
-    {py3.6,py3.8,py3.9}-bottle-v0.13.2
+    {py3.8,py3.12,py3.13}-bottle-v0.13.3
 
     {py3.6}-falcon-v1.4.1
     {py3.6,py3.7}-falcon-v2.0.0
@@ -296,11 +294,11 @@ envlist =
     # ~~~ Misc ~~~
     {py3.6,py3.12,py3.13}-loguru-v0.7.3
 
-    {py3.6}-trytond-v4.6.9
+    {py3.6}-trytond-v4.6.22
     {py3.6}-trytond-v4.8.18
     {py3.6,py3.7,py3.8}-trytond-v5.8.16
     {py3.8,py3.10,py3.11}-trytond-v6.8.17
-    {py3.8,py3.11,py3.12}-trytond-v7.0.9
+    {py3.8,py3.11,py3.12}-trytond-v7.0.29
     {py3.8,py3.11,py3.12}-trytond-v7.4.9
 
     {py3.7,py3.12,py3.13}-typer-v0.15.2
@@ -517,8 +515,8 @@ deps =
 
     # ~~~ AI ~~~
     cohere-v5.4.0: cohere==5.4.0
-    cohere-v5.9.4: cohere==5.9.4
-    cohere-v5.13.9: cohere==5.13.9
+    cohere-v5.8.1: cohere==5.8.1
+    cohere-v5.11.4: cohere==5.11.4
     cohere-v5.15.0: cohere==5.15.0
 
     huggingface_hub-v0.22.2: huggingface_hub==0.22.2
@@ -540,9 +538,8 @@ deps =
     redis_py_cluster_legacy-v2.0.0: redis-py-cluster==2.0.0
     redis_py_cluster_legacy-v2.1.3: redis-py-cluster==2.1.3
 
-    sqlalchemy-v1.3.9: sqlalchemy==1.3.9
+    sqlalchemy-v1.3.24: sqlalchemy==1.3.24
     sqlalchemy-v1.4.54: sqlalchemy==1.4.54
-    sqlalchemy-v2.0.9: sqlalchemy==2.0.9
     sqlalchemy-v2.0.40: sqlalchemy==2.0.40
 
 
@@ -569,7 +566,7 @@ deps =
     ariadne-v0.20.1: ariadne==0.20.1
     ariadne-v0.22: ariadne==0.22
     ariadne-v0.24.0: ariadne==0.24.0
-    ariadne-v0.26.1: ariadne==0.26.1
+    ariadne-v0.26.2: ariadne==0.26.2
     ariadne: fastapi
     ariadne: flask
     ariadne: httpx
@@ -589,7 +586,7 @@ deps =
     strawberry-v0.209.8: strawberry-graphql[fastapi,flask]==0.209.8
     strawberry-v0.228.0: strawberry-graphql[fastapi,flask]==0.228.0
     strawberry-v0.247.2: strawberry-graphql[fastapi,flask]==0.247.2
-    strawberry-v0.265.1: strawberry-graphql[fastapi,flask]==0.265.1
+    strawberry-v0.266.0: strawberry-graphql[fastapi,flask]==0.266.0
     strawberry: httpx
     strawberry-v0.209.8: pydantic<2.11
     strawberry-v0.228.0: pydantic<2.11
@@ -633,12 +630,11 @@ deps =
 
 
     # ~~~ Web 1 ~~~
-    django-v1.11.9: django==1.11.9
     django-v1.11.29: django==1.11.29
     django-v2.2.28: django==2.2.28
     django-v3.2.25: django==3.2.25
     django-v4.2.20: django==4.2.20
-    django-v5.0.9: django==5.0.9
+    django-v5.0.14: django==5.0.14
     django-v5.2: django==5.2
     django: psycopg2-binary
     django: djangorestframework
@@ -646,24 +642,21 @@ deps =
     django: Werkzeug
     django-v3.2.25: pytest-asyncio
     django-v4.2.20: pytest-asyncio
-    django-v5.0.9: pytest-asyncio
+    django-v5.0.14: pytest-asyncio
     django-v5.2: pytest-asyncio
     django-v2.2.28: six
-    django-v1.11.9: djangorestframework>=3.0,<4.0
-    django-v1.11.9: Werkzeug<2.1.0
     django-v1.11.29: djangorestframework>=3.0,<4.0
     django-v1.11.29: Werkzeug<2.1.0
     django-v2.2.28: djangorestframework>=3.0,<4.0
     django-v2.2.28: Werkzeug<2.1.0
     django-v3.2.25: djangorestframework>=3.0,<4.0
     django-v3.2.25: Werkzeug<2.1.0
-    django-v1.11.9: pytest-django<4.0
     django-v1.11.29: pytest-django<4.0
     django-v2.2.28: pytest-django<4.0
     django-v2.2.28: channels[daphne]
     django-v3.2.25: channels[daphne]
     django-v4.2.20: channels[daphne]
-    django-v5.0.9: channels[daphne]
+    django-v5.0.14: channels[daphne]
     django-v5.2: channels[daphne]
 
     flask-v1.1.4: flask==1.1.4
@@ -707,7 +700,7 @@ deps =
 
     # ~~~ Web 2 ~~~
     bottle-v0.12.25: bottle==0.12.25
-    bottle-v0.13.2: bottle==0.13.2
+    bottle-v0.13.3: bottle==0.13.3
     bottle: werkzeug<2.1.0
 
     falcon-v1.4.1: falcon==1.4.1
@@ -756,14 +749,14 @@ deps =
     # ~~~ Misc ~~~
     loguru-v0.7.3: loguru==0.7.3
 
-    trytond-v4.6.9: trytond==4.6.9
+    trytond-v4.6.22: trytond==4.6.22
     trytond-v4.8.18: trytond==4.8.18
     trytond-v5.8.16: trytond==5.8.16
     trytond-v6.8.17: trytond==6.8.17
-    trytond-v7.0.9: trytond==7.0.9
+    trytond-v7.0.29: trytond==7.0.29
     trytond-v7.4.9: trytond==7.4.9
     trytond: werkzeug
-    trytond-v4.6.9: werkzeug<1.0
+    trytond-v4.6.22: werkzeug<1.0
     trytond-v4.8.18: werkzeug<1.0
 
     typer-v0.15.2: typer==0.15.2


### PR DESCRIPTION
Toxgen should only consider the highest patch release of each `major.minor` version. For the most part this was working fine as long as the releases were ordered as expected in PyPI, but in cases where a lower patch version succeeded a higher patch version in the release list from PyPI, we would incorrectly consider the lower patch version as well, instead of ignoring it in favor of the higher patch.

Example:
- we pull releases `[1.2.3, 1.2.4, 1.2.5, 1.2.2]` from PyPI (in that order)
- we consolidate `1.2.3, 1.2.4, 1.2.5` into one version, `1.2.5`, as expected
- `1.2.2` will not disappear into `1.2.5` because of a faulty check in toxgen and will instead be considered as a new version
- our resulting list of releases eligible for testing will be `[1.2.5, 1.2.2]` instead of just `[1.2.5]`, which then results in picking versions that are not nicely spaced apart