### PR TITLE
ci: Remove toxgen check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,28 +33,6 @@ jobs:
           pip install tox
           tox -e linters
 
-  check-ci-config:
-    name: Check CI config
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-
-    steps:
-      - uses: actions/checkout@v5.0.0
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
-          fetch-depth: 0
-      - uses: actions/setup-python@v6
-        with:
-          python-version: 3.12
-
-      - name: Detect unexpected changes to tox.ini or CI
-        run: |
-          pip install -e .
-          pip install -r scripts/populate_tox/requirements.txt
-          python scripts/populate_tox/populate_tox.py --fail-on-changes
-          pip install -r scripts/split_tox_gh_actions/requirements.txt
-          python scripts/split_tox_gh_actions/split_tox_gh_actions.py --fail-on-changes
-
   build_lambda_layer:
     name: Build Package
     runs-on: ubuntu-latest

--- a/scripts/populate_tox/README.md
+++ b/scripts/populate_tox/README.md
@@ -14,7 +14,7 @@ combination of hardcoded and generated entries.
 
 The `populate_tox.py` script fills out the auto-generated part of that template.
 It does this by querying PyPI for each framework's package and its metadata and
-then determining which versions make sense to test to get good coverage.
+then determining which versions it makes sense to test to get good coverage.
 
 By default, the lowest supported and latest version of a framework are always
 tested, with a number of releases in between:
@@ -22,17 +22,16 @@ tested, with a number of releases in between:
 - If the package doesn't have multiple majors, we pick two versions in between
   lowest and highest.
 
