### PR TITLE
feat(langchain): Update LLM span operation to gen_ai.generate_text

### DIFF
--- a/sentry_sdk/integrations/langchain.py
+++ b/sentry_sdk/integrations/langchain.py
@@ -351,7 +351,6 @@ class SentryLangchainCallback(BaseCallbackHandler):  # type: ignore[misc]
         metadata: "Optional[Dict[str, Any]]" = None,
         **kwargs: "Any",
     ) -> "Any":
-        """Run when LLM starts running."""
         with capture_internal_exceptions():
             if not run_id:
                 return
@@ -369,8 +368,8 @@ class SentryLangchainCallback(BaseCallbackHandler):  # type: ignore[misc]
             watched_span = self._create_span(
                 run_id,
                 parent_run_id,
-                op=OP.GEN_AI_PIPELINE,
-                name=kwargs.get("name") or "Langchain LLM call",
+                op=OP.GEN_AI_GENERATE_TEXT,
+                name=f"generate_text {model}".strip(),
                 origin=LangchainIntegration.origin,
             )
             span = watched_span.span

--- a/tests/integrations/langchain/test_langchain.py
+++ b/tests/integrations/langchain/test_langchain.py
@@ -851,12 +851,14 @@ def test_langchain_integration_with_langchain_core_only(sentry_init, capture_eve
         assert tx["type"] == "transaction"
 
         llm_spans = [
-            span for span in tx.get("spans", []) if span.get("op") == "gen_ai.pipeline"
+            span
+            for span in tx.get("spans", [])
+            if span.get("op") == "gen_ai.generate_text"
         ]
         assert len(llm_spans) > 0
 
         llm_span = llm_spans[0]
-        assert llm_span["description"] == "Langchain LLM call"
+        assert llm_span["description"] == "generate_text gpt-3.5-turbo"
         assert llm_span["data"]["gen_ai.request.model"] == "gpt-3.5-turbo"
         assert (
             llm_span["data"]["gen_ai.response.text"]
@@ -1062,7 +1064,7 @@ def test_langchain_message_truncation(sentry_init, capture_events):
     assert tx["type"] == "transaction"
 
     llm_spans = [
-        span for span in tx.get("spans", []) if span.get("op") == "gen_ai.pipeline"
+        span for span in tx.get("spans", []) if span.get("op") == "gen_ai.generate_text"
     ]
     assert len(llm_spans) > 0
 
@@ -1776,7 +1778,7 @@ def test_langchain_response_model_extraction(
     assert tx["type"] == "transaction"
 
     llm_spans = [
-        span for span in tx.get("spans", []) if span.get("op") == "gen_ai.pipeline"
+        span for span in tx.get("spans", []) if span.get("op") == "gen_ai.generate_text"
     ]
     assert len(llm_spans) > 0
 


### PR DESCRIPTION
Update LangChain integration to use the new `gen_ai.generate_text` operation for LLM call spans, aligning with OpenTelemetry semantic conventions.

**Changes:**
- Changed LLM span operation from `gen_ai.pipeline` to `gen_ai.generate_text`
- Updated span naming to include the model identifier: `generate_text {model}` instead of generic "Langchain LLM call"
- Removed unnecessary docstring from callback method
- Updated test assertions to validate the new operation and naming convention

This change improves observability by using more specific operation types that accurately reflect the semantic nature of LLM generation calls, and includes the model identifier for better span context.

Related to SDK-669. Replaces some of the changes introduced in #5705 (this is being broken down into 2 parts due to upcoming changes in the langchain test suite)