### PR TITLE
test: Trigger Pytest failure when an unraisable exception occurs

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -909,7 +909,7 @@ commands =
     ; Running `pytest` as an executable suffers from an import error
     ; when loading tests in scenarios. In particular, django fails to
     ; load the settings from the test module.
-    python -m pytest {env:TESTPATH} -o junit_suite_name={envname} {posargs}
+    python -m pytest -W error::pytest.PytestUnraisableExceptionWarning {env:TESTPATH} -o junit_suite_name={envname} {posargs}
 
 [testenv:linters]
 commands =


### PR DESCRIPTION
To test you can revert changes in https://github.com/getsentry/sentry-python/pull/4736, or just flip the `manual_span_cleanup` argument. The OpenAI tests should then fail.

Closes https://github.com/getsentry/sentry-python/issues/4723.