### PR TITLE
test(loguru): Remove hardcoded line number in test_just_log

### DIFF
--- a/tests/integrations/loguru/test_loguru.py
+++ b/tests/integrations/loguru/test_loguru.py
@@ -1,4 +1,5 @@
 from unittest.mock import MagicMock, patch
+import inspect
 
 import pytest
 from loguru import logger
@@ -54,12 +55,17 @@ def test_just_log(
     )
     events = capture_events()
 
+    frame = inspect.currentframe()
+    assert frame is not None
+    log_line_number = frame.f_lineno + 1
     getattr(logger, level.name.lower())("test")
 
     formatted_message = (
         " | "
         + "{:9}".format(level.name.upper())
-        + "| tests.integrations.loguru.test_loguru:test_just_log:57 - test"
+        + "| tests.integrations.loguru.test_loguru:test_just_log:{} - test".format(
+            log_line_number
+        )
     )
 
     if not created_event:

--- a/tests/integrations/loguru/test_loguru.py
+++ b/tests/integrations/loguru/test_loguru.py
@@ -73,8 +73,7 @@ def test_just_log(
             (breadcrumb,) = breadcrumbs
             assert breadcrumb["level"] == expected_sentry_level
             assert breadcrumb["category"] == "tests.integrations.loguru.test_loguru"
-            # Check that the message matches the expected pattern with a line number
-            assert re.search(expected_pattern, breadcrumb["message"][23:])
+            assert re.fullmatch(expected_pattern, breadcrumb["message"][23:])
         else:
             assert not breadcrumbs
 
@@ -87,8 +86,7 @@ def test_just_log(
     (event,) = events
     assert event["level"] == expected_sentry_level
     assert event["logger"] == "tests.integrations.loguru.test_loguru"
-    # Check that the message matches the expected pattern with a line number
-    assert re.search(expected_pattern, event["logentry"]["message"][23:])
+    assert re.fullmatch(expected_pattern, event["logentry"]["message"][23:])
 
 
 def test_breadcrumb_format(sentry_init, capture_events, uninstall_integration, request):


### PR DESCRIPTION
Use inspect to dynamically compute the correct line number instead of hard coding it.

Fixes GH-4454
https://github.com/getsentry/sentry-python/issues/4454
<!-- Describe your PR here -->

Changed the loguru test_just_log test to use inspection logic for the line number instead of hard coding it.