### PR TITLE
Revert `traces_sample_rate` default change

### DIFF
--- a/sentry_sdk/consts.py
+++ b/sentry_sdk/consts.py
@@ -551,7 +551,7 @@ class ClientConstructor:
         debug=None,  # type: Optional[bool]
         attach_stacktrace=False,  # type: bool
         ca_certs=None,  # type: Optional[str]
-        traces_sample_rate=0,  # type: Optional[float]
+        traces_sample_rate=None,  # type: Optional[float]
         traces_sampler=None,  # type: Optional[TracesSampler]
         profiles_sample_rate=None,  # type: Optional[float]
         profiles_sampler=None,  # type: Optional[TracesSampler]

--- a/tests/integrations/aiohttp/test_aiohttp.py
+++ b/tests/integrations/aiohttp/test_aiohttp.py
@@ -461,10 +461,7 @@ async def test_trace_from_headers_if_performance_enabled(
 async def test_trace_from_headers_if_performance_disabled(
     sentry_init, aiohttp_client, capture_events
 ):
-    sentry_init(
-        integrations=[AioHttpIntegration()],
-        traces_sample_rate=None,  # disable all performance monitoring
-    )
+    sentry_init(integrations=[AioHttpIntegration()])
 
     async def hello(request):
         capture_message("It's a good day to try dividing by 0")

--- a/tests/integrations/asgi/test_asgi.py
+++ b/tests/integrations/asgi/test_asgi.py
@@ -269,9 +269,7 @@ async def test_has_trace_if_performance_disabled(
     asgi3_app_with_error_and_msg,
     capture_events,
 ):
-    sentry_init(
-        traces_sample_rate=None,  # disable all performance monitoring
-    )
+    sentry_init()
     app = SentryAsgiMiddleware(asgi3_app_with_error_and_msg)
 
     with pytest.raises(ZeroDivisionError):
@@ -327,9 +325,7 @@ async def test_trace_from_headers_if_performance_disabled(
     asgi3_app_with_error_and_msg,
     capture_events,
 ):
-    sentry_init(
-        traces_sample_rate=None,  # disable all performance monitoring
-    )
+    sentry_init()
     app = SentryAsgiMiddleware(asgi3_app_with_error_and_msg)
 
     trace_id = "582b43a4192642f0b136d5159a501701"

--- a/tests/integrations/django/asgi/test_asgi.py
+++ b/tests/integrations/django/asgi/test_asgi.py
@@ -335,10 +335,7 @@ async def test_has_trace_if_performance_enabled(sentry_init, capture_events):
     django.VERSION < (3, 1), reason="async views have been introduced in Django 3.1"
 )
 async def test_has_trace_if_performance_disabled(sentry_init, capture_events):
-    sentry_init(
-        integrations=[DjangoIntegration()],
-        traces_sample_rate=None,  # disable all performance monitoring
-    )
+    sentry_init(integrations=[DjangoIntegration()])
 
     events = capture_events()
 
@@ -401,10 +398,7 @@ async def test_trace_from_headers_if_performance_enabled(sentry_init, capture_ev
     django.VERSION < (3, 1), reason="async views have been introduced in Django 3.1"
 )
 async def test_trace_from_headers_if_performance_disabled(sentry_init, capture_events):
-    sentry_init(
-        integrations=[DjangoIntegration()],
-        traces_sample_rate=None,  # disable all performance monitoring
-    )
+    sentry_init(integrations=[DjangoIntegration()])
 
     events = capture_events()
 

--- a/tests/integrations/django/test_basic.py
+++ b/tests/integrations/django/test_basic.py
@@ -241,7 +241,6 @@ def test_trace_from_headers_if_performance_disabled(
                 http_methods_to_capture=("HEAD",),
             )
         ],
-        traces_sample_rate=None,  # disable all performance monitoring
     )
 
     events = capture_events()

