### PR TITLE
Migrate to modern threading interface

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -612,7 +612,7 @@ def create_mock_http_server():
     mock_server_port = get_free_port()
     mock_server = HTTPServer(("localhost", mock_server_port), MockServerRequestHandler)
     mock_server_thread = Thread(target=mock_server.serve_forever)
-    mock_server_thread.setDaemon(True)
+    mock_server_thread.daemon = True
     mock_server_thread.start()
 
     return mock_server_port


### PR DESCRIPTION
### PR Summary
This small PR resolves the `threading` library warnings, which you can find in the [CI logs](https://github.com/getsentry/sentry-python/actions/runs/15490014338/job/43613162178#step:6:3523):
```python
/home/runner/work/sentry-python/sentry-python/tests/conftest.py:608: DeprecationWarning: setDaemon() is deprecated, set the daemon attribute instead
    mock_server_thread.setDaemon(True)
```
