### PR TITLE
feat(span-first): Better span first estimates

### DIFF
--- a/sentry_sdk/_span_batcher.py
+++ b/sentry_sdk/_span_batcher.py
@@ -95,7 +95,7 @@ class SpanBatcher(Batcher["StreamedSpan"]):
         # estimate the attributes separately.
         estimate = 210
         for value in item._attributes.values():
-            estimate += 7
+            estimate += 50
 
             if isinstance(value, str):
                 estimate += len(value)


### PR DESCRIPTION
We were underestimating the size of spans with particularly bulky attributes, and flushing the buffer too late as a result. Take attribute size into account for estimating.