### PR TITLE
Add log message when `DedupeIntegration` is dropping an error.

### DIFF
--- a/sentry_sdk/integrations/dedupe.py
+++ b/sentry_sdk/integrations/dedupe.py
@@ -1,5 +1,5 @@
 import sentry_sdk
-from sentry_sdk.utils import ContextVar
+from sentry_sdk.utils import ContextVar, logger
 from sentry_sdk.integrations import Integration
 from sentry_sdk.scope import add_global_event_processor
 
@@ -37,7 +37,9 @@ class DedupeIntegration(Integration):
 
             exc = exc_info[1]
             if integration._last_seen.get(None) is exc:
+                logger.info("DedupeIntegration dropped duplicated error event %s", exc)
                 return None
+
             integration._last_seen.set(exc)
             return event
 


### PR DESCRIPTION
Make it clearer for the user what is happening.

resolves: PY-1840