### PR TITLE
Fix FastAPI recursive exceptions

### DIFF
--- a/sentry_sdk/utils.py
+++ b/sentry_sdk/utils.py
@@ -869,7 +869,8 @@ def exceptions_from_error(
         # This would lead to an infinite loop, so we skip the causing exception
         # in this case. (because it is the same as the base_exception above)
         if (
-            isinstance(causing_exception, ExceptionGroup)
+            BaseExceptionGroup is not None
+            and isinstance(causing_exception, BaseExceptionGroup)
             and len(causing_exception.exceptions) == 1
             and causing_exception.exceptions[0] == exc_value
         ):


### PR DESCRIPTION
In some cases FastAPI emits an exception that has as `__cause__` an ExceptionGroup that contains a single excpetion. That single exepction is the original exception. This PR prevents an infinite loop by trying to add this construct in the `exception.values` field. 

It also introduces an hard upper limit of chained/nested transaction, to never run into an infinite loop.