### PR TITLE
tests(logs): avoid failures when running with integrations enabled

### DIFF
--- a/tests/test_logs.py
+++ b/tests/test_logs.py
@@ -447,6 +447,8 @@ def test_logger_with_all_attributes(sentry_init, capture_envelopes):
     assert isinstance(attributes["thread.name"], str)
     del attributes["thread.name"]
 
+    assert attributes.pop("sentry.sdk.name").startswith("sentry.python")
+
     # Assert on the remaining non-dynamic attributes.
     assert attributes == {
         "foo": "bar",
@@ -457,7 +459,6 @@ def test_logger_with_all_attributes(sentry_init, capture_envelopes):
         "sentry.message.template": "log #%d",
         "sentry.message.parameter.0": 1,
         "sentry.environment": "production",
-        "sentry.sdk.name": "sentry.python",
         "sentry.sdk.version": VERSION,
         "sentry.severity_number": 13,
         "sentry.severity_text": "warn",


### PR DESCRIPTION
When (at least) one of integrations is enabled (because some dependencies
are installed in the environment), `sentry.sdk.name` is changed from
`sentry.python` to `sentry.python.[FIRST_ENABLED_INTEGRATION]` which
makes `test_logs_attributes` fail. Prevent failure by relaxing the check.

This change is beneficial not only for packaging (this patch was required
for packaging for Fedora), but also for running tests with `pytest`
directly.

See also: https://github.com/getsentry/sentry-python/pull/4316

<!-- Describe your PR here -->

---

Thank you for contributing to `sentry-python`! Please add tests to validate your changes, and lint your code using `tox -e linters`.

Running the test suite on your PR might require maintainer approval.
