### PR TITLE
fix(integrations/ray): Correctly pass keyword arguments to ray.remote function

### DIFF
--- a/sentry_sdk/integrations/ray.py
+++ b/sentry_sdk/integrations/ray.py
@@ -53,7 +53,10 @@ def _patch_ray_remote():
             return old_remote(f, *args, **kwargs)
 
         def wrapper(user_f):
+            # type: (Callable[..., Any]) -> Any
+            @functools.wraps(user_f)
             def new_func(*f_args, _tracing=None, **f_kwargs):
+                # type: (Any, Optional[dict[str, Any]], Any) -> Any
                 _check_sentry_initialized()
 
                 transaction = sentry_sdk.continue_trace(
@@ -116,7 +119,7 @@ def _patch_ray_remote():
         else:
             return wrapper
 
-    ray.remote = new_remote
+    ray.remote = new_remote  # type: ignore[assignment]
 
 
 def _capture_exception(exc_info, **kwargs):

--- a/sentry_sdk/integrations/ray.py
+++ b/sentry_sdk/integrations/ray.py
@@ -42,73 +42,79 @@ def _patch_ray_remote():
     old_remote = ray.remote
 
     @functools.wraps(old_remote)
-    def new_remote(f, *args, **kwargs):
-        # type: (Callable[..., Any], *Any, **Any) -> Callable[..., Any]
+    def new_remote(f=None, *args, **kwargs):
+        # type: (Optional[Callable[..., Any]], *Any, **Any) -> Callable[..., Any]
+
         if inspect.isclass(f):
             # Ray Actors
             # (https://docs.ray.io/en/latest/ray-core/actors.html)
             # are not supported
             # (Only Ray Tasks are supported)
-            return old_remote(f, *args, *kwargs)
+            return old_remote(f, *args, **kwargs)
 
-        def _f(*f_args, _tracing=None, **f_kwargs):
-            # type: (Any, Optional[dict[str, Any]],  Any) -> Any
-            """
-            Ray Worker
-            """
-            _check_sentry_initialized()
+        def wrapper(user_f):
+            def new_func(*f_args, _tracing=None, **f_kwargs):
+                _check_sentry_initialized()
 
-            transaction = sentry_sdk.continue_trace(
-                _tracing or {},
-                op=OP.QUEUE_TASK_RAY,
-                name=qualname_from_function(f),
-                origin=RayIntegration.origin,
-                source=TransactionSource.TASK,
-            )
+                transaction = sentry_sdk.continue_trace(
+                    _tracing or {},
+                    op=OP.QUEUE_TASK_RAY,
+                    name=qualname_from_function(user_f),
+                    origin=RayIntegration.origin,
+                    source=TransactionSource.TASK,
+                )
 
-            with sentry_sdk.start_transaction(transaction) as transaction:
-                try:
-                    result = f(*f_args, **f_kwargs)
-                    transaction.set_status(SPANSTATUS.OK)
-                except Exception:
-                    transaction.set_status(SPANSTATUS.INTERNAL_ERROR)
-                    exc_info = sys.exc_info()
-                    _capture_exception(exc_info)
-                    reraise(*exc_info)
+                with sentry_sdk.start_transaction(transaction) as transaction:
+                    try:
+                        result = user_f(*f_args, **f_kwargs)
+                        transaction.set_status(SPANSTATUS.OK)
+                    except Exception:
+                        transaction.set_status(SPANSTATUS.INTERNAL_ERROR)
+                        exc_info = sys.exc_info()
+                        _capture_exception(exc_info)
+                        reraise(*exc_info)
 
-                return result
+                    return result
 
-        rv = old_remote(_f, *args, *kwargs)
-        old_remote_method = rv.remote
+            if f:
+                rv = old_remote(new_func)
+            else:
+                rv = old_remote(*args, **kwargs)(new_func)
+            old_remote_method = rv.remote
 
-        def _remote_method_with_header_propagation(*args, **kwargs):
-            # type: (*Any, **Any) -> Any
-            """
-            Ray Client
-            """
-            with sentry_sdk.start_span(
-                op=OP.QUEUE_SUBMIT_RAY,
-                name=qualname_from_function(f),
-                origin=RayIntegration.origin,
-            ) as span:
-                tracing = {
-                    k: v
-                    for k, v in sentry_sdk.get_current_scope().iter_trace_propagation_headers()
-                }
-                try:
-                    result = old_remote_method(*args, **kwargs, _tracing=tracing)
-                    span.set_status(SPANSTATUS.OK)
-                except Exception:
-                    span.set_status(SPANSTATUS.INTERNAL_ERROR)
-                    exc_info = sys.exc_info()
-                    _capture_exception(exc_info)
-                    reraise(*exc_info)
+            def _remote_method_with_header_propagation(*args, **kwargs):
+                # type: (*Any, **Any) -> Any
+                """
+                Ray Client
+                """
+                with sentry_sdk.start_span(
+                    op=OP.QUEUE_SUBMIT_RAY,
+                    name=qualname_from_function(user_f),
+                    origin=RayIntegration.origin,
+                ) as span:
+                    tracing = {
+                        k: v
+                        for k, v in sentry_sdk.get_current_scope().iter_trace_propagation_headers()
+                    }
+                    try:
+                        result = old_remote_method(*args, **kwargs, _tracing=tracing)
+                        span.set_status(SPANSTATUS.OK)
+                    except Exception:
+                        span.set_status(SPANSTATUS.INTERNAL_ERROR)
+                        exc_info = sys.exc_info()
+                        _capture_exception(exc_info)
+                        reraise(*exc_info)
 
-                return result
+                    return result
 
-        rv.remote = _remote_method_with_header_propagation
+            rv.remote = _remote_method_with_header_propagation
 
-        return rv
+            return rv
+
+        if f is not None:
+            return wrapper(f)
+        else:
+            return wrapper
 
     ray.remote = new_remote
 

--- a/sentry_sdk/integrations/ray.py
+++ b/sentry_sdk/integrations/ray.py
@@ -14,7 +14,7 @@ from sentry_sdk.utils import (
 )
 
 try:
-    import ray
+    import ray  # type: ignore[import-not-found]
 except ImportError:
     raise DidNotEnable("Ray not installed.")
 import functools
@@ -118,7 +118,7 @@ def _patch_ray_remote():
         else:
             return wrapper
 
-    ray.remote = new_remote  # type: ignore[assignment]
+    ray.remote = new_remote
 
 
 def _capture_exception(exc_info, **kwargs):

--- a/sentry_sdk/integrations/ray.py
+++ b/sentry_sdk/integrations/ray.py
@@ -14,7 +14,7 @@ from sentry_sdk.utils import (
 )
 
 try:
-    import ray  # type: ignore[import-not-found]
+    import ray
 except ImportError:
     raise DidNotEnable("Ray not installed.")
 import functools
@@ -54,7 +54,6 @@ def _patch_ray_remote():
 
         def wrapper(user_f):
             # type: (Callable[..., Any]) -> Any
-            @functools.wraps(user_f)
             def new_func(*f_args, _tracing=None, **f_kwargs):
                 # type: (Any, Optional[dict[str, Any]], Any) -> Any
                 _check_sentry_initialized()

--- a/tests/integrations/ray/test_ray.py
+++ b/tests/integrations/ray/test_ray.py
@@ -59,7 +59,9 @@ def read_error_from_log(job_id):
 
 
 @pytest.mark.forked
-@pytest.mark.parametrize("task_options", [{}, {"num_cpus": 0}])
+@pytest.mark.parametrize(
+    "task_options", [{}, {"num_cpus": 0, "memory": 1024 * 1024 * 10}]
+)
 def test_tracing_in_ray_tasks(task_options):
     setup_sentry()
 

--- a/tests/integrations/ray/test_ray.py
+++ b/tests/integrations/ray/test_ray.py
@@ -59,7 +59,8 @@ def read_error_from_log(job_id):
 
 
 @pytest.mark.forked
-def test_tracing_in_ray_tasks():
+@pytest.mark.parametrize("task_options", [{}, {"num_cpus": 0}])
+def test_tracing_in_ray_tasks(task_options):
     setup_sentry()
 
     ray.init(
@@ -69,13 +70,18 @@ def test_tracing_in_ray_tasks():
         }
     )
 
-    # Setup ray task
-    @ray.remote
     def example_task():
         with sentry_sdk.start_span(op="task", name="example task step"):
             ...
 
         return sentry_sdk.get_client().transport.envelopes
+
+    # Setup ray task, calling decorator directly instead of @,
+    # to accommodate for test parametrization
+    if task_options:
+        example_task = ray.remote(**task_options)(example_task)
+    else:
+        example_task = ray.remote(example_task)
 
     with sentry_sdk.start_transaction(op="task", name="ray test transaction"):
         worker_envelopes = ray.get(example_task.remote())


### PR DESCRIPTION
Monkey-patched implementation was passing the provided keyword arguments incorrectly due to a typo - "*kwargs" was used instead of "**kwargs" twice.

Fixed integration started hitting an assert in the Ray codebase that requires for users to use "@ray.remote" decorator either with no arguments and no parentheses, or with some of the arguments provided.

An additional wrapper function was added to support both scenarios.

---

Thank you for contributing to `sentry-python`! Please add tests to validate your changes, and lint your code using `tox -e linters`.

Running the test suite on your PR might require maintainer approval.