### PR TITLE
fix(tests): Don't assume release is set

### DIFF
--- a/tests/test_logs.py
+++ b/tests/test_logs.py
@@ -230,6 +230,8 @@ def test_logs_attributes(sentry_init, capture_envelopes):
     for k, v in attrs.items():
         assert logs[0]["attributes"][k] == v
     assert logs[0]["attributes"]["sentry.environment"] == "production"
+    if sentry_sdk.get_client().options.get("release") is not None:
+        assert "sentry.release" in logs[0]["attributes"]
     assert logs[0]["attributes"]["sentry.message.parameter.my_var"] == "some value"
     assert logs[0]["attributes"][SPANDATA.SERVER_ADDRESS] == "test-server"
     assert logs[0]["attributes"]["sentry.sdk.name"].startswith("sentry.python")

--- a/tests/test_logs.py
+++ b/tests/test_logs.py
@@ -230,7 +230,6 @@ def test_logs_attributes(sentry_init, capture_envelopes):
     for k, v in attrs.items():
         assert logs[0]["attributes"][k] == v
     assert logs[0]["attributes"]["sentry.environment"] == "production"
-    assert "sentry.release" in logs[0]["attributes"]
     assert logs[0]["attributes"]["sentry.message.parameter.my_var"] == "some value"
     assert logs[0]["attributes"][SPANDATA.SERVER_ADDRESS] == "test-server"
     assert logs[0]["attributes"]["sentry.sdk.name"].startswith("sentry.python")


### PR DESCRIPTION
### Description
Even though we try to figure out the current release automatically if it's not provided, it can still end up being `None`. If that's the case, it won't be attached to logs. The `test_logs_attributes` test assumes there always is a release, which is incorrect.

I opted for conditionally checking for `sentry.release` in the test instead of removing the check altogether, even though the test itself is supposed to test custom user provided attributes. The reason is that there is no other generic logs test testing `sentry.release`.

#### Issues
Closes https://github.com/getsentry/sentry-python/issues/4878

#### Reminders
- Please add tests to validate your changes, and lint your code using `tox -e linters`.
- Add GH Issue ID _&_ Linear ID (if applicable)
- PR title should use [conventional commit](https://develop.sentry.dev/engineering-practices/commit-messages/#type) style (`feat:`, `fix:`, `ref:`, `meta:`)
- For external contributors: [CONTRIBUTING.md](https://github.com/getsentry/sentry-python/blob/master/CONTRIBUTING.md), [Sentry SDK development docs](https://develop.sentry.dev/sdk/), [Discord community](https://discord.gg/Ww9hbqr)
