### PR TITLE
ci: Limit `update-tox` action to master branch

### DIFF
--- a/.github/workflows/update-tox.yml
+++ b/.github/workflows/update-tox.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   update-tox:
     name: Update test matrix
+    if: github.ref == 'refs/heads/master'
     runs-on: ubuntu-latest
     timeout-minutes: 10
 
@@ -59,7 +60,6 @@ jobs:
           BRANCH_NAME: ${{ steps.create-branch.outputs.branch_name }}
           COMMIT_TITLE: ${{ steps.create-branch.outputs.commit_title }}
           DATE: ${{ steps.create-branch.outputs.date }}
-          BASE_BRANCH: ${{ github.ref_name }}
         with:
           script: |
             const branchName = process.env.BRANCH_NAME;
@@ -105,7 +105,7 @@ jobs:
                 repo: context.repo.repo,
                 title: commitTitle + ' (' + date + ')',
                 head: branchName,
-                base: process.env.BASE_BRANCH,
+                base: 'master',
                 body: prBody,
             });
 


### PR DESCRIPTION
### Description
<!-- What changed and why? -->

#### Issues

Closes https://github.com/getsentry/sentry-python/issues/6170

#### Reminders
- Please add tests to validate your changes, and lint your code using `tox -e linters`.
- Add GH Issue ID _&_ Linear ID (if applicable)
- PR title should use [conventional commit](https://develop.sentry.dev/engineering-practices/commit-messages/#type) style (`feat:`, `fix:`, `ref:`, `meta:`)
- For external contributors: [CONTRIBUTING.md](https://github.com/getsentry/sentry-python/blob/master/CONTRIBUTING.md), [Sentry SDK development docs](https://develop.sentry.dev/sdk/), [Discord community](https://discord.gg/Ww9hbqr)
