### PR TITLE
fix(django): Db query recording improvements.

### DIFF
--- a/sentry_sdk/integrations/django/__init__.py
+++ b/sentry_sdk/integrations/django/__init__.py
@@ -779,7 +779,7 @@ def _set_db_data(span, cursor_or_db):
             span.set_data(SPANDATA.SERVER_PORT, str(cached_config["port"]))
         if cached_config.get("unix_socket"):
             span.set_data(SPANDATA.SERVER_SOCKET_ADDRESS, cached_config["unix_socket"])
-        if cached_config.get("vendor"):
+        if cached_config.get("vendor") and span._data.get(SPANDATA.DB_SYSTEM) is None:
             span.set_data(SPANDATA.DB_SYSTEM, cached_config["vendor"])
 
         return  # Success - exit early

--- a/sentry_sdk/integrations/django/__init__.py
+++ b/sentry_sdk/integrations/django/__init__.py
@@ -640,7 +640,9 @@ def _cache_database_configurations():
                     "db_name": db_config.get("NAME"),
                     "host": db_config.get("HOST", "localhost"),
                     "port": db_config.get("PORT"),
-                    "vendor": db_wrapper.vendor,
+                    "vendor": (
+                        db_wrapper.vendor if hasattr(db_wrapper, "vendor") else None
+                    ),
                     "unix_socket": db_config.get("OPTIONS", {}).get("unix_socket"),
                     "engine": db_config.get("ENGINE"),
                 }
@@ -739,8 +741,9 @@ def install_sql_hook():
             name="connect",
             origin=DjangoIntegration.origin_db,
         ) as span:
+            connection = real_connect(self)
             _set_db_data(span, self)
-            return real_connect(self)
+            return connection
 
     CursorWrapper.execute = execute
     CursorWrapper.executemany = executemany

--- a/sentry_sdk/integrations/django/__init__.py
+++ b/sentry_sdk/integrations/django/__init__.py
@@ -649,7 +649,7 @@ def _cache_database_configurations():
 
                     _cached_db_configs[alias] = {
                         "db_name": db_config.get("NAME"),
-                        "host": db_config.get("HOST", "localhost"),
+                        "host": db_config.get("HOST"),
                         "port": db_config.get("PORT"),
                         "unix_socket": db_config.get("OPTIONS", {}).get("unix_socket"),
                         "engine": db_config.get("ENGINE"),
@@ -743,7 +743,7 @@ def install_sql_hook():
             with capture_internal_exceptions():
                 _set_db_data(span, self)
 
-        return connection
+            return connection
 
     CursorWrapper.execute = execute
     CursorWrapper.executemany = executemany

--- a/sentry_sdk/integrations/django/__init__.py
+++ b/sentry_sdk/integrations/django/__init__.py
@@ -652,8 +652,9 @@ def _cache_database_configurations():
                         "engine": db_config.get("ENGINE"),
                     }
 
-                    db_wrapper = connections.get(alias)
-                    if db_wrapper is None:
+                    try:
+                        db_wrapper = connections[alias]
+                    except (KeyError, Exception):
                         continue
 
                     if hasattr(db_wrapper, "vendor"):

--- a/sentry_sdk/integrations/django/__init__.py
+++ b/sentry_sdk/integrations/django/__init__.py
@@ -740,8 +740,10 @@ def install_sql_hook():
             origin=DjangoIntegration.origin_db,
         ) as span:
             connection = real_connect(self)
-            _set_db_data(span, self)
-            return connection
+            with capture_internal_exceptions():
+                _set_db_data(span, self)
+
+        return connection
 
     CursorWrapper.execute = execute
     CursorWrapper.executemany = executemany

--- a/sentry_sdk/integrations/django/__init__.py
+++ b/sentry_sdk/integrations/django/__init__.py
@@ -1,7 +1,7 @@
+import inspect
 import sys
 import threading
 import weakref
-import inspect
 from importlib import import_module
 
 import sentry_sdk

--- a/sentry_sdk/integrations/django/__init__.py
+++ b/sentry_sdk/integrations/django/__init__.py
@@ -779,6 +779,9 @@ def _set_db_data(span, cursor_or_db):
             span.set_data(SPANDATA.SERVER_PORT, str(cached_config["port"]))
         if cached_config.get("unix_socket"):
             span.set_data(SPANDATA.SERVER_SOCKET_ADDRESS, cached_config["unix_socket"])
+        if cached_config.get("vendor"):
+            span.set_data(SPANDATA.DB_SYSTEM, cached_config["vendor"])
+
         return  # Success - exit early
 
     # Fallback to dynamic database metadata collection.

