### PR TITLE
Fix pytest collection warning

### DIFF
--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1342,6 +1342,8 @@ class TestSpanClientReports:
     Tests for client reports related to spans.
     """
 
+    __test__ = False
+
     @staticmethod
     def span_dropper(spans_to_drop):
         """


### PR DESCRIPTION
fixes 

```
PytestCollectionWarning: cannot collect test class 'TestSpanClientReports' because it has a __init__ constructor (from: tests/test_client.py)
    class TestSpanClientReports:
```