### PR TITLE
fix(google_genai): populate response_id and model_version in streaming accumulator

### DIFF
--- a/sentry_sdk/integrations/google_genai/streaming.py
+++ b/sentry_sdk/integrations/google_genai/streaming.py
@@ -72,6 +72,13 @@ def accumulate_streaming_response(
         if extracted_tool_calls:
             tool_calls.extend(extracted_tool_calls)
 
+        # Capture response_id and model_version from the first chunk that
+        # contains them (subsequent chunks typically carry the same values).
+        if not response_id:
+            response_id = getattr(chunk, "response_id", None) or None
+        if not model:
+            model = getattr(chunk, "model_version", None) or None
+
         # Use last possible chunk, in case of interruption, and
         # gracefully handle missing intermediate tokens by taking maximum
         # with previous token reporting.


### PR DESCRIPTION
## Summary

Fixes #5812

## Problem

`accumulate_streaming_response()` in `sentry_sdk/integrations/google_genai/streaming.py` initialises `response_id` and `model` to `None` and **never reads them from the streaming chunks**. This means streaming spans always have `null` for `gen_ai.response.id` and `gen_ai.response.model`.

The non-streaming code path in `utils.py` already captures both fields correctly:

```python
if getattr(response, "response_id", None):
    span.set_data(SPANDATA.GEN_AI_RESPONSE_ID, response.response_id)
if getattr(response, "model_version", None):
    span.set_data(SPANDATA.GEN_AI_RESPONSE_MODEL, response.model_version)
```

## Fix

Read `chunk.response_id` and `chunk.model_version` inside the chunk-accumulation loop, keeping the first non-empty value:

```python
if not response_id:
    response_id = getattr(chunk, "response_id", None) or None
if not model:
    model = getattr(chunk, "model_version", None) or None
```

This mirrors how the Gemini SDK itself exposes metadata on streaming chunks and is consistent with the non-streaming code path.
