### PR TITLE
test(spark): Improve `test_spark` speed

### DIFF
--- a/tests/integrations/spark/test_spark.py
+++ b/tests/integrations/spark/test_spark.py
@@ -28,11 +28,12 @@ def sentry_init_with_reset(sentry_init):
     _processed_integrations.discard("spark")
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture(scope="session")
 def create_spark_context():
     conf = SparkConf().set("spark.driver.bindAddress", "127.0.0.1")
-    yield lambda: SparkContext(conf=conf, appName="Testing123")
-    SparkContext._active_spark_context.stop()
+    sc = SparkContext(conf=conf, appName="Testing123")
+    yield lambda: sc
+    sc.stop()
 
 
 def test_set_app_properties(create_spark_context):
@@ -61,12 +62,18 @@ def test_start_sentry_listener(create_spark_context):
 def test_initialize_spark_integration_before_spark_context_init(
     mock_patch_spark_context_init,
     sentry_init_with_reset,
-    create_spark_context,
 ):
-    sentry_init_with_reset()
-    create_spark_context()
+    # As we are using the same SparkContext connection for the whole session,
+    # we clean it during this test.
+    original_context = SparkContext._active_spark_context
+    SparkContext._active_spark_context = None
 
-    mock_patch_spark_context_init.assert_called_once()
+    try:
+        sentry_init_with_reset()
+        mock_patch_spark_context_init.assert_called_once()
+    finally:
+        # Restore the original one.
+        SparkContext._active_spark_context = original_context
 
 
 @patch("sentry_sdk.integrations.spark.spark_driver._activate_integration")


### PR DESCRIPTION
Fixes GH-4623

### Description
I'm trying to improve the `test_spark.py` speed using the same Spark connection in the entire test session.

In my local it has passed from <img width="149" height="21" alt="image" src="https://github.com/user-attachments/assets/4fd339c5-ef01-4bf8-b032-731e5faecc2a" /> to <img width="151" height="20" alt="image" src="https://github.com/user-attachments/assets/480e71ba-f313-460d-beb3-3cd0dbcb50ac" />