### PR TITLE
Considerably raise `DEFAULT_MAX_VALUE_LENGTH`

### DIFF
--- a/sentry_sdk/consts.py
+++ b/sentry_sdk/consts.py
@@ -3,7 +3,7 @@ from enum import Enum
 from typing import TYPE_CHECKING
 
 # up top to prevent circular import due to integration import
-# This is more or less arbitrary large-ish value for now, so that we allow
+# This is more or less an arbitrary large-ish value for now, so that we allow
 # pretty long strings (like LLM prompts), but still have *some* upper limit
 # until we verify that removing the trimming completely is safe.
 DEFAULT_MAX_VALUE_LENGTH = 100_000

--- a/sentry_sdk/consts.py
+++ b/sentry_sdk/consts.py
@@ -3,7 +3,7 @@ from enum import Enum
 from typing import TYPE_CHECKING
 
 # up top to prevent circular import due to integration import
-DEFAULT_MAX_VALUE_LENGTH = 1024
+DEFAULT_MAX_VALUE_LENGTH = 100_000
 
 DEFAULT_MAX_STACK_FRAMES = 100
 DEFAULT_ADD_FULL_STACK = False

--- a/sentry_sdk/consts.py
+++ b/sentry_sdk/consts.py
@@ -3,6 +3,9 @@ from enum import Enum
 from typing import TYPE_CHECKING
 
 # up top to prevent circular import due to integration import
+# This is more or less arbitrary large-ish value for now, so that we allow
+# pretty long strings (like LLM prompts), but still have *some* upper limit
+# until we verify that removing the trimming completely is safe.
 DEFAULT_MAX_VALUE_LENGTH = 100_000
 
 DEFAULT_MAX_STACK_FRAMES = 100

