### PR TITLE
fix(grpc): Fix AttributeError when instrumenting with OTel

### DIFF
--- a/sentry_sdk/integrations/grpc/__init__.py
+++ b/sentry_sdk/integrations/grpc/__init__.py
@@ -127,7 +127,7 @@ def _wrap_async_server(func: Callable[P, AsyncServer]) -> Callable[P, AsyncServe
         **kwargs: P.kwargs,
     ) -> Server:
         server_interceptor = AsyncServerInterceptor()
-        interceptors = (server_interceptor, *(interceptors or []))
+        interceptors = [server_interceptor, *(interceptors or [])]
         return func(*args, interceptors=interceptors, **kwargs)  # type: ignore
 
     return patched_aio_server  # type: ignore


### PR DESCRIPTION
OTel also wraps `grpc.aio.server`, but expects the `interceptors` arg to be a list, while Sentry [turns it into a tuple](https://github.com/getsentry/sentry-python/blob/94414cdcdce2a311355967ee7b43e7035cf954ce/sentry_sdk/integrations/grpc/__init__.py#L130).

Fixes https://github.com/getsentry/sentry-python/issues/4389