### PR TITLE
test(stdlib):  Stop mocking `HTTPSConnection.send` in trace header tests

### DIFF
--- a/tests/integrations/stdlib/test_httplib.py
+++ b/tests/integrations/stdlib/test_httplib.py
@@ -202,14 +202,23 @@ def test_httplib_misuse(sentry_init, capture_events, request):
     )
 
 
-def test_outgoing_trace_headers(sentry_init, monkeypatch):
-    # HTTPSConnection.send is passed a string containing (among other things)
-    # the headers on the request. Mock it so we can check the headers, and also
-    # so it doesn't try to actually talk to the internet.
-    mock_send = mock.Mock()
-    monkeypatch.setattr(HTTPSConnection, "send", mock_send)
+def test_outgoing_trace_headers(sentry_init, capture_events):
+    original_send = HTTPConnection.send
+
+    request_headers = {}
+
+    class HttpConnectionRecordingRequestHeaders(HTTPConnection):
+        def send(self, *args, **kwargs) -> None:
+            request_str = args[0]
+            for line in request_str.decode("utf-8").split("\r\n")[1:]:
+                if line:
+                    key, val = line.split(": ")
+                    request_headers[key] = val
+
+            original_send(self, *args, **kwargs)
 
     sentry_init(traces_sample_rate=1.0)
+    events = capture_events()
 
     headers = {
         "sentry-trace": "771a43a4192642f0b136d5159a501700-1234567890abcdef-1",
@@ -228,73 +237,76 @@ def test_outgoing_trace_headers(sentry_init, monkeypatch):
         op="greeting.sniff",
         trace_id="12312012123120121231201212312012",
     ) as transaction:
-        HTTPSConnection("www.squirrelchasers.com").request("GET", "/top-chasers")
+        connection = HttpConnectionRecordingRequestHeaders("localhost", port=PORT)
+        connection.request("GET", "/top-chasers")
+        connection.getresponse()
 
-        (request_str,) = mock_send.call_args[0]
-        request_headers = {}
-        for line in request_str.decode("utf-8").split("\r\n")[1:]:
-            if line:
-                key, val = line.split(": ")
-                request_headers[key] = val
+    (event,) = events
+    request_span = event["spans"][-1]
+    expected_sentry_trace = "{trace_id}-{parent_span_id}-{sampled}".format(
+        trace_id=event["contexts"]["trace"]["trace_id"],
+        parent_span_id=request_span["span_id"],
+        sampled=1,
+    )
+    assert request_headers["sentry-trace"] == expected_sentry_trace
 
-        request_span = transaction._span_recorder.spans[-1]
-        expected_sentry_trace = "{trace_id}-{parent_span_id}-{sampled}".format(
-            trace_id=transaction.trace_id,
-            parent_span_id=request_span.span_id,
-            sampled=1,
-        )
-        assert request_headers["sentry-trace"] == expected_sentry_trace
+    expected_outgoing_baggage = (
+        "sentry-trace_id=771a43a4192642f0b136d5159a501700,"
+        "sentry-public_key=49d0f7386ad645858ae85020e393bef3,"
+        "sentry-sample_rate=1.0,"
+        "sentry-user_id=Am%C3%A9lie,"
+        "sentry-sample_rand=0.132521102938283"
+    )
 
-        expected_outgoing_baggage = (
-            "sentry-trace_id=771a43a4192642f0b136d5159a501700,"
-            "sentry-public_key=49d0f7386ad645858ae85020e393bef3,"
-            "sentry-sample_rate=1.0,"
-            "sentry-user_id=Am%C3%A9lie,"
-            "sentry-sample_rand=0.132521102938283"
-        )
-
-        assert request_headers["baggage"] == expected_outgoing_baggage
+    assert request_headers["baggage"] == expected_outgoing_baggage
 
 
-def test_outgoing_trace_headers_head_sdk(sentry_init, monkeypatch):
-    # HTTPSConnection.send is passed a string containing (among other things)
-    # the headers on the request. Mock it so we can check the headers, and also
-    # so it doesn't try to actually talk to the internet.
-    mock_send = mock.Mock()
-    monkeypatch.setattr(HTTPSConnection, "send", mock_send)
+def test_outgoing_trace_headers_head_sdk(sentry_init, capture_events):
+    original_send = HTTPConnection.send
+
+    request_headers = {}
+
+    class HttpConnectionRecordingRequestHeaders(HTTPConnection):
+        def send(self, *args, **kwargs) -> None:
+            request_str = args[0]
+            for line in request_str.decode("utf-8").split("\r\n")[1:]:
+                if line:
+                    key, val = line.split(": ")
+                    request_headers[key] = val
+
+            original_send(self, *args, **kwargs)
 
     sentry_init(traces_sample_rate=0.5, release="foo")
+    events = capture_events()
+
     with mock.patch("sentry_sdk.tracing_utils.Random.randrange", return_value=250000):
         transaction = continue_trace({})
 
     with start_transaction(transaction=transaction, name="Head SDK tx") as transaction:
