### PR TITLE
ref(openai): Separate output handling

### DIFF
--- a/sentry_sdk/integrations/openai.py
+++ b/sentry_sdk/integrations/openai.py
@@ -462,7 +462,7 @@ def _set_embeddings_input_data(
     _commmon_set_input_data(span, kwargs)
 
 
-def _common_set_output_data(
+def _set_common_output_data(
     span: "Span",
     response: "Any",
     kwargs: "dict[str, Any]",
@@ -727,7 +727,7 @@ def _set_completions_api_output_data(
     start_time: "Optional[float]" = None,
     finish_span: bool = True,
 ) -> None:
-    _common_set_output_data(
+    _set_common_output_data(
         span,
         response,
         kwargs,
@@ -745,7 +745,7 @@ def _set_streaming_completions_api_output_data(
     start_time: "Optional[float]" = None,
     finish_span: bool = True,
 ) -> None:
-    _common_set_output_data(
+    _set_common_output_data(
         span,
         response,
         kwargs,
@@ -763,7 +763,7 @@ def _set_responses_api_output_data(
     start_time: "Optional[float]" = None,
     finish_span: bool = True,
 ) -> None:
-    _common_set_output_data(
+    _set_common_output_data(
         span,
         response,
         kwargs,
@@ -781,7 +781,7 @@ def _set_streaming_responses_api_output_data(
     start_time: "Optional[float]" = None,
     finish_span: bool = True,
 ) -> None:
-    _common_set_output_data(
+    _set_common_output_data(
         span,
         response,
         kwargs,
@@ -799,7 +799,7 @@ def _set_embeddings_output_data(
     start_time: "Optional[float]" = None,
     finish_span: bool = True,
 ) -> None:
-    _common_set_output_data(
+    _set_common_output_data(
         span,
         response,
         kwargs,


### PR DESCRIPTION
### Description
<!-- What changed and why? -->

Create separate functions for output-handling of `openai` Responses, Completions, and Embedding API functions. Create streaming variants where applicable.

#### Issues
<!--
* resolves: #1234
* resolves: LIN-1234
-->

#### Reminders
- Please add tests to validate your changes, and lint your code using `tox -e linters`.
- Add GH Issue ID _&_ Linear ID (if applicable)
- PR title should use [conventional commit](https://develop.sentry.dev/engineering-practices/commit-messages/#type) style (`feat:`, `fix:`, `ref:`, `meta:`)
- For external contributors: [CONTRIBUTING.md](https://github.com/getsentry/sentry-python/blob/master/CONTRIBUTING.md), [Sentry SDK development docs](https://develop.sentry.dev/sdk/), [Discord community](https://discord.gg/Ww9hbqr)
