### PR TITLE
tests: Remove openai pin and update tox

### DIFF
--- a/scripts/populate_tox/config.py
+++ b/scripts/populate_tox/config.py
@@ -181,7 +181,6 @@ TEST_SUITE_CONFIG = {
         "package": "openai-agents",
         "deps": {
             "*": ["pytest-asyncio"],
-            "<=0.2.10": ["openai<1.103.0"],
         },
         "python": ">=3.10",
     },

--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,7 @@
 # The file (and all resulting CI YAMLs) then need to be regenerated via
 # "scripts/generate-test-files.sh".
 #
-# Last generated: 2025-09-02T14:49:13.002983+00:00
+# Last generated: 2025-09-03T12:58:38.268084+00:00
 
 [tox]
 requires =
@@ -125,7 +125,7 @@ envlist =
     {py3.8,py3.11,py3.12}-anthropic-v0.16.0
     {py3.8,py3.11,py3.12}-anthropic-v0.32.0
     {py3.8,py3.11,py3.12}-anthropic-v0.48.0
-    {py3.8,py3.12,py3.13}-anthropic-v0.64.0
+    {py3.8,py3.12,py3.13}-anthropic-v0.65.0
 
     {py3.9,py3.10,py3.11}-cohere-v5.4.0
     {py3.9,py3.11,py3.12}-cohere-v5.9.4
@@ -143,12 +143,12 @@ envlist =
     {py3.8,py3.11,py3.12}-openai-base-v1.0.1
     {py3.8,py3.11,py3.12}-openai-base-v1.35.15
     {py3.8,py3.11,py3.12}-openai-base-v1.69.0
-    {py3.8,py3.12,py3.13}-openai-base-v1.103.0
+    {py3.8,py3.12,py3.13}-openai-base-v1.104.2
 
     {py3.8,py3.11,py3.12}-openai-notiktoken-v1.0.1
     {py3.8,py3.11,py3.12}-openai-notiktoken-v1.35.15
     {py3.8,py3.11,py3.12}-openai-notiktoken-v1.69.0
-    {py3.8,py3.12,py3.13}-openai-notiktoken-v1.103.0
+    {py3.8,py3.12,py3.13}-openai-notiktoken-v1.104.2
 
     {py3.10,py3.11,py3.12}-openai_agents-v0.0.19
     {py3.10,py3.12,py3.13}-openai_agents-v0.1.0
@@ -493,7 +493,7 @@ deps =
     anthropic-v0.16.0: anthropic==0.16.0
     anthropic-v0.32.0: anthropic==0.32.0
     anthropic-v0.48.0: anthropic==0.48.0
-    anthropic-v0.64.0: anthropic==0.64.0
+    anthropic-v0.65.0: anthropic==0.65.0
     anthropic: pytest-asyncio
     anthropic-v0.16.0: httpx<0.28.0
     anthropic-v0.32.0: httpx<0.28.0
@@ -522,7 +522,7 @@ deps =
     openai-base-v1.0.1: openai==1.0.1
     openai-base-v1.35.15: openai==1.35.15
     openai-base-v1.69.0: openai==1.69.0
-    openai-base-v1.103.0: openai==1.103.0
+    openai-base-v1.104.2: openai==1.104.2
     openai-base: pytest-asyncio
     openai-base: tiktoken
     openai-base-v1.0.1: httpx<0.28
@@ -531,7 +531,7 @@ deps =
     openai-notiktoken-v1.0.1: openai==1.0.1
     openai-notiktoken-v1.35.15: openai==1.35.15
     openai-notiktoken-v1.69.0: openai==1.69.0
-    openai-notiktoken-v1.103.0: openai==1.103.0
+    openai-notiktoken-v1.104.2: openai==1.104.2
     openai-notiktoken: pytest-asyncio
     openai-notiktoken-v1.0.1: httpx<0.28
     openai-notiktoken-v1.35.15: httpx<0.28
@@ -540,9 +540,6 @@ deps =
     openai_agents-v0.1.0: openai-agents==0.1.0
     openai_agents-v0.2.10: openai-agents==0.2.10
     openai_agents: pytest-asyncio
-    openai_agents-v0.0.19: openai<1.103.0
-    openai_agents-v0.1.0: openai<1.103.0
-    openai_agents-v0.2.10: openai<1.103.0
 
     huggingface_hub-v0.22.2: huggingface_hub==0.22.2
     huggingface_hub-v0.26.5: huggingface_hub==0.26.5


### PR DESCRIPTION
[v1.104.2](https://github.com/openai/openai-python/releases/tag/v1.104.2) of openai added back the missing export that was causing problems for `openai_agents`, so we can remove the version pin again.