### PR TITLE
fix(google-genai): deactivate google genai when langchain is used

### DIFF
--- a/sentry_sdk/integrations/__init__.py
+++ b/sentry_sdk/integrations/__init__.py
@@ -167,7 +167,7 @@ _MIN_VERSIONS = {
 
 
 _INTEGRATION_DEACTIVATES = {
-    "langchain": {"openai", "anthropic"},
+    "langchain": {"openai", "anthropic", "google_genai"},
     "openai_agents": {"openai"},
     "pydantic_ai": {"openai", "anthropic"},
 }

--- a/tests/test_ai_integration_deactivation.py
+++ b/tests/test_ai_integration_deactivation.py
@@ -57,6 +57,7 @@ def test_integration_deactivates_map_exists():
     assert "langchain" in _INTEGRATION_DEACTIVATES
     assert "openai" in _INTEGRATION_DEACTIVATES["langchain"]
     assert "anthropic" in _INTEGRATION_DEACTIVATES["langchain"]
+    assert "google_genai" in _INTEGRATION_DEACTIVATES["langchain"]
     assert "openai_agents" in _INTEGRATION_DEACTIVATES
     assert "openai" in _INTEGRATION_DEACTIVATES["openai_agents"]
     assert "pydantic_ai" in _INTEGRATION_DEACTIVATES


### PR DESCRIPTION
- we are seeing duplicate spans for google genai and langchain
- deactivate google genai when langchain is used

