### PR TITLE
fix(loguru): Move integration setup from `__init__` to `setup_once`

### DIFF
--- a/sentry_sdk/integrations/loguru.py
+++ b/sentry_sdk/integrations/loguru.py
@@ -48,8 +48,8 @@ DEFAULT_EVENT_LEVEL = LoggingLevels.ERROR.value
 class LoguruIntegration(Integration):
     identifier = "loguru"
 
-    level = DEFAULT_LEVEL
-    event_level = DEFAULT_EVENT_LEVEL
+    level = DEFAULT_LEVEL  # type: Optional[int]
+    event_level = DEFAULT_EVENT_LEVEL  # type: Optional[int]
     breadcrumb_format = DEFAULT_FORMAT
     event_format = DEFAULT_FORMAT
 

--- a/tests/integrations/loguru/test_loguru.py
+++ b/tests/integrations/loguru/test_loguru.py
@@ -32,7 +32,12 @@ def test_just_log(
     expected_sentry_level,
     disable_breadcrumbs,
     disable_events,
+    uninstall_integration,
+    request,
 ):
+    uninstall_integration("loguru")
+    request.addfinalizer(logger.remove)
+
     sentry_init(
         integrations=[
             LoguruIntegration(
@@ -49,7 +54,7 @@ def test_just_log(
     formatted_message = (
         " | "
         + "{:9}".format(level.name.upper())
-        + "| tests.integrations.loguru.test_loguru:test_just_log:47 - test"
+        + "| tests.integrations.loguru.test_loguru:test_just_log:53 - test"
     )
 
     if not created_event:
@@ -78,7 +83,10 @@ def test_just_log(
     assert event["logentry"]["message"][23:] == formatted_message
 
 
-def test_breadcrumb_format(sentry_init, capture_events):
+def test_breadcrumb_format(sentry_init, capture_events, uninstall_integration, request):
+    uninstall_integration("loguru")
+    request.addfinalizer(logger.remove)
+
     sentry_init(
         integrations=[
             LoguruIntegration(
@@ -98,7 +106,10 @@ def test_breadcrumb_format(sentry_init, capture_events):
     assert breadcrumb["message"] == formatted_message
 
 
-def test_event_format(sentry_init, capture_events):
+def test_event_format(sentry_init, capture_events, uninstall_integration, request):
+    uninstall_integration("loguru")
+    request.addfinalizer(logger.remove)
+
     sentry_init(
         integrations=[
             LoguruIntegration(

--- a/tests/integrations/loguru/test_loguru.py
+++ b/tests/integrations/loguru/test_loguru.py
@@ -54,7 +54,7 @@ def test_just_log(
     formatted_message = (
         " | "
         + "{:9}".format(level.name.upper())
-        + "| tests.integrations.loguru.test_loguru:test_just_log:53 - test"
+        + "| tests.integrations.loguru.test_loguru:test_just_log:52 - test"
     )
 
     if not created_event:


### PR DESCRIPTION
We shouldn't have setup code in an integration's `__init__`. This can be called an arbitrary amount of times. `setup_once` exists so that the code is only guaranteed to run once.

Having integration setup in `__init__` also means that the integration currently can't be disabled via `disabled_integrations`.

Fixes https://github.com/getsentry/sentry-python/issues/4398