### PR TITLE
feat(tracing): Add option to exclude specific span origins

### DIFF
--- a/sentry_sdk/consts.py
+++ b/sentry_sdk/consts.py
@@ -981,7 +981,7 @@ class ClientConstructor:
             If `trace_propagation_targets` is not provided, trace data is attached to every outgoing request from the
             instrumented client.
 
-        :param exclude_span_origins: An optional list of strings or regex patterns to exclude span creation based
+        :param exclude_span_origins: An optional list of strings or regex patterns to disable span creation based
             on span origin. When a span's origin would match any of the provided patterns, the span will not be
             created.
 

--- a/sentry_sdk/consts.py
+++ b/sentry_sdk/consts.py
@@ -981,18 +981,16 @@ class ClientConstructor:
             If `trace_propagation_targets` is not provided, trace data is attached to every outgoing request from the
             instrumented client.
 
-        :param disabled_span_origins: An optional list of strings or regex patterns to disable span creation.
-
-            When a span's origin would match any of the provided regex patterns, the span will not be created.
+        :param disabled_span_origins: An optional list of strings or regex patterns to disable span creation based
+            on span origin. When a span's origin would match any of the provided patterns, the span will not be
+            created.
 
             This can be useful to disable automatic span creation from specific integrations without disabling the
             entire integration.
 
-            The option may contain a list of strings or regex against which the span origins are matched.
-            String entries do not have to be full matches, meaning a span origin is matched when it _contains_
+            The option may contain a list of strings or regexes against which the span origins are matched.
+            String entries do not have to be full matches, meaning a span origin is matched when it contains
             a string provided through the option.
-
-            If `disabled_span_origins` is not provided, all spans will be created normally.
 
         :param functions_to_trace: An optional list of functions that should be set up for tracing.
 

--- a/sentry_sdk/consts.py
+++ b/sentry_sdk/consts.py
@@ -649,7 +649,7 @@ class ClientConstructor:
         trace_propagation_targets=[  # noqa: B006
             MATCH_ALL
         ],  # type: Optional[Sequence[str]]
-        disabled_span_origins=None,  # type: Optional[Sequence[str]]
+        exclude_span_origins=None,  # type: Optional[Sequence[str]]
         functions_to_trace=[],  # type: Sequence[Dict[str, str]]  # noqa: B006
         event_scrubber=None,  # type: Optional[sentry_sdk.scrubber.EventScrubber]
         max_value_length=DEFAULT_MAX_VALUE_LENGTH,  # type: int
@@ -981,11 +981,11 @@ class ClientConstructor:
             If `trace_propagation_targets` is not provided, trace data is attached to every outgoing request from the
             instrumented client.
 
-        :param disabled_span_origins: An optional list of strings or regex patterns to disable span creation based
+        :param exclude_span_origins: An optional list of strings or regex patterns to exclude span creation based
             on span origin. When a span's origin would match any of the provided patterns, the span will not be
             created.
 
-            This can be useful to disable automatic span creation from specific integrations without disabling the
+            This can be useful to exclude automatic span creation from specific integrations without disabling the
             entire integration.
 
             The option may contain a list of strings or regexes against which the span origins are matched.

--- a/sentry_sdk/consts.py
+++ b/sentry_sdk/consts.py
@@ -649,6 +649,7 @@ class ClientConstructor:
         trace_propagation_targets=[  # noqa: B006
             MATCH_ALL
         ],  # type: Optional[Sequence[str]]
+        disabled_span_origins=None,  # type: Optional[Sequence[str]]
         functions_to_trace=[],  # type: Sequence[Dict[str, str]]  # noqa: B006
         event_scrubber=None,  # type: Optional[sentry_sdk.scrubber.EventScrubber]
         max_value_length=DEFAULT_MAX_VALUE_LENGTH,  # type: int
@@ -979,6 +980,19 @@ class ClientConstructor:
 
             If `trace_propagation_targets` is not provided, trace data is attached to every outgoing request from the
             instrumented client.
+
+        :param disabled_span_origins: An optional list of strings or regex patterns to disable span creation.
+
+            When a span's origin would match any of the provided regex patterns, the span will not be created.
+
+            This can be useful to disable automatic span creation from specific integrations without disabling the
+            entire integration.
+
+            The option may contain a list of strings or regex against which the span origins are matched.
+            String entries do not have to be full matches, meaning a span origin is matched when it _contains_
+            a string provided through the option.
+
+            If `disabled_span_origins` is not provided, all spans will be created normally.
 
         :param functions_to_trace: An optional list of functions that should be set up for tracing.
 

