### PR TITLE
Fix transaction naming for django-ninja endpoints with transaction_style="function_name" 

### DIFF
--- a/tests/integrations/django/myapp/urls.py
+++ b/tests/integrations/django/myapp/urls.py
@@ -157,5 +157,9 @@ try:
 except AttributeError:
     pass
 
+# django-ninja
+if views.ninja_api is not None:
+    urlpatterns.append(path("ninja/", views.ninja_api.urls))
+
 handler500 = views.handler500
 handler404 = views.handler404

--- a/tests/integrations/django/myapp/views.py
+++ b/tests/integrations/django/myapp/views.py
@@ -370,3 +370,29 @@ def send_myapp_custom_signal(request):
     myapp_custom_signal.send(sender="hello")
     myapp_custom_signal_silenced.send(sender="hello")
     return HttpResponse("ok")
+
+
+# django-ninja integration
+try:
+    from ninja import NinjaAPI
+
+    ninja_api = NinjaAPI()
+
+    @ninja_api.get("/ninja-hello")
+    def ninja_hello(request):
+        """Ninja hello endpoint"""
+        return {"message": "Hello from Ninja"}
+
+    @ninja_api.post("/ninja-hello")
+    def ninja_hello_post(request):
+        """Ninja hello POST endpoint"""
+        return {"message": "POST Hello from Ninja"}
+
+    @ninja_api.get("/ninja-message")
+    def ninja_message(request):
+        """Ninja message endpoint that captures a message"""
+        capture_message("ninja message")
+        return {"message": "Ninja message sent"}
+
+except ImportError:
+    ninja_api = None

--- a/tests/integrations/django/test_ninja.py
+++ b/tests/integrations/django/test_ninja.py
@@ -1,0 +1,78 @@
+"""Tests for django-ninja integration with transaction_style="function_name"."""
+
+import pytest
+
+django = pytest.importorskip("django")
+ninja = pytest.importorskip("ninja")
+
+from sentry_sdk.integrations.django import DjangoIntegration
+
+
+@pytest.mark.parametrize(
+    "transaction_style,url,expected_transaction,expected_source",
+    [
+        (
+            "function_name",
+            "/ninja/ninja-message",
+            "tests.integrations.django.myapp.views.ninja_message",
+            "component",
+        ),
+        (
+            "url",
+            "/ninja/ninja-message",
+            "/ninja/ninja-message",
+            "route",
+        ),
+    ],
+)
+def test_ninja_transaction_style(
+    sentry_init,
+    client,
+    capture_events,
+    transaction_style,
+    url,
+    expected_transaction,
+    expected_source,
+):
+    """Test that django-ninja endpoints work correctly with different transaction styles."""
+    sentry_init(
+        integrations=[DjangoIntegration(transaction_style=transaction_style)],
+        send_default_pii=True,
+    )
+    events = capture_events()
+
+    # Make the request
+    response = client.get(url)
+    assert response.status_code == 200
+
+    # Check the captured event
+    (event,) = events
+    assert event["transaction"] == expected_transaction
+    assert event["transaction_info"] == {"source": expected_source}
+
+
+def test_ninja_multiple_methods_same_path(
+    sentry_init,
+    client,
+    capture_events,
+):
+    """Test that ninja endpoints with multiple HTTP methods on same path work correctly."""
+    sentry_init(
+        integrations=[DjangoIntegration(transaction_style="function_name")],
+        send_default_pii=True,
+    )
+    events = capture_events()
+
+    # Test GET
+    response = client.get("/ninja/ninja-hello")
+    assert response.status_code == 200
+
+    # Test POST - note that ninja-hello has both GET and POST handlers
+    response = client.post("/ninja/ninja-hello")
+    assert response.status_code == 200
+
+    # We should have 0 events because ninja-hello doesn't capture messages
+    # This test just validates that the endpoints don't error and can be properly
+    # resolved by the integration without crashing
+    assert len(events) == 0
+


### PR DESCRIPTION
### Description
DISCLAIMER: We patched django using a middleware to fix this and wanted to contribute it back to sentry, delegated this to copilot and it looks ok, no intention to be ai-slop, just wanted to raise the issue here.

Django-ninja endpoints were all grouped under `ninja.operation.PathView._sync_view` when using `transaction_style="function_name"`, making it impossible to distinguish between different API endpoints in Sentry.

Django's `resolve()` returns the PathView wrapper function instead of the actual endpoint. The wrapper is shared across all endpoints on the same path, causing the grouping issue.

## Changes

- **Added `_unwrap_django_ninja_view()`** - Detects PathView wrappers by checking `__qualname__`, extracts the PathView instance from the closure, matches the HTTP method to the correct Operation, and returns the actual endpoint function
- **Modified `_set_transaction_name_and_source()`** - Calls unwrapper when `transaction_style="function_name"` before extracting the transaction name
- **Added integration tests** - Validates both `function_name` and `url` transaction styles work correctly with ninja endpoints

## Example

Before this change, all these endpoints would be grouped as `ninja.operation.PathView._sync_view`:

```python
@api.get("/users")
def list_users(request):
    ...

@api.post("/users")
def create_user(request):
    ...
```

After this change, they get distinct names: `myapp.views.list_users` and `myapp.views.create_user`.