### PR TITLE
refactor(ai): Remove `gen_ai.tool.type` span attribute

### DIFF
--- a/sentry_sdk/consts.py
+++ b/sentry_sdk/consts.py
@@ -636,12 +636,6 @@ class SPANDATA:
     Example: "rainy, 57°F"
     """
 
-    GEN_AI_TOOL_TYPE = "gen_ai.tool.type"
-    """
-    The type of tool being used.
-    Example: "function"
-    """
-
     GEN_AI_USAGE_INPUT_TOKENS = "gen_ai.usage.input_tokens"
     """
     The number of tokens in the input.

--- a/sentry_sdk/integrations/google_genai/utils.py
+++ b/sentry_sdk/integrations/google_genai/utils.py
@@ -597,7 +597,6 @@ def _create_tool_span(tool_name: str, tool_doc: "Optional[str]") -> "Span":
         origin=ORIGIN,
     )
     span.set_data(SPANDATA.GEN_AI_TOOL_NAME, tool_name)
-    span.set_data(SPANDATA.GEN_AI_TOOL_TYPE, "function")
     if tool_doc:
         span.set_data(SPANDATA.GEN_AI_TOOL_DESCRIPTION, tool_doc)
     return span

--- a/sentry_sdk/integrations/openai_agents/spans/execute_tool.py
+++ b/sentry_sdk/integrations/openai_agents/spans/execute_tool.py
@@ -23,9 +23,6 @@ def execute_tool_span(
 
     span.set_data(SPANDATA.GEN_AI_OPERATION_NAME, "execute_tool")
 
-    if tool.__class__.__name__ == "FunctionTool":
-        span.set_data(SPANDATA.GEN_AI_TOOL_TYPE, "function")
-
     span.set_data(SPANDATA.GEN_AI_TOOL_NAME, tool.name)
     span.set_data(SPANDATA.GEN_AI_TOOL_DESCRIPTION, tool.description)
 

--- a/sentry_sdk/integrations/openai_agents/utils.py
+++ b/sentry_sdk/integrations/openai_agents/utils.py
@@ -247,7 +247,6 @@ def _create_mcp_execute_tool_spans(
                 description=f"execute_tool {output.name}",
                 start_timestamp=span.start_timestamp,
             ) as execute_tool_span:
-                execute_tool_span.set_data(SPANDATA.GEN_AI_TOOL_TYPE, "mcp")
                 execute_tool_span.set_data(SPANDATA.GEN_AI_TOOL_NAME, output.name)
                 if should_send_default_pii():
                     execute_tool_span.set_data(

--- a/sentry_sdk/integrations/pydantic_ai/patches/tools.py
+++ b/sentry_sdk/integrations/pydantic_ai/patches/tools.py
@@ -14,13 +14,6 @@ if TYPE_CHECKING:
     from typing import Any
 
 try:
-    from pydantic_ai.mcp import MCPServer  # type: ignore
-
-    HAS_MCP = True
-except ImportError:
-    HAS_MCP = False
-
-try:
     from pydantic_ai._tool_manager import ToolManager  # type: ignore
     from pydantic_ai.exceptions import ToolRetryError  # type: ignore
 except ImportError:
@@ -52,11 +45,6 @@ def _patch_execute_tool_call() -> None:
         tool = self.tools.get(name) if self.tools else None
         selected_tool_definition = getattr(tool, "tool_def", None)
 
-        # Determine tool type by checking tool.toolset
-        tool_type = "function"
-        if tool and HAS_MCP and isinstance(tool.toolset, MCPServer):
-            tool_type = "mcp"
-
         # Get agent from contextvar
         agent = get_current_agent()
 
@@ -73,7 +61,6 @@ def _patch_execute_tool_call() -> None:
                     name,
                     args_dict,
                     agent,
-                    tool_type=tool_type,
                     tool_definition=selected_tool_definition,
                 ) as span:
                     try:
@@ -131,11 +118,6 @@ def _patch_call_tool() -> None:
         tool = self.tools.get(name) if self.tools else None
         selected_tool_definition = getattr(tool, "tool_def", None)
 
-        # Determine tool type by checking tool.toolset
-        tool_type = "function"  # default
-        if tool and HAS_MCP and isinstance(tool.toolset, MCPServer):
-            tool_type = "mcp"
-
         # Get agent from contextvar
         agent = get_current_agent()
 
@@ -152,7 +134,6 @@ def _patch_call_tool() -> None:
                     name,
                     args_dict,
                     agent,
-                    tool_type=tool_type,
                     tool_definition=selected_tool_definition,
                 ) as span:
                     try:

