### PR TITLE
fix(logs): send `severity_text`: `warn` instead of `warning`

### DIFF
--- a/sentry_sdk/logger.py
+++ b/sentry_sdk/logger.py
@@ -51,6 +51,6 @@ def _capture_log(severity_text, severity_number, template, **kwargs):
 trace = functools.partial(_capture_log, "trace", 1)
 debug = functools.partial(_capture_log, "debug", 5)
 info = functools.partial(_capture_log, "info", 9)
-warning = functools.partial(_capture_log, "warning", 13)
+warning = functools.partial(_capture_log, "warn", 13)
 error = functools.partial(_capture_log, "error", 17)
 fatal = functools.partial(_capture_log, "fatal", 21)

--- a/tests/test_logs.py
+++ b/tests/test_logs.py
@@ -102,7 +102,7 @@ def test_logs_basics(sentry_init, capture_envelopes):
     assert logs[2].get("severity_text") == "info"
     assert logs[2].get("severity_number") == 9
 
-    assert logs[3].get("severity_text") == "warning"
+    assert logs[3].get("severity_text") == "warn"
     assert logs[3].get("severity_number") == 13
 
     assert logs[4].get("severity_text") == "error"
@@ -155,7 +155,7 @@ def test_logs_before_send_log(sentry_init, capture_envelopes):
     assert logs[0]["severity_text"] == "trace"
     assert logs[1]["severity_text"] == "debug"
     assert logs[2]["severity_text"] == "info"
-    assert logs[3]["severity_text"] == "warning"
+    assert logs[3]["severity_text"] == "warn"
     assert before_log_called[0]
 
 


### PR DESCRIPTION
We need to send `warn` as the `severity_text` for warning level logs, not `warning`.
If we send `warning` it will not be recognized by the backend and the severity will show up as `UNKNOWN` in the frontend.
See screenshot for comparison of after and before.

![Screenshot 2025-05-16 at 18 24 50](https://github.com/user-attachments/assets/240e3c6d-0f68-49e8-b79b-a67ac0e8a5d4)
