### PR TITLE
Remove MAX_EVENT_BYTES

### DIFF
--- a/sentry_sdk/serializer.py
+++ b/sentry_sdk/serializer.py
@@ -39,16 +39,6 @@ if TYPE_CHECKING:
 serializable_str_types = (str, bytes, bytearray, memoryview)
 
 
-# Maximum length of JSON-serialized event payloads that can be safely sent
-# before the server may reject the event due to its size. This is not intended
-# to reflect actual values defined server-side, but rather only be an upper
-# bound for events sent by the SDK.
-#
-# Can be overwritten if wanting to send more bytes, e.g. with a custom server.
-# When changing this, keep in mind that events may be a little bit larger than
-# this value due to attached metadata, so keep the number conservative.
-MAX_EVENT_BYTES = 10**6
-
 # Maximum depth and breadth of databags. Excess data will be trimmed. If
 # max_request_body_size is "always", request bodies won't be trimmed.
 MAX_DATABAG_DEPTH = 5

--- a/tests/integrations/sqlalchemy/test_sqlalchemy.py
+++ b/tests/integrations/sqlalchemy/test_sqlalchemy.py
@@ -14,9 +14,7 @@ from sqlalchemy import text
 import sentry_sdk
 from sentry_sdk.consts import DEFAULT_MAX_VALUE_LENGTH, SPANDATA
 from sentry_sdk.integrations.sqlalchemy import SqlalchemyIntegration
-from sentry_sdk.serializer import MAX_EVENT_BYTES
 from sentry_sdk.tracing_utils import record_sql_queries
-from sentry_sdk.utils import json_dumps
 
 
 def test_orm_queries(sentry_init, capture_events):
@@ -255,8 +253,6 @@ def test_large_event_not_truncated(sentry_init, capture_events):
                 )
 
     (event,) = events
-
-    assert len(json_dumps(event)) > MAX_EVENT_BYTES
 
     # Some spans are discarded.
     assert len(event["spans"]) == 1000


### PR DESCRIPTION
Remove `MAX_EVENT_BYTES` (which doesn't seem to be used anyway?)