### PR TITLE
fix(openai): stop setting transaction status on AI span errors

### DIFF
--- a/sentry_sdk/integrations/openai.py
+++ b/sentry_sdk/integrations/openai.py
@@ -23,10 +23,10 @@ from sentry_sdk.ai._openai_responses_api import (
     _is_system_instruction as _is_system_instruction_responses,
     _get_system_instructions as _get_system_instructions_responses,
 )
-from sentry_sdk.consts import SPANDATA
+from sentry_sdk.consts import SPANDATA, SPANSTATUS
 from sentry_sdk.integrations import DidNotEnable, Integration
 from sentry_sdk.scope import should_send_default_pii
-from sentry_sdk.tracing_utils import set_span_errored
+
 from sentry_sdk.utils import (
     capture_internal_exceptions,
     event_from_exception,
@@ -129,7 +129,11 @@ def _capture_exception(exc: "Any", manual_span_cleanup: bool = True) -> None:
     # Close an eventually open span
     # We need to do this by hand because we are not using the start_span context manager
     current_span = sentry_sdk.get_current_span()
-    set_span_errored(current_span)
+    # Only mark the AI span as errored; do not propagate to the containing
+    # HTTP transaction — AI integrations must not interfere with the
+    # transaction status.  (fixes #5789)
+    if current_span is not None:
+        current_span.set_status(SPANSTATUS.INTERNAL_ERROR)
 
     if manual_span_cleanup and current_span is not None:
         current_span.__exit__(None, None, None)

--- a/tests/integrations/openai/test_openai.py
+++ b/tests/integrations/openai/test_openai.py
@@ -975,7 +975,10 @@ def test_span_status_error(sentry_init, capture_events):
     assert error["level"] == "error"
     assert transaction["spans"][0]["status"] == "internal_error"
     assert transaction["spans"][0]["tags"]["status"] == "internal_error"
-    assert transaction["contexts"]["trace"]["status"] == "internal_error"
+    # The openai integration must NOT set the transaction status to
+    # internal_error — only the inner span should be errored so that
+    # HTTP transactions are left intact.  (fixes #5789)
+    assert transaction["contexts"]["trace"]["status"] != "internal_error"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
### Description

AI integrations should not interfere with HTTP transactions.

`_capture_exception()` called `set_span_errored(current_span)` which propagated `INTERNAL_ERROR` to the containing HTTP transaction. Replace with a direct `current_span.set_status()` call that only marks the AI span errored.

- `sentry_sdk/integrations/openai.py` — `set_span_errored` removed, direct `set_status` used
- `tests/integrations/openai/test_openai.py` — transaction status assertion updated

#### Issues
* resolves: #5789