### PR TITLE
feat(anthropic) Update span attributes to use `gen_ai.*` namespace instead of `ai.*`

### DIFF
--- a/sentry_sdk/ai/utils.py
+++ b/sentry_sdk/ai/utils.py
@@ -22,7 +22,7 @@ def _normalize_data(data, unpack=True):
             return _normalize_data(data[0], unpack=unpack)  # remove empty dimensions
         return list(_normalize_data(x, unpack=unpack) for x in data)
     if isinstance(data, dict):
-        return {k: _normalize_data(v, unpack) for (k, v) in data.items()}
+        return {k: _normalize_data(v, unpack=unpack) for (k, v) in data.items()}
 
     return data
 

--- a/sentry_sdk/ai/utils.py
+++ b/sentry_sdk/ai/utils.py
@@ -19,10 +19,10 @@ def _normalize_data(data, unpack=True):
             return data
     if isinstance(data, list):
         if unpack and len(data) == 1:
-            return _normalize_data(data[0])  # remove empty dimensions
-        return list(_normalize_data(x) for x in data)
+            return _normalize_data(data[0], unpack=unpack)  # remove empty dimensions
+        return list(_normalize_data(x, unpack=unpack) for x in data)
     if isinstance(data, dict):
-        return {k: _normalize_data(v) for (k, v) in data.items()}
+        return {k: _normalize_data(v, unpack) for (k, v) in data.items()}
 
     return data
 

--- a/sentry_sdk/ai/utils.py
+++ b/sentry_sdk/ai/utils.py
@@ -7,8 +7,8 @@ from sentry_sdk.tracing import Span
 from sentry_sdk.utils import logger
 
 
-def _normalize_data(data):
-    # type: (Any) -> Any
+def _normalize_data(data, unpack=True):
+    # type: (Any, bool) -> Any
 
     # convert pydantic data (e.g. OpenAI v1+) to json compatible format
     if hasattr(data, "model_dump"):
@@ -18,7 +18,7 @@ def _normalize_data(data):
             logger.warning("Could not convert pydantic data to JSON: %s", e)
             return data
     if isinstance(data, list):
-        if len(data) == 1:
+        if unpack and len(data) == 1:
             return _normalize_data(data[0])  # remove empty dimensions
         return list(_normalize_data(x) for x in data)
     if isinstance(data, dict):
@@ -27,9 +27,9 @@ def _normalize_data(data):
     return data
 
 
-def set_data_normalized(span, key, value):
-    # type: (Span, str, Any) -> None
-    normalized = _normalize_data(value)
+def set_data_normalized(span, key, value, unpack=True):
+    # type: (Span, str, Any, bool) -> None
+    normalized = _normalize_data(value, unpack=unpack)
     if isinstance(normalized, (int, float, bool, str)):
         span.set_data(key, normalized)
     else:

--- a/sentry_sdk/integrations/anthropic.py
+++ b/sentry_sdk/integrations/anthropic.py
@@ -192,9 +192,11 @@ def _sentry_patched_create_common(f, *args, **kwargs):
     except TypeError:
         return f(*args, **kwargs)
 
+    model = kwargs.get("model", "")
+
     span = sentry_sdk.start_span(
         op=OP.GEN_AI_CHAT,
-        description="Anthropic messages create",
+        name=f"chat {model}",
         origin=AnthropicIntegration.origin,
     )
     span.__enter__()
