### PR TITLE
docs: Document span filtering migration to span first

### DIFF
--- a/MIGRATION_GUIDE.md
+++ b/MIGRATION_GUIDE.md
@@ -190,3 +190,41 @@ Looking to upgrade from Sentry SDK 1.x to 2.x? Here's a comprehensive list of wh
 - Deprecated `sentry_sdk.transport.Transport.capture_event`. Please use `sentry_sdk.transport.Transport.capture_envelope`, instead.
 - Passing a function to `sentry_sdk.init`'s `transport` keyword argument has been deprecated. If you wish to provide a custom transport, please pass a `sentry_sdk.transport.Transport` instance or a subclass.
 - The parameter `propagate_hub` in `ThreadingIntegration()` was deprecated and renamed to `propagate_scope`.
+
+## Migrating Span Filtering to Span First
+
+If you are using the experimental **Span First** mode (also known as span streaming, enabled via `_experiments={"trace_lifecycle": "stream"}`), you might notice that individual spans are sent in real-time and do not pass together through `before_send_transaction`.
+
+To filter or ignore individual spans in Span First mode, you can use the experimental `ignore_spans` configuration option:
+
+```python
+import sentry_sdk
+import re
+
+sentry_sdk.init(
+    dsn="...",
+    traces_sample_rate=1.0,  # Required for tracing
+    _experiments={
+        "trace_lifecycle": "stream",
+        "ignore_spans": [
+            "ignore_this_exact_name",  # 1. Match by name (String)
+            re.compile(r"^GET /static/.*"),  # 2. Match by name (Regex Range)
+            {"name": "ignore_by_name_dict"},  # 3. Match by name (Dict)
+            {  # 4. Match by Span Attribute
+                "attributes": {
+                    "http.status_code": 200,
+                }
+            }
+        ]
+    }
+)
+```
+
+### Key Differences:
+- **Before (Transaction Mode)**: You filtered child spans by mutating `event["spans"]` inside `before_send_transaction`.
+- **After (Span First)**: You define rules up-front in `ignore_spans`. If a rule matches, a `NoOpStreamedSpan` is returned immediately resulting in no overhead.
+- **Inheritance**: Any child span started with an ignored parent will automatically be ignored as well.
+
+> [!NOTE]
+> `ignore_spans` is currently an experimental feature reading from `_experiments`.
+


### PR DESCRIPTION
## What
- Adds documentation to `MIGRATION_GUIDE.md` explaining how to filter individual spans in the experimental "Span First" (streaming) mode.
- Provides code examples for using the experimental `ignore_spans` configuration with String, Regex, and Dict rules.

## Why
- In transaction-based mode, spans are filtered in `before_send_transaction`.
- In Span First mode, spans are streamed individually and bypass `before_send_transaction`.
- Fixes #5363.

## How
- Added a section `## Migrating Span Filtering to Span First` in `MIGRATION_GUIDE.md`.
- Described the difference between modes and how `_experiments={"ignore_spans": [...]}` can be used.
- Verified that rules (String, Regex, and Attributes) match internally using `is_ignored_span()`.

## Testing
- Created a test script to verify `is_ignored_span()` behavior with multiple rule types (exact match, dictionary, attribute match).
- Confirmed child spans inherit the parent's ignored state structure.

## Risks / Impact
- None, as it is documentation-only for an existing experimental config.

## Checklist
- [x] Linked the relevant issue (Fixes #5363).
- [x] Described problem, solution and impact.
- [x] Added or updated tests where appropriate (Verified logic with scratchpad tests).
- [x] Verified no secrets or sensitive data are introduced.
