### PR TITLE
feat: Add "K_REVISION" to environment variable release check (exposed by cloud run)

### DIFF
--- a/sentry_sdk/utils.py
+++ b/sentry_sdk/utils.py
@@ -154,6 +154,7 @@ def get_default_release():
         "CODEBUILD_RESOLVED_SOURCE_VERSION",
         "CIRCLE_SHA1",
         "GAE_DEPLOYMENT_ID",
+        "K_REVISION",
     ):
         release = os.environ.get(var)
         if release:


### PR DESCRIPTION
### Description
Google cloud run [exposes](https://docs.cloud.google.com/run/docs/container-contract#services-env-vars) `K_REVISION` env varibale to keep track of revisions. This can be a good candidate for sentry release.
Today it already works for Google app engine via `GAE_DEPLOYMENT_ID`