### PR TITLE
ci: Add workflow to close unvetted non-maintainer PRs

### DIFF
--- a/.github/workflows/close-unvetted-pr.yml
+++ b/.github/workflows/close-unvetted-pr.yml
@@ -196,7 +196,7 @@ jobs:
 
                 for (const user of usersToCheck) {
                   if (user === prAuthor) continue;
-                  if (await isMaintainer(ref.owner, ref.repo, user)) {
+                  if (await isMaintainer(repo.owner, repo.repo, user)) {
                     maintainerParticipated = true;
                     core.info(`Maintainer ${user} participated in ${ref.owner}/${ref.repo}#${ref.number}.`);
                     break;


### PR DESCRIPTION
Adds a GitHub Action that automatically closes PRs from non-maintainers (users without write+ repo access) that don't meet contribution requirements.

The workflow runs on `pull_request_target: [opened]` and checks three conditions, closing the PR with a specific message for each:

1. **No issue reference** — PR body must reference a `getsentry` issue (`#123`, `getsentry/repo#123`, or full GitHub URL)
2. **No maintainer discussion** — both the PR author and a maintainer must have participated in the referenced issue (opening the issue counts as participation)
3. **Issue assigned to someone else** — if the issue has assignees and none of them are the PR author, the work is already claimed

If a PR references multiple issues, it stays open as long as ANY referenced issue passes all checks. Uses the SDK Maintainer Bot app token for API calls, consistent with the existing draft enforcement workflow.

All closures add the `violating-contribution-guidelines` label and link to `CONTRIBUTING.md`.