### PR TITLE
fix: Make PropagationContext.from_incoming_data always return a PropagationContext

### DIFF
--- a/sentry_sdk/scope.py
+++ b/sentry_sdk/scope.py
@@ -510,11 +510,12 @@ class Scope:
         If there is `incoming_data` overwrite existing propagation context.
         If there is no `incoming_data` create new propagation context, but do NOT overwrite if already existing.
         """
-        if incoming_data:
-            propagation_context = PropagationContext.from_incoming_data(incoming_data)
-            if propagation_context is not None:
-                self._propagation_context = propagation_context
+        if incoming_data is not None:
+            self._propagation_context = PropagationContext.from_incoming_data(
+                incoming_data
+            )
 
+        # TODO-neel this below is a BIG code smell but requires a bunch of other refactoring
         if self._type != ScopeType.CURRENT:
             if self._propagation_context is None:
                 self.set_new_propagation_context()

--- a/sentry_sdk/tracing_utils.py
+++ b/sentry_sdk/tracing_utils.py
@@ -447,7 +447,8 @@ class PropagationContext:
 
     @classmethod
     def from_incoming_data(cls, incoming_data):
-        # type: (Dict[str, Any]) -> Optional[PropagationContext]
+        # type: (Dict[str, Any]) -> PropagationContext
+        propagation_context = PropagationContext()
         normalized_data = normalize_incoming_data(incoming_data)
 
         sentry_trace_header = normalized_data.get(SENTRY_TRACE_HEADER_NAME)
@@ -455,7 +456,7 @@ class PropagationContext:
 
         # nothing to propagate if no sentry-trace
         if sentrytrace_data is None:
-            return None
+            return propagation_context
 
         baggage_header = normalized_data.get(BAGGAGE_HEADER_NAME)
         baggage = (
@@ -463,9 +464,8 @@ class PropagationContext:
         )
 
         if not _should_continue_trace(baggage):
-            return None
+            return propagation_context
 
-        propagation_context = PropagationContext()
         propagation_context.update(sentrytrace_data)
         if baggage:
             propagation_context.baggage = baggage

--- a/tests/tracing/test_integration_tests.py
+++ b/tests/tracing/test_integration_tests.py
@@ -419,3 +419,14 @@ def test_continue_trace_strict_trace_continuation(
         )
         assert transaction.parent_span_id != "1234567890abcdef"
         assert not transaction.parent_sampled
+
+
+def test_continue_trace_forces_new_traces_when_no_propagation(sentry_init):
+    """This is to make sure we don't have a long running trace because of TWP logic for the no propagation case."""
+
+    sentry_init(traces_sample_rate=1.0)
+
+    tx1 = continue_trace({}, name="tx1")
+    tx2 = continue_trace({}, name="tx2")
+
+    assert tx1.trace_id != tx2.trace_id


### PR DESCRIPTION
### Description

When there is any sort of incoming data, and since `continue_trace` is always intended to be at a system boundary, we always want to force a new trace if there's no incoming propagation or a mismatched propagation headers (for `strict_trace_continuation`).

What previously happened in these cases: a single `trace_id` was kept alive in the `propagation_context` even when these were meant to be new independent traces (see screenshot that shows undesired behavior before this fix).

I think this will actually solve many complaints about long living traces that were never supposed to be such.


<img width="1828" height="649" alt="image" src="https://github.com/user-attachments/assets/dd14e74a-0c0c-44a0-affc-994519655ab3" />
