### PR TITLE
ref: Add `active` to `StreamedSpan` (3)

### DIFF
--- a/sentry_sdk/traces.py
+++ b/sentry_sdk/traces.py
@@ -148,6 +148,10 @@ class StreamedSpan:
         self._name = name
 
     @property
+    def active(self) -> bool:
+        return self._active
+
+    @property
     def span_id(self) -> str:
         if not self._span_id:
             self._span_id = uuid.uuid4().hex[16:]


### PR DESCRIPTION
### Description
`active` is also part of the public API (`start_span(name="...", active=False)`), so it'll need to propagate to the `StreamedSpan` class.

#### Issues
<!--
* resolves: #1234
* resolves: LIN-1234
-->

#### Reminders
- Please add tests to validate your changes, and lint your code using `tox -e linters`.
- Add GH Issue ID _&_ Linear ID (if applicable)
- PR title should use [conventional commit](https://develop.sentry.dev/engineering-practices/commit-messages/#type) style (`feat:`, `fix:`, `ref:`, `meta:`)
- For external contributors: [CONTRIBUTING.md](https://github.com/getsentry/sentry-python/blob/master/CONTRIBUTING.md), [Sentry SDK development docs](https://develop.sentry.dev/sdk/), [Discord community](https://discord.gg/Ww9hbqr)
