### PR TITLE
fix(gcp): Inject scopes in TimeoutThread exception with GCP

### DIFF
--- a/sentry_sdk/integrations/gcp.py
+++ b/sentry_sdk/integrations/gcp.py
@@ -75,7 +75,12 @@ def _wrap_func(func):
                 ):
                     waiting_time = configured_time - TIMEOUT_WARNING_BUFFER
 
-                    timeout_thread = TimeoutThread(waiting_time, configured_time)
+                    timeout_thread = TimeoutThread(
+                        waiting_time,
+                        configured_time,
+                        isolation_scope=scope,
+                        current_scope=sentry_sdk.get_current_scope(),
+                    )
 
                     # Starting the thread to raise timeout warning exception
                     timeout_thread.start()

--- a/tests/integrations/gcp/test_gcp.py
+++ b/tests/integrations/gcp/test_gcp.py
@@ -196,6 +196,7 @@ def test_timeout_error(run_cloud_function):
         functionhandler = None
         event = {}
         def cloud_function(functionhandler, event):
+            sentry_sdk.set_tag("cloud_function", "true")
             time.sleep(10)
             return "3"
         """
@@ -218,6 +219,8 @@ def test_timeout_error(run_cloud_function):
     )
     assert exception["mechanism"]["type"] == "threading"
     assert not exception["mechanism"]["handled"]
+
+    assert envelope_items[0]["tags"]["cloud_function"] == "true"
 
 
 def test_performance_no_error(run_cloud_function):


### PR DESCRIPTION
### Description

Missing tags and breadcrumbs on sentry_sdk>=2.26.1 when GCP functions time out are an unintended consequences of https://github.com/getsentry/sentry-python/commit/2d392af3ea6da91ddbdde55d18e15c24dce6b59b

See the analogous fix for AWS: https://github.com/getsentry/sentry-python/pull/4914#issuecomment-3415562585

#### Issues

Closes https://github.com/getsentry/sentry-python/issues/4958

#### Reminders
- Please add tests to validate your changes, and lint your code using `tox -e linters`.
- Add GH Issue ID _&_ Linear ID (if applicable)
- PR title should use [conventional commit](https://develop.sentry.dev/engineering-practices/commit-messages/#type) style (`feat:`, `fix:`, `ref:`, `meta:`)
- For external contributors: [CONTRIBUTING.md](https://github.com/getsentry/sentry-python/blob/master/CONTRIBUTING.md), [Sentry SDK development docs](https://develop.sentry.dev/sdk/), [Discord community](https://discord.gg/Ww9hbqr)
