### PR TITLE
ref(celery): Do not record nameless tasks

### DIFF
--- a/sentry_sdk/integrations/celery/__init__.py
+++ b/sentry_sdk/integrations/celery/__init__.py
@@ -480,6 +480,11 @@ def _patch_producer_publish() -> None:
             kwargs_headers = {}
 
         task_name = kwargs_headers.get("task")
+
+        if not task_name:
+            # Filter out heartbeat and other internal Celery events
+            return original_publish(self, *args, **kwargs)
+
         task_id = kwargs_headers.get("id")
         retries = kwargs_headers.get("retries")
 


### PR DESCRIPTION
### Description
Internal Celery events like heartbeat follow the same `Producer.publish` code path as usual Celery tasks. However, they do not have a name, unlike user-defined tasks; and there is no active transaction when the patch is executed.

The impact of this change depends on whether the SDK is running in normal or span streaming mode:

- In **normal mode**, this change shouldn't have any visible impact. The spans that we're now explicitly not creating wouldn't have been sent to Sentry anyway because they lack a transaction.
- In **span streaming mode**, this change will allow us to keep the same behavior as before. Without this change, the heartbeat spans would actually be emitted and promoted to segments, since there is no active segment. This leads to a lot of "unknown Celery task" clutter in Sentry with no value.

#### Issues
<!--
* resolves: #1234
* resolves: LIN-1234
-->

#### Reminders
- Please add tests to validate your changes, and lint your code using `tox -e linters`.
- Add GH Issue ID _&_ Linear ID (if applicable)
- PR title should use [conventional commit](https://develop.sentry.dev/engineering-practices/commit-messages/#type) style (`feat:`, `fix:`, `ref:`, `meta:`)
- For external contributors: [CONTRIBUTING.md](https://github.com/getsentry/sentry-python/blob/master/CONTRIBUTING.md), [Sentry SDK development docs](https://develop.sentry.dev/sdk/), [Discord community](https://discord.gg/Ww9hbqr)
