### PR TITLE
fix(openai): guard against AttributeError on LegacyAPIResponse in streaming helpers

### DIFF
--- a/sentry_sdk/integrations/openai.py
+++ b/sentry_sdk/integrations/openai.py
@@ -623,6 +623,15 @@ def _set_streaming_completions_api_output_data(
     ttft: "Optional[float]" = None
     data_buf: "list[list[str]]" = []  # one for each choice
 
+    if not hasattr(response, "_iterator"):
+        # The response is not a Stream object (e.g. a LegacyAPIResponse returned
+        # when third-party libraries such as LiteLLM use the openai client with
+        # openai >= 2.x).  We cannot wrap the iterator, so we skip instrumentation
+        # and close the span immediately to avoid an AttributeError.
+        if finish_span:
+            span.__exit__(None, None, None)
+        return
+
     old_iterator = response._iterator
 
     def new_iterator() -> "Iterator[ChatCompletionChunk]":
@@ -755,6 +764,15 @@ def _set_streaming_responses_api_output_data(
 
     ttft: "Optional[float]" = None
     data_buf: "list[list[str]]" = []  # one for each choice
+
+    if not hasattr(response, "_iterator"):
+        # The response is not a Stream object (e.g. a LegacyAPIResponse returned
+        # when third-party libraries such as LiteLLM use the openai client with
+        # openai >= 2.x).  We cannot wrap the iterator, so we skip instrumentation
+        # and close the span immediately to avoid an AttributeError.
+        if finish_span:
+            span.__exit__(None, None, None)
+        return
 
     old_iterator = response._iterator
 


### PR DESCRIPTION
## Summary

Fixes #5890

## Problem

When a third-party library (LiteLLM, and potentially others) uses the `openai` Python SDK through sentry-python's `OpenAIIntegration`, and the OpenAI library returns a `LegacyAPIResponse` object instead of a `Stream` (observed with `openai >= 2.x`), both `_set_streaming_completions_api_output_data` and `_set_streaming_responses_api_output_data` raise:

```
AttributeError: 'LegacyAPIResponse' object has no attribute '_iterator'
```

This exception propagates to the caller as:

```
litellm.InternalServerError: OpenAIException - 'LegacyAPIResponse' object has no attribute '_iterator'
```

Breaking streaming completely when Sentry is initialised. The only workaround is to explicitly disable `OpenAIIntegration`.

## Root Cause

Both streaming helper functions unconditionally access `response._iterator`:

```python
old_iterator = response._iterator  # AttributeError when response is LegacyAPIResponse
```

## Fix

Add a `hasattr(response, "_iterator")` guard at the start of both functions. When the attribute is absent, the span is closed and the function returns early, leaving the original (unmodified) response untouched so the caller can iterate it normally.

```python
if not hasattr(response, "_iterator"):
    if finish_span:
        span.__exit__(None, None, None)
    return
```

This is a purely defensive change — it does not affect the normal `Stream`/`AsyncStream` path.

## Testing

Reproducer (requires `sentry-sdk`, `litellm`, `openai >= 2.x`):

```python
import sentry_sdk
import litellm

sentry_sdk.init(dsn="...")

response = litellm.completion(
    model="gpt-4.1-nano",
    messages=[{"role": "user", "content": "hello"}],
    stream=True,
)
for chunk in response:
    print(chunk)  # Previously raised InternalServerError
```