-        HTTPSConnection("www.squirrelchasers.com").request("GET", "/top-chasers")
+        connection = HttpConnectionRecordingRequestHeaders("localhost", port=PORT)
+        connection.request("GET", "/top-chasers")
+        connection.getresponse()
 
-        (request_str,) = mock_send.call_args[0]
-        request_headers = {}
-        for line in request_str.decode("utf-8").split("\r\n")[1:]:
-            if line:
-                key, val = line.split(": ")
-                request_headers[key] = val
+    (event,) = events
+    request_span = event["spans"][-1]
+    expected_sentry_trace = "{trace_id}-{parent_span_id}-{sampled}".format(
+        trace_id=event["contexts"]["trace"]["trace_id"],
+        parent_span_id=request_span["span_id"],
+        sampled=1,
+    )
 
-        request_span = transaction._span_recorder.spans[-1]
-        expected_sentry_trace = "{trace_id}-{parent_span_id}-{sampled}".format(
-            trace_id=transaction.trace_id,
-            parent_span_id=request_span.span_id,
-            sampled=1,
-        )
-        assert request_headers["sentry-trace"] == expected_sentry_trace
+    assert request_headers["sentry-trace"] == expected_sentry_trace
 
-        expected_outgoing_baggage = (
-            "sentry-trace_id=%s,"
-            "sentry-sample_rand=0.250000,"
-            "sentry-environment=production,"
-            "sentry-release=foo,"
-            "sentry-sample_rate=0.5,"
-            "sentry-sampled=%s"
-        ) % (transaction.trace_id, "true" if transaction.sampled else "false")
+    expected_outgoing_baggage = (
+        "sentry-trace_id=%s,"
+        "sentry-sample_rand=0.250000,"
+        "sentry-environment=production,"
+        "sentry-release=foo,"
+        "sentry-sample_rate=0.5,"
+        "sentry-sampled=%s"
+    ) % (transaction.trace_id, "true" if transaction.sampled else "false")
 
-        assert request_headers["baggage"] == expected_outgoing_baggage
+    assert request_headers["baggage"] == expected_outgoing_baggage
 
 
 @pytest.mark.parametrize(

--- a/tests/integrations/stdlib/test_httplib.py
+++ b/tests/integrations/stdlib/test_httplib.py
@@ -1,4 +1,5 @@
 import os
+import socket
 import datetime
 from http.client import HTTPConnection, HTTPSConnection
 from http.server import BaseHTTPRequestHandler, HTTPServer
@@ -203,11 +204,13 @@ def test_httplib_misuse(sentry_init, capture_events, request):
 
 
 def test_outgoing_trace_headers(sentry_init, capture_events):
-    original_send = HTTPConnection.send
+    sentry_init(traces_sample_rate=1.0)
+
+    already_patched_getresponse = HTTPSConnection.getresponse
 
     request_headers = {}
 
-    class HttpConnectionRecordingRequestHeaders(HTTPConnection):
+    class HTTPSConnectionRecordingRequestHeaders(HTTPSConnection):
         def send(self, *args, **kwargs) -> None:
             request_str = args[0]
             for line in request_str.decode("utf-8").split("\r\n")[1:]:
@@ -215,9 +218,14 @@ def test_outgoing_trace_headers(sentry_init, capture_events):
                     key, val = line.split(": ")
                     request_headers[key] = val
 
-            original_send(self, *args, **kwargs)
+            server_sock, client_sock = socket.socketpair()
+            server_sock.sendall(b"HTTP/1.1 200 OK\r\n\r\n")
+            server_sock.close()
+            self.sock = client_sock
 
-    sentry_init(traces_sample_rate=1.0)
+        def getresponse(self, *args, **kwargs):
+            return already_patched_getresponse(self, *args, **kwargs)
+
     events = capture_events()
 
     headers = {
@@ -237,7 +245,7 @@ def test_outgoing_trace_headers(sentry_init, capture_events):
         op="greeting.sniff",
         trace_id="12312012123120121231201212312012",
     ) as transaction:
-        connection = HttpConnectionRecordingRequestHeaders("localhost", port=PORT)
+        connection = HTTPSConnectionRecordingRequestHeaders("localhost", port=PORT)
         connection.request("GET", "/top-chasers")
         connection.getresponse()
 
@@ -262,11 +270,13 @@ def test_outgoing_trace_headers(sentry_init, capture_events):
 
 
 def test_outgoing_trace_headers_head_sdk(sentry_init, capture_events):
-    original_send = HTTPConnection.send
+    sentry_init(traces_sample_rate=0.5, release="foo")
+
+    already_patched_getresponse = HTTPSConnection.getresponse
 
     request_headers = {}
 
-    class HttpConnectionRecordingRequestHeaders(HTTPConnection):
+    class HTTPSConnectionRecordingRequestHeaders(HTTPSConnection):
         def send(self, *args, **kwargs) -> None:
             request_str = args[0]
             for line in request_str.decode("utf-8").split("\r\n")[1:]:
@@ -274,16 +284,21 @@ def test_outgoing_trace_headers_head_sdk(sentry_init, capture_events):
                     key, val = line.split(": ")
                     request_headers[key] = val
 
-            original_send(self, *args, **kwargs)
+            server_sock, client_sock = socket.socketpair()
+            server_sock.sendall(b"HTTP/1.1 200 OK\r\n\r\n")
+            server_sock.close()
+            self.sock = client_sock
 
-    sentry_init(traces_sample_rate=0.5, release="foo")
+        def getresponse(self, *args, **kwargs):
+            return already_patched_getresponse(self, *args, **kwargs)
+
     events = capture_events()
 
     with mock.patch("sentry_sdk.tracing_utils.Random.randrange", return_value=250000):
         transaction = continue_trace({})
 
     with start_transaction(transaction=transaction, name="Head SDK tx") as transaction:
-        connection = HttpConnectionRecordingRequestHeaders("localhost", port=PORT)
+        connection = HTTPSConnectionRecordingRequestHeaders("localhost", port=PORT)
         connection.request("GET", "/top-chasers")
         connection.getresponse()
 
@@ -369,18 +384,32 @@ def test_outgoing_trace_headers_head_sdk(sentry_init, capture_events):
     ],
 )
 def test_option_trace_propagation_targets(
-    sentry_init, monkeypatch, trace_propagation_targets, host, path, trace_propagated
+    sentry_init, trace_propagation_targets, host, path, trace_propagated
 ):
