### PR TITLE
test: Assert `traces_sampler` called once

### DIFF
--- a/tests/tracing/test_sampling.py
+++ b/tests/tracing/test_sampling.py
@@ -218,7 +218,7 @@ def test_passes_attributes_from_start_span_to_traces_sampler(
     sentry_init(traces_sampler=traces_sampler)
 
     with start_span(attributes={"dogs": "yes", "cats": "maybe"}):
-        traces_sampler.assert_any_call(
+        traces_sampler.assert_called_once_with(
             DictionaryContaining({"dogs": "yes", "cats": "maybe"})
         )
 


### PR DESCRIPTION
Currently, this test only asserts that the `traces_sampler` is called at least once with the given arguments. However, we would expect it to be called exactly once.

This PR changes the assertion to assert that the `traces_sampler` was called exactly one time, and that that call included the given arguments.

<!-- Describe your PR here -->

---

Thank you for contributing to `sentry-python`! Please add tests to validate your changes, and lint your code using `tox -e linters`.

Running the test suite on your PR might require maintainer approval.