### PR TITLE
fix(cohere): stop setting transaction status on AI span errors

### DIFF
--- a/sentry_sdk/integrations/cohere.py
+++ b/sentry_sdk/integrations/cohere.py
@@ -3,12 +3,12 @@ from functools import wraps
 
 from sentry_sdk import consts
 from sentry_sdk.ai.monitoring import record_token_usage
-from sentry_sdk.consts import SPANDATA
+from sentry_sdk.consts import SPANDATA, SPANSTATUS
 from sentry_sdk.ai.utils import set_data_normalized
 
 from typing import TYPE_CHECKING
 
-from sentry_sdk.tracing_utils import set_span_errored
+from sentry_sdk.tracing_utils import get_current_span
 
 if TYPE_CHECKING:
     from typing import Any, Callable, Iterator
@@ -84,7 +84,11 @@ class CohereIntegration(Integration):
 
 
 def _capture_exception(exc: "Any") -> None:
-    set_span_errored()
+    # Only mark the current AI span as errored; do not propagate to the
+    # containing HTTP transaction.  (fixes #5792)
+    span = get_current_span()
+    if span is not None:
+        span.set_status(SPANSTATUS.INTERNAL_ERROR)
 
     event, hint = event_from_exception(
         exc,

--- a/tests/integrations/cohere/test_cohere.py
+++ b/tests/integrations/cohere/test_cohere.py
@@ -183,7 +183,9 @@ def test_span_status_error(sentry_init, capture_events):
     assert error["level"] == "error"
     assert transaction["spans"][0]["status"] == "internal_error"
     assert transaction["spans"][0]["tags"]["status"] == "internal_error"
-    assert transaction["contexts"]["trace"]["status"] == "internal_error"
+    # The cohere integration must NOT set the transaction status to
+    # internal_error — only the inner span should be errored.  (fixes #5792)
+    assert transaction["contexts"]["trace"]["status"] != "internal_error"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
### Description

AI integrations should not interfere with HTTP transactions.

`_capture_exception()` called `set_span_errored()` (no span argument) which sets the current span AND the containing transaction to `INTERNAL_ERROR`. Replace with `get_current_span()` + direct `span.set_status()` that only affects the AI span.

**Changed files:**
- `sentry_sdk/integrations/cohere.py`
- `tests/integrations/cohere/test_cohere.py`

#### Issues
* resolves: #5792