### PR TITLE
tests: Support dashes in test suite names

### DIFF
--- a/scripts/split_tox_gh_actions/split_tox_gh_actions.py
+++ b/scripts/split_tox_gh_actions/split_tox_gh_actions.py
@@ -204,6 +204,8 @@ def parse_tox():
     py_versions_pinned = defaultdict(set)
     py_versions_latest = defaultdict(set)
 
+    parsed_correctly = True
+
     for line in lines:
         # normalize lines
         line = line.strip().lower()
@@ -237,6 +239,10 @@ def parse_tox():
 
         except ValueError:
             print(f"ERROR reading line {line}")
+            parsed_correctly = False
+
+    if not parsed_correctly:
+        raise RuntimeError("Failed to parse tox.ini")
 
     py_versions_pinned = _normalize_py_versions(py_versions_pinned)
     py_versions_latest = _normalize_py_versions(py_versions_latest)

--- a/scripts/split_tox_gh_actions/split_tox_gh_actions.py
+++ b/scripts/split_tox_gh_actions/split_tox_gh_actions.py
@@ -241,7 +241,6 @@ def parse_tox():
                 py_versions_pinned[framework] |= raw_python_versions
 
         except Exception:
-            raise
             print(f"ERROR reading line {line}")
             parsed_correctly = False
 


### PR DESCRIPTION
- actually support dashes in integration names in `tox.ini`/toxgen
- make `split_tox_gh_actions.py` actually fail if it fails to parse `tox.ini`

Context: `split_tox_gh_actions.py` was actually failing because it assumed there can't be dashes in test suite names, but since it was just printing the error instead of actually exiting with an error code, we didn't notice this in CI.