### PR TITLE
fix: Default breadcrumbs value for events without breadcrumbs

### DIFF
--- a/sentry_sdk/client.py
+++ b/sentry_sdk/client.py
@@ -622,7 +622,8 @@ class _Client(BaseClient):
             )
         if previous_total_breadcrumbs is not None:
             event["breadcrumbs"] = AnnotatedValue(
-                event.get("breadcrumbs", []), {"len": previous_total_breadcrumbs}
+                event.get("breadcrumbs", {"values": []}),
+                {"len": previous_total_breadcrumbs},
             )
 
         # Postprocess the event here so that annotated types do


### PR DESCRIPTION
### Description
<!-- What changed and why? -->

The breadcrumbs dictionary is normally initialized in `Scope._apply_breadcrumbs_to_event()`:

https://github.com/getsentry/sentry-python/blob/b11c2f2c0e1b36b7c6128eabe994f8e7257a50d0/sentry_sdk/scope.py#L1379-L1385

However, the method is only invoked if the event is not a span or a check in:

https://github.com/getsentry/sentry-python/blob/b11c2f2c0e1b36b7c6128eabe994f8e7257a50d0/sentry_sdk/scope.py#L1550-L1552 

The user that reported the issue is filtering on a check in. Their suspicion that the `AnnotatedValue` created a default `breadcrumbs` value of the wrong type for check ins is correct.

Add the following snippet to `tests/test_client.py` to test. I didn't push this test because I don't see why we're adding truncated breadcrumbs metadata to spans and check ins in the first place.

```
@pytest.mark.parametrize(
    "sdk_options, expected_breadcrumbs",
    [({}, DEFAULT_MAX_BREADCRUMBS), ({"max_breadcrumbs": 50}, 50)],
)
def test_max_breadcrumbs_span_option(
    sentry_init, capture_events, sdk_options, expected_breadcrumbs
):
    sentry_init(traces_sample_rate=1.0, **sdk_options)
    events = capture_events()

    for _ in range(1231):
        add_breadcrumb({"type": "sourdough"})

    with start_transaction(name="transaction"):
        pass

    assert "values" in events[0]["breadcrumbs"]
```


#### Issues
<!--
* resolves: #1234
* resolves: LIN-1234
-->

Closes https://github.com/getsentry/sentry-python/issues/4951

#### Reminders
- Please add tests to validate your changes, and lint your code using `tox -e linters`.
- Add GH Issue ID _&_ Linear ID (if applicable)
- PR title should use [conventional commit](https://develop.sentry.dev/engineering-practices/commit-messages/#type) style (`feat:`, `fix:`, `ref:`, `meta:`)
- For external contributors: [CONTRIBUTING.md](https://github.com/getsentry/sentry-python/blob/master/CONTRIBUTING.md), [Sentry SDK development docs](https://develop.sentry.dev/sdk/), [Discord community](https://discord.gg/Ww9hbqr)