--- a/tests/integrations/wsgi/test_wsgi.py
+++ b/tests/integrations/wsgi/test_wsgi.py
@@ -238,9 +238,7 @@ def test_has_trace_if_performance_disabled(
         capture_message("Attempting to fetch the ball")
         raise ValueError("Fetch aborted. The ball was not returned.")
 
-    sentry_init(
-        traces_sample_rate=None,  # disable all performance monitoring
-    )
+    sentry_init()
     app = SentryWsgiMiddleware(dogpark)
     client = Client(app)
     events = capture_events()
@@ -303,9 +301,7 @@ def test_trace_from_headers_if_performance_disabled(
         capture_message("Attempting to fetch the ball")
         raise ValueError("Fetch aborted. The ball was not returned.")
 
-    sentry_init(
-        traces_sample_rate=None,  # disable all performance monitoring
-    )
+    sentry_init()
     app = SentryWsgiMiddleware(dogpark)
     client = Client(app)
     events = capture_events()

--- a/tests/opentelemetry/test_sampler.py
+++ b/tests/opentelemetry/test_sampler.py
@@ -178,8 +178,8 @@ def test_sampling_traces_sampler_boolean(sentry_init, capture_envelopes):
 @pytest.mark.parametrize(
     "traces_sample_rate, expected_num_of_envelopes",
     [
-        # special case for testing, do not pass any traces_sample_rate to init() (the default traces_sample_rate=0 will be used)
-        (USE_DEFAULT_TRACES_SAMPLE_RATE, 1),
+        # special case for testing, do not pass any traces_sample_rate to init() (the default traces_sample_rate=None will be used)
+        (USE_DEFAULT_TRACES_SAMPLE_RATE, 0),
         # traces_sample_rate=None means do not create new traces, and also do not continue incoming traces. So, no envelopes at all.
         (None, 0),
         # traces_sample_rate=0 means do not create new traces (0% of the requests), but continue incoming traces. So envelopes will be created only if there is an incoming trace.
@@ -229,9 +229,9 @@ def test_sampling_parent_sampled(
 @pytest.mark.parametrize(
     "traces_sample_rate, upstream_sampled, expected_num_of_envelopes",
     [
-        # special case for testing, do not pass any traces_sample_rate to init() (the default traces_sample_rate=0 will be used)
+        # special case for testing, do not pass any traces_sample_rate to init() (the default traces_sample_rate=None will be used)
         (USE_DEFAULT_TRACES_SAMPLE_RATE, 0, 0),
-        (USE_DEFAULT_TRACES_SAMPLE_RATE, 1, 1),
+        (USE_DEFAULT_TRACES_SAMPLE_RATE, 1, 0),
         # traces_sample_rate=None means do not create new traces, and also do not continue incoming traces. So, no envelopes at all.
         (None, 0, 0),
         (None, 1, 0),

--- a/tests/test_dsc.py
+++ b/tests/test_dsc.py
@@ -287,8 +287,8 @@ def test_dsc_continuation_of_trace_sample_rate_changed_in_traces_sampler(
                 "local_traces_sampler_result": None,
                 "local_traces_sample_rate": None,
             },
-            1.0,  # expected_sample_rate
-            "true",  # expected_sampled
+            None,  # expected_sample_rate
+            "tracing-disabled-no-transactions-should-be-sent",  # expected_sampled (traces_sample_rate=None disables all transaction creation)
         ),
         (  # 6 traces_sampler overrides incoming  (traces_sample_rate not set)
             {

--- a/tests/tracing/test_trace_propagation.py
+++ b/tests/tracing/test_trace_propagation.py
@@ -190,7 +190,11 @@ def test_with_incoming_trace_and_trace_propagation_targets_matching(
             requests.get("http://example.com")
 
     # CHECK if performance data (a transaction/span) is sent to Sentry
-    if traces_sample_rate is None or incoming_parent_sampled == "0":
+    if (
+        traces_sample_rate is None
+        or traces_sample_rate == USE_DEFAULT_TRACES_SAMPLE_RATE
+        or incoming_parent_sampled == "0"
+    ):
         assert len(events) == 0
     else:
         if incoming_parent_sampled == "1" or traces_sample_rate == 1:
@@ -264,7 +268,11 @@ def test_with_incoming_trace_and_trace_propagation_targets_not_matching(
             requests.get("http://example.com")
 
     # CHECK if performance data (a transaction/span) is sent to Sentry
-    if traces_sample_rate is None or incoming_parent_sampled == "0":
+    if (
+        traces_sample_rate is None
+        or traces_sample_rate == USE_DEFAULT_TRACES_SAMPLE_RATE
+        or incoming_parent_sampled == "0"
+    ):
         assert len(events) == 0
     else:
         if incoming_parent_sampled == "1" or traces_sample_rate == 1:


### PR DESCRIPTION
The default of `traces_sample_rate` should be `None`. This was a misunderstanding. With this default tracing without performance (twp) works, and this is the behavior that we like to have. 

Original change is in this PR: https://github.com/getsentry/sentry-python/pull/4335

See also this for better understanding: https://develop.sentry.dev/sdk/telemetry/traces/trace-propagation-cheat-sheet/