### PR TITLE
fix(ci): Remove tracerite pin (almost)

### DIFF
--- a/scripts/populate_tox/tox.jinja
+++ b/scripts/populate_tox/tox.jinja
@@ -329,6 +329,7 @@ deps =
     sanic-v{24.6}: sanic_testing
     sanic-latest: sanic_testing
     {py3.6}-sanic: aiocontextvars==0.2.1
+    {py3.8}-sanic: tracerite<1.1.2
     sanic-v0.8: sanic~=0.8.0
     sanic-v20: sanic~=20.0
     sanic-v24.6: sanic~=24.6.0

--- a/tox.ini
+++ b/tox.ini
@@ -490,6 +490,7 @@ deps =
     sanic-v{24.6}: sanic_testing
     sanic-latest: sanic_testing
     {py3.6}-sanic: aiocontextvars==0.2.1
+    {py3.8}-sanic: tracerite<1.1.2
     sanic-v0.8: sanic~=0.8.0
     sanic-v20: sanic~=20.0
     sanic-v24.6: sanic~=24.6.0


### PR DESCRIPTION
This partially reverts commit 3f9acc4cf74da1543a2b8fc14799ed186ef58053.

- tracerite 1.12 contained syntax that did not work on Python 3.x
- tracerite 1.13 was then released, containing a fix
- however, on Python 3.8 newest tracerite seems to be using importlib features that were only added in 3.9 (see below), so still pinning it to an older version there

```
Traceback:
.tox/py3.8-sanic-v24.6/lib/python3.8/site-packages/_pytest/python.py:493: in importtestmodule
    mod = import_path(
.tox/py3.8-sanic-v24.6/lib/python3.8/site-packages/_pytest/pathlib.py:587: in import_path
    importlib.import_module(module_name)
../../.pyenv/versions/3.8.18/lib/python3.8/importlib/__init__.py:127: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
<frozen importlib._bootstrap>:1014: in _gcd_import
    ???
<frozen importlib._bootstrap>:991: in _find_and_load
    ???
<frozen importlib._bootstrap>:961: in _find_and_load_unlocked
    ???
<frozen importlib._bootstrap>:219: in _call_with_frames_removed
    ???
<frozen importlib._bootstrap>:1014: in _gcd_import
    ???
<frozen importlib._bootstrap>:991: in _find_and_load
    ???
<frozen importlib._bootstrap>:975: in _find_and_load_unlocked
    ???
<frozen importlib._bootstrap>:671: in _load_unlocked
    ???
<frozen importlib._bootstrap_external>:843: in exec_module
    ???
<frozen importlib._bootstrap>:219: in _call_with_frames_removed
    ???
tests/integrations/sanic/__init__.py:3: in <module>
    import sanic
.tox/py3.8-sanic-v24.6/lib/python3.8/site-packages/sanic/__init__.py:6: in <module>
    from sanic.app import Sanic
.tox/py3.8-sanic-v24.6/lib/python3.8/site-packages/sanic/app.py:58: in <module>
    from sanic.application.state import ApplicationState, ServerStage
.tox/py3.8-sanic-v24.6/lib/python3.8/site-packages/sanic/application/state.py:13: in <module>
    from sanic.server.async_server import AsyncioServer
.tox/py3.8-sanic-v24.6/lib/python3.8/site-packages/sanic/server/__init__.py:5: in <module>
    from sanic.server.runners import serve
.tox/py3.8-sanic-v24.6/lib/python3.8/site-packages/sanic/server/runners.py:6: in <module>
    from sanic.config import Config
.tox/py3.8-sanic-v24.6/lib/python3.8/site-packages/sanic/config.py:13: in <module>
    from sanic.errorpages import DEFAULT_FORMAT, check_error_format
.tox/py3.8-sanic-v24.6/lib/python3.8/site-packages/sanic/errorpages.py:27: in <module>
    from sanic.pages.error import ErrorPage
.tox/py3.8-sanic-v24.6/lib/python3.8/site-packages/sanic/pages/error.py:3: in <module>
    import tracerite.html
.tox/py3.8-sanic-v24.6/lib/python3.8/site-packages/tracerite/__init__.py:1: in <module>
    from .html import html_traceback
.tox/py3.8-sanic-v24.6/lib/python3.8/site-packages/tracerite/html.py:5: in <module>
    from importlib.resources import files
E   ImportError: cannot import name 'files' from 'importlib.resources' (/Users/ivana/.pyenv/versions/3.8.18/lib/python3.8/importlib/resources.py)
```