### PR TITLE
fix(anthropic): stop setting transaction status on AI span errors

### DIFF
--- a/sentry_sdk/integrations/anthropic.py
+++ b/sentry_sdk/integrations/anthropic.py
@@ -17,7 +17,7 @@ from sentry_sdk.ai.utils import (
 from sentry_sdk.consts import OP, SPANDATA, SPANSTATUS
 from sentry_sdk.integrations import _check_minimum_version, DidNotEnable, Integration
 from sentry_sdk.scope import should_send_default_pii
-from sentry_sdk.tracing_utils import set_span_errored
+from sentry_sdk.tracing_utils import get_current_span
 from sentry_sdk.utils import (
     capture_internal_exceptions,
     event_from_exception,
@@ -74,7 +74,12 @@ class AnthropicIntegration(Integration):
 
 
 def _capture_exception(exc: "Any") -> None:
-    set_span_errored()
+    # Only mark the current AI span as errored; do not propagate to the
+    # containing HTTP transaction — AI integrations must not interfere with
+    # the transaction status.  See: https://github.com/getsentry/sentry-python/issues/5790
+    span = get_current_span()
+    if span is not None:
+        span.set_status(SPANSTATUS.INTERNAL_ERROR)
 
     event, hint = event_from_exception(
         exc,

--- a/tests/integrations/anthropic/test_anthropic.py
+++ b/tests/integrations/anthropic/test_anthropic.py
@@ -706,7 +706,10 @@ def test_exception_message_create(sentry_init, capture_events):
 
     (event, transaction) = events
     assert event["level"] == "error"
-    assert transaction["contexts"]["trace"]["status"] == "internal_error"
+    # The Anthropic integration must NOT set the transaction status to
+    # internal_error — only its own span should be marked errored so that
+    # HTTP transactions are left intact.  (fixes #5790)
+    assert transaction["contexts"]["trace"]["status"] != "internal_error"
 
 
 def test_span_status_error(sentry_init, capture_events):
@@ -729,7 +732,9 @@ def test_span_status_error(sentry_init, capture_events):
     assert error["level"] == "error"
     assert transaction["spans"][0]["status"] == "internal_error"
     assert transaction["spans"][0]["tags"]["status"] == "internal_error"
-    assert transaction["contexts"]["trace"]["status"] == "internal_error"
+    # The transaction itself must NOT be marked internal_error by the AI
+    # integration — only the inner span should be errored.  (fixes #5790)
+    assert transaction["contexts"]["trace"]["status"] != "internal_error"
     assert transaction["spans"][0]["data"][SPANDATA.GEN_AI_OPERATION_NAME] == "chat"
 
 
@@ -754,7 +759,9 @@ async def test_span_status_error_async(sentry_init, capture_events):
     assert error["level"] == "error"
     assert transaction["spans"][0]["status"] == "internal_error"
     assert transaction["spans"][0]["tags"]["status"] == "internal_error"
-    assert transaction["contexts"]["trace"]["status"] == "internal_error"
+    # The transaction itself must NOT be marked internal_error by the AI
+    # integration — only the inner span should be errored.  (fixes #5790)
+    assert transaction["contexts"]["trace"]["status"] != "internal_error"
     assert transaction["spans"][0]["data"][SPANDATA.GEN_AI_OPERATION_NAME] == "chat"
 
 
@@ -776,7 +783,10 @@ async def test_exception_message_create_async(sentry_init, capture_events):
 
     (event, transaction) = events
     assert event["level"] == "error"
-    assert transaction["contexts"]["trace"]["status"] == "internal_error"
+    # The Anthropic integration must NOT set the transaction status to
+    # internal_error — only its own span should be marked errored so that
+    # HTTP transactions are left intact.  (fixes #5790)
+    assert transaction["contexts"]["trace"]["status"] != "internal_error"
 
 
 def test_span_origin(sentry_init, capture_events):


### PR DESCRIPTION
### Description

AI integrations should not interfere with HTTP transactions.

The previous `_capture_exception()` called `set_span_errored()`, which **not only** marked the current AI span as `INTERNAL_ERROR` but **also** propagated that status to the **containing HTTP transaction** via:

```python
span.containing_transaction.set_status(SPANSTATUS.INTERNAL_ERROR)
```

This is incorrect: the HTTP layer owns the transaction status, and an Anthropic API error is an application-level event that should only affect the AI-specific span.

**Fix:** Replace `set_span_errored()` with a direct `span.set_status()` call that does **not** touch the containing transaction.

**Affected files:**
- `sentry_sdk/integrations/anthropic.py` — removed `set_span_errored()`, now only marks the current span
- `tests/integrations/anthropic/test_anthropic.py` — updated 4 error tests to assert the transaction trace status is NOT set to `internal_error` by the integration

#### Issues
* resolves: #5790

#### Reminders
- [x] Tests updated (4 assertions changed from `== internal_error` to `!= internal_error`)
- [x] No new lint issues
- [x] PR title uses conventional commit style