### PR TITLE
test(mcp): Use `TestClient` for Streamable HTTP

### DIFF
--- a/tests/integrations/mcp/test_mcp.py
+++ b/tests/integrations/mcp/test_mcp.py
@@ -29,10 +29,10 @@ except ImportError:
             return super(AsyncMock, self).__call__(*args, **kwargs)
 
 
-from mcp.types import GetPromptResult, PromptMessage, TextContent
-from mcp.server.lowlevel.helper_types import ReadResourceContents
 from mcp.server.lowlevel import Server
 from mcp.server.lowlevel.server import request_ctx
+from mcp.types import GetPromptResult, PromptMessage, TextContent
+from mcp.server.lowlevel.helper_types import ReadResourceContents
 
 try:
     from mcp.server.lowlevel.server import request_ctx


### PR DESCRIPTION
### Description
<!-- What changed and why? -->

Stop mocking transport layer of `mcp` package in tests.

Converts functions annotated with `@mcp.call_tool`, and analogous resource and prompt decorators, to async if, and only if, an exception is raised when going through the transport layer.

#### Issues
<!--
* resolves: #1234
* resolves: LIN-1234
-->

#### Reminders
- Please add tests to validate your changes, and lint your code using `tox -e linters`.
- Add GH Issue ID _&_ Linear ID (if applicable)
- PR title should use [conventional commit](https://develop.sentry.dev/engineering-practices/commit-messages/#type) style (`feat:`, `fix:`, `ref:`, `meta:`)
- For external contributors: [CONTRIBUTING.md](https://github.com/getsentry/sentry-python/blob/master/CONTRIBUTING.md), [Sentry SDK development docs](https://develop.sentry.dev/sdk/), [Discord community](https://discord.gg/Ww9hbqr)
