### PR TITLE
fix(langgraph): add missing attributes to invoke_agent span

### DIFF
--- a/sentry_sdk/integrations/langgraph.py
+++ b/sentry_sdk/integrations/langgraph.py
@@ -1,5 +1,5 @@
 from functools import wraps
-from typing import Any, Callable, List, Optional
+from typing import Any, Callable, Dict, List, Optional, Tuple
 
 import sentry_sdk
 from sentry_sdk.ai.utils import (
@@ -10,6 +10,7 @@ from sentry_sdk.ai.utils import (
 from sentry_sdk.consts import OP, SPANDATA
 from sentry_sdk.integrations import DidNotEnable, Integration
 from sentry_sdk.scope import should_send_default_pii
+from sentry_sdk.tracing_utils import _get_value
 from sentry_sdk.utils import safe_serialize
 
 
@@ -103,6 +104,127 @@ def _parse_langgraph_messages(state):
     return normalized_messages if normalized_messages else None
 
 
+def _extract_model_from_config(config):
+    # type: (Any) -> Optional[str]
+    if not config:
+        return None
+
+    if isinstance(config, dict):
+        model = config.get("model")
+        if model:
+            return str(model)
+
+        configurable = config.get("configurable", {})
+        if isinstance(configurable, dict):
+            model = configurable.get("model")
+            if model:
+                return str(model)
+
+    if hasattr(config, "model"):
+        return str(config.model)
+
+    if hasattr(config, "configurable"):
+        configurable = config.configurable
+        if isinstance(configurable, dict):
+            model = configurable.get("model")
+            if model:
+                return str(model)
+        elif hasattr(configurable, "model"):
+            return str(configurable.model)
+
+    return None
+
+
+def _extract_model_from_pregel(pregel_instance):
+    # type: (Any) -> Optional[str]
+    if hasattr(pregel_instance, "config"):
+        model = _extract_model_from_config(pregel_instance.config)
+        if model:
+            return model
+
+    if hasattr(pregel_instance, "nodes"):
+        nodes = pregel_instance.nodes
+        if isinstance(nodes, dict):
+            for node_name, node in nodes.items():
+                if hasattr(node, "bound") and hasattr(node.bound, "model_name"):
+                    return str(node.bound.model_name)
+                if hasattr(node, "runnable") and hasattr(node.runnable, "model_name"):
+                    return str(node.runnable.model_name)
+
+    return None
+
+
+def _get_token_usage(obj):
+    # type: (Any) -> Optional[Dict[str, Any]]
+    possible_names = ("usage", "token_usage", "usage_metadata")
+
+    for name in possible_names:
+        usage = _get_value(obj, name)
+        if usage is not None:
+            return usage
+
+    if isinstance(obj, dict):
+        messages = obj.get("messages", [])
+        if messages and isinstance(messages, list):
+            for message in reversed(messages):
+                for name in possible_names:
+                    usage = _get_value(message, name)
+                    if usage is not None:
+                        return usage
+
+    return None
+
+
+def _extract_tokens(token_usage):
+    # type: (Any) -> Tuple[Optional[int], Optional[int], Optional[int]]
+    input_tokens = _get_value(token_usage, "prompt_tokens") or _get_value(
+        token_usage, "input_tokens"
+    )
+    output_tokens = _get_value(token_usage, "completion_tokens") or _get_value(
+        token_usage, "output_tokens"
+    )
+    total_tokens = _get_value(token_usage, "total_tokens")
+
+    return input_tokens, output_tokens, total_tokens
+
+
+def _record_token_usage(span, response):
+    # type: (Any, Any) -> None
+    token_usage = _get_token_usage(response)
+    if not token_usage:
+        return
+
+    input_tokens, output_tokens, total_tokens = _extract_tokens(token_usage)
+
+    if input_tokens is not None:
+        span.set_data(SPANDATA.GEN_AI_USAGE_INPUT_TOKENS, input_tokens)
+
+    if output_tokens is not None:
+        span.set_data(SPANDATA.GEN_AI_USAGE_OUTPUT_TOKENS, output_tokens)
+
+    if total_tokens is not None:
+        span.set_data(SPANDATA.GEN_AI_USAGE_TOTAL_TOKENS, total_tokens)
+
+
+def _extract_model_from_response(result):
+    # type: (Any) -> Optional[str]
+    if isinstance(result, dict):
+        messages = result.get("messages", [])
+        if messages and isinstance(messages, list):
+            for message in reversed(messages):
+                if hasattr(message, "response_metadata"):
+                    metadata = message.response_metadata
+                    if isinstance(metadata, dict):
+                        model = metadata.get("model")
+                        if model:
+                            return str(model)
+                        model_name = metadata.get("model_name")
+                        if model_name:
+                            return str(model_name)
+
+    return None
+
+
 def _wrap_state_graph_compile(f):
     # type: (Callable[..., Any]) -> Callable[..., Any]
     @wraps(f)
@@ -175,7 +297,14 @@ def _wrap_pregel_invoke(f):
 
             span.set_data(SPANDATA.GEN_AI_OPERATION_NAME, "invoke_agent")
 
-            # Store input messages to later compare with output
+            request_model = _extract_model_from_pregel(self)
+            if not request_model and len(kwargs) > 0:
+                config = kwargs.get("config")
+                request_model = _extract_model_from_config(config)
+
+            if request_model:
+                span.set_data(SPANDATA.GEN_AI_REQUEST_MODEL, request_model)
+
             input_messages = None
             if (
                 len(args) > 0
@@ -198,6 +327,14 @@ def _wrap_pregel_invoke(f):
                         )
 
             result = f(self, *args, **kwargs)
+
+            response_model = _extract_model_from_response(result)
+            if response_model:
+                span.set_data(SPANDATA.GEN_AI_RESPONSE_MODEL, response_model)
+            elif request_model:
+                span.set_data(SPANDATA.GEN_AI_RESPONSE_MODEL, request_model)
+
+            _record_token_usage(span, result)
 
             _set_response_attributes(span, input_messages, result, integration)
 
@@ -232,6 +369,14 @@ def _wrap_pregel_ainvoke(f):
 
             span.set_data(SPANDATA.GEN_AI_OPERATION_NAME, "invoke_agent")
 
+            request_model = _extract_model_from_pregel(self)
+            if not request_model and len(kwargs) > 0:
+                config = kwargs.get("config")
+                request_model = _extract_model_from_config(config)
+
+            if request_model:
+                span.set_data(SPANDATA.GEN_AI_REQUEST_MODEL, request_model)
+
             input_messages = None
             if (
                 len(args) > 0
@@ -254,6 +399,14 @@ def _wrap_pregel_ainvoke(f):
                         )
 
             result = await f(self, *args, **kwargs)
+
+            response_model = _extract_model_from_response(result)
+            if response_model:
+                span.set_data(SPANDATA.GEN_AI_RESPONSE_MODEL, response_model)
+            elif request_model:
+                span.set_data(SPANDATA.GEN_AI_RESPONSE_MODEL, request_model)
+
+            _record_token_usage(span, result)
 
             _set_response_attributes(span, input_messages, result, integration)
 


### PR DESCRIPTION
- Add missing attributes to invoke_agent span: 
       gen_ai.request.model
       gen_ai.response.model
       gen_ai.usage.input_tokens
       gen_ai.usage.output_tokens
       gen_ai.usage.total_tokens
       gen_ai.request.messages


Closes TET-1456