### PR TITLE
fix(google_genai): guard against None content.parts in _extract_response_text

### DIFF
--- a/sentry_sdk/integrations/google_genai/utils.py
+++ b/sentry_sdk/integrations/google_genai/utils.py
@@ -695,7 +695,9 @@ def _extract_response_text(
 
     texts = []
     for candidate in response.candidates:
-        if not hasattr(candidate, "content") or not hasattr(candidate.content, "parts"):
+        if not hasattr(candidate, "content") or not getattr(
+            candidate.content, "parts", None
+        ):
             continue
 
         for part in candidate.content.parts:

--- a/tests/integrations/google_genai/test_google_genai.py
+++ b/tests/integrations/google_genai/test_google_genai.py
@@ -2107,3 +2107,47 @@ def test_extract_contents_messages_object_with_text_attribute():
     assert len(result) == 1
     assert result[0]["role"] == "user"
     assert result[0]["content"] == [{"text": "Object text", "type": "text"}]
+
+
+def test_response_with_none_content_parts(sentry_init, capture_events, mock_genai_client):
+    """Test that _extract_response_text does not raise TypeError when
+    candidate.content.parts is explicitly set to None (attribute exists but is None).
+    See https://github.com/getsentry/sentry-python/issues/5854
+    """
+    sentry_init(
+        integrations=[GoogleGenAIIntegration()],
+        traces_sample_rate=1.0,
+    )
+    events = capture_events()
+
+    # Response where parts is present but explicitly None
+    response_json = {
+        "candidates": [
+            {
+                "content": {
+                    "role": "model",
+                    "parts": None,
+                },
+                "finishReason": "STOP",
+            }
+        ],
+    }
+
+    mock_http_response = create_mock_http_response(response_json)
+
+    with mock.patch.object(
+        mock_genai_client._api_client, "request", return_value=mock_http_response
+    ):
+        with start_transaction(name="google_genai"):
+            # Should not raise TypeError: 'NoneType' object is not iterable
+            response = mock_genai_client.models.generate_content(
+                model="gemini-1.5-flash",
+                contents="Test",
+                config=create_test_config(),
+            )
+
+    assert response is not None
+    (event,) = events
+    chat_span = event["spans"][0]
+    # No response text should be recorded
+    assert chat_span["data"].get(SPANDATA.GEN_AI_RESPONSE_TEXT) is None


### PR DESCRIPTION
### Description

When a Gemini API candidate's `content.parts` attribute is **present but set to `None`** (e.g. an interrupted generation or a model turn with no text), the existing `hasattr(candidate.content, "parts")` guard passed but the subsequent `for part in candidate.content.parts` loop raised:

```
TypeError: 'NoneType' object is not iterable
```

The fix replaces the `hasattr` sentinel with `getattr(..., None)`, which evaluates falsy for both **absent** and **None-valued** attributes, matching the pattern used elsewhere in the file (e.g. line 220).

**Changed files:**
- `sentry_sdk/integrations/google_genai/utils.py` — one-line guard fix
- `tests/integrations/google_genai/test_google_genai.py` — regression test

#### Issues
* resolves: #5854

#### Reminders
- [x] Tests added (`test_response_with_none_content_parts`)
- [x] Lint: no new code style issues introduced
- [x] PR title uses conventional commit style