### PR TITLE
tests: Remove old system for checking for regressions

### DIFF
--- a/.github/workflows/test-integrations-ai.yml
+++ b/.github/workflows/test-integrations-ai.yml
@@ -22,8 +22,8 @@ env:
   CACHED_BUILD_PATHS: |
     ${{ github.workspace }}/dist-serverless
 jobs:
-  test-ai-pinned:
-    name: AI (pinned)
+  test-ai:
+    name: AI
     timeout-minutes: 30
     runs-on: ${{ matrix.os }}
     strategy:
@@ -50,42 +50,42 @@ jobs:
       - name: Erase coverage
         run: |
           coverage erase
-      - name: Test anthropic pinned
+      - name: Test anthropic
         run: |
           set -x # print commands that are executed
-          ./scripts/runtox.sh --exclude-latest "py${{ matrix.python-version }}-anthropic"
-      - name: Test cohere pinned
+          ./scripts/runtox.sh "py${{ matrix.python-version }}-anthropic"
+      - name: Test cohere
         run: |
           set -x # print commands that are executed
-          ./scripts/runtox.sh --exclude-latest "py${{ matrix.python-version }}-cohere"
-      - name: Test langchain-base pinned
+          ./scripts/runtox.sh "py${{ matrix.python-version }}-cohere"
+      - name: Test langchain-base
         run: |
           set -x # print commands that are executed
-          ./scripts/runtox.sh --exclude-latest "py${{ matrix.python-version }}-langchain-base"
-      - name: Test langchain-notiktoken pinned
+          ./scripts/runtox.sh "py${{ matrix.python-version }}-langchain-base"
+      - name: Test langchain-notiktoken
         run: |
           set -x # print commands that are executed
-          ./scripts/runtox.sh --exclude-latest "py${{ matrix.python-version }}-langchain-notiktoken"
-      - name: Test openai-base pinned
+          ./scripts/runtox.sh "py${{ matrix.python-version }}-langchain-notiktoken"
+      - name: Test openai-base
         run: |
           set -x # print commands that are executed
-          ./scripts/runtox.sh --exclude-latest "py${{ matrix.python-version }}-openai-base"
-      - name: Test openai-notiktoken pinned
+          ./scripts/runtox.sh "py${{ matrix.python-version }}-openai-base"
+      - name: Test openai-notiktoken
         run: |
           set -x # print commands that are executed
-          ./scripts/runtox.sh --exclude-latest "py${{ matrix.python-version }}-openai-notiktoken"
-      - name: Test langgraph pinned
+          ./scripts/runtox.sh "py${{ matrix.python-version }}-openai-notiktoken"
+      - name: Test langgraph
         run: |
           set -x # print commands that are executed
-          ./scripts/runtox.sh --exclude-latest "py${{ matrix.python-version }}-langgraph"
-      - name: Test openai_agents pinned
+          ./scripts/runtox.sh "py${{ matrix.python-version }}-langgraph"
+      - name: Test openai_agents
         run: |
           set -x # print commands that are executed
-          ./scripts/runtox.sh --exclude-latest "py${{ matrix.python-version }}-openai_agents"
-      - name: Test huggingface_hub pinned
+          ./scripts/runtox.sh "py${{ matrix.python-version }}-openai_agents"
+      - name: Test huggingface_hub
         run: |
           set -x # print commands that are executed
-          ./scripts/runtox.sh --exclude-latest "py${{ matrix.python-version }}-huggingface_hub"
+          ./scripts/runtox.sh "py${{ matrix.python-version }}-huggingface_hub"
       - name: Generate coverage XML (Python 3.6)
         if: ${{ !cancelled() && matrix.python-version == '3.6' }}
         run: |
@@ -115,7 +115,6 @@ jobs:
           verbose: true
   check_required_tests:
     name: All pinned AI tests passed
-    needs: test-ai-pinned
     # Always run this, even if a dependent job failed
     if: always()
     runs-on: ubuntu-22.04

--- a/.github/workflows/test-integrations-ai.yml
+++ b/.github/workflows/test-integrations-ai.yml
@@ -114,12 +114,13 @@ jobs:
           files: .junitxml
           verbose: true
   check_required_tests:
-    name: All pinned AI tests passed
+    name: All AI tests passed
+    needs: test-ai
     # Always run this, even if a dependent job failed
     if: always()
     runs-on: ubuntu-22.04
     steps:
       - name: Check for failures
-        if: needs.test-ai-pinned.result != 'success'
+        if: needs.test-ai.result != 'success'
         run: |
           echo "One of the dependent jobs has failed. You may need to re-run it." && exit 1

--- a/.github/workflows/test-integrations-cloud.yml
+++ b/.github/workflows/test-integrations-cloud.yml
@@ -22,8 +22,8 @@ env:
   CACHED_BUILD_PATHS: |
     ${{ github.workspace }}/dist-serverless
 jobs:
-  test-cloud-pinned:
-    name: Cloud (pinned)
+  test-cloud:
+    name: Cloud
     timeout-minutes: 30
     runs-on: ${{ matrix.os }}
     strategy:
@@ -54,26 +54,26 @@ jobs:
       - name: Erase coverage
         run: |
           coverage erase
-      - name: Test aws_lambda pinned
+      - name: Test aws_lambda
         run: |
           set -x # print commands that are executed
-          ./scripts/runtox.sh --exclude-latest "py${{ matrix.python-version }}-aws_lambda"
-      - name: Test boto3 pinned
+          ./scripts/runtox.sh "py${{ matrix.python-version }}-aws_lambda"
+      - name: Test boto3
         run: |
           set -x # print commands that are executed
-          ./scripts/runtox.sh --exclude-latest "py${{ matrix.python-version }}-boto3"
-      - name: Test chalice pinned
+          ./scripts/runtox.sh "py${{ matrix.python-version }}-boto3"
+      - name: Test chalice
         run: |
           set -x # print commands that are executed
-          ./scripts/runtox.sh --exclude-latest "py${{ matrix.python-version }}-chalice"
-      - name: Test cloud_resource_context pinned
+          ./scripts/runtox.sh "py${{ matrix.python-version }}-chalice"
+      - name: Test cloud_resource_context
         run: |
           set -x # print commands that are executed
