### PR TITLE
# Refactor test_pydantic_ai to use public APIs (#5637)

### DIFF
--- a/tests/integrations/pydantic_ai/test_pydantic_ai.py
+++ b/tests/integrations/pydantic_ai/test_pydantic_ai.py
@@ -2693,7 +2693,9 @@ async def test_binary_content_encoding_mixed_content(sentry_init, capture_events
     await agent.run(["Here is an image:", binary_content, "What do you see?"])
 
     (event,) = events
-    span_data = event["spans"][0]["data"]
+    chat_spans = [s for s in event.get("spans", []) if s.get("op") == "gen_ai.chat"]
+    assert chat_spans, "Sentry should have captured a gen_ai.chat span"
+    span_data = chat_spans[0].get("data", {})
     messages_data = _get_messages_from_span(span_data)
 
     # Verify both text and binary content are present


### PR DESCRIPTION
## What
- Replaced all direct calls to the internal function `_set_input_messages` with higher-level public APIs, such as `Agent.run()`, or supported module-level wrappers (`ai_client_span`).
- Removed fragile `MagicMock` setups and manual manipulation of internal message content representations in unit tests.

## Why
- Testing internal functions makes test suites fragile to implementation detail drift.
- This cleanup ensures the Sentry tests operate on the exact data structures and execution branches that integration users would encounter on `pydantic_ai` usage.
- Fixes #5637

## How
- **test_input_messages_error_handling**: Rewritten to pass invalid lists into `ai_client_span`, maintaining full coverage over the silent catch block logic.
- **test_message_parts_with_list_content**: Refactored to triggers execution via static `Agent.run(["item1", "item2"])` which models native structural parsing securely.
- **test_message_with_system_prompt_part**: Refactored to pass history of real `ModelRequest` with `SystemPromptPart` directly to `.run(message_history=...)`.
- **test_message_with_instructions**: Preserved via module wrapper `ai_client_span` which bypasses internal calls without direct binding errors.
- **test_set_input_messages_without_prompts**: Refactored to run the Agent on an integration initialized with `include_prompts=False`.

## Testing
- Setup isolated python VirtualEnv `.venv`.
- Validated with local pytest:
  ```powershell
  .venv\Scripts\pytest tests/integrations/pydantic_ai/test_pydantic_ai.py
  ```
- **Outcome:** 100% tests Passed, no failures.

## Risks / Impact
- **Risks:** None. Changes operate purely in the test suite files.

## Checklist
- [x] Linked the relevant issue (Fixes #5637).
- [x] Described problem, solution and impact.
- [x] Added or updated tests where appropriate.
- [x] Verified no secrets or sensitive data are introduced.
