### PR TITLE
fix(celery): Do not send extra check-in

### DIFF
--- a/sentry_sdk/integrations/celery/__init__.py
+++ b/sentry_sdk/integrations/celery/__init__.py
@@ -9,7 +9,7 @@ from sentry_sdk.consts import OP, SPANSTATUS, SPANDATA
 from sentry_sdk.integrations import _check_minimum_version, Integration, DidNotEnable
 from sentry_sdk.integrations.celery.beat import (
     _patch_beat_apply_entry,
-    _patch_redbeat_maybe_due,
+    _patch_redbeat_apply_async,
     _setup_celery_beat_signals,
 )
 from sentry_sdk.integrations.celery.utils import _now_seconds_since_epoch
@@ -73,7 +73,7 @@ class CeleryIntegration(Integration):
         self.exclude_beat_tasks = exclude_beat_tasks
 
         _patch_beat_apply_entry()
-        _patch_redbeat_maybe_due()
+        _patch_redbeat_apply_async()
         _setup_celery_beat_signals(monitor_beat_tasks)
 
     @staticmethod

--- a/sentry_sdk/integrations/celery/beat.py
+++ b/sentry_sdk/integrations/celery/beat.py
@@ -202,12 +202,12 @@ def _patch_beat_apply_entry():
     Scheduler.apply_entry = _wrap_beat_scheduler(Scheduler.apply_entry)
 
 
-def _patch_redbeat_maybe_due():
+def _patch_redbeat_apply_async():
     # type: () -> None
     if RedBeatScheduler is None:
         return
 
-    RedBeatScheduler.maybe_due = _wrap_beat_scheduler(RedBeatScheduler.maybe_due)
+    RedBeatScheduler.apply_async = _wrap_beat_scheduler(RedBeatScheduler.apply_async)
 
 
 def _setup_celery_beat_signals(monitor_beat_tasks):


### PR DESCRIPTION
When using the RedBeatScheduler, we're sending an extra in-progress check-in at scheduler start. Since this is never followed by an ok or error check-in, the check-in is marked as timed out in Sentry.

We're patching the scheduler's `maybe_due`, which (as the name implies) [might not end up executing the task](https://github.com/sibson/redbeat/blob/bdefad23b47f75e2e85d45f46f9f16dd00a93d40/redbeat/schedulers.py#L506-L508). This is indeed what seems to be happening -- `maybe_due` is run when the scheduler starts, but without scheduling the task. We don't check whether `maybe_due` actually ended up scheduling anything and always fire an in-progress check-in.

Patching the [scheduler's `apply_async`](https://github.com/sibson/redbeat/blob/bdefad23b47f75e2e85d45f46f9f16dd00a93d40/redbeat/schedulers.py#L511) instead.

Closes https://github.com/getsentry/sentry-python/issues/4392