### PR TITLE
fix(openai): normalize Pydantic objects before JSON serialization in truncate_messages_by_size

### DIFF
--- a/sentry_sdk/ai/utils.py
+++ b/sentry_sdk/ai/utils.py
@@ -660,6 +660,10 @@ def truncate_messages_by_size(
     In the single message case, the serialized message size may exceed `max_bytes`, because
     truncation is based only on character count in that case.
     """
+    # Normalize messages to ensure JSON serialization works
+    # (handles Pydantic objects from OpenAI SDK v1+)
+    messages = _normalize_data(messages, unpack=False)
+
     serialized_json = json.dumps(messages, separators=(",", ":"))
     current_size = len(serialized_json.encode("utf-8"))
 


### PR DESCRIPTION
## Summary

The OpenAI SDK v1+ returns Pydantic model instances (e.g., `ResponseFunctionToolCall`) which are not directly JSON serializable. When these objects are passed to `truncate_messages_by_size()`, the `json.dumps()` call fails with a `TypeError`:

```
TypeError: Object of type ResponseFunctionToolCall is not JSON serializable
```

The `_normalize_data()` helper already exists in this file and properly handles Pydantic objects by calling `.model_dump()`, but it wasn't being used in `truncate_messages_by_size()`.

## The Fix

This PR adds normalization at the start of `truncate_messages_by_size()` to ensure all Pydantic objects are converted to JSON-compatible dicts before serialization:

```python
# Normalize messages to ensure JSON serialization works
# (handles Pydantic objects from OpenAI SDK v1+)
messages = _normalize_data(messages, unpack=False)
```

## Reproduction

When using the OpenAI SDK's Responses API with tool calls and Sentry's OpenAI integration enabled:

```python
from openai import OpenAI
from openai.types.responses import ResponseFunctionToolCall

client = OpenAI()
response = client.responses.create(
    model="gpt-4o",
    input=[
        {"role": "user", "content": "What's the weather?"},
        {
            "role": "assistant", 
            "content": [ResponseFunctionToolCall(
                type="function_call",
                id="call_123",
                call_id="call_123",
                name="get_weather",
                arguments='{"location": "NYC"}'
            )]
        }
    ]
)
```

This crashes with the `TypeError` because Sentry's integration tries to serialize the messages for tracing.

Fixes #5350