### PR TITLE
Add `add_attachment()` top level API

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -25,6 +25,7 @@ Capturing Data
 Enriching Events
 ================
 
+.. autofunction:: sentry_sdk.api.add_attachment
 .. autofunction:: sentry_sdk.api.add_breadcrumb
 .. autofunction:: sentry_sdk.api.set_context
 .. autofunction:: sentry_sdk.api.set_extra
@@ -63,4 +64,3 @@ Managing Scope (advanced)
 .. autofunction:: sentry_sdk.api.push_scope
 
 .. autofunction:: sentry_sdk.api.new_scope
-

--- a/sentry_sdk/__init__.py
+++ b/sentry_sdk/__init__.py
@@ -15,6 +15,7 @@ __all__ = [  # noqa
     "integrations",
     # From sentry_sdk.api
     "init",
+    "add_attachment",
     "add_breadcrumb",
     "capture_event",
     "capture_exception",

--- a/sentry_sdk/api.py
+++ b/sentry_sdk/api.py
@@ -51,6 +51,7 @@ else:
 # When changing this, update __all__ in __init__.py too
 __all__ = [
     "init",
+    "add_attachment",
     "add_breadcrumb",
     "capture_event",
     "capture_exception",
@@ -182,6 +183,20 @@ def capture_exception(
 ):
     # type: (...) -> Optional[str]
     return get_current_scope().capture_exception(error, scope=scope, **scope_kwargs)
+
+
+@scopemethod
+def add_attachment(
+    bytes=None,  # type: Union[None, bytes, Callable[[], bytes]]
+    filename=None,  # type: Optional[str]
+    path=None,  # type: Optional[str]
+    content_type=None,  # type: Optional[str]
+    add_to_transactions=False,  # type: bool
+):
+    # type: (...) -> None
+    return get_isolation_scope().add_attachment(
+        bytes, filename, path, content_type, add_to_transactions
+    )
 
 
 @scopemethod


### PR DESCRIPTION
Users should not need to get the Scope and add the attachment there, we can do it for them. This has been first [implemented in SDK 3.0](https://github.com/getsentry/sentry-python/pull/4360) and is now back ported to 2.x.