### PR TITLE
fix(openai): Only wrap types with _iterator for streamed responses

### DIFF
--- a/sentry_sdk/integrations/openai.py
+++ b/sentry_sdk/integrations/openai.py
@@ -1102,7 +1102,7 @@ def _new_responses_create_common(f: "Any", *args: "Any", **kwargs: "Any") -> "An
     response = yield f, args, kwargs
 
     # Attribute check to fail gracefully if the attribute is not present in future `openai` versions.
-    if isinstance(response, Stream):
+    if isinstance(response, Stream) and hasattr(response, "_iterator"):
         input = kwargs.get("input")
 
         if input is not None and isinstance(input, str):
@@ -1119,7 +1119,7 @@ def _new_responses_create_common(f: "Any", *args: "Any", **kwargs: "Any") -> "An
         )
 
     # Attribute check to fail gracefully if the attribute is not present in future `openai` versions.
-    elif isinstance(response, AsyncStream):
+    elif isinstance(response, AsyncStream) and hasattr(response, "_iterator"):
         input = kwargs.get("input")
 
         if input is not None and isinstance(input, str):


### PR DESCRIPTION
### Description
<!-- What changed and why? -->

Only wrap streaming responses when the `_iterator` attribute is defined on the returned object.
Create separate functions for wrapping synchronous and asynchronous Completions and Responses APIs.
- `ttft` is now a local variable in each wrapper instead of a nonlocal variable.

Tracing `LegacyAPIResponse` is intentionally left out of scope.

#### Issues

Closes https://github.com/getsentry/sentry-python/issues/5890

#### Reminders
- Please add tests to validate your changes, and lint your code using `tox -e linters`.
- Add GH Issue ID _&_ Linear ID (if applicable)
- PR title should use [conventional commit](https://develop.sentry.dev/engineering-practices/commit-messages/#type) style (`feat:`, `fix:`, `ref:`, `meta:`)
- For external contributors: [CONTRIBUTING.md](https://github.com/getsentry/sentry-python/blob/master/CONTRIBUTING.md), [Sentry SDK development docs](https://develop.sentry.dev/sdk/), [Discord community](https://discord.gg/Ww9hbqr)
