### PR TITLE
breaking(transport): Make HTTP2Transport the default

### DIFF
--- a/MIGRATION_GUIDE.md
+++ b/MIGRATION_GUIDE.md
@@ -33,7 +33,7 @@ sentry_sdk.init(
 
 - The SDK now supports Python 3.7 and higher.
 - Tag values on event dictionaries, which are passed to `before_send` and `before_send_transaction`, now are always `str` values. Previously, despite tag values being typed as `str`, they often had different values. Therefore, if you have configured any `before_send` and `before_send_transaction` functions which perform some logic based on tag values, you need to check and if needed update those functions to correctly handle `str` values.
-- The SDK now uses HTTP/2 for its default transport. This can be disabled via setting `http2=False` in `sentry_sdk.init()`.
+- The SDK now uses HTTP/2 for its default transport. This can be disabled via setting `http2=False` in `sentry_sdk.init()`. This change also affects `socket_options` as HTTP/2 requires persistent connections. If you want to disable keep-alive, consider disabling HTTP/2 as passing an empty list to `socket_options` would _not_ disable keep alive.
 
 #### Error Capturing
 

--- a/MIGRATION_GUIDE.md
+++ b/MIGRATION_GUIDE.md
@@ -33,7 +33,7 @@ sentry_sdk.init(
 
 - The SDK now supports Python 3.7 and higher.
 - Tag values on event dictionaries, which are passed to `before_send` and `before_send_transaction`, now are always `str` values. Previously, despite tag values being typed as `str`, they often had different values. Therefore, if you have configured any `before_send` and `before_send_transaction` functions which perform some logic based on tag values, you need to check and if needed update those functions to correctly handle `str` values.
-- The SDK now uses HTTP/2 for its default transport. This can be disabled via the `http2` named argument in the SDK constructor.
+- The SDK now uses HTTP/2 for its default transport. This can be disabled via setting `http2=False` in `sentry_sdk.init()`.
 
 #### Error Capturing
 

--- a/MIGRATION_GUIDE.md
+++ b/MIGRATION_GUIDE.md
@@ -33,6 +33,7 @@ sentry_sdk.init(
 
 - The SDK now supports Python 3.7 and higher.
 - Tag values on event dictionaries, which are passed to `before_send` and `before_send_transaction`, now are always `str` values. Previously, despite tag values being typed as `str`, they often had different values. Therefore, if you have configured any `before_send` and `before_send_transaction` functions which perform some logic based on tag values, you need to check and if needed update those functions to correctly handle `str` values.
+- The SDK now uses HTTP/2 for its default transport. This can be disabled via the `http2` named argument in the SDK constructor.
 
 #### Error Capturing
 

--- a/sentry_sdk/consts.py
+++ b/sentry_sdk/consts.py
@@ -970,7 +970,7 @@ class ClientConstructor:
         max_stack_frames: Optional[int] = DEFAULT_MAX_STACK_FRAMES,
         enable_logs: bool = False,
         before_send_log: Optional[Callable[[Log, Hint], Optional[Log]]] = None,
-        http2=None,  # type: Optional[bool],
+        http2: Optional[bool] = None,
     ) -> None:
         """Initialize the Sentry SDK with the given parameters. All parameters described here can be used in a call to `sentry_sdk.init()`.
 

--- a/sentry_sdk/consts.py
+++ b/sentry_sdk/consts.py
@@ -69,7 +69,6 @@ if TYPE_CHECKING:
             "transport_compression_level": Optional[int],
             "transport_compression_algo": Optional[CompressionAlgo],
             "transport_num_pools": Optional[int],
-            "transport_http2": Optional[bool],
             "enable_logs": Optional[bool],
             "before_send_log": Optional[Callable[[Log, Hint], Optional[Log]]],
         },
@@ -662,6 +661,7 @@ class ClientConstructor:
         custom_repr=None,  # type: Optional[Callable[..., Optional[str]]]
         add_full_stack=DEFAULT_ADD_FULL_STACK,  # type: bool
         max_stack_frames=DEFAULT_MAX_STACK_FRAMES,  # type: Optional[int]
+        http2=None,  # type: Optional[bool]
     ):
         # type: (...) -> None
         """Initialize the Sentry SDK with the given parameters. All parameters described here can be used in a call to `sentry_sdk.init()`.

--- a/sentry_sdk/consts.py
+++ b/sentry_sdk/consts.py
@@ -1024,6 +1024,8 @@ class ClientConstructor:
             This is relative to the tracing sample rate - e.g. `0.5` means 50% of sampled transactions will be
             profiled.
 
+        :param http2: Defaults to `True`, enables HTTP/2 support for the SDK.
+
         :param profiles_sampler:
 
         :param profiler_mode:

--- a/sentry_sdk/consts.py
+++ b/sentry_sdk/consts.py
@@ -77,8 +77,6 @@ if TYPE_CHECKING:
             "transport_compression_level": Optional[int],
             "transport_compression_algo": Optional[CompressionAlgo],
             "transport_num_pools": Optional[int],
-            "enable_logs": Optional[bool],
-            "before_send_log": Optional[Callable[[Log, Hint], Optional[Log]]],
             "transport_async": Optional[bool],
         },
         total=False,

--- a/sentry_sdk/transport.py
+++ b/sentry_sdk/transport.py
@@ -806,7 +806,7 @@ def make_transport(options):
     # We default to using HTTP2 transport if the user also has the required h2
     # library installed (through the subclass check). The reason is h2 not being
     # available on py3.7 which we still support.
-    use_http2_transport = options.get("http2", True) and not issubclass(
+    use_http2_transport = options.get("http2") != False and not issubclass(
         Http2Transport, HttpTransport
     )
 

--- a/sentry_sdk/transport.py
+++ b/sentry_sdk/transport.py
@@ -806,7 +806,7 @@ def make_transport(options):
     # We default to using HTTP2 transport if the user also has the required h2
     # library installed (through the subclass check). The reason is h2 not being
     # available on py3.7 which we still support.
-    use_http2_transport = options.get("http2") != False and not issubclass(
+    use_http2_transport = options.get("http2") is not False and not issubclass(
         Http2Transport, HttpTransport
     )
 

--- a/sentry_sdk/transport.py
+++ b/sentry_sdk/transport.py
@@ -803,7 +803,12 @@ def make_transport(options):
     # type: (Dict[str, Any]) -> Optional[Transport]
     ref_transport = options["transport"]
 
-    use_http2_transport = options.get("_experiments", {}).get("transport_http2", False)
+    # We default to using HTTP2 transport if the user also has the required h2
+    # library installed (through the subclass check). The reason is h2 not being
+    # available on py3.7 which we still support.
+    use_http2_transport = options.get("http2", True) and not issubclass(
+        Http2Transport, HttpTransport
+    )
 
     # By default, we use the http transport class
     transport_cls = (

--- a/tests/integrations/excepthook/test_excepthook.py
+++ b/tests/integrations/excepthook/test_excepthook.py
@@ -5,10 +5,10 @@ import subprocess
 from textwrap import dedent
 
 
-TEST_PARAMETERS = [("", "HttpTransport")]
+TEST_PARAMETERS = [("http2=False", "HttpTransport")]
 
 if sys.version_info >= (3, 8):
-    TEST_PARAMETERS.append(('_experiments={"transport_http2": True}', "Http2Transport"))
+    TEST_PARAMETERS.append(("", "Http2Transport"))
 
 
 @pytest.mark.parametrize("options, transport", TEST_PARAMETERS)

--- a/tests/integrations/typer/test_typer.py
+++ b/tests/integrations/typer/test_typer.py
@@ -26,7 +26,7 @@ def test_catch_exceptions(tmpdir):
         if event is not None:
             print(event)
 
-    transport.HttpTransport.capture_envelope = capture_envelope
+    transport.BaseHttpTransport.capture_envelope = capture_envelope
 
     init("http://foobar@localhost/123", integrations=[TyperIntegration()])
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -362,8 +362,8 @@ def test_proxy(monkeypatch, testcase, http2):
 def test_socks_proxy(testcase, http2):
     kwargs = {}
 
-    if not http2:
-        kwargs["http2"] = False
+    if http2:
+        kwargs["_experiments"] = {"transport_http2": True}
 
     if testcase["arg_http_proxy"] is not None:
         kwargs["http_proxy"] = testcase["arg_http_proxy"]
@@ -565,10 +565,10 @@ def test_capture_event_works(sentry_init):
 )
 def test_atexit(tmpdir, monkeypatch, num_messages, http2):
     if http2:
-        options = "http2=True"
+        options = '_experiments={"transport_http2": True}'
         transport = "Http2Transport"
     else:
-        options = "http2=False"
+        options = ""
         transport = "HttpTransport"
 
     app = tmpdir.join("app.py")

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -258,8 +258,8 @@ def test_proxy(monkeypatch, testcase, http2):
 
     kwargs = {}
 
-    if http2:
-        kwargs["_experiments"] = {"transport_http2": True}
+    if not http2:
+        kwargs["http2"] = False
 
     if testcase["arg_http_proxy"] is not None:
         kwargs["http_proxy"] = testcase["arg_http_proxy"]
@@ -362,8 +362,8 @@ def test_proxy(monkeypatch, testcase, http2):
 def test_socks_proxy(testcase, http2):
     kwargs = {}
 
-    if http2:
-        kwargs["_experiments"] = {"transport_http2": True}
+    if not http2:
+        kwargs["http2"] = False
 
     if testcase["arg_http_proxy"] is not None:
         kwargs["http_proxy"] = testcase["arg_http_proxy"]
@@ -565,10 +565,10 @@ def test_capture_event_works(sentry_init):
 )
 def test_atexit(tmpdir, monkeypatch, num_messages, http2):
     if http2:
-        options = '_experiments={"transport_http2": True}'
+        options = "http2=True"
         transport = "Http2Transport"
     else:
-        options = ""
+        options = "http2=False"
         transport = "HttpTransport"
 
     app = tmpdir.join("app.py")

--- a/tests/test_transport.py
+++ b/tests/test_transport.py
@@ -83,7 +83,7 @@ def mock_transaction_envelope(span_count: int) -> Envelope:
 @pytest.mark.parametrize("use_pickle", (True, False))
 @pytest.mark.parametrize("compression_level", (0, 9, None))
 @pytest.mark.parametrize("compression_algo", ("gzip", "br", "<invalid>", None))
-@pytest.mark.parametrize("http2", [True, False] if PY38 else [False])
+@pytest.mark.parametrize("http2", [None, False])
 def test_transport_works(
     capturing_server,
     request,
@@ -106,11 +106,9 @@ def test_transport_works(
     if compression_algo is not None:
         experiments["transport_compression_algo"] = compression_algo
 
-    if not http2:
-        experiments["http2"] = False
-
     client = make_client(
         debug=debug,
+        http2=http2,
         _experiments=experiments,
     )
 


### PR DESCRIPTION
Making the HTTP2 transport the default when `h2` and `httpcore` packages are installed. We've been testing this on Sentry SaaS for a while without any issues.

We should promote installing the SDK as `sentry-sdk[http2]` for this to be picked up though. Since we still have to support Python 3.7 and `h2` not being supported there, we cannot install it by default and use HTTP2 directly.


---

EDIT: please merge after potel dogfooding