### PR TITLE
test: Assert `setup_once()` only raises `DidNotEnable` with shadowed dependencies

### DIFF
--- a/tests/test_shadowed_module.py
+++ b/tests/test_shadowed_module.py
@@ -79,10 +79,9 @@ def test_shadowed_modules_when_importing_integrations(
     An integration is determined to be for a third-party module if it cannot
     be imported in the environment in which the tests run.
     """
-    module_path = (
-        pathlib.Path("sentry_sdk") / "integrations" / integration_submodule_name
-    )
-    import_path = ".".join(module_path.with_suffix("").parts)
+    parts = integration_submodule_name.split(".")
+    module_path = pathlib.Path("sentry_sdk") / "integrations" / pathlib.Path(*parts)
+    import_path = ".".join(("sentry_sdk", "integrations", *parts))
 
     integration_dependencies = set()
     for py_file in pathlib.Path(module_path).rglob("*.py"):


### PR DESCRIPTION
### Description
<!-- What changed and why? -->

Extend shadowed module test to verify that imports are correctly gated in `setup_once()` methods.

We only considered exceptions when importing the module containing an integration in https://github.com/getsentry/sentry-python/issues/5140. An `AttributeError` due to a shadowed import *inside* `setup_once()` led to a new issue https://github.com/getsentry/sentry-python/issues/5298.

The following test failures are raised without the added ignore list.

```
_______________________________________________________________________________________ test_shadowed_modules_when_importing_integrations[beam] _______________________________________________________________________________________
tests/test_shadowed_module.py:125: in test_shadowed_modules_when_importing_integrations
    integration.setup_once()
sentry_sdk/integrations/beam.py:39: in setup_once
    from apache_beam.transforms.core import DoFn, ParDo  # type: ignore
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
E   ModuleNotFoundError: No module named 'apache_beam.transforms'; 'apache_beam' is not a package
______________________________________________________________________________________ test_shadowed_modules_when_importing_integrations[spark] _______________________________________________________________________________________
tests/test_shadowed_module.py:139: in test_shadowed_modules_when_importing_integrations
    integration.setup_once()
sentry_sdk/integrations/spark/spark_driver.py:20: in setup_once
    _setup_sentry_tracing()
sentry_sdk/integrations/spark/spark_driver.py:111: in _setup_sentry_tracing
    from pyspark import SparkContext
E   ImportError: cannot import name 'SparkContext' from 'pyspark' (unknown location)
```


#### Issues
<!--
* resolves: #1234
* resolves: LIN-1234
-->

#### Reminders
- Please add tests to validate your changes, and lint your code using `tox -e linters`.
- Add GH Issue ID _&_ Linear ID (if applicable)
- PR title should use [conventional commit](https://develop.sentry.dev/engineering-practices/commit-messages/#type) style (`feat:`, `fix:`, `ref:`, `meta:`)
- For external contributors: [CONTRIBUTING.md](https://github.com/getsentry/sentry-python/blob/master/CONTRIBUTING.md), [Sentry SDK development docs](https://develop.sentry.dev/sdk/), [Discord community](https://discord.gg/Ww9hbqr)
