### PR TITLE
ref: Tweak StreamedSpan interface (2)

### DIFF
--- a/sentry_sdk/traces.py
+++ b/sentry_sdk/traces.py
@@ -70,6 +70,7 @@ class StreamedSpan:
     __slots__ = (
         "_name",
         "_attributes",
+        "_active",
         "_span_id",
         "_trace_id",
         "_status",
@@ -80,9 +81,11 @@ class StreamedSpan:
         *,
         name: str,
         attributes: "Optional[Attributes]" = None,
+        active: bool = True,
         trace_id: "Optional[str]" = None,
     ):
         self._name: str = name
+        self._active: bool = active
         self._attributes: "Attributes" = {}
         if attributes:
             for attribute, value in attributes.items():
@@ -99,7 +102,8 @@ class StreamedSpan:
             f"<{self.__class__.__name__}("
             f"name={self._name}, "
             f"trace_id={self.trace_id}, "
-            f"span_id={self.span_id})>"
+            f"span_id={self.span_id}, "
+            f"active={self._active})>"
         )
 
     def get_attributes(self) -> "Attributes":
@@ -142,6 +146,10 @@ class StreamedSpan:
     @name.setter
     def name(self, name: str) -> None:
         self._name = name
+
+    @property
+    def active(self) -> bool:
+        return self._active
 
     @property
     def span_id(self) -> str:


### PR DESCRIPTION
### Description
- add a `__repr__`
- remove `set_x()` methods, `set_http_status` to keep API surface minimal
- remove getters/setters in favor of properties where applicable (status, name)
- add a warning when setting an unsupported span status value

#### Issues
<!--
* resolves: #1234
* resolves: LIN-1234
-->

#### Reminders
- Please add tests to validate your changes, and lint your code using `tox -e linters`.
- Add GH Issue ID _&_ Linear ID (if applicable)
- PR title should use [conventional commit](https://develop.sentry.dev/engineering-practices/commit-messages/#type) style (`feat:`, `fix:`, `ref:`, `meta:`)
- For external contributors: [CONTRIBUTING.md](https://github.com/getsentry/sentry-python/blob/master/CONTRIBUTING.md), [Sentry SDK development docs](https://develop.sentry.dev/sdk/), [Discord community](https://discord.gg/Ww9hbqr)
