### PR TITLE
feat(starlette): Set transaction name when middleware spans are disabled

### DIFF
--- a/tests/integrations/fastapi/test_fastapi.py
+++ b/tests/integrations/fastapi/test_fastapi.py
@@ -469,6 +469,7 @@ def test_transaction_name_in_traces_sampler(
     client.get(request_url)
 
 
+@pytest.mark.parametrize("middleware_spans", [False, True])
 @pytest.mark.parametrize(
     "request_url,transaction_style,expected_transaction_name,expected_transaction_source",
     [
@@ -488,6 +489,7 @@ def test_transaction_name_in_traces_sampler(
 )
 def test_transaction_name_in_middleware(
     sentry_init,
+    middleware_spans,
     request_url,
     transaction_style,
     expected_transaction_name,
@@ -500,8 +502,12 @@ def test_transaction_name_in_middleware(
     sentry_init(
         auto_enabling_integrations=False,  # Make sure that httpx integration is not added, because it adds tracing information to the starlette test clients request.
         integrations=[
-            StarletteIntegration(transaction_style=transaction_style),
-            FastApiIntegration(transaction_style=transaction_style),
+            StarletteIntegration(
+                transaction_style=transaction_style, middleware_spans=middleware_spans
+            ),
+            FastApiIntegration(
+                transaction_style=transaction_style, middleware_spans=middleware_spans
+            ),
         ],
         traces_sample_rate=1.0,
     )

--- a/tests/integrations/starlette/test_starlette.py
+++ b/tests/integrations/starlette/test_starlette.py
@@ -1099,6 +1099,7 @@ def test_transaction_name_in_traces_sampler(
     client.get(request_url)
 
 
+@pytest.mark.parametrize("middleware_spans", [False, True])
 @pytest.mark.parametrize(
     "request_url,transaction_style,expected_transaction_name,expected_transaction_source",
     [
@@ -1118,6 +1119,7 @@ def test_transaction_name_in_traces_sampler(
 )
 def test_transaction_name_in_middleware(
     sentry_init,
+    middleware_spans,
     request_url,
     transaction_style,
     expected_transaction_name,
@@ -1130,7 +1132,9 @@ def test_transaction_name_in_middleware(
     sentry_init(
         auto_enabling_integrations=False,  # Make sure that httpx integration is not added, because it adds tracing information to the starlette test clients request.
         integrations=[
-            StarletteIntegration(transaction_style=transaction_style),
+            StarletteIntegration(
+                transaction_style=transaction_style, middleware_spans=middleware_spans
+            ),
         ],
         traces_sample_rate=1.0,
     )


### PR DESCRIPTION
### Description
<!-- What changed and why? -->

Set the name of Starlette and FastAPI server transactions independently of the `middleware_spans` option.

The `test_transaction_name_in_middleware()` test previously failed if middleware spans are disabled.

#### Issues
<!--
* resolves: #1234
* resolves: LIN-1234
-->

#### Reminders
- Please add tests to validate your changes, and lint your code using `tox -e linters`.
- Add GH Issue ID _&_ Linear ID (if applicable)
- PR title should use [conventional commit](https://develop.sentry.dev/engineering-practices/commit-messages/#type) style (`feat:`, `fix:`, `ref:`, `meta:`)
- For external contributors: [CONTRIBUTING.md](https://github.com/getsentry/sentry-python/blob/master/CONTRIBUTING.md), [Sentry SDK development docs](https://develop.sentry.dev/sdk/), [Discord community](https://discord.gg/Ww9hbqr)
