### PR TITLE
fix(rq): Support rq 2.7.0+ where SimpleWorker inherits from BaseWorker

### DIFF
--- a/sentry_sdk/integrations/rq.py
+++ b/sentry_sdk/integrations/rq.py
@@ -23,6 +23,14 @@ try:
 except ImportError:
     raise DidNotEnable("RQ not installed")
 
+try:
+    from rq.worker import BaseWorker
+
+    if not hasattr(BaseWorker, "perform_job"):
+        BaseWorker = None
+except ImportError:
+    BaseWorker = None
+
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -47,12 +55,7 @@ class RqIntegration(Integration):
         # instead of Worker, so we need to patch BaseWorker to cover both.
         # For older versions where BaseWorker doesn't exist or doesn't have
         # perform_job, we patch Worker.
-        try:
-            from rq.worker import BaseWorker
-
-            worker_cls = BaseWorker if hasattr(BaseWorker, "perform_job") else Worker
-        except ImportError:
-            worker_cls = Worker
+        worker_cls = BaseWorker if BaseWorker is not None else Worker
 
         old_perform_job = worker_cls.perform_job
 


### PR DESCRIPTION
## Summary
- In rq 2.7.0, `SimpleWorker` was refactored to inherit directly from `BaseWorker` instead of `Worker` ([rq#2336](https://github.com/rq/rq/pull/2336)). This broke our integration because we only monkey-patched `Worker.perform_job` and `Worker.handle_exception`, which `SimpleWorker` no longer inherits.
- Now patches `BaseWorker` when available (rq >= 1.7.0), falling back to `Worker` for older versions. Since both `Worker` and `SimpleWorker` inherit from `BaseWorker`, this covers both worker types.

## Test plan
- [x] `py3.14-rq-v2.6.1`: 10 passed (backward compat)
- [x] `py3.14-rq-v2.7.0`: 10 passed (new version)

🤖 Generated with [Claude Code](https://claude.com/claude-code)