### PR TITLE
fix(integrations): properly distinguish between network.transport and mcp.transport

### DIFF
--- a/sentry_sdk/consts.py
+++ b/sentry_sdk/consts.py
@@ -706,6 +706,12 @@ class SPANDATA:
     Example: 6379
     """
 
+    NETWORK_TRANSPORT = "network.transport"
+    """
+    The transport protocol used for the network connection.
+    Example: "tcp", "udp", "unix"
+    """
+
     PROFILER_ID = "profiler_id"
     """
     Label identifying the profiler id that the span occurred in. This should be a string.
@@ -824,7 +830,7 @@ class SPANDATA:
     MCP_TRANSPORT = "mcp.transport"
     """
     The transport method used for MCP communication.
-    Example: "pipe" (stdio), "tcp" (HTTP/WebSocket/SSE)
+    Example: "http", "sse", "stdio"
     """
 
     MCP_SESSION_ID = "mcp.session.id"


### PR DESCRIPTION
### Description

Fixes the wrong handling of `mcp.transport`, it should be one of "http", "sse", or "stdio", not "pipe" or "tcp". These values are for the [`network.transport`](https://opentelemetry.io/docs/specs/semconv/registry/attributes/network/#network-transport) attribute which was also introduced.

#### Issues

* closes https://linear.app/getsentry/issue/TET-1354/mcp-transport-vs-network-transport
