### PR TITLE
feat(argv): Support span streaming

### DIFF
--- a/sentry_sdk/traces.py
+++ b/sentry_sdk/traces.py
@@ -7,6 +7,7 @@ You can enable span streaming mode via
 sentry_sdk.init(_experiments={"trace_lifecycle": "stream"}).
 """
 
+import sys
 import uuid
 import warnings
 from datetime import datetime, timedelta, timezone
@@ -294,6 +295,8 @@ class StreamedSpan:
         self._start_profile()
         self._set_profile_id(get_profiler_id())
 
+        self._set_segment_attributes()
+
         self._start()
 
     def __repr__(self) -> str:
@@ -551,6 +554,12 @@ class StreamedSpan:
         try_autostart_continuous_profiler()
 
         self._continuous_profile = try_profile_lifecycle_trace_start()
+
+    def _set_segment_attributes(self) -> None:
+        if not self._is_segment():
+            return
+
+        self.set_attribute("process.command_args", sys.argv)
 
 
 class NoOpStreamedSpan(StreamedSpan):

--- a/tests/tracing/test_span_streaming.py
+++ b/tests/tracing/test_span_streaming.py
@@ -1504,6 +1504,46 @@ def test_profile_stops_when_segment_ends(
     assert get_profiler_id() is None, "profiler should have stopped"
 
 
+def test_default_attributes(sentry_init, capture_envelopes):
+    sentry_init(
+        server_name="test-server",
+        release="1.0.0",
+        traces_sample_rate=1.0,
+        _experiments={"trace_lifecycle": "stream"},
+    )
+
+    envelopes = capture_envelopes()
+
+    with sentry_sdk.traces.start_span(name="test"):
+        ...
+
+    sentry_sdk.get_client().flush()
+
+    assert len(envelopes) == 1
+    assert len(envelopes[0].items) == 1
+    item = envelopes[0].items[0]
+
+    assert item.type == "span"
+    assert item.headers == {
+        "type": "span",
+        "item_count": 1,
+        "content_type": "application/vnd.sentry.items.span.v2+json",
+    }
+    assert item.payload.json["items"][0]["attributes"] == {
+        "thread.id": {"value": mock.ANY, "type": "string"},
+        "thread.name": {"value": "MainThread", "type": "string"},
+        "process.command_args": {"value": mock.ANY, "type": "array"},
+        "sentry.segment.id": {"value": mock.ANY, "type": "string"},
+        "sentry.segment.name": {"value": "test", "type": "string"},
+        "sentry.sdk.name": {"value": "sentry.python", "type": "string"},
+        "sentry.sdk.version": {"value": mock.ANY, "type": "string"},
+        "server.address": {"value": "test-server", "type": "string"},
+        "sentry.environment": {"value": "production", "type": "string"},
+        "sentry.release": {"value": "1.0.0", "type": "string"},
+        "sentry.origin": {"value": "manual", "type": "string"},
+    }
+
+
 def test_transport_format(sentry_init, capture_envelopes):
     sentry_init(
         server_name="test-server",
@@ -1539,18 +1579,17 @@ def test_transport_format(sentry_init, capture_envelopes):
                 "is_segment": True,
                 "start_timestamp": mock.ANY,
                 "end_timestamp": mock.ANY,
-                "attributes": {
-                    "thread.id": {"value": mock.ANY, "type": "string"},
-                    "thread.name": {"value": "MainThread", "type": "string"},
-                    "sentry.segment.id": {"value": mock.ANY, "type": "string"},
-                    "sentry.segment.name": {"value": "test", "type": "string"},
-                    "sentry.sdk.name": {"value": "sentry.python", "type": "string"},
-                    "sentry.sdk.version": {"value": mock.ANY, "type": "string"},
-                    "server.address": {"value": "test-server", "type": "string"},
-                    "sentry.environment": {"value": "production", "type": "string"},
-                    "sentry.release": {"value": "1.0.0", "type": "string"},
-                    "sentry.origin": {"value": "manual", "type": "string"},
-                },
+                "attributes": mock.ANY,
             }
         ]
     }
+    for attribute, value in item.payload.json["items"][0]["attributes"].items():
+        assert isinstance(attribute, str)
+
+        assert isinstance(value, dict)
+        assert (
+            len(value) == 2
+        )  # technically, "unit" is also supported, but we don't currently set it anywhere
+        assert "value" in value
+        assert "type" in value
+        assert value["type"] in ("string", "boolean", "integer", "double", "array")


### PR DESCRIPTION
### Description
The `argv` integration currently sets `sys.argv` on events, including transactions. In span streaming, this corresponds to setting an attribute on the segment span. The attr was added to Sentry conventions in https://github.com/getsentry/sentry-conventions/commit/420bab80acf5aefa08697639b5c7651f4b15beb6.

I also split up the span streaming transport format test into:
1) a test that only checks the transport format (not so much the actual data, just that it's formatted correctly) and
2) a test that checks that the default set of attributes we expect is set.

#### Issues
Closes https://github.com/getsentry/sentry-python/issues/5998
Closes https://linear.app/getsentry/issue/PY-2300/migrate-argv-to-span-first

#### Reminders
- Please add tests to validate your changes, and lint your code using `tox -e linters`.
- Add GH Issue ID _&_ Linear ID (if applicable)
- PR title should use [conventional commit](https://develop.sentry.dev/engineering-practices/commit-messages/#type) style (`feat:`, `fix:`, `ref:`, `meta:`)
- For external contributors: [CONTRIBUTING.md](https://github.com/getsentry/sentry-python/blob/master/CONTRIBUTING.md), [Sentry SDK development docs](https://develop.sentry.dev/sdk/), [Discord community](https://discord.gg/Ww9hbqr)
