### PR TITLE
chore: Add type for metric units

### DIFF
--- a/sentry_sdk/_types.py
+++ b/sentry_sdk/_types.py
@@ -256,7 +256,7 @@ if TYPE_CHECKING:
     )
 
     MetricType = Literal["counter", "gauge", "distribution"]
-    MetricUnit = Union[DurationUnit, InformationUnit]
+    MetricUnit = Union[DurationUnit, InformationUnit, str]
 
     Metric = TypedDict(
         "Metric",


### PR DESCRIPTION
SDKs should not restrict what strings can be sent as a metric unit, but should provide hints/types/constants to help determine what values are supported.