### PR TITLE
Fix typo in CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
   default 1024 characters/bytes).
 
   If you want to adjust the limit, you can set a
-  [`max_value_limit`](https://docs.sentry.io/platforms/python/configuration/options/#max_value_length)
+  [`max_value_length`](https://docs.sentry.io/platforms/python/configuration/options/#max_value_length)
   in your `sentry_sdk.init()`.
 
 - `OpenAI` integration update (#4612) by @antonpirker


### PR DESCRIPTION
Just a typo in the changelog that confused me for a minute while I searched for that variable.