### PR TITLE
Put feature flags on isolation scope

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -25,6 +25,7 @@ Capturing Data
 Enriching Events
 ================
 
+.. autofunction:: sentry_sdk.api.add_attachment
 .. autofunction:: sentry_sdk.api.add_breadcrumb
 .. autofunction:: sentry_sdk.api.set_context
 .. autofunction:: sentry_sdk.api.set_extra
@@ -63,4 +64,3 @@ Managing Scope (advanced)
 .. autofunction:: sentry_sdk.api.push_scope
 
 .. autofunction:: sentry_sdk.api.new_scope
-

--- a/sentry_sdk/__init__.py
+++ b/sentry_sdk/__init__.py
@@ -15,6 +15,7 @@ __all__ = [  # noqa
     "integrations",
     # From sentry_sdk.api
     "init",
+    "add_attachment",
     "add_breadcrumb",
     "capture_event",
     "capture_exception",

--- a/sentry_sdk/api.py
+++ b/sentry_sdk/api.py
@@ -51,6 +51,7 @@ else:
 # When changing this, update __all__ in __init__.py too
 __all__ = [
     "init",
+    "add_attachment",
     "add_breadcrumb",
     "capture_event",
     "capture_exception",
@@ -182,6 +183,20 @@ def capture_exception(
 ):
     # type: (...) -> Optional[str]
     return get_current_scope().capture_exception(error, scope=scope, **scope_kwargs)
+
+
+@scopemethod
+def add_attachment(
+    bytes=None,  # type: Union[None, bytes, Callable[[], bytes]]
+    filename=None,  # type: Optional[str]
+    path=None,  # type: Optional[str]
+    content_type=None,  # type: Optional[str]
+    add_to_transactions=False,  # type: bool
+):
+    # type: (...) -> None
+    return get_isolation_scope().add_attachment(
+        bytes, filename, path, content_type, add_to_transactions
+    )
 
 
 @scopemethod

--- a/sentry_sdk/feature_flags.py
+++ b/sentry_sdk/feature_flags.py
@@ -64,7 +64,7 @@ def add_feature_flag(flag, result):
     Records a flag and its value to be sent on subsequent error events.
     We recommend you do this on flag evaluations. Flags are buffered per Sentry scope.
     """
-    flags = sentry_sdk.get_current_scope().flags
+    flags = sentry_sdk.get_isolation_scope().flags
     flags.set(flag, result)
 
     span = sentry_sdk.get_current_span()

--- a/tests/test_feature_flags.py
+++ b/tests/test_feature_flags.py
@@ -47,11 +47,17 @@ async def test_featureflags_integration_spans_async(sentry_init, capture_events)
     except ValueError as e:
         sentry_sdk.capture_exception(e)
 
-    assert events[0]["contexts"]["flags"] == {
-        "values": [
-            {"flag": "hello", "result": False},
-        ]
-    }
+    found = False
+    for event in events:
+        if "exception" in event.keys():
+            assert event["contexts"]["flags"] == {
+                "values": [
+                    {"flag": "hello", "result": False},
+                ]
+            }
+            found = True
+
+    assert found, "No event with exception found"
 
 
 def test_featureflags_integration_spans_sync(sentry_init, capture_events):
@@ -69,11 +75,17 @@ def test_featureflags_integration_spans_sync(sentry_init, capture_events):
     except ValueError as e:
         sentry_sdk.capture_exception(e)
 
-    assert events[0]["contexts"]["flags"] == {
-        "values": [
-            {"flag": "hello", "result": False},
-        ]
-    }
+    found = False
+    for event in events:
+        if "exception" in event.keys():
+            assert event["contexts"]["flags"] == {
+                "values": [
+                    {"flag": "hello", "result": False},
+                ]
+            }
+            found = True
+
+    assert found, "No event with exception found"
 
 
 def test_featureflags_integration_threaded(

--- a/tests/test_feature_flags.py
+++ b/tests/test_feature_flags.py
@@ -31,6 +31,51 @@ def test_featureflags_integration(sentry_init, capture_events, uninstall_integra
     }
 
 
+@pytest.mark.asyncio
+async def test_featureflags_integration_spans_async(sentry_init, capture_events):
+    sentry_init(
+        traces_sample_rate=1.0,
+    )
+    events = capture_events()
+
+    add_feature_flag("hello", False)
+
+    try:
+        with sentry_sdk.start_span(name="test-span"):
+            with sentry_sdk.start_span(name="test-span-2"):
+                raise ValueError("something wrong!")
+    except ValueError as e:
+        sentry_sdk.capture_exception(e)
+
+    assert events[0]["contexts"]["flags"] == {
+        "values": [
+            {"flag": "hello", "result": False},
+        ]
+    }
+
+
+def test_featureflags_integration_spans_sync(sentry_init, capture_events):
+    sentry_init(
+        traces_sample_rate=1.0,
+    )
+    events = capture_events()
+
+    add_feature_flag("hello", False)
+
+    try:
+        with sentry_sdk.start_span(name="test-span"):
+            with sentry_sdk.start_span(name="test-span-2"):
+                raise ValueError("something wrong!")
+    except ValueError as e:
+        sentry_sdk.capture_exception(e)
+
+    assert events[0]["contexts"]["flags"] == {
+        "values": [
+            {"flag": "hello", "result": False},
+        ]
+    }
+
+
 def test_featureflags_integration_threaded(
     sentry_init, capture_events, uninstall_integration
 ):


### PR DESCRIPTION
Feature flags should life on the isolation Scope. This has been first [implemented in SDK 3.0](https://github.com/getsentry/sentry-python/pull/4353) and is now back ported to 2.x.