### PR TITLE
Integrate async transport with SDK

### DIFF
--- a/requirements-testing.txt
+++ b/requirements-testing.txt
@@ -12,7 +12,7 @@ asttokens
 responses
 pysocks
 socksio
-httpcore[http2]
+httpcore[http2,asyncio]
 setuptools
 freezegun
 Brotli

--- a/requirements-testing.txt
+++ b/requirements-testing.txt
@@ -12,8 +12,8 @@ asttokens
 responses
 pysocks
 socksio
-httpcore[http2]; python_version < "3.8"
-httpcore[http2,asyncio]; python_version >= "3.8" # asyncio support only supported for Python 3.8+
+httpcore[http2]<1.0; python_version < "3.8"
+httpcore[http2,asyncio]>=1.0; python_version >= "3.8" # asyncio support only supported for Python 3.8+
 setuptools
 freezegun
 Brotli

--- a/requirements-testing.txt
+++ b/requirements-testing.txt
@@ -12,7 +12,8 @@ asttokens
 responses
 pysocks
 socksio
-httpcore[http2,asyncio]>=1.0 # From 1.0, httpcore async is optional
+httpcore[http2]; python_version < "3.8"
+httpcore[http2,asyncio]>=1.0; python_version >= "3.8" # asyncio support only supported for Python 3.8+
 setuptools
 freezegun
 Brotli

--- a/requirements-testing.txt
+++ b/requirements-testing.txt
@@ -12,7 +12,7 @@ asttokens
 responses
 pysocks
 socksio
-httpcore[http2]
+httpcore[http2,asyncio]>=1.0 # From 1.0, httpcore async is optional
 setuptools
 freezegun
 Brotli

--- a/requirements-testing.txt
+++ b/requirements-testing.txt
@@ -12,8 +12,7 @@ asttokens
 responses
 pysocks
 socksio
-httpcore[http2]<1.0; python_version < "3.8"
-httpcore[http2,asyncio]>=1.0; python_version >= "3.8" # asyncio support only supported for Python 3.8+
+httpcore[http2]
 setuptools
 freezegun
 Brotli

--- a/requirements-testing.txt
+++ b/requirements-testing.txt
@@ -13,7 +13,7 @@ responses
 pysocks
 socksio
 httpcore[http2]; python_version < "3.8"
-httpcore[http2,asyncio]>=1.0; python_version >= "3.8" # asyncio support only supported for Python 3.8+
+httpcore[http2,asyncio]; python_version >= "3.8" # asyncio support only supported for Python 3.8+
 setuptools
 freezegun
 Brotli

--- a/scripts/populate_tox/config.py
+++ b/scripts/populate_tox/config.py
@@ -96,7 +96,7 @@ TEST_SUITE_CONFIG = {
                 "pytest-asyncio",
                 "python-multipart",
                 "requests",
-                "anyio<4",
+                "anyio>=3,<5",
             ],
             # There's an incompatibility between FastAPI's TestClient, which is
             # actually Starlette's TestClient, which is actually httpx's Client.

--- a/scripts/populate_tox/config.py
+++ b/scripts/populate_tox/config.py
@@ -106,6 +106,7 @@ TEST_SUITE_CONFIG = {
             # FastAPI versions we use older httpx which still supports the
             # deprecated argument.
             "<0.110.1": ["httpx<0.28.0"],
+            "<0.80": ["anyio<4"],
             "py3.6": ["aiocontextvars"],
         },
     },

--- a/scripts/populate_tox/tox.jinja
+++ b/scripts/populate_tox/tox.jinja
@@ -207,7 +207,7 @@ deps =
     httpx-v0.25: pytest-httpx==0.25.0
     httpx: pytest-httpx
     # anyio is a dep of httpx
-    httpx: anyio<4.0.0
+    httpx: anyio>=3,<5
     httpx-v0.16: httpx~=0.16.0
     httpx-v0.18: httpx~=0.18.0
     httpx-v0.20: httpx~=0.20.0

--- a/sentry_sdk/api.py
+++ b/sentry_sdk/api.py
@@ -226,6 +226,14 @@ def flush(
     return get_client().flush(timeout=timeout, callback=callback)
 
 
+@clientmethod
+def flush_async(
+    timeout: Optional[float] = None,
+    callback: Optional[Callable[[int, float], None]] = None,
+) -> None:
+    return get_client().flush_async(timeout=timeout, callback=callback)
+
+
 def start_span(**kwargs: Any) -> Span:
     """
     Start and return a span.

--- a/sentry_sdk/api.py
+++ b/sentry_sdk/api.py
@@ -227,11 +227,11 @@ def flush(
 
 
 @clientmethod
-def flush_async(
+async def flush_async(
     timeout: Optional[float] = None,
     callback: Optional[Callable[[int, float], None]] = None,
 ) -> None:
-    return get_client().flush_async(timeout=timeout, callback=callback)
+    return await get_client().flush_async(timeout=timeout, callback=callback)
 
 
 def start_span(**kwargs: Any) -> Span:

--- a/sentry_sdk/client.py
+++ b/sentry_sdk/client.py
@@ -982,7 +982,9 @@ class _Client(BaseClient):
                 return
             await self.flush_async(timeout=timeout, callback=callback)
             self._close_components()
-            await self.transport.kill()
+            kill_task = self.transport.kill()  # type: ignore
+            if kill_task is not None:
+                await kill_task
             self.transport = None
 
     def flush(

--- a/sentry_sdk/client.py
+++ b/sentry_sdk/client.py
@@ -3,7 +3,6 @@ import os
 import uuid
 import random
 import socket
-import asyncio
 from collections.abc import Mapping
 from datetime import datetime, timezone
 from importlib import import_module
@@ -923,14 +922,6 @@ class _Client(BaseClient):
             raise ValueError("Integration has no name")
 
         return self.integrations.get(integration_name)
-
-    def _close_transport(self) -> Optional[asyncio.Task[None]]:
-        """Close transport and return cleanup task if any."""
-        if self.transport is not None:
-            cleanup_task = self.transport.kill()  # type: ignore
-            self.transport = None
-            return cleanup_task
-        return None
 
     def _close_components(self) -> None:
         """Kill all client components in the correct order."""

--- a/sentry_sdk/client.py
+++ b/sentry_sdk/client.py
@@ -918,7 +918,7 @@ class _Client(BaseClient):
     def _close_transport(self) -> Optional[asyncio.Task[None]]:
         """Close transport and return cleanup task if any."""
         if self.transport is not None:
-            cleanup_task = self.transport.kill()
+            cleanup_task = self.transport.kill()  # type: ignore
             self.transport = None
             return cleanup_task
         return None
@@ -963,7 +963,9 @@ class _Client(BaseClient):
                         _flush_and_close(timeout, callback)
                     )
                 except RuntimeError:
+                    # Shutdown the components anyway
                     self._close_components()
+                    self._close_transport()
                     logger.warning("Event loop not running, aborting close.")
                     return None
                 # Enforce flush before shutdown

--- a/sentry_sdk/client.py
+++ b/sentry_sdk/client.py
@@ -939,6 +939,7 @@ class _Client(BaseClient):
         async def _flush_and_close(
             timeout: Optional[float], callback: Optional[Callable[[int, float], None]]
         ) -> None:
+
             await self._flush_async(timeout=timeout, callback=callback)
             self._close_components()
 
@@ -996,6 +997,9 @@ class _Client(BaseClient):
     async def _flush_async(
         self, timeout: Optional[float], callback: Optional[Callable[[int, float], None]]
     ) -> None:
+
+        if timeout is None:
+            timeout = self.options["shutdown_timeout"]
 
         self.session_flusher.flush()
         if self.log_batcher is not None:

--- a/sentry_sdk/client.py
+++ b/sentry_sdk/client.py
@@ -1023,8 +1023,6 @@ class _Client(BaseClient):
         self.session_flusher.flush()
         if self.log_batcher is not None:
             self.log_batcher.flush()
-
-        # For async transport, flush() returns a Task that needs to be awaited
         flush_task = self.transport.flush(timeout=timeout, callback=callback)  # type: ignore
         if flush_task is not None:
             await flush_task

--- a/sentry_sdk/client.py
+++ b/sentry_sdk/client.py
@@ -1023,7 +1023,11 @@ class _Client(BaseClient):
         self.session_flusher.flush()
         if self.log_batcher is not None:
             self.log_batcher.flush()
-        await self.transport.flush_async(timeout=timeout, callback=callback)  # type: ignore
+
+        # For async transport, flush() returns a Task that needs to be awaited
+        flush_task = self.transport.flush(timeout=timeout, callback=callback)  # type: ignore
+        if flush_task is not None:
+            await flush_task
 
     def __enter__(self) -> _Client:
         return self

--- a/sentry_sdk/client.py
+++ b/sentry_sdk/client.py
@@ -950,7 +950,7 @@ class _Client(BaseClient):
             else:
                 self.flush(timeout=timeout, callback=callback)
                 self._close_components()
-                return None
+        return None
 
     def flush(
         self,
@@ -967,6 +967,7 @@ class _Client(BaseClient):
         if self.transport is not None:
             if timeout is None:
                 timeout = self.options["shutdown_timeout"]
+            assert timeout is not None  # shutdown_timeout should never be None
 
             self.session_flusher.flush()
 
@@ -979,12 +980,12 @@ class _Client(BaseClient):
                 )
             else:
                 self.transport.flush(timeout=timeout, callback=callback)
-
-            return None
+        return None
 
     async def _flush_async(
-        self, timeout: float, callback: Optional[Callable[[int, float], None]]
+        self, timeout: Optional[float], callback: Optional[Callable[[int, float], None]]
     ) -> None:
+
         self.session_flusher.flush()
         if self.log_batcher is not None:
             self.log_batcher.flush()

--- a/sentry_sdk/client.py
+++ b/sentry_sdk/client.py
@@ -959,7 +959,9 @@ class _Client(BaseClient):
             await self._close_components_async()
 
         if self.transport is not None:
-            if isinstance(self.transport, AsyncHttpTransport):
+            if isinstance(self.transport, AsyncHttpTransport) and hasattr(
+                self.transport, "loop"
+            ):
 
                 try:
                     flush_task = self.transport.loop.create_task(
@@ -996,7 +998,9 @@ class _Client(BaseClient):
             if timeout is None:
                 timeout = self.options["shutdown_timeout"]
 
-            if isinstance(self.transport, AsyncHttpTransport):
+            if isinstance(self.transport, AsyncHttpTransport) and hasattr(
+                self.transport, "loop"
+            ):
                 try:
                     return self.transport.loop.create_task(
                         self._flush_async(timeout, callback)

--- a/sentry_sdk/client.py
+++ b/sentry_sdk/client.py
@@ -215,6 +215,12 @@ class BaseClient:
     def flush(self, *args: Any, **kwargs: Any) -> None:
         return None
 
+    async def close_async(self, *args: Any, **kwargs: Any) -> None:
+        return None
+
+    async def flush_async(self, *args: Any, **kwargs: Any) -> None:
+        return None
+
     def __enter__(self) -> BaseClient:
         return self
 
@@ -934,61 +940,58 @@ class _Client(BaseClient):
         if self.monitor:
             self.monitor.kill()
 
-    async def _close_components_async(self) -> None:
-        """Async version of _close_components that properly awaits transport cleanup."""
-        self._close_components()
-        cleanup_task = self._close_transport()
-        if cleanup_task is not None:
-            await cleanup_task
-
-    def close(  # type: ignore[override]
+    def close(
         self,
         timeout: Optional[float] = None,
         callback: Optional[Callable[[int, float], None]] = None,
-    ) -> Optional[asyncio.Task[None]]:
+    ) -> None:
         """
         Close the client and shut down the transport. Arguments have the same
-        semantics as :py:meth:`Client.flush`. When using the async transport, close needs to be awaited to block.
+        semantics as :py:meth:`Client.flush`.
         """
-
-        async def _flush_and_close(
-            timeout: Optional[float], callback: Optional[Callable[[int, float], None]]
-        ) -> None:
-
-            await self._flush_async(timeout=timeout, callback=callback)
-            await self._close_components_async()
-
         if self.transport is not None:
             if isinstance(self.transport, AsyncHttpTransport) and hasattr(
                 self.transport, "loop"
             ):
+                logger.debug(
+                    "close() used with AsyncHttpTransport, aborting. Please use close_async() instead."
+                )
+                return
+            self.flush(timeout=timeout, callback=callback)
+            self._close_components()
+            self.transport.kill()
+            self.transport = None
 
-                try:
-                    flush_task = self.transport.loop.create_task(
-                        _flush_and_close(timeout, callback)
-                    )
-                except RuntimeError:
-                    # Shutdown the components anyway
-                    self._close_components()
-                    self._close_transport()
-                    logger.warning("Event loop not running, aborting close.")
-                    return None
-                # Enforce flush before shutdown
-                return flush_task
-            else:
-                self.flush(timeout=timeout, callback=callback)
-                self._close_components()
-                self._close_transport()
-
-        return None
-
-    def flush(  # type: ignore[override]
+    async def close_async(
         self,
         timeout: Optional[float] = None,
         callback: Optional[Callable[[int, float], None]] = None,
-    ) -> Optional[asyncio.Task[None]]:
+    ) -> None:
         """
-        Wait for the current events to be sent. When using the async transport, flush needs to be awaited to block.
+        Asynchronously close the client and shut down the transport. Arguments have the same
+        semantics as :py:meth:`Client.flush_async`.
+        """
+        if self.transport is not None:
+            if not (
+                isinstance(self.transport, AsyncHttpTransport)
+                and hasattr(self.transport, "loop")
+            ):
+                logger.debug(
+                    "close_async() used with non-async transport, aborting. Please use close() instead."
+                )
+                return
+            await self.flush_async(timeout=timeout, callback=callback)
+            self._close_components()
+            await self.transport.kill()
+            self.transport = None
+
+    def flush(
+        self,
+        timeout: Optional[float] = None,
+        callback: Optional[Callable[[int, float], None]] = None,
+    ) -> None:
+        """
+        Wait for the current events to be sent.
 
         :param timeout: Wait for at most `timeout` seconds. If no `timeout` is provided, the `shutdown_timeout` option value is used.
 
@@ -998,37 +1001,40 @@ class _Client(BaseClient):
             if isinstance(self.transport, AsyncHttpTransport) and hasattr(
                 self.transport, "loop"
             ):
-                try:
-                    return self.transport.loop.create_task(
-                        self._flush_async(timeout, callback)
-                    )
-                except RuntimeError:
-                    logger.warning("Event loop not running, aborting flush.")
-                    return None
-            else:
-                self._flush_sync(timeout, callback)
-        return None
+                logger.debug(
+                    "flush() used with AsyncHttpTransport, aborting. Please use flush_async() instead."
+                )
+                return
+            if timeout is None:
+                timeout = self.options["shutdown_timeout"]
+            self._flush_components()
 
-    def _flush_sync(
-        self, timeout: Optional[float], callback: Optional[Callable[[int, float], None]]
-    ) -> None:
-        """Synchronous flush implementation."""
-        if timeout is None:
-            timeout = self.options["shutdown_timeout"]
-
-        self._flush_components()
-        if self.transport is not None:
             self.transport.flush(timeout=timeout, callback=callback)
 
-    async def _flush_async(
-        self, timeout: Optional[float], callback: Optional[Callable[[int, float], None]]
+    async def flush_async(
+        self,
+        timeout: Optional[float] = None,
+        callback: Optional[Callable[[int, float], None]] = None,
     ) -> None:
-        """Asynchronous flush implementation."""
-        if timeout is None:
-            timeout = self.options["shutdown_timeout"]
+        """
+        Asynchronously wait for the current events to be sent.
 
-        self._flush_components()
+        :param timeout: Wait for at most `timeout` seconds. If no `timeout` is provided, the `shutdown_timeout` option value is used.
+
+        :param callback: Is invoked with the number of pending events and the configured timeout.
+        """
         if self.transport is not None:
+            if not (
+                isinstance(self.transport, AsyncHttpTransport)
+                and hasattr(self.transport, "loop")
+            ):
+                logger.debug(
+                    "flush_async() used with non-async transport, aborting. Please use flush() instead."
+                )
+                return
+            if timeout is None:
+                timeout = self.options["shutdown_timeout"]
+            self._flush_components()
             flush_task = self.transport.flush(timeout=timeout, callback=callback)  # type: ignore
             if flush_task is not None:
                 await flush_task

--- a/sentry_sdk/client.py
+++ b/sentry_sdk/client.py
@@ -930,7 +930,7 @@ class _Client(BaseClient):
         self,
         timeout: Optional[float] = None,
         callback: Optional[Callable[[int, float], None]] = None,
-    ) -> Optional[asyncio.Task[None]]:
+    ) -> Optional[asyncio.Task[None]]:  # type: ignore[override]
         """
         Close the client and shut down the transport. Arguments have the same
         semantics as :py:meth:`Client.flush`. When using the async transport, close needs to be awaited to block.
@@ -956,7 +956,7 @@ class _Client(BaseClient):
         self,
         timeout: Optional[float] = None,
         callback: Optional[Callable[[int, float], None]] = None,
-    ) -> Optional[asyncio.Task[None]]:
+    ) -> Optional[asyncio.Task[None]]:  # type: ignore[override]
         """
         Wait for the current events to be sent. When using the async transport, flush needs to be awaited to block.
 

