### PR TITLE
Remove pyrsistent from test dependencies

### DIFF
--- a/requirements-testing.txt
+++ b/requirements-testing.txt
@@ -6,7 +6,6 @@ pytest-forked
 pytest-localserver
 pytest-watch
 jsonschema
-pyrsistent
 executing
 asttokens
 responses


### PR DESCRIPTION
The `pyrsistent` dependency in `requirements-testing.txt` does not appear to be used anywhere, so I removed it.

In Fedora, I maintain the [`python-pyrsistent` package](https://src.fedoraproject.org/rpms/python-pyrsistent), and [`python-sentry-sdk`](https://src.fedoraproject.org/rpms/python-sentry-sdk) is the only thing that still depends on it. Since this dependency appears to be vestigial, my goal is to remove it both upstream and downstream and then orphan `python-pyrsistent` in Fedora as an unused leaf package.