### PR TITLE
fix(mcp): Handle all awaitable return types

### DIFF
--- a/sentry_sdk/integrations/mcp.py
+++ b/sentry_sdk/integrations/mcp.py
@@ -469,7 +469,7 @@ def _create_instrumented_decorator(
     def instrumented_decorator(func: "Callable[..., Any]") -> "Callable[..., Any]":
         @wraps(func)
         async def wrapper(*args: "Any") -> "Any":
-            return await _handler_wrapper(handler_type, func, args)
+            return await _handler_wrapper(handler_type, func, args, force_await=False)
 
         # Then register it with the original MCP decorator
         return original_decorator(*decorator_args, **decorator_kwargs)(wrapper)
@@ -543,7 +543,6 @@ def _patch_fastmcp() -> None:
                 args,
                 kwargs,
                 self,
-                force_await=True,
             )
 
         FastMCP._get_prompt_mcp = patched_get_prompt_mcp
@@ -561,7 +560,6 @@ def _patch_fastmcp() -> None:
                 args,
                 kwargs,
                 self,
-                force_await=True,
             )
 
         FastMCP._read_resource_mcp = patched_read_resource_mcp


### PR DESCRIPTION
### Description
<!-- What changed and why? -->

The handler registered with `Server.call_tool` is **always** awaited in the `mcp` internals. Registering a handler which is not a coroutine function or does not return a type implementing `__await__` raises an exception. This exception is swallowed by `mcp` if `raise_exceptions=False`.

https://github.com/modelcontextprotocol/python-sdk/blob/050aeb64569ae2115f1946f721efd6d7c439d43e/src/mcp/server/lowlevel/server.py#L781

--- 

The `mcp.tool.result.content` attribute now holds the awaited return value of the registered handler, in the case that the return value is awaitable but not a coroutine function.

The test below previously fails.

```python
class AwaitableDict:
    def __init__(self, value):
        self.value = value
    
    def __await__(self):
        yield None
        return self.value

async def test_awaitable(
    sentry_init, capture_events, stdio
):
    """Test that synchronous tool handlers create proper spans"""
    sentry_init(
        integrations=[MCPIntegration(include_prompts=True)],
        traces_sample_rate=1.0,
        send_default_pii=True,
    )
    events = capture_events()

    server = Server("test-server")

    @server.call_tool()
    def test_tool(tool_name, arguments):  # Note: synchronous function
        return AwaitableDict({"result": "success", "value": 42})

    with start_transaction(name="mcp tx"):
        result = await stdio(
            server,
            method="tools/call",
            params={
                "name": "calculate",
                "arguments": {"x": 10, "y": 5},
            },
            request_id="req-123",
        )

    (tx,) = events
    span = tx["spans"][0]

    assert span["data"][SPANDATA.MCP_TOOL_RESULT_CONTENT] == json.dumps(
            {
                "result": "success",
                "value": 42,
            }
        )
```

#### Issues
<!--
* resolves: #1234
* resolves: LIN-1234
-->

#### Reminders
- Please add tests to validate your changes, and lint your code using `tox -e linters`.
- Add GH Issue ID _&_ Linear ID (if applicable)
- PR title should use [conventional commit](https://develop.sentry.dev/engineering-practices/commit-messages/#type) style (`feat:`, `fix:`, `ref:`, `meta:`)
- For external contributors: [CONTRIBUTING.md](https://github.com/getsentry/sentry-python/blob/master/CONTRIBUTING.md), [Sentry SDK development docs](https://develop.sentry.dev/sdk/), [Discord community](https://discord.gg/Ww9hbqr)