--- a/sentry_sdk/client.py
+++ b/sentry_sdk/client.py
@@ -926,11 +926,11 @@ class _Client(BaseClient):
             self.transport.kill()
             self.transport = None
 
-    def close(
+    def close(  # type: ignore[override]
         self,
         timeout: Optional[float] = None,
         callback: Optional[Callable[[int, float], None]] = None,
-    ) -> Optional[asyncio.Task[None]]:  # type: ignore[override]
+    ) -> Optional[asyncio.Task[None]]:
         """
         Close the client and shut down the transport. Arguments have the same
         semantics as :py:meth:`Client.flush`. When using the async transport, close needs to be awaited to block.
@@ -952,11 +952,11 @@ class _Client(BaseClient):
                 self._close_components()
         return None
 
-    def flush(
+    def flush(  # type: ignore[override]
         self,
         timeout: Optional[float] = None,
         callback: Optional[Callable[[int, float], None]] = None,
-    ) -> Optional[asyncio.Task[None]]:  # type: ignore[override]
+    ) -> Optional[asyncio.Task[None]]:
         """
         Wait for the current events to be sent. When using the async transport, flush needs to be awaited to block.
 

--- a/sentry_sdk/client.py
+++ b/sentry_sdk/client.py
@@ -988,10 +988,10 @@ class _Client(BaseClient):
             else:
                 self.session_flusher.flush()
 
-            if self.log_batcher is not None:
-                self.log_batcher.flush()
+                if self.log_batcher is not None:
+                    self.log_batcher.flush()
 
-            self.transport.flush(timeout=timeout, callback=callback)
+                self.transport.flush(timeout=timeout, callback=callback)
         return None
 
     async def _flush_async(

--- a/sentry_sdk/client.py
+++ b/sentry_sdk/client.py
@@ -951,6 +951,7 @@ class _Client(BaseClient):
                         _flush_and_close(timeout, callback)
                     )
                 except RuntimeError:
+                    self._close_components()
                     logger.warning("Event loop not running, aborting close.")
                     return None
                 # Enforce flush before shutdown
@@ -975,12 +976,6 @@ class _Client(BaseClient):
         if self.transport is not None:
             if timeout is None:
                 timeout = self.options["shutdown_timeout"]
-            assert timeout is not None  # shutdown_timeout should never be None
-
-            self.session_flusher.flush()
-
-            if self.log_batcher is not None:
-                self.log_batcher.flush()
 
             if isinstance(self.transport, AsyncHttpTransport):
                 try:
@@ -991,6 +986,11 @@ class _Client(BaseClient):
                     logger.warning("Event loop not running, aborting flush.")
                     return None
             else:
+                self.session_flusher.flush()
+
+            if self.log_batcher is not None:
+                self.log_batcher.flush()
+
                 self.transport.flush(timeout=timeout, callback=callback)
         return None
 

--- a/sentry_sdk/client.py
+++ b/sentry_sdk/client.py
@@ -991,7 +991,7 @@ class _Client(BaseClient):
             if self.log_batcher is not None:
                 self.log_batcher.flush()
 
-                self.transport.flush(timeout=timeout, callback=callback)
+            self.transport.flush(timeout=timeout, callback=callback)
         return None
 
     async def _flush_async(

--- a/sentry_sdk/consts.py
+++ b/sentry_sdk/consts.py
@@ -75,6 +75,7 @@ if TYPE_CHECKING:
             "transport_compression_algo": Optional[CompressionAlgo],
             "transport_num_pools": Optional[int],
             "transport_http2": Optional[bool],
+            "transport_async": Optional[bool],
             "enable_logs": Optional[bool],
             "before_send_log": Optional[Callable[[Log, Hint], Optional[Log]]],
         },

--- a/sentry_sdk/integrations/asyncio.py
+++ b/sentry_sdk/integrations/asyncio.py
@@ -53,9 +53,7 @@ def patch_loop_close() -> None:
             if not isinstance(client.transport, AsyncHttpTransport):
                 return
 
-            task = client.close()  # type: ignore
-            if task is not None:
-                await task
+            await client.close_async()
         except Exception:
             logger.warning("Sentry flush failed during loop shutdown", exc_info=True)
 

--- a/sentry_sdk/integrations/asyncio.py
+++ b/sentry_sdk/integrations/asyncio.py
@@ -148,10 +148,9 @@ class AsyncioIntegration(Integration):
                     if not isinstance(client.transport, AsyncHttpTransport):
                         return
 
-                    t = client.close()
+                    t = client.close()  # type: ignore
                     if t is not None:
