### PR TITLE
docs: Fix `middleware_spans` docstring

### DIFF
--- a/sentry_sdk/integrations/django/__init__.py
+++ b/sentry_sdk/integrations/django/__init__.py
@@ -109,7 +109,7 @@ class DjangoIntegration(Integration):
     Auto instrument a Django application.
 
     :param transaction_style: How to derive transaction names. Either `"function_name"` or `"url"`. Defaults to `"url"`.
-    :param middleware_spans: Whether to create spans for middleware. Defaults to `True`.
+    :param middleware_spans: Whether to create spans for middleware. Defaults to `False`.
     :param signals_spans: Whether to create spans for signals. Defaults to `True`.
     :param signals_denylist: A list of signals to ignore when creating spans.
     :param cache_spans: Whether to create spans for cache operations. Defaults to `False`.


### PR DESCRIPTION
We updated the option default, but forgot to update the docstring.
