### PR TITLE
Add async transport

### DIFF
--- a/sentry_sdk/transport.py
+++ b/sentry_sdk/transport.py
@@ -768,8 +768,10 @@ class AsyncHttpTransport(HttpTransportCore):
         for task in self.background_tasks:
             task.cancel()
         self.background_tasks.clear()
-
-        self._loop.create_task(self._pool.aclose())  # type: ignore
+        try:
+            self._loop.create_task(self._pool.aclose())  # type: ignore
+        except RuntimeError:
+            logger.warning("Event loop not running, aborting kill.")
 
 
 class HttpTransport(BaseHttpTransport):

--- a/sentry_sdk/transport.py
+++ b/sentry_sdk/transport.py
@@ -1029,6 +1029,8 @@ def make_transport(options: Dict[str, Any]) -> Optional[Transport]:
             # No event loop running, fall back to sync transport
             logger.warning("No event loop running, falling back to sync transport.")
             transport_cls = Http2Transport if use_http2_transport else HttpTransport
+    else:
+        transport_cls = Http2Transport if use_http2_transport else HttpTransport
 
     if isinstance(ref_transport, Transport):
         return ref_transport

--- a/sentry_sdk/transport.py
+++ b/sentry_sdk/transport.py
@@ -779,7 +779,9 @@ class AsyncHttpTransport(HttpTransportCore):
             task.cancel()
         self.background_tasks.clear()
         try:
-            self._loop.create_task(self._pool.aclose())  # type: ignore
+            task = self._loop.create_task(self._pool.aclose())  # type: ignore
+            self.background_tasks.add(task)
+            task.add_done_callback(lambda t: self.background_tasks.discard(t))
         except RuntimeError:
             logger.warning("Event loop not running, aborting kill.")
 

--- a/sentry_sdk/transport.py
+++ b/sentry_sdk/transport.py
@@ -6,6 +6,7 @@ import gzip
 import socket
 import ssl
 import time
+import asyncio
 from datetime import datetime, timedelta, timezone
 from collections import defaultdict
 from urllib.request import getproxies
@@ -569,6 +570,187 @@ class BaseHttpTransport(HttpTransportCore):
         if timeout > 0:
             self._worker.submit(lambda: self._flush_client_reports(force=True))
             self._worker.flush(timeout, callback)
+
+
+class AsyncHttpTransport(HttpTransportCore):
+    def __init__(self: Self, options: Dict[str, Any]) -> None:
+        super().__init__(options)
+        # Requires event loop at init time
+        self._loop = asyncio.get_running_loop()
+        self.background_tasks = set()
+
+    async def _send_envelope(self: Self, envelope: Envelope) -> None:
+        _prepared_envelope = self._prepare_envelope(envelope)
+        if _prepared_envelope is None:
+            return None
+        envelope, body, headers = _prepared_envelope
+        await self._send_request(
+            body.getvalue(),
+            headers=headers,
+            endpoint_type=EndpointType.ENVELOPE,
+            envelope=envelope,
+        )
+        return None
+
+    async def _send_request(
+        self: Self,
+        body: bytes,
+        headers: Dict[str, str],
+        endpoint_type: EndpointType,
+        envelope: Optional[Envelope],
+    ) -> None:
+        self._update_headers(headers)
+        try:
+            response = await self._request(
+                "POST",
+                endpoint_type,
+                body,
+                headers,
+            )
+        except Exception:
+            self._handle_request_error(envelope=envelope, loss_reason="network")
+            raise
+        try:
+            self._handle_response(response=response, envelope=envelope)
+        finally:
+            response.close()
+
+    async def _request(
+        self: Self,
+        method: str,
+        endpoint_type: EndpointType,
+        body: Any,
+        headers: Mapping[str, str],
+    ) -> httpcore.Response:
+        return await self._pool.request(
+            method,
+            self._auth.get_api_url(endpoint_type),
+            content=body,
+            headers=headers,  # type: ignore
+        )
+
+    def _flush_client_reports(self: Self, force: bool = False) -> None:
+        client_report = self._fetch_pending_client_report(force=force, interval=60)
+        if client_report is not None:
+            self.capture_envelope(Envelope(items=[client_report]))
+
+    async def _capture_envelope(self: Self, envelope: Envelope) -> None:
+        async def send_envelope_wrapper() -> None:
+            with capture_internal_exceptions():
+                await self._send_envelope(envelope)
+                self._flush_client_reports()
+
+        if not self._worker.submit(send_envelope_wrapper):
+            self.on_dropped_event("full_queue")
+            for item in envelope.items:
+                self.record_lost_event("queue_overflow", item=item)
+
+    def capture_envelope(self: Self, envelope: Envelope) -> None:
+        # Synchronous entry point
+        if asyncio.get_running_loop() is not None:
+            # We are on the main thread running the event loop
+            task = asyncio.create_task(self._capture_envelope(envelope))
+            self.background_tasks.add(task)
+            task.add_done_callback(self.background_tasks.discard)
+        else:
+            # We are in a background thread, not running an event loop,
+            # have to launch the task on the loop in a threadsafe way.
+            asyncio.run_coroutine_threadsafe(
+                self._capture_envelope(envelope),
+                self._loop,
+            )
+
+    async def flush_async(
+        self: Self,
+        timeout: float,
+        callback: Optional[Callable[[int, float], None]] = None,
+    ) -> None:
+        logger.debug("Flushing HTTP transport")
+
+        if timeout > 0:
+            self._worker.submit(lambda: self._flush_client_reports(force=True))
+            await self._worker.flush_async(timeout, callback)  # type: ignore
+
+    def _get_pool_options(self: Self) -> Dict[str, Any]:
+        options: Dict[str, Any] = {
+            "http2": False,  # no HTTP2 for now
+            "retries": 3,
+        }
+
+        socket_options = (
+            self.options["socket_options"]
+            if self.options["socket_options"] is not None
+            else []
+        )
+
+        used_options = {(o[0], o[1]) for o in socket_options}
+        for default_option in KEEP_ALIVE_SOCKET_OPTIONS:
+            if (default_option[0], default_option[1]) not in used_options:
+                socket_options.append(default_option)
+
+        options["socket_options"] = socket_options
+
+        ssl_context = ssl.create_default_context()
+        ssl_context.load_verify_locations(
+            self.options["ca_certs"]  # User-provided bundle from the SDK init
+            or os.environ.get("SSL_CERT_FILE")
+            or os.environ.get("REQUESTS_CA_BUNDLE")
+            or certifi.where()
+        )
+        cert_file = self.options["cert_file"] or os.environ.get("CLIENT_CERT_FILE")
+        key_file = self.options["key_file"] or os.environ.get("CLIENT_KEY_FILE")
+        if cert_file is not None:
+            ssl_context.load_cert_chain(cert_file, key_file)
+
+        options["ssl_context"] = ssl_context
+
+        return options
+
+    def _make_pool(
+        self: Self,
+    ) -> Union[
+        httpcore.AsyncSOCKSProxy, httpcore.AsyncHTTPProxy, httpcore.AsyncConnectionPool
+    ]:
+        if self.parsed_dsn is None:
+            raise ValueError("Cannot create HTTP-based transport without valid DSN")
+        proxy = None
+        no_proxy = self._in_no_proxy(self.parsed_dsn)
+
+        # try HTTPS first
+        https_proxy = self.options["https_proxy"]
+        if self.parsed_dsn.scheme == "https" and (https_proxy != ""):
+            proxy = https_proxy or (not no_proxy and getproxies().get("https"))
+
+        # maybe fallback to HTTP proxy
+        http_proxy = self.options["http_proxy"]
+        if not proxy and (http_proxy != ""):
+            proxy = http_proxy or (not no_proxy and getproxies().get("http"))
+
+        opts = self._get_pool_options()
+
+        if proxy:
+            proxy_headers = self.options["proxy_headers"]
+            if proxy_headers:
+                opts["proxy_headers"] = proxy_headers
+
+            if proxy.startswith("socks"):
+                try:
+                    if "socket_options" in opts:
+                        socket_options = opts.pop("socket_options")
+                        if socket_options:
+                            logger.warning(
+                                "You have defined socket_options but using a SOCKS proxy which doesn't support these. We'll ignore socket_options."
+                            )
+                    return httpcore.AsyncSOCKSProxy(proxy_url=proxy, **opts)
+                except RuntimeError:
+                    logger.warning(
+                        "You have configured a SOCKS proxy (%s) but support for SOCKS proxies is not installed. Disabling proxy support.",
+                        proxy,
+                    )
+            else:
+                return httpcore.AsyncHTTPProxy(proxy_url=proxy, **opts)
+
+        return httpcore.AsyncConnectionPool(**opts)
 
 
 class HttpTransport(BaseHttpTransport):

