### PR TITLE
Give users classes for easier manual instrumentation.

### DIFF
--- a/sentry_sdk/__init__.py
+++ b/sentry_sdk/__init__.py
@@ -50,6 +50,8 @@ __all__ = [  # noqa
     "start_session",
     "end_session",
     "set_transaction_name",
+    "SpanAttr",
+    "SpanOp",
 ]
 
 # Initialize the debug support after everything is loaded

--- a/sentry_sdk/api.py
+++ b/sentry_sdk/api.py
@@ -4,7 +4,11 @@ from contextlib import contextmanager
 
 from sentry_sdk import tracing_utils, Client
 from sentry_sdk._init_implementation import init
-from sentry_sdk.consts import INSTRUMENTER
+from sentry_sdk.consts import (  # noqa: N811
+    INSTRUMENTER,
+    OP as SpanOp,
+    SPANDATA as SpanAttr,
+)
 from sentry_sdk.scope import Scope, _ScopeManager, new_scope, isolation_scope
 from sentry_sdk.tracing import NoOpSpan, Transaction, trace
 from sentry_sdk.crons import monitor
@@ -85,6 +89,8 @@ __all__ = [
     "start_session",
     "end_session",
     "set_transaction_name",
+    "SpanAttr",
+    "SpanOp",
 ]
 
 


### PR DESCRIPTION
We have internal classes for setting `Span.op` and to set correct names for `Span.data/Span.attribute` items. Make them public so users can use `SpanAttr` and `SpanOp` for better manual instrumentation.