### PR TITLE
⚡️ Speed up function `has_tracing_enabled` by 15%

### DIFF
--- a/sentry_sdk/tracing_utils.py
+++ b/sentry_sdk/tracing_utils.py
@@ -101,12 +101,12 @@ def has_tracing_enabled(options):
     if options is None:
         return False
 
-    return bool(
-        options.get("enable_tracing") is not False
-        and (
-            options.get("traces_sample_rate") is not None
-            or options.get("traces_sampler") is not None
-        )
+    if options.get("enable_tracing") is False:
+        return False
+
+    return (
+        options.get("traces_sample_rate") is not None
+        or options.get("traces_sampler") is not None
     )
 
 
@@ -527,7 +527,9 @@ class PropagationContext:
             )
             return
 
-        self.dynamic_sampling_context["sample_rand"] = f"{sample_rand:.6f}"  # noqa: E231
+        self.dynamic_sampling_context["sample_rand"] = (
+            f"{sample_rand:.6f}"  # noqa: E231
+        )
 
     def _sample_rand(self):
         # type: () -> Optional[str]


### PR DESCRIPTION
<!-- CODEFLASH_OPTIMIZATION: {"function":"has_tracing_enabled","file":"sentry_sdk/tracing_utils.py","speedup_pct":"15%","speedup_x":"0.15x","original_runtime":"64.4 microseconds","best_runtime":"56.0 microseconds","optimization_type":"general","timestamp":"2025-10-02T15:53:30.092Z","version":"1.0"} -->
#### 📄 15% (0.15x) speedup for ***`has_tracing_enabled` in `sentry_sdk/tracing_utils.py`***

Looks like an important function to me. I have 60 more optimizations for sentry-python at https://github.com/codeflash-ai/sentry-python/pulls that i would like to collaborate with to merge. 

⏱️ Runtime : **`64.4 microseconds`** **→** **`56.0 microseconds`** (best of `65` runs)

#### 📝 Explanation and details


The optimized code improves performance by restructuring the conditional logic to enable early returns and reduce unnecessary operations:

**Key Optimizations:**


1. **Removed redundant `bool()` wrapper**: The original code wrapped the entire expression in `bool()`, which adds function call overhead. The optimized version returns boolean values directly from the conditional expressions.

2. **Flattened conditional structure**: The optimized code separates the `enable_tracing` check from the tracing keys check, making the logic flow more linear and avoiding complex nested boolean expressions.

**Performance Impact:**
The 14% speedup is most pronounced when `enable_tracing=False` (20-29% faster in those test cases), as the function can exit early without performing additional dictionary lookups. Cases with missing or non-False `enable_tracing` values also benefit (8-24% faster) from the cleaner boolean logic and removal of the `bool()` wrapper.

**Best suited for:** Applications where tracing is frequently disabled (`enable_tracing=False`) or where the function is called frequently with various option configurations, as the early return pattern and reduced function call overhead provide consistent performance gains across different scenarios.



✅ **Correctness verification report:**

| Test                        | Status            |
| --------------------------- | ----------------- |
| ⚙️ Existing Unit Tests | ✅ **43 Passed** |
| 🌀 Generated Regression Tests | ✅ **68 Passed** |
| ⏪ Replay Tests | 🔘 **None Found** |
| 🔎 Concolic Coverage Tests | 🔘 **None Found** |
|📊 Tests Coverage       | 100.0% |
<details>
<summary>⚙️ Existing Unit Tests and Runtime</summary>

| Test File::Test Function                     | Original ⏱️   | Optimized ⏱️   | Speedup   |
|:---------------------------------------------|:--------------|:---------------|:----------|
| `test_basics.py::test_option_enable_tracing` | 9.32μs        | 7.70μs         | 21.0%✅   |

</details>

<details>
<summary>🌀 Generated Regression Tests and Runtime</summary>

