### PR TITLE
tests: fix test_stacktrace_big_recursion failure due to argv

### DIFF
--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -1151,10 +1151,8 @@ def test_stacktrace_big_recursion(sentry_init, capture_events):
     (event,) = events
 
     assert event["exception"]["values"][0]["stacktrace"] is None
-    assert event["_meta"] == {
-        "exception": {
-            "values": {"0": {"stacktrace": {"": {"rem": [["!config", "x"]]}}}}
-        }
+    assert event["_meta"]["exception"] == {
+        "values": {"0": {"stacktrace": {"": {"rem": [["!config", "x"]]}}}}
     }
 
     # On my machine, it takes about 100-200ms to capture the exception,


### PR DESCRIPTION
Sometimes I see the test failing because the event contains `extras`
with `sys.argv` key in addition to `exception`. There's probably some
state leaking between tests, but regardless this patch should make the
test case slightly more robust.

Signed-off-by: Ihar Hrachyshka <ihar.hrachyshka@gmail.com>
