### PR TITLE
fix(celery): Get transport's `driver_type` from broker's URL

### DIFF
--- a/sentry_sdk/integrations/celery/__init__.py
+++ b/sentry_sdk/integrations/celery/__init__.py
@@ -1,6 +1,7 @@
 import sys
 from collections.abc import Mapping
 from functools import wraps
+from urllib.parse import urlparse
 
 import sentry_sdk
 from sentry_sdk import isolation_scope
@@ -392,11 +393,9 @@ def _wrap_task_call(task: "Any", f: "F") -> "F":
                     )
 
                 with capture_internal_exceptions():
-                    with task.app.connection() as conn:
-                        span.set_data(
-                            SPANDATA.MESSAGING_SYSTEM,
-                            conn.transport.driver_type,
-                        )
+                    task_broker_url = task.app.conf.broker_url
+                    driver_type = urlparse(task_broker_url).scheme
+                    span.set_data(SPANDATA.MESSAGING_SYSTEM, driver_type)
 
                 return f(*args, **kwargs)
         except Exception:


### PR DESCRIPTION
### Description
Under the hood within Kombu (the messaging library used by Celery), the `driver_type` is ultimately derived from the broker's URL that's provided in the Celery configuration by the user via either the `broker` or `broker_url` arguments.

We can accomplish the same thing in our context, removing the need to open a connection to the broker to determine the `driver_type` to set in the span.

The `broker_url` is set in both of the following scenarios:
- `app = Celery("tasks", broker_url=<your-broker-url>)`
- `app = Celery("tasks", broker=<your-broker-url>)`

#### Issues
- Fixes PY-2071
- Fixes https://github.com/getsentry/sentry-python/issues/5428