### PR TITLE
ci: Auto-run CI on toxgen PRs

### DIFF
--- a/.github/workflows/update-tox.yml
+++ b/.github/workflows/update-tox.yml
@@ -42,7 +42,7 @@ jobs:
         run: |
           COMMIT_TITLE="ci: 🤖 Update test matrix with new releases"
           DATE=`date +%m/%d`
-          BRANCH_NAME="toxgen/update"
+          BRANCH_NAME="toxgen/update-$(date +%m-%d)"
 
           git checkout -B "$BRANCH_NAME"
           git add --all
@@ -108,4 +108,19 @@ jobs:
                 repo: context.repo.repo,
                 issue_number: pr.number,
                 labels: ['Component: CI', 'Component: Tests']
+            });
+
+            // Close and reopen the PR to trigger CI
+            // (PRs created by GITHUB_TOKEN don't trigger workflows)
+            await github.rest.pulls.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: pr.number,
+                state: 'closed'
+            });
+            await github.rest.pulls.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: pr.number,
+                state: 'open'
             });


### PR DESCRIPTION
### Description
Currently, CI is not run on toxgen PRs. Try whether closing and opening the PR would do the trick.

#### Issues
<!--
* resolves: #1234
* resolves: LIN-1234
-->

#### Reminders
- Please add tests to validate your changes, and lint your code using `tox -e linters`.
- Add GH Issue ID _&_ Linear ID (if applicable)
- PR title should use [conventional commit](https://develop.sentry.dev/engineering-practices/commit-messages/#type) style (`feat:`, `fix:`, `ref:`, `meta:`)
- For external contributors: [CONTRIBUTING.md](https://github.com/getsentry/sentry-python/blob/master/CONTRIBUTING.md), [Sentry SDK development docs](https://develop.sentry.dev/sdk/), [Discord community](https://discord.gg/Ww9hbqr)
