### PR TITLE
test(pyramid): Support alpha suffixes in version parsing

### DIFF
--- a/tests/integrations/pyramid/test_pyramid.py
+++ b/tests/integrations/pyramid/test_pyramid.py
@@ -19,7 +19,7 @@ from tests.conftest import unpack_werkzeug_response
 try:
     from importlib.metadata import version
 
-    PYRAMID_VERSION = Version(version("pyramid"))
+    PYRAMID_VERSION = Version(version("pyramid")).release
 
 except ImportError:
     # < py3.8
@@ -312,7 +312,7 @@ def test_errorhandler_ok(
 
 
 @pytest.mark.skipif(
-    PYRAMID_VERSION < Version("1.9"),
+    PYRAMID_VERSION < (1, 9),
     reason="We don't have the right hooks in older Pyramid versions",
 )
 def test_errorhandler_500(


### PR DESCRIPTION
### Description
<!-- What changed and why? -->

Pyramid released an alpha version: https://github.com/Pylons/pyramid/releases/tag/2.1a1

#### Issues
<!--
* resolves: #1234
* resolves: LIN-1234
-->

#### Reminders
- Please add tests to validate your changes, and lint your code using `tox -e linters`.
- Add GH Issue ID _&_ Linear ID (if applicable)
- PR title should use [conventional commit](https://develop.sentry.dev/engineering-practices/commit-messages/#type) style (`feat:`, `fix:`, `ref:`, `meta:`)
- For external contributors: [CONTRIBUTING.md](https://github.com/getsentry/sentry-python/blob/master/CONTRIBUTING.md), [Sentry SDK development docs](https://develop.sentry.dev/sdk/), [Discord community](https://discord.gg/Ww9hbqr)
