### PR TITLE
tests: bump test timeout for recursion stacktrace extract to 2s

### DIFF
--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -1160,5 +1160,5 @@ def test_stacktrace_big_recursion(sentry_init, capture_events):
     # On my machine, it takes about 100-200ms to capture the exception,
     # so this limit should be generous enough.
     assert (
-        capture_end_time - capture_start_time < 10**9
+        capture_end_time - capture_start_time < 10**9 * 2
     ), "stacktrace capture took too long, check that frame limit is set correctly"


### PR DESCRIPTION
In some loaded environments, the test may take slightly longer than 1s
to extract the stacktrace. This was noticed in nixpkgs build system
where the load is generally high due to high build parallelism and
resource constraints. I was sometimes getting failures because the time
it took was e.g. ~1.2s (less than current timeout of 1s).

Disclosure: we'll probably end up disabling the test in nixpkgs anyway
because we try to avoid time sensitive tests. Regardless, this bump may
help someone else in a similar situation or environment.

Signed-off-by: Ihar Hrachyshka <ihar.hrachyshka@gmail.com>
