### PR TITLE
Add async span context manager

### DIFF
--- a/sentry_sdk/tracing.py
+++ b/sentry_sdk/tracing.py
@@ -278,6 +278,14 @@ class Span:
         self.finish()
         self.deactivate()
 
+    async def __aenter__(self) -> Span:
+        return self.__enter__()
+
+    async def __aexit__(
+        self, ty: Optional[Any], value: Optional[Any], tb: Optional[Any]
+    ) -> None:
+        return self.__exit__(ty, value, tb)
+
     @property
     def description(self) -> Optional[str]:
         return self.get_attribute(SentrySpanAttribute.DESCRIPTION)


### PR DESCRIPTION
Add an async span context manager to allow for cleaner nesting in async code. Currently only delegates to the synchronous context manager.

Fixes GH-2007

