### PR TITLE
fix(openai-agents): Move _set_agent_data call to ai_client_span function

### DIFF
--- a/sentry_sdk/integrations/openai_agents/spans/ai_client.py
+++ b/sentry_sdk/integrations/openai_agents/spans/ai_client.py
@@ -28,12 +28,13 @@ def ai_client_span(agent, get_response_kwargs):
     # TODO-anton: remove hardcoded stuff and replace something that also works for embedding and so on
     span.set_data(SPANDATA.GEN_AI_OPERATION_NAME, "chat")
 
+    _set_agent_data(span, agent)
+
     return span
 
 
 def update_ai_client_span(span, agent, get_response_kwargs, result):
     # type: (sentry_sdk.tracing.Span, Agent, dict[str, Any], Any) -> None
-    _set_agent_data(span, agent)
     _set_usage_data(span, result.usage)
     _set_input_data(span, get_response_kwargs)
     _set_output_data(span, result)


### PR DESCRIPTION
### Description
We can set the agent data early, so that we get input model and other data, even if there's an exception while running the agent

#### Issues
Resolves: TET-1205
