### PR TITLE
fix(tracing): Use `hasattr` for `_ctx_token`

### DIFF
--- a/sentry_sdk/tracing.py
+++ b/sentry_sdk/tracing.py
@@ -248,7 +248,7 @@ class Span:
         self._ctx_token = context.attach(ctx)
 
     def deactivate(self) -> None:
-        if self._ctx_token:
+        if hasattr(self, "_ctx_token"):
             context.detach(self._ctx_token)
             del self._ctx_token
 


### PR DESCRIPTION
We currently use an `if self._ctx_token` check to determine if a span has a `_ctx_token`. However, this check is incorrect, since `_ctx_token` is only sometimes set. Furthermore, when `_ctx_token` is set, we should always have a `_ctx_token`.

Therefore, using `hasattr` is what we want.

<!-- Describe your PR here -->

---

Thank you for contributing to `sentry-python`! Please add tests to validate your changes, and lint your code using `tox -e linters`.

Running the test suite on your PR might require maintainer approval.