### PR TITLE
fix(langchain): Wrap finish_reason in array for gen_ai span attribute

### DIFF
--- a/sentry_sdk/integrations/langchain.py
+++ b/sentry_sdk/integrations/langchain.py
@@ -554,7 +554,8 @@ class SentryLangchainCallback(BaseCallbackHandler):  # type: ignore[misc]
                     finish_reason = generation.generation_info.get("finish_reason")
                     if finish_reason is not None:
                         span.set_data(
-                            SPANDATA.GEN_AI_RESPONSE_FINISH_REASONS, finish_reason
+                            SPANDATA.GEN_AI_RESPONSE_FINISH_REASONS,
+                            [finish_reason],
                         )
                 except AttributeError:
                     pass

--- a/tests/integrations/langchain/test_langchain.py
+++ b/tests/integrations/langchain/test_langchain.py
@@ -297,6 +297,12 @@ def test_langchain_agent(
             f"and include_prompts={include_prompts}"
         )
 
+    # Verify finish_reasons is always an array of strings
+    assert chat_spans[0]["data"][SPANDATA.GEN_AI_RESPONSE_FINISH_REASONS] == [
+        "function_call"
+    ]
+    assert chat_spans[1]["data"][SPANDATA.GEN_AI_RESPONSE_FINISH_REASONS] == ["stop"]
+
     # Verify that available tools are always recorded regardless of PII settings
     for chat_span in chat_spans:
         span_data = chat_span.get("data", {})


### PR DESCRIPTION
The gen_ai.response.finish_reasons attribute should be an array of strings per the semantic convention. Wrap the single finish_reason value in a list before setting the span data.

Resolves #5664 and PY-2139