### PR TITLE
fix(openai_agents): stop setting transaction status on AI span errors

### DIFF
--- a/sentry_sdk/integrations/openai_agents/utils.py
+++ b/sentry_sdk/integrations/openai_agents/utils.py
@@ -11,7 +11,7 @@ from sentry_sdk.ai.utils import (
 from sentry_sdk.consts import SPANDATA, SPANSTATUS, OP
 from sentry_sdk.integrations import DidNotEnable
 from sentry_sdk.scope import should_send_default_pii
-from sentry_sdk.tracing_utils import set_span_errored
+from sentry_sdk.tracing_utils import get_current_span
 from sentry_sdk.utils import event_from_exception, safe_serialize
 from sentry_sdk.ai._openai_completions_api import _transform_system_instructions
 from sentry_sdk.ai._openai_responses_api import (
@@ -36,7 +36,12 @@ except ImportError:
 
 
 def _capture_exception(exc: "Any") -> None:
-    set_span_errored()
+    # Only mark the current AI span as errored; do not propagate to the
+    # containing HTTP transaction — AI integrations must not interfere with
+    # the transaction status.  See: https://github.com/getsentry/sentry-python/issues/5794
+    span = get_current_span()
+    if span is not None:
+        span.set_status(SPANSTATUS.INTERNAL_ERROR)
 
     event, hint = event_from_exception(
         exc,
@@ -47,7 +52,9 @@ def _capture_exception(exc: "Any") -> None:
 
 
 def _record_exception_on_span(span: "Span", error: Exception) -> "Any":
-    set_span_errored(span)
+    # Only mark this specific span as errored; do not touch the transaction.
+    # See: https://github.com/getsentry/sentry-python/issues/5794
+    span.set_status(SPANSTATUS.INTERNAL_ERROR)
     span.set_data("span.status", "error")
 
     # Optionally capture the error details if we have them

--- a/tests/integrations/openai_agents/test_openai_agents.py
+++ b/tests/integrations/openai_agents/test_openai_agents.py
@@ -1860,7 +1860,10 @@ async def test_span_status_error(sentry_init, capture_events, test_agent):
     assert error["level"] == "error"
     assert transaction["spans"][0]["status"] == "internal_error"
     assert transaction["spans"][0]["tags"]["status"] == "internal_error"
-    assert transaction["contexts"]["trace"]["status"] == "internal_error"
+    # The openai-agents integration must NOT set the transaction status to
+    # internal_error — only the inner span should be errored so that HTTP
+    # transactions are left intact.  (fixes #5794)
+    assert transaction["contexts"]["trace"]["status"] != "internal_error"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
### Description

AI integrations should not interfere with HTTP transactions.

`_capture_exception()` and `_record_exception_on_span()` were calling `set_span_errored()`, which propagated `INTERNAL_ERROR` to the **containing HTTP transaction** in addition to the AI span. This violates the principle that the HTTP layer owns the transaction status.

**Fix:** Replace `set_span_errored()` calls with direct `span.set_status(SPANSTATUS.INTERNAL_ERROR)` that only marks the AI span errored, without touching the containing transaction.

**Changed files:**
- `sentry_sdk/integrations/openai_agents/utils.py` — `_capture_exception()` and `_record_exception_on_span()` no longer touch the transaction
- `tests/integrations/openai_agents/test_openai_agents.py` — updated assertion: transaction trace status must NOT be `internal_error`

#### Issues
* resolves: #5794

#### Reminders
- [x] Tests updated
- [x] No new lint issues
- [x] PR title uses conventional commit style