### PR TITLE
Pin zope.event

### DIFF
--- a/scripts/populate_tox/tox.jinja
+++ b/scripts/populate_tox/tox.jinja
@@ -173,6 +173,7 @@ deps =
     {py3.6,py3.7}-gevent: pytest<7.0.0
     {py3.8,py3.9,py3.10,py3.11,py3.12}-gevent: pytest
     gevent: pytest-asyncio
+    {py3.10,py3.11}-gevent: zope.event<5.0.0
 
     # === Integrations ===
 

--- a/tox.ini
+++ b/tox.ini
@@ -336,6 +336,7 @@ deps =
     {py3.6,py3.7}-gevent: pytest<7.0.0
     {py3.8,py3.9,py3.10,py3.11,py3.12}-gevent: pytest
     gevent: pytest-asyncio
+    {py3.10,py3.11}-gevent: zope.event<5.0.0
 
     # === Integrations ===
 


### PR DESCRIPTION
zope.event [released](https://pypi.org/project/zope.event/#history) a new version recently that broke our gevent ci