### PR TITLE
fix(anthropic): Close span on `GeneratorExit`

### DIFF
--- a/sentry_sdk/integrations/anthropic.py
+++ b/sentry_sdk/integrations/anthropic.py
@@ -398,26 +398,27 @@ def _wrap_synchronous_message_iterator(
             )
             yield event
     finally:
-        # Anthropic's input_tokens excludes cached/cache_write tokens.
-        # Normalize to total input tokens for correct cost calculations.
-        total_input = (
-            usage.input_tokens
-            + (usage.cache_read_input_tokens or 0)
-            + (usage.cache_write_input_tokens or 0)
-        )
+        with capture_internal_exceptions():
+            # Anthropic's input_tokens excludes cached/cache_write tokens.
+            # Normalize to total input tokens for correct cost calculations.
+            total_input = (
+                usage.input_tokens
+                + (usage.cache_read_input_tokens or 0)
+                + (usage.cache_write_input_tokens or 0)
+            )
 
-        _set_output_data(
-            span=span,
-            integration=integration,
-            model=model,
-            input_tokens=total_input,
-            output_tokens=usage.output_tokens,
-            cache_read_input_tokens=usage.cache_read_input_tokens,
-            cache_write_input_tokens=usage.cache_write_input_tokens,
-            content_blocks=[{"text": "".join(content_blocks), "type": "text"}],
-            finish_span=True,
-            response_id=response_id,
-        )
+            _set_output_data(
+                span=span,
+                integration=integration,
+                model=model,
+                input_tokens=total_input,
+                output_tokens=usage.output_tokens,
+                cache_read_input_tokens=usage.cache_read_input_tokens,
+                cache_write_input_tokens=usage.cache_write_input_tokens,
+                content_blocks=[{"text": "".join(content_blocks), "type": "text"}],
+                finish_span=True,
+                response_id=response_id,
+            )
 
 
 async def _wrap_asynchronous_message_iterator(
@@ -466,26 +467,27 @@ async def _wrap_asynchronous_message_iterator(
             )
             yield event
     finally:
-        # Anthropic's input_tokens excludes cached/cache_write tokens.
-        # Normalize to total input tokens for correct cost calculations.
-        total_input = (
-            usage.input_tokens
-            + (usage.cache_read_input_tokens or 0)
-            + (usage.cache_write_input_tokens or 0)
-        )
+        with capture_internal_exceptions():
+            # Anthropic's input_tokens excludes cached/cache_write tokens.
+            # Normalize to total input tokens for correct cost calculations.
+            total_input = (
+                usage.input_tokens
+                + (usage.cache_read_input_tokens or 0)
+                + (usage.cache_write_input_tokens or 0)
+            )
 
-        _set_output_data(
-            span=span,
-            integration=integration,
-            model=model,
-            input_tokens=total_input,
-            output_tokens=usage.output_tokens,
-            cache_read_input_tokens=usage.cache_read_input_tokens,
-            cache_write_input_tokens=usage.cache_write_input_tokens,
-            content_blocks=[{"text": "".join(content_blocks), "type": "text"}],
-            finish_span=True,
-            response_id=response_id,
-        )
+            _set_output_data(
+                span=span,
+                integration=integration,
+                model=model,
+                input_tokens=total_input,
+                output_tokens=usage.output_tokens,
+                cache_read_input_tokens=usage.cache_read_input_tokens,
+                cache_write_input_tokens=usage.cache_write_input_tokens,
+                content_blocks=[{"text": "".join(content_blocks), "type": "text"}],
+                finish_span=True,
+                response_id=response_id,
+            )
 
 
 def _set_output_data(


### PR DESCRIPTION
### Description
<!-- What changed and why? -->

Run post-iterator steps in a finally block so they run even if the generator does not complete.

#### Issues
<!--
* resolves: #1234
* resolves: LIN-1234
-->

#### Reminders
- Please add tests to validate your changes, and lint your code using `tox -e linters`.
- Add GH Issue ID _&_ Linear ID (if applicable)
- PR title should use [conventional commit](https://develop.sentry.dev/engineering-practices/commit-messages/#type) style (`feat:`, `fix:`, `ref:`, `meta:`)
- For external contributors: [CONTRIBUTING.md](https://github.com/getsentry/sentry-python/blob/master/CONTRIBUTING.md), [Sentry SDK development docs](https://develop.sentry.dev/sdk/), [Discord community](https://discord.gg/Ww9hbqr)
