### PR TITLE
ref: Remove "experimental" from log func name

### DIFF
--- a/sentry_sdk/client.py
+++ b/sentry_sdk/client.py
@@ -213,7 +213,7 @@ class BaseClient:
         # type: (*Any, **Any) -> Optional[str]
         return None
 
-    def _capture_experimental_log(self, log):
+    def _capture_log(self, log):
         # type: (Log) -> None
         pass
 
@@ -877,7 +877,7 @@ class _Client(BaseClient):
 
         return return_value
 
-    def _capture_experimental_log(self, log):
+    def _capture_log(self, log):
         # type: (Optional[Log]) -> None
         if not has_logs_enabled(self.options) or log is None:
             return

--- a/sentry_sdk/integrations/logging.py
+++ b/sentry_sdk/integrations/logging.py
@@ -409,7 +409,7 @@ class SentryLogsHandler(_BaseHandler):
             attrs["logger.name"] = record.name
 
         # noinspection PyProtectedMember
-        client._capture_experimental_log(
+        client._capture_log(
             {
                 "severity_text": otel_severity_text,
                 "severity_number": otel_severity_number,

--- a/sentry_sdk/integrations/loguru.py
+++ b/sentry_sdk/integrations/loguru.py
@@ -193,7 +193,7 @@ def loguru_sentry_logs_handler(message):
     if record.get("name"):
         attrs["logger.name"] = record["name"]
 
-    client._capture_experimental_log(
+    client._capture_log(
         {
             "severity_text": otel_severity_text,
             "severity_number": otel_severity_number,

--- a/sentry_sdk/logger.py
+++ b/sentry_sdk/logger.py
@@ -46,7 +46,7 @@ def _capture_log(severity_text, severity_number, template, **kwargs):
     }
 
     # noinspection PyProtectedMember
-    client._capture_experimental_log(
+    client._capture_log(
         {
             "severity_text": severity_text,
             "severity_number": severity_number,


### PR DESCRIPTION
### Description
Logs are not experimental anymore, but one of the internal log-related functions still had "experimental" in the name.

#### Issues
<!--
* resolves: #1234
* resolves: LIN-1234
-->

#### Reminders
- Please add tests to validate your changes, and lint your code using `tox -e linters`.
- Add GH Issue ID _&_ Linear ID (if applicable)
- PR title should use [conventional commit](https://develop.sentry.dev/engineering-practices/commit-messages/#type) style (`feat:`, `fix:`, `ref:`, `meta:`)
- For external contributors: [CONTRIBUTING.md](https://github.com/getsentry/sentry-python/blob/master/CONTRIBUTING.md), [Sentry SDK development docs](https://develop.sentry.dev/sdk/), [Discord community](https://discord.gg/Ww9hbqr)
