### PR TITLE
chore(ci): update outdated pinned action version comments

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
     - name: Get auth token
       id: token
-      uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v2
+      uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
       with:
         app-id: ${{ vars.SENTRY_RELEASE_BOT_CLIENT_ID }}
         private-key: ${{ secrets.SENTRY_RELEASE_BOT_PRIVATE_KEY }}
@@ -31,7 +31,7 @@ jobs:
         token: ${{ steps.token.outputs.token }}
         fetch-depth: 0
     - name: Prepare release
-      uses: getsentry/craft@ba01e596c4a4c07692f0de10b0d4fe05f3dd0292 # v2
+      uses: getsentry/craft@ba01e596c4a4c07692f0de10b0d4fe05f3dd0292 # v2.25.2
       env:
         GITHUB_TOKEN: ${{ steps.token.outputs.token }}
       with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
       with:
         app-id: ${{ vars.SENTRY_RELEASE_BOT_CLIENT_ID }}
         private-key: ${{ secrets.SENTRY_RELEASE_BOT_PRIVATE_KEY }}
-    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         token: ${{ steps.token.outputs.token }}
         fetch-depth: 0


### PR DESCRIPTION
### Description
Noticed that in https://github.com/getsentry/sentry-python/pull/5981/changes the version comment wasn't updated; seems to have been shortened in https://github.com/getsentry/sentry-python/pull/5290/changes#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L23 and then after that `dependabot` doesn't touch the version tag comment anymore.

---

### Current pinned release commits for reference

https://github.com/actions/create-github-app-token/commit/1b10c78c7865c340bc4f6099eb2f838309f1e8c3 -> v3.1.1
https://github.com/actions/checkout/commit/de0fac2e4500dabe0009e67214ff5f5447ce83dd -> v6.0.2
https://github.com/getsentry/craft/commit/ba01e596c4a4c07692f0de10b0d4fe05f3dd0292 -> v2.25.2
