### PR TITLE
fix(google_genai): populate response_id and model_version in streaming accumulator

### DIFF
--- a/sentry_sdk/integrations/google_genai/streaming.py
+++ b/sentry_sdk/integrations/google_genai/streaming.py
@@ -72,6 +72,12 @@ def accumulate_streaming_response(
         if extracted_tool_calls:
             tool_calls.extend(extracted_tool_calls)
 
+        # Capture response_id and model_version from the first chunk that has them
+        if response_id is None:
+            response_id = getattr(chunk, "response_id", None)
+        if model is None:
+            model = getattr(chunk, "model_version", None)
+
         # Use last possible chunk, in case of interruption, and
         # gracefully handle missing intermediate tokens by taking maximum
         # with previous token reporting.

--- a/tests/integrations/google_genai/test_google_genai.py
+++ b/tests/integrations/google_genai/test_google_genai.py
@@ -525,6 +525,11 @@ def test_streaming_generate_content(sentry_init, capture_events, mock_genai_clie
     # Verify model name
     assert chat_span["data"][SPANDATA.GEN_AI_REQUEST_MODEL] == "gemini-1.5-flash"
 
+    # Verify response_id and model_version are captured from the first chunk
+    # that contains them (fixes: streaming always returns null for these fields)
+    assert chat_span["data"][SPANDATA.GEN_AI_RESPONSE_ID] == "response-id-stream-123"
+    assert chat_span["data"][SPANDATA.GEN_AI_RESPONSE_MODEL] == "gemini-1.5-flash"
+
 
 def test_span_origin(sentry_init, capture_events, mock_genai_client):
     sentry_init(


### PR DESCRIPTION
### Description

`accumulate_streaming_response()` in `streaming.py` initialises `response_id` and `model` to `None` (lines 53-54) but **never populates them** from the streaming chunks. As a result, streaming spans always have `null` for `gen_ai.response.id` and `gen_ai.response.model`, while the non-streaming path in `utils.py:888-892` correctly captures both fields.

**Fix:** after processing tool-calls for each chunk, extract `response_id` and `model_version` from the first chunk that carries them — the same pattern the non-streaming path already uses.

**Changed files:**
- `sentry_sdk/integrations/google_genai/streaming.py` — extract `response_id` / `model_version` in accumulation loop
- `tests/integrations/google_genai/test_google_genai.py` — add assertions to the existing streaming test that verify both fields are now recorded on the span

#### Issues
* resolves: #5812

#### Reminders
- [x] Tests updated (`test_streaming_generate_content` now asserts `GEN_AI_RESPONSE_ID` and `GEN_AI_RESPONSE_MODEL`)
- [x] No new lint issues
- [x] PR title uses conventional commit style