### PR TITLE
chore: Remove Lambda urllib3 pin on Python 3.10+

### DIFF
--- a/requirements-aws-lambda-layer.txt
+++ b/requirements-aws-lambda-layer.txt
@@ -1,3 +1,8 @@
 certifi
 urllib3
+# In Lambda functions botocore is used, and botocore has
+# restrictions on urllib3
+# https://github.com/boto/botocore/blob/develop/setup.cfg
+# So we pin this here to make our Lambda layer work with
+# Lambda Function using Python 3.7+
 urllib3<1.27; python_version < "3.10"


### PR DESCRIPTION
See [botocore](https://github.com/boto/botocore/blob/0b28c3155f160a68fd901c9eb80a7a6a45a16216/setup.cfg#L8)