-          ./scripts/runtox.sh --exclude-latest "py${{ matrix.python-version }}-cloud_resource_context"
-      - name: Test gcp pinned
+          ./scripts/runtox.sh "py${{ matrix.python-version }}-cloud_resource_context"
+      - name: Test gcp
         run: |
           set -x # print commands that are executed
-          ./scripts/runtox.sh --exclude-latest "py${{ matrix.python-version }}-gcp"
+          ./scripts/runtox.sh "py${{ matrix.python-version }}-gcp"
       - name: Generate coverage XML (Python 3.6)
         if: ${{ !cancelled() && matrix.python-version == '3.6' }}
         run: |
@@ -103,7 +103,6 @@ jobs:
           verbose: true
   check_required_tests:
     name: All pinned Cloud tests passed
-    needs: test-cloud-pinned
     # Always run this, even if a dependent job failed
     if: always()
     runs-on: ubuntu-22.04

--- a/.github/workflows/test-integrations-cloud.yml
+++ b/.github/workflows/test-integrations-cloud.yml
@@ -102,12 +102,13 @@ jobs:
           files: .junitxml
           verbose: true
   check_required_tests:
-    name: All pinned Cloud tests passed
+    name: All Cloud tests passed
+    needs: test-cloud
     # Always run this, even if a dependent job failed
     if: always()
     runs-on: ubuntu-22.04
     steps:
       - name: Check for failures
-        if: needs.test-cloud-pinned.result != 'success'
+        if: needs.test-cloud.result != 'success'
         run: |
           echo "One of the dependent jobs has failed. You may need to re-run it." && exit 1

--- a/.github/workflows/test-integrations-common.yml
+++ b/.github/workflows/test-integrations-common.yml
@@ -82,12 +82,13 @@ jobs:
           files: .junitxml
           verbose: true
   check_required_tests:
-    name: All pinned Common tests passed
+    name: All Common tests passed
+    needs: test-common
     # Always run this, even if a dependent job failed
     if: always()
     runs-on: ubuntu-22.04
     steps:
       - name: Check for failures
-        if: needs.test-common-pinned.result != 'success'
+        if: needs.test-common.result != 'success'
         run: |
           echo "One of the dependent jobs has failed. You may need to re-run it." && exit 1

--- a/.github/workflows/test-integrations-common.yml
+++ b/.github/workflows/test-integrations-common.yml
@@ -22,8 +22,8 @@ env:
   CACHED_BUILD_PATHS: |
     ${{ github.workspace }}/dist-serverless
 jobs:
-  test-common-pinned:
-    name: Common (pinned)
+  test-common:
+    name: Common
     timeout-minutes: 30
     runs-on: ${{ matrix.os }}
     strategy:
@@ -50,10 +50,10 @@ jobs:
       - name: Erase coverage
         run: |
           coverage erase
-      - name: Test common pinned
+      - name: Test common
         run: |
           set -x # print commands that are executed
-          ./scripts/runtox.sh --exclude-latest "py${{ matrix.python-version }}-common"
+          ./scripts/runtox.sh "py${{ matrix.python-version }}-common"
       - name: Generate coverage XML (Python 3.6)
         if: ${{ !cancelled() && matrix.python-version == '3.6' }}
         run: |
@@ -83,7 +83,6 @@ jobs:
           verbose: true
   check_required_tests:
     name: All pinned Common tests passed
-    needs: test-common-pinned
     # Always run this, even if a dependent job failed
     if: always()
     runs-on: ubuntu-22.04

--- a/.github/workflows/test-integrations-dbs.yml
+++ b/.github/workflows/test-integrations-dbs.yml
@@ -22,8 +22,8 @@ env:
   CACHED_BUILD_PATHS: |
     ${{ github.workspace }}/dist-serverless
 jobs:
-  test-dbs-pinned:
-    name: DBs (pinned)
+  test-dbs:
+    name: DBs
     timeout-minutes: 30
     runs-on: ${{ matrix.os }}
     strategy:
@@ -70,30 +70,30 @@ jobs:
       - name: Erase coverage
         run: |
           coverage erase
-      - name: Test asyncpg pinned
+      - name: Test asyncpg
         run: |
           set -x # print commands that are executed
-          ./scripts/runtox.sh --exclude-latest "py${{ matrix.python-version }}-asyncpg"
-      - name: Test clickhouse_driver pinned
+          ./scripts/runtox.sh "py${{ matrix.python-version }}-asyncpg"
+      - name: Test clickhouse_driver
         run: |
           set -x # print commands that are executed
-          ./scripts/runtox.sh --exclude-latest "py${{ matrix.python-version }}-clickhouse_driver"
-      - name: Test pymongo pinned
+          ./scripts/runtox.sh "py${{ matrix.python-version }}-clickhouse_driver"
+      - name: Test pymongo
         run: |
           set -x # print commands that are executed
-          ./scripts/runtox.sh --exclude-latest "py${{ matrix.python-version }}-pymongo"
-      - name: Test redis pinned
+          ./scripts/runtox.sh "py${{ matrix.python-version }}-pymongo"
+      - name: Test redis
         run: |
           set -x # print commands that are executed
-          ./scripts/runtox.sh --exclude-latest "py${{ matrix.python-version }}-redis"
-      - name: Test redis_py_cluster_legacy pinned
+          ./scripts/runtox.sh "py${{ matrix.python-version }}-redis"
+      - name: Test redis_py_cluster_legacy
         run: |
           set -x # print commands that are executed
-          ./scripts/runtox.sh --exclude-latest "py${{ matrix.python-version }}-redis_py_cluster_legacy"
-      - name: Test sqlalchemy pinned
+          ./scripts/runtox.sh "py${{ matrix.python-version }}-redis_py_cluster_legacy"
+      - name: Test sqlalchemy
         run: |
           set -x # print commands that are executed
-          ./scripts/runtox.sh --exclude-latest "py${{ matrix.python-version }}-sqlalchemy"
+          ./scripts/runtox.sh "py${{ matrix.python-version }}-sqlalchemy"
       - name: Generate coverage XML (Python 3.6)
         if: ${{ !cancelled() && matrix.python-version == '3.6' }}
         run: |
@@ -123,7 +123,6 @@ jobs:
           verbose: true
   check_required_tests:
     name: All pinned DBs tests passed
-    needs: test-dbs-pinned
     # Always run this, even if a dependent job failed
     if: always()
     runs-on: ubuntu-22.04

