### PR TITLE
ref: Remove `datetime_from_isoformat`

### DIFF
--- a/sentry_sdk/scope.py
+++ b/sentry_sdk/scope.py
@@ -37,7 +37,6 @@ from sentry_sdk.utils import (
     capture_internal_exception,
     capture_internal_exceptions,
     ContextVar,
-    datetime_from_isoformat,
     disable_capture_event,
     event_from_exception,
     exc_info_from_error,
@@ -1390,7 +1389,9 @@ class Scope:
             if not isinstance(event["breadcrumbs"], AnnotatedValue):
                 for crumb in event["breadcrumbs"]["values"]:
                     if isinstance(crumb["timestamp"], str):
-                        crumb["timestamp"] = datetime_from_isoformat(crumb["timestamp"])
+                        crumb["timestamp"] = datetime.fromisoformat(
+                            crumb["timestamp"]
+                        ).astimezone(timezone.utc)
 
                 event["breadcrumbs"]["values"].sort(
                     key=lambda crumb: crumb["timestamp"]

--- a/sentry_sdk/utils.py
+++ b/sentry_sdk/utils.py
@@ -250,31 +250,6 @@ def format_timestamp(value):
     return utctime.strftime("%Y-%m-%dT%H:%M:%S.%fZ")
 
 
-ISO_TZ_SEPARATORS = frozenset(("+", "-"))
-
-
-def datetime_from_isoformat(value):
-    # type: (str) -> datetime
-    try:
-        result = datetime.fromisoformat(value)
-    except (AttributeError, ValueError):
-        # py 3.6
-        timestamp_format = (
-            "%Y-%m-%dT%H:%M:%S.%f" if "." in value else "%Y-%m-%dT%H:%M:%S"
-        )
-        if value.endswith("Z"):
-            value = value[:-1] + "+0000"
-
-        if value[-6] in ISO_TZ_SEPARATORS:
-            timestamp_format += "%z"
-            value = value[:-3] + value[-2:]
-        elif value[-5] in ISO_TZ_SEPARATORS:
-            timestamp_format += "%z"
-
-        result = datetime.strptime(value, timestamp_format)
-    return result.astimezone(timezone.utc)
-
-
 def event_hint_with_exc_info(exc_info=None):
     # type: (Optional[ExcInfo]) -> Dict[str, Optional[ExcInfo]]
     """Creates a hint with the exc info filled in."""

--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -8,7 +8,6 @@ from collections import Counter
 
 import pytest
 from sentry_sdk.client import Client
-from sentry_sdk.utils import datetime_from_isoformat
 
 import sentry_sdk
 import sentry_sdk.scope
@@ -421,7 +420,10 @@ def test_breadcrumb_ordering(sentry_init, capture_events):
 
     assert len(event["breadcrumbs"]["values"]) == len(timestamps)
     timestamps_from_event = [
-        datetime_from_isoformat(x["timestamp"]) for x in event["breadcrumbs"]["values"]
+        datetime.datetime.fromisoformat(x["timestamp"]).astimezone(
+            datetime.timezone.utc
+        )
+        for x in event["breadcrumbs"]["values"]
     ]
     assert timestamps_from_event == sorted(timestamps)
 
@@ -462,7 +464,10 @@ def test_breadcrumb_ordering_different_types(sentry_init, capture_events):
 
     assert len(event["breadcrumbs"]["values"]) == len(timestamps)
     timestamps_from_event = [
-        datetime_from_isoformat(x["timestamp"]) for x in event["breadcrumbs"]["values"]
+        datetime.datetime.fromisoformat(x["timestamp"]).astimezone(
+            datetime.timezone.utc
+        )
+        for x in event["breadcrumbs"]["values"]
     ]
     assert timestamps_from_event == sorted(timestamps)
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -13,7 +13,6 @@ from sentry_sdk._queue import Queue
 from sentry_sdk.utils import (
     Components,
     Dsn,
-    datetime_from_isoformat,
     env_to_bool,
     format_timestamp,
     get_current_thread_meta,
@@ -62,72 +61,6 @@ def _normalize_distribution_name(name):
     for more details.
     """
     return re.sub(r"[-_.]+", "-", name).lower()
-
-
-isoformat_inputs_and_datetime_outputs = (
-    (
-        "2021-01-01T00:00:00.000000Z",
-        datetime(2021, 1, 1, tzinfo=timezone.utc),
-    ),  # UTC time
-    (
-        "2021-01-01T00:00:00.000000",
-        datetime(2021, 1, 1).astimezone(timezone.utc),
-    ),  # No TZ -- assume local but convert to UTC
-    (
-        "2021-01-01T00:00:00Z",
-        datetime(2021, 1, 1, tzinfo=timezone.utc),
-    ),  # UTC - No milliseconds
-    (
-        "2021-01-01T00:00:00.000000+00:00",
-        datetime(2021, 1, 1, tzinfo=timezone.utc),
-    ),
-    (
-        "2021-01-01T00:00:00.000000-00:00",
-        datetime(2021, 1, 1, tzinfo=timezone.utc),
-    ),
-    (
-        "2021-01-01T00:00:00.000000+0000",
-        datetime(2021, 1, 1, tzinfo=timezone.utc),
-    ),
-    (
-        "2021-01-01T00:00:00.000000-0000",
-        datetime(2021, 1, 1, tzinfo=timezone.utc),
-    ),
-    (
-        "2020-12-31T00:00:00.000000+02:00",
-        datetime(2020, 12, 31, tzinfo=timezone(timedelta(hours=2))),
-    ),  # UTC+2 time
-    (
-        "2020-12-31T00:00:00.000000-0200",
-        datetime(2020, 12, 31, tzinfo=timezone(timedelta(hours=-2))),
-    ),  # UTC-2 time
-    (
-        "2020-12-31T00:00:00-0200",
-        datetime(2020, 12, 31, tzinfo=timezone(timedelta(hours=-2))),
-    ),  # UTC-2 time - no milliseconds
-)
-
-
-@pytest.mark.parametrize(
-    ("input_str", "expected_output"),
-    isoformat_inputs_and_datetime_outputs,
-)
-def test_datetime_from_isoformat(input_str, expected_output):
-    assert datetime_from_isoformat(input_str) == expected_output, input_str
-
-
-@pytest.mark.parametrize(
-    ("input_str", "expected_output"),
-    isoformat_inputs_and_datetime_outputs,
-)
-def test_datetime_from_isoformat_with_py_36_or_lower(input_str, expected_output):
-    """
-    `fromisoformat` was added in Python version 3.7
-    """
-    with mock.patch("sentry_sdk.utils.datetime") as datetime_mocked:
-        datetime_mocked.fromisoformat.side_effect = AttributeError()
-        datetime_mocked.strptime = datetime.strptime
-        assert datetime_from_isoformat(input_str) == expected_output, input_str
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
### Description
The only purpose of this util function was compatibility with Python 3.6.

#### Issues
Closes https://github.com/getsentry/sentry-python/issues/5009

#### Reminders
- Please add tests to validate your changes, and lint your code using `tox -e linters`.
- Add GH Issue ID _&_ Linear ID (if applicable)
- PR title should use [conventional commit](https://develop.sentry.dev/engineering-practices/commit-messages/#type) style (`feat:`, `fix:`, `ref:`, `meta:`)
- For external contributors: [CONTRIBUTING.md](https://github.com/getsentry/sentry-python/blob/master/CONTRIBUTING.md), [Sentry SDK development docs](https://develop.sentry.dev/sdk/), [Discord community](https://discord.gg/Ww9hbqr)
