### PR TITLE
ref(gnu-integration): update clickhouse stacktrace parsing

### DIFF
--- a/sentry_sdk/integrations/gnu_backtrace.py
+++ b/sentry_sdk/integrations/gnu_backtrace.py
@@ -12,7 +12,7 @@ if TYPE_CHECKING:
     from sentry_sdk._types import Event
 
 
-FUNCTION_RE =r"[^@]+?)\s+@\s+0x[0-9a-fA-F]+"
+FUNCTION_RE = r"[^@]+?)\s+@\s+0x[0-9a-fA-F]+"
 
 FRAME_RE = r"""
 ^(?P<index>\d+)\.\s+(?P<function>{FUNCTION_RE}\s+in\s+(?P<package>.+)$

--- a/tests/integrations/test_gnu_backtrace.py
+++ b/tests/integrations/test_gnu_backtrace.py
@@ -31,6 +31,7 @@ LINES = r"""
 24. ? @ 0x00000000000d162c in /usr/lib/aarch64-linux-gnu/libc-2.31.so
 """
 
+
 @pytest.mark.parametrize("input", LINES.strip().splitlines())
 def test_basic(sentry_init, capture_events, input):
     sentry_init(integrations=[GnuBacktraceIntegration()])


### PR DESCRIPTION
This integration was added back in 2019 https://github.com/getsentry/sentry-python/pull/288 but I think since then the stack trace from clickhouse driver has changed, anyway I tried to update it so that it parses the stack trace again (screenshots below)

However, I do see that we have a  [`ClickhouseDriverIntegration`](https://github.com/getsentry/sentry-python/blob/master/sentry_sdk/integrations/clickhouse_driver.py) now so I'm not sure if this functionality should be rolled up with it. I chose not to since the snuba codebase doesnt use that integration and it seemed reasonable to want the stack trace formatted without having the spans added



> <img width="1021" height="239" alt="Screenshot 2025-07-18 at 5 50 19 PM" src="https://github.com/user-attachments/assets/a479b2f1-477f-43ac-959a-c8a6cf9104ea" />


> <img width="1020" height="694" alt="Screenshot 2025-07-18 at 5 46 08 PM" src="https://github.com/user-attachments/assets/c2b26f71-fd58-4536-b6cd-f7c3941b482f" />


