### PR TITLE
test: Join thread in continuous profiler test

### DIFF
--- a/tests/profiler/test_continuous_profiler.py
+++ b/tests/profiler/test_continuous_profiler.py
@@ -271,8 +271,7 @@ def test_continuous_profiler_auto_start_and_manual_stop(
             pass
 
     # Wait so profiles are captured before assertions.
-    sentry_sdk.profiler.continuous_profiler._scheduler.running = False
-    sentry_sdk.profiler.continuous_profiler._scheduler.thread.join()
+    sentry_sdk.profiler.continuous_profiler._scheduler.teardown()
 
     assert_single_transaction_with_profile_chunks(envelopes, thread)
 

--- a/tests/profiler/test_continuous_profiler.py
+++ b/tests/profiler/test_continuous_profiler.py
@@ -213,6 +213,7 @@ def assert_single_transaction_without_profile_chunks(envelopes):
     assert "profile" not in transaction["contexts"]
 
 
+@pytest.mark.forked
 @pytest.mark.parametrize(
     "mode",
     [

--- a/tests/profiler/test_continuous_profiler.py
+++ b/tests/profiler/test_continuous_profiler.py
@@ -213,7 +213,6 @@ def assert_single_transaction_without_profile_chunks(envelopes):
     assert "profile" not in transaction["contexts"]
 
 
-@pytest.mark.forked
 @pytest.mark.parametrize(
     "mode",
     [
@@ -243,7 +242,10 @@ def assert_single_transaction_without_profile_chunks(envelopes):
         pytest.param(get_client_options(False), id="experiment"),
     ],
 )
-@mock.patch("sentry_sdk.profiler.continuous_profiler.PROFILE_BUFFER_SECONDS", 0.01)
+@mock.patch(
+    "sentry_sdk.profiler.continuous_profiler.ProfileBuffer.should_flush",
+    lambda a, b: True,
+)  # Force flushing profile of first transaction.
 def test_continuous_profiler_auto_start_and_manual_stop(
     sentry_init,
     capture_envelopes,
@@ -265,7 +267,11 @@ def test_continuous_profiler_auto_start_and_manual_stop(
 
     with sentry_sdk.start_transaction(name="profiling"):
         with sentry_sdk.start_span(op="op"):
-            time.sleep(0.05)
+            pass
+
+    # Wait so profiles are captured before assertions.
+    sentry_sdk.profiler.continuous_profiler._scheduler.running = False
+    sentry_sdk.profiler.continuous_profiler._scheduler.thread.join()
 
     assert_single_transaction_with_profile_chunks(envelopes, thread)
 


### PR DESCRIPTION
### Description
<!-- What changed and why? -->

Flush the profiler's buffer after the first profile is collected, and suspend execution of main thread to wait for the profiler's buffer to flush before evaluating assertions. 

According to the logs in the following failed run

https://github.com/getsentry/sentry-python/actions/runs/24769385099/job/72476526451

the test fails with the following stack trace:

```
FAILED tests/profiler/test_continuous_profiler.py::test_continuous_profiler_auto_start_and_manual_stop[non-experiment-start_profile_session/stop_profile_session (deprecated)-thread] - tests/profiler/test_continuous_profiler.py:270: in test_continuous_profiler_auto_start_and_manual_stop
    assert_single_transaction_with_profile_chunks(envelopes, thread)
tests/profiler/test_continuous_profiler.py:147: in assert_single_transaction_with_profile_chunks
    assert len(items["profile_chunk"]) > 0
E   assert 0 > 0
E    +  where 0 = len([])
```

The stack trace shows that profiles were not collected in the test transport by the time the assertion is executed.

The assertion runs before any manual calls to start and stop the profiler. The profiler is auto-activated and creates a profile for the transaction context manager.

#### Issues
<!--
* resolves: #1234
* resolves: LIN-1234
-->

#### Reminders
- Please add tests to validate your changes, and lint your code using `tox -e linters`.
- Add GH Issue ID _&_ Linear ID (if applicable)
- PR title should use [conventional commit](https://develop.sentry.dev/engineering-practices/commit-messages/#type) style (`feat:`, `fix:`, `ref:`, `meta:`)
- For external contributors: [CONTRIBUTING.md](https://github.com/getsentry/sentry-python/blob/master/CONTRIBUTING.md), [Sentry SDK development docs](https://develop.sentry.dev/sdk/), [Discord community](https://discord.gg/Ww9hbqr)
