### PR TITLE
Add external_propagation_context support

### DIFF
--- a/tests/integrations/logging/test_logging.py
+++ b/tests/integrations/logging/test_logging.py
@@ -478,6 +478,10 @@ def test_logger_with_all_attributes(sentry_init, capture_envelopes):
 
     assert attributes.pop("sentry.sdk.name").startswith("sentry.python")
 
+    assert "sentry.trace.parent_span_id" in attributes
+    assert isinstance(attributes["sentry.trace.parent_span_id"], str)
+    del attributes["sentry.trace.parent_span_id"]
+
     # Assert on the remaining non-dynamic attributes.
     assert attributes == {
         "foo": "bar",

--- a/tests/integrations/loguru/test_loguru.py
+++ b/tests/integrations/loguru/test_loguru.py
@@ -458,6 +458,10 @@ def test_logger_with_all_attributes(
 
     assert attributes.pop("sentry.sdk.name").startswith("sentry.python")
 
+    assert "sentry.trace.parent_span_id" in attributes
+    assert isinstance(attributes["sentry.trace.parent_span_id"], str)
+    del attributes["sentry.trace.parent_span_id"]
+
     # Assert on the remaining non-dynamic attributes.
     assert attributes == {
         "logger.name": "tests.integrations.loguru.test_loguru",

--- a/tests/test_logs.py
+++ b/tests/test_logs.py
@@ -310,7 +310,7 @@ def test_logs_tied_to_transactions(sentry_init, capture_envelopes):
     """
     Log messages are also tied to transactions.
     """
-    sentry_init(enable_logs=True)
+    sentry_init(enable_logs=True, traces_sample_rate=1.0)
     envelopes = capture_envelopes()
 
     with sentry_sdk.start_transaction(name="test-transaction") as trx:
@@ -326,7 +326,7 @@ def test_logs_tied_to_spans(sentry_init, capture_envelopes):
     """
     Log messages are also tied to spans.
     """
-    sentry_init(enable_logs=True)
+    sentry_init(enable_logs=True, traces_sample_rate=1.0)
     envelopes = capture_envelopes()
 
     with sentry_sdk.start_transaction(name="test-transaction"):

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -122,7 +122,7 @@ def test_metrics_with_span(sentry_init, capture_envelopes):
     sentry_init(traces_sample_rate=1.0)
     envelopes = capture_envelopes()
 
-    with sentry_sdk.start_transaction(op="test", name="test-span"):
+    with sentry_sdk.start_transaction(op="test", name="test-span") as transaction:
         sentry_sdk.metrics.count("test.span.counter", 1)
 
     get_client().flush()
@@ -131,24 +131,26 @@ def test_metrics_with_span(sentry_init, capture_envelopes):
     assert len(metrics) == 1
 
     assert metrics[0]["trace_id"] is not None
-    assert metrics[0]["trace_id"] != "00000000-0000-0000-0000-000000000000"
-    assert metrics[0]["span_id"] is not None
+    assert metrics[0]["trace_id"] == transaction.trace_id
+    assert metrics[0]["span_id"] == transaction.span_id
 
 
 def test_metrics_tracing_without_performance(sentry_init, capture_envelopes):
     sentry_init()
     envelopes = capture_envelopes()
 
-    sentry_sdk.metrics.count("test.span.counter", 1)
+    with sentry_sdk.isolation_scope() as isolation_scope:
+        sentry_sdk.metrics.count("test.span.counter", 1)
 
     get_client().flush()
 
     metrics = envelopes_to_metrics(envelopes)
     assert len(metrics) == 1
 
-    assert metrics[0]["trace_id"] is not None
-    assert metrics[0]["trace_id"] != "00000000-0000-0000-0000-000000000000"
-    assert metrics[0]["span_id"] is None
+    propagation_context = isolation_scope._propagation_context
+    assert propagation_context is not None
+    assert metrics[0]["trace_id"] == propagation_context.trace_id
+    assert metrics[0]["span_id"] == propagation_context.span_id
 
 
 def test_metrics_before_send(sentry_init, capture_envelopes):


### PR DESCRIPTION
If we are on an external tracing system like otel, we allow registering a new source of `trace_id/span_id` that takes precedence over the scope's propagation_context.

* Also reworked logs and metrics to use `get_trace_context`
* Cleaned up handling of `get_trace_context` that is still messy but a bit more clearer now regarding which underlying `propagation_context` is used