-#### Caveats
+Each test suite requires at least some configuration to be added to
+`TEST_SUITE_CONFIG` in `scripts/populate_tox/config.py`. If you're adding a new
+integration, check out the [Add a new test suite](#add-a-new-test-suite) section.
 
-- Make sure the integration name is the same everywhere. If it consists of
-  multiple words, use an underscore instead of a hyphen.
+## Test suite config
 
-## Defining constraints
-
-The `TEST_SUITE_CONFIG` dictionary defines, for each integration test suite,
-the main package (framework, library) to test with; any additional test
-dependencies, optionally gated behind specific conditions; and optionally
-the Python versions to test on.
+The `TEST_SUITE_CONFIG` dictionary in `scripts/populate_tox/config.py` defines,
+for each integration test suite, the main package (framework, library) to test
+with; any additional test dependencies, optionally gated behind specific
+conditions; and optionally the Python versions to test on.
 
 Constraints are defined using the format specified below. The following sections
 describe each key.
@@ -58,7 +57,7 @@ in [packaging.specifiers](https://packaging.pypa.io/en/stable/specifiers.html).
 
 ### `package`
 
-The name of the third party package as it's listed on PyPI. The script will
+The name of the third-party package as it's listed on PyPI. The script will
 be picking different versions of this package to test.
 
 This key is mandatory.
@@ -69,7 +68,7 @@ The test dependencies of the test suite. They're defined as a dictionary of
 `rule: [package1, package2, ...]` key-value pairs. All packages
 in the package list of a rule will be installed as long as the rule applies.
 
-`rule`s are predefined. Each `rule` must be one of the following:
+Each `rule` must be one of the following:
   - `*`: packages will be always installed
   - a version specifier on the main package (e.g. `<=0.32`): packages will only
     be installed if the main package falls into the version bounds specified
@@ -77,7 +76,7 @@ in the package list of a rule will be installed as long as the rule applies.
     installed if the Python version matches one from the list
 
 Rules can be used to specify version bounds on older versions of the main
-package's dependencies, for example. If e.g. Flask tests generally need
+package's dependencies, for example. If Flask tests generally need
 Werkzeug and don't care about its version, but Flask older than 3.0 needs
 a specific Werkzeug version to work, you can say:
 
@@ -176,7 +175,7 @@ be expressed like so:
 ### `integration_name`
 
 Sometimes, the name of the test suite doesn't match the name of the integration.
-For example, we have the `openai_base` and `openai_notiktoken` test suites, both
+For example, we have the `openai-base` and `openai-notiktoken` test suites, both
 of which are actually testing the `openai` integration. If this is the case, you
 can use the `integration_name` key to define the name of the integration. If not
 provided, it will default to the name of the test suite.
@@ -193,6 +192,11 @@ greater than 2, as the oldest and latest supported versions will always be
 picked. Additionally, if there is a recent prerelease, it'll also always be
 picked (this doesn't count towards `num_versions`).
 
+For instance, `num_versions` set to `2` will only test the first supported and
+the last release of the package. `num_versions` equal to `3` will test the first
+supported, the last release, and one release in between; `num_versions` set to `4`
+will test an additional release in between. In all these cases, if there is
+a recent prerelease, it'll be picked as well in addition to the picked versions.
 
 ## How-Tos
 
@@ -202,9 +206,10 @@ picked (this doesn't count towards `num_versions`).
    in `integrations/__init__.py`. This should be the lowest version of the
    framework that we can guarantee works with the SDK. If you've just added the
    integration, you should generally set this to the latest version of the framework
-   at the time.
+   at the time, unless you've verified the integration works for earlier versions
+   as well.
 2. Add the integration and any constraints to `TEST_SUITE_CONFIG`. See the
-   "Defining constraints" section for the format.
+   [Test suite config](#test-suite-config) section for the format.
 3. Add the integration to one of the groups in the `GROUPS` dictionary in
    `scripts/split_tox_gh_actions/split_tox_gh_actions.py`.
 4. Run `scripts/generate-test-files.sh` and commit the changes.

--- a/scripts/populate_tox/config.py
+++ b/scripts/populate_tox/config.py
@@ -1,7 +1,6 @@
 # The TEST_SUITE_CONFIG dictionary defines, for each integration test suite,
-# the main package (framework, library) to test with; any additional test
-# dependencies, optionally gated behind specific conditions; and optionally
-# the Python versions to test on.
+# at least the main package (framework, library) to test with. Additional
+# test dependencies, Python versions to test on, etc. can also be defined here.
 #
 # See scripts/populate_tox/README.md for more info on the format and examples.
 

--- a/scripts/populate_tox/tox.jinja
+++ b/scripts/populate_tox/tox.jinja
@@ -1,14 +1,16 @@
-# Tox (http://codespeak.net/~hpk/tox/) is a tool for running tests
-# in multiple virtualenvs. This configuration file will run the
-# test suite on all supported python versions. To use it, "pip install tox"
-# and then run "tox" from this directory.
+# DON'T EDIT THIS FILE BY HAND. This file has been generated from a template by
+# `scripts/populate_tox/populate_tox.py`.
 #
-# This file has been generated from a template
-# by "scripts/populate_tox/populate_tox.py". Any changes to the file should
-# be made in the template (if you want to change a hardcoded part of the file)
-# or in the script (if you want to change the auto-generated part).
-# The file (and all resulting CI YAMLs) then needs to be regenerated via
-# "scripts/generate-test-files.sh".
+# Any changes to the test matrix should be made
+# - either in the script config in `scripts/populate_tox/config.py` (if you want
+#   to change the auto-generated part)
+# - or in the template in `scripts/populate_tox/tox.jinja` (if you want to change
+#   a hardcoded part of the file)
+#
+# This file (and all resulting CI YAMLs) then needs to be regenerated via
+# `scripts/generate-test-files.sh`.
+#
+# See also `scripts/populate_tox/README.md` for more info.
 
 [tox]
 requires =


### PR DESCRIPTION
### Description

Removing the Check CI Config step altogether as well as associated parts of the toxgen script (`fail_on_changes`). Added a BIG ALL CAPS WARNING to tox.ini instead. Also updated the toxgen readme a bit.

Removing the check should be fine because we haven't actually seen cases of people trying to edit tox.ini directly -- if this happens in the future it's easy to notice in the PR. If we don't notice it then, we can notice it during the weekly toxgen update. And if don't notice it then, the file simply gets overwritten. 🤷🏻‍♀️ 


### The Problem With Checking `tox.ini`: The Long Read

In order to check manual changes to `tox.ini` on a PR, we hash the file, then run toxgen, hash the result, and compare. If the hashes differ, we fail the check. This works fine as long as there have been no new releases between the two points in time when `tox.ini` was last committed and when we ran the check.

This is usually not the case. There are new releases all the time. When we then rerun toxgen, the resulting `tox.ini` is different from the committed one, indicating changes and failing the check, even without any manual changes to the file.

One solution to this is always saving the timestamp of the last time `tox.ini` was generated, and then when rerunning toxgen for the purposes of the check, ignoring all new releases past the timestamp. This means any changes we detect were actually made by the user.

However, the explicit timestamp is prone to merge conflicts. Anytime `master` has had a toxgen update, and a PR is made that also ran toxgen, the PR will have a merge conflict on the timestamp field that needs to be sorted out manually. This is annoying and unnecessary.

(An attempt was made to use an implicit timestamp instead in the form of the commit timestamp, but this doesn't work since we squash commits on master, so the timestamp of the last commit that touched `tox.ini` is actually much later than the change was made. There are also other problems, like someone running the toxgen but committing the change much later, etc.)

### Solutions considered
- using a custom merge driver to resolve the timestamp conflict automatically (doesn't work on GH PRs)
- running toxgen in CI on each PR and committing the change (introduces new package releases unrelated to the PR)
- not checking in `tox.ini` at all, but running toxgen on each PR (introduces new package releases unrelated to the PR)
- finding a different commit to use as the implicit timestamp (doesn't work because we squash commits on `master`)
- ...





#### Issues
Closes https://github.com/getsentry/sentry-python/issues/4886

#### Reminders
- Please add tests to validate your changes, and lint your code using `tox -e linters`.
- Add GH Issue ID _&_ Linear ID (if applicable)
- PR title should use [conventional commit](https://develop.sentry.dev/engineering-practices/commit-messages/#type) style (`feat:`, `fix:`, `ref:`, `meta:`)
- For external contributors: [CONTRIBUTING.md](https://github.com/getsentry/sentry-python/blob/master/CONTRIBUTING.md), [Sentry SDK development docs](https://develop.sentry.dev/sdk/), [Discord community](https://discord.gg/Ww9hbqr)
