### PR TITLE
Pin snowballstemmer for now

### DIFF
--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -3,3 +3,4 @@ shibuya
 sphinx<8.2
 sphinx-autodoc-typehints[type_comments]>=1.8.0
 typing-extensions
+snowballstemmer<3.0


### PR DESCRIPTION
Make apidocs buildable again -- we can investigate later if we can update something instead without needing the pin, but this is now blocking merges