@@ -207,11 +209,11 @@ def _sentry_patched_create_common(f, *args, **kwargs):
         if hasattr(result, "content"):
             input_tokens, output_tokens = _get_token_usage(result)
             _set_output_data(
-                span,
-                integration,
-                getattr(result, "model", None),
-                input_tokens,
-                output_tokens,
+                span=span,
+                integration=integration,
+                model=getattr(result, "model", None),
+                input_tokens=input_tokens,
+                output_tokens=output_tokens,
                 content_blocks=[
                     (
                         content_block.to_dict()
@@ -243,8 +245,8 @@ def _sentry_patched_create_common(f, *args, **kwargs):
                     yield event
 
                 _set_output_data(
-                    span,
-                    integration,
+                    span=span,
+                    integration=integration,
                     model=model,
                     input_tokens=input_tokens,
                     output_tokens=output_tokens,
@@ -268,8 +270,8 @@ def _sentry_patched_create_common(f, *args, **kwargs):
                     yield event
 
                 _set_output_data(
-                    span,
-                    integration,
+                    span=span,
+                    integration=integration,
                     model=model,
                     input_tokens=input_tokens,
                     output_tokens=output_tokens,

--- a/sentry_sdk/integrations/anthropic.py
+++ b/sentry_sdk/integrations/anthropic.py
@@ -215,12 +215,12 @@ def _sentry_patched_create_common(f, *args, **kwargs):
                 input_tokens=input_tokens,
                 output_tokens=output_tokens,
                 content_blocks=[
-                    (
-                        content_block.to_dict()
-                        if hasattr(content_block, "to_dict")
-                        else content_block.model_dump()
-                    )
+                    {
+                        "type": "text",
+                        "text": content_block.text,
+                    }
                     for content_block in result.content
+                    if hasattr(content_block, "text")
                 ],
                 finish_span=True,
             )

--- a/sentry_sdk/integrations/anthropic.py
+++ b/sentry_sdk/integrations/anthropic.py
@@ -212,7 +212,12 @@ def _sentry_patched_create_common(f, *args, **kwargs):
                 input_tokens,
                 output_tokens,
                 content_blocks=[
-                    content_block.to_dict() for content_block in result.content
+                    (
+                        content_block.to_dict()
+                        if hasattr(content_block, "to_dict")
+                        else content_block.model_dump()
+                    )
+                    for content_block in result.content
                 ],
                 finish_span=True,
             )

--- a/sentry_sdk/integrations/anthropic.py
+++ b/sentry_sdk/integrations/anthropic.py
@@ -192,7 +192,7 @@ def _sentry_patched_create_common(f, *args, **kwargs):
         return f(*args, **kwargs)
 
     span = sentry_sdk.start_span(
-        op=OP.ANTHROPIC_MESSAGES_CREATE,
+        op=OP.GEN_AI_CHAT,
         description="Anthropic messages create",
         origin=AnthropicIntegration.origin,
     )

--- a/sentry_sdk/integrations/anthropic.py
+++ b/sentry_sdk/integrations/anthropic.py
@@ -129,6 +129,7 @@ def _set_input_data(span, kwargs, integration):
         "max_tokens": SPANDATA.GEN_AI_REQUEST_MAX_TOKENS,
         "model": SPANDATA.GEN_AI_REQUEST_MODEL,
         "temperature": SPANDATA.GEN_AI_REQUEST_TEMPERATURE,
+        "top_k": SPANDATA.GEN_AI_REQUEST_TOP_K,
         "top_p": SPANDATA.GEN_AI_REQUEST_TOP_P,
     }
     for key, attribute in kwargs_keys_to_attributes.items():

--- a/sentry_sdk/integrations/anthropic.py
+++ b/sentry_sdk/integrations/anthropic.py
@@ -196,7 +196,7 @@ def _sentry_patched_create_common(f, *args, **kwargs):
 
     span = sentry_sdk.start_span(
         op=OP.GEN_AI_CHAT,
-        name=f"chat {model}",
+        name=f"chat {model}".strip(),
         origin=AnthropicIntegration.origin,
     )
     span.__enter__()

--- a/sentry_sdk/integrations/anthropic.py
+++ b/sentry_sdk/integrations/anthropic.py
@@ -16,7 +16,11 @@ from sentry_sdk.utils import (
 )
 
 try:
-    from anthropic import NOT_GIVEN
+    try:
+        from anthropic import NOT_GIVEN
+    except ImportError:
+        NOT_GIVEN = None
+
     from anthropic.resources import AsyncMessages, Messages
 
     if TYPE_CHECKING:

--- a/sentry_sdk/integrations/anthropic.py
+++ b/sentry_sdk/integrations/anthropic.py
@@ -3,6 +3,7 @@ from typing import TYPE_CHECKING
 
 import sentry_sdk
 from sentry_sdk.ai.monitoring import record_token_usage
+from sentry_sdk.ai.utils import set_data_normalized
 from sentry_sdk.consts import OP, SPANDATA
 from sentry_sdk.integrations import _check_minimum_version, DidNotEnable, Integration
 from sentry_sdk.scope import should_send_default_pii
@@ -10,9 +11,11 @@ from sentry_sdk.utils import (
     capture_internal_exceptions,
     event_from_exception,
     package_version,
+    safe_serialize,
 )
 
 try:
+    from anthropic import NOT_GIVEN
     from anthropic.resources import AsyncMessages, Messages
 
     if TYPE_CHECKING:
@@ -53,8 +56,11 @@ def _capture_exception(exc):
     sentry_sdk.capture_event(event, hint=hint)
 
 
-def _calculate_token_usage(result, span):
-    # type: (Messages, Span) -> None
+def _get_token_usage(result):
+    # type: (Messages) -> tuple[int, int]
+    """
+    Get token usage from the Anthropic response.
+    """
     input_tokens = 0
     output_tokens = 0
     if hasattr(result, "usage"):
@@ -64,37 +70,13 @@ def _calculate_token_usage(result, span):
         if hasattr(usage, "output_tokens") and isinstance(usage.output_tokens, int):
             output_tokens = usage.output_tokens
 
-    total_tokens = input_tokens + output_tokens
-
-    record_token_usage(
-        span,
-        input_tokens=input_tokens,
-        output_tokens=output_tokens,
-        total_tokens=total_tokens,
-    )
+    return input_tokens, output_tokens
 
 
-def _get_responses(content):
-    # type: (list[Any]) -> list[dict[str, Any]]
+def _collect_ai_data(event, model, input_tokens, output_tokens, content_blocks):
+    # type: (MessageStreamEvent, str | None, int, int, list[str]) -> tuple[str | None, int, int, list[str]]
     """
-    Get JSON of a Anthropic responses.
-    """
-    responses = []
-    for item in content:
-        if hasattr(item, "text"):
-            responses.append(
-                {
-                    "type": item.type,
-                    "text": item.text,
-                }
-            )
-    return responses
-
-
-def _collect_ai_data(event, input_tokens, output_tokens, content_blocks):
-    # type: (MessageStreamEvent, int, int, list[str]) -> tuple[int, int, list[str]]
-    """
-    Count token usage and collect content blocks from the AI streaming response.
+    Collect model information, token usage, and collect content blocks from the AI streaming response.
     """
     with capture_internal_exceptions():
         if hasattr(event, "type"):
@@ -102,6 +84,7 @@ def _collect_ai_data(event, input_tokens, output_tokens, content_blocks):
                 usage = event.message.usage
                 input_tokens += usage.input_tokens
                 output_tokens += usage.output_tokens
+                model = event.message.model or model
             elif event.type == "content_block_start":
                 pass
             elif event.type == "content_block_delta":
@@ -114,31 +97,69 @@ def _collect_ai_data(event, input_tokens, output_tokens, content_blocks):
             elif event.type == "message_delta":
                 output_tokens += event.usage.output_tokens
 
-    return input_tokens, output_tokens, content_blocks
+    return model, input_tokens, output_tokens, content_blocks
 
 
-def _add_ai_data_to_span(
-    span, integration, input_tokens, output_tokens, content_blocks
-):
-    # type: (Span, AnthropicIntegration, int, int, list[str]) -> None
+def _set_input_data(span, kwargs, integration):
+    # type: (Span, dict[str, Any], AnthropicIntegration) -> None
     """
-    Add token usage and content blocks from the AI streaming response to the span.
+    Set input data for the span based on the provided keyword arguments for the anthropic message creation.
     """
-    with capture_internal_exceptions():
-        if should_send_default_pii() and integration.include_prompts:
-            complete_message = "".join(content_blocks)
-            span.set_data(
-                SPANDATA.AI_RESPONSES,
-                [{"type": "text", "text": complete_message}],
-            )
-        total_tokens = input_tokens + output_tokens
-        record_token_usage(
-            span,
-            input_tokens=input_tokens,
-            output_tokens=output_tokens,
-            total_tokens=total_tokens,
+    messages = kwargs.get("messages")
+    if (
+        messages is not None
+        and len(messages) > 0
+        and should_send_default_pii()
+        and integration.include_prompts
+    ):
+        set_data_normalized(span, SPANDATA.GEN_AI_REQUEST_MESSAGES, messages)
+
+    kwargs_keys_to_attributes = {
+        "max_tokens": SPANDATA.GEN_AI_REQUEST_MAX_TOKENS,
+        "model": SPANDATA.GEN_AI_REQUEST_MODEL,
+        "stream": SPANDATA.GEN_AI_RESPONSE_STREAMING,
+        "temperature": SPANDATA.GEN_AI_REQUEST_TEMPERATURE,
+        "top_p": SPANDATA.GEN_AI_REQUEST_TOP_P,
+    }
+    for key, attribute in kwargs_keys_to_attributes.items():
+        value = kwargs.get(key)
+        if value is not NOT_GIVEN or value is not None:
+            set_data_normalized(span, attribute, value)
+
+    # Input attributes: Tools
+    tools = kwargs.get("tools")
+    if tools is not NOT_GIVEN and tools is not None and len(tools) > 0:
+        set_data_normalized(
+            span, SPANDATA.GEN_AI_REQUEST_AVAILABLE_TOOLS, safe_serialize(tools)
         )
-        span.set_data(SPANDATA.AI_STREAMING, True)
+
+
+def _set_output_data(
+    span,
+    integration,
+    model,
+    input_tokens,
+    output_tokens,
+    content_blocks,
+    finish_span=True,
+):
+    # type: (Span, AnthropicIntegration, str | None, int | None, int | None, list[Any], bool) -> None
+    """
+    Set output data for the span based on the AI response."""
+    span.set_data(SPANDATA.GEN_AI_RESPONSE_MODEL, model)
+    if should_send_default_pii() and integration.include_prompts:
+        set_data_normalized(span, SPANDATA.GEN_AI_RESPONSE_TEXT, content_blocks)
+
+    record_token_usage(
+        span,
+        input_tokens=input_tokens,
+        output_tokens=output_tokens,
+    )
+
+    # TODO: GEN_AI_RESPONSE_TOOL_CALLS ?
+
+    if finish_span:
+        span.__exit__(None, None, None)
 
 
 def _sentry_patched_create_common(f, *args, **kwargs):
@@ -162,24 +183,22 @@ def _sentry_patched_create_common(f, *args, **kwargs):
     )
     span.__enter__()
 
+    _set_input_data(span, kwargs, integration)
+
     result = yield f, args, kwargs
 
-    # add data to span and finish it
-    messages = list(kwargs["messages"])
-    model = kwargs.get("model")
-
     with capture_internal_exceptions():
-        span.set_data(SPANDATA.AI_MODEL_ID, model)
-        span.set_data(SPANDATA.AI_STREAMING, False)
-
-        if should_send_default_pii() and integration.include_prompts:
-            span.set_data(SPANDATA.AI_INPUT_MESSAGES, messages)
-
         if hasattr(result, "content"):
-            if should_send_default_pii() and integration.include_prompts:
-                span.set_data(SPANDATA.AI_RESPONSES, _get_responses(result.content))
-            _calculate_token_usage(result, span)
-            span.__exit__(None, None, None)
+            input_tokens, output_tokens = _get_token_usage(result)
+            _set_output_data(
+                span,
+                integration,
+                getattr(result, "model", None),
+                input_tokens,
+                output_tokens,
+                content_blocks=result.content,
+                finish_span=True,
+            )
 
         # Streaming response
         elif hasattr(result, "_iterator"):
@@ -187,37 +206,53 @@ def _sentry_patched_create_common(f, *args, **kwargs):
 
             def new_iterator():
                 # type: () -> Iterator[MessageStreamEvent]
+                model = None
                 input_tokens = 0
                 output_tokens = 0
                 content_blocks = []  # type: list[str]
 
                 for event in old_iterator:
-                    input_tokens, output_tokens, content_blocks = _collect_ai_data(
-                        event, input_tokens, output_tokens, content_blocks
+                    model, input_tokens, output_tokens, content_blocks = (
+                        _collect_ai_data(
+                            event, model, input_tokens, output_tokens, content_blocks
+                        )
                     )
                     yield event
 
-                _add_ai_data_to_span(
-                    span, integration, input_tokens, output_tokens, content_blocks
+                _set_output_data(
+                    span,
+                    integration,
+                    model=model,
+                    input_tokens=input_tokens,
+                    output_tokens=output_tokens,
+                    content_blocks=content_blocks,
+                    finish_span=True,
                 )
-                span.__exit__(None, None, None)
 
             async def new_iterator_async():
                 # type: () -> AsyncIterator[MessageStreamEvent]
+                model = None
                 input_tokens = 0
                 output_tokens = 0
                 content_blocks = []  # type: list[str]
 
                 async for event in old_iterator:
-                    input_tokens, output_tokens, content_blocks = _collect_ai_data(
-                        event, input_tokens, output_tokens, content_blocks
+                    model, input_tokens, output_tokens, content_blocks = (
+                        _collect_ai_data(
+                            event, model, input_tokens, output_tokens, content_blocks
+                        )
                     )
                     yield event
 
-                _add_ai_data_to_span(
-                    span, integration, input_tokens, output_tokens, content_blocks
+                _set_output_data(
+                    span,
+                    integration,
+                    model=model,
+                    input_tokens=input_tokens,
+                    output_tokens=output_tokens,
+                    content_blocks=content_blocks,
+                    finish_span=True,
                 )
-                span.__exit__(None, None, None)
 
             if str(type(result._iterator)) == "<class 'async_generator'>":
                 result._iterator = new_iterator_async()

--- a/sentry_sdk/integrations/starlite.py
+++ b/sentry_sdk/integrations/starlite.py
@@ -17,7 +17,7 @@ try:
     from starlite.plugins.base import get_plugin_for_value  # type: ignore
     from starlite.routes.http import HTTPRoute  # type: ignore
     from starlite.utils import ConnectionDataExtractor, is_async_callable, Ref  # type: ignore
-    from pydantic import BaseModel
+    from pydantic import BaseModel  # type: ignore
 except ImportError:
     raise DidNotEnable("Starlite is not installed")
 

--- a/tests/integrations/anthropic/test_anthropic.py
+++ b/tests/integrations/anthropic/test_anthropic.py
@@ -823,19 +823,19 @@ def test_set_output_data_with_input_json_delta(sentry_init):
     with start_transaction(name="test"):
         span = start_span()
         integration = AnthropicIntegration()
-
+        json_deltas = ["{'test': 'data',", "'more': 'json'}"]
         _set_output_data(
             span,
             integration,
             model="",
             input_tokens=10,
             output_tokens=20,
-            content_blocks=["{'test': 'data',", "'more': 'json'}"],
+            content_blocks=[{"text": "".join(json_deltas), "type": "text"}],
         )
 
         assert (
             span._data.get(SPANDATA.GEN_AI_RESPONSE_TEXT)
-            == "[\"{'test': 'data',\", \"'more': 'json'}\"]"
+            == "[{\"text\": \"{'test': 'data','more': 'json'}\", \"type\": \"text\"}]"
         )
         assert span._data.get(SPANDATA.GEN_AI_USAGE_INPUT_TOKENS) == 10
         assert span._data.get(SPANDATA.GEN_AI_USAGE_OUTPUT_TOKENS) == 20

--- a/tests/integrations/anthropic/test_anthropic.py
+++ b/tests/integrations/anthropic/test_anthropic.py
@@ -123,7 +123,7 @@ def test_nonstreaming_create_message(
         )
         assert (
             span["data"][SPANDATA.GEN_AI_RESPONSE_TEXT]
-            == '[{"type": "text", "text": "Hi, I\'m Claude."}]'
+            == '[{"text": "Hi, I\'m Claude.", "type": "text"}]'
         )
     else:
         assert SPANDATA.GEN_AI_REQUEST_MESSAGES not in span["data"]
@@ -195,7 +195,7 @@ async def test_nonstreaming_create_message_async(
         )
         assert (
             span["data"][SPANDATA.GEN_AI_RESPONSE_TEXT]
-            == '[{"type": "text", "text": "Hi, I\'m Claude."}]'
+            == '[{"text": "Hi, I\'m Claude.", "type": "text"}]'
         )
     else:
         assert SPANDATA.GEN_AI_REQUEST_MESSAGES not in span["data"]

--- a/tests/integrations/anthropic/test_anthropic.py
+++ b/tests/integrations/anthropic/test_anthropic.py
@@ -114,21 +114,21 @@ def test_nonstreaming_create_message(
 
     assert span["op"] == OP.ANTHROPIC_MESSAGES_CREATE
     assert span["description"] == "Anthropic messages create"
-    assert span["data"][SPANDATA.AI_MODEL_ID] == "model"
+    assert span["data"][SPANDATA.GEN_AI_REQUEST_MODEL] == "model"
 
     if send_default_pii and include_prompts:
-        assert span["data"][SPANDATA.AI_INPUT_MESSAGES] == messages
-        assert span["data"][SPANDATA.AI_RESPONSES] == [
+        assert span["data"][SPANDATA.GEN_AI_REQUEST_MESSAGES] == messages
+        assert span["data"][SPANDATA.GEN_AI_RESPONSE_TEXT] == [
             {"type": "text", "text": "Hi, I'm Claude."}
         ]
     else:
-        assert SPANDATA.AI_INPUT_MESSAGES not in span["data"]
-        assert SPANDATA.AI_RESPONSES not in span["data"]
+        assert SPANDATA.GEN_AI_REQUEST_MESSAGES not in span["data"]
+        assert SPANDATA.GEN_AI_RESPONSE_TEXT not in span["data"]
 
-    assert span["data"]["gen_ai.usage.input_tokens"] == 10
-    assert span["data"]["gen_ai.usage.output_tokens"] == 20
-    assert span["data"]["gen_ai.usage.total_tokens"] == 30
-    assert span["data"][SPANDATA.AI_STREAMING] is False
+    assert span["data"][SPANDATA.GEN_AI_USAGE_INPUT_TOKENS] == 10
+    assert span["data"][SPANDATA.GEN_AI_USAGE_OUTPUT_TOKENS] == 20
+    assert span["data"][SPANDATA.GEN_AI_USAGE_TOTAL_TOKENS] == 30
+    assert span["data"][SPANDATA.GEN_AI_RESPONSE_STREAMING] is False
 
 
 @pytest.mark.asyncio
@@ -182,21 +182,21 @@ async def test_nonstreaming_create_message_async(
 
     assert span["op"] == OP.ANTHROPIC_MESSAGES_CREATE
     assert span["description"] == "Anthropic messages create"
-    assert span["data"][SPANDATA.AI_MODEL_ID] == "model"
+    assert span["data"][SPANDATA.GEN_AI_REQUEST_MODEL] == "model"
 
     if send_default_pii and include_prompts:
-        assert span["data"][SPANDATA.AI_INPUT_MESSAGES] == messages
-        assert span["data"][SPANDATA.AI_RESPONSES] == [
+        assert span["data"][SPANDATA.GEN_AI_REQUEST_MESSAGES] == messages
+        assert span["data"][SPANDATA.GEN_AI_RESPONSE_TEXT] == [
             {"type": "text", "text": "Hi, I'm Claude."}
         ]
     else:
-        assert SPANDATA.AI_INPUT_MESSAGES not in span["data"]
-        assert SPANDATA.AI_RESPONSES not in span["data"]
+        assert SPANDATA.GEN_AI_REQUEST_MESSAGES not in span["data"]
+        assert SPANDATA.GEN_AI_RESPONSE_TEXT not in span["data"]
 
-    assert span["data"]["gen_ai.usage.input_tokens"] == 10
-    assert span["data"]["gen_ai.usage.output_tokens"] == 20
-    assert span["data"]["gen_ai.usage.total_tokens"] == 30
-    assert span["data"][SPANDATA.AI_STREAMING] is False
+    assert span["data"][SPANDATA.GEN_AI_USAGE_INPUT_TOKENS] == 10
+    assert span["data"][SPANDATA.GEN_AI_USAGE_OUTPUT_TOKENS] == 20
+    assert span["data"][SPANDATA.GEN_AI_USAGE_TOTAL_TOKENS] == 30
+    assert span["data"][SPANDATA.GEN_AI_RESPONSE_STREAMING] is False
 
 
 @pytest.mark.parametrize(
@@ -281,22 +281,22 @@ def test_streaming_create_message(
 
     assert span["op"] == OP.ANTHROPIC_MESSAGES_CREATE
     assert span["description"] == "Anthropic messages create"
-    assert span["data"][SPANDATA.AI_MODEL_ID] == "model"
+    assert span["data"][SPANDATA.GEN_AI_REQUEST_MODEL] == "model"
 
     if send_default_pii and include_prompts:
-        assert span["data"][SPANDATA.AI_INPUT_MESSAGES] == messages
-        assert span["data"][SPANDATA.AI_RESPONSES] == [
+        assert span["data"][SPANDATA.GEN_AI_REQUEST_MESSAGES] == messages
+        assert span["data"][SPANDATA.GEN_AI_RESPONSE_TEXT] == [
             {"type": "text", "text": "Hi! I'm Claude!"}
         ]
 
     else:
-        assert SPANDATA.AI_INPUT_MESSAGES not in span["data"]
-        assert SPANDATA.AI_RESPONSES not in span["data"]
+        assert SPANDATA.GEN_AI_REQUEST_MESSAGES not in span["data"]
+        assert SPANDATA.GEN_AI_RESPONSE_TEXT not in span["data"]
 
-    assert span["data"]["gen_ai.usage.input_tokens"] == 10
-    assert span["data"]["gen_ai.usage.output_tokens"] == 30
-    assert span["data"]["gen_ai.usage.total_tokens"] == 40
-    assert span["data"][SPANDATA.AI_STREAMING] is True
+    assert span["data"][SPANDATA.GEN_AI_USAGE_INPUT_TOKENS] == 10
+    assert span["data"][SPANDATA.GEN_AI_USAGE_OUTPUT_TOKENS] == 30
+    assert span["data"][SPANDATA.GEN_AI_USAGE_TOTAL_TOKENS] == 40
+    assert span["data"][SPANDATA.GEN_AI_RESPONSE_STREAMING] is True
 
 
 @pytest.mark.asyncio
@@ -384,22 +384,22 @@ async def test_streaming_create_message_async(
 
     assert span["op"] == OP.ANTHROPIC_MESSAGES_CREATE
     assert span["description"] == "Anthropic messages create"
-    assert span["data"][SPANDATA.AI_MODEL_ID] == "model"
+    assert span["data"][SPANDATA.GEN_AI_REQUEST_MODEL] == "model"
 
     if send_default_pii and include_prompts:
-        assert span["data"][SPANDATA.AI_INPUT_MESSAGES] == messages
-        assert span["data"][SPANDATA.AI_RESPONSES] == [
+        assert span["data"][SPANDATA.GEN_AI_REQUEST_MESSAGES] == messages
+        assert span["data"][SPANDATA.GEN_AI_RESPONSE_TEXT] == [
             {"type": "text", "text": "Hi! I'm Claude!"}
         ]
 
     else:
-        assert SPANDATA.AI_INPUT_MESSAGES not in span["data"]
-        assert SPANDATA.AI_RESPONSES not in span["data"]
+        assert SPANDATA.GEN_AI_REQUEST_MESSAGES not in span["data"]
+        assert SPANDATA.GEN_AI_RESPONSE_TEXT not in span["data"]
 
-    assert span["data"]["gen_ai.usage.input_tokens"] == 10
-    assert span["data"]["gen_ai.usage.output_tokens"] == 30
-    assert span["data"]["gen_ai.usage.total_tokens"] == 40
-    assert span["data"][SPANDATA.AI_STREAMING] is True
+    assert span["data"][SPANDATA.GEN_AI_USAGE_INPUT_TOKENS] == 10
+    assert span["data"][SPANDATA.GEN_AI_USAGE_OUTPUT_TOKENS] == 30
+    assert span["data"][SPANDATA.GEN_AI_USAGE_TOTAL_TOKENS] == 40
+    assert span["data"][SPANDATA.GEN_AI_RESPONSE_STREAMING] is True
 
 
 @pytest.mark.skipif(
@@ -514,21 +514,21 @@ def test_streaming_create_message_with_input_json_delta(
 
     assert span["op"] == OP.ANTHROPIC_MESSAGES_CREATE
     assert span["description"] == "Anthropic messages create"
-    assert span["data"][SPANDATA.AI_MODEL_ID] == "model"
+    assert span["data"][SPANDATA.GEN_AI_REQUEST_MODEL] == "model"
 
     if send_default_pii and include_prompts:
-        assert span["data"][SPANDATA.AI_INPUT_MESSAGES] == messages
-        assert span["data"][SPANDATA.AI_RESPONSES] == [
+        assert span["data"][SPANDATA.GEN_AI_REQUEST_MESSAGES] == messages
+        assert span["data"][SPANDATA.GEN_AI_RESPONSE_TEXT] == [
             {"text": "{'location': 'San Francisco, CA'}", "type": "text"}
         ]
     else:
-        assert SPANDATA.AI_INPUT_MESSAGES not in span["data"]
-        assert SPANDATA.AI_RESPONSES not in span["data"]
+        assert SPANDATA.GEN_AI_REQUEST_MESSAGES not in span["data"]
+        assert SPANDATA.GEN_AI_RESPONSE_TEXT not in span["data"]
 
-    assert span["data"]["gen_ai.usage.input_tokens"] == 366
-    assert span["data"]["gen_ai.usage.output_tokens"] == 51
-    assert span["data"]["gen_ai.usage.total_tokens"] == 417
-    assert span["data"][SPANDATA.AI_STREAMING] is True
+    assert span["data"][SPANDATA.GEN_AI_USAGE_INPUT_TOKENS] == 366
+    assert span["data"][SPANDATA.GEN_AI_USAGE_OUTPUT_TOKENS] == 51
+    assert span["data"][SPANDATA.GEN_AI_USAGE_TOTAL_TOKENS] == 417
+    assert span["data"][SPANDATA.GEN_AI_RESPONSE_STREAMING] is True
 
 
 @pytest.mark.asyncio
@@ -650,22 +650,22 @@ async def test_streaming_create_message_with_input_json_delta_async(
 
     assert span["op"] == OP.ANTHROPIC_MESSAGES_CREATE
     assert span["description"] == "Anthropic messages create"
-    assert span["data"][SPANDATA.AI_MODEL_ID] == "model"
+    assert span["data"][SPANDATA.GEN_AI_REQUEST_MODEL] == "model"
 
     if send_default_pii and include_prompts:
-        assert span["data"][SPANDATA.AI_INPUT_MESSAGES] == messages
-        assert span["data"][SPANDATA.AI_RESPONSES] == [
+        assert span["data"][SPANDATA.GEN_AI_REQUEST_MESSAGES] == messages
+        assert span["data"][SPANDATA.GEN_AI_RESPONSE_TEXT] == [
             {"text": "{'location': 'San Francisco, CA'}", "type": "text"}
         ]
 
     else:
-        assert SPANDATA.AI_INPUT_MESSAGES not in span["data"]
-        assert SPANDATA.AI_RESPONSES not in span["data"]
+        assert SPANDATA.GEN_AI_REQUEST_MESSAGES not in span["data"]
+        assert SPANDATA.GEN_AI_RESPONSE_TEXT not in span["data"]
 
-    assert span["data"]["gen_ai.usage.input_tokens"] == 366
-    assert span["data"]["gen_ai.usage.output_tokens"] == 51
-    assert span["data"]["gen_ai.usage.total_tokens"] == 417
-    assert span["data"][SPANDATA.AI_STREAMING] is True
+    assert span["data"][SPANDATA.GEN_AI_USAGE_INPUT_TOKENS] == 366
+    assert span["data"][SPANDATA.GEN_AI_USAGE_OUTPUT_TOKENS] == 51
+    assert span["data"][SPANDATA.GEN_AI_USAGE_TOTAL_TOKENS] == 417
+    assert span["data"][SPANDATA.GEN_AI_RESPONSE_STREAMING] is True
 
 
 def test_exception_message_create(sentry_init, capture_events):
@@ -810,7 +810,7 @@ def test_add_ai_data_to_span_with_input_json_delta(sentry_init):
         assert span._data.get("ai.responses") == [
             {"type": "text", "text": "{'test': 'data','more': 'json'}"}
         ]
-        assert span._data.get("ai.streaming") is True
-        assert span._data.get("gen_ai.usage.input_tokens") == 10
-        assert span._data.get("gen_ai.usage.output_tokens") == 20
-        assert span._data.get("gen_ai.usage.total_tokens") == 30
+        assert span._data.get(SPANDATA.GEN_AI_RESPONSE_STREAMING) is True
+        assert span._data.get(SPANDATA.GEN_AI_USAGE_INPUT_TOKENS) == 10
+        assert span._data.get(SPANDATA.GEN_AI_USAGE_OUTPUT_TOKENS) == 20
+        assert span._data.get(SPANDATA.GEN_AI_USAGE_TOTAL_TOKENS) == 30

--- a/tests/integrations/anthropic/test_anthropic.py
+++ b/tests/integrations/anthropic/test_anthropic.py
@@ -112,7 +112,7 @@ def test_nonstreaming_create_message(
     assert len(event["spans"]) == 1
     (span,) = event["spans"]
 
-    assert span["op"] == OP.ANTHROPIC_MESSAGES_CREATE
+    assert span["op"] == OP.GEN_AI_CHAT
     assert span["description"] == "Anthropic messages create"
     assert span["data"][SPANDATA.GEN_AI_REQUEST_MODEL] == "model"
 
@@ -184,7 +184,7 @@ async def test_nonstreaming_create_message_async(
     assert len(event["spans"]) == 1
     (span,) = event["spans"]
 
-    assert span["op"] == OP.ANTHROPIC_MESSAGES_CREATE
+    assert span["op"] == OP.GEN_AI_CHAT
     assert span["description"] == "Anthropic messages create"
     assert span["data"][SPANDATA.GEN_AI_REQUEST_MODEL] == "model"
 
@@ -287,7 +287,7 @@ def test_streaming_create_message(
     assert len(event["spans"]) == 1
     (span,) = event["spans"]
 
-    assert span["op"] == OP.ANTHROPIC_MESSAGES_CREATE
+    assert span["op"] == OP.GEN_AI_CHAT
     assert span["description"] == "Anthropic messages create"
     assert span["data"][SPANDATA.GEN_AI_REQUEST_MODEL] == "model"
 
@@ -394,7 +394,7 @@ async def test_streaming_create_message_async(
     assert len(event["spans"]) == 1
     (span,) = event["spans"]
 
-    assert span["op"] == OP.ANTHROPIC_MESSAGES_CREATE
+    assert span["op"] == OP.GEN_AI_CHAT
     assert span["description"] == "Anthropic messages create"
     assert span["data"][SPANDATA.GEN_AI_REQUEST_MODEL] == "model"
 
@@ -528,7 +528,7 @@ def test_streaming_create_message_with_input_json_delta(
     assert len(event["spans"]) == 1
     (span,) = event["spans"]
 
-    assert span["op"] == OP.ANTHROPIC_MESSAGES_CREATE
+    assert span["op"] == OP.GEN_AI_CHAT
     assert span["description"] == "Anthropic messages create"
     assert span["data"][SPANDATA.GEN_AI_REQUEST_MODEL] == "model"
 
@@ -668,7 +668,7 @@ async def test_streaming_create_message_with_input_json_delta_async(
     assert len(event["spans"]) == 1
     (span,) = event["spans"]
 
-    assert span["op"] == OP.ANTHROPIC_MESSAGES_CREATE
+    assert span["op"] == OP.GEN_AI_CHAT
     assert span["description"] == "Anthropic messages create"
     assert span["data"][SPANDATA.GEN_AI_REQUEST_MODEL] == "model"
 

--- a/tests/integrations/anthropic/test_anthropic.py
+++ b/tests/integrations/anthropic/test_anthropic.py
@@ -113,7 +113,7 @@ def test_nonstreaming_create_message(
     (span,) = event["spans"]
 
     assert span["op"] == OP.GEN_AI_CHAT
-    assert span["description"] == "Anthropic messages create"
+    assert span["description"] == "chat model"
     assert span["data"][SPANDATA.GEN_AI_REQUEST_MODEL] == "model"
 
     if send_default_pii and include_prompts:
@@ -185,7 +185,7 @@ async def test_nonstreaming_create_message_async(
     (span,) = event["spans"]
 
     assert span["op"] == OP.GEN_AI_CHAT
-    assert span["description"] == "Anthropic messages create"
+    assert span["description"] == "chat model"
     assert span["data"][SPANDATA.GEN_AI_REQUEST_MODEL] == "model"
 
     if send_default_pii and include_prompts:
@@ -288,7 +288,7 @@ def test_streaming_create_message(
     (span,) = event["spans"]
 
     assert span["op"] == OP.GEN_AI_CHAT
-    assert span["description"] == "Anthropic messages create"
+    assert span["description"] == "chat model"
     assert span["data"][SPANDATA.GEN_AI_REQUEST_MODEL] == "model"
 
     if send_default_pii and include_prompts:
@@ -395,7 +395,7 @@ async def test_streaming_create_message_async(
     (span,) = event["spans"]
 
     assert span["op"] == OP.GEN_AI_CHAT
-    assert span["description"] == "Anthropic messages create"
+    assert span["description"] == "chat model"
     assert span["data"][SPANDATA.GEN_AI_REQUEST_MODEL] == "model"
 
     if send_default_pii and include_prompts:
@@ -529,7 +529,7 @@ def test_streaming_create_message_with_input_json_delta(
     (span,) = event["spans"]
 
     assert span["op"] == OP.GEN_AI_CHAT
-    assert span["description"] == "Anthropic messages create"
+    assert span["description"] == "chat model"
     assert span["data"][SPANDATA.GEN_AI_REQUEST_MODEL] == "model"
 
     if send_default_pii and include_prompts:
@@ -669,7 +669,7 @@ async def test_streaming_create_message_with_input_json_delta_async(
     (span,) = event["spans"]
 
     assert span["op"] == OP.GEN_AI_CHAT
-    assert span["description"] == "Anthropic messages create"
+    assert span["description"] == "chat model"
     assert span["data"][SPANDATA.GEN_AI_REQUEST_MODEL] == "model"
 
     if send_default_pii and include_prompts:

--- a/tests/integrations/anthropic/test_anthropic.py
+++ b/tests/integrations/anthropic/test_anthropic.py
@@ -123,7 +123,7 @@ def test_nonstreaming_create_message(
         )
         assert (
             span["data"][SPANDATA.GEN_AI_RESPONSE_TEXT]
-            == '[{"text": "Hi, I\'m Claude.", "type": "text"}]'
+            == '[{"type": "text", "text": "Hi, I\'m Claude."}]'
         )
     else:
         assert SPANDATA.GEN_AI_REQUEST_MESSAGES not in span["data"]
@@ -195,7 +195,7 @@ async def test_nonstreaming_create_message_async(
         )
         assert (
             span["data"][SPANDATA.GEN_AI_RESPONSE_TEXT]
-            == '[{"text": "Hi, I\'m Claude.", "type": "text"}]'
+            == '[{"type": "text", "text": "Hi, I\'m Claude."}]'
         )
     else:
         assert SPANDATA.GEN_AI_REQUEST_MESSAGES not in span["data"]


### PR DESCRIPTION
Update `AnthropicIntegration` to support Otel and Sentry AI Agents module compatible span attributes of `gen_ai.*` family.

Closes https://linear.app/getsentry/issue/TET-996/improve-integration-for-anthropic-sdk