### PR TITLE
chore(Crons): Log message for debugging Crons check-ins.

### DIFF
--- a/sentry_sdk/crons/api.py
+++ b/sentry_sdk/crons/api.py
@@ -56,7 +56,7 @@ def capture_checkin(
     sentry_sdk.capture_event(check_in_event)
 
     logger.debug(
-        f"[Crons] Captured check-in({check_in_event.get('check_in_id')}): {check_in_event.get('monitor_slug')} -> {check_in_event.get('status')}"
+        f"[Crons] Captured check-in ({check_in_event.get('check_in_id')}): {check_in_event.get('monitor_slug')} -> {check_in_event.get('status')}"
     )
 
     return check_in_event["check_in_id"]


### PR DESCRIPTION
A debug message to see what check-ins are send including the `monitor_slug` and the check-in `status`. 

If you set `sentry_sdk.init(.., debug=True)` then there will be a debug log message:
`"[Crons] Captured check-in ({check-in-id}): {monitor-slug} -> {status}"`