### PR TITLE
fix: Rename op `db` to `db.query`

### DIFF
--- a/MIGRATION_GUIDE.md
+++ b/MIGRATION_GUIDE.md
@@ -18,6 +18,7 @@ Looking to upgrade from Sentry SDK 2.x to 3.x? Here's a comprehensive list of wh
 - The `Span()` constructor does not accept a `hub` parameter anymore.
 - `Span.finish()` does not accept a `hub` parameter anymore.
 - `Span.finish()` no longer returns the `event_id` if the event is sent to sentry.
+- Some integrations were creating spans with `op` `db`. This was changed to `db.query`.
 - The `Profile()` constructor does not accept a `hub` parameter anymore.
 - A `Profile` object does not have a `.hub` property anymore.
 - `MAX_PROFILE_DURATION_NS`, `PROFILE_MINIMUM_SAMPLES`, `Profile`, `Scheduler`, `ThreadScheduler`, `GeventScheduler`, `has_profiling_enabled`, `setup_profiler`, `teardown_profiler` are no longer accessible from `sentry_sdk.profiler`. They're still accessible from `sentry_sdk.profiler.transaction_profiler`.
@@ -30,6 +31,7 @@ Looking to upgrade from Sentry SDK 2.x to 3.x? Here's a comprehensive list of wh
 - We updated how we handle `ExceptionGroup`s. You will now get more data if ExceptionGroups are appearing in chained exceptions. It could happen that after updating the SDK the grouping of issues change because of this. So eventually you will see the same exception in two Sentry issues (one from before the update, one from after the update)
 - The integration for Python `logging` module does not send Sentry issues by default anymore when calling `logging.error()`, `logging.critical()` or `logging.exception()`. If you want to preserve the old behavior use `sentry_sdk.init(integrations=[LoggingIntegration(event_level="ERROR")])`.
 - The `SentrySpanProcessor` and `SentryPropagator` are exported from `sentry_sdk.opentelemetry` instead of `sentry_sdk.integrations.opentelemetry`.
+- PyMongo breadcrumb type was changed from `db` to `query`.
 - The integration-specific content of the `sampling_context` argument of `traces_sampler` and `profiles_sampler` now looks different.
   - The Celery integration doesn't add the `celery_job` dictionary anymore. Instead, the individual keys are now available as:
 

--- a/sentry_sdk/consts.py
+++ b/sentry_sdk/consts.py
@@ -496,7 +496,7 @@ class OP:
     CACHE_PUT = "cache.put"
     COHERE_CHAT_COMPLETIONS_CREATE = "ai.chat_completions.create.cohere"
     COHERE_EMBEDDINGS_CREATE = "ai.embeddings.create.cohere"
-    DB = "db"
+    DB_QUERY = "db.query"
     DB_REDIS = "db.redis"
     EVENT_DJANGO = "event.django"
     FUNCTION = "function"

