### PR TITLE
fix(profiling): Fix race condition while processing profiles

### DIFF
--- a/sentry_sdk/profiler/continuous_profiler.py
+++ b/sentry_sdk/profiler/continuous_profiler.py
@@ -370,7 +370,13 @@ class ContinuousScheduler:
                 # that are starting profiles are not blocked until it
                 # can acquire the lock.
                 for _ in range(new_profiles):
-                    self.active_profiles.add(self.new_profiles.popleft())
+                    try:
+                        profile = self.new_profiles.popleft()
+                    except IndexError:
+                        # If another thread is concurrently popping profiles, we could
+                        # end up with an empty deque here.
+                        break
+                    self.active_profiles.add(profile)
                 inactive_profiles = []
 
                 for profile in self.active_profiles:


### PR DESCRIPTION
If multiple threads happen to be processing profiles, we could encounter a race condition, that would lead to more profiles being processed than are available in the `new_profiles` deque. To avoid this, we can break upon encountering an `IndexError`.

This line appears to be the most likely cause of #4542 – in any case, handling an `IndexError` is not harmful

Fixes #4542

<!-- Describe your PR here -->

---

Thank you for contributing to `sentry-python`! Please add tests to validate your changes, and lint your code using `tox -e linters`.

Running the test suite on your PR might require maintainer approval.