### PR TITLE
Migrate typing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -214,3 +214,6 @@ exclude = [
   "grpc_test_service_pb2.py",
   "grpc_test_service_pb2_grpc.py",
 ]
+per-file-ignores = [
+  "sentry_sdk/integrations/spark/*:N802,N803",
+]

--- a/sentry_sdk/_compat.py
+++ b/sentry_sdk/_compat.py
@@ -1,12 +1,9 @@
+from __future__ import annotations
 import sys
-
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from typing import Any
-    from typing import TypeVar
-
-    T = TypeVar("T")
 
 
 PY38 = sys.version_info[0] == 3 and sys.version_info[1] >= 8
@@ -14,18 +11,15 @@ PY310 = sys.version_info[0] == 3 and sys.version_info[1] >= 10
 PY311 = sys.version_info[0] == 3 and sys.version_info[1] >= 11
 
 
-def with_metaclass(meta, *bases):
-    # type: (Any, *Any) -> Any
+def with_metaclass(meta: Any, *bases: Any) -> Any:
     class MetaClass(type):
-        def __new__(metacls, name, this_bases, d):
-            # type: (Any, Any, Any, Any) -> Any
+        def __new__(metacls: Any, name: Any, this_bases: Any, d: Any) -> Any:
             return meta(name, bases, d)
 
     return type.__new__(MetaClass, "temporary_class", (), {})
 
 
-def check_uwsgi_thread_support():
-    # type: () -> bool
+def check_uwsgi_thread_support() -> bool:
     # We check two things here:
     #
     # 1. uWSGI doesn't run in threaded mode by default -- issue a warning if
@@ -45,8 +39,7 @@ def check_uwsgi_thread_support():
 
     from sentry_sdk.consts import FALSE_VALUES
 
-    def enabled(option):
-        # type: (str) -> bool
+    def enabled(option: str) -> bool:
         value = opt.get(option, False)
         if isinstance(value, bool):
             return value

--- a/sentry_sdk/_init_implementation.py
+++ b/sentry_sdk/_init_implementation.py
@@ -1,23 +1,23 @@
+from __future__ import annotations
+
 from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from typing import Optional, Any
 
 import sentry_sdk
 from sentry_sdk.consts import ClientConstructor
 from sentry_sdk.opentelemetry.scope import setup_scope_context_management
 
-if TYPE_CHECKING:
-    from typing import Any, Optional
 
-
-def _check_python_deprecations():
-    # type: () -> None
+def _check_python_deprecations() -> None:
     # Since we're likely to deprecate Python versions in the future, I'm keeping
     # this handy function around. Use this to detect the Python version used and
     # to output logger.warning()s if it's deprecated.
     pass
 
 
-def _init(*args, **kwargs):
-    # type: (*Optional[str], **Any) -> None
+def _init(*args: Optional[str], **kwargs: Any) -> None:
     """Initializes the SDK and optionally integrations.
 
     This takes the same arguments as the client constructor.

--- a/sentry_sdk/_log_batcher.py
+++ b/sentry_sdk/_log_batcher.py
@@ -1,37 +1,35 @@
+from __future__ import annotations
 import os
 import random
 import threading
 from datetime import datetime, timezone
-from typing import Optional, List, Callable, TYPE_CHECKING, Any
 
 from sentry_sdk.utils import format_timestamp, safe_repr
 from sentry_sdk.envelope import Envelope, Item, PayloadRef
 
+from typing import TYPE_CHECKING
+
 if TYPE_CHECKING:
     from sentry_sdk._types import Log
+    from typing import Optional, List, Callable, Any
 
 
 class LogBatcher:
     MAX_LOGS_BEFORE_FLUSH = 100
     FLUSH_WAIT_TIME = 5.0
 
-    def __init__(
-        self,
-        capture_func,  # type: Callable[[Envelope], None]
-    ):
-        # type: (...) -> None
-        self._log_buffer = []  # type: List[Log]
+    def __init__(self, capture_func: Callable[[Envelope], None]) -> None:
+        self._log_buffer: List[Log] = []
         self._capture_func = capture_func
         self._running = True
         self._lock = threading.Lock()
 
-        self._flush_event = threading.Event()  # type: threading.Event
+        self._flush_event: threading.Event = threading.Event()
 
-        self._flusher = None  # type: Optional[threading.Thread]
-        self._flusher_pid = None  # type: Optional[int]
+        self._flusher: Optional[threading.Thread] = None
+        self._flusher_pid: Optional[int] = None
 
-    def _ensure_thread(self):
-        # type: (...) -> bool
+    def _ensure_thread(self) -> bool:
         """For forking processes we might need to restart this thread.
         This ensures that our process actually has that thread running.
         """
@@ -63,18 +61,13 @@ class LogBatcher:
 
         return True
 
-    def _flush_loop(self):
-        # type: (...) -> None
+    def _flush_loop(self) -> None:
         while self._running:
             self._flush_event.wait(self.FLUSH_WAIT_TIME + random.random())
             self._flush_event.clear()
             self._flush()
 
-    def add(
-        self,
-        log,  # type: Log
-    ):
-        # type: (...) -> None
+    def add(self, log: Log) -> None:
         if not self._ensure_thread() or self._flusher is None:
             return None
 
@@ -83,8 +76,7 @@ class LogBatcher:
             if len(self._log_buffer) >= self.MAX_LOGS_BEFORE_FLUSH:
                 self._flush_event.set()
 
-    def kill(self):
-        # type: (...) -> None
+    def kill(self) -> None:
         if self._flusher is None:
             return
 
@@ -92,15 +84,12 @@ class LogBatcher:
         self._flush_event.set()
         self._flusher = None
 
-    def flush(self):
-        # type: (...) -> None
+    def flush(self) -> None:
         self._flush()
 
     @staticmethod
-    def _log_to_transport_format(log):
-        # type: (Log) -> Any
-        def format_attribute(val):
-            # type: (int | float | str | bool) -> Any
+    def _log_to_transport_format(log: Log) -> Any:
+        def format_attribute(val: int | float | str | bool) -> Any:
             if isinstance(val, bool):
                 return {"value": val, "type": "boolean"}
             if isinstance(val, int):
@@ -128,8 +117,7 @@ class LogBatcher:
 
         return res
 
-    def _flush(self):
-        # type: (...) -> Optional[Envelope]
+    def _flush(self) -> Optional[Envelope]:
 
         envelope = Envelope(
             headers={"sent_at": format_timestamp(datetime.now(timezone.utc))}

--- a/sentry_sdk/_log_batcher.py
+++ b/sentry_sdk/_log_batcher.py
@@ -24,7 +24,7 @@ class LogBatcher:
         self._running = True
         self._lock = threading.Lock()
 
-        self._flush_event: threading.Event = threading.Event()
+        self._flush_event = threading.Event()
 
         self._flusher: Optional[threading.Thread] = None
         self._flusher_pid: Optional[int] = None

--- a/sentry_sdk/_lru_cache.py
+++ b/sentry_sdk/_lru_cache.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -8,17 +10,15 @@ _SENTINEL = object()
 
 
 class LRUCache:
-    def __init__(self, max_size):
-        # type: (int) -> None
+    def __init__(self, max_size: int) -> None:
         if max_size <= 0:
             raise AssertionError(f"invalid max_size: {max_size}")
         self.max_size = max_size
-        self._data = {}  # type: dict[Any, Any]
+        self._data: dict[Any, Any] = {}
         self.hits = self.misses = 0
         self.full = False
 
-    def set(self, key, value):
-        # type: (Any, Any) -> None
+    def set(self, key: Any, value: Any) -> None:
         current = self._data.pop(key, _SENTINEL)
         if current is not _SENTINEL:
             self._data[key] = value
@@ -29,8 +29,7 @@ class LRUCache:
             self._data[key] = value
         self.full = len(self._data) >= self.max_size
 
-    def get(self, key, default=None):
-        # type: (Any, Any) -> Any
+    def get(self, key: Any, default: Any = None) -> Any:
         try:
             ret = self._data.pop(key)
         except KeyError:
@@ -42,6 +41,5 @@ class LRUCache:
 
         return ret
 
-    def get_all(self):
-        # type: () -> list[tuple[Any, Any]]
+    def get_all(self) -> list[tuple[Any, Any]]:
         return list(self._data.items())

--- a/sentry_sdk/_queue.py
+++ b/sentry_sdk/_queue.py
@@ -76,10 +76,8 @@ import threading
 from collections import deque
 from time import time
 
-from typing import TYPE_CHECKING
+from typing import Any
 
-if TYPE_CHECKING:
-    from typing import Any
 
 __all__ = ["EmptyError", "FullError", "Queue"]
 
@@ -275,7 +273,7 @@ class Queue:
 
     # Initialize the queue representation
     def _init(self, maxsize):
-        self.queue = deque()  # type: Any
+        self.queue: Any = deque()
 
     def _qsize(self):
         return len(self.queue)

--- a/sentry_sdk/_queue.py
+++ b/sentry_sdk/_queue.py
@@ -76,7 +76,10 @@ import threading
 from collections import deque
 from time import time
 
-from typing import Any
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from typing import Any
 
 
 __all__ = ["EmptyError", "FullError", "Queue"]

--- a/sentry_sdk/_types.py
+++ b/sentry_sdk/_types.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import TYPE_CHECKING, TypeVar, Union
 
 
@@ -18,32 +20,27 @@ class AnnotatedValue:
 
     __slots__ = ("value", "metadata")
 
-    def __init__(self, value, metadata):
-        # type: (Optional[Any], Dict[str, Any]) -> None
+    def __init__(self, value: Optional[Any], metadata: Dict[str, Any]) -> None:
         self.value = value
         self.metadata = metadata
 
-    def __eq__(self, other):
-        # type: (Any) -> bool
+    def __eq__(self, other: Any) -> bool:
         if not isinstance(other, AnnotatedValue):
             return False
 
         return self.value == other.value and self.metadata == other.metadata
 
-    def __str__(self):
-        # type: (AnnotatedValue) -> str
+    def __str__(self) -> str:
         return str({"value": str(self.value), "metadata": str(self.metadata)})
 
-    def __len__(self):
-        # type: (AnnotatedValue) -> int
+    def __len__(self) -> int:
         if self.value is not None:
             return len(self.value)
         else:
             return 0
 
     @classmethod
-    def removed_because_raw_data(cls):
-        # type: () -> AnnotatedValue
+    def removed_because_raw_data(cls) -> AnnotatedValue:
         """The value was removed because it could not be parsed. This is done for request body values that are not json nor a form."""
         return AnnotatedValue(
             value="",
@@ -58,8 +55,7 @@ class AnnotatedValue:
         )
 
     @classmethod
-    def removed_because_over_size_limit(cls, value=""):
-        # type: (Any) -> AnnotatedValue
+    def removed_because_over_size_limit(cls, value: Any = "") -> AnnotatedValue:
         """
         The actual value was removed because the size of the field exceeded the configured maximum size,
         for example specified with the max_request_body_size sdk option.
@@ -77,8 +73,7 @@ class AnnotatedValue:
         )
 
     @classmethod
-    def substituted_because_contains_sensitive_data(cls):
-        # type: () -> AnnotatedValue
+    def substituted_because_contains_sensitive_data(cls) -> AnnotatedValue:
         """The actual value was removed because it contained sensitive information."""
         return AnnotatedValue(
             value=SENSITIVE_DATA_SUBSTITUTE,

--- a/sentry_sdk/_werkzeug.py
+++ b/sentry_sdk/_werkzeug.py
@@ -32,12 +32,12 @@ THIS SOFTWARE AND DOCUMENTATION, EVEN IF ADVISED OF THE POSSIBILITY OF
 SUCH DAMAGE.
 """
 
+from __future__ import annotations
+
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from typing import Dict
-    from typing import Iterator
-    from typing import Tuple
+    from typing import Dict, Iterator, Tuple
 
 
 #
@@ -47,8 +47,7 @@ if TYPE_CHECKING:
 # We need this function because Django does not give us a "pure" http header
 # dict. So we might as well use it for all WSGI integrations.
 #
-def _get_headers(environ):
-    # type: (Dict[str, str]) -> Iterator[Tuple[str, str]]
+def _get_headers(environ: Dict[str, str]) -> Iterator[Tuple[str, str]]:
     """
     Returns only proper HTTP headers.
     """
@@ -67,8 +66,7 @@ def _get_headers(environ):
 # `get_host` comes from `werkzeug.wsgi.get_host`
 # https://github.com/pallets/werkzeug/blob/1.0.1/src/werkzeug/wsgi.py#L145
 #
-def get_host(environ, use_x_forwarded_for=False):
-    # type: (Dict[str, str], bool) -> str
+def get_host(environ: Dict[str, str], use_x_forwarded_for: bool = False) -> str:
     """
     Return the host for the given WSGI environment.
     """

--- a/sentry_sdk/ai/monitoring.py
+++ b/sentry_sdk/ai/monitoring.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import inspect
 from functools import wraps
 
@@ -15,22 +16,17 @@ if TYPE_CHECKING:
 _ai_pipeline_name = ContextVar("ai_pipeline_name", default=None)
 
 
-def set_ai_pipeline_name(name):
-    # type: (Optional[str]) -> None
+def set_ai_pipeline_name(name: Optional[str]) -> None:
     _ai_pipeline_name.set(name)
 
 
-def get_ai_pipeline_name():
-    # type: () -> Optional[str]
+def get_ai_pipeline_name() -> Optional[str]:
     return _ai_pipeline_name.get()
 
 
-def ai_track(description, **span_kwargs):
-    # type: (str, Any) -> Callable[..., Any]
-    def decorator(f):
-        # type: (Callable[..., Any]) -> Callable[..., Any]
-        def sync_wrapped(*args, **kwargs):
-            # type: (Any, Any) -> Any
+def ai_track(description: str, **span_kwargs: Any) -> Callable[..., Any]:
+    def decorator(f: Callable[..., Any]) -> Callable[..., Any]:
+        def sync_wrapped(*args: Any, **kwargs: Any) -> Any:
             curr_pipeline = _ai_pipeline_name.get()
             op = span_kwargs.get("op", "ai.run" if curr_pipeline else "ai.pipeline")
 
@@ -60,8 +56,7 @@ def ai_track(description, **span_kwargs):
                         _ai_pipeline_name.set(None)
                     return res
 
-        async def async_wrapped(*args, **kwargs):
-            # type: (Any, Any) -> Any
+        async def async_wrapped(*args: Any, **kwargs: Any) -> Any:
             curr_pipeline = _ai_pipeline_name.get()
             op = span_kwargs.get("op", "ai.run" if curr_pipeline else "ai.pipeline")
 
@@ -100,9 +95,11 @@ def ai_track(description, **span_kwargs):
 
 
 def record_token_usage(
-    span, prompt_tokens=None, completion_tokens=None, total_tokens=None
-):
-    # type: (Span, Optional[int], Optional[int], Optional[int]) -> None
+    span: Span,
+    prompt_tokens: Optional[int] = None,
+    completion_tokens: Optional[int] = None,
+    total_tokens: Optional[int] = None,
+) -> None:
     ai_pipeline_name = get_ai_pipeline_name()
     if ai_pipeline_name:
         span.set_attribute(SPANDATA.AI_PIPELINE_NAME, ai_pipeline_name)

--- a/sentry_sdk/ai/utils.py
+++ b/sentry_sdk/ai/utils.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -7,8 +8,7 @@ from sentry_sdk.tracing import Span
 from sentry_sdk.utils import logger
 
 
-def _normalize_data(data):
-    # type: (Any) -> Any
+def _normalize_data(data: Any) -> Any:
 
     # convert pydantic data (e.g. OpenAI v1+) to json compatible format
     if hasattr(data, "model_dump"):
@@ -26,7 +26,6 @@ def _normalize_data(data):
     return data
 
 
-def set_data_normalized(span, key, value):
-    # type: (Span, str, Any) -> None
+def set_data_normalized(span: Span, key: str, value: Any) -> None:
     normalized = _normalize_data(value)
     span.set_attribute(key, normalized)

--- a/sentry_sdk/api.py
+++ b/sentry_sdk/api.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import inspect
 from contextlib import contextmanager
 
@@ -20,20 +21,22 @@ from sentry_sdk.opentelemetry.scope import (
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from collections.abc import Mapping
-
-    from typing import Any
-    from typing import Dict
-    from typing import Optional
-    from typing import Callable
-    from typing import TypeVar
-    from typing import Union
-    from typing import Generator
-
-    import sentry_sdk
+    from typing import Any, Optional, Callable, TypeVar, Union, Generator
 
     T = TypeVar("T")
     F = TypeVar("F", bound=Callable[..., Any])
+
+    from collections.abc import Mapping
+    from sentry_sdk.client import BaseClient
+    from sentry_sdk.tracing import Span
+    from sentry_sdk._types import (
+        Event,
+        Hint,
+        LogLevelStr,
+        ExcInfo,
+        BreadcrumbHint,
+        Breadcrumb,
+    )
 
 
 # When changing this, update __all__ in __init__.py too
@@ -74,8 +77,7 @@ __all__ = [
 ]
 
 
-def scopemethod(f):
-    # type: (F) -> F
+def scopemethod(f: F) -> F:
     f.__doc__ = "%s\n\n%s" % (
         "Alias for :py:meth:`sentry_sdk.Scope.%s`" % f.__name__,
         inspect.getdoc(getattr(Scope, f.__name__)),
@@ -83,8 +85,7 @@ def scopemethod(f):
     return f
 
 
-def clientmethod(f):
-    # type: (F) -> F
+def clientmethod(f: F) -> F:
     f.__doc__ = "%s\n\n%s" % (
         "Alias for :py:meth:`sentry_sdk.Client.%s`" % f.__name__,
         inspect.getdoc(getattr(Client, f.__name__)),
@@ -93,13 +94,11 @@ def clientmethod(f):
 
 
 @scopemethod
-def get_client():
-    # type: () -> sentry_sdk.client.BaseClient
+def get_client() -> BaseClient:
     return Scope.get_client()
 
 
-def is_initialized():
-    # type: () -> bool
+def is_initialized() -> bool:
     """
     .. versionadded:: 2.0.0
 
@@ -113,26 +112,22 @@ def is_initialized():
 
 
 @scopemethod
-def get_global_scope():
-    # type: () -> BaseScope
+def get_global_scope() -> BaseScope:
     return Scope.get_global_scope()
 
 
 @scopemethod
-def get_isolation_scope():
-    # type: () -> Scope
+def get_isolation_scope() -> Scope:
     return Scope.get_isolation_scope()
 
 
 @scopemethod
-def get_current_scope():
-    # type: () -> Scope
+def get_current_scope() -> Scope:
     return Scope.get_current_scope()
 
 
 @scopemethod
-def last_event_id():
-    # type: () -> Optional[str]
+def last_event_id() -> Optional[str]:
     """
     See :py:meth:`sentry_sdk.Scope.last_event_id` documentation regarding
     this method's limitations.
@@ -142,23 +137,21 @@ def last_event_id():
 
 @scopemethod
 def capture_event(
-    event,  # type: sentry_sdk._types.Event
-    hint=None,  # type: Optional[sentry_sdk._types.Hint]
-    scope=None,  # type: Optional[Any]
-    **scope_kwargs,  # type: Any
-):
-    # type: (...) -> Optional[str]
+    event: Event,
+    hint: Optional[Hint] = None,
+    scope: Optional[Any] = None,
+    **scope_kwargs: Any,
+) -> Optional[str]:
     return get_current_scope().capture_event(event, hint, scope=scope, **scope_kwargs)
 
 
 @scopemethod
 def capture_message(
-    message,  # type: str
-    level=None,  # type: Optional[sentry_sdk._types.LogLevelStr]
-    scope=None,  # type: Optional[Any]
-    **scope_kwargs,  # type: Any
-):
-    # type: (...) -> Optional[str]
+    message: str,
+    level: Optional[LogLevelStr] = None,
+    scope: Optional[Any] = None,
+    **scope_kwargs: Any,
+) -> Optional[str]:
     return get_current_scope().capture_message(
         message, level, scope=scope, **scope_kwargs
     )
@@ -166,23 +159,21 @@ def capture_message(
 
 @scopemethod
 def capture_exception(
-    error=None,  # type: Optional[Union[BaseException, sentry_sdk._types.ExcInfo]]
-    scope=None,  # type: Optional[Any]
-    **scope_kwargs,  # type: Any
-):
-    # type: (...) -> Optional[str]
+    error: Optional[Union[BaseException, ExcInfo]] = None,
+    scope: Optional[Any] = None,
+    **scope_kwargs: Any,
+) -> Optional[str]:
     return get_current_scope().capture_exception(error, scope=scope, **scope_kwargs)
 
 
 @scopemethod
 def add_attachment(
-    bytes=None,  # type: Union[None, bytes, Callable[[], bytes]]
-    filename=None,  # type: Optional[str]
-    path=None,  # type: Optional[str]
-    content_type=None,  # type: Optional[str]
-    add_to_transactions=False,  # type: bool
-):
-    # type: (...) -> None
+    bytes: Union[None, bytes, Callable[[], bytes]] = None,
+    filename: Optional[str] = None,
+    path: Optional[str] = None,
+    content_type: Optional[str] = None,
+    add_to_transactions: bool = False,
+) -> None:
     return get_isolation_scope().add_attachment(
         bytes, filename, path, content_type, add_to_transactions
     )
@@ -190,61 +181,52 @@ def add_attachment(
 
 @scopemethod
 def add_breadcrumb(
-    crumb=None,  # type: Optional[sentry_sdk._types.Breadcrumb]
-    hint=None,  # type: Optional[sentry_sdk._types.BreadcrumbHint]
-    **kwargs,  # type: Any
-):
-    # type: (...) -> None
+    crumb: Optional[Breadcrumb] = None,
+    hint: Optional[BreadcrumbHint] = None,
+    **kwargs: Any,
+) -> None:
     return get_isolation_scope().add_breadcrumb(crumb, hint, **kwargs)
 
 
 @scopemethod
-def set_tag(key, value):
-    # type: (str, Any) -> None
+def set_tag(key: str, value: Any) -> None:
     return get_isolation_scope().set_tag(key, value)
 
 
 @scopemethod
-def set_tags(tags):
-    # type: (Mapping[str, object]) -> None
+def set_tags(tags: Mapping[str, object]) -> None:
     return get_isolation_scope().set_tags(tags)
 
 
 @scopemethod
-def set_context(key, value):
-    # type: (str, Dict[str, Any]) -> None
+def set_context(key: str, value: dict[str, Any]) -> None:
     return get_isolation_scope().set_context(key, value)
 
 
 @scopemethod
-def set_extra(key, value):
-    # type: (str, Any) -> None
+def set_extra(key: str, value: Any) -> None:
     return get_isolation_scope().set_extra(key, value)
 
 
 @scopemethod
-def set_user(value):
-    # type: (Optional[Dict[str, Any]]) -> None
+def set_user(value: Optional[dict[str, Any]]) -> None:
     return get_isolation_scope().set_user(value)
 
 
 @scopemethod
-def set_level(value):
-    # type: (sentry_sdk._types.LogLevelStr) -> None
+def set_level(value: LogLevelStr) -> None:
     return get_isolation_scope().set_level(value)
 
 
 @clientmethod
 def flush(
-    timeout=None,  # type: Optional[float]
-    callback=None,  # type: Optional[Callable[[int, float], None]]
-):
-    # type: (...) -> None
+    timeout: Optional[float] = None,
+    callback: Optional[Callable[[int, float], None]] = None,
+) -> None:
     return get_client().flush(timeout=timeout, callback=callback)
 
 
-def start_span(**kwargs):
-    # type: (Any) -> sentry_sdk.tracing.Span
+def start_span(**kwargs: Any) -> Span:
     """
     Start and return a span.
 
@@ -260,11 +242,7 @@ def start_span(**kwargs):
     return get_current_scope().start_span(**kwargs)
 
 
-def start_transaction(
-    transaction=None,  # type: Optional[sentry_sdk.tracing.Span]
-    **kwargs,  # type: Any
-):
-    # type: (...) -> sentry_sdk.tracing.Span
+def start_transaction(transaction: Optional[Span] = None, **kwargs: Any) -> Span:
     """
     .. deprecated:: 3.0.0
         This function is deprecated and will be removed in a future release.
@@ -303,24 +281,21 @@ def start_transaction(
     )
 
 
-def get_current_span(scope=None):
-    # type: (Optional[Scope]) -> Optional[sentry_sdk.tracing.Span]
+def get_current_span(scope: Optional[Scope] = None) -> Optional[Span]:
     """
     Returns the currently active span if there is one running, otherwise `None`
     """
     return tracing_utils.get_current_span(scope)
 
 
-def get_traceparent():
-    # type: () -> Optional[str]
+def get_traceparent() -> Optional[str]:
     """
     Returns the traceparent either from the active span or from the scope.
     """
     return get_current_scope().get_traceparent()
 
 
-def get_baggage():
-    # type: () -> Optional[str]
+def get_baggage() -> Optional[str]:
     """
     Returns Baggage either from the active span or from the scope.
     """
@@ -332,8 +307,7 @@ def get_baggage():
 
 
 @contextmanager
-def continue_trace(environ_or_headers):
-    # type: (Dict[str, Any]) -> Generator[None, None, None]
+def continue_trace(environ_or_headers: dict[str, Any]) -> Generator[None, None, None]:
     """
     Sets the propagation context from environment or headers to continue an incoming trace.
     """

--- a/sentry_sdk/api.py
+++ b/sentry_sdk/api.py
@@ -317,13 +317,11 @@ def continue_trace(environ_or_headers: dict[str, Any]) -> Generator[None, None, 
 
 @scopemethod
 def start_session(
-    session_mode="application",  # type: str
-):
-    # type: (...) -> None
+    session_mode: str = "application",
+) -> None:
     return get_isolation_scope().start_session(session_mode=session_mode)
 
 
 @scopemethod
-def end_session():
-    # type: () -> None
+def end_session() -> None:
     return get_isolation_scope().end_session()

--- a/sentry_sdk/attachments.py
+++ b/sentry_sdk/attachments.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import os
 import mimetypes
 
@@ -31,13 +32,12 @@ class Attachment:
 
     def __init__(
         self,
-        bytes=None,  # type: Union[None, bytes, Callable[[], bytes]]
-        filename=None,  # type: Optional[str]
-        path=None,  # type: Optional[str]
-        content_type=None,  # type: Optional[str]
-        add_to_transactions=False,  # type: bool
-    ):
-        # type: (...) -> None
+        bytes: Union[None, bytes, Callable[[], bytes]] = None,
+        filename: Optional[str] = None,
+        path: Optional[str] = None,
+        content_type: Optional[str] = None,
+        add_to_transactions: bool = False,
+    ) -> None:
         if bytes is None and path is None:
             raise TypeError("path or raw bytes required for attachment")
         if filename is None and path is not None:
@@ -52,10 +52,9 @@ class Attachment:
         self.content_type = content_type
         self.add_to_transactions = add_to_transactions
 
-    def to_envelope_item(self):
-        # type: () -> Item
+    def to_envelope_item(self) -> Item:
         """Returns an envelope item for this attachment."""
-        payload = None  # type: Union[None, PayloadRef, bytes]
+        payload: Union[None, PayloadRef, bytes] = None
         if self.bytes is not None:
             if callable(self.bytes):
                 payload = self.bytes()
@@ -70,6 +69,5 @@ class Attachment:
             filename=self.filename,
         )
 
-    def __repr__(self):
-        # type: () -> str
+    def __repr__(self) -> str:
         return "<Attachment %r>" % (self.filename,)

--- a/sentry_sdk/client.py
+++ b/sentry_sdk/client.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import os
 import uuid
 import random
@@ -5,7 +6,7 @@ import socket
 from collections.abc import Mapping
 from datetime import datetime, timezone
 from importlib import import_module
-from typing import TYPE_CHECKING, List, Dict, cast, overload
+from typing import TYPE_CHECKING, cast, overload
 
 import sentry_sdk
 from sentry_sdk._compat import check_uwsgi_thread_support
@@ -48,13 +49,17 @@ from sentry_sdk.monitor import Monitor
 from sentry_sdk.spotlight import setup_spotlight
 
 if TYPE_CHECKING:
-    from typing import Any
-    from typing import Callable
-    from typing import Optional
-    from typing import Sequence
-    from typing import Type
-    from typing import Union
-    from typing import TypeVar
+    from typing import (
+        Any,
+        Callable,
+        Optional,
+        Sequence,
+        Type,
+        Union,
+        TypeVar,
+        List,
+        Dict,
+    )
 
     from sentry_sdk._types import Event, Hint, SDKInfo, Log
     from sentry_sdk.integrations import Integration
@@ -64,22 +69,22 @@ if TYPE_CHECKING:
     from sentry_sdk.transport import Transport
     from sentry_sdk._log_batcher import LogBatcher
 
-    I = TypeVar("I", bound=Integration)  # noqa: E741
+    IntegrationType = TypeVar("IntegrationType", bound=Integration)  # noqa: E741
+
 
 _client_init_debug = ContextVar("client_init_debug")
 
 
-SDK_INFO = {
+SDK_INFO: "SDKInfo" = {
     "name": "sentry.python",  # SDK name will be overridden after integrations have been loaded with sentry_sdk.integrations.setup_integrations()
     "version": VERSION,
     "packages": [{"name": "pypi:sentry-sdk", "version": VERSION}],
-}  # type: SDKInfo
+}
 
 
-def _get_options(*args, **kwargs):
-    # type: (*Optional[str], **Any) -> Dict[str, Any]
+def _get_options(*args: Optional[str], **kwargs: Any) -> Dict[str, Any]:
     if args and (isinstance(args[0], (bytes, str)) or args[0] is None):
-        dsn = args[0]  # type: Optional[str]
+        dsn: Optional[str] = args[0]
         args = args[1:]
     else:
         dsn = None
@@ -149,37 +154,31 @@ class BaseClient:
     The basic definition of a client that is used for sending data to Sentry.
     """
 
-    spotlight = None  # type: Optional[SpotlightClient]
+    spotlight: Optional[SpotlightClient] = None
 
-    def __init__(self, options=None):
-        # type: (Optional[Dict[str, Any]]) -> None
-        self.options = (
+    def __init__(self, options: Optional[Dict[str, Any]] = None) -> None:
+        self.options: Dict[str, Any] = (
             options if options is not None else DEFAULT_OPTIONS
-        )  # type: Dict[str, Any]
+        )
 
-        self.transport = None  # type: Optional[Transport]
-        self.monitor = None  # type: Optional[Monitor]
-        self.log_batcher = None  # type: Optional[LogBatcher]
+        self.transport: Optional[Transport] = None
+        self.monitor: Optional[Monitor] = None
+        self.log_batcher: Optional[LogBatcher] = None
 
-    def __getstate__(self, *args, **kwargs):
-        # type: (*Any, **Any) -> Any
+    def __getstate__(self, *args: Any, **kwargs: Any) -> Any:
         return {"options": {}}
 
-    def __setstate__(self, *args, **kwargs):
-        # type: (*Any, **Any) -> None
+    def __setstate__(self, *args: Any, **kwargs: Any) -> None:
         pass
 
     @property
-    def dsn(self):
-        # type: () -> Optional[str]
+    def dsn(self) -> Optional[str]:
         return None
 
-    def should_send_default_pii(self):
-        # type: () -> bool
+    def should_send_default_pii(self) -> bool:
         return False
 
-    def is_active(self):
-        # type: () -> bool
+    def is_active(self) -> bool:
         """
         .. versionadded:: 2.0.0
 
@@ -187,48 +186,40 @@ class BaseClient:
         """
         return False
 
-    def capture_event(self, *args, **kwargs):
-        # type: (*Any, **Any) -> Optional[str]
+    def capture_event(self, *args: Any, **kwargs: Any) -> Optional[str]:
         return None
 
-    def _capture_experimental_log(self, log):
-        # type: (Log) -> None
+    def _capture_experimental_log(self, log: "Log") -> None:
         pass
 
-    def capture_session(self, *args, **kwargs):
-        # type: (*Any, **Any) -> None
+    def capture_session(self, *args: Any, **kwargs: Any) -> None:
         return None
 
     if TYPE_CHECKING:
 
         @overload
-        def get_integration(self, name_or_class):
-            # type: (str) -> Optional[Integration]
-            ...
+        def get_integration(self, name_or_class: str) -> Optional[Integration]: ...
 
         @overload
-        def get_integration(self, name_or_class):
-            # type: (type[I]) -> Optional[I]
-            ...
+        def get_integration(
+            self, name_or_class: type[IntegrationType]
+        ) -> Optional[IntegrationType]: ...
 
-    def get_integration(self, name_or_class):
-        # type: (Union[str, type[Integration]]) -> Optional[Integration]
+    def get_integration(
+        self, name_or_class: Union[str, type[Integration]]
+    ) -> Optional[Integration]:
         return None
 
-    def close(self, *args, **kwargs):
-        # type: (*Any, **Any) -> None
+    def close(self, *args: Any, **kwargs: Any) -> None:
         return None
 
-    def flush(self, *args, **kwargs):
-        # type: (*Any, **Any) -> None
+    def flush(self, *args: Any, **kwargs: Any) -> None:
         return None
 
-    def __enter__(self):
-        # type: () -> BaseClient
+    def __enter__(self) -> BaseClient:
         return self
 
-    def __exit__(self, exc_type, exc_value, tb):
-        # type: (Any, Any, Any) -> None
+    def __exit__(self, exc_type: Any, exc_value: Any, tb: Any) -> None:
         return None
 
 
@@ -252,22 +243,20 @@ class _Client(BaseClient):
     Alias of :py:class:`sentry_sdk.Client`. (Was created for better intelisense support)
     """
 
-    def __init__(self, *args, **kwargs):
-        # type: (*Any, **Any) -> None
-        super(_Client, self).__init__(options=get_options(*args, **kwargs))
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super(_Client, self).__init__(options=_get_options(*args, **kwargs))
         self._init_impl()
 
-    def __getstate__(self):
-        # type: () -> Any
+    def __getstate__(self) -> Any:
         return {"options": self.options}
 
-    def __setstate__(self, state):
-        # type: (Any) -> None
+    def __setstate__(self, state: Any) -> None:
         self.options = state["options"]
         self._init_impl()
 
-    def _setup_instrumentation(self, functions_to_trace):
-        # type: (Sequence[Dict[str, str]]) -> None
+    def _setup_instrumentation(
+        self, functions_to_trace: Sequence[Dict[str, str]]
+    ) -> None:
         """
         Instruments the functions given in the list `functions_to_trace` with the `@sentry_sdk.tracing.trace` decorator.
         """
@@ -317,12 +306,10 @@ class _Client(BaseClient):
                     e,
                 )
 
-    def _init_impl(self):
-        # type: () -> None
+    def _init_impl(self) -> None:
         old_debug = _client_init_debug.get(False)
 
-        def _capture_envelope(envelope):
-            # type: (Envelope) -> None
+        def _capture_envelope(envelope: Envelope) -> None:
             if self.transport is not None:
                 self.transport.capture_envelope(envelope)
 
@@ -423,8 +410,7 @@ class _Client(BaseClient):
             # need to check if it's safe to use them.
             check_uwsgi_thread_support()
 
-    def is_active(self):
-        # type: () -> bool
+    def is_active(self) -> bool:
         """
         .. versionadded:: 2.0.0
 
@@ -432,8 +418,7 @@ class _Client(BaseClient):
         """
         return True
 
-    def should_send_default_pii(self):
-        # type: () -> bool
+    def should_send_default_pii(self) -> bool:
         """
         .. versionadded:: 2.0.0
 
@@ -442,28 +427,26 @@ class _Client(BaseClient):
         return self.options.get("send_default_pii") or False
 
     @property
-    def dsn(self):
-        # type: () -> Optional[str]
+    def dsn(self) -> Optional[str]:
         """Returns the configured DSN as string."""
         return self.options["dsn"]
 
     def _prepare_event(
         self,
-        event,  # type: Event
-        hint,  # type: Hint
-        scope,  # type: Optional[Scope]
-    ):
-        # type: (...) -> Optional[Event]
+        event: Event,
+        hint: Hint,
+        scope: Optional[Scope],
+    ) -> Optional[Event]:
 
-        previous_total_spans = None  # type: Optional[int]
-        previous_total_breadcrumbs = None  # type: Optional[int]
+        previous_total_spans: Optional[int] = None
+        previous_total_breadcrumbs: Optional[int] = None
 
         if event.get("timestamp") is None:
             event["timestamp"] = datetime.now(timezone.utc)
 
         if scope is not None:
             is_transaction = event.get("type") == "transaction"
-            spans_before = len(cast(List[Dict[str, object]], event.get("spans", [])))
+            spans_before = len(cast("List[Dict[str, object]]", event.get("spans", [])))
             event_ = scope.apply_to_event(event, hint, self.options)
 
             # one of the event/error processors returned None
@@ -481,16 +464,16 @@ class _Client(BaseClient):
                         )
                 return None
 
-            event = event_  # type: Optional[Event]  # type: ignore[no-redef]
+            event = event_  # Updated event from scope
             spans_delta = spans_before - len(
-                cast(List[Dict[str, object]], event.get("spans", []))
+                cast("List[Dict[str, object]]", event.get("spans", []))
             )
             if is_transaction and spans_delta > 0 and self.transport is not None:
                 self.transport.record_lost_event(
                     "event_processor", data_category="span", quantity=spans_delta
                 )
 
-            dropped_spans = event.pop("_dropped_spans", 0) + spans_delta  # type: int
+            dropped_spans: int = event.pop("_dropped_spans", 0) + spans_delta
             if dropped_spans > 0:
                 previous_total_spans = spans_before + dropped_spans
             if scope._n_breadcrumbs_truncated > 0:
@@ -578,7 +561,7 @@ class _Client(BaseClient):
             and event is not None
             and event.get("type") != "transaction"
         ):
-            new_event = None  # type: Optional[Event]
+            new_event: Optional["Event"] = None
             with capture_internal_exceptions():
                 new_event = before_send(event, hint or {})
             if new_event is None:
@@ -595,7 +578,7 @@ class _Client(BaseClient):
                 if event.get("exception"):
                     DedupeIntegration.reset_last_seen()
 
-            event = new_event  # type: Optional[Event]  # type: ignore[no-redef]
+            event = new_event  # Updated event from before_send
 
         before_send_transaction = self.options["before_send_transaction"]
         if (
@@ -604,7 +587,7 @@ class _Client(BaseClient):
             and event.get("type") == "transaction"
         ):
             new_event = None
-            spans_before = len(cast(List[Dict[str, object]], event.get("spans", [])))
+            spans_before = len(cast("List[Dict[str, object]]", event.get("spans", [])))
             with capture_internal_exceptions():
                 new_event = before_send_transaction(event, hint or {})
             if new_event is None:
@@ -620,19 +603,18 @@ class _Client(BaseClient):
                     )
             else:
                 spans_delta = spans_before - len(
-                    cast(List[Dict[str, object]], new_event.get("spans", []))
+                    cast("List[Dict[str, object]]", new_event.get("spans", []))
                 )
                 if spans_delta > 0 and self.transport is not None:
                     self.transport.record_lost_event(
                         reason="before_send", data_category="span", quantity=spans_delta
                     )
 
-            event = new_event  # type: Optional[Event]  # type: ignore[no-redef]
+            event = new_event  # Updated event from before_send_transaction
 
         return event
 
-    def _is_ignored_error(self, event, hint):
-        # type: (Event, Hint) -> bool
+    def _is_ignored_error(self, event: Event, hint: Hint) -> bool:
         exc_info = hint.get("exc_info")
         if exc_info is None:
             return False
@@ -655,11 +637,10 @@ class _Client(BaseClient):
 
     def _should_capture(
         self,
-        event,  # type: Event
-        hint,  # type: Hint
-        scope=None,  # type: Optional[Scope]
-    ):
-        # type: (...) -> bool
+        event: "Event",
+        hint: "Hint",
+        scope: Optional["Scope"] = None,
+    ) -> bool:
         # Transactions are sampled independent of error events.
         is_transaction = event.get("type") == "transaction"
         if is_transaction:
@@ -677,10 +658,9 @@ class _Client(BaseClient):
 
     def _should_sample_error(
         self,
-        event,  # type: Event
-        hint,  # type: Hint
-    ):
-        # type: (...) -> bool
+        event: Event,
+        hint: Hint,
+    ) -> bool:
         error_sampler = self.options.get("error_sampler", None)
 
         if callable(error_sampler):
@@ -725,10 +705,9 @@ class _Client(BaseClient):
 
     def _update_session_from_event(
         self,
-        session,  # type: Session
-        event,  # type: Event
-    ):
-        # type: (...) -> None
+        session: Session,
+        event: Event,
+    ) -> None:
 
         crashed = False
         errored = False
@@ -764,11 +743,10 @@ class _Client(BaseClient):
 
     def capture_event(
         self,
-        event,  # type: Event
-        hint=None,  # type: Optional[Hint]
-        scope=None,  # type: Optional[Scope]
-    ):
-        # type: (...) -> Optional[str]
+        event: Event,
+        hint: Optional[Hint] = None,
+        scope: Optional[Scope] = None,
+    ) -> Optional[str]:
         """Captures an event.
 
         :param event: A ready-made event that can be directly sent to Sentry.
@@ -779,9 +757,9 @@ class _Client(BaseClient):
 
         :returns: An event ID. May be `None` if there is no DSN set or of if the SDK decided to discard the event for other reasons. In such situations setting `debug=True` on `init()` may help.
         """
-        hint = dict(hint or ())  # type: Hint
+        hint_dict: Hint = dict(hint or ())
 
-        if not self._should_capture(event, hint, scope):
+        if not self._should_capture(event, hint_dict, scope):
             return None
 
         profile = event.pop("profile", None)
@@ -789,7 +767,7 @@ class _Client(BaseClient):
         event_id = event.get("event_id")
         if event_id is None:
             event["event_id"] = event_id = uuid.uuid4().hex
-        event_opt = self._prepare_event(event, hint, scope)
+        event_opt = self._prepare_event(event, hint_dict, scope)
         if event_opt is None:
             return None
 
@@ -805,19 +783,19 @@ class _Client(BaseClient):
         if (
             not is_transaction
             and not is_checkin
-            and not self._should_sample_error(event, hint)
+            and not self._should_sample_error(event, hint_dict)
         ):
             return None
 
-        attachments = hint.get("attachments")
+        attachments = hint_dict.get("attachments")
 
         trace_context = event_opt.get("contexts", {}).get("trace") or {}
         dynamic_sampling_context = trace_context.pop("dynamic_sampling_context", {})
 
-        headers = {
+        headers: dict[str, object] = {
             "event_id": event_opt["event_id"],
             "sent_at": format_timestamp(datetime.now(timezone.utc)),
-        }  # type: dict[str, object]
+        }
 
         if dynamic_sampling_context:
             headers["trace"] = dynamic_sampling_context
@@ -847,8 +825,7 @@ class _Client(BaseClient):
 
         return return_value
 
-    def _capture_experimental_log(self, log):
-        # type: (Log) -> None
+    def _capture_experimental_log(self, log: Log) -> None:
         logs_enabled = self.options["_experiments"].get("enable_logs", False)
         if not logs_enabled:
             return
@@ -914,10 +891,7 @@ class _Client(BaseClient):
         if self.log_batcher:
             self.log_batcher.add(log)
 
-    def capture_session(
-        self, session  # type: Session
-    ):
-        # type: (...) -> None
+    def capture_session(self, session: Session) -> None:
         if not session.release:
             logger.info("Discarded session update because of missing release")
         else:
@@ -926,19 +900,16 @@ class _Client(BaseClient):
     if TYPE_CHECKING:
 
         @overload
-        def get_integration(self, name_or_class):
-            # type: (str) -> Optional[Integration]
-            ...
+        def get_integration(self, name_or_class: str) -> Optional[Integration]: ...
 
         @overload
-        def get_integration(self, name_or_class):
-            # type: (type[I]) -> Optional[I]
-            ...
+        def get_integration(
+            self, name_or_class: type[IntegrationType]
+        ) -> Optional[IntegrationType]: ...
 
     def get_integration(
-        self, name_or_class  # type: Union[str, Type[Integration]]
-    ):
-        # type: (...) -> Optional[Integration]
+        self, name_or_class: Union[str, Type[Integration]]
+    ) -> Optional[Integration]:
         """Returns the integration for this client by name or class.
         If the client does not have that integration then `None` is returned.
         """
@@ -953,10 +924,9 @@ class _Client(BaseClient):
 
     def close(
         self,
-        timeout=None,  # type: Optional[float]
-        callback=None,  # type: Optional[Callable[[int, float], None]]
-    ):
-        # type: (...) -> None
+        timeout: Optional[float] = None,
+        callback: Optional[Callable[[int, float], None]] = None,
+    ) -> None:
         """
         Close the client and shut down the transport. Arguments have the same
         semantics as :py:meth:`Client.flush`.
@@ -977,10 +947,9 @@ class _Client(BaseClient):
 
     def flush(
         self,
-        timeout=None,  # type: Optional[float]
-        callback=None,  # type: Optional[Callable[[int, float], None]]
-    ):
-        # type: (...) -> None
+        timeout: Optional[float] = None,
+        callback: Optional[Callable[[int, float], None]] = None,
+    ) -> None:
         """
         Wait for the current events to be sent.
 
@@ -998,16 +967,12 @@ class _Client(BaseClient):
 
             self.transport.flush(timeout=timeout, callback=callback)
 
-    def __enter__(self):
-        # type: () -> _Client
+    def __enter__(self) -> _Client:
         return self
 
-    def __exit__(self, exc_type, exc_value, tb):
-        # type: (Any, Any, Any) -> None
+    def __exit__(self, exc_type: Any, exc_value: Any, tb: Any) -> None:
         self.close()
 
-
-from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     # Make mypy, PyCharm and other static analyzers think `get_options` is a

--- a/sentry_sdk/consts.py
+++ b/sentry_sdk/consts.py
@@ -1,6 +1,20 @@
+from __future__ import annotations
 import itertools
 from enum import Enum
 from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from typing import (
+        Optional,
+        Callable,
+        Union,
+        List,
+        Type,
+        Dict,
+        Any,
+        Sequence,
+        Tuple,
+    )
 
 # up top to prevent circular import due to integration import
 DEFAULT_MAX_VALUE_LENGTH = 1024
@@ -26,17 +40,6 @@ class CompressionAlgo(Enum):
 
 
 if TYPE_CHECKING:
-    import sentry_sdk
-
-    from typing import Optional
-    from typing import Callable
-    from typing import Union
-    from typing import List
-    from typing import Type
-    from typing import Dict
-    from typing import Any
-    from typing import Sequence
-    from typing import Tuple
     from typing_extensions import Literal
     from typing_extensions import TypedDict
 
@@ -51,6 +54,8 @@ if TYPE_CHECKING:
         TracesSampler,
         TransactionProcessor,
     )
+
+    import sentry_sdk
 
     # Experiments are feature flags to enable and disable certain unstable SDK
     # functionality. Changing them from the defaults (`None`) in production
@@ -728,8 +733,7 @@ class TransactionSource(str, Enum):
     URL = "url"
     VIEW = "view"
 
-    def __str__(self):
-        # type: () -> str
+    def __str__(self) -> str:
         return self.value
 
 
@@ -757,68 +761,73 @@ class ClientConstructor:
 
     def __init__(
         self,
-        dsn=None,  # type: Optional[str]
+        dsn: Optional[str] = None,
         *,
-        max_breadcrumbs=DEFAULT_MAX_BREADCRUMBS,  # type: int
-        release=None,  # type: Optional[str]
-        environment=None,  # type: Optional[str]
-        server_name=None,  # type: Optional[str]
-        shutdown_timeout=2,  # type: float
-        integrations=[],  # type: Sequence[sentry_sdk.integrations.Integration]  # noqa: B006
-        in_app_include=[],  # type: List[str]  # noqa: B006
-        in_app_exclude=[],  # type: List[str]  # noqa: B006
-        default_integrations=True,  # type: bool
-        dist=None,  # type: Optional[str]
-        transport=None,  # type: Optional[Union[sentry_sdk.transport.Transport, Type[sentry_sdk.transport.Transport], Callable[[Event], None]]]
-        transport_queue_size=DEFAULT_QUEUE_SIZE,  # type: int
-        sample_rate=1.0,  # type: float
-        send_default_pii=None,  # type: Optional[bool]
-        http_proxy=None,  # type: Optional[str]
-        https_proxy=None,  # type: Optional[str]
-        ignore_errors=[],  # type: Sequence[Union[type, str]]  # noqa: B006
-        max_request_body_size="medium",  # type: str
-        socket_options=None,  # type: Optional[List[Tuple[int, int, int | bytes]]]
-        keep_alive=None,  # type: Optional[bool]
-        before_send=None,  # type: Optional[EventProcessor]
-        before_breadcrumb=None,  # type: Optional[BreadcrumbProcessor]
-        debug=None,  # type: Optional[bool]
-        attach_stacktrace=False,  # type: bool
-        ca_certs=None,  # type: Optional[str]
-        traces_sample_rate=None,  # type: Optional[float]
-        traces_sampler=None,  # type: Optional[TracesSampler]
-        profiles_sample_rate=None,  # type: Optional[float]
-        profiles_sampler=None,  # type: Optional[TracesSampler]
-        profiler_mode=None,  # type: Optional[ProfilerMode]
-        profile_lifecycle="manual",  # type: Literal["manual", "trace"]
-        profile_session_sample_rate=None,  # type: Optional[float]
-        auto_enabling_integrations=True,  # type: bool
-        disabled_integrations=None,  # type: Optional[Sequence[sentry_sdk.integrations.Integration]]
-        auto_session_tracking=True,  # type: bool
-        send_client_reports=True,  # type: bool
-        _experiments={},  # type: Experiments  # noqa: B006
-        proxy_headers=None,  # type: Optional[Dict[str, str]]
-        before_send_transaction=None,  # type: Optional[TransactionProcessor]
-        project_root=None,  # type: Optional[str]
-        include_local_variables=True,  # type: Optional[bool]
-        include_source_context=True,  # type: Optional[bool]
-        trace_propagation_targets=[  # noqa: B006
-            MATCH_ALL
-        ],  # type: Optional[Sequence[str]]
-        functions_to_trace=[],  # type: Sequence[Dict[str, str]]  # noqa: B006
-        event_scrubber=None,  # type: Optional[sentry_sdk.scrubber.EventScrubber]
-        max_value_length=DEFAULT_MAX_VALUE_LENGTH,  # type: int
-        enable_backpressure_handling=True,  # type: bool
-        error_sampler=None,  # type: Optional[Callable[[Event, Hint], Union[float, bool]]]
-        enable_db_query_source=True,  # type: bool
-        db_query_source_threshold_ms=100,  # type: int
-        spotlight=None,  # type: Optional[Union[bool, str]]
-        cert_file=None,  # type: Optional[str]
-        key_file=None,  # type: Optional[str]
-        custom_repr=None,  # type: Optional[Callable[..., Optional[str]]]
-        add_full_stack=DEFAULT_ADD_FULL_STACK,  # type: bool
-        max_stack_frames=DEFAULT_MAX_STACK_FRAMES,  # type: Optional[int]
-    ):
-        # type: (...) -> None
+        max_breadcrumbs: int = DEFAULT_MAX_BREADCRUMBS,
+        release: Optional[str] = None,
+        environment: Optional[str] = None,
+        server_name: Optional[str] = None,
+        shutdown_timeout: float = 2,
+        integrations: Sequence[sentry_sdk.integrations.Integration] = [],  # noqa: B006
+        in_app_include: List[str] = [],  # noqa: B006
+        in_app_exclude: List[str] = [],  # noqa: B006
+        default_integrations: bool = True,
+        dist: Optional[str] = None,
+        transport: Optional[
+            Union[
+                sentry_sdk.transport.Transport,
+                Type[sentry_sdk.transport.Transport],
+                Callable[[Event], None],
+            ]
+        ] = None,
+        transport_queue_size: int = DEFAULT_QUEUE_SIZE,
+        sample_rate: float = 1.0,
+        send_default_pii: Optional[bool] = None,
+        http_proxy: Optional[str] = None,
+        https_proxy: Optional[str] = None,
+        ignore_errors: Sequence[Union[type, str]] = [],  # noqa: B006
+        max_request_body_size: str = "medium",
+        socket_options: Optional[List[Tuple[int, int, int | bytes]]] = None,
+        keep_alive: Optional[bool] = None,
+        before_send: Optional[EventProcessor] = None,
+        before_breadcrumb: Optional[BreadcrumbProcessor] = None,
+        debug: Optional[bool] = None,
+        attach_stacktrace: bool = False,
+        ca_certs: Optional[str] = None,
+        traces_sample_rate: Optional[float] = None,
+        traces_sampler: Optional[TracesSampler] = None,
+        profiles_sample_rate: Optional[float] = None,
+        profiles_sampler: Optional[TracesSampler] = None,
+        profiler_mode: Optional[ProfilerMode] = None,
+        profile_lifecycle: Literal["manual", "trace"] = "manual",
+        profile_session_sample_rate: Optional[float] = None,
+        auto_enabling_integrations: bool = True,
+        disabled_integrations: Optional[
+            Sequence[sentry_sdk.integrations.Integration]
+        ] = None,
+        auto_session_tracking: bool = True,
+        send_client_reports: bool = True,
+        _experiments: Experiments = {},  # noqa: B006
+        proxy_headers: Optional[Dict[str, str]] = None,
+        before_send_transaction: Optional[TransactionProcessor] = None,
+        project_root: Optional[str] = None,
+        include_local_variables: Optional[bool] = True,
+        include_source_context: Optional[bool] = True,
+        trace_propagation_targets: Optional[Sequence[str]] = [MATCH_ALL],  # noqa: B006
+        functions_to_trace: Sequence[Dict[str, str]] = [],  # noqa: B006
+        event_scrubber: Optional[sentry_sdk.scrubber.EventScrubber] = None,
+        max_value_length: int = DEFAULT_MAX_VALUE_LENGTH,
+        enable_backpressure_handling: bool = True,
+        error_sampler: Optional[Callable[[Event, Hint], Union[float, bool]]] = None,
+        enable_db_query_source: bool = True,
+        db_query_source_threshold_ms: int = 100,
+        spotlight: Optional[Union[bool, str]] = None,
+        cert_file: Optional[str] = None,
+        key_file: Optional[str] = None,
+        custom_repr: Optional[Callable[..., Optional[str]]] = None,
+        add_full_stack: bool = DEFAULT_ADD_FULL_STACK,
+        max_stack_frames: Optional[int] = DEFAULT_MAX_STACK_FRAMES,
+    ) -> None:
         """Initialize the Sentry SDK with the given parameters. All parameters described here can be used in a call to `sentry_sdk.init()`.
 
         :param dsn: The DSN tells the SDK where to send the events.
@@ -1198,8 +1207,7 @@ class ClientConstructor:
         pass
 
 
-def _get_default_options():
-    # type: () -> dict[str, Any]
+def _get_default_options() -> dict[str, Any]:
     import inspect
 
     a = inspect.getfullargspec(ClientConstructor.__init__)

--- a/sentry_sdk/crons/api.py
+++ b/sentry_sdk/crons/api.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import uuid
 
 import sentry_sdk
@@ -10,17 +11,16 @@ if TYPE_CHECKING:
 
 
 def _create_check_in_event(
-    monitor_slug=None,  # type: Optional[str]
-    check_in_id=None,  # type: Optional[str]
-    status=None,  # type: Optional[str]
-    duration_s=None,  # type: Optional[float]
-    monitor_config=None,  # type: Optional[MonitorConfig]
-):
-    # type: (...) -> Event
+    monitor_slug: Optional[str] = None,
+    check_in_id: Optional[str] = None,
+    status: Optional[str] = None,
+    duration_s: Optional[float] = None,
+    monitor_config: Optional[MonitorConfig] = None,
+) -> Event:
     options = sentry_sdk.get_client().options
-    check_in_id = check_in_id or uuid.uuid4().hex  # type: str
+    check_in_id = check_in_id or uuid.uuid4().hex
 
-    check_in = {
+    check_in: Event = {
         "type": "check_in",
         "monitor_slug": monitor_slug,
         "check_in_id": check_in_id,
@@ -28,7 +28,7 @@ def _create_check_in_event(
         "duration": duration_s,
         "environment": options.get("environment", None),
         "release": options.get("release", None),
-    }  # type: Event
+    }
 
     if monitor_config:
         check_in["monitor_config"] = monitor_config
@@ -37,13 +37,12 @@ def _create_check_in_event(
 
 
 def capture_checkin(
-    monitor_slug=None,  # type: Optional[str]
-    check_in_id=None,  # type: Optional[str]
-    status=None,  # type: Optional[str]
-    duration=None,  # type: Optional[float]
-    monitor_config=None,  # type: Optional[MonitorConfig]
-):
-    # type: (...) -> str
+    monitor_slug: Optional[str] = None,
+    check_in_id: Optional[str] = None,
+    status: Optional[str] = None,
+    duration: Optional[float] = None,
+    monitor_config: Optional[MonitorConfig] = None,
+) -> str:
     check_in_event = _create_check_in_event(
         monitor_slug=monitor_slug,
         check_in_id=check_in_id,

--- a/sentry_sdk/debug.py
+++ b/sentry_sdk/debug.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import sys
 import logging
 
@@ -8,22 +9,19 @@ from logging import LogRecord
 
 
 class _DebugFilter(logging.Filter):
-    def filter(self, record):
-        # type: (LogRecord) -> bool
+    def filter(self, record: LogRecord) -> bool:
         if _client_init_debug.get(False):
             return True
 
         return get_client().options["debug"]
 
 
-def init_debug_support():
-    # type: () -> None
+def init_debug_support() -> None:
     if not logger.handlers:
         configure_logger()
 
 
-def configure_logger():
-    # type: () -> None
+def configure_logger() -> None:
     _handler = logging.StreamHandler(sys.stderr)
     _handler.setFormatter(logging.Formatter(" [sentry] %(levelname)s: %(message)s"))
     logger.addHandler(_handler)

--- a/sentry_sdk/feature_flags.py
+++ b/sentry_sdk/feature_flags.py
@@ -1,23 +1,22 @@
+from __future__ import annotations
 import copy
 import sentry_sdk
 from sentry_sdk._lru_cache import LRUCache
 from threading import Lock
 
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from typing import TypedDict
+    from typing import Any, TypedDict
 
     FlagData = TypedDict("FlagData", {"flag": str, "result": bool})
-
 
 DEFAULT_FLAG_CAPACITY = 100
 
 
 class FlagBuffer:
 
-    def __init__(self, capacity):
-        # type: (int) -> None
+    def __init__(self, capacity: int) -> None:
         self.capacity = capacity
         self.lock = Lock()
 
@@ -25,26 +24,22 @@ class FlagBuffer:
         # directly you're on your own!
         self.__buffer = LRUCache(capacity)
 
-    def clear(self):
-        # type: () -> None
+    def clear(self) -> None:
         self.__buffer = LRUCache(self.capacity)
 
-    def __deepcopy__(self, memo):
-        # type: (dict[int, Any]) -> FlagBuffer
+    def __deepcopy__(self, memo: dict[int, Any]) -> FlagBuffer:
         with self.lock:
             buffer = FlagBuffer(self.capacity)
             buffer.__buffer = copy.deepcopy(self.__buffer, memo)
             return buffer
 
-    def get(self):
-        # type: () -> list[FlagData]
+    def get(self) -> list[FlagData]:
         with self.lock:
             return [
                 {"flag": key, "result": value} for key, value in self.__buffer.get_all()
             ]
 
-    def set(self, flag, result):
-        # type: (str, bool) -> None
+    def set(self, flag: str, result: bool) -> None:
         if isinstance(result, FlagBuffer):
             # If someone were to insert `self` into `self` this would create a circular dependency
             # on the lock. This is of course a deadlock. However, this is far outside the expected
@@ -58,8 +53,7 @@ class FlagBuffer:
             self.__buffer.set(flag, result)
 
 
-def add_feature_flag(flag, result):
-    # type: (str, bool) -> None
+def add_feature_flag(flag: str, result: bool) -> None:
     """
     Records a flag and its value to be sent on subsequent error events.
     We recommend you do this on flag evaluations. Flags are buffered per Sentry scope.

--- a/sentry_sdk/integrations/__init__.py
+++ b/sentry_sdk/integrations/__init__.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from abc import ABC, abstractmethod
 from threading import Lock
 
@@ -23,20 +24,20 @@ _DEFAULT_FAILED_REQUEST_STATUS_CODES = frozenset(range(500, 600))
 _installer_lock = Lock()
 
 # Set of all integration identifiers we have attempted to install
-_processed_integrations = set()  # type: Set[str]
+_processed_integrations: Set[str] = set()
 
 # Set of all integration identifiers we have actually installed
-_installed_integrations = set()  # type: Set[str]
+_installed_integrations: Set[str] = set()
 
 
 def _generate_default_integrations_iterator(
-    integrations,  # type: List[str]
-    auto_enabling_integrations,  # type: List[str]
-):
-    # type: (...) -> Callable[[bool], Iterator[Type[Integration]]]
+    integrations: List[str],
+    auto_enabling_integrations: List[str],
+) -> Callable[[bool], Iterator[Type[Integration]]]:
 
-    def iter_default_integrations(with_auto_enabling_integrations):
-        # type: (bool) -> Iterator[Type[Integration]]
+    def iter_default_integrations(
+        with_auto_enabling_integrations: bool,
+    ) -> Iterator[Type[Integration]]:
         """Returns an iterator of the default integration classes:"""
         from importlib import import_module
 
@@ -165,12 +166,13 @@ _MIN_VERSIONS = {
 
 
 def setup_integrations(
-    integrations,
-    with_defaults=True,
-    with_auto_enabling_integrations=False,
-    disabled_integrations=None,
-):
-    # type: (Sequence[Integration], bool, bool, Optional[Sequence[Union[type[Integration], Integration]]]) -> Dict[str, Integration]
+    integrations: Sequence[Integration],
+    with_defaults: bool = True,
+    with_auto_enabling_integrations: bool = False,
+    disabled_integrations: Optional[
+        Sequence[Union[type[Integration], Integration]]
+    ] = None,
+) -> Dict[str, Integration]:
     """
     Given a list of integration instances, this installs them all.
 
@@ -239,8 +241,11 @@ def setup_integrations(
     return integrations
 
 
-def _check_minimum_version(integration, version, package=None):
-    # type: (type[Integration], Optional[tuple[int, ...]], Optional[str]) -> None
+def _check_minimum_version(
+    integration: type[Integration],
+    version: Optional[tuple[int, ...]],
+    package: Optional[str] = None,
+) -> None:
     package = package or integration.identifier
 
     if version is None:
@@ -276,13 +281,12 @@ class Integration(ABC):
     install = None
     """Legacy method, do not implement."""
 
-    identifier = None  # type: str
+    identifier: str
     """String unique ID of integration type"""
 
     @staticmethod
     @abstractmethod
-    def setup_once():
-        # type: () -> None
+    def setup_once() -> None:
         """
         Initialize the integration.
 

--- a/sentry_sdk/integrations/_wsgi_common.py
+++ b/sentry_sdk/integrations/_wsgi_common.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import json
 from copy import deepcopy
 
@@ -50,8 +51,9 @@ DEFAULT_HTTP_METHODS_TO_CAPTURE = (
 )
 
 
-def request_body_within_bounds(client, content_length):
-    # type: (Optional[sentry_sdk.client.BaseClient], int) -> bool
+def request_body_within_bounds(
+    client: Optional[sentry_sdk.client.BaseClient], content_length: int
+) -> bool:
     if client is None:
         return False
 
@@ -73,17 +75,15 @@ class RequestExtractor:
     # it. Only some child classes implement all methods that raise
     # NotImplementedError in this class.
 
-    def __init__(self, request):
-        # type: (Any) -> None
+    def __init__(self, request: Any) -> None:
         self.request = request
 
-    def extract_into_event(self, event):
-        # type: (Event) -> None
+    def extract_into_event(self, event: Event) -> None:
         client = sentry_sdk.get_client()
         if not client.is_active():
             return
 
-        data = None  # type: Optional[Union[AnnotatedValue, Dict[str, Any]]]
+        data: Optional[Union[AnnotatedValue, Dict[str, Any]]] = None
 
         content_length = self.content_length()
         request_info = event.get("request", {})
@@ -119,27 +119,22 @@ class RequestExtractor:
 
         event["request"] = deepcopy(request_info)
 
-    def content_length(self):
-        # type: () -> int
+    def content_length(self) -> int:
         try:
             return int(self.env().get("CONTENT_LENGTH", 0))
         except ValueError:
             return 0
 
-    def cookies(self):
-        # type: () -> MutableMapping[str, Any]
+    def cookies(self) -> MutableMapping[str, Any]:
         raise NotImplementedError()
 
-    def raw_data(self):
-        # type: () -> Optional[Union[str, bytes]]
+    def raw_data(self) -> Optional[Union[str, bytes]]:
         raise NotImplementedError()
 
-    def form(self):
-        # type: () -> Optional[Dict[str, Any]]
+    def form(self) -> Optional[Dict[str, Any]]:
         raise NotImplementedError()
 
-    def parsed_body(self):
-        # type: () -> Optional[Dict[str, Any]]
+    def parsed_body(self) -> Optional[Dict[str, Any]]:
         try:
             form = self.form()
         except Exception:
@@ -161,12 +156,10 @@ class RequestExtractor:
 
         return self.json()
 
-    def is_json(self):
-        # type: () -> bool
+    def is_json(self) -> bool:
         return _is_json_content_type(self.env().get("CONTENT_TYPE"))
 
-    def json(self):
-        # type: () -> Optional[Any]
+    def json(self) -> Optional[Any]:
         try:
             if not self.is_json():
                 return None
@@ -190,21 +183,17 @@ class RequestExtractor:
 
         return None
 
-    def files(self):
-        # type: () -> Optional[Dict[str, Any]]
+    def files(self) -> Optional[Dict[str, Any]]:
         raise NotImplementedError()
 
-    def size_of_file(self, file):
-        # type: (Any) -> int
+    def size_of_file(self, file: Any) -> int:
         raise NotImplementedError()
 
-    def env(self):
-        # type: () -> Dict[str, Any]
+    def env(self) -> Dict[str, Any]:
         raise NotImplementedError()
 
 
-def _is_json_content_type(ct):
-    # type: (Optional[str]) -> bool
+def _is_json_content_type(ct: Optional[str]) -> bool:
     mt = (ct or "").split(";", 1)[0]
     return (
         mt == "application/json"
@@ -213,8 +202,9 @@ def _is_json_content_type(ct):
     )
 
 
-def _filter_headers(headers):
-    # type: (Mapping[str, str]) -> Mapping[str, Union[AnnotatedValue, str]]
+def _filter_headers(
+    headers: Mapping[str, str],
+) -> Mapping[str, Union[AnnotatedValue, str]]:
     if should_send_default_pii():
         return headers
 
@@ -228,8 +218,7 @@ def _filter_headers(headers):
     }
 
 
-def _request_headers_to_span_attributes(headers):
-    # type: (dict[str, str]) -> dict[str, str]
+def _request_headers_to_span_attributes(headers: dict[str, str]) -> dict[str, str]:
     attributes = {}
 
     headers = _filter_headers(headers)

--- a/sentry_sdk/integrations/argv.py
+++ b/sentry_sdk/integrations/argv.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import sys
 
 import sentry_sdk
@@ -16,11 +17,9 @@ class ArgvIntegration(Integration):
     identifier = "argv"
 
     @staticmethod
-    def setup_once():
-        # type: () -> None
+    def setup_once() -> None:
         @add_global_event_processor
-        def processor(event, hint):
-            # type: (Event, Optional[Hint]) -> Optional[Event]
+        def processor(event: Event, hint: Optional[Hint]) -> Optional[Event]:
             if sentry_sdk.get_client().get_integration(ArgvIntegration) is not None:
                 extra = event.setdefault("extra", {})
                 # If some event processor decided to set extra to e.g. an

--- a/sentry_sdk/integrations/arq.py
+++ b/sentry_sdk/integrations/arq.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import sys
 
 import sentry_sdk
@@ -45,8 +46,7 @@ class ArqIntegration(Integration):
     origin = f"auto.queue.{identifier}"
 
     @staticmethod
-    def setup_once():
-        # type: () -> None
+    def setup_once() -> None:
 
         try:
             if isinstance(ARQ_VERSION, str):
@@ -66,13 +66,13 @@ class ArqIntegration(Integration):
         ignore_logger("arq.worker")
 
 
-def patch_enqueue_job():
-    # type: () -> None
+def patch_enqueue_job() -> None:
     old_enqueue_job = ArqRedis.enqueue_job
     original_kwdefaults = old_enqueue_job.__kwdefaults__
 
-    async def _sentry_enqueue_job(self, function, *args, **kwargs):
-        # type: (ArqRedis, str, *Any, **Any) -> Optional[Job]
+    async def _sentry_enqueue_job(
+        self: ArqRedis, function: str, *args: Any, **kwargs: Any
+    ) -> Optional[Job]:
         integration = sentry_sdk.get_client().get_integration(ArqIntegration)
         if integration is None:
             return await old_enqueue_job(self, function, *args, **kwargs)
@@ -89,12 +89,10 @@ def patch_enqueue_job():
     ArqRedis.enqueue_job = _sentry_enqueue_job
 
 
-def patch_run_job():
-    # type: () -> None
+def patch_run_job() -> None:
     old_run_job = Worker.run_job
 
-    async def _sentry_run_job(self, job_id, score):
-        # type: (Worker, str, int) -> None
+    async def _sentry_run_job(self: Worker, job_id: str, score: int) -> None:
         integration = sentry_sdk.get_client().get_integration(ArqIntegration)
         if integration is None:
             return await old_run_job(self, job_id, score)
@@ -123,8 +121,7 @@ def patch_run_job():
     Worker.run_job = _sentry_run_job
 
 
-def _capture_exception(exc_info):
-    # type: (ExcInfo) -> None
+def _capture_exception(exc_info: ExcInfo) -> None:
     scope = sentry_sdk.get_current_scope()
 
     if scope.root_span is not None:
@@ -142,10 +139,10 @@ def _capture_exception(exc_info):
     sentry_sdk.capture_event(event, hint=hint)
 
 
-def _make_event_processor(ctx, *args, **kwargs):
-    # type: (Dict[Any, Any], *Any, **Any) -> EventProcessor
-    def event_processor(event, hint):
-        # type: (Event, Hint) -> Optional[Event]
+def _make_event_processor(
+    ctx: Dict[Any, Any], *args: Any, **kwargs: Any
+) -> EventProcessor:
+    def event_processor(event: Event, hint: Hint) -> Optional[Event]:
 
         with capture_internal_exceptions():
             scope = sentry_sdk.get_current_scope()
@@ -173,11 +170,9 @@ def _make_event_processor(ctx, *args, **kwargs):
     return event_processor
 
 
-def _wrap_coroutine(name, coroutine):
-    # type: (str, WorkerCoroutine) -> WorkerCoroutine
+def _wrap_coroutine(name: str, coroutine: WorkerCoroutine) -> WorkerCoroutine:
 
-    async def _sentry_coroutine(ctx, *args, **kwargs):
-        # type: (Dict[Any, Any], *Any, **Any) -> Any
+    async def _sentry_coroutine(ctx: Dict[Any, Any], *args: Any, **kwargs: Any) -> Any:
         integration = sentry_sdk.get_client().get_integration(ArqIntegration)
         if integration is None:
             return await coroutine(ctx, *args, **kwargs)
@@ -198,13 +193,11 @@ def _wrap_coroutine(name, coroutine):
     return _sentry_coroutine
 
 
-def patch_create_worker():
-    # type: () -> None
+def patch_create_worker() -> None:
     old_create_worker = arq.worker.create_worker
 
     @ensure_integration_enabled(ArqIntegration, old_create_worker)
-    def _sentry_create_worker(*args, **kwargs):
-        # type: (*Any, **Any) -> Worker
+    def _sentry_create_worker(*args: Any, **kwargs: Any) -> Worker:
         settings_cls = args[0]
 
         if isinstance(settings_cls, dict):
@@ -243,16 +236,14 @@ def patch_create_worker():
     arq.worker.create_worker = _sentry_create_worker
 
 
-def _get_arq_function(func):
-    # type: (Union[str, Function, WorkerCoroutine]) -> Function
+def _get_arq_function(func: Union[str, Function, WorkerCoroutine]) -> Function:
     arq_func = arq.worker.func(func)
     arq_func.coroutine = _wrap_coroutine(arq_func.name, arq_func.coroutine)
 
     return arq_func
 
 
-def _get_arq_cron_job(cron_job):
-    # type: (CronJob) -> CronJob
+def _get_arq_cron_job(cron_job: CronJob) -> CronJob:
     cron_job.coroutine = _wrap_coroutine(cron_job.name, cron_job.coroutine)
 
     return cron_job

--- a/sentry_sdk/integrations/asgi.py
+++ b/sentry_sdk/integrations/asgi.py
@@ -4,6 +4,7 @@ An ASGI middleware.
 Based on Tom Christie's `sentry-asgi <https://github.com/encode/sentry-asgi>`.
 """
 
+from __future__ import annotations
 import asyncio
 import inspect
 from copy import deepcopy
@@ -61,8 +62,7 @@ ASGI_SCOPE_PROPERTY_TO_ATTRIBUTE = {
 }
 
 
-def _capture_exception(exc, mechanism_type="asgi"):
-    # type: (Any, str) -> None
+def _capture_exception(exc: Any, mechanism_type: str = "asgi") -> None:
 
     event, hint = event_from_exception(
         exc,
@@ -72,8 +72,7 @@ def _capture_exception(exc, mechanism_type="asgi"):
     sentry_sdk.capture_event(event, hint=hint)
 
 
-def _looks_like_asgi3(app):
-    # type: (Any) -> bool
+def _looks_like_asgi3(app: Any) -> bool:
     """
     Try to figure out if an application object supports ASGI3.
 
@@ -100,14 +99,13 @@ class SentryAsgiMiddleware:
 
     def __init__(
         self,
-        app,  # type: Any
-        unsafe_context_data=False,  # type: bool
-        transaction_style="endpoint",  # type: str
-        mechanism_type="asgi",  # type: str
-        span_origin=None,  # type: Optional[str]
-        http_methods_to_capture=DEFAULT_HTTP_METHODS_TO_CAPTURE,  # type: Tuple[str, ...]
-    ):
-        # type: (...) -> None
+        app: Any,
+        unsafe_context_data: bool = False,
+        transaction_style: str = "endpoint",
+        mechanism_type: str = "asgi",
+        span_origin: Optional[str] = None,
+        http_methods_to_capture: Tuple[str, ...] = DEFAULT_HTTP_METHODS_TO_CAPTURE,
+    ) -> None:
         """
         Instrument an ASGI application with Sentry. Provides HTTP/websocket
         data to sent events and basic handling for exceptions bubbling up
@@ -145,42 +143,41 @@ class SentryAsgiMiddleware:
         self.http_methods_to_capture = http_methods_to_capture
 
         if _looks_like_asgi3(app):
-            self.__call__ = self._run_asgi3  # type: Callable[..., Any]
+            self.__call__: Callable[..., Any] = self._run_asgi3
         else:
             self.__call__ = self._run_asgi2
 
-    def _capture_lifespan_exception(self, exc):
-        # type: (Exception) -> None
+    def _capture_lifespan_exception(self, exc: Exception) -> None:
         """Capture exceptions raise in application lifespan handlers.
 
         The separate function is needed to support overriding in derived integrations that use different catching mechanisms.
         """
         return _capture_exception(exc=exc, mechanism_type=self.mechanism_type)
 
-    def _capture_request_exception(self, exc):
-        # type: (Exception) -> None
+    def _capture_request_exception(self, exc: Exception) -> None:
         """Capture exceptions raised in incoming request handlers.
 
         The separate function is needed to support overriding in derived integrations that use different catching mechanisms.
         """
         return _capture_exception(exc=exc, mechanism_type=self.mechanism_type)
 
-    def _run_asgi2(self, scope):
-        # type: (Any) -> Any
-        async def inner(receive, send):
-            # type: (Any, Any) -> Any
+    def _run_asgi2(self, scope: Any) -> Any:
+        async def inner(receive: Any, send: Any) -> Any:
             return await self._run_app(scope, receive, send, asgi_version=2)
 
         return inner
 
-    async def _run_asgi3(self, scope, receive, send):
-        # type: (Any, Any, Any) -> Any
+    async def _run_asgi3(self, scope: Any, receive: Any, send: Any) -> Any:
         return await self._run_app(scope, receive, send, asgi_version=3)
 
     async def _run_original_app(
-        self, scope, receive, send, asgi_version, is_lifespan=False
-    ):
-        # type: (Any, Any, Any, Any, int) -> Any
+        self,
+        scope: Any,
+        receive: Any,
+        send: Any,
+        asgi_version: Any,
+        is_lifespan: int = False,
+    ) -> Any:
         try:
             if asgi_version == 2:
                 return await self.app(scope)(receive, send)
@@ -194,8 +191,9 @@ class SentryAsgiMiddleware:
                 self._capture_request_exception(exc)
             raise exc from None
 
-    async def _run_app(self, scope, receive, send, asgi_version):
-        # type: (Any, Any, Any, int) -> Any
+    async def _run_app(
+        self, scope: Any, receive: Any, send: Any, asgi_version: int
+    ) -> Any:
         is_recursive_asgi_middleware = _asgi_middleware_applied.get(False)
         is_lifespan = scope["type"] == "lifespan"
         if is_recursive_asgi_middleware or is_lifespan:
@@ -251,8 +249,9 @@ class SentryAsgiMiddleware:
                                 logger.debug("[ASGI] Started transaction: %s", span)
                                 span.set_tag("asgi.type", ty)
 
-                            async def _sentry_wrapped_send(event):
-                                # type: (Dict[str, Any]) -> Any
+                            async def _sentry_wrapped_send(
+                                event: Dict[str, Any],
+                            ) -> Any:
                                 is_http_response = (
                                     event.get("type") == "http.response.start"
                                     and span is not None
@@ -273,8 +272,9 @@ class SentryAsgiMiddleware:
         finally:
             _asgi_middleware_applied.set(False)
 
-    def event_processor(self, event, hint, asgi_scope):
-        # type: (Event, Hint, Any) -> Optional[Event]
+    def event_processor(
+        self, event: Event, hint: Hint, asgi_scope: Any
+    ) -> Optional[Event]:
         request_data = event.get("request", {})
         request_data.update(_get_request_data(asgi_scope))
         event["request"] = deepcopy(request_data)
@@ -313,11 +313,11 @@ class SentryAsgiMiddleware:
     # data to your liking it's recommended to use the `before_send` callback
     # for that.
 
-    def _get_transaction_name_and_source(self, transaction_style, asgi_scope):
-        # type: (SentryAsgiMiddleware, str, Any) -> Tuple[str, str]
+    def _get_transaction_name_and_source(
+        self: SentryAsgiMiddleware, transaction_style: str, asgi_scope: Any
+    ) -> Tuple[str, str]:
         name = None
         source = SOURCE_FOR_STYLE[transaction_style]
-        ty = asgi_scope.get("type")
 
         if transaction_style == "endpoint":
             endpoint = asgi_scope.get("endpoint")
@@ -327,7 +327,7 @@ class SentryAsgiMiddleware:
             if endpoint:
                 name = transaction_from_function(endpoint) or ""
             else:
-                name = _get_url(asgi_scope, "http" if ty == "http" else "ws", host=None)
+                name = _get_url(asgi_scope)
                 source = TransactionSource.URL
 
         elif transaction_style == "url":
@@ -339,7 +339,7 @@ class SentryAsgiMiddleware:
                 if path is not None:
                     name = path
             else:
-                name = _get_url(asgi_scope, "http" if ty == "http" else "ws", host=None)
+                name = _get_url(asgi_scope)
                 source = TransactionSource.URL
 
         if name is None:
@@ -350,8 +350,7 @@ class SentryAsgiMiddleware:
         return name, source
 
 
-def _prepopulate_attributes(scope):
-    # type: (Any) -> dict[str, Any]
+def _prepopulate_attributes(scope: Any) -> dict[str, Any]:
     """Unpack ASGI scope into serializable OTel attributes."""
     scope = scope or {}
 

--- a/sentry_sdk/integrations/atexit.py
+++ b/sentry_sdk/integrations/atexit.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import os
 import sys
 import atexit
@@ -12,15 +13,13 @@ if TYPE_CHECKING:
     from typing import Optional
 
 
-def default_callback(pending, timeout):
-    # type: (int, int) -> None
+def default_callback(pending: int, timeout: int) -> None:
     """This is the default shutdown callback that is set on the options.
     It prints out a message to stderr that informs the user that some events
     are still pending and the process is waiting for them to flush out.
     """
 
-    def echo(msg):
-        # type: (str) -> None
+    def echo(msg: str) -> None:
         sys.stderr.write(msg + "\n")
 
     echo("Sentry is attempting to send %i pending events" % pending)
@@ -32,18 +31,15 @@ def default_callback(pending, timeout):
 class AtexitIntegration(Integration):
     identifier = "atexit"
 
-    def __init__(self, callback=None):
-        # type: (Optional[Any]) -> None
+    def __init__(self, callback: Optional[Any] = None) -> None:
         if callback is None:
             callback = default_callback
         self.callback = callback
 
     @staticmethod
-    def setup_once():
-        # type: () -> None
+    def setup_once() -> None:
         @atexit.register
-        def _shutdown():
-            # type: () -> None
+        def _shutdown() -> None:
             client = sentry_sdk.get_client()
             integration = client.get_integration(AtexitIntegration)
 

--- a/sentry_sdk/integrations/aws_lambda.py
+++ b/sentry_sdk/integrations/aws_lambda.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import functools
 import json
 import re
@@ -54,11 +55,9 @@ CONTEXT_TO_ATTRIBUTES = {
 }
 
 
-def _wrap_init_error(init_error):
-    # type: (F) -> F
+def _wrap_init_error(init_error: F) -> F:
     @ensure_integration_enabled(AwsLambdaIntegration, init_error)
-    def sentry_init_error(*args, **kwargs):
-        # type: (*Any, **Any) -> Any
+    def sentry_init_error(*args: Any, **kwargs: Any) -> Any:
         client = sentry_sdk.get_client()
 
         with capture_internal_exceptions():
@@ -86,11 +85,11 @@ def _wrap_init_error(init_error):
     return sentry_init_error  # type: ignore
 
 
-def _wrap_handler(handler):
-    # type: (F) -> F
+def _wrap_handler(handler: F) -> F:
     @functools.wraps(handler)
-    def sentry_handler(aws_event, aws_context, *args, **kwargs):
-        # type: (Any, Any, *Any, **Any) -> Any
+    def sentry_handler(
+        aws_event: Any, aws_context: Any, *args: Any, **kwargs: Any
+    ) -> Any:
 
         # Per https://docs.aws.amazon.com/lambda/latest/dg/python-handler.html,
         # `event` here is *likely* a dictionary, but also might be a number of
@@ -192,8 +191,7 @@ def _wrap_handler(handler):
     return sentry_handler  # type: ignore
 
 
-def _drain_queue():
-    # type: () -> None
+def _drain_queue() -> None:
     with capture_internal_exceptions():
         client = sentry_sdk.get_client()
         integration = client.get_integration(AwsLambdaIntegration)
@@ -207,13 +205,11 @@ class AwsLambdaIntegration(Integration):
     identifier = "aws_lambda"
     origin = f"auto.function.{identifier}"
 
-    def __init__(self, timeout_warning=False):
-        # type: (bool) -> None
+    def __init__(self, timeout_warning: bool = False) -> None:
         self.timeout_warning = timeout_warning
 
     @staticmethod
-    def setup_once():
-        # type: () -> None
+    def setup_once() -> None:
 
         lambda_bootstrap = get_lambda_bootstrap()
         if not lambda_bootstrap:
@@ -249,10 +245,8 @@ class AwsLambdaIntegration(Integration):
         # Patch the runtime client to drain the queue. This should work
         # even when the SDK is initialized inside of the handler
 
-        def _wrap_post_function(f):
-            # type: (F) -> F
-            def inner(*args, **kwargs):
-                # type: (*Any, **Any) -> Any
+        def _wrap_post_function(f: F) -> F:
+            def inner(*args: Any, **kwargs: Any) -> Any:
                 _drain_queue()
                 return f(*args, **kwargs)
 
@@ -270,8 +264,7 @@ class AwsLambdaIntegration(Integration):
         )
 
 
-def get_lambda_bootstrap():
-    # type: () -> Optional[Any]
+def get_lambda_bootstrap() -> Optional[Any]:
 
     # Python 3.7: If the bootstrap module is *already imported*, it is the
     # one we actually want to use (no idea what's in __main__)
@@ -307,12 +300,14 @@ def get_lambda_bootstrap():
         return None
 
 
-def _make_request_event_processor(aws_event, aws_context, configured_timeout):
-    # type: (Any, Any, Any) -> EventProcessor
+def _make_request_event_processor(
+    aws_event: Any, aws_context: Any, configured_timeout: Any
+) -> EventProcessor:
     start_time = datetime.now(timezone.utc)
 
-    def event_processor(sentry_event, hint, start_time=start_time):
-        # type: (Event, Hint, datetime) -> Optional[Event]
+    def event_processor(
+        sentry_event: Event, hint: Hint, start_time: datetime = start_time
+    ) -> Optional[Event]:
         remaining_time_in_milis = aws_context.get_remaining_time_in_millis()
         exec_duration = configured_timeout - remaining_time_in_milis
 
@@ -375,8 +370,7 @@ def _make_request_event_processor(aws_event, aws_context, configured_timeout):
     return event_processor
 
 
-def _get_url(aws_event, aws_context):
-    # type: (Any, Any) -> str
+def _get_url(aws_event: Any, aws_context: Any) -> str:
     path = aws_event.get("path", None)
 
     headers = aws_event.get("headers")
@@ -392,8 +386,7 @@ def _get_url(aws_event, aws_context):
     return "awslambda:///{}".format(aws_context.function_name)
 
 
-def _get_cloudwatch_logs_url(aws_context, start_time):
-    # type: (Any, datetime) -> str
+def _get_cloudwatch_logs_url(aws_context: Any, start_time: datetime) -> str:
     """
     Generates a CloudWatchLogs console URL based on the context object
 
@@ -424,8 +417,7 @@ def _get_cloudwatch_logs_url(aws_context, start_time):
     return url
 
 
-def _parse_formatted_traceback(formatted_tb):
-    # type: (list[str]) -> list[dict[str, Any]]
+def _parse_formatted_traceback(formatted_tb: list[str]) -> list[dict[str, Any]]:
     frames = []
     for frame in formatted_tb:
         match = re.match(r'File "(.+)", line (\d+), in (.+)', frame.strip())
@@ -446,8 +438,7 @@ def _parse_formatted_traceback(formatted_tb):
     return frames
 
 
-def _event_from_error_json(error_json):
-    # type: (dict[str, Any]) -> Event
+def _event_from_error_json(error_json: dict[str, Any]) -> Event:
     """
     Converts the error JSON from AWS Lambda into a Sentry error event.
     This is not a full fletched event, but better than nothing.
@@ -455,7 +446,7 @@ def _event_from_error_json(error_json):
     This is an example of where AWS creates the error JSON:
     https://github.com/aws/aws-lambda-python-runtime-interface-client/blob/2.2.1/awslambdaric/bootstrap.py#L479
     """
-    event = {
+    event: Event = {
         "level": "error",
         "exception": {
             "values": [
@@ -474,13 +465,12 @@ def _event_from_error_json(error_json):
                 }
             ],
         },
-    }  # type: Event
+    }
 
     return event
 
 
-def _prepopulate_attributes(aws_event, aws_context):
-    # type: (Any, Any) -> dict[str, Any]
+def _prepopulate_attributes(aws_event: Any, aws_context: Any) -> dict[str, Any]:
     attributes = {
         "cloud.provider": "aws",
     }

--- a/sentry_sdk/integrations/beam.py
+++ b/sentry_sdk/integrations/beam.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import sys
 import types
 from functools import wraps
@@ -35,8 +36,7 @@ class BeamIntegration(Integration):
     identifier = "beam"
 
     @staticmethod
-    def setup_once():
-        # type: () -> None
+    def setup_once() -> None:
         from apache_beam.transforms.core import DoFn, ParDo  # type: ignore
 
         ignore_logger("root")
@@ -52,8 +52,7 @@ class BeamIntegration(Integration):
 
         old_init = ParDo.__init__
 
-        def sentry_init_pardo(self, fn, *args, **kwargs):
-            # type: (ParDo, Any, *Any, **Any) -> Any
+        def sentry_init_pardo(self: ParDo, fn: Any, *args: Any, **kwargs: Any) -> Any:
             # Do not monkey patch init twice
             if not getattr(self, "_sentry_is_patched", False):
                 for func_name in function_patches:
@@ -79,14 +78,12 @@ class BeamIntegration(Integration):
         ParDo.__init__ = sentry_init_pardo
 
 
-def _wrap_inspect_call(cls, func_name):
-    # type: (Any, Any) -> Any
+def _wrap_inspect_call(cls: Any, func_name: Any) -> Any:
 
     if not hasattr(cls, func_name):
         return None
 
-    def _inspect(self):
-        # type: (Any) -> Any
+    def _inspect(self: Any) -> Any:
         """
         Inspect function overrides the way Beam gets argspec.
         """
@@ -113,15 +110,13 @@ def _wrap_inspect_call(cls, func_name):
     return _inspect
 
 
-def _wrap_task_call(func):
-    # type: (F) -> F
+def _wrap_task_call(func: F) -> F:
     """
     Wrap task call with a try catch to get exceptions.
     """
 
     @wraps(func)
-    def _inner(*args, **kwargs):
-        # type: (*Any, **Any) -> Any
+    def _inner(*args: Any, **kwargs: Any) -> Any:
         try:
             gen = func(*args, **kwargs)
         except Exception:
@@ -136,8 +131,7 @@ def _wrap_task_call(func):
 
 
 @ensure_integration_enabled(BeamIntegration)
-def _capture_exception(exc_info):
-    # type: (ExcInfo) -> None
+def _capture_exception(exc_info: ExcInfo) -> None:
     """
     Send Beam exception to Sentry.
     """
@@ -151,8 +145,7 @@ def _capture_exception(exc_info):
     sentry_sdk.capture_event(event, hint=hint)
 
 
-def raise_exception():
-    # type: () -> None
+def raise_exception() -> None:
     """
     Raise an exception.
     """
@@ -162,8 +155,7 @@ def raise_exception():
     reraise(*exc_info)
 
 
-def _wrap_generator_call(gen):
-    # type: (Iterator[T]) -> Iterator[T]
+def _wrap_generator_call(gen: Iterator[T]) -> Iterator[T]:
     """
     Wrap the generator to handle any failures.
     """

--- a/sentry_sdk/integrations/boto3.py
+++ b/sentry_sdk/integrations/boto3.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from functools import partial
 
 import sentry_sdk
@@ -34,15 +35,15 @@ class Boto3Integration(Integration):
     origin = f"auto.http.{identifier}"
 
     @staticmethod
-    def setup_once():
-        # type: () -> None
+    def setup_once() -> None:
         version = parse_version(BOTOCORE_VERSION)
         _check_minimum_version(Boto3Integration, version, "botocore")
 
         orig_init = BaseClient.__init__
 
-        def sentry_patched_init(self, *args, **kwargs):
-            # type: (Type[BaseClient], *Any, **Any) -> None
+        def sentry_patched_init(
+            self: Type[BaseClient], *args: Any, **kwargs: Any
+        ) -> None:
             orig_init(self, *args, **kwargs)
             meta = self.meta
             service_id = meta.service_model.service_id.hyphenize()
@@ -57,8 +58,9 @@ class Boto3Integration(Integration):
 
 
 @ensure_integration_enabled(Boto3Integration)
-def _sentry_request_created(service_id, request, operation_name, **kwargs):
-    # type: (str, AWSRequest, str, **Any) -> None
+def _sentry_request_created(
+    service_id: str, request: AWSRequest, operation_name: str, **kwargs: Any
+) -> None:
     description = "aws.%s.%s" % (service_id, operation_name)
     span = sentry_sdk.start_span(
         op=OP.HTTP_CLIENT,
@@ -92,9 +94,10 @@ def _sentry_request_created(service_id, request, operation_name, **kwargs):
     request.context["_sentrysdk_span_data"] = data
 
 
-def _sentry_after_call(context, parsed, **kwargs):
-    # type: (Dict[str, Any], Dict[str, Any], **Any) -> None
-    span = context.pop("_sentrysdk_span", None)  # type: Optional[Span]
+def _sentry_after_call(
+    context: Dict[str, Any], parsed: Dict[str, Any], **kwargs: Any
+) -> None:
+    span: Optional[Span] = context.pop("_sentrysdk_span", None)
 
     # Span could be absent if the integration is disabled.
     if span is None:
@@ -122,8 +125,7 @@ def _sentry_after_call(context, parsed, **kwargs):
 
     orig_read = body.read
 
-    def sentry_streaming_body_read(*args, **kwargs):
-        # type: (*Any, **Any) -> bytes
+    def sentry_streaming_body_read(*args: Any, **kwargs: Any) -> bytes:
         try:
             ret = orig_read(*args, **kwargs)
             if not ret:
@@ -137,8 +139,7 @@ def _sentry_after_call(context, parsed, **kwargs):
 
     orig_close = body.close
 
-    def sentry_streaming_body_close(*args, **kwargs):
-        # type: (*Any, **Any) -> None
+    def sentry_streaming_body_close(*args: Any, **kwargs: Any) -> None:
         streaming_span.finish()
         orig_close(*args, **kwargs)
 
@@ -147,9 +148,10 @@ def _sentry_after_call(context, parsed, **kwargs):
     span.__exit__(None, None, None)
 
 
-def _sentry_after_call_error(context, exception, **kwargs):
-    # type: (Dict[str, Any], Type[BaseException], **Any) -> None
-    span = context.pop("_sentrysdk_span", None)  # type: Optional[Span]
+def _sentry_after_call_error(
+    context: Dict[str, Any], exception: Type[BaseException], **kwargs: Any
+) -> None:
+    span: Optional[Span] = context.pop("_sentrysdk_span", None)
 
     # Span could be absent if the integration is disabled.
     if span is None:

--- a/sentry_sdk/integrations/bottle.py
+++ b/sentry_sdk/integrations/bottle.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import functools
 
 import sentry_sdk
@@ -55,11 +56,10 @@ class BottleIntegration(Integration):
 
     def __init__(
         self,
-        transaction_style="endpoint",  # type: str
+        transaction_style: str = "endpoint",
         *,
-        failed_request_status_codes=_DEFAULT_FAILED_REQUEST_STATUS_CODES,  # type: Set[int]
-    ):
-        # type: (...) -> None
+        failed_request_status_codes: Set[int] = _DEFAULT_FAILED_REQUEST_STATUS_CODES,
+    ) -> None:
 
         if transaction_style not in TRANSACTION_STYLE_VALUES:
             raise ValueError(
@@ -70,16 +70,16 @@ class BottleIntegration(Integration):
         self.failed_request_status_codes = failed_request_status_codes
 
     @staticmethod
-    def setup_once():
-        # type: () -> None
+    def setup_once() -> None:
         version = parse_version(BOTTLE_VERSION)
         _check_minimum_version(BottleIntegration, version)
 
         old_app = Bottle.__call__
 
         @ensure_integration_enabled(BottleIntegration, old_app)
-        def sentry_patched_wsgi_app(self, environ, start_response):
-            # type: (Any, Dict[str, str], Callable[..., Any]) -> _ScopedResponse
+        def sentry_patched_wsgi_app(
+            self: Any, environ: Dict[str, str], start_response: Callable[..., Any]
+        ) -> _ScopedResponse:
             middleware = SentryWsgiMiddleware(
                 lambda *a, **kw: old_app(self, *a, **kw),
                 span_origin=BottleIntegration.origin,
@@ -92,8 +92,7 @@ class BottleIntegration(Integration):
         old_handle = Bottle._handle
 
         @functools.wraps(old_handle)
-        def _patched_handle(self, environ):
-            # type: (Bottle, Dict[str, Any]) -> Any
+        def _patched_handle(self: Bottle, environ: Dict[str, Any]) -> Any:
             integration = sentry_sdk.get_client().get_integration(BottleIntegration)
             if integration is None:
                 return old_handle(self, environ)
@@ -112,16 +111,14 @@ class BottleIntegration(Integration):
         old_make_callback = Route._make_callback
 
         @functools.wraps(old_make_callback)
-        def patched_make_callback(self, *args, **kwargs):
-            # type: (Route, *object, **object) -> Any
+        def patched_make_callback(self: Route, *args: object, **kwargs: object) -> Any:
             prepared_callback = old_make_callback(self, *args, **kwargs)
 
             integration = sentry_sdk.get_client().get_integration(BottleIntegration)
             if integration is None:
                 return prepared_callback
 
-            def wrapped_callback(*args, **kwargs):
-                # type: (*object, **object) -> Any
+            def wrapped_callback(*args: object, **kwargs: object) -> Any:
                 try:
                     res = prepared_callback(*args, **kwargs)
                 except Exception as exception:
@@ -142,38 +139,33 @@ class BottleIntegration(Integration):
 
 
 class BottleRequestExtractor(RequestExtractor):
-    def env(self):
-        # type: () -> Dict[str, str]
+    def env(self) -> Dict[str, str]:
         return self.request.environ
 
-    def cookies(self):
-        # type: () -> Dict[str, str]
+    def cookies(self) -> Dict[str, str]:
         return self.request.cookies
 
-    def raw_data(self):
-        # type: () -> bytes
+    def raw_data(self) -> bytes:
         return self.request.body.read()
 
-    def form(self):
-        # type: () -> FormsDict
+    def form(self) -> FormsDict:
         if self.is_json():
             return None
         return self.request.forms.decode()
 
-    def files(self):
-        # type: () -> Optional[Dict[str, str]]
+    def files(self) -> Optional[Dict[str, str]]:
         if self.is_json():
             return None
 
         return self.request.files
 
-    def size_of_file(self, file):
-        # type: (FileUpload) -> int
+    def size_of_file(self, file: FileUpload) -> int:
         return file.content_length
 
 
-def _set_transaction_name_and_source(event, transaction_style, request):
-    # type: (Event, str, Any) -> None
+def _set_transaction_name_and_source(
+    event: Event, transaction_style: str, request: Any
+) -> None:
     name = ""
 
     if transaction_style == "url":
@@ -196,11 +188,11 @@ def _set_transaction_name_and_source(event, transaction_style, request):
     event["transaction_info"] = {"source": SOURCE_FOR_STYLE[transaction_style]}
 
 
-def _make_request_event_processor(app, request, integration):
-    # type: (Bottle, LocalRequest, BottleIntegration) -> EventProcessor
+def _make_request_event_processor(
+    app: Bottle, request: LocalRequest, integration: BottleIntegration
+) -> EventProcessor:
 
-    def event_processor(event, hint):
-        # type: (Event, dict[str, Any]) -> Event
+    def event_processor(event: Event, hint: dict[str, Any]) -> Event:
         _set_transaction_name_and_source(event, integration.transaction_style, request)
 
         with capture_internal_exceptions():
@@ -211,8 +203,7 @@ def _make_request_event_processor(app, request, integration):
     return event_processor
 
 
-def _capture_exception(exception, handled):
-    # type: (BaseException, bool) -> None
+def _capture_exception(exception: BaseException, handled: bool) -> None:
     event, hint = event_from_exception(
         exception,
         client_options=sentry_sdk.get_client().options,

--- a/sentry_sdk/integrations/celery/__init__.py
+++ b/sentry_sdk/integrations/celery/__init__.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import sys
 from collections.abc import Mapping
 from functools import wraps
@@ -62,11 +63,10 @@ class CeleryIntegration(Integration):
 
     def __init__(
         self,
-        propagate_traces=True,
-        monitor_beat_tasks=False,
-        exclude_beat_tasks=None,
-    ):
-        # type: (bool, bool, Optional[List[str]]) -> None
+        propagate_traces: bool = True,
+        monitor_beat_tasks: bool = False,
+        exclude_beat_tasks: Optional[List[str]] = None,
+    ) -> None:
         self.propagate_traces = propagate_traces
         self.monitor_beat_tasks = monitor_beat_tasks
         self.exclude_beat_tasks = exclude_beat_tasks
@@ -76,8 +76,7 @@ class CeleryIntegration(Integration):
         _setup_celery_beat_signals(monitor_beat_tasks)
 
     @staticmethod
-    def setup_once():
-        # type: () -> None
+    def setup_once() -> None:
         _check_minimum_version(CeleryIntegration, CELERY_VERSION)
 
         _patch_build_tracer()
@@ -97,16 +96,14 @@ class CeleryIntegration(Integration):
         ignore_logger("celery.redirected")
 
 
-def _set_status(status):
-    # type: (str) -> None
+def _set_status(status: str) -> None:
     with capture_internal_exceptions():
         span = sentry_sdk.get_current_span()
         if span is not None:
             span.set_status(status)
 
 
-def _capture_exception(task, exc_info):
-    # type: (Any, ExcInfo) -> None
+def _capture_exception(task: Any, exc_info: ExcInfo) -> None:
     client = sentry_sdk.get_client()
     if client.get_integration(CeleryIntegration) is None:
         return
@@ -129,10 +126,10 @@ def _capture_exception(task, exc_info):
     sentry_sdk.capture_event(event, hint=hint)
 
 
-def _make_event_processor(task, uuid, args, kwargs, request=None):
-    # type: (Any, Any, Any, Any, Optional[Any]) -> EventProcessor
-    def event_processor(event, hint):
-        # type: (Event, Hint) -> Optional[Event]
+def _make_event_processor(
+    task: Any, uuid: Any, args: Any, kwargs: Any, request: Optional[Any] = None
+) -> EventProcessor:
+    def event_processor(event: Event, hint: Hint) -> Optional[Event]:
 
         with capture_internal_exceptions():
             tags = event.setdefault("tags", {})
@@ -158,8 +155,9 @@ def _make_event_processor(task, uuid, args, kwargs, request=None):
     return event_processor
 
 
-def _update_celery_task_headers(original_headers, span, monitor_beat_tasks):
-    # type: (dict[str, Any], Optional[Span], bool) -> dict[str, Any]
+def _update_celery_task_headers(
+    original_headers: dict[str, Any], span: Optional[Span], monitor_beat_tasks: bool
+) -> dict[str, Any]:
     """
     Updates the headers of the Celery task with the tracing information
     and eventually Sentry Crons monitoring information for beat tasks.
@@ -233,20 +231,16 @@ def _update_celery_task_headers(original_headers, span, monitor_beat_tasks):
 
 
 class NoOpMgr:
-    def __enter__(self):
-        # type: () -> None
+    def __enter__(self) -> None:
         return None
 
-    def __exit__(self, exc_type, exc_value, traceback):
-        # type: (Any, Any, Any) -> None
+    def __exit__(self, exc_type: Any, exc_value: Any, traceback: Any) -> None:
         return None
 
 
-def _wrap_task_run(f):
-    # type: (F) -> F
+def _wrap_task_run(f: F) -> F:
     @wraps(f)
-    def apply_async(*args, **kwargs):
-        # type: (*Any, **Any) -> Any
+    def apply_async(*args: Any, **kwargs: Any) -> Any:
         # Note: kwargs can contain headers=None, so no setdefault!
         # Unsure which backend though.
         integration = sentry_sdk.get_client().get_integration(CeleryIntegration)
@@ -262,7 +256,7 @@ def _wrap_task_run(f):
             return f(*args, **kwargs)
 
         if isinstance(args[0], Task):
-            task_name = args[0].name  # type: str
+            task_name: str = args[0].name
         elif len(args) > 1 and isinstance(args[1], str):
             task_name = args[1]
         else:
@@ -270,7 +264,7 @@ def _wrap_task_run(f):
 
         task_started_from_beat = sentry_sdk.get_isolation_scope()._name == "celery-beat"
 
-        span_mgr = (
+        span_mgr: Union[Span, NoOpMgr] = (
             sentry_sdk.start_span(
                 op=OP.QUEUE_SUBMIT_CELERY,
                 name=task_name,
@@ -279,7 +273,7 @@ def _wrap_task_run(f):
             )
             if not task_started_from_beat
             else NoOpMgr()
-        )  # type: Union[Span, NoOpMgr]
+        )
 
         with span_mgr as span:
             kwargs["headers"] = _update_celery_task_headers(
@@ -290,8 +284,7 @@ def _wrap_task_run(f):
     return apply_async  # type: ignore
 
 
-def _wrap_tracer(task, f):
-    # type: (Any, F) -> F
+def _wrap_tracer(task: Any, f: F) -> F:
 
     # Need to wrap tracer for pushing the scope before prerun is sent, and
     # popping it after postrun is sent.
@@ -301,8 +294,7 @@ def _wrap_tracer(task, f):
     # crashes.
     @wraps(f)
     @ensure_integration_enabled(CeleryIntegration, f)
-    def _inner(*args, **kwargs):
-        # type: (*Any, **Any) -> Any
+    def _inner(*args: Any, **kwargs: Any) -> Any:
         with isolation_scope() as scope:
             scope._name = "celery"
             scope.clear_breadcrumbs()
@@ -333,8 +325,7 @@ def _wrap_tracer(task, f):
     return _inner  # type: ignore
 
 
-def _set_messaging_destination_name(task, span):
-    # type: (Any, Span) -> None
+def _set_messaging_destination_name(task: Any, span: Span) -> None:
     """Set "messaging.destination.name" tag for span"""
     with capture_internal_exceptions():
         delivery_info = task.request.delivery_info
@@ -346,8 +337,7 @@ def _set_messaging_destination_name(task, span):
                 span.set_attribute(SPANDATA.MESSAGING_DESTINATION_NAME, routing_key)
 
 
-def _wrap_task_call(task, f):
-    # type: (Any, F) -> F
+def _wrap_task_call(task: Any, f: F) -> F:
 
     # Need to wrap task call because the exception is caught before we get to
     # see it. Also celery's reported stacktrace is untrustworthy.
@@ -358,8 +348,7 @@ def _wrap_task_call(task, f):
     # to add @functools.wraps(f) here.
     # https://github.com/getsentry/sentry-python/issues/421
     @ensure_integration_enabled(CeleryIntegration, f)
-    def _inner(*args, **kwargs):
-        # type: (*Any, **Any) -> Any
+    def _inner(*args: Any, **kwargs: Any) -> Any:
         try:
             with sentry_sdk.start_span(
                 op=OP.QUEUE_PROCESS,
@@ -409,14 +398,12 @@ def _wrap_task_call(task, f):
     return _inner  # type: ignore
 
 
-def _patch_build_tracer():
-    # type: () -> None
+def _patch_build_tracer() -> None:
     import celery.app.trace as trace  # type: ignore
 
     original_build_tracer = trace.build_tracer
 
-    def sentry_build_tracer(name, task, *args, **kwargs):
-        # type: (Any, Any, *Any, **Any) -> Any
+    def sentry_build_tracer(name: Any, task: Any, *args: Any, **kwargs: Any) -> Any:
         if not getattr(task, "_sentry_is_patched", False):
             # determine whether Celery will use __call__ or run and patch
             # accordingly
@@ -435,20 +422,17 @@ def _patch_build_tracer():
     trace.build_tracer = sentry_build_tracer
 
 
-def _patch_task_apply_async():
-    # type: () -> None
+def _patch_task_apply_async() -> None:
     Task.apply_async = _wrap_task_run(Task.apply_async)
 
 
-def _patch_celery_send_task():
-    # type: () -> None
+def _patch_celery_send_task() -> None:
     from celery import Celery
 
     Celery.send_task = _wrap_task_run(Celery.send_task)
 
 
-def _patch_worker_exit():
-    # type: () -> None
+def _patch_worker_exit() -> None:
 
     # Need to flush queue before worker shutdown because a crashing worker will
     # call os._exit
@@ -456,8 +440,7 @@ def _patch_worker_exit():
 
     original_workloop = Worker.workloop
 
-    def sentry_workloop(*args, **kwargs):
-        # type: (*Any, **Any) -> Any
+    def sentry_workloop(*args: Any, **kwargs: Any) -> Any:
         try:
             return original_workloop(*args, **kwargs)
         finally:
@@ -471,13 +454,11 @@ def _patch_worker_exit():
     Worker.workloop = sentry_workloop
 
 
-def _patch_producer_publish():
-    # type: () -> None
+def _patch_producer_publish() -> None:
     original_publish = Producer.publish
 
     @ensure_integration_enabled(CeleryIntegration, original_publish)
-    def sentry_publish(self, *args, **kwargs):
-        # type: (Producer, *Any, **Any) -> Any
+    def sentry_publish(self: Producer, *args: Any, **kwargs: Any) -> Any:
         kwargs_headers = kwargs.get("headers", {})
         if not isinstance(kwargs_headers, Mapping):
             # Ensure kwargs_headers is a Mapping, so we can safely call get().
@@ -521,8 +502,7 @@ def _patch_producer_publish():
     Producer.publish = sentry_publish
 
 
-def _prepopulate_attributes(task, args, kwargs):
-    # type: (Any, *Any, **Any) -> dict[str, str]
+def _prepopulate_attributes(task: Any, args: Any, kwargs: Any) -> dict[str, str]:
     attributes = {
         "celery.job.task": task.name,
     }

--- a/sentry_sdk/integrations/celery/beat.py
+++ b/sentry_sdk/integrations/celery/beat.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import sentry_sdk
 from sentry_sdk.crons import capture_checkin, MonitorStatus
 from sentry_sdk.integrations import DidNotEnable
@@ -42,8 +43,7 @@ except ImportError:
     RedBeatScheduler = None
 
 
-def _get_headers(task):
-    # type: (Task) -> dict[str, Any]
+def _get_headers(task: Task) -> dict[str, Any]:
     headers = task.request.get("headers") or {}
 
     # flatten nested headers
@@ -56,12 +56,13 @@ def _get_headers(task):
     return headers
 
 
-def _get_monitor_config(celery_schedule, app, monitor_name):
-    # type: (Any, Celery, str) -> MonitorConfig
-    monitor_config = {}  # type: MonitorConfig
-    schedule_type = None  # type: Optional[MonitorConfigScheduleType]
-    schedule_value = None  # type: Optional[Union[str, int]]
-    schedule_unit = None  # type: Optional[MonitorConfigScheduleUnit]
+def _get_monitor_config(
+    celery_schedule: Any, app: Celery, monitor_name: str
+) -> MonitorConfig:
+    monitor_config: MonitorConfig = {}
+    schedule_type: Optional[MonitorConfigScheduleType] = None
+    schedule_value: Optional[Union[str, int]] = None
+    schedule_unit: Optional[MonitorConfigScheduleUnit] = None
 
     if isinstance(celery_schedule, crontab):
         schedule_type = "crontab"
@@ -113,8 +114,11 @@ def _get_monitor_config(celery_schedule, app, monitor_name):
     return monitor_config
 
 
-def _apply_crons_data_to_schedule_entry(scheduler, schedule_entry, integration):
-    # type: (Any, Any, sentry_sdk.integrations.celery.CeleryIntegration) -> None
+def _apply_crons_data_to_schedule_entry(
+    scheduler: Any,
+    schedule_entry: Any,
+    integration: sentry_sdk.integrations.celery.CeleryIntegration,
+) -> None:
     """
     Add Sentry Crons information to the schedule_entry headers.
     """
@@ -158,8 +162,7 @@ def _apply_crons_data_to_schedule_entry(scheduler, schedule_entry, integration):
     schedule_entry.options["headers"] = headers
 
 
-def _wrap_beat_scheduler(original_function):
-    # type: (Callable[..., Any]) -> Callable[..., Any]
+def _wrap_beat_scheduler(original_function: Callable[..., Any]) -> Callable[..., Any]:
     """
     Makes sure that:
     - a new Sentry trace is started for each task started by Celery Beat and
@@ -178,8 +181,7 @@ def _wrap_beat_scheduler(original_function):
 
     from sentry_sdk.integrations.celery import CeleryIntegration
 
-    def sentry_patched_scheduler(*args, **kwargs):
-        # type: (*Any, **Any) -> None
+    def sentry_patched_scheduler(*args: Any, **kwargs: Any) -> None:
         integration = sentry_sdk.get_client().get_integration(CeleryIntegration)
         if integration is None:
             return original_function(*args, **kwargs)
@@ -197,29 +199,25 @@ def _wrap_beat_scheduler(original_function):
     return sentry_patched_scheduler
 
 
-def _patch_beat_apply_entry():
-    # type: () -> None
+def _patch_beat_apply_entry() -> None:
     Scheduler.apply_entry = _wrap_beat_scheduler(Scheduler.apply_entry)
 
 
-def _patch_redbeat_apply_async():
-    # type: () -> None
+def _patch_redbeat_apply_async() -> None:
     if RedBeatScheduler is None:
         return
 
     RedBeatScheduler.apply_async = _wrap_beat_scheduler(RedBeatScheduler.apply_async)
 
 
-def _setup_celery_beat_signals(monitor_beat_tasks):
-    # type: (bool) -> None
+def _setup_celery_beat_signals(monitor_beat_tasks: bool) -> None:
     if monitor_beat_tasks:
         task_success.connect(crons_task_success)
         task_failure.connect(crons_task_failure)
         task_retry.connect(crons_task_retry)
 
 
-def crons_task_success(sender, **kwargs):
-    # type: (Task, dict[Any, Any]) -> None
+def crons_task_success(sender: Task, **kwargs: dict[Any, Any]) -> None:
     logger.debug("celery_task_success %s", sender)
     headers = _get_headers(sender)
 
@@ -243,8 +241,7 @@ def crons_task_success(sender, **kwargs):
     )
 
 
-def crons_task_failure(sender, **kwargs):
-    # type: (Task, dict[Any, Any]) -> None
+def crons_task_failure(sender: Task, **kwargs: dict[Any, Any]) -> None:
     logger.debug("celery_task_failure %s", sender)
     headers = _get_headers(sender)
 
@@ -268,8 +265,7 @@ def crons_task_failure(sender, **kwargs):
     )
 
 
-def crons_task_retry(sender, **kwargs):
-    # type: (Task, dict[Any, Any]) -> None
+def crons_task_retry(sender: Task, **kwargs: dict[Any, Any]) -> None:
     logger.debug("celery_task_retry %s", sender)
     headers = _get_headers(sender)
 

--- a/sentry_sdk/integrations/celery/utils.py
+++ b/sentry_sdk/integrations/celery/utils.py
@@ -1,13 +1,20 @@
+from __future__ import annotations
 import time
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from typing import Any, Tuple
+    from typing import Any, Tuple, List
     from sentry_sdk._types import MonitorConfigScheduleUnit
 
 
-def _now_seconds_since_epoch():
-    # type: () -> float
+TIME_UNITS: List[Tuple[MonitorConfigScheduleUnit, float]] = [
+    ("day", 60 * 60 * 24.0),
+    ("hour", 60 * 60.0),
+    ("minute", 60.0),
+]
+
+
+def _now_seconds_since_epoch() -> float:
     # We cannot use `time.perf_counter()` when dealing with the duration
     # of a Celery task, because the start of a Celery task and
     # the end are recorded in different processes.
@@ -16,28 +23,19 @@ def _now_seconds_since_epoch():
     return time.time()
 
 
-def _get_humanized_interval(seconds):
-    # type: (float) -> Tuple[int, MonitorConfigScheduleUnit]
-    TIME_UNITS = (  # noqa: N806
-        ("day", 60 * 60 * 24.0),
-        ("hour", 60 * 60.0),
-        ("minute", 60.0),
-    )
-
+def _get_humanized_interval(seconds: float) -> Tuple[int, MonitorConfigScheduleUnit]:
     seconds = float(seconds)
     for unit, divider in TIME_UNITS:
         if seconds >= divider:
             interval = int(seconds / divider)
-            return (interval, cast("MonitorConfigScheduleUnit", unit))
+            return (interval, unit)
 
     return (int(seconds), "second")
 
 
 class NoOpMgr:
-    def __enter__(self):
-        # type: () -> None
+    def __enter__(self) -> None:
         return None
 
-    def __exit__(self, exc_type, exc_value, traceback):
-        # type: (Any, Any, Any) -> None
+    def __exit__(self, exc_type: Any, exc_value: Any, traceback: Any) -> None:
         return None

--- a/sentry_sdk/integrations/chalice.py
+++ b/sentry_sdk/integrations/chalice.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import sys
 from functools import wraps
 
@@ -32,8 +33,7 @@ if TYPE_CHECKING:
 
 
 class EventSourceHandler(ChaliceEventSourceHandler):  # type: ignore
-    def __call__(self, event, context):
-        # type: (Any, Any) -> Any
+    def __call__(self, event: Any, context: Any) -> Any:
         client = sentry_sdk.get_client()
 
         with sentry_sdk.isolation_scope() as scope:
@@ -56,11 +56,9 @@ class EventSourceHandler(ChaliceEventSourceHandler):  # type: ignore
                 reraise(*exc_info)
 
 
-def _get_view_function_response(app, view_function, function_args):
-    # type: (Any, F, Any) -> F
+def _get_view_function_response(app: Any, view_function: F, function_args: Any) -> F:
     @wraps(view_function)
-    def wrapped_view_function(**function_args):
-        # type: (**Any) -> Any
+    def wrapped_view_function(**function_args: Any) -> Any:
         client = sentry_sdk.get_client()
         with sentry_sdk.isolation_scope() as scope:
             with capture_internal_exceptions():
@@ -99,8 +97,7 @@ class ChaliceIntegration(Integration):
     identifier = "chalice"
 
     @staticmethod
-    def setup_once():
-        # type: () -> None
+    def setup_once() -> None:
 
         version = parse_version(CHALICE_VERSION)
 
@@ -116,8 +113,9 @@ class ChaliceIntegration(Integration):
                 RestAPIEventHandler._get_view_function_response
             )
 
-        def sentry_event_response(app, view_function, function_args):
-            # type: (Any, F, Dict[str, Any]) -> Any
+        def sentry_event_response(
+            app: Any, view_function: F, function_args: Dict[str, Any]
+        ) -> Any:
             wrapped_view_function = _get_view_function_response(
                 app, view_function, function_args
             )

--- a/sentry_sdk/integrations/cloud_resource_context.py
+++ b/sentry_sdk/integrations/cloud_resource_context.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import json
 import urllib3
 
@@ -65,13 +66,11 @@ class CloudResourceContextIntegration(Integration):
 
     gcp_metadata = None
 
-    def __init__(self, cloud_provider=""):
-        # type: (str) -> None
+    def __init__(self, cloud_provider: str = "") -> None:
         CloudResourceContextIntegration.cloud_provider = cloud_provider
 
     @classmethod
-    def _is_aws(cls):
-        # type: () -> bool
+    def _is_aws(cls) -> bool:
         try:
             r = cls.http.request(
                 "PUT",
@@ -95,8 +94,7 @@ class CloudResourceContextIntegration(Integration):
             return False
 
     @classmethod
-    def _get_aws_context(cls):
-        # type: () -> Dict[str, str]
+    def _get_aws_context(cls) -> Dict[str, str]:
         ctx = {
             "cloud.provider": CLOUD_PROVIDER.AWS,
             "cloud.platform": CLOUD_PLATFORM.AWS_EC2,
@@ -149,8 +147,7 @@ class CloudResourceContextIntegration(Integration):
         return ctx
 
     @classmethod
-    def _is_gcp(cls):
-        # type: () -> bool
+    def _is_gcp(cls) -> bool:
         try:
             r = cls.http.request(
                 "GET",
@@ -174,8 +171,7 @@ class CloudResourceContextIntegration(Integration):
             return False
 
     @classmethod
-    def _get_gcp_context(cls):
-        # type: () -> Dict[str, str]
+    def _get_gcp_context(cls) -> Dict[str, str]:
         ctx = {
             "cloud.provider": CLOUD_PROVIDER.GCP,
             "cloud.platform": CLOUD_PLATFORM.GCP_COMPUTE_ENGINE,
@@ -229,8 +225,7 @@ class CloudResourceContextIntegration(Integration):
         return ctx
 
     @classmethod
-    def _get_cloud_provider(cls):
-        # type: () -> str
+    def _get_cloud_provider(cls) -> str:
         if cls._is_aws():
             return CLOUD_PROVIDER.AWS
 
@@ -240,8 +235,7 @@ class CloudResourceContextIntegration(Integration):
         return ""
 
     @classmethod
-    def _get_cloud_resource_context(cls):
-        # type: () -> Dict[str, str]
+    def _get_cloud_resource_context(cls) -> Dict[str, str]:
         cloud_provider = (
             cls.cloud_provider
             if cls.cloud_provider != ""
@@ -253,8 +247,7 @@ class CloudResourceContextIntegration(Integration):
         return {}
 
     @staticmethod
-    def setup_once():
-        # type: () -> None
+    def setup_once() -> None:
         cloud_provider = CloudResourceContextIntegration.cloud_provider
         unsupported_cloud_provider = (
             cloud_provider != "" and cloud_provider not in context_getters.keys()

--- a/sentry_sdk/integrations/dedupe.py
+++ b/sentry_sdk/integrations/dedupe.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import sentry_sdk
 from sentry_sdk.utils import ContextVar
 from sentry_sdk.integrations import Integration
@@ -14,16 +15,13 @@ if TYPE_CHECKING:
 class DedupeIntegration(Integration):
     identifier = "dedupe"
 
-    def __init__(self):
-        # type: () -> None
+    def __init__(self) -> None:
         self._last_seen = ContextVar("last-seen")
 
     @staticmethod
-    def setup_once():
-        # type: () -> None
+    def setup_once() -> None:
         @add_global_event_processor
-        def processor(event, hint):
-            # type: (Event, Optional[Hint]) -> Optional[Event]
+        def processor(event: Event, hint: Optional[Hint]) -> Optional[Event]:
             if hint is None:
                 return event
 
@@ -42,8 +40,7 @@ class DedupeIntegration(Integration):
             return event
 
     @staticmethod
-    def reset_last_seen():
-        # type: () -> None
+    def reset_last_seen() -> None:
         integration = sentry_sdk.get_client().get_integration(DedupeIntegration)
         if integration is None:
             return

--- a/sentry_sdk/integrations/django/__init__.py
+++ b/sentry_sdk/integrations/django/__init__.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import functools
 import inspect
 import sys
@@ -107,18 +108,17 @@ class DjangoIntegration(Integration):
     middleware_spans = None
     signals_spans = None
     cache_spans = None
-    signals_denylist = []  # type: list[signals.Signal]
+    signals_denylist: list[signals.Signal] = []
 
     def __init__(
         self,
-        transaction_style="url",  # type: str
-        middleware_spans=True,  # type: bool
-        signals_spans=True,  # type: bool
-        cache_spans=True,  # type: bool
-        signals_denylist=None,  # type: Optional[list[signals.Signal]]
-        http_methods_to_capture=DEFAULT_HTTP_METHODS_TO_CAPTURE,  # type: tuple[str, ...]
-    ):
-        # type: (...) -> None
+        transaction_style: str = "url",
+        middleware_spans: bool = True,
+        signals_spans: bool = True,
+        cache_spans: bool = True,
+        signals_denylist: Optional[list[signals.Signal]] = None,
+        http_methods_to_capture: tuple[str, ...] = DEFAULT_HTTP_METHODS_TO_CAPTURE,
+    ) -> None:
         if transaction_style not in TRANSACTION_STYLE_VALUES:
             raise ValueError(
                 "Invalid value for transaction_style: %s (must be in %s)"
@@ -135,8 +135,7 @@ class DjangoIntegration(Integration):
         self.http_methods_to_capture = tuple(map(str.upper, http_methods_to_capture))
 
     @staticmethod
-    def setup_once():
-        # type: () -> None
+    def setup_once() -> None:
         _check_minimum_version(DjangoIntegration, DJANGO_VERSION)
 
         install_sql_hook()
@@ -151,8 +150,9 @@ class DjangoIntegration(Integration):
         old_app = WSGIHandler.__call__
 
         @ensure_integration_enabled(DjangoIntegration, old_app)
-        def sentry_patched_wsgi_handler(self, environ, start_response):
-            # type: (Any, Dict[str, str], Callable[..., Any]) -> _ScopedResponse
+        def sentry_patched_wsgi_handler(
+            self: Any, environ: Dict[str, str], start_response: Callable[..., Any]
+        ) -> _ScopedResponse:
             bound_old_app = old_app.__get__(self, WSGIHandler)
 
             from django.conf import settings
@@ -182,8 +182,9 @@ class DjangoIntegration(Integration):
         signals.got_request_exception.connect(_got_request_exception)
 
         @add_global_event_processor
-        def process_django_templates(event, hint):
-            # type: (Event, Optional[Hint]) -> Optional[Event]
+        def process_django_templates(
+            event: Event, hint: Optional[Hint]
+        ) -> Optional[Event]:
             if hint is None:
                 return event
 
@@ -225,8 +226,9 @@ class DjangoIntegration(Integration):
             return event
 
         @add_global_repr_processor
-        def _django_queryset_repr(value, hint):
-            # type: (Any, Dict[str, Any]) -> Union[NotImplementedType, str]
+        def _django_queryset_repr(
+            value: Any, hint: Dict[str, Any]
+        ) -> Union[NotImplementedType, str]:
             try:
                 # Django 1.6 can fail to import `QuerySet` when Django settings
                 # have not yet been initialized.
@@ -261,8 +263,7 @@ _DRF_PATCHED = False
 _DRF_PATCH_LOCK = threading.Lock()
 
 
-def _patch_drf():
-    # type: () -> None
+def _patch_drf() -> None:
     """
     Patch Django Rest Framework for more/better request data. DRF's request
     type is a wrapper around Django's request type. The attribute we're
@@ -305,8 +306,9 @@ def _patch_drf():
                 old_drf_initial = APIView.initial
 
                 @functools.wraps(old_drf_initial)
-                def sentry_patched_drf_initial(self, request, *args, **kwargs):
-                    # type: (APIView, Any, *Any, **Any) -> Any
+                def sentry_patched_drf_initial(
+                    self: APIView, request: Any, *args: Any, **kwargs: Any
+                ) -> Any:
                     with capture_internal_exceptions():
                         request._request._sentry_drf_request_backref = weakref.ref(
                             request
@@ -317,8 +319,7 @@ def _patch_drf():
                 APIView.initial = sentry_patched_drf_initial
 
 
-def _patch_channels():
-    # type: () -> None
+def _patch_channels() -> None:
     try:
         from channels.http import AsgiHandler  # type: ignore
     except ImportError:
@@ -342,8 +343,7 @@ def _patch_channels():
     patch_channels_asgi_handler_impl(AsgiHandler)
 
 
-def _patch_django_asgi_handler():
-    # type: () -> None
+def _patch_django_asgi_handler() -> None:
     try:
         from django.core.handlers.asgi import ASGIHandler
     except ImportError:
@@ -364,8 +364,9 @@ def _patch_django_asgi_handler():
     patch_django_asgi_handler_impl(ASGIHandler)
 
 
-def _set_transaction_name_and_source(scope, transaction_style, request):
-    # type: (sentry_sdk.Scope, str, WSGIRequest) -> None
+def _set_transaction_name_and_source(
+    scope: sentry_sdk.Scope, transaction_style: str, request: WSGIRequest
+) -> None:
     try:
         transaction_name = None
         if transaction_style == "function_name":
@@ -408,8 +409,7 @@ def _set_transaction_name_and_source(scope, transaction_style, request):
         pass
 
 
-def _before_get_response(request):
-    # type: (WSGIRequest) -> None
+def _before_get_response(request: WSGIRequest) -> None:
     integration = sentry_sdk.get_client().get_integration(DjangoIntegration)
     if integration is None:
         return
@@ -425,8 +425,9 @@ def _before_get_response(request):
     )
 
 
-def _attempt_resolve_again(request, scope, transaction_style):
-    # type: (WSGIRequest, sentry_sdk.Scope, str) -> None
+def _attempt_resolve_again(
+    request: WSGIRequest, scope: sentry_sdk.Scope, transaction_style: str
+) -> None:
     """
     Some django middlewares overwrite request.urlconf
     so we need to respect that contract,
@@ -438,8 +439,7 @@ def _attempt_resolve_again(request, scope, transaction_style):
     _set_transaction_name_and_source(scope, transaction_style, request)
 
 
-def _after_get_response(request):
-    # type: (WSGIRequest) -> None
+def _after_get_response(request: WSGIRequest) -> None:
     integration = sentry_sdk.get_client().get_integration(DjangoIntegration)
     if integration is None or integration.transaction_style != "url":
         return
@@ -448,8 +448,7 @@ def _after_get_response(request):
     _attempt_resolve_again(request, scope, integration.transaction_style)
 
 
-def _patch_get_response():
-    # type: () -> None
+def _patch_get_response() -> None:
     """
     patch get_response, because at that point we have the Django request object
     """
@@ -458,8 +457,9 @@ def _patch_get_response():
     old_get_response = BaseHandler.get_response
 
     @functools.wraps(old_get_response)
-    def sentry_patched_get_response(self, request):
-        # type: (Any, WSGIRequest) -> Union[HttpResponse, BaseException]
+    def sentry_patched_get_response(
+        self: Any, request: WSGIRequest
+    ) -> Union[HttpResponse, BaseException]:
         _before_get_response(request)
         rv = old_get_response(self, request)
         _after_get_response(request)
@@ -473,10 +473,10 @@ def _patch_get_response():
         patch_get_response_async(BaseHandler, _before_get_response)
 
 
-def _make_wsgi_request_event_processor(weak_request, integration):
-    # type: (Callable[[], WSGIRequest], DjangoIntegration) -> EventProcessor
-    def wsgi_request_event_processor(event, hint):
-        # type: (Event, dict[str, Any]) -> Event
+def _make_wsgi_request_event_processor(
+    weak_request: Callable[[], WSGIRequest], integration: DjangoIntegration
+) -> EventProcessor:
+    def wsgi_request_event_processor(event: Event, hint: dict[str, Any]) -> Event:
         # if the request is gone we are fine not logging the data from
         # it.  This might happen if the processor is pushed away to
         # another thread.
@@ -501,8 +501,7 @@ def _make_wsgi_request_event_processor(weak_request, integration):
     return wsgi_request_event_processor
 
 
-def _got_request_exception(request=None, **kwargs):
-    # type: (WSGIRequest, **Any) -> None
+def _got_request_exception(request: WSGIRequest = None, **kwargs: Any) -> None:
     client = sentry_sdk.get_client()
     integration = client.get_integration(DjangoIntegration)
     if integration is None:
@@ -521,8 +520,7 @@ def _got_request_exception(request=None, **kwargs):
 
 
 class DjangoRequestExtractor(RequestExtractor):
-    def __init__(self, request):
-        # type: (Union[WSGIRequest, ASGIRequest]) -> None
+    def __init__(self, request: Union[WSGIRequest, ASGIRequest]) -> None:
         try:
             drf_request = request._sentry_drf_request_backref()
             if drf_request is not None:
@@ -531,18 +529,16 @@ class DjangoRequestExtractor(RequestExtractor):
             pass
         self.request = request
 
-    def env(self):
-        # type: () -> Dict[str, str]
+    def env(self) -> Dict[str, str]:
         return self.request.META
 
-    def cookies(self):
-        # type: () -> Dict[str, Union[str, AnnotatedValue]]
+    def cookies(self) -> Dict[str, Union[str, AnnotatedValue]]:
         privacy_cookies = [
             django_settings.CSRF_COOKIE_NAME,
             django_settings.SESSION_COOKIE_NAME,
         ]
 
-        clean_cookies = {}  # type: Dict[str, Union[str, AnnotatedValue]]
+        clean_cookies: Dict[str, Union[str, AnnotatedValue]] = {}
         for key, val in self.request.COOKIES.items():
             if key in privacy_cookies:
                 clean_cookies[key] = SENSITIVE_DATA_SUBSTITUTE
@@ -551,32 +547,26 @@ class DjangoRequestExtractor(RequestExtractor):
 
         return clean_cookies
 
-    def raw_data(self):
-        # type: () -> bytes
+    def raw_data(self) -> bytes:
         return self.request.body
 
-    def form(self):
-        # type: () -> QueryDict
+    def form(self) -> QueryDict:
         return self.request.POST
 
-    def files(self):
-        # type: () -> MultiValueDict
+    def files(self) -> MultiValueDict:
         return self.request.FILES
 
-    def size_of_file(self, file):
-        # type: (Any) -> int
+    def size_of_file(self, file: Any) -> int:
         return file.size
 
-    def parsed_body(self):
-        # type: () -> Optional[Dict[str, Any]]
+    def parsed_body(self) -> Optional[Dict[str, Any]]:
         try:
             return self.request.data
         except Exception:
             return RequestExtractor.parsed_body(self)
 
 
-def _set_user_info(request, event):
-    # type: (WSGIRequest, Event) -> None
+def _set_user_info(request: WSGIRequest, event: Event) -> None:
     user_info = event.setdefault("user", {})
 
     user = getattr(request, "user", None)
@@ -600,8 +590,7 @@ def _set_user_info(request, event):
         pass
 
 
-def install_sql_hook():
-    # type: () -> None
+def install_sql_hook() -> None:
     """If installed this causes Django's queries to be captured."""
     try:
         from django.db.backends.utils import CursorWrapper
@@ -615,8 +604,7 @@ def install_sql_hook():
     real_connect = BaseDatabaseWrapper.connect
 
     @ensure_integration_enabled(DjangoIntegration, real_execute)
-    def execute(self, sql, params=None):
-        # type: (CursorWrapper, Any, Optional[Any]) -> Any
+    def execute(self: CursorWrapper, sql: Any, params: Optional[Any] = None) -> Any:
         with record_sql_queries(
             cursor=self.cursor,
             query=sql,
@@ -634,8 +622,7 @@ def install_sql_hook():
         return result
 
     @ensure_integration_enabled(DjangoIntegration, real_executemany)
-    def executemany(self, sql, param_list):
-        # type: (CursorWrapper, Any, List[Any]) -> Any
+    def executemany(self: CursorWrapper, sql: Any, param_list: List[Any]) -> Any:
         with record_sql_queries(
             cursor=self.cursor,
             query=sql,
@@ -654,8 +641,7 @@ def install_sql_hook():
         return result
 
     @ensure_integration_enabled(DjangoIntegration, real_connect)
-    def connect(self):
-        # type: (BaseDatabaseWrapper) -> None
+    def connect(self: BaseDatabaseWrapper) -> None:
         with capture_internal_exceptions():
             sentry_sdk.add_breadcrumb(message="connect", category="query")
 
@@ -674,8 +660,7 @@ def install_sql_hook():
     ignore_logger("django.db.backends")
 
 
-def _set_db_data(span, cursor_or_db):
-    # type: (Span, Any) -> None
+def _set_db_data(span: Span, cursor_or_db: Any) -> None:
     db = cursor_or_db.db if hasattr(cursor_or_db, "db") else cursor_or_db
     vendor = db.vendor
     span.set_attribute(SPANDATA.DB_SYSTEM, vendor)

--- a/sentry_sdk/integrations/django/asgi.py
+++ b/sentry_sdk/integrations/django/asgi.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 """
 Instrumentation for Django 3.0
 
@@ -51,10 +53,8 @@ else:
         return func
 
 
-def _make_asgi_request_event_processor(request):
-    # type: (ASGIRequest) -> EventProcessor
-    def asgi_request_event_processor(event, hint):
-        # type: (Event, dict[str, Any]) -> Event
+def _make_asgi_request_event_processor(request: ASGIRequest) -> EventProcessor:
+    def asgi_request_event_processor(event: Event, hint: dict[str, Any]) -> Event:
         # if the request is gone we are fine not logging the data from
         # it.  This might happen if the processor is pushed away to
         # another thread.
@@ -81,16 +81,16 @@ def _make_asgi_request_event_processor(request):
     return asgi_request_event_processor
 
 
-def patch_django_asgi_handler_impl(cls):
-    # type: (Any) -> None
+def patch_django_asgi_handler_impl(cls: Any) -> None:
 
     from sentry_sdk.integrations.django import DjangoIntegration
 
     old_app = cls.__call__
 
     @functools.wraps(old_app)
-    async def sentry_patched_asgi_handler(self, scope, receive, send):
-        # type: (Any, Any, Any, Any) -> Any
+    async def sentry_patched_asgi_handler(
+        self: Any, scope: Any, receive: Any, send: Any
+    ) -> Any:
         integration = sentry_sdk.get_client().get_integration(DjangoIntegration)
         if integration is None:
             return await old_app(self, scope, receive, send)
@@ -111,8 +111,7 @@ def patch_django_asgi_handler_impl(cls):
         old_create_request = cls.create_request
 
         @ensure_integration_enabled(DjangoIntegration, old_create_request)
-        def sentry_patched_create_request(self, *args, **kwargs):
-            # type: (Any, *Any, **Any) -> Any
+        def sentry_patched_create_request(self: Any, *args: Any, **kwargs: Any) -> Any:
             request, error_response = old_create_request(self, *args, **kwargs)
             scope = sentry_sdk.get_isolation_scope()
             scope.add_event_processor(_make_asgi_request_event_processor(request))
@@ -122,21 +121,20 @@ def patch_django_asgi_handler_impl(cls):
         cls.create_request = sentry_patched_create_request
 
 
-def patch_get_response_async(cls, _before_get_response):
-    # type: (Any, Any) -> None
+def patch_get_response_async(cls: Any, _before_get_response: Any) -> None:
     old_get_response_async = cls.get_response_async
 
     @functools.wraps(old_get_response_async)
-    async def sentry_patched_get_response_async(self, request):
-        # type: (Any, Any) -> Union[HttpResponse, BaseException]
+    async def sentry_patched_get_response_async(
+        self: Any, request: Any
+    ) -> Union[HttpResponse, BaseException]:
         _before_get_response(request)
         return await old_get_response_async(self, request)
 
     cls.get_response_async = sentry_patched_get_response_async
 
 
-def patch_channels_asgi_handler_impl(cls):
-    # type: (Any) -> None
+def patch_channels_asgi_handler_impl(cls: Any) -> None:
     import channels  # type: ignore
 
     from sentry_sdk.integrations.django import DjangoIntegration
@@ -145,8 +143,9 @@ def patch_channels_asgi_handler_impl(cls):
         old_app = cls.__call__
 
         @functools.wraps(old_app)
-        async def sentry_patched_asgi_handler(self, receive, send):
-            # type: (Any, Any, Any) -> Any
+        async def sentry_patched_asgi_handler(
+            self: Any, receive: Any, send: Any
+        ) -> Any:
             integration = sentry_sdk.get_client().get_integration(DjangoIntegration)
             if integration is None:
                 return await old_app(self, receive, send)
@@ -168,13 +167,11 @@ def patch_channels_asgi_handler_impl(cls):
         patch_django_asgi_handler_impl(cls)
 
 
-def wrap_async_view(callback):
-    # type: (Any) -> Any
+def wrap_async_view(callback: Any) -> Any:
     from sentry_sdk.integrations.django import DjangoIntegration
 
     @functools.wraps(callback)
-    async def sentry_wrapped_callback(request, *args, **kwargs):
-        # type: (Any, *Any, **Any) -> Any
+    async def sentry_wrapped_callback(request: Any, *args: Any, **kwargs: Any) -> Any:
         current_scope = sentry_sdk.get_current_scope()
         if current_scope.root_span is not None:
             current_scope.root_span.update_active_thread()
@@ -194,8 +191,7 @@ def wrap_async_view(callback):
     return sentry_wrapped_callback
 
 
-def _asgi_middleware_mixin_factory(_check_middleware_span):
-    # type: (Callable[..., Any]) -> Any
+def _asgi_middleware_mixin_factory(_check_middleware_span: Callable[..., Any]) -> Any:
     """
     Mixin class factory that generates a middleware mixin for handling requests
     in async mode.
@@ -205,14 +201,12 @@ def _asgi_middleware_mixin_factory(_check_middleware_span):
         if TYPE_CHECKING:
             _inner = None
 
-        def __init__(self, get_response):
-            # type: (Callable[..., Any]) -> None
+        def __init__(self, get_response: Callable[..., Any]) -> None:
             self.get_response = get_response
             self._acall_method = None
             self._async_check()
 
-        def _async_check(self):
-            # type: () -> None
+        def _async_check(self) -> None:
             """
             If get_response is a coroutine function, turns us into async mode so
             a thread is not consumed during a whole request.
@@ -221,16 +215,14 @@ def _asgi_middleware_mixin_factory(_check_middleware_span):
             if iscoroutinefunction(self.get_response):
                 markcoroutinefunction(self)
 
-        def async_route_check(self):
-            # type: () -> bool
+        def async_route_check(self) -> bool:
             """
             Function that checks if we are in async mode,
             and if we are forwards the handling of requests to __acall__
             """
             return iscoroutinefunction(self.get_response)
 
-        async def __acall__(self, *args, **kwargs):
-            # type: (*Any, **Any) -> Any
+        async def __acall__(self, *args: Any, **kwargs: Any) -> Any:
             f = self._acall_method
             if f is None:
                 if hasattr(self._inner, "__acall__"):

--- a/sentry_sdk/integrations/django/signals_handlers.py
+++ b/sentry_sdk/integrations/django/signals_handlers.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from functools import wraps
 
 from django.dispatch import Signal
@@ -13,8 +14,7 @@ if TYPE_CHECKING:
     from typing import Any, Union
 
 
-def _get_receiver_name(receiver):
-    # type: (Callable[..., Any]) -> str
+def _get_receiver_name(receiver: Callable[..., Any]) -> str:
     name = ""
 
     if hasattr(receiver, "__qualname__"):
@@ -38,8 +38,7 @@ def _get_receiver_name(receiver):
     return name
 
 
-def patch_signals():
-    # type: () -> None
+def patch_signals() -> None:
     """
     Patch django signal receivers to create a span.
 
@@ -51,19 +50,21 @@ def patch_signals():
     old_live_receivers = Signal._live_receivers
 
     @wraps(old_live_receivers)
-    def _sentry_live_receivers(self, sender):
-        # type: (Signal, Any) -> Union[tuple[list[Callable[..., Any]], list[Callable[..., Any]]], list[Callable[..., Any]]]
+    def _sentry_live_receivers(self: Signal, sender: Any) -> Union[
+        tuple[list[Callable[..., Any]], list[Callable[..., Any]]],
+        list[Callable[..., Any]],
+    ]:
         if DJANGO_VERSION >= (5, 0):
             sync_receivers, async_receivers = old_live_receivers(self, sender)
         else:
             sync_receivers = old_live_receivers(self, sender)
             async_receivers = []
 
-        def sentry_sync_receiver_wrapper(receiver):
-            # type: (Callable[..., Any]) -> Callable[..., Any]
+        def sentry_sync_receiver_wrapper(
+            receiver: Callable[..., Any],
+        ) -> Callable[..., Any]:
             @wraps(receiver)
-            def wrapper(*args, **kwargs):
-                # type: (Any, Any) -> Any
+            def wrapper(*args: Any, **kwargs: Any) -> Any:
                 signal_name = _get_receiver_name(receiver)
                 with sentry_sdk.start_span(
                     op=OP.EVENT_DJANGO,

--- a/sentry_sdk/integrations/django/templates.py
+++ b/sentry_sdk/integrations/django/templates.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import functools
 
 from django.template import TemplateSyntaxError
@@ -18,8 +19,9 @@ if TYPE_CHECKING:
     from typing import Tuple
 
 
-def get_template_frame_from_exception(exc_value):
-    # type: (Optional[BaseException]) -> Optional[Dict[str, Any]]
+def get_template_frame_from_exception(
+    exc_value: Optional[BaseException],
+) -> Optional[Dict[str, Any]]:
 
     # As of Django 1.9 or so the new template debug thing showed up.
     if hasattr(exc_value, "template_debug"):
@@ -41,8 +43,7 @@ def get_template_frame_from_exception(exc_value):
     return None
 
 
-def _get_template_name_description(template_name):
-    # type: (str) -> str
+def _get_template_name_description(template_name: str) -> str:
     if isinstance(template_name, (list, tuple)):
         if template_name:
             return "[{}, ...]".format(template_name[0])
@@ -50,8 +51,7 @@ def _get_template_name_description(template_name):
         return template_name
 
 
-def patch_templates():
-    # type: () -> None
+def patch_templates() -> None:
     from django.template.response import SimpleTemplateResponse
     from sentry_sdk.integrations.django import DjangoIntegration
 
@@ -59,8 +59,7 @@ def patch_templates():
 
     @property  # type: ignore
     @ensure_integration_enabled(DjangoIntegration, real_rendered_content.fget)
-    def rendered_content(self):
-        # type: (SimpleTemplateResponse) -> str
+    def rendered_content(self: SimpleTemplateResponse) -> str:
         with sentry_sdk.start_span(
             op=OP.TEMPLATE_RENDER,
             name=_get_template_name_description(self.template_name),
@@ -80,8 +79,13 @@ def patch_templates():
 
     @functools.wraps(real_render)
     @ensure_integration_enabled(DjangoIntegration, real_render)
-    def render(request, template_name, context=None, *args, **kwargs):
-        # type: (django.http.HttpRequest, str, Optional[Dict[str, Any]], *Any, **Any) -> django.http.HttpResponse
+    def render(
+        request: django.http.HttpRequest,
+        template_name: str,
+        context: Optional[Dict[str, Any]] = None,
+        *args: Any,
+        **kwargs: Any,
+    ) -> django.http.HttpResponse:
 
         # Inject trace meta tags into template context
         context = context or {}
@@ -103,8 +107,7 @@ def patch_templates():
     django.shortcuts.render = render
 
 
-def _get_template_frame_from_debug(debug):
-    # type: (Dict[str, Any]) -> Dict[str, Any]
+def _get_template_frame_from_debug(debug: Dict[str, Any]) -> Dict[str, Any]:
     if debug is None:
         return None
 
@@ -135,8 +138,7 @@ def _get_template_frame_from_debug(debug):
     }
 
 
-def _linebreak_iter(template_source):
-    # type: (str) -> Iterator[int]
+def _linebreak_iter(template_source: str) -> Iterator[int]:
     yield 0
     p = template_source.find("\n")
     while p >= 0:
@@ -144,8 +146,9 @@ def _linebreak_iter(template_source):
         p = template_source.find("\n", p + 1)
 
 
-def _get_template_frame_from_source(source):
-    # type: (Tuple[Origin, Tuple[int, int]]) -> Optional[Dict[str, Any]]
+def _get_template_frame_from_source(
+    source: Tuple[Origin, Tuple[int, int]],
+) -> Optional[Dict[str, Any]]:
     if not source:
         return None
 

--- a/sentry_sdk/integrations/django/transactions.py
+++ b/sentry_sdk/integrations/django/transactions.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 """
 Copied from raven-python.
 
@@ -27,8 +29,7 @@ except ImportError:
     from django.core.urlresolvers import get_resolver
 
 
-def get_regex(resolver_or_pattern):
-    # type: (Union[URLPattern, URLResolver]) -> Pattern[str]
+def get_regex(resolver_or_pattern: Union[URLPattern, URLResolver]) -> Pattern[str]:
     """Utility method for django's deprecated resolver.regex"""
     try:
         regex = resolver_or_pattern.regex
@@ -48,10 +49,9 @@ class RavenResolver:
     _either_option_matcher = re.compile(r"\[([^\]]+)\|([^\]]+)\]")
     _camel_re = re.compile(r"([A-Z]+)([a-z])")
 
-    _cache = {}  # type: Dict[URLPattern, str]
+    _cache: Dict[URLPattern, str] = {}
 
-    def _simplify(self, pattern):
-        # type: (Union[URLPattern, URLResolver]) -> str
+    def _simplify(self, pattern: Union[URLPattern, URLResolver]) -> str:
         r"""
         Clean up urlpattern regexes into something readable by humans:
 
@@ -102,8 +102,12 @@ class RavenResolver:
 
         return result
 
-    def _resolve(self, resolver, path, parents=None):
-        # type: (URLResolver, str, Optional[List[URLResolver]]) -> Optional[str]
+    def _resolve(
+        self,
+        resolver: URLResolver,
+        path: str,
+        parents: Optional[List[URLResolver]] = None,
+    ) -> Optional[str]:
 
         match = get_regex(resolver).search(path)  # Django < 2.0
 
@@ -142,10 +146,11 @@ class RavenResolver:
 
     def resolve(
         self,
-        path,  # type: str
-        urlconf=None,  # type: Union[None, Tuple[URLPattern, URLPattern, URLResolver], Tuple[URLPattern]]
-    ):
-        # type: (...) -> Optional[str]
+        path: str,
+        urlconf: Union[
+            None, Tuple[URLPattern, URLPattern, URLResolver], Tuple[URLPattern]
+        ] = None,
+    ) -> Optional[str]:
         resolver = get_resolver(urlconf)
         match = self._resolve(resolver, path)
         return match

--- a/sentry_sdk/integrations/django/views.py
+++ b/sentry_sdk/integrations/django/views.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import functools
 
 import sentry_sdk
@@ -21,8 +22,7 @@ except (ImportError, SyntaxError):
     wrap_async_view = None  # type: ignore
 
 
-def patch_views():
-    # type: () -> None
+def patch_views() -> None:
 
     from django.core.handlers.base import BaseHandler
     from django.template.response import SimpleTemplateResponse
@@ -32,8 +32,7 @@ def patch_views():
     old_render = SimpleTemplateResponse.render
 
     @functools.wraps(old_render)
-    def sentry_patched_render(self):
-        # type: (SimpleTemplateResponse) -> Any
+    def sentry_patched_render(self: SimpleTemplateResponse) -> Any:
         with sentry_sdk.start_span(
             op=OP.VIEW_RESPONSE_RENDER,
             name="serialize response",
@@ -43,8 +42,7 @@ def patch_views():
             return old_render(self)
 
     @functools.wraps(old_make_view_atomic)
-    def sentry_patched_make_view_atomic(self, *args, **kwargs):
-        # type: (Any, *Any, **Any) -> Any
+    def sentry_patched_make_view_atomic(self: Any, *args: Any, **kwargs: Any) -> Any:
         callback = old_make_view_atomic(self, *args, **kwargs)
 
         # XXX: The wrapper function is created for every request. Find more
@@ -71,13 +69,11 @@ def patch_views():
     BaseHandler.make_view_atomic = sentry_patched_make_view_atomic
 
 
-def _wrap_sync_view(callback):
-    # type: (Any) -> Any
+def _wrap_sync_view(callback: Any) -> Any:
     from sentry_sdk.integrations.django import DjangoIntegration
 
     @functools.wraps(callback)
-    def sentry_wrapped_callback(request, *args, **kwargs):
-        # type: (Any, *Any, **Any) -> Any
+    def sentry_wrapped_callback(request: Any, *args: Any, **kwargs: Any) -> Any:
         current_scope = sentry_sdk.get_current_scope()
         if current_scope.root_span is not None:
             current_scope.root_span.update_active_thread()

--- a/sentry_sdk/integrations/excepthook.py
+++ b/sentry_sdk/integrations/excepthook.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import sys
 
 import sentry_sdk
@@ -28,8 +29,7 @@ class ExcepthookIntegration(Integration):
 
     always_run = False
 
-    def __init__(self, always_run=False):
-        # type: (bool) -> None
+    def __init__(self, always_run: bool = False) -> None:
 
         if not isinstance(always_run, bool):
             raise ValueError(
@@ -39,15 +39,16 @@ class ExcepthookIntegration(Integration):
         self.always_run = always_run
 
     @staticmethod
-    def setup_once():
-        # type: () -> None
+    def setup_once() -> None:
         sys.excepthook = _make_excepthook(sys.excepthook)
 
 
-def _make_excepthook(old_excepthook):
-    # type: (Excepthook) -> Excepthook
-    def sentry_sdk_excepthook(type_, value, traceback):
-        # type: (Type[BaseException], BaseException, Optional[TracebackType]) -> None
+def _make_excepthook(old_excepthook: Excepthook) -> Excepthook:
+    def sentry_sdk_excepthook(
+        type_: Type[BaseException],
+        value: BaseException,
+        traceback: Optional[TracebackType],
+    ) -> None:
         integration = sentry_sdk.get_client().get_integration(ExcepthookIntegration)
 
         # Note: If  we replace this with ensure_integration_enabled then
@@ -70,8 +71,7 @@ def _make_excepthook(old_excepthook):
     return sentry_sdk_excepthook
 
 
-def _should_send(always_run=False):
-    # type: (bool) -> bool
+def _should_send(always_run: bool = False) -> bool:
     if always_run:
         return True
 

--- a/sentry_sdk/integrations/executing.py
+++ b/sentry_sdk/integrations/executing.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import sentry_sdk
 from sentry_sdk.integrations import Integration, DidNotEnable
 from sentry_sdk.scope import add_global_event_processor
@@ -20,12 +21,10 @@ class ExecutingIntegration(Integration):
     identifier = "executing"
 
     @staticmethod
-    def setup_once():
-        # type: () -> None
+    def setup_once() -> None:
 
         @add_global_event_processor
-        def add_executing_info(event, hint):
-            # type: (Event, Optional[Hint]) -> Optional[Event]
+        def add_executing_info(event: Event, hint: Optional[Hint]) -> Optional[Event]:
             if sentry_sdk.get_client().get_integration(ExecutingIntegration) is None:
                 return event
 

--- a/sentry_sdk/integrations/falcon.py
+++ b/sentry_sdk/integrations/falcon.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import sentry_sdk
 from sentry_sdk.consts import SOURCE_FOR_STYLE
 from sentry_sdk.integrations import _check_minimum_version, Integration, DidNotEnable
@@ -33,30 +34,25 @@ falcon_helpers = falcon.app_helpers
 falcon_app_class = falcon.App
 
 
-_FALCON_UNSET = None  # type: Optional[object]
+_FALCON_UNSET: Optional[object] = None
 with capture_internal_exceptions():
     from falcon.request import _UNSET as _FALCON_UNSET  # type: ignore[import-not-found, no-redef]
 
 
 class FalconRequestExtractor(RequestExtractor):
-    def env(self):
-        # type: () -> Dict[str, Any]
+    def env(self) -> Dict[str, Any]:
         return self.request.env
 
-    def cookies(self):
-        # type: () -> Dict[str, Any]
+    def cookies(self) -> Dict[str, Any]:
         return self.request.cookies
 
-    def form(self):
-        # type: () -> None
+    def form(self) -> None:
         return None  # No such concept in Falcon
 
-    def files(self):
-        # type: () -> None
+    def files(self) -> None:
         return None  # No such concept in Falcon
 
-    def raw_data(self):
-        # type: () -> Optional[str]
+    def raw_data(self) -> Optional[str]:
 
         # As request data can only be read once we won't make this available
         # to Sentry. Just send back a dummy string in case there was a
@@ -68,8 +64,7 @@ class FalconRequestExtractor(RequestExtractor):
         else:
             return None
 
-    def json(self):
-        # type: () -> Optional[Dict[str, Any]]
+    def json(self) -> Optional[Dict[str, Any]]:
         # fallback to cached_media = None if self.request._media is not available
         cached_media = None
         with capture_internal_exceptions():
@@ -90,8 +85,7 @@ class FalconRequestExtractor(RequestExtractor):
 class SentryFalconMiddleware:
     """Captures exceptions in Falcon requests and send to Sentry"""
 
-    def process_request(self, req, resp, *args, **kwargs):
-        # type: (Any, Any, *Any, **Any) -> None
+    def process_request(self, req: Any, resp: Any, *args: Any, **kwargs: Any) -> None:
         integration = sentry_sdk.get_client().get_integration(FalconIntegration)
         if integration is None:
             return
@@ -110,8 +104,7 @@ class FalconIntegration(Integration):
 
     transaction_style = ""
 
-    def __init__(self, transaction_style="uri_template"):
-        # type: (str) -> None
+    def __init__(self, transaction_style: str = "uri_template") -> None:
         if transaction_style not in TRANSACTION_STYLE_VALUES:
             raise ValueError(
                 "Invalid value for transaction_style: %s (must be in %s)"
@@ -120,8 +113,7 @@ class FalconIntegration(Integration):
         self.transaction_style = transaction_style
 
     @staticmethod
-    def setup_once():
-        # type: () -> None
+    def setup_once() -> None:
 
         version = parse_version(FALCON_VERSION)
         _check_minimum_version(FalconIntegration, version)
@@ -131,12 +123,10 @@ class FalconIntegration(Integration):
         _patch_prepare_middleware()
 
 
-def _patch_wsgi_app():
-    # type: () -> None
+def _patch_wsgi_app() -> None:
     original_wsgi_app = falcon_app_class.__call__
 
-    def sentry_patched_wsgi_app(self, env, start_response):
-        # type: (falcon.API, Any, Any) -> Any
+    def sentry_patched_wsgi_app(self: falcon.API, env: Any, start_response: Any) -> Any:
         integration = sentry_sdk.get_client().get_integration(FalconIntegration)
         if integration is None:
             return original_wsgi_app(self, env, start_response)
@@ -151,13 +141,11 @@ def _patch_wsgi_app():
     falcon_app_class.__call__ = sentry_patched_wsgi_app
 
 
-def _patch_handle_exception():
-    # type: () -> None
+def _patch_handle_exception() -> None:
     original_handle_exception = falcon_app_class._handle_exception
 
     @ensure_integration_enabled(FalconIntegration, original_handle_exception)
-    def sentry_patched_handle_exception(self, *args):
-        # type: (falcon.API, *Any) -> Any
+    def sentry_patched_handle_exception(self: falcon.API, *args: Any) -> Any:
         # NOTE(jmagnusson): falcon 2.0 changed falcon.API._handle_exception
         # method signature from `(ex, req, resp, params)` to
         # `(req, resp, ex, params)`
@@ -189,14 +177,12 @@ def _patch_handle_exception():
     falcon_app_class._handle_exception = sentry_patched_handle_exception
 
 
-def _patch_prepare_middleware():
-    # type: () -> None
+def _patch_prepare_middleware() -> None:
     original_prepare_middleware = falcon_helpers.prepare_middleware
 
     def sentry_patched_prepare_middleware(
-        middleware=None, independent_middleware=False, asgi=False
-    ):
-        # type: (Any, Any, bool) -> Any
+        middleware: Any = None, independent_middleware: Any = False, asgi: bool = False
+    ) -> Any:
         if asgi:
             # We don't support ASGI Falcon apps, so we don't patch anything here
             return original_prepare_middleware(middleware, independent_middleware, asgi)
@@ -212,8 +198,7 @@ def _patch_prepare_middleware():
     falcon_helpers.prepare_middleware = sentry_patched_prepare_middleware
 
 
-def _exception_leads_to_http_5xx(ex, response):
-    # type: (Exception, falcon.Response) -> bool
+def _exception_leads_to_http_5xx(ex: Exception, response: falcon.Response) -> bool:
     is_server_error = isinstance(ex, falcon.HTTPError) and (ex.status or "").startswith(
         "5"
     )
@@ -224,13 +209,13 @@ def _exception_leads_to_http_5xx(ex, response):
     return (is_server_error or is_unhandled_error) and _has_http_5xx_status(response)
 
 
-def _has_http_5xx_status(response):
-    # type: (falcon.Response) -> bool
+def _has_http_5xx_status(response: falcon.Response) -> bool:
     return response.status.startswith("5")
 
 
-def _set_transaction_name_and_source(event, transaction_style, request):
-    # type: (Event, str, falcon.Request) -> None
+def _set_transaction_name_and_source(
+    event: Event, transaction_style: str, request: falcon.Request
+) -> None:
     name_for_style = {
         "uri_template": request.uri_template,
         "path": request.path,
@@ -239,11 +224,11 @@ def _set_transaction_name_and_source(event, transaction_style, request):
     event["transaction_info"] = {"source": SOURCE_FOR_STYLE[transaction_style]}
 
 
-def _make_request_event_processor(req, integration):
-    # type: (falcon.Request, FalconIntegration) -> EventProcessor
+def _make_request_event_processor(
+    req: falcon.Request, integration: FalconIntegration
+) -> EventProcessor:
 
-    def event_processor(event, hint):
-        # type: (Event, dict[str, Any]) -> Event
+    def event_processor(event: Event, hint: dict[str, Any]) -> Event:
         _set_transaction_name_and_source(event, integration.transaction_style, req)
 
         with capture_internal_exceptions():

--- a/sentry_sdk/integrations/fastapi.py
+++ b/sentry_sdk/integrations/fastapi.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import asyncio
 from copy import deepcopy
 from functools import wraps
@@ -38,13 +39,13 @@ class FastApiIntegration(StarletteIntegration):
     identifier = "fastapi"
 
     @staticmethod
-    def setup_once():
-        # type: () -> None
+    def setup_once() -> None:
         patch_get_request_handler()
 
 
-def _set_transaction_name_and_source(scope, transaction_style, request):
-    # type: (sentry_sdk.Scope, str, Any) -> None
+def _set_transaction_name_and_source(
+    scope: sentry_sdk.Scope, transaction_style: str, request: Any
+) -> None:
     name = ""
 
     if transaction_style == "endpoint":
@@ -71,12 +72,10 @@ def _set_transaction_name_and_source(scope, transaction_style, request):
     )
 
 
-def patch_get_request_handler():
-    # type: () -> None
+def patch_get_request_handler() -> None:
     old_get_request_handler = fastapi.routing.get_request_handler
 
-    def _sentry_get_request_handler(*args, **kwargs):
-        # type: (*Any, **Any) -> Any
+    def _sentry_get_request_handler(*args: Any, **kwargs: Any) -> Any:
         dependant = kwargs.get("dependant")
         if (
             dependant
@@ -86,8 +85,7 @@ def patch_get_request_handler():
             old_call = dependant.call
 
             @wraps(old_call)
-            def _sentry_call(*args, **kwargs):
-                # type: (*Any, **Any) -> Any
+            def _sentry_call(*args: Any, **kwargs: Any) -> Any:
                 current_scope = sentry_sdk.get_current_scope()
                 if current_scope.root_span is not None:
                     current_scope.root_span.update_active_thread()
@@ -102,8 +100,7 @@ def patch_get_request_handler():
 
         old_app = old_get_request_handler(*args, **kwargs)
 
-        async def _sentry_app(*args, **kwargs):
-            # type: (*Any, **Any) -> Any
+        async def _sentry_app(*args: Any, **kwargs: Any) -> Any:
             integration = sentry_sdk.get_client().get_integration(FastApiIntegration)
             if integration is None:
                 return await old_app(*args, **kwargs)
@@ -117,10 +114,10 @@ def patch_get_request_handler():
             extractor = StarletteRequestExtractor(request)
             info = await extractor.extract_request_info()
 
-            def _make_request_event_processor(req, integration):
-                # type: (Any, Any) -> Callable[[Event, Dict[str, Any]], Event]
-                def event_processor(event, hint):
-                    # type: (Event, Dict[str, Any]) -> Event
+            def _make_request_event_processor(
+                req: Any, integration: Any
+            ) -> Callable[[Event, Dict[str, Any]], Event]:
+                def event_processor(event: Event, hint: Dict[str, Any]) -> Event:
 
                     # Extract information from request
                     request_info = event.get("request", {})

--- a/sentry_sdk/integrations/flask.py
+++ b/sentry_sdk/integrations/flask.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import sentry_sdk
 from sentry_sdk.consts import SOURCE_FOR_STYLE
 from sentry_sdk.integrations import _check_minimum_version, DidNotEnable, Integration
@@ -57,10 +58,9 @@ class FlaskIntegration(Integration):
 
     def __init__(
         self,
-        transaction_style="endpoint",  # type: str
-        http_methods_to_capture=DEFAULT_HTTP_METHODS_TO_CAPTURE,  # type: tuple[str, ...]
-    ):
-        # type: (...) -> None
+        transaction_style: str = "endpoint",
+        http_methods_to_capture: tuple[str, ...] = DEFAULT_HTTP_METHODS_TO_CAPTURE,
+    ) -> None:
         if transaction_style not in TRANSACTION_STYLE_VALUES:
             raise ValueError(
                 "Invalid value for transaction_style: %s (must be in %s)"
@@ -70,8 +70,7 @@ class FlaskIntegration(Integration):
         self.http_methods_to_capture = tuple(map(str.upper, http_methods_to_capture))
 
     @staticmethod
-    def setup_once():
-        # type: () -> None
+    def setup_once() -> None:
         try:
             from quart import Quart  # type: ignore
 
@@ -93,8 +92,9 @@ class FlaskIntegration(Integration):
 
         old_app = Flask.__call__
 
-        def sentry_patched_wsgi_app(self, environ, start_response):
-            # type: (Any, Dict[str, str], Callable[..., Any]) -> _ScopedResponse
+        def sentry_patched_wsgi_app(
+            self: Any, environ: Dict[str, str], start_response: Callable[..., Any]
+        ) -> _ScopedResponse:
             if sentry_sdk.get_client().get_integration(FlaskIntegration) is None:
                 return old_app(self, environ, start_response)
 
@@ -114,8 +114,9 @@ class FlaskIntegration(Integration):
         Flask.__call__ = sentry_patched_wsgi_app
 
 
-def _add_sentry_trace(sender, template, context, **extra):
-    # type: (Flask, Any, Dict[str, Any], **Any) -> None
+def _add_sentry_trace(
+    sender: Flask, template: Any, context: Dict[str, Any], **extra: Any
+) -> None:
     if "sentry_trace" in context:
         return
 
@@ -125,8 +126,9 @@ def _add_sentry_trace(sender, template, context, **extra):
     context["sentry_trace_meta"] = trace_meta
 
 
-def _set_transaction_name_and_source(scope, transaction_style, request):
-    # type: (sentry_sdk.Scope, str, Request) -> None
+def _set_transaction_name_and_source(
+    scope: sentry_sdk.Scope, transaction_style: str, request: Request
+) -> None:
     try:
         name_for_style = {
             "url": request.url_rule.rule,
@@ -140,8 +142,7 @@ def _set_transaction_name_and_source(scope, transaction_style, request):
         pass
 
 
-def _request_started(app, **kwargs):
-    # type: (Flask, **Any) -> None
+def _request_started(app: Flask, **kwargs: Any) -> None:
     integration = sentry_sdk.get_client().get_integration(FlaskIntegration)
     if integration is None:
         return
@@ -160,47 +161,39 @@ def _request_started(app, **kwargs):
 
 
 class FlaskRequestExtractor(RequestExtractor):
-    def env(self):
-        # type: () -> Dict[str, str]
+    def env(self) -> Dict[str, str]:
         return self.request.environ
 
-    def cookies(self):
-        # type: () -> Dict[Any, Any]
+    def cookies(self) -> Dict[Any, Any]:
         return {
             k: v[0] if isinstance(v, list) and len(v) == 1 else v
             for k, v in self.request.cookies.items()
         }
 
-    def raw_data(self):
-        # type: () -> bytes
+    def raw_data(self) -> bytes:
         return self.request.get_data()
 
-    def form(self):
-        # type: () -> ImmutableMultiDict[str, Any]
+    def form(self) -> ImmutableMultiDict[str, Any]:
         return self.request.form
 
-    def files(self):
-        # type: () -> ImmutableMultiDict[str, Any]
+    def files(self) -> ImmutableMultiDict[str, Any]:
         return self.request.files
 
-    def is_json(self):
-        # type: () -> bool
+    def is_json(self) -> bool:
         return self.request.is_json
 
-    def json(self):
-        # type: () -> Any
+    def json(self) -> Any:
         return self.request.get_json(silent=True)
 
-    def size_of_file(self, file):
-        # type: (FileStorage) -> int
+    def size_of_file(self, file: FileStorage) -> int:
         return file.content_length
 
 
-def _make_request_event_processor(app, request, integration):
-    # type: (Flask, Callable[[], Request], FlaskIntegration) -> EventProcessor
+def _make_request_event_processor(
+    app: Flask, request: Callable[[], Request], integration: FlaskIntegration
+) -> EventProcessor:
 
-    def inner(event, hint):
-        # type: (Event, dict[str, Any]) -> Event
+    def inner(event: Event, hint: dict[str, Any]) -> Event:
 
         # if the request is gone we are fine not logging the data from
         # it.  This might happen if the processor is pushed away to
@@ -221,8 +214,9 @@ def _make_request_event_processor(app, request, integration):
 
 
 @ensure_integration_enabled(FlaskIntegration)
-def _capture_exception(sender, exception, **kwargs):
-    # type: (Flask, Union[ValueError, BaseException], **Any) -> None
+def _capture_exception(
+    sender: Flask, exception: Union[ValueError, BaseException], **kwargs: Any
+) -> None:
     event, hint = event_from_exception(
         exception,
         client_options=sentry_sdk.get_client().options,
@@ -232,8 +226,7 @@ def _capture_exception(sender, exception, **kwargs):
     sentry_sdk.capture_event(event, hint=hint)
 
 
-def _add_user_to_event(event):
-    # type: (Event) -> None
+def _add_user_to_event(event: Event) -> None:
     if flask_login is None:
         return
 

--- a/sentry_sdk/integrations/gcp.py
+++ b/sentry_sdk/integrations/gcp.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import functools
 import sys
 from copy import deepcopy
@@ -39,11 +40,11 @@ if TYPE_CHECKING:
     F = TypeVar("F", bound=Callable[..., Any])
 
 
-def _wrap_func(func):
-    # type: (F) -> F
+def _wrap_func(func: F) -> F:
     @functools.wraps(func)
-    def sentry_func(functionhandler, gcp_event, *args, **kwargs):
-        # type: (Any, Any, *Any, **Any) -> Any
+    def sentry_func(
+        functionhandler: Any, gcp_event: Any, *args: Any, **kwargs: Any
+    ) -> Any:
         client = sentry_sdk.get_client()
 
         integration = client.get_integration(GcpIntegration)
@@ -118,13 +119,11 @@ class GcpIntegration(Integration):
     identifier = "gcp"
     origin = f"auto.function.{identifier}"
 
-    def __init__(self, timeout_warning=False):
-        # type: (bool) -> None
+    def __init__(self, timeout_warning: bool = False) -> None:
         self.timeout_warning = timeout_warning
 
     @staticmethod
-    def setup_once():
-        # type: () -> None
+    def setup_once() -> None:
         import __main__ as gcp_functions
 
         if not hasattr(gcp_functions, "worker_v1"):
@@ -140,11 +139,11 @@ class GcpIntegration(Integration):
         )
 
 
-def _make_request_event_processor(gcp_event, configured_timeout, initial_time):
-    # type: (Any, Any, Any) -> EventProcessor
+def _make_request_event_processor(
+    gcp_event: Any, configured_timeout: Any, initial_time: Any
+) -> EventProcessor:
 
-    def event_processor(event, hint):
-        # type: (Event, Hint) -> Optional[Event]
+    def event_processor(event: Event, hint: Hint) -> Optional[Event]:
 
         final_time = datetime.now(timezone.utc)
         time_diff = final_time - initial_time
@@ -195,8 +194,7 @@ def _make_request_event_processor(gcp_event, configured_timeout, initial_time):
     return event_processor
 
 
-def _get_google_cloud_logs_url(final_time):
-    # type: (datetime) -> str
+def _get_google_cloud_logs_url(final_time: datetime) -> str:
     """
     Generates a Google Cloud Logs console URL based on the environment variables
     Arguments:
@@ -238,8 +236,7 @@ EVENT_TO_ATTRIBUTE = {
 }
 
 
-def _prepopulate_attributes(gcp_event):
-    # type: (Any) -> dict[str, Any]
+def _prepopulate_attributes(gcp_event: Any) -> dict[str, Any]:
     attributes = {
         "cloud.provider": "gcp",
     }

--- a/sentry_sdk/integrations/gnu_backtrace.py
+++ b/sentry_sdk/integrations/gnu_backtrace.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import re
 
 import sentry_sdk
@@ -38,17 +39,14 @@ class GnuBacktraceIntegration(Integration):
     identifier = "gnu_backtrace"
 
     @staticmethod
-    def setup_once():
-        # type: () -> None
+    def setup_once() -> None:
         @add_global_event_processor
-        def process_gnu_backtrace(event, hint):
-            # type: (Event, dict[str, Any]) -> Event
+        def process_gnu_backtrace(event: Event, hint: dict[str, Any]) -> Event:
             with capture_internal_exceptions():
                 return _process_gnu_backtrace(event, hint)
 
 
-def _process_gnu_backtrace(event, hint):
-    # type: (Event, dict[str, Any]) -> Event
+def _process_gnu_backtrace(event: Event, hint: dict[str, Any]) -> Event:
     if sentry_sdk.get_client().get_integration(GnuBacktraceIntegration) is None:
         return event
 

--- a/sentry_sdk/integrations/gql.py
+++ b/sentry_sdk/integrations/gql.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import sentry_sdk
 from sentry_sdk.utils import (
     event_from_exception,
@@ -34,19 +35,17 @@ class GQLIntegration(Integration):
     identifier = "gql"
 
     @staticmethod
-    def setup_once():
-        # type: () -> None
+    def setup_once() -> None:
         gql_version = parse_version(gql.__version__)
         _check_minimum_version(GQLIntegration, gql_version)
 
         _patch_execute()
 
 
-def _data_from_document(document):
-    # type: (DocumentNode) -> EventDataType
+def _data_from_document(document: DocumentNode) -> EventDataType:
     try:
         operation_ast = get_operation_ast(document)
-        data = {"query": print_ast(document)}  # type: EventDataType
+        data: EventDataType = {"query": print_ast(document)}
 
         if operation_ast is not None:
             data["variables"] = operation_ast.variable_definitions
@@ -58,8 +57,7 @@ def _data_from_document(document):
         return dict()
 
 
-def _transport_method(transport):
-    # type: (Union[Transport, AsyncTransport]) -> str
+def _transport_method(transport: Union[Transport, AsyncTransport]) -> str:
     """
     The RequestsHTTPTransport allows defining the HTTP method; all
     other transports use POST.
@@ -70,8 +68,9 @@ def _transport_method(transport):
         return "POST"
 
 
-def _request_info_from_transport(transport):
-    # type: (Union[Transport, AsyncTransport, None]) -> Dict[str, str]
+def _request_info_from_transport(
+    transport: Union[Transport, AsyncTransport, None],
+) -> Dict[str, str]:
     if transport is None:
         return {}
 
@@ -87,13 +86,13 @@ def _request_info_from_transport(transport):
     return request_info
 
 
-def _patch_execute():
-    # type: () -> None
+def _patch_execute() -> None:
     real_execute = gql.Client.execute
 
     @ensure_integration_enabled(GQLIntegration, real_execute)
-    def sentry_patched_execute(self, document, *args, **kwargs):
-        # type: (gql.Client, DocumentNode, Any, Any) -> Any
+    def sentry_patched_execute(
+        self: gql.Client, document: DocumentNode, *args: Any, **kwargs: Any
+    ) -> Any:
         scope = sentry_sdk.get_isolation_scope()
         scope.add_event_processor(_make_gql_event_processor(self, document))
 
@@ -112,10 +111,10 @@ def _patch_execute():
     gql.Client.execute = sentry_patched_execute
 
 
-def _make_gql_event_processor(client, document):
-    # type: (gql.Client, DocumentNode) -> EventProcessor
-    def processor(event, hint):
-        # type: (Event, dict[str, Any]) -> Event
+def _make_gql_event_processor(
+    client: gql.Client, document: DocumentNode
+) -> EventProcessor:
+    def processor(event: Event, hint: dict[str, Any]) -> Event:
         try:
             errors = hint["exc_info"][1].errors
         except (AttributeError, KeyError):

--- a/sentry_sdk/integrations/grpc/__init__.py
+++ b/sentry_sdk/integrations/grpc/__init__.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from functools import wraps
 
 import grpc
@@ -130,10 +131,10 @@ def _wrap_async_server(func: Callable[P, AsyncServer]) -> Callable[P, AsyncServe
         **kwargs: P.kwargs,
     ) -> Server:
         server_interceptor = AsyncServerInterceptor()
-        interceptors = [
+        interceptors: Sequence[grpc.ServerInterceptor] = [
             server_interceptor,
             *(interceptors or []),
-        ]  # type: Sequence[grpc.ServerInterceptor]
+        ]
 
         try:
             # We prefer interceptors as a list because of compatibility with

--- a/sentry_sdk/integrations/grpc/aio/server.py
+++ b/sentry_sdk/integrations/grpc/aio/server.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import sentry_sdk
 from sentry_sdk.consts import OP
 from sentry_sdk.integrations import DidNotEnable
@@ -21,14 +22,19 @@ except ImportError:
 
 
 class ServerInterceptor(grpc.aio.ServerInterceptor):  # type: ignore
-    def __init__(self, find_name=None):
-        # type: (ServerInterceptor, Callable[[ServicerContext], str] | None) -> None
+    def __init__(
+        self: ServerInterceptor,
+        find_name: Callable[[ServicerContext], str] | None = None,
+    ) -> None:
         self._find_method_name = find_name or self._find_name
 
         super().__init__()
 
-    async def intercept_service(self, continuation, handler_call_details):
-        # type: (ServerInterceptor, Callable[[HandlerCallDetails], Awaitable[RpcMethodHandler]], HandlerCallDetails) -> Optional[Awaitable[RpcMethodHandler]]
+    async def intercept_service(
+        self: ServerInterceptor,
+        continuation: Callable[[HandlerCallDetails], Awaitable[RpcMethodHandler]],
+        handler_call_details: HandlerCallDetails,
+    ) -> Optional[Awaitable[RpcMethodHandler]]:
         self._handler_call_details = handler_call_details
         handler = await continuation(handler_call_details)
         if handler is None:
@@ -37,8 +43,7 @@ class ServerInterceptor(grpc.aio.ServerInterceptor):  # type: ignore
         if not handler.request_streaming and not handler.response_streaming:
             handler_factory = grpc.unary_unary_rpc_method_handler
 
-            async def wrapped(request, context):
-                # type: (Any, ServicerContext) -> Any
+            async def wrapped(request: Any, context: ServicerContext) -> Any:
                 name = self._find_method_name(context)
                 if not name:
                     return await handler(request, context)
@@ -66,24 +71,21 @@ class ServerInterceptor(grpc.aio.ServerInterceptor):  # type: ignore
         elif not handler.request_streaming and handler.response_streaming:
             handler_factory = grpc.unary_stream_rpc_method_handler
 
-            async def wrapped(request, context):  # type: ignore
-                # type: (Any, ServicerContext) -> Any
+            async def wrapped(request: Any, context: ServicerContext) -> Any:  # type: ignore
                 async for r in handler.unary_stream(request, context):
                     yield r
 
         elif handler.request_streaming and not handler.response_streaming:
             handler_factory = grpc.stream_unary_rpc_method_handler
 
-            async def wrapped(request, context):
-                # type: (Any, ServicerContext) -> Any
+            async def wrapped(request: Any, context: ServicerContext) -> Any:
                 response = handler.stream_unary(request, context)
                 return await response
 
         elif handler.request_streaming and handler.response_streaming:
             handler_factory = grpc.stream_stream_rpc_method_handler
 
-            async def wrapped(request, context):  # type: ignore
-                # type: (Any, ServicerContext) -> Any
+            async def wrapped(request: Any, context: ServicerContext) -> Any:  # type: ignore
                 async for r in handler.stream_stream(request, context):
                     yield r
 
@@ -93,6 +95,5 @@ class ServerInterceptor(grpc.aio.ServerInterceptor):  # type: ignore
             response_serializer=handler.response_serializer,
         )
 
-    def _find_name(self, context):
-        # type: (ServicerContext) -> str
+    def _find_name(self, context: ServicerContext) -> str:
         return self._handler_call_details.method

--- a/sentry_sdk/integrations/grpc/client.py
+++ b/sentry_sdk/integrations/grpc/client.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import sentry_sdk
 from sentry_sdk.consts import OP
 from sentry_sdk.integrations import DidNotEnable
@@ -23,8 +24,12 @@ class ClientInterceptor(
 ):
     _is_intercepted = False
 
-    def intercept_unary_unary(self, continuation, client_call_details, request):
-        # type: (ClientInterceptor, Callable[[ClientCallDetails, Message], _UnaryOutcome], ClientCallDetails, Message) -> _UnaryOutcome
+    def intercept_unary_unary(
+        self: ClientInterceptor,
+        continuation: Callable[[ClientCallDetails, Message], _UnaryOutcome],
+        client_call_details: ClientCallDetails,
+        request: Message,
+    ) -> _UnaryOutcome:
         method = client_call_details.method
 
         with sentry_sdk.start_span(
@@ -45,8 +50,14 @@ class ClientInterceptor(
 
             return response
 
-    def intercept_unary_stream(self, continuation, client_call_details, request):
-        # type: (ClientInterceptor, Callable[[ClientCallDetails, Message], Union[Iterable[Any], UnaryStreamCall]], ClientCallDetails, Message) -> Union[Iterator[Message], Call]
+    def intercept_unary_stream(
+        self: ClientInterceptor,
+        continuation: Callable[
+            [ClientCallDetails, Message], Union[Iterable[Any], UnaryStreamCall]
+        ],
+        client_call_details: ClientCallDetails,
+        request: Message,
+    ) -> Union[Iterator[Message], Call]:
         method = client_call_details.method
 
         with sentry_sdk.start_span(
@@ -62,17 +73,16 @@ class ClientInterceptor(
                 client_call_details
             )
 
-            response = continuation(
-                client_call_details, request
-            )  # type: UnaryStreamCall
+            response: UnaryStreamCall = continuation(client_call_details, request)
             # Setting code on unary-stream leads to execution getting stuck
             # span.set_attribute("code", response.code().name)
 
             return response
 
     @staticmethod
-    def _update_client_call_details_metadata_from_scope(client_call_details):
-        # type: (ClientCallDetails) -> ClientCallDetails
+    def _update_client_call_details_metadata_from_scope(
+        client_call_details: ClientCallDetails,
+    ) -> ClientCallDetails:
         metadata = (
             list(client_call_details.metadata) if client_call_details.metadata else []
         )

--- a/sentry_sdk/integrations/grpc/consts.py
+++ b/sentry_sdk/integrations/grpc/consts.py
@@ -1,1 +1,3 @@
+from __future__ import annotations
+
 SPAN_ORIGIN = "auto.grpc.grpc"

--- a/sentry_sdk/integrations/httpx.py
+++ b/sentry_sdk/integrations/httpx.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import sentry_sdk
 from sentry_sdk.consts import OP, SPANDATA, BAGGAGE_HEADER_NAME
 from sentry_sdk.integrations import Integration, DidNotEnable
@@ -32,8 +33,7 @@ class HttpxIntegration(Integration):
     origin = f"auto.http.{identifier}"
 
     @staticmethod
-    def setup_once():
-        # type: () -> None
+    def setup_once() -> None:
         """
         httpx has its own transport layer and can be customized when needed,
         so patch Client.send and AsyncClient.send to support both synchronous and async interfaces.
@@ -42,13 +42,11 @@ class HttpxIntegration(Integration):
         _install_httpx_async_client()
 
 
-def _install_httpx_client():
-    # type: () -> None
+def _install_httpx_client() -> None:
     real_send = Client.send
 
     @ensure_integration_enabled(HttpxIntegration, real_send)
-    def send(self, request, **kwargs):
-        # type: (Client, Request, **Any) -> Response
+    def send(self: Client, request: Request, **kwargs: Any) -> Response:
         parsed_url = None
         with capture_internal_exceptions():
             parsed_url = parse_url(str(request.url), sanitize=False)
@@ -112,12 +110,10 @@ def _install_httpx_client():
     Client.send = send
 
 
-def _install_httpx_async_client():
-    # type: () -> None
+def _install_httpx_async_client() -> None:
     real_send = AsyncClient.send
 
-    async def send(self, request, **kwargs):
-        # type: (AsyncClient, Request, **Any) -> Response
+    async def send(self: AsyncClient, request: Request, **kwargs: Any) -> Response:
         if sentry_sdk.get_client().get_integration(HttpxIntegration) is None:
             return await real_send(self, request, **kwargs)
 
@@ -184,8 +180,9 @@ def _install_httpx_async_client():
     AsyncClient.send = send
 
 
-def _add_sentry_baggage_to_headers(headers, sentry_baggage):
-    # type: (MutableMapping[str, str], str) -> None
+def _add_sentry_baggage_to_headers(
+    headers: MutableMapping[str, str], sentry_baggage: str
+) -> None:
     """Add the Sentry baggage to the headers.
 
     This function directly mutates the provided headers. The provided sentry_baggage

--- a/sentry_sdk/integrations/huey.py
+++ b/sentry_sdk/integrations/huey.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import sys
 from datetime import datetime
 
@@ -45,19 +46,16 @@ class HueyIntegration(Integration):
     origin = f"auto.queue.{identifier}"
 
     @staticmethod
-    def setup_once():
-        # type: () -> None
+    def setup_once() -> None:
         patch_enqueue()
         patch_execute()
 
 
-def patch_enqueue():
-    # type: () -> None
+def patch_enqueue() -> None:
     old_enqueue = Huey.enqueue
 
     @ensure_integration_enabled(HueyIntegration, old_enqueue)
-    def _sentry_enqueue(self, task):
-        # type: (Huey, Task) -> Optional[Union[Result, ResultGroup]]
+    def _sentry_enqueue(self: Huey, task: Task) -> Optional[Union[Result, ResultGroup]]:
         with sentry_sdk.start_span(
             op=OP.QUEUE_SUBMIT_HUEY,
             name=task.name,
@@ -77,10 +75,8 @@ def patch_enqueue():
     Huey.enqueue = _sentry_enqueue
 
 
-def _make_event_processor(task):
-    # type: (Any) -> EventProcessor
-    def event_processor(event, hint):
-        # type: (Event, Hint) -> Optional[Event]
+def _make_event_processor(task: Any) -> EventProcessor:
+    def event_processor(event: Event, hint: Hint) -> Optional[Event]:
 
         with capture_internal_exceptions():
             tags = event.setdefault("tags", {})
@@ -107,8 +103,7 @@ def _make_event_processor(task):
     return event_processor
 
 
-def _capture_exception(exc_info):
-    # type: (ExcInfo) -> None
+def _capture_exception(exc_info: ExcInfo) -> None:
     scope = sentry_sdk.get_current_scope()
 
     if scope.root_span is not None:
@@ -126,12 +121,10 @@ def _capture_exception(exc_info):
     scope.capture_event(event, hint=hint)
 
 
-def _wrap_task_execute(func):
-    # type: (F) -> F
+def _wrap_task_execute(func: F) -> F:
 
     @ensure_integration_enabled(HueyIntegration, func)
-    def _sentry_execute(*args, **kwargs):
-        # type: (*Any, **Any) -> Any
+    def _sentry_execute(*args: Any, **kwargs: Any) -> Any:
         try:
             result = func(*args, **kwargs)
         except Exception:
@@ -148,13 +141,13 @@ def _wrap_task_execute(func):
     return _sentry_execute  # type: ignore
 
 
-def patch_execute():
-    # type: () -> None
+def patch_execute() -> None:
     old_execute = Huey._execute
 
     @ensure_integration_enabled(HueyIntegration, old_execute)
-    def _sentry_execute(self, task, timestamp=None):
-        # type: (Huey, Task, Optional[datetime]) -> Any
+    def _sentry_execute(
+        self: Huey, task: Task, timestamp: Optional[datetime] = None
+    ) -> Any:
         with sentry_sdk.isolation_scope() as scope:
             with capture_internal_exceptions():
                 scope._name = "huey"

--- a/sentry_sdk/integrations/huggingface_hub.py
+++ b/sentry_sdk/integrations/huggingface_hub.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from functools import wraps
 
 from sentry_sdk import consts
@@ -27,13 +28,11 @@ class HuggingfaceHubIntegration(Integration):
     identifier = "huggingface_hub"
     origin = f"auto.ai.{identifier}"
 
-    def __init__(self, include_prompts=True):
-        # type: (HuggingfaceHubIntegration, bool) -> None
+    def __init__(self: HuggingfaceHubIntegration, include_prompts: bool = True) -> None:
         self.include_prompts = include_prompts
 
     @staticmethod
-    def setup_once():
-        # type: () -> None
+    def setup_once() -> None:
         huggingface_hub.inference._client.InferenceClient.text_generation = (
             _wrap_text_generation(
                 huggingface_hub.inference._client.InferenceClient.text_generation
@@ -41,8 +40,7 @@ class HuggingfaceHubIntegration(Integration):
         )
 
 
-def _capture_exception(exc):
-    # type: (Any) -> None
+def _capture_exception(exc: Any) -> None:
     event, hint = event_from_exception(
         exc,
         client_options=sentry_sdk.get_client().options,
@@ -51,11 +49,9 @@ def _capture_exception(exc):
     sentry_sdk.capture_event(event, hint=hint)
 
 
-def _wrap_text_generation(f):
-    # type: (Callable[..., Any]) -> Callable[..., Any]
+def _wrap_text_generation(f: Callable[..., Any]) -> Callable[..., Any]:
     @wraps(f)
-    def new_text_generation(*args, **kwargs):
-        # type: (*Any, **Any) -> Any
+    def new_text_generation(*args: Any, **kwargs: Any) -> Any:
         integration = sentry_sdk.get_client().get_integration(HuggingfaceHubIntegration)
         if integration is None:
             return f(*args, **kwargs)
@@ -124,8 +120,7 @@ def _wrap_text_generation(f):
 
             if kwargs.get("details", False):
                 # res is Iterable[TextGenerationStreamOutput]
-                def new_details_iterator():
-                    # type: () -> Iterable[ChatCompletionStreamOutput]
+                def new_details_iterator() -> Iterable[ChatCompletionStreamOutput]:
                     with capture_internal_exceptions():
                         tokens_used = 0
                         data_buf: list[str] = []
@@ -153,8 +148,7 @@ def _wrap_text_generation(f):
             else:
                 # res is Iterable[str]
 
-                def new_iterator():
-                    # type: () -> Iterable[str]
+                def new_iterator() -> Iterable[str]:
                     data_buf: list[str] = []
                     with capture_internal_exceptions():
                         for s in res:

--- a/sentry_sdk/integrations/langchain.py
+++ b/sentry_sdk/integrations/langchain.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import itertools
 from collections import OrderedDict
 from functools import wraps
@@ -60,37 +61,41 @@ class LangchainIntegration(Integration):
     max_spans = 1024
 
     def __init__(
-        self, include_prompts=True, max_spans=1024, tiktoken_encoding_name=None
-    ):
-        # type: (LangchainIntegration, bool, int, Optional[str]) -> None
+        self: LangchainIntegration,
+        include_prompts: bool = True,
+        max_spans: int = 1024,
+        tiktoken_encoding_name: Optional[str] = None,
+    ) -> None:
         self.include_prompts = include_prompts
         self.max_spans = max_spans
         self.tiktoken_encoding_name = tiktoken_encoding_name
 
     @staticmethod
-    def setup_once():
-        # type: () -> None
+    def setup_once() -> None:
         manager._configure = _wrap_configure(manager._configure)
 
 
 class WatchedSpan:
-    num_completion_tokens = 0  # type: int
-    num_prompt_tokens = 0  # type: int
-    no_collect_tokens = False  # type: bool
-    children = []  # type: List[WatchedSpan]
-    is_pipeline = False  # type: bool
+    num_completion_tokens: int = 0
+    num_prompt_tokens: int = 0
+    no_collect_tokens: bool = False
+    children: List[WatchedSpan] = []
+    is_pipeline: bool = False
 
-    def __init__(self, span):
-        # type: (Span) -> None
+    def __init__(self, span: Span) -> None:
         self.span = span
 
 
 class SentryLangchainCallback(BaseCallbackHandler):  # type: ignore[misc]
     """Base callback handler that can be used to handle callbacks from langchain."""
 
-    def __init__(self, max_span_map_size, include_prompts, tiktoken_encoding_name=None):
-        # type: (int, bool, Optional[str]) -> None
-        self.span_map = OrderedDict()  # type: OrderedDict[UUID, WatchedSpan]
+    def __init__(
+        self,
+        max_span_map_size: int,
+        include_prompts: bool,
+        tiktoken_encoding_name: Optional[str] = None,
+    ) -> None:
+        self.span_map: OrderedDict[UUID, WatchedSpan] = OrderedDict()
         self.max_span_map_size = max_span_map_size
         self.include_prompts = include_prompts
 
@@ -100,21 +105,18 @@ class SentryLangchainCallback(BaseCallbackHandler):  # type: ignore[misc]
 
             self.tiktoken_encoding = tiktoken.get_encoding(tiktoken_encoding_name)
 
-    def count_tokens(self, s):
-        # type: (str) -> int
+    def count_tokens(self, s: str) -> int:
         if self.tiktoken_encoding is not None:
             return len(self.tiktoken_encoding.encode_ordinary(s))
         return 0
 
-    def gc_span_map(self):
-        # type: () -> None
+    def gc_span_map(self) -> None:
 
         while len(self.span_map) > self.max_span_map_size:
             run_id, watched_span = self.span_map.popitem(last=False)
             self._exit_span(watched_span, run_id)
 
-    def _handle_error(self, run_id, error):
-        # type: (UUID, Any) -> None
+    def _handle_error(self, run_id: UUID, error: Any) -> None:
         if not run_id or run_id not in self.span_map:
             return
 
@@ -126,14 +128,17 @@ class SentryLangchainCallback(BaseCallbackHandler):  # type: ignore[misc]
         span_data.span.finish()
         del self.span_map[run_id]
 
-    def _normalize_langchain_message(self, message):
-        # type: (BaseMessage) -> Any
+    def _normalize_langchain_message(self, message: BaseMessage) -> Any:
         parsed = {"content": message.content, "role": message.type}
         parsed.update(message.additional_kwargs)
         return parsed
 
-    def _create_span(self, run_id, parent_id, **kwargs):
-        # type: (SentryLangchainCallback, UUID, Optional[Any], Any) -> WatchedSpan
+    def _create_span(
+        self: SentryLangchainCallback,
+        run_id: UUID,
+        parent_id: Optional[Any],
+        **kwargs: Any,
+    ) -> WatchedSpan:
 
         parent_watched_span = self.span_map.get(parent_id) if parent_id else None
         sentry_span = sentry_sdk.start_span(
@@ -160,8 +165,9 @@ class SentryLangchainCallback(BaseCallbackHandler):  # type: ignore[misc]
         self.gc_span_map()
         return watched_span
 
-    def _exit_span(self, span_data, run_id):
-        # type: (SentryLangchainCallback, WatchedSpan, UUID) -> None
+    def _exit_span(
+        self: SentryLangchainCallback, span_data: WatchedSpan, run_id: UUID
+    ) -> None:
 
         if span_data.is_pipeline:
             set_ai_pipeline_name(None)
@@ -171,17 +177,16 @@ class SentryLangchainCallback(BaseCallbackHandler):  # type: ignore[misc]
         del self.span_map[run_id]
 
     def on_llm_start(
-        self,
-        serialized,
-        prompts,
+        self: SentryLangchainCallback,
+        serialized: Dict[str, Any],
+        prompts: List[str],
         *,
-        run_id,
-        tags=None,
-        parent_run_id=None,
-        metadata=None,
-        **kwargs,
-    ):
-        # type: (SentryLangchainCallback, Dict[str, Any], List[str], UUID, Optional[List[str]], Optional[UUID], Optional[Dict[str, Any]], Any) -> Any
+        run_id: UUID,
+        tags: Optional[List[str]] = None,
+        parent_run_id: Optional[UUID] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+        **kwargs: Any,
+    ) -> Any:
         """Run when LLM starts running."""
         with capture_internal_exceptions():
             if not run_id:
@@ -202,8 +207,14 @@ class SentryLangchainCallback(BaseCallbackHandler):  # type: ignore[misc]
                 if k in all_params:
                     set_data_normalized(span, v, all_params[k])
 
-    def on_chat_model_start(self, serialized, messages, *, run_id, **kwargs):
-        # type: (SentryLangchainCallback, Dict[str, Any], List[List[BaseMessage]], UUID, Any) -> Any
+    def on_chat_model_start(
+        self: SentryLangchainCallback,
+        serialized: Dict[str, Any],
+        messages: List[List[BaseMessage]],
+        *,
+        run_id: UUID,
+        **kwargs: Any,
+    ) -> Any:
         """Run when Chat Model starts running."""
         with capture_internal_exceptions():
             if not run_id:
@@ -248,8 +259,9 @@ class SentryLangchainCallback(BaseCallbackHandler):  # type: ignore[misc]
                             message.content
                         ) + self.count_tokens(message.type)
 
-    def on_llm_new_token(self, token, *, run_id, **kwargs):
-        # type: (SentryLangchainCallback, str, UUID, Any) -> Any
+    def on_llm_new_token(
+        self: SentryLangchainCallback, token: str, *, run_id: UUID, **kwargs: Any
+    ) -> Any:
         """Run on new LLM token. Only available when streaming is enabled."""
         with capture_internal_exceptions():
             if not run_id or run_id not in self.span_map:
@@ -259,8 +271,13 @@ class SentryLangchainCallback(BaseCallbackHandler):  # type: ignore[misc]
                 return
             span_data.num_completion_tokens += self.count_tokens(token)
 
-    def on_llm_end(self, response, *, run_id, **kwargs):
-        # type: (SentryLangchainCallback, LLMResult, UUID, Any) -> Any
+    def on_llm_end(
+        self: SentryLangchainCallback,
+        response: LLMResult,
+        *,
+        run_id: UUID,
+        **kwargs: Any,
+    ) -> Any:
         """Run when LLM ends running."""
         with capture_internal_exceptions():
             if not run_id:
@@ -298,14 +315,25 @@ class SentryLangchainCallback(BaseCallbackHandler):  # type: ignore[misc]
 
             self._exit_span(span_data, run_id)
 
-    def on_llm_error(self, error, *, run_id, **kwargs):
-        # type: (SentryLangchainCallback, Union[Exception, KeyboardInterrupt], UUID, Any) -> Any
+    def on_llm_error(
+        self: SentryLangchainCallback,
+        error: Union[Exception, KeyboardInterrupt],
+        *,
+        run_id: UUID,
+        **kwargs: Any,
+    ) -> Any:
         """Run when LLM errors."""
         with capture_internal_exceptions():
             self._handle_error(run_id, error)
 
-    def on_chain_start(self, serialized, inputs, *, run_id, **kwargs):
-        # type: (SentryLangchainCallback, Dict[str, Any], Dict[str, Any], UUID, Any) -> Any
+    def on_chain_start(
+        self: SentryLangchainCallback,
+        serialized: Dict[str, Any],
+        inputs: Dict[str, Any],
+        *,
+        run_id: UUID,
+        **kwargs: Any,
+    ) -> Any:
         """Run when chain starts running."""
         with capture_internal_exceptions():
             if not run_id:
@@ -325,8 +353,13 @@ class SentryLangchainCallback(BaseCallbackHandler):  # type: ignore[misc]
             if metadata:
                 set_data_normalized(watched_span.span, SPANDATA.AI_METADATA, metadata)
 
-    def on_chain_end(self, outputs, *, run_id, **kwargs):
-        # type: (SentryLangchainCallback, Dict[str, Any], UUID, Any) -> Any
+    def on_chain_end(
+        self: SentryLangchainCallback,
+        outputs: Dict[str, Any],
+        *,
+        run_id: UUID,
+        **kwargs: Any,
+    ) -> Any:
         """Run when chain ends running."""
         with capture_internal_exceptions():
             if not run_id or run_id not in self.span_map:
@@ -337,13 +370,23 @@ class SentryLangchainCallback(BaseCallbackHandler):  # type: ignore[misc]
                 return
             self._exit_span(span_data, run_id)
 
-    def on_chain_error(self, error, *, run_id, **kwargs):
-        # type: (SentryLangchainCallback, Union[Exception, KeyboardInterrupt], UUID, Any) -> Any
+    def on_chain_error(
+        self: SentryLangchainCallback,
+        error: Union[Exception, KeyboardInterrupt],
+        *,
+        run_id: UUID,
+        **kwargs: Any,
+    ) -> Any:
         """Run when chain errors."""
         self._handle_error(run_id, error)
 
-    def on_agent_action(self, action, *, run_id, **kwargs):
-        # type: (SentryLangchainCallback, AgentAction, UUID, Any) -> Any
+    def on_agent_action(
+        self: SentryLangchainCallback,
+        action: AgentAction,
+        *,
+        run_id: UUID,
+        **kwargs: Any,
+    ) -> Any:
         with capture_internal_exceptions():
             if not run_id:
                 return
@@ -359,8 +402,13 @@ class SentryLangchainCallback(BaseCallbackHandler):  # type: ignore[misc]
                     watched_span.span, SPANDATA.AI_INPUT_MESSAGES, action.tool_input
                 )
 
-    def on_agent_finish(self, finish, *, run_id, **kwargs):
-        # type: (SentryLangchainCallback, AgentFinish, UUID, Any) -> Any
+    def on_agent_finish(
+        self: SentryLangchainCallback,
+        finish: AgentFinish,
+        *,
+        run_id: UUID,
+        **kwargs: Any,
+    ) -> Any:
         with capture_internal_exceptions():
             if not run_id:
                 return
@@ -374,8 +422,14 @@ class SentryLangchainCallback(BaseCallbackHandler):  # type: ignore[misc]
                 )
             self._exit_span(span_data, run_id)
 
-    def on_tool_start(self, serialized, input_str, *, run_id, **kwargs):
-        # type: (SentryLangchainCallback, Dict[str, Any], str, UUID, Any) -> Any
+    def on_tool_start(
+        self: SentryLangchainCallback,
+        serialized: Dict[str, Any],
+        input_str: str,
+        *,
+        run_id: UUID,
+        **kwargs: Any,
+    ) -> Any:
         """Run when tool starts running."""
         with capture_internal_exceptions():
             if not run_id:
@@ -398,8 +452,9 @@ class SentryLangchainCallback(BaseCallbackHandler):  # type: ignore[misc]
                         watched_span.span, SPANDATA.AI_METADATA, kwargs.get("metadata")
                     )
 
-    def on_tool_end(self, output, *, run_id, **kwargs):
-        # type: (SentryLangchainCallback, str, UUID, Any) -> Any
+    def on_tool_end(
+        self: SentryLangchainCallback, output: str, *, run_id: UUID, **kwargs: Any
+    ) -> Any:
         """Run when tool ends running."""
         with capture_internal_exceptions():
             if not run_id or run_id not in self.span_map:
@@ -412,24 +467,27 @@ class SentryLangchainCallback(BaseCallbackHandler):  # type: ignore[misc]
                 set_data_normalized(span_data.span, SPANDATA.AI_RESPONSES, output)
             self._exit_span(span_data, run_id)
 
-    def on_tool_error(self, error, *args, run_id, **kwargs):
-        # type: (SentryLangchainCallback, Union[Exception, KeyboardInterrupt], UUID, Any) -> Any
+    def on_tool_error(
+        self,
+        error: SentryLangchainCallback,
+        *args: Union[Exception, KeyboardInterrupt],
+        run_id: UUID,
+        **kwargs: Any,
+    ) -> Any:
         """Run when tool errors."""
         self._handle_error(run_id, error)
 
 
-def _wrap_configure(f):
-    # type: (Callable[..., Any]) -> Callable[..., Any]
+def _wrap_configure(f: Callable[..., Any]) -> Callable[..., Any]:
 
     @wraps(f)
     def new_configure(
-        callback_manager_cls,  # type: type
-        inheritable_callbacks=None,  # type: Callbacks
-        local_callbacks=None,  # type: Callbacks
-        *args,  # type: Any
-        **kwargs,  # type: Any
-    ):
-        # type: (...) -> Any
+        callback_manager_cls: type,
+        inheritable_callbacks: Callbacks = None,
+        local_callbacks: Callbacks = None,
+        *args: Any,
+        **kwargs: Any,
+    ) -> Any:
 
         integration = sentry_sdk.get_client().get_integration(LangchainIntegration)
         if integration is None:

--- a/sentry_sdk/integrations/launchdarkly.py
+++ b/sentry_sdk/integrations/launchdarkly.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from sentry_sdk.feature_flags import add_feature_flag
@@ -20,8 +21,7 @@ except ImportError:
 class LaunchDarklyIntegration(Integration):
     identifier = "launchdarkly"
 
-    def __init__(self, ld_client=None):
-        # type: (LDClient | None) -> None
+    def __init__(self, ld_client: LDClient | None = None) -> None:
         """
         :param client: An initialized LDClient instance. If a client is not provided, this
             integration will attempt to use the shared global instance.
@@ -38,25 +38,28 @@ class LaunchDarklyIntegration(Integration):
         client.add_hook(LaunchDarklyHook())
 
     @staticmethod
-    def setup_once():
-        # type: () -> None
+    def setup_once() -> None:
         pass
 
 
 class LaunchDarklyHook(Hook):
 
     @property
-    def metadata(self):
-        # type: () -> Metadata
+    def metadata(self) -> Metadata:
         return Metadata(name="sentry-flag-auditor")
 
-    def after_evaluation(self, series_context, data, detail):
-        # type: (EvaluationSeriesContext, dict[Any, Any], EvaluationDetail) -> dict[Any, Any]
+    def after_evaluation(
+        self,
+        series_context: EvaluationSeriesContext,
+        data: dict[Any, Any],
+        detail: EvaluationDetail,
+    ) -> dict[Any, Any]:
         if isinstance(detail.value, bool):
             add_feature_flag(series_context.key, detail.value)
 
         return data
 
-    def before_evaluation(self, series_context, data):
-        # type: (EvaluationSeriesContext, dict[Any, Any]) -> dict[Any, Any]
+    def before_evaluation(
+        self, series_context: EvaluationSeriesContext, data: dict[Any, Any]
+    ) -> dict[Any, Any]:
         return data  # No-op.

--- a/sentry_sdk/integrations/litestar.py
+++ b/sentry_sdk/integrations/litestar.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from collections.abc import Set
 import sentry_sdk
 from sentry_sdk.consts import OP, TransactionSource, SOURCE_FOR_STYLE
@@ -52,13 +53,12 @@ class LitestarIntegration(Integration):
 
     def __init__(
         self,
-        failed_request_status_codes=_DEFAULT_FAILED_REQUEST_STATUS_CODES,  # type: Set[int]
+        failed_request_status_codes: Set[int] = _DEFAULT_FAILED_REQUEST_STATUS_CODES,
     ) -> None:
         self.failed_request_status_codes = failed_request_status_codes
 
     @staticmethod
-    def setup_once():
-        # type: () -> None
+    def setup_once() -> None:
         patch_app_init()
         patch_middlewares()
         patch_http_route_handle()
@@ -75,8 +75,9 @@ class LitestarIntegration(Integration):
 
 
 class SentryLitestarASGIMiddleware(SentryAsgiMiddleware):
-    def __init__(self, app, span_origin=LitestarIntegration.origin):
-        # type: (ASGIApp, str) -> None
+    def __init__(
+        self, app: ASGIApp, span_origin: str = LitestarIntegration.origin
+    ) -> None:
 
         super().__init__(
             app=app,
@@ -86,8 +87,7 @@ class SentryLitestarASGIMiddleware(SentryAsgiMiddleware):
             span_origin=span_origin,
         )
 
-    def _capture_request_exception(self, exc):
-        # type: (Exception) -> None
+    def _capture_request_exception(self, exc: Exception) -> None:
         """Avoid catching exceptions from request handlers.
 
         Those exceptions are already handled in Litestar.after_exception handler.
@@ -96,8 +96,7 @@ class SentryLitestarASGIMiddleware(SentryAsgiMiddleware):
         pass
 
 
-def patch_app_init():
-    # type: () -> None
+def patch_app_init() -> None:
     """
     Replaces the Litestar class's `__init__` function in order to inject `after_exception` handlers and set the
     `SentryLitestarASGIMiddleware` as the outmost middleware in the stack.
@@ -108,8 +107,7 @@ def patch_app_init():
     old__init__ = Litestar.__init__
 
     @ensure_integration_enabled(LitestarIntegration, old__init__)
-    def injection_wrapper(self, *args, **kwargs):
-        # type: (Litestar, *Any, **Any) -> None
+    def injection_wrapper(self: Litestar, *args: Any, **kwargs: Any) -> None:
         kwargs["after_exception"] = [
             exception_handler,
             *(kwargs.get("after_exception") or []),
@@ -123,13 +121,11 @@ def patch_app_init():
     Litestar.__init__ = injection_wrapper
 
 
-def patch_middlewares():
-    # type: () -> None
+def patch_middlewares() -> None:
     old_resolve_middleware_stack = BaseRouteHandler.resolve_middleware
 
     @ensure_integration_enabled(LitestarIntegration, old_resolve_middleware_stack)
-    def resolve_middleware_wrapper(self):
-        # type: (BaseRouteHandler) -> list[Middleware]
+    def resolve_middleware_wrapper(self: BaseRouteHandler) -> list[Middleware]:
         return [
             enable_span_for_middleware(middleware)
             for middleware in old_resolve_middleware_stack(self)
@@ -138,8 +134,7 @@ def patch_middlewares():
     BaseRouteHandler.resolve_middleware = resolve_middleware_wrapper
 
 
-def enable_span_for_middleware(middleware):
-    # type: (Middleware) -> Middleware
+def enable_span_for_middleware(middleware: Middleware) -> Middleware:
     if (
         not hasattr(middleware, "__call__")  # noqa: B004
         or middleware is SentryLitestarASGIMiddleware
@@ -147,12 +142,13 @@ def enable_span_for_middleware(middleware):
         return middleware
 
     if isinstance(middleware, DefineMiddleware):
-        old_call = middleware.middleware.__call__  # type: ASGIApp
+        old_call: ASGIApp = middleware.middleware.__call__
     else:
         old_call = middleware.__call__
 
-    async def _create_span_call(self, scope, receive, send):
-        # type: (MiddlewareProtocol, LitestarScope, Receive, Send) -> None
+    async def _create_span_call(
+        self: MiddlewareProtocol, scope: LitestarScope, receive: Receive, send: Send
+    ) -> None:
         if sentry_sdk.get_client().get_integration(LitestarIntegration) is None:
             return await old_call(self, scope, receive, send)
 
@@ -166,8 +162,9 @@ def enable_span_for_middleware(middleware):
             middleware_span.set_tag("litestar.middleware_name", middleware_name)
 
             # Creating spans for the "receive" callback
-            async def _sentry_receive(*args, **kwargs):
-                # type: (*Any, **Any) -> Union[HTTPReceiveMessage, WebSocketReceiveMessage]
+            async def _sentry_receive(
+                *args: Any, **kwargs: Any
+            ) -> Union[HTTPReceiveMessage, WebSocketReceiveMessage]:
                 if sentry_sdk.get_client().get_integration(LitestarIntegration) is None:
                     return await receive(*args, **kwargs)
                 with sentry_sdk.start_span(
@@ -184,8 +181,7 @@ def enable_span_for_middleware(middleware):
             new_receive = _sentry_receive if not receive_patched else receive
 
             # Creating spans for the "send" callback
-            async def _sentry_send(message):
-                # type: (Message) -> None
+            async def _sentry_send(message: Message) -> None:
                 if sentry_sdk.get_client().get_integration(LitestarIntegration) is None:
                     return await send(message)
                 with sentry_sdk.start_span(
@@ -214,19 +210,19 @@ def enable_span_for_middleware(middleware):
     return middleware
 
 
-def patch_http_route_handle():
-    # type: () -> None
+def patch_http_route_handle() -> None:
     old_handle = HTTPRoute.handle
 
-    async def handle_wrapper(self, scope, receive, send):
-        # type: (HTTPRoute, HTTPScope, Receive, Send) -> None
+    async def handle_wrapper(
+        self: HTTPRoute, scope: HTTPScope, receive: Receive, send: Send
+    ) -> None:
         if sentry_sdk.get_client().get_integration(LitestarIntegration) is None:
             return await old_handle(self, scope, receive, send)
 
         sentry_scope = sentry_sdk.get_isolation_scope()
-        request = scope["app"].request_class(
+        request: Request[Any, Any] = scope["app"].request_class(
             scope=scope, receive=receive, send=send
-        )  # type: Request[Any, Any]
+        )
         extracted_request_data = ConnectionDataExtractor(
             parse_body=True, parse_query=True
         )(request)
@@ -234,8 +230,7 @@ def patch_http_route_handle():
 
         request_data = await body
 
-        def event_processor(event, _):
-            # type: (Event, Hint) -> Event
+        def event_processor(event: Event, _: Hint) -> Event:
             route_handler = scope.get("route_handler")
 
             request_info = event.get("request", {})
@@ -279,8 +274,7 @@ def patch_http_route_handle():
     HTTPRoute.handle = handle_wrapper
 
 
-def retrieve_user_from_scope(scope):
-    # type: (LitestarScope) -> Optional[dict[str, Any]]
+def retrieve_user_from_scope(scope: LitestarScope) -> Optional[dict[str, Any]]:
     scope_user = scope.get("user")
     if isinstance(scope_user, dict):
         return scope_user
@@ -291,9 +285,8 @@ def retrieve_user_from_scope(scope):
 
 
 @ensure_integration_enabled(LitestarIntegration)
-def exception_handler(exc, scope):
-    # type: (Exception, LitestarScope) -> None
-    user_info = None  # type: Optional[dict[str, Any]]
+def exception_handler(exc: Exception, scope: LitestarScope) -> None:
+    user_info: Optional[dict[str, Any]] = None
     if should_send_default_pii():
         user_info = retrieve_user_from_scope(scope)
     if user_info and isinstance(user_info, dict):

--- a/sentry_sdk/integrations/logging.py
+++ b/sentry_sdk/integrations/logging.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import logging
 import sys
 from datetime import datetime, timezone
@@ -64,9 +65,8 @@ _IGNORED_LOGGERS = set(
 
 
 def ignore_logger(
-    name,  # type: str
-):
-    # type: (...) -> None
+    name: str,
+) -> None:
     """This disables recording (both in breadcrumbs and as events) calls to
     a logger of a specific name.  Among other uses, many of our integrations
     use this to prevent their actions being recorded as breadcrumbs. Exposed
@@ -82,11 +82,10 @@ class LoggingIntegration(Integration):
 
     def __init__(
         self,
-        level=DEFAULT_LEVEL,
-        event_level=DEFAULT_EVENT_LEVEL,
-        sentry_logs_level=DEFAULT_LEVEL,
-    ):
-        # type: (Optional[int], Optional[int], Optional[int]) -> None
+        level: Optional[int] = DEFAULT_LEVEL,
+        event_level: Optional[int] = DEFAULT_EVENT_LEVEL,
+        sentry_logs_level: Optional[int] = DEFAULT_LEVEL,
+    ) -> None:
         self._handler = None
         self._breadcrumb_handler = None
         self._sentry_logs_handler = None
@@ -100,8 +99,7 @@ class LoggingIntegration(Integration):
         if event_level is not None:
             self._handler = EventHandler(level=event_level)
 
-    def _handle_record(self, record):
-        # type: (LogRecord) -> None
+    def _handle_record(self, record: LogRecord) -> None:
         if self._handler is not None and record.levelno >= self._handler.level:
             self._handler.handle(record)
 
@@ -118,12 +116,10 @@ class LoggingIntegration(Integration):
             self._sentry_logs_handler.handle(record)
 
     @staticmethod
-    def setup_once():
-        # type: () -> None
+    def setup_once() -> None:
         old_callhandlers = logging.Logger.callHandlers
 
-        def sentry_patched_callhandlers(self, record):
-            # type: (Any, LogRecord) -> Any
+        def sentry_patched_callhandlers(self: Any, record: LogRecord) -> Any:
             # keeping a local reference because the
             # global might be discarded on shutdown
             ignored_loggers = _IGNORED_LOGGERS
@@ -179,22 +175,19 @@ class _BaseHandler(logging.Handler):
         )
     )
 
-    def _can_record(self, record):
-        # type: (LogRecord) -> bool
+    def _can_record(self, record: LogRecord) -> bool:
         """Prevents ignored loggers from recording"""
         for logger in _IGNORED_LOGGERS:
             if fnmatch(record.name.strip(), logger):
                 return False
         return True
 
-    def _logging_to_event_level(self, record):
-        # type: (LogRecord) -> str
+    def _logging_to_event_level(self, record: LogRecord) -> str:
         return LOGGING_TO_EVENT_LEVEL.get(
             record.levelno, record.levelname.lower() if record.levelname else ""
         )
 
-    def _extra_from_record(self, record):
-        # type: (LogRecord) -> MutableMapping[str, object]
+    def _extra_from_record(self, record: LogRecord) -> MutableMapping[str, object]:
         return {
             k: v
             for k, v in vars(record).items()
@@ -210,14 +203,12 @@ class EventHandler(_BaseHandler):
     Note that you do not have to use this class if the logging integration is enabled, which it is by default.
     """
 
-    def emit(self, record):
-        # type: (LogRecord) -> Any
+    def emit(self, record: LogRecord) -> Any:
         with capture_internal_exceptions():
             self.format(record)
             return self._emit(record)
 
-    def _emit(self, record):
-        # type: (LogRecord) -> None
+    def _emit(self, record: LogRecord) -> None:
         if not self._can_record(record):
             return
 
@@ -304,14 +295,12 @@ class BreadcrumbHandler(_BaseHandler):
     Note that you do not have to use this class if the logging integration is enabled, which it is by default.
     """
 
-    def emit(self, record):
-        # type: (LogRecord) -> Any
+    def emit(self, record: LogRecord) -> Any:
         with capture_internal_exceptions():
             self.format(record)
             return self._emit(record)
 
-    def _emit(self, record):
-        # type: (LogRecord) -> None
+    def _emit(self, record: LogRecord) -> None:
         if not self._can_record(record):
             return
 
@@ -319,8 +308,7 @@ class BreadcrumbHandler(_BaseHandler):
             self._breadcrumb_from_record(record), hint={"log_record": record}
         )
 
-    def _breadcrumb_from_record(self, record):
-        # type: (LogRecord) -> Dict[str, Any]
+    def _breadcrumb_from_record(self, record: LogRecord) -> Dict[str, Any]:
         return {
             "type": "log",
             "level": self._logging_to_event_level(record),
@@ -338,8 +326,7 @@ class SentryLogsHandler(_BaseHandler):
     Note that you do not have to use this class if the logging integration is enabled, which it is by default.
     """
 
-    def emit(self, record):
-        # type: (LogRecord) -> Any
+    def emit(self, record: LogRecord) -> Any:
         with capture_internal_exceptions():
             self.format(record)
             if not self._can_record(record):
@@ -354,13 +341,12 @@ class SentryLogsHandler(_BaseHandler):
 
             self._capture_log_from_record(client, record)
 
-    def _capture_log_from_record(self, client, record):
-        # type: (BaseClient, LogRecord) -> None
+    def _capture_log_from_record(self, client: BaseClient, record: LogRecord) -> None:
         otel_severity_number, otel_severity_text = _log_level_to_otel(
             record.levelno, SEVERITY_TO_OTEL_SEVERITY
         )
         project_root = client.options["project_root"]
-        attrs = self._extra_from_record(record)  # type: Any
+        attrs: Any = self._extra_from_record(record)
         attrs["sentry.origin"] = "auto.logger.log"
         if isinstance(record.msg, str):
             attrs["sentry.message.template"] = record.msg

--- a/sentry_sdk/integrations/loguru.py
+++ b/sentry_sdk/integrations/loguru.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import enum
 
 import sentry_sdk
@@ -65,21 +66,20 @@ SEVERITY_TO_OTEL_SEVERITY = {
 class LoguruIntegration(Integration):
     identifier = "loguru"
 
-    level = DEFAULT_LEVEL  # type: Optional[int]
-    event_level = DEFAULT_EVENT_LEVEL  # type: Optional[int]
+    level: Optional[int] = DEFAULT_LEVEL
+    event_level: Optional[int] = DEFAULT_EVENT_LEVEL
     breadcrumb_format = DEFAULT_FORMAT
     event_format = DEFAULT_FORMAT
-    sentry_logs_level = DEFAULT_LEVEL  # type: Optional[int]
+    sentry_logs_level: Optional[int] = DEFAULT_LEVEL
 
     def __init__(
         self,
-        level=DEFAULT_LEVEL,
-        event_level=DEFAULT_EVENT_LEVEL,
-        breadcrumb_format=DEFAULT_FORMAT,
-        event_format=DEFAULT_FORMAT,
-        sentry_logs_level=DEFAULT_LEVEL,
-    ):
-        # type: (Optional[int], Optional[int], str | loguru.FormatFunction, str | loguru.FormatFunction, Optional[int]) -> None
+        level: Optional[int] = DEFAULT_LEVEL,
+        event_level: Optional[int] = DEFAULT_EVENT_LEVEL,
+        breadcrumb_format: str | loguru.FormatFunction = DEFAULT_FORMAT,
+        event_format: str | loguru.FormatFunction = DEFAULT_FORMAT,
+        sentry_logs_level: Optional[int] = DEFAULT_LEVEL,
+    ) -> None:
         LoguruIntegration.level = level
         LoguruIntegration.event_level = event_level
         LoguruIntegration.breadcrumb_format = breadcrumb_format
@@ -87,8 +87,7 @@ class LoguruIntegration(Integration):
         LoguruIntegration.sentry_logs_level = sentry_logs_level
 
     @staticmethod
-    def setup_once():
-        # type: () -> None
+    def setup_once() -> None:
         if LoguruIntegration.level is not None:
             logger.add(
                 LoguruBreadcrumbHandler(level=LoguruIntegration.level),
@@ -111,8 +110,7 @@ class LoguruIntegration(Integration):
 
 
 class _LoguruBaseHandler(_BaseHandler):
-    def __init__(self, *args, **kwargs):
-        # type: (*Any, **Any) -> None
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         if kwargs.get("level"):
             kwargs["level"] = SENTRY_LEVEL_FROM_LOGURU_LEVEL.get(
                 kwargs.get("level", ""), DEFAULT_LEVEL
@@ -120,8 +118,7 @@ class _LoguruBaseHandler(_BaseHandler):
 
         super().__init__(*args, **kwargs)
 
-    def _logging_to_event_level(self, record):
-        # type: (LogRecord) -> str
+    def _logging_to_event_level(self, record: LogRecord) -> str:
         try:
             return SENTRY_LEVEL_FROM_LOGURU_LEVEL[
                 LoggingLevels(record.levelno).name
@@ -142,8 +139,7 @@ class LoguruBreadcrumbHandler(_LoguruBaseHandler, BreadcrumbHandler):
     pass
 
 
-def loguru_sentry_logs_handler(message):
-    # type: (Message) -> None
+def loguru_sentry_logs_handler(message: Message) -> None:
     # This is intentionally a callable sink instead of a standard logging handler
     # since otherwise we wouldn't get direct access to message.record
     client = sentry_sdk.get_client()
@@ -166,7 +162,7 @@ def loguru_sentry_logs_handler(message):
         record["level"].no, SEVERITY_TO_OTEL_SEVERITY
     )
 
-    attrs = {"sentry.origin": "auto.logger.loguru"}  # type: dict[str, Any]
+    attrs: dict[str, Any] = {"sentry.origin": "auto.logger.loguru"}
 
     project_root = client.options["project_root"]
     if record.get("file"):

--- a/sentry_sdk/integrations/modules.py
+++ b/sentry_sdk/integrations/modules.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import sentry_sdk
 from sentry_sdk.integrations import Integration
 from sentry_sdk.scope import add_global_event_processor
@@ -14,11 +15,9 @@ class ModulesIntegration(Integration):
     identifier = "modules"
 
     @staticmethod
-    def setup_once():
-        # type: () -> None
+    def setup_once() -> None:
         @add_global_event_processor
-        def processor(event, hint):
-            # type: (Event, Any) -> Event
+        def processor(event: Event, hint: Any) -> Event:
             if event.get("type") == "transaction":
                 return event
 

--- a/sentry_sdk/integrations/openai.py
+++ b/sentry_sdk/integrations/openai.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from functools import wraps
 
 import sentry_sdk
@@ -32,8 +33,11 @@ class OpenAIIntegration(Integration):
     identifier = "openai"
     origin = f"auto.ai.{identifier}"
 
-    def __init__(self, include_prompts=True, tiktoken_encoding_name=None):
-        # type: (OpenAIIntegration, bool, Optional[str]) -> None
+    def __init__(
+        self: OpenAIIntegration,
+        include_prompts: bool = True,
+        tiktoken_encoding_name: Optional[str] = None,
+    ) -> None:
         self.include_prompts = include_prompts
 
         self.tiktoken_encoding = None
@@ -43,8 +47,7 @@ class OpenAIIntegration(Integration):
             self.tiktoken_encoding = tiktoken.get_encoding(tiktoken_encoding_name)
 
     @staticmethod
-    def setup_once():
-        # type: () -> None
+    def setup_once() -> None:
         Completions.create = _wrap_chat_completion_create(Completions.create)
         Embeddings.create = _wrap_embeddings_create(Embeddings.create)
 
@@ -53,15 +56,13 @@ class OpenAIIntegration(Integration):
         )
         AsyncEmbeddings.create = _wrap_async_embeddings_create(AsyncEmbeddings.create)
 
-    def count_tokens(self, s):
-        # type: (OpenAIIntegration, str) -> int
+    def count_tokens(self: OpenAIIntegration, s: str) -> int:
         if self.tiktoken_encoding is not None:
             return len(self.tiktoken_encoding.encode_ordinary(s))
         return 0
 
 
-def _capture_exception(exc):
-    # type: (Any) -> None
+def _capture_exception(exc: Any) -> None:
     event, hint = event_from_exception(
         exc,
         client_options=sentry_sdk.get_client().options,
@@ -71,12 +72,15 @@ def _capture_exception(exc):
 
 
 def _calculate_chat_completion_usage(
-    messages, response, span, streaming_message_responses, count_tokens
-):
-    # type: (Iterable[ChatCompletionMessageParam], Any, Span, Optional[List[str]], Callable[..., Any]) -> None
-    completion_tokens = 0  # type: Optional[int]
-    prompt_tokens = 0  # type: Optional[int]
-    total_tokens = 0  # type: Optional[int]
+    messages: Iterable[ChatCompletionMessageParam],
+    response: Any,
+    span: Span,
+    streaming_message_responses: Optional[List[str]],
+    count_tokens: Callable[..., Any],
+) -> None:
+    completion_tokens: Optional[int] = 0
+    prompt_tokens: Optional[int] = 0
+    total_tokens: Optional[int] = 0
     if hasattr(response, "usage"):
         if hasattr(response.usage, "completion_tokens") and isinstance(
             response.usage.completion_tokens, int
@@ -114,8 +118,7 @@ def _calculate_chat_completion_usage(
     record_token_usage(span, prompt_tokens, completion_tokens, total_tokens)
 
 
-def _new_chat_completion_common(f, *args, **kwargs):
-    # type: (Any, *Any, **Any) -> Any
+def _new_chat_completion_common(f: Any, *args: Any, **kwargs: Any) -> Any:
     integration = sentry_sdk.get_client().get_integration(OpenAIIntegration)
     if integration is None:
         return f(*args, **kwargs)
@@ -168,8 +171,7 @@ def _new_chat_completion_common(f, *args, **kwargs):
 
             old_iterator = res._iterator
 
-            def new_iterator():
-                # type: () -> Iterator[ChatCompletionChunk]
+            def new_iterator() -> Iterator[ChatCompletionChunk]:
                 with capture_internal_exceptions():
                     for x in old_iterator:
                         if hasattr(x, "choices"):
@@ -201,8 +203,7 @@ def _new_chat_completion_common(f, *args, **kwargs):
                         )
                 span.__exit__(None, None, None)
 
-            async def new_iterator_async():
-                # type: () -> AsyncIterator[ChatCompletionChunk]
+            async def new_iterator_async() -> AsyncIterator[ChatCompletionChunk]:
                 with capture_internal_exceptions():
                     async for x in old_iterator:
                         if hasattr(x, "choices"):
@@ -245,10 +246,8 @@ def _new_chat_completion_common(f, *args, **kwargs):
     return res
 
 
-def _wrap_chat_completion_create(f):
-    # type: (Callable[..., Any]) -> Callable[..., Any]
-    def _execute_sync(f, *args, **kwargs):
-        # type: (Any, *Any, **Any) -> Any
+def _wrap_chat_completion_create(f: Callable[..., Any]) -> Callable[..., Any]:
+    def _execute_sync(f: Any, *args: Any, **kwargs: Any) -> Any:
         gen = _new_chat_completion_common(f, *args, **kwargs)
 
         try:
@@ -268,8 +267,7 @@ def _wrap_chat_completion_create(f):
             return e.value
 
     @wraps(f)
-    def _sentry_patched_create_sync(*args, **kwargs):
-        # type: (*Any, **Any) -> Any
+    def _sentry_patched_create_sync(*args: Any, **kwargs: Any) -> Any:
         integration = sentry_sdk.get_client().get_integration(OpenAIIntegration)
         if integration is None or "messages" not in kwargs:
             # no "messages" means invalid call (in all versions of openai), let it return error
@@ -280,10 +278,8 @@ def _wrap_chat_completion_create(f):
     return _sentry_patched_create_sync
 
 
-def _wrap_async_chat_completion_create(f):
-    # type: (Callable[..., Any]) -> Callable[..., Any]
-    async def _execute_async(f, *args, **kwargs):
-        # type: (Any, *Any, **Any) -> Any
+def _wrap_async_chat_completion_create(f: Callable[..., Any]) -> Callable[..., Any]:
+    async def _execute_async(f: Any, *args: Any, **kwargs: Any) -> Any:
         gen = _new_chat_completion_common(f, *args, **kwargs)
 
         try:
@@ -303,8 +299,7 @@ def _wrap_async_chat_completion_create(f):
             return e.value
 
     @wraps(f)
-    async def _sentry_patched_create_async(*args, **kwargs):
-        # type: (*Any, **Any) -> Any
+    async def _sentry_patched_create_async(*args: Any, **kwargs: Any) -> Any:
         integration = sentry_sdk.get_client().get_integration(OpenAIIntegration)
         if integration is None or "messages" not in kwargs:
             # no "messages" means invalid call (in all versions of openai), let it return error
@@ -315,8 +310,7 @@ def _wrap_async_chat_completion_create(f):
     return _sentry_patched_create_async
 
 
-def _new_embeddings_create_common(f, *args, **kwargs):
-    # type: (Any, *Any, **Any) -> Any
+def _new_embeddings_create_common(f: Any, *args: Any, **kwargs: Any) -> Any:
     integration = sentry_sdk.get_client().get_integration(OpenAIIntegration)
     if integration is None:
         return f(*args, **kwargs)
@@ -363,10 +357,8 @@ def _new_embeddings_create_common(f, *args, **kwargs):
         return response
 
 
-def _wrap_embeddings_create(f):
-    # type: (Any) -> Any
-    def _execute_sync(f, *args, **kwargs):
-        # type: (Any, *Any, **Any) -> Any
+def _wrap_embeddings_create(f: Any) -> Any:
+    def _execute_sync(f: Any, *args: Any, **kwargs: Any) -> Any:
         gen = _new_embeddings_create_common(f, *args, **kwargs)
 
         try:
@@ -386,8 +378,7 @@ def _wrap_embeddings_create(f):
             return e.value
 
     @wraps(f)
-    def _sentry_patched_create_sync(*args, **kwargs):
-        # type: (*Any, **Any) -> Any
+    def _sentry_patched_create_sync(*args: Any, **kwargs: Any) -> Any:
         integration = sentry_sdk.get_client().get_integration(OpenAIIntegration)
         if integration is None:
             return f(*args, **kwargs)
@@ -397,10 +388,8 @@ def _wrap_embeddings_create(f):
     return _sentry_patched_create_sync
 
 
-def _wrap_async_embeddings_create(f):
-    # type: (Any) -> Any
-    async def _execute_async(f, *args, **kwargs):
-        # type: (Any, *Any, **Any) -> Any
+def _wrap_async_embeddings_create(f: Any) -> Any:
+    async def _execute_async(f: Any, *args: Any, **kwargs: Any) -> Any:
         gen = _new_embeddings_create_common(f, *args, **kwargs)
 
         try:
@@ -420,8 +409,7 @@ def _wrap_async_embeddings_create(f):
             return e.value
 
     @wraps(f)
-    async def _sentry_patched_create_async(*args, **kwargs):
-        # type: (*Any, **Any) -> Any
+    async def _sentry_patched_create_async(*args: Any, **kwargs: Any) -> Any:
         integration = sentry_sdk.get_client().get_integration(OpenAIIntegration)
         if integration is None:
             return await f(*args, **kwargs)

--- a/sentry_sdk/integrations/openfeature.py
+++ b/sentry_sdk/integrations/openfeature.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from sentry_sdk.feature_flags import add_feature_flag
@@ -18,20 +19,24 @@ class OpenFeatureIntegration(Integration):
     identifier = "openfeature"
 
     @staticmethod
-    def setup_once():
-        # type: () -> None
+    def setup_once() -> None:
         # Register the hook within the global openfeature hooks list.
         api.add_hooks(hooks=[OpenFeatureHook()])
 
 
 class OpenFeatureHook(Hook):
 
-    def after(self, hook_context, details, hints):
-        # type: (HookContext, FlagEvaluationDetails[bool], HookHints) -> None
+    def after(
+        self,
+        hook_context: HookContext,
+        details: FlagEvaluationDetails[bool],
+        hints: HookHints,
+    ) -> None:
         if isinstance(details.value, bool):
             add_feature_flag(details.flag_key, details.value)
 
-    def error(self, hook_context, exception, hints):
-        # type: (HookContext, Exception, HookHints) -> None
+    def error(
+        self, hook_context: HookContext, exception: Exception, hints: HookHints
+    ) -> None:
         if isinstance(hook_context.default_value, bool):
             add_feature_flag(hook_context.flag_key, hook_context.default_value)

--- a/sentry_sdk/integrations/pure_eval.py
+++ b/sentry_sdk/integrations/pure_eval.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import ast
 
 import sentry_sdk
@@ -35,12 +36,10 @@ class PureEvalIntegration(Integration):
     identifier = "pure_eval"
 
     @staticmethod
-    def setup_once():
-        # type: () -> None
+    def setup_once() -> None:
 
         @add_global_event_processor
-        def add_executing_info(event, hint):
-            # type: (Event, Optional[Hint]) -> Optional[Event]
+        def add_executing_info(event: Event, hint: Optional[Hint]) -> Optional[Event]:
             if sentry_sdk.get_client().get_integration(PureEvalIntegration) is None:
                 return event
 
@@ -81,8 +80,7 @@ class PureEvalIntegration(Integration):
             return event
 
 
-def pure_eval_frame(frame):
-    # type: (FrameType) -> Dict[str, Any]
+def pure_eval_frame(frame: FrameType) -> Dict[str, Any]:
     source = executing.Source.for_frame(frame)
     if not source.tree:
         return {}
@@ -103,16 +101,14 @@ def pure_eval_frame(frame):
     evaluator = pure_eval.Evaluator.from_frame(frame)
     expressions = evaluator.interesting_expressions_grouped(scope)
 
-    def closeness(expression):
-        # type: (Tuple[List[Any], Any]) -> Tuple[int, int]
+    def closeness(expression: Tuple[List[Any], Any]) -> Tuple[int, int]:
         # Prioritise expressions with a node closer to the statement executed
         # without being after that statement
         # A higher return value is better - the expression will appear
         # earlier in the list of values and is less likely to be trimmed
         nodes, _value = expression
 
-        def start(n):
-            # type: (ast.expr) -> Tuple[int, int]
+        def start(n: ast.expr) -> Tuple[int, int]:
             return (n.lineno, n.col_offset)
 
         nodes_before_stmt = [

--- a/sentry_sdk/integrations/pymongo.py
+++ b/sentry_sdk/integrations/pymongo.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import copy
 
 import sentry_sdk
@@ -41,8 +42,7 @@ SAFE_COMMAND_ATTRIBUTES = [
 ]
 
 
-def _strip_pii(command):
-    # type: (Dict[str, Any]) -> Dict[str, Any]
+def _strip_pii(command: Dict[str, Any]) -> Dict[str, Any]:
     for key in command:
         is_safe_field = key in SAFE_COMMAND_ATTRIBUTES
         if is_safe_field:
@@ -84,8 +84,7 @@ def _strip_pii(command):
     return command
 
 
-def _get_db_data(event):
-    # type: (Any) -> Dict[str, Any]
+def _get_db_data(event: Any) -> Dict[str, Any]:
     data = {}
 
     data[SPANDATA.DB_SYSTEM] = "mongodb"
@@ -106,16 +105,16 @@ def _get_db_data(event):
 
 
 class CommandTracer(monitoring.CommandListener):
-    def __init__(self):
-        # type: () -> None
-        self._ongoing_operations = {}  # type: Dict[int, Span]
+    def __init__(self) -> None:
+        self._ongoing_operations: Dict[int, Span] = {}
 
-    def _operation_key(self, event):
-        # type: (Union[CommandFailedEvent, CommandStartedEvent, CommandSucceededEvent]) -> int
+    def _operation_key(
+        self,
+        event: Union[CommandFailedEvent, CommandStartedEvent, CommandSucceededEvent],
+    ) -> int:
         return event.request_id
 
-    def started(self, event):
-        # type: (CommandStartedEvent) -> None
+    def started(self, event: CommandStartedEvent) -> None:
         if sentry_sdk.get_client().get_integration(PyMongoIntegration) is None:
             return
 
@@ -172,8 +171,7 @@ class CommandTracer(monitoring.CommandListener):
 
             self._ongoing_operations[self._operation_key(event)] = span.__enter__()
 
-    def failed(self, event):
-        # type: (CommandFailedEvent) -> None
+    def failed(self, event: CommandFailedEvent) -> None:
         if sentry_sdk.get_client().get_integration(PyMongoIntegration) is None:
             return
 
@@ -184,8 +182,7 @@ class CommandTracer(monitoring.CommandListener):
         except KeyError:
             return
 
-    def succeeded(self, event):
-        # type: (CommandSucceededEvent) -> None
+    def succeeded(self, event: CommandSucceededEvent) -> None:
         if sentry_sdk.get_client().get_integration(PyMongoIntegration) is None:
             return
 
@@ -202,6 +199,5 @@ class PyMongoIntegration(Integration):
     origin = f"auto.db.{identifier}"
 
     @staticmethod
-    def setup_once():
-        # type: () -> None
+    def setup_once() -> None:
         monitoring.register(CommandTracer())

--- a/sentry_sdk/integrations/pyramid.py
+++ b/sentry_sdk/integrations/pyramid.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import functools
 import os
 import sys
@@ -40,8 +41,7 @@ if TYPE_CHECKING:
 
 if getattr(Request, "authenticated_userid", None):
 
-    def authenticated_userid(request):
-        # type: (Request) -> Optional[Any]
+    def authenticated_userid(request: Request) -> Optional[Any]:
         return request.authenticated_userid
 
 else:
@@ -58,8 +58,7 @@ class PyramidIntegration(Integration):
 
     transaction_style = ""
 
-    def __init__(self, transaction_style="route_name"):
-        # type: (str) -> None
+    def __init__(self, transaction_style: str = "route_name") -> None:
         if transaction_style not in TRANSACTION_STYLE_VALUES:
             raise ValueError(
                 "Invalid value for transaction_style: %s (must be in %s)"
@@ -68,15 +67,15 @@ class PyramidIntegration(Integration):
         self.transaction_style = transaction_style
 
     @staticmethod
-    def setup_once():
-        # type: () -> None
+    def setup_once() -> None:
         from pyramid import router
 
         old_call_view = router._call_view
 
         @functools.wraps(old_call_view)
-        def sentry_patched_call_view(registry, request, *args, **kwargs):
-            # type: (Any, Request, *Any, **Any) -> Response
+        def sentry_patched_call_view(
+            registry: Any, request: Request, *args: Any, **kwargs: Any
+        ) -> Response:
             integration = sentry_sdk.get_client().get_integration(PyramidIntegration)
             if integration is None:
                 return old_call_view(registry, request, *args, **kwargs)
@@ -96,8 +95,9 @@ class PyramidIntegration(Integration):
         if hasattr(Request, "invoke_exception_view"):
             old_invoke_exception_view = Request.invoke_exception_view
 
-            def sentry_patched_invoke_exception_view(self, *args, **kwargs):
-                # type: (Request, *Any, **Any) -> Any
+            def sentry_patched_invoke_exception_view(
+                self: Request, *args: Any, **kwargs: Any
+            ) -> Any:
                 rv = old_invoke_exception_view(self, *args, **kwargs)
 
                 if (
@@ -116,10 +116,12 @@ class PyramidIntegration(Integration):
         old_wsgi_call = router.Router.__call__
 
         @ensure_integration_enabled(PyramidIntegration, old_wsgi_call)
-        def sentry_patched_wsgi_call(self, environ, start_response):
-            # type: (Any, Dict[str, str], Callable[..., Any]) -> _ScopedResponse
-            def sentry_patched_inner_wsgi_call(environ, start_response):
-                # type: (Dict[str, Any], Callable[..., Any]) -> Any
+        def sentry_patched_wsgi_call(
+            self: Any, environ: Dict[str, str], start_response: Callable[..., Any]
+        ) -> _ScopedResponse:
+            def sentry_patched_inner_wsgi_call(
+                environ: Dict[str, Any], start_response: Callable[..., Any]
+            ) -> Any:
                 try:
                     return old_wsgi_call(self, environ, start_response)
                 except Exception:
@@ -137,8 +139,7 @@ class PyramidIntegration(Integration):
 
 
 @ensure_integration_enabled(PyramidIntegration)
-def _capture_exception(exc_info):
-    # type: (ExcInfo) -> None
+def _capture_exception(exc_info: ExcInfo) -> None:
     if exc_info[0] is None or issubclass(exc_info[0], HTTPException):
         return
 
@@ -151,8 +152,9 @@ def _capture_exception(exc_info):
     sentry_sdk.capture_event(event, hint=hint)
 
 
-def _set_transaction_name_and_source(scope, transaction_style, request):
-    # type: (sentry_sdk.Scope, str, Request) -> None
+def _set_transaction_name_and_source(
+    scope: sentry_sdk.Scope, transaction_style: str, request: Request
+) -> None:
     try:
         name_for_style = {
             "route_name": request.matched_route.name,
@@ -167,40 +169,33 @@ def _set_transaction_name_and_source(scope, transaction_style, request):
 
 
 class PyramidRequestExtractor(RequestExtractor):
-    def url(self):
-        # type: () -> str
+    def url(self) -> str:
         return self.request.path_url
 
-    def env(self):
-        # type: () -> Dict[str, str]
+    def env(self) -> Dict[str, str]:
         return self.request.environ
 
-    def cookies(self):
-        # type: () -> RequestCookies
+    def cookies(self) -> RequestCookies:
         return self.request.cookies
 
-    def raw_data(self):
-        # type: () -> str
+    def raw_data(self) -> str:
         return self.request.text
 
-    def form(self):
-        # type: () -> Dict[str, str]
+    def form(self) -> Dict[str, str]:
         return {
             key: value
             for key, value in self.request.POST.items()
             if not getattr(value, "filename", None)
         }
 
-    def files(self):
-        # type: () -> Dict[str, _FieldStorageWithFile]
+    def files(self) -> Dict[str, _FieldStorageWithFile]:
         return {
             key: value
             for key, value in self.request.POST.items()
             if getattr(value, "filename", None)
         }
 
-    def size_of_file(self, postdata):
-        # type: (_FieldStorageWithFile) -> int
+    def size_of_file(self, postdata: _FieldStorageWithFile) -> int:
         file = postdata.file
         try:
             return os.fstat(file.fileno()).st_size
@@ -208,10 +203,10 @@ class PyramidRequestExtractor(RequestExtractor):
             return 0
 
 
-def _make_event_processor(weak_request, integration):
-    # type: (Callable[[], Request], PyramidIntegration) -> EventProcessor
-    def pyramid_event_processor(event, hint):
-        # type: (Event, Dict[str, Any]) -> Event
+def _make_event_processor(
+    weak_request: Callable[[], Request], integration: PyramidIntegration
+) -> EventProcessor:
+    def pyramid_event_processor(event: Event, hint: Dict[str, Any]) -> Event:
         request = weak_request()
         if request is None:
             return event

--- a/sentry_sdk/integrations/quart.py
+++ b/sentry_sdk/integrations/quart.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import asyncio
 import inspect
 from functools import wraps
@@ -60,8 +61,7 @@ class QuartIntegration(Integration):
 
     transaction_style = ""
 
-    def __init__(self, transaction_style="endpoint"):
-        # type: (str) -> None
+    def __init__(self, transaction_style: str = "endpoint") -> None:
         if transaction_style not in TRANSACTION_STYLE_VALUES:
             raise ValueError(
                 "Invalid value for transaction_style: %s (must be in %s)"
@@ -70,8 +70,7 @@ class QuartIntegration(Integration):
         self.transaction_style = transaction_style
 
     @staticmethod
-    def setup_once():
-        # type: () -> None
+    def setup_once() -> None:
 
         request_started.connect(_request_websocket_started)
         websocket_started.connect(_request_websocket_started)
@@ -83,12 +82,12 @@ class QuartIntegration(Integration):
         patch_scaffold_route()
 
 
-def patch_asgi_app():
-    # type: () -> None
+def patch_asgi_app() -> None:
     old_app = Quart.__call__
 
-    async def sentry_patched_asgi_app(self, scope, receive, send):
-        # type: (Any, Any, Any, Any) -> Any
+    async def sentry_patched_asgi_app(
+        self: Any, scope: Any, receive: Any, send: Any
+    ) -> Any:
         if sentry_sdk.get_client().get_integration(QuartIntegration) is None:
             return await old_app(self, scope, receive, send)
 
@@ -102,16 +101,13 @@ def patch_asgi_app():
     Quart.__call__ = sentry_patched_asgi_app
 
 
-def patch_scaffold_route():
-    # type: () -> None
+def patch_scaffold_route() -> None:
     old_route = Scaffold.route
 
-    def _sentry_route(*args, **kwargs):
-        # type: (*Any, **Any) -> Any
+    def _sentry_route(*args: Any, **kwargs: Any) -> Any:
         old_decorator = old_route(*args, **kwargs)
 
-        def decorator(old_func):
-            # type: (Any) -> Any
+        def decorator(old_func: Any) -> Any:
 
             if inspect.isfunction(old_func) and not asyncio.iscoroutinefunction(
                 old_func
@@ -119,8 +115,7 @@ def patch_scaffold_route():
 
                 @wraps(old_func)
                 @ensure_integration_enabled(QuartIntegration, old_func)
-                def _sentry_func(*args, **kwargs):
-                    # type: (*Any, **Any) -> Any
+                def _sentry_func(*args: Any, **kwargs: Any) -> Any:
                     current_scope = sentry_sdk.get_current_scope()
                     if current_scope.root_span is not None:
                         current_scope.root_span.update_active_thread()
@@ -140,8 +135,9 @@ def patch_scaffold_route():
     Scaffold.route = _sentry_route
 
 
-def _set_transaction_name_and_source(scope, transaction_style, request):
-    # type: (sentry_sdk.Scope, str, Request) -> None
+def _set_transaction_name_and_source(
+    scope: sentry_sdk.Scope, transaction_style: str, request: Request
+) -> None:
 
     try:
         name_for_style = {
@@ -156,8 +152,7 @@ def _set_transaction_name_and_source(scope, transaction_style, request):
         pass
 
 
-async def _request_websocket_started(app, **kwargs):
-    # type: (Quart, **Any) -> None
+async def _request_websocket_started(app: Quart, **kwargs: Any) -> None:
     integration = sentry_sdk.get_client().get_integration(QuartIntegration)
     if integration is None:
         return
@@ -178,10 +173,10 @@ async def _request_websocket_started(app, **kwargs):
     scope.add_event_processor(evt_processor)
 
 
-def _make_request_event_processor(app, request, integration):
-    # type: (Quart, Request, QuartIntegration) -> EventProcessor
-    def inner(event, hint):
-        # type: (Event, dict[str, Any]) -> Event
+def _make_request_event_processor(
+    app: Quart, request: Request, integration: QuartIntegration
+) -> EventProcessor:
+    def inner(event: Event, hint: dict[str, Any]) -> Event:
         # if the request is gone we are fine not logging the data from
         # it.  This might happen if the processor is pushed away to
         # another thread.
@@ -207,8 +202,9 @@ def _make_request_event_processor(app, request, integration):
     return inner
 
 
-async def _capture_exception(sender, exception, **kwargs):
-    # type: (Quart, Union[ValueError, BaseException], **Any) -> None
+async def _capture_exception(
+    sender: Quart, exception: Union[ValueError, BaseException], **kwargs: Any
+) -> None:
     integration = sentry_sdk.get_client().get_integration(QuartIntegration)
     if integration is None:
         return
@@ -222,8 +218,7 @@ async def _capture_exception(sender, exception, **kwargs):
     sentry_sdk.capture_event(event, hint=hint)
 
 
-def _add_user_to_event(event):
-    # type: (Event) -> None
+def _add_user_to_event(event: Event) -> None:
     if quart_auth is None:
         return
 

--- a/sentry_sdk/integrations/ray.py
+++ b/sentry_sdk/integrations/ray.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import inspect
 import sys
 
@@ -29,8 +30,7 @@ if TYPE_CHECKING:
 DEFAULT_TRANSACTION_NAME = "unknown Ray function"
 
 
-def _check_sentry_initialized():
-    # type: () -> None
+def _check_sentry_initialized() -> None:
     if sentry_sdk.get_client().is_active():
         return
 
@@ -39,13 +39,13 @@ def _check_sentry_initialized():
     )
 
 
-def _patch_ray_remote():
-    # type: () -> None
+def _patch_ray_remote() -> None:
     old_remote = ray.remote
 
     @functools.wraps(old_remote)
-    def new_remote(f=None, *args, **kwargs):
-        # type: (Optional[Callable[..., Any]], *Any, **Any) -> Callable[..., Any]
+    def new_remote(
+        f: Optional[Callable[..., Any]] = None, *args: Any, **kwargs: Any
+    ) -> Callable[..., Any]:
 
         if inspect.isclass(f):
             # Ray Actors
@@ -54,10 +54,10 @@ def _patch_ray_remote():
             # (Only Ray Tasks are supported)
             return old_remote(f, *args, **kwargs)
 
-        def wrapper(user_f):
-            # type: (Callable[..., Any]) -> Any
-            def new_func(*f_args, _tracing=None, **f_kwargs):
-                # type: (Any, Optional[dict[str, Any]], Any) -> Any
+        def wrapper(user_f: Callable[..., Any]) -> Any:
+            def new_func(
+                *f_args: Any, _tracing: Optional[dict[str, Any]] = None, **f_kwargs: Any
+            ) -> Any:
                 _check_sentry_initialized()
 
                 root_span_name = (
@@ -91,8 +91,9 @@ def _patch_ray_remote():
                 rv = old_remote(*args, **kwargs)(new_func)
             old_remote_method = rv.remote
 
-            def _remote_method_with_header_propagation(*args, **kwargs):
-                # type: (*Any, **Any) -> Any
+            def _remote_method_with_header_propagation(
+                *args: Any, **kwargs: Any
+            ) -> Any:
                 """
                 Ray Client
                 """
@@ -129,8 +130,7 @@ def _patch_ray_remote():
     ray.remote = new_remote
 
 
-def _capture_exception(exc_info, **kwargs):
-    # type: (ExcInfo, **Any) -> None
+def _capture_exception(exc_info: ExcInfo, **kwargs: Any) -> None:
     client = sentry_sdk.get_client()
 
     event, hint = event_from_exception(
@@ -149,8 +149,7 @@ class RayIntegration(Integration):
     origin = f"auto.queue.{identifier}"
 
     @staticmethod
-    def setup_once():
-        # type: () -> None
+    def setup_once() -> None:
         version = package_version("ray")
         _check_minimum_version(RayIntegration, version)
 

--- a/sentry_sdk/integrations/redis/__init__.py
+++ b/sentry_sdk/integrations/redis/__init__.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from sentry_sdk.integrations import Integration, DidNotEnable
 from sentry_sdk.integrations.redis.consts import _DEFAULT_MAX_DATA_SIZE
 from sentry_sdk.integrations.redis.rb import _patch_rb
@@ -15,14 +16,16 @@ if TYPE_CHECKING:
 class RedisIntegration(Integration):
     identifier = "redis"
 
-    def __init__(self, max_data_size=_DEFAULT_MAX_DATA_SIZE, cache_prefixes=None):
-        # type: (int, Optional[list[str]]) -> None
+    def __init__(
+        self,
+        max_data_size: int = _DEFAULT_MAX_DATA_SIZE,
+        cache_prefixes: Optional[list[str]] = None,
+    ) -> None:
         self.max_data_size = max_data_size
         self.cache_prefixes = cache_prefixes if cache_prefixes is not None else []
 
     @staticmethod
-    def setup_once():
-        # type: () -> None
+    def setup_once() -> None:
         try:
             from redis import StrictRedis, client
         except ImportError:

--- a/sentry_sdk/integrations/redis/_async_common.py
+++ b/sentry_sdk/integrations/redis/_async_common.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import sentry_sdk
 from sentry_sdk.consts import OP
 from sentry_sdk.integrations.redis.consts import SPAN_ORIGIN
@@ -24,15 +25,16 @@ if TYPE_CHECKING:
 
 
 def patch_redis_async_pipeline(
-    pipeline_cls, is_cluster, get_command_args_fn, get_db_data_fn
-):
-    # type: (Union[type[Pipeline[Any]], type[ClusterPipeline[Any]]], bool, Any, Callable[[Any], dict[str, Any]]) -> None
+    pipeline_cls: Union[type[Pipeline[Any]], type[ClusterPipeline[Any]]],
+    is_cluster: bool,
+    get_command_args_fn: Any,
+    get_db_data_fn: Callable[[Any], dict[str, Any]],
+) -> None:
     old_execute = pipeline_cls.execute
 
     from sentry_sdk.integrations.redis import RedisIntegration
 
-    async def _sentry_execute(self, *args, **kwargs):
-        # type: (Any, *Any, **Any) -> Any
+    async def _sentry_execute(self: Any, *args: Any, **kwargs: Any) -> Any:
         if sentry_sdk.get_client().get_integration(RedisIntegration) is None:
             return await old_execute(self, *args, **kwargs)
 
@@ -67,14 +69,18 @@ def patch_redis_async_pipeline(
     pipeline_cls.execute = _sentry_execute  # type: ignore
 
 
-def patch_redis_async_client(cls, is_cluster, get_db_data_fn):
-    # type: (Union[type[StrictRedis[Any]], type[RedisCluster[Any]]], bool, Callable[[Any], dict[str, Any]]) -> None
+def patch_redis_async_client(
+    cls: Union[type[StrictRedis[Any]], type[RedisCluster[Any]]],
+    is_cluster: bool,
+    get_db_data_fn: Callable[[Any], dict[str, Any]],
+) -> None:
     old_execute_command = cls.execute_command
 
     from sentry_sdk.integrations.redis import RedisIntegration
 
-    async def _sentry_execute_command(self, name, *args, **kwargs):
-        # type: (Any, str, *Any, **Any) -> Any
+    async def _sentry_execute_command(
+        self: Any, name: str, *args: Any, **kwargs: Any
+    ) -> Any:
         integration = sentry_sdk.get_client().get_integration(RedisIntegration)
         if integration is None:
             return await old_execute_command(self, name, *args, **kwargs)

--- a/sentry_sdk/integrations/redis/_sync_common.py
+++ b/sentry_sdk/integrations/redis/_sync_common.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import sentry_sdk
 from sentry_sdk.consts import OP
 from sentry_sdk.integrations.redis.consts import SPAN_ORIGIN
@@ -22,18 +23,16 @@ if TYPE_CHECKING:
 
 
 def patch_redis_pipeline(
-    pipeline_cls,
-    is_cluster,
-    get_command_args_fn,
-    get_db_data_fn,
-):
-    # type: (Any, bool, Any, Callable[[Any], dict[str, Any]]) -> None
+    pipeline_cls: Any,
+    is_cluster: bool,
+    get_command_args_fn: Any,
+    get_db_data_fn: Callable[[Any], dict[str, Any]],
+) -> None:
     old_execute = pipeline_cls.execute
 
     from sentry_sdk.integrations.redis import RedisIntegration
 
-    def sentry_patched_execute(self, *args, **kwargs):
-        # type: (Any, *Any, **Any) -> Any
+    def sentry_patched_execute(self: Any, *args: Any, **kwargs: Any) -> Any:
         if sentry_sdk.get_client().get_integration(RedisIntegration) is None:
             return old_execute(self, *args, **kwargs)
 
@@ -64,8 +63,9 @@ def patch_redis_pipeline(
     pipeline_cls.execute = sentry_patched_execute
 
 
-def patch_redis_client(cls, is_cluster, get_db_data_fn):
-    # type: (Any, bool, Callable[[Any], dict[str, Any]]) -> None
+def patch_redis_client(
+    cls: Any, is_cluster: bool, get_db_data_fn: Callable[[Any], dict[str, Any]]
+) -> None:
     """
     This function can be used to instrument custom redis client classes or
     subclasses.
@@ -74,8 +74,9 @@ def patch_redis_client(cls, is_cluster, get_db_data_fn):
 
     from sentry_sdk.integrations.redis import RedisIntegration
 
-    def sentry_patched_execute_command(self, name, *args, **kwargs):
-        # type: (Any, str, *Any, **Any) -> Any
+    def sentry_patched_execute_command(
+        self: Any, name: str, *args: Any, **kwargs: Any
+    ) -> Any:
         integration = sentry_sdk.get_client().get_integration(RedisIntegration)
         if integration is None:
             return old_execute_command(self, name, *args, **kwargs)

--- a/sentry_sdk/integrations/redis/modules/caches.py
+++ b/sentry_sdk/integrations/redis/modules/caches.py
@@ -2,6 +2,7 @@
 Code used for the Caches module in Sentry
 """
 
+from __future__ import annotations
 from sentry_sdk.consts import OP, SPANDATA
 from sentry_sdk.integrations.redis.utils import _get_safe_key, _key_as_string
 from sentry_sdk.utils import capture_internal_exceptions
@@ -16,8 +17,7 @@ if TYPE_CHECKING:
     from typing import Any, Optional
 
 
-def _get_op(name):
-    # type: (str) -> Optional[str]
+def _get_op(name: str) -> Optional[str]:
     op = None
     if name.lower() in GET_COMMANDS:
         op = OP.CACHE_GET
@@ -27,8 +27,12 @@ def _get_op(name):
     return op
 
 
-def _compile_cache_span_properties(redis_command, args, kwargs, integration):
-    # type: (str, tuple[Any, ...], dict[str, Any], RedisIntegration) -> dict[str, Any]
+def _compile_cache_span_properties(
+    redis_command: str,
+    args: tuple[Any, ...],
+    kwargs: dict[str, Any],
+    integration: RedisIntegration,
+) -> dict[str, Any]:
     key = _get_safe_key(redis_command, args, kwargs)
     key_as_string = _key_as_string(key)
     keys_as_string = key_as_string.split(", ")
@@ -61,8 +65,12 @@ def _compile_cache_span_properties(redis_command, args, kwargs, integration):
     return properties
 
 
-def _get_cache_span_description(redis_command, args, kwargs, integration):
-    # type: (str, tuple[Any, ...], dict[str, Any], RedisIntegration) -> str
+def _get_cache_span_description(
+    redis_command: str,
+    args: tuple[Any, ...],
+    kwargs: dict[str, Any],
+    integration: RedisIntegration,
+) -> str:
     description = _key_as_string(_get_safe_key(redis_command, args, kwargs))
 
     data_should_be_truncated = (
@@ -74,8 +82,9 @@ def _get_cache_span_description(redis_command, args, kwargs, integration):
     return description
 
 
-def _get_cache_data(redis_client, properties, return_value):
-    # type: (Any, dict[str, Any], Optional[Any]) -> dict[str, Any]
+def _get_cache_data(
+    redis_client: Any, properties: dict[str, Any], return_value: Optional[Any]
+) -> dict[str, Any]:
     data = {}
 
     with capture_internal_exceptions():

--- a/sentry_sdk/integrations/redis/modules/queries.py
+++ b/sentry_sdk/integrations/redis/modules/queries.py
@@ -2,6 +2,7 @@
 Code used for the Queries module in Sentry
 """
 
+from __future__ import annotations
 from sentry_sdk.consts import OP, SPANDATA
 from sentry_sdk.integrations.redis.utils import _get_safe_command
 from sentry_sdk.utils import capture_internal_exceptions
@@ -14,8 +15,9 @@ if TYPE_CHECKING:
     from typing import Any
 
 
-def _compile_db_span_properties(integration, redis_command, args):
-    # type: (RedisIntegration, str, tuple[Any, ...]) -> dict[str, Any]
+def _compile_db_span_properties(
+    integration: RedisIntegration, redis_command: str, args: tuple[Any, ...]
+) -> dict[str, Any]:
     description = _get_db_span_description(integration, redis_command, args)
 
     properties = {
@@ -26,8 +28,9 @@ def _compile_db_span_properties(integration, redis_command, args):
     return properties
 
 
-def _get_db_span_description(integration, command_name, args):
-    # type: (RedisIntegration, str, tuple[Any, ...]) -> str
+def _get_db_span_description(
+    integration: RedisIntegration, command_name: str, args: tuple[Any, ...]
+) -> str:
     description = command_name
 
     with capture_internal_exceptions():
@@ -42,8 +45,7 @@ def _get_db_span_description(integration, command_name, args):
     return description
 
 
-def _get_connection_data(connection_params):
-    # type: (dict[str, Any]) -> dict[str, Any]
+def _get_connection_data(connection_params: dict[str, Any]) -> dict[str, Any]:
     data = {
         SPANDATA.DB_SYSTEM: "redis",
     }
@@ -63,8 +65,7 @@ def _get_connection_data(connection_params):
     return data
 
 
-def _get_db_data(redis_instance):
-    # type: (Redis[Any]) -> dict[str, Any]
+def _get_db_data(redis_instance: Redis[Any]) -> dict[str, Any]:
     try:
         return _get_connection_data(redis_instance.connection_pool.connection_kwargs)
     except AttributeError:

--- a/sentry_sdk/integrations/redis/rb.py
+++ b/sentry_sdk/integrations/redis/rb.py
@@ -4,12 +4,13 @@ Instrumentation for Redis Blaster (rb)
 https://github.com/getsentry/rb
 """
 
+from __future__ import annotations
+
 from sentry_sdk.integrations.redis._sync_common import patch_redis_client
 from sentry_sdk.integrations.redis.modules.queries import _get_db_data
 
 
-def _patch_rb():
-    # type: () -> None
+def _patch_rb() -> None:
     try:
         import rb.clients  # type: ignore
     except ImportError:

--- a/sentry_sdk/integrations/redis/redis.py
+++ b/sentry_sdk/integrations/redis/redis.py
@@ -4,6 +4,8 @@ Instrumentation for Redis
 https://github.com/redis/redis-py
 """
 
+from __future__ import annotations
+
 from sentry_sdk.integrations.redis._sync_common import (
     patch_redis_client,
     patch_redis_pipeline,
@@ -16,13 +18,11 @@ if TYPE_CHECKING:
     from typing import Any, Sequence
 
 
-def _get_redis_command_args(command):
-    # type: (Any) -> Sequence[Any]
+def _get_redis_command_args(command: Any) -> Sequence[Any]:
     return command[0]
 
 
-def _patch_redis(StrictRedis, client):  # noqa: N803
-    # type: (Any, Any) -> None
+def _patch_redis(StrictRedis: Any, client: Any) -> None:  # noqa: N803
     patch_redis_client(
         StrictRedis,
         is_cluster=False,

--- a/sentry_sdk/integrations/redis/redis_cluster.py
+++ b/sentry_sdk/integrations/redis/redis_cluster.py
@@ -5,6 +5,8 @@ This is part of the main redis-py client.
 https://github.com/redis/redis-py/blob/master/redis/cluster.py
 """
 
+from __future__ import annotations
+
 from sentry_sdk.integrations.redis._sync_common import (
     patch_redis_client,
     patch_redis_pipeline,
@@ -25,8 +27,9 @@ if TYPE_CHECKING:
     )
 
 
-def _get_async_cluster_db_data(async_redis_cluster_instance):
-    # type: (AsyncRedisCluster[Any]) -> dict[str, Any]
+def _get_async_cluster_db_data(
+    async_redis_cluster_instance: AsyncRedisCluster[Any],
+) -> dict[str, Any]:
     default_node = async_redis_cluster_instance.get_default_node()
     if default_node is not None and default_node.connection_kwargs is not None:
         return _get_connection_data(default_node.connection_kwargs)
@@ -34,8 +37,9 @@ def _get_async_cluster_db_data(async_redis_cluster_instance):
         return {}
 
 
-def _get_async_cluster_pipeline_db_data(async_redis_cluster_pipeline_instance):
-    # type: (AsyncClusterPipeline[Any]) -> dict[str, Any]
+def _get_async_cluster_pipeline_db_data(
+    async_redis_cluster_pipeline_instance: AsyncClusterPipeline[Any],
+) -> dict[str, Any]:
     with capture_internal_exceptions():
         client = getattr(async_redis_cluster_pipeline_instance, "cluster_client", None)
         if client is None:
@@ -50,8 +54,7 @@ def _get_async_cluster_pipeline_db_data(async_redis_cluster_pipeline_instance):
         return _get_async_cluster_db_data(client)
 
 
-def _get_cluster_db_data(redis_cluster_instance):
-    # type: (RedisCluster[Any]) -> dict[str, Any]
+def _get_cluster_db_data(redis_cluster_instance: RedisCluster[Any]) -> dict[str, Any]:
     default_node = redis_cluster_instance.get_default_node()
 
     if default_node is not None:
@@ -64,8 +67,7 @@ def _get_cluster_db_data(redis_cluster_instance):
         return {}
 
 
-def _patch_redis_cluster():
-    # type: () -> None
+def _patch_redis_cluster() -> None:
     """Patches the cluster module on redis SDK (as opposed to rediscluster library)"""
     try:
         from redis import RedisCluster, cluster

--- a/sentry_sdk/integrations/redis/redis_py_cluster_legacy.py
+++ b/sentry_sdk/integrations/redis/redis_py_cluster_legacy.py
@@ -5,6 +5,8 @@ The project redis-py-cluster is EOL and was integrated into redis-py starting fr
 https://github.com/grokzen/redis-py-cluster
 """
 
+from __future__ import annotations
+
 from sentry_sdk.integrations.redis._sync_common import (
     patch_redis_client,
     patch_redis_pipeline,
@@ -13,8 +15,7 @@ from sentry_sdk.integrations.redis.modules.queries import _get_db_data
 from sentry_sdk.integrations.redis.utils import _parse_rediscluster_command
 
 
-def _patch_rediscluster():
-    # type: () -> None
+def _patch_rediscluster() -> None:
     try:
         import rediscluster  # type: ignore
     except ImportError:

--- a/sentry_sdk/integrations/redis/utils.py
+++ b/sentry_sdk/integrations/redis/utils.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import sentry_sdk
 from sentry_sdk.consts import SPANDATA
 from sentry_sdk.integrations.redis.consts import (
@@ -26,8 +27,7 @@ TAG_KEYS = [
 ]
 
 
-def _update_span(span, *data_bags):
-    # type: (Span, *dict[str, Any]) -> None
+def _update_span(span: Span, *data_bags: dict[str, Any]) -> None:
     """
     Set tags and data on the given span to data from the given data bags.
     """
@@ -39,8 +39,7 @@ def _update_span(span, *data_bags):
                 span.set_attribute(key, value)
 
 
-def _create_breadcrumb(message, *data_bags):
-    # type: (str, *dict[str, Any]) -> None
+def _create_breadcrumb(message: str, *data_bags: dict[str, Any]) -> None:
     """
     Create a breadcrumb containing the tags data from the given data bags.
     """
@@ -58,8 +57,7 @@ def _create_breadcrumb(message, *data_bags):
     )
 
 
-def _get_safe_command(name, args):
-    # type: (str, Sequence[Any]) -> str
+def _get_safe_command(name: str, args: Sequence[Any]) -> str:
     command_parts = [name]
 
     for i, arg in enumerate(args):
@@ -86,8 +84,7 @@ def _get_safe_command(name, args):
     return command
 
 
-def _safe_decode(key):
-    # type: (Any) -> str
+def _safe_decode(key: Any) -> str:
     if isinstance(key, bytes):
         try:
             return key.decode()
@@ -97,8 +94,7 @@ def _safe_decode(key):
     return str(key)
 
 
-def _key_as_string(key):
-    # type: (Any) -> str
+def _key_as_string(key: Any) -> str:
     if isinstance(key, (dict, list, tuple)):
         key = ", ".join(_safe_decode(x) for x in key)
     elif isinstance(key, bytes):
@@ -111,8 +107,9 @@ def _key_as_string(key):
     return key
 
 
-def _get_safe_key(method_name, args, kwargs):
-    # type: (str, Optional[tuple[Any, ...]], Optional[dict[str, Any]]) -> Optional[tuple[str, ...]]
+def _get_safe_key(
+    method_name: str, args: Optional[tuple[Any, ...]], kwargs: Optional[dict[str, Any]]
+) -> Optional[tuple[str, ...]]:
     """
     Gets the key (or keys) from the given method_name.
     The method_name could be a redis command or a django caching command
@@ -142,17 +139,20 @@ def _get_safe_key(method_name, args, kwargs):
     return key
 
 
-def _parse_rediscluster_command(command):
-    # type: (Any) -> Sequence[Any]
+def _parse_rediscluster_command(command: Any) -> Sequence[Any]:
     return command.args
 
 
-def _get_pipeline_data(is_cluster, get_command_args_fn, is_transaction, command_seq):
-    # type: (bool, Any, bool, Sequence[Any]) -> dict[str, Any]
-    data = {
+def _get_pipeline_data(
+    is_cluster: bool,
+    get_command_args_fn: Any,
+    is_transaction: bool,
+    command_seq: Sequence[Any],
+) -> dict[str, Any]:
+    data: dict[str, Any] = {
         "redis.is_cluster": is_cluster,
         "redis.transaction": is_transaction,
-    }  # type: dict[str, Any]
+    }
 
     commands = []
     for i, arg in enumerate(command_seq):
@@ -168,11 +168,10 @@ def _get_pipeline_data(is_cluster, get_command_args_fn, is_transaction, command_
     return data
 
 
-def _get_client_data(is_cluster, name, *args):
-    # type: (bool, str, *Any) -> dict[str, Any]
-    data = {
+def _get_client_data(is_cluster: bool, name: str, *args: Any) -> dict[str, Any]:
+    data: dict[str, Any] = {
         "redis.is_cluster": is_cluster,
-    }  # type: dict[str, Any]
+    }
 
     if name:
         data["redis.command"] = name

--- a/sentry_sdk/integrations/rq.py
+++ b/sentry_sdk/integrations/rq.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import weakref
 
 import sentry_sdk
@@ -49,16 +50,16 @@ class RqIntegration(Integration):
     origin = f"auto.queue.{identifier}"
 
     @staticmethod
-    def setup_once():
-        # type: () -> None
+    def setup_once() -> None:
         version = parse_version(RQ_VERSION)
         _check_minimum_version(RqIntegration, version)
 
         old_perform_job = Worker.perform_job
 
         @ensure_integration_enabled(RqIntegration, old_perform_job)
-        def sentry_patched_perform_job(self, job, queue, *args, **kwargs):
-            # type: (Any, Job, Queue, *Any, **Any) -> bool
+        def sentry_patched_perform_job(
+            self: Any, job: Job, queue: Queue, *args: Any, **kwargs: Any
+        ) -> bool:
             with sentry_sdk.new_scope() as scope:
                 try:
                     transaction_name = job.func_name or DEFAULT_TRANSACTION_NAME
@@ -95,8 +96,9 @@ class RqIntegration(Integration):
 
         old_handle_exception = Worker.handle_exception
 
-        def sentry_patched_handle_exception(self, job, *exc_info, **kwargs):
-            # type: (Worker, Any, *Any, **Any) -> Any
+        def sentry_patched_handle_exception(
+            self: Worker, job: Any, *exc_info: Any, **kwargs: Any
+        ) -> Any:
             retry = (
                 hasattr(job, "retries_left")
                 and job.retries_left
@@ -113,8 +115,7 @@ class RqIntegration(Integration):
         old_enqueue_job = Queue.enqueue_job
 
         @ensure_integration_enabled(RqIntegration, old_enqueue_job)
-        def sentry_patched_enqueue_job(self, job, **kwargs):
-            # type: (Queue, Any, **Any) -> Any
+        def sentry_patched_enqueue_job(self: Queue, job: Any, **kwargs: Any) -> Any:
             job.meta["_sentry_trace_headers"] = dict(
                 sentry_sdk.get_current_scope().iter_trace_propagation_headers()
             )
@@ -126,10 +127,8 @@ class RqIntegration(Integration):
         ignore_logger("rq.worker")
 
 
-def _make_event_processor(weak_job):
-    # type: (Callable[[], Job]) -> EventProcessor
-    def event_processor(event, hint):
-        # type: (Event, dict[str, Any]) -> Event
+def _make_event_processor(weak_job: Callable[[], Job]) -> EventProcessor:
+    def event_processor(event: Event, hint: dict[str, Any]) -> Event:
         job = weak_job()
         if job is not None:
             with capture_internal_exceptions():
@@ -159,8 +158,7 @@ def _make_event_processor(weak_job):
     return event_processor
 
 
-def _capture_exception(exc_info, **kwargs):
-    # type: (ExcInfo, **Any) -> None
+def _capture_exception(exc_info: ExcInfo, **kwargs: Any) -> None:
     client = sentry_sdk.get_client()
 
     event, hint = event_from_exception(
@@ -172,8 +170,7 @@ def _capture_exception(exc_info, **kwargs):
     sentry_sdk.capture_event(event, hint=hint)
 
 
-def _prepopulate_attributes(job, queue):
-    # type: (Job, Queue) -> dict[str, Any]
+def _prepopulate_attributes(job: Job, queue: Queue) -> dict[str, Any]:
     attributes = {
         "messaging.system": "rq",
         "rq.job.id": job.id,

--- a/sentry_sdk/integrations/rust_tracing.py
+++ b/sentry_sdk/integrations/rust_tracing.py
@@ -30,9 +30,13 @@ sentry_sdk.init(
 Each native extension requires its own integration.
 """
 
+from __future__ import annotations
 import json
 from enum import Enum, auto
-from typing import Any, Callable, Dict, Optional
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from typing import Any, Callable, Dict, Optional
 
 import sentry_sdk
 from sentry_sdk.integrations import Integration
@@ -56,8 +60,7 @@ class EventTypeMapping(Enum):
     Event = auto()
 
 
-def tracing_level_to_sentry_level(level):
-    # type: (str) -> sentry_sdk._types.LogLevelStr
+def tracing_level_to_sentry_level(level: str) -> sentry_sdk._types.LogLevelStr:
     level = RustTracingLevel(level)
     if level in (RustTracingLevel.Trace, RustTracingLevel.Debug):
         return "debug"
@@ -97,15 +100,15 @@ def process_event(event: Dict[str, Any]) -> None:
 
     logger = metadata.get("target")
     level = tracing_level_to_sentry_level(metadata.get("level"))
-    message = event.get("message")  # type: sentry_sdk._types.Any
+    message: sentry_sdk._types.Any = event.get("message")
     contexts = extract_contexts(event)
 
-    sentry_event = {
+    sentry_event: sentry_sdk._types.Event = {
         "logger": logger,
         "level": level,
         "message": message,
         "contexts": contexts,
-    }  # type: sentry_sdk._types.Event
+    }
 
     sentry_sdk.capture_event(sentry_event)
 

--- a/sentry_sdk/integrations/sanic.py
+++ b/sentry_sdk/integrations/sanic.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import sys
 import weakref
 from inspect import isawaitable
@@ -59,8 +60,9 @@ class SanicIntegration(Integration):
     origin = f"auto.http.{identifier}"
     version = None
 
-    def __init__(self, unsampled_statuses=frozenset({404})):
-        # type: (Optional[Container[int]]) -> None
+    def __init__(
+        self, unsampled_statuses: Optional[Container[int]] = frozenset({404})
+    ) -> None:
         """
         The unsampled_statuses parameter can be used to specify for which HTTP statuses the
         transactions should not be sent to Sentry. By default, transactions are sent for all
@@ -70,8 +72,7 @@ class SanicIntegration(Integration):
         self._unsampled_statuses = unsampled_statuses or set()
 
     @staticmethod
-    def setup_once():
-        # type: () -> None
+    def setup_once() -> None:
         SanicIntegration.version = parse_version(SANIC_VERSION)
         _check_minimum_version(SanicIntegration, SanicIntegration.version)
 
@@ -103,56 +104,45 @@ class SanicIntegration(Integration):
 
 
 class SanicRequestExtractor(RequestExtractor):
-    def content_length(self):
-        # type: () -> int
+    def content_length(self) -> int:
         if self.request.body is None:
             return 0
         return len(self.request.body)
 
-    def cookies(self):
-        # type: () -> Dict[str, str]
+    def cookies(self) -> Dict[str, str]:
         return dict(self.request.cookies)
 
-    def raw_data(self):
-        # type: () -> bytes
+    def raw_data(self) -> bytes:
         return self.request.body
 
-    def form(self):
-        # type: () -> RequestParameters
+    def form(self) -> RequestParameters:
         return self.request.form
 
-    def is_json(self):
-        # type: () -> bool
+    def is_json(self) -> bool:
         raise NotImplementedError()
 
-    def json(self):
-        # type: () -> Optional[Any]
+    def json(self) -> Optional[Any]:
         return self.request.json
 
-    def files(self):
-        # type: () -> RequestParameters
+    def files(self) -> RequestParameters:
         return self.request.files
 
-    def size_of_file(self, file):
-        # type: (Any) -> int
+    def size_of_file(self, file: Any) -> int:
         return len(file.body or ())
 
 
-def _setup_sanic():
-    # type: () -> None
+def _setup_sanic() -> None:
     Sanic._startup = _startup
     ErrorHandler.lookup = _sentry_error_handler_lookup
 
 
-def _setup_legacy_sanic():
-    # type: () -> None
+def _setup_legacy_sanic() -> None:
     Sanic.handle_request = _legacy_handle_request
     Router.get = _legacy_router_get
     ErrorHandler.lookup = _sentry_error_handler_lookup
 
 
-async def _startup(self):
-    # type: (Sanic) -> None
+async def _startup(self: Sanic) -> None:
     # This happens about as early in the lifecycle as possible, just after the
     # Request object is created. The body has not yet been consumed.
     self.signal("http.lifecycle.request")(_context_enter)
@@ -171,8 +161,7 @@ async def _startup(self):
     await old_startup(self)
 
 
-async def _context_enter(request):
-    # type: (Request) -> None
+async def _context_enter(request: Request) -> None:
     request.ctx._sentry_do_integration = (
         sentry_sdk.get_client().get_integration(SanicIntegration) is not None
     )
@@ -203,8 +192,9 @@ async def _context_enter(request):
     ).__enter__()
 
 
-async def _context_exit(request, response=None):
-    # type: (Request, Optional[BaseHTTPResponse]) -> None
+async def _context_exit(
+    request: Request, response: Optional[BaseHTTPResponse] = None
+) -> None:
     with capture_internal_exceptions():
         if not request.ctx._sentry_do_integration:
             return
@@ -233,8 +223,7 @@ async def _context_exit(request, response=None):
         request.ctx._sentry_scope_manager.__exit__(None, None, None)
 
 
-async def _set_transaction(request, route, **_):
-    # type: (Request, Route, **Any) -> None
+async def _set_transaction(request: Request, route: Route, **_: Any) -> None:
     if request.ctx._sentry_do_integration:
         with capture_internal_exceptions():
             scope = sentry_sdk.get_current_scope()
@@ -242,8 +231,9 @@ async def _set_transaction(request, route, **_):
             scope.set_transaction_name(route_name, source=TransactionSource.COMPONENT)
 
 
-def _sentry_error_handler_lookup(self, exception, *args, **kwargs):
-    # type: (Any, Exception, *Any, **Any) -> Optional[object]
+def _sentry_error_handler_lookup(
+    self: Any, exception: Exception, *args: Any, **kwargs: Any
+) -> Optional[object]:
     _capture_exception(exception)
     old_error_handler = old_error_handler_lookup(self, exception, *args, **kwargs)
 
@@ -253,8 +243,9 @@ def _sentry_error_handler_lookup(self, exception, *args, **kwargs):
     if sentry_sdk.get_client().get_integration(SanicIntegration) is None:
         return old_error_handler
 
-    async def sentry_wrapped_error_handler(request, exception):
-        # type: (Request, Exception) -> Any
+    async def sentry_wrapped_error_handler(
+        request: Request, exception: Exception
+    ) -> Any:
         try:
             response = old_error_handler(request, exception)
             if isawaitable(response):
@@ -276,8 +267,9 @@ def _sentry_error_handler_lookup(self, exception, *args, **kwargs):
     return sentry_wrapped_error_handler
 
 
-async def _legacy_handle_request(self, request, *args, **kwargs):
-    # type: (Any, Request, *Any, **Any) -> Any
+async def _legacy_handle_request(
+    self: Any, request: Request, *args: Any, **kwargs: Any
+) -> Any:
     if sentry_sdk.get_client().get_integration(SanicIntegration) is None:
         return await old_handle_request(self, request, *args, **kwargs)
 
@@ -294,8 +286,7 @@ async def _legacy_handle_request(self, request, *args, **kwargs):
         return response
 
 
-def _legacy_router_get(self, *args):
-    # type: (Any, Union[Any, Request]) -> Any
+def _legacy_router_get(self: Any, *args: Union[Any, Request]) -> Any:
     rv = old_router_get(self, *args)
     if sentry_sdk.get_client().get_integration(SanicIntegration) is not None:
         with capture_internal_exceptions():
@@ -325,8 +316,7 @@ def _legacy_router_get(self, *args):
 
 
 @ensure_integration_enabled(SanicIntegration)
-def _capture_exception(exception):
-    # type: (Union[ExcInfo, BaseException]) -> None
+def _capture_exception(exception: Union[ExcInfo, BaseException]) -> None:
     with capture_internal_exceptions():
         event, hint = event_from_exception(
             exception,
@@ -340,10 +330,8 @@ def _capture_exception(exception):
         sentry_sdk.capture_event(event, hint=hint)
 
 
-def _make_request_processor(weak_request):
-    # type: (Callable[[], Request]) -> EventProcessor
-    def sanic_processor(event, hint):
-        # type: (Event, Optional[Hint]) -> Optional[Event]
+def _make_request_processor(weak_request: Callable[[], Request]) -> EventProcessor:
+    def sanic_processor(event: Event, hint: Optional[Hint]) -> Optional[Event]:
 
         try:
             if hint and issubclass(hint["exc_info"][0], SanicException):

--- a/sentry_sdk/integrations/socket.py
+++ b/sentry_sdk/integrations/socket.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import socket
 
 import sentry_sdk
@@ -17,8 +18,7 @@ class SocketIntegration(Integration):
     origin = f"auto.socket.{identifier}"
 
     @staticmethod
-    def setup_once():
-        # type: () -> None
+    def setup_once() -> None:
         """
         patches two of the most used functions of socket: create_connection and getaddrinfo(dns resolver)
         """
@@ -26,8 +26,9 @@ class SocketIntegration(Integration):
         _patch_getaddrinfo()
 
 
-def _get_span_description(host, port):
-    # type: (Union[bytes, str, None], Union[bytes, str, int, None]) -> str
+def _get_span_description(
+    host: Union[bytes, str, None], port: Union[bytes, str, int, None]
+) -> str:
 
     try:
         host = host.decode()  # type: ignore
@@ -43,16 +44,14 @@ def _get_span_description(host, port):
     return description
 
 
-def _patch_create_connection():
-    # type: () -> None
+def _patch_create_connection() -> None:
     real_create_connection = socket.create_connection
 
     def create_connection(
-        address,
-        timeout=socket._GLOBAL_DEFAULT_TIMEOUT,  # type: ignore
-        source_address=None,
-    ):
-        # type: (Tuple[Optional[str], int], Optional[float], Optional[Tuple[Union[bytearray, bytes, str], int]])-> socket.socket
+        address: Tuple[Optional[str], int],
+        timeout: Optional[float] = socket._GLOBAL_DEFAULT_TIMEOUT,  # type: ignore
+        source_address: Optional[Tuple[Union[bytearray, bytes, str], int]] = None,
+    ) -> socket.socket:
         integration = sentry_sdk.get_client().get_integration(SocketIntegration)
         if integration is None:
             return real_create_connection(address, timeout, source_address)
@@ -76,12 +75,25 @@ def _patch_create_connection():
     socket.create_connection = create_connection  # type: ignore
 
 
-def _patch_getaddrinfo():
-    # type: () -> None
+def _patch_getaddrinfo() -> None:
     real_getaddrinfo = socket.getaddrinfo
 
-    def getaddrinfo(host, port, family=0, type=0, proto=0, flags=0):
-        # type: (Union[bytes, str, None], Union[bytes, str, int, None], int, int, int, int) -> List[Tuple[AddressFamily, SocketKind, int, str, Union[Tuple[str, int], Tuple[str, int, int, int], Tuple[int, bytes]]]]
+    def getaddrinfo(
+        host: Union[bytes, str, None],
+        port: Union[bytes, str, int, None],
+        family: int = 0,
+        type: int = 0,
+        proto: int = 0,
+        flags: int = 0,
+    ) -> List[
+        Tuple[
+            AddressFamily,
+            SocketKind,
+            int,
+            str,
+            Union[Tuple[str, int], Tuple[str, int, int, int], Tuple[int, bytes]],
+        ]
+    ]:
         integration = sentry_sdk.get_client().get_integration(SocketIntegration)
         if integration is None:
             return real_getaddrinfo(host, port, family, type, proto, flags)

--- a/sentry_sdk/integrations/spark/__init__.py
+++ b/sentry_sdk/integrations/spark/__init__.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from sentry_sdk.integrations.spark.spark_driver import SparkIntegration
 from sentry_sdk.integrations.spark.spark_worker import SparkWorkerIntegration
 

--- a/sentry_sdk/integrations/spark/spark_driver.py
+++ b/sentry_sdk/integrations/spark/spark_driver.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import sentry_sdk
 from sentry_sdk.integrations import Integration
 from sentry_sdk.utils import capture_internal_exceptions, ensure_integration_enabled
@@ -16,13 +17,11 @@ class SparkIntegration(Integration):
     identifier = "spark"
 
     @staticmethod
-    def setup_once():
-        # type: () -> None
+    def setup_once() -> None:
         _setup_sentry_tracing()
 
 
-def _set_app_properties():
-    # type: () -> None
+def _set_app_properties() -> None:
     """
     Set properties in driver that propagate to worker processes, allowing for workers to have access to those properties.
     This allows worker integration to have access to app_name and application_id.
@@ -41,8 +40,7 @@ def _set_app_properties():
         )
 
 
-def _start_sentry_listener(sc):
-    # type: (SparkContext) -> None
+def _start_sentry_listener(sc: SparkContext) -> None:
     """
     Start java gateway server to add custom `SparkListener`
     """
@@ -54,13 +52,11 @@ def _start_sentry_listener(sc):
     sc._jsc.sc().addSparkListener(listener)
 
 
-def _add_event_processor(sc):
-    # type: (SparkContext) -> None
+def _add_event_processor(sc: SparkContext) -> None:
     scope = sentry_sdk.get_isolation_scope()
 
     @scope.add_event_processor
-    def process_event(event, hint):
-        # type: (Event, Hint) -> Optional[Event]
+    def process_event(event: Event, hint: Hint) -> Optional[Event]:
         with capture_internal_exceptions():
             if sentry_sdk.get_client().get_integration(SparkIntegration) is None:
                 return event
@@ -90,23 +86,22 @@ def _add_event_processor(sc):
         return event
 
 
-def _activate_integration(sc):
-    # type: (SparkContext) -> None
+def _activate_integration(sc: SparkContext) -> None:
 
     _start_sentry_listener(sc)
     _set_app_properties()
     _add_event_processor(sc)
 
 
-def _patch_spark_context_init():
-    # type: () -> None
+def _patch_spark_context_init() -> None:
     from pyspark import SparkContext
 
     spark_context_init = SparkContext._do_init
 
     @ensure_integration_enabled(SparkIntegration, spark_context_init)
-    def _sentry_patched_spark_context_init(self, *args, **kwargs):
-        # type: (SparkContext, *Any, **Any) -> Optional[Any]
+    def _sentry_patched_spark_context_init(
+        self: SparkContext, *args: Any, **kwargs: Any
+    ) -> Optional[Any]:
         rv = spark_context_init(self, *args, **kwargs)
         _activate_integration(self)
         return rv
@@ -114,8 +109,7 @@ def _patch_spark_context_init():
     SparkContext._do_init = _sentry_patched_spark_context_init
 
 
-def _setup_sentry_tracing():
-    # type: () -> None
+def _setup_sentry_tracing() -> None:
     from pyspark import SparkContext
 
     if SparkContext._active_spark_context is not None:
@@ -125,102 +119,76 @@ def _setup_sentry_tracing():
 
 
 class SparkListener:
-    def onApplicationEnd(self, applicationEnd):  # noqa: N802,N803
-        # type: (Any) -> None
+    def onApplicationEnd(self, applicationEnd: Any) -> None:
         pass
 
-    def onApplicationStart(self, applicationStart):  # noqa: N802,N803
-        # type: (Any) -> None
+    def onApplicationStart(self, applicationStart: Any) -> None:
         pass
 
-    def onBlockManagerAdded(self, blockManagerAdded):  # noqa: N802,N803
-        # type: (Any) -> None
+    def onBlockManagerAdded(self, blockManagerAdded: Any) -> None:
         pass
 
-    def onBlockManagerRemoved(self, blockManagerRemoved):  # noqa: N802,N803
-        # type: (Any) -> None
+    def onBlockManagerRemoved(self, blockManagerRemoved: Any) -> None:
         pass
 
-    def onBlockUpdated(self, blockUpdated):  # noqa: N802,N803
-        # type: (Any) -> None
+    def onBlockUpdated(self, blockUpdated: Any) -> None:
         pass
 
-    def onEnvironmentUpdate(self, environmentUpdate):  # noqa: N802,N803
-        # type: (Any) -> None
+    def onEnvironmentUpdate(self, environmentUpdate: Any) -> None:
         pass
 
-    def onExecutorAdded(self, executorAdded):  # noqa: N802,N803
-        # type: (Any) -> None
+    def onExecutorAdded(self, executorAdded: Any) -> None:
         pass
 
-    def onExecutorBlacklisted(self, executorBlacklisted):  # noqa: N802,N803
-        # type: (Any) -> None
+    def onExecutorBlacklisted(self, executorBlacklisted: Any) -> None:
         pass
 
-    def onExecutorBlacklistedForStage(  # noqa: N802
-        self, executorBlacklistedForStage  # noqa: N803
-    ):
-        # type: (Any) -> None
+    def onExecutorBlacklistedForStage(self, executorBlacklistedForStage: Any) -> None:
         pass
 
-    def onExecutorMetricsUpdate(self, executorMetricsUpdate):  # noqa: N802,N803
-        # type: (Any) -> None
+    def onExecutorMetricsUpdate(self, executorMetricsUpdate: Any) -> None:
         pass
 
-    def onExecutorRemoved(self, executorRemoved):  # noqa: N802,N803
-        # type: (Any) -> None
+    def onExecutorRemoved(self, executorRemoved: Any) -> None:
         pass
 
-    def onJobEnd(self, jobEnd):  # noqa: N802,N803
-        # type: (Any) -> None
+    def onJobEnd(self, jobEnd: Any) -> None:
         pass
 
-    def onJobStart(self, jobStart):  # noqa: N802,N803
-        # type: (Any) -> None
+    def onJobStart(self, jobStart: Any) -> None:
         pass
 
-    def onNodeBlacklisted(self, nodeBlacklisted):  # noqa: N802,N803
-        # type: (Any) -> None
+    def onNodeBlacklisted(self, nodeBlacklisted: Any) -> None:
         pass
 
-    def onNodeBlacklistedForStage(self, nodeBlacklistedForStage):  # noqa: N802,N803
-        # type: (Any) -> None
+    def onNodeBlacklistedForStage(self, nodeBlacklistedForStage: Any) -> None:
         pass
 
-    def onNodeUnblacklisted(self, nodeUnblacklisted):  # noqa: N802,N803
-        # type: (Any) -> None
+    def onNodeUnblacklisted(self, nodeUnblacklisted: Any) -> None:
         pass
 
-    def onOtherEvent(self, event):  # noqa: N802,N803
-        # type: (Any) -> None
+    def onOtherEvent(self, event: Any) -> None:
         pass
 
-    def onSpeculativeTaskSubmitted(self, speculativeTask):  # noqa: N802,N803
-        # type: (Any) -> None
+    def onSpeculativeTaskSubmitted(self, speculativeTask: Any) -> None:
         pass
 
-    def onStageCompleted(self, stageCompleted):  # noqa: N802,N803
-        # type: (Any) -> None
+    def onStageCompleted(self, stageCompleted: Any) -> None:
         pass
 
-    def onStageSubmitted(self, stageSubmitted):  # noqa: N802,N803
-        # type: (Any) -> None
+    def onStageSubmitted(self, stageSubmitted: Any) -> None:
         pass
 
-    def onTaskEnd(self, taskEnd):  # noqa: N802,N803
-        # type: (Any) -> None
+    def onTaskEnd(self, taskEnd: Any) -> None:
         pass
 
-    def onTaskGettingResult(self, taskGettingResult):  # noqa: N802,N803
-        # type: (Any) -> None
+    def onTaskGettingResult(self, taskGettingResult: Any) -> None:
         pass
 
-    def onTaskStart(self, taskStart):  # noqa: N802,N803
-        # type: (Any) -> None
+    def onTaskStart(self, taskStart: Any) -> None:
         pass
 
-    def onUnpersistRDD(self, unpersistRDD):  # noqa: N802,N803
-        # type: (Any) -> None
+    def onUnpersistRDD(self, unpersistRDD: Any) -> None:
         pass
 
     class Java:
@@ -230,25 +198,22 @@ class SparkListener:
 class SentryListener(SparkListener):
     def _add_breadcrumb(
         self,
-        level,  # type: str
-        message,  # type: str
-        data=None,  # type: Optional[dict[str, Any]]
-    ):
-        # type: (...) -> None
+        level: str,
+        message: str,
+        data: Optional[dict[str, Any]] = None,
+    ) -> None:
         sentry_sdk.get_isolation_scope().add_breadcrumb(
             level=level, message=message, data=data
         )
 
-    def onJobStart(self, jobStart):  # noqa: N802,N803
-        # type: (Any) -> None
+    def onJobStart(self, jobStart: Any) -> None:
         sentry_sdk.get_isolation_scope().clear_breadcrumbs()
 
         message = "Job {} Started".format(jobStart.jobId())
         self._add_breadcrumb(level="info", message=message)
         _set_app_properties()
 
-    def onJobEnd(self, jobEnd):  # noqa: N802,N803
-        # type: (Any) -> None
+    def onJobEnd(self, jobEnd: Any) -> None:
         level = ""
         message = ""
         data = {"result": jobEnd.jobResult().toString()}
@@ -262,8 +227,7 @@ class SentryListener(SparkListener):
 
         self._add_breadcrumb(level=level, message=message, data=data)
 
-    def onStageSubmitted(self, stageSubmitted):  # noqa: N802,N803
-        # type: (Any) -> None
+    def onStageSubmitted(self, stageSubmitted: Any) -> None:
         stage_info = stageSubmitted.stageInfo()
         message = "Stage {} Submitted".format(stage_info.stageId())
 
@@ -275,8 +239,7 @@ class SentryListener(SparkListener):
         self._add_breadcrumb(level="info", message=message, data=data)
         _set_app_properties()
 
-    def onStageCompleted(self, stageCompleted):  # noqa: N802,N803
-        # type: (Any) -> None
+    def onStageCompleted(self, stageCompleted: Any) -> None:
         from py4j.protocol import Py4JJavaError  # type: ignore
 
         stage_info = stageCompleted.stageInfo()
@@ -300,8 +263,7 @@ class SentryListener(SparkListener):
         self._add_breadcrumb(level=level, message=message, data=data)
 
 
-def _get_attempt_id(stage_info):
-    # type: (Any) -> Optional[int]
+def _get_attempt_id(stage_info: Any) -> Optional[int]:
     try:
         return stage_info.attemptId()
     except Exception:

--- a/sentry_sdk/integrations/spark/spark_worker.py
+++ b/sentry_sdk/integrations/spark/spark_worker.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import sys
 
 import sentry_sdk
@@ -23,15 +24,13 @@ class SparkWorkerIntegration(Integration):
     identifier = "spark_worker"
 
     @staticmethod
-    def setup_once():
-        # type: () -> None
+    def setup_once() -> None:
         import pyspark.daemon as original_daemon
 
         original_daemon.worker_main = _sentry_worker_main
 
 
-def _capture_exception(exc_info):
-    # type: (ExcInfo) -> None
+def _capture_exception(exc_info: ExcInfo) -> None:
     client = sentry_sdk.get_client()
 
     mechanism = {"type": "spark", "handled": False}
@@ -53,22 +52,20 @@ def _capture_exception(exc_info):
     if rv:
         rv.reverse()
         hint = event_hint_with_exc_info(exc_info)
-        event = {"level": "error", "exception": {"values": rv}}  # type: Event
+        event: Event = {"level": "error", "exception": {"values": rv}}
 
         _tag_task_context()
 
         sentry_sdk.capture_event(event, hint=hint)
 
 
-def _tag_task_context():
-    # type: () -> None
+def _tag_task_context() -> None:
     from pyspark.taskcontext import TaskContext
 
     scope = sentry_sdk.get_isolation_scope()
 
     @scope.add_event_processor
-    def process_event(event, hint):
-        # type: (Event, Hint) -> Optional[Event]
+    def process_event(event: Event, hint: Hint) -> Optional[Event]:
         with capture_internal_exceptions():
             integration = sentry_sdk.get_client().get_integration(
                 SparkWorkerIntegration
@@ -103,8 +100,7 @@ def _tag_task_context():
         return event
 
 
-def _sentry_worker_main(*args, **kwargs):
-    # type: (*Optional[Any], **Optional[Any]) -> None
+def _sentry_worker_main(*args: Optional[Any], **kwargs: Optional[Any]) -> None:
     import pyspark.worker as original_worker
 
     try:

--- a/sentry_sdk/integrations/sqlalchemy.py
+++ b/sentry_sdk/integrations/sqlalchemy.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from sentry_sdk.consts import SPANSTATUS, SPANDATA
 from sentry_sdk.integrations import _check_minimum_version, Integration, DidNotEnable
 from sentry_sdk.tracing_utils import add_query_source, record_sql_queries
@@ -29,8 +30,7 @@ class SqlalchemyIntegration(Integration):
     origin = f"auto.db.{identifier}"
 
     @staticmethod
-    def setup_once():
-        # type: () -> None
+    def setup_once() -> None:
         version = parse_version(SQLALCHEMY_VERSION)
         _check_minimum_version(SqlalchemyIntegration, version)
 
@@ -41,9 +41,14 @@ class SqlalchemyIntegration(Integration):
 
 @ensure_integration_enabled(SqlalchemyIntegration)
 def _before_cursor_execute(
-    conn, cursor, statement, parameters, context, executemany, *args
-):
-    # type: (Any, Any, Any, Any, Any, bool, *Any) -> None
+    conn: Any,
+    cursor: Any,
+    statement: Any,
+    parameters: Any,
+    context: Any,
+    executemany: bool,
+    *args: Any,
+) -> None:
     ctx_mgr = record_sql_queries(
         cursor,
         statement,
@@ -62,13 +67,14 @@ def _before_cursor_execute(
 
 
 @ensure_integration_enabled(SqlalchemyIntegration)
-def _after_cursor_execute(conn, cursor, statement, parameters, context, *args):
-    # type: (Any, Any, Any, Any, Any, *Any) -> None
-    ctx_mgr = getattr(
+def _after_cursor_execute(
+    conn: Any, cursor: Any, statement: Any, parameters: Any, context: Any, *args: Any
+) -> None:
+    ctx_mgr: Optional[ContextManager[Any]] = getattr(
         context, "_sentry_sql_span_manager", None
-    )  # type: Optional[ContextManager[Any]]
+    )
 
-    span = getattr(context, "_sentry_sql_span", None)  # type: Optional[Span]
+    span: Optional[Span] = getattr(context, "_sentry_sql_span", None)
     if span is not None:
         with capture_internal_exceptions():
             add_query_source(span)
@@ -78,13 +84,12 @@ def _after_cursor_execute(conn, cursor, statement, parameters, context, *args):
         ctx_mgr.__exit__(None, None, None)
 
 
-def _handle_error(context, *args):
-    # type: (Any, *Any) -> None
+def _handle_error(context: Any, *args: Any) -> None:
     execution_context = context.execution_context
     if execution_context is None:
         return
 
-    span = getattr(execution_context, "_sentry_sql_span", None)  # type: Optional[Span]
+    span: Optional[Span] = getattr(execution_context, "_sentry_sql_span", None)
 
     if span is not None:
         span.set_status(SPANSTATUS.INTERNAL_ERROR)
@@ -92,9 +97,9 @@ def _handle_error(context, *args):
     # _after_cursor_execute does not get called for crashing SQL stmts. Judging
     # from SQLAlchemy codebase it does seem like any error coming into this
     # handler is going to be fatal.
-    ctx_mgr = getattr(
+    ctx_mgr: Optional[ContextManager[Any]] = getattr(
         execution_context, "_sentry_sql_span_manager", None
-    )  # type: Optional[ContextManager[Any]]
+    )
 
     if ctx_mgr is not None:
         execution_context._sentry_sql_span_manager = None
@@ -102,8 +107,7 @@ def _handle_error(context, *args):
 
 
 # See: https://docs.sqlalchemy.org/en/20/dialects/index.html
-def _get_db_system(name):
-    # type: (str) -> Optional[str]
+def _get_db_system(name: str) -> Optional[str]:
     name = str(name)
 
     if "sqlite" in name:
@@ -124,8 +128,7 @@ def _get_db_system(name):
     return None
 
 
-def _set_db_data(span, conn):
-    # type: (Span, Any) -> None
+def _set_db_data(span: Span, conn: Any) -> None:
     db_system = _get_db_system(conn.engine.name)
     if db_system is not None:
         span.set_attribute(SPANDATA.DB_SYSTEM, db_system)

--- a/sentry_sdk/integrations/starlite.py
+++ b/sentry_sdk/integrations/starlite.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import sentry_sdk
 from sentry_sdk.consts import OP, SOURCE_FOR_STYLE, TransactionSource
 from sentry_sdk.integrations import DidNotEnable, Integration
@@ -48,16 +49,16 @@ class StarliteIntegration(Integration):
     origin = f"auto.http.{identifier}"
 
     @staticmethod
-    def setup_once():
-        # type: () -> None
+    def setup_once() -> None:
         patch_app_init()
         patch_middlewares()
         patch_http_route_handle()
 
 
 class SentryStarliteASGIMiddleware(SentryAsgiMiddleware):
-    def __init__(self, app, span_origin=StarliteIntegration.origin):
-        # type: (ASGIApp, str) -> None
+    def __init__(
+        self, app: ASGIApp, span_origin: str = StarliteIntegration.origin
+    ) -> None:
         super().__init__(
             app=app,
             unsafe_context_data=False,
@@ -67,8 +68,7 @@ class SentryStarliteASGIMiddleware(SentryAsgiMiddleware):
         )
 
 
-def patch_app_init():
-    # type: () -> None
+def patch_app_init() -> None:
     """
     Replaces the Starlite class's `__init__` function in order to inject `after_exception` handlers and set the
     `SentryStarliteASGIMiddleware` as the outmost middleware in the stack.
@@ -79,8 +79,7 @@ def patch_app_init():
     old__init__ = Starlite.__init__
 
     @ensure_integration_enabled(StarliteIntegration, old__init__)
-    def injection_wrapper(self, *args, **kwargs):
-        # type: (Starlite, *Any, **Any) -> None
+    def injection_wrapper(self: Starlite, *args: Any, **kwargs: Any) -> None:
         after_exception = kwargs.pop("after_exception", [])
         kwargs.update(
             after_exception=[
@@ -101,13 +100,11 @@ def patch_app_init():
     Starlite.__init__ = injection_wrapper
 
 
-def patch_middlewares():
-    # type: () -> None
+def patch_middlewares() -> None:
     old_resolve_middleware_stack = BaseRouteHandler.resolve_middleware
 
     @ensure_integration_enabled(StarliteIntegration, old_resolve_middleware_stack)
-    def resolve_middleware_wrapper(self):
-        # type: (BaseRouteHandler) -> list[Middleware]
+    def resolve_middleware_wrapper(self: BaseRouteHandler) -> list[Middleware]:
         return [
             enable_span_for_middleware(middleware)
             for middleware in old_resolve_middleware_stack(self)
@@ -116,8 +113,7 @@ def patch_middlewares():
     BaseRouteHandler.resolve_middleware = resolve_middleware_wrapper
 
 
-def enable_span_for_middleware(middleware):
-    # type: (Middleware) -> Middleware
+def enable_span_for_middleware(middleware: Middleware) -> Middleware:
     if (
         not hasattr(middleware, "__call__")  # noqa: B004
         or middleware is SentryStarliteASGIMiddleware
@@ -125,12 +121,13 @@ def enable_span_for_middleware(middleware):
         return middleware
 
     if isinstance(middleware, DefineMiddleware):
-        old_call = middleware.middleware.__call__  # type: ASGIApp
+        old_call: ASGIApp = middleware.middleware.__call__
     else:
         old_call = middleware.__call__
 
-    async def _create_span_call(self, scope, receive, send):
-        # type: (MiddlewareProtocol, StarliteScope, Receive, Send) -> None
+    async def _create_span_call(
+        self: MiddlewareProtocol, scope: StarliteScope, receive: Receive, send: Send
+    ) -> None:
         if sentry_sdk.get_client().get_integration(StarliteIntegration) is None:
             return await old_call(self, scope, receive, send)
 
@@ -144,8 +141,9 @@ def enable_span_for_middleware(middleware):
             middleware_span.set_tag("starlite.middleware_name", middleware_name)
 
             # Creating spans for the "receive" callback
-            async def _sentry_receive(*args, **kwargs):
-                # type: (*Any, **Any) -> Union[HTTPReceiveMessage, WebSocketReceiveMessage]
+            async def _sentry_receive(
+                *args: Any, **kwargs: Any
+            ) -> Union[HTTPReceiveMessage, WebSocketReceiveMessage]:
                 if sentry_sdk.get_client().get_integration(StarliteIntegration) is None:
                     return await receive(*args, **kwargs)
                 with sentry_sdk.start_span(
@@ -162,8 +160,7 @@ def enable_span_for_middleware(middleware):
             new_receive = _sentry_receive if not receive_patched else receive
 
             # Creating spans for the "send" callback
-            async def _sentry_send(message):
-                # type: (Message) -> None
+            async def _sentry_send(message: Message) -> None:
                 if sentry_sdk.get_client().get_integration(StarliteIntegration) is None:
                     return await send(message)
                 with sentry_sdk.start_span(
@@ -192,19 +189,19 @@ def enable_span_for_middleware(middleware):
     return middleware
 
 
-def patch_http_route_handle():
-    # type: () -> None
+def patch_http_route_handle() -> None:
     old_handle = HTTPRoute.handle
 
-    async def handle_wrapper(self, scope, receive, send):
-        # type: (HTTPRoute, HTTPScope, Receive, Send) -> None
+    async def handle_wrapper(
+        self: HTTPRoute, scope: HTTPScope, receive: Receive, send: Send
+    ) -> None:
         if sentry_sdk.get_client().get_integration(StarliteIntegration) is None:
             return await old_handle(self, scope, receive, send)
 
         sentry_scope = sentry_sdk.get_isolation_scope()
-        request = scope["app"].request_class(
+        request: Request[Any, Any] = scope["app"].request_class(
             scope=scope, receive=receive, send=send
-        )  # type: Request[Any, Any]
+        )
         extracted_request_data = ConnectionDataExtractor(
             parse_body=True, parse_query=True
         )(request)
@@ -212,8 +209,7 @@ def patch_http_route_handle():
 
         request_data = await body
 
-        def event_processor(event, _):
-            # type: (Event, Hint) -> Event
+        def event_processor(event: Event, _: Hint) -> Event:
             route_handler = scope.get("route_handler")
 
             request_info = event.get("request", {})
@@ -256,8 +252,7 @@ def patch_http_route_handle():
     HTTPRoute.handle = handle_wrapper
 
 
-def retrieve_user_from_scope(scope):
-    # type: (StarliteScope) -> Optional[dict[str, Any]]
+def retrieve_user_from_scope(scope: StarliteScope) -> Optional[dict[str, Any]]:
     scope_user = scope.get("user")
     if not scope_user:
         return None
@@ -276,9 +271,8 @@ def retrieve_user_from_scope(scope):
 
 
 @ensure_integration_enabled(StarliteIntegration)
-def exception_handler(exc, scope, _):
-    # type: (Exception, StarliteScope, State) -> None
-    user_info = None  # type: Optional[dict[str, Any]]
+def exception_handler(exc: Exception, scope: StarliteScope, _: State) -> None:
+    user_info: Optional[dict[str, Any]] = None
     if should_send_default_pii():
         user_info = retrieve_user_from_scope(scope)
     if user_info and isinstance(user_info, dict):

--- a/sentry_sdk/integrations/statsig.py
+++ b/sentry_sdk/integrations/statsig.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from functools import wraps
 from typing import Any, TYPE_CHECKING
 
@@ -19,8 +20,7 @@ class StatsigIntegration(Integration):
     identifier = "statsig"
 
     @staticmethod
-    def setup_once():
-        # type: () -> None
+    def setup_once() -> None:
         version = parse_version(STATSIG_VERSION)
         _check_minimum_version(StatsigIntegration, version, "statsig")
 
@@ -28,8 +28,9 @@ class StatsigIntegration(Integration):
         old_check_gate = statsig_module.check_gate
 
         @wraps(old_check_gate)
-        def sentry_check_gate(user, gate, *args, **kwargs):
-            # type: (StatsigUser, str, *Any, **Any) -> Any
+        def sentry_check_gate(
+            user: StatsigUser, gate: str, *args: Any, **kwargs: Any
+        ) -> Any:
             enabled = old_check_gate(user, gate, *args, **kwargs)
             add_feature_flag(gate, enabled)
             return enabled

--- a/sentry_sdk/integrations/stdlib.py
+++ b/sentry_sdk/integrations/stdlib.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import os
 import subprocess
 import sys
@@ -34,25 +35,23 @@ if TYPE_CHECKING:
     from sentry_sdk._types import Event, Hint
 
 
-_RUNTIME_CONTEXT = {
+_RUNTIME_CONTEXT: dict[str, object] = {
     "name": platform.python_implementation(),
     "version": "%s.%s.%s" % (sys.version_info[:3]),
     "build": sys.version,
-}  # type: dict[str, object]
+}
 
 
 class StdlibIntegration(Integration):
     identifier = "stdlib"
 
     @staticmethod
-    def setup_once():
-        # type: () -> None
+    def setup_once() -> None:
         _install_httplib()
         _install_subprocess()
 
         @add_global_event_processor
-        def add_python_runtime_context(event, hint):
-            # type: (Event, Hint) -> Optional[Event]
+        def add_python_runtime_context(event: Event, hint: Hint) -> Optional[Event]:
             if sentry_sdk.get_client().get_integration(StdlibIntegration) is not None:
                 contexts = event.setdefault("contexts", {})
                 if isinstance(contexts, dict) and "runtime" not in contexts:
@@ -61,13 +60,13 @@ class StdlibIntegration(Integration):
             return event
 
 
-def _install_httplib():
-    # type: () -> None
+def _install_httplib() -> None:
     real_putrequest = HTTPConnection.putrequest
     real_getresponse = HTTPConnection.getresponse
 
-    def putrequest(self, method, url, *args, **kwargs):
-        # type: (HTTPConnection, str, str, *Any, **Any) -> Any
+    def putrequest(
+        self: HTTPConnection, method: str, url: str, *args: Any, **kwargs: Any
+    ) -> Any:
         host = self.host
         port = self.port
         default_port = self.default_port
@@ -134,8 +133,7 @@ def _install_httplib():
 
         return rv
 
-    def getresponse(self, *args, **kwargs):
-        # type: (HTTPConnection, *Any, **Any) -> Any
+    def getresponse(self: HTTPConnection, *args: Any, **kwargs: Any) -> Any:
         span = getattr(self, "_sentrysdk_span", None)
 
         if span is None:
@@ -167,8 +165,13 @@ def _install_httplib():
     HTTPConnection.getresponse = getresponse  # type: ignore[method-assign]
 
 
-def _init_argument(args, kwargs, name, position, setdefault_callback=None):
-    # type: (List[Any], Dict[Any, Any], str, int, Optional[Callable[[Any], Any]]) -> Any
+def _init_argument(
+    args: List[Any],
+    kwargs: Dict[Any, Any],
+    name: str,
+    position: int,
+    setdefault_callback: Optional[Callable[[Any], Any]] = None,
+) -> Any:
     """
     given (*args, **kwargs) of a function call, retrieve (and optionally set a
     default for) an argument by either name or position.
@@ -198,13 +201,13 @@ def _init_argument(args, kwargs, name, position, setdefault_callback=None):
     return rv
 
 
-def _install_subprocess():
-    # type: () -> None
+def _install_subprocess() -> None:
     old_popen_init = subprocess.Popen.__init__
 
     @ensure_integration_enabled(StdlibIntegration, old_popen_init)
-    def sentry_patched_popen_init(self, *a, **kw):
-        # type: (subprocess.Popen[Any], *Any, **Any) -> None
+    def sentry_patched_popen_init(
+        self: subprocess.Popen[Any], *a: Any, **kw: Any
+    ) -> None:
         # Convert from tuple to list to be able to set values.
         a = list(a)
 
@@ -279,8 +282,9 @@ def _install_subprocess():
     old_popen_wait = subprocess.Popen.wait
 
     @ensure_integration_enabled(StdlibIntegration, old_popen_wait)
-    def sentry_patched_popen_wait(self, *a, **kw):
-        # type: (subprocess.Popen[Any], *Any, **Any) -> Any
+    def sentry_patched_popen_wait(
+        self: subprocess.Popen[Any], *a: Any, **kw: Any
+    ) -> Any:
         with sentry_sdk.start_span(
             op=OP.SUBPROCESS_WAIT,
             origin="auto.subprocess.stdlib.subprocess",
@@ -294,8 +298,9 @@ def _install_subprocess():
     old_popen_communicate = subprocess.Popen.communicate
 
     @ensure_integration_enabled(StdlibIntegration, old_popen_communicate)
-    def sentry_patched_popen_communicate(self, *a, **kw):
-        # type: (subprocess.Popen[Any], *Any, **Any) -> Any
+    def sentry_patched_popen_communicate(
+        self: subprocess.Popen[Any], *a: Any, **kw: Any
+    ) -> Any:
         with sentry_sdk.start_span(
             op=OP.SUBPROCESS_COMMUNICATE,
             origin="auto.subprocess.stdlib.subprocess",
@@ -307,6 +312,5 @@ def _install_subprocess():
     subprocess.Popen.communicate = sentry_patched_popen_communicate  # type: ignore
 
 
-def get_subprocess_traceparent_headers():
-    # type: () -> EnvironHeaders
+def get_subprocess_traceparent_headers() -> EnvironHeaders:
     return EnvironHeaders(os.environ, prefix="SUBPROCESS_")

--- a/sentry_sdk/integrations/strawberry.py
+++ b/sentry_sdk/integrations/strawberry.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import functools
 import hashlib
 from inspect import isawaitable
@@ -62,8 +63,7 @@ class StrawberryIntegration(Integration):
     identifier = "strawberry"
     origin = f"auto.graphql.{identifier}"
 
-    def __init__(self, async_execution=None):
-        # type: (Optional[bool]) -> None
+    def __init__(self, async_execution: Optional[bool] = None) -> None:
         if async_execution not in (None, False, True):
             raise ValueError(
                 'Invalid value for async_execution: "{}" (must be bool)'.format(
@@ -73,8 +73,7 @@ class StrawberryIntegration(Integration):
         self.async_execution = async_execution
 
     @staticmethod
-    def setup_once():
-        # type: () -> None
+    def setup_once() -> None:
         version = package_version("strawberry-graphql")
         _check_minimum_version(StrawberryIntegration, version, "strawberry-graphql")
 
@@ -82,13 +81,11 @@ class StrawberryIntegration(Integration):
         _patch_views()
 
 
-def _patch_schema_init():
-    # type: () -> None
+def _patch_schema_init() -> None:
     old_schema_init = Schema.__init__
 
     @functools.wraps(old_schema_init)
-    def _sentry_patched_schema_init(self, *args, **kwargs):
-        # type: (Schema, Any, Any) -> None
+    def _sentry_patched_schema_init(self: Schema, *args: Any, **kwargs: Any) -> None:
         integration = sentry_sdk.get_client().get_integration(StrawberryIntegration)
         if integration is None:
             return old_schema_init(self, *args, **kwargs)
@@ -121,17 +118,15 @@ def _patch_schema_init():
 
 class SentryAsyncExtension(SchemaExtension):
     def __init__(
-        self,
+        self: Any,
         *,
-        execution_context=None,
-    ):
-        # type: (Any, Optional[ExecutionContext]) -> None
+        execution_context: Optional[ExecutionContext] = None,
+    ) -> None:
         if execution_context:
             self.execution_context = execution_context
 
     @cached_property
-    def _resource_name(self):
-        # type: () -> str
+    def _resource_name(self) -> str:
         query_hash = self.hash_query(self.execution_context.query)  # type: ignore
 
         if self.execution_context.operation_name:
@@ -139,12 +134,10 @@ class SentryAsyncExtension(SchemaExtension):
 
         return query_hash
 
-    def hash_query(self, query):
-        # type: (str) -> str
+    def hash_query(self, query: str) -> str:
         return hashlib.md5(query.encode("utf-8")).hexdigest()
 
-    def on_operation(self):
-        # type: () -> Generator[None, None, None]
+    def on_operation(self) -> Generator[None, None, None]:
         self._operation_name = self.execution_context.operation_name
 
         operation_type = "query"
@@ -205,8 +198,7 @@ class SentryAsyncExtension(SchemaExtension):
             if root_span:
                 root_span.op = op
 
-    def on_validate(self):
-        # type: () -> Generator[None, None, None]
+    def on_validate(self) -> Generator[None, None, None]:
         with sentry_sdk.start_span(
             op=OP.GRAPHQL_VALIDATE,
             name="validation",
@@ -214,8 +206,7 @@ class SentryAsyncExtension(SchemaExtension):
         ):
             yield
 
-    def on_parse(self):
-        # type: () -> Generator[None, None, None]
+    def on_parse(self) -> Generator[None, None, None]:
         with sentry_sdk.start_span(
             op=OP.GRAPHQL_PARSE,
             name="parsing",
@@ -223,12 +214,21 @@ class SentryAsyncExtension(SchemaExtension):
         ):
             yield
 
-    def should_skip_tracing(self, _next, info):
-        # type: (Callable[[Any, GraphQLResolveInfo, Any, Any], Any], GraphQLResolveInfo) -> bool
+    def should_skip_tracing(
+        self,
+        _next: Callable[[Any, GraphQLResolveInfo, Any, Any], Any],
+        info: GraphQLResolveInfo,
+    ) -> bool:
         return strawberry_should_skip_tracing(_next, info)
 
-    async def _resolve(self, _next, root, info, *args, **kwargs):
-        # type: (Callable[[Any, GraphQLResolveInfo, Any, Any], Any], Any, GraphQLResolveInfo, str, Any) -> Any
+    async def _resolve(
+        self,
+        _next: Callable[[Any, GraphQLResolveInfo, Any, Any], Any],
+        root: Any,
+        info: GraphQLResolveInfo,
+        *args: str,
+        **kwargs: Any,
+    ) -> Any:
         result = _next(root, info, *args, **kwargs)
 
         if isawaitable(result):
@@ -236,8 +236,14 @@ class SentryAsyncExtension(SchemaExtension):
 
         return result
 
-    async def resolve(self, _next, root, info, *args, **kwargs):
-        # type: (Callable[[Any, GraphQLResolveInfo, Any, Any], Any], Any, GraphQLResolveInfo, str, Any) -> Any
+    async def resolve(
+        self,
+        _next: Callable[[Any, GraphQLResolveInfo, Any, Any], Any],
+        root: Any,
+        info: GraphQLResolveInfo,
+        *args: str,
+        **kwargs: Any,
+    ) -> Any:
         if self.should_skip_tracing(_next, info):
             return await self._resolve(_next, root, info, *args, **kwargs)
 
@@ -257,8 +263,14 @@ class SentryAsyncExtension(SchemaExtension):
 
 
 class SentrySyncExtension(SentryAsyncExtension):
-    def resolve(self, _next, root, info, *args, **kwargs):
-        # type: (Callable[[Any, Any, Any, Any], Any], Any, GraphQLResolveInfo, str, Any) -> Any
+    def resolve(
+        self,
+        _next: Callable[[Any, Any, Any, Any], Any],
+        root: Any,
+        info: GraphQLResolveInfo,
+        *args: str,
+        **kwargs: Any,
+    ) -> Any:
         if self.should_skip_tracing(_next, info):
             return _next(root, info, *args, **kwargs)
 
@@ -277,24 +289,26 @@ class SentrySyncExtension(SentryAsyncExtension):
             return _next(root, info, *args, **kwargs)
 
 
-def _patch_views():
-    # type: () -> None
+def _patch_views() -> None:
     old_async_view_handle_errors = async_base_view.AsyncBaseHTTPView._handle_errors
     old_sync_view_handle_errors = sync_base_view.SyncBaseHTTPView._handle_errors
 
-    def _sentry_patched_async_view_handle_errors(self, errors, response_data):
-        # type: (Any, List[GraphQLError], GraphQLHTTPResponse) -> None
+    def _sentry_patched_async_view_handle_errors(
+        self: Any, errors: List[GraphQLError], response_data: GraphQLHTTPResponse
+    ) -> None:
         old_async_view_handle_errors(self, errors, response_data)
         _sentry_patched_handle_errors(self, errors, response_data)
 
-    def _sentry_patched_sync_view_handle_errors(self, errors, response_data):
-        # type: (Any, List[GraphQLError], GraphQLHTTPResponse) -> None
+    def _sentry_patched_sync_view_handle_errors(
+        self: Any, errors: List[GraphQLError], response_data: GraphQLHTTPResponse
+    ) -> None:
         old_sync_view_handle_errors(self, errors, response_data)
         _sentry_patched_handle_errors(self, errors, response_data)
 
     @ensure_integration_enabled(StrawberryIntegration)
-    def _sentry_patched_handle_errors(self, errors, response_data):
-        # type: (Any, List[GraphQLError], GraphQLHTTPResponse) -> None
+    def _sentry_patched_handle_errors(
+        self: Any, errors: List[GraphQLError], response_data: GraphQLHTTPResponse
+    ) -> None:
         if not errors:
             return
 
@@ -322,18 +336,18 @@ def _patch_views():
     )
 
 
-def _make_request_event_processor(execution_context):
-    # type: (ExecutionContext) -> EventProcessor
+def _make_request_event_processor(
+    execution_context: ExecutionContext,
+) -> EventProcessor:
 
-    def inner(event, hint):
-        # type: (Event, dict[str, Any]) -> Event
+    def inner(event: Event, hint: dict[str, Any]) -> Event:
         with capture_internal_exceptions():
             if should_send_default_pii():
                 request_data = event.setdefault("request", {})
                 request_data["api_target"] = "graphql"
 
                 if not request_data.get("data"):
-                    data = {"query": execution_context.query}  # type: dict[str, Any]
+                    data: dict[str, Any] = {"query": execution_context.query}
                     if execution_context.variables:
                         data["variables"] = execution_context.variables
                     if execution_context.operation_name:
@@ -352,11 +366,11 @@ def _make_request_event_processor(execution_context):
     return inner
 
 
-def _make_response_event_processor(response_data):
-    # type: (GraphQLHTTPResponse) -> EventProcessor
+def _make_response_event_processor(
+    response_data: GraphQLHTTPResponse,
+) -> EventProcessor:
 
-    def inner(event, hint):
-        # type: (Event, dict[str, Any]) -> Event
+    def inner(event: Event, hint: dict[str, Any]) -> Event:
         with capture_internal_exceptions():
             if should_send_default_pii():
                 contexts = event.setdefault("contexts", {})
@@ -367,8 +381,7 @@ def _make_response_event_processor(response_data):
     return inner
 
 
-def _guess_if_using_async(extensions):
-    # type: (List[SchemaExtension]) -> bool
+def _guess_if_using_async(extensions: List[SchemaExtension]) -> bool:
     return bool(
         {"starlette", "starlite", "litestar", "fastapi"} & set(_get_installed_modules())
     )

--- a/sentry_sdk/integrations/sys_exit.py
+++ b/sentry_sdk/integrations/sys_exit.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import functools
 import sys
 
@@ -24,23 +25,19 @@ class SysExitIntegration(Integration):
 
     identifier = "sys_exit"
 
-    def __init__(self, *, capture_successful_exits=False):
-        # type: (bool) -> None
+    def __init__(self, *, capture_successful_exits: bool = False) -> None:
         self._capture_successful_exits = capture_successful_exits
 
     @staticmethod
-    def setup_once():
-        # type: () -> None
+    def setup_once() -> None:
         SysExitIntegration._patch_sys_exit()
 
     @staticmethod
-    def _patch_sys_exit():
-        # type: () -> None
-        old_exit = sys.exit  # type: Callable[[Union[str, int, None]], NoReturn]
+    def _patch_sys_exit() -> None:
+        old_exit: Callable[[Union[str, int, None]], NoReturn] = sys.exit
 
         @functools.wraps(old_exit)
-        def sentry_patched_exit(__status=0):
-            # type: (Union[str, int, None]) -> NoReturn
+        def sentry_patched_exit(__status: Union[str, int, None] = 0) -> NoReturn:
             # @ensure_integration_enabled ensures that this is non-None
             integration = sentry_sdk.get_client().get_integration(SysExitIntegration)
             if integration is None:
@@ -60,8 +57,7 @@ class SysExitIntegration(Integration):
         sys.exit = sentry_patched_exit
 
 
-def _capture_exception(exc):
-    # type: (SystemExit) -> None
+def _capture_exception(exc: SystemExit) -> None:
     event, hint = event_from_exception(
         exc,
         client_options=sentry_sdk.get_client().options,

--- a/sentry_sdk/integrations/threading.py
+++ b/sentry_sdk/integrations/threading.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import sys
 import warnings
 from functools import wraps
@@ -28,13 +29,11 @@ if TYPE_CHECKING:
 class ThreadingIntegration(Integration):
     identifier = "threading"
 
-    def __init__(self, propagate_scope=True):
-        # type: (bool) -> None
+    def __init__(self, propagate_scope: bool = True) -> None:
         self.propagate_scope = propagate_scope
 
     @staticmethod
-    def setup_once():
-        # type: () -> None
+    def setup_once() -> None:
         old_start = Thread.start
 
         try:
@@ -47,8 +46,7 @@ class ThreadingIntegration(Integration):
             channels_version = None
 
         @wraps(old_start)
-        def sentry_start(self, *a, **kw):
-            # type: (Thread, *Any, **Any) -> Any
+        def sentry_start(self: Thread, *a: Any, **kw: Any) -> Any:
             integration = sentry_sdk.get_client().get_integration(ThreadingIntegration)
             if integration is None:
                 return old_start(self, *a, **kw)
@@ -98,13 +96,14 @@ class ThreadingIntegration(Integration):
         Thread.start = sentry_start  # type: ignore
 
 
-def _wrap_run(isolation_scope_to_use, current_scope_to_use, old_run_func):
-    # type: (sentry_sdk.Scope, sentry_sdk.Scope, F) -> F
+def _wrap_run(
+    isolation_scope_to_use: sentry_sdk.Scope,
+    current_scope_to_use: sentry_sdk.Scope,
+    old_run_func: F,
+) -> F:
     @wraps(old_run_func)
-    def run(*a, **kw):
-        # type: (*Any, **Any) -> Any
-        def _run_old_run_func():
-            # type: () -> Any
+    def run(*a: Any, **kw: Any) -> Any:
+        def _run_old_run_func() -> Any:
             try:
                 self = current_thread()
                 return old_run_func(self, *a, **kw)
@@ -118,8 +117,7 @@ def _wrap_run(isolation_scope_to_use, current_scope_to_use, old_run_func):
     return run  # type: ignore
 
 
-def _capture_exception():
-    # type: () -> ExcInfo
+def _capture_exception() -> ExcInfo:
     exc_info = sys.exc_info()
 
     client = sentry_sdk.get_client()

--- a/sentry_sdk/integrations/tornado.py
+++ b/sentry_sdk/integrations/tornado.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import weakref
 import contextlib
 from inspect import iscoroutinefunction
@@ -56,8 +57,7 @@ class TornadoIntegration(Integration):
     origin = f"auto.http.{identifier}"
 
     @staticmethod
-    def setup_once():
-        # type: () -> None
+    def setup_once() -> None:
         _check_minimum_version(TornadoIntegration, TORNADO_VERSION)
 
         if not HAS_REAL_CONTEXTVARS:
@@ -77,16 +77,18 @@ class TornadoIntegration(Integration):
         if awaitable:
             # Starting Tornado 6 RequestHandler._execute method is a standard Python coroutine (async/await)
             # In that case our method should be a coroutine function too
-            async def sentry_execute_request_handler(self, *args, **kwargs):
-                # type: (RequestHandler, *Any, **Any) -> Any
+            async def sentry_execute_request_handler(
+                self: RequestHandler, *args: Any, **kwargs: Any
+            ) -> Any:
                 with _handle_request_impl(self):
                     return await old_execute(self, *args, **kwargs)
 
         else:
 
             @coroutine  # type: ignore
-            def sentry_execute_request_handler(self, *args, **kwargs):
-                # type: (RequestHandler, *Any, **Any) -> Any
+            def sentry_execute_request_handler(
+                self: RequestHandler, *args: Any, **kwargs: Any
+            ) -> Any:
                 with _handle_request_impl(self):
                     result = yield from old_execute(self, *args, **kwargs)
                     return result
@@ -95,8 +97,14 @@ class TornadoIntegration(Integration):
 
         old_log_exception = RequestHandler.log_exception
 
-        def sentry_log_exception(self, ty, value, tb, *args, **kwargs):
-            # type: (Any, type, BaseException, Any, *Any, **Any) -> Optional[Any]
+        def sentry_log_exception(
+            self: Any,
+            ty: type,
+            value: BaseException,
+            tb: Any,
+            *args: Any,
+            **kwargs: Any,
+        ) -> Optional[Any]:
             _capture_exception(ty, value, tb)
             return old_log_exception(self, ty, value, tb, *args, **kwargs)
 
@@ -104,8 +112,7 @@ class TornadoIntegration(Integration):
 
 
 @contextlib.contextmanager
-def _handle_request_impl(self):
-    # type: (RequestHandler) -> Generator[None, None, None]
+def _handle_request_impl(self: RequestHandler) -> Generator[None, None, None]:
     integration = sentry_sdk.get_client().get_integration(TornadoIntegration)
 
     if integration is None:
@@ -136,8 +143,7 @@ def _handle_request_impl(self):
 
 
 @ensure_integration_enabled(TornadoIntegration)
-def _capture_exception(ty, value, tb):
-    # type: (type, BaseException, Any) -> None
+def _capture_exception(ty: type, value: BaseException, tb: Any) -> None:
     if isinstance(value, HTTPError):
         return
 
@@ -150,10 +156,8 @@ def _capture_exception(ty, value, tb):
     sentry_sdk.capture_event(event, hint=hint)
 
 
-def _make_event_processor(weak_handler):
-    # type: (Callable[[], RequestHandler]) -> EventProcessor
-    def tornado_processor(event, hint):
-        # type: (Event, dict[str, Any]) -> Event
+def _make_event_processor(weak_handler: Callable[[], RequestHandler]) -> EventProcessor:
+    def tornado_processor(event: Event, hint: dict[str, Any]) -> Event:
         handler = weak_handler()
         if handler is None:
             return event
@@ -192,42 +196,34 @@ def _make_event_processor(weak_handler):
 
 
 class TornadoRequestExtractor(RequestExtractor):
-    def content_length(self):
-        # type: () -> int
+    def content_length(self) -> int:
         if self.request.body is None:
             return 0
         return len(self.request.body)
 
-    def cookies(self):
-        # type: () -> Dict[str, str]
+    def cookies(self) -> Dict[str, str]:
         return {k: v.value for k, v in self.request.cookies.items()}
 
-    def raw_data(self):
-        # type: () -> bytes
+    def raw_data(self) -> bytes:
         return self.request.body
 
-    def form(self):
-        # type: () -> Dict[str, Any]
+    def form(self) -> Dict[str, Any]:
         return {
             k: [v.decode("latin1", "replace") for v in vs]
             for k, vs in self.request.body_arguments.items()
         }
 
-    def is_json(self):
-        # type: () -> bool
+    def is_json(self) -> bool:
         return _is_json_content_type(self.request.headers.get("content-type"))
 
-    def files(self):
-        # type: () -> Dict[str, Any]
+    def files(self) -> Dict[str, Any]:
         return {k: v[0] for k, v in self.request.files.items() if v}
 
-    def size_of_file(self, file):
-        # type: (Any) -> int
+    def size_of_file(self, file: Any) -> int:
         return len(file.body or ())
 
 
-def _prepopulate_attributes(request):
-    # type: (HTTPServerRequest) -> dict[str, Any]
+def _prepopulate_attributes(request: HTTPServerRequest) -> dict[str, Any]:
     # https://www.tornadoweb.org/en/stable/httputil.html#tornado.httputil.HTTPServerRequest
     attributes = {}
 

--- a/sentry_sdk/integrations/trytond.py
+++ b/sentry_sdk/integrations/trytond.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import sentry_sdk
 from sentry_sdk.integrations import _check_minimum_version, Integration
 from sentry_sdk.integrations.wsgi import SentryWsgiMiddleware
@@ -15,11 +16,11 @@ class TrytondWSGIIntegration(Integration):
     identifier = "trytond_wsgi"
     origin = f"auto.http.{identifier}"
 
-    def __init__(self):  # type: () -> None
+    def __init__(self) -> None:
         pass
 
     @staticmethod
-    def setup_once():  # type: () -> None
+    def setup_once() -> None:
         _check_minimum_version(TrytondWSGIIntegration, trytond_version)
 
         app.wsgi_app = SentryWsgiMiddleware(
@@ -28,7 +29,7 @@ class TrytondWSGIIntegration(Integration):
         )
 
         @ensure_integration_enabled(TrytondWSGIIntegration)
-        def error_handler(e):  # type: (Exception) -> None
+        def error_handler(e: Exception) -> None:
             if isinstance(e, TrytonException):
                 return
             else:

--- a/sentry_sdk/integrations/typer.py
+++ b/sentry_sdk/integrations/typer.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import sentry_sdk
 from sentry_sdk.utils import (
     capture_internal_exceptions,
@@ -30,15 +31,16 @@ class TyperIntegration(Integration):
     identifier = "typer"
 
     @staticmethod
-    def setup_once():
-        # type: () -> None
+    def setup_once() -> None:
         typer.main.except_hook = _make_excepthook(typer.main.except_hook)  # type: ignore
 
 
-def _make_excepthook(old_excepthook):
-    # type: (Excepthook) -> Excepthook
-    def sentry_sdk_excepthook(type_, value, traceback):
-        # type: (Type[BaseException], BaseException, Optional[TracebackType]) -> None
+def _make_excepthook(old_excepthook: Excepthook) -> Excepthook:
+    def sentry_sdk_excepthook(
+        type_: Type[BaseException],
+        value: BaseException,
+        traceback: Optional[TracebackType],
+    ) -> None:
         integration = sentry_sdk.get_client().get_integration(TyperIntegration)
 
         # Note: If we replace this with ensure_integration_enabled then

--- a/sentry_sdk/integrations/unleash.py
+++ b/sentry_sdk/integrations/unleash.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from functools import wraps
 from typing import Any
 
@@ -14,14 +15,14 @@ class UnleashIntegration(Integration):
     identifier = "unleash"
 
     @staticmethod
-    def setup_once():
-        # type: () -> None
+    def setup_once() -> None:
         # Wrap and patch evaluation methods (class methods)
         old_is_enabled = UnleashClient.is_enabled
 
         @wraps(old_is_enabled)
-        def sentry_is_enabled(self, feature, *args, **kwargs):
-            # type: (UnleashClient, str, *Any, **Any) -> Any
+        def sentry_is_enabled(
+            self: UnleashClient, feature: str, *args: Any, **kwargs: Any
+        ) -> Any:
             enabled = old_is_enabled(self, feature, *args, **kwargs)
 
             # We have no way of knowing what type of unleash feature this is, so we have to treat

--- a/sentry_sdk/integrations/wsgi.py
+++ b/sentry_sdk/integrations/wsgi.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import sys
 from functools import partial
 
@@ -25,22 +26,26 @@ if TYPE_CHECKING:
     from typing import Callable
     from typing import Dict
     from typing import Iterator
+    from typing import Iterable
     from typing import Any
     from typing import Tuple
+    from typing import List
     from typing import Optional
-    from typing import TypeVar
     from typing import Protocol
 
     from sentry_sdk.utils import ExcInfo
     from sentry_sdk._types import Event, EventProcessor
 
-    WsgiResponseIter = TypeVar("WsgiResponseIter")
-    WsgiResponseHeaders = TypeVar("WsgiResponseHeaders")
-    WsgiExcInfo = TypeVar("WsgiExcInfo")
+    WsgiResponseIter = Iterable[bytes]
+    WsgiResponseHeaders = List[Tuple[str, str]]
 
     class StartResponse(Protocol):
-        def __call__(self, status, response_headers, exc_info=None):  # type: ignore
-            # type: (str, WsgiResponseHeaders, Optional[WsgiExcInfo]) -> WsgiResponseIter
+        def __call__(
+            self,
+            status: str,
+            response_headers: WsgiResponseHeaders,
+            exc_info: Optional[ExcInfo] = None,
+        ) -> WsgiResponseIter:
             pass
 
 
@@ -58,13 +63,11 @@ ENVIRON_TO_ATTRIBUTE = {
 }
 
 
-def wsgi_decoding_dance(s, charset="utf-8", errors="replace"):
-    # type: (str, str, str) -> str
+def wsgi_decoding_dance(s: str, charset: str = "utf-8", errors: str = "replace") -> str:
     return s.encode("latin1").decode(charset, errors)
 
 
-def get_request_url(environ, use_x_forwarded_for=False):
-    # type: (Dict[str, str], bool) -> str
+def get_request_url(environ: Dict[str, str], use_x_forwarded_for: bool = False) -> str:
     """Return the absolute URL without query string for the given WSGI
     environment."""
     script_name = environ.get("SCRIPT_NAME", "").rstrip("/")
@@ -88,19 +91,19 @@ class SentryWsgiMiddleware:
 
     def __init__(
         self,
-        app,  # type: Callable[[Dict[str, str], Callable[..., Any]], Any]
-        use_x_forwarded_for=False,  # type: bool
-        span_origin=None,  # type: Optional[str]
-        http_methods_to_capture=DEFAULT_HTTP_METHODS_TO_CAPTURE,  # type: Tuple[str, ...]
-    ):
-        # type: (...) -> None
+        app: Callable[[Dict[str, str], Callable[..., Any]], Any],
+        use_x_forwarded_for: bool = False,
+        span_origin: Optional[str] = None,
+        http_methods_to_capture: Tuple[str, ...] = DEFAULT_HTTP_METHODS_TO_CAPTURE,
+    ) -> None:
         self.app = app
         self.use_x_forwarded_for = use_x_forwarded_for
         self.span_origin = span_origin
         self.http_methods_to_capture = http_methods_to_capture
 
-    def __call__(self, environ, start_response):
-        # type: (Dict[str, str], Callable[..., Any]) -> _ScopedResponse
+    def __call__(
+        self, environ: Dict[str, str], start_response: Callable[..., Any]
+    ) -> _ScopedResponse:
         if _wsgi_middleware_applied.get(False):
             return self.app(environ, start_response)
 
@@ -144,8 +147,12 @@ class SentryWsgiMiddleware:
 
         return _ScopedResponse(scope, response)
 
-    def _run_original_app(self, environ, start_response, span):
-        # type: (dict[str, str], StartResponse, Optional[Span]) -> Any
+    def _run_original_app(
+        self,
+        environ: dict[str, str],
+        start_response: StartResponse,
+        span: Optional[Span],
+    ) -> Any:
         try:
             return self.app(
                 environ,
@@ -159,14 +166,13 @@ class SentryWsgiMiddleware:
             reraise(*_capture_exception())
 
 
-def _sentry_start_response(  # type: ignore
-    old_start_response,  # type: StartResponse
-    span,  # type: Optional[Span]
-    status,  # type: str
-    response_headers,  # type: WsgiResponseHeaders
-    exc_info=None,  # type: Optional[WsgiExcInfo]
-):
-    # type: (...) -> WsgiResponseIter
+def _sentry_start_response(
+    old_start_response: StartResponse,
+    span: Optional[Span],
+    status: str,
+    response_headers: WsgiResponseHeaders,
+    exc_info: Optional[ExcInfo] = None,
+) -> WsgiResponseIter:
     with capture_internal_exceptions():
         status_int = int(status.split(" ", 1)[0])
         if span is not None:
@@ -181,8 +187,7 @@ def _sentry_start_response(  # type: ignore
         return old_start_response(status, response_headers, exc_info)
 
 
-def _get_environ(environ):
-    # type: (Dict[str, str]) -> Iterator[Tuple[str, str]]
+def _get_environ(environ: Dict[str, str]) -> Iterator[Tuple[str, str]]:
     """
     Returns our explicitly included environment variables we want to
     capture (server name, port and remote addr if pii is enabled).
@@ -198,8 +203,7 @@ def _get_environ(environ):
             yield key, environ[key]
 
 
-def get_client_ip(environ):
-    # type: (Dict[str, str]) -> Optional[Any]
+def get_client_ip(environ: Dict[str, str]) -> Optional[Any]:
     """
     Infer the user IP address from various headers. This cannot be used in
     security sensitive situations since the value may be forged from a client,
@@ -218,8 +222,7 @@ def get_client_ip(environ):
     return environ.get("REMOTE_ADDR")
 
 
-def _capture_exception():
-    # type: () -> ExcInfo
+def _capture_exception() -> ExcInfo:
     """
     Captures the current exception and sends it to Sentry.
     Returns the ExcInfo tuple to it can be reraised afterwards.
@@ -253,13 +256,11 @@ class _ScopedResponse:
 
     __slots__ = ("_response", "_scope")
 
-    def __init__(self, scope, response):
-        # type: (sentry_sdk.Scope, Iterator[bytes]) -> None
+    def __init__(self, scope: sentry_sdk.Scope, response: Iterator[bytes]) -> None:
         self._scope = scope
         self._response = response
 
-    def __iter__(self):
-        # type: () -> Iterator[bytes]
+    def __iter__(self) -> Iterator[bytes]:
         iterator = iter(self._response)
 
         while True:
@@ -273,8 +274,7 @@ class _ScopedResponse:
 
             yield chunk
 
-    def close(self):
-        # type: () -> None
+    def close(self) -> None:
         with sentry_sdk.use_isolation_scope(self._scope):
             try:
                 self._response.close()  # type: ignore
@@ -284,8 +284,9 @@ class _ScopedResponse:
                 reraise(*_capture_exception())
 
 
-def _make_wsgi_event_processor(environ, use_x_forwarded_for):
-    # type: (Dict[str, str], bool) -> EventProcessor
+def _make_wsgi_event_processor(
+    environ: Dict[str, str], use_x_forwarded_for: bool
+) -> EventProcessor:
     # It's a bit unfortunate that we have to extract and parse the request data
     # from the environ so eagerly, but there are a few good reasons for this.
     #
@@ -305,8 +306,7 @@ def _make_wsgi_event_processor(environ, use_x_forwarded_for):
     env = dict(_get_environ(environ))
     headers = _filter_headers(dict(_get_headers(environ)))
 
-    def event_processor(event, hint):
-        # type: (Event, Dict[str, Any]) -> Event
+    def event_processor(event: Event, hint: Dict[str, Any]) -> Event:
         with capture_internal_exceptions():
             # if the code below fails halfway through we at least have some data
             request_info = event.setdefault("request", {})
@@ -327,8 +327,9 @@ def _make_wsgi_event_processor(environ, use_x_forwarded_for):
     return event_processor
 
 
-def _prepopulate_attributes(wsgi_environ, use_x_forwarded_for=False):
-    # type: (dict[str, str], bool) -> dict[str, str]
+def _prepopulate_attributes(
+    wsgi_environ: dict[str, str], use_x_forwarded_for: bool = False
+) -> dict[str, str]:
     """Extract span attributes from the WSGI environment."""
     attributes = {}
 

--- a/sentry_sdk/logger.py
+++ b/sentry_sdk/logger.py
@@ -1,7 +1,12 @@
 # NOTE: this is the logger sentry exposes to users, not some generic logger.
+from __future__ import annotations
 import functools
 import time
-from typing import Any
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from typing import Any
 
 from sentry_sdk import get_client
 from sentry_sdk.utils import safe_repr
@@ -18,13 +23,14 @@ OTEL_RANGES = [
 ]
 
 
-def _capture_log(severity_text, severity_number, template, **kwargs):
-    # type: (str, int, str, **Any) -> None
+def _capture_log(
+    severity_text: str, severity_number: int, template: str, **kwargs: Any
+) -> None:
     client = get_client()
 
-    attrs = {
+    attrs: dict[str, str | bool | float | int] = {
         "sentry.message.template": template,
-    }  # type: dict[str, str | bool | float | int]
+    }
     if "attributes" in kwargs:
         attrs.update(kwargs.pop("attributes"))
     for k, v in kwargs.items():
@@ -65,8 +71,7 @@ error = functools.partial(_capture_log, "error", 17)
 fatal = functools.partial(_capture_log, "fatal", 21)
 
 
-def _otel_severity_text(otel_severity_number):
-    # type: (int) -> str
+def _otel_severity_text(otel_severity_number: int) -> str:
     for (lower, upper), severity in OTEL_RANGES:
         if lower <= otel_severity_number <= upper:
             return severity
@@ -74,8 +79,7 @@ def _otel_severity_text(otel_severity_number):
     return "default"
 
 
-def _log_level_to_otel(level, mapping):
-    # type: (int, dict[Any, int]) -> tuple[int, str]
+def _log_level_to_otel(level: int, mapping: dict[Any, int]) -> tuple[int, str]:
     for py_level, otel_severity_number in sorted(mapping.items(), reverse=True):
         if level >= py_level:
             return otel_severity_number, _otel_severity_text(otel_severity_number)

--- a/sentry_sdk/monitor.py
+++ b/sentry_sdk/monitor.py
@@ -1,14 +1,15 @@
+from __future__ import annotations
 import os
 import time
 from threading import Thread, Lock
 
-import sentry_sdk
 from sentry_sdk.utils import logger
 
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from typing import Optional
+    from sentry_sdk.transport import Transport
 
 
 MAX_DOWNSAMPLE_FACTOR = 10
@@ -23,21 +24,19 @@ class Monitor:
 
     name = "sentry.monitor"
 
-    def __init__(self, transport, interval=10):
-        # type: (sentry_sdk.transport.Transport, float) -> None
-        self.transport = transport  # type: sentry_sdk.transport.Transport
-        self.interval = interval  # type: float
+    def __init__(self, transport: Transport, interval: float = 10) -> None:
+        self.transport: Transport = transport
+        self.interval: float = interval
 
         self._healthy = True
-        self._downsample_factor = 0  # type: int
+        self._downsample_factor: int = 0
 
-        self._thread = None  # type: Optional[Thread]
+        self._thread: Optional[Thread] = None
         self._thread_lock = Lock()
-        self._thread_for_pid = None  # type: Optional[int]
+        self._thread_for_pid: Optional[int] = None
         self._running = True
 
-    def _ensure_running(self):
-        # type: () -> None
+    def _ensure_running(self) -> None:
         """
         Check that the monitor has an active thread to run in, or create one if not.
 
@@ -52,8 +51,7 @@ class Monitor:
             if self._thread_for_pid == os.getpid() and self._thread is not None:
                 return None
 
-            def _thread():
-                # type: (...) -> None
+            def _thread() -> None:
                 while self._running:
                     time.sleep(self.interval)
                     if self._running:
@@ -74,13 +72,11 @@ class Monitor:
 
         return None
 
-    def run(self):
-        # type: () -> None
+    def run(self) -> None:
         self.check_health()
         self.set_downsample_factor()
 
-    def set_downsample_factor(self):
-        # type: () -> None
+    def set_downsample_factor(self) -> None:
         if self._healthy:
             if self._downsample_factor > 0:
                 logger.debug(
@@ -95,8 +91,7 @@ class Monitor:
                 self._downsample_factor,
             )
 
-    def check_health(self):
-        # type: () -> None
+    def check_health(self) -> None:
         """
         Perform the actual health checks,
         currently only checks if the transport is rate-limited.
@@ -104,21 +99,17 @@ class Monitor:
         """
         self._healthy = self.transport.is_healthy()
 
-    def is_healthy(self):
-        # type: () -> bool
+    def is_healthy(self) -> bool:
         self._ensure_running()
         return self._healthy
 
     @property
-    def downsample_factor(self):
-        # type: () -> int
+    def downsample_factor(self) -> int:
         self._ensure_running()
         return self._downsample_factor
 
-    def kill(self):
-        # type: () -> None
+    def kill(self) -> None:
         self._running = False
 
-    def __del__(self):
-        # type: () -> None
+    def __del__(self) -> None:
         self.kill()

--- a/sentry_sdk/opentelemetry/consts.py
+++ b/sentry_sdk/opentelemetry/consts.py
@@ -1,5 +1,4 @@
 from opentelemetry.context import create_key
-from sentry_sdk.tracing_utils import Baggage
 
 
 # propagation keys
@@ -13,9 +12,10 @@ SENTRY_USE_CURRENT_SCOPE_KEY = create_key("sentry_use_current_scope")
 SENTRY_USE_ISOLATION_SCOPE_KEY = create_key("sentry_use_isolation_scope")
 
 # trace state keys
-TRACESTATE_SAMPLED_KEY = Baggage.SENTRY_PREFIX + "sampled"
-TRACESTATE_SAMPLE_RATE_KEY = Baggage.SENTRY_PREFIX + "sample_rate"
-TRACESTATE_SAMPLE_RAND_KEY = Baggage.SENTRY_PREFIX + "sample_rand"
+SENTRY_PREFIX = "sentry-"
+TRACESTATE_SAMPLED_KEY = SENTRY_PREFIX + "sampled"
+TRACESTATE_SAMPLE_RATE_KEY = SENTRY_PREFIX + "sample_rate"
+TRACESTATE_SAMPLE_RAND_KEY = SENTRY_PREFIX + "sample_rand"
 
 # misc
 OTEL_SENTRY_CONTEXT = "otel"

--- a/sentry_sdk/opentelemetry/span_processor.py
+++ b/sentry_sdk/opentelemetry/span_processor.py
@@ -1,5 +1,5 @@
+from __future__ import annotations
 from collections import deque, defaultdict
-from typing import cast
 
 from opentelemetry.trace import (
     format_trace_id,
@@ -52,30 +52,24 @@ class SentrySpanProcessor(SpanProcessor):
     Converts OTel spans into Sentry spans so they can be sent to the Sentry backend.
     """
 
-    def __new__(cls):
-        # type: () -> SentrySpanProcessor
+    def __new__(cls) -> SentrySpanProcessor:
         if not hasattr(cls, "instance"):
             cls.instance = super().__new__(cls)
 
         return cls.instance
 
-    def __init__(self):
-        # type: () -> None
-        self._children_spans = defaultdict(
-            list
-        )  # type: DefaultDict[int, List[ReadableSpan]]
-        self._dropped_spans = defaultdict(lambda: 0)  # type: DefaultDict[int, int]
+    def __init__(self) -> None:
+        self._children_spans: DefaultDict[int, List[ReadableSpan]] = defaultdict(list)
+        self._dropped_spans: DefaultDict[int, int] = defaultdict(lambda: 0)
 
-    def on_start(self, span, parent_context=None):
-        # type: (Span, Optional[Context]) -> None
+    def on_start(self, span: Span, parent_context: Optional[Context] = None) -> None:
         if is_sentry_span(span):
             return
 
         self._add_root_span(span, get_current_span(parent_context))
         self._start_profile(span)
 
-    def on_end(self, span):
-        # type: (ReadableSpan) -> None
+    def on_end(self, span: ReadableSpan) -> None:
         if is_sentry_span(span):
             return
 
@@ -88,18 +82,15 @@ class SentrySpanProcessor(SpanProcessor):
             self._append_child_span(span)
 
     # TODO-neel-potel not sure we need a clear like JS
-    def shutdown(self):
-        # type: () -> None
+    def shutdown(self) -> None:
         pass
 
     # TODO-neel-potel change default? this is 30 sec
     # TODO-neel-potel call this in client.flush
-    def force_flush(self, timeout_millis=30000):
-        # type: (int) -> bool
+    def force_flush(self, timeout_millis: int = 30000) -> bool:
         return True
 
-    def _add_root_span(self, span, parent_span):
-        # type: (Span, AbstractSpan) -> None
+    def _add_root_span(self, span: Span, parent_span: AbstractSpan) -> None:
         """
         This is required to make Span.root_span work
         since we can't traverse back to the root purely with otel efficiently.
@@ -112,8 +103,7 @@ class SentrySpanProcessor(SpanProcessor):
             # root span points to itself
             set_sentry_meta(span, "root_span", span)
 
-    def _start_profile(self, span):
-        # type: (Span) -> None
+    def _start_profile(self, span: Span) -> None:
         try_autostart_continuous_profiler()
 
         profiler_id = get_profiler_id()
@@ -148,14 +138,12 @@ class SentrySpanProcessor(SpanProcessor):
                 span.set_attribute(SPANDATA.PROFILER_ID, profiler_id)
             set_sentry_meta(span, "continuous_profile", continuous_profile)
 
-    def _stop_profile(self, span):
-        # type: (ReadableSpan) -> None
+    def _stop_profile(self, span: ReadableSpan) -> None:
         continuous_profiler = get_sentry_meta(span, "continuous_profile")
         if continuous_profiler:
             continuous_profiler.stop()
 
-    def _flush_root_span(self, span):
-        # type: (ReadableSpan) -> None
+    def _flush_root_span(self, span: ReadableSpan) -> None:
         transaction_event = self._root_span_to_transaction_event(span)
         if not transaction_event:
             return
@@ -176,8 +164,7 @@ class SentrySpanProcessor(SpanProcessor):
         sentry_sdk.capture_event(transaction_event)
         self._cleanup_references([span] + collected_spans)
 
-    def _append_child_span(self, span):
-        # type: (ReadableSpan) -> None
+    def _append_child_span(self, span: ReadableSpan) -> None:
         if not span.parent:
             return
 
@@ -192,14 +179,13 @@ class SentrySpanProcessor(SpanProcessor):
         else:
             self._dropped_spans[span.parent.span_id] += 1
 
-    def _collect_children(self, span):
-        # type: (ReadableSpan) -> tuple[List[ReadableSpan], int]
+    def _collect_children(self, span: ReadableSpan) -> tuple[List[ReadableSpan], int]:
         if not span.context:
             return [], 0
 
         children = []
         dropped_spans = 0
-        bfs_queue = deque()  # type: Deque[int]
+        bfs_queue: Deque[int] = deque()
         bfs_queue.append(span.context.span_id)
 
         while bfs_queue:
@@ -215,8 +201,7 @@ class SentrySpanProcessor(SpanProcessor):
 
     # we construct the event from scratch here
     # and not use the current Transaction class for easier refactoring
-    def _root_span_to_transaction_event(self, span):
-        # type: (ReadableSpan) -> Optional[Event]
+    def _root_span_to_transaction_event(self, span: ReadableSpan) -> Optional[Event]:
         if not span.context:
             return None
 
@@ -250,23 +235,20 @@ class SentrySpanProcessor(SpanProcessor):
             }
         )
 
-        profile = cast("Optional[Profile]", get_sentry_meta(span, "profile"))
-        if profile:
+        profile = get_sentry_meta(span, "profile")
+        if profile is not None and isinstance(profile, Profile):
             profile.__exit__(None, None, None)
             if profile.valid():
                 event["profile"] = profile
 
         return event
 
-    def _span_to_json(self, span):
-        # type: (ReadableSpan) -> Optional[dict[str, Any]]
+    def _span_to_json(self, span: ReadableSpan) -> Optional[dict[str, Any]]:
         if not span.context:
             return None
 
-        # This is a safe cast because dict[str, Any] is a superset of Event
-        span_json = cast(
-            "dict[str, Any]", self._common_span_transaction_attributes_as_json(span)
-        )
+        # need to ignore the type here due to TypedDict nonsense
+        span_json: Optional[dict[str, Any]] = self._common_span_transaction_attributes_as_json(span)  # type: ignore
         if span_json is None:
             return None
 
@@ -299,15 +281,16 @@ class SentrySpanProcessor(SpanProcessor):
 
         return span_json
 
-    def _common_span_transaction_attributes_as_json(self, span):
-        # type: (ReadableSpan) -> Optional[Event]
+    def _common_span_transaction_attributes_as_json(
+        self, span: ReadableSpan
+    ) -> Optional[Event]:
         if not span.start_time or not span.end_time:
             return None
 
-        common_json = {
+        common_json: Event = {
             "start_timestamp": convert_from_otel_timestamp(span.start_time),
             "timestamp": convert_from_otel_timestamp(span.end_time),
-        }  # type: Event
+        }
 
         tags = extract_span_attributes(span, SentrySpanAttribute.TAG)
         if tags:
@@ -315,13 +298,11 @@ class SentrySpanProcessor(SpanProcessor):
 
         return common_json
 
-    def _cleanup_references(self, spans):
-        # type: (List[ReadableSpan]) -> None
+    def _cleanup_references(self, spans: List[ReadableSpan]) -> None:
         for span in spans:
             delete_sentry_meta(span)
 
-    def _log_debug_info(self):
-        # type: () -> None
+    def _log_debug_info(self) -> None:
         import pprint
 
         pprint.pprint(

--- a/sentry_sdk/opentelemetry/tracing.py
+++ b/sentry_sdk/opentelemetry/tracing.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from opentelemetry import trace
 from opentelemetry.propagate import set_global_textmap
 from opentelemetry.sdk.trace import TracerProvider, Span, ReadableSpan
@@ -10,16 +11,14 @@ from sentry_sdk.opentelemetry import (
 from sentry_sdk.utils import logger
 
 
-def patch_readable_span():
-    # type: () -> None
+def patch_readable_span() -> None:
     """
     We need to pass through sentry specific metadata/objects from Span to ReadableSpan
     to work with them consistently in the SpanProcessor.
     """
     old_readable_span = Span._readable_span
 
-    def sentry_patched_readable_span(self):
-        # type: (Span) -> ReadableSpan
+    def sentry_patched_readable_span(self: Span) -> ReadableSpan:
         readable_span = old_readable_span(self)
         readable_span._sentry_meta = getattr(self, "_sentry_meta", {})  # type: ignore[attr-defined]
         return readable_span
@@ -27,8 +26,7 @@ def patch_readable_span():
     Span._readable_span = sentry_patched_readable_span  # type: ignore[method-assign]
 
 
-def setup_sentry_tracing():
-    # type: () -> None
+def setup_sentry_tracing() -> None:
     # TracerProvider can only be set once. If we're the first ones setting it,
     # there's no issue. If it already exists, we need to patch it.
     from opentelemetry.trace import _TRACER_PROVIDER

--- a/sentry_sdk/opentelemetry/utils.py
+++ b/sentry_sdk/opentelemetry/utils.py
@@ -1,5 +1,5 @@
+from __future__ import annotations
 import re
-from typing import cast
 from datetime import datetime, timezone
 
 from urllib3.util import parse_url as urlparse
@@ -30,8 +30,10 @@ from sentry_sdk.tracing_utils import Baggage, get_span_status_from_http_code
 from sentry_sdk._types import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from typing import Any, Optional, Mapping, Sequence, Union
+    from typing import Any, Optional, Mapping, Sequence, Union, Type, TypeVar
     from sentry_sdk._types import OtelExtractedSpanData
+
+    T = TypeVar("T")
 
 
 GRPC_ERROR_MAP = {
@@ -54,8 +56,7 @@ GRPC_ERROR_MAP = {
 }
 
 
-def is_sentry_span(span):
-    # type: (ReadableSpan) -> bool
+def is_sentry_span(span: ReadableSpan) -> bool:
     """
     Break infinite loop:
     HTTP requests to Sentry are caught by OTel and send again to Sentry.
@@ -65,10 +66,8 @@ def is_sentry_span(span):
     if not span.attributes:
         return False
 
-    span_url = span.attributes.get(SpanAttributes.HTTP_URL, None)
-    span_url = cast("Optional[str]", span_url)
-
-    if not span_url:
+    span_url = get_typed_attribute(span.attributes, SpanAttributes.HTTP_URL, str)
+    if span_url is None:
         return False
 
     dsn_url = None
@@ -89,32 +88,30 @@ def is_sentry_span(span):
     return False
 
 
-def convert_from_otel_timestamp(time):
-    # type: (int) -> datetime
+def convert_from_otel_timestamp(time: int) -> datetime:
     """Convert an OTel nanosecond-level timestamp to a datetime."""
     return datetime.fromtimestamp(time / 1e9, timezone.utc)
 
 
-def convert_to_otel_timestamp(time):
-    # type: (Union[datetime, float]) -> int
+def convert_to_otel_timestamp(time: Union[datetime, float]) -> int:
     """Convert a datetime to an OTel timestamp (with nanosecond precision)."""
     if isinstance(time, datetime):
         return int(time.timestamp() * 1e9)
     return int(time * 1e9)
 
 
-def extract_transaction_name_source(span):
-    # type: (ReadableSpan) -> tuple[Optional[str], Optional[str]]
+def extract_transaction_name_source(
+    span: ReadableSpan,
+) -> tuple[Optional[str], Optional[str]]:
     if not span.attributes:
         return (None, None)
     return (
-        cast("Optional[str]", span.attributes.get(SentrySpanAttribute.NAME)),
-        cast("Optional[str]", span.attributes.get(SentrySpanAttribute.SOURCE)),
+        get_typed_attribute(span.attributes, SentrySpanAttribute.NAME, str),
+        get_typed_attribute(span.attributes, SentrySpanAttribute.SOURCE, str),
     )
 
 
-def extract_span_data(span):
-    # type: (ReadableSpan) -> OtelExtractedSpanData
+def extract_span_data(span: ReadableSpan) -> OtelExtractedSpanData:
     op = span.name
     description = span.name
     status, http_status = extract_span_status(span)
@@ -122,15 +119,15 @@ def extract_span_data(span):
     if span.attributes is None:
         return (op, description, status, http_status, origin)
 
-    attribute_op = cast("Optional[str]", span.attributes.get(SentrySpanAttribute.OP))
+    attribute_op = get_typed_attribute(span.attributes, SentrySpanAttribute.OP, str)
     op = attribute_op or op
-    description = cast(
-        "str", span.attributes.get(SentrySpanAttribute.DESCRIPTION) or description
+    description = (
+        get_typed_attribute(span.attributes, SentrySpanAttribute.DESCRIPTION, str)
+        or description
     )
-    origin = cast("Optional[str]", span.attributes.get(SentrySpanAttribute.ORIGIN))
+    origin = get_typed_attribute(span.attributes, SentrySpanAttribute.ORIGIN, str)
 
-    http_method = span.attributes.get(SpanAttributes.HTTP_METHOD)
-    http_method = cast("Optional[str]", http_method)
+    http_method = get_typed_attribute(span.attributes, SpanAttributes.HTTP_METHOD, str)
     if http_method:
         return span_data_for_http_method(span)
 
@@ -165,11 +162,10 @@ def extract_span_data(span):
     return (op, description, status, http_status, origin)
 
 
-def span_data_for_http_method(span):
-    # type: (ReadableSpan) -> OtelExtractedSpanData
+def span_data_for_http_method(span: ReadableSpan) -> OtelExtractedSpanData:
     span_attributes = span.attributes or {}
 
-    op = cast("Optional[str]", span_attributes.get(SentrySpanAttribute.OP))
+    op = get_typed_attribute(span_attributes, SentrySpanAttribute.OP, str)
     if op is None:
         op = "http"
 
@@ -184,10 +180,9 @@ def span_data_for_http_method(span):
     peer_name = span_attributes.get(SpanAttributes.NET_PEER_NAME)
 
     # TODO-neel-potel remove description completely
-    description = span_attributes.get(
-        SentrySpanAttribute.DESCRIPTION
-    ) or span_attributes.get(SentrySpanAttribute.NAME)
-    description = cast("Optional[str]", description)
+    description = get_typed_attribute(
+        span_attributes, SentrySpanAttribute.DESCRIPTION, str
+    ) or get_typed_attribute(span_attributes, SentrySpanAttribute.NAME, str)
     if description is None:
         description = f"{http_method}"
 
@@ -199,7 +194,7 @@ def span_data_for_http_method(span):
             description = f"{http_method} {peer_name}"
         else:
             url = span_attributes.get(SpanAttributes.HTTP_URL)
-            url = cast("Optional[str]", url)
+            url = get_typed_attribute(span_attributes, SpanAttributes.HTTP_URL, str)
 
             if url:
                 parsed_url = urlparse(url)
@@ -210,28 +205,24 @@ def span_data_for_http_method(span):
 
     status, http_status = extract_span_status(span)
 
-    origin = cast("Optional[str]", span_attributes.get(SentrySpanAttribute.ORIGIN))
+    origin = get_typed_attribute(span_attributes, SentrySpanAttribute.ORIGIN, str)
 
     return (op, description, status, http_status, origin)
 
 
-def span_data_for_db_query(span):
-    # type: (ReadableSpan) -> OtelExtractedSpanData
+def span_data_for_db_query(span: ReadableSpan) -> OtelExtractedSpanData:
     span_attributes = span.attributes or {}
 
-    op = cast("str", span_attributes.get(SentrySpanAttribute.OP, OP.DB))
-
-    statement = span_attributes.get(SpanAttributes.DB_STATEMENT, None)
-    statement = cast("Optional[str]", statement)
+    op = get_typed_attribute(span_attributes, SentrySpanAttribute.OP, str) or OP.DB
+    statement = get_typed_attribute(span_attributes, SpanAttributes.DB_STATEMENT, str)
 
     description = statement or span.name
-    origin = cast("Optional[str]", span_attributes.get(SentrySpanAttribute.ORIGIN))
+    origin = get_typed_attribute(span_attributes, SentrySpanAttribute.ORIGIN, str)
 
     return (op, description, None, None, origin)
 
 
-def extract_span_status(span):
-    # type: (ReadableSpan) -> tuple[Optional[str], Optional[int]]
+def extract_span_status(span: ReadableSpan) -> tuple[Optional[str], Optional[int]]:
     span_attributes = span.attributes or {}
     status = span.status or None
 
@@ -266,8 +257,19 @@ def extract_span_status(span):
         return (SPANSTATUS.UNKNOWN_ERROR, None)
 
 
-def infer_status_from_attributes(span_attributes):
-    # type: (Mapping[str, str | bool | int | float | Sequence[str] | Sequence[bool] | Sequence[int] | Sequence[float]]) -> tuple[Optional[str], Optional[int]]
+def infer_status_from_attributes(
+    span_attributes: Mapping[
+        str,
+        str
+        | bool
+        | int
+        | float
+        | Sequence[str]
+        | Sequence[bool]
+        | Sequence[int]
+        | Sequence[float],
+    ],
+) -> tuple[Optional[str], Optional[int]]:
     http_status = get_http_status_code(span_attributes)
 
     if http_status:
@@ -280,10 +282,23 @@ def infer_status_from_attributes(span_attributes):
     return (None, None)
 
 
-def get_http_status_code(span_attributes):
-    # type: (Mapping[str, str | bool | int | float | Sequence[str] | Sequence[bool] | Sequence[int] | Sequence[float]]) -> Optional[int]
+def get_http_status_code(
+    span_attributes: Mapping[
+        str,
+        str
+        | bool
+        | int
+        | float
+        | Sequence[str]
+        | Sequence[bool]
+        | Sequence[int]
+        | Sequence[float],
+    ],
+) -> Optional[int]:
     try:
-        http_status = span_attributes.get(SpanAttributes.HTTP_RESPONSE_STATUS_CODE)
+        http_status = get_typed_attribute(
+            span_attributes, SpanAttributes.HTTP_RESPONSE_STATUS_CODE, int
+        )
     except AttributeError:
         # HTTP_RESPONSE_STATUS_CODE was added in 1.21, so if we're on an older
         # OTel version SpanAttributes.HTTP_RESPONSE_STATUS_CODE will throw an
@@ -292,19 +307,18 @@ def get_http_status_code(span_attributes):
 
     if http_status is None:
         # Fall back to the deprecated attribute
-        http_status = span_attributes.get(SpanAttributes.HTTP_STATUS_CODE)
-
-    http_status = cast("Optional[int]", http_status)
+        http_status = get_typed_attribute(
+            span_attributes, SpanAttributes.HTTP_STATUS_CODE, int
+        )
 
     return http_status
 
 
-def extract_span_attributes(span, namespace):
-    # type: (ReadableSpan, str) -> dict[str, Any]
+def extract_span_attributes(span: ReadableSpan, namespace: str) -> dict[str, Any]:
     """
     Extract Sentry-specific span attributes and make them look the way Sentry expects.
     """
-    extracted_attrs = {}  # type: dict[str, Any]
+    extracted_attrs: dict[str, Any] = {}
 
     for attr, value in (span.attributes or {}).items():
         if attr.startswith(namespace):
@@ -314,8 +328,9 @@ def extract_span_attributes(span, namespace):
     return extracted_attrs
 
 
-def get_trace_context(span, span_data=None):
-    # type: (ReadableSpan, Optional[OtelExtractedSpanData]) -> dict[str, Any]
+def get_trace_context(
+    span: ReadableSpan, span_data: Optional[OtelExtractedSpanData] = None
+) -> dict[str, Any]:
     if not span.context:
         return {}
 
@@ -328,13 +343,13 @@ def get_trace_context(span, span_data=None):
 
     (op, _, status, _, origin) = span_data
 
-    trace_context = {
+    trace_context: dict[str, Any] = {
         "trace_id": trace_id,
         "span_id": span_id,
         "parent_span_id": parent_span_id,
         "op": op,
         "origin": origin or DEFAULT_SPAN_ORIGIN,
-    }  # type: dict[str, Any]
+    }
 
     if status:
         trace_context["status"] = status
@@ -350,8 +365,7 @@ def get_trace_context(span, span_data=None):
     return trace_context
 
 
-def trace_state_from_baggage(baggage):
-    # type: (Baggage) -> TraceState
+def trace_state_from_baggage(baggage: Baggage) -> TraceState:
     items = []
     for k, v in baggage.sentry_items.items():
         key = Baggage.SENTRY_PREFIX + quote(k)
@@ -360,13 +374,11 @@ def trace_state_from_baggage(baggage):
     return TraceState(items)
 
 
-def baggage_from_trace_state(trace_state):
-    # type: (TraceState) -> Baggage
+def baggage_from_trace_state(trace_state: TraceState) -> Baggage:
     return Baggage(dsc_from_trace_state(trace_state))
 
 
-def serialize_trace_state(trace_state):
-    # type: (TraceState) -> str
+def serialize_trace_state(trace_state: TraceState) -> str:
     sentry_items = []
     for k, v in trace_state.items():
         if Baggage.SENTRY_PREFIX_REGEX.match(k):
@@ -374,8 +386,7 @@ def serialize_trace_state(trace_state):
     return ",".join(key + "=" + value for key, value in sentry_items)
 
 
-def dsc_from_trace_state(trace_state):
-    # type: (TraceState) -> dict[str, str]
+def dsc_from_trace_state(trace_state: TraceState) -> dict[str, str]:
     dsc = {}
     for k, v in trace_state.items():
         if Baggage.SENTRY_PREFIX_REGEX.match(k):
@@ -384,16 +395,14 @@ def dsc_from_trace_state(trace_state):
     return dsc
 
 
-def has_incoming_trace(trace_state):
-    # type: (TraceState) -> bool
+def has_incoming_trace(trace_state: TraceState) -> bool:
     """
     The existence of a sentry-trace_id in the baggage implies we continued an upstream trace.
     """
     return (Baggage.SENTRY_PREFIX + "trace_id") in trace_state
 
 
-def get_trace_state(span):
-    # type: (Union[AbstractSpan, ReadableSpan]) -> TraceState
+def get_trace_state(span: Union[AbstractSpan, ReadableSpan]) -> TraceState:
     """
     Get the existing trace_state with sentry items
     or populate it if we are the head SDK.
@@ -451,34 +460,45 @@ def get_trace_state(span):
         return trace_state
 
 
-def get_sentry_meta(span, key):
-    # type: (Union[AbstractSpan, ReadableSpan], str) -> Any
+def get_sentry_meta(span: Union[AbstractSpan, ReadableSpan], key: str) -> Any:
     sentry_meta = getattr(span, "_sentry_meta", None)
     return sentry_meta.get(key) if sentry_meta else None
 
 
-def set_sentry_meta(span, key, value):
-    # type: (Union[AbstractSpan, ReadableSpan], str, Any) -> None
+def set_sentry_meta(
+    span: Union[AbstractSpan, ReadableSpan], key: str, value: Any
+) -> None:
     sentry_meta = getattr(span, "_sentry_meta", {})
     sentry_meta[key] = value
     span._sentry_meta = sentry_meta  # type: ignore[union-attr]
 
 
-def delete_sentry_meta(span):
-    # type: (Union[AbstractSpan, ReadableSpan]) -> None
+def delete_sentry_meta(span: Union[AbstractSpan, ReadableSpan]) -> None:
     try:
         del span._sentry_meta  # type: ignore[union-attr]
     except AttributeError:
         pass
 
 
-def get_profile_context(span):
-    # type: (ReadableSpan) -> Optional[dict[str, str]]
+def get_profile_context(span: ReadableSpan) -> Optional[dict[str, str]]:
     if not span.attributes:
         return None
 
-    profiler_id = cast("Optional[str]", span.attributes.get(SPANDATA.PROFILER_ID))
+    profiler_id = get_typed_attribute(span.attributes, SPANDATA.PROFILER_ID, str)
     if profiler_id is None:
         return None
 
     return {"profiler_id": profiler_id}
+
+
+def get_typed_attribute(
+    attributes: Mapping[str, Any], key: str, type: Type[T]
+) -> Optional[T]:
+    """
+    helper method to coerce types of attribute values
+    """
+    value = attributes.get(key)
+    if value is not None and isinstance(value, type):
+        return value
+    else:
+        return None

--- a/sentry_sdk/profiler/transaction_profiler.py
+++ b/sentry_sdk/profiler/transaction_profiler.py
@@ -281,7 +281,8 @@ class Profile:
             self.sampled = False
             return
 
-        if not is_valid_sample_rate(sample_rate, source="Profiling"):
+        sample_rate = is_valid_sample_rate(sample_rate, source="Profiling")
+        if sample_rate is None:
             logger.warning(
                 "[Profiling] Discarding profile because of invalid sample rate."
             )
@@ -291,14 +292,14 @@ class Profile:
         # Now we roll the dice. random.random is inclusive of 0, but not of 1,
         # so strict < is safe here. In case sample_rate is a boolean, cast it
         # to a float (True becomes 1.0 and False becomes 0.0)
-        self.sampled = random.random() < float(sample_rate)
+        self.sampled = random.random() < sample_rate
 
         if self.sampled:
             logger.debug("[Profiling] Initializing profile")
         else:
             logger.debug(
                 "[Profiling] Discarding profile because it's not included in the random sample (sample rate = {sample_rate})".format(
-                    sample_rate=float(sample_rate)
+                    sample_rate=sample_rate
                 )
             )
 

--- a/sentry_sdk/profiler/transaction_profiler.py
+++ b/sentry_sdk/profiler/transaction_profiler.py
@@ -25,6 +25,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 """
 
+from __future__ import annotations
 import atexit
 import os
 import platform
@@ -99,7 +100,7 @@ try:
     from gevent.monkey import get_original
     from gevent.threadpool import ThreadPool as _ThreadPool
 
-    ThreadPool = _ThreadPool  # type: Optional[Type[_ThreadPool]]
+    ThreadPool: Optional[Type[_ThreadPool]] = _ThreadPool
     thread_sleep = get_original("time", "sleep")
 except ImportError:
     thread_sleep = time.sleep
@@ -107,7 +108,7 @@ except ImportError:
     ThreadPool = None
 
 
-_scheduler = None  # type: Optional[Scheduler]
+_scheduler: Optional[Scheduler] = None
 
 
 # The minimum number of unique samples that must exist in a profile to be
@@ -115,8 +116,7 @@ _scheduler = None  # type: Optional[Scheduler]
 PROFILE_MINIMUM_SAMPLES = 2
 
 
-def has_profiling_enabled(options):
-    # type: (Dict[str, Any]) -> bool
+def has_profiling_enabled(options: Dict[str, Any]) -> bool:
     profiles_sampler = options["profiles_sampler"]
     if profiles_sampler is not None:
         return True
@@ -128,8 +128,7 @@ def has_profiling_enabled(options):
     return False
 
 
-def setup_profiler(options):
-    # type: (Dict[str, Any]) -> bool
+def setup_profiler(options: Dict[str, Any]) -> bool:
     global _scheduler
 
     if _scheduler is not None:
@@ -172,8 +171,7 @@ def setup_profiler(options):
     return True
 
 
-def teardown_profiler():
-    # type: () -> None
+def teardown_profiler() -> None:
 
     global _scheduler
 
@@ -189,40 +187,38 @@ MAX_PROFILE_DURATION_NS = int(3e10)  # 30 seconds
 class Profile:
     def __init__(
         self,
-        sampled,  # type: Optional[bool]
-        start_ns,  # type: int
-        scheduler=None,  # type: Optional[Scheduler]
-    ):
-        # type: (...) -> None
+        sampled: Optional[bool],
+        start_ns: int,
+        scheduler: Optional[Scheduler] = None,
+    ) -> None:
         self.scheduler = _scheduler if scheduler is None else scheduler
 
-        self.event_id = uuid.uuid4().hex  # type: str
+        self.event_id: str = uuid.uuid4().hex
 
-        self.sampled = sampled  # type: Optional[bool]
+        self.sampled: Optional[bool] = sampled
 
         # Various framework integrations are capable of overwriting the active thread id.
         # If it is set to `None` at the end of the profile, we fall back to the default.
-        self._default_active_thread_id = get_current_thread_meta()[0] or 0  # type: int
-        self.active_thread_id = None  # type: Optional[int]
+        self._default_active_thread_id: int = get_current_thread_meta()[0] or 0
+        self.active_thread_id: Optional[int] = None
 
         try:
-            self.start_ns = start_ns  # type: int
+            self.start_ns: int = start_ns
         except AttributeError:
             self.start_ns = 0
 
-        self.stop_ns = 0  # type: int
-        self.active = False  # type: bool
+        self.stop_ns: int = 0
+        self.active: bool = False
 
-        self.indexed_frames = {}  # type: Dict[FrameId, int]
-        self.indexed_stacks = {}  # type: Dict[StackId, int]
-        self.frames = []  # type: List[ProcessedFrame]
-        self.stacks = []  # type: List[ProcessedStack]
-        self.samples = []  # type: List[ProcessedSample]
+        self.indexed_frames: Dict[FrameId, int] = {}
+        self.indexed_stacks: Dict[StackId, int] = {}
+        self.frames: List[ProcessedFrame] = []
+        self.stacks: List[ProcessedStack] = []
+        self.samples: List[ProcessedSample] = []
 
         self.unique_samples = 0
 
-    def update_active_thread_id(self):
-        # type: () -> None
+    def update_active_thread_id(self) -> None:
         self.active_thread_id = get_current_thread_meta()[0]
         logger.debug(
             "[Profiling] updating active thread id to {tid}".format(
@@ -230,8 +226,7 @@ class Profile:
             )
         )
 
-    def _set_initial_sampling_decision(self, sampling_context):
-        # type: (SamplingContext) -> None
+    def _set_initial_sampling_decision(self, sampling_context: SamplingContext) -> None:
         """
         Sets the profile's sampling decision according to the following
         precedence rules:
@@ -303,8 +298,7 @@ class Profile:
                 )
             )
 
-    def start(self):
-        # type: () -> None
+    def start(self) -> None:
         if not self.sampled or self.active:
             return
 
@@ -315,8 +309,7 @@ class Profile:
             self.start_ns = time.perf_counter_ns()
         self.scheduler.start_profiling(self)
 
-    def stop(self):
-        # type: () -> None
+    def stop(self) -> None:
         if not self.sampled or not self.active:
             return
 
@@ -325,8 +318,7 @@ class Profile:
         self.active = False
         self.stop_ns = time.perf_counter_ns()
 
-    def __enter__(self):
-        # type: () -> Profile
+    def __enter__(self) -> Profile:
         scope = sentry_sdk.get_isolation_scope()
         old_profile = scope.profile
         scope.profile = self
@@ -337,8 +329,9 @@ class Profile:
 
         return self
 
-    def __exit__(self, ty, value, tb):
-        # type: (Optional[Any], Optional[Any], Optional[Any]) -> None
+    def __exit__(
+        self, ty: Optional[Any], value: Optional[Any], tb: Optional[Any]
+    ) -> None:
         self.stop()
 
         scope, old_profile = self._context_manager_state
@@ -346,8 +339,7 @@ class Profile:
 
         scope.profile = old_profile
 
-    def write(self, ts, sample):
-        # type: (int, ExtractedSample) -> None
+    def write(self, ts: int, sample: ExtractedSample) -> None:
         if not self.active:
             return
 
@@ -390,18 +382,17 @@ class Profile:
                 # When this happens, we abandon the current sample as it's bad.
                 capture_internal_exception(sys.exc_info())
 
-    def process(self):
-        # type: () -> ProcessedProfile
+    def process(self) -> ProcessedProfile:
 
         # This collects the thread metadata at the end of a profile. Doing it
         # this way means that any threads that terminate before the profile ends
         # will not have any metadata associated with it.
-        thread_metadata = {
+        thread_metadata: Dict[str, ProcessedThreadMetadata] = {
             str(thread.ident): {
                 "name": str(thread.name),
             }
             for thread in threading.enumerate()
-        }  # type: Dict[str, ProcessedThreadMetadata]
+        }
 
         return {
             "frames": self.frames,
@@ -410,8 +401,7 @@ class Profile:
             "thread_metadata": thread_metadata,
         }
 
-    def to_json(self, event_opt, options):
-        # type: (Event, Dict[str, Any]) -> Dict[str, Any]
+    def to_json(self, event_opt: Event, options: Dict[str, Any]) -> Dict[str, Any]:
         profile = self.process()
 
         set_in_app_in_frames(
@@ -461,8 +451,7 @@ class Profile:
             ],
         }
 
-    def valid(self):
-        # type: () -> bool
+    def valid(self) -> bool:
         client = sentry_sdk.get_client()
         if not client.is_active():
             return False
@@ -489,39 +478,35 @@ class Profile:
 
 
 class Scheduler(ABC):
-    mode = "unknown"  # type: ProfilerMode
+    mode: ProfilerMode = "unknown"
 
-    def __init__(self, frequency):
-        # type: (int) -> None
+    def __init__(self, frequency: int) -> None:
         self.interval = 1.0 / frequency
 
         self.sampler = self.make_sampler()
 
         # cap the number of new profiles at any time so it does not grow infinitely
-        self.new_profiles = deque(maxlen=128)  # type: Deque[Profile]
-        self.active_profiles = set()  # type: Set[Profile]
+        self.new_profiles: Deque[Profile] = deque(maxlen=128)
+        self.active_profiles: Set[Profile] = set()
 
-    def __enter__(self):
-        # type: () -> Scheduler
+    def __enter__(self) -> Scheduler:
         self.setup()
         return self
 
-    def __exit__(self, ty, value, tb):
-        # type: (Optional[Any], Optional[Any], Optional[Any]) -> None
+    def __exit__(
+        self, ty: Optional[Any], value: Optional[Any], tb: Optional[Any]
+    ) -> None:
         self.teardown()
 
     @abstractmethod
-    def setup(self):
-        # type: () -> None
+    def setup(self) -> None:
         pass
 
     @abstractmethod
-    def teardown(self):
-        # type: () -> None
+    def teardown(self) -> None:
         pass
 
-    def ensure_running(self):
-        # type: () -> None
+    def ensure_running(self) -> None:
         """
         Ensure the scheduler is running. By default, this method is a no-op.
         The method should be overridden by any implementation for which it is
@@ -529,19 +514,16 @@ class Scheduler(ABC):
         """
         return None
 
-    def start_profiling(self, profile):
-        # type: (Profile) -> None
+    def start_profiling(self, profile: Profile) -> None:
         self.ensure_running()
         self.new_profiles.append(profile)
 
-    def make_sampler(self):
-        # type: () -> Callable[..., None]
+    def make_sampler(self) -> Callable[..., None]:
         cwd = os.getcwd()
 
         cache = LRUCache(max_size=256)
 
-        def _sample_stack(*args, **kwargs):
-            # type: (*Any, **Any) -> None
+        def _sample_stack(*args: Any, **kwargs: Any) -> None:
             """
             Take a sample of the stack on all the threads in the process.
             This should be called at a regular interval to collect samples.
@@ -612,32 +594,28 @@ class ThreadScheduler(Scheduler):
     the sampler at a regular interval.
     """
 
-    mode = "thread"  # type: ProfilerMode
+    mode: ProfilerMode = "thread"
     name = "sentry.profiler.ThreadScheduler"
 
-    def __init__(self, frequency):
-        # type: (int) -> None
+    def __init__(self, frequency: int) -> None:
         super().__init__(frequency=frequency)
 
         # used to signal to the thread that it should stop
         self.running = False
-        self.thread = None  # type: Optional[threading.Thread]
-        self.pid = None  # type: Optional[int]
+        self.thread: Optional[threading.Thread] = None
+        self.pid: Optional[int] = None
         self.lock = threading.Lock()
 
-    def setup(self):
-        # type: () -> None
+    def setup(self) -> None:
         pass
 
-    def teardown(self):
-        # type: () -> None
+    def teardown(self) -> None:
         if self.running:
             self.running = False
             if self.thread is not None:
                 self.thread.join()
 
-    def ensure_running(self):
-        # type: () -> None
+    def ensure_running(self) -> None:
         """
         Check that the profiler has an active thread to run in, and start one if
         that's not the case.
@@ -675,8 +653,7 @@ class ThreadScheduler(Scheduler):
                 self.thread = None
                 return
 
-    def run(self):
-        # type: () -> None
+    def run(self) -> None:
         last = time.perf_counter()
 
         while self.running:
@@ -708,11 +685,10 @@ class GeventScheduler(Scheduler):
        results in a sample containing only the sampler's code.
     """
 
-    mode = "gevent"  # type: ProfilerMode
+    mode: ProfilerMode = "gevent"
     name = "sentry.profiler.GeventScheduler"
 
-    def __init__(self, frequency):
-        # type: (int) -> None
+    def __init__(self, frequency: int) -> None:
 
         if ThreadPool is None:
             raise ValueError("Profiler mode: {} is not available".format(self.mode))
@@ -721,27 +697,24 @@ class GeventScheduler(Scheduler):
 
         # used to signal to the thread that it should stop
         self.running = False
-        self.thread = None  # type: Optional[_ThreadPool]
-        self.pid = None  # type: Optional[int]
+        self.thread: Optional[_ThreadPool] = None
+        self.pid: Optional[int] = None
 
         # This intentionally uses the gevent patched threading.Lock.
         # The lock will be required when first trying to start profiles
         # as we need to spawn the profiler thread from the greenlets.
         self.lock = threading.Lock()
 
-    def setup(self):
-        # type: () -> None
+    def setup(self) -> None:
         pass
 
-    def teardown(self):
-        # type: () -> None
+    def teardown(self) -> None:
         if self.running:
             self.running = False
             if self.thread is not None:
                 self.thread.join()
 
-    def ensure_running(self):
-        # type: () -> None
+    def ensure_running(self) -> None:
         pid = os.getpid()
 
         # is running on the right process
@@ -768,8 +741,7 @@ class GeventScheduler(Scheduler):
                 self.thread = None
                 return
 
-    def run(self):
-        # type: () -> None
+    def run(self) -> None:
         last = time.perf_counter()
 
         while self.running:

--- a/sentry_sdk/profiler/utils.py
+++ b/sentry_sdk/profiler/utils.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import os
 from collections import deque
 
@@ -63,14 +64,12 @@ MAX_STACK_DEPTH = 128
 
 if PY311:
 
-    def get_frame_name(frame):
-        # type: (FrameType) -> str
+    def get_frame_name(frame: FrameType) -> str:
         return frame.f_code.co_qualname
 
 else:
 
-    def get_frame_name(frame):
-        # type: (FrameType) -> str
+    def get_frame_name(frame: FrameType) -> str:
 
         f_code = frame.f_code
         co_varnames = f_code.co_varnames
@@ -117,13 +116,11 @@ else:
         return name
 
 
-def frame_id(raw_frame):
-    # type: (FrameType) -> FrameId
+def frame_id(raw_frame: FrameType) -> FrameId:
     return (raw_frame.f_code.co_filename, raw_frame.f_lineno, get_frame_name(raw_frame))
 
 
-def extract_frame(fid, raw_frame, cwd):
-    # type: (FrameId, FrameType, str) -> ProcessedFrame
+def extract_frame(fid: FrameId, raw_frame: FrameType, cwd: str) -> ProcessedFrame:
     abs_path = raw_frame.f_code.co_filename
 
     try:
@@ -152,12 +149,11 @@ def extract_frame(fid, raw_frame, cwd):
 
 
 def extract_stack(
-    raw_frame,  # type: Optional[FrameType]
-    cache,  # type: LRUCache
-    cwd,  # type: str
-    max_stack_depth=MAX_STACK_DEPTH,  # type: int
-):
-    # type: (...) -> ExtractedStack
+    raw_frame: Optional[FrameType],
+    cache: LRUCache,
+    cwd: str,
+    max_stack_depth: int = MAX_STACK_DEPTH,
+) -> ExtractedStack:
     """
     Extracts the stack starting the specified frame. The extracted stack
     assumes the specified frame is the top of the stack, and works back
@@ -167,7 +163,7 @@ def extract_stack(
     only the first `MAX_STACK_DEPTH` frames will be returned.
     """
 
-    raw_frames = deque(maxlen=max_stack_depth)  # type: Deque[FrameType]
+    raw_frames: Deque[FrameType] = deque(maxlen=max_stack_depth)
 
     while raw_frame is not None:
         f_back = raw_frame.f_back

--- a/sentry_sdk/scope.py
+++ b/sentry_sdk/scope.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import os
 import sys
 import warnings
@@ -43,22 +44,25 @@ from sentry_sdk.utils import (
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
+    from typing import (
+        Any,
+        Callable,
+        Deque,
+        Dict,
+        Generator,
+        Iterator,
+        List,
+        Optional,
+        ParamSpec,
+        Tuple,
+        TypeVar,
+        Union,
+        Self,
+    )
+
     from collections.abc import Mapping, MutableMapping
 
-    from typing import Any
-    from typing import Callable
-    from typing import Deque
-    from typing import Dict
-    from typing import Generator
-    from typing import Iterator
-    from typing import List
-    from typing import Optional
-    from typing import ParamSpec
-    from typing import Tuple
-    from typing import TypeVar
-    from typing import Union
-    from typing import Self
-
+    import sentry_sdk
     from sentry_sdk._types import (
         Breadcrumb,
         BreadcrumbHint,
@@ -71,8 +75,6 @@ if TYPE_CHECKING:
         Type,
     )
 
-    import sentry_sdk
-
     P = ParamSpec("P")
     R = TypeVar("R")
 
@@ -84,7 +86,7 @@ if TYPE_CHECKING:
 # In case this is a http server (think web framework) with multiple users
 # the data will be added to events of all users.
 # Typically this is used for process wide data such as the release.
-_global_scope = None  # type: Optional[Scope]
+_global_scope: Optional[Scope] = None
 
 # Holds data for the active request.
 # This is used to isolate data for different requests or users.
@@ -96,7 +98,7 @@ _isolation_scope = ContextVar("isolation_scope", default=None)
 # This can be used to manually add additional data to a span.
 _current_scope = ContextVar("current_scope", default=None)
 
-global_event_processors = []  # type: List[EventProcessor]
+global_event_processors: List[EventProcessor] = []
 
 
 class ScopeType(Enum):
@@ -106,21 +108,17 @@ class ScopeType(Enum):
     MERGED = "merged"
 
 
-def add_global_event_processor(processor):
-    # type: (EventProcessor) -> None
+def add_global_event_processor(processor: EventProcessor) -> None:
     global_event_processors.append(processor)
 
 
-def _attr_setter(fn):
-    # type: (Any) -> Any
+def _attr_setter(fn: Any) -> Any:
     return property(fset=fn, doc=fn.__doc__)
 
 
-def _disable_capture(fn):
-    # type: (F) -> F
+def _disable_capture(fn: F) -> F:
     @wraps(fn)
-    def wrapper(self, *args, **kwargs):
-        # type: (Any, *Dict[str, Any], **Any) -> Any
+    def wrapper(self: Any, *args: Any, **kwargs: Any) -> Any:
         if not self._should_capture:
             return
         try:
@@ -172,31 +170,29 @@ class Scope:
         "_flags",
     )
 
-    def __init__(self, ty=None):
-        # type: (Optional[ScopeType]) -> None
+    def __init__(self, ty: Optional[ScopeType] = None) -> None:
         self._type = ty
 
-        self._event_processors = []  # type: List[EventProcessor]
-        self._error_processors = []  # type: List[ErrorProcessor]
+        self._event_processors: List[EventProcessor] = []
+        self._error_processors: List[ErrorProcessor] = []
 
-        self._name = None  # type: Optional[str]
-        self._propagation_context = None  # type: Optional[PropagationContext]
-        self._n_breadcrumbs_truncated = 0  # type: int
+        self._name: Optional[str] = None
+        self._propagation_context: Optional[PropagationContext] = None
+        self._n_breadcrumbs_truncated: int = 0
 
-        self.client = NonRecordingClient()  # type: sentry_sdk.client.BaseClient
+        self.client: sentry_sdk.client.BaseClient = NonRecordingClient()
 
         self.clear()
 
         incoming_trace_information = self._load_trace_data_from_env()
         self.generate_propagation_context(incoming_data=incoming_trace_information)
 
-    def __copy__(self):
-        # type: () -> Self
+    def __copy__(self) -> Self:
         """
         Returns a copy of this scope.
         This also creates a copy of all referenced data structures.
         """
-        rv = object.__new__(self.__class__)  # type: Self
+        rv: Self = object.__new__(self.__class__)
 
         rv._type = self._type
         rv.client = self.client
@@ -232,8 +228,7 @@ class Scope:
         return rv
 
     @classmethod
-    def get_current_scope(cls):
-        # type: () -> Scope
+    def get_current_scope(cls) -> Scope:
         """
         .. versionadded:: 2.0.0
 
@@ -247,16 +242,14 @@ class Scope:
         return current_scope
 
     @classmethod
-    def _get_current_scope(cls):
-        # type: () -> Optional[Scope]
+    def _get_current_scope(cls) -> Optional[Scope]:
         """
         Returns the current scope without creating a new one. Internal use only.
         """
         return _current_scope.get()
 
     @classmethod
-    def set_current_scope(cls, new_current_scope):
-        # type: (Scope) -> None
+    def set_current_scope(cls, new_current_scope: Scope) -> None:
         """
         .. versionadded:: 2.0.0
 
@@ -266,8 +259,7 @@ class Scope:
         _current_scope.set(new_current_scope)
 
     @classmethod
-    def get_isolation_scope(cls):
-        # type: () -> Scope
+    def get_isolation_scope(cls) -> Scope:
         """
         .. versionadded:: 2.0.0
 
@@ -281,16 +273,14 @@ class Scope:
         return isolation_scope
 
     @classmethod
-    def _get_isolation_scope(cls):
-        # type: () -> Optional[Scope]
+    def _get_isolation_scope(cls) -> Optional[Scope]:
         """
         Returns the isolation scope without creating a new one. Internal use only.
         """
         return _isolation_scope.get()
 
     @classmethod
-    def set_isolation_scope(cls, new_isolation_scope):
-        # type: (Scope) -> None
+    def set_isolation_scope(cls, new_isolation_scope: Scope) -> None:
         """
         .. versionadded:: 2.0.0
 
@@ -300,8 +290,7 @@ class Scope:
         _isolation_scope.set(new_isolation_scope)
 
     @classmethod
-    def get_global_scope(cls):
-        # type: () -> Scope
+    def get_global_scope(cls) -> Scope:
         """
         .. versionadded:: 2.0.0
 
@@ -314,8 +303,7 @@ class Scope:
         return _global_scope
 
     @classmethod
-    def last_event_id(cls):
-        # type: () -> Optional[str]
+    def last_event_id(cls) -> Optional[str]:
         """
         .. versionadded:: 2.2.0
 
@@ -330,8 +318,11 @@ class Scope:
         """
         return cls.get_isolation_scope()._last_event_id
 
-    def _merge_scopes(self, additional_scope=None, additional_scope_kwargs=None):
-        # type: (Optional[Scope], Optional[Dict[str, Any]]) -> Self
+    def _merge_scopes(
+        self,
+        additional_scope: Optional[Scope] = None,
+        additional_scope_kwargs: Optional[Dict[str, Any]] = None,
+    ) -> Self:
         """
         Merges global, isolation and current scope into a new scope and
         adds the given additional scope or additional scope kwargs to it.
@@ -366,8 +357,7 @@ class Scope:
         return final_scope
 
     @classmethod
-    def get_client(cls):
-        # type: () -> sentry_sdk.client.BaseClient
+    def get_client(cls) -> sentry_sdk.client.BaseClient:
         """
         .. versionadded:: 2.0.0
 
@@ -393,18 +383,18 @@ class Scope:
         if client is not None and client.is_active():
             return client
 
-        try:
-            client = _global_scope.client  # type: ignore
-        except AttributeError:
-            client = None
+        if _global_scope:
+            try:
+                client = _global_scope.client
+            except AttributeError:
+                client = None
 
         if client is not None and client.is_active():
             return client
 
         return NonRecordingClient()
 
-    def set_client(self, client=None):
-        # type: (Optional[sentry_sdk.client.BaseClient]) -> None
+    def set_client(self, client: Optional[sentry_sdk.client.BaseClient] = None) -> None:
         """
         .. versionadded:: 2.0.0
 
@@ -416,8 +406,7 @@ class Scope:
         """
         self.client = client if client is not None else NonRecordingClient()
 
-    def fork(self):
-        # type: () -> Self
+    def fork(self) -> Self:
         """
         .. versionadded:: 2.0.0
 
@@ -426,8 +415,7 @@ class Scope:
         forked_scope = copy(self)
         return forked_scope
 
-    def _load_trace_data_from_env(self):
-        # type: () -> Optional[Dict[str, str]]
+    def _load_trace_data_from_env(self) -> Optional[Dict[str, str]]:
         """
         Load Sentry trace id and baggage from environment variables.
         Can be disabled by setting SENTRY_USE_ENVIRONMENT to "false".
@@ -453,15 +441,15 @@ class Scope:
 
         return incoming_trace_information or None
 
-    def set_new_propagation_context(self):
-        # type: () -> None
+    def set_new_propagation_context(self) -> None:
         """
         Creates a new propagation context and sets it as `_propagation_context`. Overwriting existing one.
         """
         self._propagation_context = PropagationContext()
 
-    def generate_propagation_context(self, incoming_data=None):
-        # type: (Optional[Dict[str, str]]) -> None
+    def generate_propagation_context(
+        self, incoming_data: Optional[dict[str, str]] = None
+    ) -> None:
         """
         Makes sure the propagation context is set on the scope.
         If there is `incoming_data` overwrite existing propagation context.
@@ -476,16 +464,14 @@ class Scope:
             if self._propagation_context is None:
                 self.set_new_propagation_context()
 
-    def get_dynamic_sampling_context(self):
-        # type: () -> Optional[Dict[str, str]]
+    def get_dynamic_sampling_context(self) -> Optional[Dict[str, str]]:
         """
         Returns the Dynamic Sampling Context from the baggage or populates one.
         """
         baggage = self.get_baggage()
         return baggage.dynamic_sampling_context() if baggage else None
 
-    def get_traceparent(self, *args, **kwargs):
-        # type: (Any, Any) -> Optional[str]
+    def get_traceparent(self, *args: Any, **kwargs: Any) -> Optional[str]:
         """
         Returns the Sentry "sentry-trace" header (aka the traceparent) from the
         currently active span or the scopes Propagation Context.
@@ -507,8 +493,7 @@ class Scope:
         # Fall back to isolation scope's traceparent. It always has one
         return self.get_isolation_scope().get_traceparent()
 
-    def get_baggage(self, *args, **kwargs):
-        # type: (Any, Any) -> Optional[Baggage]
+    def get_baggage(self, *args: Any, **kwargs: Any) -> Optional[Baggage]:
         """
         Returns the Sentry "baggage" header containing trace information from the
         currently active span or the scopes Propagation Context.
@@ -534,25 +519,23 @@ class Scope:
         # Fall back to isolation scope's baggage. It always has one
         return self.get_isolation_scope().get_baggage()
 
-    def get_trace_context(self):
-        # type: () -> Any
+    def get_trace_context(self) -> Any:
         """
         Returns the Sentry "trace" context from the Propagation Context.
         """
         if self._propagation_context is None:
             return None
 
-        trace_context = {
+        trace_context: Dict[str, Any] = {
             "trace_id": self._propagation_context.trace_id,
             "span_id": self._propagation_context.span_id,
             "parent_span_id": self._propagation_context.parent_span_id,
             "dynamic_sampling_context": self.get_dynamic_sampling_context(),
-        }  # type: Dict[str, Any]
+        }
 
         return trace_context
 
-    def trace_propagation_meta(self, *args, **kwargs):
-        # type: (*Any, **Any) -> str
+    def trace_propagation_meta(self, *args: Any, **kwargs: Any) -> str:
         """
         Return meta tags which should be injected into HTML templates
         to allow propagation of trace information.
@@ -575,8 +558,7 @@ class Scope:
 
         return meta
 
-    def iter_headers(self):
-        # type: () -> Iterator[Tuple[str, str]]
+    def iter_headers(self) -> Iterator[Tuple[str, str]]:
         """
         Creates a generator which returns the `sentry-trace` and `baggage` headers from the Propagation Context.
         """
@@ -589,8 +571,9 @@ class Scope:
             if baggage is not None:
                 yield BAGGAGE_HEADER_NAME, baggage.serialize()
 
-    def iter_trace_propagation_headers(self, *args, **kwargs):
-        # type: (Any, Any) -> Generator[Tuple[str, str], None, None]
+    def iter_trace_propagation_headers(
+        self, *args: Any, **kwargs: Any
+    ) -> Generator[Tuple[str, str], None, None]:
         """
         Return HTTP headers which allow propagation of trace data.
 
@@ -624,8 +607,7 @@ class Scope:
                         for header in isolation_scope.iter_headers():
                             yield header
 
-    def get_active_propagation_context(self):
-        # type: () -> Optional[PropagationContext]
+    def get_active_propagation_context(self) -> Optional[PropagationContext]:
         if self._propagation_context is not None:
             return self._propagation_context
 
@@ -639,37 +621,35 @@ class Scope:
 
         return None
 
-    def clear(self):
-        # type: () -> None
+    def clear(self) -> None:
         """Clears the entire scope."""
-        self._level = None  # type: Optional[LogLevelStr]
-        self._fingerprint = None  # type: Optional[List[str]]
-        self._transaction = None  # type: Optional[str]
-        self._transaction_info = {}  # type: MutableMapping[str, str]
-        self._user = None  # type: Optional[Dict[str, Any]]
+        self._level: Optional[LogLevelStr] = None
+        self._fingerprint: Optional[List[str]] = None
+        self._transaction: Optional[str] = None
+        self._transaction_info: MutableMapping[str, str] = {}
+        self._user: Optional[Dict[str, Any]] = None
 
-        self._tags = {}  # type: Dict[str, Any]
-        self._contexts = {}  # type: Dict[str, Dict[str, Any]]
-        self._extras = {}  # type: MutableMapping[str, Any]
-        self._attachments = []  # type: List[Attachment]
+        self._tags: Dict[str, Any] = {}
+        self._contexts: Dict[str, Dict[str, Any]] = {}
+        self._extras: MutableMapping[str, Any] = {}
+        self._attachments: List[Attachment] = []
 
         self.clear_breadcrumbs()
-        self._should_capture = True  # type: bool
+        self._should_capture: bool = True
 
-        self._span = None  # type: Optional[Span]
-        self._session = None  # type: Optional[Session]
-        self._force_auto_session_tracking = None  # type: Optional[bool]
+        self._span: Optional[Span] = None
+        self._session: Optional[Session] = None
+        self._force_auto_session_tracking: Optional[bool] = None
 
-        self._profile = None  # type: Optional[Profile]
+        self._profile: Optional[Profile] = None
 
         self._propagation_context = None
 
         # self._last_event_id is only applicable to isolation scopes
-        self._last_event_id = None  # type: Optional[str]
-        self._flags = None  # type: Optional[FlagBuffer]
+        self._last_event_id: Optional[str] = None
+        self._flags: Optional[FlagBuffer] = None
 
-    def set_level(self, value):
-        # type: (LogLevelStr) -> None
+    def set_level(self, value: LogLevelStr) -> None:
         """
         Sets the level for the scope.
 
@@ -678,22 +658,19 @@ class Scope:
         self._level = value
 
     @_attr_setter
-    def fingerprint(self, value):
-        # type: (Optional[List[str]]) -> None
+    def fingerprint(self, value: Optional[List[str]]) -> None:
         """When set this overrides the default fingerprint."""
         self._fingerprint = value
 
     @property
-    def root_span(self):
-        # type: () -> Optional[Span]
+    def root_span(self) -> Optional[Span]:
         """Return the root span in the scope, if any."""
         if self._span is None:
             return None
 
         return self._span.root_span
 
-    def set_transaction_name(self, name, source=None):
-        # type: (str, Optional[str]) -> None
+    def set_transaction_name(self, name: str, source: Optional[str] = None) -> None:
         """Set the transaction name and optionally the transaction source."""
         self._transaction = name
 
@@ -706,17 +683,14 @@ class Scope:
             self._transaction_info["source"] = source
 
     @property
-    def transaction_name(self):
-        # type: () -> Optional[str]
+    def transaction_name(self) -> Optional[str]:
         return self._transaction
 
     @property
-    def transaction_source(self):
-        # type: () -> Optional[str]
+    def transaction_source(self) -> Optional[str]:
         return self._transaction_info.get("source")
 
-    def set_user(self, value):
-        # type: (Optional[Dict[str, Any]]) -> None
+    def set_user(self, value: Optional[Dict[str, Any]]) -> None:
         """Sets a user for the scope."""
         self._user = value
         session = self.get_isolation_scope()._session
@@ -724,24 +698,20 @@ class Scope:
             session.update(user=value)
 
     @property
-    def span(self):
-        # type: () -> Optional[Span]
+    def span(self) -> Optional[Span]:
         """Get current tracing span."""
         return self._span
 
     @property
-    def profile(self):
-        # type: () -> Optional[Profile]
+    def profile(self) -> Optional[Profile]:
         return self._profile
 
     @profile.setter
-    def profile(self, profile):
-        # type: (Optional[Profile]) -> None
+    def profile(self, profile: Optional[Profile]) -> None:
 
         self._profile = profile
 
-    def set_tag(self, key, value):
-        # type: (str, Any) -> None
+    def set_tag(self, key: str, value: Any) -> None:
         """
         Sets a tag for a key to a specific value.
 
@@ -751,8 +721,7 @@ class Scope:
         """
         self._tags[key] = value
 
-    def set_tags(self, tags):
-        # type: (Mapping[str, object]) -> None
+    def set_tags(self, tags: Mapping[str, object]) -> None:
         """Sets multiple tags at once.
 
         This method updates multiple tags at once. The tags are passed as a dictionary
@@ -770,8 +739,7 @@ class Scope:
         """
         self._tags.update(tags)
 
-    def remove_tag(self, key):
-        # type: (str) -> None
+    def remove_tag(self, key: str) -> None:
         """
         Removes a specific tag.
 
@@ -781,53 +749,46 @@ class Scope:
 
     def set_context(
         self,
-        key,  # type: str
-        value,  # type: Dict[str, Any]
-    ):
-        # type: (...) -> None
+        key: str,
+        value: Dict[str, Any],
+    ) -> None:
         """
         Binds a context at a certain key to a specific value.
         """
         self._contexts[key] = value
 
     def remove_context(
-        self, key  # type: str
-    ):
-        # type: (...) -> None
+        self,
+        key: str,
+    ) -> None:
         """Removes a context."""
         self._contexts.pop(key, None)
 
     def set_extra(
         self,
-        key,  # type: str
-        value,  # type: Any
-    ):
-        # type: (...) -> None
+        key: str,
+        value: Any,
+    ) -> None:
         """Sets an extra key to a specific value."""
         self._extras[key] = value
 
-    def remove_extra(
-        self, key  # type: str
-    ):
-        # type: (...) -> None
+    def remove_extra(self, key: str) -> None:
         """Removes a specific extra key."""
         self._extras.pop(key, None)
 
-    def clear_breadcrumbs(self):
-        # type: () -> None
+    def clear_breadcrumbs(self) -> None:
         """Clears breadcrumb buffer."""
-        self._breadcrumbs = deque()  # type: Deque[Breadcrumb]
+        self._breadcrumbs: Deque[Breadcrumb] = deque()
         self._n_breadcrumbs_truncated = 0
 
     def add_attachment(
         self,
-        bytes=None,  # type: Union[None, bytes, Callable[[], bytes]]
-        filename=None,  # type: Optional[str]
-        path=None,  # type: Optional[str]
-        content_type=None,  # type: Optional[str]
-        add_to_transactions=False,  # type: bool
-    ):
-        # type: (...) -> None
+        bytes: Union[None, bytes, Callable[[], bytes]] = None,
+        filename: Optional[str] = None,
+        path: Optional[str] = None,
+        content_type: Optional[str] = None,
+        add_to_transactions: bool = False,
+    ) -> None:
         """Adds an attachment to future events sent from this scope.
 
         The parameters are the same as for the :py:class:`sentry_sdk.attachments.Attachment` constructor.
@@ -842,8 +803,12 @@ class Scope:
             )
         )
 
-    def add_breadcrumb(self, crumb=None, hint=None, **kwargs):
-        # type: (Optional[Breadcrumb], Optional[BreadcrumbHint], Any) -> None
+    def add_breadcrumb(
+        self,
+        crumb: Optional[Breadcrumb] = None,
+        hint: Optional[BreadcrumbHint] = None,
+        **kwargs: Any,
+    ) -> None:
         """
         Adds a breadcrumb.
 
@@ -861,12 +826,12 @@ class Scope:
         before_breadcrumb = client.options.get("before_breadcrumb")
         max_breadcrumbs = client.options.get("max_breadcrumbs", DEFAULT_MAX_BREADCRUMBS)
 
-        crumb = dict(crumb or ())  # type: Breadcrumb
+        crumb: Breadcrumb = dict(crumb or ())
         crumb.update(kwargs)
         if not crumb:
             return
 
-        hint = dict(hint or ())  # type: Hint
+        hint: Hint = dict(hint or ())
 
         if crumb.get("timestamp") is None:
             crumb["timestamp"] = datetime.now(timezone.utc)
@@ -887,8 +852,7 @@ class Scope:
             self._breadcrumbs.popleft()
             self._n_breadcrumbs_truncated += 1
 
-    def start_transaction(self, **kwargs):
-        # type: (Any) -> Union[NoOpSpan, Span]
+    def start_transaction(self, **kwargs: Any) -> Union[NoOpSpan, Span]:
         """
         .. deprecated:: 3.0.0
             This function is deprecated and will be removed in a future release.
@@ -901,8 +865,7 @@ class Scope:
         )
         return NoOpSpan(**kwargs)
 
-    def start_span(self, **kwargs):
-        # type: (Any) -> Union[NoOpSpan, Span]
+    def start_span(self, **kwargs: Any) -> Union[NoOpSpan, Span]:
         """
         Start a span whose parent is the currently active span, if any.
 
@@ -915,16 +878,22 @@ class Scope:
         return NoOpSpan(**kwargs)
 
     @contextmanager
-    def continue_trace(self, environ_or_headers):
-        # type: (Dict[str, Any]) -> Generator[None, None, None]
+    def continue_trace(
+        self, environ_or_headers: Dict[str, Any]
+    ) -> Generator[None, None, None]:
         """
         Sets the propagation context from environment or headers to continue an incoming trace.
         """
         self.generate_propagation_context(environ_or_headers)
         yield
 
-    def capture_event(self, event, hint=None, scope=None, **scope_kwargs):
-        # type: (Event, Optional[Hint], Optional[Scope], Any) -> Optional[str]
+    def capture_event(
+        self,
+        event: Event,
+        hint: Optional[Hint] = None,
+        scope: Optional[Scope] = None,
+        **scope_kwargs: Any,
+    ) -> Optional[str]:
         """
         Captures an event.
 
@@ -955,8 +924,13 @@ class Scope:
 
         return event_id
 
-    def capture_message(self, message, level=None, scope=None, **scope_kwargs):
-        # type: (str, Optional[LogLevelStr], Optional[Scope], Any) -> Optional[str]
+    def capture_message(
+        self,
+        message: str,
+        level: Optional[LogLevelStr] = None,
+        scope: Optional[Scope] = None,
+        **scope_kwargs: Any,
+    ) -> Optional[str]:
         """
         Captures a message.
 
@@ -979,15 +953,19 @@ class Scope:
         if level is None:
             level = "info"
 
-        event = {
+        event: Event = {
             "message": message,
             "level": level,
-        }  # type: Event
+        }
 
         return self.capture_event(event, scope=scope, **scope_kwargs)
 
-    def capture_exception(self, error=None, scope=None, **scope_kwargs):
-        # type: (Optional[Union[BaseException, ExcInfo]], Optional[Scope], Any) -> Optional[str]
+    def capture_exception(
+        self,
+        error: Optional[Union[BaseException, ExcInfo]] = None,
+        scope: Optional[Scope] = None,
+        **scope_kwargs: Any,
+    ) -> Optional[str]:
         """Captures an exception.
 
         :param error: An exception to capture. If `None`, `sys.exc_info()` will be used.
@@ -1020,8 +998,7 @@ class Scope:
 
         return None
 
-    def start_session(self, *args, **kwargs):
-        # type: (*Any, **Any) -> None
+    def start_session(self, *args: Any, **kwargs: Any) -> None:
         """Starts a new session."""
         session_mode = kwargs.pop("session_mode", "application")
 
@@ -1035,8 +1012,7 @@ class Scope:
             session_mode=session_mode,
         )
 
-    def end_session(self, *args, **kwargs):
-        # type: (*Any, **Any) -> None
+    def end_session(self, *args: Any, **kwargs: Any) -> None:
         """Ends the current session if there is one."""
         session = self._session
         self._session = None
@@ -1045,8 +1021,7 @@ class Scope:
             session.close()
             self.get_client().capture_session(session)
 
-    def stop_auto_session_tracking(self, *args, **kwargs):
-        # type: (*Any, **Any) -> None
+    def stop_auto_session_tracking(self, *args: Any, **kwargs: Any) -> None:
         """Stops automatic session tracking.
 
         This temporarily session tracking for the current scope when called.
@@ -1055,18 +1030,14 @@ class Scope:
         self.end_session()
         self._force_auto_session_tracking = False
 
-    def resume_auto_session_tracking(self):
-        # type: (...) -> None
+    def resume_auto_session_tracking(self) -> None:
         """Resumes automatic session tracking for the current scope if
         disabled earlier.  This requires that generally automatic session
         tracking is enabled.
         """
         self._force_auto_session_tracking = None
 
-    def add_event_processor(
-        self, func  # type: EventProcessor
-    ):
-        # type: (...) -> None
+    def add_event_processor(self, func: EventProcessor) -> None:
         """Register a scope local event processor on the scope.
 
         :param func: This function behaves like `before_send.`
@@ -1082,10 +1053,9 @@ class Scope:
 
     def add_error_processor(
         self,
-        func,  # type: ErrorProcessor
-        cls=None,  # type: Optional[Type[BaseException]]
-    ):
-        # type: (...) -> None
+        func: ErrorProcessor,
+        cls: Optional[Type[BaseException]] = None,
+    ) -> None:
         """Register a scope local error processor on the scope.
 
         :param func: A callback that works similar to an event processor but is invoked with the original exception info triple as second argument.
@@ -1096,8 +1066,7 @@ class Scope:
             cls_ = cls  # For mypy.
             real_func = func
 
-            def func(event, exc_info):
-                # type: (Event, ExcInfo) -> Optional[Event]
+            def wrapped_func(event: Event, exc_info: ExcInfo) -> Optional[Event]:
                 try:
                     is_inst = isinstance(exc_info[1], cls_)
                 except Exception:
@@ -1106,15 +1075,17 @@ class Scope:
                     return real_func(event, exc_info)
                 return event
 
-        self._error_processors.append(func)
+        self._error_processors.append(wrapped_func)
 
-    def _apply_level_to_event(self, event, hint, options):
-        # type: (Event, Hint, Optional[Dict[str, Any]]) -> None
+    def _apply_level_to_event(
+        self, event: Event, hint: Hint, options: Optional[Dict[str, Any]]
+    ) -> None:
         if self._level is not None:
             event["level"] = self._level
 
-    def _apply_breadcrumbs_to_event(self, event, hint, options):
-        # type: (Event, Hint, Optional[Dict[str, Any]]) -> None
+    def _apply_breadcrumbs_to_event(
+        self, event: Event, hint: Hint, options: Optional[Dict[str, Any]]
+    ) -> None:
         event.setdefault("breadcrumbs", {})
 
         # This check is just for mypy -
@@ -1136,38 +1107,45 @@ class Scope:
             logger.debug("Error when sorting breadcrumbs", exc_info=err)
             pass
 
-    def _apply_user_to_event(self, event, hint, options):
-        # type: (Event, Hint, Optional[Dict[str, Any]]) -> None
+    def _apply_user_to_event(
+        self, event: Event, hint: Hint, options: Optional[Dict[str, Any]]
+    ) -> None:
         if event.get("user") is None and self._user is not None:
             event["user"] = self._user
 
-    def _apply_transaction_name_to_event(self, event, hint, options):
-        # type: (Event, Hint, Optional[Dict[str, Any]]) -> None
+    def _apply_transaction_name_to_event(
+        self, event: Event, hint: Hint, options: Optional[Dict[str, Any]]
+    ) -> None:
         if event.get("transaction") is None and self._transaction is not None:
             event["transaction"] = self._transaction
 
-    def _apply_transaction_info_to_event(self, event, hint, options):
-        # type: (Event, Hint, Optional[Dict[str, Any]]) -> None
+    def _apply_transaction_info_to_event(
+        self, event: Event, hint: Hint, options: Optional[Dict[str, Any]]
+    ) -> None:
         if event.get("transaction_info") is None and self._transaction_info is not None:
             event["transaction_info"] = self._transaction_info
 
-    def _apply_fingerprint_to_event(self, event, hint, options):
-        # type: (Event, Hint, Optional[Dict[str, Any]]) -> None
+    def _apply_fingerprint_to_event(
+        self, event: Event, hint: Hint, options: Optional[Dict[str, Any]]
+    ) -> None:
         if event.get("fingerprint") is None and self._fingerprint is not None:
             event["fingerprint"] = self._fingerprint
 
-    def _apply_extra_to_event(self, event, hint, options):
-        # type: (Event, Hint, Optional[Dict[str, Any]]) -> None
+    def _apply_extra_to_event(
+        self, event: Event, hint: Hint, options: Optional[Dict[str, Any]]
+    ) -> None:
         if self._extras:
             event.setdefault("extra", {}).update(self._extras)
 
-    def _apply_tags_to_event(self, event, hint, options):
-        # type: (Event, Hint, Optional[Dict[str, Any]]) -> None
+    def _apply_tags_to_event(
+        self, event: Event, hint: Hint, options: Optional[Dict[str, Any]]
+    ) -> None:
         if self._tags:
             event.setdefault("tags", {}).update(self._tags)
 
-    def _apply_contexts_to_event(self, event, hint, options):
-        # type: (Event, Hint, Optional[Dict[str, Any]]) -> None
+    def _apply_contexts_to_event(
+        self, event: Event, hint: Hint, options: Optional[Dict[str, Any]]
+    ) -> None:
         if self._contexts:
             event.setdefault("contexts", {}).update(self._contexts)
 
@@ -1176,7 +1154,8 @@ class Scope:
         # Add "trace" context
         if contexts.get("trace") is None:
             if (
-                has_tracing_enabled(options)
+                options is not None
+                and has_tracing_enabled(options)
                 and self._span is not None
                 and self._span.is_valid
             ):
@@ -1184,21 +1163,20 @@ class Scope:
             else:
                 contexts["trace"] = self.get_trace_context()
 
-    def _apply_flags_to_event(self, event, hint, options):
-        # type: (Event, Hint, Optional[Dict[str, Any]]) -> None
+    def _apply_flags_to_event(
+        self, event: Event, hint: Hint, options: Optional[Dict[str, Any]]
+    ) -> None:
         flags = self.flags.get()
         if len(flags) > 0:
             event.setdefault("contexts", {}).setdefault("flags", {}).update(
                 {"values": flags}
             )
 
-    def _drop(self, cause, ty):
-        # type: (Any, str) -> Optional[Any]
+    def _drop(self, cause: Any, ty: str) -> Optional[Any]:
         logger.info("%s (%s) dropped event", ty, cause)
         return None
 
-    def run_error_processors(self, event, hint):
-        # type: (Event, Hint) -> Optional[Event]
+    def run_error_processors(self, event: Event, hint: Hint) -> Optional[Event]:
         """
         Runs the error processors on the event and returns the modified event.
         """
@@ -1219,8 +1197,7 @@ class Scope:
 
         return event
 
-    def run_event_processors(self, event, hint):
-        # type: (Event, Hint) -> Optional[Event]
+    def run_event_processors(self, event: Event, hint: Hint) -> Optional[Event]:
         """
         Runs the event processors on the event and returns the modified event.
         """
@@ -1240,7 +1217,7 @@ class Scope:
             )
 
             for event_processor in event_processors:
-                new_event = event  # type: Optional[Event]
+                new_event: Optional[Event] = event
                 with capture_internal_exceptions():
                     new_event = event_processor(event, hint)
                 if new_event is None:
@@ -1252,11 +1229,10 @@ class Scope:
     @_disable_capture
     def apply_to_event(
         self,
-        event,  # type: Event
-        hint,  # type: Hint
-        options=None,  # type: Optional[Dict[str, Any]]
-    ):
-        # type: (...) -> Optional[Event]
+        event: Event,
+        hint: Hint,
+        options: Optional[Dict[str, Any]] = None,
+    ) -> Optional[Event]:
         """Applies the information contained on the scope to the given event."""
         ty = event.get("type")
         is_transaction = ty == "transaction"
@@ -1302,8 +1278,7 @@ class Scope:
 
         return event
 
-    def update_from_scope(self, scope):
-        # type: (Scope) -> None
+    def update_from_scope(self, scope: Scope) -> None:
         """Update the scope with another scope's data."""
         if scope._level is not None:
             self._level = scope._level
@@ -1346,14 +1321,13 @@ class Scope:
 
     def update_from_kwargs(
         self,
-        user=None,  # type: Optional[Any]
-        level=None,  # type: Optional[LogLevelStr]
-        extras=None,  # type: Optional[Dict[str, Any]]
-        contexts=None,  # type: Optional[Dict[str, Dict[str, Any]]]
-        tags=None,  # type: Optional[Dict[str, str]]
-        fingerprint=None,  # type: Optional[List[str]]
-    ):
-        # type: (...) -> None
+        user: Optional[Any] = None,
+        level: Optional[LogLevelStr] = None,
+        extras: Optional[Dict[str, Any]] = None,
+        contexts: Optional[Dict[str, Dict[str, Any]]] = None,
+        tags: Optional[Dict[str, str]] = None,
+        fingerprint: Optional[List[str]] = None,
+    ) -> None:
         """Update the scope's attributes."""
         if level is not None:
             self._level = level
@@ -1368,8 +1342,7 @@ class Scope:
         if fingerprint is not None:
             self._fingerprint = fingerprint
 
-    def __repr__(self):
-        # type: () -> str
+    def __repr__(self) -> str:
         return "<%s id=%s name=%s type=%s>" % (
             self.__class__.__name__,
             hex(id(self)),
@@ -1378,8 +1351,7 @@ class Scope:
         )
 
     @property
-    def flags(self):
-        # type: () -> FlagBuffer
+    def flags(self) -> FlagBuffer:
         if self._flags is None:
             max_flags = (
                 self.get_client().options["_experiments"].get("max_flags")
@@ -1390,8 +1362,7 @@ class Scope:
 
 
 @contextmanager
-def new_scope():
-    # type: () -> Generator[Scope, None, None]
+def new_scope() -> Generator[Scope, None, None]:
     """
     .. versionadded:: 2.0.0
 
@@ -1428,8 +1399,7 @@ def new_scope():
 
 
 @contextmanager
-def use_scope(scope):
-    # type: (Scope) -> Generator[Scope, None, None]
+def use_scope(scope: Scope) -> Generator[Scope, None, None]:
     """
     .. versionadded:: 2.0.0
 
@@ -1466,8 +1436,7 @@ def use_scope(scope):
 
 
 @contextmanager
-def isolation_scope():
-    # type: () -> Generator[Scope, None, None]
+def isolation_scope() -> Generator[Scope, None, None]:
     """
     .. versionadded:: 2.0.0
 
@@ -1515,8 +1484,7 @@ def isolation_scope():
 
 
 @contextmanager
-def use_isolation_scope(isolation_scope):
-    # type: (Scope) -> Generator[Scope, None, None]
+def use_isolation_scope(isolation_scope: Scope) -> Generator[Scope, None, None]:
     """
     .. versionadded:: 2.0.0
 
@@ -1561,14 +1529,10 @@ def use_isolation_scope(isolation_scope):
             capture_internal_exception(sys.exc_info())
 
 
-def should_send_default_pii():
-    # type: () -> bool
+def should_send_default_pii() -> bool:
     """Shortcut for `Scope.get_client().should_send_default_pii()`."""
     return Scope.get_client().should_send_default_pii()
 
 
 # Circular imports
 from sentry_sdk.client import NonRecordingClient
-
-if TYPE_CHECKING:
-    import sentry_sdk.client

--- a/sentry_sdk/scrubber.py
+++ b/sentry_sdk/scrubber.py
@@ -5,10 +5,10 @@ from sentry_sdk.utils import (
     iter_event_frames,
 )
 
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from typing import List, Dict, Optional
+    from typing import List, Optional
     from sentry_sdk._types import Event
 
 
@@ -159,9 +159,10 @@ class EventScrubber:
     def scrub_spans(self, event: Event) -> None:
         with capture_internal_exceptions():
             if "spans" in event:
-                for span in cast("List[Dict[str, object]]", event["spans"]):
-                    if "data" in span:
-                        self.scrub_dict(span["data"])
+                if not isinstance(event["spans"], AnnotatedValue):
+                    for span in event["spans"]:
+                        if "data" in span:
+                            self.scrub_dict(span["data"])
 
     def scrub_event(self, event: Event) -> None:
         self.scrub_request(event)

--- a/sentry_sdk/serializer.py
+++ b/sentry_sdk/serializer.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import sys
 import math
 from collections.abc import Mapping, Sequence, Set
@@ -55,29 +56,25 @@ MAX_DATABAG_BREADTH = 10
 CYCLE_MARKER = "<cyclic>"
 
 
-global_repr_processors = []  # type: List[ReprProcessor]
+global_repr_processors: List[ReprProcessor] = []
 
 
-def add_global_repr_processor(processor):
-    # type: (ReprProcessor) -> None
+def add_global_repr_processor(processor: ReprProcessor) -> None:
     global_repr_processors.append(processor)
 
 
 class Memo:
     __slots__ = ("_ids", "_objs")
 
-    def __init__(self):
-        # type: () -> None
-        self._ids = {}  # type: Dict[int, Any]
-        self._objs = []  # type: List[Any]
+    def __init__(self) -> None:
+        self._ids: Dict[int, Any] = {}
+        self._objs: List[Any] = []
 
-    def memoize(self, obj):
-        # type: (Any) -> ContextManager[bool]
+    def memoize(self, obj: Any) -> ContextManager[bool]:
         self._objs.append(obj)
         return self
 
-    def __enter__(self):
-        # type: () -> bool
+    def __enter__(self) -> bool:
         obj = self._objs[-1]
         if id(obj) in self._ids:
             return True
@@ -87,16 +84,14 @@ class Memo:
 
     def __exit__(
         self,
-        ty,  # type: Optional[Type[BaseException]]
-        value,  # type: Optional[BaseException]
-        tb,  # type: Optional[TracebackType]
-    ):
-        # type: (...) -> None
+        ty: Optional[Type[BaseException]],
+        value: Optional[BaseException],
+        tb: Optional[TracebackType],
+    ) -> None:
         self._ids.pop(id(self._objs.pop()), None)
 
 
-def serialize(event, **kwargs):
-    # type: (Union[Dict[str, Any], Event], **Any) -> Dict[str, Any]
+def serialize(event: Union[Dict[str, Any], Event], **kwargs: Any) -> Dict[str, Any]:
     """
     A very smart serializer that takes a dict and emits a json-friendly dict.
     Currently used for serializing the final Event and also prematurely while fetching the stack
@@ -117,18 +112,15 @@ def serialize(event, **kwargs):
 
     """
     memo = Memo()
-    path = []  # type: List[Segment]
-    meta_stack = []  # type: List[Dict[str, Any]]
+    path: List[Segment] = []
+    meta_stack: List[Dict[str, Any]] = []
 
-    keep_request_bodies = (
-        kwargs.pop("max_request_body_size", None) == "always"
-    )  # type: bool
-    max_value_length = kwargs.pop("max_value_length", None)  # type: Optional[int]
+    keep_request_bodies: bool = kwargs.pop("max_request_body_size", None) == "always"
+    max_value_length: Optional[int] = kwargs.pop("max_value_length", None)
     is_vars = kwargs.pop("is_vars", False)
-    custom_repr = kwargs.pop("custom_repr", None)  # type: Callable[..., Optional[str]]
+    custom_repr: Callable[..., Optional[str]] = kwargs.pop("custom_repr", None)
 
-    def _safe_repr_wrapper(value):
-        # type: (Any) -> str
+    def _safe_repr_wrapper(value: Any) -> str:
         try:
             repr_value = None
             if custom_repr is not None:
@@ -137,8 +129,7 @@ def serialize(event, **kwargs):
         except Exception:
             return safe_repr(value)
 
-    def _annotate(**meta):
-        # type: (**Any) -> None
+    def _annotate(**meta: Any) -> None:
         while len(meta_stack) <= len(path):
             try:
                 segment = path[len(meta_stack) - 1]
@@ -150,8 +141,7 @@ def serialize(event, **kwargs):
 
         meta_stack[-1].setdefault("", {}).update(meta)
 
-    def _is_databag():
-        # type: () -> Optional[bool]
+    def _is_databag() -> Optional[bool]:
         """
         A databag is any value that we need to trim.
         True for stuff like vars, request bodies, breadcrumbs and extra.
@@ -179,8 +169,7 @@ def serialize(event, **kwargs):
 
         return False
 
-    def _is_request_body():
-        # type: () -> Optional[bool]
+    def _is_request_body() -> Optional[bool]:
         try:
             if path[0] == "request" and path[1] == "data":
                 return True
@@ -190,15 +179,14 @@ def serialize(event, **kwargs):
         return False
 
     def _serialize_node(
-        obj,  # type: Any
-        is_databag=None,  # type: Optional[bool]
-        is_request_body=None,  # type: Optional[bool]
-        should_repr_strings=None,  # type: Optional[bool]
-        segment=None,  # type: Optional[Segment]
-        remaining_breadth=None,  # type: Optional[Union[int, float]]
-        remaining_depth=None,  # type: Optional[Union[int, float]]
-    ):
-        # type: (...) -> Any
+        obj: Any,
+        is_databag: Optional[bool] = None,
+        is_request_body: Optional[bool] = None,
+        should_repr_strings: Optional[bool] = None,
+        segment: Optional[Segment] = None,
+        remaining_breadth: Optional[Union[int, float]] = None,
+        remaining_depth: Optional[Union[int, float]] = None,
+    ) -> Any:
         if segment is not None:
             path.append(segment)
 
@@ -227,22 +215,20 @@ def serialize(event, **kwargs):
                 path.pop()
                 del meta_stack[len(path) + 1 :]
 
-    def _flatten_annotated(obj):
-        # type: (Any) -> Any
+    def _flatten_annotated(obj: Any) -> Any:
         if isinstance(obj, AnnotatedValue):
             _annotate(**obj.metadata)
             obj = obj.value
         return obj
 
     def _serialize_node_impl(
-        obj,
-        is_databag,
-        is_request_body,
-        should_repr_strings,
-        remaining_depth,
-        remaining_breadth,
-    ):
-        # type: (Any, Optional[bool], Optional[bool], Optional[bool], Optional[Union[float, int]], Optional[Union[float, int]]) -> Any
+        obj: Any,
+        is_databag: Optional[bool],
+        is_request_body: Optional[bool],
+        should_repr_strings: Optional[bool],
+        remaining_depth: Optional[Union[float, int]],
+        remaining_breadth: Optional[Union[float, int]],
+    ) -> Any:
         if isinstance(obj, AnnotatedValue):
             should_repr_strings = False
         if should_repr_strings is None:
@@ -306,7 +292,7 @@ def serialize(event, **kwargs):
             # might mutate our dictionary while we're still iterating over it.
             obj = dict(obj.items())
 
-            rv_dict = {}  # type: Dict[str, Any]
+            rv_dict: Dict[str, Any] = {}
             i = 0
 
             for k, v in obj.items():

--- a/sentry_sdk/serializer.py
+++ b/sentry_sdk/serializer.py
@@ -26,7 +26,7 @@ if TYPE_CHECKING:
     from typing import Type
     from typing import Union
 
-    from sentry_sdk._types import NotImplementedType
+    from sentry_sdk._types import NotImplementedType, Event
 
     Span = Dict[str, Any]
 
@@ -96,7 +96,7 @@ class Memo:
 
 
 def serialize(event, **kwargs):
-    # type: (Dict[str, Any], **Any) -> Dict[str, Any]
+    # type: (Union[Dict[str, Any], Event], **Any) -> Dict[str, Any]
     """
     A very smart serializer that takes a dict and emits a json-friendly dict.
     Currently used for serializing the final Event and also prematurely while fetching the stack

--- a/sentry_sdk/session.py
+++ b/sentry_sdk/session.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import uuid
 from datetime import datetime, timezone
 
@@ -6,23 +7,15 @@ from sentry_sdk.utils import format_timestamp
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from typing import Optional
-    from typing import Union
-    from typing import Any
-    from typing import Dict
-
     from sentry_sdk._types import SessionStatus
+    from typing import Optional, Union, Any, Dict
 
 
-def _minute_trunc(ts):
-    # type: (datetime) -> datetime
+def _minute_trunc(ts: datetime) -> datetime:
     return ts.replace(second=0, microsecond=0)
 
 
-def _make_uuid(
-    val,  # type: Union[str, uuid.UUID]
-):
-    # type: (...) -> uuid.UUID
+def _make_uuid(val: Union[str, uuid.UUID]) -> uuid.UUID:
     if isinstance(val, uuid.UUID):
         return val
     return uuid.UUID(val)
@@ -31,21 +24,20 @@ def _make_uuid(
 class Session:
     def __init__(
         self,
-        sid=None,  # type: Optional[Union[str, uuid.UUID]]
-        did=None,  # type: Optional[str]
-        timestamp=None,  # type: Optional[datetime]
-        started=None,  # type: Optional[datetime]
-        duration=None,  # type: Optional[float]
-        status=None,  # type: Optional[SessionStatus]
-        release=None,  # type: Optional[str]
-        environment=None,  # type: Optional[str]
-        user_agent=None,  # type: Optional[str]
-        ip_address=None,  # type: Optional[str]
-        errors=None,  # type: Optional[int]
-        user=None,  # type: Optional[Any]
-        session_mode="application",  # type: str
-    ):
-        # type: (...) -> None
+        sid: Optional[Union[str, uuid.UUID]] = None,
+        did: Optional[str] = None,
+        timestamp: Optional[datetime] = None,
+        started: Optional[datetime] = None,
+        duration: Optional[float] = None,
+        status: Optional[SessionStatus] = None,
+        release: Optional[str] = None,
+        environment: Optional[str] = None,
+        user_agent: Optional[str] = None,
+        ip_address: Optional[str] = None,
+        errors: Optional[int] = None,
+        user: Optional[Any] = None,
+        session_mode: str = "application",
+    ) -> None:
         if sid is None:
             sid = uuid.uuid4()
         if started is None:
@@ -53,14 +45,14 @@ class Session:
         if status is None:
             status = "ok"
         self.status = status
-        self.did = None  # type: Optional[str]
+        self.did: Optional[str] = None
         self.started = started
-        self.release = None  # type: Optional[str]
-        self.environment = None  # type: Optional[str]
-        self.duration = None  # type: Optional[float]
-        self.user_agent = None  # type: Optional[str]
-        self.ip_address = None  # type: Optional[str]
-        self.session_mode = session_mode  # type: str
+        self.release: Optional[str] = None
+        self.environment: Optional[str] = None
+        self.duration: Optional[float] = None
+        self.user_agent: Optional[str] = None
+        self.ip_address: Optional[str] = None
+        self.session_mode: str = session_mode
         self.errors = 0
 
         self.update(
@@ -77,26 +69,24 @@ class Session:
         )
 
     @property
-    def truncated_started(self):
-        # type: (...) -> datetime
+    def truncated_started(self) -> datetime:
         return _minute_trunc(self.started)
 
     def update(
         self,
-        sid=None,  # type: Optional[Union[str, uuid.UUID]]
-        did=None,  # type: Optional[str]
-        timestamp=None,  # type: Optional[datetime]
-        started=None,  # type: Optional[datetime]
-        duration=None,  # type: Optional[float]
-        status=None,  # type: Optional[SessionStatus]
-        release=None,  # type: Optional[str]
-        environment=None,  # type: Optional[str]
-        user_agent=None,  # type: Optional[str]
-        ip_address=None,  # type: Optional[str]
-        errors=None,  # type: Optional[int]
-        user=None,  # type: Optional[Any]
-    ):
-        # type: (...) -> None
+        sid: Optional[Union[str, uuid.UUID]] = None,
+        did: Optional[str] = None,
+        timestamp: Optional[datetime] = None,
+        started: Optional[datetime] = None,
+        duration: Optional[float] = None,
+        status: Optional[SessionStatus] = None,
+        release: Optional[str] = None,
+        environment: Optional[str] = None,
+        user_agent: Optional[str] = None,
+        ip_address: Optional[str] = None,
+        errors: Optional[int] = None,
+        user: Optional[Any] = None,
+    ) -> None:
         # If a user is supplied we pull some data form it
         if user:
             if ip_address is None:
@@ -129,19 +119,13 @@ class Session:
         if status is not None:
             self.status = status
 
-    def close(
-        self, status=None  # type: Optional[SessionStatus]
-    ):
-        # type: (...) -> Any
+    def close(self, status: Optional[SessionStatus] = None) -> Any:
         if status is None and self.status == "ok":
             status = "exited"
         if status is not None:
             self.update(status=status)
 
-    def get_json_attrs(
-        self, with_user_info=True  # type: Optional[bool]
-    ):
-        # type: (...) -> Any
+    def get_json_attrs(self, with_user_info: bool = True) -> Any:
         attrs = {}
         if self.release is not None:
             attrs["release"] = self.release
@@ -154,15 +138,14 @@ class Session:
                 attrs["user_agent"] = self.user_agent
         return attrs
 
-    def to_json(self):
-        # type: (...) -> Any
-        rv = {
+    def to_json(self) -> Any:
+        rv: Dict[str, Any] = {
             "sid": str(self.sid),
             "init": True,
             "started": format_timestamp(self.started),
             "timestamp": format_timestamp(self.timestamp),
             "status": self.status,
-        }  # type: Dict[str, Any]
+        }
         if self.errors:
             rv["errors"] = self.errors
         if self.did is not None:

--- a/sentry_sdk/spotlight.py
+++ b/sentry_sdk/spotlight.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import io
 import logging
 import os
@@ -12,11 +13,7 @@ from itertools import chain, product
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from typing import Any
-    from typing import Callable
-    from typing import Dict
-    from typing import Optional
-    from typing import Self
+    from typing import Any, Callable, Dict, Optional
 
 from sentry_sdk.utils import (
     logger as sentry_logger,
@@ -34,14 +31,12 @@ DJANGO_SPOTLIGHT_MIDDLEWARE_PATH = "sentry_sdk.spotlight.SpotlightMiddleware"
 
 
 class SpotlightClient:
-    def __init__(self, url):
-        # type: (str) -> None
+    def __init__(self, url: str) -> None:
         self.url = url
         self.http = urllib3.PoolManager()
         self.fails = 0
 
-    def capture_envelope(self, envelope):
-        # type: (Envelope) -> None
+    def capture_envelope(self, envelope: Envelope) -> None:
         body = io.BytesIO()
         envelope.serialize_into(body)
         try:
@@ -90,11 +85,10 @@ try:
     )
 
     class SpotlightMiddleware(MiddlewareMixin):  # type: ignore[misc]
-        _spotlight_script = None  # type: Optional[str]
-        _spotlight_url = None  # type: Optional[str]
+        _spotlight_script: Optional[str] = None
+        _spotlight_url: Optional[str] = None
 
-        def __init__(self, get_response):
-            # type: (Self, Callable[..., HttpResponse]) -> None
+        def __init__(self, get_response: Callable[..., HttpResponse]) -> None:
             super().__init__(get_response)
 
             import sentry_sdk.api
@@ -111,8 +105,7 @@ try:
             self._spotlight_url = urllib.parse.urljoin(spotlight_client.url, "../")
 
         @property
-        def spotlight_script(self):
-            # type: (Self) -> Optional[str]
+        def spotlight_script(self) -> Optional[str]:
             if self._spotlight_url is not None and self._spotlight_script is None:
                 try:
                     spotlight_js_url = urllib.parse.urljoin(
@@ -136,8 +129,9 @@ try:
 
             return self._spotlight_script
 
-        def process_response(self, _request, response):
-            # type: (Self, HttpRequest, HttpResponse) -> Optional[HttpResponse]
+        def process_response(
+            self, _request: HttpRequest, response: HttpResponse
+        ) -> Optional[HttpResponse]:
             content_type_header = tuple(
                 p.strip()
                 for p in response.headers.get("Content-Type", "").lower().split(";")
@@ -181,8 +175,9 @@ try:
 
             return response
 
-        def process_exception(self, _request, exception):
-            # type: (Self, HttpRequest, Exception) -> Optional[HttpResponseServerError]
+        def process_exception(
+            self, _request: HttpRequest, exception: Exception
+        ) -> Optional[HttpResponseServerError]:
             if not settings.DEBUG or not self._spotlight_url:
                 return None
 
@@ -207,8 +202,7 @@ except ImportError:
     settings = None
 
 
-def setup_spotlight(options):
-    # type: (Dict[str, Any]) -> Optional[SpotlightClient]
+def setup_spotlight(options: Dict[str, Any]) -> Optional[SpotlightClient]:
     _handler = logging.StreamHandler(sys.stderr)
     _handler.setFormatter(logging.Formatter(" [spotlight] %(levelname)s: %(message)s"))
     logger.addHandler(_handler)

--- a/sentry_sdk/tracing.py
+++ b/sentry_sdk/tracing.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from datetime import datetime
 import json
 import warnings
@@ -45,29 +46,26 @@ from sentry_sdk.utils import (
     should_be_treated_as_error,
 )
 
-from typing import TYPE_CHECKING, cast
-
+from typing import TYPE_CHECKING, cast, overload
 
 if TYPE_CHECKING:
-    from collections.abc import Callable
-    from typing import Any
-    from typing import Dict
-    from typing import Iterator
-    from typing import Optional
-    from typing import overload
-    from typing import ParamSpec
-    from typing import Tuple
-    from typing import Union
-    from typing import TypeVar
+    from typing import (
+        Callable,
+        Any,
+        Dict,
+        Iterator,
+        Optional,
+        ParamSpec,
+        Tuple,
+        Union,
+        TypeVar,
+    )
+    from sentry_sdk._types import SamplingContext
+    from sentry_sdk.tracing_utils import Baggage
 
     P = ParamSpec("P")
     R = TypeVar("R")
 
-    from sentry_sdk._types import (
-        SamplingContext,
-    )
-
-    from sentry_sdk.tracing_utils import Baggage
 
 _FLAGS_CAPACITY = 10
 _OTEL_VERSION = parse_version(otel_version)
@@ -76,88 +74,65 @@ tracer = otel_trace.get_tracer(__name__)
 
 
 class NoOpSpan:
-    def __init__(self, **kwargs):
-        # type: (Any) -> None
+    def __init__(self, **kwargs: Any) -> None:
         pass
 
-    def __repr__(self):
-        # type: () -> str
+    def __repr__(self) -> str:
         return "<%s>" % self.__class__.__name__
 
     @property
-    def root_span(self):
-        # type: () -> Optional[Span]
+    def root_span(self) -> Optional[Span]:
         return None
 
-    def start_child(self, **kwargs):
-        # type: (**Any) -> NoOpSpan
+    def start_child(self, **kwargs: Any) -> NoOpSpan:
         return NoOpSpan()
 
-    def to_traceparent(self):
-        # type: () -> str
+    def to_traceparent(self) -> str:
         return ""
 
-    def to_baggage(self):
-        # type: () -> Optional[Baggage]
+    def to_baggage(self) -> Optional[Baggage]:
         return None
 
-    def get_baggage(self):
-        # type: () -> Optional[Baggage]
+    def get_baggage(self) -> Optional[Baggage]:
         return None
 
-    def iter_headers(self):
-        # type: () -> Iterator[Tuple[str, str]]
+    def iter_headers(self) -> Iterator[Tuple[str, str]]:
         return iter(())
 
-    def set_tag(self, key, value):
-        # type: (str, Any) -> None
+    def set_tag(self, key: str, value: Any) -> None:
         pass
 
-    def set_data(self, key, value):
-        # type: (str, Any) -> None
+    def set_data(self, key: str, value: Any) -> None:
         pass
 
-    def set_status(self, value):
-        # type: (str) -> None
+    def set_status(self, value: str) -> None:
         pass
 
-    def set_http_status(self, http_status):
-        # type: (int) -> None
+    def set_http_status(self, http_status: int) -> None:
         pass
 
-    def is_success(self):
-        # type: () -> bool
+    def is_success(self) -> bool:
         return True
 
-    def to_json(self):
-        # type: () -> Dict[str, Any]
+    def to_json(self) -> Dict[str, Any]:
         return {}
 
-    def get_trace_context(self):
-        # type: () -> Any
+    def get_trace_context(self) -> Any:
         return {}
 
-    def get_profile_context(self):
-        # type: () -> Any
+    def get_profile_context(self) -> Any:
         return {}
 
-    def finish(
-        self,
-        end_timestamp=None,  # type: Optional[Union[float, datetime]]
-    ):
-        # type: (...) -> None
+    def finish(self, end_timestamp: Optional[Union[float, datetime]] = None) -> None:
         pass
 
-    def set_context(self, key, value):
-        # type: (str, dict[str, Any]) -> None
+    def set_context(self, key: str, value: dict[str, Any]) -> None:
         pass
 
-    def init_span_recorder(self, maxlen):
-        # type: (int) -> None
+    def init_span_recorder(self, maxlen: int) -> None:
         pass
 
-    def _set_initial_sampling_decision(self, sampling_context):
-        # type: (SamplingContext) -> None
+    def _set_initial_sampling_decision(self, sampling_context: SamplingContext) -> None:
         pass
 
 
@@ -169,21 +144,20 @@ class Span:
     def __init__(
         self,
         *,
-        op=None,  # type: Optional[str]
-        description=None,  # type: Optional[str]
-        status=None,  # type: Optional[str]
-        sampled=None,  # type: Optional[bool]
-        start_timestamp=None,  # type: Optional[Union[datetime, float]]
-        origin=None,  # type: Optional[str]
-        name=None,  # type: Optional[str]
-        source=TransactionSource.CUSTOM,  # type: str
-        attributes=None,  # type: Optional[dict[str, Any]]
-        only_if_parent=False,  # type: bool
-        parent_span=None,  # type: Optional[Span]
-        otel_span=None,  # type: Optional[OtelSpan]
-        span=None,  # type: Optional[Span]
-    ):
-        # type: (...) -> None
+        op: Optional[str] = None,
+        description: Optional[str] = None,
+        status: Optional[str] = None,
+        sampled: Optional[bool] = None,
+        start_timestamp: Optional[Union[datetime, float]] = None,
+        origin: Optional[str] = None,
+        name: Optional[str] = None,
+        source: str = TransactionSource.CUSTOM,
+        attributes: Optional[dict[str, Any]] = None,
+        only_if_parent: bool = False,
+        parent_span: Optional[Span] = None,
+        otel_span: Optional[OtelSpan] = None,
+        span: Optional[Span] = None,
+    ) -> None:
         """
         If otel_span is passed explicitly, just acts as a proxy.
 
@@ -248,14 +222,12 @@ class Span:
 
                 self.update_active_thread()
 
-    def __eq__(self, other):
-        # type: (object) -> bool
+    def __eq__(self, other: object) -> bool:
         if not isinstance(other, Span):
             return False
         return self._otel_span == other._otel_span
 
-    def __repr__(self):
-        # type: () -> str
+    def __repr__(self) -> str:
         return (
             "<%s(op=%r, name:%r, trace_id=%r, span_id=%r, parent_span_id=%r, sampled=%r, origin=%r)>"
             % (
@@ -270,25 +242,23 @@ class Span:
             )
         )
 
-    def activate(self):
-        # type: () -> None
+    def activate(self) -> None:
         ctx = otel_trace.set_span_in_context(self._otel_span)
         # set as the implicit current context
         self._ctx_token = context.attach(ctx)
 
-    def deactivate(self):
-        # type: () -> None
+    def deactivate(self) -> None:
         if self._ctx_token:
             context.detach(self._ctx_token)
             del self._ctx_token
 
-    def __enter__(self):
-        # type: () -> Span
+    def __enter__(self) -> Span:
         self.activate()
         return self
 
-    def __exit__(self, ty, value, tb):
-        # type: (Optional[Any], Optional[Any], Optional[Any]) -> None
+    def __exit__(
+        self, ty: Optional[Any], value: Optional[Any], tb: Optional[Any]
+    ) -> None:
         if value is not None and should_be_treated_as_error(ty, value):
             self.set_status(SPANSTATUS.INTERNAL_ERROR)
         else:
@@ -303,41 +273,34 @@ class Span:
         self.deactivate()
 
     @property
-    def description(self):
-        # type: () -> Optional[str]
+    def description(self) -> Optional[str]:
         return self.get_attribute(SentrySpanAttribute.DESCRIPTION)
 
     @description.setter
-    def description(self, value):
-        # type: (Optional[str]) -> None
+    def description(self, value: Optional[str]) -> None:
         self.set_attribute(SentrySpanAttribute.DESCRIPTION, value)
 
     @property
-    def origin(self):
-        # type: () -> Optional[str]
+    def origin(self) -> Optional[str]:
         return self.get_attribute(SentrySpanAttribute.ORIGIN)
 
     @origin.setter
-    def origin(self, value):
-        # type: (Optional[str]) -> None
+    def origin(self, value: Optional[str]) -> None:
         self.set_attribute(SentrySpanAttribute.ORIGIN, value)
 
     @property
-    def root_span(self):
-        # type: () -> Optional[Span]
+    def root_span(self) -> Optional[Span]:
         root_otel_span = cast(
             "Optional[OtelSpan]", get_sentry_meta(self._otel_span, "root_span")
         )
         return Span(otel_span=root_otel_span) if root_otel_span else None
 
     @property
-    def is_root_span(self):
-        # type: () -> bool
+    def is_root_span(self) -> bool:
         return self.root_span == self
 
     @property
-    def parent_span_id(self):
-        # type: () -> Optional[str]
+    def parent_span_id(self) -> Optional[str]:
         if (
             not isinstance(self._otel_span, ReadableSpan)
             or self._otel_span.parent is None
@@ -346,70 +309,58 @@ class Span:
         return format_span_id(self._otel_span.parent.span_id)
 
     @property
-    def trace_id(self):
-        # type: () -> str
+    def trace_id(self) -> str:
         return format_trace_id(self._otel_span.get_span_context().trace_id)
 
     @property
-    def span_id(self):
-        # type: () -> str
+    def span_id(self) -> str:
         return format_span_id(self._otel_span.get_span_context().span_id)
 
     @property
-    def is_valid(self):
-        # type: () -> bool
+    def is_valid(self) -> bool:
         return self._otel_span.get_span_context().is_valid and isinstance(
             self._otel_span, ReadableSpan
         )
 
     @property
-    def sampled(self):
-        # type: () -> Optional[bool]
+    def sampled(self) -> Optional[bool]:
         return self._otel_span.get_span_context().trace_flags.sampled
 
     @property
-    def sample_rate(self):
-        # type: () -> Optional[float]
+    def sample_rate(self) -> Optional[float]:
         sample_rate = self._otel_span.get_span_context().trace_state.get(
             TRACESTATE_SAMPLE_RATE_KEY
         )
         return float(sample_rate) if sample_rate is not None else None
 
     @property
-    def op(self):
-        # type: () -> Optional[str]
+    def op(self) -> Optional[str]:
         return self.get_attribute(SentrySpanAttribute.OP)
 
     @op.setter
-    def op(self, value):
-        # type: (Optional[str]) -> None
+    def op(self, value: Optional[str]) -> None:
         self.set_attribute(SentrySpanAttribute.OP, value)
 
     @property
-    def name(self):
-        # type: () -> Optional[str]
+    def name(self) -> Optional[str]:
         return self.get_attribute(SentrySpanAttribute.NAME)
 
     @name.setter
-    def name(self, value):
-        # type: (Optional[str]) -> None
+    def name(self, value: Optional[str]) -> None:
         self.set_attribute(SentrySpanAttribute.NAME, value)
 
     @property
-    def source(self):
-        # type: () -> str
+    def source(self) -> str:
         return (
             self.get_attribute(SentrySpanAttribute.SOURCE) or TransactionSource.CUSTOM
         )
 
     @source.setter
-    def source(self, value):
-        # type: (str) -> None
+    def source(self, value: str) -> None:
         self.set_attribute(SentrySpanAttribute.SOURCE, value)
 
     @property
-    def start_timestamp(self):
-        # type: () -> Optional[datetime]
+    def start_timestamp(self) -> Optional[datetime]:
         if not isinstance(self._otel_span, ReadableSpan):
             return None
 
@@ -420,8 +371,7 @@ class Span:
         return convert_from_otel_timestamp(start_time)
 
     @property
-    def timestamp(self):
-        # type: () -> Optional[datetime]
+    def timestamp(self) -> Optional[datetime]:
         if not isinstance(self._otel_span, ReadableSpan):
             return None
 
@@ -431,17 +381,14 @@ class Span:
 
         return convert_from_otel_timestamp(end_time)
 
-    def start_child(self, **kwargs):
-        # type: (**Any) -> Span
+    def start_child(self, **kwargs: Any) -> Span:
         return Span(parent_span=self, **kwargs)
 
-    def iter_headers(self):
-        # type: () -> Iterator[Tuple[str, str]]
+    def iter_headers(self) -> Iterator[Tuple[str, str]]:
         yield SENTRY_TRACE_HEADER_NAME, self.to_traceparent()
         yield BAGGAGE_HEADER_NAME, serialize_trace_state(self.trace_state)
 
-    def to_traceparent(self):
-        # type: () -> str
+    def to_traceparent(self) -> str:
         if self.sampled is True:
             sampled = "1"
         elif self.sampled is False:
@@ -456,24 +403,19 @@ class Span:
         return traceparent
 
     @property
-    def trace_state(self):
-        # type: () -> TraceState
+    def trace_state(self) -> TraceState:
         return get_trace_state(self._otel_span)
 
-    def to_baggage(self):
-        # type: () -> Baggage
+    def to_baggage(self) -> Baggage:
         return self.get_baggage()
 
-    def get_baggage(self):
-        # type: () -> Baggage
+    def get_baggage(self) -> Baggage:
         return baggage_from_trace_state(self.trace_state)
 
-    def set_tag(self, key, value):
-        # type: (str, Any) -> None
+    def set_tag(self, key: str, value: Any) -> None:
         self.set_attribute(f"{SentrySpanAttribute.TAG}.{key}", value)
 
-    def set_data(self, key, value):
-        # type: (str, Any) -> None
+    def set_data(self, key: str, value: Any) -> None:
         warnings.warn(
             "`Span.set_data` is deprecated. Please use `Span.set_attribute` instead.",
             DeprecationWarning,
@@ -483,8 +425,7 @@ class Span:
         # TODO-neel-potel we cannot add dicts here
         self.set_attribute(key, value)
 
-    def get_attribute(self, name):
-        # type: (str) -> Optional[Any]
+    def get_attribute(self, name: str) -> Optional[Any]:
         if (
             not isinstance(self._otel_span, ReadableSpan)
             or not self._otel_span.attributes
@@ -492,8 +433,7 @@ class Span:
             return None
         return self._otel_span.attributes.get(name)
 
-    def set_attribute(self, key, value):
-        # type: (str, Any) -> None
+    def set_attribute(self, key: str, value: Any) -> None:
         # otel doesn't support None as values, preferring to not set the key
         # at all instead
         if value is None:
@@ -505,8 +445,7 @@ class Span:
         self._otel_span.set_attribute(key, serialized_value)
 
     @property
-    def status(self):
-        # type: () -> Optional[str]
+    def status(self) -> Optional[str]:
         """
         Return the Sentry `SPANSTATUS` corresponding to the underlying OTel status.
         Because differences in possible values in OTel `StatusCode` and
@@ -523,8 +462,7 @@ class Span:
         else:
             return SPANSTATUS.UNKNOWN_ERROR
 
-    def set_status(self, status):
-        # type: (str) -> None
+    def set_status(self, status: str) -> None:
         if status == SPANSTATUS.OK:
             otel_status = StatusCode.OK
             otel_description = None
@@ -537,37 +475,31 @@ class Span:
         else:
             self._otel_span.set_status(Status(otel_status, otel_description))
 
-    def set_thread(self, thread_id, thread_name):
-        # type: (Optional[int], Optional[str]) -> None
+    def set_thread(self, thread_id: Optional[int], thread_name: Optional[str]) -> None:
         if thread_id is not None:
             self.set_attribute(SPANDATA.THREAD_ID, str(thread_id))
 
             if thread_name is not None:
                 self.set_attribute(SPANDATA.THREAD_NAME, thread_name)
 
-    def update_active_thread(self):
-        # type: () -> None
+    def update_active_thread(self) -> None:
         thread_id, thread_name = get_current_thread_meta()
         self.set_thread(thread_id, thread_name)
 
-    def set_http_status(self, http_status):
-        # type: (int) -> None
+    def set_http_status(self, http_status: int) -> None:
         self.set_attribute(SPANDATA.HTTP_STATUS_CODE, http_status)
         self.set_status(get_span_status_from_http_code(http_status))
 
-    def is_success(self):
-        # type: () -> bool
+    def is_success(self) -> bool:
         return self.status == SPANSTATUS.OK
 
-    def finish(self, end_timestamp=None):
-        # type: (Optional[Union[float, datetime]]) -> None
+    def finish(self, end_timestamp: Optional[Union[float, datetime]] = None) -> None:
         if end_timestamp is not None:
             self._otel_span.end(convert_to_otel_timestamp(end_timestamp))
         else:
             self._otel_span.end()
 
-    def to_json(self):
-        # type: () -> dict[str, Any]
+    def to_json(self) -> dict[str, Any]:
         """
         Only meant for testing. Not used internally anymore.
         """
@@ -575,21 +507,18 @@ class Span:
             return {}
         return json.loads(self._otel_span.to_json())
 
-    def get_trace_context(self):
-        # type: () -> dict[str, Any]
+    def get_trace_context(self) -> dict[str, Any]:
         if not isinstance(self._otel_span, ReadableSpan):
             return {}
 
         return get_trace_context(self._otel_span)
 
-    def set_context(self, key, value):
-        # type: (str, Any) -> None
+    def set_context(self, key: str, value: Any) -> None:
         # TODO-neel-potel we cannot add dicts here
 
         self.set_attribute(f"{SentrySpanAttribute.CONTEXT}.{key}", value)
 
-    def set_flag(self, flag, value):
-        # type: (str, bool) -> None
+    def set_flag(self, flag: str, value: bool) -> None:
         flag_count = self.get_attribute("_flag.count") or 0
         if flag_count < _FLAGS_CAPACITY:
             self.set_attribute(f"flag.evaluation.{flag}", value)
@@ -603,18 +532,17 @@ Transaction = Span
 if TYPE_CHECKING:
 
     @overload
-    def trace(func=None):
-        # type: (None) -> Callable[[Callable[P, R]], Callable[P, R]]
+    def trace(func: None = None) -> Callable[[Callable[P, R]], Callable[P, R]]:
         pass
 
     @overload
-    def trace(func):
-        # type: (Callable[P, R]) -> Callable[P, R]
+    def trace(func: Callable[P, R]) -> Callable[P, R]:
         pass
 
 
-def trace(func=None):
-    # type: (Optional[Callable[P, R]]) -> Union[Callable[P, R], Callable[[Callable[P, R]], Callable[P, R]]]
+def trace(
+    func: Optional[Callable[P, R]] = None,
+) -> Union[Callable[P, R], Callable[[Callable[P, R]], Callable[P, R]]]:
     """
     Decorator to start a child span under the existing current transaction.
     If there is no current transaction, then nothing will be traced.

--- a/sentry_sdk/tracing.py
+++ b/sentry_sdk/tracing.py
@@ -46,7 +46,7 @@ from sentry_sdk.utils import (
     should_be_treated_as_error,
 )
 
-from typing import TYPE_CHECKING, cast, overload
+from typing import TYPE_CHECKING, overload
 
 if TYPE_CHECKING:
     from typing import (
@@ -290,8 +290,8 @@ class Span:
 
     @property
     def root_span(self) -> Optional[Span]:
-        root_otel_span = cast(
-            "Optional[OtelSpan]", get_sentry_meta(self._otel_span, "root_span")
+        root_otel_span: Optional[OtelSpan] = get_sentry_meta(
+            self._otel_span, "root_span"
         )
         return Span(otel_span=root_otel_span) if root_otel_span else None
 

--- a/sentry_sdk/tracing_utils.py
+++ b/sentry_sdk/tracing_utils.py
@@ -752,7 +752,7 @@ def get_current_span(
 def _generate_sample_rand(
     trace_id: Optional[str],
     interval: tuple[float, float] = (0.0, 1.0),
-) -> Optional[Decimal]:
+) -> Decimal:
     """Generate a sample_rand value from a trace ID.
 
     The generated value will be pseudorandomly chosen from the provided

--- a/sentry_sdk/transport.py
+++ b/sentry_sdk/transport.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from abc import ABC, abstractmethod
 import io
 import os
@@ -14,6 +15,14 @@ try:
 except ImportError:
     brotli = None
 
+try:
+    import httpcore
+    import h2  # noqa: F401
+
+    HTTP2_ENABLED = True
+except ImportError:
+    HTTP2_ENABLED = False
+
 import urllib3
 import certifi
 
@@ -22,20 +31,23 @@ from sentry_sdk.utils import Dsn, logger, capture_internal_exceptions
 from sentry_sdk.worker import BackgroundWorker
 from sentry_sdk.envelope import Envelope, Item, PayloadRef
 
-from typing import TYPE_CHECKING, cast, List, Dict
+from typing import TYPE_CHECKING, cast
 
 if TYPE_CHECKING:
-    from typing import Any
-    from typing import Callable
-    from typing import DefaultDict
-    from typing import Iterable
-    from typing import Mapping
-    from typing import Optional
-    from typing import Self
-    from typing import Tuple
-    from typing import Type
-    from typing import Union
-
+    from typing import (
+        List,
+        Dict,
+        Any,
+        Callable,
+        DefaultDict,
+        Iterable,
+        Mapping,
+        Optional,
+        Tuple,
+        Type,
+        Union,
+        Self,
+    )
     from urllib3.poolmanager import PoolManager
     from urllib3.poolmanager import ProxyManager
 
@@ -62,10 +74,9 @@ class Transport(ABC):
     A transport is used to send an event to sentry.
     """
 
-    parsed_dsn = None  # type: Optional[Dsn]
+    parsed_dsn: Optional[Dsn] = None
 
-    def __init__(self, options=None):
-        # type: (Self, Optional[Dict[str, Any]]) -> None
+    def __init__(self: Self, options: Optional[Dict[str, Any]] = None) -> None:
         self.options = options
         if options and options["dsn"] is not None and options["dsn"]:
             self.parsed_dsn = Dsn(options["dsn"])
@@ -73,8 +84,7 @@ class Transport(ABC):
             self.parsed_dsn = None
 
     @abstractmethod
-    def capture_envelope(self, envelope):
-        # type: (Self, Envelope) -> None
+    def capture_envelope(self: Self, envelope: Envelope) -> None:
         """
         Send an envelope to Sentry.
 
@@ -85,11 +95,10 @@ class Transport(ABC):
         pass
 
     def flush(
-        self,
-        timeout,
-        callback=None,
-    ):
-        # type: (Self, float, Optional[Any]) -> None
+        self: Self,
+        timeout: float,
+        callback: Optional[Any] = None,
+    ) -> None:
         """
         Wait `timeout` seconds for the current events to be sent out.
 
@@ -98,8 +107,7 @@ class Transport(ABC):
         """
         return None
 
-    def kill(self):
-        # type: (Self) -> None
+    def kill(self: Self) -> None:
         """
         Forcefully kills the transport.
 
@@ -109,14 +117,13 @@ class Transport(ABC):
         return None
 
     def record_lost_event(
-        self,
-        reason,  # type: str
-        data_category=None,  # type: Optional[EventDataCategory]
-        item=None,  # type: Optional[Item]
+        self: Self,
+        reason: str,
+        data_category: Optional[EventDataCategory] = None,
+        item: Optional[Item] = None,
         *,
-        quantity=1,  # type: int
-    ):
-        # type: (...) -> None
+        quantity: int = 1,
+    ) -> None:
         """This increments a counter for event loss by reason and
         data category by the given positive-int quantity (default 1).
 
@@ -133,20 +140,19 @@ class Transport(ABC):
         """
         return None
 
-    def is_healthy(self):
-        # type: (Self) -> bool
+    def is_healthy(self: Self) -> bool:
         return True
 
-    def __del__(self):
-        # type: (Self) -> None
+    def __del__(self: Self) -> None:
         try:
             self.kill()
         except Exception:
             pass
 
 
-def _parse_rate_limits(header, now=None):
-    # type: (str, Optional[datetime]) -> Iterable[Tuple[Optional[EventDataCategory], datetime]]
+def _parse_rate_limits(
+    header: str, now: Optional[datetime] = None
+) -> Iterable[Tuple[Optional[EventDataCategory], datetime]]:
     if now is None:
         now = datetime.now(timezone.utc)
 
@@ -168,21 +174,20 @@ class BaseHttpTransport(Transport):
 
     TIMEOUT = 30  # seconds
 
-    def __init__(self, options):
-        # type: (Self, Dict[str, Any]) -> None
+    def __init__(self: Self, options: Dict[str, Any]) -> None:
         from sentry_sdk.consts import VERSION
 
         Transport.__init__(self, options)
         assert self.parsed_dsn is not None
-        self.options = options  # type: Dict[str, Any]
+        self.options: Dict[str, Any] = options
         self._worker = BackgroundWorker(queue_size=options["transport_queue_size"])
         self._auth = self.parsed_dsn.to_auth("sentry.python/%s" % VERSION)
-        self._disabled_until = {}  # type: Dict[Optional[EventDataCategory], datetime]
+        self._disabled_until: Dict[Optional[EventDataCategory], datetime] = {}
         # We only use this Retry() class for the `get_retry_after` method it exposes
         self._retry = urllib3.util.Retry()
-        self._discarded_events = defaultdict(
-            int
-        )  # type: DefaultDict[Tuple[EventDataCategory, str], int]
+        self._discarded_events: DefaultDict[Tuple[EventDataCategory, str], int] = (
+            defaultdict(int)
+        )
         self._last_client_report_sent = time.time()
 
         self._pool = self._make_pool()
@@ -227,14 +232,13 @@ class BaseHttpTransport(Transport):
             self._compression_level = 4
 
     def record_lost_event(
-        self,
-        reason,  # type: str
-        data_category=None,  # type: Optional[EventDataCategory]
-        item=None,  # type: Optional[Item]
+        self: Self,
+        reason: str,
+        data_category: Optional[EventDataCategory] = None,
+        item: Optional[Item] = None,
         *,
-        quantity=1,  # type: int
-    ):
-        # type: (...) -> None
+        quantity: int = 1,
+    ) -> None:
         if not self.options["send_client_reports"]:
             return
 
@@ -248,7 +252,7 @@ class BaseHttpTransport(Transport):
 
                 # +1 for the transaction itself
                 span_count = (
-                    len(cast(List[Dict[str, object]], event.get("spans") or [])) + 1
+                    len(cast("List[Dict[str, object]]", event.get("spans") or [])) + 1
                 )
                 self.record_lost_event(reason, "span", quantity=span_count)
 
@@ -262,12 +266,12 @@ class BaseHttpTransport(Transport):
 
         self._discarded_events[data_category, reason] += quantity
 
-    def _get_header_value(self, response, header):
-        # type: (Self, Any, str) -> Optional[str]
+    def _get_header_value(self: Self, response: Any, header: str) -> Optional[str]:
         return response.headers.get(header)
 
-    def _update_rate_limits(self, response):
-        # type: (Self, Union[urllib3.BaseHTTPResponse, httpcore.Response]) -> None
+    def _update_rate_limits(
+        self: Self, response: Union[urllib3.BaseHTTPResponse, httpcore.Response]
+    ) -> None:
 
         # new sentries with more rate limit insights.  We honor this header
         # no matter of the status code to update our internal rate limits.
@@ -292,16 +296,13 @@ class BaseHttpTransport(Transport):
             )
 
     def _send_request(
-        self,
-        body,
-        headers,
-        endpoint_type=EndpointType.ENVELOPE,
-        envelope=None,
-    ):
-        # type: (Self, bytes, Dict[str, str], EndpointType, Optional[Envelope]) -> None
-
-        def record_loss(reason):
-            # type: (str) -> None
+        self: Self,
+        body: bytes,
+        headers: Dict[str, str],
+        endpoint_type: EndpointType = EndpointType.ENVELOPE,
+        envelope: Optional[Envelope] = None,
+    ) -> None:
+        def record_loss(reason: str) -> None:
             if envelope is None:
                 self.record_lost_event(reason, data_category="error")
             else:
@@ -348,12 +349,12 @@ class BaseHttpTransport(Transport):
         finally:
             response.close()
 
-    def on_dropped_event(self, _reason):
-        # type: (Self, str) -> None
+    def on_dropped_event(self: Self, _reason: str) -> None:
         return None
 
-    def _fetch_pending_client_report(self, force=False, interval=60):
-        # type: (Self, bool, int) -> Optional[Item]
+    def _fetch_pending_client_report(
+        self: Self, force: bool = False, interval: int = 60
+    ) -> Optional[Item]:
         if not self.options["send_client_reports"]:
             return None
 
@@ -383,37 +384,30 @@ class BaseHttpTransport(Transport):
             type="client_report",
         )
 
-    def _flush_client_reports(self, force=False):
-        # type: (Self, bool) -> None
+    def _flush_client_reports(self: Self, force: bool = False) -> None:
         client_report = self._fetch_pending_client_report(force=force, interval=60)
         if client_report is not None:
             self.capture_envelope(Envelope(items=[client_report]))
 
-    def _check_disabled(self, category):
-        # type: (str) -> bool
-        def _disabled(bucket):
-            # type: (Any) -> bool
+    def _check_disabled(self: Self, category: EventDataCategory) -> bool:
+        def _disabled(bucket: Optional[EventDataCategory]) -> bool:
             ts = self._disabled_until.get(bucket)
             return ts is not None and ts > datetime.now(timezone.utc)
 
         return _disabled(category) or _disabled(None)
 
-    def _is_rate_limited(self):
-        # type: (Self) -> bool
+    def _is_rate_limited(self: Self) -> bool:
         return any(
             ts > datetime.now(timezone.utc) for ts in self._disabled_until.values()
         )
 
-    def _is_worker_full(self):
-        # type: (Self) -> bool
+    def _is_worker_full(self: Self) -> bool:
         return self._worker.full()
 
-    def is_healthy(self):
-        # type: (Self) -> bool
+    def is_healthy(self: Self) -> bool:
         return not (self._is_worker_full() or self._is_rate_limited())
 
-    def _send_envelope(self, envelope):
-        # type: (Self, Envelope) -> None
+    def _send_envelope(self: Self, envelope: Envelope) -> None:
 
         # remove all items from the envelope which are over quota
         new_items = []
@@ -465,8 +459,9 @@ class BaseHttpTransport(Transport):
         )
         return None
 
-    def _serialize_envelope(self, envelope):
-        # type: (Self, Envelope) -> tuple[Optional[str], io.BytesIO]
+    def _serialize_envelope(
+        self: Self, envelope: Envelope
+    ) -> tuple[Optional[str], io.BytesIO]:
         content_encoding = None
         body = io.BytesIO()
         if self._compression_level == 0 or self._compression_algo is None:
@@ -487,12 +482,10 @@ class BaseHttpTransport(Transport):
 
         return content_encoding, body
 
-    def _get_pool_options(self):
-        # type: (Self) -> Dict[str, Any]
+    def _get_pool_options(self: Self) -> Dict[str, Any]:
         raise NotImplementedError()
 
-    def _in_no_proxy(self, parsed_dsn):
-        # type: (Self, Dsn) -> bool
+    def _in_no_proxy(self: Self, parsed_dsn: Dsn) -> bool:
         no_proxy = getproxies().get("no")
         if not no_proxy:
             return False
@@ -502,26 +495,28 @@ class BaseHttpTransport(Transport):
                 return True
         return False
 
-    def _make_pool(self):
-        # type: (Self) -> Union[PoolManager, ProxyManager, httpcore.SOCKSProxy, httpcore.HTTPProxy, httpcore.ConnectionPool]
+    def _make_pool(
+        self: Self,
+    ) -> Union[
+        PoolManager,
+        ProxyManager,
+        httpcore.SOCKSProxy,
+        httpcore.HTTPProxy,
+        httpcore.ConnectionPool,
+    ]:
         raise NotImplementedError()
 
     def _request(
-        self,
-        method,
-        endpoint_type,
-        body,
-        headers,
-    ):
-        # type: (Self, str, EndpointType, Any, Mapping[str, str]) -> Union[urllib3.BaseHTTPResponse, httpcore.Response]
+        self: Self,
+        method: str,
+        endpoint_type: EndpointType,
+        body: Any,
+        headers: Mapping[str, str],
+    ) -> Union[urllib3.BaseHTTPResponse, httpcore.Response]:
         raise NotImplementedError()
 
-    def capture_envelope(
-        self, envelope  # type: Envelope
-    ):
-        # type: (...) -> None
-        def send_envelope_wrapper():
-            # type: () -> None
+    def capture_envelope(self: Self, envelope: Envelope) -> None:
+        def send_envelope_wrapper() -> None:
             with capture_internal_exceptions():
                 self._send_envelope(envelope)
                 self._flush_client_reports()
@@ -532,19 +527,17 @@ class BaseHttpTransport(Transport):
                 self.record_lost_event("queue_overflow", item=item)
 
     def flush(
-        self,
-        timeout,
-        callback=None,
-    ):
-        # type: (Self, float, Optional[Callable[[int, float], None]]) -> None
+        self: Self,
+        timeout: float,
+        callback: Optional[Callable[[int, float], None]] = None,
+    ) -> None:
         logger.debug("Flushing HTTP transport")
 
         if timeout > 0:
             self._worker.submit(lambda: self._flush_client_reports(force=True))
             self._worker.flush(timeout, callback)
 
-    def kill(self):
-        # type: (Self) -> None
+    def kill(self: Self) -> None:
         logger.debug("Killing HTTP transport")
         self._worker.kill()
 
@@ -553,8 +546,7 @@ class HttpTransport(BaseHttpTransport):
     if TYPE_CHECKING:
         _pool: Union[PoolManager, ProxyManager]
 
-    def _get_pool_options(self):
-        # type: (Self) -> Dict[str, Any]
+    def _get_pool_options(self: Self) -> Dict[str, Any]:
 
         num_pools = self.options.get("_experiments", {}).get("transport_num_pools")
         options = {
@@ -563,7 +555,7 @@ class HttpTransport(BaseHttpTransport):
             "timeout": urllib3.Timeout(total=self.TIMEOUT),
         }
 
-        socket_options = None  # type: Optional[List[Tuple[int, int, int | bytes]]]
+        socket_options: Optional[List[Tuple[int, int, int | bytes]]] = None
 
         if self.options["socket_options"] is not None:
             socket_options = self.options["socket_options"]
@@ -596,8 +588,7 @@ class HttpTransport(BaseHttpTransport):
 
         return options
 
-    def _make_pool(self):
-        # type: (Self) -> Union[PoolManager, ProxyManager]
+    def _make_pool(self: Self) -> Union[PoolManager, ProxyManager]:
         if self.parsed_dsn is None:
             raise ValueError("Cannot create HTTP-based transport without valid DSN")
 
@@ -643,13 +634,12 @@ class HttpTransport(BaseHttpTransport):
             return urllib3.PoolManager(**opts)
 
     def _request(
-        self,
-        method,
-        endpoint_type,
-        body,
-        headers,
-    ):
-        # type: (Self, str, EndpointType, Any, Mapping[str, str]) -> urllib3.BaseHTTPResponse
+        self: Self,
+        method: str,
+        endpoint_type: EndpointType,
+        body: Any,
+        headers: Mapping[str, str],
+    ) -> urllib3.BaseHTTPResponse:
         return self._pool.request(
             method,
             self._auth.get_api_url(endpoint_type),
@@ -658,14 +648,10 @@ class HttpTransport(BaseHttpTransport):
         )
 
 
-try:
-    import httpcore
-    import h2  # noqa: F401
-except ImportError:
+if not HTTP2_ENABLED:
     # Sorry, no Http2Transport for you
     class Http2Transport(HttpTransport):
-        def __init__(self, options):
-            # type: (Self, Dict[str, Any]) -> None
+        def __init__(self: Self, options: Dict[str, Any]) -> None:
             super().__init__(options)
             logger.warning(
                 "You tried to use HTTP2Transport but don't have httpcore[http2] installed. Falling back to HTTPTransport."
@@ -683,8 +669,7 @@ else:
                 httpcore.SOCKSProxy, httpcore.HTTPProxy, httpcore.ConnectionPool
             ]
 
-        def _get_header_value(self, response, header):
-            # type: (Self, httpcore.Response, str) -> Optional[str]
+        def _get_header_value(self: Self, response: Any, header: str) -> Optional[str]:
             return next(
                 (
                     val.decode("ascii")
@@ -695,13 +680,12 @@ else:
             )
 
         def _request(
-            self,
-            method,
-            endpoint_type,
-            body,
-            headers,
-        ):
-            # type: (Self, str, EndpointType, Any, Mapping[str, str]) -> httpcore.Response
+            self: Self,
+            method: str,
+            endpoint_type: EndpointType,
+            body: Any,
+            headers: Mapping[str, str],
+        ) -> httpcore.Response:
             response = self._pool.request(
                 method,
                 self._auth.get_api_url(endpoint_type),
@@ -718,13 +702,12 @@ else:
             )
             return response
 
-        def _get_pool_options(self):
-            # type: (Self) -> Dict[str, Any]
-            options = {
+        def _get_pool_options(self: Self) -> Dict[str, Any]:
+            options: Dict[str, Any] = {
                 "http2": self.parsed_dsn is not None
                 and self.parsed_dsn.scheme == "https",
                 "retries": 3,
-            }  # type: Dict[str, Any]
+            }
 
             socket_options = (
                 self.options["socket_options"]
@@ -755,8 +738,9 @@ else:
 
             return options
 
-        def _make_pool(self):
-            # type: (Self) -> Union[httpcore.SOCKSProxy, httpcore.HTTPProxy, httpcore.ConnectionPool]
+        def _make_pool(
+            self: Self,
+        ) -> Union[httpcore.SOCKSProxy, httpcore.HTTPProxy, httpcore.ConnectionPool]:
             if self.parsed_dsn is None:
                 raise ValueError("Cannot create HTTP-based transport without valid DSN")
             proxy = None
@@ -799,16 +783,15 @@ else:
             return httpcore.ConnectionPool(**opts)
 
 
-def make_transport(options):
-    # type: (Dict[str, Any]) -> Optional[Transport]
+def make_transport(options: Dict[str, Any]) -> Optional[Transport]:
     ref_transport = options["transport"]
 
     use_http2_transport = options.get("_experiments", {}).get("transport_http2", False)
 
     # By default, we use the http transport class
-    transport_cls = (
+    transport_cls: Type[Transport] = (
         Http2Transport if use_http2_transport else HttpTransport
-    )  # type: Type[Transport]
+    )
 
     if isinstance(ref_transport, Transport):
         return ref_transport

--- a/sentry_sdk/utils.py
+++ b/sentry_sdk/utils.py
@@ -1561,10 +1561,11 @@ def parse_url(url: str, sanitize: bool = True) -> ParsedUrl:
     )
 
 
-def is_valid_sample_rate(rate: Any, source: str) -> bool:
+def is_valid_sample_rate(rate: Any, source: str) -> Optional[float]:
     """
     Checks the given sample rate to make sure it is valid type and value (a
     boolean or a number between 0 and 1, inclusive).
+    Returns the final float value to use if valid.
     """
 
     # both booleans and NaN are instances of Real, so a) checking for Real
@@ -1576,7 +1577,7 @@ def is_valid_sample_rate(rate: Any, source: str) -> bool:
                 source=source, rate=rate, type=type(rate)
             )
         )
-        return False
+        return None
 
     # in case rate is a boolean, it will get cast to 1 if it's True and 0 if it's False
     rate = float(rate)
@@ -1586,9 +1587,9 @@ def is_valid_sample_rate(rate: Any, source: str) -> bool:
                 source=source, rate=rate
             )
         )
-        return False
+        return None
 
-    return True
+    return rate
 
 
 def match_regex_list(

--- a/sentry_sdk/utils.py
+++ b/sentry_sdk/utils.py
@@ -1027,14 +1027,10 @@ def exc_info_from_error(error: Union[BaseException, ExcInfo]) -> ExcInfo:
     else:
         raise ValueError("Expected Exception object to report, got %s!" % type(error))
 
-    exc_info = (exc_type, exc_value, tb)
-
-    if TYPE_CHECKING:
-        # This cast is safe because exc_type and exc_value are either both
-        # None or both not None.
-        exc_info = cast("ExcInfo", exc_info)
-
-    return exc_info
+    if exc_type is not None and exc_value is not None:
+        return (exc_type, exc_value, tb)
+    else:
+        return (None, None, None)
 
 
 def merge_stack_frames(

--- a/sentry_sdk/worker.py
+++ b/sentry_sdk/worker.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import os
 import threading
 
@@ -9,38 +10,32 @@ from sentry_sdk.consts import DEFAULT_QUEUE_SIZE
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from typing import Any
-    from typing import Optional
-    from typing import Callable
+    from typing import Any, Optional, Callable
 
 
 _TERMINATOR = object()
 
 
 class BackgroundWorker:
-    def __init__(self, queue_size=DEFAULT_QUEUE_SIZE):
-        # type: (int) -> None
-        self._queue = Queue(queue_size)  # type: Queue
+    def __init__(self, queue_size: int = DEFAULT_QUEUE_SIZE) -> None:
+        self._queue: Queue = Queue(queue_size)
         self._lock = threading.Lock()
-        self._thread = None  # type: Optional[threading.Thread]
-        self._thread_for_pid = None  # type: Optional[int]
+        self._thread: Optional[threading.Thread] = None
+        self._thread_for_pid: Optional[int] = None
 
     @property
-    def is_alive(self):
-        # type: () -> bool
+    def is_alive(self) -> bool:
         if self._thread_for_pid != os.getpid():
             return False
         if not self._thread:
             return False
         return self._thread.is_alive()
 
-    def _ensure_thread(self):
-        # type: () -> None
+    def _ensure_thread(self) -> None:
         if not self.is_alive:
             self.start()
 
-    def _timed_queue_join(self, timeout):
-        # type: (float) -> bool
+    def _timed_queue_join(self, timeout: float) -> bool:
         deadline = time() + timeout
         queue = self._queue
 
@@ -57,8 +52,7 @@ class BackgroundWorker:
         finally:
             queue.all_tasks_done.release()
 
-    def start(self):
-        # type: () -> None
+    def start(self) -> None:
         with self._lock:
             if not self.is_alive:
                 self._thread = threading.Thread(
@@ -74,8 +68,7 @@ class BackgroundWorker:
                     # send out events.
                     self._thread = None
 
-    def kill(self):
-        # type: () -> None
+    def kill(self) -> None:
         """
         Kill worker thread. Returns immediately. Not useful for
         waiting on shutdown for events, use `flush` for that.
@@ -91,20 +84,17 @@ class BackgroundWorker:
                 self._thread = None
                 self._thread_for_pid = None
 
-    def flush(self, timeout, callback=None):
-        # type: (float, Optional[Any]) -> None
+    def flush(self, timeout: float, callback: Optional[Any] = None) -> None:
         logger.debug("background worker got flush request")
         with self._lock:
             if self.is_alive and timeout > 0.0:
                 self._wait_flush(timeout, callback)
         logger.debug("background worker flushed")
 
-    def full(self):
-        # type: () -> bool
+    def full(self) -> bool:
         return self._queue.full()
 
-    def _wait_flush(self, timeout, callback):
-        # type: (float, Optional[Any]) -> None
+    def _wait_flush(self, timeout: float, callback: Optional[Any]) -> None:
         initial_timeout = min(0.1, timeout)
         if not self._timed_queue_join(initial_timeout):
             pending = self._queue.qsize() + 1
@@ -116,8 +106,7 @@ class BackgroundWorker:
                 pending = self._queue.qsize() + 1
                 logger.error("flush timed out, dropped %s events", pending)
 
-    def submit(self, callback):
-        # type: (Callable[[], None]) -> bool
+    def submit(self, callback: Callable[[], None]) -> bool:
         self._ensure_thread()
         try:
             self._queue.put_nowait(callback)
@@ -125,8 +114,7 @@ class BackgroundWorker:
         except FullError:
             return False
 
-    def _target(self):
-        # type: () -> None
+    def _target(self) -> None:
         while True:
             callback = self._queue.get()
             try:

--- a/tests/integrations/logging/test_logging.py
+++ b/tests/integrations/logging/test_logging.py
@@ -259,8 +259,8 @@ def test_logging_captured_warnings(sentry_init, capture_events, recwarn):
     assert events[1]["logentry"]["params"] == []
 
     # Using recwarn suppresses the "third" warning in the test output
-    assert len(recwarn) == 1
-    assert str(recwarn[0].message) == "third"
+    third_warnings = [w for w in recwarn if str(w.message) == "third"]
+    assert len(third_warnings) == 1
 
 
 def test_ignore_logger(sentry_init, capture_events):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -493,7 +493,7 @@ def test_accepts_valid_sample_rate(rate):
     with mock.patch.object(logger, "warning", mock.Mock()):
         result = is_valid_sample_rate(rate, source="Testing")
         assert logger.warning.called is False
-        assert result is True
+        assert result == float(rate)
 
 
 @pytest.mark.parametrize(
@@ -514,7 +514,7 @@ def test_warns_on_invalid_sample_rate(rate, StringContaining):  # noqa: N803
     with mock.patch.object(logger, "warning", mock.Mock()):
         result = is_valid_sample_rate(rate, source="Testing")
         logger.warning.assert_any_call(StringContaining("Given sample rate is invalid"))
-        assert result is False
+        assert result is None
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
extracted from https://github.com/getsentry/sentry-python/pull/4487/files with lots of manual fixes

* migrate old style `# type: bla` to inline types
* most importantly use [`__future__.annotations`](https://peps.python.org/pep-0563/#enabling-the-future-behavior-in-python-3-7) so that we can simply use forward annotations without wrapping them in strings like we did before, this simplifies things substantially
* also guard only things that shouldn't be imported under `TYPE_CHECKING`, in the future it seems we should avoid using `TYPE_CHECKING` completely
* https://github.com/getsentry/sentry-python/pull/4510
* https://github.com/getsentry/sentry-python/pull/4522
* https://github.com/getsentry/sentry-python/pull/4529
* https://github.com/getsentry/sentry-python/pull/4530
* https://github.com/getsentry/sentry-python/pull/4532
* https://github.com/getsentry/sentry-python/pull/4533
* https://github.com/getsentry/sentry-python/pull/4534

closes https://github.com/getsentry/sentry-python/issues/2585