--- a/sentry_sdk/tracing.py
+++ b/sentry_sdk/tracing.py
@@ -37,7 +37,10 @@ from sentry_sdk.opentelemetry.utils import (
     get_sentry_meta,
     serialize_trace_state,
 )
-from sentry_sdk.tracing_utils import get_span_status_from_http_code
+from sentry_sdk.tracing_utils import (
+    get_span_status_from_http_code,
+    is_span_origin_disabled,
+)
 from sentry_sdk.utils import (
     _serialize_span_attribute,
     get_current_thread_meta,
@@ -205,10 +208,12 @@ class Span:
                     not parent_span_context.is_valid or parent_span_context.is_remote
                 )
 
+            if not skip_span and is_span_origin_disabled(origin):
+                skip_span = True
+
             if skip_span:
                 self._otel_span = INVALID_SPAN
             else:
-
                 if start_timestamp is not None:
                     # OTel timestamps have nanosecond precision
                     start_timestamp = convert_to_otel_timestamp(start_timestamp)

--- a/sentry_sdk/tracing.py
+++ b/sentry_sdk/tracing.py
@@ -208,6 +208,7 @@ class Span:
                     not parent_span_context.is_valid or parent_span_context.is_remote
                 )
 
+            origin = origin or DEFAULT_SPAN_ORIGIN
             if not skip_span and _is_span_origin_excluded(origin):
                 skip_span = True
 
@@ -244,7 +245,7 @@ class Span:
                     attributes=attributes,
                 )
 
-                self.origin = origin or DEFAULT_SPAN_ORIGIN
+                self.origin = origin
                 self.description = description
                 self.name = span_name
 

--- a/sentry_sdk/tracing.py
+++ b/sentry_sdk/tracing.py
@@ -39,7 +39,7 @@ from sentry_sdk.opentelemetry.utils import (
 )
 from sentry_sdk.tracing_utils import (
     get_span_status_from_http_code,
-    is_span_origin_disabled,
+    _is_span_origin_disabled,
 )
 from sentry_sdk.utils import (
     _serialize_span_attribute,
@@ -208,7 +208,7 @@ class Span:
                     not parent_span_context.is_valid or parent_span_context.is_remote
                 )
 
-            if not skip_span and is_span_origin_disabled(origin):
+            if not skip_span and _is_span_origin_disabled(origin):
                 skip_span = True
 
             if skip_span:

--- a/sentry_sdk/tracing.py
+++ b/sentry_sdk/tracing.py
@@ -39,7 +39,7 @@ from sentry_sdk.opentelemetry.utils import (
 )
 from sentry_sdk.tracing_utils import (
     get_span_status_from_http_code,
-    _is_span_origin_disabled,
+    _is_span_origin_excluded,
 )
 from sentry_sdk.utils import (
     _serialize_span_attribute,
@@ -208,7 +208,7 @@ class Span:
                     not parent_span_context.is_valid or parent_span_context.is_remote
                 )
 
-            if not skip_span and _is_span_origin_disabled(origin):
+            if not skip_span and _is_span_origin_excluded(origin):
                 skip_span = True
 
             if skip_span:

--- a/sentry_sdk/tracing_utils.py
+++ b/sentry_sdk/tracing_utils.py
@@ -689,7 +689,7 @@ def should_propagate_trace(client, url):
     return match_regex_list(url, trace_propagation_targets, substring_matching=True)
 
 
-def _is_span_origin_disabled(origin):
+def _is_span_origin_excluded(origin):
     # type: (Optional[str]) -> bool
     """
     Check if spans with this origin should be ignored based on the `exclude_span_origins` option.

--- a/sentry_sdk/tracing_utils.py
+++ b/sentry_sdk/tracing_utils.py
@@ -689,6 +689,22 @@ def should_propagate_trace(client, url):
     return match_regex_list(url, trace_propagation_targets, substring_matching=True)
 
 
+def is_span_origin_disabled(origin):
+    # type: (Optional[str]) -> bool
+    """
+    Check if spans with this origin should be ignored.
+    """
+    if origin is None:
+        return False
+
+    client = sentry_sdk.get_client()
+    disabled_span_origins = client.options.get("disabled_span_origins")
+    if not disabled_span_origins:
+        return False
+
+    return match_regex_list(origin, disabled_span_origins, substring_matching=True)
+
+
 def normalize_incoming_data(incoming_data):
     # type: (Dict[str, Any]) -> Dict[str, Any]
     """

