### PR TITLE
feat(ourlogs): canonicalize paths from the logger integration

### DIFF
--- a/sentry_sdk/integrations/logging.py
+++ b/sentry_sdk/integrations/logging.py
@@ -355,6 +355,7 @@ class SentryLogsHandler(_BaseHandler):
         # type: (BaseClient, LogRecord) -> None
         scope = sentry_sdk.get_current_scope()
         otel_severity_number, otel_severity_text = _python_level_to_otel(record.levelno)
+        project_root = client.options["project_root"]
         attrs = {
             "sentry.origin": "auto.logger.log",
         }  # type: dict[str, str | bool | float | int]
@@ -374,7 +375,10 @@ class SentryLogsHandler(_BaseHandler):
         if record.lineno:
             attrs["code.line.number"] = record.lineno
         if record.pathname:
-            attrs["code.file.path"] = record.pathname
+            if record.pathname.startswith(project_root):
+                attrs["code.file.path"] = record.pathname[len(project_root) + 1 :]
+            else:
+                attrs["code.file.path"] = record.pathname
         if record.funcName:
             attrs["code.function.name"] = record.funcName
 

--- a/sentry_sdk/integrations/logging.py
+++ b/sentry_sdk/integrations/logging.py
@@ -375,7 +375,7 @@ class SentryLogsHandler(_BaseHandler):
         if record.lineno:
             attrs["code.line.number"] = record.lineno
         if record.pathname:
-            if record.pathname.startswith(project_root):
+            if project_root is not None and record.pathname.startswith(project_root):
                 attrs["code.file.path"] = record.pathname[len(project_root) + 1 :]
             else:
                 attrs["code.file.path"] = record.pathname


### PR DESCRIPTION
We'd like to allow linking to the 'source code' line in the logs page - this canonicalizes the path relative to the project root (if one is defined)

![Screenshot 2025-04-28 at 12 03 45 PM](https://github.com/user-attachments/assets/89dde691-d9c3-45b2-b289-c42996496bf3)

Solves LOGS-58
