### PR TITLE
Migrate typing for opentelemetry files

### DIFF
--- a/sentry_sdk/opentelemetry/span_processor.py
+++ b/sentry_sdk/opentelemetry/span_processor.py
@@ -247,7 +247,7 @@ class SentrySpanProcessor(SpanProcessor):
         if not span.context:
             return None
 
-        # need ot ignore the type here due to TypedDict nonsense
+        # need to ignore the type here due to TypedDict nonsense
         span_json: Optional[dict[str, Any]] = self._common_span_transaction_attributes_as_json(span)  # type: ignore
         if span_json is None:
             return None

--- a/sentry_sdk/opentelemetry/span_processor.py
+++ b/sentry_sdk/opentelemetry/span_processor.py
@@ -1,5 +1,5 @@
+from __future__ import annotations
 from collections import deque, defaultdict
-from typing import cast
 
 from opentelemetry.trace import (
     format_trace_id,
@@ -52,30 +52,24 @@ class SentrySpanProcessor(SpanProcessor):
     Converts OTel spans into Sentry spans so they can be sent to the Sentry backend.
     """
 
-    def __new__(cls):
-        # type: () -> SentrySpanProcessor
+    def __new__(cls) -> SentrySpanProcessor:
         if not hasattr(cls, "instance"):
             cls.instance = super().__new__(cls)
 
         return cls.instance
 
-    def __init__(self):
-        # type: () -> None
-        self._children_spans = defaultdict(
-            list
-        )  # type: DefaultDict[int, List[ReadableSpan]]
-        self._dropped_spans = defaultdict(lambda: 0)  # type: DefaultDict[int, int]
+    def __init__(self) -> None:
+        self._children_spans: DefaultDict[int, List[ReadableSpan]] = defaultdict(list)
+        self._dropped_spans: DefaultDict[int, int] = defaultdict(lambda: 0)
 
-    def on_start(self, span, parent_context=None):
-        # type: (Span, Optional[Context]) -> None
+    def on_start(self, span: Span, parent_context: Optional[Context] = None) -> None:
         if is_sentry_span(span):
             return
 
         self._add_root_span(span, get_current_span(parent_context))
         self._start_profile(span)
 
-    def on_end(self, span):
-        # type: (ReadableSpan) -> None
+    def on_end(self, span: ReadableSpan) -> None:
         if is_sentry_span(span):
             return
 
@@ -88,18 +82,15 @@ class SentrySpanProcessor(SpanProcessor):
             self._append_child_span(span)
 
     # TODO-neel-potel not sure we need a clear like JS
-    def shutdown(self):
-        # type: () -> None
+    def shutdown(self) -> None:
         pass
 
     # TODO-neel-potel change default? this is 30 sec
     # TODO-neel-potel call this in client.flush
-    def force_flush(self, timeout_millis=30000):
-        # type: (int) -> bool
+    def force_flush(self, timeout_millis: int = 30000) -> bool:
         return True
 
-    def _add_root_span(self, span, parent_span):
-        # type: (Span, AbstractSpan) -> None
+    def _add_root_span(self, span: Span, parent_span: AbstractSpan) -> None:
         """
         This is required to make Span.root_span work
         since we can't traverse back to the root purely with otel efficiently.
@@ -112,8 +103,7 @@ class SentrySpanProcessor(SpanProcessor):
             # root span points to itself
             set_sentry_meta(span, "root_span", span)
 
-    def _start_profile(self, span):
-        # type: (Span) -> None
+    def _start_profile(self, span: Span) -> None:
         try_autostart_continuous_profiler()
 
         profiler_id = get_profiler_id()
@@ -148,14 +138,12 @@ class SentrySpanProcessor(SpanProcessor):
                 span.set_attribute(SPANDATA.PROFILER_ID, profiler_id)
             set_sentry_meta(span, "continuous_profile", continuous_profile)
 
-    def _stop_profile(self, span):
-        # type: (ReadableSpan) -> None
+    def _stop_profile(self, span: ReadableSpan) -> None:
         continuous_profiler = get_sentry_meta(span, "continuous_profile")
         if continuous_profiler:
             continuous_profiler.stop()
 
-    def _flush_root_span(self, span):
-        # type: (ReadableSpan) -> None
+    def _flush_root_span(self, span: ReadableSpan) -> None:
         transaction_event = self._root_span_to_transaction_event(span)
         if not transaction_event:
             return
@@ -176,8 +164,7 @@ class SentrySpanProcessor(SpanProcessor):
         sentry_sdk.capture_event(transaction_event)
         self._cleanup_references([span] + collected_spans)
 
-    def _append_child_span(self, span):
-        # type: (ReadableSpan) -> None
+    def _append_child_span(self, span: ReadableSpan) -> None:
         if not span.parent:
             return
 
@@ -192,14 +179,13 @@ class SentrySpanProcessor(SpanProcessor):
         else:
             self._dropped_spans[span.parent.span_id] += 1
 
-    def _collect_children(self, span):
-        # type: (ReadableSpan) -> tuple[List[ReadableSpan], int]
+    def _collect_children(self, span: ReadableSpan) -> tuple[List[ReadableSpan], int]:
         if not span.context:
             return [], 0
 
         children = []
         dropped_spans = 0
-        bfs_queue = deque()  # type: Deque[int]
+        bfs_queue: Deque[int] = deque()
         bfs_queue.append(span.context.span_id)
 
         while bfs_queue:
@@ -215,8 +201,7 @@ class SentrySpanProcessor(SpanProcessor):
 
     # we construct the event from scratch here
     # and not use the current Transaction class for easier refactoring
-    def _root_span_to_transaction_event(self, span):
-        # type: (ReadableSpan) -> Optional[Event]
+    def _root_span_to_transaction_event(self, span: ReadableSpan) -> Optional[Event]:
         if not span.context:
             return None
 
@@ -250,23 +235,20 @@ class SentrySpanProcessor(SpanProcessor):
             }
         )
 
