### PR TITLE
fix(opentelemetry): Handle None span context

### DIFF
--- a/sentry_sdk/integrations/opentelemetry/span_processor.py
+++ b/sentry_sdk/integrations/opentelemetry/span_processor.py
@@ -124,7 +124,8 @@ class SentrySpanProcessor(SpanProcessor):
         if client.options["instrumenter"] != INSTRUMENTER.OTEL:
             return
 
-        if not otel_span.get_span_context().is_valid:
+        span_context = otel_span.get_span_context()
+        if span_context is None or not span_context.is_valid:
             return
 
         if self._is_sentry_span(otel_span):
@@ -183,7 +184,7 @@ class SentrySpanProcessor(SpanProcessor):
             return
 
         span_context = otel_span.get_span_context()
-        if not span_context.is_valid:
+        if span_context is None or not span_context.is_valid:
             return
 
         span_id = format_span_id(span_context.span_id)
@@ -263,16 +264,17 @@ class SentrySpanProcessor(SpanProcessor):
         trace_data: "dict[str, Any]" = {}
         span_context = otel_span.get_span_context()
 
-        span_id = format_span_id(span_context.span_id)
-        trace_data["span_id"] = span_id
+        if span_context is not None:
+            span_id = format_span_id(span_context.span_id)
+            trace_data["span_id"] = span_id
 
-        trace_id = format_trace_id(span_context.trace_id)
-        trace_data["trace_id"] = trace_id
+            trace_id = format_trace_id(span_context.trace_id)
+            trace_data["trace_id"] = trace_id
 
-        parent_span_id = (
-            format_span_id(otel_span.parent.span_id) if otel_span.parent else None
-        )
-        trace_data["parent_span_id"] = parent_span_id
+            parent_span_id = (
+                format_span_id(otel_span.parent.span_id) if otel_span.parent else None
+            )
+            trace_data["parent_span_id"] = parent_span_id
 
         sentry_trace_data = get_value(SENTRY_TRACE_KEY, parent_context)
         sentry_trace_data = cast("dict[str, Union[str, bool, None]]", sentry_trace_data)

--- a/sentry_sdk/integrations/opentelemetry/span_processor.py
+++ b/sentry_sdk/integrations/opentelemetry/span_processor.py
@@ -34,6 +34,7 @@ except ImportError:
 if TYPE_CHECKING:
     from typing import Any, Optional, Union
     from opentelemetry import context as context_api
+    from opentelemetry.trace import SpanContext
     from sentry_sdk._types import Event, Hint
 
 OPEN_TELEMETRY_CONTEXT = "otel"
@@ -131,7 +132,7 @@ class SentrySpanProcessor(SpanProcessor):
         if self._is_sentry_span(otel_span):
             return
 
-        trace_data = self._get_trace_data(otel_span, parent_context)
+        trace_data = self._get_trace_data(otel_span, span_context, parent_context)
 
         parent_span_id = trace_data["parent_span_id"]
         sentry_parent_span = (
@@ -256,25 +257,26 @@ class SentrySpanProcessor(SpanProcessor):
         return ctx
 
     def _get_trace_data(
-        self, otel_span: "OTelSpan", parent_context: "Optional[context_api.Context]"
+        self,
+        otel_span: "OTelSpan",
+        span_context: "SpanContext",
+        parent_context: "Optional[context_api.Context]",
     ) -> "dict[str, Any]":
         """
         Extracts tracing information from one OTel span and its parent OTel context.
         """
         trace_data: "dict[str, Any]" = {}
-        span_context = otel_span.get_span_context()
 
-        if span_context is not None:
-            span_id = format_span_id(span_context.span_id)
-            trace_data["span_id"] = span_id
+        span_id = format_span_id(span_context.span_id)
+        trace_data["span_id"] = span_id
 
-            trace_id = format_trace_id(span_context.trace_id)
-            trace_data["trace_id"] = trace_id
+        trace_id = format_trace_id(span_context.trace_id)
+        trace_data["trace_id"] = trace_id
 
-            parent_span_id = (
-                format_span_id(otel_span.parent.span_id) if otel_span.parent else None
-            )
-            trace_data["parent_span_id"] = parent_span_id
+        parent_span_id = (
+            format_span_id(otel_span.parent.span_id) if otel_span.parent else None
+        )
+        trace_data["parent_span_id"] = parent_span_id
 
         sentry_trace_data = get_value(SENTRY_TRACE_KEY, parent_context)
         sentry_trace_data = cast("dict[str, Union[str, bool, None]]", sentry_trace_data)

--- a/sentry_sdk/integrations/opentelemetry/span_processor.py
+++ b/sentry_sdk/integrations/opentelemetry/span_processor.py
@@ -132,7 +132,9 @@ class SentrySpanProcessor(SpanProcessor):
         if self._is_sentry_span(otel_span):
             return
 
-        trace_data = self._get_trace_data(otel_span, span_context, parent_context)
+        trace_data = self._get_trace_data(
+            span_context, otel_span.parent, parent_context
+        )
 
         parent_span_id = trace_data["parent_span_id"]
         sentry_parent_span = (
@@ -258,12 +260,12 @@ class SentrySpanProcessor(SpanProcessor):
 
     def _get_trace_data(
         self,
-        otel_span: "OTelSpan",
         span_context: "SpanContext",
+        parent_span_context: "Optional[SpanContext]",
         parent_context: "Optional[context_api.Context]",
     ) -> "dict[str, Any]":
         """
-        Extracts tracing information from one OTel span and its parent OTel context.
+        Extracts tracing information from one OTel span's context and its parent OTel context.
         """
         trace_data: "dict[str, Any]" = {}
 
@@ -274,7 +276,7 @@ class SentrySpanProcessor(SpanProcessor):
         trace_data["trace_id"] = trace_id
 
         parent_span_id = (
-            format_span_id(otel_span.parent.span_id) if otel_span.parent else None
+            format_span_id(parent_span_context.span_id) if parent_span_context else None
         )
         trace_data["parent_span_id"] = parent_span_id
 

--- a/tests/integrations/opentelemetry/test_span_processor.py
+++ b/tests/integrations/opentelemetry/test_span_processor.py
@@ -68,7 +68,9 @@ def test_get_trace_data_with_span_and_trace():
     parent_context = {}
 
     span_processor = SentrySpanProcessor()
-    sentry_trace_data = span_processor._get_trace_data(otel_span, parent_context)
+    sentry_trace_data = span_processor._get_trace_data(
+        otel_span.get_span_context(), otel_span.parent, parent_context
+    )
     assert sentry_trace_data["trace_id"] == "1234567890abcdef1234567890abcdef"
     assert sentry_trace_data["span_id"] == "1234567890abcdef"
     assert sentry_trace_data["parent_span_id"] is None
@@ -90,7 +92,9 @@ def test_get_trace_data_with_span_and_trace_and_parent():
     parent_context = {}
 
     span_processor = SentrySpanProcessor()
-    sentry_trace_data = span_processor._get_trace_data(otel_span, parent_context)
+    sentry_trace_data = span_processor._get_trace_data(
+        otel_span.get_span_context(), otel_span.parent, parent_context
+    )
     assert sentry_trace_data["trace_id"] == "1234567890abcdef1234567890abcdef"
     assert sentry_trace_data["span_id"] == "1234567890abcdef"
     assert sentry_trace_data["parent_span_id"] == "abcdef1234567890"
@@ -121,7 +125,9 @@ def test_get_trace_data_with_sentry_trace():
         ],
     ):
         span_processor = SentrySpanProcessor()
