### PR TITLE
fix(profiler): Stop nulling buffer on teardown

### DIFF
--- a/sentry_sdk/profiler/continuous_profiler.py
+++ b/sentry_sdk/profiler/continuous_profiler.py
@@ -506,8 +506,6 @@ class ThreadContinuousScheduler(ContinuousScheduler):
             self.thread.join()
             self.thread = None
 
-        self.buffer = None
-
 
 class GeventContinuousScheduler(ContinuousScheduler):
     """
@@ -579,8 +577,6 @@ class GeventContinuousScheduler(ContinuousScheduler):
         if self.thread is not None:
             self.thread.join()
             self.thread = None
-
-        self.buffer = None
 
 
 PROFILE_BUFFER_SECONDS = 60


### PR DESCRIPTION
There's still the occasional race condition in the GEvent tests that may be related to fast "start/stop" cycles, and the `teardown` functions were not updated as part of https://github.com/getsentry/sentry-python/pull/5622#discussion_r2931508792

These changes remove `self.buffer = None` from `teardown()` in both `ThreadContinuousScheduler` and `GeventContinuousScheduler` in favour of using a local variable to assign `self.buffer` to before setting the local variable to `None`

Fixes PY-2140
Fixes #5673