### PR TITLE
fix: Pin shibuya

### DIFF
--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,5 +1,5 @@
 gevent
-shibuya
+shibuya<2025.9.22
 sphinx<8.2
 sphinx-autodoc-typehints[type_comments]>=1.8.0
 typing-extensions


### PR DESCRIPTION
### Description
Apidocs build started [failing](https://github.com/getsentry/sentry-python/actions/runs/17918383503/job/50946544869?pr=4837) a couple hours ago. A new version of the shibuya theme was released recently, which seems to be the culprit.

Pinning for now to unblock, will investigate whether we can just adapt.

#### Issues
<!--
* resolves: #1234
* resolves: LIN-1234
-->

#### Reminders
- Please add tests to validate your changes, and lint your code using `tox -e linters`.
- Add GH Issue ID _&_ Linear ID (if applicable)
- PR title should use [conventional commit](https://develop.sentry.dev/engineering-practices/commit-messages/#type) style (`feat:`, `fix:`, `ref:`, `meta:`)
- For external contributors: [CONTRIBUTING.md](https://github.com/getsentry/sentry-python/blob/master/CONTRIBUTING.md), [Sentry SDK development docs](https://develop.sentry.dev/sdk/), [Discord community](https://discord.gg/Ww9hbqr)
