### PR TITLE
fix(typing): Make event processor types consistent

### DIFF
--- a/sentry_sdk/integrations/arq.py
+++ b/sentry_sdk/integrations/arq.py
@@ -134,7 +134,7 @@ def _capture_exception(exc_info):
 def _make_event_processor(ctx, *args, **kwargs):
     # type: (Dict[Any, Any], *Any, **Any) -> EventProcessor
     def event_processor(event, hint):
-        # type: (Event, Hint) -> Optional[Event]
+        # type: (Event, Hint) -> Event
 
         with capture_internal_exceptions():
             scope = sentry_sdk.get_current_scope()

--- a/sentry_sdk/integrations/asgi.py
+++ b/sentry_sdk/integrations/asgi.py
@@ -270,7 +270,7 @@ class SentryAsgiMiddleware:
             _asgi_middleware_applied.set(False)
 
     def event_processor(self, event, hint, asgi_scope):
-        # type: (Event, Hint, Any) -> Optional[Event]
+        # type: (Event, Hint, Any) -> Event
         request_data = event.get("request", {})
         request_data.update(_get_request_data(asgi_scope))
         event["request"] = deepcopy(request_data)

--- a/sentry_sdk/integrations/aws_lambda.py
+++ b/sentry_sdk/integrations/aws_lambda.py
@@ -334,7 +334,7 @@ def _make_request_event_processor(aws_event, aws_context, configured_timeout):
     start_time = datetime.now(timezone.utc)
 
     def event_processor(sentry_event, hint, start_time=start_time):
-        # type: (Event, Hint, datetime) -> Optional[Event]
+        # type: (Event, Hint, datetime) -> Event
         remaining_time_in_milis = aws_context.get_remaining_time_in_millis()
         exec_duration = configured_timeout - remaining_time_in_milis
 

--- a/sentry_sdk/integrations/dramatiq.py
+++ b/sentry_sdk/integrations/dramatiq.py
@@ -17,8 +17,8 @@ from dramatiq.errors import Retry  # type: ignore
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from typing import Any, Callable, Dict, Optional, Union
-    from sentry_sdk._types import Event, Hint
+    from typing import Any, Dict, Optional, Union
+    from sentry_sdk._types import Event, Hint, EventProcessor
 
 
 class DramatiqIntegration(Integration):
@@ -128,10 +128,10 @@ class SentryMiddleware(Middleware):  # type: ignore[misc]
 
 
 def _make_message_event_processor(message, integration):
-    # type: (Message, DramatiqIntegration) -> Callable[[Event, Hint], Optional[Event]]
+    # type: (Message, DramatiqIntegration) -> EventProcessor
 
     def inner(event, hint):
-        # type: (Event, Hint) -> Optional[Event]
+        # type: (Event, Hint) -> Event
         with capture_internal_exceptions():
             DramatiqMessageExtractor(message).extract_into_event(event)
 

--- a/sentry_sdk/integrations/fastapi.py
+++ b/sentry_sdk/integrations/fastapi.py
@@ -11,8 +11,8 @@ from sentry_sdk.utils import transaction_from_function
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from typing import Any, Callable, Dict
-    from sentry_sdk._types import Event
+    from typing import Any, Dict
+    from sentry_sdk._types import Event, EventProcessor
 
 try:
     from sentry_sdk.integrations.starlette import (
@@ -112,7 +112,7 @@ def patch_get_request_handler():
             info = await extractor.extract_request_info()
 
             def _make_request_event_processor(req, integration):
-                # type: (Any, Any) -> Callable[[Event, Dict[str, Any]], Event]
+                # type: (Any, Any) -> EventProcessor
                 def event_processor(event, hint):
                     # type: (Event, Dict[str, Any]) -> Event
 

--- a/sentry_sdk/integrations/gcp.py
+++ b/sentry_sdk/integrations/gcp.py
@@ -30,7 +30,6 @@ if TYPE_CHECKING:
     from typing import Any
     from typing import TypeVar
     from typing import Callable
-    from typing import Optional
 
     from sentry_sdk._types import EventProcessor, Event, Hint
 
@@ -154,7 +153,7 @@ def _make_request_event_processor(gcp_event, configured_timeout, initial_time):
     # type: (Any, Any, Any) -> EventProcessor
 
     def event_processor(event, hint):
-        # type: (Event, Hint) -> Optional[Event]
+        # type: (Event, Hint) -> Event
 
         final_time = datetime.now(timezone.utc)
         time_diff = final_time - initial_time

--- a/sentry_sdk/integrations/huey.py
+++ b/sentry_sdk/integrations/huey.py
@@ -78,7 +78,7 @@ def patch_enqueue():
 def _make_event_processor(task):
     # type: (Any) -> EventProcessor
     def event_processor(event, hint):
-        # type: (Event, Hint) -> Optional[Event]
+        # type: (Event, Hint) -> Event
 
         with capture_internal_exceptions():
             tags = event.setdefault("tags", {})

--- a/sentry_sdk/integrations/spark/spark_driver.py
+++ b/sentry_sdk/integrations/spark/spark_driver.py
@@ -60,7 +60,7 @@ def _add_event_processor(sc):
 
     @scope.add_event_processor
     def process_event(event, hint):
-        # type: (Event, Hint) -> Optional[Event]
+        # type: (Event, Hint) -> Event
         with capture_internal_exceptions():
             if sentry_sdk.get_client().get_integration(SparkIntegration) is None:
                 return event

--- a/sentry_sdk/integrations/spark/spark_worker.py
+++ b/sentry_sdk/integrations/spark/spark_worker.py
@@ -68,7 +68,7 @@ def _tag_task_context():
 
     @scope.add_event_processor
     def process_event(event, hint):
-        # type: (Event, Hint) -> Optional[Event]
+        # type: (Event, Hint) -> Event
         with capture_internal_exceptions():
             integration = sentry_sdk.get_client().get_integration(
                 SparkWorkerIntegration

--- a/sentry_sdk/integrations/starlette.py
+++ b/sentry_sdk/integrations/starlette.py
@@ -38,7 +38,7 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from typing import Any, Awaitable, Callable, Container, Dict, Optional, Tuple, Union
 
-    from sentry_sdk._types import Event, HttpStatusCodeRange
+    from sentry_sdk._types import Event, HttpStatusCodeRange, EventProcessor
 
 try:
     import starlette  # type: ignore
@@ -454,7 +454,7 @@ def patch_request_response():
                 info = await extractor.extract_request_info()
 
                 def _make_request_event_processor(req, integration):
-                    # type: (Any, Any) -> Callable[[Event, dict[str, Any]], Event]
+                    # type: (Any, Any) -> EventProcessor
                     def event_processor(event, hint):
                         # type: (Event, Dict[str, Any]) -> Event
 


### PR DESCRIPTION
Some of the event processors in our integrations have a return type of `Event` when they never return `None`, while others keep the more general `Optional[Event]`. Returning `Event` where possible allows us to see at a glance that the event processors set by the integration cannot drop an event.

Also make use of the `EventProcessor` in a few more places.