### PR TITLE
tests: Move pure_eval under toxgen

### DIFF
--- a/scripts/populate_tox/config.py
+++ b/scripts/populate_tox/config.py
@@ -224,6 +224,9 @@ TEST_SUITE_CONFIG = {
     "openfeature": {
         "package": "openfeature-sdk",
     },
+    "pure_eval": {
+        "package": "pure_eval",
+    },
     "pymongo": {
         "package": "pymongo",
         "deps": {

--- a/scripts/populate_tox/populate_tox.py
+++ b/scripts/populate_tox/populate_tox.py
@@ -70,7 +70,6 @@ IGNORE = {
     # of these from the IGNORE list
     "gcp",
     "httpx",
-    "pure_eval",
     "ray",
     "redis",
     "requests",

--- a/scripts/populate_tox/tox.jinja
+++ b/scripts/populate_tox/tox.jinja
@@ -61,9 +61,6 @@ envlist =
     # OpenTelemetry Experimental (POTel)
     {py3.8,py3.9,py3.10,py3.11,py3.12,py3.13}-potel
 
-    # pure_eval
-    {py3.6,py3.12,py3.13}-pure_eval
-
     # Ray
     {py3.10,py3.11}-ray-v{2.34}
     {py3.10,py3.11}-ray-latest
@@ -176,9 +173,6 @@ deps =
 
     # OpenTelemetry Experimental (POTel)
     potel: -e .[opentelemetry-experimental]
-
-    # pure_eval
-    pure_eval: pure_eval
 
     # Ray
     ray-v2.34: ray~=2.34.0

--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,7 @@
 # The file (and all resulting CI YAMLs) then need to be regenerated via
 # "scripts/generate-test-files.sh".
 #
-# Last generated: 2025-09-17T07:20:17.058541+00:00
+# Last generated: 2025-09-17T14:43:06.969007+00:00
 
 [tox]
 requires =
@@ -60,9 +60,6 @@ envlist =
 
     # OpenTelemetry Experimental (POTel)
     {py3.8,py3.9,py3.10,py3.11,py3.12,py3.13}-potel
-
-    # pure_eval
-    {py3.6,py3.12,py3.13}-pure_eval
 
     # Ray
     {py3.10,py3.11}-ray-v{2.34}
@@ -317,6 +314,10 @@ envlist =
     # ~~~ Misc ~~~
     {py3.6,py3.12,py3.13}-loguru-v0.7.3
 
+    {py3.6,py3.7,py3.8}-pure_eval-v0.0.3
+    {py3.6,py3.8,py3.9}-pure_eval-v0.1.1
+    {py3.7,py3.12,py3.13}-pure_eval-v0.2.3
+
     {py3.6}-trytond-v4.6.22
     {py3.6}-trytond-v4.8.18
     {py3.6,py3.7,py3.8}-trytond-v5.8.16
@@ -401,9 +402,6 @@ deps =
 
     # OpenTelemetry Experimental (POTel)
     potel: -e .[opentelemetry-experimental]
-
-    # pure_eval
-    pure_eval: pure_eval
 
     # Ray
     ray-v2.34: ray~=2.34.0
@@ -808,6 +806,10 @@ deps =
 
     # ~~~ Misc ~~~
     loguru-v0.7.3: loguru==0.7.3
+
+    pure_eval-v0.0.3: pure_eval==0.0.3
+    pure_eval-v0.1.1: pure_eval==0.1.1
+    pure_eval-v0.2.3: pure_eval==0.2.3
 
     trytond-v4.6.22: trytond==4.6.22
     trytond-v4.8.18: trytond==4.8.18


### PR DESCRIPTION
### Description
- moved pure_eval under toxgen

#### Issues
Ref https://github.com/getsentry/sentry-python/issues/4506

#### Reminders
- Please add tests to validate your changes, and lint your code using `tox -e linters`.
- Add GH Issue ID _&_ Linear ID (if applicable)
- PR title should use [conventional commit](https://develop.sentry.dev/engineering-practices/commit-messages/#type) style (`feat:`, `fix:`, `ref:`, `meta:`)
- For external contributors: [CONTRIBUTING.md](https://github.com/getsentry/sentry-python/blob/master/CONTRIBUTING.md), [Sentry SDK development docs](https://develop.sentry.dev/sdk/), [Discord community](https://discord.gg/Ww9hbqr)