--- a/sentry_sdk/tracing_utils.py
+++ b/sentry_sdk/tracing_utils.py
@@ -355,11 +355,12 @@ def _format_sql(cursor, sql):
             real_sql = cursor.mogrify(sql)
             if isinstance(real_sql, bytes):
                 # Use UTF-8 as default, with latin1 fallback for edge cases
+                bytes_sql = real_sql  # make pypy happy (type narrowing to bytes)
                 try:
-                    real_sql = real_sql.decode("utf-8")
+                    real_sql = bytes_sql.decode("utf-8")
                 except UnicodeDecodeError:
                     # If UTF-8 fails, try latin1 as fallback
-                    real_sql = real_sql.decode("latin1", errors="replace")
+                    real_sql = bytes_sql.decode("latin1", errors="replace")
     except Exception:
         real_sql = None
 

--- a/sentry_sdk/tracing_utils.py
+++ b/sentry_sdk/tracing_utils.py
@@ -354,13 +354,7 @@ def _format_sql(cursor, sql):
         if hasattr(cursor, "mogrify"):
             real_sql = cursor.mogrify(sql)
             if isinstance(real_sql, bytes):
-                # Use UTF-8 as default, with latin1 fallback for edge cases
-                bytes_sql = real_sql  # make pypy happy (type narrowing to bytes)
-                try:
-                    real_sql = bytes_sql.decode("utf-8")
-                except UnicodeDecodeError:
-                    # If UTF-8 fails, try latin1 as fallback
-                    real_sql = bytes_sql.decode("latin1", errors="replace")
+                real_sql = real_sql.decode(cursor.connection.encoding)
     except Exception:
         real_sql = None
 

--- a/sentry_sdk/tracing_utils.py
+++ b/sentry_sdk/tracing_utils.py
@@ -354,7 +354,12 @@ def _format_sql(cursor, sql):
         if hasattr(cursor, "mogrify"):
             real_sql = cursor.mogrify(sql)
             if isinstance(real_sql, bytes):
-                real_sql = real_sql.decode(cursor.connection.encoding)
+                # Use UTF-8 as default, with latin1 fallback for edge cases
+                try:
+                    real_sql = real_sql.decode("utf-8")
+                except UnicodeDecodeError:
+                    # If UTF-8 fails, try latin1 as fallback
+                    real_sql = real_sql.decode("latin1", errors="replace")
     except Exception:
         real_sql = None
 

--- a/tests/integrations/django/test_db_query_data.py
+++ b/tests/integrations/django/test_db_query_data.py
@@ -963,10 +963,10 @@ def test_set_db_data_empty_cached_values(sentry_init):
     mock_cursor.db = mock_db
 
     _cached_db_configs["empty_config_db"] = {
-        "db_name": None,  # Should not be set
-        "host": "",  # Should not be set (empty string)
-        "port": None,  # Should not be set
-        "unix_socket": None,  # Should not be set
+        "db_name": None,
+        "host": None,
+        "port": None,
+        "unix_socket": None,
         "engine": "django.db.backends.postgresql",
         "vendor": "postgresql",
     }
@@ -983,7 +983,7 @@ def test_set_db_data_empty_cached_values(sentry_init):
     # Verify empty/None values were not set
     not_expected_calls = [
         mock.call("db.name", None),
-        mock.call("server.address", ""),
+        mock.call("server.address", None),
         mock.call("server.port", None),
         mock.call("server.socket.address", None),
     ]

--- a/tests/integrations/django/test_db_query_data.py
+++ b/tests/integrations/django/test_db_query_data.py
@@ -642,7 +642,7 @@ def test_set_db_data_fallback_to_connection_params(sentry_init):
     # Verify fallback was used
     mock_db.get_connection_params.assert_called_once()
     mock_logger.debug.assert_called_with(
-        "Cached db connection config retrieval failed for %s. Trying db.get_connection_params().",
+        "Cached db connection params retrieval failed for %s. Trying db.get_connection_params().",
         "uncached_db",
     )
 
@@ -732,7 +732,7 @@ def test_set_db_data_fallback_to_direct_connection_psycopg2(sentry_init):
     # Verify logging
     assert mock_logger.debug.call_count == 2
     mock_logger.debug.assert_any_call(
-        "Cached db connection config retrieval failed for %s. Trying db.get_connection_params().",
+        "Cached db connection params retrieval failed for %s. Trying db.get_connection_params().",
         "direct_db",
     )
     mock_logger.debug.assert_any_call(


### PR DESCRIPTION
Improve how we record db query connection parameters. This reads the database connection configuration on integration startup from the Django `settings.py` file and caches them in a thread safe manner. 

When db operations are performed we read the connection data from the cache with a fallback to an improved version to the old logic. We first try to call `db.get_connection_params()` and if this also fails access the connection directly.

refs #4604