### PR TITLE
chore: Deprecate `gen_ai.choice` and `gen_ai.user.message`

### DIFF
--- a/sentry_sdk/consts.py
+++ b/sentry_sdk/consts.py
@@ -473,6 +473,9 @@ class SPANDATA:
 
     GEN_AI_CHOICE = "gen_ai.choice"
     """
+    .. deprecated::
+        This attribute is deprecated. Use the gen_ai.output.messages attribute instead.
+
     The model's response message.
     Example: "The weather in Paris is rainy and overcast, with temperatures around 57°F"
     """
@@ -677,6 +680,9 @@ class SPANDATA:
 
     GEN_AI_USER_MESSAGE = "gen_ai.user.message"
     """
+    .. deprecated::
+        This attribute is deprecated. Use the gen_ai.input.messages attribute instead.
+
     The user message passed to the model.
     Example: "What's the weather in Paris?"
     """


### PR DESCRIPTION
### Description
<!-- What changed and why? -->

Updated in line with conventions: https://github.com/getsentry/sentry-conventions/pull/253

#### Issues

Contributes to PY-2083

#### Reminders
- Please add tests to validate your changes, and lint your code using `tox -e linters`.
- Add GH Issue ID _&_ Linear ID (if applicable)
- PR title should use [conventional commit](https://develop.sentry.dev/engineering-practices/commit-messages/#type) style (`feat:`, `fix:`, `ref:`, `meta:`)
- For external contributors: [CONTRIBUTING.md](https://github.com/getsentry/sentry-python/blob/master/CONTRIBUTING.md), [Sentry SDK development docs](https://develop.sentry.dev/sdk/), [Discord community](https://discord.gg/Ww9hbqr)
