### PR TITLE
feat(scope): Remove `client` parameter

### DIFF
--- a/MIGRATION_GUIDE.md
+++ b/MIGRATION_GUIDE.md
@@ -16,6 +16,7 @@ Looking to upgrade from Sentry SDK 2.x to 3.x? Here's a comprehensive list of wh
 - `sentry_sdk.start_transaction`/`sentry_sdk.start_span` no longer takes the following arguments: `span`, `parent_sampled`, `trace_id`, `span_id` or `parent_span_id`.
 - You can no longer change the sampled status of a span with `span.sampled = False` after starting it.
 - The `Span()` constructor does not accept a `hub` parameter anymore.
+- The `sentry_sdk.Scope()` constructor no longer accepts a `client` parameter.
 - `Span.finish()` does not accept a `hub` parameter anymore.
 - `Span.finish()` no longer returns the `event_id` if the event is sent to sentry.
 - The `Profile()` constructor does not accept a `hub` parameter anymore.
@@ -31,6 +32,7 @@ Looking to upgrade from Sentry SDK 2.x to 3.x? Here's a comprehensive list of wh
 - The integration for Python `logging` module does not send Sentry issues by default anymore when calling `logging.error()`, `logging.critical()` or `logging.exception()`. If you want to preserve the old behavior use `sentry_sdk.init(integrations=[LoggingIntegration(event_level="ERROR")])`.
 - The `SentrySpanProcessor` and `SentryPropagator` are exported from `sentry_sdk.opentelemetry` instead of `sentry_sdk.integrations.opentelemetry`.
 - The integration-specific content of the `sampling_context` argument of `traces_sampler` and `profiles_sampler` now looks different.
+
   - The Celery integration doesn't add the `celery_job` dictionary anymore. Instead, the individual keys are now available as:
 
     | Dictionary keys        | Sampling context key        | Example                        |
@@ -132,7 +134,6 @@ Looking to upgrade from Sentry SDK 2.x to 3.x? Here's a comprehensive list of wh
     | `gcp_event.method`                | `http.request.method`          |
     | `gcp_event.query_string`          | `url.query`                    |
     | `gcp_event.headers`               | `http.request.header.{header}` |
-
 
 ### Removed
 

--- a/sentry_sdk/scope.py
+++ b/sentry_sdk/scope.py
@@ -172,8 +172,8 @@ class Scope:
         "_flags",
     )
 
-    def __init__(self, ty=None, client=None):
-        # type: (Optional[ScopeType], Optional[sentry_sdk.Client]) -> None
+    def __init__(self, ty=None):
+        # type: (Optional[ScopeType]) -> None
         self._type = ty
 
         self._event_processors = []  # type: List[EventProcessor]
@@ -184,9 +184,6 @@ class Scope:
         self._n_breadcrumbs_truncated = 0  # type: int
 
         self.client = NonRecordingClient()  # type: sentry_sdk.client.BaseClient
-
-        if client is not None:
-            self.set_client(client)
 
         self.clear()
 

--- a/tests/test_scope.py
+++ b/tests/test_scope.py
@@ -216,7 +216,8 @@ def test_scope_client():
     assert scope.client.__class__ == NonRecordingClient
 
     custom_client = Client()
-    scope = Scope(ty="test_more", client=custom_client)
+    scope = Scope(ty="test_more")
+    scope.set_client(custom_client)
     assert scope._type == "test_more"
     assert scope.client is not None
     assert scope.client.__class__ == Client


### PR DESCRIPTION
We don't use the `client` parameter in the `Scope`'s constructor, perhaps we can remove it and simplify the API. It is still possible to set the client with `Scope.set_client`.

BREAKING CHANGE: `sentry_sdk.Scope` no longer has a `client` parameter.

<!-- Describe your PR here -->

---

Thank you for contributing to `sentry-python`! Please add tests to validate your changes, and lint your code using `tox -e linters`.

Running the test suite on your PR might require maintainer approval.