### PR TITLE
feat(ci): cancel in-progress PR workflows on new commit push

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,10 @@ on:
 
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 


### PR DESCRIPTION
this adds concurrency cancellation to pull_request workflows so that pushing a new commit to a PR automatically cancels any still-running workflow from the previous commit

99% of the time if you push a new commit you don't care about the previous workflow if its still running

**we already do this for all sentry+getsentry pull_request workflows**

we (devinfra) can't measure this yet but this would greatly help decrease org-wide runner queue pressure!