### PR TITLE
tests: Move arq under toxgen

### DIFF
--- a/scripts/populate_tox/config.py
+++ b/scripts/populate_tox/config.py
@@ -29,6 +29,13 @@ TEST_SUITE_CONFIG = {
         },
         "python": ">=3.8",
     },
+    "arq": {
+        "package": "arq",
+        "deps": {
+            "*": ["async-timeout", "pytest-asyncio", "fakeredis>=2.2.0,<2.8"],
+            "<=0.23": ["pydantic<2"],
+        },
+    },
     "bottle": {
         "package": "bottle",
         "deps": {

--- a/scripts/populate_tox/populate_tox.py
+++ b/scripts/populate_tox/populate_tox.py
@@ -67,7 +67,6 @@ IGNORE = {
     "potel",
     # Integrations that can be migrated -- we should eventually remove all
     # of these from the IGNORE list
-    "arq",
     "asyncpg",
     "beam",
     "boto3",

--- a/scripts/populate_tox/tox.jinja
+++ b/scripts/populate_tox/tox.jinja
@@ -36,10 +36,6 @@ envlist =
     # At a minimum, we should test against at least the lowest
     # and the latest supported version of a framework.
 
-    # Arq
-    {py3.7,py3.11}-arq-v{0.23}
-    {py3.7,py3.12,py3.13}-arq-latest
-
     # Asgi
     {py3.7,py3.12,py3.13}-asgi
 
@@ -163,14 +159,6 @@ deps =
     {py3.10,py3.11}-gevent: zope.event<5.0.0
 
     # === Integrations ===
-
-    # Arq
-    arq-v0.23: arq~=0.23.0
-    arq-v0.23: pydantic<2
-    arq-latest: arq
-    arq: fakeredis>=2.2.0,<2.8
-    arq: pytest-asyncio
-    arq: async-timeout
 
     # Asgi
     asgi: pytest-asyncio

--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,7 @@
 # The file (and all resulting CI YAMLs) then need to be regenerated via
 # "scripts/generate-test-files.sh".
 #
-# Last generated: 2025-09-02T10:59:55.249513+00:00
+# Last generated: 2025-09-02T13:17:31.600009+00:00
 
 [tox]
 requires =
@@ -227,6 +227,11 @@ envlist =
 
 
     # ~~~ Tasks ~~~
+    {py3.7,py3.9,py3.10}-arq-v0.23
+    {py3.7,py3.10,py3.11}-arq-v0.24.0
+    {py3.7,py3.10,py3.11}-arq-v0.25.0
+    {py3.8,py3.11,py3.12}-arq-v0.26.3
+
     {py3.6,py3.7,py3.8}-celery-v4.4.7
     {py3.6,py3.7,py3.8}-celery-v5.0.5
     {py3.8,py3.12,py3.13}-celery-v5.5.3
@@ -632,6 +637,15 @@ deps =
 
 
     # ~~~ Tasks ~~~
+    arq-v0.23: arq==0.23
+    arq-v0.24.0: arq==0.24.0
+    arq-v0.25.0: arq==0.25.0
+    arq-v0.26.3: arq==0.26.3
+    arq: async-timeout
+    arq: pytest-asyncio
+    arq: fakeredis>=2.2.0,<2.8
+    arq-v0.23: pydantic<2
+
     celery-v4.4.7: celery==4.4.7
     celery-v5.0.5: celery==5.0.5
     celery-v5.5.3: celery==5.5.3

--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,7 @@
 # The file (and all resulting CI YAMLs) then need to be regenerated via
 # "scripts/generate-test-files.sh".
 #
-# Last generated: 2025-09-02T13:17:31.600009+00:00
+# Last generated: 2025-09-02T13:21:02.126682+00:00
 
 [tox]
 requires =
@@ -35,10 +35,6 @@ envlist =
     #
     # At a minimum, we should test against at least the lowest
     # and the latest supported version of a framework.
-
-    # Arq
-    {py3.7,py3.11}-arq-v{0.23}
-    {py3.7,py3.12,py3.13}-arq-latest
 
     # Asgi
     {py3.7,py3.12,py3.13}-asgi
@@ -357,14 +353,6 @@ deps =
     {py3.10,py3.11}-gevent: zope.event<5.0.0
 
     # === Integrations ===
-
-    # Arq
-    arq-v0.23: arq~=0.23.0
-    arq-v0.23: pydantic<2
-    arq-latest: arq
-    arq: fakeredis>=2.2.0,<2.8
-    arq: pytest-asyncio
-    arq: async-timeout
 
     # Asgi
     asgi: pytest-asyncio

--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,7 @@
 # The file (and all resulting CI YAMLs) then need to be regenerated via
 # "scripts/generate-test-files.sh".
 #
-# Last generated: 2025-09-03T14:56:29.318609+00:00
+# Last generated: 2025-09-03T15:01:21.035943+00:00
 
 [tox]
 requires =
@@ -119,9 +119,9 @@ envlist =
 
     # ~~~ AI ~~~
     {py3.8,py3.11,py3.12}-anthropic-v0.16.0
-    {py3.8,py3.11,py3.12}-anthropic-v0.32.0
-    {py3.8,py3.11,py3.12}-anthropic-v0.48.0
-    {py3.8,py3.12,py3.13}-anthropic-v0.65.0
+    {py3.8,py3.11,py3.12}-anthropic-v0.33.1
+    {py3.8,py3.11,py3.12}-anthropic-v0.50.0
+    {py3.8,py3.12,py3.13}-anthropic-v0.66.0
 
     {py3.9,py3.10,py3.11}-cohere-v5.4.0
     {py3.9,py3.11,py3.12}-cohere-v5.9.4
@@ -484,13 +484,12 @@ deps =
 
     # ~~~ AI ~~~
     anthropic-v0.16.0: anthropic==0.16.0
-    anthropic-v0.32.0: anthropic==0.32.0
-    anthropic-v0.48.0: anthropic==0.48.0
-    anthropic-v0.65.0: anthropic==0.65.0
+    anthropic-v0.33.1: anthropic==0.33.1
+    anthropic-v0.50.0: anthropic==0.50.0
+    anthropic-v0.66.0: anthropic==0.66.0
     anthropic: pytest-asyncio
     anthropic-v0.16.0: httpx<0.28.0
-    anthropic-v0.32.0: httpx<0.28.0
-    anthropic-v0.48.0: httpx<0.28.0
+    anthropic-v0.33.1: httpx<0.28.0
 
     cohere-v5.4.0: cohere==5.4.0
     cohere-v5.9.4: cohere==5.9.4


### PR DESCRIPTION
Remove hardcoded arq config, generate with toxgen instead.