### PR TITLE
fix(monitor): release `Monitor._thread_lock` after fork (#6148)

### DIFF
--- a/sentry_sdk/monitor.py
+++ b/sentry_sdk/monitor.py
@@ -23,6 +23,9 @@ class Monitor:
 
     name = "sentry.monitor"
 
+    _thread: "Optional[Thread]"
+    _thread_for_pid: "Optional[int]"
+
     def __init__(
         self, transport: "sentry_sdk.transport.Transport", interval: float = 10
     ) -> None:
@@ -31,11 +34,24 @@ class Monitor:
 
         self._healthy = True
         self._downsample_factor: int = 0
-
-        self._thread: "Optional[Thread]" = None
-        self._thread_lock = Lock()
-        self._thread_for_pid: "Optional[int]" = None
         self._running = True
+        self._reset_thread_state()
+
+        # See https://github.com/getsentry/sentry-python/issues/6148.
+        # If os.fork() runs while another thread holds self._thread_lock,
+        # the child inherits the lock locked but the holding thread does
+        # not exist in the child, so the lock can never be released and
+        # _ensure_running deadlocks forever. Reinitialise the lock and
+        # cached thread/pid in the child so it starts clean regardless
+        # of inherited state. register_at_fork is POSIX-only; Windows
+        # uses spawn.
+        if hasattr(os, "register_at_fork"):
+            os.register_at_fork(after_in_child=self._reset_thread_state)
+
+    def _reset_thread_state(self) -> None:
+        self._thread = None
+        self._thread_lock = Lock()
+        self._thread_for_pid = None
 
     def _ensure_running(self) -> None:
         """

--- a/sentry_sdk/monitor.py
+++ b/sentry_sdk/monitor.py
@@ -1,5 +1,6 @@
 import os
 import time
+import weakref
 from threading import Thread, Lock
 
 import sentry_sdk
@@ -43,10 +44,19 @@ class Monitor:
         # not exist in the child, so the lock can never be released and
         # _ensure_running deadlocks forever. Reinitialise the lock and
         # cached thread/pid in the child so it starts clean regardless
-        # of inherited state. register_at_fork is POSIX-only; Windows
-        # uses spawn.
+        # of inherited state. We bind via a WeakMethod so the
+        # permanently-registered fork handler does not pin this Monitor
+        # (and its Transport): register_at_fork has no unregister API.
+        # POSIX-only; Windows uses spawn.
         if hasattr(os, "register_at_fork"):
-            os.register_at_fork(after_in_child=self._reset_thread_state)
+            weak_reset = weakref.WeakMethod(self._reset_thread_state)
+
+            def _reset_in_child() -> None:
+                method = weak_reset()
+                if method is not None:
+                    method()
+
+            os.register_at_fork(after_in_child=_reset_in_child)
 
     def _reset_thread_state(self) -> None:
         self._thread = None

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -1,5 +1,9 @@
+import os
+import sys
 from collections import Counter
 from unittest import mock
+
+import pytest
 
 import sentry_sdk
 from sentry_sdk.transport import Transport
@@ -99,3 +103,39 @@ def test_monitor_no_thread_on_shutdown_no_errors(sentry_init):
         assert monitor._thread is None
         monitor.run()
         assert monitor._thread is None
+
+
+@pytest.mark.skipif(
+    sys.platform == "win32"
+    or not hasattr(os, "fork")
+    or not hasattr(os, "register_at_fork"),
+    reason="requires POSIX fork and os.register_at_fork (Python 3.7+)",
+)
+def test_monitor_thread_lock_reset_in_child_after_fork(sentry_init):
+    """Regression test for #6148.
+
+    If os.fork() runs while Monitor._thread_lock is held, the child
+    inherits the lock locked. The holding thread does not exist in the
+    child, so the lock can never be released and _ensure_running
+    deadlocks forever. The after-fork hook must replace the lock with
+    a fresh one in the child.
+    """
+    sentry_init(transport=HealthyTestTransport())
+    monitor = sentry_sdk.get_client().monitor
+    assert monitor is not None
+
+    original_lock = monitor._thread_lock
+    original_lock.acquire()
+    pid = os.fork()
+    if pid == 0:
+        # Child: was the lock object replaced and is the new one not
+        # held? Without the fix, _thread_lock is `original_lock`
+        # inherited locked, so `replaced` is False. blocking=False
+        # guarantees the child can't hang on a regression.
+        replaced = monitor._thread_lock is not original_lock
+        unheld = monitor._thread_lock.acquire(blocking=False)
+        os._exit(0 if replaced and unheld else 1)
+
+    original_lock.release()
+    _, status = os.waitpid(pid, 0)
+    assert os.WIFEXITED(status) and os.WEXITSTATUS(status) == 0


### PR DESCRIPTION
### Description
If `os.fork()` runs while another thread holds `Monitor._thread_lock`, the child process inherits the lock locked. The holding thread does not exist in the child, so the lock can never be released and `_ensure_running` deadlocks forever.

Register an `os.register_at_fork(after_in_child=...)` hook that recreates `_thread_lock` and clears the cached thread / pid in the child, so the new process always starts with a clean monitor state regardless of what the parent was doing at fork time.

Adds a regression test that acquires the lock, forks, and asserts the child sees a fresh, unheld lock.

#### Issues
* resolves: #6148
* resolves: [PY-2390](https://linear.app/getsentry/issue/PY-2390/monitor-thread-lock-leaked-into-forked-children-causing-child)