### PR TITLE
feat(tracing): Add convenience function `update_current_span`.

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -41,6 +41,7 @@ Performance Monitoring
 .. autofunction:: sentry_sdk.api.get_current_span
 .. autofunction:: sentry_sdk.api.start_span
 .. autofunction:: sentry_sdk.api.start_transaction
+.. autofunction:: sentry_sdk.api.update_current_span
 
 
 Distributed Tracing

--- a/sentry_sdk/__init__.py
+++ b/sentry_sdk/__init__.py
@@ -50,6 +50,7 @@ __all__ = [  # noqa
     "start_session",
     "end_session",
     "set_transaction_name",
+    "update_current_span",
 ]
 
 # Initialize the debug support after everything is loaded

--- a/sentry_sdk/api.py
+++ b/sentry_sdk/api.py
@@ -476,8 +476,8 @@ def set_transaction_name(name, source=None):
     return get_current_scope().set_transaction_name(name, source)
 
 
-def update_current_span(op=None, name=None, attributes=None):
-    # type: (Optional[str], Optional[str], Optional[dict[str, Union[str, int, float, bool]]]) -> None
+def update_current_span(op=None, name=None, attributes=None, data=None):
+    # type: (Optional[str], Optional[str], Optional[dict[str, Union[str, int, float, bool]]], Optional[dict[str, Any]]) -> None
     """
     Update the current active span with the provided parameters.
 
@@ -496,6 +496,15 @@ def update_current_span(op=None, name=None, attributes=None):
         "SELECT * FROM users"). If not provided, the span's name will remain unchanged.
     :type name: str or None
 
+    :param data: A dictionary of key-value pairs to add as data to the span. This
+        data will be merged with any existing span data. If not provided,
+        no data will be added.
+
+        .. deprecated:: 2.35.0
+            Use ``attributes`` instead. The ``data`` parameter will be removed
+            in a future version.
+    :type data: dict[str, Union[str, int, float, bool]] or None
+
     :param attributes: A dictionary of key-value pairs to add as attributes to the span.
         Attribute values must be strings, integers, floats, or booleans. These
         attributes will be merged with any existing span data. If not provided,
@@ -504,7 +513,7 @@ def update_current_span(op=None, name=None, attributes=None):
 
     :returns: None
 
-    .. versionadded:: 2.0.0
+    .. versionadded:: 2.35.0
 
     Example::
 
@@ -528,6 +537,19 @@ def update_current_span(op=None, name=None, attributes=None):
     if name is not None:
         # internally it is still description
         current_span.description = name
+
+    if data is not None and attributes is not None:
+        raise ValueError(
+            "Cannot provide both `data` and `attributes`. Please use only `attributes`."
+        )
+
+    if data is not None:
+        warnings.warn(
+            "The `data` parameter is deprecated. Please use `attributes` instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        attributes = data
 
     if attributes is not None:
         current_span.update_data(attributes)

--- a/sentry_sdk/api.py
+++ b/sentry_sdk/api.py
@@ -85,6 +85,7 @@ __all__ = [
     "start_session",
     "end_session",
     "set_transaction_name",
+    "update_current_span",
 ]
 
 
@@ -473,3 +474,27 @@ def end_session():
 def set_transaction_name(name, source=None):
     # type: (str, Optional[str]) -> None
     return get_current_scope().set_transaction_name(name, source)
+
+
+def update_current_span(op=None, name=None, attributes=None):
+    # type: (Optional[str], Optional[str], Optional[dict[str, Union[str, int, float, bool]]]) -> None
+    """
+    Update the current span with the given parameters.
+    :param op: The operation of the span.
+    :param name: The name of the span.
+    :param attributes: The attributes of the span.
+    """
+    current_span = get_current_span()
+
+    if current_span is None:
+        return
+
+    if op is not None:
+        current_span.op = op
+
+    if name is not None:
+        # internally it is still description
+        current_span.description = name
+
+    if attributes is not None:
+        current_span.update_data(attributes)

--- a/sentry_sdk/api.py
+++ b/sentry_sdk/api.py
@@ -479,10 +479,43 @@ def set_transaction_name(name, source=None):
 def update_current_span(op=None, name=None, attributes=None):
     # type: (Optional[str], Optional[str], Optional[dict[str, Union[str, int, float, bool]]]) -> None
     """
-    Update the current span with the given parameters.
-    :param op: The operation of the span.
-    :param name: The name of the span.
-    :param attributes: The attributes of the span.
+    Update the current active span with the provided parameters.
+
+    This function allows you to modify properties of the currently active span.
+    If no span is currently active, this function will do nothing.
+
+    :param op: The operation name for the span. This is a high-level description
+        of what the span represents (e.g., "http.client", "db.query").
+        You can use predefined constants from :py:class:`sentry_sdk.consts.OP`
+        or provide your own string. If not provided, the span's operation will
+        remain unchanged.
+    :type op: str or None
+
+    :param name: The human-readable name/description for the span. This provides
+        more specific details about what the span represents (e.g., "GET /api/users",
+        "SELECT * FROM users"). If not provided, the span's name will remain unchanged.
+    :type name: str or None
+
+    :param attributes: A dictionary of key-value pairs to add as attributes to the span.
+        Attribute values must be strings, integers, floats, or booleans. These
+        attributes will be merged with any existing span data. If not provided,
+        no attributes will be added.
+    :type attributes: dict[str, Union[str, int, float, bool]] or None
+
+    :returns: None
+
+    .. versionadded:: 2.0.0
+
+    Example::
+
+        import sentry_sdk
+        from sentry_sdk.consts import OP
+
+        sentry_sdk.update_current_span(
+            op=OP.FUNCTION,
+            name="process_user_data",
+            attributes={"user_id": 123, "batch_size": 50}
+        )
     """
     current_span = get_current_span()
 


### PR DESCRIPTION
Manually setting data on spans for our insights modules can be made easier. This PR introduces a convenience function.

Right now users need to do some like this:

```python
import sentry_sdk

span = sentry_sdk.get_current_span()
if span is not None:
    span.description = f"Some {dynamic} name"
    span.set_attribute("key1", "value1")
    span.set_attribute("key2", "value2")
```

With this new convenience function a user can do:
```python
import sentry_sdk

sentry_sdk.update_current_span(
    name=f"Some {dynamic} name",
    attributes={
        "key1": "value1",
        "key2": "value2",
    },
)
