### PR TITLE
fix(span-streaming): Always preserialize attributes

### DIFF
--- a/sentry_sdk/traces.py
+++ b/sentry_sdk/traces.py
@@ -39,11 +39,10 @@ class StreamedSpan:
         trace_id: "Optional[str]" = None,
     ):
         self.name: str = name
+        self._attributes: "Attributes" = {}
         if attributes:
             for attribute, value in attributes.items():
                 self.set_attribute(attribute, value)
-        else:
-            self._attributes: "Attributes" = {}
 
         self._trace_id = trace_id
 


### PR DESCRIPTION
We were not preserializing attributes set directly on span creation.
