### PR TITLE
fix: Fix links to files in toxgen PRs

### DIFF
--- a/.github/workflows/update-tox.yml
+++ b/.github/workflows/update-tox.yml
@@ -65,16 +65,16 @@ jobs:
             ## How it works
             - Scan PyPI for all supported releases of all frameworks we have a dedicated test suite for.
             - Pick a representative sample of releases to run our test suite against. We always test the latest and oldest supported version.
-            - Update [tox.ini](tox.ini) with the new releases.
+            - Update [tox.ini](https://github.com/getsentry/sentry-python/blob/master/tox.ini) with the new releases.
 
             ## Action required
             - If CI passes on this PR, it's safe to approve and merge. It means our integrations can handle new versions of frameworks that got pulled in.
             - If CI doesn't pass on this PR, this points to an incompatibility of either our integration or our test setup with a new version of a framework.
-                - Check what the failures look like and either fix them, or update the [test config](scripts/populate_tox/config.py) and rerun [scripts/generate-test-files.sh](scripts/generate-test-files.sh). See [README.md](scripts/populate_tox/README.md) for what configuration options are available.
+                - Check what the failures look like and either fix them, or update the [test config](https://github.com/getsentry/sentry-python/blob/master/scripts/populate_tox/config.py) and rerun [scripts/generate-test-files.sh](https://github.com/getsentry/sentry-python/blob/master/scripts/generate-test-files.sh). See [scripts/populate_tox/README.md](https://github.com/getsentry/sentry-python/blob/master/scripts/populate_tox/README.md) for what configuration options are available.
 
              _____________________
 
-            _🤖 This PR was automatically created using [a GitHub action](.github/workflows/update-tox.yml)._`.replace(/^ {16}/gm, '')
+            _🤖 This PR was automatically created using [a GitHub action](https://github.com/getsentry/sentry-python/blob/master/.github/workflows/update-tox.yml)._`.replace(/^ {16}/gm, '')
 
             // Close existing toxgen PRs as they're now obsolete
 


### PR DESCRIPTION
### Description
The toxgen PR template contains links to files in the repo, but they were broken, fixing that here.

#### Issues
<!--
* resolves: #1234
* resolves: LIN-1234
-->

#### Reminders
- Please add tests to validate your changes, and lint your code using `tox -e linters`.
- Add GH Issue ID _&_ Linear ID (if applicable)
- PR title should use [conventional commit](https://develop.sentry.dev/engineering-practices/commit-messages/#type) style (`feat:`, `fix:`, `ref:`, `meta:`)
- For external contributors: [CONTRIBUTING.md](../CONTRIBUTING.md), [Sentry SDK development docs](https://develop.sentry.dev/sdk/), [Discord community](https://discord.gg/Ww9hbqr)
