### PR TITLE
ref(ai): Rename generate_text to text_completion

### DIFF
--- a/sentry_sdk/consts.py
+++ b/sentry_sdk/consts.py
@@ -921,7 +921,7 @@ class OP:
     GEN_AI_CREATE_AGENT = "gen_ai.create_agent"
     GEN_AI_EMBEDDINGS = "gen_ai.embeddings"
     GEN_AI_EXECUTE_TOOL = "gen_ai.execute_tool"
-    GEN_AI_GENERATE_TEXT = "gen_ai.generate_text"
+    GEN_AI_TEXT_COMPLETION = "gen_ai.text_completion"
     GEN_AI_HANDOFF = "gen_ai.handoff"
     GEN_AI_PIPELINE = "gen_ai.pipeline"
     GEN_AI_INVOKE_AGENT = "gen_ai.invoke_agent"

--- a/sentry_sdk/integrations/huggingface_hub.py
+++ b/sentry_sdk/integrations/huggingface_hub.py
@@ -41,7 +41,7 @@ class HuggingfaceHubIntegration(Integration):
         huggingface_hub.inference._client.InferenceClient.text_generation = (
             _wrap_huggingface_task(
                 huggingface_hub.inference._client.InferenceClient.text_generation,
-                OP.GEN_AI_GENERATE_TEXT,
+                OP.GEN_AI_TEXT_COMPLETION,
             )
         )
         huggingface_hub.inference._client.InferenceClient.chat_completion = (

--- a/sentry_sdk/integrations/langchain.py
+++ b/sentry_sdk/integrations/langchain.py
@@ -377,13 +377,13 @@ class SentryLangchainCallback(BaseCallbackHandler):  # type: ignore[misc]
             watched_span = self._create_span(
                 run_id,
                 parent_run_id,
-                op=OP.GEN_AI_GENERATE_TEXT,
-                name=f"generate_text {model}".strip(),
+                op=OP.GEN_AI_TEXT_COMPLETION,
+                name=f"text_completion {model}".strip(),
                 origin=LangchainIntegration.origin,
             )
             span = watched_span.span
 
-            span.set_data(SPANDATA.GEN_AI_OPERATION_NAME, "generate_text")
+            span.set_data(SPANDATA.GEN_AI_OPERATION_NAME, "text_completion")
 
             pipeline_name = kwargs.get("name")
             if pipeline_name:

--- a/tests/integrations/huggingface_hub/test_huggingface_hub.py
+++ b/tests/integrations/huggingface_hub/test_huggingface_hub.py
@@ -507,12 +507,12 @@ def test_text_generation(
 
     assert span is not None
 
-    assert span["op"] == "gen_ai.generate_text"
-    assert span["description"] == "generate_text test-model"
+    assert span["op"] == "gen_ai.text_completion"
+    assert span["description"] == "text_completion test-model"
     assert span["origin"] == "auto.ai.huggingface_hub"
 
     expected_data = {
-        "gen_ai.operation.name": "generate_text",
+        "gen_ai.operation.name": "text_completion",
         "gen_ai.request.model": "test-model",
         "gen_ai.response.finish_reasons": "length",
         "gen_ai.response.streaming": False,
@@ -576,12 +576,12 @@ def test_text_generation_streaming(
 
     assert span is not None
 
-    assert span["op"] == "gen_ai.generate_text"
-    assert span["description"] == "generate_text test-model"
+    assert span["op"] == "gen_ai.text_completion"
+    assert span["description"] == "text_completion test-model"
     assert span["origin"] == "auto.ai.huggingface_hub"
 
     expected_data = {
-        "gen_ai.operation.name": "generate_text",
+        "gen_ai.operation.name": "text_completion",
         "gen_ai.request.model": "test-model",
         "gen_ai.response.finish_reasons": "length",
         "gen_ai.response.streaming": True,

--- a/tests/integrations/langchain/test_langchain.py
+++ b/tests/integrations/langchain/test_langchain.py
@@ -153,12 +153,14 @@ def test_langchain_text_completion(
     assert tx["type"] == "transaction"
 
     llm_spans = [
-        span for span in tx.get("spans", []) if span.get("op") == "gen_ai.generate_text"
+        span
+        for span in tx.get("spans", [])
+        if span.get("op") == "gen_ai.text_completion"
     ]
     assert len(llm_spans) > 0
 
     llm_span = llm_spans[0]
-    assert llm_span["description"] == "generate_text gpt-3.5-turbo"
+    assert llm_span["description"] == "text_completion gpt-3.5-turbo"
     assert llm_span["data"]["gen_ai.system"] == "openai"
     assert llm_span["data"]["gen_ai.pipeline.name"] == "my-snazzy-pipeline"
     assert llm_span["data"]["gen_ai.request.model"] == "gpt-3.5-turbo"
@@ -1294,12 +1296,14 @@ def test_langchain_message_truncation(sentry_init, capture_events):
     assert tx["type"] == "transaction"
 
     llm_spans = [
-        span for span in tx.get("spans", []) if span.get("op") == "gen_ai.generate_text"
+        span
+        for span in tx.get("spans", [])
+        if span.get("op") == "gen_ai.text_completion"
     ]
     assert len(llm_spans) > 0
 
     llm_span = llm_spans[0]
-    assert llm_span["data"]["gen_ai.operation.name"] == "generate_text"
+    assert llm_span["data"]["gen_ai.operation.name"] == "text_completion"
     assert llm_span["data"][SPANDATA.GEN_AI_PIPELINE_NAME] == "my_pipeline"
 
     assert SPANDATA.GEN_AI_REQUEST_MESSAGES in llm_span["data"]
@@ -2010,12 +2014,14 @@ def test_langchain_response_model_extraction(
     assert tx["type"] == "transaction"
 
     llm_spans = [
-        span for span in tx.get("spans", []) if span.get("op") == "gen_ai.generate_text"
+        span
+        for span in tx.get("spans", [])
+        if span.get("op") == "gen_ai.text_completion"
     ]
     assert len(llm_spans) > 0
 
     llm_span = llm_spans[0]
-    assert llm_span["data"]["gen_ai.operation.name"] == "generate_text"
+    assert llm_span["data"]["gen_ai.operation.name"] == "text_completion"
 
     if expected_model is not None:
         assert SPANDATA.GEN_AI_RESPONSE_MODEL in llm_span["data"]
@@ -2311,7 +2317,9 @@ def test_langchain_ai_system_detection(
     assert tx["type"] == "transaction"
 
     llm_spans = [
-        span for span in tx.get("spans", []) if span.get("op") == "gen_ai.generate_text"
+        span
+        for span in tx.get("spans", [])
+        if span.get("op") == "gen_ai.text_completion"
     ]
     assert len(llm_spans) > 0
 


### PR DESCRIPTION
Rename the `gen_ai.generate_text` span op to `gen_ai.text_completion` across the langchain and huggingface_hub integrations, aligning with updated naming conventions.

The constant `OP.GEN_AI_GENERATE_TEXT` is renamed to `OP.GEN_AI_TEXT_COMPLETION`, and all span names, operation name data, and test assertions are updated accordingly. The huggingface_hub integration derives its span description dynamically from the op string, so no additional changes were needed there beyond the op reference.

Refs PY-2268