### PR TITLE
fix(huggingface_hub): stop setting transaction status on AI span errors

### DIFF
--- a/sentry_sdk/integrations/huggingface_hub.py
+++ b/sentry_sdk/integrations/huggingface_hub.py
@@ -5,10 +5,10 @@ from functools import wraps
 import sentry_sdk
 from sentry_sdk.ai.monitoring import record_token_usage
 from sentry_sdk.ai.utils import set_data_normalized
-from sentry_sdk.consts import OP, SPANDATA
+from sentry_sdk.consts import OP, SPANDATA, SPANSTATUS
 from sentry_sdk.integrations import DidNotEnable, Integration
 from sentry_sdk.scope import should_send_default_pii
-from sentry_sdk.tracing_utils import set_span_errored
+from sentry_sdk.tracing_utils import get_current_span
 from sentry_sdk.utils import (
     capture_internal_exceptions,
     event_from_exception,
@@ -53,7 +53,11 @@ class HuggingfaceHubIntegration(Integration):
 
 
 def _capture_exception(exc: "Any") -> None:
-    set_span_errored()
+    # Only mark the current AI span as errored; do not propagate to the
+    # containing HTTP transaction.  (fixes #5793)
+    span = get_current_span()
+    if span is not None:
+        span.set_status(SPANSTATUS.INTERNAL_ERROR)
 
     event, hint = event_from_exception(
         exc,

--- a/tests/integrations/huggingface_hub/test_huggingface_hub.py
+++ b/tests/integrations/huggingface_hub/test_huggingface_hub.py
@@ -835,7 +835,9 @@ def test_span_status_error(
     assert span["status"] == "internal_error"
     assert span["tags"]["status"] == "internal_error"
 
-    assert transaction["contexts"]["trace"]["status"] == "internal_error"
+    # The huggingface_hub integration must NOT set the transaction status to
+    # internal_error — only the inner span should be errored.  (fixes #5793)
+    assert transaction["contexts"]["trace"]["status"] != "internal_error"
 
 
 @pytest.mark.httpx_mock(assert_all_requests_were_expected=False)


### PR DESCRIPTION
### Description

AI integrations should not interfere with HTTP transactions.

`_capture_exception()` called `set_span_errored()` which propagated `INTERNAL_ERROR` to the containing HTTP transaction. Replace with `get_current_span()` + direct `span.set_status()` that only affects the AI span.

**Changed files:**
- `sentry_sdk/integrations/huggingface_hub.py`
- `tests/integrations/huggingface_hub/test_huggingface_hub.py`

#### Issues
* resolves: #5793