### PR TITLE
ref(openai-agents): Remove `set_data_normalized` for primitive attributes

### DIFF
--- a/sentry_sdk/integrations/openai_agents/utils.py
+++ b/sentry_sdk/integrations/openai_agents/utils.py
@@ -239,10 +239,8 @@ def _create_mcp_execute_tool_spans(
                 description=f"execute_tool {output.name}",
                 start_timestamp=span.start_timestamp,
             ) as execute_tool_span:
-                set_data_normalized(execute_tool_span, SPANDATA.GEN_AI_TOOL_TYPE, "mcp")
-                set_data_normalized(
-                    execute_tool_span, SPANDATA.GEN_AI_TOOL_NAME, output.name
-                )
+                execute_tool_span.set_data(SPANDATA.GEN_AI_TOOL_TYPE, "mcp")
+                execute_tool_span.set_data(SPANDATA.GEN_AI_TOOL_NAME, output.name)
                 if should_send_default_pii():
                     execute_tool_span.set_data(
                         SPANDATA.GEN_AI_TOOL_INPUT, output.arguments


### PR DESCRIPTION
### Description
<!-- What changed and why? -->

Remove `set_data_normalized()` for attributes that do not require normalization.

The output is narrowed to an instance of `McpCall`, which has a string `name` field:

https://github.com/openai/openai-python/blob/3e0c05b84a2056870abf3bd6a5e7849020209cc3/src/openai/types/responses/response_item.py#L191

#### Issues
<!--
* resolves: #1234
* resolves: LIN-1234
-->

#### Reminders
- Please add tests to validate your changes, and lint your code using `tox -e linters`.
- Add GH Issue ID _&_ Linear ID (if applicable)
- PR title should use [conventional commit](https://develop.sentry.dev/engineering-practices/commit-messages/#type) style (`feat:`, `fix:`, `ref:`, `meta:`)
- For external contributors: [CONTRIBUTING.md](https://github.com/getsentry/sentry-python/blob/master/CONTRIBUTING.md), [Sentry SDK development docs](https://develop.sentry.dev/sdk/), [Discord community](https://discord.gg/Ww9hbqr)
