### PR TITLE
tests: Modify databag depth test assertions

### DIFF
--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -784,6 +784,7 @@ def test_databag_depth_stripping(sentry_init, capture_events):
 
     third_level_list = second_level_list[0]
     assert type(third_level_list) == list
+    assert len(third_level_list) == 1
 
     inner_value_repr = third_level_list[0]
     assert type(inner_value_repr) == str


### PR DESCRIPTION
### Description
<!-- What changed and why? -->

The check fails on https://github.com/getsentry/sentry-python/pull/4896 because `repr` does not throw an exception with a deeply nested list **only** on the GitHub CI **and only** with Python 3.14. Locally, the representation of the deeply nested list is replaced with `<broken repr>`, but on CI two thousand square brackets are added to the event and the JSON size assertion is exceeded.

https://github.com/getsentry/sentry-python/blob/6e92aa4d3fe5a74984330f5f48ada4410dddc687/sentry_sdk/utils.py#L539-L544

#### Issues
<!--
* resolves: #1234
* resolves: LIN-1234
-->

#### Reminders
- Please add tests to validate your changes, and lint your code using `tox -e linters`.
- Add GH Issue ID _&_ Linear ID (if applicable)
- PR title should use [conventional commit](https://develop.sentry.dev/engineering-practices/commit-messages/#type) style (`feat:`, `fix:`, `ref:`, `meta:`)
- For external contributors: [CONTRIBUTING.md](https://github.com/getsentry/sentry-python/blob/master/CONTRIBUTING.md), [Sentry SDK development docs](https://develop.sentry.dev/sdk/), [Discord community](https://discord.gg/Ww9hbqr)
