### PR TITLE
feat: Turn the unraisable exception integration on by default

### DIFF
--- a/sentry_sdk/integrations/__init__.py
+++ b/sentry_sdk/integrations/__init__.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 from abc import ABC, abstractmethod
 from threading import Lock
+import sys
 
 from sentry_sdk.utils import logger
 
@@ -73,6 +74,11 @@ _DEFAULT_INTEGRATIONS = [
     "sentry_sdk.integrations.stdlib.StdlibIntegration",
     "sentry_sdk.integrations.threading.ThreadingIntegration",
 ]
+
+if sys.version_info >= (3, 8):
+    _DEFAULT_INTEGRATIONS.append(
+        "sentry_sdk.integrations.unraisablehook.UnraisablehookIntegration"
+    )
 
 _AUTO_ENABLING_INTEGRATIONS = [
     "sentry_sdk.integrations.aiohttp.AioHttpIntegration",


### PR DESCRIPTION
See https://github.com/getsentry/sentry-python/pull/4733#discussion_r2318008411