-                        # Wait for the task to complete.
-                        await t  # type: ignore
+                        await t
                 except Exception:
                     logger.warning(
                         "Sentry flush failed during loop shutdown", exc_info=True
@@ -165,7 +164,7 @@ class AsyncioIntegration(Integration):
                 finally:
                     orig_close()
 
-            loop.close = _patched_close
+            loop.close = _patched_close  # type: ignore
             loop._sentry_flush_patched = True  # type: ignore
 
         _patch_loop_close()

--- a/sentry_sdk/transport.py
+++ b/sentry_sdk/transport.py
@@ -1027,6 +1027,8 @@ def make_transport(options: Dict[str, Any]) -> Optional[Transport]:
             # No event loop running, fall back to sync transport
             logger.warning("No event loop running, falling back to sync transport.")
             transport_cls = Http2Transport if use_http2_transport else HttpTransport
+    else:
+        transport_cls = Http2Transport if use_http2_transport else HttpTransport
 
     if isinstance(ref_transport, Transport):
         return ref_transport

--- a/sentry_sdk/transport.py
+++ b/sentry_sdk/transport.py
@@ -1019,11 +1019,14 @@ def make_transport(options: Dict[str, Any]) -> Optional[Transport]:
     use_http2_transport = options.get("_experiments", {}).get("transport_http2", False)
     use_async_transport = options.get("_experiments", {}).get("transport_async", False)
     # By default, we use the http transport class
-    if use_async_transport and asyncio.get_running_loop() is not None:
-        transport_cls: Type[Transport] = AsyncHttpTransport
-    else:
-        use_http2 = use_http2_transport
-        transport_cls = Http2Transport if use_http2 else HttpTransport
+    if use_async_transport:
+        try:
+            asyncio.get_running_loop()
+            transport_cls: Type[Transport] = AsyncHttpTransport
+        except RuntimeError:
+            # No event loop running, fall back to sync transport
+            logger.warning("No event loop running, falling back to sync transport.")
+            transport_cls = Http2Transport if use_http2_transport else HttpTransport
 
     if isinstance(ref_transport, Transport):
         return ref_transport

--- a/sentry_sdk/transport.py
+++ b/sentry_sdk/transport.py
@@ -777,7 +777,9 @@ class AsyncHttpTransport(HttpTransportCore):
             task.cancel()
         self.background_tasks.clear()
         try:
-            self._loop.create_task(self._pool.aclose())  # type: ignore
+            task = self._loop.create_task(self._pool.aclose())  # type: ignore
+            self.background_tasks.add(task)
+            task.add_done_callback(lambda t: self.background_tasks.discard(t))
         except RuntimeError:
             logger.warning("Event loop not running, aborting kill.")
 

--- a/sentry_sdk/transport.py
+++ b/sentry_sdk/transport.py
@@ -576,7 +576,7 @@ class AsyncHttpTransport(HttpTransportCore):
         super().__init__(options)
         # Requires event loop at init time
         self._loop = asyncio.get_running_loop()
-        self.background_tasks = set()
+        self.background_tasks: set[asyncio.Task[None]] = set()
 
     async def _send_envelope(self: Self, envelope: Envelope) -> None:
         _prepared_envelope = self._prepare_envelope(envelope)
@@ -614,7 +614,7 @@ class AsyncHttpTransport(HttpTransportCore):
         finally:
             response.close()
 
-    async def _request(
+    async def _request(  # type: ignore[override]
         self: Self,
         method: str,
         endpoint_type: EndpointType,

--- a/sentry_sdk/transport.py
+++ b/sentry_sdk/transport.py
@@ -1049,7 +1049,7 @@ def make_transport(options: Dict[str, Any]) -> Optional[Transport]:
     use_async_transport = options.get("_experiments", {}).get("transport_async", False)
     async_integration = any(
         integration.__class__.__name__ == "AsyncioIntegration"
-        for integration in options.get("integrations", [])
+        for integration in options.get("integrations") or []
     )
 
     # By default, we use the http transport class

--- a/sentry_sdk/transport.py
+++ b/sentry_sdk/transport.py
@@ -6,6 +6,7 @@ import gzip
 import socket
 import ssl
 import time
+import asyncio
 from datetime import datetime, timedelta, timezone
 from collections import defaultdict
 from urllib.request import getproxies
@@ -567,6 +568,187 @@ class BaseHttpTransport(HttpTransportCore):
         if timeout > 0:
             self._worker.submit(lambda: self._flush_client_reports(force=True))
             self._worker.flush(timeout, callback)
+
+
+class AsyncHttpTransport(HttpTransportCore):
+    def __init__(self: Self, options: Dict[str, Any]) -> None:
+        super().__init__(options)
+        # Requires event loop at init time
+        self._loop = asyncio.get_running_loop()
+        self.background_tasks = set()
+
+    async def _send_envelope(self: Self, envelope: Envelope) -> None:
+        _prepared_envelope = self._prepare_envelope(envelope)
+        if _prepared_envelope is None:
+            return None
+        envelope, body, headers = _prepared_envelope
+        await self._send_request(
+            body.getvalue(),
+            headers=headers,
+            endpoint_type=EndpointType.ENVELOPE,
+            envelope=envelope,
+        )
+        return None
+
+    async def _send_request(
+        self: Self,
+        body: bytes,
+        headers: Dict[str, str],
+        endpoint_type: EndpointType,
+        envelope: Optional[Envelope],
+    ) -> None:
+        self._update_headers(headers)
+        try:
+            response = await self._request(
+                "POST",
+                endpoint_type,
+                body,
+                headers,
+            )
+        except Exception:
+            self._handle_request_error(envelope=envelope, loss_reason="network")
+            raise
+        try:
+            self._handle_response(response=response, envelope=envelope)
+        finally:
+            response.close()
+
+    async def _request(
+        self: Self,
+        method: str,
+        endpoint_type: EndpointType,
+        body: Any,
+        headers: Mapping[str, str],
+    ) -> httpcore.Response:
+        return await self._pool.request(
+            method,
+            self._auth.get_api_url(endpoint_type),
+            content=body,
+            headers=headers,  # type: ignore
+        )
+
+    def _flush_client_reports(self: Self, force: bool = False) -> None:
+        client_report = self._fetch_pending_client_report(force=force, interval=60)
+        if client_report is not None:
+            self.capture_envelope(Envelope(items=[client_report]))
+
+    async def _capture_envelope(self: Self, envelope: Envelope) -> None:
+        async def send_envelope_wrapper() -> None:
+            with capture_internal_exceptions():
+                await self._send_envelope(envelope)
+                self._flush_client_reports()
+
+        if not self._worker.submit(send_envelope_wrapper):
+            self.on_dropped_event("full_queue")
+            for item in envelope.items:
+                self.record_lost_event("queue_overflow", item=item)
+
+    def capture_envelope(self: Self, envelope: Envelope) -> None:
+        # Synchronous entry point
+        if asyncio.get_running_loop() is not None:
+            # We are on the main thread running the event loop
+            task = asyncio.create_task(self._capture_envelope(envelope))
+            self.background_tasks.add(task)
+            task.add_done_callback(self.background_tasks.discard)
+        else:
+            # We are in a background thread, not running an event loop,
+            # have to launch the task on the loop in a threadsafe way.
+            asyncio.run_coroutine_threadsafe(
+                self._capture_envelope(envelope),
+                self._loop,
+            )
+
+    async def flush_async(
+        self: Self,
+        timeout: float,
+        callback: Optional[Callable[[int, float], None]] = None,
+    ) -> None:
+        logger.debug("Flushing HTTP transport")
+
+        if timeout > 0:
+            self._worker.submit(lambda: self._flush_client_reports(force=True))
+            await self._worker.flush_async(timeout, callback)  # type: ignore
+
+    def _get_pool_options(self: Self) -> Dict[str, Any]:
+        options: Dict[str, Any] = {
+            "http2": False,  # no HTTP2 for now
+            "retries": 3,
+        }
+
+        socket_options = (
+            self.options["socket_options"]
+            if self.options["socket_options"] is not None
+            else []
+        )
+
+        used_options = {(o[0], o[1]) for o in socket_options}
+        for default_option in KEEP_ALIVE_SOCKET_OPTIONS:
+            if (default_option[0], default_option[1]) not in used_options:
+                socket_options.append(default_option)
+
+        options["socket_options"] = socket_options
+
+        ssl_context = ssl.create_default_context()
+        ssl_context.load_verify_locations(
+            self.options["ca_certs"]  # User-provided bundle from the SDK init
+            or os.environ.get("SSL_CERT_FILE")
+            or os.environ.get("REQUESTS_CA_BUNDLE")
+            or certifi.where()
+        )
+        cert_file = self.options["cert_file"] or os.environ.get("CLIENT_CERT_FILE")
+        key_file = self.options["key_file"] or os.environ.get("CLIENT_KEY_FILE")
+        if cert_file is not None:
+            ssl_context.load_cert_chain(cert_file, key_file)
+
+        options["ssl_context"] = ssl_context
+
+        return options
+
+    def _make_pool(
+        self: Self,
+    ) -> Union[
+        httpcore.AsyncSOCKSProxy, httpcore.AsyncHTTPProxy, httpcore.AsyncConnectionPool
+    ]:
+        if self.parsed_dsn is None:
+            raise ValueError("Cannot create HTTP-based transport without valid DSN")
+        proxy = None
+        no_proxy = self._in_no_proxy(self.parsed_dsn)
+
+        # try HTTPS first
+        https_proxy = self.options["https_proxy"]
+        if self.parsed_dsn.scheme == "https" and (https_proxy != ""):
+            proxy = https_proxy or (not no_proxy and getproxies().get("https"))
+
+        # maybe fallback to HTTP proxy
+        http_proxy = self.options["http_proxy"]
+        if not proxy and (http_proxy != ""):
+            proxy = http_proxy or (not no_proxy and getproxies().get("http"))
+
+        opts = self._get_pool_options()
+
+        if proxy:
+            proxy_headers = self.options["proxy_headers"]
+            if proxy_headers:
+                opts["proxy_headers"] = proxy_headers
+
+            if proxy.startswith("socks"):
+                try:
+                    if "socket_options" in opts:
+                        socket_options = opts.pop("socket_options")
+                        if socket_options:
+                            logger.warning(
+                                "You have defined socket_options but using a SOCKS proxy which doesn't support these. We'll ignore socket_options."
+                            )
+                    return httpcore.AsyncSOCKSProxy(proxy_url=proxy, **opts)
+                except RuntimeError:
+                    logger.warning(
+                        "You have configured a SOCKS proxy (%s) but support for SOCKS proxies is not installed. Disabling proxy support.",
+                        proxy,
+                    )
+            else:
+                return httpcore.AsyncHTTPProxy(proxy_url=proxy, **opts)
+
+        return httpcore.AsyncConnectionPool(**opts)
 
 
 class HttpTransport(BaseHttpTransport):

--- a/sentry_sdk/transport.py
+++ b/sentry_sdk/transport.py
@@ -790,7 +790,7 @@ class AsyncHttpTransport(HttpTransportCore):
         self.background_tasks.clear()
         try:
             # Return the pool cleanup task so caller can await it if needed
-            return self._loop.create_task(self._pool.aclose())  # type: ignore
+            return self.loop.create_task(self._pool.aclose())  # type: ignore
         except RuntimeError:
             logger.warning("Event loop not running, aborting kill.")
             return None

--- a/sentry_sdk/transport.py
+++ b/sentry_sdk/transport.py
@@ -227,7 +227,11 @@ class HttpTransportCore(Transport):
 
     def _create_worker(self, options: dict[str, Any]) -> Worker:
         async_enabled = options.get("_experiments", {}).get("transport_async", False)
-        worker_cls = AsyncWorker if async_enabled else BackgroundWorker
+        try:
+            asyncio.get_running_loop()
+            worker_cls = AsyncWorker if async_enabled else BackgroundWorker
+        except RuntimeError:
+            worker_cls = BackgroundWorker
         return worker_cls(queue_size=options["transport_queue_size"])
 
     def record_lost_event(

--- a/sentry_sdk/transport.py
+++ b/sentry_sdk/transport.py
@@ -579,7 +579,7 @@ class AsyncHttpTransport(HttpTransportCore):
     def __init__(self: Self, options: Dict[str, Any]) -> None:
         super().__init__(options)
         # Requires event loop at init time
-        self._loop = asyncio.get_running_loop()
+        self.loop: asyncio.AbstractEventLoop = asyncio.get_running_loop()
         self.background_tasks: set[asyncio.Task[None]] = set()
 
     def _get_header_value(self: Self, response: Any, header: str) -> Optional[str]:

--- a/sentry_sdk/transport.py
+++ b/sentry_sdk/transport.py
@@ -766,8 +766,10 @@ class AsyncHttpTransport(HttpTransportCore):
         for task in self.background_tasks:
             task.cancel()
         self.background_tasks.clear()
-
-        self._loop.create_task(self._pool.aclose())  # type: ignore
+        try:
+            self._loop.create_task(self._pool.aclose())  # type: ignore
+        except RuntimeError:
+            logger.warning("Event loop not running, aborting kill.")
 
 
 class HttpTransport(BaseHttpTransport):

--- a/sentry_sdk/transport.py
+++ b/sentry_sdk/transport.py
@@ -585,9 +585,115 @@ class BaseHttpTransport(HttpTransportCore):
             self._worker.flush(timeout, callback)
 
 
+class HttpTransport(BaseHttpTransport):
+    if TYPE_CHECKING:
+        _pool: Union[PoolManager, ProxyManager]
+
+    def _get_pool_options(self: Self) -> Dict[str, Any]:
+
+        num_pools = self.options.get("_experiments", {}).get("transport_num_pools")
+        options = {
+            "num_pools": 2 if num_pools is None else int(num_pools),
+            "cert_reqs": "CERT_REQUIRED",
+            "timeout": urllib3.Timeout(total=self.TIMEOUT),
+        }
+
+        socket_options: Optional[List[Tuple[int, int, int | bytes]]] = None
+
+        if self.options["socket_options"] is not None:
+            socket_options = self.options["socket_options"]
+
+        if self.options["keep_alive"]:
+            if socket_options is None:
+                socket_options = []
+
+            used_options = {(o[0], o[1]) for o in socket_options}
+            for default_option in KEEP_ALIVE_SOCKET_OPTIONS:
+                if (default_option[0], default_option[1]) not in used_options:
+                    socket_options.append(default_option)
+
+        if socket_options is not None:
+            options["socket_options"] = socket_options
+
+        options["ca_certs"] = (
+            self.options["ca_certs"]  # User-provided bundle from the SDK init
+            or os.environ.get("SSL_CERT_FILE")
+            or os.environ.get("REQUESTS_CA_BUNDLE")
+            or certifi.where()
+        )
+
+        options["cert_file"] = self.options["cert_file"] or os.environ.get(
+            "CLIENT_CERT_FILE"
+        )
+        options["key_file"] = self.options["key_file"] or os.environ.get(
+            "CLIENT_KEY_FILE"
+        )
+
+        return options
+
+    def _make_pool(self: Self) -> Union[PoolManager, ProxyManager]:
+        if self.parsed_dsn is None:
+            raise ValueError("Cannot create HTTP-based transport without valid DSN")
+
+        proxy = None
+        no_proxy = self._in_no_proxy(self.parsed_dsn)
+
+        # try HTTPS first
+        https_proxy = self.options["https_proxy"]
+        if self.parsed_dsn.scheme == "https" and (https_proxy != ""):
+            proxy = https_proxy or (not no_proxy and getproxies().get("https"))
+
+        # maybe fallback to HTTP proxy
+        http_proxy = self.options["http_proxy"]
+        if not proxy and (http_proxy != ""):
+            proxy = http_proxy or (not no_proxy and getproxies().get("http"))
+
+        opts = self._get_pool_options()
+
+        if proxy:
+            proxy_headers = self.options["proxy_headers"]
+            if proxy_headers:
+                opts["proxy_headers"] = proxy_headers
+
+            if proxy.startswith("socks"):
+                use_socks_proxy = True
+                try:
+                    # Check if PySocks dependency is available
+                    from urllib3.contrib.socks import SOCKSProxyManager
+                except ImportError:
+                    use_socks_proxy = False
+                    logger.warning(
+                        "You have configured a SOCKS proxy (%s) but support for SOCKS proxies is not installed. Disabling proxy support. Please add `PySocks` (or `urllib3` with the `[socks]` extra) to your dependencies.",
+                        proxy,
+                    )
+
+                if use_socks_proxy:
+                    return SOCKSProxyManager(proxy, **opts)
+                else:
+                    return urllib3.PoolManager(**opts)
+            else:
+                return urllib3.ProxyManager(proxy, **opts)
+        else:
+            return urllib3.PoolManager(**opts)
+
+    def _request(
+        self: Self,
+        method: str,
+        endpoint_type: EndpointType,
+        body: Any,
+        headers: Mapping[str, str],
+    ) -> urllib3.BaseHTTPResponse:
+        return self._pool.request(
+            method,
+            self._auth.get_api_url(endpoint_type),
+            body=body,
+            headers=headers,
+        )
+
+
 if not ASYNC_TRANSPORT_ENABLED:
     # Sorry, no AsyncHttpTransport for you
-    AsyncHttpTransport = BaseHttpTransport
+    AsyncHttpTransport = HttpTransport
 
 else:
 
@@ -801,112 +907,6 @@ else:
                 return None
 
 
-class HttpTransport(BaseHttpTransport):
-    if TYPE_CHECKING:
-        _pool: Union[PoolManager, ProxyManager]
-
-    def _get_pool_options(self: Self) -> Dict[str, Any]:
-
-        num_pools = self.options.get("_experiments", {}).get("transport_num_pools")
-        options = {
-            "num_pools": 2 if num_pools is None else int(num_pools),
-            "cert_reqs": "CERT_REQUIRED",
-            "timeout": urllib3.Timeout(total=self.TIMEOUT),
-        }
-
-        socket_options: Optional[List[Tuple[int, int, int | bytes]]] = None
-
-        if self.options["socket_options"] is not None:
-            socket_options = self.options["socket_options"]
-
-        if self.options["keep_alive"]:
-            if socket_options is None:
-                socket_options = []
-
-            used_options = {(o[0], o[1]) for o in socket_options}
-            for default_option in KEEP_ALIVE_SOCKET_OPTIONS:
-                if (default_option[0], default_option[1]) not in used_options:
-                    socket_options.append(default_option)
-
-        if socket_options is not None:
-            options["socket_options"] = socket_options
-
-        options["ca_certs"] = (
-            self.options["ca_certs"]  # User-provided bundle from the SDK init
-            or os.environ.get("SSL_CERT_FILE")
-            or os.environ.get("REQUESTS_CA_BUNDLE")
-            or certifi.where()
-        )
-
-        options["cert_file"] = self.options["cert_file"] or os.environ.get(
-            "CLIENT_CERT_FILE"
-        )
-        options["key_file"] = self.options["key_file"] or os.environ.get(
-            "CLIENT_KEY_FILE"
-        )
-
-        return options
-
-    def _make_pool(self: Self) -> Union[PoolManager, ProxyManager]:
-        if self.parsed_dsn is None:
-            raise ValueError("Cannot create HTTP-based transport without valid DSN")
-
-        proxy = None
-        no_proxy = self._in_no_proxy(self.parsed_dsn)
-
-        # try HTTPS first
-        https_proxy = self.options["https_proxy"]
-        if self.parsed_dsn.scheme == "https" and (https_proxy != ""):
-            proxy = https_proxy or (not no_proxy and getproxies().get("https"))
-
-        # maybe fallback to HTTP proxy
-        http_proxy = self.options["http_proxy"]
-        if not proxy and (http_proxy != ""):
-            proxy = http_proxy or (not no_proxy and getproxies().get("http"))
-
-        opts = self._get_pool_options()
-
-        if proxy:
-            proxy_headers = self.options["proxy_headers"]
-            if proxy_headers:
-                opts["proxy_headers"] = proxy_headers
-
-            if proxy.startswith("socks"):
-                use_socks_proxy = True
-                try:
-                    # Check if PySocks dependency is available
-                    from urllib3.contrib.socks import SOCKSProxyManager
-                except ImportError:
-                    use_socks_proxy = False
-                    logger.warning(
-                        "You have configured a SOCKS proxy (%s) but support for SOCKS proxies is not installed. Disabling proxy support. Please add `PySocks` (or `urllib3` with the `[socks]` extra) to your dependencies.",
-                        proxy,
-                    )
-
-                if use_socks_proxy:
-                    return SOCKSProxyManager(proxy, **opts)
-                else:
-                    return urllib3.PoolManager(**opts)
-            else:
-                return urllib3.ProxyManager(proxy, **opts)
-        else:
-            return urllib3.PoolManager(**opts)
-
-    def _request(
-        self: Self,
-        method: str,
-        endpoint_type: EndpointType,
-        body: Any,
-        headers: Mapping[str, str],
-    ) -> urllib3.BaseHTTPResponse:
-        return self._pool.request(
-            method,
-            self._auth.get_api_url(endpoint_type),
-            body=body,
-            headers=headers,
-        )
-
-
 if not HTTP2_ENABLED:
     # Sorry, no Http2Transport for you
     class Http2Transport(HttpTransport):
@@ -1047,6 +1047,11 @@ def make_transport(options: Dict[str, Any]) -> Optional[Transport]:
 
     use_http2_transport = options.get("_experiments", {}).get("transport_http2", False)
     use_async_transport = options.get("_experiments", {}).get("transport_async", False)
+    async_integration = any(
+        integration.__class__.__name__ == "AsyncioIntegration"
+        for integration in options.get("integrations", [])
+    )
+
     # By default, we use the http transport class
     transport_cls: Type[Transport] = (
         Http2Transport if use_http2_transport else HttpTransport
@@ -1054,7 +1059,12 @@ def make_transport(options: Dict[str, Any]) -> Optional[Transport]:
     if use_async_transport and ASYNC_TRANSPORT_ENABLED:
         try:
             asyncio.get_running_loop()
-            transport_cls = AsyncHttpTransport
+            if async_integration:
+                transport_cls = AsyncHttpTransport
+            else:
+                logger.warning(
+                    "You tried to use AsyncHttpTransport but the AsyncioIntegration is not enabled. Falling back to sync transport."
+                )
         except RuntimeError:
             # No event loop running, fall back to sync transport
             logger.warning("No event loop running, falling back to sync transport.")

--- a/sentry_sdk/transport.py
+++ b/sentry_sdk/transport.py
@@ -669,18 +669,18 @@ class AsyncHttpTransport(HttpTransportCore):
     def capture_envelope(self: Self, envelope: Envelope) -> None:
         # Synchronous entry point
         try:
-            asyncio.get_running_loop()
             # We are on the main thread running the event loop
+            asyncio.get_running_loop()
             task = asyncio.create_task(self._capture_envelope(envelope))
             self.background_tasks.add(task)
             task.add_done_callback(self.background_tasks.discard)
         except RuntimeError:
             # We are in a background thread, not running an event loop,
             # have to launch the task on the loop in a threadsafe way.
-            if self._loop and self._loop.is_running():
+            if self.loop and self.loop.is_running():
                 asyncio.run_coroutine_threadsafe(
                     self._capture_envelope(envelope),
-                    self._loop,
+                    self.loop,
                 )
             else:
                 # The event loop is no longer running
@@ -702,7 +702,7 @@ class AsyncHttpTransport(HttpTransportCore):
 
     def _get_pool_options(self: Self) -> Dict[str, Any]:
         options: Dict[str, Any] = {
-            "http2": False,  # no HTTP2 for now
+            "http2": False,  # no HTTP2 for now, should probably just work with this setting
             "retries": 3,
         }
 

--- a/sentry_sdk/transport.py
+++ b/sentry_sdk/transport.py
@@ -636,6 +636,14 @@ class AsyncHttpTransport(HttpTransportCore):
             self._auth.get_api_url(endpoint_type),
             content=body,
             headers=headers,  # type: ignore
+            extensions={
+                "timeout": {
+                    "pool": self.TIMEOUT,
+                    "connect": self.TIMEOUT,
+                    "write": self.TIMEOUT,
+                    "read": self.TIMEOUT,
+                }
+            },
         )
 
     def _flush_client_reports(self: Self, force: bool = False) -> None:

--- a/sentry_sdk/transport.py
+++ b/sentry_sdk/transport.py
@@ -581,7 +581,7 @@ class AsyncHttpTransport(HttpTransportCore):
     def __init__(self: Self, options: Dict[str, Any]) -> None:
         super().__init__(options)
         # Requires event loop at init time
-        self._loop = asyncio.get_running_loop()
+        self.loop = asyncio.get_running_loop()
         self.background_tasks: set[asyncio.Task[None]] = set()
 
     def _get_header_value(self: Self, response: Any, header: str) -> Optional[str]:
@@ -679,10 +679,10 @@ class AsyncHttpTransport(HttpTransportCore):
         except RuntimeError:
             # We are in a background thread, not running an event loop,
             # have to launch the task on the loop in a threadsafe way.
-            if self._loop and self._loop.is_running():
+            if self.loop and self.loop.is_running():
                 asyncio.run_coroutine_threadsafe(
                     self._capture_envelope(envelope),
-                    self._loop,
+                    self.loop,
                 )
             else:
                 # The event loop is no longer running
@@ -793,7 +793,7 @@ class AsyncHttpTransport(HttpTransportCore):
         self.background_tasks.clear()
         try:
             # Return the pool cleanup task so caller can await it if needed
-            return self._loop.create_task(self._pool.aclose())  # type: ignore
+            return self.loop.create_task(self._pool.aclose())  # type: ignore
         except RuntimeError:
             logger.warning("Event loop not running, aborting kill.")
             return None

--- a/sentry_sdk/transport.py
+++ b/sentry_sdk/transport.py
@@ -578,6 +578,16 @@ class AsyncHttpTransport(HttpTransportCore):
         self._loop = asyncio.get_running_loop()
         self.background_tasks: set[asyncio.Task[None]] = set()
 
+    def _get_header_value(self: Self, response: Any, header: str) -> Optional[str]:
+        return next(
+            (
+                val.decode("ascii")
+                for key, val in response.headers
+                if key.decode("ascii").lower() == header
+            ),
+            None,
+        )
+
     async def _send_envelope(self: Self, envelope: Envelope) -> None:
         _prepared_envelope = self._prepare_envelope(envelope)
         if _prepared_envelope is None:
@@ -612,7 +622,7 @@ class AsyncHttpTransport(HttpTransportCore):
         try:
             self._handle_response(response=response, envelope=envelope)
         finally:
-            response.close()
+            await response.aclose()
 
     async def _request(  # type: ignore[override]
         self: Self,

--- a/sentry_sdk/transport.py
+++ b/sentry_sdk/transport.py
@@ -669,8 +669,8 @@ class AsyncHttpTransport(HttpTransportCore):
     def capture_envelope(self: Self, envelope: Envelope) -> None:
         # Synchronous entry point
         try:
-            # We are on the main thread running the event loop
             asyncio.get_running_loop()
+            # We are on the main thread running the event loop
             task = asyncio.create_task(self._capture_envelope(envelope))
             self.background_tasks.add(task)
             task.add_done_callback(self.background_tasks.discard)
@@ -702,7 +702,7 @@ class AsyncHttpTransport(HttpTransportCore):
 
     def _get_pool_options(self: Self) -> Dict[str, Any]:
         options: Dict[str, Any] = {
-            "http2": False,  # no HTTP2 for now, should probably just work with this setting
+            "http2": False,  # no HTTP2 for now
             "retries": 3,
         }
 

--- a/sentry_sdk/transport.py
+++ b/sentry_sdk/transport.py
@@ -759,6 +759,16 @@ class AsyncHttpTransport(HttpTransportCore):
 
         return httpcore.AsyncConnectionPool(**opts)
 
+    def kill(self: Self) -> None:
+
+        logger.debug("Killing HTTP transport")
+        self._worker.kill()
+        for task in self.background_tasks:
+            task.cancel()
+        self.background_tasks.clear()
+
+        self._loop.create_task(self._pool.aclose())  # type: ignore
+
 
 class HttpTransport(BaseHttpTransport):
     if TYPE_CHECKING:

--- a/sentry_sdk/transport.py
+++ b/sentry_sdk/transport.py
@@ -781,7 +781,7 @@ class AsyncHttpTransport(HttpTransportCore):
 
         return httpcore.AsyncConnectionPool(**opts)
 
-    def kill(self: Self) -> None:
+    def kill(self: Self) -> Optional[asyncio.Task[None]]:  # type: ignore
 
         logger.debug("Killing HTTP transport")
         self._worker.kill()
@@ -789,11 +789,11 @@ class AsyncHttpTransport(HttpTransportCore):
             task.cancel()
         self.background_tasks.clear()
         try:
-            task = self._loop.create_task(self._pool.aclose())  # type: ignore
-            self.background_tasks.add(task)
-            task.add_done_callback(lambda t: self.background_tasks.discard(t))
+            # Return the pool cleanup task so caller can await it if needed
+            return self._loop.create_task(self._pool.aclose())  # type: ignore
         except RuntimeError:
             logger.warning("Event loop not running, aborting kill.")
+            return None
 
 
 class HttpTransport(BaseHttpTransport):

--- a/sentry_sdk/transport.py
+++ b/sentry_sdk/transport.py
@@ -29,6 +29,8 @@ except ImportError:
     HTTP2_ENABLED = False
 
 try:
+    import anyio  # noqa: F401
+
     ASYNC_TRANSPORT_ENABLED = httpcore is not None
 except ImportError:
     ASYNC_TRANSPORT_ENABLED = False

--- a/sentry_sdk/transport.py
+++ b/sentry_sdk/transport.py
@@ -781,7 +781,7 @@ class AsyncHttpTransport(HttpTransportCore):
 
         return httpcore.AsyncConnectionPool(**opts)
 
-    def kill(self: Self) -> Optional[asyncio.Task[None]]:  # type: ignore
+    def kill(self: Self) -> Optional[asyncio.Task[None]]:  # type: ignore[override]
 
         logger.debug("Killing HTTP transport")
         self._worker.kill()

--- a/sentry_sdk/worker.py
+++ b/sentry_sdk/worker.py
@@ -182,7 +182,7 @@ class AsyncWorker(Worker):
         self._task_for_pid: Optional[int] = None
         self._loop: Optional[asyncio.AbstractEventLoop] = None
         # Track active callback tasks so they have a strong reference and can be cancelled on kill
-        self._active_tasks: set[asyncio.Task] = set()
+        self._active_tasks: set[asyncio.Task[None]] = set()
 
     @property
     def is_alive(self) -> bool:

--- a/sentry_sdk/worker.py
+++ b/sentry_sdk/worker.py
@@ -195,6 +195,7 @@ class AsyncWorker(Worker):
             self._task.cancel()
             self._task = None
             self._task_for_pid = None
+            self._loop = None
 
     def start(self) -> None:
         if not self.is_alive:

--- a/sentry_sdk/worker.py
+++ b/sentry_sdk/worker.py
@@ -181,6 +181,8 @@ class AsyncWorker(Worker):
         # Event loop needs to remain in the same process
         self._task_for_pid: Optional[int] = None
         self._loop: Optional[asyncio.AbstractEventLoop] = None
+        # Track active callback tasks so they have a strong reference and can be cancelled on kill
+        self._active_tasks: set[asyncio.Task] = set()
 
     @property
     def is_alive(self) -> bool:
@@ -195,6 +197,12 @@ class AsyncWorker(Worker):
             self._task.cancel()
             self._task = None
             self._task_for_pid = None
+            # Also cancel any active callback tasks
+            # Avoid modifying the set while cancelling tasks
+            tasks_to_cancel = set(self._active_tasks)
+            for task in tasks_to_cancel:
+                task.cancel()
+            self._active_tasks.clear()
             self._loop = None
 
     def start(self) -> None:
@@ -256,16 +264,30 @@ class AsyncWorker(Worker):
     async def _target(self) -> None:
         while True:
             callback = await self._queue.get()
-            try:
-                if inspect.iscoroutinefunction(callback):
-                    # Callback is an async coroutine, need to await it
-                    await callback()
-                else:
-                    # Callback is a sync function, need to call it
-                    callback()
-            except Exception:
-                logger.error("Failed processing job", exc_info=True)
-            finally:
-                self._queue.task_done()
+            # Firing tasks instead of awaiting them allows for concurrent requests
+            task = asyncio.create_task(self._process_callback(callback))
+            # Create a strong reference to the task so it can be cancelled on kill
+            # and does not get garbage collected while running
+            self._active_tasks.add(task)
+            task.add_done_callback(self._on_task_complete)
             # Yield to let the event loop run other tasks
             await asyncio.sleep(0)
+
+    async def _process_callback(self, callback: Callable[[], Any]) -> None:
+        if inspect.iscoroutinefunction(callback):
+            # Callback is an async coroutine, need to await it
+            await callback()
+        else:
+            # Callback is a sync function, need to call it
+            callback()
+
+    def _on_task_complete(self, task: asyncio.Task[None]) -> None:
+        try:
+            task.result()
+        except Exception:
+            logger.error("Failed processing job", exc_info=True)
+        finally:
+            # Mark the task as done and remove it from the active tasks set
+            # This happens only after the task has completed
+            self._queue.task_done()
+            self._active_tasks.discard(task)

--- a/sentry_sdk/worker.py
+++ b/sentry_sdk/worker.py
@@ -176,8 +176,8 @@ class BackgroundWorker(Worker):
 
 class AsyncWorker(Worker):
     def __init__(self, queue_size: int = DEFAULT_QUEUE_SIZE) -> None:
-        self._queue: asyncio.Queue = asyncio.Queue(queue_size)
-        self._task: Optional[asyncio.Task] = None
+        self._queue: asyncio.Queue[Callable[[], Any]] = asyncio.Queue(queue_size)
+        self._task: Optional[asyncio.Task[None]] = None
         # Event loop needs to remain in the same process
         self._task_for_pid: Optional[int] = None
         self._loop: Optional[asyncio.AbstractEventLoop] = None

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1732,7 +1732,7 @@ async def test_async_proxy(monkeypatch, testcase):
             )
             assert proxy_headers == testcase["arg_proxy_headers"]
 
-    await client.close()
+    await client.close_async()
 
 
 @pytest.mark.parametrize(
@@ -1820,4 +1820,4 @@ async def test_async_socks_proxy(testcase):
         f"but got {str(type(client.transport._pool))}"
     )
 
-    await client.close()
+    await client.close_async()

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -23,6 +23,8 @@ from sentry_sdk import (
 from sentry_sdk.spotlight import DEFAULT_SPOTLIGHT_URL
 from sentry_sdk.utils import capture_internal_exception
 from sentry_sdk.integrations.executing import ExecutingIntegration
+from sentry_sdk.integrations.asyncio import AsyncioIntegration
+
 from sentry_sdk.transport import Transport, AsyncHttpTransport
 from sentry_sdk.serializer import MAX_DATABAG_BREADTH
 from sentry_sdk.consts import DEFAULT_MAX_BREADCRUMBS, DEFAULT_MAX_VALUE_LENGTH
@@ -1693,7 +1695,10 @@ async def test_async_proxy(monkeypatch, testcase):
     if testcase.get("env_no_proxy") is not None:
         monkeypatch.setenv("NO_PROXY", testcase["env_no_proxy"])
 
-    kwargs = {"_experiments": {"transport_async": True}}
+    kwargs = {
+        "_experiments": {"transport_async": True},
+        "integrations": [AsyncioIntegration()],
+    }
 
     if testcase["arg_http_proxy"] is not None:
         kwargs["http_proxy"] = testcase["arg_http_proxy"]
@@ -1795,7 +1800,10 @@ async def test_async_socks_proxy(testcase):
     # These are just the same tests as the sync ones, but they need to be run in an event loop
     # and respect the shutdown behavior of the async transport
 
-    kwargs = {"_experiments": {"transport_async": True}}
+    kwargs = {
+        "_experiments": {"transport_async": True},
+        "integrations": [AsyncioIntegration()],
+    }
 
     if testcase["arg_http_proxy"] is not None:
         kwargs["http_proxy"] = testcase["arg_http_proxy"]

--- a/tests/test_transport.py
+++ b/tests/test_transport.py
@@ -33,6 +33,7 @@ from sentry_sdk.transport import (
     AsyncHttpTransport,
 )
 from sentry_sdk.integrations.logging import LoggingIntegration, ignore_logger
+from sentry_sdk.integrations.asyncio import AsyncioIntegration
 
 
 server = None
@@ -183,6 +184,7 @@ async def test_transport_works_async(
     client = make_client(
         debug=debug,
         _experiments=experiments,
+        integrations=[AsyncioIntegration()],
     )
 
     if use_pickle:
@@ -812,7 +814,7 @@ async def test_async_transport_background_thread_capture(
     """Test capture_envelope from background threads uses run_coroutine_threadsafe"""
     caplog.set_level(logging.DEBUG)
     experiments = {"transport_async": True}
-    client = make_client(_experiments=experiments)
+    client = make_client(_experiments=experiments, integrations=[AsyncioIntegration()])
     assert isinstance(client.transport, AsyncHttpTransport)
     sentry_sdk.get_global_scope().set_client(client)
     captured_from_thread = []
@@ -843,7 +845,7 @@ async def test_async_transport_event_loop_closed_scenario(
     """Test behavior when trying to capture after event loop context ends"""
     caplog.set_level(logging.DEBUG)
     experiments = {"transport_async": True}
-    client = make_client(_experiments=experiments)
+    client = make_client(_experiments=experiments, integrations=[AsyncioIntegration()])
     sentry_sdk.get_global_scope().set_client(client)
     original_loop = client.transport.loop
 
@@ -869,7 +871,7 @@ async def test_async_transport_concurrent_requests(
     """Test multiple simultaneous envelope submissions"""
     caplog.set_level(logging.DEBUG)
     experiments = {"transport_async": True}
-    client = make_client(_experiments=experiments)
+    client = make_client(_experiments=experiments, integrations=[AsyncioIntegration()])
     assert isinstance(client.transport, AsyncHttpTransport)
     sentry_sdk.get_global_scope().set_client(client)
 
@@ -891,7 +893,7 @@ async def test_async_transport_rate_limiting_with_concurrency(
 ):
     """Test async transport rate limiting with concurrent requests"""
     experiments = {"transport_async": True}
-    client = make_client(_experiments=experiments)
+    client = make_client(_experiments=experiments, integrations=[AsyncioIntegration()])
 
     assert isinstance(client.transport, AsyncHttpTransport)
     sentry_sdk.get_global_scope().set_client(client)
@@ -929,6 +931,7 @@ async def test_async_two_way_ssl_authentication():
         cert_file=cert_file,
         key_file=key_file,
         _experiments={"transport_async": True},
+        integrations=[AsyncioIntegration()],
     )
     assert isinstance(client.transport, AsyncHttpTransport)
 

--- a/tests/test_transport.py
+++ b/tests/test_transport.py
@@ -204,9 +204,9 @@ async def test_transport_works_async(
     capture_message("löl")
 
     if client_flush_method == "close":
-        await client.close(timeout=2.0)
+        await client.close_async(timeout=2.0)
     if client_flush_method == "flush":
-        await client.flush(timeout=2.0)
+        await client.flush_async(timeout=2.0)
 
     out, err = capsys.readouterr()
     assert not err and not out
@@ -230,7 +230,7 @@ async def test_transport_works_async(
     # Therefore, we need to explicitly close the client to clean up the worker task
     assert any("Sending envelope" in record.msg for record in caplog.records) == debug
     if client_flush_method == "flush":
-        await client.close(timeout=2.0)
+        await client.close_async(timeout=2.0)
 
 
 @pytest.mark.parametrize(
@@ -833,7 +833,7 @@ async def test_async_transport_background_thread_capture(
     thread.join()
     assert not exception_from_thread
     assert captured_from_thread
-    await client.close(timeout=2.0)
+    await client.close_async(timeout=2.0)
     assert capturing_server.captured
 
 
@@ -860,7 +860,7 @@ async def test_async_transport_event_loop_closed_scenario(
                 )
 
     client.transport.loop = original_loop
-    await client.close(timeout=2.0)
+    await client.close_async(timeout=2.0)
 
 
 @pytest.mark.asyncio
@@ -882,7 +882,7 @@ async def test_async_transport_concurrent_requests(
 
     tasks = [send_message(i) for i in range(num_messages)]
     await asyncio.gather(*tasks)
-    await client.close(timeout=2.0)
+    await client.close_async(timeout=2.0)
     assert len(capturing_server.captured) == num_messages
 
 
@@ -916,7 +916,7 @@ async def test_async_transport_rate_limiting_with_concurrency(
     await asyncio.sleep(0.1)
     # New request should be dropped due to rate limiting
     assert len(capturing_server.captured) == 0
-    await client.close(timeout=2.0)
+    await client.close_async(timeout=2.0)
 
 
 @pytest.mark.asyncio
@@ -938,4 +938,4 @@ async def test_async_two_way_ssl_authentication():
     options = client.transport._get_pool_options()
     assert options["ssl_context"] is not None
 
-    await client.close()
+    await client.close_async()

--- a/tests/test_transport.py
+++ b/tests/test_transport.py
@@ -763,6 +763,47 @@ def test_handle_unexpected_status_invokes_handle_request_error(
     assert seen == ["status_500"]
 
 
+def test_handle_request_error_basic_coverage(make_client, monkeypatch):
+    client = make_client()
+    transport = client.transport
+
+    monkeypatch.setattr(transport._worker, "submit", lambda fn: fn() or True)
+
+    # Track method calls
+    calls = []
+
+    def mock_on_dropped_event(reason):
+        calls.append(("on_dropped_event", reason))
+
+    def mock_record_lost_event(reason, data_category=None, item=None):
+        calls.append(("record_lost_event", reason, data_category, item))
+
+    monkeypatch.setattr(transport, "on_dropped_event", mock_on_dropped_event)
+    monkeypatch.setattr(transport, "record_lost_event", mock_record_lost_event)
+
+    # Test case 1: envelope is None
+    transport._handle_request_error(envelope=None, loss_reason="test_reason")
+
+    assert len(calls) == 2
+    assert calls[0] == ("on_dropped_event", "test_reason")
+    assert calls[1] == ("record_lost_event", "network_error", "error", None)
+
+    # Reset
+    calls.clear()
+
+    # Test case 2: envelope with items
+    envelope = Envelope()
+    envelope.add_item(mock.MagicMock())  # Simple mock item
+    envelope.add_item(mock.MagicMock())  # Another mock item
+
+    transport._handle_request_error(envelope=envelope, loss_reason="connection_error")
+
+    assert len(calls) == 3
+    assert calls[0] == ("on_dropped_event", "connection_error")
+    assert calls[1][0:2] == ("record_lost_event", "network_error")
+    assert calls[2][0:2] == ("record_lost_event", "network_error")
+
+
 @pytest.mark.asyncio
 @pytest.mark.skipif(not PY38, reason="Async transport requires Python 3.8+")
 async def test_async_transport_background_thread_capture(

--- a/tests/test_transport.py
+++ b/tests/test_transport.py
@@ -880,9 +880,7 @@ async def test_async_transport_concurrent_requests(
 
     tasks = [send_message(i) for i in range(num_messages)]
     await asyncio.gather(*tasks)
-    transport = client.transport
     await client.close(timeout=2.0)
-    assert len(transport.background_tasks) == 0
     assert len(capturing_server.captured) == num_messages
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,7 @@
 # The file (and all resulting CI YAMLs) then need to be regenerated via
 # "scripts/generate-test-files.sh".
 #
-# Last generated: 2025-07-29T08:10:08.981379+00:00
+# Last generated: 2025-07-29T08:26:02.455474+00:00
 
 [tox]
 requires =
@@ -378,7 +378,7 @@ deps =
     httpx-v0.25: pytest-httpx==0.25.0
     httpx: pytest-httpx
     # anyio is a dep of httpx
-    httpx: anyio<4.0.0
+    httpx: anyio>=3,<5
     httpx-v0.16: httpx~=0.16.0
     httpx-v0.18: httpx~=0.18.0
     httpx-v0.20: httpx~=0.20.0

--- a/tox.ini
+++ b/tox.ini
@@ -376,7 +376,6 @@ deps =
     httpx-v0.25: pytest-httpx==0.25.0
     httpx: pytest-httpx
     # anyio is a dep of httpx
-    httpx: anyio<4.0.0
     httpx-v0.16: httpx~=0.16.0
     httpx-v0.18: httpx~=0.18.0
     httpx-v0.20: httpx~=0.20.0

--- a/tox.ini
+++ b/tox.ini
@@ -376,6 +376,7 @@ deps =
     httpx-v0.25: pytest-httpx==0.25.0
     httpx: pytest-httpx
     # anyio is a dep of httpx
+    httpx: anyio<4.0.0
     httpx-v0.16: httpx~=0.16.0
     httpx-v0.18: httpx~=0.18.0
     httpx-v0.20: httpx~=0.20.0

--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,7 @@
 # The file (and all resulting CI YAMLs) then need to be regenerated via
 # "scripts/generate-test-files.sh".
 #
-# Last generated: 2025-07-29T08:45:43.951088+00:00
+# Last generated: 2025-07-30T13:59:12.959550+00:00
 
 [tox]
 requires =
@@ -125,9 +125,9 @@ envlist =
 
     # ~~~ Common ~~~
     {py3.7,py3.8,py3.9}-common-v1.4.1
-    {py3.7,py3.8,py3.9,py3.10,py3.11}-common-v1.14.0
-    {py3.8,py3.9,py3.10,py3.11}-common-v1.24.0
-    {py3.9,py3.10,py3.11,py3.12,py3.13}-common-v1.35.0
+    {py3.7,py3.8,py3.9,py3.10,py3.11}-common-v1.15.0
+    {py3.8,py3.9,py3.10,py3.11,py3.12}-common-v1.26.0
+    {py3.9,py3.10,py3.11,py3.12,py3.13}-common-v1.36.0
 
 
     # ~~~ AI ~~~
@@ -141,9 +141,9 @@ envlist =
     {py3.9,py3.11,py3.12}-cohere-v5.13.12
     {py3.9,py3.11,py3.12}-cohere-v5.16.1
 
-    {py3.9,py3.11,py3.12}-openai_agents-v0.0.19
-    {py3.9,py3.12,py3.13}-openai_agents-v0.1.0
-    {py3.9,py3.12,py3.13}-openai_agents-v0.2.3
+    {py3.10,py3.11,py3.12}-openai_agents-v0.0.19
+    {py3.10,py3.12,py3.13}-openai_agents-v0.1.0
+    {py3.10,py3.12,py3.13}-openai_agents-v0.2.4
 
     {py3.8,py3.10,py3.11}-huggingface_hub-v0.22.2
     {py3.8,py3.11,py3.12}-huggingface_hub-v0.26.5
@@ -165,7 +165,7 @@ envlist =
 
     {py3.7,py3.8,py3.9}-sqlalchemy-v1.3.24
     {py3.7,py3.11,py3.12}-sqlalchemy-v1.4.54
-    {py3.7,py3.12,py3.13}-sqlalchemy-v2.0.41
+    {py3.7,py3.12,py3.13}-sqlalchemy-v2.0.42
 
 
     # ~~~ Flags ~~~
@@ -202,9 +202,6 @@ envlist =
     {py3.8,py3.12,py3.13}-graphene-v3.4.3
 
     {py3.8,py3.10,py3.11}-strawberry-v0.209.8
-    {py3.8,py3.11,py3.12}-strawberry-v0.232.2
-    {py3.8,py3.12,py3.13}-strawberry-v0.255.0
-    {py3.9,py3.12,py3.13}-strawberry-v0.278.0
     {py3.8,py3.11,py3.12}-strawberry-v0.232.2
     {py3.8,py3.12,py3.13}-strawberry-v0.255.0
     {py3.9,py3.12,py3.13}-strawberry-v0.278.0
@@ -254,7 +251,6 @@ envlist =
     {py3.7,py3.10,py3.11}-starlette-v0.26.1
     {py3.8,py3.11,py3.12}-starlette-v0.36.3
     {py3.9,py3.12,py3.13}-starlette-v0.47.2
-    {py3.9,py3.12,py3.13}-starlette-v0.47.2
 
     {py3.7,py3.9,py3.10}-fastapi-v0.79.1
     {py3.7,py3.10,py3.11}-fastapi-v0.91.0
@@ -274,7 +270,6 @@ envlist =
     {py3.7,py3.8,py3.9}-falcon-v3.0.1
     {py3.7,py3.11,py3.12}-falcon-v3.1.3
     {py3.8,py3.11,py3.12}-falcon-v4.0.2
-    {py3.8,py3.11,py3.12}-falcon-v4.1.0a3
     {py3.8,py3.11,py3.12}-falcon-v4.1.0a3
 
     {py3.8,py3.10,py3.11}-litestar-v2.0.1
@@ -302,8 +297,6 @@ envlist =
     {py3.7}-trytond-v5.0.63
     {py3.7,py3.8}-trytond-v5.8.16
     {py3.8,py3.10,py3.11}-trytond-v6.8.17
-    {py3.8,py3.11,py3.12}-trytond-v7.0.34
-    {py3.9,py3.12,py3.13}-trytond-v7.6.4
     {py3.8,py3.11,py3.12}-trytond-v7.0.34
     {py3.9,py3.12,py3.13}-trytond-v7.6.4
 
@@ -491,9 +484,9 @@ deps =
 
     # ~~~ Common ~~~
     common-v1.4.1: opentelemetry-sdk==1.4.1
-    common-v1.14.0: opentelemetry-sdk==1.14.0
-    common-v1.24.0: opentelemetry-sdk==1.24.0
-    common-v1.35.0: opentelemetry-sdk==1.35.0
+    common-v1.15.0: opentelemetry-sdk==1.15.0
+    common-v1.26.0: opentelemetry-sdk==1.26.0
+    common-v1.36.0: opentelemetry-sdk==1.36.0
     common: pytest
     common: pytest-asyncio
     py3.7-common: pytest<7.0.0
@@ -517,8 +510,7 @@ deps =
 
     openai_agents-v0.0.19: openai-agents==0.0.19
     openai_agents-v0.1.0: openai-agents==0.1.0
-    openai_agents-v0.2.3: openai-agents==0.2.3
-    openai_agents-v0.2.3: openai-agents==0.2.3
+    openai_agents-v0.2.4: openai-agents==0.2.4
     openai_agents: pytest-asyncio
 
     huggingface_hub-v0.22.2: huggingface_hub==0.22.2
@@ -542,7 +534,7 @@ deps =
 
     sqlalchemy-v1.3.24: sqlalchemy==1.3.24
     sqlalchemy-v1.4.54: sqlalchemy==1.4.54
-    sqlalchemy-v2.0.41: sqlalchemy==2.0.41
+    sqlalchemy-v2.0.42: sqlalchemy==2.0.42
 
 
     # ~~~ Flags ~~~
@@ -591,13 +583,8 @@ deps =
     strawberry-v0.232.2: strawberry-graphql[fastapi,flask]==0.232.2
     strawberry-v0.255.0: strawberry-graphql[fastapi,flask]==0.255.0
     strawberry-v0.278.0: strawberry-graphql[fastapi,flask]==0.278.0
-    strawberry-v0.232.2: strawberry-graphql[fastapi,flask]==0.232.2
-    strawberry-v0.255.0: strawberry-graphql[fastapi,flask]==0.255.0
-    strawberry-v0.278.0: strawberry-graphql[fastapi,flask]==0.278.0
     strawberry: httpx
     strawberry-v0.209.8: pydantic<2.11
-    strawberry-v0.232.2: pydantic<2.11
-    strawberry-v0.255.0: pydantic<2.11
     strawberry-v0.232.2: pydantic<2.11
     strawberry-v0.255.0: pydantic<2.11
 
@@ -680,7 +667,6 @@ deps =
     starlette-v0.26.1: starlette==0.26.1
     starlette-v0.36.3: starlette==0.36.3
     starlette-v0.47.2: starlette==0.47.2
-    starlette-v0.47.2: starlette==0.47.2
     starlette: pytest-asyncio
     starlette: python-multipart
     starlette: requests
@@ -725,7 +711,6 @@ deps =
     falcon-v3.1.3: falcon==3.1.3
     falcon-v4.0.2: falcon==4.0.2
     falcon-v4.1.0a3: falcon==4.1.0a3
-    falcon-v4.1.0a3: falcon==4.1.0a3
 
     litestar-v2.0.1: litestar==2.0.1
     litestar-v2.5.5: litestar==2.5.5
@@ -769,8 +754,6 @@ deps =
     trytond-v5.0.63: trytond==5.0.63
     trytond-v5.8.16: trytond==5.8.16
     trytond-v6.8.17: trytond==6.8.17
-    trytond-v7.0.34: trytond==7.0.34
-    trytond-v7.6.4: trytond==7.6.4
     trytond-v7.0.34: trytond==7.0.34
     trytond-v7.6.4: trytond==7.6.4
     trytond: werkzeug

--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,7 @@
 # The file (and all resulting CI YAMLs) then need to be regenerated via
 # "scripts/generate-test-files.sh".
 #
-# Last generated: 2025-07-15T08:55:25.785747+00:00
+# Last generated: 2025-07-29T08:10:08.981379+00:00
 
 [tox]
 requires =
@@ -132,9 +132,9 @@ envlist =
 
     # ~~~ AI ~~~
     {py3.8,py3.11,py3.12}-anthropic-v0.16.0
-    {py3.8,py3.11,py3.12}-anthropic-v0.30.1
-    {py3.8,py3.11,py3.12}-anthropic-v0.44.0
-    {py3.8,py3.11,py3.12}-anthropic-v0.57.1
+    {py3.8,py3.11,py3.12}-anthropic-v0.31.2
+    {py3.8,py3.11,py3.12}-anthropic-v0.46.0
+    {py3.8,py3.12,py3.13}-anthropic-v0.60.0
 
     {py3.9,py3.10,py3.11}-cohere-v5.4.0
     {py3.9,py3.11,py3.12}-cohere-v5.9.4
@@ -143,11 +143,13 @@ envlist =
 
     {py3.9,py3.11,py3.12}-openai_agents-v0.0.19
     {py3.9,py3.12,py3.13}-openai_agents-v0.1.0
+    {py3.9,py3.12,py3.13}-openai_agents-v0.2.3
 
     {py3.8,py3.10,py3.11}-huggingface_hub-v0.22.2
     {py3.8,py3.11,py3.12}-huggingface_hub-v0.26.5
     {py3.8,py3.12,py3.13}-huggingface_hub-v0.30.2
-    {py3.8,py3.12,py3.13}-huggingface_hub-v0.33.4
+    {py3.8,py3.12,py3.13}-huggingface_hub-v0.34.2
+    {py3.8,py3.12,py3.13}-huggingface_hub-v0.35.0rc0
 
 
     # ~~~ DBs ~~~
@@ -176,9 +178,9 @@ envlist =
     {py3.9,py3.12,py3.13}-openfeature-v0.8.1
 
     {py3.7,py3.12,py3.13}-statsig-v0.55.3
-    {py3.7,py3.12,py3.13}-statsig-v0.56.0
     {py3.7,py3.12,py3.13}-statsig-v0.57.3
-    {py3.7,py3.12,py3.13}-statsig-v0.59.0
+    {py3.7,py3.12,py3.13}-statsig-v0.59.1
+    {py3.7,py3.12,py3.13}-statsig-v0.61.0
 
     {py3.8,py3.12,py3.13}-unleash-v6.0.1
     {py3.8,py3.12,py3.13}-unleash-v6.1.0
@@ -200,17 +202,16 @@ envlist =
     {py3.8,py3.12,py3.13}-graphene-v3.4.3
 
     {py3.8,py3.10,py3.11}-strawberry-v0.209.8
-    {py3.8,py3.11,py3.12}-strawberry-v0.231.1
-    {py3.8,py3.12,py3.13}-strawberry-v0.253.1
-    {py3.9,py3.12,py3.13}-strawberry-v0.276.0
+    {py3.8,py3.11,py3.12}-strawberry-v0.232.2
+    {py3.8,py3.12,py3.13}-strawberry-v0.255.0
+    {py3.9,py3.12,py3.13}-strawberry-v0.278.0
 
 
     # ~~~ Network ~~~
     {py3.7,py3.8}-grpc-v1.32.0
     {py3.7,py3.9,py3.10}-grpc-v1.46.5
     {py3.7,py3.11,py3.12}-grpc-v1.60.2
-    {py3.9,py3.12,py3.13}-grpc-v1.73.1
-    {py3.9,py3.12,py3.13}-grpc-v1.74.0rc1
+    {py3.9,py3.12,py3.13}-grpc-v1.74.0
 
 
     # ~~~ Tasks ~~~
@@ -249,7 +250,7 @@ envlist =
     {py3.7,py3.9,py3.10}-starlette-v0.16.0
     {py3.7,py3.10,py3.11}-starlette-v0.26.1
     {py3.8,py3.11,py3.12}-starlette-v0.36.3
-    {py3.9,py3.12,py3.13}-starlette-v0.47.1
+    {py3.9,py3.12,py3.13}-starlette-v0.47.2
 
     {py3.7,py3.9,py3.10}-fastapi-v0.79.1
     {py3.7,py3.10,py3.11}-fastapi-v0.91.0
@@ -261,7 +262,7 @@ envlist =
     {py3.7}-aiohttp-v3.4.4
     {py3.7,py3.8,py3.9}-aiohttp-v3.7.4
     {py3.8,py3.12,py3.13}-aiohttp-v3.10.11
-    {py3.9,py3.12,py3.13}-aiohttp-v3.12.14
+    {py3.9,py3.12,py3.13}-aiohttp-v3.12.15
 
     {py3.7}-bottle-v0.12.25
     {py3.8,py3.12,py3.13}-bottle-v0.13.4
@@ -269,6 +270,7 @@ envlist =
     {py3.7,py3.8,py3.9}-falcon-v3.0.1
     {py3.7,py3.11,py3.12}-falcon-v3.1.3
     {py3.8,py3.11,py3.12}-falcon-v4.0.2
+    {py3.8,py3.11,py3.12}-falcon-v4.1.0a3
 
     {py3.8,py3.10,py3.11}-litestar-v2.0.1
     {py3.8,py3.11,py3.12}-litestar-v2.5.5
@@ -295,8 +297,8 @@ envlist =
     {py3.7}-trytond-v5.0.63
     {py3.7,py3.8}-trytond-v5.8.16
     {py3.8,py3.10,py3.11}-trytond-v6.8.17
-    {py3.8,py3.11,py3.12}-trytond-v7.0.33
-    {py3.9,py3.12,py3.13}-trytond-v7.6.3
+    {py3.8,py3.11,py3.12}-trytond-v7.0.34
+    {py3.9,py3.12,py3.13}-trytond-v7.6.4
 
     {py3.7,py3.12,py3.13}-typer-v0.15.4
     {py3.7,py3.12,py3.13}-typer-v0.16.0
@@ -493,13 +495,13 @@ deps =
 
     # ~~~ AI ~~~
     anthropic-v0.16.0: anthropic==0.16.0
-    anthropic-v0.30.1: anthropic==0.30.1
-    anthropic-v0.44.0: anthropic==0.44.0
-    anthropic-v0.57.1: anthropic==0.57.1
+    anthropic-v0.31.2: anthropic==0.31.2
+    anthropic-v0.46.0: anthropic==0.46.0
+    anthropic-v0.60.0: anthropic==0.60.0
     anthropic: pytest-asyncio
     anthropic-v0.16.0: httpx<0.28.0
-    anthropic-v0.30.1: httpx<0.28.0
-    anthropic-v0.44.0: httpx<0.28.0
+    anthropic-v0.31.2: httpx<0.28.0
+    anthropic-v0.46.0: httpx<0.28.0
 
     cohere-v5.4.0: cohere==5.4.0
     cohere-v5.9.4: cohere==5.9.4
@@ -508,12 +510,14 @@ deps =
 
     openai_agents-v0.0.19: openai-agents==0.0.19
     openai_agents-v0.1.0: openai-agents==0.1.0
+    openai_agents-v0.2.3: openai-agents==0.2.3
     openai_agents: pytest-asyncio
 
     huggingface_hub-v0.22.2: huggingface_hub==0.22.2
     huggingface_hub-v0.26.5: huggingface_hub==0.26.5
     huggingface_hub-v0.30.2: huggingface_hub==0.30.2
-    huggingface_hub-v0.33.4: huggingface_hub==0.33.4
+    huggingface_hub-v0.34.2: huggingface_hub==0.34.2
+    huggingface_hub-v0.35.0rc0: huggingface_hub==0.35.0rc0
 
 
     # ~~~ DBs ~~~
@@ -543,9 +547,9 @@ deps =
     openfeature-v0.8.1: openfeature-sdk==0.8.1
 
     statsig-v0.55.3: statsig==0.55.3
-    statsig-v0.56.0: statsig==0.56.0
     statsig-v0.57.3: statsig==0.57.3
-    statsig-v0.59.0: statsig==0.59.0
+    statsig-v0.59.1: statsig==0.59.1
+    statsig-v0.61.0: statsig==0.61.0
     statsig: typing_extensions
 
     unleash-v6.0.1: UnleashClient==6.0.1
@@ -576,21 +580,20 @@ deps =
     py3.6-graphene: aiocontextvars
 
     strawberry-v0.209.8: strawberry-graphql[fastapi,flask]==0.209.8
-    strawberry-v0.231.1: strawberry-graphql[fastapi,flask]==0.231.1
-    strawberry-v0.253.1: strawberry-graphql[fastapi,flask]==0.253.1
-    strawberry-v0.276.0: strawberry-graphql[fastapi,flask]==0.276.0
+    strawberry-v0.232.2: strawberry-graphql[fastapi,flask]==0.232.2
+    strawberry-v0.255.0: strawberry-graphql[fastapi,flask]==0.255.0
+    strawberry-v0.278.0: strawberry-graphql[fastapi,flask]==0.278.0
     strawberry: httpx
     strawberry-v0.209.8: pydantic<2.11
-    strawberry-v0.231.1: pydantic<2.11
-    strawberry-v0.253.1: pydantic<2.11
+    strawberry-v0.232.2: pydantic<2.11
+    strawberry-v0.255.0: pydantic<2.11
 
 
     # ~~~ Network ~~~
     grpc-v1.32.0: grpcio==1.32.0
     grpc-v1.46.5: grpcio==1.46.5
     grpc-v1.60.2: grpcio==1.60.2
-    grpc-v1.73.1: grpcio==1.73.1
-    grpc-v1.74.0rc1: grpcio==1.74.0rc1
+    grpc-v1.74.0: grpcio==1.74.0
     grpc: protobuf
     grpc: mypy-protobuf
     grpc: types-protobuf
@@ -663,7 +666,7 @@ deps =
     starlette-v0.16.0: starlette==0.16.0
     starlette-v0.26.1: starlette==0.26.1
     starlette-v0.36.3: starlette==0.36.3
-    starlette-v0.47.1: starlette==0.47.1
+    starlette-v0.47.2: starlette==0.47.2
     starlette: pytest-asyncio
     starlette: python-multipart
     starlette: requests
@@ -683,7 +686,7 @@ deps =
     fastapi: pytest-asyncio
     fastapi: python-multipart
     fastapi: requests
-    fastapi: anyio<4
+    fastapi: anyio>=3,<5
     fastapi-v0.79.1: httpx<0.28.0
     fastapi-v0.91.0: httpx<0.28.0
     fastapi-v0.103.2: httpx<0.28.0
@@ -694,10 +697,10 @@ deps =
     aiohttp-v3.4.4: aiohttp==3.4.4
     aiohttp-v3.7.4: aiohttp==3.7.4
     aiohttp-v3.10.11: aiohttp==3.10.11
-    aiohttp-v3.12.14: aiohttp==3.12.14
+    aiohttp-v3.12.15: aiohttp==3.12.15
     aiohttp: pytest-aiohttp
     aiohttp-v3.10.11: pytest-asyncio
-    aiohttp-v3.12.14: pytest-asyncio
+    aiohttp-v3.12.15: pytest-asyncio
 
     bottle-v0.12.25: bottle==0.12.25
     bottle-v0.13.4: bottle==0.13.4
@@ -706,6 +709,7 @@ deps =
     falcon-v3.0.1: falcon==3.0.1
     falcon-v3.1.3: falcon==3.1.3
     falcon-v4.0.2: falcon==4.0.2
+    falcon-v4.1.0a3: falcon==4.1.0a3
 
     litestar-v2.0.1: litestar==2.0.1
     litestar-v2.5.5: litestar==2.5.5
@@ -749,8 +753,8 @@ deps =
     trytond-v5.0.63: trytond==5.0.63
     trytond-v5.8.16: trytond==5.8.16
     trytond-v6.8.17: trytond==6.8.17
-    trytond-v7.0.33: trytond==7.0.33
-    trytond-v7.6.3: trytond==7.6.3
+    trytond-v7.0.34: trytond==7.0.34
+    trytond-v7.6.4: trytond==7.6.4
     trytond: werkzeug
     trytond-v5.0.63: werkzeug<1.0
 

--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,7 @@
 # The file (and all resulting CI YAMLs) then need to be regenerated via
 # "scripts/generate-test-files.sh".
 #
-# Last generated: 2025-07-29T08:26:02.455474+00:00
+# Last generated: 2025-07-29T08:45:43.951088+00:00
 
 [tox]
 requires =
@@ -148,7 +148,7 @@ envlist =
     {py3.8,py3.10,py3.11}-huggingface_hub-v0.22.2
     {py3.8,py3.11,py3.12}-huggingface_hub-v0.26.5
     {py3.8,py3.12,py3.13}-huggingface_hub-v0.30.2
-    {py3.8,py3.12,py3.13}-huggingface_hub-v0.34.2
+    {py3.8,py3.12,py3.13}-huggingface_hub-v0.34.3
     {py3.8,py3.12,py3.13}-huggingface_hub-v0.35.0rc0
 
 
@@ -516,7 +516,7 @@ deps =
     huggingface_hub-v0.22.2: huggingface_hub==0.22.2
     huggingface_hub-v0.26.5: huggingface_hub==0.26.5
     huggingface_hub-v0.30.2: huggingface_hub==0.30.2
-    huggingface_hub-v0.34.2: huggingface_hub==0.34.2
+    huggingface_hub-v0.34.3: huggingface_hub==0.34.3
     huggingface_hub-v0.35.0rc0: huggingface_hub==0.35.0rc0
 
 
@@ -690,6 +690,7 @@ deps =
     fastapi-v0.79.1: httpx<0.28.0
     fastapi-v0.91.0: httpx<0.28.0
     fastapi-v0.103.2: httpx<0.28.0
+    fastapi-v0.79.1: anyio<4
     py3.6-fastapi: aiocontextvars
 
 


### PR DESCRIPTION
Integrate the async transport with the rest of the SDK. Provide a new experimental option `transport_async` that enables the async transport if an event loop is running. Otherwise, fall back to the sync transport.

Furthermore, adapt the client to work with the async transport. To this end, flush and close were changed to be non blocking and awaitable in an async context to avoid deadlocks, however close enforces a completed flush before shutdown. As there are to my knowledge no background threads running flush/close, these methods are currently not thread-safe/loop-aware for async, which can be changed if necessary.

Atexit issue: The atexit integration used by the SDK runs after the event loop has already closed if asyncio.run() is used. This makes it impossible for the async flush to happen, as atexit calls client.close(), but a loop is no longer present. I attempted to apply [this fix](https://discuss.python.org/t/atexit-for-asyncio/13911) by patching the loop close in the asyncio integration, but I am unsure if I did it correctly/put it in the correct spot, or if this is a good idea. From my SDK test however, it seems to fix the flush issue. Note also that this will apparently be patched in Python 3.14, as per the discussion in the linked thread.

As a final note, I added event loop checking. Whenever the event loop is used, the transport/client catch RuntimeErrors, which would be thrown in case the event loop was already shut down. I am not sure if this is a case we need to consider, but I added it for now because I did not want the transport to potentially throw RuntimeError if the event loop is shutdown during a program. If this should be left out currently for simplicity, I can remove it again.

I added the [httpcore[asyncio] ](https://www.encode.io/httpcore/async/) dependency to requirements-testing, as it is needed for the async httpcore functionality.

GH-4601