### PR TITLE
fix(logging): Strip log `record.name` for more robust matching

### DIFF
--- a/sentry_sdk/integrations/logging.py
+++ b/sentry_sdk/integrations/logging.py
@@ -119,7 +119,10 @@ class LoggingIntegration(Integration):
                 # the integration.  Otherwise we have a high chance of getting
                 # into a recursion error when the integration is resolved
                 # (this also is slower).
-                if ignored_loggers is not None and record.name not in ignored_loggers:
+                if (
+                    ignored_loggers is not None
+                    and record.name.strip() not in ignored_loggers
+                ):
                     integration = sentry_sdk.get_client().get_integration(
                         LoggingIntegration
                     )
@@ -164,7 +167,7 @@ class _BaseHandler(logging.Handler):
         # type: (LogRecord) -> bool
         """Prevents ignored loggers from recording"""
         for logger in _IGNORED_LOGGERS:
-            if fnmatch(record.name, logger):
+            if fnmatch(record.name.strip(), logger):
                 return False
         return True
 

--- a/tests/integrations/logging/test_logging.py
+++ b/tests/integrations/logging/test_logging.py
@@ -230,6 +230,18 @@ def test_ignore_logger(sentry_init, capture_events):
     assert not events
 
 
+def test_ignore_logger_whitespace_padding(sentry_init, capture_events):
+    """Here we test insensitivity to whitespace padding of ignored loggers"""
+    sentry_init(integrations=[LoggingIntegration()], default_integrations=False)
+    events = capture_events()
+
+    ignore_logger("testfoo")
+
+    padded_logger = logging.getLogger("       testfoo   ")
+    padded_logger.error("hi")
+    assert not events
+
+
 def test_ignore_logger_wildcard(sentry_init, capture_events):
     sentry_init(integrations=[LoggingIntegration()], default_integrations=False)
     events = capture_events()


### PR DESCRIPTION
Hi! In the Python SDK, more specifically `sentry_sdk/integrations/logging.py`, a couple of loggers are ignored to avoid recursion errors.
```py
_IGNORED_LOGGERS = set(
    ["sentry_sdk.errors", "urllib3.connectionpool", "urllib3.connection"]
)
```
Log records from these loggers are discarded, using an exact match on `record.name`. Unforunately, this breaks if the user modifies `record.name`,  e.g. for formatting, which is what we were doing for log display (before becoming aware that Sentry relied on it after investigating an infinite recursion issue).
```py
class _LengthFormatter(logging.Formatter):
    def format(self, record):
        """
        Format a log record's header to a constant length
        """
        if len(record.name) > _MAX_LOGGER_NAME_LENGTH:
            sep = "..."
            cut = _MAX_LOGGER_NAME_LENGTH // 3 - len(sep)
            record.name = record.name[:cut] + sep + record.name[-(_MAX_LOGGER_NAME_LENGTH - cut - len(sep)) :]
        record.name = record.name.ljust(_MAX_LOGGER_NAME_LENGTH)

        record.levelname = record.levelname.ljust(_MAX_LOGGER_LEVEL_NAME_LENGTH)
        return super().format(record)
```

As you can see, `record.name` is right-padded with blank spaces. We have found a workaround since, but given that it has taken us quite some time to find the issue, I thought that maybe it could affect others. This PR proposes matching `record.name.strip()` instead for increased robustness.