-        profile = cast("Optional[Profile]", get_sentry_meta(span, "profile"))
-        if profile:
+        profile = get_sentry_meta(span, "profile")
+        if profile is not None and isinstance(profile, Profile):
             profile.__exit__(None, None, None)
             if profile.valid():
                 event["profile"] = profile
 
         return event
 
-    def _span_to_json(self, span):
-        # type: (ReadableSpan) -> Optional[dict[str, Any]]
+    def _span_to_json(self, span: ReadableSpan) -> Optional[dict[str, Any]]:
         if not span.context:
             return None
 
-        # This is a safe cast because dict[str, Any] is a superset of Event
-        span_json = cast(
-            "dict[str, Any]", self._common_span_transaction_attributes_as_json(span)
-        )
+        # need ot ignore the type here due to TypedDict nonsense
+        span_json: Optional[dict[str, Any]] = self._common_span_transaction_attributes_as_json(span)  # type: ignore
         if span_json is None:
             return None
 
@@ -299,15 +281,16 @@ class SentrySpanProcessor(SpanProcessor):
 
         return span_json
 
-    def _common_span_transaction_attributes_as_json(self, span):
-        # type: (ReadableSpan) -> Optional[Event]
+    def _common_span_transaction_attributes_as_json(
+        self, span: ReadableSpan
+    ) -> Optional[Event]:
         if not span.start_time or not span.end_time:
             return None
 
-        common_json = {
+        common_json: Event = {
             "start_timestamp": convert_from_otel_timestamp(span.start_time),
             "timestamp": convert_from_otel_timestamp(span.end_time),
-        }  # type: Event
+        }
 
         tags = extract_span_attributes(span, SentrySpanAttribute.TAG)
         if tags:
@@ -315,13 +298,11 @@ class SentrySpanProcessor(SpanProcessor):
 
         return common_json
 
-    def _cleanup_references(self, spans):
-        # type: (List[ReadableSpan]) -> None
+    def _cleanup_references(self, spans: List[ReadableSpan]) -> None:
         for span in spans:
             delete_sentry_meta(span)
 
