### PR TITLE
ref(tests): Replace deprecated `enable_tracing`with `traces_sample_rate`

### DIFF
--- a/tests/integrations/asyncpg/test_asyncpg.py
+++ b/tests/integrations/asyncpg/test_asyncpg.py
@@ -485,7 +485,7 @@ async def test_connection_pool(sentry_init, capture_events) -> None:
 async def test_query_source_disabled(sentry_init, capture_events):
     sentry_options = {
         "integrations": [AsyncPGIntegration()],
-        "enable_tracing": True,
+        "traces_sample_rate": 1.0,
         "enable_db_query_source": False,
         "db_query_source_threshold_ms": 0,
     }
@@ -523,7 +523,7 @@ async def test_query_source_enabled(
 ):
     sentry_options = {
         "integrations": [AsyncPGIntegration()],
-        "enable_tracing": True,
+        "traces_sample_rate": 1.0,
         "db_query_source_threshold_ms": 0,
     }
     if enable_db_query_source is not None:
@@ -559,7 +559,7 @@ async def test_query_source_enabled(
 async def test_query_source(sentry_init, capture_events):
     sentry_init(
         integrations=[AsyncPGIntegration()],
-        enable_tracing=True,
+        traces_sample_rate=1.0,
         enable_db_query_source=True,
         db_query_source_threshold_ms=0,
     )
@@ -609,7 +609,7 @@ async def test_query_source_with_module_in_search_path(sentry_init, capture_even
     """
     sentry_init(
         integrations=[AsyncPGIntegration()],
-        enable_tracing=True,
+        traces_sample_rate=1.0,
         enable_db_query_source=True,
         db_query_source_threshold_ms=0,
     )
@@ -655,7 +655,7 @@ async def test_query_source_with_module_in_search_path(sentry_init, capture_even
 async def test_no_query_source_if_duration_too_short(sentry_init, capture_events):
     sentry_init(
         integrations=[AsyncPGIntegration()],
-        enable_tracing=True,
+        traces_sample_rate=1.0,
         enable_db_query_source=True,
         db_query_source_threshold_ms=100,
     )
@@ -700,7 +700,7 @@ async def test_no_query_source_if_duration_too_short(sentry_init, capture_events
 async def test_query_source_if_duration_over_threshold(sentry_init, capture_events):
     sentry_init(
         integrations=[AsyncPGIntegration()],
-        enable_tracing=True,
+        traces_sample_rate=1.0,
         enable_db_query_source=True,
         db_query_source_threshold_ms=100,
     )

--- a/tests/integrations/celery/test_celery.py
+++ b/tests/integrations/celery/test_celery.py
@@ -606,7 +606,7 @@ def test_apply_async_no_args(init_celery):
 def test_messaging_destination_name_default_exchange(
     mock_request, routing_key, init_celery, capture_events
 ):
-    celery_app = init_celery(enable_tracing=True)
+    celery_app = init_celery(traces_sample_rate=1.0)
     events = capture_events()
     mock_request.delivery_info = {"routing_key": routing_key, "exchange": ""}
 
@@ -630,7 +630,7 @@ def test_messaging_destination_name_nondefault_exchange(
     that the routing key is the queue name. Other exchanges may not guarantee this
     behavior.
     """
-    celery_app = init_celery(enable_tracing=True)
+    celery_app = init_celery(traces_sample_rate=1.0)
     events = capture_events()
     mock_request.delivery_info = {"routing_key": "celery", "exchange": "custom"}
 
@@ -645,7 +645,7 @@ def test_messaging_destination_name_nondefault_exchange(
 
 
 def test_messaging_id(init_celery, capture_events):
-    celery = init_celery(enable_tracing=True)
+    celery = init_celery(traces_sample_rate=1.0)
     events = capture_events()
 
     @celery.task
@@ -659,7 +659,7 @@ def test_messaging_id(init_celery, capture_events):
 
 
 def test_retry_count_zero(init_celery, capture_events):
-    celery = init_celery(enable_tracing=True)
+    celery = init_celery(traces_sample_rate=1.0)
     events = capture_events()
 
     @celery.task()
@@ -676,7 +676,7 @@ def test_retry_count_zero(init_celery, capture_events):
 def test_retry_count_nonzero(mock_request, init_celery, capture_events):
     mock_request.retries = 3
 
-    celery = init_celery(enable_tracing=True)
+    celery = init_celery(traces_sample_rate=1.0)
     events = capture_events()
 
     @celery.task()
@@ -691,7 +691,7 @@ def test_retry_count_nonzero(mock_request, init_celery, capture_events):
 
 @pytest.mark.parametrize("system", ("redis", "amqp"))
 def test_messaging_system(system, init_celery, capture_events):
-    celery = init_celery(enable_tracing=True)
+    celery = init_celery(traces_sample_rate=1.0)
     events = capture_events()
 
     # Does not need to be a real URL, since we use always eager
@@ -716,7 +716,7 @@ def test_producer_span_data(system, monkeypatch, sentry_init, capture_events):
 
     monkeypatch.setattr(kombu.messaging.Producer, "_publish", publish)
 
-    sentry_init(integrations=[CeleryIntegration()], enable_tracing=True)
+    sentry_init(integrations=[CeleryIntegration()], traces_sample_rate=1.0)
     celery = Celery(__name__, broker=f"{system}://example.com")  # noqa: E231
     events = capture_events()
 
@@ -754,7 +754,7 @@ def test_receive_latency(init_celery, capture_events):
 
 
 def tests_span_origin_consumer(init_celery, capture_events):
-    celery = init_celery(enable_tracing=True)
+    celery = init_celery(traces_sample_rate=1.0)
     celery.conf.broker_url = "redis://example.com"  # noqa: E231
 
     events = capture_events()
@@ -778,7 +778,7 @@ def tests_span_origin_producer(monkeypatch, sentry_init, capture_events):
 
     monkeypatch.setattr(kombu.messaging.Producer, "_publish", publish)
 
-    sentry_init(integrations=[CeleryIntegration()], enable_tracing=True)
+    sentry_init(integrations=[CeleryIntegration()], traces_sample_rate=1.0)
     celery = Celery(__name__, broker="redis://example.com")  # noqa: E231
 
     events = capture_events()
@@ -807,7 +807,7 @@ def test_send_task_wrapped(
     capture_events,
     reset_integrations,
 ):
-    sentry_init(integrations=[CeleryIntegration()], enable_tracing=True)
+    sentry_init(integrations=[CeleryIntegration()], traces_sample_rate=1.0)
     celery = Celery(__name__, broker="redis://example.com")  # noqa: E231
 
     events = capture_events()

--- a/tests/integrations/celery/test_update_celery_task_headers.py
+++ b/tests/integrations/celery/test_update_celery_task_headers.py
@@ -71,7 +71,7 @@ def test_monitor_beat_tasks_with_headers(monitor_beat_tasks):
 
 
 def test_span_with_transaction(sentry_init):
-    sentry_init(enable_tracing=True)
+    sentry_init(traces_sample_rate=1.0)
     headers = {}
     monitor_beat_tasks = False
 
@@ -91,7 +91,7 @@ def test_span_with_transaction(sentry_init):
 
 
 def test_span_with_transaction_custom_headers(sentry_init):
-    sentry_init(enable_tracing=True)
+    sentry_init(traces_sample_rate=1.0)
     headers = {
         "baggage": BAGGAGE_VALUE,
         "sentry-trace": SENTRY_TRACE_VALUE,

--- a/tests/integrations/graphene/test_graphene.py
+++ b/tests/integrations/graphene/test_graphene.py
@@ -207,7 +207,7 @@ def test_no_event_if_no_errors_sync(sentry_init, capture_events):
 def test_graphql_span_holds_query_information(sentry_init, capture_events):
     sentry_init(
         integrations=[GrapheneIntegration(), FlaskIntegration()],
-        enable_tracing=True,
+        traces_sample_rate=1.0,
         default_integrations=False,
     )
     events = capture_events()

--- a/tests/integrations/sqlalchemy/test_sqlalchemy.py
+++ b/tests/integrations/sqlalchemy/test_sqlalchemy.py
@@ -301,7 +301,7 @@ def test_engine_name_not_string(sentry_init):
 def test_query_source_disabled(sentry_init, capture_events):
     sentry_options = {
         "integrations": [SqlalchemyIntegration()],
-        "enable_tracing": True,
+        "traces_sample_rate": 1.0,
         "enable_db_query_source": False,
         "db_query_source_threshold_ms": 0,
     }
@@ -352,7 +352,7 @@ def test_query_source_disabled(sentry_init, capture_events):
 def test_query_source_enabled(sentry_init, capture_events, enable_db_query_source):
     sentry_options = {
         "integrations": [SqlalchemyIntegration()],
-        "enable_tracing": True,
+        "traces_sample_rate": 1.0,
         "db_query_source_threshold_ms": 0,
     }
     if enable_db_query_source is not None:
@@ -403,7 +403,7 @@ def test_query_source_enabled(sentry_init, capture_events, enable_db_query_sourc
 def test_query_source(sentry_init, capture_events):
     sentry_init(
         integrations=[SqlalchemyIntegration()],
-        enable_tracing=True,
+        traces_sample_rate=1.0,
         enable_db_query_source=True,
         db_query_source_threshold_ms=0,
     )
@@ -468,7 +468,7 @@ def test_query_source_with_module_in_search_path(sentry_init, capture_events):
     """
     sentry_init(
         integrations=[SqlalchemyIntegration()],
-        enable_tracing=True,
+        traces_sample_rate=1.0,
         enable_db_query_source=True,
         db_query_source_threshold_ms=0,
     )
@@ -531,7 +531,7 @@ def test_query_source_with_module_in_search_path(sentry_init, capture_events):
 def test_no_query_source_if_duration_too_short(sentry_init, capture_events):
     sentry_init(
         integrations=[SqlalchemyIntegration()],
-        enable_tracing=True,
+        traces_sample_rate=1.0,
         enable_db_query_source=True,
         db_query_source_threshold_ms=100,
     )
@@ -597,7 +597,7 @@ def test_no_query_source_if_duration_too_short(sentry_init, capture_events):
 def test_query_source_if_duration_over_threshold(sentry_init, capture_events):
     sentry_init(
         integrations=[SqlalchemyIntegration()],
-        enable_tracing=True,
+        traces_sample_rate=1.0,
         enable_db_query_source=True,
         db_query_source_threshold_ms=100,
     )

--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -1092,7 +1092,7 @@ def test_classmethod_instance_tracing(sentry_init, capture_events):
 
 
 def test_last_event_id(sentry_init):
-    sentry_init(enable_tracing=True)
+    sentry_init(traces_sample_rate=1.0)
 
     assert last_event_id() is None
 
@@ -1102,7 +1102,7 @@ def test_last_event_id(sentry_init):
 
 
 def test_last_event_id_transaction(sentry_init):
-    sentry_init(enable_tracing=True)
+    sentry_init(traces_sample_rate=1.0)
 
     assert last_event_id() is None
 
@@ -1113,7 +1113,7 @@ def test_last_event_id_transaction(sentry_init):
 
 
 def test_last_event_id_scope(sentry_init):
-    sentry_init(enable_tracing=True)
+    sentry_init(traces_sample_rate=1.0)
 
     # Should not crash
     with isolation_scope() as scope:

--- a/tests/test_scope.py
+++ b/tests/test_scope.py
@@ -876,7 +876,7 @@ def test_set_tags():
 
 
 def test_last_event_id(sentry_init):
-    sentry_init(enable_tracing=True)
+    sentry_init(traces_sample_rate=1.0)
 
     assert Scope.last_event_id() is None
 
@@ -886,7 +886,7 @@ def test_last_event_id(sentry_init):
 
 
 def test_last_event_id_transaction(sentry_init):
-    sentry_init(enable_tracing=True)
+    sentry_init(traces_sample_rate=1.0)
 
     assert Scope.last_event_id() is None
 
@@ -897,7 +897,7 @@ def test_last_event_id_transaction(sentry_init):
 
 
 def test_last_event_id_cleared(sentry_init):
-    sentry_init(enable_tracing=True)
+    sentry_init(traces_sample_rate=1.0)
 
     # Make sure last_event_id is set
     sentry_sdk.capture_exception(Exception("test"))

--- a/tests/tracing/test_misc.py
+++ b/tests/tracing/test_misc.py
@@ -478,7 +478,7 @@ def test_start_transaction_updates_scope_name_source(sentry_init):
 
 @pytest.mark.parametrize("sampled", (True, None))
 def test_transaction_dropped_debug_not_started(sentry_init, sampled):
-    sentry_init(enable_tracing=True)
+    sentry_init(traces_sample_rate=1.0)
 
     tx = Transaction(sampled=sampled)
 
@@ -498,7 +498,7 @@ def test_transaction_dropped_debug_not_started(sentry_init, sampled):
 
 
 def test_transaction_dropeed_sampled_false(sentry_init):
-    sentry_init(enable_tracing=True)
+    sentry_init(traces_sample_rate=1.0)
 
     tx = Transaction(sampled=False)
 
@@ -516,7 +516,7 @@ def test_transaction_dropeed_sampled_false(sentry_init):
 
 
 def test_transaction_not_started_warning(sentry_init):
-    sentry_init(enable_tracing=True)
+    sentry_init(traces_sample_rate=1.0)
 
     tx = Transaction()
 

--- a/tests/tracing/test_propagation.py
+++ b/tests/tracing/test_propagation.py
@@ -3,7 +3,7 @@ import pytest
 
 
 def test_standalone_span_iter_headers(sentry_init):
-    sentry_init(enable_tracing=True)
+    sentry_init(traces_sample_rate=1.0)
 
     with sentry_sdk.start_span(op="test") as span:
         with pytest.raises(StopIteration):
@@ -12,7 +12,7 @@ def test_standalone_span_iter_headers(sentry_init):
 
 
 def test_span_in_span_iter_headers(sentry_init):
-    sentry_init(enable_tracing=True)
+    sentry_init(traces_sample_rate=1.0)
 
     with sentry_sdk.start_span(op="test"):
         with sentry_sdk.start_span(op="test2") as span_inner:
@@ -22,7 +22,7 @@ def test_span_in_span_iter_headers(sentry_init):
 
 
 def test_span_in_transaction(sentry_init):
-    sentry_init(enable_tracing=True)
+    sentry_init(traces_sample_rate=1.0)
 
     with sentry_sdk.start_transaction(op="test"):
         with sentry_sdk.start_span(op="test2") as span:
@@ -31,7 +31,7 @@ def test_span_in_transaction(sentry_init):
 
 
 def test_span_in_span_in_transaction(sentry_init):
-    sentry_init(enable_tracing=True)
+    sentry_init(traces_sample_rate=1.0)
 
     with sentry_sdk.start_transaction(op="test"):
         with sentry_sdk.start_span(op="test2"):


### PR DESCRIPTION
- Replaced deprecated `enable_tracing=True` with `traces_sample_rate=1.0` across 9 test files
- Preserved tests that specifically test the `enable_tracing` option itself (`test_enable_tracing_deprecated`, `test_option_enable_tracing`, `test_celery_trace_propagation_enable_tracing`)