### PR TITLE
remove python 3.6 compat code

### DIFF
--- a/sentry_sdk/_compat.py
+++ b/sentry_sdk/_compat.py
@@ -9,7 +9,6 @@ if TYPE_CHECKING:
     T = TypeVar("T")
 
 
-PY37 = sys.version_info[0] == 3 and sys.version_info[1] >= 7
 PY38 = sys.version_info[0] == 3 and sys.version_info[1] >= 8
 PY310 = sys.version_info[0] == 3 and sys.version_info[1] >= 10
 PY311 = sys.version_info[0] == 3 and sys.version_info[1] >= 11

--- a/sentry_sdk/_types.py
+++ b/sentry_sdk/_types.py
@@ -1,8 +1,4 @@
-try:
-    from re import Pattern
-except ImportError:
-    # 3.6
-    from typing import Pattern
+from re import Pattern
 
 from typing import TYPE_CHECKING, TypeVar, Union
 

--- a/sentry_sdk/client.py
+++ b/sentry_sdk/client.py
@@ -163,12 +163,7 @@ def _get_options(*args: "Optional[str]", **kwargs: "Any") -> "Dict[str, Any]":
     return rv
 
 
-try:
-    # Python 3.6+
-    module_not_found_error = ModuleNotFoundError
-except Exception:
-    # Older Python versions
-    module_not_found_error = ImportError  # type: ignore
+module_not_found_error = ModuleNotFoundError
 
 
 class BaseClient:

--- a/sentry_sdk/integrations/_wsgi_common.py
+++ b/sentry_sdk/integrations/_wsgi_common.py
@@ -1,4 +1,4 @@
-from contextlib import contextmanager
+from contextlib import nullcontext
 import json
 from copy import deepcopy
 
@@ -51,11 +51,6 @@ DEFAULT_HTTP_METHODS_TO_CAPTURE = (
     "TRACE",
 )
 
-
-# This noop context manager can be replaced with "from contextlib import nullcontext" when we drop Python 3.6 support
-@contextmanager
-def nullcontext() -> "Iterator[None]":
-    yield
 
 
 def request_body_within_bounds(

--- a/sentry_sdk/integrations/aws_lambda.py
+++ b/sentry_sdk/integrations/aws_lambda.py
@@ -214,76 +214,42 @@ class AwsLambdaIntegration(Integration):
             )
             return
 
-        pre_37 = hasattr(lambda_bootstrap, "handle_http_request")  # Python 3.6
+        lambda_bootstrap.LambdaRuntimeClient.post_init_error = _wrap_init_error(
+            lambda_bootstrap.LambdaRuntimeClient.post_init_error
+        )
 
-        if pre_37:
-            old_handle_event_request = lambda_bootstrap.handle_event_request
+        old_handle_event_request = lambda_bootstrap.handle_event_request
 
