### PR TITLE
Dual POTel setup improvements

### DIFF
--- a/sentry_sdk/opentelemetry/span_processor.py
+++ b/sentry_sdk/opentelemetry/span_processor.py
@@ -71,6 +71,7 @@ class SentrySpanProcessor(SpanProcessor):
             return
 
         self._add_root_span(span, get_current_span(parent_context))
+        self._add_origin(span)
         self._start_profile(span)
 
     def on_end(self, span):
@@ -96,6 +97,13 @@ class SentrySpanProcessor(SpanProcessor):
     def force_flush(self, timeout_millis=30000):
         # type: (int) -> bool
         return True
+
+    def _add_origin(self, span):
+        # type: (Span) -> None
+        if span.instrumentation_scope and span.instrumentation_scope.name:
+            span.set_attribute(
+                SentrySpanAttribute.ORIGIN, span.instrumentation_scope.name
+            )
 
     def _add_root_span(self, span, parent_span):
         # type: (Span, AbstractSpan) -> None


### PR DESCRIPTION
- If a `TracerProvider` already exists, patch it. `TracerProvider` is a singleton, so if we aren't the first one setting it up, we need to use the existing one.
- If an OTel span starts, record its `instrumentation_scope.name` (e.g. `opentelemetry.instrumentation.flask`) and turn it into `origin` at the end. This allows us to differentiate between spans auto-instrumented by Sentry and OTel.