### PR TITLE
Respect parent_sampled decision in propagation_context sentry-trace header

### DIFF
--- a/sentry_sdk/opentelemetry/sampler.py
+++ b/sentry_sdk/opentelemetry/sampler.py
@@ -234,7 +234,7 @@ class SentrySampler(Sampler):
                     )
             else:
                 logger.debug(
-                    f"[Tracing] Ignoring sampled param for non-root span {name}"
+                    f"[Tracing.Sampler] Ignoring sampled param for non-root span {name}"
                 )
 
         # Check if there is a traces_sampler
@@ -264,7 +264,7 @@ class SentrySampler(Sampler):
         # If the sample rate is invalid, drop the span
         if not is_valid_sample_rate(sample_rate, source=self.__class__.__name__):
             logger.warning(
-                f"[Tracing] Discarding {name} because of invalid sample rate."
+                f"[Tracing.Sampler] Discarding {name} because of invalid sample rate."
             )
             return dropped_result(parent_span_context, attributes)
 
@@ -279,6 +279,11 @@ class SentrySampler(Sampler):
         sampled = sample_rand < Decimal.from_float(sample_rate)
 
         if sampled:
+            if is_root_span:
+                logger.debug(
+                    f"[Tracing.Sampler] Sampled #{name} with sample_rate: {sample_rate} and sample_rand: {sample_rand}"
+                )
+
             return sampled_result(
                 parent_span_context,
                 attributes,
@@ -286,6 +291,11 @@ class SentrySampler(Sampler):
                 sample_rand=None if sample_rand == parent_sample_rand else sample_rand,
             )
         else:
+            if is_root_span:
+                logger.debug(
+                    f"[Tracing.Sampler] Dropped #{name} with sample_rate: {sample_rate} and sample_rand: {sample_rand}"
+                )
+
             return dropped_result(
                 parent_span_context,
                 attributes,

--- a/sentry_sdk/scope.py
+++ b/sentry_sdk/scope.py
@@ -505,11 +505,7 @@ class Scope:
 
         # If this scope has a propagation context, return traceparent from there
         if self._propagation_context is not None:
-            traceparent = "%s-%s" % (
-                self._propagation_context.trace_id,
-                self._propagation_context.span_id,
-            )
-            return traceparent
+            return self._propagation_context.to_traceparent()
 
         # Fall back to isolation scope's traceparent. It always has one
         return self.get_isolation_scope().get_traceparent()

--- a/sentry_sdk/tracing_utils.py
+++ b/sentry_sdk/tracing_utils.py
@@ -432,6 +432,21 @@ class PropagationContext:
         # type: (str) -> None
         self._span_id = value
 
+    def to_traceparent(self):
+        # type: () -> str
+        if self.parent_sampled is True:
+            sampled = "1"
+        elif self.parent_sampled is False:
+            sampled = "0"
+        else:
+            sampled = None
+
+        traceparent = "%s-%s" % (self.trace_id, self.span_id)
+        if sampled is not None:
+            traceparent += "-%s" % (sampled,)
+
+        return traceparent
+
     def update(self, other_dict):
         # type: (Dict[str, Any]) -> None
         """


### PR DESCRIPTION
Since we don't automatically have unsampled spans running, this caused a change in behavior when an upstream sampling decision needs to be propagated further downstream.

### Explanation of problem
When an incoming trace has `sampled` set to 0 (`trace_id-span_id-0`),
in the past we would propagate this since we would have an active span/transaction running but just not sampled, so downstream would also receive `trace_id-span_id-0` from that active span.
Now, we actually don't have an active span since we don't sample (just how otel works), so instead of sending the `trace_id-span_id-0`  as before, we would have sent `trace_id-other_span_id` from the `propagation_context`  instead.
This would cause the downstream service to not receive the `-0`  flag and would thus sample independently, which is a regression.