### PR TITLE
ref(langgraph): Remove `set_data_normalized` for primitive attributes

### DIFF
--- a/sentry_sdk/integrations/langgraph.py
+++ b/sentry_sdk/integrations/langgraph.py
@@ -347,7 +347,7 @@ def _set_response_model_name(span: "sentry_sdk.tracing.Span", messages: "Any") -
     if model_name is None:
         return
 
-    set_data_normalized(span, SPANDATA.GEN_AI_RESPONSE_MODEL, model_name)
+    span.set_data(SPANDATA.GEN_AI_RESPONSE_MODEL, model_name)
 
 
 def _set_response_attributes(
@@ -378,9 +378,7 @@ def _set_response_attributes(
 
     tool_calls = _extract_tool_calls(new_messages)
     if tool_calls:
-        set_data_normalized(
-            span,
+        span.set_data(
             SPANDATA.GEN_AI_RESPONSE_TOOL_CALLS,
             safe_serialize(tool_calls),
-            unpack=False,
         )


### PR DESCRIPTION
### Description
<!-- What changed and why? -->

Remove `set_data_normalized()` for attributes that do not require normalization.

#### Issues
<!--
* resolves: #1234
* resolves: LIN-1234
-->

#### Reminders
- Please add tests to validate your changes, and lint your code using `tox -e linters`.
- Add GH Issue ID _&_ Linear ID (if applicable)
- PR title should use [conventional commit](https://develop.sentry.dev/engineering-practices/commit-messages/#type) style (`feat:`, `fix:`, `ref:`, `meta:`)
- For external contributors: [CONTRIBUTING.md](https://github.com/getsentry/sentry-python/blob/master/CONTRIBUTING.md), [Sentry SDK development docs](https://develop.sentry.dev/sdk/), [Discord community](https://discord.gg/Ww9hbqr)
