### PR TITLE
test(fastmcp): Wrap prompt in `Message`

### DIFF
--- a/tests/integrations/fastmcp/test_fastmcp.py
+++ b/tests/integrations/fastmcp/test_fastmcp.py
@@ -625,7 +625,7 @@ async def test_fastmcp_prompt_sync(
                 },
             }
 
-            if Message is not None:
+            if FASTMCP_VERSION is not None and FASTMCP_VERSION.startswith("3"):
                 message = Message(message)
 
             return [message]
@@ -714,7 +714,7 @@ async def test_fastmcp_prompt_async(
                 },
             }
 
-            if Message is not None:
+            if FASTMCP_VERSION is not None and FASTMCP_VERSION.startswith("3"):
                 message1 = Message(message1)
                 message2 = Message(message2)
 


### PR DESCRIPTION
### Description
<!-- What changed and why? -->

The following error is returned from `result.json()` without the change:

```
{'jsonrpc': '2.0', 'id': 'req-async-prompt', 'error': {'code': 0, 'message': 'Error rendering prompt async_prompt.'}}
```

I haven't investigated this in much depth, but Cursor fetched me this from the upgrade guide 😄 

https://github.com/jlowin/fastmcp/blob/main/docs/development/upgrade-guide.mdx#prompts-use-message-class

#### Issues
<!--
* resolves: #1234
* resolves: LIN-1234
-->

#### Reminders
- Please add tests to validate your changes, and lint your code using `tox -e linters`.
- Add GH Issue ID _&_ Linear ID (if applicable)
- PR title should use [conventional commit](https://develop.sentry.dev/engineering-practices/commit-messages/#type) style (`feat:`, `fix:`, `ref:`, `meta:`)
- For external contributors: [CONTRIBUTING.md](https://github.com/getsentry/sentry-python/blob/master/CONTRIBUTING.md), [Sentry SDK development docs](https://develop.sentry.dev/sdk/), [Discord community](https://discord.gg/Ww9hbqr)
