### PR TITLE
tests(huggingface): Support 1.0.0rc7

### DIFF
--- a/tests/integrations/huggingface_hub/test_huggingface_hub.py
+++ b/tests/integrations/huggingface_hub/test_huggingface_hub.py
@@ -34,6 +34,15 @@ else:
     )
 
 
+def get_hf_provider_inference_client():
+    # The provider parameter was added in version 0.28.0 of huggingface_hub
+    return (
+        InferenceClient(model="test-model", provider="hf-inference")
+        if HF_VERSION >= (0, 28, 0)
+        else InferenceClient(model="test-model")
+    )
+
+
 def _add_mock_response(
     httpx_mock, rsps, method, url, json=None, status=200, body=None, headers=None
 ):
@@ -616,12 +625,7 @@ def test_chat_completion(
     )
     events = capture_events()
 
-    # The provider parameter was added in version 0.28.0 of huggingface_hub
-    client = (
-        InferenceClient(model="test-model", provider="hf-inference")
-        if HF_VERSION >= (0, 28, 0)
-        else InferenceClient(model="test-model")
-    )
+    client = get_hf_provider_inference_client()
 
     with sentry_sdk.start_transaction(name="test"):
         client.chat_completion(
@@ -693,12 +697,7 @@ def test_chat_completion_streaming(
     )
     events = capture_events()
 
-    # The provider parameter was added in version 0.28.0 of huggingface_hub
-    client = (
-        InferenceClient(model="test-model", provider="hf-inference")
-        if HF_VERSION >= (0, 28, 0)
-        else InferenceClient(model="test-model")
-    )
+    client = get_hf_provider_inference_client()
 
     with sentry_sdk.start_transaction(name="test"):
         _ = list(
@@ -762,12 +761,7 @@ def test_chat_completion_api_error(
     sentry_init(traces_sample_rate=1.0)
     events = capture_events()
 
-    # The provider parameter was added in version 0.28.0 of huggingface_hub
-    client = (
-        InferenceClient(model="test-model", provider="hf-inference")
-        if HF_VERSION >= (0, 28, 0)
-        else InferenceClient(model="test-model")
-    )
+    client = get_hf_provider_inference_client()
 
     with sentry_sdk.start_transaction(name="test"):
         with pytest.raises(HfHubHTTPError):
@@ -819,12 +813,7 @@ def test_span_status_error(sentry_init, capture_events, mock_hf_api_with_errors)
     sentry_init(traces_sample_rate=1.0)
     events = capture_events()
 
-    # The provider parameter was added in version 0.28.0 of huggingface_hub
-    client = (
-        InferenceClient(model="test-model", provider="hf-inference")
-        if HF_VERSION >= (0, 28, 0)
-        else InferenceClient(model="test-model")
-    )
+    client = get_hf_provider_inference_client()
 
     with sentry_sdk.start_transaction(name="test"):
         with pytest.raises(HfHubHTTPError):
@@ -869,12 +858,7 @@ def test_chat_completion_with_tools(
     )
     events = capture_events()
 
-    # The provider parameter was added in version 0.28.0 of huggingface_hub
-    client = (
-        InferenceClient(model="test-model", provider="hf-inference")
-        if HF_VERSION >= (0, 28, 0)
-        else InferenceClient(model="test-model")
-    )
+    client = get_hf_provider_inference_client()
 
     tools = [
         {
@@ -963,12 +947,7 @@ def test_chat_completion_streaming_with_tools(
     )
     events = capture_events()
 
-    # The provider parameter was added in version 0.28.0 of huggingface_hub
-    client = (
-        InferenceClient(model="test-model", provider="hf-inference")
-        if HF_VERSION >= (0, 28, 0)
-        else InferenceClient(model="test-model")
-    )
+    client = get_hf_provider_inference_client()
 
     tools = [
         {


### PR DESCRIPTION
### Description
<!-- What changed and why? -->

The CI fails when you generate `tox.ini`, as `huggingface_hub` complains about a missing API key. See https://github.com/getsentry/sentry-python/actions/runs/18707992581/job/53349699759.

Always use `HFInferenceConversational()` for chat completions, which is the behavior prior to version 1.0.0rc7 of `huggingface_hub` due to our mock:

https://github.com/getsentry/sentry-python/blob/dcd94ed0ce7b68095120db0bf9e2998cdd11b0dc/tests/integrations/huggingface_hub/test_huggingface_hub.py#L69-L92

We know we have always tested **only** `HFInferenceConversational()` because it's the only provider which does not raise an exception when the API key is missing:

https://github.com/huggingface/huggingface_hub/blob/61bc87eb4d774c477ee87c9bf14aa9557ccb4e34/src/huggingface_hub/inference/_providers/hf_inference.py#L31

#### Issues

Closes https://github.com/getsentry/sentry-python/issues/4978

#### Reminders
- Please add tests to validate your changes, and lint your code using `tox -e linters`.
- Add GH Issue ID _&_ Linear ID (if applicable)
- PR title should use [conventional commit](https://develop.sentry.dev/engineering-practices/commit-messages/#type) style (`feat:`, `fix:`, `ref:`, `meta:`)
- For external contributors: [CONTRIBUTING.md](https://github.com/getsentry/sentry-python/blob/master/CONTRIBUTING.md), [Sentry SDK development docs](https://develop.sentry.dev/sdk/), [Discord community](https://discord.gg/Ww9hbqr)
