### PR TITLE
feat(integrations): Support gql 4.0-style execute

### DIFF
--- a/sentry_sdk/integrations/gql.py
+++ b/sentry_sdk/integrations/gql.py
@@ -140,7 +140,7 @@ def _make_gql_event_processor(client, document_or_request):
             if GraphQLRequest is not None and isinstance(
                 document_or_request, GraphQLRequest
             ):
-                # In v4.0.0, execute moved to GraphQLRequest instead of
+                # In v4.0.0, gql moved to using GraphQLRequest instead of
                 # DocumentNode in execute
                 # https://github.com/graphql-python/gql/pull/556
                 document = document_or_request.document

--- a/sentry_sdk/integrations/gql.py
+++ b/sentry_sdk/integrations/gql.py
@@ -21,7 +21,7 @@ try:
 
     try:
         # gql 4.0+
-        from gql import GraphQLRequest  # type: ignore[import-not-found]
+        from gql import GraphQLRequest
     except ImportError:
         GraphQLRequest = None
 


### PR DESCRIPTION
gql 4.0 [changed](https://github.com/graphql-python/gql/pull/556/files) the signature of the `execute` function which we were patching. Instead of a `DocumentNode` it now gets a `GraphQLRequest` (which contains the `document` attribute with the `DocumentNode`). This means we need to update the way we're extracting additional data in the event processor.