### PR TITLE
[do not merge] PoC: Call OTel's `instrument_app` in Flask integration

### DIFF
--- a/sentry_sdk/opentelemetry/tracing.py
+++ b/sentry_sdk/opentelemetry/tracing.py
@@ -20,6 +20,17 @@ from sentry_sdk.utils import logger
 
 READABLE_SPAN_PATCHED = False
 
+SENTRY_TRACER_PROVIDER = TracerProvider(
+    sampler=SentrySampler(),
+    resource=Resource.create(
+        {
+            RESOURCE_SERVICE_NAME: "sentry-python",
+            RESOURCE_SERVICE_VERSION: VERSION,
+            RESOURCE_SERVICE_NAMESPACE: "sentry",
+        }
+    ),
+)
+
 
 def patch_readable_span() -> None:
     """
@@ -51,16 +62,7 @@ def setup_sentry_tracing() -> None:
 
     else:
         logger.debug("[Tracing] No TracerProvider set, creating a new one")
-        tracer_provider = TracerProvider(
-            sampler=SentrySampler(),
-            resource=Resource.create(
-                {
-                    RESOURCE_SERVICE_NAME: "sentry-python",
-                    RESOURCE_SERVICE_VERSION: VERSION,
-                    RESOURCE_SERVICE_NAMESPACE: "sentry",
-                }
-            ),
-        )
+        tracer_provider = SENTRY_TRACER_PROVIDER
         trace.set_tracer_provider(tracer_provider)
 
     try:

--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,7 @@ setup(
         "urllib3>=1.26.11",
         "certifi",
         "opentelemetry-sdk>=1.4.0",
+        "opentelemetry-instrumentation-flask",
     ],
     extras_require={
         "aiohttp": ["aiohttp>=3.5"],


### PR DESCRIPTION
Minimal PoC for how we could invoke OTel's Flask auto-instrumentation without needing the user to do any additional setup (or requiring them to move their `sentry_sdk.init()`).

Note that this PR results in double instrumentation since we haven't disabled Sentry's tracing. This is just for showing that we can invoke OTel like this.

Example app:
```python
from flask import Flask
import sentry_sdk

sentry_sdk.init(
    debug=True,
    traces_sample_rate=1.0,
)

app = Flask(__name__)

@app.route("/")
def home():
    return 'ok'
```