### PR TITLE
Handle ValueError in scope resets

### DIFF
--- a/sentry_sdk/scope.py
+++ b/sentry_sdk/scope.py
@@ -1679,7 +1679,7 @@ def new_scope():
         try:
             # restore original scope
             _current_scope.reset(token)
-        except LookupError:
+        except (LookupError, ValueError):
             capture_internal_exception(sys.exc_info())
 
 
@@ -1717,7 +1717,7 @@ def use_scope(scope):
         try:
             # restore original scope
             _current_scope.reset(token)
-        except LookupError:
+        except (LookupError, ValueError):
             capture_internal_exception(sys.exc_info())
 
 
@@ -1761,12 +1761,12 @@ def isolation_scope():
         # restore original scopes
         try:
             _current_scope.reset(current_token)
-        except LookupError:
+        except (LookupError, ValueError):
             capture_internal_exception(sys.exc_info())
 
         try:
             _isolation_scope.reset(isolation_token)
-        except LookupError:
+        except (LookupError, ValueError):
             capture_internal_exception(sys.exc_info())
 
 
@@ -1808,12 +1808,12 @@ def use_isolation_scope(isolation_scope):
         # restore original scopes
         try:
             _current_scope.reset(current_token)
-        except LookupError:
+        except (LookupError, ValueError):
             capture_internal_exception(sys.exc_info())
 
         try:
             _isolation_scope.reset(isolation_token)
-        except LookupError:
+        except (LookupError, ValueError):
             capture_internal_exception(sys.exc_info())
 
 


### PR DESCRIPTION
### Description
when async generators throw a `GeneratorExit` we end up with

```
ValueError: <Token var=<ContextVar name='current_scope' default=None at 0x7f04cf05fb50> at 0x7f04ceb17340> was created in a different Context
```

so just catch that and rely on GC to cleanup the contextvar since we can't be smarter than that anyway for this case.

#### Issues
* resolves: #4925 
* resolves: PY-1886