--- a/.github/workflows/test-integrations-dbs.yml
+++ b/.github/workflows/test-integrations-dbs.yml
@@ -122,12 +122,13 @@ jobs:
           files: .junitxml
           verbose: true
   check_required_tests:
-    name: All pinned DBs tests passed
+    name: All DBs tests passed
+    needs: test-dbs
     # Always run this, even if a dependent job failed
     if: always()
     runs-on: ubuntu-22.04
     steps:
       - name: Check for failures
-        if: needs.test-dbs-pinned.result != 'success'
+        if: needs.test-dbs.result != 'success'
         run: |
           echo "One of the dependent jobs has failed. You may need to re-run it." && exit 1

--- a/.github/workflows/test-integrations-flags.yml
+++ b/.github/workflows/test-integrations-flags.yml
@@ -22,8 +22,8 @@ env:
   CACHED_BUILD_PATHS: |
     ${{ github.workspace }}/dist-serverless
 jobs:
-  test-flags-pinned:
-    name: Flags (pinned)
+  test-flags:
+    name: Flags
     timeout-minutes: 30
     runs-on: ${{ matrix.os }}
     strategy:
@@ -50,22 +50,22 @@ jobs:
       - name: Erase coverage
         run: |
           coverage erase
-      - name: Test launchdarkly pinned
+      - name: Test launchdarkly
         run: |
           set -x # print commands that are executed
-          ./scripts/runtox.sh --exclude-latest "py${{ matrix.python-version }}-launchdarkly"
-      - name: Test openfeature pinned
+          ./scripts/runtox.sh "py${{ matrix.python-version }}-launchdarkly"
+      - name: Test openfeature
         run: |
           set -x # print commands that are executed
-          ./scripts/runtox.sh --exclude-latest "py${{ matrix.python-version }}-openfeature"
-      - name: Test statsig pinned
+          ./scripts/runtox.sh "py${{ matrix.python-version }}-openfeature"
+      - name: Test statsig
         run: |
           set -x # print commands that are executed
-          ./scripts/runtox.sh --exclude-latest "py${{ matrix.python-version }}-statsig"
-      - name: Test unleash pinned
+          ./scripts/runtox.sh "py${{ matrix.python-version }}-statsig"
+      - name: Test unleash
         run: |
           set -x # print commands that are executed
-          ./scripts/runtox.sh --exclude-latest "py${{ matrix.python-version }}-unleash"
+          ./scripts/runtox.sh "py${{ matrix.python-version }}-unleash"
       - name: Generate coverage XML (Python 3.6)
         if: ${{ !cancelled() && matrix.python-version == '3.6' }}
         run: |
@@ -95,7 +95,6 @@ jobs:
           verbose: true
   check_required_tests:
     name: All pinned Flags tests passed
-    needs: test-flags-pinned
     # Always run this, even if a dependent job failed
     if: always()
     runs-on: ubuntu-22.04

--- a/.github/workflows/test-integrations-flags.yml
+++ b/.github/workflows/test-integrations-flags.yml
@@ -94,12 +94,13 @@ jobs:
           files: .junitxml
           verbose: true
   check_required_tests:
-    name: All pinned Flags tests passed
+    name: All Flags tests passed
+    needs: test-flags
     # Always run this, even if a dependent job failed
     if: always()
     runs-on: ubuntu-22.04
     steps:
       - name: Check for failures
-        if: needs.test-flags-pinned.result != 'success'
+        if: needs.test-flags.result != 'success'
         run: |
           echo "One of the dependent jobs has failed. You may need to re-run it." && exit 1

--- a/.github/workflows/test-integrations-gevent.yml
+++ b/.github/workflows/test-integrations-gevent.yml
@@ -82,12 +82,13 @@ jobs:
           files: .junitxml
           verbose: true
   check_required_tests:
-    name: All pinned Gevent tests passed
+    name: All Gevent tests passed
+    needs: test-gevent
     # Always run this, even if a dependent job failed
     if: always()
     runs-on: ubuntu-22.04
     steps:
       - name: Check for failures
-        if: needs.test-gevent-pinned.result != 'success'
+        if: needs.test-gevent.result != 'success'
         run: |
           echo "One of the dependent jobs has failed. You may need to re-run it." && exit 1

--- a/.github/workflows/test-integrations-gevent.yml
+++ b/.github/workflows/test-integrations-gevent.yml
@@ -22,8 +22,8 @@ env:
   CACHED_BUILD_PATHS: |
     ${{ github.workspace }}/dist-serverless
 jobs:
-  test-gevent-pinned:
-    name: Gevent (pinned)
+  test-gevent:
+    name: Gevent
     timeout-minutes: 30
     runs-on: ${{ matrix.os }}
     strategy:
@@ -50,10 +50,10 @@ jobs:
       - name: Erase coverage
         run: |
           coverage erase
-      - name: Test gevent pinned
+      - name: Test gevent
         run: |
           set -x # print commands that are executed
-          ./scripts/runtox.sh --exclude-latest "py${{ matrix.python-version }}-gevent"
+          ./scripts/runtox.sh "py${{ matrix.python-version }}-gevent"
       - name: Generate coverage XML (Python 3.6)
         if: ${{ !cancelled() && matrix.python-version == '3.6' }}
         run: |
@@ -83,7 +83,6 @@ jobs:
           verbose: true
   check_required_tests:
     name: All pinned Gevent tests passed
-    needs: test-gevent-pinned
     # Always run this, even if a dependent job failed
     if: always()
     runs-on: ubuntu-22.04

--- a/.github/workflows/test-integrations-graphql.yml
+++ b/.github/workflows/test-integrations-graphql.yml
@@ -94,12 +94,13 @@ jobs:
           files: .junitxml
           verbose: true
   check_required_tests:
-    name: All pinned GraphQL tests passed
+    name: All GraphQL tests passed
+    needs: test-graphql
     # Always run this, even if a dependent job failed
     if: always()
     runs-on: ubuntu-22.04
     steps:
       - name: Check for failures
-        if: needs.test-graphql-pinned.result != 'success'
+        if: needs.test-graphql.result != 'success'
         run: |
           echo "One of the dependent jobs has failed. You may need to re-run it." && exit 1

--- a/.github/workflows/test-integrations-graphql.yml
+++ b/.github/workflows/test-integrations-graphql.yml
@@ -22,8 +22,8 @@ env:
   CACHED_BUILD_PATHS: |
     ${{ github.workspace }}/dist-serverless
 jobs:
