### PR TITLE
ref(ai): Remove unused GEN_AI_PIPELINE operation constant

### DIFF
--- a/sentry_sdk/consts.py
+++ b/sentry_sdk/consts.py
@@ -923,7 +923,6 @@ class OP:
     GEN_AI_EXECUTE_TOOL = "gen_ai.execute_tool"
     GEN_AI_GENERATE_TEXT = "gen_ai.generate_text"
     GEN_AI_HANDOFF = "gen_ai.handoff"
-    GEN_AI_PIPELINE = "gen_ai.pipeline"
     GEN_AI_INVOKE_AGENT = "gen_ai.invoke_agent"
     GEN_AI_RESPONSES = "gen_ai.responses"
     GRAPHQL_EXECUTE = "graphql.execute"


### PR DESCRIPTION
Remove the legacy `GEN_AI_PIPELINE` operation constant. It is no longer used by any integration.

Refs PY-2143 and #5679 