### PR TITLE
feat(tracemetrics): Add sample_rate to metrics api calls

### DIFF
--- a/sentry_sdk/metrics.py
+++ b/sentry_sdk/metrics.py
@@ -8,7 +8,6 @@ from typing import TYPE_CHECKING
 
 import sentry_sdk
 from sentry_sdk.utils import safe_repr
-from sentry_sdk.tracing_utils import _generate_sample_rand
 
 if TYPE_CHECKING:
     from typing import Any, Optional, Union
@@ -41,35 +40,7 @@ def _capture_metric(
             )
 
     if sample_rate is not None:
-        if sample_rate <= 0.0 or sample_rate > 1.0:
-            if client.transport is not None:
-                client.transport.record_lost_event(
-                    "invalid_sample_rate",
-                    data_category="trace_metric",
-                    quantity=1,
-                )
-            return
-
-        trace_id = None
-        scope = sentry_sdk.get_current_scope()
-        if scope.span is not None:
-            trace_id = scope.span.trace_id
-        elif scope._propagation_context is not None:
-            trace_id = scope._propagation_context.trace_id
-
-        if trace_id is not None and sample_rate < 1.0:
-            sample_rand = _generate_sample_rand(trace_id)
-            if sample_rand >= sample_rate:
-                if client.transport is not None:
-                    client.transport.record_lost_event(
-                        "sample_rate",
-                        data_category="trace_metric",
-                        quantity=1,
-                    )
-                return
-
-        if sample_rate != 1.0 and trace_id is not None:
-            attrs["sentry.client_sample_rate"] = sample_rate
+        attrs["sentry.client_sample_rate"] = sample_rate
 
     metric = {
         "timestamp": time.time(),

--- a/sentry_sdk/metrics.py
+++ b/sentry_sdk/metrics.py
@@ -1,6 +1,6 @@
 """
-NOTE: This file contains experimental code that may be changed or removed at any
-time without prior notice.
+NOTE: This file contains experimental code that may be changed or removed at
+any time without prior notice.
 """
 
 import time
@@ -19,6 +19,7 @@ def _capture_metric(
     value,  # type: float
     unit=None,  # type: Optional[str]
     attributes=None,  # type: Optional[dict[str, Any]]
+    sample_rate=None,  # type: Optional[float]
 ):
     # type: (...) -> None
     client = sentry_sdk.get_client()
@@ -36,6 +37,19 @@ def _capture_metric(
                 )
                 else safe_repr(v)
             )
+
+    if sample_rate is not None:
+        if sample_rate <= 0.0 or sample_rate > 1.0:
+            if client.transport is not None:
+                client.transport.record_lost_event(
+                    "invalid_sample_rate",
+                    data_category="trace_metric",
+                    quantity=1,
+                )
+            return
+
+        if sample_rate != 1.0:
+            attrs["sentry.client_sample_rate"] = sample_rate
 
     metric = {
         "timestamp": time.time(),
@@ -56,9 +70,10 @@ def count(
     value,  # type: float
     unit=None,  # type: Optional[str]
     attributes=None,  # type: Optional[dict[str, Any]]
+    sample_rate=None,  # type: Optional[float]
 ):
     # type: (...) -> None
-    _capture_metric(name, "counter", value, unit, attributes)
+    _capture_metric(name, "counter", value, unit, attributes, sample_rate)
 
 
 def gauge(
@@ -66,9 +81,10 @@ def gauge(
     value,  # type: float
     unit=None,  # type: Optional[str]
     attributes=None,  # type: Optional[dict[str, Any]]
+    sample_rate=None,  # type: Optional[float]
 ):
     # type: (...) -> None
-    _capture_metric(name, "gauge", value, unit, attributes)
+    _capture_metric(name, "gauge", value, unit, attributes, sample_rate)
 
 
 def distribution(
@@ -76,6 +92,7 @@ def distribution(
     value,  # type: float
     unit=None,  # type: Optional[str]
     attributes=None,  # type: Optional[dict[str, Any]]
+    sample_rate=None,  # type: Optional[float]
 ):
     # type: (...) -> None
-    _capture_metric(name, "distribution", value, unit, attributes)
+    _capture_metric(name, "distribution", value, unit, attributes, sample_rate)

--- a/sentry_sdk/metrics.py
+++ b/sentry_sdk/metrics.py
@@ -68,7 +68,7 @@ def _capture_metric(
                     )
                 return
 
-        if sample_rate != 1.0:
+        if sample_rate != 1.0 and trace_id is not None:
             attrs["sentry.client_sample_rate"] = sample_rate
 
     metric = {

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -344,56 +344,6 @@ def test_metrics_no_sample_rate(sentry_init, capture_envelopes):
     assert "sentry.client_sample_rate" not in metrics[0]["attributes"]
 
 
-def test_metrics_sample_rate_no_trace_context(sentry_init, capture_envelopes):
-    """Test sentry.client_sample_rate not set when there's no trace context."""
-    sentry_init()
-    envelopes = capture_envelopes()
-
-    # Send metrics with sample_rate but without any active transaction/span
-    sentry_sdk.metrics.count("test.counter", 1, sample_rate=0.5)
-    sentry_sdk.metrics.gauge("test.gauge", 42, sample_rate=0.8)
-
-    get_client().flush()
-    metrics = envelopes_to_metrics(envelopes)
-
-    assert len(metrics) == 2
-
-    # When there's no trace context, no sampling is performed,
-    # so sentry.client_sample_rate should not be set
-    assert "sentry.client_sample_rate" not in metrics[0]["attributes"]
-    assert "sentry.client_sample_rate" not in metrics[1]["attributes"]
-
-
-def test_metrics_sample_rate_with_trace_context(
-    sentry_init, capture_envelopes, monkeypatch
-):
-    """Test sentry.client_sample_rate is set when there's a trace context."""
-    sentry_init(traces_sample_rate=1.0)
-    envelopes = capture_envelopes()
-
-    # Mock the random sampling to ensure all metrics are included
-    with mock.patch(
-        "sentry_sdk.tracing_utils.Random.randrange",
-        return_value=0,  # Always sample (0 < any positive sample_rate)
-    ):
-        # Send metrics with sample_rate within an active transaction
-        with sentry_sdk.start_transaction() as _:
-            sentry_sdk.metrics.count("test.counter", 1, sample_rate=0.5)
-            sentry_sdk.metrics.gauge("test.gauge", 42, sample_rate=0.8)
-            sentry_sdk.metrics.distribution("test.distribution", 200, sample_rate=1.0)
-
-    get_client().flush()
-    metrics = envelopes_to_metrics(envelopes)
-
-    assert len(metrics) == 3
-
-    # When there's a trace context and sample_rate < 1.0, set attribute
-    assert metrics[0]["attributes"]["sentry.client_sample_rate"] == 0.5
-    assert metrics[1]["attributes"]["sentry.client_sample_rate"] == 0.8
-    # sample_rate=1.0 doesn't need the attribute
-    assert "sentry.client_sample_rate" not in metrics[2]["attributes"]
-
-
 @pytest.mark.parametrize("sample_rand", (0.0, 0.25, 0.5, 0.75))
 @pytest.mark.parametrize("sample_rate", (0.0, 0.25, 0.5, 0.75, 1.0))
 def test_metrics_sampling_decision(


### PR DESCRIPTION
### Summary
This allows for a sample_rate (0, 1.0] to be sent on a per metric basis.

Refs LOGS-495