### PR TITLE
Remove explicit __del__'s in threaded classes

### DIFF
--- a/sentry_sdk/monitor.py
+++ b/sentry_sdk/monitor.py
@@ -118,7 +118,3 @@ class Monitor:
     def kill(self):
         # type: () -> None
         self._running = False
-
-    def __del__(self):
-        # type: () -> None
-        self.kill()

--- a/sentry_sdk/sessions.py
+++ b/sentry_sdk/sessions.py
@@ -271,7 +271,3 @@ class SessionFlusher:
     def kill(self):
         # type: (...) -> None
         self.__shutdown_requested.set()
-
-    def __del__(self):
-        # type: (...) -> None
-        self.kill()

--- a/sentry_sdk/transport.py
+++ b/sentry_sdk/transport.py
@@ -158,13 +158,6 @@ class Transport(ABC):
         # type: (Self) -> bool
         return True
 
-    def __del__(self):
-        # type: (Self) -> None
-        try:
-            self.kill()
-        except Exception:
-            pass
-
 
 def _parse_rate_limits(header, now=None):
     # type: (str, Optional[datetime]) -> Iterable[Tuple[Optional[EventDataCategory], datetime]]


### PR DESCRIPTION
The changes in #4577 introduced a bit of flakiness on pre-3.10 due to a weird interaction of `capsys`, `stderr` logging and our object lifecycles.

In this PR, I'm removing all the explicit `__del__` `kill`s since we [call them all explicitly in `client.close`](https://github.com/getsentry/sentry-python/blob/09c2e32cc7a618e49f5d8ae59e22d8b12f253687/sentry_sdk/client.py#L1001-L1021) anyway and that's already cleaner. Having logic in `__del__` causes non-deterministic GC behavior, especially with threaded code.

Stacktrace is linked in a comment below where you can see the `transport.__del__` method is causing the weird `reentrant` logging bug to `stderr`.
  