### PR TITLE
ref(scope): Set global attrs on global scope

### DIFF
--- a/sentry_sdk/scope.py
+++ b/sentry_sdk/scope.py
@@ -366,7 +366,7 @@ class Scope:
 
         return _global_scope
 
-    def _set_global_attributes(self) -> None:
+    def set_global_attributes(self) -> None:
         from sentry_sdk.client import SDK_INFO
 
         self.set_attribute("sentry.sdk.name", SDK_INFO["name"])
@@ -493,7 +493,7 @@ class Scope:
             # We need a client to set the initial global attributes on the global
             # scope since they mostly come from client options, so populate them
             # as soon as a client is set
-            sentry_sdk.get_global_scope()._set_global_attributes()
+            sentry_sdk.get_global_scope().set_global_attributes()
         else:
             self.client = NonRecordingClient()
 


### PR DESCRIPTION
### Description
Since we now have scope attributes, we can set global attributes on the global scope and they'll get automatically applied when the scopes are merged.

#### Issues
<!--
* resolves: #1234
* resolves: LIN-1234
-->

#### Reminders
- Please add tests to validate your changes, and lint your code using `tox -e linters`.
- Add GH Issue ID _&_ Linear ID (if applicable)
- PR title should use [conventional commit](https://develop.sentry.dev/engineering-practices/commit-messages/#type) style (`feat:`, `fix:`, `ref:`, `meta:`)
- For external contributors: [CONTRIBUTING.md](https://github.com/getsentry/sentry-python/blob/master/CONTRIBUTING.md), [Sentry SDK development docs](https://develop.sentry.dev/sdk/), [Discord community](https://discord.gg/Ww9hbqr)
