### PR TITLE
fix: Just re-raise the original exception, as-is

### DIFF
--- a/sentry_sdk/integrations/asgi.py
+++ b/sentry_sdk/integrations/asgi.py
@@ -183,7 +183,7 @@ class SentryAsgiMiddleware:
 
             except Exception as exc:
                 self._capture_lifespan_exception(exc)
-                raise exc from None
+                raise
 
         _asgi_middleware_applied.set(True)
         try:
@@ -259,7 +259,7 @@ class SentryAsgiMiddleware:
                                 )
                         except Exception as exc:
                             self._capture_request_exception(exc)
-                            raise exc from None
+                            raise
         finally:
             _asgi_middleware_applied.set(False)
 


### PR DESCRIPTION
### Description

In Python `raise … from None` is an explicit request to raise the exception but to suppress any exception chaining. (See: https://docs.python.org/3/tutorial/errors.html#exception-chaining)

This means that if, when an ASGI exception crashes, an exception causes another exception, that when the second exception (which has the first chained to it) reaches this point in the stack, these lines will re-raise it, but remove the chained exception. This can be confusing: ASGI frameworks will normally log a stack trace of the crashing application, but that stack trace will now be truncated, due to this `from None` removing the chained exception.

The chained exception (which is the exception that kicked off the entire stack unwind) is usually the more interesting one, when you're debugging.

Neither of the two changed lines seem to have a reason for `… from None`. Additionally, since they just re-raise the original exception, simply "`raise`" suffices.

#### Issues

* resolves: #5624

#### Reminders
- Please add tests to validate your changes, and lint your code using `tox -e linters`.
- Add GH Issue ID _&_ Linear ID (if applicable)
- PR title should use [conventional commit](https://develop.sentry.dev/engineering-practices/commit-messages/#type) style (`feat:`, `fix:`, `ref:`, `meta:`)
- For external contributors: [CONTRIBUTING.md](https://github.com/getsentry/sentry-python/blob/master/CONTRIBUTING.md), [Sentry SDK development docs](https://develop.sentry.dev/sdk/), [Discord community](https://discord.gg/Ww9hbqr)
