### PR TITLE
ref: Remove `_capture_experimental_log` `scope` parameter

### DIFF
--- a/sentry_sdk/integrations/logging.py
+++ b/sentry_sdk/integrations/logging.py
@@ -352,7 +352,6 @@ class SentryLogsHandler(_BaseHandler):
 
     def _capture_log_from_record(self, client, record):
         # type: (BaseClient, LogRecord) -> None
-        scope = sentry_sdk.get_current_scope()
         otel_severity_number, otel_severity_text = _python_level_to_otel(record.levelno)
         project_root = client.options["project_root"]
         attrs = self._extra_from_record(record)  # type: Any
@@ -394,7 +393,6 @@ class SentryLogsHandler(_BaseHandler):
 
         # noinspection PyProtectedMember
         client._capture_experimental_log(
-            scope,
             {
                 "severity_text": otel_severity_text,
                 "severity_number": otel_severity_number,

--- a/sentry_sdk/logger.py
+++ b/sentry_sdk/logger.py
@@ -3,14 +3,13 @@ import functools
 import time
 from typing import Any
 
-from sentry_sdk import get_client, get_current_scope
+from sentry_sdk import get_client
 from sentry_sdk.utils import safe_repr
 
 
 def _capture_log(severity_text, severity_number, template, **kwargs):
     # type: (str, int, str, **Any) -> None
     client = get_client()
-    scope = get_current_scope()
 
     attrs = {
         "sentry.message.template": template,
@@ -36,7 +35,6 @@ def _capture_log(severity_text, severity_number, template, **kwargs):
 
     # noinspection PyProtectedMember
     client._capture_experimental_log(
-        scope,
         {
             "severity_text": severity_text,
             "severity_number": severity_number,


### PR DESCRIPTION
We are always just using the current scope anyway; it is less confusing if we eliminate the parameter

Stacked on:
  - #4423