### PR TITLE
chore: Reexport module `profiler`

### DIFF
--- a/sentry_sdk/__init__.py
+++ b/sentry_sdk/__init__.py
@@ -1,4 +1,4 @@
-from sentry_sdk import integrations, logger, profiler
+from sentry_sdk import profiler
 from sentry_sdk.scope import Scope
 from sentry_sdk.transport import Transport, HttpTransport
 from sentry_sdk.client import Client


### PR DESCRIPTION
<!-- Describe your PR here -->

The example provided by sentry causes pylance to report `"profiler" is not a known attribute of module "sentry_sdk"`

<img width="1472" alt="image" src="https://github.com/user-attachments/assets/2aa683f4-9221-4eae-abdf-ead3e4d741dc" />
