### PR TITLE
ref(pydantic-ai): Remove `set_data_normalized` for the `gen_ai.response.model` attribute

### DIFF
--- a/sentry_sdk/integrations/pydantic_ai/spans/ai_client.py
+++ b/sentry_sdk/integrations/pydantic_ai/spans/ai_client.py
@@ -207,7 +207,7 @@ def _set_output_data(span: "sentry_sdk.tracing.Span", response: "Any") -> None:
     if not response:
         return
 
-    set_data_normalized(span, SPANDATA.GEN_AI_RESPONSE_MODEL, response.model_name)
+    span.set_data(SPANDATA.GEN_AI_RESPONSE_MODEL, response.model_name)
     try:
         # Extract text from ModelResponse
         if hasattr(response, "parts"):


### PR DESCRIPTION
### Description
<!-- What changed and why? -->

Remove `set_data_normalized()` for attributes that do not require normalization.

The `model_name` field on `ModelResponse` is a `str` or `None` according to the type annotation.

https://github.com/pydantic/pydantic-ai/blame/1b1edd7e0fd608e160759d2ee7f63b8475bae8d3/pydantic_ai_slim/pydantic_ai/messages.py#L1354

#### Issues
<!--
* resolves: #1234
* resolves: LIN-1234
-->

#### Reminders
- Please add tests to validate your changes, and lint your code using `tox -e linters`.
- Add GH Issue ID _&_ Linear ID (if applicable)
- PR title should use [conventional commit](https://develop.sentry.dev/engineering-practices/commit-messages/#type) style (`feat:`, `fix:`, `ref:`, `meta:`)
- For external contributors: [CONTRIBUTING.md](https://github.com/getsentry/sentry-python/blob/master/CONTRIBUTING.md), [Sentry SDK development docs](https://develop.sentry.dev/sdk/), [Discord community](https://discord.gg/Ww9hbqr)
