### PR TITLE
Deprecate continue_from_headers

### DIFF
--- a/sentry_sdk/integrations/grpc/aio/server.py
+++ b/sentry_sdk/integrations/grpc/aio/server.py
@@ -44,7 +44,7 @@ class ServerInterceptor(grpc.aio.ServerInterceptor):  # type: ignore
                     return await handler(request, context)
 
                 # What if the headers are empty?
-                transaction = Transaction.continue_from_headers(
+                transaction = sentry_sdk.continue_trace(
                     dict(context.invocation_metadata()),
                     op=OP.GRPC_SERVER,
                     name=name,

--- a/sentry_sdk/integrations/grpc/server.py
+++ b/sentry_sdk/integrations/grpc/server.py
@@ -38,7 +38,7 @@ class ServerInterceptor(grpc.ServerInterceptor):  # type: ignore
                 if name:
                     metadata = dict(context.invocation_metadata())
 
-                    transaction = Transaction.continue_from_headers(
+                    transaction = sentry_sdk.continue_trace(
                         metadata,
                         op=OP.GRPC_SERVER,
                         name=name,

--- a/sentry_sdk/tracing.py
+++ b/sentry_sdk/tracing.py
@@ -478,6 +478,8 @@ class Span:
     ):
         # type: (...) -> Transaction
         """
+        DEPRECATED: Use :py:meth:`sentry_sdk.continue_trace`.
+
         Create a Transaction with the given params, then add in data pulled from
         the ``sentry-trace`` and ``baggage`` headers from the environ (if any)
         before returning the Transaction.
@@ -489,11 +491,6 @@ class Span:
 
         :param environ: The ASGI/WSGI environ to pull information from.
         """
-        if cls is Span:
-            logger.warning(
-                "Deprecated: use Transaction.continue_from_environ "
-                "instead of Span.continue_from_environ."
-            )
         return Transaction.continue_from_headers(EnvironHeaders(environ), **kwargs)
 
     @classmethod
@@ -506,6 +503,8 @@ class Span:
     ):
         # type: (...) -> Transaction
         """
+        DEPRECATED: Use :py:meth:`sentry_sdk.continue_trace`.
+
         Create a transaction with the given params (including any data pulled from
         the ``sentry-trace`` and ``baggage`` headers).
 
@@ -513,12 +512,7 @@ class Span:
         :param _sample_rand: If provided, we override the sample_rand value from the
             incoming headers with this value. (internal use only)
         """
-        # TODO move this to the Transaction class
-        if cls is Span:
-            logger.warning(
-                "Deprecated: use Transaction.continue_from_headers "
-                "instead of Span.continue_from_headers."
-            )
+        logger.warning("Deprecated: use sentry_sdk.continue_trace instead.")
 
         # TODO-neel move away from this kwargs stuff, it's confusing and opaque
         # make more explicit
@@ -572,16 +566,11 @@ class Span:
     ):
         # type: (...) -> Optional[Transaction]
         """
-        DEPRECATED: Use :py:meth:`sentry_sdk.tracing.Span.continue_from_headers`.
+        DEPRECATED: Use :py:meth:`sentry_sdk.continue_trace`.
 
         Create a ``Transaction`` with the given params, then add in data pulled from
         the given ``sentry-trace`` header value before returning the ``Transaction``.
         """
-        logger.warning(
-            "Deprecated: Use Transaction.continue_from_headers(headers, **kwargs) "
-            "instead of from_traceparent(traceparent, **kwargs)"
-        )
-
         if not traceparent:
             return None
 

--- a/tests/tracing/test_sampling.py
+++ b/tests/tracing/test_sampling.py
@@ -5,8 +5,7 @@ from unittest import mock
 import pytest
 
 import sentry_sdk
-from sentry_sdk import start_span, start_transaction, capture_exception
-from sentry_sdk.tracing import Transaction
+from sentry_sdk import start_span, start_transaction, capture_exception, continue_trace
 from sentry_sdk.tracing_utils import Baggage
 from sentry_sdk.utils import logger
 
@@ -196,8 +195,9 @@ def test_passes_parent_sampling_decision_in_sampling_context(
         )
     )
 
-    transaction = Transaction.continue_from_headers(
-        headers={"sentry-trace": sentry_trace_header}, name="dogpark"
+    transaction = sentry_sdk.continue_trace(
+        {"sentry-trace": sentry_trace_header},
+        name="dogpark",
     )
 
     def mock_set_initial_sampling_decision(_, sampling_context):


### PR DESCRIPTION
### Description

`continue_trace` should be the only recommended way of continuing upstream traces now.

