### PR TITLE
Add `enable_logs`, `before_send_log` as top-level options

### DIFF
--- a/sentry_sdk/client.py
+++ b/sentry_sdk/client.py
@@ -37,6 +37,7 @@ from sentry_sdk.consts import (
 )
 from sentry_sdk.integrations import _DEFAULT_INTEGRATIONS, setup_integrations
 from sentry_sdk.integrations.dedupe import DedupeIntegration
+from sentry_sdk.logger import has_logs_enabled
 from sentry_sdk.sessions import SessionFlusher
 from sentry_sdk.envelope import Envelope
 from sentry_sdk.profiler.continuous_profiler import setup_continuous_profiler
@@ -382,7 +383,7 @@ class _Client(BaseClient):
                     )
 
             self.log_batcher = None
-            if experiments.get("enable_logs", False):
+            if has_logs_enabled(self.options):
                 from sentry_sdk._log_batcher import LogBatcher
 
                 self.log_batcher = LogBatcher(capture_func=_capture_envelope)
@@ -899,8 +900,7 @@ class _Client(BaseClient):
 
     def _capture_experimental_log(self, log):
         # type: (Log) -> None
-        logs_enabled = self.options["_experiments"].get("enable_logs", False)
-        if not logs_enabled:
+        if not has_logs_enabled(self.options):
             return
 
         current_scope = sentry_sdk.get_current_scope()

--- a/sentry_sdk/client.py
+++ b/sentry_sdk/client.py
@@ -37,7 +37,6 @@ from sentry_sdk.consts import (
 )
 from sentry_sdk.integrations import _DEFAULT_INTEGRATIONS, setup_integrations
 from sentry_sdk.integrations.dedupe import DedupeIntegration
-from sentry_sdk.logger import has_logs_enabled, get_before_send_log
 from sentry_sdk.sessions import SessionFlusher
 from sentry_sdk.envelope import Envelope
 from sentry_sdk.profiler.continuous_profiler import setup_continuous_profiler
@@ -383,6 +382,9 @@ class _Client(BaseClient):
                     )
 
             self.log_batcher = None
+
+            from sentry_sdk.logger import has_logs_enabled
+
             if has_logs_enabled(self.options):
                 from sentry_sdk._log_batcher import LogBatcher
 
@@ -900,6 +902,8 @@ class _Client(BaseClient):
 
     def _capture_experimental_log(self, log):
         # type: (Log) -> None
+        from sentry_sdk.logger import get_before_send_log, has_logs_enabled
+
         if not has_logs_enabled(self.options):
             return
 

--- a/sentry_sdk/client.py
+++ b/sentry_sdk/client.py
@@ -37,7 +37,7 @@ from sentry_sdk.consts import (
 )
 from sentry_sdk.integrations import _DEFAULT_INTEGRATIONS, setup_integrations
 from sentry_sdk.integrations.dedupe import DedupeIntegration
-from sentry_sdk.logger import has_logs_enabled
+from sentry_sdk.logger import has_logs_enabled, get_before_send_log
 from sentry_sdk.sessions import SessionFlusher
 from sentry_sdk.envelope import Envelope
 from sentry_sdk.profiler.continuous_profiler import setup_continuous_profiler
@@ -955,7 +955,7 @@ class _Client(BaseClient):
                 f'[Sentry Logs] [{log.get("severity_text")}] {log.get("body")}'
             )
 
-        before_send_log = self.options["_experiments"].get("before_send_log")
+        before_send_log = get_before_send_log(self.options)
         if before_send_log is not None:
             log = before_send_log(log, {})
         if log is None:

--- a/sentry_sdk/client.py
+++ b/sentry_sdk/client.py
@@ -901,10 +901,10 @@ class _Client(BaseClient):
         return return_value
 
     def _capture_experimental_log(self, log):
-        # type: (Log) -> None
+        # type: (Optional[Log]) -> None
         from sentry_sdk.logger import get_before_send_log, has_logs_enabled
 
