### PR TITLE
fix(openai): update response text extraction method 

### DIFF
--- a/sentry_sdk/integrations/openai.py
+++ b/sentry_sdk/integrations/openai.py
@@ -237,7 +237,7 @@ def _set_output_data(span, response, kwargs, integration, finish_span=True):
 
     if hasattr(response, "choices"):
         if should_send_default_pii() and integration.include_prompts:
-            response_text = [choice.message.dict() for choice in response.choices]
+            response_text = [choice.message.model_dump() for choice in response.choices]
             if len(response_text) > 0:
                 set_data_normalized(span, SPANDATA.GEN_AI_RESPONSE_TEXT, response_text)
 


### PR DESCRIPTION
### Description
Switched to Pydantic v2's `model_dump()` instead of `.dict()` for serialization.
This ensures compatibility with newer Pydantic versions and avoids deprecation warnings during OpenAI response parsing.


#### Issues
* Resolves this... [sentry issue](https://stan-yz.sentry.io/share/issue/6b650b6da09c44f194153a088037e7f7/)


#### Reminders
- Please add tests to validate your changes, and lint your code using `tox -e linters`.
- Add GH Issue ID _&_ Linear ID (if applicable)
- PR title should use [conventional commit](https://develop.sentry.dev/engineering-practices/commit-messages/#type) style (`feat:`, `fix:`, `ref:`, `meta:`)
- For external contributors: [CONTRIBUTING.md](https://github.com/getsentry/sentry-python/blob/master/CONTRIBUTING.md), [Sentry SDK development docs](https://develop.sentry.dev/sdk/), [Discord community](https://discord.gg/Ww9hbqr)
