### PR TITLE
Make OpenAI span data OTel compatible

### DIFF
--- a/sentry_sdk/consts.py
+++ b/sentry_sdk/consts.py
@@ -417,7 +417,7 @@ class SPANDATA:
     GEN_AI_REQUEST_MODEL = "gen_ai.request.model"
     """
     The model identifier being used for the request.
-    Example: "gpt-4-turbo-preview"
+    Example: "gpt-4-turbo"
     """
 
     GEN_AI_REQUEST_PRESENCE_PENALTY = "gen_ai.request.presence_penalty"

--- a/sentry_sdk/integrations/openai.py
+++ b/sentry_sdk/integrations/openai.py
@@ -271,7 +271,7 @@ def _set_output_data(span, response, kwargs, integration, finish_span=True):
                         data_buf[0].append(x.delta or "")
 
                     # OpenAI responses API end of streaming response
-                    if isinstance(x, ResponseCompletedEvent):
+                    if RESPONSES_API_ENABLED and isinstance(x, ResponseCompletedEvent):
                         _calculate_token_usage(
                             messages,
                             x.response,
@@ -326,7 +326,7 @@ def _set_output_data(span, response, kwargs, integration, finish_span=True):
                         data_buf[0].append(x.delta or "")
 
                     # OpenAI responses API end of streaming response
-                    if isinstance(x, ResponseCompletedEvent):
+                    if RESPONSES_API_ENABLED and isinstance(x, ResponseCompletedEvent):
                         _calculate_token_usage(
                             messages,
                             x.response,

--- a/sentry_sdk/integrations/openai.py
+++ b/sentry_sdk/integrations/openai.py
@@ -174,13 +174,15 @@ def _set_request_data(span, kwargs, operation, integration):
 
     # Common attributes
     model = kwargs.get("model")
-    streaming = kwargs.get("stream")
     set_data_normalized(span, SPANDATA.GEN_AI_SYSTEM, "openai")
     set_data_normalized(span, SPANDATA.GEN_AI_REQUEST_MODEL, model)
     set_data_normalized(span, SPANDATA.GEN_AI_OPERATION_NAME, operation)
-    set_data_normalized(span, SPANDATA.AI_STREAMING, streaming)
 
     # Optional attributes
+    streaming = kwargs.get("stream")
+    if streaming is not None:
+        set_data_normalized(span, SPANDATA.AI_STREAMING, streaming)
+
     max_tokens = kwargs.get("max_tokens")
     if max_tokens is not None:
         set_data_normalized(span, SPANDATA.GEN_AI_REQUEST_MAX_TOKENS, max_tokens)

--- a/sentry_sdk/integrations/openai.py
+++ b/sentry_sdk/integrations/openai.py
@@ -226,6 +226,7 @@ def _set_output_data(span, response, kwargs, integration, finish_span=True):
                     SPANDATA.GEN_AI_RESPONSE_TEXT,
                     safe_serialize(response_text),
                 )
+        _calculate_token_usage(messages, response, span, None, integration.count_tokens)
         if finish_span:
             span.__exit__(None, None, None)
 
@@ -238,6 +239,7 @@ def _set_output_data(span, response, kwargs, integration, finish_span=True):
                     SPANDATA.GEN_AI_RESPONSE_TEXT,
                     safe_serialize(response_text),
                 )
+        _calculate_token_usage(messages, response, span, None, integration.count_tokens)
         if finish_span:
             span.__exit__(None, None, None)
 
@@ -360,10 +362,9 @@ def _set_output_data(span, response, kwargs, integration, finish_span=True):
         else:
             response._iterator = new_iterator()
     else:
+        _calculate_token_usage(messages, response, span, None, integration.count_tokens)
         if finish_span:
             span.__exit__(None, None, None)
-
-    _calculate_token_usage(messages, response, span, None, integration.count_tokens)
 
 
 def _new_chat_completion_common(f, *args, **kwargs):

--- a/sentry_sdk/integrations/openai.py
+++ b/sentry_sdk/integrations/openai.py
@@ -100,7 +100,7 @@ def _get_usage(usage, names):
 def _calculate_token_usage(
     messages, response, span, streaming_message_responses, count_tokens
 ):
-    # type: (Iterable[ChatCompletionMessageParam], Any, Span, Optional[List[str]], Callable[..., Any]) -> None
+    # type: (Optional[Iterable[ChatCompletionMessageParam]], Any, Span, Optional[List[str]], Callable[..., Any]) -> None
     input_tokens = 0  # type: Optional[int]
     input_tokens_cached = 0  # type: Optional[int]
     output_tokens = 0  # type: Optional[int]
