### PR TITLE
feat: non-experimental `enable_metrics` option

### DIFF
--- a/sentry_sdk/consts.py
+++ b/sentry_sdk/consts.py
@@ -1005,6 +1005,7 @@ class ClientConstructor:
         enable_logs=False,  # type: bool
         before_send_log=None,  # type: Optional[Callable[[Log, Hint], Optional[Log]]]
         trace_ignore_status_codes=frozenset(),  # type: AbstractSet[int]
+        enable_metrics=True,  # type: bool
     ):
         # type: (...) -> None
         """Initialize the Sentry SDK with the given parameters. All parameters described here can be used in a call to `sentry_sdk.init()`.

--- a/sentry_sdk/utils.py
+++ b/sentry_sdk/utils.py
@@ -2047,6 +2047,14 @@ def get_before_send_log(options):
     )
 
 
+def has_metrics_enabled(options):
+    # type: (Optional[dict[str, Any]]) -> bool
+    if options is None:
+        return False
+
+    return bool(options.get("enable_metrics", True))
+
+
 def get_before_send_metric(options):
     # type: (Optional[dict[str, Any]]) -> Optional[Callable[[Metric, Hint], Optional[Metric]]]
     if options is None:

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -33,6 +33,18 @@ def envelopes_to_metrics(envelopes):
     return res
 
 
+def test_metrics_disabled(sentry_init, capture_envelopes):
+    sentry_init(enable_metrics=False)
+
+    envelopes = capture_envelopes()
+
+    sentry_sdk.metrics.count("test.counter", 1)
+    sentry_sdk.metrics.gauge("test.gauge", 42)
+    sentry_sdk.metrics.distribution("test.distribution", 200)
+
+    assert len(envelopes) == 0
+
+
 def test_metrics_basics(sentry_init, capture_envelopes):
     sentry_init()
     envelopes = capture_envelopes()


### PR DESCRIPTION
### Description
<!-- What changed and why? -->

Add a toggle for metrics in the form of an `enable_metrics` flag that defaults to `True`.

The PR is not undoing https://github.com/getsentry/sentry-python/pull/5046 because

- the new flag default to `True`; and
- the new flag is a stable top level option as per the spec: https://github.com/getsentry/sentry-docs/pull/15178

#### Issues
<!--
* resolves: #1234
* resolves: LIN-1234
-->

#### Reminders
- Please add tests to validate your changes, and lint your code using `tox -e linters`.
- Add GH Issue ID _&_ Linear ID (if applicable)
- PR title should use [conventional commit](https://develop.sentry.dev/engineering-practices/commit-messages/#type) style (`feat:`, `fix:`, `ref:`, `meta:`)
- For external contributors: [CONTRIBUTING.md](https://github.com/getsentry/sentry-python/blob/master/CONTRIBUTING.md), [Sentry SDK development docs](https://develop.sentry.dev/sdk/), [Discord community](https://discord.gg/Ww9hbqr)
