### PR TITLE
ref(celery): Remove unused `NoOpMgr` from utils

### DIFF
--- a/sentry_sdk/integrations/celery/utils.py
+++ b/sentry_sdk/integrations/celery/utils.py
@@ -2,7 +2,7 @@ import time
 from typing import TYPE_CHECKING, cast
 
 if TYPE_CHECKING:
-    from typing import Any, Tuple
+    from typing import Tuple
     from sentry_sdk._types import MonitorConfigScheduleUnit
 
 
@@ -29,11 +29,3 @@ def _get_humanized_interval(seconds: float) -> "Tuple[int, MonitorConfigSchedule
             return (interval, cast("MonitorConfigScheduleUnit", unit))
 
     return (int(seconds), "second")
-
-
-class NoOpMgr:
-    def __enter__(self) -> None:
-        return None
-
-    def __exit__(self, exc_type: "Any", exc_value: "Any", traceback: "Any") -> None:
-        return None


### PR DESCRIPTION
In the Celery integration, we use a custom `NoOpMgr` to make working with context managers a bit easier. It's defined in the file where we use it. There is another, completely unused copy in the `utils.py` of the Celery integration. Remove that one.

Note: Once we drop 3.6 support, we can replace the custom class with `nullcontext` from the standard library.