### PR TITLE
tests: Move quart under toxgen

### DIFF
--- a/.github/workflows/test-integrations-web-2.yml
+++ b/.github/workflows/test-integrations-web-2.yml
@@ -29,7 +29,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8","3.9","3.12","3.13"]
+        python-version: ["3.9","3.12","3.13"]
         # python3.6 reached EOL and is no longer being supported on
         # new versions of hosted runners on Github Actions
         # ubuntu-20.04 is the last version that supported python3.6

--- a/scripts/populate_tox/config.py
+++ b/scripts/populate_tox/config.py
@@ -236,7 +236,7 @@ TEST_SUITE_CONFIG = {
         "package": "quart",
         "deps": {
             "*": ["quart-auth", "pytest-asyncio", "Werkzeug"],
-            "<0.19": [
+            "<0.18": [
                 "blinker<1.6",
                 "jinja2<3.1.0",
                 "Werkzeug<2.1.0",

--- a/scripts/populate_tox/config.py
+++ b/scripts/populate_tox/config.py
@@ -232,6 +232,19 @@ TEST_SUITE_CONFIG = {
             "*": ["werkzeug<2.1.0"],
         },
     },
+    "quart": {
+        "package": "quart",
+        "deps": {
+            "*": ["quart-auth", "pytest-asyncio", "Werkzeug"],
+            "<0.19": [
+                "blinker<1.6",
+                "jinja2<3.1.0",
+                "Werkzeug<2.1.0",
+                "hypercorn<0.15.0",
+            ],
+            "py3.8": ["taskgroup==0.0.0a4"],
+        },
+    },
     "redis_py_cluster_legacy": {
         "package": "redis-py-cluster",
     },

--- a/scripts/populate_tox/config.py
+++ b/scripts/populate_tox/config.py
@@ -236,6 +236,7 @@ TEST_SUITE_CONFIG = {
         "package": "quart",
         "deps": {
             "*": ["quart-auth", "pytest-asyncio", "Werkzeug"],
+            ">=0.19": ["quart-flask-patch"],
             "<0.19": [
                 "blinker<1.6",
                 "jinja2<3.1.0",

--- a/scripts/populate_tox/config.py
+++ b/scripts/populate_tox/config.py
@@ -236,10 +236,10 @@ TEST_SUITE_CONFIG = {
         "package": "quart",
         "deps": {
             "*": ["quart-auth", "pytest-asyncio", "Werkzeug"],
-            "<0.18": [
+            "<0.19": [
                 "blinker<1.6",
                 "jinja2<3.1.0",
-                "Werkzeug<2.1.0",
+                "Werkzeug<2.3.0",
                 "hypercorn<0.15.0",
             ],
             "py3.8": ["taskgroup==0.0.0a4"],

--- a/scripts/populate_tox/populate_tox.py
+++ b/scripts/populate_tox/populate_tox.py
@@ -57,7 +57,8 @@ IGNORE = {
     # pypi package to install in different versions).
     #
     # Test suites that will have to remain hardcoded since they don't fit the
-    # toxgen usecase
+    # toxgen usecase (there is no one package that should be tested in different
+    # versions)
     "asgi",
     "aws_lambda",
     "cloud_resource_context",
@@ -70,7 +71,6 @@ IGNORE = {
     "gcp",
     "httpx",
     "pure_eval",
-    "quart",
     "ray",
     "redis",
     "requests",

--- a/scripts/populate_tox/tox.jinja
+++ b/scripts/populate_tox/tox.jinja
@@ -64,11 +64,6 @@ envlist =
     # pure_eval
     {py3.6,py3.12,py3.13}-pure_eval
 
-    # Quart
-    {py3.7,py3.11}-quart-v{0.16}
-    {py3.8,py3.11,py3.12}-quart-v{0.19}
-    {py3.8,py3.12,py3.13}-quart-latest
-
     # Ray
     {py3.10,py3.11}-ray-v{2.34}
     {py3.10,py3.11}-ray-latest
@@ -183,20 +178,6 @@ deps =
 
     # pure_eval
     pure_eval: pure_eval
-
-    # Quart
-    quart: quart-auth
-    quart: pytest-asyncio
-    quart-{v0.19,latest}: quart-flask-patch
-    quart-v0.16: blinker<1.6
-    quart-v0.16: jinja2<3.1.0
-    quart-v0.16: Werkzeug<2.1.0
-    quart-v0.16: hypercorn<0.15.0
-    quart-v0.16: quart~=0.16.0
-    quart-v0.19: Werkzeug>=3.0.0
-    quart-v0.19: quart~=0.19.0
-    {py3.8}-quart: taskgroup==0.0.0a4
-    quart-latest: quart
 
     # Ray
     ray-v2.34: ray~=2.34.0

--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,7 @@
 # The file (and all resulting CI YAMLs) then need to be regenerated via
 # "scripts/generate-test-files.sh".
 #
-# Last generated: 2025-09-08T11:30:25.607331+00:00
+# Last generated: 2025-09-08T11:35:09.849536+00:00
 
 [tox]
 requires =
@@ -63,11 +63,6 @@ envlist =
 
     # pure_eval
     {py3.6,py3.12,py3.13}-pure_eval
-
-    # Quart
-    {py3.7,py3.11}-quart-v{0.16}
-    {py3.8,py3.11,py3.12}-quart-v{0.19}
-    {py3.8,py3.12,py3.13}-quart-latest
 
     # Ray
     {py3.10,py3.11}-ray-v{2.34}
@@ -407,20 +402,6 @@ deps =
 
     # pure_eval
     pure_eval: pure_eval
-
-    # Quart
-    quart: quart-auth
-    quart: pytest-asyncio
-    quart-{v0.19,latest}: quart-flask-patch
-    quart-v0.16: blinker<1.6
-    quart-v0.16: jinja2<3.1.0
-    quart-v0.16: Werkzeug<2.1.0
-    quart-v0.16: hypercorn<0.15.0
-    quart-v0.16: quart~=0.16.0
-    quart-v0.19: Werkzeug>=3.0.0
-    quart-v0.19: quart~=0.19.0
-    {py3.8}-quart: taskgroup==0.0.0a4
-    quart-latest: quart
 
     # Ray
     ray-v2.34: ray~=2.34.0
@@ -786,6 +767,7 @@ deps =
     quart: quart-auth
     quart: pytest-asyncio
     quart: Werkzeug
+    quart-v0.20.0: quart-flask-patch
     quart-v0.16.3: blinker<1.6
     quart-v0.16.3: jinja2<3.1.0
     quart-v0.16.3: Werkzeug<2.3.0

--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,7 @@
 # The file (and all resulting CI YAMLs) then need to be regenerated via
 # "scripts/generate-test-files.sh".
 #
-# Last generated: 2025-09-08T07:57:05.055231+00:00
+# Last generated: 2025-09-08T08:08:36.384197+00:00
 
 [tox]
 requires =
@@ -788,12 +788,16 @@ deps =
     quart: Werkzeug
     quart-v0.16.3: blinker<1.6
     quart-v0.16.3: jinja2<3.1.0
-    quart-v0.16.3: Werkzeug<2.1.0
+    quart-v0.16.3: Werkzeug<2.3.0
     quart-v0.16.3: hypercorn<0.15.0
     quart-v0.17.0: blinker<1.6
     quart-v0.17.0: jinja2<3.1.0
-    quart-v0.17.0: Werkzeug<2.1.0
+    quart-v0.17.0: Werkzeug<2.3.0
     quart-v0.17.0: hypercorn<0.15.0
+    quart-v0.18.4: blinker<1.6
+    quart-v0.18.4: jinja2<3.1.0
+    quart-v0.18.4: Werkzeug<2.3.0
+    quart-v0.18.4: hypercorn<0.15.0
     {py3.8}-quart: taskgroup==0.0.0a4
 
     starlite-v1.48.1: starlite==1.48.1

--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,7 @@
 # The file (and all resulting CI YAMLs) then need to be regenerated via
 # "scripts/generate-test-files.sh".
 #
-# Last generated: 2025-09-05T07:52:27.350774+00:00
+# Last generated: 2025-09-08T07:42:19.779461+00:00
 
 [tox]
 requires =
@@ -128,8 +128,8 @@ envlist =
     {py3.8,py3.11,py3.12}-openai-notiktoken-v1.71.0
     {py3.8,py3.12,py3.13}-openai-notiktoken-v1.106.1
 
-    {py3.9,py3.12,py3.13}-langgraph-v0.6.6
-    {py3.10,py3.12,py3.13}-langgraph-v1.0.0a2
+    {py3.9,py3.12,py3.13}-langgraph-v0.6.7
+    {py3.10,py3.12,py3.13}-langgraph-v1.0.0a3
 
     {py3.10,py3.11,py3.12}-openai_agents-v0.0.19
     {py3.10,py3.12,py3.13}-openai_agents-v0.1.0
@@ -146,7 +146,7 @@ envlist =
     {py3.6,py3.7}-boto3-v1.12.49
     {py3.6,py3.9,py3.10}-boto3-v1.20.54
     {py3.7,py3.11,py3.12}-boto3-v1.28.85
-    {py3.9,py3.12,py3.13}-boto3-v1.40.24
+    {py3.9,py3.12,py3.13}-boto3-v1.40.25
 
     {py3.6,py3.7,py3.8}-chalice-v1.16.0
     {py3.6,py3.7,py3.8}-chalice-v1.21.9
@@ -205,7 +205,7 @@ envlist =
     {py3.6,py3.9,py3.10}-gql-v3.4.1
     {py3.7,py3.11,py3.12}-gql-v3.5.3
     {py3.9,py3.12,py3.13}-gql-v4.0.0
-    {py3.9,py3.12,py3.13}-gql-v4.1.0b0
+    {py3.9,py3.12,py3.13}-gql-v4.2.0b0
 
     {py3.6,py3.9,py3.10}-graphene-v3.3
     {py3.8,py3.12,py3.13}-graphene-v3.4.3
@@ -213,7 +213,7 @@ envlist =
     {py3.8,py3.10,py3.11}-strawberry-v0.209.8
     {py3.8,py3.11,py3.12}-strawberry-v0.233.3
     {py3.9,py3.12,py3.13}-strawberry-v0.257.0
-    {py3.9,py3.12,py3.13}-strawberry-v0.281.0
+    {py3.9,py3.12,py3.13}-strawberry-v0.282.0
 
 
     # ~~~ Network ~~~
@@ -251,7 +251,7 @@ envlist =
 
     {py3.8,py3.9}-spark-v3.0.3
     {py3.8,py3.10,py3.11}-spark-v3.5.6
-    {py3.9,py3.12,py3.13}-spark-v4.0.0
+    {py3.9,py3.12,py3.13}-spark-v4.0.1
 
 
     # ~~~ Web 1 ~~~
@@ -302,6 +302,11 @@ envlist =
     {py3.6,py3.8,py3.9}-pyramid-v1.10.8
     {py3.6,py3.10,py3.11}-pyramid-v2.0.2
 
+    {py3.7,py3.9,py3.10}-quart-v0.16.3
+    {py3.7,py3.9,py3.10}-quart-v0.17.0
+    {py3.7,py3.10,py3.11}-quart-v0.18.4
+    {py3.9,py3.12,py3.13}-quart-v0.20.0
+
     {py3.8,py3.10,py3.11}-starlite-v1.48.1
     {py3.8,py3.10,py3.11}-starlite-v1.49.0
     {py3.8,py3.10,py3.11}-starlite-v1.50.2
@@ -325,7 +330,7 @@ envlist =
 
     {py3.7,py3.12,py3.13}-typer-v0.15.4
     {py3.7,py3.12,py3.13}-typer-v0.16.1
-    {py3.7,py3.12,py3.13}-typer-v0.17.3
+    {py3.7,py3.12,py3.13}-typer-v0.17.4
 
 
 
@@ -515,8 +520,8 @@ deps =
     openai-notiktoken-v1.0.1: httpx<0.28
     openai-notiktoken-v1.36.1: httpx<0.28
 
-    langgraph-v0.6.6: langgraph==0.6.6
-    langgraph-v1.0.0a2: langgraph==1.0.0a2
+    langgraph-v0.6.7: langgraph==0.6.7
+    langgraph-v1.0.0a3: langgraph==1.0.0a3
 
     openai_agents-v0.0.19: openai-agents==0.0.19
     openai_agents-v0.1.0: openai-agents==0.1.0
@@ -534,7 +539,7 @@ deps =
     boto3-v1.12.49: boto3==1.12.49
     boto3-v1.20.54: boto3==1.20.54
     boto3-v1.28.85: boto3==1.28.85
-    boto3-v1.40.24: boto3==1.40.24
+    boto3-v1.40.25: boto3==1.40.25
     {py3.7,py3.8}-boto3: urllib3<2.0.0
 
     chalice-v1.16.0: chalice==1.16.0
@@ -601,7 +606,7 @@ deps =
     gql-v3.4.1: gql[all]==3.4.1
     gql-v3.5.3: gql[all]==3.5.3
     gql-v4.0.0: gql[all]==4.0.0
-    gql-v4.1.0b0: gql[all]==4.1.0b0
+    gql-v4.2.0b0: gql[all]==4.2.0b0
 
     graphene-v3.3: graphene==3.3
     graphene-v3.4.3: graphene==3.4.3
@@ -614,7 +619,7 @@ deps =
     strawberry-v0.209.8: strawberry-graphql[fastapi,flask]==0.209.8
     strawberry-v0.233.3: strawberry-graphql[fastapi,flask]==0.233.3
     strawberry-v0.257.0: strawberry-graphql[fastapi,flask]==0.257.0
-    strawberry-v0.281.0: strawberry-graphql[fastapi,flask]==0.281.0
+    strawberry-v0.282.0: strawberry-graphql[fastapi,flask]==0.282.0
     strawberry: httpx
     strawberry-v0.209.8: pydantic<2.11
     strawberry-v0.233.3: pydantic<2.11
@@ -667,7 +672,7 @@ deps =
 
     spark-v3.0.3: pyspark==3.0.3
     spark-v3.5.6: pyspark==3.5.6
-    spark-v4.0.0: pyspark==4.0.0
+    spark-v4.0.1: pyspark==4.0.1
 
 
     # ~~~ Web 1 ~~~
@@ -774,6 +779,27 @@ deps =
     pyramid-v2.0.2: pyramid==2.0.2
     pyramid: werkzeug<2.1.0
 
+    quart-v0.16.3: quart==0.16.3
+    quart-v0.17.0: quart==0.17.0
+    quart-v0.18.4: quart==0.18.4
+    quart-v0.20.0: quart==0.20.0
+    quart: quart-auth
+    quart: pytest-asyncio
+    quart: Werkzeug
+    quart-v0.16.3: blinker<1.6
+    quart-v0.16.3: jinja2<3.1.0
+    quart-v0.16.3: Werkzeug<2.1.0
+    quart-v0.16.3: hypercorn<0.15.0
+    quart-v0.17.0: blinker<1.6
+    quart-v0.17.0: jinja2<3.1.0
+    quart-v0.17.0: Werkzeug<2.1.0
+    quart-v0.17.0: hypercorn<0.15.0
+    quart-v0.18.4: blinker<1.6
+    quart-v0.18.4: jinja2<3.1.0
+    quart-v0.18.4: Werkzeug<2.1.0
+    quart-v0.18.4: hypercorn<0.15.0
+    {py3.8}-quart: taskgroup==0.0.0a4
+
     starlite-v1.48.1: starlite==1.48.1
     starlite-v1.49.0: starlite==1.49.0
     starlite-v1.50.2: starlite==1.50.2
@@ -810,7 +836,7 @@ deps =
 
     typer-v0.15.4: typer==0.15.4
     typer-v0.16.1: typer==0.16.1
-    typer-v0.17.3: typer==0.17.3
+    typer-v0.17.4: typer==0.17.4
 
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,7 @@
 # The file (and all resulting CI YAMLs) then need to be regenerated via
 # "scripts/generate-test-files.sh".
 #
-# Last generated: 2025-09-08T07:42:19.779461+00:00
+# Last generated: 2025-09-08T07:57:05.055231+00:00
 
 [tox]
 requires =
@@ -794,10 +794,6 @@ deps =
     quart-v0.17.0: jinja2<3.1.0
     quart-v0.17.0: Werkzeug<2.1.0
     quart-v0.17.0: hypercorn<0.15.0
-    quart-v0.18.4: blinker<1.6
-    quart-v0.18.4: jinja2<3.1.0
-    quart-v0.18.4: Werkzeug<2.1.0
-    quart-v0.18.4: hypercorn<0.15.0
     {py3.8}-quart: taskgroup==0.0.0a4
 
     starlite-v1.48.1: starlite==1.48.1


### PR DESCRIPTION
Other updates got pulled in when regenerating the test matrix; if we merge https://github.com/getsentry/sentry-python/pull/4777 before them I can rebase this to only contain quart.

Ref https://github.com/getsentry/sentry-python/issues/4506