### PR TITLE
feat(logs): Add user attributes to logs

### DIFF
--- a/sentry_sdk/client.py
+++ b/sentry_sdk/client.py
@@ -927,6 +927,21 @@ class _Client(BaseClient):
             elif propagation_context is not None:
                 log["trace_id"] = propagation_context.trace_id
 
+        # The user, if present, is always set on the isolation scope.
+        if self.should_send_default_pii() and isolation_scope._user is not None:
+            for log_attribute, user_attribute in (
+                ("user.id", "id"),
+                ("user.name", "username"),
+                ("user.email", "email"),
+            ):
+                if (
+                    user_attribute in isolation_scope._user
+                    and log_attribute not in log["attributes"]
+                ):
+                    log["attributes"][log_attribute] = isolation_scope._user[
+                        user_attribute
+                    ]
+
         # If debug is enabled, log the log to the console
         debug = self.options.get("debug", False)
         if debug:

--- a/tests/test_logs.py
+++ b/tests/test_logs.py
@@ -484,6 +484,49 @@ def test_auto_flush_logs_after_100(sentry_init, capture_envelopes):
     raise AssertionError("200 logs were never flushed after five seconds")
 
 
+def test_user_attributes(sentry_init, capture_envelopes):
+    """User attributes are sent if send_default_pii is True."""
+    sentry_init(send_default_pii=True, _experiments={"enable_logs": True})
+
+    sentry_sdk.set_user({"id": "1", "email": "test@example.com", "username": "test"})
+    envelopes = capture_envelopes()
+
+    python_logger = logging.Logger("test-logger")
+    python_logger.warning("Hello, world!")
+
+    get_client().flush()
+
+    logs = envelopes_to_logs(envelopes)
+    (log,) = logs
+
+    # Check that all expected user attributes are present.
+    assert log["attributes"].items() >= {
+        ("user.id", "1"),
+        ("user.email", "test@example.com"),
+        ("user.name", "test"),
+    }
+
+
+def test_user_attributes_no_pii(sentry_init, capture_envelopes):
+    """Ensure no user attributes are sent if send_default_pii is False."""
+    sentry_init(_experiments={"enable_logs": True})
+
+    sentry_sdk.set_user({"id": "1", "email": "test@example.com", "username": "test"})
+    envelopes = capture_envelopes()
+
+    python_logger = logging.Logger("test-logger")
+    python_logger.warning("Hello, world!")
+
+    get_client().flush()
+
+    logs = envelopes_to_logs(envelopes)
+
+    (log,) = logs
+    assert "user.id" not in log["attributes"]
+    assert "user.email" not in log["attributes"]
+    assert "user.name" not in log["attributes"]
+
+
 @minimum_python_37
 def test_auto_flush_logs_after_5s(sentry_init, capture_envelopes):
     """


### PR DESCRIPTION
Example log with user attributes: https://sentry-sdks.sentry.io/explore/logs/trace/362b3309f7f9471eb504af407bf51932/?logsSortBys=-timestamp&project=4505239425777664&source=logs&tab=logs&timestamp=1748448946

Closes #4422