### PR TITLE
feat(anthropic): Set gen_ai.response.finish_reasons on span

### DIFF
--- a/sentry_sdk/consts.py
+++ b/sentry_sdk/consts.py
@@ -499,7 +499,7 @@ class SPANDATA:
     GEN_AI_RESPONSE_FINISH_REASONS = "gen_ai.response.finish_reasons"
     """
     The reason why the model stopped generating.
-    Example: "COMPLETE"
+    Example: ["COMPLETE"]
     """
 
     GEN_AI_RESPONSE_ID = "gen_ai.response.id"

--- a/sentry_sdk/integrations/anthropic.py
+++ b/sentry_sdk/integrations/anthropic.py
@@ -359,7 +359,7 @@ def _set_output_data(
     Set output data for the span based on the AI response."""
     span.set_data(SPANDATA.GEN_AI_RESPONSE_MODEL, model)
     if finish_reason is not None:
-        span.set_data(SPANDATA.GEN_AI_RESPONSE_FINISH_REASONS, finish_reason)
+        span.set_data(SPANDATA.GEN_AI_RESPONSE_FINISH_REASONS, [finish_reason])
     if should_send_default_pii() and integration.include_prompts:
         output_messages: "dict[str, list[Any]]" = {
             "response": [],

--- a/tests/integrations/anthropic/test_anthropic.py
+++ b/tests/integrations/anthropic/test_anthropic.py
@@ -135,7 +135,7 @@ def test_nonstreaming_create_message(
     assert span["data"][SPANDATA.GEN_AI_USAGE_OUTPUT_TOKENS] == 20
     assert span["data"][SPANDATA.GEN_AI_USAGE_TOTAL_TOKENS] == 30
     assert span["data"][SPANDATA.GEN_AI_RESPONSE_STREAMING] is False
-    assert span["data"][SPANDATA.GEN_AI_RESPONSE_FINISH_REASONS] == "end_turn"
+    assert span["data"][SPANDATA.GEN_AI_RESPONSE_FINISH_REASONS] == ["end_turn"]
 
 
 @pytest.mark.asyncio
@@ -206,7 +206,7 @@ async def test_nonstreaming_create_message_async(
     assert span["data"][SPANDATA.GEN_AI_USAGE_OUTPUT_TOKENS] == 20
     assert span["data"][SPANDATA.GEN_AI_USAGE_TOTAL_TOKENS] == 30
     assert span["data"][SPANDATA.GEN_AI_RESPONSE_STREAMING] is False
-    assert span["data"][SPANDATA.GEN_AI_RESPONSE_FINISH_REASONS] == "end_turn"
+    assert span["data"][SPANDATA.GEN_AI_RESPONSE_FINISH_REASONS] == ["end_turn"]
 
 
 def test_streaming_create_message_with_finish_reason(sentry_init, capture_events):
@@ -261,7 +261,7 @@ def test_streaming_create_message_with_finish_reason(sentry_init, capture_events
     (event,) = events
     (span,) = event["spans"]
 
-    assert span["data"][SPANDATA.GEN_AI_RESPONSE_FINISH_REASONS] == "end_turn"
+    assert span["data"][SPANDATA.GEN_AI_RESPONSE_FINISH_REASONS] == ["end_turn"]
 
 
 @pytest.mark.asyncio
@@ -321,7 +321,7 @@ async def test_streaming_create_message_with_finish_reason_async(
     (event,) = events
     (span,) = event["spans"]
 
-    assert span["data"][SPANDATA.GEN_AI_RESPONSE_FINISH_REASONS] == "end_turn"
+    assert span["data"][SPANDATA.GEN_AI_RESPONSE_FINISH_REASONS] == ["end_turn"]
 
 
 @pytest.mark.parametrize(
@@ -663,7 +663,7 @@ def test_streaming_create_message_with_input_json_delta(
     assert span["data"][SPANDATA.GEN_AI_USAGE_OUTPUT_TOKENS] == 41
     assert span["data"][SPANDATA.GEN_AI_USAGE_TOTAL_TOKENS] == 407
     assert span["data"][SPANDATA.GEN_AI_RESPONSE_STREAMING] is True
-    assert span["data"][SPANDATA.GEN_AI_RESPONSE_FINISH_REASONS] == "tool_use"
+    assert span["data"][SPANDATA.GEN_AI_RESPONSE_FINISH_REASONS] == ["tool_use"]
 
 
 @pytest.mark.asyncio
@@ -806,7 +806,7 @@ async def test_streaming_create_message_with_input_json_delta_async(
     assert span["data"][SPANDATA.GEN_AI_USAGE_OUTPUT_TOKENS] == 41
     assert span["data"][SPANDATA.GEN_AI_USAGE_TOTAL_TOKENS] == 407
     assert span["data"][SPANDATA.GEN_AI_RESPONSE_STREAMING] is True
-    assert span["data"][SPANDATA.GEN_AI_RESPONSE_FINISH_REASONS] == "tool_use"
+    assert span["data"][SPANDATA.GEN_AI_RESPONSE_FINISH_REASONS] == ["tool_use"]
 
 
 def test_exception_message_create(sentry_init, capture_events):


### PR DESCRIPTION
Set the `gen_ai.response.finish_reasons` span attribute from Anthropic API responses.

Extracts `stop_reason` from both non-streaming (`result.stop_reason`) and streaming (`message_delta` event) responses. The value is stored as an array of strings per [OpenTelemetry semantic conventions](https://opentelemetry.io/docs/specs/semconv/gen-ai/gen-ai-spans/).

Refs PY-2136
Fixes #5658 