### PR TITLE
ref(litellm): Remove dead attributes

### DIFF
--- a/sentry_sdk/integrations/litellm.py
+++ b/sentry_sdk/integrations/litellm.py
@@ -159,16 +159,6 @@ def _input_callback(kwargs: "Dict[str, Any]") -> None:
         if value is not None:
             set_data_normalized(span, attribute, value)
 
-    # Record LiteLLM-specific parameters
-    litellm_params = {
-        "api_base": kwargs.get("api_base"),
-        "api_version": kwargs.get("api_version"),
-        "custom_llm_provider": kwargs.get("custom_llm_provider"),
-    }
-    for key, value in litellm_params.items():
-        if value is not None:
-            set_data_normalized(span, f"gen_ai.litellm.{key}", value)
-
 
 def _success_callback(
     kwargs: "Dict[str, Any]",

--- a/tests/integrations/litellm/test_litellm.py
+++ b/tests/integrations/litellm/test_litellm.py
@@ -532,42 +532,6 @@ def test_additional_parameters(sentry_init, capture_events):
     assert span["data"][SPANDATA.GEN_AI_REQUEST_PRESENCE_PENALTY] == 0.5
 
 
-def test_litellm_specific_parameters(sentry_init, capture_events):
-    """Test that LiteLLM-specific parameters are captured."""
-    sentry_init(
-        integrations=[LiteLLMIntegration()],
-        traces_sample_rate=1.0,
-    )
-    events = capture_events()
-
-    messages = [{"role": "user", "content": "Hello!"}]
-    mock_response = MockCompletionResponse()
-
-    with start_transaction(name="litellm test"):
-        kwargs = {
-            "model": "gpt-3.5-turbo",
-            "messages": messages,
-            "api_base": "https://custom-api.example.com",
-            "api_version": "2023-01-01",
-            "custom_llm_provider": "custom_provider",
-        }
-
-        _input_callback(kwargs)
-        _success_callback(
-            kwargs,
-            mock_response,
-            datetime.now(),
-            datetime.now(),
-        )
-
-    (event,) = events
-    (span,) = event["spans"]
-
-    assert span["data"]["gen_ai.litellm.api_base"] == "https://custom-api.example.com"
-    assert span["data"]["gen_ai.litellm.api_version"] == "2023-01-01"
-    assert span["data"]["gen_ai.litellm.custom_llm_provider"] == "custom_provider"
-
-
 def test_no_integration(sentry_init, capture_events):
     """Test that when integration is not enabled, callbacks don't break."""
     sentry_init(


### PR DESCRIPTION
### Description
<!-- What changed and why? -->

The `api_base`, `api_version` and `custom_llm_provider` values are stored in `litellm_params` and are not passed as top level keyword arguments to `litellm.input_callback` callbacks. See https://github.com/BerriAI/litellm/blob/5e80e075c7d12a816bea9bc4f6fed4c876aae9c8/litellm/litellm_core_utils/litellm_logging.py#L414.

The attributes were therefore not set.

#### Issues
<!--
* resolves: #1234
* resolves: LIN-1234
-->

#### Reminders
- Please add tests to validate your changes, and lint your code using `tox -e linters`.
- Add GH Issue ID _&_ Linear ID (if applicable)
- PR title should use [conventional commit](https://develop.sentry.dev/engineering-practices/commit-messages/#type) style (`feat:`, `fix:`, `ref:`, `meta:`)
- For external contributors: [CONTRIBUTING.md](https://github.com/getsentry/sentry-python/blob/master/CONTRIBUTING.md), [Sentry SDK development docs](https://develop.sentry.dev/sdk/), [Discord community](https://discord.gg/Ww9hbqr)
