### PR TITLE
feat(anthropic): Record finish reasons in AI monitoring spans

### DIFF
--- a/sentry_sdk/integrations/langchain.py
+++ b/sentry_sdk/integrations/langchain.py
@@ -554,7 +554,8 @@ class SentryLangchainCallback(BaseCallbackHandler):  # type: ignore[misc]
                     finish_reason = generation.generation_info.get("finish_reason")
                     if finish_reason is not None:
                         span.set_data(
-                            SPANDATA.GEN_AI_RESPONSE_FINISH_REASONS, finish_reason
+                            SPANDATA.GEN_AI_RESPONSE_FINISH_REASONS,
+                            [finish_reason],
                         )
                 except AttributeError:
                     pass

--- a/tests/integrations/langchain/test_langchain.py
+++ b/tests/integrations/langchain/test_langchain.py
@@ -297,6 +297,12 @@ def test_langchain_agent(
             f"and include_prompts={include_prompts}"
         )
 
+    # Verify finish_reasons is always an array of strings
+    assert chat_spans[0]["data"][SPANDATA.GEN_AI_RESPONSE_FINISH_REASONS] == [
+        "function_call"
+    ]
+    assert chat_spans[1]["data"][SPANDATA.GEN_AI_RESPONSE_FINISH_REASONS] == ["stop"]
+
     # Verify that available tools are always recorded regardless of PII settings
     for chat_span in chat_spans:
         span_data = chat_span.get("data", {})


### PR DESCRIPTION
Add `GEN_AI_RESPONSE_FINISH_REASONS` span data to the Anthropic integration by capturing `stop_reason` from API responses.

For non-streaming responses, the `stop_reason` is read directly from the `Message` result. For streaming responses, it's extracted from the `MessageDeltaEvent` delta and passed through the `_collect_ai_data` helper.

This brings the Anthropic integration in line with the OpenAI integration's finish reason tracking.