-        if not has_logs_enabled(self.options):
+        if not has_logs_enabled(self.options) or log is None:
             return
 
         current_scope = sentry_sdk.get_current_scope()
@@ -962,6 +962,7 @@ class _Client(BaseClient):
         before_send_log = get_before_send_log(self.options)
         if before_send_log is not None:
             log = before_send_log(log, {})
+
         if log is None:
             return
 

--- a/sentry_sdk/client.py
+++ b/sentry_sdk/client.py
@@ -23,6 +23,8 @@ from sentry_sdk.utils import (
     handle_in_app,
     is_gevent,
     logger,
+    get_before_send_log,
+    has_logs_enabled,
 )
 from sentry_sdk.serializer import serialize
 from sentry_sdk.tracing import trace
@@ -382,8 +384,6 @@ class _Client(BaseClient):
                     )
 
             self.log_batcher = None
-
-            from sentry_sdk.logger import has_logs_enabled
 
             if has_logs_enabled(self.options):
                 from sentry_sdk._log_batcher import LogBatcher
@@ -902,8 +902,6 @@ class _Client(BaseClient):
 
     def _capture_experimental_log(self, log):
         # type: (Optional[Log]) -> None
-        from sentry_sdk.logger import get_before_send_log, has_logs_enabled
-
         if not has_logs_enabled(self.options) or log is None:
             return
 

--- a/sentry_sdk/consts.py
+++ b/sentry_sdk/consts.py
@@ -1183,6 +1183,11 @@ class ClientConstructor:
         :param enable_logs: Set `enable_logs` to True to enable the SDK to emit
             Sentry logs. Defaults to False.
 
+        :param before_send_log: An optional function to modify or filter out logs
+            before they're sent to Sentry. Any modifications to the log in this
+            function will be retained. If the function returns None, the log will
+            not be sent to Sentry.
+
         :param _experiments:
         """
         pass

--- a/sentry_sdk/consts.py
+++ b/sentry_sdk/consts.py
@@ -798,6 +798,7 @@ class ClientConstructor:
         custom_repr=None,  # type: Optional[Callable[..., Optional[str]]]
         add_full_stack=DEFAULT_ADD_FULL_STACK,  # type: bool
         max_stack_frames=DEFAULT_MAX_STACK_FRAMES,  # type: Optional[int]
+        enable_logs=False,  # type: bool
     ):
         # type: (...) -> None
         """Initialize the Sentry SDK with the given parameters. All parameters described here can be used in a call to `sentry_sdk.init()`.
@@ -1168,7 +1169,6 @@ class ClientConstructor:
 
         :param profile_session_sample_rate:
 
-
         :param enable_tracing:
 
         :param propagate_traces:
@@ -1178,6 +1178,9 @@ class ClientConstructor:
         :param spotlight:
 
         :param instrumenter:
+
+        :param enable_logs: Set `enable_logs` to True to enable the SDK to emit
+            Sentry logs. Defaults to False.
 
         :param _experiments:
         """

--- a/sentry_sdk/consts.py
+++ b/sentry_sdk/consts.py
@@ -799,6 +799,7 @@ class ClientConstructor:
         add_full_stack=DEFAULT_ADD_FULL_STACK,  # type: bool
         max_stack_frames=DEFAULT_MAX_STACK_FRAMES,  # type: Optional[int]
         enable_logs=False,  # type: bool
+        before_send_log=None,  # type: Optional[Callable[[Log, Hint], Optional[Log]]]
     ):
         # type: (...) -> None
         """Initialize the Sentry SDK with the given parameters. All parameters described here can be used in a call to `sentry_sdk.init()`.

--- a/sentry_sdk/integrations/logging.py
+++ b/sentry_sdk/integrations/logging.py
@@ -5,13 +5,14 @@ from fnmatch import fnmatch
 
 import sentry_sdk
 from sentry_sdk.client import BaseClient
-from sentry_sdk.logger import _log_level_to_otel, has_logs_enabled
+from sentry_sdk.logger import _log_level_to_otel
 from sentry_sdk.utils import (
     safe_repr,
     to_string,
     event_from_exception,
     current_stacktrace,
     capture_internal_exceptions,
+    has_logs_enabled,
 )
 from sentry_sdk.integrations import Integration
 

