### PR TITLE
fix(langchain): Make `span_map` an instance variable

### DIFF
--- a/sentry_sdk/integrations/langchain.py
+++ b/sentry_sdk/integrations/langchain.py
@@ -89,12 +89,9 @@ class WatchedSpan:
 class SentryLangchainCallback(BaseCallbackHandler):  # type: ignore[misc]
     """Base callback handler that can be used to handle callbacks from langchain."""
 
-    span_map = OrderedDict()  # type: OrderedDict[UUID, WatchedSpan]
-
-    max_span_map_size = 0
-
     def __init__(self, max_span_map_size, include_prompts, tiktoken_encoding_name=None):
         # type: (int, bool, Optional[str]) -> None
+        self.span_map = OrderedDict()  # type: OrderedDict[UUID, WatchedSpan]
         self.max_span_map_size = max_span_map_size
         self.include_prompts = include_prompts
 

--- a/tests/integrations/langchain/test_langchain.py
+++ b/tests/integrations/langchain/test_langchain.py
@@ -416,3 +416,15 @@ def test_manual_callback_no_duplication(sentry_init):
 
     # Verify the callback ID matches our manual callback
     assert id(manual_callback) in tracked_callback_instances
+
+
+def test_span_map_is_instance_variable():
+    """Test that each SentryLangchainCallback instance has its own span_map."""
+    # Create two separate callback instances
+    callback1 = SentryLangchainCallback(max_span_map_size=100, include_prompts=True)
+    callback2 = SentryLangchainCallback(max_span_map_size=100, include_prompts=True)
+
+    # Verify they have different span_map instances
+    assert (
+        callback1.span_map is not callback2.span_map
+    ), "span_map should be an instance variable, not shared between instances"


### PR DESCRIPTION
`span_map` should be an instance variable; otherwise, separate instances of the `SentryLangchainCallback` share the same `span_map` object, which is clearly not intended here.

Also, remove the `max_span_map_size` class variable, it is always set on the instance, and so not needed.

Ref #4443