### PR TITLE
clean up experimental otel references

### DIFF
--- a/sentry_sdk/integrations/opentelemetry/integration.py
+++ b/sentry_sdk/integrations/opentelemetry/integration.py
@@ -1,7 +1,5 @@
 """
-IMPORTANT: The contents of this file are part of a proof of concept and as such
-are experimental and not suitable for production use. They may be changed or
-removed at any time without prior notice.
+OpenTelemetry integration for Sentry.
 """
 
 from sentry_sdk.integrations import DidNotEnable, Integration
@@ -32,10 +30,7 @@ class OpenTelemetryIntegration(Integration):
 
     @staticmethod
     def setup_once() -> None:
-        logger.warning(
-            "[OTel] Initializing highly experimental OpenTelemetry support. "
-            "Use at your own risk."
-        )
+        logger.debug("[OTel] Initializing OpenTelemetry support.")
 
         _setup_sentry_tracing()
         # _setup_instrumentors()

--- a/sentry_sdk/traces.py
+++ b/sentry_sdk/traces.py
@@ -1,6 +1,4 @@
 """
-EXPERIMENTAL. Do not use in production.
-
 The API in this file is only meant to be used in span streaming mode.
 
 You can enable span streaming mode via
@@ -98,9 +96,6 @@ def start_span(
     """
     Start a span.
 
-    EXPERIMENTAL. Use sentry_sdk.start_transaction() and sentry_sdk.start_span()
-    instead.
-
     The span's parent, unless provided explicitly via the `parent_span` argument,
     will be the current active span, if any. If there is none, this span will
     become the root of a new span tree. If you explicitly want this span to be
@@ -172,8 +167,6 @@ def continue_trace(incoming: "dict[str, Any]") -> None:
     """
     Continue a trace from headers or environment variables.
 
-    EXPERIMENTAL. Use sentry_sdk.continue_trace() instead.
-
     This function sets the propagation context on the scope. Any span started
     in the updated scope will belong under the trace extracted from the
     provided propagation headers or environment variables.
@@ -197,8 +190,6 @@ def continue_trace(incoming: "dict[str, Any]") -> None:
 def new_trace() -> None:
     """
     Resets the propagation context, forcing a new trace.
-
-    EXPERIMENTAL.
 
     This function sets the propagation context on the scope. Any span started
     in the updated scope will start its own trace.
@@ -695,8 +686,6 @@ def trace(
 ) -> "Union[Callable[P, R], Callable[[Callable[P, R]], Callable[P, R]]]":
     """
     Decorator to start a span around a function call.
-
-    EXPERIMENTAL. Use @sentry_sdk.trace instead.
 
     This decorator automatically creates a new span when the decorated function
     is called, and finishes the span when the function returns or raises an exception.


### PR DESCRIPTION
remove experimental warnings and labels from traces.py and the otel integration, and drop the otel_powered_performance experiment flag from consts since otel support is no longer experimental

fixes #5028