--- a/sentry_sdk/integrations/logging.py
+++ b/sentry_sdk/integrations/logging.py
@@ -5,7 +5,7 @@ from fnmatch import fnmatch
 
 import sentry_sdk
 from sentry_sdk.client import BaseClient
-from sentry_sdk.logger import _log_level_to_otel
+from sentry_sdk.logger import _log_level_to_otel, has_logs_enabled
 from sentry_sdk.utils import (
     safe_repr,
     to_string,
@@ -344,7 +344,7 @@ class SentryLogsHandler(_BaseHandler):
             if not client.is_active():
                 return
 
-            if not client.options["_experiments"].get("enable_logs", False):
+            if not has_logs_enabled(client.options):
                 return
 
             self._capture_log_from_record(client, record)

--- a/sentry_sdk/integrations/loguru.py
+++ b/sentry_sdk/integrations/loguru.py
@@ -7,7 +7,7 @@ from sentry_sdk.integrations.logging import (
     EventHandler,
     _BaseHandler,
 )
-from sentry_sdk.logger import _log_level_to_otel
+from sentry_sdk.logger import _log_level_to_otel, has_logs_enabled
 
 from typing import TYPE_CHECKING
 
@@ -151,7 +151,7 @@ def loguru_sentry_logs_handler(message):
     if not client.is_active():
         return
 
-    if not client.options["_experiments"].get("enable_logs", False):
+    if not has_logs_enabled(client.options):
         return
 
     record = message.record

--- a/sentry_sdk/integrations/loguru.py
+++ b/sentry_sdk/integrations/loguru.py
@@ -7,7 +7,8 @@ from sentry_sdk.integrations.logging import (
     EventHandler,
     _BaseHandler,
 )
-from sentry_sdk.logger import _log_level_to_otel, has_logs_enabled
+from sentry_sdk.logger import _log_level_to_otel
+from sentry_sdk.utils import has_logs_enabled
 
 from typing import TYPE_CHECKING
 

--- a/sentry_sdk/logger.py
+++ b/sentry_sdk/logger.py
@@ -1,10 +1,11 @@
 # NOTE: this is the logger sentry exposes to users, not some generic logger.
 import functools
 import time
-from typing import Any, Optional
+from typing import Any, Callable, Optional
 
 from sentry_sdk import get_client
 from sentry_sdk.utils import safe_repr
+from sentry_sdk.types import Log, Hint
 
 OTEL_RANGES = [
     # ((severity level range), severity text)
@@ -91,4 +92,14 @@ def has_logs_enabled(options):
     return bool(
         options.get("enable_logs", False)
         or options["_experiments"].get("enable_logs", False)
+    )
+
+
+def get_before_send_log(options):
+    # type: (Optional[dict[str, Any]]) -> Optional[Callable[[Log, Hint], Optional[Log]]]
+    if options is None:
+        return None
+
+    return options.get("before_send_log") or options["_experiments"].get(
+        "before_send_log"
     )

--- a/sentry_sdk/logger.py
+++ b/sentry_sdk/logger.py
@@ -1,7 +1,7 @@
 # NOTE: this is the logger sentry exposes to users, not some generic logger.
 import functools
 import time
-from typing import Any
+from typing import Any, Optional
 
 from sentry_sdk import get_client
 from sentry_sdk.utils import safe_repr
@@ -81,3 +81,14 @@ def _log_level_to_otel(level, mapping):
             return otel_severity_number, _otel_severity_text(otel_severity_number)
 
     return 0, "default"
+
+
+def has_logs_enabled(options):
+    # type: (Optional[dict[str, Any]]) -> bool
+    if options is None:
+        return False
+
+    return bool(
+        options.get("enable_logs", False)
+        or options["_experiments"].get("enable_logs", False)
+    )

--- a/sentry_sdk/logger.py
+++ b/sentry_sdk/logger.py
@@ -1,11 +1,10 @@
 # NOTE: this is the logger sentry exposes to users, not some generic logger.
 import functools
 import time
-from typing import Any, Callable, Optional
+from typing import Any
 
 from sentry_sdk import get_client
 from sentry_sdk.utils import safe_repr
-from sentry_sdk.types import Log, Hint
 
 OTEL_RANGES = [
     # ((severity level range), severity text)
@@ -82,24 +81,3 @@ def _log_level_to_otel(level, mapping):
             return otel_severity_number, _otel_severity_text(otel_severity_number)
 
     return 0, "default"
-
-
-def has_logs_enabled(options):
-    # type: (Optional[dict[str, Any]]) -> bool
-    if options is None:
-        return False
-
-    return bool(
-        options.get("enable_logs", False)
-        or options["_experiments"].get("enable_logs", False)
-    )
-
-
-def get_before_send_log(options):
-    # type: (Optional[dict[str, Any]]) -> Optional[Callable[[Log, Hint], Optional[Log]]]
-    if options is None:
-        return None
-
-    return options.get("before_send_log") or options["_experiments"].get(
-        "before_send_log"
-    )

--- a/sentry_sdk/utils.py
+++ b/sentry_sdk/utils.py
@@ -59,7 +59,7 @@ if TYPE_CHECKING:
 
     from gevent.hub import Hub
 
-    from sentry_sdk._types import Event, ExcInfo
+    from sentry_sdk._types import Event, ExcInfo, Log, Hint
 
     P = ParamSpec("P")
     R = TypeVar("R")
@@ -1984,3 +1984,24 @@ def safe_serialize(data):
         return json.dumps(serialized, default=str)
     except Exception:
         return str(data)
+
+
+def has_logs_enabled(options):
+    # type: (Optional[dict[str, Any]]) -> bool
+    if options is None:
+        return False
+
+    return bool(
+        options.get("enable_logs", False)
+        or options["_experiments"].get("enable_logs", False)
+    )
+
+
+def get_before_send_log(options):
+    # type: (Optional[dict[str, Any]]) -> Optional[Callable[[Log, Hint], Optional[Log]]]
+    if options is None:
+        return None
+
+    return options.get("before_send_log") or options["_experiments"].get(
+        "before_send_log"
+    )

--- a/tests/integrations/logging/test_logging.py
+++ b/tests/integrations/logging/test_logging.py
@@ -304,7 +304,7 @@ def test_sentry_logs_warning(sentry_init, capture_envelopes):
     """
     The python logger module should create 'warn' sentry logs if the flag is on.
     """
-    sentry_init(_experiments={"enable_logs": True})
+    sentry_init(enable_logs=True)
     envelopes = capture_envelopes()
 
     python_logger = logging.Logger("test-logger")
@@ -329,7 +329,7 @@ def test_sentry_logs_debug(sentry_init, capture_envelopes):
     """
     The python logger module should not create 'debug' sentry logs if the flag is on by default
     """
-    sentry_init(_experiments={"enable_logs": True})
+    sentry_init(enable_logs=True)
     envelopes = capture_envelopes()
 
     python_logger = logging.Logger("test-logger")
@@ -344,7 +344,7 @@ def test_no_log_infinite_loop(sentry_init, capture_envelopes):
     If 'debug' mode is true, and you set a low log level in the logging integration, there should be no infinite loops.
     """
     sentry_init(
-        _experiments={"enable_logs": True},
+        enable_logs=True,
         integrations=[LoggingIntegration(sentry_logs_level=logging.DEBUG)],
         debug=True,
     )
@@ -361,7 +361,7 @@ def test_logging_errors(sentry_init, capture_envelopes):
     """
     The python logger module should be able to log errors without erroring
     """
-    sentry_init(_experiments={"enable_logs": True})
+    sentry_init(enable_logs=True)
     envelopes = capture_envelopes()
 
     python_logger = logging.Logger("test-logger")
@@ -396,7 +396,7 @@ def test_log_strips_project_root(sentry_init, capture_envelopes):
     The python logger should strip project roots from the log record path
     """
     sentry_init(
-        _experiments={"enable_logs": True},
+        enable_logs=True,
         project_root="/custom/test",
     )
     envelopes = capture_envelopes()
@@ -425,7 +425,7 @@ def test_logger_with_all_attributes(sentry_init, capture_envelopes):
     """
     The python logger should be able to log all attributes, including extra data.
     """
-    sentry_init(_experiments={"enable_logs": True})
+    sentry_init(enable_logs=True)
     envelopes = capture_envelopes()
 
     python_logger = logging.Logger("test-logger")
@@ -498,7 +498,7 @@ def test_sentry_logs_named_parameters(sentry_init, capture_envelopes):
     """
     The python logger module should capture named parameters from dictionary arguments in Sentry logs.
     """
-    sentry_init(_experiments={"enable_logs": True})
+    sentry_init(enable_logs=True)
     envelopes = capture_envelopes()
 
     python_logger = logging.Logger("test-logger")
@@ -543,7 +543,7 @@ def test_sentry_logs_named_parameters_complex_values(sentry_init, capture_envelo
     """
     The python logger module should handle complex values in named parameters using safe_repr.
     """
-    sentry_init(_experiments={"enable_logs": True})
+    sentry_init(enable_logs=True)
     envelopes = capture_envelopes()
 
     python_logger = logging.Logger("test-logger")

--- a/tests/integrations/loguru/test_loguru.py
+++ b/tests/integrations/loguru/test_loguru.py
@@ -141,7 +141,7 @@ def test_sentry_logs_warning(
     uninstall_integration("loguru")
     request.addfinalizer(logger.remove)
 
-    sentry_init(_experiments={"enable_logs": True})
+    sentry_init(enable_logs=True)
     envelopes = capture_envelopes()
 
     logger.warning("this is {} a {}", "just", "template")
@@ -165,7 +165,7 @@ def test_sentry_logs_debug(
     uninstall_integration("loguru")
     request.addfinalizer(logger.remove)
 
-    sentry_init(_experiments={"enable_logs": True})
+    sentry_init(enable_logs=True)
     envelopes = capture_envelopes()
 
     logger.debug("this is %s a template %s", "1", "2")
@@ -182,7 +182,7 @@ def test_sentry_log_levels(
 
     sentry_init(
         integrations=[LoguruIntegration(sentry_logs_level=LoggingLevels.SUCCESS)],
-        _experiments={"enable_logs": True},
+        enable_logs=True,
     )
     envelopes = capture_envelopes()
 
@@ -216,7 +216,7 @@ def test_disable_loguru_logs(
 
     sentry_init(
         integrations=[LoguruIntegration(sentry_logs_level=None)],
-        _experiments={"enable_logs": True},
+        enable_logs=True,
     )
     envelopes = capture_envelopes()
 
@@ -267,7 +267,7 @@ def test_no_log_infinite_loop(
     request.addfinalizer(logger.remove)
 
     sentry_init(
-        _experiments={"enable_logs": True},
+        enable_logs=True,
         integrations=[LoguruIntegration(sentry_logs_level=LoggingLevels.DEBUG)],
         debug=True,
     )
@@ -284,7 +284,7 @@ def test_logging_errors(sentry_init, capture_envelopes, uninstall_integration, r
     uninstall_integration("loguru")
     request.addfinalizer(logger.remove)
 
-    sentry_init(_experiments={"enable_logs": True})
+    sentry_init(enable_logs=True)
     envelopes = capture_envelopes()
 
     logger.error(Exception("test exc 1"))
@@ -313,7 +313,7 @@ def test_log_strips_project_root(
     request.addfinalizer(logger.remove)
 
     sentry_init(
-        _experiments={"enable_logs": True},
+        enable_logs=True,
         project_root="/custom/test",
     )
     envelopes = capture_envelopes()
@@ -362,7 +362,7 @@ def test_log_keeps_full_path_if_not_in_project_root(
     request.addfinalizer(logger.remove)
 
     sentry_init(
-        _experiments={"enable_logs": True},
+        enable_logs=True,
         project_root="/custom/test",
     )
     envelopes = capture_envelopes()
@@ -410,7 +410,7 @@ def test_logger_with_all_attributes(
     uninstall_integration("loguru")
     request.addfinalizer(logger.remove)
 
-    sentry_init(_experiments={"enable_logs": True})
+    sentry_init(enable_logs=True)
     envelopes = capture_envelopes()
 
     logger.warning("log #{}", 1)

--- a/tests/test_logs.py
+++ b/tests/test_logs.py
@@ -80,7 +80,7 @@ def test_logs_disabled_by_default(sentry_init, capture_envelopes):
 
 @minimum_python_37
 def test_logs_basics(sentry_init, capture_envelopes):
-    sentry_init(_experiments={"enable_logs": True})
+    sentry_init(enable_logs=True)
     envelopes = capture_envelopes()
 
     sentry_sdk.logger.trace("This is a 'trace' log...")
@@ -163,7 +163,7 @@ def test_logs_attributes(sentry_init, capture_envelopes):
     """
     Passing arbitrary attributes to log messages.
     """
-    sentry_init(_experiments={"enable_logs": True}, server_name="test-server")
+    sentry_init(enable_logs=True, server_name="test-server")
     envelopes = capture_envelopes()
 
     attrs = {
@@ -196,7 +196,7 @@ def test_logs_message_params(sentry_init, capture_envelopes):
     """
     This is the official way of how to pass vars to log messages.
     """
-    sentry_init(_experiments={"enable_logs": True})
+    sentry_init(enable_logs=True)
     envelopes = capture_envelopes()
 
     sentry_sdk.logger.warning("The recorded value was '{int_var}'", int_var=1)
@@ -239,7 +239,7 @@ def test_logs_tied_to_transactions(sentry_init, capture_envelopes):
     """
     Log messages are also tied to transactions.
     """
-    sentry_init(_experiments={"enable_logs": True})
+    sentry_init(enable_logs=True)
     envelopes = capture_envelopes()
 
     with sentry_sdk.start_transaction(name="test-transaction") as trx:
@@ -255,7 +255,7 @@ def test_logs_tied_to_spans(sentry_init, capture_envelopes):
     """
     Log messages are also tied to spans.
     """
-    sentry_init(_experiments={"enable_logs": True})
+    sentry_init(enable_logs=True)
     envelopes = capture_envelopes()
 
     with sentry_sdk.start_transaction(name="test-transaction"):
@@ -271,7 +271,7 @@ def test_auto_flush_logs_after_100(sentry_init, capture_envelopes):
     """
     If you log >100 logs, it should automatically trigger a flush.
     """
-    sentry_init(_experiments={"enable_logs": True})
+    sentry_init(enable_logs=True)
     envelopes = capture_envelopes()
 
     python_logger = logging.Logger("test-logger")
@@ -288,7 +288,7 @@ def test_auto_flush_logs_after_100(sentry_init, capture_envelopes):
 
 def test_log_user_attributes(sentry_init, capture_envelopes):
     """User attributes are sent if enable_logs is True."""
-    sentry_init(_experiments={"enable_logs": True})
+    sentry_init(enable_logs=True)
 
     sentry_sdk.set_user({"id": "1", "email": "test@example.com", "username": "test"})
     envelopes = capture_envelopes()
@@ -314,7 +314,7 @@ def test_auto_flush_logs_after_5s(sentry_init, capture_envelopes):
     """
     If you log a single log, it should automatically flush after 5 seconds, at most 10 seconds.
     """
-    sentry_init(_experiments={"enable_logs": True})
+    sentry_init(enable_logs=True)
     envelopes = capture_envelopes()
 
     python_logger = logging.Logger("test-logger")


### PR DESCRIPTION
Promote `enable_logs` and `before_send_log` to regular (non-experimental) SDK options. Keep supporting the experimental versions too, for backwards compat.

Closes https://github.com/getsentry/sentry-python/issues/4641