### PR TITLE
test: Remove `test_installed_modules`

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -30,7 +30,6 @@ from sentry_sdk.utils import (
     serialize_frame,
     is_sentry_url,
     _get_installed_modules,
-    _generate_installed_modules,
     ensure_integration_enabled,
     to_string,
     exc_info_from_error,
@@ -665,47 +664,6 @@ def test_safe_str_fails():
     result = safe_str(obj)
 
     assert result == repr(obj)
-
-
-def test_installed_modules():
-    try:
-        from importlib.metadata import distributions, version
-
-        importlib_available = True
-    except ImportError:
-        importlib_available = False
-
-    try:
-        import pkg_resources
-
-        pkg_resources_available = True
-    except ImportError:
-        pkg_resources_available = False
-
-    installed_distributions = {
-        _normalize_distribution_name(dist): version
-        for dist, version in _generate_installed_modules()
-    }
-
-    if importlib_available:
-        importlib_distributions = {
-            _normalize_distribution_name(dist.metadata.get("Name", None)): version(
-                dist.metadata.get("Name", None)
-            )
-            for dist in distributions()
-            if dist.metadata.get("Name", None) is not None
-            and version(dist.metadata.get("Name", None)) is not None
-        }
-        assert installed_distributions == importlib_distributions
-
-    elif pkg_resources_available:
-        pkg_resources_distributions = {
-            _normalize_distribution_name(dist.key): dist.version
-            for dist in pkg_resources.working_set
-        }
-        assert installed_distributions == pkg_resources_distributions
-    else:
-        pytest.fail("Neither importlib nor pkg_resources is available")
 
 
 def test_installed_modules_caching():


### PR DESCRIPTION
The test `test_installed_modules` appears to not be all that useful.

The test exists to verify the behavior of the [`_generate_installed_modules` function](https://github.com/getsentry/sentry-python/blob/9b66f3b51502ca600554c711bc3f599c18f8f18b/sentry_sdk/utils.py#L1689). However, all the test does is essentially check the output of `_generate_installed_modules` against a refactored version of the function call itself.

In short, in its current form, the test appears to not make too much sense. As the test recently started failing, let's just delete it.

<!-- Describe your PR here -->

---

Thank you for contributing to `sentry-python`! Please add tests to validate your changes, and lint your code using `tox -e linters`.

Running the test suite on your PR might require maintainer approval.