### PR TITLE
ref(huggingface-hub): Remove `set_data_normalized` for the `gen_ai.response.finish_reasons` attribute

### DIFF
--- a/sentry_sdk/integrations/huggingface_hub.py
+++ b/sentry_sdk/integrations/huggingface_hub.py
@@ -184,8 +184,7 @@ def _wrap_huggingface_task(f: "Callable[..., Any]", op: str) -> "Callable[..., A
                 span.set_data(SPANDATA.GEN_AI_RESPONSE_MODEL, response_model)
 
             if finish_reason is not None:
-                set_data_normalized(
-                    span,
+                span.set_data(
                     SPANDATA.GEN_AI_RESPONSE_FINISH_REASONS,
                     finish_reason,
                 )
@@ -258,8 +257,7 @@ def _wrap_huggingface_task(f: "Callable[..., Any]", op: str) -> "Callable[..., A
                             yield chunk
 
                         if finish_reason is not None:
-                            set_data_normalized(
-                                span,
+                            span.set_data(
                                 SPANDATA.GEN_AI_RESPONSE_FINISH_REASONS,
                                 finish_reason,
                             )
@@ -337,8 +335,7 @@ def _wrap_huggingface_task(f: "Callable[..., Any]", op: str) -> "Callable[..., A
                             )
 
                         if finish_reason is not None:
-                            set_data_normalized(
-                                span,
+                            span.set_data(
                                 SPANDATA.GEN_AI_RESPONSE_FINISH_REASONS,
                                 finish_reason,
                             )


### PR DESCRIPTION
### Description
<!-- What changed and why? -->

Remove `set_data_normalized()` for attributes that do not require normalization.

#### Issues
<!--
* resolves: #1234
* resolves: LIN-1234
-->

#### Reminders
- Please add tests to validate your changes, and lint your code using `tox -e linters`.
- Add GH Issue ID _&_ Linear ID (if applicable)
- PR title should use [conventional commit](https://develop.sentry.dev/engineering-practices/commit-messages/#type) style (`feat:`, `fix:`, `ref:`, `meta:`)
- For external contributors: [CONTRIBUTING.md](https://github.com/getsentry/sentry-python/blob/master/CONTRIBUTING.md), [Sentry SDK development docs](https://develop.sentry.dev/sdk/), [Discord community](https://discord.gg/Ww9hbqr)
