### PR TITLE
ci: Add auto-label GH action

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,3 +1,8 @@
+# This configuration is used by Craft to categorize changelog entries based on
+# PR labels. To avoid some manual work, there is a PR labeling GitHub action in
+# .github/workflows/pr-labeler.yml that adds a changelog label to PRs based on
+# the title.
+
 changelog:
   exclude:
     labels:

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -1,3 +1,7 @@
+# This action adds changelog labels to PRs that are then used by the release
+# notes generator in Craft. The configuration for which labels map to what
+# changelog categories can be found in .github/release.yml.
+
 name: Label PR for Changelog
 
 on:


### PR DESCRIPTION
### Description
Add a GH action that auto-labels PRs based on title.

If a PR is opened or edited, the action:
- reads the existing labels
- if there already is a Changelog label, it terminates early to not overwrite whatever the developer chose
- if there is no Changelog label, it reads the PR title and matches it against a map of common patterns
- if it matches, the label is added
- if there is no match, it doesn't add a label

#### Issues
<!--
* resolves: #1234
* resolves: LIN-1234
-->

#### Reminders
- Please add tests to validate your changes, and lint your code using `tox -e linters`.
- Add GH Issue ID _&_ Linear ID (if applicable)
- PR title should use [conventional commit](https://develop.sentry.dev/engineering-practices/commit-messages/#type) style (`feat:`, `fix:`, `ref:`, `meta:`)
- For external contributors: [CONTRIBUTING.md](https://github.com/getsentry/sentry-python/blob/master/CONTRIBUTING.md), [Sentry SDK development docs](https://develop.sentry.dev/sdk/), [Discord community](https://discord.gg/Ww9hbqr)
