### PR TITLE
test: Remove skipped test

### DIFF
--- a/tests/tracing/test_deprecated.py
+++ b/tests/tracing/test_deprecated.py
@@ -9,24 +9,6 @@ from sentry_sdk import start_span
 from sentry_sdk.tracing import Span
 
 
-@pytest.mark.skip(reason="This deprecated feature has been removed in SDK 2.0.")
-def test_start_span_to_start_transaction(sentry_init, capture_events):
-    # XXX: this only exists for backwards compatibility with code before
-    # Transaction / start_transaction were introduced.
-    sentry_init(traces_sample_rate=1.0)
-    events = capture_events()
-
-    with start_span(transaction="/1/"):
-        pass
-
-    with start_span(Span(transaction="/2/")):
-        pass
-
-    assert len(events) == 2
-    assert events[0]["transaction"] == "/1/"
-    assert events[1]["transaction"] == "/2/"
-
-
 @pytest.mark.parametrize(
     "parameter_value_getter",
     # Use lambda to avoid Hub deprecation warning here (will suppress it in the test)


### PR DESCRIPTION
This test appears to be testing functionality no longer in the SDK.