### PR TITLE
feat(ai): automatically wrap the root span for several AI/Agent frameworks in a transaction

### DIFF
--- a/sentry_sdk/ai/utils.py
+++ b/sentry_sdk/ai/utils.py
@@ -1,8 +1,9 @@
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from typing import Any
+    from typing import Any, Callable
 
+import sentry_sdk
 from sentry_sdk.tracing import Span
 from sentry_sdk.utils import logger
 
@@ -34,3 +35,12 @@ def set_data_normalized(span, key, value, unpack=True):
         span.set_data(key, normalized)
     else:
         span.set_data(key, str(normalized))
+
+
+def get_start_span_function():
+    # type: () -> Callable[..., Any]
+    current_span = sentry_sdk.get_current_span()
+    transaction_exists = (
+        current_span is not None and current_span.containing_transaction == current_span
+    )
+    return sentry_sdk.start_span if transaction_exists else sentry_sdk.start_transaction

--- a/sentry_sdk/integrations/anthropic.py
+++ b/sentry_sdk/integrations/anthropic.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING
 
 import sentry_sdk
 from sentry_sdk.ai.monitoring import record_token_usage
-from sentry_sdk.ai.utils import set_data_normalized
+from sentry_sdk.ai.utils import set_data_normalized, get_start_span_function
 from sentry_sdk.consts import OP, SPANDATA
 from sentry_sdk.integrations import _check_minimum_version, DidNotEnable, Integration
 from sentry_sdk.scope import should_send_default_pii
@@ -194,7 +194,7 @@ def _sentry_patched_create_common(f, *args, **kwargs):
 
     model = kwargs.get("model", "")
 
-    span = sentry_sdk.start_span(
+    span = get_start_span_function()(
         op=OP.GEN_AI_CHAT,
         name=f"chat {model}".strip(),
         origin=AnthropicIntegration.origin,

--- a/sentry_sdk/integrations/langchain.py
+++ b/sentry_sdk/integrations/langchain.py
@@ -4,7 +4,7 @@ from functools import wraps
 
 import sentry_sdk
 from sentry_sdk.ai.monitoring import set_ai_pipeline_name
-from sentry_sdk.ai.utils import set_data_normalized
+from sentry_sdk.ai.utils import set_data_normalized, get_start_span_function
 from sentry_sdk.consts import OP, SPANDATA
 from sentry_sdk.integrations import DidNotEnable, Integration
 from sentry_sdk.scope import should_send_default_pii
@@ -626,8 +626,9 @@ def _wrap_agent_executor_invoke(f):
             return f(self, *args, **kwargs)
 
         agent_name, tools = _get_request_data(self, args, kwargs)
+        start_span_function = get_start_span_function()
 
-        with sentry_sdk.start_span(
+        with start_span_function(
             op=OP.GEN_AI_INVOKE_AGENT,
             name=f"invoke_agent {agent_name}" if agent_name else "invoke_agent",
             origin=LangchainIntegration.origin,
@@ -684,8 +685,9 @@ def _wrap_agent_executor_stream(f):
             return f(self, *args, **kwargs)
 
         agent_name, tools = _get_request_data(self, args, kwargs)
+        start_span_function = get_start_span_function()
 
-        span = sentry_sdk.start_span(
+        span = start_span_function(
             op=OP.GEN_AI_INVOKE_AGENT,
             name=f"invoke_agent {agent_name}".strip(),
             origin=LangchainIntegration.origin,

--- a/sentry_sdk/integrations/openai_agents/spans/agent_workflow.py
+++ b/sentry_sdk/integrations/openai_agents/spans/agent_workflow.py
@@ -1,7 +1,7 @@
 import sentry_sdk
+from sentry_sdk.ai.utils import get_start_span_function
 
 from ..consts import SPAN_ORIGIN
-from ..utils import _get_start_span_function
 
 from typing import TYPE_CHECKING
 
@@ -13,7 +13,7 @@ def agent_workflow_span(agent):
     # type: (agents.Agent) -> sentry_sdk.tracing.Span
 
     # Create a transaction or a span if an transaction is already active
-    span = _get_start_span_function()(
+    span = get_start_span_function()(
         name=f"{agent.name} workflow",
         origin=SPAN_ORIGIN,
     )

--- a/sentry_sdk/integrations/openai_agents/spans/invoke_agent.py
+++ b/sentry_sdk/integrations/openai_agents/spans/invoke_agent.py
@@ -1,5 +1,6 @@
 import sentry_sdk
 from sentry_sdk.consts import OP, SPANDATA
+from sentry_sdk.ai.utils import get_start_span_function
 
 from ..consts import SPAN_ORIGIN
 from ..utils import _set_agent_data
@@ -13,7 +14,8 @@ if TYPE_CHECKING:
 
 def invoke_agent_span(context, agent):
     # type: (agents.RunContextWrapper, agents.Agent) -> sentry_sdk.tracing.Span
-    span = sentry_sdk.start_span(
+    start_span_function = get_start_span_function()
+    span = start_span_function(
         op=OP.GEN_AI_INVOKE_AGENT,
         name=f"invoke_agent {agent.name}",
         origin=SPAN_ORIGIN,

--- a/sentry_sdk/integrations/openai_agents/utils.py
+++ b/sentry_sdk/integrations/openai_agents/utils.py
@@ -8,7 +8,6 @@ from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from typing import Any
-    from typing import Callable
     from agents import Usage
 
 try:
@@ -26,15 +25,6 @@ def _capture_exception(exc):
         mechanism={"type": "openai_agents", "handled": False},
     )
     sentry_sdk.capture_event(event, hint=hint)
-
-
-def _get_start_span_function():
-    # type: () -> Callable[..., Any]
-    current_span = sentry_sdk.get_current_span()
-    transaction_exists = (
-        current_span is not None and current_span.containing_transaction == current_span
-    )
-    return sentry_sdk.start_span if transaction_exists else sentry_sdk.start_transaction
 
 
 def _set_agent_data(span, agent):


### PR DESCRIPTION
This includes:
 - anthropic: message.create
 - langchain: 'invoke_agent' spans
 - openai_agent: 'invoke_agent' spans + agent workflow (which was already like that)


Closes https://linear.app/getsentry/issue/TET-1048/auto-wrap-gen-aiinvoke-agent-if-no-transaction-in-scope