--- a/sentry_sdk/integrations/pydantic_ai/spans/execute_tool.py
+++ b/sentry_sdk/integrations/pydantic_ai/spans/execute_tool.py
@@ -16,7 +16,6 @@ def execute_tool_span(
     tool_name: str,
     tool_args: "Any",
     agent: "Any",
-    tool_type: str = "function",
     tool_definition: "Optional[ToolDefinition]" = None,
 ) -> "sentry_sdk.tracing.Span":
     """Create a span for tool execution.
@@ -25,7 +24,6 @@ def execute_tool_span(
         tool_name: The name of the tool being executed
         tool_args: The arguments passed to the tool
         agent: The agent executing the tool
-        tool_type: The type of tool ("function" for regular tools, "mcp" for MCP services)
         tool_definition: The definition of the tool, if available
     """
     span = sentry_sdk.start_span(
@@ -35,7 +33,6 @@ def execute_tool_span(
     )
 
     span.set_data(SPANDATA.GEN_AI_OPERATION_NAME, "execute_tool")
-    span.set_data(SPANDATA.GEN_AI_TOOL_TYPE, tool_type)
     span.set_data(SPANDATA.GEN_AI_TOOL_NAME, tool_name)
 
     if tool_definition is not None and hasattr(tool_definition, "description"):

--- a/tests/integrations/google_genai/test_google_genai.py
+++ b/tests/integrations/google_genai/test_google_genai.py
@@ -373,7 +373,6 @@ def test_tool_execution(sentry_init, capture_events):
     assert tool_span["op"] == OP.GEN_AI_EXECUTE_TOOL
     assert tool_span["description"] == "execute_tool get_weather"
     assert tool_span["data"][SPANDATA.GEN_AI_TOOL_NAME] == "get_weather"
-    assert tool_span["data"][SPANDATA.GEN_AI_TOOL_TYPE] == "function"
     assert (
         tool_span["data"][SPANDATA.GEN_AI_TOOL_DESCRIPTION]
         == "Get the weather for a location"

--- a/tests/integrations/openai_agents/test_openai_agents.py
+++ b/tests/integrations/openai_agents/test_openai_agents.py
@@ -1274,8 +1274,6 @@ async def test_tool_execution_span(
     assert tool_span["data"]["gen_ai.tool.input"] == '{"message": "hello"}'
     assert tool_span["data"]["gen_ai.tool.name"] == "simple_test_tool"
     assert tool_span["data"]["gen_ai.tool.output"] == "Tool executed with: hello"
-    assert tool_span["data"]["gen_ai.tool.type"] == "function"
-
     assert ai_client_span2["description"] == "chat gpt-4"
     assert ai_client_span2["data"]["gen_ai.agent.name"] == "test_agent"
     assert ai_client_span2["data"]["gen_ai.operation.name"] == "chat"
@@ -1896,17 +1894,13 @@ async def test_mcp_tool_execution_spans(
     # Find the MCP execute_tool span
     mcp_tool_span = None
     for span in spans:
-        if (
-            span.get("description") == "execute_tool test_mcp_tool"
-            and span.get("data", {}).get("gen_ai.tool.type") == "mcp"
-        ):
+        if span.get("description") == "execute_tool test_mcp_tool":
             mcp_tool_span = span
             break
 
     # Verify the MCP tool span was created
     assert mcp_tool_span is not None, "MCP execute_tool span was not created"
     assert mcp_tool_span["description"] == "execute_tool test_mcp_tool"
-    assert mcp_tool_span["data"]["gen_ai.tool.type"] == "mcp"
     assert mcp_tool_span["data"]["gen_ai.tool.name"] == "test_mcp_tool"
     assert mcp_tool_span["data"]["gen_ai.tool.input"] == '{"query": "search term"}'
     assert (
@@ -2028,17 +2022,13 @@ async def test_mcp_tool_execution_with_error(
     # Find the MCP execute_tool span with error
     mcp_tool_span = None
     for span in spans:
-        if (
-            span.get("description") == "execute_tool failing_mcp_tool"
-            and span.get("data", {}).get("gen_ai.tool.type") == "mcp"
-        ):
+        if span.get("description") == "execute_tool failing_mcp_tool":
             mcp_tool_span = span
             break
 
     # Verify the MCP tool span was created with error status
     assert mcp_tool_span is not None, "MCP execute_tool span was not created"
     assert mcp_tool_span["description"] == "execute_tool failing_mcp_tool"
-    assert mcp_tool_span["data"]["gen_ai.tool.type"] == "mcp"
     assert mcp_tool_span["data"]["gen_ai.tool.name"] == "failing_mcp_tool"
     assert mcp_tool_span["data"]["gen_ai.tool.input"] == '{"query": "test"}'
     assert mcp_tool_span["data"]["gen_ai.tool.output"] is None
@@ -2158,17 +2148,13 @@ async def test_mcp_tool_execution_without_pii(
     # Find the MCP execute_tool span
     mcp_tool_span = None
     for span in spans:
-        if (
-            span.get("description") == "execute_tool test_mcp_tool"
-            and span.get("data", {}).get("gen_ai.tool.type") == "mcp"
-        ):
+        if span.get("description") == "execute_tool test_mcp_tool":
             mcp_tool_span = span
             break
 
     # Verify the MCP tool span was created but without input/output
     assert mcp_tool_span is not None, "MCP execute_tool span was not created"
     assert mcp_tool_span["description"] == "execute_tool test_mcp_tool"
-    assert mcp_tool_span["data"]["gen_ai.tool.type"] == "mcp"
     assert mcp_tool_span["data"]["gen_ai.tool.name"] == "test_mcp_tool"
 
     # Verify input and output are not included when send_default_pii is False

--- a/tests/integrations/pydantic_ai/test_pydantic_ai.py
+++ b/tests/integrations/pydantic_ai/test_pydantic_ai.py
@@ -275,7 +275,6 @@ async def test_agent_with_tools(sentry_init, capture_events, test_agent):
     tool_span = tool_spans[0]
     assert "execute_tool" in tool_span["description"]
     assert tool_span["data"]["gen_ai.operation.name"] == "execute_tool"
-    assert tool_span["data"]["gen_ai.tool.type"] == "function"
     assert tool_span["data"]["gen_ai.tool.name"] == "add_numbers"
     assert "gen_ai.tool.input" in tool_span["data"]
     assert "gen_ai.tool.output" in tool_span["data"]
@@ -348,14 +347,12 @@ async def test_agent_with_tool_model_retry(
     model_retry_tool_span = tool_spans[0]
     assert "execute_tool" in model_retry_tool_span["description"]
     assert model_retry_tool_span["data"]["gen_ai.operation.name"] == "execute_tool"
-    assert model_retry_tool_span["data"]["gen_ai.tool.type"] == "function"
     assert model_retry_tool_span["data"]["gen_ai.tool.name"] == "add_numbers"
     assert "gen_ai.tool.input" in model_retry_tool_span["data"]
 
     tool_span = tool_spans[1]
     assert "execute_tool" in tool_span["description"]
     assert tool_span["data"]["gen_ai.operation.name"] == "execute_tool"
-    assert tool_span["data"]["gen_ai.tool.type"] == "function"
     assert tool_span["data"]["gen_ai.tool.name"] == "add_numbers"
     assert "gen_ai.tool.input" in tool_span["data"]
     assert "gen_ai.tool.output" in tool_span["data"]
@@ -427,7 +424,6 @@ async def test_agent_with_tool_validation_error(
     model_retry_tool_span = tool_spans[0]
     assert "execute_tool" in model_retry_tool_span["description"]
     assert model_retry_tool_span["data"]["gen_ai.operation.name"] == "execute_tool"
-    assert model_retry_tool_span["data"]["gen_ai.tool.type"] == "function"
     assert model_retry_tool_span["data"]["gen_ai.tool.name"] == "add_numbers"
     assert "gen_ai.tool.input" in model_retry_tool_span["data"]
 


### PR DESCRIPTION
## Summary
- Remove setting of `gen_ai.tool.type` span data from all AI integrations (openai_agents, pydantic_ai, google_genai)
- Remove the `SPANDATA.GEN_AI_TOOL_TYPE` constant
- Clean up now-unused `MCPServer`/`HAS_MCP` imports in pydantic_ai integration

Closes PY-2286

## Test plan
- [x] Linters pass (`tox -e linters`)
- [x] mypy passes (`tox -e mypy`)
- [ ] Integration tests pass for openai_agents, pydantic_ai, google_genai

🤖 Generated with [Claude Code](https://claude.com/claude-code)