### PR TITLE
Patch `TracerProvider` if it already exists

### DIFF
--- a/sentry_sdk/opentelemetry/tracing.py
+++ b/sentry_sdk/opentelemetry/tracing.py
@@ -31,9 +31,9 @@ def setup_sentry_tracing():
     # type: () -> None
     # TracerProvider can only be set once. If we're the first ones setting it,
     # there's no issue. If it already exists, we need to patch it.
-    from opentelemetry.trace import _TRACER_PROVIDER_SET_ONCE
+    from opentelemetry.trace import _TRACER_PROVIDER
 
-    if _TRACER_PROVIDER_SET_ONCE._done:
+    if _TRACER_PROVIDER is not None:
         logger.debug("[Tracing] Detected an existing TracerProvider, patching")
         tracer_provider = trace.get_tracer_provider()
         tracer_provider.sampler = SentrySampler()

--- a/sentry_sdk/opentelemetry/tracing.py
+++ b/sentry_sdk/opentelemetry/tracing.py
@@ -29,7 +29,6 @@ def patch_readable_span():
 
 def setup_sentry_tracing():
     # type: () -> None
-
     # TracerProvider can only be set once. If we're the first ones setting it,
     # there's no issue. If it already exists, we need to patch it.
     from opentelemetry.trace import _TRACER_PROVIDER_SET_ONCE
@@ -37,13 +36,12 @@ def setup_sentry_tracing():
     if _TRACER_PROVIDER_SET_ONCE._done:
         logger.debug("[Tracing] Detected an existing TracerProvider, patching")
         tracer_provider = trace.get_tracer_provider()
-        tracer_provider.add_span_processor(SentrySpanProcessor())
         tracer_provider.sampler = SentrySampler()
 
     else:
         logger.debug("[Tracing] No TracerProvider set, creating a new one")
         tracer_provider = TracerProvider(sampler=SentrySampler())
-        tracer_provider.add_span_processor(SentrySpanProcessor())
         trace.set_tracer_provider(tracer_provider)
 
+    tracer_provider.add_span_processor(SentrySpanProcessor())
     set_global_textmap(SentryPropagator())

--- a/sentry_sdk/opentelemetry/tracing.py
+++ b/sentry_sdk/opentelemetry/tracing.py
@@ -43,5 +43,17 @@ def setup_sentry_tracing():
         tracer_provider = TracerProvider(sampler=SentrySampler())
         trace.set_tracer_provider(tracer_provider)
 
-    tracer_provider.add_span_processor(SentrySpanProcessor())  # type: ignore[attr-defined]
+    try:
+        existing_span_processors = (
+            tracer_provider._active_span_processor._span_processors
+        )
+    except Exception:
+        existing_span_processors = []
+
+    for span_processor in existing_span_processors:
+        if isinstance(span_processor, SentrySpanProcessor):
+            break
+    else:
+        tracer_provider.add_span_processor(SentrySpanProcessor())  # type: ignore[attr-defined]
+
     set_global_textmap(SentryPropagator())

--- a/sentry_sdk/opentelemetry/tracing.py
+++ b/sentry_sdk/opentelemetry/tracing.py
@@ -1,7 +1,6 @@
 from opentelemetry import trace
 from opentelemetry.propagate import set_global_textmap
 from opentelemetry.sdk.trace import TracerProvider, Span, ReadableSpan
