### PR TITLE
fix(tracemetrics): Bump metric buffer to 1k                          …

### DIFF
--- a/sentry_sdk/_metrics_batcher.py
+++ b/sentry_sdk/_metrics_batcher.py
@@ -12,7 +12,7 @@ if TYPE_CHECKING:
 
 
 class MetricsBatcher:
-    MAX_METRICS_BEFORE_FLUSH = 100
+    MAX_METRICS_BEFORE_FLUSH = 1000
     FLUSH_WAIT_TIME = 5.0
 
     def __init__(


### PR DESCRIPTION
### Summary
We've been noticing some discards from clients for likely buffer reason (primarily on python, though fixing it on both sdks). Metrics were initially set to 100 to match logs but the size limit for a metric in relay is ~1000x less (~1-2kb at the moment) so the memory pressure should be fine (it'd cap in the single digit megabyte range).

