### PR TITLE
feat: Allow configuring `keep_alive` via environment variable

### DIFF
--- a/sentry_sdk/client.py
+++ b/sentry_sdk/client.py
@@ -142,6 +142,11 @@ def _get_options(*args, **kwargs):
         )
         rv["socket_options"] = None
 
+    if rv["keep_alive"] is None:
+        rv["keep_alive"] = (
+            env_to_bool(os.environ.get("SENTRY_KEEP_ALIVE"), strict=True) or False
+        )
+
     if rv["enable_tracing"] is not None:
         warnings.warn(
             "The `enable_tracing` parameter is deprecated. Please use `traces_sample_rate` instead.",

--- a/sentry_sdk/consts.py
+++ b/sentry_sdk/consts.py
@@ -518,7 +518,7 @@ class ClientConstructor:
         ignore_errors=[],  # type: Sequence[Union[type, str]]  # noqa: B006
         max_request_body_size="medium",  # type: str
         socket_options=None,  # type: Optional[List[Tuple[int, int, int | bytes]]]
-        keep_alive=False,  # type: bool
+        keep_alive=None,  # type: Optional[bool]
         before_send=None,  # type: Optional[EventProcessor]
         before_breadcrumb=None,  # type: Optional[BreadcrumbProcessor]
         debug=None,  # type: Optional[bool]


### PR DESCRIPTION
This commit enables the `keep_alive` option to be set via the `SENTRY_KEEP_ALIVE` environment variable. When both the environment variable and the argument are provided, the argument takes precedence.

Closes #4354