### PR TITLE
ci: Set explicit base-branch for codecov action

### DIFF
--- a/.github/workflows/test-integrations-agents.yml
+++ b/.github/workflows/test-integrations-agents.yml
@@ -79,6 +79,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           files: coverage.xml
           junit-xml-pattern: .junitxml
+          base-branch: master
           verbose: true
   check_required_tests:
     name: All Agents tests passed

--- a/.github/workflows/test-integrations-ai-workflow.yml
+++ b/.github/workflows/test-integrations-ai-workflow.yml
@@ -83,6 +83,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           files: coverage.xml
           junit-xml-pattern: .junitxml
+          base-branch: master
           verbose: true
   check_required_tests:
     name: All AI Workflow tests passed

--- a/.github/workflows/test-integrations-ai.yml
+++ b/.github/workflows/test-integrations-ai.yml
@@ -99,6 +99,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           files: coverage.xml
           junit-xml-pattern: .junitxml
+          base-branch: master
           verbose: true
   check_required_tests:
     name: All AI tests passed

--- a/.github/workflows/test-integrations-cloud.yml
+++ b/.github/workflows/test-integrations-cloud.yml
@@ -95,6 +95,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           files: coverage.xml
           junit-xml-pattern: .junitxml
+          base-branch: master
           verbose: true
   check_required_tests:
     name: All Cloud tests passed

--- a/.github/workflows/test-integrations-common.yml
+++ b/.github/workflows/test-integrations-common.yml
@@ -75,6 +75,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           files: coverage.xml
           junit-xml-pattern: .junitxml
+          base-branch: master
           verbose: true
   check_required_tests:
     name: All Common tests passed

--- a/.github/workflows/test-integrations-dbs.yml
+++ b/.github/workflows/test-integrations-dbs.yml
@@ -115,6 +115,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           files: coverage.xml
           junit-xml-pattern: .junitxml
+          base-branch: master
           verbose: true
   check_required_tests:
     name: All DBs tests passed

--- a/.github/workflows/test-integrations-flags.yml
+++ b/.github/workflows/test-integrations-flags.yml
@@ -87,6 +87,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           files: coverage.xml
           junit-xml-pattern: .junitxml
+          base-branch: master
           verbose: true
   check_required_tests:
     name: All Flags tests passed

--- a/.github/workflows/test-integrations-gevent.yml
+++ b/.github/workflows/test-integrations-gevent.yml
@@ -75,6 +75,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           files: coverage.xml
           junit-xml-pattern: .junitxml
+          base-branch: master
           verbose: true
   check_required_tests:
     name: All Gevent tests passed

--- a/.github/workflows/test-integrations-graphql.yml
+++ b/.github/workflows/test-integrations-graphql.yml
@@ -87,6 +87,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           files: coverage.xml
           junit-xml-pattern: .junitxml
+          base-branch: master
           verbose: true
   check_required_tests:
     name: All GraphQL tests passed

--- a/.github/workflows/test-integrations-mcp.yml
+++ b/.github/workflows/test-integrations-mcp.yml
@@ -79,6 +79,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           files: coverage.xml
           junit-xml-pattern: .junitxml
+          base-branch: master
           verbose: true
   check_required_tests:
     name: All MCP tests passed

--- a/.github/workflows/test-integrations-misc.yml
+++ b/.github/workflows/test-integrations-misc.yml
@@ -107,6 +107,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           files: coverage.xml
           junit-xml-pattern: .junitxml
+          base-branch: master
           verbose: true
   check_required_tests:
     name: All Misc tests passed

--- a/.github/workflows/test-integrations-network.yml
+++ b/.github/workflows/test-integrations-network.yml
@@ -87,6 +87,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           files: coverage.xml
           junit-xml-pattern: .junitxml
+          base-branch: master
           verbose: true
   check_required_tests:
     name: All Network tests passed

--- a/.github/workflows/test-integrations-tasks.yml
+++ b/.github/workflows/test-integrations-tasks.yml
@@ -110,6 +110,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           files: coverage.xml
           junit-xml-pattern: .junitxml
+          base-branch: master
           verbose: true
   check_required_tests:
     name: All Tasks tests passed

--- a/.github/workflows/test-integrations-web-1.yml
+++ b/.github/workflows/test-integrations-web-1.yml
@@ -105,6 +105,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           files: coverage.xml
           junit-xml-pattern: .junitxml
+          base-branch: master
           verbose: true
   check_required_tests:
     name: All Web 1 tests passed

--- a/.github/workflows/test-integrations-web-2.yml
+++ b/.github/workflows/test-integrations-web-2.yml
@@ -111,6 +111,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           files: coverage.xml
           junit-xml-pattern: .junitxml
+          base-branch: master
           verbose: true
   check_required_tests:
     name: All Web 2 tests passed

--- a/scripts/split_tox_gh_actions/templates/test_group.jinja
+++ b/scripts/split_tox_gh_actions/templates/test_group.jinja
@@ -101,4 +101,5 @@
           token: {% raw %}${{ secrets.GITHUB_TOKEN }}{% endraw %}
           files: coverage.xml
           junit-xml-pattern: .junitxml
+          base-branch: master
           verbose: true


### PR DESCRIPTION
## Summary

- Explicitly sets `base-branch: master` on the `getsentry/codecov-action` step in all test-integration workflows
- The change is made in the Jinja template (`scripts/split_tox_gh_actions/templates/test_group.jinja`) and all 15 workflow files are regenerated
- Fixes codecov's auto-detection of the default branch failing, which caused incorrect coverage comparisons on PRs (see https://github.com/getsentry/sentry-python/actions/runs/24350025657/job/71101512671?pr=5978)

Refs PY-2295 and fixes #5991 

## Test plan

- [ ] Verify codecov coverage checks run correctly against `master` on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)