### PR TITLE
remove scope.span setter

### DIFF
--- a/sentry_sdk/scope.py
+++ b/sentry_sdk/scope.py
@@ -878,20 +878,8 @@ class Scope:
 
     @property
     def span(self) -> "Optional[Union[Span, StreamedSpan]]":
-        """Get/set current tracing span or transaction."""
+        """Get current tracing span or transaction."""
         return self._span
-
-    @span.setter
-    def span(self, span: "Optional[Union[Span, StreamedSpan]]") -> None:
-        self._span = span
-        # XXX: this differs from the implementation in JS, there Scope.setSpan
-        # does not set Scope._transactionName.
-        if isinstance(span, Transaction):
-            transaction = span
-            if transaction.name:
-                self._transaction = transaction.name
-                if transaction.source:
-                    self._transaction_info["source"] = transaction.source
 
     @property
     def profile(self) -> "Optional[Profile]":

--- a/sentry_sdk/traces.py
+++ b/sentry_sdk/traces.py
@@ -343,7 +343,7 @@ class StreamedSpan:
     def _start(self) -> None:
         if self._active:
             old_span = self._scope.span
-            self._scope.span = self
+            self._scope._span = self
             self._previous_span_on_scope = old_span
 
     def _end(self, end_timestamp: "Optional[Union[float, datetime]]" = None) -> None:
@@ -361,7 +361,7 @@ class StreamedSpan:
             with capture_internal_exceptions():
                 old_span = self._previous_span_on_scope
                 del self._previous_span_on_scope
-                self._scope.span = old_span
+                self._scope._span = old_span
 
         # Set attributes from the segment. These are set on span end on purpose
         # so that we have the best chance to capture the segment's final name
@@ -591,7 +591,7 @@ class NoOpStreamedSpan(StreamedSpan):
             return
 
         old_span = self._scope.span
-        self._scope.span = self
+        self._scope._span = self
         self._previous_span_on_scope = old_span
 
     def _end(self, end_timestamp: "Optional[Union[float, datetime]]" = None) -> None:
@@ -614,7 +614,7 @@ class NoOpStreamedSpan(StreamedSpan):
             with capture_internal_exceptions():
                 old_span = self._previous_span_on_scope
                 del self._previous_span_on_scope
-                self._scope.span = old_span
+                self._scope._span = old_span
 
         self._finished = True
 

--- a/sentry_sdk/tracing.py
+++ b/sentry_sdk/tracing.py
@@ -388,7 +388,7 @@ class Span:
     def __enter__(self) -> "Span":
         scope = self.scope or sentry_sdk.get_current_scope()
         old_span = scope.span
-        scope.span = self
+        scope._span = self
         self._context_manager_state = (scope, old_span)
         return self
 
@@ -402,7 +402,7 @@ class Span:
             scope, old_span = self._context_manager_state
             del self._context_manager_state
             self.finish(scope)
-            scope.span = old_span
+            scope._span = old_span
 
     @property
     def containing_transaction(self) -> "Optional[Transaction]":
@@ -873,6 +873,13 @@ class Transaction(Span):
             )
 
         super().__enter__()
+
+        # Propagate transaction name and source to the scope
+        scope = self.scope or sentry_sdk.get_current_scope()
+        if self.name:
+            scope._transaction = self.name
+            if self.source:
+                scope._transaction_info["source"] = self.source
 
         if self._profile is not None:
             self._profile.__enter__()

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -41,7 +41,7 @@ def test_get_current_span_default_hub(sentry_init):
 
     scope = get_current_scope()
     fake_span = mock.MagicMock()
-    scope.span = fake_span
+    scope._span = fake_span
 
     assert get_current_span() == fake_span
 


### PR DESCRIPTION
remove the scope.span property setter and update internal usages to set scope._span directly. the transaction name/source propagation that was in the setter is now in Transaction.__enter__

fixes #5026