### PR TITLE
fix(asyncio): Add task_isolation setting for AsyncioIntegration (#5371)

### DIFF
--- a/sentry_sdk/integrations/asyncio.py
+++ b/sentry_sdk/integrations/asyncio.py
@@ -65,8 +65,11 @@ def patch_asyncio() -> None:
                     AsyncioIntegration
                 )
                 task_spans = integration.task_spans if integration else False
+                task_isolation = integration.task_isolation if integration else True
 
-                with sentry_sdk.isolation_scope():
+                context = sentry_sdk.isolation_scope() if task_isolation else nullcontext()
+
+                with context:
                     with (
                         sentry_sdk.start_span(
                             op=OP.FUNCTION,
@@ -150,8 +153,9 @@ class AsyncioIntegration(Integration):
     identifier = "asyncio"
     origin = f"auto.function.{identifier}"
 
-    def __init__(self, task_spans: bool = True) -> None:
+    def __init__(self, task_spans: bool = True, task_isolation: bool = True) -> None:
         self.task_spans = task_spans
+        self.task_isolation = task_isolation
 
     @staticmethod
     def setup_once() -> None:


### PR DESCRIPTION
### Problem
Currently, `AsyncioIntegration` wraps every asyncio task in a new `isolation_scope()`. While this is great for isolating background tasks, it prevents scope data (like tags set via `sentry_sdk.set_tag()`) inside async endpoints from propagating back to the parent middleware transaction (e.g. in FastAPI/Starlette).

### Solution
This PR adds a `task_isolation: bool` parameter (default `True`) to `AsyncioIntegration`. 
Setting `task_isolation=False` disables the automatic `isolation_scope()` for tasks, allowing tags written inside endpoints to correctly attach to the outer HTTP transaction trace.

Fixes #5371

### Verification
Verified with a reproduction script that with `task_isolation=False`, tags set inside local endpoint asyncio tasks correctly surface on the captured HTTP response transaction.