### PR TITLE
fix(huggingface_hub): Stop setting transaction status in huggingface_hub

### DIFF
--- a/sentry_sdk/integrations/huggingface_hub.py
+++ b/sentry_sdk/integrations/huggingface_hub.py
@@ -1,21 +1,19 @@
-import sys
 import inspect
+import sys
 from functools import wraps
+from typing import TYPE_CHECKING
 
 import sentry_sdk
 from sentry_sdk.ai.monitoring import record_token_usage
 from sentry_sdk.ai.utils import set_data_normalized
-from sentry_sdk.consts import OP, SPANDATA
+from sentry_sdk.consts import OP, SPANDATA, SPANSTATUS
 from sentry_sdk.integrations import DidNotEnable, Integration
 from sentry_sdk.scope import should_send_default_pii
-from sentry_sdk.tracing_utils import set_span_errored
 from sentry_sdk.utils import (
     capture_internal_exceptions,
     event_from_exception,
     reraise,
 )
-
-from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from typing import Any, Callable, Iterable
@@ -53,8 +51,6 @@ class HuggingfaceHubIntegration(Integration):
 
 
 def _capture_exception(exc: "Any") -> None:
-    set_span_errored()
-
     event, hint = event_from_exception(
         exc,
         client_options=sentry_sdk.get_client().options,
@@ -131,6 +127,7 @@ def _wrap_huggingface_task(f: "Callable[..., Any]", op: str) -> "Callable[..., A
             exc_info = sys.exc_info()
             with capture_internal_exceptions():
                 _capture_exception(e)
+                span.set_status(SPANSTATUS.INTERNAL_ERROR)
                 span.__exit__(None, None, None)
             reraise(*exc_info)
 

--- a/tests/integrations/huggingface_hub/test_huggingface_hub.py
+++ b/tests/integrations/huggingface_hub/test_huggingface_hub.py
@@ -1,15 +1,14 @@
-from unittest import mock
-import pytest
 import re
-import responses
+from typing import TYPE_CHECKING
+from unittest import mock
 
+import pytest
+import responses
 from huggingface_hub import InferenceClient
 
 import sentry_sdk
-from sentry_sdk.utils import package_version
 from sentry_sdk.integrations.huggingface_hub import HuggingfaceHubIntegration
-
-from typing import TYPE_CHECKING
+from sentry_sdk.utils import package_version
 
 try:
     from huggingface_hub.utils._errors import HfHubHTTPError
@@ -833,8 +832,6 @@ def test_span_status_error(
     assert span is not None
     assert span["status"] == "internal_error"
     assert span["tags"]["status"] == "internal_error"
-
-    assert transaction["contexts"]["trace"]["status"] == "internal_error"
 
 
 @pytest.mark.httpx_mock(assert_all_requests_were_expected=False)


### PR DESCRIPTION
### Description
- Prevent the Hugging Face AI integration from changing root HTTP transaction status when API call fails
 
- Keep error visibility on the integration span so failures are still captured and observable 

#### Issues

* resolves: #5793 
* resolves: [PY-2201](https://linear.app/getsentry/issue/PY-2201/huggingface-hub-stop-setting-transaction-status)


#### Reminders
- Please add tests to validate your changes, and lint your code using `tox -e linters`.
- Add GH Issue ID _&_ Linear ID (if applicable)
- PR title should use [conventional commit](https://develop.sentry.dev/engineering-practices/commit-messages/#type) style (`feat:`, `fix:`, `ref:`, `meta:`)
- For external contributors: [CONTRIBUTING.md](https://github.com/getsentry/sentry-python/blob/master/CONTRIBUTING.md), [Sentry SDK development docs](https://develop.sentry.dev/sdk/), [Discord community](https://discord.gg/Ww9hbqr)
