### PR TITLE
fix(langchain): stop setting transaction status on AI span errors

### DIFF
--- a/sentry_sdk/integrations/langchain.py
+++ b/sentry_sdk/integrations/langchain.py
@@ -17,10 +17,10 @@ from sentry_sdk.ai.utils import (
     truncate_and_annotate_messages,
     transform_content_part,
 )
-from sentry_sdk.consts import OP, SPANDATA
+from sentry_sdk.consts import OP, SPANDATA, SPANSTATUS
 from sentry_sdk.integrations import DidNotEnable, Integration
 from sentry_sdk.scope import should_send_default_pii
-from sentry_sdk.tracing_utils import _get_value, set_span_errored
+from sentry_sdk.tracing_utils import _get_value
 from sentry_sdk.utils import capture_internal_exceptions, logger
 
 if TYPE_CHECKING:
@@ -296,7 +296,9 @@ class SentryLangchainCallback(BaseCallbackHandler):  # type: ignore[misc]
 
             span_data = self.span_map[run_id]
             span = span_data.span
-            set_span_errored(span)
+            # Only mark this AI span as errored; do not propagate to the
+            # containing HTTP transaction.  (fixes #5791)
+            span.set_status(SPANSTATUS.INTERNAL_ERROR)
 
             sentry_sdk.capture_exception(error, span.scope)
 
@@ -1102,7 +1104,9 @@ def _wrap_agent_executor_stream(f: "Callable[..., Any]") -> "Callable[..., Any]"
                     set_data_normalized(span, SPANDATA.GEN_AI_RESPONSE_TEXT, output)
             except Exception:
                 exc_info = sys.exc_info()
-                set_span_errored(span)
+                # Only mark this AI span as errored; do not touch the transaction.
+                # (fixes #5791)
+                span.set_status(SPANSTATUS.INTERNAL_ERROR)
                 raise
             finally:
                 # Ensure cleanup happens even if iterator is abandoned or fails
@@ -1128,7 +1132,9 @@ def _wrap_agent_executor_stream(f: "Callable[..., Any]") -> "Callable[..., Any]"
                     set_data_normalized(span, SPANDATA.GEN_AI_RESPONSE_TEXT, output)
             except Exception:
                 exc_info = sys.exc_info()
-                set_span_errored(span)
+                # Only mark this AI span as errored; do not touch the transaction.
+                # (fixes #5791)
+                span.set_status(SPANSTATUS.INTERNAL_ERROR)
                 raise
             finally:
                 # Ensure cleanup happens even if iterator is abandoned or fails

--- a/tests/integrations/langchain/test_langchain.py
+++ b/tests/integrations/langchain/test_langchain.py
@@ -384,7 +384,10 @@ def test_span_status_error(sentry_init, capture_events):
     assert error["level"] == "error"
     assert transaction["spans"][0]["status"] == "internal_error"
     assert transaction["spans"][0]["tags"]["status"] == "internal_error"
-    assert transaction["contexts"]["trace"]["status"] == "internal_error"
+    # The langchain integration must NOT set the transaction status to
+    # internal_error — only the inner span should be errored so that
+    # HTTP transactions are left intact.  (fixes #5791)
+    assert transaction["contexts"]["trace"]["status"] != "internal_error"
 
 
 def test_span_origin(sentry_init, capture_events):


### PR DESCRIPTION
### Description

AI integrations should not interfere with HTTP transactions.

Three call-sites in `langchain.py` used `set_span_errored(span)` which propagated `INTERNAL_ERROR` to the containing HTTP transaction in addition to marking the AI span:

1. `SentryLangchainCallback._handle_error()` — callback-based error path
2. `new_iterator()` sync streaming wrapper — exception in generator
3. `new_iterator_async()` async streaming wrapper — exception in async generator

All three are replaced with `span.set_status(SPANSTATUS.INTERNAL_ERROR)` which only affects the given span, leaving the containing transaction untouched.

**Changed files:**
- `sentry_sdk/integrations/langchain.py` — 3 call-sites replaced; `SPANSTATUS` import added to existing consts import; `set_span_errored` import removed
- `tests/integrations/langchain/test_langchain.py` — updated `test_span_error` to assert the transaction trace status is NOT `internal_error`

#### Issues
* resolves: #5791

#### Reminders
- [x] Tests updated
- [x] No new lint issues
- [x] PR title uses conventional commit style