### PR TITLE
ci: Use craft release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,7 @@ on:
     inputs:
       version:
         description: 'Version to release (or "auto")'
-        required: true
+        required: false
       force:
         description: Force a release even when there are release-blockers (optional)
         required: false
@@ -17,6 +17,8 @@ jobs:
   release:
     uses: getsentry/craft/.github/workflows/release.yml@v2
     with:
-      version: ${{ inputs.version || 'auto' }}
+      version: ${{ github.event.inputs.version || 'auto' }}
+      force: ${{ github.event.inputs.force }}
+      merge_target: ${{ github.event.inputs.merge_target }}
     secrets: inherit
 


### PR DESCRIPTION
### Description
<!-- What changed and why? -->

The release workflow with the "minor" version created https://github.com/getsentry/publish/issues/6871, which failed upon acceptance because "minor" is not a valid version.

The craft publish action uses the resolved version: https://github.com/getsentry/craft/blob/a592b7a4b48725239e96f08c04025a0888a266a4/action.yml#L143.

The previous `action-prepare-release` action does not resolve the version when using semantic version increments like "minor".

Follows https://github.com/getsentry/craft/issues/695#issuecomment-3723150432.

#### Issues
<!--
* resolves: #1234
* resolves: LIN-1234
-->

#### Reminders
- Please add tests to validate your changes, and lint your code using `tox -e linters`.
- Add GH Issue ID _&_ Linear ID (if applicable)
- PR title should use [conventional commit](https://develop.sentry.dev/engineering-practices/commit-messages/#type) style (`feat:`, `fix:`, `ref:`, `meta:`)
- For external contributors: [CONTRIBUTING.md](https://github.com/getsentry/sentry-python/blob/master/CONTRIBUTING.md), [Sentry SDK development docs](https://develop.sentry.dev/sdk/), [Discord community](https://discord.gg/Ww9hbqr)
