### PR TITLE
feat(integrations): Add unraisable exception integration

### DIFF
--- a/sentry_sdk/integrations/__init__.py
+++ b/sentry_sdk/integrations/__init__.py
@@ -1,6 +1,5 @@
 from abc import ABC, abstractmethod
 from threading import Lock
-import sys
 
 from sentry_sdk.utils import logger
 
@@ -73,11 +72,6 @@ _DEFAULT_INTEGRATIONS = [
     "sentry_sdk.integrations.stdlib.StdlibIntegration",
     "sentry_sdk.integrations.threading.ThreadingIntegration",
 ]
-
-if sys.version_info >= (3, 8):
-    _DEFAULT_INTEGRATIONS.append(
-        "sentry_sdk.integrations.unraisablehook.UnraisablehookIntegration"
-    )
 
 _AUTO_ENABLING_INTEGRATIONS = [
     "sentry_sdk.integrations.aiohttp.AioHttpIntegration",

--- a/sentry_sdk/integrations/__init__.py
+++ b/sentry_sdk/integrations/__init__.py
@@ -1,5 +1,6 @@
 from abc import ABC, abstractmethod
 from threading import Lock
+import sys
 
 from sentry_sdk.utils import logger
 
@@ -71,8 +72,12 @@ _DEFAULT_INTEGRATIONS = [
     "sentry_sdk.integrations.modules.ModulesIntegration",
     "sentry_sdk.integrations.stdlib.StdlibIntegration",
     "sentry_sdk.integrations.threading.ThreadingIntegration",
-    "sentry_sdk.integrations.unraisablehook.UnraisablehookIntegration",
 ]
+
+if sys.version_info >= (3, 8):
+    _DEFAULT_INTEGRATIONS.append(
+        "sentry_sdk.integrations.unraisablehook.UnraisablehookIntegration"
+    )
 
 _AUTO_ENABLING_INTEGRATIONS = [
     "sentry_sdk.integrations.aiohttp.AioHttpIntegration",

--- a/sentry_sdk/integrations/__init__.py
+++ b/sentry_sdk/integrations/__init__.py
@@ -71,6 +71,7 @@ _DEFAULT_INTEGRATIONS = [
     "sentry_sdk.integrations.modules.ModulesIntegration",
     "sentry_sdk.integrations.stdlib.StdlibIntegration",
     "sentry_sdk.integrations.threading.ThreadingIntegration",
+    "sentry_sdk.integrations.unraisablehook.UnraisablehookIntegration",
 ]
 
 _AUTO_ENABLING_INTEGRATIONS = [

--- a/sentry_sdk/integrations/unraisablehook.py
+++ b/sentry_sdk/integrations/unraisablehook.py
@@ -1,0 +1,53 @@
+import sys
+
+import sentry_sdk
+from sentry_sdk.utils import (
+    capture_internal_exceptions,
+    event_from_exception,
+)
+from sentry_sdk.integrations import Integration
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from typing import Callable
+    from typing import Any
+
+
+class UnraisablehookIntegration(Integration):
+    identifier = "unraisable"
+
+    @staticmethod
+    def setup_once():
+        # type: () -> None
+        sys.unraisablehook = _make_unraisable(sys.unraisablehook)
+
+
+def _make_unraisable(old_unraisablehook):
+    # type: (Callable[[sys.UnraisableHookArgs], Any]) -> Callable[[sys.UnraisableHookArgs], Any]
+    def sentry_sdk_unraisablehook(unraisable):
+        # type: (sys.UnraisableHookArgs) -> None
+        integration = sentry_sdk.get_client().get_integration(UnraisablehookIntegration)
+
+        # Note: If  we replace this with ensure_integration_enabled then
+        # we break the exceptiongroup backport;
+        # See: https://github.com/getsentry/sentry-python/issues/3097
+        if integration is None:
+            return old_unraisablehook(unraisable)
+
+        if unraisable.exc_value and unraisable.exc_traceback:
+            with capture_internal_exceptions():
+                event, hint = event_from_exception(
+                    (
+                        unraisable.exc_type,
+                        unraisable.exc_value,
+                        unraisable.exc_traceback,
+                    ),
+                    client_options=sentry_sdk.get_client().options,
+                    mechanism={"type": "unraisablehook", "handled": False},
+                )
+                sentry_sdk.capture_event(event, hint=hint)
+
+        return old_unraisablehook(unraisable)
+
+    return sentry_sdk_unraisablehook

--- a/sentry_sdk/integrations/unraisablehook.py
+++ b/sentry_sdk/integrations/unraisablehook.py
@@ -15,7 +15,7 @@ if TYPE_CHECKING:
 
 
 class UnraisablehookIntegration(Integration):
-    identifier = "unraisable"
+    identifier = "unraisablehook"
 
     @staticmethod
     def setup_once():

--- a/tests/integrations/unraisablehook/test_unraisablehook.py
+++ b/tests/integrations/unraisablehook/test_unraisablehook.py
@@ -24,6 +24,7 @@ def test_unraisablehook(tmpdir, options, transport):
         dedent(
             """
     from sentry_sdk import init, transport
+    from sentry_sdk.integrations.unraisablehook import UnraisablehookIntegration
 
     class Undeletable:
         def __del__(self):
@@ -37,7 +38,7 @@ def test_unraisablehook(tmpdir, options, transport):
 
     transport.{transport}.capture_envelope = capture_envelope
 
-    init("http://foobar@localhost/123", {options})
+    init("http://foobar@localhost/123", integrations=[UnraisablehookIntegration()], {options})
 
     undeletable = Undeletable()
     del undeletable

--- a/tests/integrations/unraisablehook/test_unraisablehook.py
+++ b/tests/integrations/unraisablehook/test_unraisablehook.py
@@ -1,0 +1,49 @@
+import pytest
+import sys
+import subprocess
+
+from textwrap import dedent
+
+
+TEST_PARAMETERS = [("", "HttpTransport")]
+
+if sys.version_info >= (3, 8):
+    TEST_PARAMETERS.append(('_experiments={"transport_http2": True}', "Http2Transport"))
+
+
+@pytest.mark.parametrize("options, transport", TEST_PARAMETERS)
+def test_excepthook(tmpdir, options, transport):
+    app = tmpdir.join("app.py")
+    app.write(
+        dedent(
+            """
+    from sentry_sdk import init, transport
+
+    class Undeletable:
+        def __del__(self):
+            1 / 0
+
+    def capture_envelope(self, envelope):
+        print("capture_envelope was called")
+        event = envelope.get_event()
+        if event is not None:
+            print(event)
+
+    transport.{transport}.capture_envelope = capture_envelope
+
+    init("http://foobar@localhost/123", {options})
+
+    undeletable = Undeletable()
+    del undeletable
+    """.format(
+                transport=transport, options=options
+            )
+        )
+    )
+
+    output = subprocess.check_output(
+        [sys.executable, str(app)], stderr=subprocess.STDOUT
+    )
+
+    assert b"ZeroDivisionError" in output
+    assert b"capture_envelope was called" in output

--- a/tests/integrations/unraisablehook/test_unraisablehook.py
+++ b/tests/integrations/unraisablehook/test_unraisablehook.py
@@ -12,7 +12,7 @@ if sys.version_info >= (3, 8):
 
 
 @pytest.mark.parametrize("options, transport", TEST_PARAMETERS)
-def test_excepthook(tmpdir, options, transport):
+def test_unraisablehook(tmpdir, options, transport):
     app = tmpdir.join("app.py")
     app.write(
         dedent(

--- a/tests/integrations/unraisablehook/test_unraisablehook.py
+++ b/tests/integrations/unraisablehook/test_unraisablehook.py
@@ -5,12 +5,18 @@ import subprocess
 from textwrap import dedent
 
 
-TEST_PARAMETERS = [("", "HttpTransport")]
+TEST_PARAMETERS = [
+    ("", "HttpTransport"),
+    ('_experiments={"transport_http2": True}', "Http2Transport"),
+]
 
-if sys.version_info >= (3, 8):
-    TEST_PARAMETERS.append(('_experiments={"transport_http2": True}', "Http2Transport"))
+minimum_python_38 = pytest.mark.skipif(
+    sys.version_info < (3, 8),
+    reason="The unraisable exception hook is only available in Python 3.8 and above.",
+)
 
 
+@minimum_python_38
 @pytest.mark.parametrize("options, transport", TEST_PARAMETERS)
 def test_unraisablehook(tmpdir, options, transport):
     app = tmpdir.join("app.py")

--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -870,6 +870,7 @@ def test_event_processor_drop_records_client_report(
         (["celery"], "sentry.python"),
         (["dedupe"], "sentry.python"),
         (["excepthook"], "sentry.python"),
+        (["unraisablehook"], "sentry.python"),
         (["executing"], "sentry.python"),
         (["modules"], "sentry.python"),
         (["pure_eval"], "sentry.python"),


### PR DESCRIPTION
Closes https://github.com/getsentry/sentry-python/issues/374

Adds an uncaught exception integration, enabled by default. The integration forwards the exception to Sentry only if the exception value and stacktrace are set.

The implementation and tests are adapted from `excepthook`. Sets `sys.unraisablehook` instead of`sys.excepthook`, and changes relevant signatures and types. Compared with the `excepthook` integration, there is no `always_run` parameter. As far as I can tell the option was added to avoid excessive errors in interactive shells, which does not apply to unraisable errors.

Unlike in the `excepthook` tests, the `unraisablehook` test does not check for the presence of the local variable in the pre-context. The local variable from the `excepthook` test is not captured in an analogous test with an unraisable exception because an (unraisable) exception in `__del__` has a stack frame with only one level. 

A good source about unraisable exceptions: https://vstinner.github.io/sys-unraisablehook-python38.html