### PR TITLE
fix(celery): Latency should be in milliseconds, not seconds

### DIFF
--- a/sentry_sdk/integrations/celery/__init__.py
+++ b/sentry_sdk/integrations/celery/__init__.py
@@ -391,7 +391,7 @@ def _wrap_task_call(task, f):
                         )
 
                 if latency is not None:
-                    latency *= 1000
+                    latency *= 1000  # milliseconds
                     span.set_data(SPANDATA.MESSAGING_MESSAGE_RECEIVE_LATENCY, latency)
 
                 with capture_internal_exceptions():


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry-python/issues/4636