### PR TITLE
fix(threading): Handle channels shadowing

### DIFF
--- a/sentry_sdk/integrations/threading.py
+++ b/sentry_sdk/integrations/threading.py
@@ -54,11 +54,14 @@ class ThreadingIntegration(Integration):
 
         try:
             from django import VERSION as django_version  # noqa: N811
+        except ImportError:
+            django_version = None
+
+        try:
             import channels  # type: ignore[import-untyped]
 
             channels_version = channels.__version__
         except (ImportError, AttributeError):
-            django_version = None
             channels_version = None
 
         is_async_emulated_with_threads = (


### PR DESCRIPTION
### Description
Folks might have a `channels` module that has nothing to do with the `channels` package we're expecting. This will then make the code throw an `AttributeError` which we don't handle.

#### Issues
* Closes https://github.com/getsentry/sentry-python/issues/5298

#### Reminders
- Please add tests to validate your changes, and lint your code using `tox -e linters`.
- Add GH Issue ID _&_ Linear ID (if applicable)
- PR title should use [conventional commit](https://develop.sentry.dev/engineering-practices/commit-messages/#type) style (`feat:`, `fix:`, `ref:`, `meta:`)
- For external contributors: [CONTRIBUTING.md](https://github.com/getsentry/sentry-python/blob/master/CONTRIBUTING.md), [Sentry SDK development docs](https://develop.sentry.dev/sdk/), [Discord community](https://discord.gg/Ww9hbqr)
