### PR TITLE
fix(ci): Do not install newest tracerite

### DIFF
--- a/scripts/populate_tox/tox.jinja
+++ b/scripts/populate_tox/tox.jinja
@@ -326,6 +326,7 @@ deps =
     # Sanic
     sanic: websockets<11.0
     sanic: aiohttp
+    sanic: tracerite<1.1.2
     sanic-v{24.6}: sanic_testing
     sanic-latest: sanic_testing
     {py3.6}-sanic: aiocontextvars==0.2.1

--- a/scripts/populate_tox/tox.jinja
+++ b/scripts/populate_tox/tox.jinja
@@ -326,7 +326,7 @@ deps =
     # Sanic
     sanic: websockets<11.0
     sanic: aiohttp
-    sanic: tracerite<1.1.2
+    {py3.7,py3.8,py3.9,py3.10,py3.11,py3.12,py3.13}-sanic: tracerite<1.1.2
     sanic-v{24.6}: sanic_testing
     sanic-latest: sanic_testing
     {py3.6}-sanic: aiocontextvars==0.2.1

--- a/tox.ini
+++ b/tox.ini
@@ -487,6 +487,7 @@ deps =
     # Sanic
     sanic: websockets<11.0
     sanic: aiohttp
+    sanic: tracerite<1.1.2
     sanic-v{24.6}: sanic_testing
     sanic-latest: sanic_testing
     {py3.6}-sanic: aiocontextvars==0.2.1

--- a/tox.ini
+++ b/tox.ini
@@ -487,7 +487,7 @@ deps =
     # Sanic
     sanic: websockets<11.0
     sanic: aiohttp
-    sanic: tracerite<1.1.2
+    {py3.7,py3.8,py3.9,py3.10,py3.11,py3.12,py3.13}-sanic: tracerite<1.1.2
     sanic-v{24.6}: sanic_testing
     sanic-latest: sanic_testing
     {py3.6}-sanic: aiocontextvars==0.2.1


### PR DESCRIPTION
New release of `tracerite` (a transitive dependency in the sanic workflow) causes [this](https://github.com/getsentry/sentry-python/actions/runs/15735197921/job/44345942053?pr=4493) to happen.

Related `tracerite` bug report: https://github.com/sanic-org/tracerite/issues/20 Once this is fixed, we can unpin.