### PR TITLE
fix(redis): Use `command_queue` instead of `command_stack` if available

### DIFF
--- a/sentry_sdk/integrations/redis/_sync_common.py
+++ b/sentry_sdk/integrations/redis/_sync_common.py
@@ -43,11 +43,9 @@ def patch_redis_pipeline(
         ) as span:
             with capture_internal_exceptions():
                 command_seq = None
-                if getattr(self, "_execution_strategy", None) and getattr(
-                    self._execution_strategy, "command_queue", None
-                ):
+                try:
                     command_seq = self._execution_strategy.command_queue
-                else:
+                except AttributeError:
                     command_seq = self.command_stack
 
                 set_db_data_fn(span, self)

--- a/sentry_sdk/integrations/redis/_sync_common.py
+++ b/sentry_sdk/integrations/redis/_sync_common.py
@@ -42,11 +42,13 @@ def patch_redis_pipeline(
             origin=SPAN_ORIGIN,
         ) as span:
             with capture_internal_exceptions():
-                command_queue = None
+                command_seq = None
                 if getattr(self, "_execution_strategy", None) and getattr(
                     self._execution_strategy, "command_queue", None
                 ):
-                    command_queue = self._execution_strategy.command_queue
+                    command_seq = self._execution_strategy.command_queue
+                else:
+                    command_seq = self.command_stack
 
                 set_db_data_fn(span, self)
                 _set_pipeline_data(
@@ -54,8 +56,7 @@ def patch_redis_pipeline(
                     is_cluster,
                     get_command_args_fn,
                     False if is_cluster else self.transaction,
-                    self.command_stack,
-                    command_queue,
+                    command_seq,
                 )
 
             return old_execute(self, *args, **kwargs)

--- a/sentry_sdk/integrations/redis/_sync_common.py
+++ b/sentry_sdk/integrations/redis/_sync_common.py
@@ -42,6 +42,12 @@ def patch_redis_pipeline(
             origin=SPAN_ORIGIN,
         ) as span:
             with capture_internal_exceptions():
+                command_queue = None
+                if getattr(self, "_execution_strategy", None) and getattr(
+                    self._execution_strategy, "command_queue", None
+                ):
+                    command_queue = self._execution_strategy.command_queue
+
                 set_db_data_fn(span, self)
                 _set_pipeline_data(
                     span,
@@ -49,6 +55,7 @@ def patch_redis_pipeline(
                     get_command_args_fn,
                     False if is_cluster else self.transaction,
                     self.command_stack,
+                    command_queue,
                 )
 
             return old_execute(self, *args, **kwargs)

--- a/sentry_sdk/integrations/redis/utils.py
+++ b/sentry_sdk/integrations/redis/utils.py
@@ -12,8 +12,7 @@ from sentry_sdk.utils import SENSITIVE_DATA_SUBSTITUTE
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from typing import Any, List, Optional, Sequence
-    from redis.cluster import PipelineCommand
+    from typing import Any, Optional, Sequence
     from sentry_sdk.tracing import Span
 
 
@@ -111,17 +110,14 @@ def _set_pipeline_data(
     is_cluster,
     get_command_args_fn,
     is_transaction,
-    command_stack,
-    command_queue=None,
+    commands_seq,
 ):
-    # type: (Span, bool, Any, bool, Sequence[Any], Optional[List[PipelineCommand]]) -> None
+    # type: (Span, bool, Any, bool, Sequence[Any]) -> None
     span.set_tag("redis.is_cluster", is_cluster)
     span.set_tag("redis.transaction", is_transaction)
 
-    command_seq = command_stack or command_queue or []
-
     commands = []
-    for i, arg in enumerate(command_seq):
+    for i, arg in enumerate(commands_seq):
         if i >= _MAX_NUM_COMMANDS:
             break
 
@@ -131,7 +127,7 @@ def _set_pipeline_data(
     span.set_data(
         "redis.commands",
         {
-            "count": len(command_seq),
+            "count": len(commands_seq),
             "first_ten": commands,
         },
     )


### PR DESCRIPTION
This [commit](https://github.com/redis/redis-py/commit/91be4a0ff39556d5e270897740369d0b1cf9e044) in `redis-py` moved away from using the Pipeline's `command_stack` and is now using `_execution_strategy.command_queue` instead. We need to adapt to use the new command source if present.

This fixes `redis-latest` in CI.