### PR TITLE
fix(workflow): Fix permission issue with github app and PR draft graphql endpoint

### DIFF
--- a/.github/workflows/enforce-draft-pr.yml
+++ b/.github/workflows/enforce-draft-pr.yml
@@ -9,6 +9,9 @@ jobs:
     name: Enforce Draft PR
     runs-on: ubuntu-24.04
     if: github.event.pull_request.draft == false
+    permissions:
+      pull-requests: write
+      contents: write
     steps:
       - name: Generate GitHub App token
         id: app-token
@@ -19,7 +22,7 @@ jobs:
 
       - name: Convert PR to draft
         env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          GH_TOKEN: ${{github.token}}
           PR_URL: ${{ github.event.pull_request.html_url }}
         run: |
           gh pr ready "$PR_URL" --undo


### PR DESCRIPTION
### Description
There's a bug/limitation with the convertPullRequestToDraft GraphQL endpoint that does not allow GitHub app to access it, even with pull-request:write

the workaround is to use the github action token with write access to both content and pull request

#### Issues
https://linear.app/getsentry/issue/SEC-1205/github-app-graphql-limitation-with-convertpullrequesttodraft-endpoint

#### Reminders
