### PR TITLE
test(fastmcp): Remove `test_fastmcp_without_request_context()`

### DIFF
--- a/tests/integrations/fastmcp/test_fastmcp.py
+++ b/tests/integrations/fastmcp/test_fastmcp.py
@@ -896,36 +896,6 @@ async def test_fastmcp_span_origin(sentry_init, capture_events, FastMCP, stdio):
     assert mcp_spans[0]["origin"] == "auto.ai.mcp"
 
 
-@pytest.mark.parametrize("FastMCP", fastmcp_implementations, ids=fastmcp_ids)
-def test_fastmcp_without_request_context(sentry_init, capture_events, FastMCP):
-    """Test FastMCP handling when no request context is available"""
-    sentry_init(
-        integrations=[MCPIntegration()],
-        traces_sample_rate=1.0,
-    )
-    events = capture_events()
-
-    mcp = FastMCP("Test Server")
-
-    # Clear request context
-    if request_ctx is not None:
-        request_ctx.set(None)
-
-    @mcp.tool()
-    def test_tool_no_ctx(x: int) -> dict:
-        """Test tool without context"""
-        return {"result": x + 1}
-
-    with start_transaction(name="fastmcp tx"):
-        result = call_tool_through_mcp(mcp, "test_tool_no_ctx", {"x": 99})
-
-    assert result == {"result": 100}
-
-    # Should still create transaction even if context is missing
-    (tx,) = events
-    assert tx["type"] == "transaction"
-
-
 # =============================================================================
 # Transport Detection Tests
 # =============================================================================


### PR DESCRIPTION
### Description
<!-- What changed and why? -->

The request context is set immediately before running the handler we patch, so the test is verifying behavior for an unreachable state.

https://github.com/modelcontextprotocol/python-sdk/blob/6f8b791faf219329d97f422a009ac1d1674e46bb/src/mcp/server/lowlevel/server.py#L764-L780

#### Issues
<!--
* resolves: #1234
* resolves: LIN-1234
-->

#### Reminders
- Please add tests to validate your changes, and lint your code using `tox -e linters`.
- Add GH Issue ID _&_ Linear ID (if applicable)
- PR title should use [conventional commit](https://develop.sentry.dev/engineering-practices/commit-messages/#type) style (`feat:`, `fix:`, `ref:`, `meta:`)
- For external contributors: [CONTRIBUTING.md](https://github.com/getsentry/sentry-python/blob/master/CONTRIBUTING.md), [Sentry SDK development docs](https://develop.sentry.dev/sdk/), [Discord community](https://discord.gg/Ww9hbqr)
