### PR TITLE
fix(celery): Close the connection we're reading driver_type from

### DIFF
--- a/sentry_sdk/integrations/celery/__init__.py
+++ b/sentry_sdk/integrations/celery/__init__.py
@@ -392,10 +392,11 @@ def _wrap_task_call(task: "Any", f: "F") -> "F":
                     )
 
                 with capture_internal_exceptions():
-                    span.set_data(
-                        SPANDATA.MESSAGING_SYSTEM,
-                        task.app.connection().transport.driver_type,
-                    )
+                    with task.app.connection() as conn:
+                        span.set_data(
+                            SPANDATA.MESSAGING_SYSTEM,
+                            conn.transport.driver_type,
+                        )
 
                 return f(*args, **kwargs)
         except Exception:


### PR DESCRIPTION
Currently, we're reading the driver type (e.g. `redis`) from a connection. We're however not closing the connection, potentially causing file descriptor leaks.

**Aside:** Opening a connection just for the purpose of determining the driver type is not ideal in the first place. We should see whether we can get the info from elsewhere from the context of a task's `run`/`__call__` (which is where we're enriching the span with it). Or we could see whether we can cache this somehow.

For now, let's at least make sure to clean up the connection.

#### Issues
Closes https://github.com/getsentry/sentry-python/issues/5422

#### Reminders
- Please add tests to validate your changes, and lint your code using `tox -e linters`.
- Add GH Issue ID _&_ Linear ID (if applicable)
- PR title should use [conventional commit](https://develop.sentry.dev/engineering-practices/commit-messages/#type) style (`feat:`, `fix:`, `ref:`, `meta:`)
- For external contributors: [CONTRIBUTING.md](https://github.com/getsentry/sentry-python/blob/master/CONTRIBUTING.md), [Sentry SDK development docs](https://develop.sentry.dev/sdk/), [Discord community](https://discord.gg/Ww9hbqr)
