### PR TITLE
Fix Redis CI

### DIFF
--- a/scripts/populate_tox/tox.jinja
+++ b/scripts/populate_tox/tox.jinja
@@ -300,6 +300,7 @@ deps =
     {py3.7,py3.8,py3.9,py3.10,py3.11,py3.12,py3.13}-redis: pytest-asyncio
     redis-v3: redis~=3.0
     redis-v4: redis~=4.0
+    redis-v4: fakeredis<2.31.0
     redis-v5: redis~=5.0
     redis-latest: redis
 

--- a/tox.ini
+++ b/tox.ini
@@ -468,6 +468,7 @@ deps =
     {py3.7,py3.8,py3.9,py3.10,py3.11,py3.12,py3.13}-redis: pytest-asyncio
     redis-v3: redis~=3.0
     redis-v4: redis~=4.0
+    redis-v4: fakeredis<2.31.0
     redis-v5: redis~=5.0
     redis-latest: redis
 


### PR DESCRIPTION
A new version of fakeredis was released which [sets a new keyword arg](https://github.com/cunla/fakeredis-py/compare/v2.30.3..v2.31.0#diff-7d354eae970f35e5aa784b88fa4d0fb98ad887adb45b5a1cba5b8df4494c9561R183) that doesn't exist in older Redis versions