```python
import pytest  # used for our unit tests
from sentry_sdk.tracing_utils import has_tracing_enabled

# ---------------------------
# Basic Test Cases
# ---------------------------

def test_none_options_returns_false():
    # Should return False if options is None
    codeflash_output = has_tracing_enabled(None) # 535ns -> 534ns (0.187% faster)

def test_no_keys_returns_false():
    # Should return False if no relevant keys are present
    codeflash_output = has_tracing_enabled({}) # 966ns -> 852ns (13.4% faster)

def test_enable_tracing_true_and_sample_rate_set():
    # Should return True if enable_tracing is True and traces_sample_rate is set
    opts = {"enable_tracing": True, "traces_sample_rate": 0.5}
    codeflash_output = has_tracing_enabled(opts) # 844ns -> 740ns (14.1% faster)

def test_enable_tracing_true_and_sampler_set():
    # Should return True if enable_tracing is True and traces_sampler is set
    opts = {"enable_tracing": True, "traces_sampler": lambda x: 0.1}
    codeflash_output = has_tracing_enabled(opts) # 905ns -> 823ns (9.96% faster)

def test_enable_tracing_false_and_sample_rate_set():
    # Should return False if enable_tracing is False, even if traces_sample_rate is set
    opts = {"enable_tracing": False, "traces_sample_rate": 1.0}
    codeflash_output = has_tracing_enabled(opts) # 737ns -> 588ns (25.3% faster)

def test_enable_tracing_missing_and_sample_rate_set():
    # Should return True if enable_tracing is missing (defaults to True), and traces_sample_rate is set
    opts = {"traces_sample_rate": 0.1}
    codeflash_output = has_tracing_enabled(opts) # 797ns -> 701ns (13.7% faster)

def test_enable_tracing_missing_and_sampler_set():
    # Should return True if enable_tracing is missing (defaults to True), and traces_sampler is set
    opts = {"traces_sampler": lambda x: 0.2}
    codeflash_output = has_tracing_enabled(opts) # 897ns -> 829ns (8.20% faster)

def test_enable_tracing_true_and_both_tracing_keys_missing():
    # Should return False if enable_tracing is True but both tracing keys are missing
    opts = {"enable_tracing": True}
    codeflash_output = has_tracing_enabled(opts) # 938ns -> 806ns (16.4% faster)

def test_enable_tracing_false_and_both_tracing_keys_set():
    # Should return False if enable_tracing is False, even if both tracing keys are set
    opts = {"enable_tracing": False, "traces_sample_rate": 0.5, "traces_sampler": lambda x: 0.1}
    codeflash_output = has_tracing_enabled(opts) # 699ns -> 614ns (13.8% faster)

# ---------------------------
# Edge Test Cases
# ---------------------------

def test_enable_tracing_set_to_none_and_sample_rate_set():
    # Should treat enable_tracing=None as enabled
    opts = {"enable_tracing": None, "traces_sample_rate": 0.1}
    codeflash_output = has_tracing_enabled(opts) # 817ns -> 661ns (23.6% faster)

def test_enable_tracing_set_to_zero_and_sample_rate_set():
    # Should treat enable_tracing=0 as enabled (since 0 is not False)
    opts = {"enable_tracing": 0, "traces_sample_rate": 0.1}
    codeflash_output = has_tracing_enabled(opts) # 810ns -> 708ns (14.4% faster)

def test_enable_tracing_set_to_empty_string_and_sample_rate_set():
    # Should treat enable_tracing='' as enabled (since '' is not False)
    opts = {"enable_tracing": '', "traces_sample_rate": 0.1}
    codeflash_output = has_tracing_enabled(opts) # 689ns -> 629ns (9.54% faster)

def test_traces_sample_rate_set_to_none():
    # Should return True if enable_tracing is True and traces_sampler is set, even if traces_sample_rate is None
    opts = {"enable_tracing": True, "traces_sample_rate": None, "traces_sampler": lambda x: 0.2}
    codeflash_output = has_tracing_enabled(opts) # 851ns -> 760ns (12.0% faster)

def test_traces_sampler_set_to_none():
    # Should return True if enable_tracing is True and traces_sample_rate is set, even if traces_sampler is None
    opts = {"enable_tracing": True, "traces_sample_rate": 0.5, "traces_sampler": None}
    codeflash_output = has_tracing_enabled(opts) # 792ns -> 695ns (14.0% faster)

def test_traces_sample_rate_and_sampler_both_none():
    # Should return False if both tracing keys are None
    opts = {"enable_tracing": True, "traces_sample_rate": None, "traces_sampler": None}
    codeflash_output = has_tracing_enabled(opts) # 866ns -> 715ns (21.1% faster)

def test_enable_tracing_set_to_false_string():
    # Should treat enable_tracing='False' as enabled (since 'False' is not the boolean False)
    opts = {"enable_tracing": 'False', "traces_sample_rate": 0.1}
    codeflash_output = has_tracing_enabled(opts) # 810ns -> 668ns (21.3% faster)

def test_enable_tracing_set_to_boolean_false():
    # Should treat enable_tracing=False as disabled
    opts = {"enable_tracing": False, "traces_sample_rate": 0.1}
    codeflash_output = has_tracing_enabled(opts) # 711ns -> 590ns (20.5% faster)

def test_traces_sample_rate_zero():
    # Should treat traces_sample_rate=0 as set (not None)
    opts = {"enable_tracing": True, "traces_sample_rate": 0}
    codeflash_output = has_tracing_enabled(opts) # 760ns -> 685ns (10.9% faster)

def test_traces_sampler_empty_list():
    # Should treat traces_sampler=[] as set (not None)
    opts = {"enable_tracing": True, "traces_sampler": []}
    codeflash_output = has_tracing_enabled(opts) # 857ns -> 789ns (8.62% faster)

def test_enable_tracing_boolean_true_and_traces_sampler_false():
    # Should treat traces_sampler=False as set (not None)
    opts = {"enable_tracing": True, "traces_sampler": False}
    codeflash_output = has_tracing_enabled(opts) # 930ns -> 787ns (18.2% faster)

def test_enable_tracing_boolean_true_and_traces_sample_rate_false():
    # Should treat traces_sample_rate=False as set (not None)
    opts = {"enable_tracing": True, "traces_sample_rate": False}
    codeflash_output = has_tracing_enabled(opts) # 835ns -> 696ns (20.0% faster)

# ---------------------------
# Large Scale Test Cases
# ---------------------------

def test_large_options_dict_with_tracing_enabled():
    # Should return True even if options dict is large, as long as required keys are present and valid
    opts = {f"key_{i}": i for i in range(1000)}
    opts["enable_tracing"] = True
    opts["traces_sample_rate"] = 0.9
    codeflash_output = has_tracing_enabled(opts) # 888ns -> 804ns (10.4% faster)

def test_large_options_dict_with_tracing_disabled():
    # Should return False if enable_tracing is False, even if dict is large and tracing keys are present
    opts = {f"key_{i}": i for i in range(1000)}
    opts["enable_tracing"] = False
    opts["traces_sample_rate"] = 0.9
    codeflash_output = has_tracing_enabled(opts) # 734ns -> 568ns (29.2% faster)

def test_large_options_dict_missing_tracing_keys():
    # Should return False if neither traces_sample_rate nor traces_sampler is present
    opts = {f"key_{i}": i for i in range(1000)}
    opts["enable_tracing"] = True
    codeflash_output = has_tracing_enabled(opts) # 942ns -> 857ns (9.92% faster)

def test_large_options_dict_traces_sampler_only():
    # Should return True if only traces_sampler is present and enable_tracing is True
    opts = {f"key_{i}": i for i in range(1000)}
    opts["enable_tracing"] = True
    opts["traces_sampler"] = lambda x: 0.1
    codeflash_output = has_tracing_enabled(opts) # 884ns -> 805ns (9.81% faster)

def test_large_options_dict_enable_tracing_missing():
    # Should return True if enable_tracing is missing (defaults to enabled) and traces_sample_rate is present
    opts = {f"key_{i}": i for i in range(1000)}
    opts["traces_sample_rate"] = 0.7
    codeflash_output = has_tracing_enabled(opts) # 836ns -> 752ns (11.2% faster)

def test_large_options_dict_all_keys_none():
    # Should return False if all relevant keys are None
    opts = {f"key_{i}": None for i in range(1000)}
    opts["enable_tracing"] = None
    opts["traces_sample_rate"] = None
    opts["traces_sampler"] = None
    codeflash_output = has_tracing_enabled(opts) # 870ns -> 822ns (5.84% faster)

def test_large_options_dict_extra_keys():
    # Should return True if relevant keys are set, even with many extra unrelated keys
    opts = {f"random_key_{i}": i for i in range(999)}
    opts["enable_tracing"] = True
    opts["traces_sample_rate"] = 0.2
    codeflash_output = has_tracing_enabled(opts) # 899ns -> 722ns (24.5% faster)
# codeflash_output is used to check that the output of the original code is the same as that of the optimized code.
#------------------------------------------------
import pytest  # used for our unit tests
from sentry_sdk.tracing_utils import has_tracing_enabled

# unit tests

# --- Basic Test Cases ---

def test_none_options_returns_false():
    # Should return False if options is None
    codeflash_output = has_tracing_enabled(None) # 476ns -> 468ns (1.71% faster)

def test_no_tracing_keys_returns_false():
    # Should return False if neither traces_sample_rate nor traces_sampler is present
    codeflash_output = has_tracing_enabled({'enable_tracing': True}) # 943ns -> 829ns (13.8% faster)

def test_enable_tracing_true_and_sample_rate_set_returns_true():
    # Should return True if enable_tracing is True and traces_sample_rate is set
    codeflash_output = has_tracing_enabled({'enable_tracing': True, 'traces_sample_rate': 0.5}) # 768ns -> 767ns (0.130% faster)

def test_enable_tracing_true_and_sampler_set_returns_true():
    # Should return True if enable_tracing is True and traces_sampler is set
    codeflash_output = has_tracing_enabled({'enable_tracing': True, 'traces_sampler': lambda x: x}) # 773ns -> 771ns (0.259% faster)

def test_enable_tracing_missing_and_sample_rate_set_returns_true():
    # Should return True if enable_tracing is missing (default to True) and traces_sample_rate is set
    codeflash_output = has_tracing_enabled({'traces_sample_rate': 1.0}) # 831ns -> 703ns (18.2% faster)

def test_enable_tracing_missing_and_sampler_set_returns_true():
    # Should return True if enable_tracing is missing (default to True) and traces_sampler is set
    codeflash_output = has_tracing_enabled({'traces_sampler': lambda x: x}) # 916ns -> 782ns (17.1% faster)

def test_enable_tracing_false_and_sample_rate_set_returns_false():
    # Should return False if enable_tracing is False, even if traces_sample_rate is set
    codeflash_output = has_tracing_enabled({'enable_tracing': False, 'traces_sample_rate': 0.5}) # 712ns -> 589ns (20.9% faster)

def test_enable_tracing_false_and_sampler_set_returns_false():
    # Should return False if enable_tracing is False, even if traces_sampler is set
    codeflash_output = has_tracing_enabled({'enable_tracing': False, 'traces_sampler': lambda x: x}) # 698ns -> 584ns (19.5% faster)

def test_enable_tracing_false_and_no_tracing_keys_returns_false():
    # Should return False if enable_tracing is False and no tracing keys are present
    codeflash_output = has_tracing_enabled({'enable_tracing': False}) # 694ns -> 604ns (14.9% faster)

def test_enable_tracing_true_and_no_tracing_keys_returns_false():
    # Should return False if enable_tracing is True but no tracing keys are present
    codeflash_output = has_tracing_enabled({'enable_tracing': True}) # 894ns -> 793ns (12.7% faster)

def test_enable_tracing_missing_and_no_tracing_keys_returns_false():
    # Should return False if enable_tracing is missing and no tracing keys are present
    codeflash_output = has_tracing_enabled({}) # 894ns -> 779ns (14.8% faster)

# --- Edge Test Cases ---

def test_traces_sample_rate_zero_returns_true():
    # Should return True if traces_sample_rate is 0 (zero is not None)
    codeflash_output = has_tracing_enabled({'enable_tracing': True, 'traces_sample_rate': 0}) # 830ns -> 745ns (11.4% faster)

def test_traces_sample_rate_none_returns_false():
    # Should return False if traces_sample_rate is None
    codeflash_output = has_tracing_enabled({'enable_tracing': True, 'traces_sample_rate': None}) # 880ns -> 778ns (13.1% faster)

def test_traces_sampler_none_returns_false():
    # Should return False if traces_sampler is None
    codeflash_output = has_tracing_enabled({'enable_tracing': True, 'traces_sampler': None}) # 876ns -> 775ns (13.0% faster)

def test_enable_tracing_set_to_zero_returns_true():
    # Should return True if enable_tracing is 0 (0 is not False)
    codeflash_output = has_tracing_enabled({'enable_tracing': 0, 'traces_sample_rate': 1.0}) # 797ns -> 696ns (14.5% faster)

def test_enable_tracing_set_to_empty_string_returns_true():
    # Should return True if enable_tracing is '' (empty string is not False)
    codeflash_output = has_tracing_enabled({'enable_tracing': '', 'traces_sample_rate': 1.0}) # 812ns -> 683ns (18.9% faster)

def test_enable_tracing_set_to_none_returns_true():
    # Should return True if enable_tracing is None (None is not False)
    codeflash_output = has_tracing_enabled({'enable_tracing': None, 'traces_sample_rate': 1.0}) # 803ns -> 688ns (16.7% faster)

def test_enable_tracing_set_to_truthy_string_returns_true():
    # Should return True if enable_tracing is a non-empty string
    codeflash_output = has_tracing_enabled({'enable_tracing': 'yes', 'traces_sample_rate': 1.0}) # 790ns -> 706ns (11.9% faster)

def test_enable_tracing_set_to_falsy_string_returns_true():
    # Should return True if enable_tracing is 'false' (string, not boolean False)
    codeflash_output = has_tracing_enabled({'enable_tracing': 'false', 'traces_sample_rate': 1.0}) # 735ns -> 663ns (10.9% faster)

def test_enable_tracing_set_to_boolean_false_returns_false():
    # Should return False if enable_tracing is boolean False
    codeflash_output = has_tracing_enabled({'enable_tracing': False, 'traces_sample_rate': 1.0}) # 695ns -> 578ns (20.2% faster)

def test_traces_sample_rate_and_sampler_both_none_returns_false():
    # Should return False if both traces_sample_rate and traces_sampler are None
    codeflash_output = has_tracing_enabled({'enable_tracing': True, 'traces_sample_rate': None, 'traces_sampler': None}) # 898ns -> 758ns (18.5% faster)

def test_traces_sample_rate_and_sampler_both_set_returns_true():
    # Should return True if both traces_sample_rate and traces_sampler are set
    codeflash_output = has_tracing_enabled({'enable_tracing': True, 'traces_sample_rate': 0.1, 'traces_sampler': lambda x: x}) # 803ns -> 677ns (18.6% faster)

def test_extra_unrelated_keys_does_not_affect_result():
    # Should return True if unrelated keys are present but tracing keys are set
    codeflash_output = has_tracing_enabled({'enable_tracing': True, 'traces_sample_rate': 0.1, 'foo': 'bar'}) # 776ns -> 707ns (9.76% faster)
    # Should return False if unrelated keys are present but tracing keys are not set
    codeflash_output = has_tracing_enabled({'enable_tracing': True, 'foo': 'bar'}) # 676ns -> 632ns (6.96% faster)

def test_enable_tracing_set_to_boolean_true_returns_true():
    # Should return True if enable_tracing is boolean True
    codeflash_output = has_tracing_enabled({'enable_tracing': True, 'traces_sample_rate': 0.2}) # 719ns -> 656ns (9.60% faster)

def test_enable_tracing_set_to_boolean_false_and_sampler_returns_false():
    # Should return False if enable_tracing is boolean False and traces_sampler is set
    codeflash_output = has_tracing_enabled({'enable_tracing': False, 'traces_sampler': lambda x: x}) # 691ns -> 556ns (24.3% faster)

def test_enable_tracing_set_to_integer_one_returns_true():
    # Should return True if enable_tracing is integer 1 (not False)
    codeflash_output = has_tracing_enabled({'enable_tracing': 1, 'traces_sample_rate': 0.5}) # 788ns -> 637ns (23.7% faster)

def test_enable_tracing_set_to_boolean_true_and_sampler_none_returns_false():
    # Should return False if enable_tracing is True and traces_sampler is None
    codeflash_output = has_tracing_enabled({'enable_tracing': True, 'traces_sampler': None}) # 841ns -> 676ns (24.4% faster)

def test_enable_tracing_set_to_boolean_true_and_sample_rate_none_returns_false():
    # Should return False if enable_tracing is True and traces_sample_rate is None
    codeflash_output = has_tracing_enabled({'enable_tracing': True, 'traces_sample_rate': None}) # 930ns -> 772ns (20.5% faster)

def test_enable_tracing_set_to_boolean_false_and_no_tracing_keys_returns_false():
    # Should return False if enable_tracing is False and no tracing keys are present
    codeflash_output = has_tracing_enabled({'enable_tracing': False}) # 718ns -> 586ns (22.5% faster)

def test_enable_tracing_set_to_boolean_false_and_sample_rate_none_returns_false():
    # Should return False if enable_tracing is False and traces_sample_rate is None
    codeflash_output = has_tracing_enabled({'enable_tracing': False, 'traces_sample_rate': None}) # 704ns -> 596ns (18.1% faster)

def test_enable_tracing_set_to_boolean_false_and_sampler_none_returns_false():
    # Should return False if enable_tracing is False and traces_sampler is None
    codeflash_output = has_tracing_enabled({'enable_tracing': False, 'traces_sampler': None}) # 701ns -> 582ns (20.4% faster)

# --- Large Scale Test Cases ---

def test_large_options_with_tracing_enabled():
    # Should return True for large dict with enable_tracing True and traces_sample_rate set
    options = {f'key{i}': i for i in range(990)}
    options['enable_tracing'] = True
    options['traces_sample_rate'] = 0.8
    codeflash_output = has_tracing_enabled(options) # 901ns -> 800ns (12.6% faster)

def test_large_options_with_tracing_disabled():
    # Should return False for large dict with enable_tracing False and traces_sample_rate set
    options = {f'key{i}': i for i in range(990)}
    options['enable_tracing'] = False
    options['traces_sample_rate'] = 0.8
    codeflash_output = has_tracing_enabled(options) # 763ns -> 651ns (17.2% faster)

def test_large_options_with_sampler_only():
    # Should return True for large dict with enable_tracing True and traces_sampler set
    options = {f'key{i}': i for i in range(990)}
    options['enable_tracing'] = True
    options['traces_sampler'] = lambda x: x
    codeflash_output = has_tracing_enabled(options) # 949ns -> 900ns (5.44% faster)

def test_large_options_with_no_tracing_keys():
    # Should return False for large dict with no tracing keys
    options = {f'key{i}': i for i in range(1000)}
    codeflash_output = has_tracing_enabled(options) # 896ns -> 795ns (12.7% faster)

def test_large_options_with_enable_tracing_missing_and_sample_rate_set():
    # Should return True for large dict with traces_sample_rate set and enable_tracing missing
    options = {f'key{i}': i for i in range(990)}
    options['traces_sample_rate'] = 1.0
    codeflash_output = has_tracing_enabled(options) # 849ns -> 787ns (7.88% faster)

def test_large_options_with_enable_tracing_missing_and_sampler_set():
    # Should return True for large dict with traces_sampler set and enable_tracing missing
    options = {f'key{i}': i for i in range(990)}
    options['traces_sampler'] = lambda x: x
    codeflash_output = has_tracing_enabled(options) # 912ns -> 865ns (5.43% faster)

def test_large_options_with_tracing_keys_none():
    # Should return False for large dict with traces_sample_rate and traces_sampler both None
    options = {f'key{i}': i for i in range(990)}
    options['enable_tracing'] = True
    options['traces_sample_rate'] = None
    options['traces_sampler'] = None
    codeflash_output = has_tracing_enabled(options) # 922ns -> 821ns (12.3% faster)

def test_large_options_with_enable_tracing_false_and_tracing_keys_none():
    # Should return False for large dict with enable_tracing False and both tracing keys None
    options = {f'key{i}': i for i in range(990)}
    options['enable_tracing'] = False
    options['traces_sample_rate'] = None
    options['traces_sampler'] = None
    codeflash_output = has_tracing_enabled(options) # 718ns -> 654ns (9.79% faster)
# codeflash_output is used to check that the output of the original code is the same as that of the optimized code.
```

