### PR TITLE
fix(ci): Use GitHub App token for draft PR enforcement

### DIFF
--- a/.github/workflows/enforce-draft-pr.yml
+++ b/.github/workflows/enforce-draft-pr.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - name: Generate GitHub App token
         id: app-token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859  # v2
         with:
           app-id: ${{ vars.SDK_MAINTAINER_BOT_APP_ID }}
           private-key: ${{ secrets.SDK_MAINTAINER_BOT_PRIVATE_KEY }}


### PR DESCRIPTION
The default `GITHUB_TOKEN` lacks permission for the GraphQL `convertPullRequestToDraft` mutation, causing the enforce-draft-pr workflow to fail with "Resource not accessible by integration".

This switches to the new SDK Maintainer Bot GitHub App token (`SDK_MAINTAINER_BOT_APP_ID` / `SDK_MAINTAINER_BOT_PRIVATE_KEY`) which has the required pull-requests write scope for GraphQL mutations.