@@ -126,7 +126,7 @@ def _calculate_token_usage(
 
     # Manually count tokens
     if input_tokens == 0:
-        for message in messages:
+        for message in messages or []:
             if isinstance(message, dict) and "content" in message:
                 input_tokens += count_tokens(message["content"])
             elif isinstance(message, str):
@@ -161,8 +161,8 @@ def _calculate_token_usage(
 def _set_input_data(span, kwargs, operation, integration):
     # type: (Span, dict[str, Any], str, OpenAIIntegration) -> None
     # Input messages (the prompt or data sent to the model)
-    messages = kwargs.get("messages", [])
-    if messages == []:
+    messages = kwargs.get("messages")
+    if messages is None:
         messages = kwargs.get("input")
 
     if isinstance(messages, str):
@@ -196,7 +196,7 @@ def _set_input_data(span, kwargs, operation, integration):
             set_data_normalized(span, attribute, value)
 
     # Input attributes: Tools
-    tools = kwargs.get("tools", [])
+    tools = kwargs.get("tools")
     if tools is not None and len(tools) > 0:
         set_data_normalized(
             span, SPANDATA.GEN_AI_REQUEST_AVAILABLE_TOOLS, safe_serialize(tools)
@@ -210,11 +210,11 @@ def _set_output_data(span, response, kwargs, integration, finish_span=True):
 
     # Input messages (the prompt or data sent to the model)
     # used for the token usage calculation
-    messages = kwargs.get("messages", [])
-    if messages == []:
+    messages = kwargs.get("messages")
+    if messages is None:
         messages = kwargs.get("input")
 
-    if isinstance(messages, str):
+    if messages is not None and isinstance(messages, str):
         messages = [messages]
 
     if hasattr(response, "choices"):

--- a/sentry_sdk/integrations/openai.py
+++ b/sentry_sdk/integrations/openai.py
@@ -191,6 +191,12 @@ def _set_request_data(span, kwargs, operation, integration):
             span, SPANDATA.GEN_AI_REQUEST_PRESENCE_PENALTY, presence_penalty
         )
 
+    frequency_penalty = kwargs.get("frequency_penalty")
+    if frequency_penalty is not None:
+        set_data_normalized(
+            span, SPANDATA.GEN_AI_REQUEST_FREQUENCY_PENALTY, frequency_penalty
+        )
+
     temperature = kwargs.get("temperature")
     if temperature is not None:
         set_data_normalized(span, SPANDATA.GEN_AI_REQUEST_TEMPERATURE, temperature)
@@ -198,6 +204,13 @@ def _set_request_data(span, kwargs, operation, integration):
     top_p = kwargs.get("top_p")
     if top_p is not None:
         set_data_normalized(span, SPANDATA.GEN_AI_REQUEST_TOP_P, top_p)
+
+    # Tools
+    tools = kwargs.get("tools", [])
+    if tools is not None and len(tools) > 0:
+        set_data_normalized(
+            span, SPANDATA.GEN_AI_REQUEST_AVAILABLE_TOOLS, safe_serialize(tools)
+        )
 
 
 def _set_response_data(span, response, kwargs, integration):

--- a/sentry_sdk/integrations/openai.py
+++ b/sentry_sdk/integrations/openai.py
@@ -32,6 +32,7 @@ RESPONSES_API_ENABLED = True
 try:
     # responses API support was introduced in v1.66.0
     from openai.resources.responses import Responses, AsyncResponses
+    from openai.types.responses.response_completed_event import ResponseCompletedEvent
 except ImportError:
     RESPONSES_API_ENABLED = False
 
@@ -325,7 +326,7 @@ def _set_output_data(span, response, kwargs, integration, finish_span=True):
                         data_buf[0].append(x.delta or "")
 
                     # OpenAI responses API end of streaming response
-                    if x.__class__.__name__ == "ResponseCompletedEvent":
+                    if isinstance(x, ResponseCompletedEvent):
                         _calculate_token_usage(
                             messages,
                             x.response,

--- a/sentry_sdk/integrations/openai.py
+++ b/sentry_sdk/integrations/openai.py
@@ -126,8 +126,10 @@ def _calculate_token_usage(
     # Manually count tokens
     if input_tokens == 0:
         for message in messages:
-            if "content" in message:
+            if isinstance(message, dict) and "content" in message:
                 input_tokens += count_tokens(message["content"])
+            elif isinstance(message, str):
+                input_tokens += count_tokens(message)
 
     if output_tokens == 0:
         if streaming_message_responses is not None:
@@ -246,6 +248,7 @@ def _set_output_data(span, response, kwargs, integration, finish_span=True):
             # type: () -> Iterator[ChatCompletionChunk]
             with capture_internal_exceptions():
                 for x in old_iterator:
+                    # OpenAI chat completion API
                     if hasattr(x, "choices"):
                         choice_index = 0
                         for choice in x.choices:
@@ -257,6 +260,11 @@ def _set_output_data(span, response, kwargs, integration, finish_span=True):
                                     data_buf.append([])
                                 data_buf[choice_index].append(content or "")
                             choice_index += 1
+                    # OpenAI responses API
+                    elif hasattr(x, "delta"):
+                        if len(data_buf) == 0:
+                            data_buf.append([])
+                        data_buf[0].append(x.delta or "")
                     yield x
                 if len(data_buf) > 0:
                     all_responses = list(map(lambda chunk: "".join(chunk), data_buf))

--- a/sentry_sdk/integrations/openai.py
+++ b/sentry_sdk/integrations/openai.py
@@ -157,9 +157,8 @@ def _calculate_token_usage(
     )
 
 
-# TODO: rename to _set_input_data and _set_output_data
 def _set_input_data(span, kwargs, operation, integration):
-    # type: (Span, dict[str, Any], str, Integration) -> None
+    # type: (Span, dict[str, Any], str, OpenAIIntegration) -> None
     # Input messages (the prompt or data sent to the model)
     messages = kwargs.get("messages")
     if messages is None:
@@ -204,7 +203,7 @@ def _set_input_data(span, kwargs, operation, integration):
 
 
 def _set_output_data(span, response, kwargs, integration, finish_span=True):
-    # type: (Span, Any, dict[str, Any], Integration, bool) -> None
+    # type: (Span, Any, dict[str, Any], OpenAIIntegration, bool) -> None
     if hasattr(response, "model"):
         set_data_normalized(span, SPANDATA.GEN_AI_RESPONSE_MODEL, response.model)
 

--- a/sentry_sdk/integrations/openai.py
+++ b/sentry_sdk/integrations/openai.py
@@ -286,6 +286,7 @@ def _set_output_data(span, response, kwargs, integration, finish_span=True):
             # type: () -> AsyncIterator[ChatCompletionChunk]
             with capture_internal_exceptions():
                 async for x in old_iterator:
+                    # OpenAI chat completion API
                     if hasattr(x, "choices"):
                         choice_index = 0
                         for choice in x.choices:
@@ -297,6 +298,11 @@ def _set_output_data(span, response, kwargs, integration, finish_span=True):
                                     data_buf.append([])
                                 data_buf[choice_index].append(content or "")
                             choice_index += 1
+                    # OpenAI responses API
+                    elif hasattr(x, "delta"):
+                        if len(data_buf) == 0:
+                            data_buf.append([])
+                        data_buf[0].append(x.delta or "")
                     yield x
                 if len(data_buf) > 0:
                     all_responses = list(map(lambda chunk: "".join(chunk), data_buf))

--- a/sentry_sdk/integrations/openai.py
+++ b/sentry_sdk/integrations/openai.py
@@ -124,13 +124,11 @@ def _calculate_token_usage(
         total_tokens = _get_usage(response.usage, ["total_tokens"])
 
     # Manually count tokens
-    # TODO: when implementing responses API, check for responses API
     if input_tokens == 0:
         for message in messages:
             if "content" in message:
                 input_tokens += count_tokens(message["content"])
 
-    # TODO: when implementing responses API, check for responses API
     if output_tokens == 0:
         if streaming_message_responses is not None:
             for message in streaming_message_responses:
@@ -191,7 +189,9 @@ def _new_chat_completion_common(f, *args, **kwargs):
         if should_send_default_pii() and integration.include_prompts:
             set_data_normalized(span, SPANDATA.GEN_AI_REQUEST_MESSAGES, messages)
 
+        set_data_normalized(span, SPANDATA.GEN_AI_SYSTEM, "openai")
         set_data_normalized(span, SPANDATA.GEN_AI_REQUEST_MODEL, model)
+        set_data_normalized(span, SPANDATA.GEN_AI_OPERATION_NAME, "chat")
         set_data_normalized(span, SPANDATA.AI_STREAMING, streaming)
 
         if hasattr(res, "choices"):
@@ -368,7 +368,9 @@ def _new_embeddings_create_common(f, *args, **kwargs):
         name=f"embeddings {model}",
         origin=OpenAIIntegration.origin,
     ) as span:
+        set_data_normalized(span, SPANDATA.GEN_AI_SYSTEM, "openai")
         set_data_normalized(span, SPANDATA.GEN_AI_REQUEST_MODEL, model)
+        set_data_normalized(span, SPANDATA.GEN_AI_OPERATION_NAME, "embeddings")
 
         if "input" in kwargs and (
             should_send_default_pii() and integration.include_prompts
@@ -496,7 +498,9 @@ def _new_responses_create_common(f, *args, **kwargs):
     )
     span.__enter__()
 
+    set_data_normalized(span, SPANDATA.GEN_AI_SYSTEM, "openai")
     set_data_normalized(span, SPANDATA.GEN_AI_REQUEST_MODEL, model)
+    set_data_normalized(span, SPANDATA.GEN_AI_OPERATION_NAME, "responses")
 
     if should_send_default_pii() and integration.include_prompts:
         set_data_normalized(span, SPANDATA.GEN_AI_REQUEST_MESSAGES, input)

--- a/sentry_sdk/integrations/openai.py
+++ b/sentry_sdk/integrations/openai.py
@@ -180,7 +180,7 @@ def _new_chat_completion_common(f, *args, **kwargs):
 
     span = sentry_sdk.start_span(
         op=consts.OP.GEN_AI_CHAT,
-        name=f"{consts.OP.GEN_AI_CHAT} {model}",
+        name=f"chat {model}",
         origin=OpenAIIntegration.origin,
     )
     span.__enter__()
@@ -365,7 +365,7 @@ def _new_embeddings_create_common(f, *args, **kwargs):
 
     with sentry_sdk.start_span(
         op=consts.OP.GEN_AI_EMBEDDINGS,
-        name=f"{consts.OP.GEN_AI_EMBEDDINGS} {model}",
+        name=f"embeddings {model}",
         origin=OpenAIIntegration.origin,
     ) as span:
         set_data_normalized(span, SPANDATA.GEN_AI_REQUEST_MODEL, model)
@@ -491,7 +491,7 @@ def _new_responses_create_common(f, *args, **kwargs):
 
     span = sentry_sdk.start_span(
         op=consts.OP.GEN_AI_RESPONSES,
-        name=f"{consts.OP.GEN_AI_RESPONSES} {model}",
+        name=f"responses {model}",
         origin=OpenAIIntegration.origin,
     )
     span.__enter__()

--- a/sentry_sdk/integrations/openai.py
+++ b/sentry_sdk/integrations/openai.py
@@ -270,7 +270,7 @@ def _set_output_data(span, response, kwargs, integration, finish_span=True):
                         data_buf[0].append(x.delta or "")
 
                     # OpenAI responses API end of streaming response
-                    if x.__class__.__name__ == "ResponseCompletedEvent":
+                    if isinstance(x, ResponseCompletedEvent):
                         _calculate_token_usage(
                             messages,
                             x.response,
@@ -283,7 +283,7 @@ def _set_output_data(span, response, kwargs, integration, finish_span=True):
                     yield x
 
                 if len(data_buf) > 0:
-                    all_responses = list(map(lambda chunk: "".join(chunk), data_buf))
+                    all_responses = ["".join(chunk) for chunk in data_buf]
                     if should_send_default_pii() and integration.include_prompts:
                         set_data_normalized(
                             span, SPANDATA.GEN_AI_RESPONSE_TEXT, all_responses
@@ -338,7 +338,7 @@ def _set_output_data(span, response, kwargs, integration, finish_span=True):
                     yield x
 
                 if len(data_buf) > 0:
-                    all_responses = list(map(lambda chunk: "".join(chunk), data_buf))
+                    all_responses = ["".join(chunk) for chunk in data_buf]
                     if should_send_default_pii() and integration.include_prompts:
                         set_data_normalized(
                             span, SPANDATA.GEN_AI_RESPONSE_TEXT, all_responses

--- a/sentry_sdk/integrations/openai.py
+++ b/sentry_sdk/integrations/openai.py
@@ -160,8 +160,8 @@ def _calculate_token_usage(
 def _set_input_data(span, kwargs, operation, integration):
     # type: (Span, dict[str, Any], str, OpenAIIntegration) -> None
     # Input messages (the prompt or data sent to the model)
-    messages = kwargs.get("messages")
-    if messages is None:
+    messages = kwargs.get("messages", [])
+    if messages == []:
         messages = kwargs.get("input")
 
     if isinstance(messages, str):
@@ -207,8 +207,10 @@ def _set_output_data(span, response, kwargs, integration, finish_span=True):
     if hasattr(response, "model"):
         set_data_normalized(span, SPANDATA.GEN_AI_RESPONSE_MODEL, response.model)
 
-    messages = kwargs.get("messages")
-    if messages is None:
+    # Input messages (the prompt or data sent to the model)
+    # used for the token usage calculation
+    messages = kwargs.get("messages", [])
+    if messages == []:
         messages = kwargs.get("input")
 
     if isinstance(messages, str):

--- a/sentry_sdk/integrations/openai_agents/utils.py
+++ b/sentry_sdk/integrations/openai_agents/utils.py
@@ -1,16 +1,14 @@
-import json
 import sentry_sdk
 from sentry_sdk.consts import SPANDATA
 from sentry_sdk.integrations import DidNotEnable
 from sentry_sdk.scope import should_send_default_pii
-from sentry_sdk.utils import event_from_exception
+from sentry_sdk.utils import event_from_exception, safe_serialize
 
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from typing import Any
     from typing import Callable
-    from typing import Union
     from agents import Usage
 
 try:
@@ -162,49 +160,3 @@ def _set_output_data(span, result):
         span.set_data(
             SPANDATA.GEN_AI_RESPONSE_TEXT, safe_serialize(output_messages["response"])
         )
-
-
-def safe_serialize(data):
-    # type: (Any) -> str
-    """Safely serialize to a readable string."""
-
-    def serialize_item(item):
-        # type: (Any) -> Union[str, dict[Any, Any], list[Any], tuple[Any, ...]]
-        if callable(item):
-            try:
-                module = getattr(item, "__module__", None)
-                qualname = getattr(item, "__qualname__", None)
-                name = getattr(item, "__name__", "anonymous")
-
-                if module and qualname:
-                    full_path = f"{module}.{qualname}"
-                elif module and name:
-                    full_path = f"{module}.{name}"
-                else:
-                    full_path = name
-
-                return f"<function {full_path}>"
-            except Exception:
-                return f"<callable {type(item).__name__}>"
-        elif isinstance(item, dict):
-            return {k: serialize_item(v) for k, v in item.items()}
-        elif isinstance(item, (list, tuple)):
-            return [serialize_item(x) for x in item]
-        elif hasattr(item, "__dict__"):
-            try:
-                attrs = {
-                    k: serialize_item(v)
-                    for k, v in vars(item).items()
-                    if not k.startswith("_")
-                }
-                return f"<{type(item).__name__} {attrs}>"
-            except Exception:
-                return repr(item)
-        else:
-            return item
-
-    try:
-        serialized = serialize_item(data)
-        return json.dumps(serialized, default=str)
-    except Exception:
-        return str(data)

--- a/sentry_sdk/utils.py
+++ b/sentry_sdk/utils.py
@@ -1938,3 +1938,49 @@ def try_convert(convert_func, value):
         return convert_func(value)
     except Exception:
         return None
+
+
+def safe_serialize(data):
+    # type: (Any) -> str
+    """Safely serialize to a readable string."""
+
+    def serialize_item(item):
+        # type: (Any) -> Union[str, dict[Any, Any], list[Any], tuple[Any, ...]]
+        if callable(item):
+            try:
+                module = getattr(item, "__module__", None)
+                qualname = getattr(item, "__qualname__", None)
+                name = getattr(item, "__name__", "anonymous")
+
+                if module and qualname:
+                    full_path = f"{module}.{qualname}"
+                elif module and name:
+                    full_path = f"{module}.{name}"
+                else:
+                    full_path = name
+
+                return f"<function {full_path}>"
+            except Exception:
+                return f"<callable {type(item).__name__}>"
+        elif isinstance(item, dict):
+            return {k: serialize_item(v) for k, v in item.items()}
+        elif isinstance(item, (list, tuple)):
+            return [serialize_item(x) for x in item]
+        elif hasattr(item, "__dict__"):
+            try:
+                attrs = {
+                    k: serialize_item(v)
+                    for k, v in vars(item).items()
+                    if not k.startswith("_")
+                }
+                return f"<{type(item).__name__} {attrs}>"
+            except Exception:
+                return repr(item)
+        else:
+            return item
+
+    try:
+        serialized = serialize_item(data)
+        return json.dumps(serialized, default=str)
+    except Exception:
+        return str(data)

--- a/tests/integrations/openai/test_openai.py
+++ b/tests/integrations/openai/test_openai.py
@@ -1214,74 +1214,77 @@ async def test_error_in_responses_async_api(sentry_init, capture_events):
     )
 
 
-EXAMPLE_RESPONSES_STREAM = [
-    ResponseCreatedEvent(
-        sequence_number=1,
-        type="response.created",
-        response=Response(
-            id="chat-id",
-            created_at=10000000,
-            model="response-model-id",
-            object="response",
-            output=[],
-            parallel_tool_calls=False,
-            tool_choice="none",
-            tools=[],
-        ),
-    ),
-    ResponseTextDeltaEvent(
-        item_id="msg_1",
-        sequence_number=2,
-        type="response.output_text.delta",
-        logprobs=[],
-        content_index=0,
-        output_index=0,
-        delta="hel",
-    ),
-    ResponseTextDeltaEvent(
-        item_id="msg_1",
-        sequence_number=3,
-        type="response.output_text.delta",
-        logprobs=[],
-        content_index=0,
-        output_index=0,
-        delta="lo ",
-    ),
-    ResponseTextDeltaEvent(
-        item_id="msg_1",
-        sequence_number=4,
-        type="response.output_text.delta",
-        logprobs=[],
-        content_index=0,
-        output_index=0,
-        delta="world",
-    ),
-    ResponseCompletedEvent(
-        sequence_number=5,
-        type="response.completed",
-        response=Response(
-            id="chat-id",
-            created_at=10000000,
-            model="response-model-id",
-            object="response",
-            output=[],
-            parallel_tool_calls=False,
-            tool_choice="none",
-            tools=[],
-            usage=ResponseUsage(
-                input_tokens=20,
-                input_tokens_details=InputTokensDetails(
-                    cached_tokens=5,
-                ),
-                output_tokens=10,
-                output_tokens_details=OutputTokensDetails(
-                    reasoning_tokens=8,
-                ),
-                total_tokens=30,
+if SKIP_RESPONSES_TESTS:
+    EXAMPLE_RESPONSES_STREAM = []
+else:
+    EXAMPLE_RESPONSES_STREAM = [
+        ResponseCreatedEvent(
+            sequence_number=1,
+            type="response.created",
+            response=Response(
+                id="chat-id",
+                created_at=10000000,
+                model="response-model-id",
+                object="response",
+                output=[],
+                parallel_tool_calls=False,
+                tool_choice="none",
+                tools=[],
             ),
         ),
-    ),
-]
+        ResponseTextDeltaEvent(
+            item_id="msg_1",
+            sequence_number=2,
+            type="response.output_text.delta",
+            logprobs=[],
+            content_index=0,
+            output_index=0,
+            delta="hel",
+        ),
+        ResponseTextDeltaEvent(
+            item_id="msg_1",
+            sequence_number=3,
+            type="response.output_text.delta",
+            logprobs=[],
+            content_index=0,
+            output_index=0,
+            delta="lo ",
+        ),
+        ResponseTextDeltaEvent(
+            item_id="msg_1",
+            sequence_number=4,
+            type="response.output_text.delta",
+            logprobs=[],
+            content_index=0,
+            output_index=0,
+            delta="world",
+        ),
+        ResponseCompletedEvent(
+            sequence_number=5,
+            type="response.completed",
+            response=Response(
+                id="chat-id",
+                created_at=10000000,
+                model="response-model-id",
+                object="response",
+                output=[],
+                parallel_tool_calls=False,
+                tool_choice="none",
+                tools=[],
+                usage=ResponseUsage(
+                    input_tokens=20,
+                    input_tokens_details=InputTokensDetails(
+                        cached_tokens=5,
+                    ),
+                    output_tokens=10,
+                    output_tokens_details=OutputTokensDetails(
+                        reasoning_tokens=8,
+                    ),
+                    total_tokens=30,
+                ),
+            ),
+        ),
+    ]
 
 
 @pytest.mark.parametrize(

--- a/tests/integrations/openai/test_openai.py
+++ b/tests/integrations/openai/test_openai.py
@@ -6,6 +6,9 @@ from openai.types.chat import ChatCompletion, ChatCompletionMessage, ChatComplet
 from openai.types.chat.chat_completion import Choice
 from openai.types.chat.chat_completion_chunk import ChoiceDelta, Choice as DeltaChoice
 from openai.types.create_embedding_response import Usage as EmbeddingTokenUsage
+from openai.types.responses.response_text_delta_event import ResponseTextDeltaEvent
+from openai.types.responses.response_created_event import ResponseCreatedEvent
+from openai.types.responses.response_completed_event import ResponseCompletedEvent
 
 SKIP_RESPONSES_TESTS = False
 
@@ -1209,3 +1212,180 @@ async def test_error_in_responses_async_api(sentry_init, capture_events):
         error_event["contexts"]["trace"]["trace_id"]
         == transaction_event["contexts"]["trace"]["trace_id"]
     )
+
+
+EXAMPLE_RESPONSES_STREAM = [
+    ResponseCreatedEvent(
+        sequence_number=1,
+        type="response.created",
+        response=Response(
+            id="chat-id",
+            created_at=10000000,
+            model="response-model-id",
+            object="response",
+            output=[],
+            parallel_tool_calls=False,
+            tool_choice="none",
+            tools=[],
+        ),
+    ),
+    ResponseTextDeltaEvent(
+        item_id="msg_1",
+        sequence_number=2,
+        type="response.output_text.delta",
+        logprobs=[],
+        content_index=0,
+        output_index=0,
+        delta="hel",
+    ),
+    ResponseTextDeltaEvent(
+        item_id="msg_1",
+        sequence_number=3,
+        type="response.output_text.delta",
+        logprobs=[],
+        content_index=0,
+        output_index=0,
+        delta="lo ",
+    ),
+    ResponseTextDeltaEvent(
+        item_id="msg_1",
+        sequence_number=4,
+        type="response.output_text.delta",
+        logprobs=[],
+        content_index=0,
+        output_index=0,
+        delta="world",
+    ),
+    ResponseCompletedEvent(
+        sequence_number=5,
+        type="response.completed",
+        response=Response(
+            id="chat-id",
+            created_at=10000000,
+            model="response-model-id",
+            object="response",
+            output=[],
+            parallel_tool_calls=False,
+            tool_choice="none",
+            tools=[],
+            usage=ResponseUsage(
+                input_tokens=20,
+                input_tokens_details=InputTokensDetails(
+                    cached_tokens=5,
+                ),
+                output_tokens=10,
+                output_tokens_details=OutputTokensDetails(
+                    reasoning_tokens=8,
+                ),
+                total_tokens=30,
+            ),
+        ),
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    "send_default_pii, include_prompts",
+    [(True, True), (True, False), (False, True), (False, False)],
+)
+def test_streaming_responses_api(
+    sentry_init, capture_events, send_default_pii, include_prompts
+):
+    sentry_init(
+        integrations=[
+            OpenAIIntegration(
+                include_prompts=include_prompts,
+            )
+        ],
+        traces_sample_rate=1.0,
+        send_default_pii=send_default_pii,
+    )
+    events = capture_events()
+
+    client = OpenAI(api_key="z")
+    returned_stream = Stream(cast_to=None, response=None, client=client)
+    returned_stream._iterator = EXAMPLE_RESPONSES_STREAM
+    client.responses._post = mock.Mock(return_value=returned_stream)
+
+    with start_transaction(name="openai tx"):
+        response_stream = client.responses.create(
+            model="some-model",
+            input="hello",
+            stream=True,
+        )
+
+        response_string = ""
+        for item in response_stream:
+            if hasattr(item, "delta"):
+                response_string += item.delta
+
+    assert response_string == "hello world"
+
+    (transaction,) = events
+    (span,) = transaction["spans"]
+    assert span["op"] == "gen_ai.responses"
+
+    if send_default_pii and include_prompts:
+        assert span["data"][SPANDATA.GEN_AI_REQUEST_MESSAGES] == "hello"
+        assert span["data"][SPANDATA.GEN_AI_RESPONSE_TEXT] == "hello world"
+    else:
+        assert SPANDATA.GEN_AI_REQUEST_MESSAGES not in span["data"]
+        assert SPANDATA.GEN_AI_RESPONSE_TEXT not in span["data"]
+
+    assert span["data"]["gen_ai.usage.input_tokens"] == 20
+    assert span["data"]["gen_ai.usage.output_tokens"] == 10
+    assert span["data"]["gen_ai.usage.total_tokens"] == 30
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "send_default_pii, include_prompts",
+    [(True, True), (True, False), (False, True), (False, False)],
+)
+async def test_streaming_responses_api_async(
+    sentry_init, capture_events, send_default_pii, include_prompts
+):
+    sentry_init(
+        integrations=[
+            OpenAIIntegration(
+                include_prompts=include_prompts,
+            )
+        ],
+        traces_sample_rate=1.0,
+        send_default_pii=send_default_pii,
+    )
+    events = capture_events()
+
+    client = AsyncOpenAI(api_key="z")
+    returned_stream = AsyncStream(cast_to=None, response=None, client=client)
+    returned_stream._iterator = async_iterator(EXAMPLE_RESPONSES_STREAM)
+    client.responses._post = AsyncMock(return_value=returned_stream)
+
+    with start_transaction(name="openai tx"):
+        response_stream = await client.responses.create(
+            model="some-model",
+            input="hello",
+            stream=True,
+        )
+
+        response_string = ""
+        async for item in response_stream:
+            if hasattr(item, "delta"):
+                response_string += item.delta
+
+    assert response_string == "hello world"
+
+    (transaction,) = events
+    (span,) = transaction["spans"]
+    assert span["op"] == "gen_ai.responses"
+
+    if send_default_pii and include_prompts:
+        assert span["data"][SPANDATA.GEN_AI_REQUEST_MESSAGES] == "hello"
+        assert span["data"][SPANDATA.GEN_AI_RESPONSE_TEXT] == "hello world"
+    else:
+        assert SPANDATA.GEN_AI_REQUEST_MESSAGES not in span["data"]
+        assert SPANDATA.GEN_AI_RESPONSE_TEXT not in span["data"]
+
+    assert span["data"]["gen_ai.usage.input_tokens"] == 20
+    assert span["data"]["gen_ai.usage.output_tokens"] == 10
+    assert span["data"]["gen_ai.usage.total_tokens"] == 30

--- a/tests/integrations/openai/test_openai.py
+++ b/tests/integrations/openai/test_openai.py
@@ -1,3 +1,4 @@
+import json
 import pytest
 from openai import AsyncOpenAI, OpenAI, AsyncStream, Stream, OpenAIError
 from openai.types import CompletionUsage, CreateEmbeddingResponse, Embedding
@@ -52,7 +53,7 @@ EXAMPLE_CHAT_COMPLETION = ChatCompletion(
         )
     ],
     created=10000000,
-    model="model-id",
+    model="response-model-id",
     object="chat.completion",
     usage=CompletionUsage(
         completion_tokens=10,
@@ -86,7 +87,7 @@ else:
         tool_choice="none",
         tools=[],
         created_at=10000000,
-        model="model-id",
+        model="response-model-id",
         object="response",
         usage=ResponseUsage(
             input_tokens=20,
@@ -143,7 +144,7 @@ def test_nonstreaming_chat_completion(
         assert "hello" in span["data"][SPANDATA.GEN_AI_REQUEST_MESSAGES]["content"]
         assert (
             "the model response"
-            in span["data"][SPANDATA.GEN_AI_RESPONSE_TEXT]["content"]
+            in json.loads(span["data"][SPANDATA.GEN_AI_RESPONSE_TEXT])[0]["content"]
         )
     else:
         assert SPANDATA.GEN_AI_REQUEST_MESSAGES not in span["data"]
@@ -188,7 +189,7 @@ async def test_nonstreaming_chat_completion_async(
         assert "hello" in span["data"][SPANDATA.GEN_AI_REQUEST_MESSAGES]["content"]
         assert (
             "the model response"
-            in span["data"][SPANDATA.GEN_AI_RESPONSE_TEXT]["content"]
+            in json.loads(span["data"][SPANDATA.GEN_AI_RESPONSE_TEXT])[0]["content"]
         )
     else:
         assert SPANDATA.GEN_AI_REQUEST_MESSAGES not in span["data"]
@@ -986,7 +987,10 @@ def test_ai_client_span_responses_api_no_pii(sentry_init, capture_events):
     assert spans[0]["op"] == "gen_ai.responses"
     assert spans[0]["origin"] == "auto.ai.openai"
     assert spans[0]["data"] == {
+        "gen_ai.operation.name": "responses",
         "gen_ai.request.model": "gpt-4o",
+        "gen_ai.response.model": "response-model-id",
+        "gen_ai.system": "openai",
         "gen_ai.usage.input_tokens": 20,
         "gen_ai.usage.input_tokens.cached": 5,
         "gen_ai.usage.output_tokens": 10,
@@ -1026,8 +1030,11 @@ def test_ai_client_span_responses_api(sentry_init, capture_events):
     assert spans[0]["op"] == "gen_ai.responses"
     assert spans[0]["origin"] == "auto.ai.openai"
     assert spans[0]["data"] == {
+        "gen_ai.operation.name": "responses",
         "gen_ai.request.messages": "How do I check if a Python object is an instance of a class?",
         "gen_ai.request.model": "gpt-4o",
+        "gen_ai.system": "openai",
+        "gen_ai.response.model": "response-model-id",
         "gen_ai.usage.input_tokens": 20,
         "gen_ai.usage.input_tokens.cached": 5,
         "gen_ai.usage.output_tokens": 10,
@@ -1103,8 +1110,11 @@ async def test_ai_client_span_responses_async_api(sentry_init, capture_events):
     assert spans[0]["op"] == "gen_ai.responses"
     assert spans[0]["origin"] == "auto.ai.openai"
     assert spans[0]["data"] == {
+        "gen_ai.operation.name": "responses",
         "gen_ai.request.messages": "How do I check if a Python object is an instance of a class?",
         "gen_ai.request.model": "gpt-4o",
+        "gen_ai.response.model": "response-model-id",
+        "gen_ai.system": "openai",
         "gen_ai.usage.input_tokens": 20,
         "gen_ai.usage.input_tokens.cached": 5,
         "gen_ai.usage.output_tokens": 10,

--- a/tests/integrations/openai/test_openai.py
+++ b/tests/integrations/openai/test_openai.py
@@ -1291,6 +1291,7 @@ else:
     "send_default_pii, include_prompts",
     [(True, True), (True, False), (False, True), (False, False)],
 )
+@pytest.mark.skipif(SKIP_RESPONSES_TESTS, reason="Responses API not available")
 def test_streaming_responses_api(
     sentry_init, capture_events, send_default_pii, include_prompts
 ):
@@ -1345,6 +1346,7 @@ def test_streaming_responses_api(
     "send_default_pii, include_prompts",
     [(True, True), (True, False), (False, True), (False, False)],
 )
+@pytest.mark.skipif(SKIP_RESPONSES_TESTS, reason="Responses API not available")
 async def test_streaming_responses_api_async(
     sentry_init, capture_events, send_default_pii, include_prompts
 ):

--- a/tests/integrations/openai/test_openai.py
+++ b/tests/integrations/openai/test_openai.py
@@ -6,13 +6,13 @@ from openai.types.chat import ChatCompletion, ChatCompletionMessage, ChatComplet
 from openai.types.chat.chat_completion import Choice
 from openai.types.chat.chat_completion_chunk import ChoiceDelta, Choice as DeltaChoice
 from openai.types.create_embedding_response import Usage as EmbeddingTokenUsage
-from openai.types.responses.response_text_delta_event import ResponseTextDeltaEvent
-from openai.types.responses.response_created_event import ResponseCreatedEvent
-from openai.types.responses.response_completed_event import ResponseCompletedEvent
 
 SKIP_RESPONSES_TESTS = False
 
 try:
+    from openai.types.responses.response_completed_event import ResponseCompletedEvent
+    from openai.types.responses.response_created_event import ResponseCreatedEvent
+    from openai.types.responses.response_text_delta_event import ResponseTextDeltaEvent
     from openai.types.responses.response_usage import (
         InputTokensDetails,
         OutputTokensDetails,


### PR DESCRIPTION
Make sure all OpenTelemetry semantic conventions for AI clients and also the Sentry Conventions are adhered to.

Also cleans up the code a bit for better readability/maintenance.