### PR TITLE
Wrap span restoration in `__exit__` in `capture_internal_exceptions`

### DIFF
--- a/sentry_sdk/tracing.py
+++ b/sentry_sdk/tracing.py
@@ -8,6 +8,7 @@ import sentry_sdk
 from sentry_sdk.consts import INSTRUMENTER, SPANSTATUS, SPANDATA, SPANTEMPLATE
 from sentry_sdk.profiler.continuous_profiler import get_profiler_id
 from sentry_sdk.utils import (
+    capture_internal_exceptions,
     get_current_thread_meta,
     is_valid_sample_rate,
     logger,
@@ -418,10 +419,11 @@ class Span:
         if value is not None and should_be_treated_as_error(ty, value):
             self.set_status(SPANSTATUS.INTERNAL_ERROR)
 
-        scope, old_span = self._context_manager_state
-        del self._context_manager_state
-        self.finish(scope)
-        scope.span = old_span
+        with capture_internal_exceptions():
+            scope, old_span = self._context_manager_state
+            del self._context_manager_state
+            self.finish(scope)
+            scope.span = old_span
 
     @property
     def containing_transaction(self):


### PR DESCRIPTION
Ref https://github.com/getsentry/sentry-python/issues/4718

Does not solve the underlying issue and might leave things in an inconsistent state, but it's still preferable to letting an error bubble up to the user.