### PR TITLE
Fix feature flags in potel

### DIFF
--- a/.github/workflows/test-integrations-ai.yml
+++ b/.github/workflows/test-integrations-ai.yml
@@ -29,7 +29,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.7","3.9","3.11","3.12"]
+        python-version: ["3.9","3.11","3.12"]
         os: [ubuntu-22.04]
     steps:
       - uses: actions/checkout@v4.2.2

--- a/.github/workflows/test-integrations-misc.yml
+++ b/.github/workflows/test-integrations-misc.yml
@@ -29,7 +29,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.7","3.8","3.10","3.11","3.12","3.13"]
+        python-version: ["3.7","3.8","3.9","3.10","3.11","3.12","3.13"]
         os: [ubuntu-22.04]
     steps:
       - uses: actions/checkout@v4.2.2

--- a/sentry_sdk/feature_flags.py
+++ b/sentry_sdk/feature_flags.py
@@ -64,7 +64,7 @@ def add_feature_flag(flag, result):
     Records a flag and its value to be sent on subsequent error events.
     We recommend you do this on flag evaluations. Flags are buffered per Sentry scope.
     """
-    flags = sentry_sdk.get_current_scope().flags
+    flags = sentry_sdk.get_isolation_scope().flags
     flags.set(flag, result)
 
     span = sentry_sdk.get_current_span()

--- a/tests/integrations/fastapi/test_fastapi.py
+++ b/tests/integrations/fastapi/test_fastapi.py
@@ -10,7 +10,9 @@ from fastapi import FastAPI, HTTPException, Request
 from fastapi.testclient import TestClient
 from fastapi.middleware.trustedhost import TrustedHostMiddleware
 
+import sentry_sdk
 from sentry_sdk import capture_message
+from sentry_sdk.feature_flags import add_feature_flag
 from sentry_sdk.integrations.asgi import SentryAsgiMiddleware
 from sentry_sdk.integrations.fastapi import FastApiIntegration
 from sentry_sdk.integrations.starlette import StarletteIntegration
@@ -671,3 +673,32 @@ def test_app_host(sentry_init, capture_events, transaction_style):
         assert event["transaction"] == "/subapp"
     else:
         assert event["transaction"].endswith("subapp_route")
+
+
+@pytest.mark.asyncio
+async def test_feature_flags(sentry_init, capture_events):
+    sentry_init(integrations=[StarletteIntegration(), FastApiIntegration()])
+
+    events = capture_events()
+
+    app = FastAPI()
+
+    @app.get("/error")
+    async def _error():
+        add_feature_flag("hello", False)
+
+        with sentry_sdk.start_span(name="test-span"):
+            with sentry_sdk.start_span(name="test-span-2"):
+                raise ValueError("something is wrong!")
+
+    try:
+        client = TestClient(app)
+        client.get("/error")
+    except ValueError:
+        pass
+
+    assert events[0]["contexts"]["flags"] == {
+        "values": [
+            {"flag": "hello", "result": False},
+        ]
+    }

--- a/tests/integrations/fastapi/test_fastapi.py
+++ b/tests/integrations/fastapi/test_fastapi.py
@@ -677,7 +677,10 @@ def test_app_host(sentry_init, capture_events, transaction_style):
 
 @pytest.mark.asyncio
 async def test_feature_flags(sentry_init, capture_events):
-    sentry_init(integrations=[StarletteIntegration(), FastApiIntegration()])
+    sentry_init(
+        traces_sample_rate=1.0,
+        integrations=[StarletteIntegration(), FastApiIntegration()],
+    )
 
     events = capture_events()
 
@@ -697,8 +700,14 @@ async def test_feature_flags(sentry_init, capture_events):
     except ValueError:
         pass
 
-    assert events[0]["contexts"]["flags"] == {
-        "values": [
-            {"flag": "hello", "result": False},
-        ]
-    }
+    found = False
+    for event in events:
+        if "exception" in event.keys():
+            assert event["contexts"]["flags"] == {
+                "values": [
+                    {"flag": "hello", "result": False},
+                ]
+            }
+            found = True
+
+    assert found, "No event with exception found"

--- a/tests/test_feature_flags.py
+++ b/tests/test_feature_flags.py
@@ -47,11 +47,17 @@ async def test_featureflags_integration_spans_async(sentry_init, capture_events)
     except ValueError as e:
         sentry_sdk.capture_exception(e)
 
-    assert events[0]["contexts"]["flags"] == {
-        "values": [
-            {"flag": "hello", "result": False},
-        ]
-    }
+    found = False
+    for event in events:
+        if "exception" in event.keys():
+            assert event["contexts"]["flags"] == {
+                "values": [
+                    {"flag": "hello", "result": False},
+                ]
+            }
+            found = True
+
+    assert found, "No event with exception found"
 
 
 def test_featureflags_integration_spans_sync(sentry_init, capture_events):
@@ -69,11 +75,17 @@ def test_featureflags_integration_spans_sync(sentry_init, capture_events):
     except ValueError as e:
         sentry_sdk.capture_exception(e)
 
-    assert events[0]["contexts"]["flags"] == {
-        "values": [
-            {"flag": "hello", "result": False},
-        ]
-    }
+    found = False
+    for event in events:
+        if "exception" in event.keys():
+            assert event["contexts"]["flags"] == {
+                "values": [
+                    {"flag": "hello", "result": False},
+                ]
+            }
+            found = True
+
+    assert found, "No event with exception found"
 
 
 def test_featureflags_integration_threaded(

--- a/tests/test_feature_flags.py
+++ b/tests/test_feature_flags.py
@@ -31,6 +31,51 @@ def test_featureflags_integration(sentry_init, capture_events, uninstall_integra
     }
 
 
+@pytest.mark.asyncio
+async def test_featureflags_integration_spans_async(sentry_init, capture_events):
+    sentry_init(
+        traces_sample_rate=1.0,
+    )
+    events = capture_events()
+
+    add_feature_flag("hello", False)
+
+    try:
+        with sentry_sdk.start_span(name="test-span"):
+            with sentry_sdk.start_span(name="test-span-2"):
+                raise ValueError("something wrong!")
+    except ValueError as e:
+        sentry_sdk.capture_exception(e)
+
+    assert events[0]["contexts"]["flags"] == {
+        "values": [
+            {"flag": "hello", "result": False},
+        ]
+    }
+
+
+def test_featureflags_integration_spans_sync(sentry_init, capture_events):
+    sentry_init(
+        traces_sample_rate=1.0,
+    )
+    events = capture_events()
+
+    add_feature_flag("hello", False)
+
+    try:
+        with sentry_sdk.start_span(name="test-span"):
+            with sentry_sdk.start_span(name="test-span-2"):
+                raise ValueError("something wrong!")
+    except ValueError as e:
+        sentry_sdk.capture_exception(e)
+
+    assert events[0]["contexts"]["flags"] == {
+        "values": [
+            {"flag": "hello", "result": False},
+        ]
+    }
+
+
 def test_featureflags_integration_threaded(
     sentry_init, capture_events, uninstall_integration
 ):


### PR DESCRIPTION
Store feature flags on the isolation scope, that is the correct place. 

I also checked back with Colton about the behavior of feature flags, and having the flags on the isolation scope (meaning: one set of flags per request-response cycle) is the expected behavior.