--- a/tests/integrations/flask/test_flask.py
+++ b/tests/integrations/flask/test_flask.py
@@ -249,7 +249,9 @@ def test_flask_login_configured(
 
 
 def test_flask_large_json_request(sentry_init, capture_events, app):
-    sentry_init(integrations=[flask_sentry.FlaskIntegration()])
+    sentry_init(
+        integrations=[flask_sentry.FlaskIntegration()], max_request_body_size="always"
+    )
 
     data = {"foo": {"bar": "a" * (DEFAULT_MAX_VALUE_LENGTH + 10)}}
 

--- a/tests/integrations/flask/test_flask.py
+++ b/tests/integrations/flask/test_flask.py
@@ -344,7 +344,9 @@ def test_flask_empty_json_request(sentry_init, capture_events, app, data):
 
 
 def test_flask_medium_formdata_request(sentry_init, capture_events, app):
-    sentry_init(integrations=[flask_sentry.FlaskIntegration()])
+    sentry_init(
+        integrations=[flask_sentry.FlaskIntegration()], max_request_body_size="always"
+    )
 
     data = {"foo": "a" * (DEFAULT_MAX_VALUE_LENGTH + 10)}
 

--- a/tests/integrations/flask/test_flask.py
+++ b/tests/integrations/flask/test_flask.py
@@ -27,6 +27,7 @@ from sentry_sdk import (
     capture_message,
     capture_exception,
 )
+from sentry_sdk.consts import DEFAULT_MAX_VALUE_LENGTH
 from sentry_sdk.integrations.logging import LoggingIntegration
 from sentry_sdk.serializer import MAX_DATABAG_BREADTH
 
@@ -250,7 +251,7 @@ def test_flask_login_configured(
 def test_flask_large_json_request(sentry_init, capture_events, app):
     sentry_init(integrations=[flask_sentry.FlaskIntegration()])
 
-    data = {"foo": {"bar": "a" * 2000}}
+    data = {"foo": {"bar": "a" * (DEFAULT_MAX_VALUE_LENGTH + 10)}}
 
     @app.route("/", methods=["POST"])
     def index():
@@ -268,9 +269,14 @@ def test_flask_large_json_request(sentry_init, capture_events, app):
 
     (event,) = events
     assert event["_meta"]["request"]["data"]["foo"]["bar"] == {
-        "": {"len": 2000, "rem": [["!limit", "x", 1021, 1024]]}
+        "": {
+            "len": DEFAULT_MAX_VALUE_LENGTH + 10,
+            "rem": [
+                ["!limit", "x", DEFAULT_MAX_VALUE_LENGTH - 3, DEFAULT_MAX_VALUE_LENGTH]
+            ],
+        }
     }
-    assert len(event["request"]["data"]["foo"]["bar"]) == 1024
+    assert len(event["request"]["data"]["foo"]["bar"]) == DEFAULT_MAX_VALUE_LENGTH
 
 
 def test_flask_session_tracking(sentry_init, capture_envelopes, app):
@@ -338,7 +344,7 @@ def test_flask_empty_json_request(sentry_init, capture_events, app, data):
 def test_flask_medium_formdata_request(sentry_init, capture_events, app):
     sentry_init(integrations=[flask_sentry.FlaskIntegration()])
 
-    data = {"foo": "a" * 2000}
+    data = {"foo": "a" * (DEFAULT_MAX_VALUE_LENGTH + 10)}
 
     @app.route("/", methods=["POST"])
     def index():
@@ -360,9 +366,14 @@ def test_flask_medium_formdata_request(sentry_init, capture_events, app):
 
     (event,) = events
     assert event["_meta"]["request"]["data"]["foo"] == {
-        "": {"len": 2000, "rem": [["!limit", "x", 1021, 1024]]}
+        "": {
+            "len": DEFAULT_MAX_VALUE_LENGTH + 10,
+            "rem": [
+                ["!limit", "x", DEFAULT_MAX_VALUE_LENGTH - 3, DEFAULT_MAX_VALUE_LENGTH]
+            ],
+        }
     }
-    assert len(event["request"]["data"]["foo"]) == 1024
+    assert len(event["request"]["data"]["foo"]) == DEFAULT_MAX_VALUE_LENGTH
 
 
 def test_flask_formdata_request_appear_transaction_body(
@@ -441,7 +452,10 @@ def test_flask_files_and_form(sentry_init, capture_events, app):
         integrations=[flask_sentry.FlaskIntegration()], max_request_body_size="always"
     )
 
-    data = {"foo": "a" * 2000, "file": (BytesIO(b"hello"), "hello.txt")}
+    data = {
+        "foo": "a" * (DEFAULT_MAX_VALUE_LENGTH + 10),
+        "file": (BytesIO(b"hello"), "hello.txt"),
+    }
 
     @app.route("/", methods=["POST"])
     def index():
@@ -463,9 +477,14 @@ def test_flask_files_and_form(sentry_init, capture_events, app):
 
     (event,) = events
     assert event["_meta"]["request"]["data"]["foo"] == {
-        "": {"len": 2000, "rem": [["!limit", "x", 1021, 1024]]}
+        "": {
+            "len": DEFAULT_MAX_VALUE_LENGTH + 10,
+            "rem": [
+                ["!limit", "x", DEFAULT_MAX_VALUE_LENGTH - 3, DEFAULT_MAX_VALUE_LENGTH]
+            ],
+        }
     }
-    assert len(event["request"]["data"]["foo"]) == 1024
+    assert len(event["request"]["data"]["foo"]) == DEFAULT_MAX_VALUE_LENGTH
 
     assert event["_meta"]["request"]["data"]["file"] == {"": {"rem": [["!raw", "x"]]}}
     assert not event["request"]["data"]["file"]

--- a/tests/integrations/sqlalchemy/test_sqlalchemy.py
+++ b/tests/integrations/sqlalchemy/test_sqlalchemy.py
@@ -275,7 +275,12 @@ def test_large_event_not_truncated(sentry_init, capture_events):
 
     # The _meta for other truncated fields should be there as well.
     assert event["_meta"]["message"] == {
-        "": {"len": 1034, "rem": [["!limit", "x", 1021, 1024]]}
+        "": {
+            "len": DEFAULT_MAX_VALUE_LENGTH + 10,
+            "rem": [
+                ["!limit", "x", DEFAULT_MAX_VALUE_LENGTH - 3, DEFAULT_MAX_VALUE_LENGTH]
+            ],
+        }
     }
 
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -773,14 +773,14 @@ def test_databag_string_stripping(sentry_init, capture_events, benchmark):
     def inner():
         del events[:]
         try:
-            a = "A" * 1000000  # noqa
+            a = "A" * DEFAULT_MAX_VALUE_LENGTH * 100  # noqa
             1 / 0
         except Exception:
             capture_exception()
 
         (event,) = events
 
-        assert len(json.dumps(event)) < 10000
+        assert len(json.dumps(event)) < DEFAULT_MAX_VALUE_LENGTH * 100
 
 
 def test_databag_breadth_stripping(sentry_init, capture_events, benchmark):
@@ -1073,7 +1073,10 @@ def test_multiple_positional_args(sentry_init):
     "sdk_options, expected_data_length",
     [
         ({}, DEFAULT_MAX_VALUE_LENGTH),
-        ({"max_value_length": 1800}, 1800),
+        (
+            {"max_value_length": DEFAULT_MAX_VALUE_LENGTH + 1000},
+            DEFAULT_MAX_VALUE_LENGTH + 1000,
+        ),
     ],
 )
 def test_max_value_length_option(
@@ -1082,7 +1085,7 @@ def test_max_value_length_option(
     sentry_init(sdk_options)
     events = capture_events()
 
-    capture_message("a" * 2000)
+    capture_message("a" * (DEFAULT_MAX_VALUE_LENGTH + 2000))
 
     assert len(events[0]["message"]) == expected_data_length
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -773,14 +773,14 @@ def test_databag_string_stripping(sentry_init, capture_events, benchmark):
     def inner():
         del events[:]
         try:
-            a = "A" * DEFAULT_MAX_VALUE_LENGTH * 100  # noqa
+            a = "A" * DEFAULT_MAX_VALUE_LENGTH * 10  # noqa
             1 / 0
         except Exception:
             capture_exception()
 
         (event,) = events
 
-        assert len(json.dumps(event)) < DEFAULT_MAX_VALUE_LENGTH * 100
+        assert len(json.dumps(event)) < DEFAULT_MAX_VALUE_LENGTH * 10
 
 
 def test_databag_breadth_stripping(sentry_init, capture_events, benchmark):

--- a/tests/test_serializer.py
+++ b/tests/test_serializer.py
@@ -2,6 +2,7 @@ import re
 
 import pytest
 
+from sentry_sdk.consts import DEFAULT_MAX_VALUE_LENGTH
 from sentry_sdk.serializer import MAX_DATABAG_BREADTH, MAX_DATABAG_DEPTH, serialize
 
 try:
@@ -166,11 +167,11 @@ def test_no_trimming_if_max_request_body_size_is_always(body_normalizer):
 
 
 def test_max_value_length_default(body_normalizer):
-    data = {"key": "a" * 2000}
+    data = {"key": "a" * (DEFAULT_MAX_VALUE_LENGTH * 10)}
 
     result = body_normalizer(data)
 
-    assert len(result["key"]) == 1024  # fallback max length
+    assert len(result["key"]) == DEFAULT_MAX_VALUE_LENGTH  # fallback max length
 
 
 def test_max_value_length(body_normalizer):


### PR DESCRIPTION
AI prompts/messages are potentially huge.

* raise `DEFAULT_MAX_VALUE_LENGTH` (responsible for string trimming) from 1024 to 100 000
* adapt tests (and make them more generic, without hardcoded parts, where possible)

This does not seem to affect issue grouping, see e.g. https://sentry-sdks.sentry.io/issues/6774464781/events/latest/?project=4506716433416192&query=is%3Aunresolved&referrer=latest-event