-  test-graphql-pinned:
-    name: GraphQL (pinned)
+  test-graphql:
+    name: GraphQL
     timeout-minutes: 30
     runs-on: ${{ matrix.os }}
     strategy:
@@ -50,22 +50,22 @@ jobs:
       - name: Erase coverage
         run: |
           coverage erase
-      - name: Test ariadne pinned
+      - name: Test ariadne
         run: |
           set -x # print commands that are executed
-          ./scripts/runtox.sh --exclude-latest "py${{ matrix.python-version }}-ariadne"
-      - name: Test gql pinned
+          ./scripts/runtox.sh "py${{ matrix.python-version }}-ariadne"
+      - name: Test gql
         run: |
           set -x # print commands that are executed
-          ./scripts/runtox.sh --exclude-latest "py${{ matrix.python-version }}-gql"
-      - name: Test graphene pinned
+          ./scripts/runtox.sh "py${{ matrix.python-version }}-gql"
+      - name: Test graphene
         run: |
           set -x # print commands that are executed
-          ./scripts/runtox.sh --exclude-latest "py${{ matrix.python-version }}-graphene"
-      - name: Test strawberry pinned
+          ./scripts/runtox.sh "py${{ matrix.python-version }}-graphene"
+      - name: Test strawberry
         run: |
           set -x # print commands that are executed
-          ./scripts/runtox.sh --exclude-latest "py${{ matrix.python-version }}-strawberry"
+          ./scripts/runtox.sh "py${{ matrix.python-version }}-strawberry"
       - name: Generate coverage XML (Python 3.6)
         if: ${{ !cancelled() && matrix.python-version == '3.6' }}
         run: |
@@ -95,7 +95,6 @@ jobs:
           verbose: true
   check_required_tests:
     name: All pinned GraphQL tests passed
-    needs: test-graphql-pinned
     # Always run this, even if a dependent job failed
     if: always()
     runs-on: ubuntu-22.04

--- a/.github/workflows/test-integrations-misc.yml
+++ b/.github/workflows/test-integrations-misc.yml
@@ -102,12 +102,13 @@ jobs:
           files: .junitxml
           verbose: true
   check_required_tests:
-    name: All pinned Misc tests passed
+    name: All Misc tests passed
+    needs: test-misc
     # Always run this, even if a dependent job failed
     if: always()
     runs-on: ubuntu-22.04
     steps:
       - name: Check for failures
-        if: needs.test-misc-pinned.result != 'success'
+        if: needs.test-misc.result != 'success'
         run: |
           echo "One of the dependent jobs has failed. You may need to re-run it." && exit 1

--- a/.github/workflows/test-integrations-misc.yml
+++ b/.github/workflows/test-integrations-misc.yml
@@ -22,8 +22,8 @@ env:
   CACHED_BUILD_PATHS: |
     ${{ github.workspace }}/dist-serverless
 jobs:
-  test-misc-pinned:
-    name: Misc (pinned)
+  test-misc:
+    name: Misc
     timeout-minutes: 30
     runs-on: ${{ matrix.os }}
     strategy:
@@ -50,30 +50,30 @@ jobs:
       - name: Erase coverage
         run: |
           coverage erase
-      - name: Test loguru pinned
+      - name: Test loguru
         run: |
           set -x # print commands that are executed
-          ./scripts/runtox.sh --exclude-latest "py${{ matrix.python-version }}-loguru"
-      - name: Test opentelemetry pinned
+          ./scripts/runtox.sh "py${{ matrix.python-version }}-loguru"
+      - name: Test opentelemetry
         run: |
           set -x # print commands that are executed
-          ./scripts/runtox.sh --exclude-latest "py${{ matrix.python-version }}-opentelemetry"
-      - name: Test potel pinned
+          ./scripts/runtox.sh "py${{ matrix.python-version }}-opentelemetry"
+      - name: Test potel
         run: |
           set -x # print commands that are executed
-          ./scripts/runtox.sh --exclude-latest "py${{ matrix.python-version }}-potel"
-      - name: Test pure_eval pinned
+          ./scripts/runtox.sh "py${{ matrix.python-version }}-potel"
+      - name: Test pure_eval
         run: |
           set -x # print commands that are executed
-          ./scripts/runtox.sh --exclude-latest "py${{ matrix.python-version }}-pure_eval"
-      - name: Test trytond pinned
+          ./scripts/runtox.sh "py${{ matrix.python-version }}-pure_eval"
+      - name: Test trytond
         run: |
           set -x # print commands that are executed
-          ./scripts/runtox.sh --exclude-latest "py${{ matrix.python-version }}-trytond"
-      - name: Test typer pinned
+          ./scripts/runtox.sh "py${{ matrix.python-version }}-trytond"
+      - name: Test typer
         run: |
           set -x # print commands that are executed
-          ./scripts/runtox.sh --exclude-latest "py${{ matrix.python-version }}-typer"
+          ./scripts/runtox.sh "py${{ matrix.python-version }}-typer"
       - name: Generate coverage XML (Python 3.6)
         if: ${{ !cancelled() && matrix.python-version == '3.6' }}
         run: |
@@ -103,7 +103,6 @@ jobs:
           verbose: true
   check_required_tests:
     name: All pinned Misc tests passed
-    needs: test-misc-pinned
     # Always run this, even if a dependent job failed
     if: always()
     runs-on: ubuntu-22.04

--- a/.github/workflows/test-integrations-network.yml
+++ b/.github/workflows/test-integrations-network.yml
@@ -22,8 +22,8 @@ env:
   CACHED_BUILD_PATHS: |
     ${{ github.workspace }}/dist-serverless
 jobs:
-  test-network-pinned:
-    name: Network (pinned)
+  test-network:
+    name: Network
     timeout-minutes: 30
     runs-on: ${{ matrix.os }}
     strategy:
@@ -50,18 +50,18 @@ jobs:
       - name: Erase coverage
         run: |
           coverage erase
-      - name: Test grpc pinned
+      - name: Test grpc
         run: |
           set -x # print commands that are executed
-          ./scripts/runtox.sh --exclude-latest "py${{ matrix.python-version }}-grpc"
-      - name: Test httpx pinned
+          ./scripts/runtox.sh "py${{ matrix.python-version }}-grpc"
+      - name: Test httpx
         run: |
           set -x # print commands that are executed
