### PR TITLE
fix(integrations): do not exit early when config is not passed as it is not required and prohibits setting `gen_ai.request.messages`

### DIFF
--- a/sentry_sdk/integrations/google_genai/utils.py
+++ b/sentry_sdk/integrations/google_genai/utils.py
@@ -491,7 +491,7 @@ def set_span_data_for_request(span, integration, model, contents, kwargs):
                 span.set_data(span_key, value)
 
     # Set tools if available
-    if hasattr(config, "tools"):
+    if config is not None and hasattr(config, "tools"):
         tools = config.tools
         if tools:
             formatted_tools = _format_tools_for_span(tools)


### PR DESCRIPTION
#### Issues

Closes https://linear.app/getsentry/issue/TET-1454/py-google-genai-request-messages-missing
