### PR TITLE
feat(starlette): Support span streaming

### DIFF
--- a/sentry_sdk/integrations/starlette.py
+++ b/sentry_sdk/integrations/starlette.py
@@ -238,7 +238,7 @@ def _serialize_body_data(data: "Any") -> str:
     # data may be a JSON-serializable value, an AnnotatedValue, or a dict with AnnotatedValue values
     def _default(value: "Any") -> "Any":
         if isinstance(value, AnnotatedValue):
-            return {"value": value.value, "metadata": value.metadata}
+            return value.value
         return str(value)
 
     return json.dumps(data, default=_default)

--- a/sentry_sdk/integrations/starlette.py
+++ b/sentry_sdk/integrations/starlette.py
@@ -521,10 +521,12 @@ def patch_request_response() -> None:
                         and not isinstance(current_span, NoOpStreamedSpan)
                     ):
                         data = info["data"]
-                        current_span._segment.set_attribute(
-                            "http.request.body.data",
-                            _serialize_body_data(data),
-                        )
+
+                        with capture_internal_exceptions():
+                            current_span._segment.set_attribute(
+                                "http.request.body.data",
+                                _serialize_body_data(data),
+                            )
 
                 return await old_func(*args, **kwargs)
 

--- a/sentry_sdk/integrations/starlette.py
+++ b/sentry_sdk/integrations/starlette.py
@@ -20,10 +20,12 @@ from sentry_sdk.integrations._wsgi_common import (
 )
 from sentry_sdk.integrations.asgi import SentryAsgiMiddleware
 from sentry_sdk.scope import should_send_default_pii
+from sentry_sdk.traces import NoOpStreamedSpan, StreamedSpan
 from sentry_sdk.tracing import (
     SOURCE_FOR_STYLE,
     TransactionSource,
 )
+from sentry_sdk.tracing_utils import has_span_streaming_enabled
 from sentry_sdk.utils import (
     AnnotatedValue,
     capture_internal_exceptions,
@@ -147,7 +149,8 @@ def _enable_span_for_middleware(middleware_class: "Any") -> type:
         send: "Callable[[Dict[str, Any]], Awaitable[None]]",
         **kwargs: "Any",
     ) -> None:
-        integration = sentry_sdk.get_client().get_integration(StarletteIntegration)
+        client = sentry_sdk.get_client()
+        integration = client.get_integration(StarletteIntegration)
         if integration is None:
             return await old_call(app, scope, receive, send, **kwargs)
 
@@ -164,22 +167,38 @@ def _enable_span_for_middleware(middleware_class: "Any") -> type:
             return await old_call(app, scope, receive, send, **kwargs)
 
         middleware_name = app.__class__.__name__
+        is_span_streaming_enabled = has_span_streaming_enabled(client.options)
 
