### PR TITLE
Isolate async gRPC server scope per request

### DIFF
--- a/sentry_sdk/integrations/grpc/aio/server.py
+++ b/sentry_sdk/integrations/grpc/aio/server.py
@@ -47,27 +47,28 @@ class ServerInterceptor(grpc.aio.ServerInterceptor):  # type: ignore
                 if not name:
                     return await handler(request, context)
 
-                # What if the headers are empty?
-                transaction = sentry_sdk.continue_trace(
-                    dict(context.invocation_metadata()),
-                    op=OP.GRPC_SERVER,
-                    name=name,
-                    source=TransactionSource.CUSTOM,
-                    origin=SPAN_ORIGIN,
-                )
+                with sentry_sdk.isolation_scope():
+                    # What if the headers are empty?
+                    transaction = sentry_sdk.continue_trace(
+                        dict(context.invocation_metadata()),
+                        op=OP.GRPC_SERVER,
+                        name=name,
+                        source=TransactionSource.CUSTOM,
+                        origin=SPAN_ORIGIN,
+                    )
 
-                with sentry_sdk.start_transaction(transaction=transaction):
-                    try:
-                        return await handler.unary_unary(request, context)
-                    except AbortError:
-                        raise
-                    except Exception as exc:
-                        event, hint = event_from_exception(
-                            exc,
-                            mechanism={"type": "grpc", "handled": False},
-                        )
-                        sentry_sdk.capture_event(event, hint=hint)
-                        raise
+                    with sentry_sdk.start_transaction(transaction=transaction):
+                        try:
+                            return await handler.unary_unary(request, context)
+                        except AbortError:
+                            raise
+                        except Exception as exc:
+                            event, hint = event_from_exception(
+                                exc,
+                                mechanism={"type": "grpc", "handled": False},
+                            )
+                            sentry_sdk.capture_event(event, hint=hint)
+                            raise
 
         elif not handler.request_streaming and handler.response_streaming:
             handler_factory = grpc.unary_stream_rpc_method_handler

--- a/tests/integrations/grpc/test_grpc_aio.py
+++ b/tests/integrations/grpc/test_grpc_aio.py
@@ -177,6 +177,26 @@ async def test_grpc_server_abort(grpc_server_and_channel, capture_events):
 
 
 @pytest.mark.asyncio
+async def test_grpc_server_uses_isolation_scope_per_request(
+    grpc_server_and_channel, capture_events
+):
+    _, channel = grpc_server_and_channel
+    events = capture_events()
+
+    stub = gRPCTestServiceStub(channel)
+    await stub.TestServe(gRPCTestMessage(text="scope:first"))
+    await stub.TestServe(gRPCTestMessage(text="scope:second"))
+
+    first_event, second_event = events
+
+    assert first_event["extra"]["grpc_scope_marker"] == "scope:first"
+    assert "grpc_previous_scope_marker" not in first_event.get("extra", {})
+
+    assert second_event["extra"]["grpc_scope_marker"] == "scope:second"
+    assert "grpc_previous_scope_marker" not in second_event.get("extra", {})
+
+
+@pytest.mark.asyncio
 async def test_grpc_client_starts_span(
     grpc_server_and_channel, capture_events_forksafe
 ):
@@ -304,6 +324,13 @@ class TestService(gRPCTestServiceServicer):
 
     @classmethod
     async def TestServe(cls, request, context):  # noqa: N802
+        if request.text.startswith("scope:"):
+            scope = sentry_sdk.get_isolation_scope()
+            previous_marker = scope._extras.get("grpc_scope_marker")
+            if previous_marker is not None:
+                scope.set_extra("grpc_previous_scope_marker", previous_marker)
+            scope.set_extra("grpc_scope_marker", request.text)
+
         with start_span(
             op="test",
             name="test",


### PR DESCRIPTION
## Summary

Fixes #5894 by creating an `isolation_scope()` for each async gRPC unary-unary request, matching the sync interceptor and other request-oriented async integrations.

Without per-request isolation, scope state can leak between requests in the async gRPC server interceptor. That means request-local extras, tags, breadcrumbs, and similar scope data can bleed into later requests handled by the same process.

## Changes

- wrap the async unary-unary gRPC server handler in `sentry_sdk.isolation_scope()`
- add a regression test that makes two back-to-back async gRPC requests and verifies request-specific scope extras do not leak across them

## Verification

Ran:

- `python -m pytest tests/integrations/grpc/test_grpc_aio.py -q`

This async gRPC test file passed locally.
