### PR TITLE
test: Assert presence of profile chunks after shutdown

### DIFF
--- a/tests/profiler/test_continuous_profiler.py
+++ b/tests/profiler/test_continuous_profiler.py
@@ -326,7 +326,6 @@ def test_continuous_profiler_auto_start_and_manual_stop(
         pytest.param(get_client_options(False), id="experiment"),
     ],
 )
-@mock.patch("sentry_sdk.profiler.continuous_profiler.PROFILE_BUFFER_SECONDS", 0.01)
 def test_continuous_profiler_manual_start_and_stop_sampled(
     sentry_init,
     capture_envelopes,
@@ -356,14 +355,14 @@ def test_continuous_profiler_manual_start_and_stop_sampled(
         with sentry_sdk.start_transaction(name="profiling"):
             assert get_profiler_id() is not None, "profiler should be running"
             with sentry_sdk.start_span(op="op"):
-                time.sleep(0.1)
+                pass
             assert get_profiler_id() is not None, "profiler should be running"
-
-        assert_single_transaction_with_profile_chunks(envelopes, thread)
 
         assert get_profiler_id() is not None, "profiler should be running"
 
         stop_profiler_func()
+
+        assert_single_transaction_with_profile_chunks(envelopes, thread)
 
         # the profiler stops immediately in manual mode
         assert get_profiler_id() is None, "profiler should not be running"
@@ -373,7 +372,7 @@ def test_continuous_profiler_manual_start_and_stop_sampled(
         with sentry_sdk.start_transaction(name="profiling"):
             assert get_profiler_id() is None, "profiler should not be running"
             with sentry_sdk.start_span(op="op"):
-                time.sleep(0.1)
+                pass
             assert get_profiler_id() is None, "profiler should not be running"
 
         assert_single_transaction_without_profile_chunks(envelopes)

--- a/tests/profiler/test_continuous_profiler.py
+++ b/tests/profiler/test_continuous_profiler.py
@@ -326,6 +326,7 @@ def test_continuous_profiler_auto_start_and_manual_stop(
         pytest.param(get_client_options(False), id="experiment"),
     ],
 )
+@mock.patch("sentry_sdk.profiler.continuous_profiler.PROFILE_BUFFER_SECONDS", 0.01)
 def test_continuous_profiler_manual_start_and_stop_sampled(
     sentry_init,
     capture_envelopes,
@@ -355,7 +356,7 @@ def test_continuous_profiler_manual_start_and_stop_sampled(
         with sentry_sdk.start_transaction(name="profiling"):
             assert get_profiler_id() is not None, "profiler should be running"
             with sentry_sdk.start_span(op="op"):
-                pass
+                time.sleep(0.1)
             assert get_profiler_id() is not None, "profiler should be running"
 
         assert get_profiler_id() is not None, "profiler should be running"
@@ -372,7 +373,7 @@ def test_continuous_profiler_manual_start_and_stop_sampled(
         with sentry_sdk.start_transaction(name="profiling"):
             assert get_profiler_id() is None, "profiler should not be running"
             with sentry_sdk.start_span(op="op"):
-                pass
+                time.sleep(0.1)
             assert get_profiler_id() is None, "profiler should not be running"
 
         assert_single_transaction_without_profile_chunks(envelopes)


### PR DESCRIPTION
### Description
<!-- What changed and why? -->

Assert telemetry has been collected only **after** the continuous profiler shuts down. This removes the race where profiles had not yet reached the transport by the time the assertions ran.

According to the logs in the following failed run

https://github.com/getsentry/sentry-python/actions/runs/25110581685/job/73583219162

the test fails with the following stack trace:

```
_ test_continuous_profiler_manual_start_and_stop_sampled[non-experiment-start_profile_session/stop_profile_session  (deprecated)-thread] _
tests/profiler/test_continuous_profiler.py:362: in test_continuous_profiler_manual_start_and_stop_sampled
    assert_single_transaction_with_profile_chunks(envelopes, thread)
tests/profiler/test_continuous_profiler.py:147: in assert_single_transaction_with_profile_chunks
    assert len(items["profile_chunk"]) > 0
E   assert 0 > 0
E    +  where 0 = len([])
```

The stack trace shows that profiles were not collected in the test transport by the time the assertion is executed.

#### Issues
<!--
* resolves: #1234
* resolves: LIN-1234
-->

#### Reminders
- Please add tests to validate your changes, and lint your code using `tox -e linters`.
- Add GH Issue ID _&_ Linear ID (if applicable)
- PR title should use [conventional commit](https://develop.sentry.dev/engineering-practices/commit-messages/#type) style (`feat:`, `fix:`, `ref:`, `meta:`)
- For external contributors: [CONTRIBUTING.md](https://github.com/getsentry/sentry-python/blob/master/CONTRIBUTING.md), [Sentry SDK development docs](https://develop.sentry.dev/sdk/), [Discord community](https://discord.gg/Ww9hbqr)
