### PR TITLE
tests(openai-agents): Remove MagicMock from ModelResponse

### DIFF
--- a/tests/integrations/openai_agents/test_openai_agents.py
+++ b/tests/integrations/openai_agents/test_openai_agents.py
@@ -501,11 +501,8 @@ async def test_tool_execution_span(sentry_init, capture_events, test_agent):
     assert ai_client_span1["data"]["gen_ai.usage.output_tokens"] == 5
     assert ai_client_span1["data"]["gen_ai.usage.output_tokens.reasoning"] == 0
     assert ai_client_span1["data"]["gen_ai.usage.total_tokens"] == 15
-    assert re.sub(
-        r"SerializationIterator\(.*\)",
-        "NOT_CHECKED",
-        ai_client_span1["data"]["gen_ai.response.tool_calls"],
-    ) == safe_serialize(
+
+    assert ai_client_span1["data"]["gen_ai.response.tool_calls"] == safe_serialize(
         [
             {
                 "arguments": '{"message": "hello"}',
@@ -514,7 +511,6 @@ async def test_tool_execution_span(sentry_init, capture_events, test_agent):
                 "type": "function_call",
                 "id": "call_123",
                 "status": None,
-                "function": "NOT_CHECKED",
             }
         ]
     )
@@ -553,11 +549,7 @@ async def test_tool_execution_span(sentry_init, capture_events, test_agent):
         == available_tools
     )
     assert ai_client_span2["data"]["gen_ai.request.max_tokens"] == 100
-    assert re.sub(
-        r"SerializationIterator\(.*\)",
-        "NOT_CHECKED",
-        ai_client_span2["data"]["gen_ai.request.messages"],
-    ) == safe_serialize(
+    assert ai_client_span2["data"]["gen_ai.request.messages"] == safe_serialize(
         [
             {
                 "role": "system",
@@ -580,7 +572,6 @@ async def test_tool_execution_span(sentry_init, capture_events, test_agent):
                         "name": "simple_test_tool",
                         "type": "function_call",
                         "id": "call_123",
-                        "function": "NOT_CHECKED",
                     }
                 ],
             },


### PR DESCRIPTION
### Description
<!-- What changed and why? -->

Instances of `MagicMock` cannot be serialized, but model responses are serialized during the truncation proposed in https://github.com/getsentry/sentry-python/pull/5049.

The model `ResponseFunctionToolCall` does not declare a `function` field: https://github.com/openai/openai-python/blob/main/src/openai/types/responses/response_function_tool_call.py

#### Issues
<!--
* resolves: #1234
* resolves: LIN-1234
-->

#### Reminders
- Please add tests to validate your changes, and lint your code using `tox -e linters`.
- Add GH Issue ID _&_ Linear ID (if applicable)
- PR title should use [conventional commit](https://develop.sentry.dev/engineering-practices/commit-messages/#type) style (`feat:`, `fix:`, `ref:`, `meta:`)
- For external contributors: [CONTRIBUTING.md](https://github.com/getsentry/sentry-python/blob/master/CONTRIBUTING.md), [Sentry SDK development docs](https://develop.sentry.dev/sdk/), [Discord community](https://discord.gg/Ww9hbqr)
