### PR TITLE
test: Unfinished span behavior

### DIFF
--- a/tests/tracing/test_unfinished_spans.py
+++ b/tests/tracing/test_unfinished_spans.py
@@ -1,0 +1,32 @@
+import sentry_sdk
+
+
+def test_unfinished_spans(sentry_init, capture_events):
+    sentry_init(
+        traces_sample_rate=1.0,
+    )
+
+    events = capture_events()
+
+    with sentry_sdk.start_transaction(name="test"):
+        with sentry_sdk.start_span(name="span0"):
+            pass
+
+        span1 = sentry_sdk.start_span(name="span1").__enter__()
+
+        with sentry_sdk.start_span(name="span2"):
+            pass
+
+    span1.__exit__(None, None, None)
+
+    (event,) = events
+    assert event["transaction"] == "test"
+
+    spans_by_name = {span["description"]: span for span in event["spans"]}
+    assert {"span0", "span2"} == spans_by_name.keys()
+
+    assert (
+        spans_by_name["span0"]["parent_span_id"]
+        == event["contexts"]["trace"]["span_id"]
+    )
+    assert spans_by_name["span2"]["parent_span_id"] == span1.span_id


### PR DESCRIPTION
Add a test which demonstrates how unfinished spans are handled. We will use this to compare behavior with `potel-base`

<!-- Describe your PR here -->

---

Thank you for contributing to `sentry-python`! Please add tests to validate your changes, and lint your code using `tox -e linters`.

Running the test suite on your PR might require maintainer approval.