### PR TITLE
feat: Add action to run toxgen periodically

### DIFF
--- a/.github/workflows/update-tox.yml
+++ b/.github/workflows/update-tox.yml
@@ -65,7 +65,7 @@ jobs:
             ## How it works
             - Scan PyPI for all supported releases of all frameworks we have a dedicated test suite for.
             - Pick a representative sample of releases to run our test suite against. We always test the latest and oldest supported version.
-            - Update tox.ini with the new releases.
+            - Update [tox.ini](tox.ini) with the new releases.
 
             ## Action required
             - If CI passes on this PR, it's safe to approve and merge. It means our integrations can handle new versions of frameworks that got pulled in.
@@ -73,6 +73,7 @@ jobs:
                 - Check what the failures look like and either fix them, or update the [test config](scripts/populate_tox/config.py) and rerun [scripts/generate-test-files.sh](scripts/generate-test-files.sh). See [README.md](scripts/populate_tox/README.md) for what configuration options are available.
 
              _____________________
+
             _🤖 This PR was automatically created using [a GitHub action](.github/workflows/update-tox.yml)._`.replace(/^ {16}/gm, '')
 
             // Close existing toxgen PRs as they're now obsolete


### PR DESCRIPTION
### Description

Run `scripts/generate-test-files.sh` in a GitHub action every Monday morning and create a PR with the changes. If there are already any toxgen PRs open, close them.

Here's an example run of the action: https://github.com/sentrivana/sentry-python/actions/runs/17768312844 (from a fork of the repo so that I can test it)
And an example PR: https://github.com/sentrivana/sentry-python/pull/6

Action shamelessly stolen and adapted from sentry-cli. 🥔 

#### Issues
Closes https://github.com/getsentry/sentry-python/issues/4050

#### Reminders
- Please add tests to validate your changes, and lint your code using `tox -e linters`.
- Add GH Issue ID _&_ Linear ID (if applicable)
- PR title should use [conventional commit](https://develop.sentry.dev/engineering-practices/commit-messages/#type) style (`feat:`, `fix:`, `ref:`, `meta:`)
- For external contributors: [CONTRIBUTING.md](../CONTRIBUTING.md), [Sentry SDK development docs](https://develop.sentry.dev/sdk/), [Discord community](https://discord.gg/Ww9hbqr)
