### PR TITLE
Fix `openai_agents` in CI

### DIFF
--- a/scripts/populate_tox/config.py
+++ b/scripts/populate_tox/config.py
@@ -181,6 +181,7 @@ TEST_SUITE_CONFIG = {
         "package": "openai-agents",
         "deps": {
             "*": ["pytest-asyncio"],
+            "<=0.2.10": ["openai<1.103.0"],
         },
         "python": ">=3.10",
     },

--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,7 @@
 # The file (and all resulting CI YAMLs) then need to be regenerated via
 # "scripts/generate-test-files.sh".
 #
-# Last generated: 2025-09-02T12:34:09.591543+00:00
+# Last generated: 2025-09-02T14:49:13.002983+00:00
 
 [tox]
 requires =
@@ -143,12 +143,12 @@ envlist =
     {py3.8,py3.11,py3.12}-openai-base-v1.0.1
     {py3.8,py3.11,py3.12}-openai-base-v1.35.15
     {py3.8,py3.11,py3.12}-openai-base-v1.69.0
-    {py3.8,py3.12,py3.13}-openai-base-v1.102.0
+    {py3.8,py3.12,py3.13}-openai-base-v1.103.0
 
     {py3.8,py3.11,py3.12}-openai-notiktoken-v1.0.1
     {py3.8,py3.11,py3.12}-openai-notiktoken-v1.35.15
     {py3.8,py3.11,py3.12}-openai-notiktoken-v1.69.0
-    {py3.8,py3.12,py3.13}-openai-notiktoken-v1.102.0
+    {py3.8,py3.12,py3.13}-openai-notiktoken-v1.103.0
 
     {py3.10,py3.11,py3.12}-openai_agents-v0.0.19
     {py3.10,py3.12,py3.13}-openai_agents-v0.1.0
@@ -522,7 +522,7 @@ deps =
     openai-base-v1.0.1: openai==1.0.1
     openai-base-v1.35.15: openai==1.35.15
     openai-base-v1.69.0: openai==1.69.0
-    openai-base-v1.102.0: openai==1.102.0
+    openai-base-v1.103.0: openai==1.103.0
     openai-base: pytest-asyncio
     openai-base: tiktoken
     openai-base-v1.0.1: httpx<0.28
@@ -531,7 +531,7 @@ deps =
     openai-notiktoken-v1.0.1: openai==1.0.1
     openai-notiktoken-v1.35.15: openai==1.35.15
     openai-notiktoken-v1.69.0: openai==1.69.0
-    openai-notiktoken-v1.102.0: openai==1.102.0
+    openai-notiktoken-v1.103.0: openai==1.103.0
     openai-notiktoken: pytest-asyncio
     openai-notiktoken-v1.0.1: httpx<0.28
     openai-notiktoken-v1.35.15: httpx<0.28
@@ -540,6 +540,9 @@ deps =
     openai_agents-v0.1.0: openai-agents==0.1.0
     openai_agents-v0.2.10: openai-agents==0.2.10
     openai_agents: pytest-asyncio
+    openai_agents-v0.0.19: openai<1.103.0
+    openai_agents-v0.1.0: openai<1.103.0
+    openai_agents-v0.2.10: openai<1.103.0
 
     huggingface_hub-v0.22.2: huggingface_hub==0.22.2
     huggingface_hub-v0.26.5: huggingface_hub==0.26.5


### PR DESCRIPTION
A new version of `openai`, which is a dependency of `openai_agents`, [came out an hour ago](https://pypi.org/project/openai/#history), which [broke](https://github.com/getsentry/sentry-python/actions/runs/17405958869/job/49410259073) our CI. Pinning for now.