--- a/sentry_sdk/integrations/asyncpg.py
+++ b/sentry_sdk/integrations/asyncpg.py
@@ -163,7 +163,7 @@ def _wrap_connect_addr(f: Callable[..., Awaitable[T]]) -> Callable[..., Awaitabl
             return await f(*args, **kwargs)
 
         with sentry_sdk.start_span(
-            op=OP.DB,
+            op=OP.DB_QUERY,
             name="connect",
             origin=AsyncPGIntegration.origin,
             only_if_parent=True,

--- a/sentry_sdk/integrations/clickhouse_driver.py
+++ b/sentry_sdk/integrations/clickhouse_driver.py
@@ -85,7 +85,7 @@ def _wrap_start(f: Callable[P, T]) -> Callable[P, T]:
         params = args[3] if len(args) > 3 else kwargs.get("params")
 
         span = sentry_sdk.start_span(
-            op=OP.DB,
+            op=OP.DB_QUERY,
             name=query,
             origin=ClickhouseDriverIntegration.origin,
             only_if_parent=True,

--- a/sentry_sdk/integrations/django/__init__.py
+++ b/sentry_sdk/integrations/django/__init__.py
@@ -660,7 +660,7 @@ def install_sql_hook():
             sentry_sdk.add_breadcrumb(message="connect", category="query")
 
         with sentry_sdk.start_span(
-            op=OP.DB,
+            op=OP.DB_QUERY,
             name="connect",
             origin=DjangoIntegration.origin_db,
             only_if_parent=True,

--- a/sentry_sdk/integrations/pymongo.py
+++ b/sentry_sdk/integrations/pymongo.py
@@ -158,7 +158,7 @@ class CommandTracer(monitoring.CommandListener):
 
             with capture_internal_exceptions():
                 sentry_sdk.add_breadcrumb(
-                    message=query, category="query", type=OP.DB_QUERY, data=data
+                    message=query, category="query", type="query", data=data
                 )
 
             for key, value in data.items():

--- a/sentry_sdk/integrations/pymongo.py
+++ b/sentry_sdk/integrations/pymongo.py
@@ -150,7 +150,7 @@ class CommandTracer(monitoring.CommandListener):
 
             query = _serialize_span_attribute(command)
             span = sentry_sdk.start_span(
-                op=OP.DB,
+                op=OP.DB_QUERY,
                 name=query,
                 origin=PyMongoIntegration.origin,
                 only_if_parent=True,
@@ -158,7 +158,7 @@ class CommandTracer(monitoring.CommandListener):
 
             with capture_internal_exceptions():
                 sentry_sdk.add_breadcrumb(
-                    message=query, category="query", type=OP.DB, data=data
+                    message=query, category="query", type=OP.DB_QUERY, data=data
                 )
 
             for key, value in data.items():

--- a/sentry_sdk/opentelemetry/utils.py
+++ b/sentry_sdk/opentelemetry/utils.py
@@ -219,7 +219,7 @@ def span_data_for_db_query(span):
     # type: (ReadableSpan) -> OtelExtractedSpanData
     span_attributes = span.attributes or {}
 
-    op = cast("str", span_attributes.get(SentrySpanAttribute.OP, OP.DB))
+    op = cast("str", span_attributes.get(SentrySpanAttribute.OP, OP.DB_QUERY))
 
     statement = span_attributes.get(SpanAttributes.DB_STATEMENT, None)
     statement = cast("Optional[str]", statement)

--- a/sentry_sdk/tracing_utils.py
+++ b/sentry_sdk/tracing_utils.py
@@ -151,7 +151,7 @@ def record_sql_queries(
         sentry_sdk.add_breadcrumb(message=query, category="query", data=data)
 
     with sentry_sdk.start_span(
-        op=OP.DB,
+        op=OP.DB_QUERY,
         name=query,
         origin=span_origin,
         only_if_parent=True,

--- a/tests/integrations/clickhouse_driver/test_clickhouse_driver.py
+++ b/tests/integrations/clickhouse_driver/test_clickhouse_driver.py
@@ -252,13 +252,13 @@ def test_clickhouse_client_spans(
 
     expected_spans = [
         {
-            "op": "db",
+            "op": "db.query",
             "origin": "auto.db.clickhouse_driver",
             "description": "DROP TABLE IF EXISTS test",
             "data": {
                 "sentry.name": "DROP TABLE IF EXISTS test",
                 "sentry.origin": "auto.db.clickhouse_driver",
-                "sentry.op": "db",
+                "sentry.op": "db.query",
                 "db.system": "clickhouse",
                 "db.name": "",
                 "db.user": "default",
@@ -269,13 +269,13 @@ def test_clickhouse_client_spans(
             "parent_span_id": transaction_span_id,
         },
         {
-            "op": "db",
+            "op": "db.query",
             "origin": "auto.db.clickhouse_driver",
             "description": "CREATE TABLE test (x Int32) ENGINE = Memory",
             "data": {
                 "sentry.name": "CREATE TABLE test (x Int32) ENGINE = Memory",
                 "sentry.origin": "auto.db.clickhouse_driver",
-                "sentry.op": "db",
+                "sentry.op": "db.query",
                 "db.system": "clickhouse",
                 "db.name": "",
                 "db.user": "default",
@@ -286,13 +286,13 @@ def test_clickhouse_client_spans(
             "parent_span_id": transaction_span_id,
         },
         {
-            "op": "db",
+            "op": "db.query",
             "origin": "auto.db.clickhouse_driver",
             "description": "INSERT INTO test (x) VALUES",
             "data": {
                 "sentry.name": "INSERT INTO test (x) VALUES",
                 "sentry.origin": "auto.db.clickhouse_driver",
-                "sentry.op": "db",
+                "sentry.op": "db.query",
                 "db.system": "clickhouse",
                 "db.name": "",
                 "db.user": "default",
@@ -303,13 +303,13 @@ def test_clickhouse_client_spans(
             "parent_span_id": transaction_span_id,
         },
         {
-            "op": "db",
+            "op": "db.query",
             "origin": "auto.db.clickhouse_driver",
             "description": "INSERT INTO test (x) VALUES",
             "data": {
                 "sentry.name": "INSERT INTO test (x) VALUES",
                 "sentry.origin": "auto.db.clickhouse_driver",
-                "sentry.op": "db",
+                "sentry.op": "db.query",
                 "db.system": "clickhouse",
                 "db.name": "",
                 "db.user": "default",
@@ -320,13 +320,13 @@ def test_clickhouse_client_spans(
             "parent_span_id": transaction_span_id,
         },
         {
-            "op": "db",
+            "op": "db.query",
             "origin": "auto.db.clickhouse_driver",
             "description": "SELECT sum(x) FROM test WHERE x > 150",
             "data": {
                 "sentry.name": "SELECT sum(x) FROM test WHERE x > 150",
                 "sentry.origin": "auto.db.clickhouse_driver",
-                "sentry.op": "db",
+                "sentry.op": "db.query",
                 "db.system": "clickhouse",
                 "db.name": "",
                 "db.user": "default",
@@ -385,13 +385,13 @@ def test_clickhouse_client_spans_with_pii(sentry_init, capture_events) -> None:
 
     expected_spans = [
         {
-            "op": "db",
+            "op": "db.query",
             "origin": "auto.db.clickhouse_driver",
             "description": "DROP TABLE IF EXISTS test",
             "data": {
                 "sentry.name": "DROP TABLE IF EXISTS test",
                 "sentry.origin": "auto.db.clickhouse_driver",
-                "sentry.op": "db",
+                "sentry.op": "db.query",
                 "db.system": "clickhouse",
                 "db.name": "",
                 "db.user": "default",
@@ -404,13 +404,13 @@ def test_clickhouse_client_spans_with_pii(sentry_init, capture_events) -> None:
             "parent_span_id": transaction_span_id,
         },
         {
-            "op": "db",
+            "op": "db.query",
             "origin": "auto.db.clickhouse_driver",
             "description": "CREATE TABLE test (x Int32) ENGINE = Memory",
             "data": {
                 "sentry.name": "CREATE TABLE test (x Int32) ENGINE = Memory",
                 "sentry.origin": "auto.db.clickhouse_driver",
-                "sentry.op": "db",
+                "sentry.op": "db.query",
                 "db.system": "clickhouse",
                 "db.name": "",
                 "db.user": "default",
@@ -423,13 +423,13 @@ def test_clickhouse_client_spans_with_pii(sentry_init, capture_events) -> None:
             "parent_span_id": transaction_span_id,
         },
         {
-            "op": "db",
+            "op": "db.query",
             "origin": "auto.db.clickhouse_driver",
             "description": "INSERT INTO test (x) VALUES",
             "data": {
                 "sentry.name": "INSERT INTO test (x) VALUES",
                 "sentry.origin": "auto.db.clickhouse_driver",
-                "sentry.op": "db",
+                "sentry.op": "db.query",
                 "db.system": "clickhouse",
                 "db.name": "",
                 "db.user": "default",
@@ -442,13 +442,13 @@ def test_clickhouse_client_spans_with_pii(sentry_init, capture_events) -> None:
             "parent_span_id": transaction_span_id,
         },
         {
-            "op": "db",
+            "op": "db.query",
             "origin": "auto.db.clickhouse_driver",
             "description": "INSERT INTO test (x) VALUES",
             "data": {
                 "sentry.name": "INSERT INTO test (x) VALUES",
                 "sentry.origin": "auto.db.clickhouse_driver",
-                "sentry.op": "db",
+                "sentry.op": "db.query",
                 "db.system": "clickhouse",
                 "db.name": "",
                 "db.user": "default",
@@ -460,13 +460,13 @@ def test_clickhouse_client_spans_with_pii(sentry_init, capture_events) -> None:
             "parent_span_id": transaction_span_id,
         },
         {
-            "op": "db",
+            "op": "db.query",
             "origin": "auto.db.clickhouse_driver",
             "description": "SELECT sum(x) FROM test WHERE x > 150",
             "data": {
                 "sentry.name": "SELECT sum(x) FROM test WHERE x > 150",
                 "sentry.origin": "auto.db.clickhouse_driver",
-                "sentry.op": "db",
+                "sentry.op": "db.query",
                 "db.system": "clickhouse",
                 "db.name": "",
                 "db.user": "default",
@@ -726,13 +726,13 @@ def test_clickhouse_dbapi_spans(sentry_init, capture_events, capture_envelopes) 
 
     expected_spans = [
         {
-            "op": "db",
+            "op": "db.query",
             "origin": "auto.db.clickhouse_driver",
             "description": "DROP TABLE IF EXISTS test",
             "data": {
                 "sentry.name": "DROP TABLE IF EXISTS test",
                 "sentry.origin": "auto.db.clickhouse_driver",
-                "sentry.op": "db",
+                "sentry.op": "db.query",
                 "db.system": "clickhouse",
                 "db.name": "",
                 "db.user": "default",
@@ -743,13 +743,13 @@ def test_clickhouse_dbapi_spans(sentry_init, capture_events, capture_envelopes) 
             "parent_span_id": transaction_span_id,
         },
         {
-            "op": "db",
+            "op": "db.query",
             "origin": "auto.db.clickhouse_driver",
             "description": "CREATE TABLE test (x Int32) ENGINE = Memory",
             "data": {
                 "sentry.name": "CREATE TABLE test (x Int32) ENGINE = Memory",
                 "sentry.origin": "auto.db.clickhouse_driver",
-                "sentry.op": "db",
+                "sentry.op": "db.query",
                 "db.system": "clickhouse",
                 "db.name": "",
                 "db.user": "default",
@@ -760,13 +760,13 @@ def test_clickhouse_dbapi_spans(sentry_init, capture_events, capture_envelopes) 
             "parent_span_id": transaction_span_id,
         },
         {
-            "op": "db",
+            "op": "db.query",
             "origin": "auto.db.clickhouse_driver",
             "description": "INSERT INTO test (x) VALUES",
             "data": {
                 "sentry.name": "INSERT INTO test (x) VALUES",
                 "sentry.origin": "auto.db.clickhouse_driver",
-                "sentry.op": "db",
+                "sentry.op": "db.query",
                 "db.system": "clickhouse",
                 "db.name": "",
                 "db.user": "default",
@@ -777,13 +777,13 @@ def test_clickhouse_dbapi_spans(sentry_init, capture_events, capture_envelopes) 
             "parent_span_id": transaction_span_id,
         },
         {
-            "op": "db",
+            "op": "db.query",
             "origin": "auto.db.clickhouse_driver",
             "description": "INSERT INTO test (x) VALUES",
             "data": {
                 "sentry.name": "INSERT INTO test (x) VALUES",
                 "sentry.origin": "auto.db.clickhouse_driver",
-                "sentry.op": "db",
+                "sentry.op": "db.query",
                 "db.system": "clickhouse",
                 "db.name": "",
                 "db.user": "default",
@@ -794,13 +794,13 @@ def test_clickhouse_dbapi_spans(sentry_init, capture_events, capture_envelopes) 
             "parent_span_id": transaction_span_id,
         },
         {
-            "op": "db",
+            "op": "db.query",
             "origin": "auto.db.clickhouse_driver",
             "description": "SELECT sum(x) FROM test WHERE x > 150",
             "data": {
                 "sentry.name": "SELECT sum(x) FROM test WHERE x > 150",
                 "sentry.origin": "auto.db.clickhouse_driver",
-                "sentry.op": "db",
+                "sentry.op": "db.query",
                 "db.system": "clickhouse",
                 "db.name": "",
                 "db.user": "default",
@@ -860,13 +860,13 @@ def test_clickhouse_dbapi_spans_with_pii(
 
     expected_spans = [
         {
-            "op": "db",
+            "op": "db.query",
             "origin": "auto.db.clickhouse_driver",
             "description": "DROP TABLE IF EXISTS test",
             "data": {
                 "sentry.name": "DROP TABLE IF EXISTS test",
                 "sentry.origin": "auto.db.clickhouse_driver",
-                "sentry.op": "db",
+                "sentry.op": "db.query",
                 "db.system": "clickhouse",
                 "db.name": "",
                 "db.user": "default",
@@ -879,13 +879,13 @@ def test_clickhouse_dbapi_spans_with_pii(
             "parent_span_id": transaction_span_id,
         },
         {
-            "op": "db",
+            "op": "db.query",
             "origin": "auto.db.clickhouse_driver",
             "description": "CREATE TABLE test (x Int32) ENGINE = Memory",
             "data": {
                 "sentry.name": "CREATE TABLE test (x Int32) ENGINE = Memory",
                 "sentry.origin": "auto.db.clickhouse_driver",
-                "sentry.op": "db",
+                "sentry.op": "db.query",
                 "db.system": "clickhouse",
                 "db.name": "",
                 "db.user": "default",
@@ -898,13 +898,13 @@ def test_clickhouse_dbapi_spans_with_pii(
             "parent_span_id": transaction_span_id,
         },
         {
-            "op": "db",
+            "op": "db.query",
             "origin": "auto.db.clickhouse_driver",
             "description": "INSERT INTO test (x) VALUES",
             "data": {
                 "sentry.name": "INSERT INTO test (x) VALUES",
                 "sentry.origin": "auto.db.clickhouse_driver",
-                "sentry.op": "db",
+                "sentry.op": "db.query",
                 "db.system": "clickhouse",
                 "db.name": "",
                 "db.user": "default",
@@ -917,13 +917,13 @@ def test_clickhouse_dbapi_spans_with_pii(
             "parent_span_id": transaction_span_id,
         },
         {
-            "op": "db",
+            "op": "db.query",
             "origin": "auto.db.clickhouse_driver",
             "description": "INSERT INTO test (x) VALUES",
             "data": {
                 "sentry.name": "INSERT INTO test (x) VALUES",
                 "sentry.origin": "auto.db.clickhouse_driver",
-                "sentry.op": "db",
+                "sentry.op": "db.query",
                 "db.system": "clickhouse",
                 "db.name": "",
                 "db.user": "default",
@@ -936,13 +936,13 @@ def test_clickhouse_dbapi_spans_with_pii(
             "parent_span_id": transaction_span_id,
         },
         {
-            "op": "db",
+            "op": "db.query",
             "origin": "auto.db.clickhouse_driver",
             "description": "SELECT sum(x) FROM test WHERE x > 150",
             "data": {
                 "sentry.name": "SELECT sum(x) FROM test WHERE x > 150",
                 "sentry.origin": "auto.db.clickhouse_driver",
-                "sentry.op": "db",
+                "sentry.op": "db.query",
                 "db.system": "clickhouse",
                 "db.name": "",
                 "db.user": "default",

--- a/tests/integrations/django/test_basic.py
+++ b/tests/integrations/django/test_basic.py
@@ -570,11 +570,11 @@ def test_django_connect_trace(sentry_init, client, capture_events, render_span_t
     (event,) = events
 
     for span in event["spans"]:
-        if span.get("op") == "db":
+        if span.get("op") == "db.query":
             data = span.get("data")
             assert data.get(SPANDATA.DB_SYSTEM) == "postgresql"
 
-    assert '- op="db": description="connect"' in render_span_tree(event)
+    assert '- op="db.query": description="connect"' in render_span_tree(event)
 
 
 @pytest.mark.forked
@@ -639,7 +639,7 @@ def test_db_connection_span_data(sentry_init, client, capture_events):
     (event,) = events
 
     for span in event["spans"]:
-        if span.get("op") == "db":
+        if span.get("op") == "db.query":
             data = span.get("data")
             assert data.get(SPANDATA.DB_SYSTEM) == "postgresql"
             conn_params = connections["postgres"].get_connection_params()

--- a/tests/integrations/django/test_db_query_data.py
+++ b/tests/integrations/django/test_db_query_data.py
@@ -57,7 +57,7 @@ def test_query_source_disabled(sentry_init, client, capture_events):
 
     (event,) = events
     for span in event["spans"]:
-        if span.get("op") == "db" and "auth_user" in span.get("description"):
+        if span.get("op") == "db.query" and "auth_user" in span.get("description"):
             data = span.get("data", {})
 
             assert SPANDATA.CODE_LINENO not in data
@@ -100,7 +100,7 @@ def test_query_source_enabled(
 
     (event,) = events
     for span in event["spans"]:
-        if span.get("op") == "db" and "auth_user" in span.get("description"):
+        if span.get("op") == "db.query" and "auth_user" in span.get("description"):
             data = span.get("data", {})
 
             assert SPANDATA.CODE_LINENO in data
@@ -137,7 +137,7 @@ def test_query_source(sentry_init, client, capture_events):
 
     (event,) = events
     for span in event["spans"]:
-        if span.get("op") == "db" and "auth_user" in span.get("description"):
+        if span.get("op") == "db.query" and "auth_user" in span.get("description"):
             data = span.get("data", {})
 
             assert SPANDATA.CODE_LINENO in data
@@ -197,7 +197,7 @@ def test_query_source_with_module_in_search_path(sentry_init, client, capture_ev
 
     (event,) = events
     for span in event["spans"]:
-        if span.get("op") == "db" and "auth_user" in span.get("description"):
+        if span.get("op") == "db.query" and "auth_user" in span.get("description"):
             data = span.get("data", {})
 
             assert SPANDATA.CODE_LINENO in data
@@ -245,7 +245,7 @@ def test_query_source_with_in_app_exclude(sentry_init, client, capture_events):
 
     (event,) = events
     for span in event["spans"]:
-        if span.get("op") == "db" and "auth_user" in span.get("description"):
+        if span.get("op") == "db.query" and "auth_user" in span.get("description"):
             data = span.get("data", {})
 
             assert SPANDATA.CODE_LINENO in data
@@ -308,7 +308,7 @@ def test_query_source_with_in_app_include(sentry_init, client, capture_events):
 
     (event,) = events
     for span in event["spans"]:
-        if span.get("op") == "db" and "auth_user" in span.get("description"):
+        if span.get("op") == "db.query" and "auth_user" in span.get("description"):
             data = span.get("data", {})
 
             assert SPANDATA.CODE_LINENO in data
@@ -371,7 +371,7 @@ def test_no_query_source_if_duration_too_short(sentry_init, client, capture_even
 
     (event,) = events
     for span in event["spans"]:
-        if span.get("op") == "db" and "auth_user" in span.get("description"):
+        if span.get("op") == "db.query" and "auth_user" in span.get("description"):
             data = span.get("data", {})
 
             assert SPANDATA.CODE_LINENO not in data
@@ -426,7 +426,7 @@ def test_query_source_if_duration_over_threshold(sentry_init, client, capture_ev
 
     (event,) = events
     for span in event["spans"]:
-        if span.get("op") == "db" and "auth_user" in span.get("description"):
+        if span.get("op") == "db.query" and "auth_user" in span.get("description"):
             data = span.get("data", {})
 
             assert SPANDATA.CODE_LINENO in data
@@ -477,7 +477,7 @@ def test_db_span_origin_execute(sentry_init, client, capture_events):
     assert event["contexts"]["trace"]["origin"] == "auto.http.django"
 
     for span in event["spans"]:
-        if span["op"] == "db":
+        if span["op"] == "db.query":
             assert span["origin"] == "auto.db.django"
         else:
             assert span["origin"] == "auto.http.django"

--- a/tests/integrations/pymongo/test_pymongo.py
+++ b/tests/integrations/pymongo/test_pymongo.py
@@ -130,7 +130,7 @@ def test_breadcrumbs(
         assert "1" in crumb["message"]
     else:
         assert "1" not in crumb["message"]
-    assert crumb["type"] == "db.query"
+    assert crumb["type"] == "query"
     assert crumb["data"] == {
         "db.name": "test_db",
         "db.system": "mongodb",

--- a/tests/integrations/pymongo/test_pymongo.py
+++ b/tests/integrations/pymongo/test_pymongo.py
@@ -65,9 +65,9 @@ def test_transactions(sentry_init, capture_events, mongo_server, with_pii):
         for field, value in common_data.items():
             assert span["data"][field] == value
 
-    assert find["op"] == "db"
-    assert insert_success["op"] == "db"
-    assert insert_fail["op"] == "db"
+    assert find["op"] == "db.query"
+    assert insert_success["op"] == "db.query"
+    assert insert_fail["op"] == "db.query"
 
     assert find["data"]["db.operation"] == "find"
     assert insert_success["data"]["db.operation"] == "insert"
@@ -130,7 +130,7 @@ def test_breadcrumbs(
         assert "1" in crumb["message"]
     else:
         assert "1" not in crumb["message"]
-    assert crumb["type"] == "db"
+    assert crumb["type"] == "db.query"
     assert crumb["data"] == {
         "db.name": "test_db",
         "db.system": "mongodb",

--- a/tests/integrations/sqlalchemy/test_sqlalchemy.py
+++ b/tests/integrations/sqlalchemy/test_sqlalchemy.py
@@ -136,18 +136,18 @@ def test_transactions(sentry_init, capture_events, render_span_tree):
         render_span_tree(event)
         == """\
 - op="test_transaction": description=null
-  - op="db": description="SAVEPOINT sa_savepoint_1"
-  - op="db": description="SELECT person.id AS person_id, person.name AS person_name \\nFROM person\\n LIMIT ? OFFSET ?"
-  - op="db": description="RELEASE SAVEPOINT sa_savepoint_1"
-  - op="db": description="SAVEPOINT sa_savepoint_2"
-  - op="db": description="INSERT INTO person (id, name) VALUES (?, ?)"
-  - op="db": description="ROLLBACK TO SAVEPOINT sa_savepoint_2"
-  - op="db": description="SAVEPOINT sa_savepoint_3"
-  - op="db": description="INSERT INTO person (id, name) VALUES (?, ?)"
-  - op="db": description="ROLLBACK TO SAVEPOINT sa_savepoint_3"
-  - op="db": description="SAVEPOINT sa_savepoint_4"
-  - op="db": description="SELECT person.id AS person_id, person.name AS person_name \\nFROM person\\n LIMIT ? OFFSET ?"
-  - op="db": description="RELEASE SAVEPOINT sa_savepoint_4"\
+  - op="db.query": description="SAVEPOINT sa_savepoint_1"
+  - op="db.query": description="SELECT person.id AS person_id, person.name AS person_name \\nFROM person\\n LIMIT ? OFFSET ?"
+  - op="db.query": description="RELEASE SAVEPOINT sa_savepoint_1"
+  - op="db.query": description="SAVEPOINT sa_savepoint_2"
+  - op="db.query": description="INSERT INTO person (id, name) VALUES (?, ?)"
+  - op="db.query": description="ROLLBACK TO SAVEPOINT sa_savepoint_2"
+  - op="db.query": description="SAVEPOINT sa_savepoint_3"
+  - op="db.query": description="INSERT INTO person (id, name) VALUES (?, ?)"
+  - op="db.query": description="ROLLBACK TO SAVEPOINT sa_savepoint_3"
+  - op="db.query": description="SAVEPOINT sa_savepoint_4"
+  - op="db.query": description="SELECT person.id AS person_id, person.name AS person_name \\nFROM person\\n LIMIT ? OFFSET ?"
+  - op="db.query": description="RELEASE SAVEPOINT sa_savepoint_4"\
 """
     )
 
@@ -328,7 +328,7 @@ def test_query_source_disabled(sentry_init, capture_events):
     (event,) = events
 
     for span in event["spans"]:
-        if span.get("op") == "db" and span.get("description").startswith(
+        if span.get("op") == "db.query" and span.get("description").startswith(
             "SELECT person"
         ):
             data = span.get("data", {})
@@ -380,7 +380,7 @@ def test_query_source_enabled(sentry_init, capture_events, enable_db_query_sourc
     (event,) = events
 
     for span in event["spans"]:
-        if span.get("op") == "db" and span.get("description").startswith(
+        if span.get("op") == "db.query" and span.get("description").startswith(
             "SELECT person"
         ):
             data = span.get("data", {})
@@ -427,7 +427,7 @@ def test_query_source(sentry_init, capture_events):
     (event,) = events
 
     for span in event["spans"]:
-        if span.get("op") == "db" and span.get("description").startswith(
+        if span.get("op") == "db.query" and span.get("description").startswith(
             "SELECT person"
         ):
             data = span.get("data", {})
@@ -498,7 +498,7 @@ def test_query_source_with_module_in_search_path(sentry_init, capture_events):
     (event,) = events
 
     for span in event["spans"]:
-        if span.get("op") == "db" and span.get("description").startswith(
+        if span.get("op") == "db.query" and span.get("description").startswith(
             "SELECT person"
         ):
             data = span.get("data", {})
@@ -575,7 +575,7 @@ def test_no_query_source_if_duration_too_short(sentry_init, capture_events):
     (event,) = events
 
     for span in event["spans"]:
-        if span.get("op") == "db" and span.get("description").startswith(
+        if span.get("op") == "db.query" and span.get("description").startswith(
             "SELECT person"
         ):
             data = span.get("data", {})
@@ -637,7 +637,7 @@ def test_query_source_if_duration_over_threshold(sentry_init, capture_events):
     (event,) = events
 
     for span in event["spans"]:
-        if span.get("op") == "db" and span.get("description").startswith(
+        if span.get("op") == "db.query" and span.get("description").startswith(
             "SELECT person"
         ):
             data = span.get("data", {})

--- a/tests/opentelemetry/test_utils.py
+++ b/tests/opentelemetry/test_utils.py
@@ -199,7 +199,7 @@ def test_span_data_for_db_query():
     otel_span.attributes = {}
 
     op, description, status, http_status, origin = span_data_for_db_query(otel_span)
-    assert op == "db"
+    assert op == "db.query"
     assert description == "OTel Span"
     assert status is None
     assert http_status is None
@@ -208,7 +208,7 @@ def test_span_data_for_db_query():
     otel_span.attributes = {"db.statement": "SELECT * FROM table;"}
 
     op, description, status, http_status, origin = span_data_for_db_query(otel_span)
-    assert op == "db"
+    assert op == "db.query"
     assert description == "SELECT * FROM table;"
     assert status is None
     assert http_status is None


### PR DESCRIPTION
- According to our [span ops](https://develop.sentry.dev/sdk/telemetry/traces/span-operations/#database) there is no op called just `db`, but we're emitting these from django, clickhouse, asyncpg and pymongo. Changing to `db.query` instead.
- There was also a breadcrumb with type `db` that's also [officially not a supported type](https://develop.sentry.dev/sdk/data-model/event-payloads/breadcrumbs/#breadcrumb-types), changed it to `query`.

This is intentionally just on `potel-base` since it's technically a breaking change.