### PR TITLE
ref(google-genai): Remove `set_data_normalized` for the `gen_ai.response.finish_reasons` attribute

### DIFF
--- a/sentry_sdk/integrations/google_genai/utils.py
+++ b/sentry_sdk/integrations/google_genai/utils.py
@@ -881,8 +881,8 @@ def set_span_data_for_response(
 
     finish_reasons = extract_finish_reasons(response)
     if finish_reasons:
-        set_data_normalized(
-            span, SPANDATA.GEN_AI_RESPONSE_FINISH_REASONS, finish_reasons
+        span.set_data(
+            SPANDATA.GEN_AI_RESPONSE_FINISH_REASONS, json.dumps(finish_reasons)
         )
 
     if getattr(response, "response_id", None):


### PR DESCRIPTION
### Description
<!-- What changed and why? -->

Remove `set_data_normalized()` for attributes that do not require normalization.

Since `extract_finish_reasons(response)` returns a list of strings, we can directly serialize to JSON.

This attribute does not adhere to our conventions as the conventions indicate type it be a string: https://github.com/getsentry/sentry-conventions/blob/0e79c16961a747152afc2c8d86311351d2c05554/model/attributes/gen_ai/gen_ai__response__finish_reasons.json#L4

#### Issues
<!--
* resolves: #1234
* resolves: LIN-1234
-->

#### Reminders
- Please add tests to validate your changes, and lint your code using `tox -e linters`.
- Add GH Issue ID _&_ Linear ID (if applicable)
- PR title should use [conventional commit](https://develop.sentry.dev/engineering-practices/commit-messages/#type) style (`feat:`, `fix:`, `ref:`, `meta:`)
- For external contributors: [CONTRIBUTING.md](https://github.com/getsentry/sentry-python/blob/master/CONTRIBUTING.md), [Sentry SDK development docs](https://develop.sentry.dev/sdk/), [Discord community](https://discord.gg/Ww9hbqr)
