### PR TITLE
fix(google-genai): fix wrong token accounting in streaming

### DIFF
--- a/sentry_sdk/integrations/google_genai/streaming.py
+++ b/sentry_sdk/integrations/google_genai/streaming.py
@@ -43,16 +43,16 @@ def accumulate_streaming_response(
     - input_tokens: Use last non-zero value (prompt doesn't change during streaming)
     - input_tokens_cached: Use last non-zero value
     - output_tokens: Sum across chunks (incremental output)
-    - output_tokens_reasoning: Use last non-zero value
+    - output_tokens_reasoning: Sum across chunks (incremental reasoning)
     - total_tokens: Use last non-zero value (cumulative in final chunk)
     """
     accumulated_text = []
     finish_reasons = []
     tool_calls = []
     total_output_tokens = 0
+    total_reasoning_tokens = 0
     last_input_tokens = 0
     last_cached_tokens = 0
-    last_reasoning_tokens = 0
     last_total_tokens = 0
     response_id = None
     model = None
@@ -81,12 +81,11 @@ def accumulate_streaming_response(
             last_input_tokens = extracted_usage_data["input_tokens"]
         if extracted_usage_data["input_tokens_cached"]:
             last_cached_tokens = extracted_usage_data["input_tokens_cached"]
-        if extracted_usage_data["output_tokens_reasoning"]:
-            last_reasoning_tokens = extracted_usage_data["output_tokens_reasoning"]
         if extracted_usage_data["total_tokens"]:
             last_total_tokens = extracted_usage_data["total_tokens"]
 
         total_output_tokens += extracted_usage_data["output_tokens"]
+        total_reasoning_tokens += extracted_usage_data["output_tokens_reasoning"]
 
     accumulated_response = AccumulatedResponse(
         text="".join(accumulated_text),
@@ -96,7 +95,7 @@ def accumulate_streaming_response(
             input_tokens=last_input_tokens,
             output_tokens=total_output_tokens,
             input_tokens_cached=last_cached_tokens,
-            output_tokens_reasoning=last_reasoning_tokens,
+            output_tokens_reasoning=total_reasoning_tokens,
             total_tokens=last_total_tokens,
         ),
         id=response_id,

--- a/tests/integrations/google_genai/test_google_genai.py
+++ b/tests/integrations/google_genai/test_google_genai.py
@@ -472,6 +472,7 @@ def test_streaming_generate_content(sentry_init, capture_events, mock_genai_clie
             "promptTokenCount": 10,
             "candidatesTokenCount": 3,
             "totalTokenCount": 13,
+            "thoughtsTokenCount": 1,
         },
     }
 
@@ -550,9 +551,9 @@ def test_streaming_generate_content(sentry_init, capture_events, mock_genai_clie
     assert chat_span["data"][SPANDATA.GEN_AI_USAGE_INPUT_TOKENS] == 10
     assert invoke_span["data"][SPANDATA.GEN_AI_USAGE_INPUT_TOKENS] == 10
 
-    # Output tokens: sum of candidates (2 + 3 + 7 = 12) + last reasoning (3) = 15
-    assert chat_span["data"][SPANDATA.GEN_AI_USAGE_OUTPUT_TOKENS] == 15
-    assert invoke_span["data"][SPANDATA.GEN_AI_USAGE_OUTPUT_TOKENS] == 15
+    # Output tokens: sum of candidates (2 + 3 + 7 = 12) +  reasoning (0 + 1 + 3) = 16
+    assert chat_span["data"][SPANDATA.GEN_AI_USAGE_OUTPUT_TOKENS] == 16
+    assert invoke_span["data"][SPANDATA.GEN_AI_USAGE_OUTPUT_TOKENS] == 16
 
     # Total tokens: last non-zero value from final chunk = 25
     assert chat_span["data"][SPANDATA.GEN_AI_USAGE_TOTAL_TOKENS] == 25
@@ -562,9 +563,9 @@ def test_streaming_generate_content(sentry_init, capture_events, mock_genai_clie
     assert chat_span["data"][SPANDATA.GEN_AI_USAGE_INPUT_TOKENS_CACHED] == 5
     assert invoke_span["data"][SPANDATA.GEN_AI_USAGE_INPUT_TOKENS_CACHED] == 5
 
-    # Reasoning tokens: last non-zero value = 3
-    assert chat_span["data"][SPANDATA.GEN_AI_USAGE_OUTPUT_TOKENS_REASONING] == 3
-    assert invoke_span["data"][SPANDATA.GEN_AI_USAGE_OUTPUT_TOKENS_REASONING] == 3
+    # Reasoning tokens: sum across chunks = 4
+    assert chat_span["data"][SPANDATA.GEN_AI_USAGE_OUTPUT_TOKENS_REASONING] == 4
+    assert invoke_span["data"][SPANDATA.GEN_AI_USAGE_OUTPUT_TOKENS_REASONING] == 4
 
     # Verify model name
     assert chat_span["data"][SPANDATA.GEN_AI_REQUEST_MODEL] == "gemini-1.5-flash"


### PR DESCRIPTION
- Google GenAI library passes the cumulative token count, but we aggregate them over all streaming chunks, leading to inflated token counts & cost estimates
- This PR fixes that by taking the last available input tokens, while accumulating the tokens for the generated output