### PR TITLE
fix(openai-agents): add input messages to errored spans as well

### DIFF
--- a/sentry_sdk/integrations/openai_agents/spans/ai_client.py
+++ b/sentry_sdk/integrations/openai_agents/spans/ai_client.py
@@ -30,6 +30,7 @@ def ai_client_span(agent, get_response_kwargs):
     span.set_data(SPANDATA.GEN_AI_OPERATION_NAME, "chat")
 
     _set_agent_data(span, agent)
+    _set_input_data(span, get_response_kwargs)
 
     return span
 
@@ -37,6 +38,5 @@ def ai_client_span(agent, get_response_kwargs):
 def update_ai_client_span(span, agent, get_response_kwargs, result):
     # type: (sentry_sdk.tracing.Span, Agent, dict[str, Any], Any) -> None
     _set_usage_data(span, result.usage)
-    _set_input_data(span, get_response_kwargs)
     _set_output_data(span, result)
     _create_mcp_execute_tool_spans(span, result)


### PR DESCRIPTION
- Move where the input data is set to ensure that the data is there, even if the chat span errors out for some reason

Closes TET-1308