-          ./scripts/runtox.sh --exclude-latest "py${{ matrix.python-version }}-httpx"
-      - name: Test requests pinned
+          ./scripts/runtox.sh "py${{ matrix.python-version }}-httpx"
+      - name: Test requests
         run: |
           set -x # print commands that are executed
-          ./scripts/runtox.sh --exclude-latest "py${{ matrix.python-version }}-requests"
+          ./scripts/runtox.sh "py${{ matrix.python-version }}-requests"
       - name: Generate coverage XML (Python 3.6)
         if: ${{ !cancelled() && matrix.python-version == '3.6' }}
         run: |
@@ -91,7 +91,6 @@ jobs:
           verbose: true
   check_required_tests:
     name: All pinned Network tests passed
-    needs: test-network-pinned
     # Always run this, even if a dependent job failed
     if: always()
     runs-on: ubuntu-22.04

--- a/.github/workflows/test-integrations-network.yml
+++ b/.github/workflows/test-integrations-network.yml
@@ -90,12 +90,13 @@ jobs:
           files: .junitxml
           verbose: true
   check_required_tests:
-    name: All pinned Network tests passed
+    name: All Network tests passed
+    needs: test-network
     # Always run this, even if a dependent job failed
     if: always()
     runs-on: ubuntu-22.04
     steps:
       - name: Check for failures
-        if: needs.test-network-pinned.result != 'success'
+        if: needs.test-network.result != 'success'
         run: |
           echo "One of the dependent jobs has failed. You may need to re-run it." && exit 1

--- a/.github/workflows/test-integrations-tasks.yml
+++ b/.github/workflows/test-integrations-tasks.yml
@@ -22,8 +22,8 @@ env:
   CACHED_BUILD_PATHS: |
     ${{ github.workspace }}/dist-serverless
 jobs:
-  test-tasks-pinned:
-    name: Tasks (pinned)
+  test-tasks:
+    name: Tasks
     timeout-minutes: 30
     runs-on: ${{ matrix.os }}
     strategy:
@@ -57,38 +57,38 @@ jobs:
       - name: Erase coverage
         run: |
           coverage erase
-      - name: Test arq pinned
+      - name: Test arq
         run: |
           set -x # print commands that are executed
-          ./scripts/runtox.sh --exclude-latest "py${{ matrix.python-version }}-arq"
-      - name: Test beam pinned
+          ./scripts/runtox.sh "py${{ matrix.python-version }}-arq"
+      - name: Test beam
         run: |
           set -x # print commands that are executed
-          ./scripts/runtox.sh --exclude-latest "py${{ matrix.python-version }}-beam"
-      - name: Test celery pinned
+          ./scripts/runtox.sh "py${{ matrix.python-version }}-beam"
+      - name: Test celery
         run: |
           set -x # print commands that are executed
-          ./scripts/runtox.sh --exclude-latest "py${{ matrix.python-version }}-celery"
-      - name: Test dramatiq pinned
+          ./scripts/runtox.sh "py${{ matrix.python-version }}-celery"
+      - name: Test dramatiq
         run: |
           set -x # print commands that are executed
-          ./scripts/runtox.sh --exclude-latest "py${{ matrix.python-version }}-dramatiq"
-      - name: Test huey pinned
+          ./scripts/runtox.sh "py${{ matrix.python-version }}-dramatiq"
+      - name: Test huey
         run: |
           set -x # print commands that are executed
-          ./scripts/runtox.sh --exclude-latest "py${{ matrix.python-version }}-huey"
-      - name: Test ray pinned
+          ./scripts/runtox.sh "py${{ matrix.python-version }}-huey"
+      - name: Test ray
         run: |
           set -x # print commands that are executed
-          ./scripts/runtox.sh --exclude-latest "py${{ matrix.python-version }}-ray"
-      - name: Test rq pinned
+          ./scripts/runtox.sh "py${{ matrix.python-version }}-ray"
+      - name: Test rq
         run: |
           set -x # print commands that are executed
-          ./scripts/runtox.sh --exclude-latest "py${{ matrix.python-version }}-rq"
-      - name: Test spark pinned
+          ./scripts/runtox.sh "py${{ matrix.python-version }}-rq"
+      - name: Test spark
         run: |
           set -x # print commands that are executed
-          ./scripts/runtox.sh --exclude-latest "py${{ matrix.python-version }}-spark"
+          ./scripts/runtox.sh "py${{ matrix.python-version }}-spark"
       - name: Generate coverage XML (Python 3.6)
         if: ${{ !cancelled() && matrix.python-version == '3.6' }}
         run: |
@@ -118,7 +118,6 @@ jobs:
           verbose: true
   check_required_tests:
     name: All pinned Tasks tests passed
-    needs: test-tasks-pinned
     # Always run this, even if a dependent job failed
     if: always()
     runs-on: ubuntu-22.04

--- a/.github/workflows/test-integrations-tasks.yml
+++ b/.github/workflows/test-integrations-tasks.yml
@@ -117,12 +117,13 @@ jobs:
           files: .junitxml
           verbose: true
   check_required_tests:
-    name: All pinned Tasks tests passed
+    name: All Tasks tests passed
+    needs: test-tasks
     # Always run this, even if a dependent job failed
     if: always()
     runs-on: ubuntu-22.04
     steps:
       - name: Check for failures
-        if: needs.test-tasks-pinned.result != 'success'
+        if: needs.test-tasks.result != 'success'
         run: |
           echo "One of the dependent jobs has failed. You may need to re-run it." && exit 1

--- a/.github/workflows/test-integrations-web-1.yml
+++ b/.github/workflows/test-integrations-web-1.yml
@@ -112,12 +112,13 @@ jobs:
           files: .junitxml
           verbose: true
   check_required_tests:
-    name: All pinned Web 1 tests passed
+    name: All Web 1 tests passed
+    needs: test-web_1
     # Always run this, even if a dependent job failed
     if: always()
     runs-on: ubuntu-22.04
     steps:
       - name: Check for failures
-        if: needs.test-web_1-pinned.result != 'success'
+        if: needs.test-web_1.result != 'success'
         run: |
           echo "One of the dependent jobs has failed. You may need to re-run it." && exit 1