-    def _log_debug_info(self):
-        # type: () -> None
+    def _log_debug_info(self) -> None:
         import pprint
 
         pprint.pprint(

--- a/sentry_sdk/opentelemetry/tracing.py
+++ b/sentry_sdk/opentelemetry/tracing.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from opentelemetry import trace
 from opentelemetry.propagate import set_global_textmap
 from opentelemetry.sdk.trace import TracerProvider, Span, ReadableSpan
@@ -10,16 +11,14 @@ from sentry_sdk.opentelemetry import (
 from sentry_sdk.utils import logger
 
 
-def patch_readable_span():
-    # type: () -> None
+def patch_readable_span() -> None:
     """
     We need to pass through sentry specific metadata/objects from Span to ReadableSpan
     to work with them consistently in the SpanProcessor.
     """
     old_readable_span = Span._readable_span
 
-    def sentry_patched_readable_span(self):
-        # type: (Span) -> ReadableSpan
+    def sentry_patched_readable_span(self: Span) -> ReadableSpan:
         readable_span = old_readable_span(self)
         readable_span._sentry_meta = getattr(self, "_sentry_meta", {})  # type: ignore[attr-defined]
         return readable_span
@@ -27,8 +26,7 @@ def patch_readable_span():
     Span._readable_span = sentry_patched_readable_span  # type: ignore[method-assign]
 
 
-def setup_sentry_tracing():
-    # type: () -> None
+def setup_sentry_tracing() -> None:
     # TracerProvider can only be set once. If we're the first ones setting it,
     # there's no issue. If it already exists, we need to patch it.
     from opentelemetry.trace import _TRACER_PROVIDER

--- a/sentry_sdk/opentelemetry/utils.py
+++ b/sentry_sdk/opentelemetry/utils.py
@@ -66,9 +66,8 @@ def is_sentry_span(span: ReadableSpan) -> bool:
     if not span.attributes:
         return False
 
-    span_url = span.attributes.get(SpanAttributes.HTTP_URL, None)
-
-    if span_url is None or not isinstance(span_url, str):
+    span_url = get_typed_attribute(span.attributes, SpanAttributes.HTTP_URL, str)
+    if span_url is None:
         return False
 
     dsn_url = None

--- a/sentry_sdk/opentelemetry/utils.py
+++ b/sentry_sdk/opentelemetry/utils.py
@@ -1,5 +1,5 @@
+from __future__ import annotations
 import re
-from typing import cast
 from datetime import datetime, timezone
 
 from urllib3.util import parse_url as urlparse
@@ -30,8 +30,10 @@ from sentry_sdk.tracing_utils import Baggage, get_span_status_from_http_code
 from sentry_sdk._types import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from typing import Any, Optional, Mapping, Sequence, Union
+    from typing import Any, Optional, Mapping, Sequence, Union, Type, TypeVar
     from sentry_sdk._types import OtelExtractedSpanData
+
+    T = TypeVar("T")
 
 
 GRPC_ERROR_MAP = {
@@ -54,8 +56,7 @@ GRPC_ERROR_MAP = {
 }
 
 
-def is_sentry_span(span):
-    # type: (ReadableSpan) -> bool
+def is_sentry_span(span: ReadableSpan) -> bool:
     """
     Break infinite loop:
     HTTP requests to Sentry are caught by OTel and send again to Sentry.
@@ -66,9 +67,8 @@ def is_sentry_span(span):
         return False
 
     span_url = span.attributes.get(SpanAttributes.HTTP_URL, None)
-    span_url = cast("Optional[str]", span_url)
 
-    if not span_url:
+    if span_url is None or not isinstance(span_url, str):
         return False
 
     dsn_url = None
@@ -89,32 +89,30 @@ def is_sentry_span(span):
     return False
 
 
-def convert_from_otel_timestamp(time):
-    # type: (int) -> datetime
+def convert_from_otel_timestamp(time: int) -> datetime:
     """Convert an OTel nanosecond-level timestamp to a datetime."""
     return datetime.fromtimestamp(time / 1e9, timezone.utc)
 
 
-def convert_to_otel_timestamp(time):
-    # type: (Union[datetime, float]) -> int
+def convert_to_otel_timestamp(time: Union[datetime, float]) -> int:
     """Convert a datetime to an OTel timestamp (with nanosecond precision)."""
     if isinstance(time, datetime):
         return int(time.timestamp() * 1e9)
     return int(time * 1e9)
 
 
-def extract_transaction_name_source(span):
-    # type: (ReadableSpan) -> tuple[Optional[str], Optional[str]]
+def extract_transaction_name_source(
+    span: ReadableSpan,
+) -> tuple[Optional[str], Optional[str]]:
     if not span.attributes:
         return (None, None)
     return (
-        cast("Optional[str]", span.attributes.get(SentrySpanAttribute.NAME)),
-        cast("Optional[str]", span.attributes.get(SentrySpanAttribute.SOURCE)),
+        get_typed_attribute(span.attributes, SentrySpanAttribute.NAME, str),
+        get_typed_attribute(span.attributes, SentrySpanAttribute.SOURCE, str),
     )
 
 
-def extract_span_data(span):
-    # type: (ReadableSpan) -> OtelExtractedSpanData
+def extract_span_data(span: ReadableSpan) -> OtelExtractedSpanData:
     op = span.name
     description = span.name
     status, http_status = extract_span_status(span)
@@ -122,15 +120,15 @@ def extract_span_data(span):
     if span.attributes is None:
         return (op, description, status, http_status, origin)
 
-    attribute_op = cast("Optional[str]", span.attributes.get(SentrySpanAttribute.OP))
+    attribute_op = get_typed_attribute(span.attributes, SentrySpanAttribute.OP, str)
     op = attribute_op or op
-    description = cast(
-        "str", span.attributes.get(SentrySpanAttribute.DESCRIPTION) or description
+    description = (
+        get_typed_attribute(span.attributes, SentrySpanAttribute.DESCRIPTION, str)
+        or description
     )
-    origin = cast("Optional[str]", span.attributes.get(SentrySpanAttribute.ORIGIN))
+    origin = get_typed_attribute(span.attributes, SentrySpanAttribute.ORIGIN, str)
 
-    http_method = span.attributes.get(SpanAttributes.HTTP_METHOD)
-    http_method = cast("Optional[str]", http_method)
+    http_method = get_typed_attribute(span.attributes, SpanAttributes.HTTP_METHOD, str)
     if http_method:
         return span_data_for_http_method(span)
 
@@ -165,11 +163,10 @@ def extract_span_data(span):
     return (op, description, status, http_status, origin)
 
 
-def span_data_for_http_method(span):
-    # type: (ReadableSpan) -> OtelExtractedSpanData
+def span_data_for_http_method(span: ReadableSpan) -> OtelExtractedSpanData:
     span_attributes = span.attributes or {}
 
-    op = cast("Optional[str]", span_attributes.get(SentrySpanAttribute.OP))
+    op = get_typed_attribute(span_attributes, SentrySpanAttribute.OP, str)
     if op is None:
         op = "http"
 
@@ -184,10 +181,9 @@ def span_data_for_http_method(span):
     peer_name = span_attributes.get(SpanAttributes.NET_PEER_NAME)
 
     # TODO-neel-potel remove description completely
-    description = span_attributes.get(
-        SentrySpanAttribute.DESCRIPTION
-    ) or span_attributes.get(SentrySpanAttribute.NAME)
-    description = cast("Optional[str]", description)
+    description = get_typed_attribute(
+        span_attributes, SentrySpanAttribute.DESCRIPTION, str
+    ) or get_typed_attribute(span_attributes, SentrySpanAttribute.NAME, str)
     if description is None:
         description = f"{http_method}"
 
@@ -199,7 +195,7 @@ def span_data_for_http_method(span):
             description = f"{http_method} {peer_name}"
         else:
             url = span_attributes.get(SpanAttributes.HTTP_URL)
-            url = cast("Optional[str]", url)
+            url = get_typed_attribute(span_attributes, SpanAttributes.HTTP_URL, str)
 
             if url:
                 parsed_url = urlparse(url)
@@ -210,28 +206,24 @@ def span_data_for_http_method(span):
 
     status, http_status = extract_span_status(span)
 
-    origin = cast("Optional[str]", span_attributes.get(SentrySpanAttribute.ORIGIN))
+    origin = get_typed_attribute(span_attributes, SentrySpanAttribute.ORIGIN, str)
 
     return (op, description, status, http_status, origin)
 
 
-def span_data_for_db_query(span):
-    # type: (ReadableSpan) -> OtelExtractedSpanData
+def span_data_for_db_query(span: ReadableSpan) -> OtelExtractedSpanData:
     span_attributes = span.attributes or {}
 
-    op = cast("str", span_attributes.get(SentrySpanAttribute.OP, OP.DB))
-
-    statement = span_attributes.get(SpanAttributes.DB_STATEMENT, None)
-    statement = cast("Optional[str]", statement)
+    op = get_typed_attribute(span_attributes, SentrySpanAttribute.OP, str) or OP.DB
+    statement = get_typed_attribute(span_attributes, SpanAttributes.DB_STATEMENT, str)
 
     description = statement or span.name
-    origin = cast("Optional[str]", span_attributes.get(SentrySpanAttribute.ORIGIN))
+    origin = get_typed_attribute(span_attributes, SentrySpanAttribute.ORIGIN, str)
 
     return (op, description, None, None, origin)
 
 
-def extract_span_status(span):
-    # type: (ReadableSpan) -> tuple[Optional[str], Optional[int]]
+def extract_span_status(span: ReadableSpan) -> tuple[Optional[str], Optional[int]]:
     span_attributes = span.attributes or {}
     status = span.status or None
 
@@ -266,8 +258,19 @@ def extract_span_status(span):
         return (SPANSTATUS.UNKNOWN_ERROR, None)
 
 
-def infer_status_from_attributes(span_attributes):
-    # type: (Mapping[str, str | bool | int | float | Sequence[str] | Sequence[bool] | Sequence[int] | Sequence[float]]) -> tuple[Optional[str], Optional[int]]
+def infer_status_from_attributes(
+    span_attributes: Mapping[
+        str,
+        str
+        | bool
+        | int
+        | float
+        | Sequence[str]
+        | Sequence[bool]
+        | Sequence[int]
+        | Sequence[float],
+    ],
+) -> tuple[Optional[str], Optional[int]]:
     http_status = get_http_status_code(span_attributes)
 
     if http_status:
@@ -280,10 +283,23 @@ def infer_status_from_attributes(span_attributes):
     return (None, None)
 
 
-def get_http_status_code(span_attributes):
-    # type: (Mapping[str, str | bool | int | float | Sequence[str] | Sequence[bool] | Sequence[int] | Sequence[float]]) -> Optional[int]
+def get_http_status_code(
+    span_attributes: Mapping[
+        str,
+        str
+        | bool
+        | int
+        | float
+        | Sequence[str]
+        | Sequence[bool]
+        | Sequence[int]
+        | Sequence[float],
+    ],
+) -> Optional[int]:
     try:
-        http_status = span_attributes.get(SpanAttributes.HTTP_RESPONSE_STATUS_CODE)
+        http_status = get_typed_attribute(
+            span_attributes, SpanAttributes.HTTP_RESPONSE_STATUS_CODE, int
+        )
     except AttributeError:
         # HTTP_RESPONSE_STATUS_CODE was added in 1.21, so if we're on an older
         # OTel version SpanAttributes.HTTP_RESPONSE_STATUS_CODE will throw an
@@ -292,19 +308,18 @@ def get_http_status_code(span_attributes):
 
     if http_status is None:
         # Fall back to the deprecated attribute
-        http_status = span_attributes.get(SpanAttributes.HTTP_STATUS_CODE)
-
-    http_status = cast("Optional[int]", http_status)
+        http_status = get_typed_attribute(
+            span_attributes, SpanAttributes.HTTP_STATUS_CODE, int
+        )
 
     return http_status
 
 
-def extract_span_attributes(span, namespace):
-    # type: (ReadableSpan, str) -> dict[str, Any]
+def extract_span_attributes(span: ReadableSpan, namespace: str) -> dict[str, Any]:
     """
     Extract Sentry-specific span attributes and make them look the way Sentry expects.
     """
-    extracted_attrs = {}  # type: dict[str, Any]
+    extracted_attrs: dict[str, Any] = {}
 
     for attr, value in (span.attributes or {}).items():
         if attr.startswith(namespace):
@@ -314,8 +329,9 @@ def extract_span_attributes(span, namespace):
     return extracted_attrs
 
 
-def get_trace_context(span, span_data=None):
-    # type: (ReadableSpan, Optional[OtelExtractedSpanData]) -> dict[str, Any]
+def get_trace_context(
+    span: ReadableSpan, span_data: Optional[OtelExtractedSpanData] = None
+) -> dict[str, Any]:
     if not span.context:
         return {}
 
@@ -328,13 +344,13 @@ def get_trace_context(span, span_data=None):
 
     (op, _, status, _, origin) = span_data
 
-    trace_context = {
+    trace_context: dict[str, Any] = {
         "trace_id": trace_id,
         "span_id": span_id,
         "parent_span_id": parent_span_id,
         "op": op,
         "origin": origin or DEFAULT_SPAN_ORIGIN,
-    }  # type: dict[str, Any]
+    }
 
     if status:
         trace_context["status"] = status
@@ -350,8 +366,7 @@ def get_trace_context(span, span_data=None):
     return trace_context
 
 
-def trace_state_from_baggage(baggage):
-    # type: (Baggage) -> TraceState
+def trace_state_from_baggage(baggage: Baggage) -> TraceState:
     items = []
     for k, v in baggage.sentry_items.items():
         key = Baggage.SENTRY_PREFIX + quote(k)
@@ -360,13 +375,11 @@ def trace_state_from_baggage(baggage):
     return TraceState(items)
 
 
-def baggage_from_trace_state(trace_state):
-    # type: (TraceState) -> Baggage
+def baggage_from_trace_state(trace_state: TraceState) -> Baggage:
     return Baggage(dsc_from_trace_state(trace_state))
 
 
-def serialize_trace_state(trace_state):
-    # type: (TraceState) -> str
+def serialize_trace_state(trace_state: TraceState) -> str:
     sentry_items = []
     for k, v in trace_state.items():
         if Baggage.SENTRY_PREFIX_REGEX.match(k):
@@ -374,8 +387,7 @@ def serialize_trace_state(trace_state):
     return ",".join(key + "=" + value for key, value in sentry_items)
 
 
-def dsc_from_trace_state(trace_state):
-    # type: (TraceState) -> dict[str, str]
+def dsc_from_trace_state(trace_state: TraceState) -> dict[str, str]:
     dsc = {}
     for k, v in trace_state.items():
         if Baggage.SENTRY_PREFIX_REGEX.match(k):
@@ -384,16 +396,14 @@ def dsc_from_trace_state(trace_state):
     return dsc
 
 
-def has_incoming_trace(trace_state):
-    # type: (TraceState) -> bool
+def has_incoming_trace(trace_state: TraceState) -> bool:
     """
     The existence of a sentry-trace_id in the baggage implies we continued an upstream trace.
     """
     return (Baggage.SENTRY_PREFIX + "trace_id") in trace_state
 
 
-def get_trace_state(span):
-    # type: (Union[AbstractSpan, ReadableSpan]) -> TraceState
+def get_trace_state(span: Union[AbstractSpan, ReadableSpan]) -> TraceState:
     """
     Get the existing trace_state with sentry items
     or populate it if we are the head SDK.
@@ -451,34 +461,45 @@ def get_trace_state(span):
         return trace_state
 
 
-def get_sentry_meta(span, key):
-    # type: (Union[AbstractSpan, ReadableSpan], str) -> Any
+def get_sentry_meta(span: Union[AbstractSpan, ReadableSpan], key: str) -> Any:
     sentry_meta = getattr(span, "_sentry_meta", None)
     return sentry_meta.get(key) if sentry_meta else None
 
 
-def set_sentry_meta(span, key, value):
-    # type: (Union[AbstractSpan, ReadableSpan], str, Any) -> None
+def set_sentry_meta(
+    span: Union[AbstractSpan, ReadableSpan], key: str, value: Any
+) -> None:
     sentry_meta = getattr(span, "_sentry_meta", {})
     sentry_meta[key] = value
     span._sentry_meta = sentry_meta  # type: ignore[union-attr]
 
 
-def delete_sentry_meta(span):
-    # type: (Union[AbstractSpan, ReadableSpan]) -> None
+def delete_sentry_meta(span: Union[AbstractSpan, ReadableSpan]) -> None:
     try:
         del span._sentry_meta  # type: ignore[union-attr]
     except AttributeError:
         pass
 
 
-def get_profile_context(span):
-    # type: (ReadableSpan) -> Optional[dict[str, str]]
+def get_profile_context(span: ReadableSpan) -> Optional[dict[str, str]]:
     if not span.attributes:
         return None
 
-    profiler_id = cast("Optional[str]", span.attributes.get(SPANDATA.PROFILER_ID))
+    profiler_id = get_typed_attribute(span.attributes, SPANDATA.PROFILER_ID, str)
     if profiler_id is None:
         return None
 
     return {"profiler_id": profiler_id}
+
+
+def get_typed_attribute(
+    attributes: Mapping[str, Any], key: str, type: Type[T]
+) -> Optional[T]:
+    """
+    helper method to coerce types of attribute values
+    """
+    value = attributes.get(key)
+    if value is not None and isinstance(value, type):
+        return value
+    else:
+        return None

--- a/sentry_sdk/profiler/transaction_profiler.py
+++ b/sentry_sdk/profiler/transaction_profiler.py
@@ -281,7 +281,8 @@ class Profile:
             self.sampled = False
             return
 
-        if not is_valid_sample_rate(sample_rate, source="Profiling"):
+        sample_rate = is_valid_sample_rate(sample_rate, source="Profiling")
+        if sample_rate is None:
             logger.warning(
                 "[Profiling] Discarding profile because of invalid sample rate."
             )
@@ -291,14 +292,14 @@ class Profile:
         # Now we roll the dice. random.random is inclusive of 0, but not of 1,
         # so strict < is safe here. In case sample_rate is a boolean, cast it
         # to a float (True becomes 1.0 and False becomes 0.0)
-        self.sampled = random.random() < float(sample_rate)
+        self.sampled = random.random() < sample_rate
 
         if self.sampled:
             logger.debug("[Profiling] Initializing profile")
         else:
             logger.debug(
                 "[Profiling] Discarding profile because it's not included in the random sample (sample rate = {sample_rate})".format(
-                    sample_rate=float(sample_rate)
+                    sample_rate=sample_rate
                 )
             )
 

--- a/sentry_sdk/tracing_utils.py
+++ b/sentry_sdk/tracing_utils.py
@@ -752,7 +752,7 @@ def get_current_span(
 def _generate_sample_rand(
     trace_id: Optional[str],
     interval: tuple[float, float] = (0.0, 1.0),
-) -> Optional[Decimal]:
+) -> Decimal:
     """Generate a sample_rand value from a trace ID.
 
     The generated value will be pseudorandomly chosen from the provided

--- a/sentry_sdk/utils.py
+++ b/sentry_sdk/utils.py
@@ -1561,10 +1561,11 @@ def parse_url(url: str, sanitize: bool = True) -> ParsedUrl:
     )
 
 
-def is_valid_sample_rate(rate: Any, source: str) -> bool:
+def is_valid_sample_rate(rate: Any, source: str) -> Optional[float]:
     """
     Checks the given sample rate to make sure it is valid type and value (a
     boolean or a number between 0 and 1, inclusive).
+    Returns the final float value to use if valid.
     """
 
     # both booleans and NaN are instances of Real, so a) checking for Real
@@ -1576,7 +1577,7 @@ def is_valid_sample_rate(rate: Any, source: str) -> bool:
                 source=source, rate=rate, type=type(rate)
             )
         )
-        return False
+        return None
 
     # in case rate is a boolean, it will get cast to 1 if it's True and 0 if it's False
     rate = float(rate)
@@ -1586,9 +1587,9 @@ def is_valid_sample_rate(rate: Any, source: str) -> bool:
                 source=source, rate=rate
             )
         )
-        return False
+        return None
 
-    return True
+    return rate
 
 
 def match_regex_list(

--- a/tests/integrations/logging/test_logging.py
+++ b/tests/integrations/logging/test_logging.py
@@ -259,8 +259,8 @@ def test_logging_captured_warnings(sentry_init, capture_events, recwarn):
     assert events[1]["logentry"]["params"] == []
 
     # Using recwarn suppresses the "third" warning in the test output
-    assert len(recwarn) == 1
-    assert str(recwarn[0].message) == "third"
+    third_warnings = [w for w in recwarn if str(w.message) == "third"]
+    assert len(third_warnings) == 1
 
 
 def test_ignore_logger(sentry_init, capture_events):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -493,7 +493,7 @@ def test_accepts_valid_sample_rate(rate):
     with mock.patch.object(logger, "warning", mock.Mock()):
         result = is_valid_sample_rate(rate, source="Testing")
         assert logger.warning.called is False
-        assert result is True
+        assert result == float(rate)
 
 
 @pytest.mark.parametrize(
@@ -514,7 +514,7 @@ def test_warns_on_invalid_sample_rate(rate, StringContaining):  # noqa: N803
     with mock.patch.object(logger, "warning", mock.Mock()):
         result = is_valid_sample_rate(rate, source="Testing")
         logger.warning.assert_any_call(StringContaining("Given sample rate is invalid"))
-        assert result is False
+        assert result is None
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
* remove casts
* generalize `is_valid_sample_rate` to return the validated float
* added a `validate_scopes` helper method to validate the scopes entry on the context and return the narrowed type
* added a `get_typed_attribute` helper method to narrow the type on getting attributes from otel
* fix a flaky test on gevent