-    # HTTPSConnection.send is passed a string containing (among other things)
-    # the headers on the request. Mock it so we can check the headers, and also
-    # so it doesn't try to actually talk to the internet.
-    mock_send = mock.Mock()
-    monkeypatch.setattr(HTTPSConnection, "send", mock_send)
-
     sentry_init(
         trace_propagation_targets=trace_propagation_targets,
         traces_sample_rate=1.0,
     )
+
+    already_patched_getresponse = HTTPSConnection.getresponse
+
+    request_headers = {}
+
+    class HTTPSConnectionRecordingRequestHeaders(HTTPSConnection):
+        def send(self, *args, **kwargs) -> None:
+            request_str = args[0]
+            for line in request_str.decode("utf-8").split("\r\n")[1:]:
+                if line:
+                    key, val = line.split(": ")
+                    request_headers[key] = val
+
+            server_sock, client_sock = socket.socketpair()
+            server_sock.sendall(b"HTTP/1.1 200 OK\r\n\r\n")
+            server_sock.close()
+            self.sock = client_sock
+
+        def getresponse(self, *args, **kwargs):
+            return already_patched_getresponse(self, *args, **kwargs)
 
     headers = {
         "baggage": (
@@ -397,21 +426,16 @@ def test_option_trace_propagation_targets(
         op="greeting.sniff",
         trace_id="12312012123120121231201212312012",
     ) as transaction:
-        HTTPSConnection(host).request("GET", path)
+        connection = HTTPSConnectionRecordingRequestHeaders(host)
+        connection.request("GET", path)
+        connection.getresponse()
 
-        (request_str,) = mock_send.call_args[0]
-        request_headers = {}
-        for line in request_str.decode("utf-8").split("\r\n")[1:]:
-            if line:
-                key, val = line.split(": ")
-                request_headers[key] = val
-
-        if trace_propagated:
-            assert "sentry-trace" in request_headers
-            assert "baggage" in request_headers
-        else:
-            assert "sentry-trace" not in request_headers
-            assert "baggage" not in request_headers
+    if trace_propagated:
+        assert "sentry-trace" in request_headers
+        assert "baggage" in request_headers
+    else:
+        assert "sentry-trace" not in request_headers
+        assert "baggage" not in request_headers
 
 
 def test_request_source_disabled(sentry_init, capture_events):


### PR DESCRIPTION
### Description
<!-- What changed and why? -->

Emulate basic HTTP 1.1 response in `HTTPSConnection` subclass instead of inspecting `mock.Mock` arguments.

#### Issues
<!--
* resolves: #1234
* resolves: LIN-1234
-->

#### Reminders
- Please add tests to validate your changes, and lint your code using `tox -e linters`.
- Add GH Issue ID _&_ Linear ID (if applicable)
- PR title should use [conventional commit](https://develop.sentry.dev/engineering-practices/commit-messages/#type) style (`feat:`, `fix:`, `ref:`, `meta:`)
- For external contributors: [CONTRIBUTING.md](https://github.com/getsentry/sentry-python/blob/master/CONTRIBUTING.md), [Sentry SDK development docs](https://develop.sentry.dev/sdk/), [Discord community](https://discord.gg/Ww9hbqr)
