### PR TITLE
ref: remove universal bdist_wheel option

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -113,5 +113,4 @@ setup(
         "Programming Language :: Python :: 3.14",
         "Topic :: Software Development :: Libraries :: Python Modules",
     ],
-    options={"bdist_wheel": {"universal": "1"}},
 )


### PR DESCRIPTION
closes #6121.

universal wheels existed for the python 2/3 split — single `.whl` that worked on both runtimes. with python 2 long gone (setup.py only declares 3.7+ classifiers), the `bdist_wheel.universal=1` option is dead config. removing it.

modern `pip wheel` / `build` workflows produce per-runtime wheels by default, no extra flags needed.