### PR TITLE
fix(django): Set active thread ID when middleware spans are disabled

### DIFF
--- a/sentry_sdk/integrations/django/asgi.py
+++ b/sentry_sdk/integrations/django/asgi.py
@@ -180,6 +180,10 @@ def wrap_async_view(callback):
         if sentry_scope.profile is not None:
             sentry_scope.profile.update_active_thread_id()
 
+        integration = sentry_sdk.get_client().get_integration(DjangoIntegration)
+        if not integration or not integration.middleware_spans:
+            return await callback(request, *args, **kwargs)
+
         with sentry_sdk.start_span(
             op=OP.VIEW_RENDER,
             name=request.resolver_match.view_name,

--- a/sentry_sdk/integrations/django/views.py
+++ b/sentry_sdk/integrations/django/views.py
@@ -49,7 +49,7 @@ def patch_views():
         # efficient way to wrap views (or build a cache?)
 
         integration = sentry_sdk.get_client().get_integration(DjangoIntegration)
-        if integration is not None and integration.middleware_spans:
+        if integration is not None:
             is_async_view = (
                 iscoroutinefunction is not None
                 and wrap_async_view is not None
@@ -85,6 +85,10 @@ def _wrap_sync_view(callback):
         # this isn't necessary for async views since that runs on main
         if sentry_scope.profile is not None:
             sentry_scope.profile.update_active_thread_id()
+
+        integration = sentry_sdk.get_client().get_integration(DjangoIntegration)
+        if not integration or not integration.middleware_spans:
+            return callback(request, *args, **kwargs)
 
         with sentry_sdk.start_span(
             op=OP.VIEW_RENDER,

--- a/tests/integrations/django/asgi/test_asgi.py
+++ b/tests/integrations/django/asgi/test_asgi.py
@@ -118,19 +118,25 @@ async def test_async_views(sentry_init, capture_events, application):
 
 @pytest.mark.parametrize("application", APPS)
 @pytest.mark.parametrize("endpoint", ["/sync/thread_ids", "/async/thread_ids"])
+@pytest.mark.parametrize("middleware_spans", [False, True])
 @pytest.mark.asyncio
 @pytest.mark.forked
 @pytest.mark.skipif(
     django.VERSION < (3, 1), reason="async views have been introduced in Django 3.1"
 )
 async def test_active_thread_id(
-    sentry_init, capture_envelopes, teardown_profiling, endpoint, application
+    sentry_init,
+    capture_envelopes,
+    teardown_profiling,
+    endpoint,
+    application,
+    middleware_spans,
 ):
     with mock.patch(
         "sentry_sdk.profiler.transaction_profiler.PROFILE_MINIMUM_SAMPLES", 0
     ):
         sentry_init(
-            integrations=[DjangoIntegration()],
+            integrations=[DjangoIntegration(middleware_spans=middleware_spans)],
             traces_sample_rate=1.0,
             profiles_sample_rate=1.0,
         )


### PR DESCRIPTION
### Description
<!-- What changed and why? -->

Set the active thread ID on Django server transactions independently of the `middleware_spans` option.

The `test_active_thread_id()` test previously failed if middleware spans are disabled.


#### Issues

Contributes to https://github.com/getsentry/sentry-python/issues/5062

#### Reminders
- Please add tests to validate your changes, and lint your code using `tox -e linters`.
- Add GH Issue ID _&_ Linear ID (if applicable)
- PR title should use [conventional commit](https://develop.sentry.dev/engineering-practices/commit-messages/#type) style (`feat:`, `fix:`, `ref:`, `meta:`)
- For external contributors: [CONTRIBUTING.md](https://github.com/getsentry/sentry-python/blob/master/CONTRIBUTING.md), [Sentry SDK development docs](https://develop.sentry.dev/sdk/), [Discord community](https://discord.gg/Ww9hbqr)
