### PR TITLE
feat: Turn unraisable exception integration on by default

### DIFF
--- a/sentry_sdk/integrations/__init__.py
+++ b/sentry_sdk/integrations/__init__.py
@@ -1,5 +1,6 @@
 from abc import ABC, abstractmethod
 from threading import Lock
+import sys
 
 from sentry_sdk.utils import logger
 
@@ -72,6 +73,11 @@ _DEFAULT_INTEGRATIONS = [
     "sentry_sdk.integrations.stdlib.StdlibIntegration",
     "sentry_sdk.integrations.threading.ThreadingIntegration",
 ]
+
+if sys.version_info >= (3, 8):
+    _DEFAULT_INTEGRATIONS.append(
+        "sentry_sdk.integrations.unraisablehook.UnraisablehookIntegration"
+    )
 
 _AUTO_ENABLING_INTEGRATIONS = [
     "sentry_sdk.integrations.aiohttp.AioHttpIntegration",


### PR DESCRIPTION
### Description
<!-- What changed and why? -->

We've given users a chance to try the integration, and there have been no issues so far.

See https://github.com/getsentry/sentry-python/pull/4733#discussion_r2318008411.

#### Issues
<!--
* resolves: #1234
* resolves: LIN-1234
-->

#### Reminders
- Please add tests to validate your changes, and lint your code using `tox -e linters`.
- Add GH Issue ID _&_ Linear ID (if applicable)
- PR title should use [conventional commit](https://develop.sentry.dev/engineering-practices/commit-messages/#type) style (`feat:`, `fix:`, `ref:`, `meta:`)
- For external contributors: [CONTRIBUTING.md](https://github.com/getsentry/sentry-python/blob/master/CONTRIBUTING.md), [Sentry SDK development docs](https://develop.sentry.dev/sdk/), [Discord community](https://discord.gg/Ww9hbqr)