</details>


To edit these changes `git checkout codeflash/optimize-has_tracing_enabled-mg9lhdgc` and push.

[![Codeflash](https://img.shields.io/badge/Optimized%20with-Codeflash-yellow?style=flat&color=%23ffc428&logo=data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iNDgwIiBoZWlnaHQ9ImF1dG8iIHZpZXdCb3g9IjAgMCA0ODAgMjgwIiBmaWxsPSJub25lIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciPgo8cGF0aCBmaWxsLXJ1bGU9ImV2ZW5vZGQiIGNsaXAtcnVsZT0iZXZlbm9kZCIgZD0iTTI4Ni43IDAuMzc4NDE4SDIwMS43NTFMNTAuOTAxIDE0OC45MTFIMTM1Ljg1MUwwLjk2MDkzOCAyODEuOTk5SDk1LjQzNTJMMjgyLjMyNCA4OS45NjE2SDE5Ni4zNDVMMjg2LjcgMC4zNzg0MThaIiBmaWxsPSIjRkZDMDQzIi8+CjxwYXRoIGZpbGwtcnVsZT0iZXZlbm9kZCIgY2xpcC1ydWxlPSJldmVub2RkIiBkPSJNMzExLjYwNyAwLjM3ODkwNkwyNTguNTc4IDU0Ljk1MjZIMzc5LjU2N0w0MzIuMzM5IDAuMzc4OTA2SDMxMS42MDdaIiBmaWxsPSIjMEIwQTBBIi8+CjxwYXRoIGZpbGwtcnVsZT0iZXZlbm9kZCIgY2xpcC1ydWxlPSJldmVub2RkIiBkPSJNMzA5LjU0NyA4OS45NjAxTDI1Ni41MTggMTQ0LjI3NkgzNzcuNTA2TDQzMC4wMjEgODkuNzAyNkgzMDkuNTQ3Vjg5Ljk2MDFaIiBmaWxsPSIjMEIwQTBBIi8+CjxwYXRoIGZpbGwtcnVsZT0iZXZlbm9kZCIgY2xpcC1ydWxlPSJldmVub2RkIiBkPSJNMjQyLjg3MyAxNjQuNjZMMTg5Ljg0NCAyMTkuMjM0SDMxMC44MzNMMzYzLjM0NyAxNjQuNjZIMjQyLjg3M1oiIGZpbGw9IiMwQjBBMEEiLz4KPC9zdmc+Cg==)](https://codeflash.ai)