-from opentelemetry.trace import _TRACER_PROVIDER_SET_ONCE
 
 from sentry_sdk.opentelemetry import (
     SentryPropagator,
@@ -33,6 +32,8 @@ def setup_sentry_tracing():
 
     # TracerProvider can only be set once. If we're the first ones setting it,
     # there's no issue. If it already exists, we need to patch it.
+    from opentelemetry.trace import _TRACER_PROVIDER_SET_ONCE
+
     if _TRACER_PROVIDER_SET_ONCE._done:
         logger.debug("[Tracing] Detected an existing TracerProvider, patching")
         tracer_provider = trace.get_tracer_provider()

--- a/sentry_sdk/opentelemetry/tracing.py
+++ b/sentry_sdk/opentelemetry/tracing.py
@@ -35,7 +35,7 @@ def setup_sentry_tracing():
 
     if _TRACER_PROVIDER is not None:
         logger.debug("[Tracing] Detected an existing TracerProvider, patching")
-        tracer_provider = trace.get_tracer_provider()
+        tracer_provider = _TRACER_PROVIDER
         tracer_provider.sampler = SentrySampler()  # type: ignore[attr-defined]
 
     else:

--- a/sentry_sdk/opentelemetry/tracing.py
+++ b/sentry_sdk/opentelemetry/tracing.py
@@ -45,7 +45,7 @@ def setup_sentry_tracing():
 
     try:
         existing_span_processors = (
-            tracer_provider._active_span_processor._span_processors
+            tracer_provider._active_span_processor._span_processors  # type: ignore[attr-defined]
         )
     except Exception:
         existing_span_processors = []

--- a/sentry_sdk/opentelemetry/tracing.py
+++ b/sentry_sdk/opentelemetry/tracing.py
@@ -36,12 +36,12 @@ def setup_sentry_tracing():
     if _TRACER_PROVIDER is not None:
         logger.debug("[Tracing] Detected an existing TracerProvider, patching")
         tracer_provider = trace.get_tracer_provider()
-        tracer_provider.sampler = SentrySampler()
+        tracer_provider.sampler = SentrySampler()  # type: ignore[attr-defined]
 
     else:
         logger.debug("[Tracing] No TracerProvider set, creating a new one")
         tracer_provider = TracerProvider(sampler=SentrySampler())
         trace.set_tracer_provider(tracer_provider)
 
-    tracer_provider.add_span_processor(SentrySpanProcessor())
+    tracer_provider.add_span_processor(SentrySpanProcessor())  # type: ignore[attr-defined]
     set_global_textmap(SentryPropagator())

--- a/sentry_sdk/tracing.py
+++ b/sentry_sdk/tracing.py
@@ -188,7 +188,7 @@ class Span:
         If otel_span is passed explicitly, just acts as a proxy.
 
         If span is passed explicitly, use it. The only purpose of this param
-        if backwards compatibility with start_transaction(transaction=...).
+        is backwards compatibility with start_transaction(transaction=...).
 
         If only_if_parent is True, just return an INVALID_SPAN
         and avoid instrumentation if there's no active parent span.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -75,7 +75,8 @@ def clean_scopes():
     setup_initial_scopes()
 
 
-def clean_tracer(autouse=True):
+@pytest.fixture(autouse=True)
+def clean_tracer():
     """Reset TracerProvider so that we can set it up from scratch."""
     otel_trace._TRACER_PROVIDER_SET_ONCE = Once()
     otel_trace._TRACER_PROVIDER = None

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,7 +3,11 @@ import os
 import socket
 import warnings
 from opentelemetry import trace as otel_trace
-from opentelemetry.util._once import Once
+
+try:
+    from opentelemetry.util._once import Once
+except ImportError:
+    Once = None
 from threading import Thread
 from http.server import BaseHTTPRequestHandler, HTTPServer
 
@@ -78,7 +82,8 @@ def clean_scopes():
 @pytest.fixture(autouse=True)
 def clean_tracer():
     """Reset TracerProvider so that we can set it up from scratch."""
-    otel_trace._TRACER_PROVIDER_SET_ONCE = Once()
+    if Once is not None:
+        otel_trace._TRACER_PROVIDER_SET_ONCE = Once()
     otel_trace._TRACER_PROVIDER = None
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -80,7 +80,7 @@ def clean_scopes():
 
 
 @pytest.fixture(autouse=True)
-def clean_tracer():
+def clear_tracer_provider():
     """Reset TracerProvider so that we can set it up from scratch."""
     if Once is not None:
         otel_trace._TRACER_PROVIDER_SET_ONCE = Once()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,8 @@ import json
 import os
 import socket
 import warnings
+from opentelemetry import trace as otel_trace
+from opentelemetry.util._once import Once
 from threading import Thread
 from http.server import BaseHTTPRequestHandler, HTTPServer
 
@@ -71,6 +73,12 @@ def clean_scopes():
     scope._current_scope.set(None)
 
     setup_initial_scopes()
+
+
+def clean_tracer(autouse=True):
+    """Reset TracerProvider so that we can set it up from scratch."""
+    otel_trace._TRACER_PROVIDER_SET_ONCE = Once()
+    otel_trace._TRACER_PROVIDER = None
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
If a `TracerProvider` already exists, patch it. `TracerProvider` is a singleton, so if we aren't the first ones setting it up, we need to use the existing one.

In tests, reset `TracerProvider` after each test so that we start with a clean slate and it gets set up anew on init.
