### PR TITLE
fix(httpx): Set `code.namespace` and `code.function` instead of `code.function.name` in span streaming

### DIFF
--- a/sentry_sdk/tracing_utils.py
+++ b/sentry_sdk/tracing_utils.py
@@ -283,10 +283,11 @@ def add_source(
             namespace = frame.f_globals.get("__name__")
         except Exception:
             namespace = None
-        if namespace is not None and isinstance(span, LegacySpan):
-            span.set_data(SPANDATA.CODE_NAMESPACE, namespace)
-        elif namespace is not None:
-            span.set_attribute(SPANDATA.CODE_NAMESPACE, namespace)
+        if namespace is not None:
+            if isinstance(span, LegacySpan):
+                span.set_data(SPANDATA.CODE_NAMESPACE, namespace)
+            else:
+                span.set_attribute(SPANDATA.CODE_NAMESPACE, namespace)
 
         filepath = _get_frame_module_abs_path(frame)
         if filepath is not None:

--- a/sentry_sdk/tracing_utils.py
+++ b/sentry_sdk/tracing_utils.py
@@ -285,6 +285,8 @@ def add_source(
             namespace = None
         if namespace is not None and isinstance(span, LegacySpan):
             span.set_data(SPANDATA.CODE_NAMESPACE, namespace)
+        elif namespace is not None:
+            span.set_attribute(SPANDATA.CODE_NAMESPACE, namespace)
 
         filepath = _get_frame_module_abs_path(frame)
         if filepath is not None:
@@ -310,7 +312,7 @@ def add_source(
             if isinstance(span, LegacySpan):
                 span.set_data(SPANDATA.CODE_FUNCTION, frame.f_code.co_name)
             else:
-                span.set_attribute("code.function.name", frame.f_code.co_name)
+                span.set_attribute(SPANDATA.CODE_FUNCTION, frame.f_code.co_name)
 
 
 def add_query_source(span: "sentry_sdk.tracing.Span") -> None:

--- a/tests/integrations/httpx/test_httpx.py
+++ b/tests/integrations/httpx/test_httpx.py
@@ -830,8 +830,9 @@ def test_request_source_disabled_span_streaming(
     http_span = _get_http_client_span(items)
 
     assert "code.line.number" not in http_span["attributes"]
+    assert SPANDATA.CODE_NAMESPACE not in http_span["attributes"]
     assert "code.file.path" not in http_span["attributes"]
-    assert "code.function.name" not in http_span["attributes"]
+    assert SPANDATA.CODE_FUNCTION not in http_span["attributes"]
 
 
 @pytest.mark.parametrize("enable_http_request_source", [None, True])
@@ -873,8 +874,9 @@ def test_request_source_enabled_span_streaming(
     http_span = _get_http_client_span(items)
 
     assert "code.line.number" in http_span["attributes"]
+    assert SPANDATA.CODE_NAMESPACE in http_span["attributes"]
     assert "code.file.path" in http_span["attributes"]
-    assert "code.function.name" in http_span["attributes"]
+    assert SPANDATA.CODE_FUNCTION in http_span["attributes"]
 
 
 @pytest.mark.parametrize(
@@ -908,11 +910,16 @@ def test_request_source_span_streaming(
     http_span = _get_http_client_span(items)
 
     assert "code.line.number" in http_span["attributes"]
+    assert SPANDATA.CODE_NAMESPACE in http_span["attributes"]
     assert "code.file.path" in http_span["attributes"]
-    assert "code.function.name" in http_span["attributes"]
+    assert SPANDATA.CODE_FUNCTION in http_span["attributes"]
 
     assert type(http_span["attributes"]["code.line.number"]) == int
     assert http_span["attributes"]["code.line.number"] > 0
+    assert (
+        http_span["attributes"][SPANDATA.CODE_NAMESPACE]
+        == "tests.integrations.httpx.test_httpx"
+    )
     assert http_span["attributes"]["code.file.path"].endswith(
         "tests/integrations/httpx/test_httpx.py"
     )
@@ -921,7 +928,7 @@ def test_request_source_span_streaming(
     assert is_relative_path
 
     assert (
-        http_span["attributes"]["code.function.name"]
+        http_span["attributes"][SPANDATA.CODE_FUNCTION]
         == "test_request_source_span_streaming"
     )
 
@@ -966,11 +973,13 @@ def test_request_source_with_module_in_search_path_span_streaming(
     http_span = _get_http_client_span(items)
 
     assert "code.line.number" in http_span["attributes"]
+    assert SPANDATA.CODE_NAMESPACE in http_span["attributes"]
     assert "code.file.path" in http_span["attributes"]
-    assert "code.function.name" in http_span["attributes"]
+    assert SPANDATA.CODE_FUNCTION in http_span["attributes"]
 
     assert type(http_span["attributes"]["code.line.number"]) == int
     assert http_span["attributes"]["code.line.number"] > 0
+    assert http_span["attributes"][SPANDATA.CODE_NAMESPACE] == "httpx_helpers.helpers"
     assert http_span["attributes"]["code.file.path"] == "httpx_helpers/helpers.py"
 
     is_relative_path = http_span["attributes"]["code.file.path"][0] != os.sep
@@ -978,12 +987,12 @@ def test_request_source_with_module_in_search_path_span_streaming(
 
     if asyncio.iscoroutinefunction(httpx_client.get):
         assert (
-            http_span["attributes"]["code.function.name"]
+            http_span["attributes"][SPANDATA.CODE_FUNCTION]
             == "async_get_request_with_client"
         )
     else:
         assert (
-            http_span["attributes"]["code.function.name"] == "get_request_with_client"
+            http_span["attributes"][SPANDATA.CODE_FUNCTION] == "get_request_with_client"
         )
 
 
@@ -1019,8 +1028,9 @@ def test_no_request_source_if_duration_too_short_span_streaming(
     http_span = _get_http_client_span(items)
 
     assert "code.line.number" not in http_span["attributes"]
+    assert SPANDATA.CODE_NAMESPACE not in http_span["attributes"]
     assert "code.file.path" not in http_span["attributes"]
-    assert "code.function.name" not in http_span["attributes"]
+    assert SPANDATA.CODE_FUNCTION not in http_span["attributes"]
 
 
 @pytest.mark.parametrize(
@@ -1055,11 +1065,16 @@ def test_request_source_if_duration_over_threshold_span_streaming(
     http_span = _get_http_client_span(items)
 
     assert "code.line.number" in http_span["attributes"]
+    assert SPANDATA.CODE_NAMESPACE in http_span["attributes"]
     assert "code.file.path" in http_span["attributes"]
-    assert "code.function.name" in http_span["attributes"]
+    assert SPANDATA.CODE_FUNCTION in http_span["attributes"]
 
     assert type(http_span["attributes"]["code.line.number"]) == int
     assert http_span["attributes"]["code.line.number"] > 0
+    assert (
+        http_span["attributes"][SPANDATA.CODE_NAMESPACE]
+        == "tests.integrations.httpx.test_httpx"
+    )
     assert http_span["attributes"]["code.file.path"].endswith(
         "tests/integrations/httpx/test_httpx.py"
     )
@@ -1068,7 +1083,7 @@ def test_request_source_if_duration_over_threshold_span_streaming(
     assert is_relative_path
 
     assert (
-        http_span["attributes"]["code.function.name"]
+        http_span["attributes"][SPANDATA.CODE_FUNCTION]
         == "test_request_source_if_duration_over_threshold_span_streaming"
     )
 


### PR DESCRIPTION
### Description
<!-- What changed and why? -->

Slack convo:

- Based on my reading of the conventions, `code.namespace` should be `frame.f_globals.get("__name__")` + everything in `func.__qualname__` without the function name (available on all our Python versions). Using `func.__qualname__` is equivalent to calling `co_qualname` on a frame, which is only available on Python 3.11+ (disregarding cases where you could overwrite `__qualname__`).

- We set code origin by walking based on the current frame's state, i.e., we don't have a function object to call `func.__qualname__` or `qualname_from_function` on (unless I'm not looking in the right place).

- `frame.f_globals.get("__name__")` is the module name, which is not the fully-qualified name if the function is in some scope (i.e., if the function is a class method, local lambda, etc ...).

That means:

While based on descriptions `code.function.name = code.namespace + code.function`, we currently only report the module name in `code.namespace` (missing out qualification inside the module if the function is scoped).
You can run this script to see what `frame.f_globals.get(__name__)` misses:

```python
import sys

def report_code_source():
    f = sys._getframe(1)
    print(f"{f.f_globals.get("__name__")}.{f.f_code.co_name}")

class MyClass:
    def my_method(self):
        report_code_source()

MyClass().my_method()
```

#### Issues
<!--
* resolves: #1234
* resolves: LIN-1234
-->

#### Reminders
- Please add tests to validate your changes, and lint your code using `tox -e linters`.
- Add GH Issue ID _&_ Linear ID (if applicable)
- PR title should use [conventional commit](https://develop.sentry.dev/engineering-practices/commit-messages/#type) style (`feat:`, `fix:`, `ref:`, `meta:`)
- For external contributors: [CONTRIBUTING.md](https://github.com/getsentry/sentry-python/blob/master/CONTRIBUTING.md), [Sentry SDK development docs](https://develop.sentry.dev/sdk/), [Discord community](https://discord.gg/Ww9hbqr)