-        sentry_trace_data = span_processor._get_trace_data(otel_span, parent_context)
+        sentry_trace_data = span_processor._get_trace_data(
+            otel_span.get_span_context(), otel_span.parent, parent_context
+        )
         assert sentry_trace_data["trace_id"] == "1234567890abcdef1234567890abcdef"
         assert sentry_trace_data["span_id"] == "1234567890abcdef"
         assert sentry_trace_data["parent_span_id"] == "abcdef1234567890"
@@ -138,7 +144,9 @@ def test_get_trace_data_with_sentry_trace():
         ],
     ):
         span_processor = SentrySpanProcessor()
-        sentry_trace_data = span_processor._get_trace_data(otel_span, parent_context)
+        sentry_trace_data = span_processor._get_trace_data(
+            otel_span.get_span_context(), otel_span.parent, parent_context
+        )
         assert sentry_trace_data["trace_id"] == "1234567890abcdef1234567890abcdef"
         assert sentry_trace_data["span_id"] == "1234567890abcdef"
         assert sentry_trace_data["parent_span_id"] == "abcdef1234567890"
@@ -175,7 +183,9 @@ def test_get_trace_data_with_sentry_trace_and_baggage():
         ],
     ):
         span_processor = SentrySpanProcessor()
-        sentry_trace_data = span_processor._get_trace_data(otel_span, parent_context)
+        sentry_trace_data = span_processor._get_trace_data(
+            otel_span.get_span_context(), otel_span.parent, parent_context
+        )
         assert sentry_trace_data["trace_id"] == "1234567890abcdef1234567890abcdef"
         assert sentry_trace_data["span_id"] == "1234567890abcdef"
         assert sentry_trace_data["parent_span_id"] == "abcdef1234567890"


### PR DESCRIPTION
### Description
<!-- What changed and why? -->

Exit early if there is no span context, as there is no `trace_id` or `span_id` to create a Sentry span in this case.

The context of `ReadableSpan` is optional: https://github.com/open-telemetry/opentelemetry-python/blob/73d65fd2e90a2547c5c78eef1fdfcb21076a930d/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py#L420

#### Issues
<!--
* resolves: #1234
* resolves: LIN-1234
-->

#### Reminders
- Please add tests to validate your changes, and lint your code using `tox -e linters`.
- Add GH Issue ID _&_ Linear ID (if applicable)
- PR title should use [conventional commit](https://develop.sentry.dev/engineering-practices/commit-messages/#type) style (`feat:`, `fix:`, `ref:`, `meta:`)
- For external contributors: [CONTRIBUTING.md](https://github.com/getsentry/sentry-python/blob/master/CONTRIBUTING.md), [Sentry SDK development docs](https://develop.sentry.dev/sdk/), [Discord community](https://discord.gg/Ww9hbqr)
