### PR TITLE
ref: Remove Python 2 compat from qualname_from_function

### DIFF
--- a/sentry_sdk/utils.py
+++ b/sentry_sdk/utils.py
@@ -1489,6 +1489,8 @@ def qualname_from_function(func: "Callable[..., Any]") -> "Optional[str]":
 
     if hasattr(func, "__qualname__"):
         func_qualname = func.__qualname__
+    elif hasattr(func, "__name__"):
+        func_qualname = func.__name__
 
     if func_qualname is not None:
         if hasattr(func, "__module__") and isinstance(func.__module__, str):

--- a/sentry_sdk/utils.py
+++ b/sentry_sdk/utils.py
@@ -1472,16 +1472,6 @@ def qualname_from_function(func: "Callable[..., Any]") -> "Optional[str]":
     """Return the qualified name of func. Works with regular function, lambda, partial and partialmethod."""
     func_qualname: "Optional[str]" = None
 
-    # Python 2
-    try:
-        return "%s.%s.%s" % (
-            func.im_class.__module__,  # type: ignore
-            func.im_class.__name__,  # type: ignore
-            func.__name__,
-        )
-    except Exception:
-        pass
-
     prefix, suffix = "", ""
 
     if isinstance(func, partial) and hasattr(func.func, "__name__"):
@@ -1499,10 +1489,7 @@ def qualname_from_function(func: "Callable[..., Any]") -> "Optional[str]":
 
     if hasattr(func, "__qualname__"):
         func_qualname = func.__qualname__
-    elif hasattr(func, "__name__"):  # Python 2.7 has no __qualname__
-        func_qualname = func.__name__
 
-    # Python 3: methods, functions, classes
     if func_qualname is not None:
         if hasattr(func, "__module__") and isinstance(func.__module__, str):
             func_qualname = func.__module__ + "." + func_qualname


### PR DESCRIPTION
Remove two Python 2 compatibility branches from `sentry_sdk/utils.py::qualname_from_function` that can never fire.

The SDK requires Python ≥ 3.6 (`setup.py`), so the `im_class` `try/except` (Python 2 bound-method attribute) and the `elif hasattr(func, "__name__")` fallback annotated `# Python 2.7 has no __qualname__` are dead code. 

No behavior change for any Python 3 input — the return contract is preserved for callers in `tracing_utils.py`, `integrations/ray.py`, `integrations/asgi.py`, and `integrations/django/tasks.py`.

Refs PY-2298