--- a/sentry_sdk/transport.py
+++ b/sentry_sdk/transport.py
@@ -227,7 +227,11 @@ class HttpTransportCore(Transport):
 
     def _create_worker(self, options: dict[str, Any]) -> Worker:
         async_enabled = options.get("_experiments", {}).get("transport_async", False)
-        worker_cls = AsyncWorker if async_enabled else BackgroundWorker
+        try:
+            asyncio.get_running_loop()
+            worker_cls = AsyncWorker if async_enabled else BackgroundWorker
+        except RuntimeError:
+            worker_cls = BackgroundWorker
         return worker_cls(queue_size=options["transport_queue_size"])
 
     def record_lost_event(

--- a/sentry_sdk/transport.py
+++ b/sentry_sdk/transport.py
@@ -23,6 +23,15 @@ try:
     HTTP2_ENABLED = True
 except ImportError:
     HTTP2_ENABLED = False
+    httpcore = None
+
+try:
+    import httpcore  # noqa: F401
+    import anyio  # noqa: F401
+
+    ASYNC_TRANSPORT_ENABLED = True
+except ImportError:
+    ASYNC_TRANSPORT_ENABLED = False
 
 import urllib3
 import certifi
@@ -577,226 +586,239 @@ class BaseHttpTransport(HttpTransportCore):
             self._worker.flush(timeout, callback)
 
 
-class AsyncHttpTransport(HttpTransportCore):
-    def __init__(self: Self, options: Dict[str, Any]) -> None:
-        super().__init__(options)
-        # Requires event loop at init time
-        self.loop = asyncio.get_running_loop()
-        self.background_tasks: set[asyncio.Task[None]] = set()
-
-    def _get_header_value(self: Self, response: Any, header: str) -> Optional[str]:
-        return next(
-            (
-                val.decode("ascii")
-                for key, val in response.headers
-                if key.decode("ascii").lower() == header
-            ),
-            None,
-        )
-
-    async def _send_envelope(self: Self, envelope: Envelope) -> None:
-        _prepared_envelope = self._prepare_envelope(envelope)
-        if _prepared_envelope is None:
-            return None
-        envelope, body, headers = _prepared_envelope
-        await self._send_request(
-            body.getvalue(),
-            headers=headers,
-            endpoint_type=EndpointType.ENVELOPE,
-            envelope=envelope,
-        )
-        return None
-
-    async def _send_request(
-        self: Self,
-        body: bytes,
-        headers: Dict[str, str],
-        endpoint_type: EndpointType,
-        envelope: Optional[Envelope],
-    ) -> None:
-        self._update_headers(headers)
-        try:
-            response = await self._request(
-                "POST",
-                endpoint_type,
-                body,
-                headers,
+if not ASYNC_TRANSPORT_ENABLED:
+    # Sorry, no AsyncHttpTransport for you
+    class AsyncHttpTransport(BaseHttpTransport):
+        def __init__(self: Self, options: Dict[str, Any]) -> None:
+            super().__init__(options)
+            logger.warning(
+                "You tried to use AsyncHttpTransport but don't have httpcore[asyncio] installed. Falling back to sync transport."
             )
-        except Exception:
-            self._handle_request_error(envelope=envelope, loss_reason="network")
-            raise
-        try:
-            self._handle_response(response=response, envelope=envelope)
-        finally:
-            await response.aclose()
 
-    async def _request(  # type: ignore[override]
-        self: Self,
-        method: str,
-        endpoint_type: EndpointType,
-        body: Any,
-        headers: Mapping[str, str],
-    ) -> httpcore.Response:
-        return await self._pool.request(
-            method,
-            self._auth.get_api_url(endpoint_type),
-            content=body,
-            headers=headers,  # type: ignore
-            extensions={
-                "timeout": {
-                    "pool": self.TIMEOUT,
-                    "connect": self.TIMEOUT,
-                    "write": self.TIMEOUT,
-                    "read": self.TIMEOUT,
-                }
-            },
-        )
+else:
 
-    def _flush_client_reports(self: Self, force: bool = False) -> None:
-        client_report = self._fetch_pending_client_report(force=force, interval=60)
-        if client_report is not None:
-            self.capture_envelope(Envelope(items=[client_report]))
+    class AsyncHttpTransport(HttpTransportCore):
+        def __init__(self: Self, options: Dict[str, Any]) -> None:
+            super().__init__(options)
+            # Requires event loop at init time
+            self.loop = asyncio.get_running_loop()
+            self.background_tasks: set[asyncio.Task[None]] = set()
 
-    async def _capture_envelope(self: Self, envelope: Envelope) -> None:
-        async def send_envelope_wrapper() -> None:
-            with capture_internal_exceptions():
-                await self._send_envelope(envelope)
-                self._flush_client_reports()
+        def _get_header_value(self: Self, response: Any, header: str) -> Optional[str]:
+            return next(
+                (
+                    val.decode("ascii")
+                    for key, val in response.headers
+                    if key.decode("ascii").lower() == header
+                ),
+                None,
+            )
 
-        if not self._worker.submit(send_envelope_wrapper):
-            self.on_dropped_event("full_queue")
-            for item in envelope.items:
-                self.record_lost_event("queue_overflow", item=item)
-
-    def capture_envelope(self: Self, envelope: Envelope) -> None:
-        # Synchronous entry point
-        try:
-            asyncio.get_running_loop()
-            # We are on the main thread running the event loop
-            task = asyncio.create_task(self._capture_envelope(envelope))
-            self.background_tasks.add(task)
-            task.add_done_callback(self.background_tasks.discard)
-        except RuntimeError:
-            # We are in a background thread, not running an event loop,
-            # have to launch the task on the loop in a threadsafe way.
-            if self.loop and self.loop.is_running():
-                asyncio.run_coroutine_threadsafe(
-                    self._capture_envelope(envelope),
-                    self.loop,
-                )
-            else:
-                # The event loop is no longer running
-                logger.warning("Async Transport is not running in an event loop.")
-                self.on_dropped_event("no_async_context")
-                for item in envelope.items:
-                    self.record_lost_event("no_async_context", item=item)
-
-    def flush(  # type: ignore[override]
-        self: Self,
-        timeout: float,
-        callback: Optional[Callable[[int, float], None]] = None,
-    ) -> Optional[asyncio.Task[None]]:
-        logger.debug("Flushing HTTP transport")
-
-        if timeout > 0:
-            self._worker.submit(lambda: self._flush_client_reports(force=True))
-            return self._worker.flush(timeout, callback)  # type: ignore[func-returns-value]
-        return None
-
-    def _get_pool_options(self: Self) -> Dict[str, Any]:
-        options: Dict[str, Any] = {
-            "http2": False,  # no HTTP2 for now
-            "retries": 3,
-        }
-
-        socket_options = (
-            self.options["socket_options"]
-            if self.options["socket_options"] is not None
-            else []
-        )
-
-        used_options = {(o[0], o[1]) for o in socket_options}
-        for default_option in KEEP_ALIVE_SOCKET_OPTIONS:
-            if (default_option[0], default_option[1]) not in used_options:
-                socket_options.append(default_option)
-
-        options["socket_options"] = socket_options
-
-        ssl_context = ssl.create_default_context()
-        ssl_context.load_verify_locations(
-            self.options["ca_certs"]  # User-provided bundle from the SDK init
-            or os.environ.get("SSL_CERT_FILE")
-            or os.environ.get("REQUESTS_CA_BUNDLE")
-            or certifi.where()
-        )
-        cert_file = self.options["cert_file"] or os.environ.get("CLIENT_CERT_FILE")
-        key_file = self.options["key_file"] or os.environ.get("CLIENT_KEY_FILE")
-        if cert_file is not None:
-            ssl_context.load_cert_chain(cert_file, key_file)
-
-        options["ssl_context"] = ssl_context
-
-        return options
-
-    def _make_pool(
-        self: Self,
-    ) -> Union[
-        httpcore.AsyncSOCKSProxy, httpcore.AsyncHTTPProxy, httpcore.AsyncConnectionPool
-    ]:
-        if self.parsed_dsn is None:
-            raise ValueError("Cannot create HTTP-based transport without valid DSN")
-        proxy = None
-        no_proxy = self._in_no_proxy(self.parsed_dsn)
-
-        # try HTTPS first
-        https_proxy = self.options["https_proxy"]
-        if self.parsed_dsn.scheme == "https" and (https_proxy != ""):
-            proxy = https_proxy or (not no_proxy and getproxies().get("https"))
-
-        # maybe fallback to HTTP proxy
-        http_proxy = self.options["http_proxy"]
-        if not proxy and (http_proxy != ""):
-            proxy = http_proxy or (not no_proxy and getproxies().get("http"))
-
-        opts = self._get_pool_options()
-
-        if proxy:
-            proxy_headers = self.options["proxy_headers"]
-            if proxy_headers:
-                opts["proxy_headers"] = proxy_headers
-
-            if proxy.startswith("socks"):
-                try:
-                    if "socket_options" in opts:
-                        socket_options = opts.pop("socket_options")
-                        if socket_options:
-                            logger.warning(
-                                "You have defined socket_options but using a SOCKS proxy which doesn't support these. We'll ignore socket_options."
-                            )
-                    return httpcore.AsyncSOCKSProxy(proxy_url=proxy, **opts)
-                except RuntimeError:
-                    logger.warning(
-                        "You have configured a SOCKS proxy (%s) but support for SOCKS proxies is not installed. Disabling proxy support.",
-                        proxy,
-                    )
-            else:
-                return httpcore.AsyncHTTPProxy(proxy_url=proxy, **opts)
-
-        return httpcore.AsyncConnectionPool(**opts)
-
-    def kill(self: Self) -> Optional[asyncio.Task[None]]:  # type: ignore
-
-        logger.debug("Killing HTTP transport")
-        self._worker.kill()
-        for task in self.background_tasks:
-            task.cancel()
-        self.background_tasks.clear()
-        try:
-            # Return the pool cleanup task so caller can await it if needed
-            return self.loop.create_task(self._pool.aclose())  # type: ignore
-        except RuntimeError:
-            logger.warning("Event loop not running, aborting kill.")
+        async def _send_envelope(self: Self, envelope: Envelope) -> None:
+            _prepared_envelope = self._prepare_envelope(envelope)
+            if _prepared_envelope is None:
+                return None
+            envelope, body, headers = _prepared_envelope
+            await self._send_request(
+                body.getvalue(),
+                headers=headers,
+                endpoint_type=EndpointType.ENVELOPE,
+                envelope=envelope,
+            )
             return None
+
+        async def _send_request(
+            self: Self,
+            body: bytes,
+            headers: Dict[str, str],
+            endpoint_type: EndpointType,
+            envelope: Optional[Envelope],
+        ) -> None:
+            self._update_headers(headers)
+            try:
+                response = await self._request(
+                    "POST",
+                    endpoint_type,
+                    body,
+                    headers,
+                )
+            except Exception:
+                self._handle_request_error(envelope=envelope, loss_reason="network")
+                raise
+            try:
+                self._handle_response(response=response, envelope=envelope)
+            finally:
+                await response.aclose()
+
+        async def _request(  # type: ignore[override]
+            self: Self,
+            method: str,
+            endpoint_type: EndpointType,
+            body: Any,
+            headers: Mapping[str, str],
+        ) -> httpcore.Response:
+            return await self._pool.request(
+                method,
+                self._auth.get_api_url(endpoint_type),
+                content=body,
+                headers=headers,  # type: ignore
+                extensions={
+                    "timeout": {
+                        "pool": self.TIMEOUT,
+                        "connect": self.TIMEOUT,
+                        "write": self.TIMEOUT,
+                        "read": self.TIMEOUT,
+                    }
+                },
+            )
+
+        def _flush_client_reports(self: Self, force: bool = False) -> None:
+            client_report = self._fetch_pending_client_report(force=force, interval=60)
+            if client_report is not None:
+                self.capture_envelope(Envelope(items=[client_report]))
+
+        async def _capture_envelope(self: Self, envelope: Envelope) -> None:
+            async def send_envelope_wrapper() -> None:
+                with capture_internal_exceptions():
+                    await self._send_envelope(envelope)
+                    self._flush_client_reports()
+
+            if not self._worker.submit(send_envelope_wrapper):
+                self.on_dropped_event("full_queue")
+                for item in envelope.items:
+                    self.record_lost_event("queue_overflow", item=item)
+
+        def capture_envelope(self: Self, envelope: Envelope) -> None:
+            # Synchronous entry point
+            try:
+                asyncio.get_running_loop()
+                # We are on the main thread running the event loop
+                task = asyncio.create_task(self._capture_envelope(envelope))
+                self.background_tasks.add(task)
+                task.add_done_callback(self.background_tasks.discard)
+            except RuntimeError:
+                # We are in a background thread, not running an event loop,
+                # have to launch the task on the loop in a threadsafe way.
+                if self.loop and self.loop.is_running():
+                    asyncio.run_coroutine_threadsafe(
+                        self._capture_envelope(envelope),
+                        self.loop,
+                    )
+                else:
+                    # The event loop is no longer running
+                    logger.warning("Async Transport is not running in an event loop.")
+                    self.on_dropped_event("no_async_context")
+                    for item in envelope.items:
+                        self.record_lost_event("no_async_context", item=item)
+
+        def flush(  # type: ignore[override]
+            self: Self,
+            timeout: float,
+            callback: Optional[Callable[[int, float], None]] = None,
+        ) -> Optional[asyncio.Task[None]]:
+            logger.debug("Flushing HTTP transport")
+
+            if timeout > 0:
+                self._worker.submit(lambda: self._flush_client_reports(force=True))
+                return self._worker.flush(timeout, callback)  # type: ignore[func-returns-value]
+            return None
+
+        def _get_pool_options(self: Self) -> Dict[str, Any]:
+            options: Dict[str, Any] = {
+                "http2": False,  # no HTTP2 for now
+                "retries": 3,
+            }
+
+            socket_options = (
+                self.options["socket_options"]
+                if self.options["socket_options"] is not None
+                else []
+            )
+
+            used_options = {(o[0], o[1]) for o in socket_options}
+            for default_option in KEEP_ALIVE_SOCKET_OPTIONS:
+                if (default_option[0], default_option[1]) not in used_options:
+                    socket_options.append(default_option)
+
+            options["socket_options"] = socket_options
+
+            ssl_context = ssl.create_default_context()
+            ssl_context.load_verify_locations(
+                self.options["ca_certs"]  # User-provided bundle from the SDK init
+                or os.environ.get("SSL_CERT_FILE")
+                or os.environ.get("REQUESTS_CA_BUNDLE")
+                or certifi.where()
+            )
+            cert_file = self.options["cert_file"] or os.environ.get("CLIENT_CERT_FILE")
+            key_file = self.options["key_file"] or os.environ.get("CLIENT_KEY_FILE")
+            if cert_file is not None:
+                ssl_context.load_cert_chain(cert_file, key_file)
+
+            options["ssl_context"] = ssl_context
+
+            return options
+
+        def _make_pool(
+            self: Self,
+        ) -> Union[
+            httpcore.AsyncSOCKSProxy,
+            httpcore.AsyncHTTPProxy,
+            httpcore.AsyncConnectionPool,
+        ]:
+            if self.parsed_dsn is None:
+                raise ValueError("Cannot create HTTP-based transport without valid DSN")
+            proxy = None
+            no_proxy = self._in_no_proxy(self.parsed_dsn)
+
+            # try HTTPS first
+            https_proxy = self.options["https_proxy"]
+            if self.parsed_dsn.scheme == "https" and (https_proxy != ""):
+                proxy = https_proxy or (not no_proxy and getproxies().get("https"))
+
+            # maybe fallback to HTTP proxy
+            http_proxy = self.options["http_proxy"]
+            if not proxy and (http_proxy != ""):
+                proxy = http_proxy or (not no_proxy and getproxies().get("http"))
+
+            opts = self._get_pool_options()
+
+            if proxy:
+                proxy_headers = self.options["proxy_headers"]
+                if proxy_headers:
+                    opts["proxy_headers"] = proxy_headers
+
+                if proxy.startswith("socks"):
+                    try:
+                        if "socket_options" in opts:
+                            socket_options = opts.pop("socket_options")
+                            if socket_options:
+                                logger.warning(
+                                    "You have defined socket_options but using a SOCKS proxy which doesn't support these. We'll ignore socket_options."
+                                )
+                        return httpcore.AsyncSOCKSProxy(proxy_url=proxy, **opts)
+                    except RuntimeError:
+                        logger.warning(
+                            "You have configured a SOCKS proxy (%s) but support for SOCKS proxies is not installed. Disabling proxy support.",
+                            proxy,
+                        )
+                else:
+                    return httpcore.AsyncHTTPProxy(proxy_url=proxy, **opts)
+
+            return httpcore.AsyncConnectionPool(**opts)
+
+        def kill(self: Self) -> Optional[asyncio.Task[None]]:  # type: ignore
+
+            logger.debug("Killing HTTP transport")
+            self._worker.kill()
+            for task in self.background_tasks:
+                task.cancel()
+            self.background_tasks.clear()
+            try:
+                # Return the pool cleanup task so caller can await it if needed
+                return self.loop.create_task(self._pool.aclose())  # type: ignore
+            except RuntimeError:
+                logger.warning("Event loop not running, aborting kill.")
+                return None
 
 
 class HttpTransport(BaseHttpTransport):

--- a/sentry_sdk/transport.py
+++ b/sentry_sdk/transport.py
@@ -620,15 +620,14 @@ else:
 
         async def _send_envelope(self: Self, envelope: Envelope) -> None:
             _prepared_envelope = self._prepare_envelope(envelope)
-            if _prepared_envelope is None:
-                return None
-            envelope, body, headers = _prepared_envelope
-            await self._send_request(
-                body.getvalue(),
-                headers=headers,
-                endpoint_type=EndpointType.ENVELOPE,
-                envelope=envelope,
-            )
+            if _prepared_envelope is not None:
+                envelope, body, headers = _prepared_envelope
+                await self._send_request(
+                    body.getvalue(),
+                    headers=headers,
+                    endpoint_type=EndpointType.ENVELOPE,
+                    envelope=envelope,
+                )
             return None
 
         async def _send_request(
@@ -676,7 +675,7 @@ else:
                 },
             )
 
-        def _flush_client_reports(self: Self, force: bool = False) -> None:
+        async def _flush_client_reports(self: Self, force: bool = False) -> None:
             client_report = self._fetch_pending_client_report(force=force, interval=60)
             if client_report is not None:
                 self.capture_envelope(Envelope(items=[client_report]))
@@ -685,7 +684,7 @@ else:
             async def send_envelope_wrapper() -> None:
                 with capture_internal_exceptions():
                     await self._send_envelope(envelope)
-                    self._flush_client_reports()
+                    await self._flush_client_reports()
 
             if not self._worker.submit(send_envelope_wrapper):
                 self.on_dropped_event("full_queue")
@@ -711,9 +710,9 @@ else:
                 else:
                     # The event loop is no longer running
                     logger.warning("Async Transport is not running in an event loop.")
-                    self.on_dropped_event("no_async_context")
+                    self.on_dropped_event("internal_sdk_error")
                     for item in envelope.items:
-                        self.record_lost_event("no_async_context", item=item)
+                        self.record_lost_event("internal_sdk_error", item=item)
 
         def flush(  # type: ignore[override]
             self: Self,

--- a/sentry_sdk/transport.py
+++ b/sentry_sdk/transport.py
@@ -580,6 +580,16 @@ class AsyncHttpTransport(HttpTransportCore):
         self._loop = asyncio.get_running_loop()
         self.background_tasks: set[asyncio.Task[None]] = set()
 
+    def _get_header_value(self: Self, response: Any, header: str) -> Optional[str]:
+        return next(
+            (
+                val.decode("ascii")
+                for key, val in response.headers
+                if key.decode("ascii").lower() == header
+            ),
+            None,
+        )
+
     async def _send_envelope(self: Self, envelope: Envelope) -> None:
         _prepared_envelope = self._prepare_envelope(envelope)
         if _prepared_envelope is None:
@@ -614,7 +624,7 @@ class AsyncHttpTransport(HttpTransportCore):
         try:
             self._handle_response(response=response, envelope=envelope)
         finally:
-            response.close()
+            await response.aclose()
 
     async def _request(  # type: ignore[override]
         self: Self,

--- a/sentry_sdk/transport.py
+++ b/sentry_sdk/transport.py
@@ -581,7 +581,7 @@ class AsyncHttpTransport(HttpTransportCore):
     def __init__(self: Self, options: Dict[str, Any]) -> None:
         super().__init__(options)
         # Requires event loop at init time
-        self._loop = asyncio.get_running_loop()
+        self.loop = asyncio.get_running_loop()
         self.background_tasks: set[asyncio.Task[None]] = set()
 
     def _get_header_value(self: Self, response: Any, header: str) -> Optional[str]:
@@ -679,10 +679,10 @@ class AsyncHttpTransport(HttpTransportCore):
         except RuntimeError:
             # We are in a background thread, not running an event loop,
             # have to launch the task on the loop in a threadsafe way.
-            if self._loop and self._loop.is_running():
+            if self.loop and self.loop.is_running():
                 asyncio.run_coroutine_threadsafe(
                     self._capture_envelope(envelope),
-                    self._loop,
+                    self.loop,
                 )
             else:
                 # The event loop is no longer running
@@ -793,7 +793,7 @@ class AsyncHttpTransport(HttpTransportCore):
         self.background_tasks.clear()
         try:
             # Return the pool cleanup task so caller can await it if needed
-            return self._loop.create_task(self._pool.aclose())  # type: ignore
+            return self.loop.create_task(self._pool.aclose())  # type: ignore
         except RuntimeError:
             logger.warning("Event loop not running, aborting kill.")
             return None

--- a/sentry_sdk/transport.py
+++ b/sentry_sdk/transport.py
@@ -578,7 +578,7 @@ class AsyncHttpTransport(HttpTransportCore):
         super().__init__(options)
         # Requires event loop at init time
         self._loop = asyncio.get_running_loop()
-        self.background_tasks = set()
+        self.background_tasks: set[asyncio.Task[None]] = set()
 
     async def _send_envelope(self: Self, envelope: Envelope) -> None:
         _prepared_envelope = self._prepare_envelope(envelope)
@@ -616,7 +616,7 @@ class AsyncHttpTransport(HttpTransportCore):
         finally:
             response.close()
 
-    async def _request(
+    async def _request(  # type: ignore[override]
         self: Self,
         method: str,
         endpoint_type: EndpointType,

--- a/sentry_sdk/transport.py
+++ b/sentry_sdk/transport.py
@@ -23,7 +23,7 @@ try:
     HTTP2_ENABLED = True
 except ImportError:
     HTTP2_ENABLED = False
-    httpcore = None
+    httpcore = None  # type: ignore
 
 try:
     import httpcore  # noqa: F401
@@ -597,7 +597,7 @@ if not ASYNC_TRANSPORT_ENABLED:
 
 else:
 
-    class AsyncHttpTransport(HttpTransportCore):
+    class AsyncHttpTransport(HttpTransportCore):  # type: ignore
         def __init__(self: Self, options: Dict[str, Any]) -> None:
             super().__init__(options)
             # Requires event loop at init time

--- a/sentry_sdk/transport.py
+++ b/sentry_sdk/transport.py
@@ -761,6 +761,16 @@ class AsyncHttpTransport(HttpTransportCore):
 
         return httpcore.AsyncConnectionPool(**opts)
 
+    def kill(self: Self) -> None:
+
+        logger.debug("Killing HTTP transport")
+        self._worker.kill()
+        for task in self.background_tasks:
+            task.cancel()
+        self.background_tasks.clear()
+
+        self._loop.create_task(self._pool.aclose())  # type: ignore
+
 
 class HttpTransport(BaseHttpTransport):
     if TYPE_CHECKING:

--- a/sentry_sdk/transport.py
+++ b/sentry_sdk/transport.py
@@ -638,6 +638,14 @@ class AsyncHttpTransport(HttpTransportCore):
             self._auth.get_api_url(endpoint_type),
             content=body,
             headers=headers,  # type: ignore
+            extensions={
+                "timeout": {
+                    "pool": self.TIMEOUT,
+                    "connect": self.TIMEOUT,
+                    "write": self.TIMEOUT,
+                    "read": self.TIMEOUT,
+                }
+            },
         )
 
     def _flush_client_reports(self: Self, force: bool = False) -> None:

--- a/sentry_sdk/transport.py
+++ b/sentry_sdk/transport.py
@@ -700,7 +700,7 @@ class AsyncHttpTransport(HttpTransportCore):
 
         if timeout > 0:
             self._worker.submit(lambda: self._flush_client_reports(force=True))
-            return self._worker.flush(timeout, callback)
+            return self._worker.flush(timeout, callback)  # type: ignore[func-returns-value]
         return None
 
     def _get_pool_options(self: Self) -> Dict[str, Any]:

--- a/sentry_sdk/transport.py
+++ b/sentry_sdk/transport.py
@@ -691,16 +691,17 @@ class AsyncHttpTransport(HttpTransportCore):
                 for item in envelope.items:
                     self.record_lost_event("no_async_context", item=item)
 
-    async def flush_async(
+    def flush(  # type: ignore[override]
         self: Self,
         timeout: float,
         callback: Optional[Callable[[int, float], None]] = None,
-    ) -> None:
+    ) -> Optional[asyncio.Task[None]]:
         logger.debug("Flushing HTTP transport")
 
         if timeout > 0:
             self._worker.submit(lambda: self._flush_client_reports(force=True))
-            await self._worker.flush_async(timeout, callback)  # type: ignore
+            return self._worker.flush(timeout, callback)
+        return None
 
     def _get_pool_options(self: Self) -> Dict[str, Any]:
         options: Dict[str, Any] = {

--- a/sentry_sdk/transport.py
+++ b/sentry_sdk/transport.py
@@ -29,7 +29,7 @@ import certifi
 
 from sentry_sdk.consts import EndpointType
 from sentry_sdk.utils import Dsn, logger, capture_internal_exceptions
-from sentry_sdk.worker import BackgroundWorker, Worker
+from sentry_sdk.worker import BackgroundWorker, Worker, AsyncWorker
 from sentry_sdk.envelope import Envelope, Item, PayloadRef
 
 from typing import TYPE_CHECKING
@@ -225,9 +225,10 @@ class HttpTransportCore(Transport):
         elif self._compression_algo == "br":
             self._compression_level = 4
 
-    def _create_worker(self: Self, options: Dict[str, Any]) -> Worker:
-        # For now, we only support the threaded sync background worker.
-        return BackgroundWorker(queue_size=options["transport_queue_size"])
+    def _create_worker(self, options: dict[str, Any]) -> Worker:
+        async_enabled = options.get("_experiments", {}).get("transport_async", False)
+        worker_cls = AsyncWorker if async_enabled else BackgroundWorker
+        return worker_cls(queue_size=options["transport_queue_size"])
 
     def record_lost_event(
         self: Self,
@@ -647,18 +648,26 @@ class AsyncHttpTransport(HttpTransportCore):
 
     def capture_envelope(self: Self, envelope: Envelope) -> None:
         # Synchronous entry point
-        if asyncio.get_running_loop() is not None:
+        try:
+            asyncio.get_running_loop()
             # We are on the main thread running the event loop
             task = asyncio.create_task(self._capture_envelope(envelope))
             self.background_tasks.add(task)
             task.add_done_callback(self.background_tasks.discard)
-        else:
+        except RuntimeError:
             # We are in a background thread, not running an event loop,
             # have to launch the task on the loop in a threadsafe way.
-            asyncio.run_coroutine_threadsafe(
-                self._capture_envelope(envelope),
-                self._loop,
-            )
+            if self._loop and self._loop.is_running():
+                asyncio.run_coroutine_threadsafe(
+                    self._capture_envelope(envelope),
+                    self._loop,
+                )
+            else:
+                # The event loop is no longer running
+                logger.warning("Async Transport is not running in an event loop.")
+                self.on_dropped_event("no_async_context")
+                for item in envelope.items:
+                    self.record_lost_event("no_async_context", item=item)
 
     async def flush_async(
         self: Self,
@@ -998,11 +1007,13 @@ def make_transport(options: Dict[str, Any]) -> Optional[Transport]:
     ref_transport = options["transport"]
 
     use_http2_transport = options.get("_experiments", {}).get("transport_http2", False)
-
+    use_async_transport = options.get("_experiments", {}).get("transport_async", False)
     # By default, we use the http transport class
-    transport_cls: Type[Transport] = (
-        Http2Transport if use_http2_transport else HttpTransport
-    )
+    if use_async_transport and asyncio.get_running_loop() is not None:
+        transport_cls: Type[Transport] = AsyncHttpTransport
+    else:
+        use_http2 = use_http2_transport
+        transport_cls = Http2Transport if use_http2 else HttpTransport
 
     if isinstance(ref_transport, Transport):
         return ref_transport

--- a/sentry_sdk/transport.py
+++ b/sentry_sdk/transport.py
@@ -594,7 +594,6 @@ else:
             super().__init__(options)
             # Requires event loop at init time
             self.loop = asyncio.get_running_loop()
-            self.background_tasks: set[asyncio.Task[None]] = set()
 
         def _create_worker(self: Self, options: dict[str, Any]) -> Worker:
             return AsyncWorker(queue_size=options["transport_queue_size"])
@@ -792,9 +791,6 @@ else:
 
             logger.debug("Killing HTTP transport")
             self._worker.kill()
-            for task in self.background_tasks:
-                task.cancel()
-            self.background_tasks.clear()
             try:
                 # Return the pool cleanup task so caller can await it if needed
                 return self.loop.create_task(self._pool.aclose())  # type: ignore

--- a/sentry_sdk/worker.py
+++ b/sentry_sdk/worker.py
@@ -3,6 +3,7 @@ from abc import ABC, abstractmethod
 import os
 import threading
 import asyncio
+import inspect
 
 from time import sleep, time
 from sentry_sdk._queue import Queue, FullError
@@ -305,7 +306,11 @@ class AsyncWorker(Worker):
 
     async def _process_callback(self, callback: Callable[[], Any]) -> None:
         # Callback is an async coroutine, need to await it
-        await callback()
+        if inspect.iscoroutinefunction(callback):
+            await callback()
+        else:
+            # Callback is a sync function, such as _flush_client_reports()
+            callback()
 
     def _on_task_complete(self, task: asyncio.Task[None]) -> None:
         try:

--- a/sentry_sdk/worker.py
+++ b/sentry_sdk/worker.py
@@ -198,7 +198,7 @@ class AsyncWorker(Worker):
         self._task_for_pid: Optional[int] = None
         self._loop: Optional[asyncio.AbstractEventLoop] = None
         # Track active callback tasks so they have a strong reference and can be cancelled on kill
-        self._active_tasks: set[asyncio.Task] = set()
+        self._active_tasks: set[asyncio.Task[None]] = set()
 
     @property
     def is_alive(self) -> bool:

--- a/sentry_sdk/worker.py
+++ b/sentry_sdk/worker.py
@@ -259,7 +259,7 @@ class AsyncWorker(Worker):
             await self._wait_flush(timeout, callback)
         logger.debug("background worker flushed")
 
-    def submit(self, callback: Callable[[], None]) -> bool:
+    def submit(self, callback: Callable[[], Any]) -> bool:
         self._ensure_task()
 
         try:

--- a/sentry_sdk/worker.py
+++ b/sentry_sdk/worker.py
@@ -3,6 +3,7 @@ from abc import ABC, abstractmethod
 import os
 import threading
 import asyncio
+import inspect
 
 from time import sleep, time
 from sentry_sdk._queue import Queue, FullError
@@ -271,7 +272,12 @@ class AsyncWorker(Worker):
         while True:
             callback = await self._queue.get()
             try:
-                callback()
+                if inspect.iscoroutinefunction(callback):
+                    # Callback is an async coroutine, need to await it
+                    await callback()
+                else:
+                    # Callback is a sync function, need to call it
+                    callback()
             except Exception:
                 logger.error("Failed processing job", exc_info=True)
             finally:

--- a/sentry_sdk/worker.py
+++ b/sentry_sdk/worker.py
@@ -211,6 +211,7 @@ class AsyncWorker(Worker):
             self._task.cancel()
             self._task = None
             self._task_for_pid = None
+            self._loop = None
 
     def start(self) -> None:
         if not self.is_alive:

--- a/sentry_sdk/worker.py
+++ b/sentry_sdk/worker.py
@@ -45,18 +45,6 @@ class Worker(ABC):
         """
         return None
 
-    async def flush_async(
-        self, timeout: float, callback: Optional[Callable[[int, float], None]] = None
-    ) -> None:
-        """
-        Flush the worker.
-
-        This method can be awaited until the worker has flushed all events or the specified timeout is reached.
-        Default implementation is a no-op, since this method may only be relevant to some workers.
-        Subclasses should override this method if necessary.
-        """
-        return None
-
     @abstractmethod
     def full(self) -> bool:
         pass

--- a/sentry_sdk/worker.py
+++ b/sentry_sdk/worker.py
@@ -191,7 +191,8 @@ class BackgroundWorker(Worker):
 
 class AsyncWorker(Worker):
     def __init__(self, queue_size: int = DEFAULT_QUEUE_SIZE) -> None:
-        self._queue: asyncio.Queue[Any] = None
+        self._queue: asyncio.Queue[Any] = asyncio.Queue(maxsize=queue_size)
+        self._queue_size = queue_size
         self._task: Optional[asyncio.Task[None]] = None
         # Event loop needs to remain in the same process
         self._task_for_pid: Optional[int] = None

--- a/sentry_sdk/worker.py
+++ b/sentry_sdk/worker.py
@@ -252,7 +252,7 @@ class AsyncWorker(Worker):
                 pending = self._queue.qsize() + 1
                 logger.error("flush timed out, dropped %s events", pending)
 
-    async def flush(self, timeout: float, callback: Optional[Any] = None) -> None:
+    async def flush_async(self, timeout: float, callback: Optional[Any] = None) -> None:
         logger.debug("background worker got flush request")
         if self.is_alive and timeout > 0.0:
             await self._wait_flush(timeout, callback)

--- a/sentry_sdk/worker.py
+++ b/sentry_sdk/worker.py
@@ -27,10 +27,21 @@ class Worker(ABC):
     @property
     @abstractmethod
     def is_alive(self) -> bool:
+        """
+        Checks whether the worker is alive and running.
+
+        Returns True if the worker is alive, False otherwise.
+        """
         pass
 
     @abstractmethod
     def kill(self) -> None:
+        """
+        Kills the worker.
+
+        This method is used to kill the worker. The queue will be drained up to the point where the worker is killed.
+        The worker will not be able to process any more events.
+        """
         pass
 
     def flush(
@@ -47,6 +58,11 @@ class Worker(ABC):
 
     @abstractmethod
     def full(self) -> bool:
+        """
+        Checks whether the worker's queue is full.
+
+        Returns True if the queue is full, False otherwise.
+        """
         pass
 
     @abstractmethod

--- a/sentry_sdk/worker.py
+++ b/sentry_sdk/worker.py
@@ -33,7 +33,6 @@ class Worker(ABC):
     def kill(self) -> None:
         pass
 
-    @abstractmethod
     def flush(
         self, timeout: float, callback: Optional[Callable[[int, float], None]] = None
     ) -> None:
@@ -41,8 +40,22 @@ class Worker(ABC):
         Flush the worker.
 
         This method blocks until the worker has flushed all events or the specified timeout is reached.
+        Default implementation is a no-op, since this method may only be relevant to some workers.
+        Subclasses should override this method if necessary.
         """
-        pass
+        return None
+
+    async def flush_async(
+        self, timeout: float, callback: Optional[Callable[[int, float], None]] = None
+    ) -> None:
+        """
+        Flush the worker.
+
+        This method can be awaited until the worker has flushed all events or the specified timeout is reached.
+        Default implementation is a no-op, since this method may only be relevant to some workers.
+        Subclasses should override this method if necessary.
+        """
+        return None
 
     @abstractmethod
     def full(self) -> bool:

--- a/sentry_sdk/worker.py
+++ b/sentry_sdk/worker.py
@@ -192,8 +192,8 @@ class BackgroundWorker(Worker):
 
 class AsyncWorker(Worker):
     def __init__(self, queue_size: int = DEFAULT_QUEUE_SIZE) -> None:
-        self._queue: asyncio.Queue = asyncio.Queue(queue_size)
-        self._task: Optional[asyncio.Task] = None
+        self._queue: asyncio.Queue[Callable[[], Any]] = asyncio.Queue(queue_size)
+        self._task: Optional[asyncio.Task[None]] = None
         # Event loop needs to remain in the same process
         self._task_for_pid: Optional[int] = None
         self._loop: Optional[asyncio.AbstractEventLoop] = None

--- a/sentry_sdk/worker.py
+++ b/sentry_sdk/worker.py
@@ -34,7 +34,7 @@ class Worker(ABC):
         pass
 
     def flush(
-        self, timeout: float, callback: Optional[Callable[[int, float], None]] = None
+        self, timeout: float, callback: Optional[Callable[[int, float], Any]] = None
     ) -> None:
         """
         Flush the worker.
@@ -50,7 +50,7 @@ class Worker(ABC):
         pass
 
     @abstractmethod
-    def submit(self, callback: Callable[[], None]) -> bool:
+    def submit(self, callback: Callable[[], Any]) -> bool:
         """
         Schedule a callback to be executed by the worker.
 
@@ -149,7 +149,7 @@ class BackgroundWorker(Worker):
                 pending = self._queue.qsize() + 1
                 logger.error("flush timed out, dropped %s events", pending)
 
-    def submit(self, callback: Callable[[], None]) -> bool:
+    def submit(self, callback: Callable[[], Any]) -> bool:
         self._ensure_thread()
         try:
             self._queue.put_nowait(callback)

--- a/sentry_sdk/worker.py
+++ b/sentry_sdk/worker.py
@@ -3,7 +3,6 @@ from abc import ABC, abstractmethod
 import os
 import threading
 import asyncio
-import inspect
 
 from time import sleep, time
 from sentry_sdk._queue import Queue, FullError
@@ -306,11 +305,7 @@ class AsyncWorker(Worker):
 
     async def _process_callback(self, callback: Callable[[], Any]) -> None:
         # Callback is an async coroutine, need to await it
-        if inspect.iscoroutinefunction(callback):
-            await callback()
-        else:
-            # Callback is a sync function, such as _flush_client_reports()
-            callback()
+        await callback()
 
     def _on_task_complete(self, task: asyncio.Task[None]) -> None:
         try:

--- a/sentry_sdk/worker.py
+++ b/sentry_sdk/worker.py
@@ -192,7 +192,7 @@ class BackgroundWorker(Worker):
 
 class AsyncWorker(Worker):
     def __init__(self, queue_size: int = DEFAULT_QUEUE_SIZE) -> None:
-        self._queue: asyncio.Queue[Callable[[], Any]] = asyncio.Queue(queue_size)
+        self._queue: asyncio.Queue[Any] = asyncio.Queue(queue_size)
         self._task: Optional[asyncio.Task[None]] = None
         # Event loop needs to remain in the same process
         self._task_for_pid: Optional[int] = None
@@ -210,9 +210,10 @@ class AsyncWorker(Worker):
 
     def kill(self) -> None:
         if self._task:
-            self._task.cancel()
-            self._task = None
-            self._task_for_pid = None
+            try:
+                self._queue.put_nowait(_TERMINATOR)
+            except asyncio.QueueFull:
+                logger.debug("async worker queue full, kill failed")
             # Also cancel any active callback tasks
             # Avoid modifying the set while cancelling tasks
             tasks_to_cancel = set(self._active_tasks)
@@ -220,6 +221,8 @@ class AsyncWorker(Worker):
                 task.cancel()
             self._active_tasks.clear()
             self._loop = None
+            self._task = None
+            self._task_for_pid = None
 
     def start(self) -> None:
         if not self.is_alive:
@@ -280,6 +283,9 @@ class AsyncWorker(Worker):
     async def _target(self) -> None:
         while True:
             callback = await self._queue.get()
+            if callback is _TERMINATOR:
+                self._queue.task_done()
+                break
             # Firing tasks instead of awaiting them allows for concurrent requests
             task = asyncio.create_task(self._process_callback(callback))
             # Create a strong reference to the task so it can be cancelled on kill

--- a/setup.py
+++ b/setup.py
@@ -60,6 +60,7 @@ setup(
         "flask": ["flask>=0.11", "blinker>=1.1", "markupsafe"],
         "grpcio": ["grpcio>=1.21.1", "protobuf>=3.8.0"],
         "http2": ["httpcore[http2]==1.*"],
+        "asyncio": ["httpcore[asyncio]==1.*"],
         "httpx": ["httpx>=0.16.0"],
         "huey": ["huey>=2"],
         "huggingface_hub": ["huggingface_hub>=0.22"],


### PR DESCRIPTION
Add async implementation of the abstract Transport class. This transport utilizes the async task worker as well as the httpcore async functionality. 

Thread Safety: As capture_envelope is registered by the client as a callback for several background threads in the sdk, which are not running the event loop, capture_envelope in the transport is made to be thread safe and allow for execution on the event loop from other threads. The same is currently not the case for flush, as there does not seem to be a usage from background threads, however if necessary, it can also be added.

HTTP2 support: Currently not activated, but from the looks of the [httpcore docs](https://www.encode.io/httpcore/http2/) it should be as simple as setting the http2 in the init of the pool to true. This likely makes sense to support, as HTTP2 shows great performance improvements with concurrent requests.

Kill: The kill method is sync, but the pool needs to be closed asynchronously. Currently, this is done by launching a task. However, the task cannot be awaited in sync code without deadlocking, therefore kill followed by an immediate loop shutdown could technically lead to resource leakage. Therefore, I decided to make kill optionally return the async task, so it can be awaited if called from an async context.

Note also that parts of the code are very similar to the HTTP2 integration, as they both use the httpcore library. Maybe in a later PR there could be a shared superclass to avoid code duplication?

GH-4582