### PR TITLE
ref: Cleanup outgoing propagation_context logic

### DIFF
--- a/tests/test_propagationcontext.py
+++ b/tests/test_propagationcontext.py
@@ -25,7 +25,7 @@ def test_empty_context():
 
     assert ctx.parent_span_id is None
     assert ctx.parent_sampled is None
-    assert ctx.dynamic_sampling_context is None
+    assert ctx.dynamic_sampling_context == {}
 
 
 def test_context_with_values():
@@ -72,7 +72,7 @@ def test_property_setters():
     assert ctx.trace_id == "X234567890abcdef1234567890abcdef"
     assert ctx._span_id == "X234567890abcdef"
     assert ctx.span_id == "X234567890abcdef"
-    assert ctx.dynamic_sampling_context is None
+    assert ctx.dynamic_sampling_context == {}
 
 
 def test_update():
@@ -93,7 +93,7 @@ def test_update():
     assert ctx._span_id is not None
     assert ctx.parent_span_id == "Z234567890abcdef"
     assert not ctx.parent_sampled
-    assert ctx.dynamic_sampling_context is None
+    assert ctx.dynamic_sampling_context == {}
 
     assert not hasattr(ctx, "foo")
 


### PR DESCRIPTION
### Description

* Add `get_baggage`, `get_traceparent` and `iter_headers` to `PropagationContext` so that the contract is similar to `Span`. 
  * This clarifies that the `PropagationContext` and `Span` are themselves responsible for constructing these values and not the `Scope`. 
  * Currently, it is all a mess on `Scope` which does not clarify state responsibilities correctly on who holds and can populate what.
* Add `Baggage.populate_from_propagation_context` as a replacement for `Baggage.from_options` (that took a `scope` argument).
* Unify all the various `propagation_context` presence checks in `Scope` methods to `get_active_propagation_context`. 
  * This `get_active_propagation_context` logic then remains the central problem to fix in the future.


### Deprecations

The following methods are thus no longer used internally and deprecated.
* `Scope.get_dynamic_sampling_context`
* `Scope.iter_headers`
* `Baggage.from_options`


