### PR TITLE
feat(span-streaming): Add experimental `trace_lifecycle` switch (1)

### DIFF
--- a/sentry_sdk/consts.py
+++ b/sentry_sdk/consts.py
@@ -82,6 +82,7 @@ if TYPE_CHECKING:
             "before_send_log": Optional[Callable[[Log, Hint], Optional[Log]]],
             "enable_metrics": Optional[bool],
             "before_send_metric": Optional[Callable[[Metric, Hint], Optional[Metric]]],
+            "trace_lifecycle": Optional[Literal["static", "stream"]],
         },
         total=False,
     )

--- a/sentry_sdk/tracing_utils.py
+++ b/sentry_sdk/tracing_utils.py
@@ -106,6 +106,13 @@ def has_tracing_enabled(options: "Optional[Dict[str, Any]]") -> bool:
     )
 
 
+def has_span_streaming_enabled(options: "Optional[dict[str, Any]]") -> bool:
+    if options is None:
+        return False
+
+    return (options.get("_experiments") or {}).get("trace_lifecycle") == "stream"
+
+
 @contextlib.contextmanager
 def record_sql_queries(
     cursor: "Any",


### PR DESCRIPTION
- Add a new experimental `trace_lifecycle` option (used in follow up PRs)
- Add a new util function for checking which mode the SDK is in

Chipping away at https://github.com/getsentry/sentry-python/pull/5317 to transform it into reviewable and mergeable PRs.