### PR TITLE
test: Add test for `get_baggage` with DSN

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -98,13 +98,19 @@ def test_baggage_with_tracing_enabled(sentry_init):
 
 
 def test_baggage_with_dsn(sentry_init):
-    sentry_init(dsn="http://97333d956c9e40989a0139756c121c34@sentry-x.sentry-y.s.c.local/976543210", traces_sample_rate=1.0, release="2.0.0", environment="dev", transport=TestTransportWithOptions)
+    sentry_init(
+        dsn="http://97333d956c9e40989a0139756c121c34@sentry-x.sentry-y.s.c.local/976543210",
+        traces_sample_rate=1.0,
+        release="2.0.0",
+        environment="dev",
+        transport=TestTransportWithOptions,
+    )
     with start_transaction() as transaction:
         expected_baggage_re = r"^sentry-trace_id={},sentry-sample_rand=0\.\d{{6}},sentry-environment=dev,sentry-release=2\.0\.0,sentry-public_key=97333d956c9e40989a0139756c121c34,sentry-sample_rate=1\.0,sentry-sampled={}$".format(
             transaction.trace_id, "true" if transaction.sampled else "false"
         )
-        print('xx received baggage', get_baggage() )
         assert re.match(expected_baggage_re, get_baggage())
+
 
 def test_continue_trace(sentry_init):
     sentry_init()


### PR DESCRIPTION
This adds a test for `get_baggage` that demonstrates that the public key form the DSN is included in the resulting baggage string. This came up internally while debugging an incomplete baggage header in the Sentry backend. 
(Turns out the root cause was not 100% related to this test but we might wanna keep it anyway)