### PR TITLE
Fix: include feature flags in transaction trace context (#5023)

### DIFF
--- a/sentry_sdk/tracing.py
+++ b/sentry_sdk/tracing.py
@@ -743,6 +743,7 @@ class Span:
             )
 
         data = {}
+        data.update(self._flags)
 
         thread_id = self._data.get(SPANDATA.THREAD_ID)
         if thread_id is not None:
@@ -1132,7 +1133,7 @@ class Transaction(Span):
         trace_context = super().get_trace_context()
 
         if self._data:
-            trace_context["data"] = self._data
+            trace_context.setdefault("data", {}).update(self._data)
 
         return trace_context
 


### PR DESCRIPTION
This PR fixes issue #5023 where feature flags added to a Transaction (e.g. via `add_feature_flag`) were not included in the transaction event payload sent to Sentry.

### Cause:
`Transaction.get_trace_context()` was overriding the `"data"` key returned by `super().get_trace_context()` which contained the flags, replacing it entirely with `self._data` (which only contained thread info).

### Fix:
Updated `Transaction.get_trace_context()` to use `.update()` instead of complete overwrite of `"data"`:
```python
            trace_context.setdefault("data", {}).update(self._data)
```
This preserves the flags from the base `Span` class and appends the thread information correctly.