### PR TITLE
Fix threading run patch

### DIFF
--- a/sentry_sdk/integrations/threading.py
+++ b/sentry_sdk/integrations/threading.py
@@ -120,7 +120,7 @@ def _wrap_run(isolation_scope_to_use, current_scope_to_use, old_run_func):
             # type: () -> Any
             try:
                 self = current_thread()
-                return old_run_func(self, *a, **kw)
+                return old_run_func(self, *a[1:], **kw)
             except Exception:
                 reraise(*_capture_exception())
 


### PR DESCRIPTION
Since we're using `current_thread` for `self` explicitly, we need to remove the first argument from `*a`.

This actually doesn't matter since `*a, **kw` are actually both empty but since this is the way the patch is implemented (presumably for forward compat), I don't want to change the signature.

This fixes the following warning in CI since what actually happens is this:
* `Thread.run` is being patched at each `Thread.start` (and not just once as other patches do)
* So the current thread keeps getting accumulated in `*a` giving the `TypeError` for subsequent thread runs except the first


```python
 TypeError: Thread.run() takes 1 positional argument but 5 were given

tests/integrations/redis/cluster_asyncio/test_redis_cluster_asyncio.py::test_async_span_origin
  /Users/neel/sentry/sdks/sentry-python/.tox/py3.12-redis-v5/lib/python3.12/site-packages/_pytest/threadexception.py:58: PytestUnhandledThreadExceptionWarning: Exception in thread sentry.monitor
```


closes #4361 