### PR TITLE
Make logger template format safer to missing kwargs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ relay
 pip-wheel-metadata
 .mypy_cache
 .vscode/
+.claude/
 
 # for running AWS Lambda tests using AWS SAM
 sam.template.yaml

--- a/sentry_sdk/logger.py
+++ b/sentry_sdk/logger.py
@@ -4,7 +4,7 @@ import time
 from typing import Any
 
 from sentry_sdk import get_client
-from sentry_sdk.utils import safe_repr
+from sentry_sdk.utils import safe_repr, capture_internal_exceptions
 
 OTEL_RANGES = [
     # ((severity level range), severity text)
@@ -18,10 +18,19 @@ OTEL_RANGES = [
 ]
 
 
+class _dict_default_key(dict):  # type: ignore[type-arg]
+    """dict that returns the key if missing."""
+
+    def __missing__(self, key):
+        # type: (str) -> str
+        return "{" + key + "}"
+
+
 def _capture_log(severity_text, severity_number, template, **kwargs):
     # type: (str, int, str, **Any) -> None
     client = get_client()
 
+    body = template
     attrs = {}  # type: dict[str, str | bool | float | int]
     if "attributes" in kwargs:
         attrs.update(kwargs.pop("attributes"))
@@ -30,6 +39,9 @@ def _capture_log(severity_text, severity_number, template, **kwargs):
     if kwargs:
         # only attach template if there are parameters
         attrs["sentry.message.template"] = template
+
+        with capture_internal_exceptions():
+            body = template.format_map(_dict_default_key(kwargs))
 
     attrs = {
         k: (
@@ -51,7 +63,7 @@ def _capture_log(severity_text, severity_number, template, **kwargs):
             "severity_text": severity_text,
             "severity_number": severity_number,
             "attributes": attrs,
-            "body": template.format(**kwargs),
+            "body": body,
             "time_unix_nano": time.time_ns(),
             "trace_id": None,
         },


### PR DESCRIPTION
#### Issues

* resolves: #4975
* resolves: PY-1908