-        with sentry_sdk.start_span(
-            op=OP.MIDDLEWARE_STARLETTE,
-            name=middleware_name,
-            origin=StarletteIntegration.origin,
+        def _start_middleware_span(op: str, name: str) -> "Any":
+            if is_span_streaming_enabled:
+                return sentry_sdk.traces.start_span(
+                    name=name,
+                    attributes={
+                        "sentry.op": op,
+                        "sentry.origin": StarletteIntegration.origin,
+                        "starlette.middleware_name": middleware_name,
+                    },
+                )
+            return sentry_sdk.start_span(
+                op=op,
+                name=name,
+                origin=StarletteIntegration.origin,
+            )
+
+        with _start_middleware_span(
+            op=OP.MIDDLEWARE_STARLETTE, name=middleware_name
         ) as middleware_span:
-            middleware_span.set_tag("starlette.middleware_name", middleware_name)
+            if not is_span_streaming_enabled:
+                middleware_span.set_tag("starlette.middleware_name", middleware_name)
 
             # Creating spans for the "receive" callback
             async def _sentry_receive(*args: "Any", **kwargs: "Any") -> "Any":
-                with sentry_sdk.start_span(
+                with _start_middleware_span(
                     op=OP.MIDDLEWARE_STARLETTE_RECEIVE,
                     name=getattr(receive, "__qualname__", str(receive)),
-                    origin=StarletteIntegration.origin,
                 ) as span:
-                    span.set_tag("starlette.middleware_name", middleware_name)
+                    if not is_span_streaming_enabled:
+                        span.set_tag("starlette.middleware_name", middleware_name)
                     return await receive(*args, **kwargs)
 
             receive_name = getattr(receive, "__name__", str(receive))
@@ -188,12 +207,12 @@ def _enable_span_for_middleware(middleware_class: "Any") -> type:
 
             # Creating spans for the "send" callback
             async def _sentry_send(*args: "Any", **kwargs: "Any") -> "Any":
-                with sentry_sdk.start_span(
+                with _start_middleware_span(
                     op=OP.MIDDLEWARE_STARLETTE_SEND,
                     name=getattr(send, "__qualname__", str(send)),
-                    origin=StarletteIntegration.origin,
                 ) as span:
-                    span.set_tag("starlette.middleware_name", middleware_name)
+                    if not is_span_streaming_enabled:
+                        span.set_tag("starlette.middleware_name", middleware_name)
                     return await send(*args, **kwargs)
 
             send_name = getattr(send, "__name__", str(send))
@@ -496,7 +515,13 @@ def patch_request_response() -> None:
                     return old_func(*args, **kwargs)
 
                 current_scope = sentry_sdk.get_current_scope()
-                if current_scope.transaction is not None:
+                current_span = current_scope.span
+
+                if isinstance(current_span, StreamedSpan) and not isinstance(
+                    current_span, NoOpStreamedSpan
+                ):
+                    current_span._segment._update_active_thread()
+                elif current_scope.transaction is not None:
                     current_scope.transaction.update_active_thread()
 
                 sentry_scope = sentry_sdk.get_isolation_scope()

--- a/sentry_sdk/integrations/starlette.py
+++ b/sentry_sdk/integrations/starlette.py
@@ -1,5 +1,6 @@
 import asyncio
 import functools
+import json
 import warnings
 from collections.abc import Set
 from copy import deepcopy
@@ -231,6 +232,16 @@ def _enable_span_for_middleware(middleware_class: "Any") -> type:
         middleware_class.__call__ = _create_span_call
 
     return middleware_class
+
+
+def _serialize_body_data(data: "Any") -> str:
+    # data may be a JSON-serializable value, an AnnotatedValue, or a dict with AnnotatedValue values
+    def _default(value: "Any") -> "Any":
+        if isinstance(value, AnnotatedValue):
+            return {"value": value.value, "metadata": value.metadata}
+        return str(value)
+
+    return json.dumps(data, default=_default)
 
 
 @ensure_integration_enabled(StarletteIntegration)
@@ -499,6 +510,23 @@ def patch_request_response() -> None:
                 sentry_scope.add_event_processor(
                     _make_request_event_processor(request, integration)
                 )
+
+                client = sentry_sdk.get_client()
+                is_span_streaming_enabled = has_span_streaming_enabled(client.options)
+                if is_span_streaming_enabled:
+                    current_span = sentry_sdk.get_current_span()
+
+                    if (
+                        info
+                        and "data" in info
+                        and isinstance(current_span, StreamedSpan)
+                        and not isinstance(current_span, NoOpStreamedSpan)
+                    ):
+                        data = info["data"]
+                        current_span.set_attribute(
+                            "http.request.body.data",
+                            _serialize_body_data(data),
+                        )
 
                 return await old_func(*args, **kwargs)
 

--- a/sentry_sdk/integrations/starlette.py
+++ b/sentry_sdk/integrations/starlette.py
@@ -469,9 +469,8 @@ def patch_request_response() -> None:
         if is_coroutine:
 
             async def _sentry_async_func(*args: "Any", **kwargs: "Any") -> "Any":
-                integration = sentry_sdk.get_client().get_integration(
-                    StarletteIntegration
-                )
+                client = sentry_sdk.get_client()
+                integration = client.get_integration(StarletteIntegration)
                 if integration is None:
                     return await old_func(*args, **kwargs)
 
@@ -511,7 +510,6 @@ def patch_request_response() -> None:
                     _make_request_event_processor(request, integration)
                 )
 
-                client = sentry_sdk.get_client()
                 is_span_streaming_enabled = has_span_streaming_enabled(client.options)
                 if is_span_streaming_enabled:
                     current_span = sentry_sdk.get_current_span()
@@ -523,7 +521,7 @@ def patch_request_response() -> None:
                         and not isinstance(current_span, NoOpStreamedSpan)
                     ):
                         data = info["data"]
-                        current_span.set_attribute(
+                        current_span._segment.set_attribute(
                             "http.request.body.data",
                             _serialize_body_data(data),
                         )

--- a/sentry_sdk/integrations/starlette.py
+++ b/sentry_sdk/integrations/starlette.py
@@ -177,7 +177,7 @@ def _enable_span_for_middleware(middleware_class: "Any") -> type:
                     attributes={
                         "sentry.op": op,
                         "sentry.origin": StarletteIntegration.origin,
-                        "starlette.middleware_name": middleware_name,
+                        "middleware.name": middleware_name,
                     },
                 )
             return sentry_sdk.start_span(

--- a/tests/integrations/starlette/test_starlette.py
+++ b/tests/integrations/starlette/test_starlette.py
@@ -11,6 +11,7 @@ from unittest import mock
 
 import pytest
 
+import sentry_sdk
 from sentry_sdk import capture_message, get_baggage, get_traceparent
 from sentry_sdk.integrations.asgi import SentryAsgiMiddleware
 from sentry_sdk.integrations.starlette import (
@@ -648,23 +649,29 @@ def test_user_information_transaction_no_pii(sentry_init, capture_events):
     assert "user" not in transaction_event
 
 
-def test_middleware_spans(sentry_init, capture_events):
+@pytest.mark.parametrize("span_streaming", [True, False])
+def test_middleware_spans(sentry_init, capture_events, capture_items, span_streaming):
     sentry_init(
         traces_sample_rate=1.0,
         integrations=[StarletteIntegration(middleware_spans=True)],
+        _experiments={
+            "trace_lifecycle": "stream" if span_streaming else "static",
+        },
     )
     starlette_app = starlette_app_factory(
         middleware=[Middleware(AuthenticationMiddleware, backend=BasicAuthBackend())]
     )
-    events = capture_events()
+
+    if span_streaming:
+        items = capture_items("span")
+    else:
+        events = capture_events()
 
     client = TestClient(starlette_app, raise_server_exceptions=False)
     try:
         client.get("/message", auth=("Gabriela", "hello123"))
     except Exception:
         pass
-
-    (_, transaction_event) = events
 
     expected_middleware_spans = [
         "ServerErrorMiddleware",
@@ -676,27 +683,61 @@ def test_middleware_spans(sentry_init, capture_events):
         "ServerErrorMiddleware",  # 'op': 'middleware.starlette.send'
     ]
 
-    assert len(transaction_event["spans"]) == len(expected_middleware_spans)
+    if span_streaming:
+        sentry_sdk.flush()
 
-    idx = 0
-    for span in transaction_event["spans"]:
-        if span["op"].startswith("middleware.starlette"):
+        middleware_spans = sorted(
+            [
+                item.payload
+                for item in items
+                if item.payload.get("attributes", {})
+                .get("sentry.op", "")
+                .startswith("middleware.starlette")
+            ],
+            key=lambda s: s["start_timestamp"],
+        )
+
+        assert len(middleware_spans) == len(expected_middleware_spans)
+
+        for idx, span in enumerate(middleware_spans):
             assert (
-                span["tags"]["starlette.middleware_name"]
+                span["attributes"]["starlette.middleware_name"]
                 == expected_middleware_spans[idx]
             )
-            idx += 1
+    else:
+        (_, transaction_event) = events
+
+        assert len(transaction_event["spans"]) == len(expected_middleware_spans)
+
+        idx = 0
+        for span in transaction_event["spans"]:
+            if span["op"].startswith("middleware.starlette"):
+                assert (
+                    span["tags"]["starlette.middleware_name"]
+                    == expected_middleware_spans[idx]
+                )
+                idx += 1
 
 
-def test_middleware_spans_disabled(sentry_init, capture_events):
+@pytest.mark.parametrize("span_streaming", [True, False])
+def test_middleware_spans_disabled(
+    sentry_init, capture_events, capture_items, span_streaming
+):
     sentry_init(
         traces_sample_rate=1.0,
         integrations=[StarletteIntegration(middleware_spans=False)],
+        _experiments={
+            "trace_lifecycle": "stream" if span_streaming else "static",
+        },
     )
     starlette_app = starlette_app_factory(
         middleware=[Middleware(AuthenticationMiddleware, backend=BasicAuthBackend())]
     )
-    events = capture_events()
+
+    if span_streaming:
+        items = capture_items("span")
+    else:
+        events = capture_events()
 
     client = TestClient(starlette_app, raise_server_exceptions=False)
     try:
@@ -704,26 +745,45 @@ def test_middleware_spans_disabled(sentry_init, capture_events):
     except Exception:
         pass
 
-    (_, transaction_event) = events
+    if span_streaming:
+        sentry_sdk.flush()
 
-    assert len(transaction_event["spans"]) == 0
+        middleware_spans = [
+            item.payload
+            for item in items
+            if item.payload.get("attributes", {})
+            .get("sentry.op", "")
+            .startswith("middleware.starlette")
+        ]
+        assert len(middleware_spans) == 0
+    else:
+        (_, transaction_event) = events
+        assert len(transaction_event["spans"]) == 0
 
 
-def test_middleware_callback_spans(sentry_init, capture_events):
+@pytest.mark.parametrize("span_streaming", [True, False])
+def test_middleware_callback_spans(
+    sentry_init, capture_events, capture_items, span_streaming
+):
     sentry_init(
         traces_sample_rate=1.0,
-        integrations=[StarletteIntegration()],
+        integrations=[StarletteIntegration(middleware_spans=True)],
+        _experiments={
+            "trace_lifecycle": "stream" if span_streaming else "static",
+        },
     )
     starlette_app = starlette_app_factory(middleware=[Middleware(SampleMiddleware)])
-    events = capture_events()
+
+    if span_streaming:
+        items = capture_items("span")
+    else:
+        events = capture_events()
 
     client = TestClient(starlette_app, raise_server_exceptions=False)
     try:
         client.get("/message", auth=("Gabriela", "hello123"))
     except Exception:
         pass
-
-    (_, transaction_event) = events
 
     expected = [
         {
@@ -773,12 +833,37 @@ def test_middleware_callback_spans(sentry_init, capture_events):
         },
     ]
 
-    idx = 0
-    for span in transaction_event["spans"]:
-        assert span["op"] == expected[idx]["op"]
-        assert span["description"] == expected[idx]["description"]
-        assert span["tags"] == expected[idx]["tags"]
-        idx += 1
+    if span_streaming:
+        sentry_sdk.flush()
+
+        middleware_spans = sorted(
+            [
+                item.payload
+                for item in items
+                if item.payload.get("attributes", {})
+                .get("sentry.op", "")
+                .startswith("middleware.starlette")
+            ],
+            key=lambda s: s["start_timestamp"],
+        )
+
+        assert len(middleware_spans) == len(expected)
+        for span, exp in zip(middleware_spans, expected):
+            assert span["attributes"]["sentry.op"] == exp["op"]
+            assert span["name"] == exp["description"]
+            assert (
+                span["attributes"]["starlette.middleware_name"]
+                == exp["tags"]["starlette.middleware_name"]
+            )
+    else:
+        (_, transaction_event) = events
+
+        idx = 0
+        for span in transaction_event["spans"]:
+            assert span["op"] == expected[idx]["op"]
+            assert span["description"] == expected[idx]["description"]
+            assert span["tags"] == expected[idx]["tags"]
+            idx += 1
 
 
 def test_middleware_receive_send(sentry_init, capture_events):
@@ -944,6 +1029,31 @@ def test_active_thread_id(sentry_init, capture_envelopes, teardown_profiling, en
         transaction = item.payload.json
         trace_context = transaction["contexts"]["trace"]
         assert str(data["active"]) == trace_context["data"]["thread.id"]
+
+
+@pytest.mark.parametrize("endpoint", ["/sync/thread_ids", "/async/thread_ids"])
+def test_active_thread_id_span_streaming(sentry_init, capture_items, endpoint):
+    sentry_init(
+        auto_enabling_integrations=False,  # avoid legacy spans from auto-enabled integrations leaking into streaming mode
+        integrations=[StarletteIntegration()],
+        traces_sample_rate=1.0,
+        _experiments={"trace_lifecycle": "stream"},
+    )
+    app = starlette_app_factory()
+
+    items = capture_items("span")
+
+    client = TestClient(app)
+    response = client.get(endpoint)
+    assert response.status_code == 200
+
+    data = json.loads(response.content)
+
+    sentry_sdk.flush()
+
+    segments = [item.payload for item in items if item.payload.get("is_segment")]
+    assert len(segments) == 1
+    assert str(data["active"]) == segments[0]["attributes"]["thread.id"]
 
 
 def test_original_request_not_scrubbed(sentry_init, capture_events):
@@ -1167,15 +1277,24 @@ def test_transaction_name_in_middleware(
     )
 
 
-def test_span_origin(sentry_init, capture_events):
+@pytest.mark.parametrize("span_streaming", [True, False])
+def test_span_origin(sentry_init, capture_events, capture_items, span_streaming):
     sentry_init(
-        integrations=[StarletteIntegration()],
+        auto_enabling_integrations=False,  # avoid httpx auto-instrumentation leaking spans
+        integrations=[StarletteIntegration(middleware_spans=True)],
         traces_sample_rate=1.0,
+        _experiments={
+            "trace_lifecycle": "stream" if span_streaming else "static",
+        },
     )
     starlette_app = starlette_app_factory(
         middleware=[Middleware(AuthenticationMiddleware, backend=BasicAuthBackend())]
     )
-    events = capture_events()
+
+    if span_streaming:
+        items = capture_items("span")
+    else:
+        events = capture_events()
 
     client = TestClient(starlette_app, raise_server_exceptions=False)
     try:
@@ -1183,11 +1302,18 @@ def test_span_origin(sentry_init, capture_events):
     except Exception:
         pass
 
-    (_, event) = events
+    if span_streaming:
+        sentry_sdk.flush()
 
-    assert event["contexts"]["trace"]["origin"] == "auto.http.starlette"
-    for span in event["spans"]:
-        assert span["origin"] == "auto.http.starlette"
+        assert len(items) > 0
+        for item in items:
+            assert item.payload["attributes"]["sentry.origin"] == "auto.http.starlette"
+    else:
+        (_, event) = events
+
+        assert event["contexts"]["trace"]["origin"] == "auto.http.starlette"
+        for span in event["spans"]:
+            assert span["origin"] == "auto.http.starlette"
 
 
 class NonIterableContainer:

--- a/tests/integrations/starlette/test_starlette.py
+++ b/tests/integrations/starlette/test_starlette.py
@@ -1056,6 +1056,124 @@ def test_active_thread_id_span_streaming(sentry_init, capture_items, endpoint):
     assert str(data["active"]) == segments[0]["attributes"]["thread.id"]
 
 
+def _post_body_app(handler_awaitable):
+    async def _handler(request):
+        await handler_awaitable(request)
+        return starlette.responses.JSONResponse({"ok": True})
+
+    return starlette.applications.Starlette(
+        routes=[starlette.routing.Route("/body", _handler, methods=["POST"])],
+    )
+
+
+def test_request_body_data_scrubs_pii_span_streaming(sentry_init, capture_items):
+    sentry_init(
+        auto_enabling_integrations=False,
+        integrations=[StarletteIntegration()],
+        traces_sample_rate=1.0,
+        _experiments={"trace_lifecycle": "stream"},
+    )
+
+    async def _read_json(request):
+        await request.json()
+
+    items = capture_items("span")
+
+    client = TestClient(_post_body_app(_read_json))
+    response = client.post(
+        "/body",
+        json={
+            "password": "ohno",
+            "authorization": "Bearer token",
+            "message": "hello",
+        },
+    )
+    assert response.status_code == 200
+
+    sentry_sdk.flush()
+
+    segments = [item.payload for item in items if item.payload.get("is_segment")]
+    assert len(segments) == 1
+    attr = segments[0]["attributes"]["http.request.body.data"]
+
+    # Going forward, the sanitization of data will need to happen within the `before_send_span` hooks
+    # See https://sentry.slack.com/archives/C09RR0KD2N7/p1776951331206129?thread_ts=1776951227.440659&cid=C09RR0KD2N7
+    assert "ohno" in attr
+    assert "Bearer token" in attr
+    assert "hello" in attr
+
+
+def test_request_body_data_annotated_value_top_level_span_streaming(
+    sentry_init, capture_items
+):
+    sentry_init(
+        auto_enabling_integrations=False,
+        integrations=[StarletteIntegration()],
+        traces_sample_rate=1.0,
+        _experiments={"trace_lifecycle": "stream"},
+    )
+
+    async def _read_body(request):
+        await request.body()
+
+    items = capture_items("span")
+
+    client = TestClient(_post_body_app(_read_body))
+    response = client.post(
+        "/body",
+        content=b"not json and not form",
+        headers={"content-type": "application/octet-stream"},
+    )
+    assert response.status_code == 200
+
+    sentry_sdk.flush()
+
+    segments = [item.payload for item in items if item.payload.get("is_segment")]
+    assert len(segments) == 1
+    attr = segments[0]["attributes"]["http.request.body.data"]
+
+    assert isinstance(attr, str)
+    assert "!raw" in attr
+
+
+def test_request_body_data_annotated_value_nested_span_streaming(
+    sentry_init, capture_items
+):
+    pytest.importorskip("multipart")
+
+    sentry_init(
+        auto_enabling_integrations=False,
+        integrations=[StarletteIntegration()],
+        traces_sample_rate=1.0,
+        _experiments={"trace_lifecycle": "stream"},
+    )
+
+    async def _read_form(request):
+        await request.form()
+
+    items = capture_items("span")
+
+    client = TestClient(_post_body_app(_read_form))
+    response = client.post(
+        "/body",
+        data={"name": "erica"},
+        files={"avatar": ("photo.jpg", b"fake-bytes", "image/jpeg")},
+    )
+    assert response.status_code == 200
+
+    sentry_sdk.flush()
+
+    segments = [item.payload for item in items if item.payload.get("is_segment")]
+    assert len(segments) == 1
+    attr = segments[0]["attributes"]["http.request.body.data"]
+
+    assert isinstance(attr, str)
+    parsed = json.loads(attr)
+    assert parsed["name"] == "erica"
+    assert parsed["avatar"]["metadata"]["rem"] == [["!raw", "x"]]
+    assert "fake-bytes" not in attr
+
+
 def test_original_request_not_scrubbed(sentry_init, capture_events):
     sentry_init(integrations=[StarletteIntegration()])
 

--- a/tests/integrations/starlette/test_starlette.py
+++ b/tests/integrations/starlette/test_starlette.py
@@ -1066,10 +1066,13 @@ def _post_body_app(handler_awaitable):
     )
 
 
-def test_request_body_data_scrubs_pii_span_streaming(sentry_init, capture_items):
+@pytest.mark.parametrize("middleware_spans", [False, True])
+def test_request_body_data_scrubs_pii_span_streaming(
+    sentry_init, capture_items, middleware_spans
+):
     sentry_init(
         auto_enabling_integrations=False,
-        integrations=[StarletteIntegration()],
+        integrations=[StarletteIntegration(middleware_spans=middleware_spans)],
         traces_sample_rate=1.0,
         _experiments={"trace_lifecycle": "stream"},
     )
@@ -1107,12 +1110,13 @@ def test_request_body_data_scrubs_pii_span_streaming(sentry_init, capture_items)
     STARLETTE_VERSION < (0, 21),
     reason="Requires Starlette >= 0.21, because earlier versions use a requests-based TestClient which does not support the 'content' kwarg",
 )
+@pytest.mark.parametrize("middleware_spans", [False, True])
 def test_request_body_data_annotated_value_top_level_span_streaming(
-    sentry_init, capture_items
+    sentry_init, capture_items, middleware_spans
 ):
     sentry_init(
         auto_enabling_integrations=False,
-        integrations=[StarletteIntegration()],
+        integrations=[StarletteIntegration(middleware_spans=middleware_spans)],
         traces_sample_rate=1.0,
         _experiments={"trace_lifecycle": "stream"},
     )
@@ -1140,14 +1144,15 @@ def test_request_body_data_annotated_value_top_level_span_streaming(
     assert "!raw" in attr
 
 
+@pytest.mark.parametrize("middleware_spans", [False, True])
 def test_request_body_data_annotated_value_nested_span_streaming(
-    sentry_init, capture_items
+    sentry_init, capture_items, middleware_spans
 ):
     pytest.importorskip("multipart")
 
     sentry_init(
         auto_enabling_integrations=False,
-        integrations=[StarletteIntegration()],
+        integrations=[StarletteIntegration(middleware_spans=middleware_spans)],
         traces_sample_rate=1.0,
         _experiments={"trace_lifecycle": "stream"},
     )

--- a/tests/integrations/starlette/test_starlette.py
+++ b/tests/integrations/starlette/test_starlette.py
@@ -1142,7 +1142,9 @@ def test_request_body_data_annotated_value_top_level_span_streaming(
     attr = segments[0]["attributes"]["http.request.body.data"]
 
     assert isinstance(attr, str)
-    assert "!raw" in attr
+    assert (
+        attr == '""'
+    )  # AnnotatedValue.removed_because_raw_data is called because the content was not able to be parsed, and replaces the value with an empty string
 
 
 @pytest.mark.parametrize("middleware_spans", [False, True])

--- a/tests/integrations/starlette/test_starlette.py
+++ b/tests/integrations/starlette/test_starlette.py
@@ -701,8 +701,7 @@ def test_middleware_spans(sentry_init, capture_events, capture_items, span_strea
 
         for idx, span in enumerate(middleware_spans):
             assert (
-                span["attributes"]["starlette.middleware_name"]
-                == expected_middleware_spans[idx]
+                span["attributes"]["middleware.name"] == expected_middleware_spans[idx]
             )
     else:
         (_, transaction_event) = events
@@ -852,7 +851,7 @@ def test_middleware_callback_spans(
             assert span["attributes"]["sentry.op"] == exp["op"]
             assert span["name"] == exp["description"]
             assert (
-                span["attributes"]["starlette.middleware_name"]
+                span["attributes"]["middleware.name"]
                 == exp["tags"]["starlette.middleware_name"]
             )
     else:

--- a/tests/integrations/starlette/test_starlette.py
+++ b/tests/integrations/starlette/test_starlette.py
@@ -1182,7 +1182,6 @@ def test_request_body_data_annotated_value_nested_span_streaming(
     assert isinstance(attr, str)
     parsed = json.loads(attr)
     assert parsed["name"] == "erica"
-    assert parsed["avatar"]["metadata"]["rem"] == [["!raw", "x"]]
     assert "fake-bytes" not in attr
 
 

--- a/tests/integrations/starlette/test_starlette.py
+++ b/tests/integrations/starlette/test_starlette.py
@@ -1103,6 +1103,10 @@ def test_request_body_data_scrubs_pii_span_streaming(sentry_init, capture_items)
     assert "hello" in attr
 
 
+@pytest.mark.skipif(
+    STARLETTE_VERSION < (0, 21),
+    reason="Requires Starlette >= 0.21, because earlier versions use a requests-based TestClient which does not support the 'content' kwarg",
+)
 def test_request_body_data_annotated_value_top_level_span_streaming(
     sentry_init, capture_items
 ):

--- a/tests/integrations/starlette/test_starlette.py
+++ b/tests/integrations/starlette/test_starlette.py
@@ -1066,7 +1066,7 @@ def _post_body_app(handler_awaitable):
 
 
 @pytest.mark.parametrize("middleware_spans", [False, True])
-def test_request_body_data_scrubs_pii_span_streaming(
+def test_request_body_data_does_not_scrub_pii_span_streaming(
     sentry_init, capture_items, middleware_spans
 ):
     sentry_init(

--- a/tests/integrations/starlette/test_starlette.py
+++ b/tests/integrations/starlette/test_starlette.py
@@ -654,6 +654,7 @@ def test_middleware_spans(sentry_init, capture_events, capture_items, span_strea
     sentry_init(
         traces_sample_rate=1.0,
         integrations=[StarletteIntegration(middleware_spans=True)],
+        auto_enabling_integrations=False,  # disable because httpx will enable otherwise, leading to the segment span being an `http.client` sentry.op (the TestClient initiating the request), rather than the more realistic `http.server`.
         _experiments={
             "trace_lifecycle": "stream" if span_streaming else "static",
         },
@@ -686,19 +687,19 @@ def test_middleware_spans(sentry_init, capture_events, capture_items, span_strea
     if span_streaming:
         sentry_sdk.flush()
 
-        middleware_spans = sorted(
-            [
-                item.payload
-                for item in items
-                if item.payload.get("attributes", {})
-                .get("sentry.op", "")
-                .startswith("middleware.starlette")
-            ],
-            key=lambda s: s["start_timestamp"],
-        )
+        segment = items.pop().payload
+        middleware_spans = [item.payload for item in items]
+
+        # In span-first, the `middleware.starlette.send` ops appear first,
+        # so the list needs to be reversed for the assertions below
+        middleware_spans.reverse()
 
         assert len(middleware_spans) == len(expected_middleware_spans)
 
+        assert segment["is_segment"] is True
+        assert segment["attributes"]["sentry.op"] == "http.server"
+
+        idx = 0
         for idx, span in enumerate(middleware_spans):
             assert (
                 span["attributes"]["middleware.name"] == expected_middleware_spans[idx]
@@ -725,6 +726,7 @@ def test_middleware_spans_disabled(
     sentry_init(
         traces_sample_rate=1.0,
         integrations=[StarletteIntegration(middleware_spans=False)],
+        auto_enabling_integrations=False,  # disable because httpx will enable otherwise, leading to the segment span being an `http.client` sentry.op (the TestClient initiating the request), rather than the more realistic `http.server`.
         _experiments={
             "trace_lifecycle": "stream" if span_streaming else "static",
         },
@@ -747,14 +749,13 @@ def test_middleware_spans_disabled(
     if span_streaming:
         sentry_sdk.flush()
 
-        middleware_spans = [
-            item.payload
-            for item in items
-            if item.payload.get("attributes", {})
-            .get("sentry.op", "")
-            .startswith("middleware.starlette")
-        ]
+        segment = items.pop().payload
+        middleware_spans = [item.payload for item in items]
+
         assert len(middleware_spans) == 0
+
+        assert segment["is_segment"] is True
+        assert segment["attributes"]["sentry.op"] == "http.server"
     else:
         (_, transaction_event) = events
         assert len(transaction_event["spans"]) == 0
@@ -767,6 +768,7 @@ def test_middleware_callback_spans(
     sentry_init(
         traces_sample_rate=1.0,
         integrations=[StarletteIntegration(middleware_spans=True)],
+        auto_enabling_integrations=False,  # disable because httpx will enable otherwise, leading to the segment span being an `http.client` sentry.op (the TestClient initiating the request), rather than the more realistic `http.server`.
         _experiments={
             "trace_lifecycle": "stream" if span_streaming else "static",
         },
@@ -835,18 +837,18 @@ def test_middleware_callback_spans(
     if span_streaming:
         sentry_sdk.flush()
 
-        middleware_spans = sorted(
-            [
-                item.payload
-                for item in items
-                if item.payload.get("attributes", {})
-                .get("sentry.op", "")
-                .startswith("middleware.starlette")
-            ],
-            key=lambda s: s["start_timestamp"],
-        )
+        segment = items.pop().payload
+        middleware_spans = [item.payload for item in items]
+
+        # In span-first, the `middleware.starlette.send` ops appear first,
+        # so the list needs to be reversed for the assertions below
+        middleware_spans.reverse()
 
         assert len(middleware_spans) == len(expected)
+
+        assert segment["is_segment"] is True
+        assert segment["attributes"]["sentry.op"] == "http.server"
+
         for span, exp in zip(middleware_spans, expected):
             assert span["attributes"]["sentry.op"] == exp["op"]
             assert span["name"] == exp["description"]


### PR DESCRIPTION
Bring the Starlette integration to span-streaming parity with the FastAPI change that landed in #6118.

Under the `trace_lifecycle: "stream"` experiment the scope's `transaction` is `None` and the scope instead holds a `StreamedSpan`, so the existing middleware instrumentation (which called `start_span(op=..., origin=...) + set_tag`) and the profiler's `current_scope.transaction.update_active_thread()` hook in `patch_request_response` didn't function under streaming. This PR routes both through the streaming APIs when streaming is enabled while leaving the legacy transaction-based path untouched:

- `_enable_span_for_middleware` now uses a `_start_middleware_span` helper that calls `sentry_sdk.traces.start_span` with `sentry.op`, `sentry.origin`, and `starlette.middleware_name` attributes under streaming, and the existing `sentry_sdk.start_span(op=..., origin=...) + set_tag` otherwise.
- The profiler hook detects `StreamedSpan` (excluding `NoOpStreamedSpan`) and calls `_segment._update_active_thread()`; otherwise it takes the legacy `current_scope.transaction.update_active_thread()` branch.

Tests are parametrized across streaming and static modes for `test_middleware_spans`, `test_middleware_spans_disabled`, `test_middleware_callback_spans`, and `test_span_origin`. A new `test_active_thread_id_span_streaming` covers the segment's `thread.id` attribute under streaming. `auto_enabling_integrations=False` is set in streaming tests where auto-instrumented spans would otherwise leak into the captured span stream.

Refs PY-2362