### PR TITLE
feat(logging): Separate ignore lists for events/breadcrumbs and sentry logs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ sentry-python-serverless*.zip
 .eggs
 venv
 .venv
+tox.venv
 .vscode/tags
 .pytest_cache
 .hypothesis

--- a/sentry_sdk/integrations/logging.py
+++ b/sentry_sdk/integrations/logging.py
@@ -54,7 +54,15 @@ SEVERITY_TO_OTEL_SEVERITY = {
 #
 # Note: Ignoring by logger name here is better than mucking with thread-locals.
 # We do not necessarily know whether thread-locals work 100% correctly in the user's environment.
+#
+# Events/breadcrumbs and Sentry Logs have separate ignore lists so that
+# framework loggers silenced for events (e.g. django.server) can still be
+# captured as Sentry Logs.
 _IGNORED_LOGGERS = set(
+    ["sentry_sdk.errors", "urllib3.connectionpool", "urllib3.connection"]
+)
+
+_IGNORED_LOGGERS_SENTRY_LOGS = set(
     ["sentry_sdk.errors", "urllib3.connectionpool", "urllib3.connection"]
 )
 
@@ -67,9 +75,45 @@ def ignore_logger(
     use this to prevent their actions being recorded as breadcrumbs. Exposed
     to users as a way to quiet spammy loggers.
 
+    This does **not** affect Sentry Logs — use
+    :py:func:`ignore_logger_for_sentry_logs` for that.
+
     :param name: The name of the logger to ignore (same string you would pass to ``logging.getLogger``).
     """
     _IGNORED_LOGGERS.add(name)
+
+
+def ignore_logger_for_sentry_logs(
+    name: str,
+) -> None:
+    """This disables recording as Sentry Logs calls to a logger of a
+    specific name.
+
+    :param name: The name of the logger to ignore (same string you would pass to ``logging.getLogger``).
+    """
+    _IGNORED_LOGGERS_SENTRY_LOGS.add(name)
+
+
+def unignore_logger(
+    name: str,
+) -> None:
+    """Reverts a previous :py:func:`ignore_logger` call, re-enabling
+    recording of breadcrumbs and events for the named logger.
+
+    :param name: The name of the logger to unignore.
+    """
+    _IGNORED_LOGGERS.discard(name)
+
+
+def unignore_logger_for_sentry_logs(
+    name: str,
+) -> None:
+    """Reverts a previous :py:func:`ignore_logger_for_sentry_logs` call,
+    re-enabling recording of Sentry Logs for the named logger.
+
+    :param name: The name of the logger to unignore.
+    """
+    _IGNORED_LOGGERS_SENTRY_LOGS.discard(name)
 
 
 class LoggingIntegration(Integration):
@@ -104,6 +148,7 @@ class LoggingIntegration(Integration):
         ):
             self._breadcrumb_handler.handle(record)
 
+    def _handle_sentry_logs_record(self, record: "LogRecord") -> None:
         if (
             self._sentry_logs_handler is not None
             and record.levelno >= self._sentry_logs_handler.level
@@ -118,6 +163,7 @@ class LoggingIntegration(Integration):
             # keeping a local reference because the
             # global might be discarded on shutdown
             ignored_loggers = _IGNORED_LOGGERS
+            ignored_loggers_sentry_logs = _IGNORED_LOGGERS_SENTRY_LOGS
 
             try:
                 return old_callhandlers(self, record)
@@ -126,15 +172,25 @@ class LoggingIntegration(Integration):
                 # the integration.  Otherwise we have a high chance of getting
                 # into a recursion error when the integration is resolved
                 # (this also is slower).
-                if (
-                    ignored_loggers is not None
-                    and record.name.strip() not in ignored_loggers
-                ):
+                name = record.name.strip()
+
+                handle_events = (
+                    ignored_loggers is not None and name not in ignored_loggers
+                )
+                handle_sentry_logs = (
+                    ignored_loggers_sentry_logs is not None
+                    and name not in ignored_loggers_sentry_logs
+                )
+
+                if handle_events or handle_sentry_logs:
                     integration = sentry_sdk.get_client().get_integration(
                         LoggingIntegration
                     )
                     if integration is not None:
-                        integration._handle_record(record)
+                        if handle_events:
+                            integration._handle_record(record)
+                        if handle_sentry_logs:
+                            integration._handle_sentry_logs_record(record)
 
         logging.Logger.callHandlers = sentry_patched_callhandlers  # type: ignore
 
@@ -170,13 +226,6 @@ class _BaseHandler(logging.Handler):
         )
     )
 
-    def _can_record(self, record: "LogRecord") -> bool:
-        """Prevents ignored loggers from recording"""
-        for logger in _IGNORED_LOGGERS:
-            if fnmatch(record.name.strip(), logger):
-                return False
-        return True
-
     def _logging_to_event_level(self, record: "LogRecord") -> str:
         return LOGGING_TO_EVENT_LEVEL.get(
             record.levelno, record.levelname.lower() if record.levelname else ""
@@ -197,6 +246,13 @@ class EventHandler(_BaseHandler):
 
     Note that you do not have to use this class if the logging integration is enabled, which it is by default.
     """
+
+    def _can_record(self, record: "LogRecord") -> bool:
+        """Prevents ignored loggers from recording"""
+        for logger in _IGNORED_LOGGERS:
+            if fnmatch(record.name.strip(), logger):
+                return False
+        return True
 
     def emit(self, record: "LogRecord") -> "Any":
         with capture_internal_exceptions():
@@ -290,6 +346,13 @@ class BreadcrumbHandler(_BaseHandler):
     Note that you do not have to use this class if the logging integration is enabled, which it is by default.
     """
 
+    def _can_record(self, record: "LogRecord") -> bool:
+        """Prevents ignored loggers from recording"""
+        for logger in _IGNORED_LOGGERS:
+            if fnmatch(record.name.strip(), logger):
+                return False
+        return True
+
     def emit(self, record: "LogRecord") -> "Any":
         with capture_internal_exceptions():
             self.format(record)
@@ -320,6 +383,13 @@ class SentryLogsHandler(_BaseHandler):
 
     Note that you do not have to use this class if the logging integration is enabled, which it is by default.
     """
+
+    def _can_record(self, record: "LogRecord") -> bool:
+        """Prevents ignored loggers from recording"""
+        for logger in _IGNORED_LOGGERS_SENTRY_LOGS:
+            if fnmatch(record.name.strip(), logger):
+                return False
+        return True
 
     def emit(self, record: "LogRecord") -> "Any":
         with capture_internal_exceptions():

--- a/tests/integrations/logging/test_logging.py
+++ b/tests/integrations/logging/test_logging.py
@@ -5,7 +5,13 @@ import pytest
 
 from sentry_sdk import get_client
 from sentry_sdk.consts import VERSION
-from sentry_sdk.integrations.logging import LoggingIntegration, ignore_logger
+from sentry_sdk.integrations.logging import (
+    LoggingIntegration,
+    ignore_logger,
+    ignore_logger_for_sentry_logs,
+    unignore_logger,
+    unignore_logger_for_sentry_logs,
+)
 from tests.test_logs import envelopes_to_logs
 
 other_logger = logging.getLogger("testfoo")
@@ -222,34 +228,37 @@ def test_logging_captured_warnings(sentry_init, capture_events, recwarn):
     assert str(recwarn[0].message) == "third"
 
 
-def test_ignore_logger(sentry_init, capture_events):
+def test_ignore_logger(sentry_init, capture_events, request):
     sentry_init(integrations=[LoggingIntegration()], default_integrations=False)
     events = capture_events()
 
     ignore_logger("testfoo")
+    request.addfinalizer(lambda: unignore_logger("testfoo"))
 
     other_logger.error("hi")
 
     assert not events
 
 
-def test_ignore_logger_whitespace_padding(sentry_init, capture_events):
+def test_ignore_logger_whitespace_padding(sentry_init, capture_events, request):
     """Here we test insensitivity to whitespace padding of ignored loggers"""
     sentry_init(integrations=[LoggingIntegration()], default_integrations=False)
     events = capture_events()
 
     ignore_logger("testfoo")
+    request.addfinalizer(lambda: unignore_logger("testfoo"))
 
     padded_logger = logging.getLogger("       testfoo   ")
     padded_logger.error("hi")
     assert not events
 
 
-def test_ignore_logger_wildcard(sentry_init, capture_events):
+def test_ignore_logger_wildcard(sentry_init, capture_events, request):
     sentry_init(integrations=[LoggingIntegration()], default_integrations=False)
     events = capture_events()
 
     ignore_logger("testfoo.*")
+    request.addfinalizer(lambda: unignore_logger("testfoo.*"))
 
     nested_logger = logging.getLogger("testfoo.submodule")
 
@@ -260,6 +269,44 @@ def test_ignore_logger_wildcard(sentry_init, capture_events):
     (event,) = events
     assert event["logentry"]["message"] == "hi"
     assert event["logentry"]["formatted"] == "hi"
+
+
+def test_ignore_logger_does_not_affect_sentry_logs(
+    sentry_init, capture_envelopes, request
+):
+    """ignore_logger should suppress events/breadcrumbs but not Sentry Logs."""
+    sentry_init(enable_logs=True)
+    envelopes = capture_envelopes()
+
+    ignore_logger("testfoo")
+    request.addfinalizer(lambda: unignore_logger("testfoo"))
+
+    other_logger.error("hi")
+    get_client().flush()
+
+    logs = envelopes_to_logs(envelopes)
+    assert len(logs) == 1
+    assert logs[0]["body"] == "hi"
+
+
+def test_ignore_logger_for_sentry_logs(sentry_init, capture_envelopes, request):
+    """ignore_logger_for_sentry_logs should suppress Sentry Logs but not events."""
+    sentry_init(enable_logs=True)
+    envelopes = capture_envelopes()
+
+    ignore_logger_for_sentry_logs("testfoo")
+    request.addfinalizer(lambda: unignore_logger_for_sentry_logs("testfoo"))
+
+    other_logger.error("hi")
+    get_client().flush()
+
+    # Event should still be captured
+    event_envelopes = [e for e in envelopes if e.items[0].type == "event"]
+    assert len(event_envelopes) == 1
+
+    # But no Sentry Logs
+    logs = envelopes_to_logs(envelopes)
+    assert len(logs) == 0
 
 
 def test_logging_dictionary_interpolation(sentry_init, capture_events):


### PR DESCRIPTION
### Description

Split `_IGNORED_LOGGERS` into two independent sets so that framework loggers silenced for events/breadcrumbs (e.g. `django.server`) can still be captured as Sentry Logs.

- `_IGNORED_LOGGERS` controls `EventHandler` and `BreadcrumbHandler`
- `_IGNORED_LOGGERS_SENTRY_LOGS` controls `SentryLogsHandler`
- Add `ignore_logger_for_sentry_logs()` and `unignore_logger*()` helpers
- Move `_can_record` into each handler class with its own ignore set
- Split `_handle_record` into separate event and sentry-logs paths

#### Issues

* resolves: #5689
* resolves: PY-2146