--- a/.github/workflows/test-integrations-web-1.yml
+++ b/.github/workflows/test-integrations-web-1.yml
@@ -22,8 +22,8 @@ env:
   CACHED_BUILD_PATHS: |
     ${{ github.workspace }}/dist-serverless
 jobs:
-  test-web_1-pinned:
-    name: Web 1 (pinned)
+  test-web_1:
+    name: Web 1
     timeout-minutes: 30
     runs-on: ${{ matrix.os }}
     strategy:
@@ -68,22 +68,22 @@ jobs:
       - name: Erase coverage
         run: |
           coverage erase
-      - name: Test django pinned
+      - name: Test django
         run: |
           set -x # print commands that are executed
-          ./scripts/runtox.sh --exclude-latest "py${{ matrix.python-version }}-django"
-      - name: Test flask pinned
+          ./scripts/runtox.sh "py${{ matrix.python-version }}-django"
+      - name: Test flask
         run: |
           set -x # print commands that are executed
-          ./scripts/runtox.sh --exclude-latest "py${{ matrix.python-version }}-flask"
-      - name: Test starlette pinned
+          ./scripts/runtox.sh "py${{ matrix.python-version }}-flask"
+      - name: Test starlette
         run: |
           set -x # print commands that are executed
-          ./scripts/runtox.sh --exclude-latest "py${{ matrix.python-version }}-starlette"
-      - name: Test fastapi pinned
+          ./scripts/runtox.sh "py${{ matrix.python-version }}-starlette"
+      - name: Test fastapi
         run: |
           set -x # print commands that are executed
-          ./scripts/runtox.sh --exclude-latest "py${{ matrix.python-version }}-fastapi"
+          ./scripts/runtox.sh "py${{ matrix.python-version }}-fastapi"
       - name: Generate coverage XML (Python 3.6)
         if: ${{ !cancelled() && matrix.python-version == '3.6' }}
         run: |
@@ -113,7 +113,6 @@ jobs:
           verbose: true
   check_required_tests:
     name: All pinned Web 1 tests passed
-    needs: test-web_1-pinned
     # Always run this, even if a dependent job failed
     if: always()
     runs-on: ubuntu-22.04

--- a/.github/workflows/test-integrations-web-2.yml
+++ b/.github/workflows/test-integrations-web-2.yml
@@ -22,8 +22,8 @@ env:
   CACHED_BUILD_PATHS: |
     ${{ github.workspace }}/dist-serverless
 jobs:
-  test-web_2-pinned:
-    name: Web 2 (pinned)
+  test-web_2:
+    name: Web 2
     timeout-minutes: 30
     runs-on: ${{ matrix.os }}
     strategy:
@@ -50,46 +50,46 @@ jobs:
       - name: Erase coverage
         run: |
           coverage erase
-      - name: Test aiohttp pinned
+      - name: Test aiohttp
         run: |
           set -x # print commands that are executed
-          ./scripts/runtox.sh --exclude-latest "py${{ matrix.python-version }}-aiohttp"
-      - name: Test asgi pinned
+          ./scripts/runtox.sh "py${{ matrix.python-version }}-aiohttp"
+      - name: Test asgi
         run: |
           set -x # print commands that are executed
-          ./scripts/runtox.sh --exclude-latest "py${{ matrix.python-version }}-asgi"
-      - name: Test bottle pinned
+          ./scripts/runtox.sh "py${{ matrix.python-version }}-asgi"
+      - name: Test bottle
         run: |
           set -x # print commands that are executed
-          ./scripts/runtox.sh --exclude-latest "py${{ matrix.python-version }}-bottle"
-      - name: Test falcon pinned
+          ./scripts/runtox.sh "py${{ matrix.python-version }}-bottle"
+      - name: Test falcon
         run: |
           set -x # print commands that are executed
-          ./scripts/runtox.sh --exclude-latest "py${{ matrix.python-version }}-falcon"
-      - name: Test litestar pinned
+          ./scripts/runtox.sh "py${{ matrix.python-version }}-falcon"
+      - name: Test litestar
         run: |
           set -x # print commands that are executed
-          ./scripts/runtox.sh --exclude-latest "py${{ matrix.python-version }}-litestar"
-      - name: Test pyramid pinned
+          ./scripts/runtox.sh "py${{ matrix.python-version }}-litestar"
+      - name: Test pyramid
         run: |
           set -x # print commands that are executed
-          ./scripts/runtox.sh --exclude-latest "py${{ matrix.python-version }}-pyramid"
-      - name: Test quart pinned
+          ./scripts/runtox.sh "py${{ matrix.python-version }}-pyramid"
+      - name: Test quart
         run: |
           set -x # print commands that are executed
-          ./scripts/runtox.sh --exclude-latest "py${{ matrix.python-version }}-quart"
-      - name: Test sanic pinned
+          ./scripts/runtox.sh "py${{ matrix.python-version }}-quart"
+      - name: Test sanic
         run: |
           set -x # print commands that are executed
-          ./scripts/runtox.sh --exclude-latest "py${{ matrix.python-version }}-sanic"
-      - name: Test starlite pinned
+          ./scripts/runtox.sh "py${{ matrix.python-version }}-sanic"
+      - name: Test starlite
         run: |
           set -x # print commands that are executed
-          ./scripts/runtox.sh --exclude-latest "py${{ matrix.python-version }}-starlite"
-      - name: Test tornado pinned
+          ./scripts/runtox.sh "py${{ matrix.python-version }}-starlite"
+      - name: Test tornado
         run: |
           set -x # print commands that are executed
-          ./scripts/runtox.sh --exclude-latest "py${{ matrix.python-version }}-tornado"
+          ./scripts/runtox.sh "py${{ matrix.python-version }}-tornado"
       - name: Generate coverage XML (Python 3.6)
         if: ${{ !cancelled() && matrix.python-version == '3.6' }}
         run: |
@@ -119,7 +119,6 @@ jobs:
           verbose: true
   check_required_tests:
     name: All pinned Web 2 tests passed
-    needs: test-web_2-pinned
     # Always run this, even if a dependent job failed
     if: always()
     runs-on: ubuntu-22.04

--- a/.github/workflows/test-integrations-web-2.yml
+++ b/.github/workflows/test-integrations-web-2.yml
@@ -118,12 +118,13 @@ jobs:
           files: .junitxml
           verbose: true
   check_required_tests:
