### PR TITLE
ci: DRY ruff calls

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@
 # See https://pre-commit.com/hooks.html for more hooks
 repos:
 -   repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.13.2
+    rev: v0.14.10
     hooks:
     -   id: ruff-check
         args: [--fix]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,9 +1,14 @@
 # See https://pre-commit.com for more information
 # See https://pre-commit.com/hooks.html for more hooks
 repos:
+    # ruff-pre-commit is not using tool.ruff.include setting,
+    # so `files` need to be specified here.
+    # https://github.com/astral-sh/ruff-pre-commit/issues/71
 -   repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.14.10
     hooks:
     -   id: ruff-check
         args: [--fix]
+        files: ^(sentry_sdk/|tests/)
     -   id: ruff-format
+        files: ^(sentry_sdk/|tests/)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -196,6 +196,9 @@ ignore_missing_imports = true
 # Target Python 3.7+ (minimum version supported by ruff)
 target-version = "py37"
 
+# Include files and directories
+include = ["sentry_sdk/**/*.py", "tests/**/*.py"]
+
 # Exclude files and directories
 extend-exclude = [
     "*_pb2.py",     # Protocol Buffer files (covers all pb2 files including grpc_test_service_pb2.py)

--- a/tox.ini
+++ b/tox.ini
@@ -924,6 +924,6 @@ commands =
 
 [testenv:linters]
 commands =
-    ruff check tests sentry_sdk
-    ruff format --check tests sentry_sdk
+    ruff check
+    ruff format --check
     mypy sentry_sdk

--- a/tox.ini
+++ b/tox.ini
@@ -924,6 +924,5 @@ commands =
 
 [testenv:linters]
 commands =
-    ruff check
-    ruff format --check
+    pre-commit run --all-files
     mypy sentry_sdk


### PR DESCRIPTION
### Description
I was checking the lint setup and realized running pre-commit locally on latest main doesn't produce a clean result. I checked why this wasn't the case on CI and found out that pre-commit ruff and CI ruff use slightly different configuration. I tried to centralize that config, and found out there is a _bug_ with ruff-pre-commit but still DRY'ed the ruff calls.

Considering the removal of the "include" setting causes only a single change in a single file, I think that settings can be removed compeletely but I didn't want to change configuration without asking about it first.

#### Issues
-

#### Reminders
- Please add tests to validate your changes, and lint your code using `tox -e linters`.
- Add GH Issue ID _&_ Linear ID (if applicable)
- PR title should use [conventional commit](https://develop.sentry.dev/engineering-practices/commit-messages/#type) style (`feat:`, `fix:`, `ref:`, `meta:`)
- For external contributors: [CONTRIBUTING.md](https://github.com/getsentry/sentry-python/blob/master/CONTRIBUTING.md), [Sentry SDK development docs](https://develop.sentry.dev/sdk/), [Discord community](https://discord.gg/Ww9hbqr)
