### PR TITLE
ref(openai-agents): Remove error attributes

### DIFF
--- a/sentry_sdk/integrations/openai_agents/patches/agent_run.py
+++ b/sentry_sdk/integrations/openai_agents/patches/agent_run.py
@@ -153,11 +153,11 @@ async def _run_single_turn_streamed(
 
     try:
         result = await original_run_single_turn_streamed(*args, **kwargs)
-    except Exception as exc:
+    except Exception:
         exc_info = sys.exc_info()
         with capture_internal_exceptions():
             if span is not None and span.timestamp is None:
-                set_span_errored(span, exc)
+                set_span_errored(span)
                 end_invoke_agent_span(context_wrapper, agent)
             _close_streaming_workflow_span(agent)
         reraise(*exc_info)

--- a/sentry_sdk/integrations/openai_agents/patches/agent_run.py
+++ b/sentry_sdk/integrations/openai_agents/patches/agent_run.py
@@ -8,7 +8,7 @@ from ..spans import (
     end_invoke_agent_span,
     handoff_span,
 )
-from ..utils import _record_exception_on_span
+from sentry_sdk.tracing_utils import set_span_errored
 
 from typing import TYPE_CHECKING
 
@@ -99,9 +99,9 @@ async def _run_single_turn(
 
     try:
         result = await original_run_single_turn(*args, **kwargs)
-    except Exception as exc:
+    except Exception:
         if span is not None and span.timestamp is None:
-            _record_exception_on_span(span, exc)
+            set_span_errored(span)
             end_invoke_agent_span(context_wrapper, agent)
         reraise(*sys.exc_info())
 
@@ -157,7 +157,7 @@ async def _run_single_turn_streamed(
         exc_info = sys.exc_info()
         with capture_internal_exceptions():
             if span is not None and span.timestamp is None:
-                _record_exception_on_span(span, exc)
+                set_span_errored(span, exc)
                 end_invoke_agent_span(context_wrapper, agent)
             _close_streaming_workflow_span(agent)
         reraise(*exc_info)

--- a/sentry_sdk/integrations/openai_agents/patches/error_tracing.py
+++ b/sentry_sdk/integrations/openai_agents/patches/error_tracing.py
@@ -1,7 +1,7 @@
 from functools import wraps
 
 import sentry_sdk
-from ..utils import _record_exception_on_span
+from sentry_sdk.tracing_utils import set_span_errored
 
 from typing import TYPE_CHECKING
 
@@ -57,7 +57,7 @@ def _patch_error_tracing() -> None:
         # Set the current Sentry span to errored
         current_span = sentry_sdk.get_current_span()
         if current_span is not None:
-            _record_exception_on_span(current_span, error)
+            set_span_errored(current_span)
 
         # Call the original function
         return original_attach_error(error, *args, **kwargs)

--- a/sentry_sdk/integrations/openai_agents/patches/runner.py
+++ b/sentry_sdk/integrations/openai_agents/patches/runner.py
@@ -5,9 +5,10 @@ import sentry_sdk
 from sentry_sdk.consts import SPANDATA
 from sentry_sdk.integrations import DidNotEnable
 from sentry_sdk.utils import capture_internal_exceptions, reraise
+from sentry_sdk.tracing_utils import set_span_errored
 
 from ..spans import agent_workflow_span, end_invoke_agent_span
-from ..utils import _capture_exception, _record_exception_on_span
+from ..utils import _capture_exception
 
 try:
     from agents.exceptions import AgentsException
@@ -65,7 +66,7 @@ def _create_run_wrapper(original_func: "Callable[..., Any]") -> "Callable[..., A
                                 invoke_agent_span is not None
                                 and invoke_agent_span.timestamp is None
                             ):
-                                _record_exception_on_span(invoke_agent_span, exc)
+                                set_span_errored(invoke_agent_span)
                                 end_invoke_agent_span(context_wrapper, agent)
                     reraise(*exc_info)
                 except Exception as exc:

--- a/sentry_sdk/integrations/openai_agents/utils.py
+++ b/sentry_sdk/integrations/openai_agents/utils.py
@@ -11,7 +11,6 @@ from sentry_sdk.ai.utils import (
 from sentry_sdk.consts import SPANDATA, SPANSTATUS, OP
 from sentry_sdk.integrations import DidNotEnable
 from sentry_sdk.scope import should_send_default_pii
-from sentry_sdk.tracing import Span
 from sentry_sdk.tracing_utils import set_span_errored
 from sentry_sdk.utils import event_from_exception, safe_serialize
 from sentry_sdk.ai._openai_completions_api import _transform_system_instructions
@@ -23,10 +22,9 @@ from sentry_sdk.ai._openai_responses_api import (
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from typing import Any, Union
+    from typing import Any
     from agents import Usage, TResponseInputItem
 
-    from sentry_sdk.traces import StreamedSpan
     from sentry_sdk._types import TextPart
 
 try:
@@ -45,26 +43,6 @@ def _capture_exception(exc: "Any") -> None:
         mechanism={"type": "openai_agents", "handled": False},
     )
     sentry_sdk.capture_event(event, hint=hint)
-
-
-def _record_exception_on_span(
-    span: "Union[Span, StreamedSpan]", error: Exception
-) -> "Any":
-    set_span_errored(span)
-
-    if not isinstance(span, Span):
-        # TODO[span-first]: make this work with streamedspans
-        return
-
-    span.set_data("span.status", "error")
-
-    # Optionally capture the error details if we have them
-    if hasattr(error, "__class__"):
-        span.set_data("error.type", error.__class__.__name__)
-    if hasattr(error, "__str__"):
-        error_message = str(error)
-        if error_message:
-            span.set_data("error.message", error_message)
 
 
 def _set_agent_data(span: "sentry_sdk.tracing.Span", agent: "agents.Agent") -> None:


### PR DESCRIPTION
### Description
<!-- What changed and why? -->

Remove `span.status`, `error.type` and `error.message` attributes.

#### Issues
<!--
* resolves: #1234
* resolves: LIN-1234
-->

#### Reminders
- Please add tests to validate your changes, and lint your code using `tox -e linters`.
- Add GH Issue ID _&_ Linear ID (if applicable)
- PR title should use [conventional commit](https://develop.sentry.dev/engineering-practices/commit-messages/#type) style (`feat:`, `fix:`, `ref:`, `meta:`)
- For external contributors: [CONTRIBUTING.md](https://github.com/getsentry/sentry-python/blob/master/CONTRIBUTING.md), [Sentry SDK development docs](https://develop.sentry.dev/sdk/), [Discord community](https://discord.gg/Ww9hbqr)
