### PR TITLE
fix(tracing): Do not attach stacktrace to transaction

### DIFF
--- a/sentry_sdk/client.py
+++ b/sentry_sdk/client.py
@@ -516,8 +516,9 @@ class _Client(BaseClient):
         if event.get("timestamp") is None:
             event["timestamp"] = datetime.now(timezone.utc)
 
+        is_transaction = event.get("type") == "transaction"
+
         if scope is not None:
-            is_transaction = event.get("type") == "transaction"
             spans_before = len(cast(List[Dict[str, object]], event.get("spans", [])))
             event_ = scope.apply_to_event(event, hint, self.options)
 
@@ -560,7 +561,8 @@ class _Client(BaseClient):
                 )
 
         if (
-            self.options["attach_stacktrace"]
+            not is_transaction
+            and self.options["attach_stacktrace"]
             and "exception" not in event
             and "stacktrace" not in event
             and "threads" not in event

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -21,6 +21,7 @@ from sentry_sdk import (
     capture_exception,
     capture_event,
     set_tag,
+    start_transaction,
 )
 from sentry_sdk.spotlight import DEFAULT_SPOTLIGHT_URL
 from sentry_sdk.utils import capture_internal_exception
@@ -558,6 +559,15 @@ def test_attach_stacktrace_disabled(sentry_init, capture_events):
     events = capture_events()
     capture_message("HI")
 
+    (event,) = events
+    assert "threads" not in event
+
+
+def test_attach_stacktrace_transaction(sentry_init, capture_events):
+    sentry_init(traces_sample_rate=1.0, attach_stacktrace=True)
+    events = capture_events()
+    with start_transaction(name="transaction"):
+        pass
     (event,) = events
     assert "threads" not in event
 


### PR DESCRIPTION
The `attach_stacktrace` option was attaching stack traces to transactions. This is an expensive operation but the results aren't used anywhere.