### PR TITLE
ref(anthropic): Skip accumulation logic for unexpected types in streamed response

### DIFF
--- a/sentry_sdk/integrations/anthropic.py
+++ b/sentry_sdk/integrations/anthropic.py
@@ -372,6 +372,8 @@ def _wrap_synchronous_message_iterator(
     response_id = None
 
     for event in iterator:
+        # Message and content types are aliases for corresponding Raw* types, introduced in
+        # https://github.com/anthropics/anthropic-sdk-python/commit/bc9d11cd2addec6976c46db10b7c89a8c276101a
         if not isinstance(
             event,
             (
@@ -437,6 +439,8 @@ async def _wrap_asynchronous_message_iterator(
     response_id = None
 
     async for event in iterator:
+        # Message and content types are aliases for corresponding Raw* types, introduced in
+        # https://github.com/anthropics/anthropic-sdk-python/commit/bc9d11cd2addec6976c46db10b7c89a8c276101a
         if not isinstance(
             event,
             (


### PR DESCRIPTION
### Description
<!-- What changed and why? -->

Prepare for adding patches for `.stream()`, which iterate over `MessageStreamEvent`.

`MessageStreamEvent` is a superset of `RawMessageStreamEvent` returned in the iterator from `create(stream=True)`, but only `RawMessageStreamEvent` are required to collect the information required on AI Client Spans.

#### Issues
<!--
* resolves: #1234
* resolves: LIN-1234
-->

#### Reminders
- Please add tests to validate your changes, and lint your code using `tox -e linters`.
- Add GH Issue ID _&_ Linear ID (if applicable)
- PR title should use [conventional commit](https://develop.sentry.dev/engineering-practices/commit-messages/#type) style (`feat:`, `fix:`, `ref:`, `meta:`)
- For external contributors: [CONTRIBUTING.md](https://github.com/getsentry/sentry-python/blob/master/CONTRIBUTING.md), [Sentry SDK development docs](https://develop.sentry.dev/sdk/), [Discord community](https://discord.gg/Ww9hbqr)
