### PR TITLE
fix: Cast message and detail attributes before appending exception notes

### DIFF
--- a/sentry_sdk/utils.py
+++ b/sentry_sdk/utils.py
@@ -654,7 +654,7 @@ def get_errno(exc_value):
 
 def get_error_message(exc_value):
     # type: (Optional[BaseException]) -> str
-    message = str(
+    message = safe_str(
         getattr(exc_value, "message", "")
         or getattr(exc_value, "detail", "")
         or safe_str(exc_value)


### PR DESCRIPTION
### Description
<!-- What changed and why? -->

Cast  message and detail attributes on exceptions to string when generating the value attribute on the Sentry exception.

Resolves an unhandled `TypeError` when the message or detail attribute has type bytes and `get_error_message()` attempts to append string exception notes. 

#### Issues

Fixes the exception described in https://github.com/getsentry/sentry-python/issues/5050.

#### Reminders
- Please add tests to validate your changes, and lint your code using `tox -e linters`.
- Add GH Issue ID _&_ Linear ID (if applicable)
- PR title should use [conventional commit](https://develop.sentry.dev/engineering-practices/commit-messages/#type) style (`feat:`, `fix:`, `ref:`, `meta:`)
- For external contributors: [CONTRIBUTING.md](https://github.com/getsentry/sentry-python/blob/master/CONTRIBUTING.md), [Sentry SDK development docs](https://develop.sentry.dev/sdk/), [Discord community](https://discord.gg/Ww9hbqr)