--- a/sentry_sdk/tracing_utils.py
+++ b/sentry_sdk/tracing_utils.py
@@ -689,20 +689,20 @@ def should_propagate_trace(client, url):
     return match_regex_list(url, trace_propagation_targets, substring_matching=True)
 
 
-def is_span_origin_disabled(origin):
+def _is_span_origin_disabled(origin):
     # type: (Optional[str]) -> bool
     """
-    Check if spans with this origin should be ignored.
+    Check if spans with this origin should be ignored based on the `exclude_span_origins` option.
     """
     if origin is None:
         return False
 
     client = sentry_sdk.get_client()
-    disabled_span_origins = client.options.get("disabled_span_origins")
-    if not disabled_span_origins:
+    exclude_span_origins = client.options.get("exclude_span_origins")
+    if not exclude_span_origins:
         return False
 
-    return match_regex_list(origin, disabled_span_origins, substring_matching=True)
+    return match_regex_list(origin, exclude_span_origins, substring_matching=True)
 
 
 def normalize_incoming_data(incoming_data):

--- a/tests/tracing/test_span_origin.py
+++ b/tests/tracing/test_span_origin.py
@@ -62,7 +62,7 @@ def test_exclude_span_origins_empty(sentry_init, capture_events, excluded_origin
 
 
 @pytest.mark.parametrize(
-    "excluded_origins,origins,expected_events_count,expected_allowed_origins",
+    "excluded_origins,origins,expected_allowed_origins",
     [
         # Regexes
         (
@@ -72,7 +72,6 @@ def test_exclude_span_origins_empty(sentry_init, capture_events, excluded_origin
                 "auto.db.sqlite",
                 "manual",
             ],
-            1,
             ["manual"],
         ),
         # Substring matching
@@ -85,7 +84,6 @@ def test_exclude_span_origins_empty(sentry_init, capture_events, excluded_origin
                 "manual",
                 "auto.db.postgres",
             ],
-            2,
             ["manual", "auto.db.postgres"],
         ),
         # Mix and match
@@ -97,7 +95,6 @@ def test_exclude_span_origins_empty(sentry_init, capture_events, excluded_origin
                 "auto.db.postgres",
                 "auto.grpc.server",
             ],
-            1,
             ["auto.grpc.server"],
         ),
     ],
@@ -107,7 +104,6 @@ def test_exclude_span_origins_patterns(
     capture_events,
     excluded_origins,
     origins,
-    expected_events_count,
     expected_allowed_origins,
 ):
     sentry_init(
@@ -121,9 +117,9 @@ def test_exclude_span_origins_patterns(
         with start_span(name="span", origin=origin):
             pass
 
-    assert len(events) == expected_events_count
+    assert len(events) == len(expected_allowed_origins)
 
-    if expected_events_count > 0:
+    if len(expected_allowed_origins) > 0:
         captured_origins = {event["contexts"]["trace"]["origin"] for event in events}
         assert captured_origins == set(expected_allowed_origins)
 

--- a/tests/tracing/test_span_origin.py
+++ b/tests/tracing/test_span_origin.py
@@ -121,10 +121,8 @@ def test_exclude_span_origins_patterns(
         with start_span(name="span", origin=origin):
             pass
 
-    # Check total events captured
     assert len(events) == expected_events_count
 
-    # Check that only expected origins were captured
     if expected_events_count > 0:
         captured_origins = {event["contexts"]["trace"]["origin"] for event in events}
         assert captured_origins == set(expected_allowed_origins)


### PR DESCRIPTION
Allow to turn off span creation based on span origin.

This is a nice-to-have that's useful when you're double instrumenting a library with e.g. Sentry and OpenTelemetry and you want to turn off Sentry spans. (On the OTel side you can also disable specific instrumentation. By adding the possibility to do this on the Sentry side of things, we enable users to pick whichever they prefer.)

❗ **Caveats to consider before approving this:**
- Any child spans of ignored spans will be promoted to transactions unless they have `only_if_parent=True`. (This will need to be documented in the docs.)
- It can be (mis)used for filtering out any kind of spans outside of any dual OTel/Sentry scenario, basically as a workaround for the missing `ignore_spans` option that's been requested over and over again.
- As an alternative, span creation can also be turned off by simply disabling an integration. However, that also disables error capturing and anything else the integration does on top.