### PR TITLE
Fix custom model name

### DIFF
--- a/sentry_sdk/integrations/openai_agents/spans/ai_client.py
+++ b/sentry_sdk/integrations/openai_agents/spans/ai_client.py
@@ -19,9 +19,10 @@ if TYPE_CHECKING:
 def ai_client_span(agent, get_response_kwargs):
     # type: (Agent, dict[str, Any]) -> sentry_sdk.tracing.Span
     # TODO-anton: implement other types of operations. Now "chat" is hardcoded.
+    model_name = agent.model.model if hasattr(agent.model, "model") else agent.model
     span = sentry_sdk.start_span(
         op=OP.GEN_AI_CHAT,
-        description=f"chat {agent.model}",
+        description=f"chat {model_name}",
         origin=SPAN_ORIGIN,
     )
     # TODO-anton: remove hardcoded stuff and replace something that also works for embedding and so on

--- a/sentry_sdk/integrations/openai_agents/utils.py
+++ b/sentry_sdk/integrations/openai_agents/utils.py
@@ -53,7 +53,8 @@ def _set_agent_data(span, agent):
         )
 
     if agent.model:
-        span.set_data(SPANDATA.GEN_AI_REQUEST_MODEL, agent.model)
+        model_name = agent.model.model if hasattr(agent.model, "model") else agent.model
+        span.set_data(SPANDATA.GEN_AI_REQUEST_MODEL, model_name)
 
     if agent.model_settings.presence_penalty:
         span.set_data(


### PR DESCRIPTION
The `model` parameter can be a string or an object of the model itself. If it is a model, get the models name from the `.model` attribute. 