### PR TITLE
Allow multiple craft configs in the repo

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,3 +36,4 @@ jobs:
           version: ${{ github.event.inputs.version }}
           force: ${{ github.event.inputs.force }}
           merge_target: ${{ github.event.inputs.merge_target }}
+          craft_config_from_merge_target: true


### PR DESCRIPTION
Take craft config from the merge target (for having a alpha release package)

See: https://develop.sentry.dev/sdk/processes/releases/#optional-using-multiple-craft-configs-in-a-repo