### PR TITLE
tests: Move asyncpg under toxgen

### DIFF
--- a/.github/workflows/test-integrations-dbs.yml
+++ b/.github/workflows/test-integrations-dbs.yml
@@ -29,7 +29,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.7","3.8","3.11","3.12","3.13"]
+        python-version: ["3.7","3.12","3.13"]
         # python3.6 reached EOL and is no longer being supported on
         # new versions of hosted runners on Github Actions
         # ubuntu-20.04 is the last version that supported python3.6

--- a/scripts/populate_tox/config.py
+++ b/scripts/populate_tox/config.py
@@ -36,6 +36,12 @@ TEST_SUITE_CONFIG = {
             "<=0.23": ["pydantic<2"],
         },
     },
+    "asyncpg": {
+        "package": "asyncpg",
+        "deps": {
+            "*": ["pytest-asyncio"],
+        },
+    },
     "bottle": {
         "package": "bottle",
         "deps": {

--- a/scripts/populate_tox/config.py
+++ b/scripts/populate_tox/config.py
@@ -41,6 +41,7 @@ TEST_SUITE_CONFIG = {
         "deps": {
             "*": ["pytest-asyncio"],
         },
+        "python": ">=3.7",
     },
     "beam": {
         "package": "apache-beam",

--- a/scripts/populate_tox/config.py
+++ b/scripts/populate_tox/config.py
@@ -41,6 +41,7 @@ TEST_SUITE_CONFIG = {
         "deps": {
             "*": ["pytest-asyncio"],
         },
+        "python": ">=3.7",
     },
     "bottle": {
         "package": "bottle",

--- a/scripts/populate_tox/populate_tox.py
+++ b/scripts/populate_tox/populate_tox.py
@@ -67,7 +67,6 @@ IGNORE = {
     "potel",
     # Integrations that can be migrated -- we should eventually remove all
     # of these from the IGNORE list
-    "asyncpg",
     "beam",
     "boto3",
     "chalice",

--- a/scripts/populate_tox/tox.jinja
+++ b/scripts/populate_tox/tox.jinja
@@ -39,10 +39,6 @@ envlist =
     # Asgi
     {py3.7,py3.12,py3.13}-asgi
 
-    # asyncpg
-    {py3.7,py3.10}-asyncpg-v{0.23}
-    {py3.8,py3.11,py3.12}-asyncpg-latest
-
     # AWS Lambda
     {py3.8,py3.9,py3.11,py3.13}-aws_lambda
 
@@ -163,11 +159,6 @@ deps =
     # Asgi
     asgi: pytest-asyncio
     asgi: async-asgi-testclient
-
-    # Asyncpg
-    asyncpg-v0.23: asyncpg~=0.23.0
-    asyncpg-latest: asyncpg
-    asyncpg: pytest-asyncio
 
     # AWS Lambda
     aws_lambda: aws-cdk-lib

--- a/tests/integrations/asyncpg/test_asyncpg.py
+++ b/tests/integrations/asyncpg/test_asyncpg.py
@@ -11,23 +11,6 @@ The tests use the following credentials to establish a database connection.
 
 import os
 import threading
-
-
-PG_HOST = os.getenv("SENTRY_PYTHON_TEST_POSTGRES_HOST", "localhost")
-PG_PORT = int(os.getenv("SENTRY_PYTHON_TEST_POSTGRES_PORT", "5432"))
-PG_USER = os.getenv("SENTRY_PYTHON_TEST_POSTGRES_USER", "postgres")
-PG_PASSWORD = os.getenv("SENTRY_PYTHON_TEST_POSTGRES_PASSWORD", "sentry")
-PG_NAME_BASE = os.getenv("SENTRY_PYTHON_TEST_POSTGRES_NAME", "postgres")
-
-
-def _get_db_name():
-    pid = os.getpid()
-    thread_id = threading.get_ident()
-    return f"{PG_NAME_BASE}_{pid}_{thread_id}"
-
-
-PG_NAME = _get_db_name()
-
 import datetime
 from contextlib import contextmanager
 from unittest import mock
@@ -43,6 +26,20 @@ from sentry_sdk.consts import SPANDATA
 from sentry_sdk.tracing_utils import record_sql_queries
 from tests.conftest import ApproxDict
 
+PG_HOST = os.getenv("SENTRY_PYTHON_TEST_POSTGRES_HOST", "localhost")
+PG_PORT = int(os.getenv("SENTRY_PYTHON_TEST_POSTGRES_PORT", "5432"))
+PG_USER = os.getenv("SENTRY_PYTHON_TEST_POSTGRES_USER", "postgres")
+PG_PASSWORD = os.getenv("SENTRY_PYTHON_TEST_POSTGRES_PASSWORD", "sentry")
+PG_NAME_BASE = os.getenv("SENTRY_PYTHON_TEST_POSTGRES_NAME", "postgres")
+
+
+def _get_db_name():
+    pid = os.getpid()
+    thread_id = threading.get_ident()
+    return f"{PG_NAME_BASE}_{pid}_{thread_id}"
+
+
+PG_NAME = _get_db_name()
 
 PG_CONNECTION_URI = "postgresql://{}:{}@{}/{}".format(
     PG_USER, PG_PASSWORD, PG_HOST, PG_NAME
@@ -65,29 +62,6 @@ CRUMBS_CONNECT = {
 
 @pytest_asyncio.fixture(autouse=True)
 async def _clean_pg():
-    # Connect to the default postgres database to create our test database
-    default_conn_uri = "postgresql://{}:{}@{}/{}".format(
-        PG_USER, PG_PASSWORD, PG_HOST, PG_NAME_BASE
-    )
-
-    # Create the test database if it doesn't exist
-    try:
-        default_conn = await connect(default_conn_uri)
-        try:
-            # Check if database exists, create if not
-            result = await default_conn.fetchval(
-                "SELECT 1 FROM pg_database WHERE datname = $1", PG_NAME
-            )
-            if not result:
-                await default_conn.execute(f'CREATE DATABASE "{PG_NAME}"')
-        finally:
-            await default_conn.close()
-    except Exception:
-        # If we can't connect to default postgres db, assume our test db already exists
-        # or that we're connecting to the same database (PG_NAME == PG_NAME_BASE)
-        pass
-
-    # Now connect to our test database and set up the table
     conn = await connect(PG_CONNECTION_URI)
     await conn.execute("DROP TABLE IF EXISTS users")
     await conn.execute(

--- a/tests/integrations/asyncpg/test_asyncpg.py
+++ b/tests/integrations/asyncpg/test_asyncpg.py
@@ -10,7 +10,6 @@ The tests use the following credentials to establish a database connection.
 """
 
 import os
-import threading
 import datetime
 from contextlib import contextmanager
 from unittest import mock
@@ -35,8 +34,7 @@ PG_NAME_BASE = os.getenv("SENTRY_PYTHON_TEST_POSTGRES_NAME", "postgres")
 
 def _get_db_name():
     pid = os.getpid()
-    thread_id = threading.get_ident()
-    return f"{PG_NAME_BASE}_{pid}_{thread_id}"
+    return f"{PG_NAME_BASE}_{pid}"
 
 
 PG_NAME = _get_db_name()

--- a/tests/integrations/asyncpg/test_asyncpg.py
+++ b/tests/integrations/asyncpg/test_asyncpg.py
@@ -21,9 +21,6 @@ PG_NAME_BASE = os.getenv("SENTRY_PYTHON_TEST_POSTGRES_NAME", "postgres")
 
 
 def _get_db_name():
-    """Get database name, using worker/process ID for parallel test isolation."""
-    # For tox parallel execution or other parallel scenarios, use process ID
-    # This ensures each process gets its own database
     pid = os.getpid()
     thread_id = threading.get_ident()
     return f"{PG_NAME_BASE}_{pid}_{thread_id}"

--- a/tests/integrations/asyncpg/test_asyncpg.py
+++ b/tests/integrations/asyncpg/test_asyncpg.py
@@ -62,7 +62,9 @@ CRUMBS_CONNECT = {
 async def _clean_pg():
     # Create the test database if it doesn't exist
     try:
-        default_conn = await connect(PG_CONNECTION_URI)
+        default_conn = await connect(
+            "postgresql://{}:{}@{}".format(PG_USER, PG_PASSWORD, PG_HOST)
+        )
         try:
             # Check if database exists, create if not
             result = await default_conn.fetchval(

--- a/tests/integrations/asyncpg/test_asyncpg.py
+++ b/tests/integrations/asyncpg/test_asyncpg.py
@@ -3,7 +3,7 @@ Tests need pytest-asyncio installed.
 
 Tests need a local postgresql instance running, this can best be done using
 ```sh
-docker run --rm --name some-postgres -e POSTGRES_USER=foo -e POSTGRES_PASSWORD=bar -d -p 5432:5432 postgres
+docker run --rm --name some-postgres -e POSTGRES_USER=postgres -e POSTGRES_PASSWORD=sentry -d -p 5432:5432 postgres
 ```
 
 The tests use the following credentials to establish a database connection.

--- a/tests/integrations/asyncpg/test_asyncpg.py
+++ b/tests/integrations/asyncpg/test_asyncpg.py
@@ -10,6 +10,7 @@ The tests use the following credentials to establish a database connection.
 """
 
 import os
+import threading
 
 
 PG_HOST = os.getenv("SENTRY_PYTHON_TEST_POSTGRES_HOST", "localhost")
@@ -20,12 +21,12 @@ PG_NAME_BASE = os.getenv("SENTRY_PYTHON_TEST_POSTGRES_NAME", "postgres")
 
 
 def _get_db_name():
-    """Get database name, using worker ID for parallel test isolation."""
-    # Check if we're running with pytest-xdist (parallel execution)
-    worker_id = os.getenv("PYTEST_XDIST_WORKER")
-    if worker_id:
-        return f"{PG_NAME_BASE}_{worker_id}"
-    return PG_NAME_BASE
+    """Get database name, using worker/process ID for parallel test isolation."""
+    # For tox parallel execution or other parallel scenarios, use process ID
+    # This ensures each process gets its own database
+    pid = os.getpid()
+    thread_id = threading.get_ident()
+    return f"{PG_NAME_BASE}_{pid}_{thread_id}"
 
 
 PG_NAME = _get_db_name()

--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,7 @@
 # The file (and all resulting CI YAMLs) then need to be regenerated via
 # "scripts/generate-test-files.sh".
 #
-# Last generated: 2025-09-04T09:02:27.457083+00:00
+# Last generated: 2025-09-04T09:55:59.328948+00:00
 
 [tox]
 requires =
@@ -154,8 +154,8 @@ envlist =
 
 
     # ~~~ DBs ~~~
-    {py3.6,py3.8,py3.9}-asyncpg-v0.23.0
-    {py3.6,py3.9,py3.10}-asyncpg-v0.25.0
+    {py3.7,py3.8,py3.9}-asyncpg-v0.23.0
+    {py3.7,py3.9,py3.10}-asyncpg-v0.25.0
     {py3.7,py3.9,py3.10}-asyncpg-v0.27.0
     {py3.8,py3.11,py3.12}-asyncpg-v0.30.0
 

--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,7 @@
 # The file (and all resulting CI YAMLs) then need to be regenerated via
 # "scripts/generate-test-files.sh".
 #
-# Last generated: 2025-09-04T12:41:07.285452+00:00
+# Last generated: 2025-09-04T12:49:06.316162+00:00
 
 [tox]
 requires =
@@ -150,8 +150,8 @@ envlist =
 
 
     # ~~~ DBs ~~~
-    {py3.6,py3.8,py3.9}-asyncpg-v0.23.0
-    {py3.6,py3.9,py3.10}-asyncpg-v0.25.0
+    {py3.7,py3.8,py3.9}-asyncpg-v0.23.0
+    {py3.7,py3.9,py3.10}-asyncpg-v0.25.0
     {py3.7,py3.9,py3.10}-asyncpg-v0.27.0
     {py3.8,py3.11,py3.12}-asyncpg-v0.30.0
 

--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,7 @@
 # The file (and all resulting CI YAMLs) then need to be regenerated via
 # "scripts/generate-test-files.sh".
 #
-# Last generated: 2025-09-04T07:00:53.509946+00:00
+# Last generated: 2025-09-04T09:02:27.457083+00:00
 
 [tox]
 requires =
@@ -38,10 +38,6 @@ envlist =
 
     # Asgi
     {py3.7,py3.12,py3.13}-asgi
-
-    # asyncpg
-    {py3.7,py3.10}-asyncpg-v{0.23}
-    {py3.8,py3.11,py3.12}-asyncpg-latest
 
     # AWS Lambda
     {py3.8,py3.9,py3.11,py3.13}-aws_lambda
@@ -158,6 +154,11 @@ envlist =
 
 
     # ~~~ DBs ~~~
+    {py3.6,py3.8,py3.9}-asyncpg-v0.23.0
+    {py3.6,py3.9,py3.10}-asyncpg-v0.25.0
+    {py3.7,py3.9,py3.10}-asyncpg-v0.27.0
+    {py3.8,py3.11,py3.12}-asyncpg-v0.30.0
+
     {py3.7,py3.11,py3.12}-clickhouse_driver-v0.2.9
 
     {py3.6}-pymongo-v3.5.1
@@ -358,11 +359,6 @@ deps =
     asgi: pytest-asyncio
     asgi: async-asgi-testclient
 
-    # Asyncpg
-    asyncpg-v0.23: asyncpg~=0.23.0
-    asyncpg-latest: asyncpg
-    asyncpg: pytest-asyncio
-
     # AWS Lambda
     aws_lambda: aws-cdk-lib
     aws_lambda: aws-sam-cli
@@ -541,6 +537,12 @@ deps =
 
 
     # ~~~ DBs ~~~
+    asyncpg-v0.23.0: asyncpg==0.23.0
+    asyncpg-v0.25.0: asyncpg==0.25.0
+    asyncpg-v0.27.0: asyncpg==0.27.0
+    asyncpg-v0.30.0: asyncpg==0.30.0
+    asyncpg: pytest-asyncio
+
     clickhouse_driver-v0.2.9: clickhouse-driver==0.2.9
 
     pymongo-v3.5.1: pymongo==3.5.1


### PR DESCRIPTION
- remove hardcoded asyncpg config, let toxgen take care of generating it
- isolate DB so that multiple asyncpg test suites for different envs can run at the same time without touching the same DB
- update instructions on running the test suite locally


Ref https://github.com/getsentry/sentry-python/issues/4506