-            def sentry_handle_event_request(
-                request_handler: "Any", *args: "Any", **kwargs: "Any"
-            ) -> "Any":
-                request_handler = _wrap_handler(request_handler)
-                return old_handle_event_request(request_handler, *args, **kwargs)
-
-            lambda_bootstrap.handle_event_request = sentry_handle_event_request
-
-            old_handle_http_request = lambda_bootstrap.handle_http_request
-
-            def sentry_handle_http_request(
-                request_handler: "Any", *args: "Any", **kwargs: "Any"
-            ) -> "Any":
-                request_handler = _wrap_handler(request_handler)
-                return old_handle_http_request(request_handler, *args, **kwargs)
-
-            lambda_bootstrap.handle_http_request = sentry_handle_http_request
-
-            # Patch to_json to drain the queue. This should work even when the
-            # SDK is initialized inside of the handler
-
-            old_to_json = lambda_bootstrap.to_json
-
-            def sentry_to_json(*args: "Any", **kwargs: "Any") -> "Any":
-                _drain_queue()
-                return old_to_json(*args, **kwargs)
-
-            lambda_bootstrap.to_json = sentry_to_json
-        else:
-            lambda_bootstrap.LambdaRuntimeClient.post_init_error = _wrap_init_error(
-                lambda_bootstrap.LambdaRuntimeClient.post_init_error
-            )
-
-            old_handle_event_request = lambda_bootstrap.handle_event_request
-
-            def sentry_handle_event_request(  # type: ignore
+        def sentry_handle_event_request(  # type: ignore
+            lambda_runtime_client, request_handler, *args, **kwargs
+        ):
+            request_handler = _wrap_handler(request_handler)
+            return old_handle_event_request(
                 lambda_runtime_client, request_handler, *args, **kwargs
-            ):
-                request_handler = _wrap_handler(request_handler)
-                return old_handle_event_request(
-                    lambda_runtime_client, request_handler, *args, **kwargs
-                )
-
-            lambda_bootstrap.handle_event_request = sentry_handle_event_request
-
-            # Patch the runtime client to drain the queue. This should work
-            # even when the SDK is initialized inside of the handler
-
-            def _wrap_post_function(f: "F") -> "F":
-                def inner(*args: "Any", **kwargs: "Any") -> "Any":
-                    _drain_queue()
-                    return f(*args, **kwargs)
-
-                return inner  # type: ignore
-
-            lambda_bootstrap.LambdaRuntimeClient.post_invocation_result = (
-                _wrap_post_function(
-                    lambda_bootstrap.LambdaRuntimeClient.post_invocation_result
-                )
             )
-            lambda_bootstrap.LambdaRuntimeClient.post_invocation_error = (
-                _wrap_post_function(
-                    lambda_bootstrap.LambdaRuntimeClient.post_invocation_error
-                )
+
+        lambda_bootstrap.handle_event_request = sentry_handle_event_request
+
+        # Patch the runtime client to drain the queue. This should work
+        # even when the SDK is initialized inside of the handler
+
+        def _wrap_post_function(f: "F") -> "F":
+            def inner(*args: "Any", **kwargs: "Any") -> "Any":
+                _drain_queue()
+                return f(*args, **kwargs)
+
+            return inner  # type: ignore
+
+        lambda_bootstrap.LambdaRuntimeClient.post_invocation_result = (
+            _wrap_post_function(
+                lambda_bootstrap.LambdaRuntimeClient.post_invocation_result
             )
+        )
+        lambda_bootstrap.LambdaRuntimeClient.post_invocation_error = (
+            _wrap_post_function(
+                lambda_bootstrap.LambdaRuntimeClient.post_invocation_error
+            )
+        )
 
 
 def get_lambda_bootstrap() -> "Optional[Any]":

--- a/sentry_sdk/tracing_utils.py
+++ b/sentry_sdk/tracing_utils.py
@@ -11,11 +11,7 @@ from random import Random
 from urllib.parse import quote, unquote
 import uuid
 
-try:
-    from re import Pattern
-except ImportError:
-    # 3.6
-    from typing import Pattern
+from re import Pattern
 
 import sentry_sdk
 from sentry_sdk.consts import OP, SPANDATA, SPANSTATUS, SPANTEMPLATE

--- a/sentry_sdk/utils.py
+++ b/sentry_sdk/utils.py
@@ -28,7 +28,6 @@ except ImportError:
 from typing import TYPE_CHECKING
 
 import sentry_sdk
-from sentry_sdk._compat import PY37
 from sentry_sdk._types import SENSITIVE_DATA_SUBSTITUTE, Annotated, AnnotatedValue
 from sentry_sdk.consts import (
     DEFAULT_ADD_FULL_STACK,
@@ -1302,8 +1301,8 @@ def _is_contextvars_broken() -> bool:
             # that case, check if contextvars are effectively patched.
             if (
                 # Gevent 20.9.0+
-                (sys.version_info >= (3, 7) and version_tuple >= (20, 9))
-                # Gevent 20.5.0+ or Python < 3.7
+                version_tuple >= (20, 9)
+                # Gevent 20.5.0+ with patched contextvars
                 or (is_object_patched("contextvars", "ContextVar"))
             ):
                 return False
@@ -1848,15 +1847,8 @@ def ensure_integration_enabled(
     return patcher
 
 
-if PY37:
-
-    def nanosecond_time() -> int:
-        return time.perf_counter_ns()
-
-else:
-
-    def nanosecond_time() -> int:
-        return int(time.perf_counter() * 1e9)
+def nanosecond_time() -> int:
+    return time.perf_counter_ns()
 
 
 def now() -> float:

--- a/tests/test_gevent.py
+++ b/tests/test_gevent.py
@@ -3,7 +3,7 @@ import pickle
 from datetime import datetime, timezone
 
 import sentry_sdk
-from sentry_sdk._compat import PY37, PY38
+from sentry_sdk._compat import PY38
 
 import pytest
 from tests.conftest import CapturingServer
@@ -50,7 +50,7 @@ def make_client(request, capturing_server):
 @pytest.mark.parametrize("compression_level", (0, 9, None))
 @pytest.mark.parametrize(
     "compression_algo",
-    (("gzip", "br", "<invalid>", None) if PY37 else ("gzip", "<invalid>", None)),
+    ("gzip", "br", "<invalid>", None),
 )
 @pytest.mark.parametrize("http2", [True, False] if PY38 else [False])
 def test_transport_works_gevent(

--- a/tests/test_transport.py
+++ b/tests/test_transport.py
@@ -24,7 +24,7 @@ from sentry_sdk import (
     get_isolation_scope,
     Hub,
 )
-from sentry_sdk._compat import PY37, PY38
+from sentry_sdk._compat import PY38
 from sentry_sdk.envelope import Envelope, Item, parse_json, PayloadRef
 from sentry_sdk.transport import (
     KEEP_ALIVE_SOCKET_OPTIONS,
@@ -82,7 +82,7 @@ def mock_transaction_envelope(span_count: int) -> "Envelope":
 @pytest.mark.parametrize("compression_level", (0, 9, None))
 @pytest.mark.parametrize(
     "compression_algo",
-    (("gzip", "br", "<invalid>", None) if PY37 else ("gzip", "<invalid>", None)),
+    ("gzip", "br", "<invalid>", None),
 )
 @pytest.mark.parametrize("http2", [True, False] if PY38 else [False])
 def test_transport_works(


### PR DESCRIPTION
remove compat code that only existed for python 3.6 - PY37 constant, re.Pattern fallbacks, custom nullcontext, ModuleNotFoundError shim, pre-3.7 aws lambda runtime, and gevent version guard. does not touch contextvars or datetime_from_isoformat

fixes #5040