### PR TITLE
Make PropagationContext hold baggage instead of dynamic_sampling_context

### DIFF
--- a/sentry_sdk/tracing_utils.py
+++ b/sentry_sdk/tracing_utils.py
@@ -411,7 +411,7 @@ class PropagationContext:
         "_span_id",
         "parent_span_id",
         "parent_sampled",
-        "dynamic_sampling_context",
+        "baggage",
     )
 
     def __init__(
@@ -421,6 +421,7 @@ class PropagationContext:
         parent_span_id=None,  # type: Optional[str]
         parent_sampled=None,  # type: Optional[bool]
         dynamic_sampling_context=None,  # type: Optional[Dict[str, str]]
+        baggage=None,  # type: Optional[Baggage]
     ):
         # type: (...) -> None
         self._trace_id = trace_id
@@ -438,8 +439,12 @@ class PropagationContext:
         Important when the parent span originated in an upstream service,
         because we want to sample the whole trace, or nothing from the trace."""
 
-        self.dynamic_sampling_context = dynamic_sampling_context
-        """Data that is used for dynamic sampling decisions."""
+        self.baggage = baggage
+        """Parsed baggage header that is used for dynamic sampling decisions."""
+
+        """DEPRECATED this only exists for backwards compat of constructor."""
+        if baggage is None and dynamic_sampling_context is not None:
+            self.baggage = Baggage(dynamic_sampling_context)
 
     @classmethod
     def from_incoming_data(cls, incoming_data):
@@ -456,9 +461,7 @@ class PropagationContext:
 
         baggage_header = normalized_data.get(BAGGAGE_HEADER_NAME)
         if baggage_header:
-            propagation_context.dynamic_sampling_context = Baggage.from_incoming_header(
-                baggage_header
-            ).dynamic_sampling_context()
+            propagation_context.baggage = Baggage.from_incoming_header(baggage_header)
 
         propagation_context._fill_sample_rand()
 
@@ -493,6 +496,11 @@ class PropagationContext:
         # type: (str) -> None
         self._span_id = value
 
+    @property
+    def dynamic_sampling_context(self):
+        # type: () -> Optional[Dict[str, Any]]
+        return self.baggage.dynamic_sampling_context() if self.baggage else None
+
     def update(self, other_dict):
         # type: (Dict[str, Any]) -> None
         """
@@ -506,20 +514,20 @@ class PropagationContext:
 
     def __repr__(self):
         # type: (...) -> str
-        return "<PropagationContext _trace_id={} _span_id={} parent_span_id={} parent_sampled={} dynamic_sampling_context={}>".format(
+        return "<PropagationContext _trace_id={} _span_id={} parent_span_id={} parent_sampled={} baggage={}>".format(
             self._trace_id,
             self._span_id,
             self.parent_span_id,
             self.parent_sampled,
-            self.dynamic_sampling_context,
+            self.baggage,
         )
 
     def _fill_sample_rand(self):
         # type: () -> None
         """
-        Ensure that there is a valid sample_rand value in the dynamic_sampling_context.
+        Ensure that there is a valid sample_rand value in the baggage.
 
-        If there is a valid sample_rand value in the dynamic_sampling_context, we keep it.
+        If there is a valid sample_rand value in the baggage, we keep it.
         Otherwise, we generate a sample_rand value according to the following:
 
           - If we have a parent_sampled value and a sample_rate in the DSC, we compute
@@ -532,23 +540,19 @@ class PropagationContext:
 
         The sample_rand is deterministically generated from the trace_id, if present.
 
-        This function does nothing if there is no dynamic_sampling_context.
+        This function does nothing if there is no baggage.
         """
-        if self.dynamic_sampling_context is None:
+        if self.baggage is None:
             return
 
-        sample_rand = try_convert(
-            float, self.dynamic_sampling_context.get("sample_rand")
-        )
+        sample_rand = try_convert(float, self.baggage.sentry_items.get("sample_rand"))
         if sample_rand is not None and 0 <= sample_rand < 1:
             # sample_rand is present and valid, so don't overwrite it
             return
 
         # Get the sample rate and compute the transformation that will map the random value
         # to the desired range: [0, 1), [0, sample_rate), or [sample_rate, 1).
-        sample_rate = try_convert(
-            float, self.dynamic_sampling_context.get("sample_rate")
-        )
+        sample_rate = try_convert(float, self.baggage.sentry_items.get("sample_rate"))
         lower, upper = _sample_rand_range(self.parent_sampled, sample_rate)
 
         try:
@@ -564,15 +568,15 @@ class PropagationContext:
             )
             return
 
-        self.dynamic_sampling_context["sample_rand"] = f"{sample_rand:.6f}"  # noqa: E231
+        self.baggage.sentry_items["sample_rand"] = f"{sample_rand:.6f}"  # noqa: E231
 
     def _sample_rand(self):
         # type: () -> Optional[str]
-        """Convenience method to get the sample_rand value from the dynamic_sampling_context."""
-        if self.dynamic_sampling_context is None:
+        """Convenience method to get the sample_rand value from the baggage."""
+        if self.baggage is None:
             return None
 
-        return self.dynamic_sampling_context.get("sample_rand")
+        return self.baggage.sentry_items.get("sample_rand")
 
 
 class Baggage:


### PR DESCRIPTION

### Description

The `Transaction.continue_from_headers` and the `Transaction` constructor take a `Baggage` object so this was inconsistent with how I originally designed the baggage handling and created spaghetti loops between the two concepts.