-    name: All pinned Web 2 tests passed
+    name: All Web 2 tests passed
+    needs: test-web_2
     # Always run this, even if a dependent job failed
     if: always()
     runs-on: ubuntu-22.04
     steps:
       - name: Check for failures
-        if: needs.test-web_2-pinned.result != 'success'
+        if: needs.test-web_2.result != 'success'
         run: |
           echo "One of the dependent jobs has failed. You may need to re-run it." && exit 1

--- a/scripts/populate_tox/populate_tox.py
+++ b/scripts/populate_tox/populate_tox.py
@@ -49,16 +49,8 @@ CLASSIFIER_PREFIX = "Programming Language :: Python :: "
 
 IGNORE = {
     # Do not try auto-generating the tox entries for these. They will be
-    # hardcoded in tox.ini.
-    #
-    # This set should be getting smaller over time as we migrate more test
-    # suites over to this script. Some entries will probably stay forever
-    # as they don't fit the mold (e.g. common, asgi, which don't have a 3rd party
-    # pypi package to install in different versions).
-    #
-    # Test suites that will have to remain hardcoded since they don't fit the
-    # toxgen usecase (there is no one package that should be tested in different
-    # versions)
+    # hardcoded in tox.ini since they don't fit the toxgen usecase (there is no
+    # one package that should be tested in different versions).
     "asgi",
     "aws_lambda",
     "cloud_resource_context",

--- a/scripts/runtox.sh
+++ b/scripts/runtox.sh
@@ -13,25 +13,9 @@ else
     TOXPATH=./.venv/bin/tox
 fi
 
-excludelatest=false
-for arg in "$@"
-do
-    if [ "$arg" = "--exclude-latest" ]; then
-        excludelatest=true
-        shift
-        break
-    fi
-done
-
 searchstring="$1"
 
-if $excludelatest; then
-    echo "Excluding latest"
-    ENV="$($TOXPATH -l | grep -- "$searchstring" | grep -v -- '-latest' | tr $'\n' ',')"
-else
-    echo "Including latest"
-    ENV="$($TOXPATH -l | grep -- "$searchstring" | tr $'\n' ',')"
-fi
+ENV="$($TOXPATH -l | grep -- "$searchstring" | tr $'\n' ',')"
 
 if [ -z "${ENV}" ]; then
     echo "No targets found. Skipping."

--- a/scripts/split_tox_gh_actions/split_tox_gh_actions.py
+++ b/scripts/split_tox_gh_actions/split_tox_gh_actions.py
@@ -29,7 +29,7 @@ from jinja2 import Environment, FileSystemLoader
 TOXENV_REGEX = re.compile(
     r"""
     {?(?P<py_versions>(py\d+\.\d+,?)+)}?
-    -(?P<framework>[a-z](?:[a-z_]|-(?!v{?\d|latest))*[a-z0-9])
+    -(?P<framework>[a-z](?:[a-z_]|-(?!v{?\d))*[a-z0-9])
     (?:-(
         (v{?(?P<framework_versions>[0-9.]+[0-9a-z,.]*}?))
     ))?

--- a/scripts/split_tox_gh_actions/split_tox_gh_actions.py
+++ b/scripts/split_tox_gh_actions/split_tox_gh_actions.py
@@ -32,8 +32,6 @@ TOXENV_REGEX = re.compile(
     -(?P<framework>[a-z](?:[a-z_]|-(?!v{?\d|latest))*[a-z0-9])
     (?:-(
         (v{?(?P<framework_versions>[0-9.]+[0-9a-z,.]*}?))
-        |
-        (?P<framework_versions_latest>latest)
     ))?
 """,
     re.VERBOSE,
@@ -167,13 +165,11 @@ def main(fail_on_changes):
         old_hash = get_files_hash()
 
     print("Parsing tox.ini...")
-    py_versions_pinned, py_versions_latest = parse_tox()
+    py_versions = parse_tox()
 
     if fail_on_changes:
         print("Checking if all frameworks belong in a group...")
-        missing_frameworks = find_frameworks_missing_from_groups(
-            py_versions_pinned, py_versions_latest
-        )
+        missing_frameworks = find_frameworks_missing_from_groups(py_versions)
         if missing_frameworks:
             raise RuntimeError(
                 "Please add the following frameworks to the corresponding group "
@@ -183,9 +179,7 @@ def main(fail_on_changes):
 
     print("Rendering templates...")
     for group, frameworks in GROUPS.items():
-        contents = render_template(
-            group, frameworks, py_versions_pinned, py_versions_latest
-        )
+        contents = render_template(group, frameworks, py_versions)
         filename = write_file(contents, group)
         print(f"Created {filename}")
 
@@ -213,8 +207,7 @@ def parse_tox():
         if line.strip() and not line.strip().startswith("#")
     ]
 
-    py_versions_pinned = defaultdict(set)
-    py_versions_latest = defaultdict(set)
+    py_versions = defaultdict(set)
 
     parsed_correctly = True
 
@@ -232,14 +225,10 @@ def parse_tox():
             groups = parsed.groupdict()
             raw_python_versions = groups["py_versions"]
             framework = groups["framework"]
-            framework_versions_latest = groups.get("framework_versions_latest") or False
 
             # collect python versions to test the framework in
             raw_python_versions = set(raw_python_versions.split(","))
-            if framework_versions_latest:
-                py_versions_latest[framework] |= raw_python_versions
-            else:
-                py_versions_pinned[framework] |= raw_python_versions
+            py_versions[framework] |= raw_python_versions
 
         except Exception:
             print(f"ERROR reading line {line}")
@@ -248,15 +237,14 @@ def parse_tox():
     if not parsed_correctly:
         raise RuntimeError("Failed to parse tox.ini")
 
-    py_versions_pinned = _normalize_py_versions(py_versions_pinned)
-    py_versions_latest = _normalize_py_versions(py_versions_latest)
+    py_versions = _normalize_py_versions(py_versions)
 
-    return py_versions_pinned, py_versions_latest
+    return py_versions
 
 
-def find_frameworks_missing_from_groups(py_versions_pinned, py_versions_latest):
+def find_frameworks_missing_from_groups(py_versions):
     frameworks_in_a_group = _union(GROUPS.values())
-    all_frameworks = set(py_versions_pinned.keys()) | set(py_versions_latest.keys())
+    all_frameworks = set(py_versions)
     return all_frameworks - frameworks_in_a_group
 
 
@@ -296,33 +284,26 @@ def _union(seq):
     return reduce(lambda x, y: set(x) | set(y), seq)
 
 
-def render_template(group, frameworks, py_versions_pinned, py_versions_latest):
+def render_template(group, frameworks, py_versions):
     template = ENV.get_template("base.jinja")
 
-    categories = set()
-    py_versions = defaultdict(set)
+    py_versions_final = set()
     for framework in frameworks:
-        if py_versions_pinned[framework]:
-            categories.add("pinned")
-            py_versions["pinned"] |= set(py_versions_pinned[framework])
-        if py_versions_latest[framework]:
-            categories.add("latest")
-            py_versions["latest"] |= set(py_versions_latest[framework])
+        py_versions_final |= set(py_versions[framework])
 
     context = {
         "group": group,
         "frameworks": frameworks,
-        "categories": sorted(categories),
         "needs_clickhouse": bool(set(frameworks) & FRAMEWORKS_NEEDING_CLICKHOUSE),
         "needs_docker": bool(set(frameworks) & FRAMEWORKS_NEEDING_DOCKER),
         "needs_postgres": bool(set(frameworks) & FRAMEWORKS_NEEDING_POSTGRES),
         "needs_redis": bool(set(frameworks) & FRAMEWORKS_NEEDING_REDIS),
         "needs_java": bool(set(frameworks) & FRAMEWORKS_NEEDING_JAVA),
-        "py_versions": {
-            category: [f'"{version}"' for version in _normalize_py_versions(versions)]
-            for category, versions in py_versions.items()
-        },
+        "py_versions": [
+            f'"{version}"' for version in _normalize_py_versions(py_versions_final)
+        ],
     }
+
     rendered = template.render(context)
     rendered = postprocess_template(rendered)
     return rendered

--- a/scripts/split_tox_gh_actions/templates/base.jinja
+++ b/scripts/split_tox_gh_actions/templates/base.jinja
@@ -30,9 +30,6 @@ env:
     {% raw %}${{ github.workspace }}/dist-serverless{% endraw %}
 
 jobs:
-{% for category in categories %}
 {% include "test_group.jinja" %}
-{% endfor %}
-
 {% include "check_required.jinja" %}
 {% endwith %}

--- a/scripts/split_tox_gh_actions/templates/check_required.jinja
+++ b/scripts/split_tox_gh_actions/templates/check_required.jinja
@@ -1,13 +1,11 @@
   check_required_tests:
-    name: All pinned {{ group }} tests passed
-    {% if "pinned" in categories %}
-    needs: test-{{ group | replace(" ", "_") | lower }}-pinned
-    {% endif %}
+    name: All {{ group }} tests passed
+    needs: test-{{ group | replace(" ", "_") | lower }}
     # Always run this, even if a dependent job failed
     if: always()
     runs-on: ubuntu-22.04
     steps:
       - name: Check for failures
-        if: needs.test-{{ lowercase_group }}-pinned.result != 'success'
+        if: needs.test-{{ lowercase_group }}.result != 'success'
         run: |
           echo "One of the dependent jobs has failed. You may need to re-run it." && exit 1

--- a/scripts/split_tox_gh_actions/templates/test_group.jinja
+++ b/scripts/split_tox_gh_actions/templates/test_group.jinja
@@ -1,11 +1,11 @@
-  test-{{ lowercase_group }}-{{ category }}:
-    name: {{ group }} ({{ category }})
+  test-{{ lowercase_group }}:
+    name: {{ group }}
     timeout-minutes: 30
     runs-on: {% raw %}${{ matrix.os }}{% endraw %}
     strategy:
       fail-fast: false
       matrix:
-        python-version: [{{ py_versions.get(category)|join(",") }}]
+        python-version: [{{ py_versions|join(",") }}]
         # python3.6 reached EOL and is no longer being supported on
         # new versions of hosted runners on Github Actions
         # ubuntu-20.04 is the last version that supported python3.6
@@ -75,14 +75,10 @@
           coverage erase
 
       {% for framework in frameworks %}
-      - name: Test {{ framework }} {{ category }}
+      - name: Test {{ framework }}
         run: |
           set -x # print commands that are executed
-          {% if category == "pinned" %}
-          ./scripts/runtox.sh --exclude-latest "{% raw %}py${{ matrix.python-version }}{% endraw %}-{{ framework }}"
-          {% elif category == "latest" %}
-          ./scripts/runtox.sh "{% raw %}py${{ matrix.python-version }}{% endraw %}-{{ framework }}-latest"
-          {% endif %}
+          ./scripts/runtox.sh "{% raw %}py${{ matrix.python-version }}{% endraw %}-{{ framework }}"
       {% endfor %}
 
       - name: Generate coverage XML (Python 3.6)

--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,7 @@
 # The file (and all resulting CI YAMLs) then need to be regenerated via
 # "scripts/generate-test-files.sh".
 #
-# Last generated: 2025-09-19T11:39:21.755227+00:00
+# Last generated: 2025-09-19T12:13:40.132261+00:00
 
 [tox]
 requires =


### PR DESCRIPTION
### Description

With all eligible test suites now moved to toxgen, we can remove our old way of testing for regressions in new versions of packages.

For context, before toxgen we had two groups of test targets for each test suite: pinned and latest. Pinned targets used to be a small selection of hand-picked pinned versions of the package to test. Latest always pulled the newest release, to check for incompatibilities. There was a lot of code to cater to having these two different categories.

With the switch to toxgen, all targets are now pinned, and we make sure we pick a representative sample of versions to test against, always including the latest available version to detect regressions. I'm removing the code dealing with the `latest` group entirely, and removing references to anything `pinned` as this is now simply the default.

#### Issues
<!--
* resolves: #1234
* resolves: LIN-1234
-->

#### Reminders
- Please add tests to validate your changes, and lint your code using `tox -e linters`.
- Add GH Issue ID _&_ Linear ID (if applicable)
- PR title should use [conventional commit](https://develop.sentry.dev/engineering-practices/commit-messages/#type) style (`feat:`, `fix:`, `ref:`, `meta:`)
- For external contributors: [CONTRIBUTING.md](https://github.com/getsentry/sentry-python/blob/master/CONTRIBUTING.md), [Sentry SDK development docs](https://develop.sentry.dev/sdk/), [Discord community](https://discord.gg/Ww9hbqr)
