### PR TITLE
Let `set_data` accept a `dict`.

### DIFF
--- a/sentry_sdk/tracing.py
+++ b/sentry_sdk/tracing.py
@@ -598,9 +598,24 @@ class Span:
         # type: (str, Any) -> None
         self._tags[key] = value
 
-    def set_data(self, key, value):
-        # type: (str, Any) -> None
-        self._data[key] = value
+    def set_data(self, key=None, value=None):
+        # type: (Optional[Union[str, Dict[str, Any]]], Optional[Any]) -> None
+        """Set data on the span.
+        Can be called in two ways:
+        - set_data(key, value) - sets a single key-value pair
+        - set_data({"key": "value"}) - sets multiple key-value pairs from a dict
+        """
+        if key is None:
+            return
+
+        if isinstance(key, dict):
+            # Dictionary calling pattern: set_data({"key": "value"})
+            for k, v in key.items():
+                self._data[k] = v
+
+        elif isinstance(key, str):
+            # Traditional calling pattern: set_data(key, value)
+            self._data[key] = value
 
     def set_flag(self, flag, result):
         # type: (str, bool) -> None
@@ -1271,8 +1286,8 @@ class NoOpSpan(Span):
         # type: (str, Any) -> None
         pass
 
-    def set_data(self, key, value):
-        # type: (str, Any) -> None
+    def set_data(self, key=None, value=None):
+        # type: (Optional[Union[str, Dict[str, Any]]], Optional[Any]) -> None
         pass
 
     def set_status(self, value):


### PR DESCRIPTION
This allows users to set multiple `span.data` attributes at once. 
In 3.x this then will become `set_attribute` and `set_attributes` (plural form).