### PR TITLE
fix: Introduce `_get_current_streamed_span()` to keep types backwards compatible

### DIFF
--- a/sentry_sdk/__init__.py
+++ b/sentry_sdk/__init__.py
@@ -32,6 +32,7 @@ __all__ = [  # noqa
     "get_isolation_scope",
     "get_current_scope",
     "get_current_span",
+    "get_current_streamed_span",
     "get_traceparent",
     "is_initialized",
     "isolation_scope",

--- a/sentry_sdk/__init__.py
+++ b/sentry_sdk/__init__.py
@@ -32,7 +32,6 @@ __all__ = [  # noqa
     "get_isolation_scope",
     "get_current_scope",
     "get_current_span",
-    "get_current_streamed_span",
     "get_traceparent",
     "is_initialized",
     "isolation_scope",

--- a/sentry_sdk/api.py
+++ b/sentry_sdk/api.py
@@ -543,12 +543,7 @@ def update_current_span(
             attributes={"user_id": 123, "batch_size": 50}
         )
     """
-    current_span = get_current_span()
-
-    if current_span is None:
-        return
-
-    if isinstance(current_span, StreamedSpan):
+    if isinstance(get_current_streamed_span(), StreamedSpan):
         warnings.warn(
             "The `update_current_span` API isn't available in streaming mode. "
             "Retrieve the current span with get_current_span() and use its API "
@@ -556,6 +551,11 @@ def update_current_span(
             DeprecationWarning,
             stacklevel=2,
         )
+        return
+
+    current_span = get_current_span()
+
+    if current_span is None:
         return
 
     if op is not None:

--- a/sentry_sdk/api.py
+++ b/sentry_sdk/api.py
@@ -6,7 +6,7 @@ from sentry_sdk import tracing_utils, Client
 from sentry_sdk._init_implementation import init
 from sentry_sdk.consts import INSTRUMENTER
 from sentry_sdk.scope import Scope, _ScopeManager, new_scope, isolation_scope
-from sentry_sdk.traces import StreamedSpan
+from sentry_sdk.traces import StreamedSpan, _get_current_streamed_span
 from sentry_sdk.tracing import NoOpSpan, Transaction, trace
 from sentry_sdk.crons import monitor
 
@@ -67,7 +67,6 @@ __all__ = [
     "get_isolation_scope",
     "get_current_scope",
     "get_current_span",
-    "get_current_streamed_span",
     "get_traceparent",
     "is_initialized",
     "isolation_scope",
@@ -430,15 +429,6 @@ def get_current_span(
     return tracing_utils.get_current_span(scope)
 
 
-def get_current_streamed_span(
-    scope: "Optional[Scope]" = None,
-) -> "Optional[StreamedSpan]":
-    """
-    Returns the currently active streamed span if there is one running, otherwise `None`
-    """
-    return tracing_utils.get_current_streamed_span(scope)
-
-
 def get_traceparent() -> "Optional[str]":
     """
     Returns the traceparent either from the active span or from the scope.
@@ -543,7 +533,7 @@ def update_current_span(
             attributes={"user_id": 123, "batch_size": 50}
         )
     """
-    if isinstance(get_current_streamed_span(), StreamedSpan):
+    if isinstance(_get_current_streamed_span(), StreamedSpan):
         warnings.warn(
             "The `update_current_span` API isn't available in streaming mode. "
             "Retrieve the current span with get_current_span() and use its API "

--- a/sentry_sdk/api.py
+++ b/sentry_sdk/api.py
@@ -67,6 +67,7 @@ __all__ = [
     "get_isolation_scope",
     "get_current_scope",
     "get_current_span",
+    "get_current_streamed_span",
     "get_traceparent",
     "is_initialized",
     "isolation_scope",

--- a/sentry_sdk/api.py
+++ b/sentry_sdk/api.py
@@ -422,11 +422,20 @@ def set_measurement(name: str, value: float, unit: "MeasurementUnit" = "") -> No
 
 def get_current_span(
     scope: "Optional[Scope]" = None,
-) -> "Optional[Union[Span, StreamedSpan]]":
+) -> "Optional[Span]":
     """
     Returns the currently active span if there is one running, otherwise `None`
     """
     return tracing_utils.get_current_span(scope)
+
+
+def get_current_streamed_span(
+    scope: "Optional[Scope]" = None,
+) -> "Optional[StreamedSpan]":
+    """
+    Returns the currently active streamed span if there is one running, otherwise `None`
+    """
+    return tracing_utils.get_current_streamed_span(scope)
 
 
 def get_traceparent() -> "Optional[str]":

--- a/sentry_sdk/integrations/celery/__init__.py
+++ b/sentry_sdk/integrations/celery/__init__.py
@@ -98,13 +98,16 @@ class CeleryIntegration(Integration):
 
 
 def _set_status(status: str) -> None:
+    client = sentry_sdk.get_client()
+    span_streaming = has_span_streaming_enabled(client.options)
+
     with capture_internal_exceptions():
         scope = sentry_sdk.get_current_scope()
-        if scope.span is not None:
-            if isinstance(scope.span, Span):
-                scope.span.set_status(status)
-            else:
-                scope.span.status = "ok" if status == "ok" else "error"
+
+        if span_streaming and scope.streamed_span is not None:
+            scope.streamed_span.status = "ok" if status == "ok" else "error"
+        elif not span_streaming and scope.span is not None:
+            scope.span.set_status(status)
 
 
 def _capture_exception(task: "Any", exc_info: "ExcInfo") -> None:

--- a/sentry_sdk/integrations/celery/__init__.py
+++ b/sentry_sdk/integrations/celery/__init__.py
@@ -15,7 +15,7 @@ from sentry_sdk.integrations.celery.beat import (
 from sentry_sdk.integrations.celery.utils import _now_seconds_since_epoch
 from sentry_sdk.integrations.logging import ignore_logger
 from sentry_sdk.scope import should_send_default_pii
-from sentry_sdk.traces import StreamedSpan
+from sentry_sdk.traces import StreamedSpan, _get_current_streamed_span
 from sentry_sdk.tracing import BAGGAGE_HEADER_NAME, Span, TransactionSource
 from sentry_sdk.tracing_utils import Baggage, has_span_streaming_enabled
 from sentry_sdk.utils import (
@@ -292,10 +292,7 @@ def _wrap_task_run(f: "F") -> "F":
 
         span_mgr: "Union[StreamedSpan, Span, NoOpMgr]" = NoOpMgr()
         if span_streaming:
-            if (
-                not task_started_from_beat
-                and sentry_sdk.get_current_streamed_span() is not None
-            ):
+            if not task_started_from_beat and _get_current_streamed_span() is not None:
                 span_mgr = sentry_sdk.traces.start_span(
                     name=task_name,
                     attributes={
@@ -576,7 +573,7 @@ def _patch_producer_publish() -> None:
 
         span: "Union[StreamedSpan, Span, None]" = None
         if span_streaming:
-            if sentry_sdk.get_current_streamed_span() is not None:
+            if _get_current_streamed_span() is not None:
                 span = sentry_sdk.traces.start_span(
                     name=task_name,
                     attributes={

--- a/sentry_sdk/integrations/celery/__init__.py
+++ b/sentry_sdk/integrations/celery/__init__.py
@@ -292,7 +292,10 @@ def _wrap_task_run(f: "F") -> "F":
 
         span_mgr: "Union[StreamedSpan, Span, NoOpMgr]" = NoOpMgr()
         if span_streaming:
-            if not task_started_from_beat and sentry_sdk.get_current_span() is not None:
+            if (
+                not task_started_from_beat
+                and sentry_sdk.get_current_streamed_span() is not None
+            ):
                 span_mgr = sentry_sdk.traces.start_span(
                     name=task_name,
                     attributes={
@@ -573,7 +576,7 @@ def _patch_producer_publish() -> None:
 
         span: "Union[StreamedSpan, Span, None]" = None
         if span_streaming:
-            if sentry_sdk.get_current_span() is not None:
+            if sentry_sdk.get_current_streamed_span() is not None:
                 span = sentry_sdk.traces.start_span(
                     name=task_name,
                     attributes={

--- a/sentry_sdk/integrations/fastapi.py
+++ b/sentry_sdk/integrations/fastapi.py
@@ -5,7 +5,7 @@ from functools import wraps
 import sentry_sdk
 from sentry_sdk.integrations import DidNotEnable
 from sentry_sdk.scope import should_send_default_pii
-from sentry_sdk.traces import NoOpStreamedSpan
+from sentry_sdk.traces import NoOpStreamedSpan, StreamedSpan
 from sentry_sdk.tracing import SOURCE_FOR_STYLE, TransactionSource
 from sentry_sdk.tracing_utils import has_span_streaming_enabled
 from sentry_sdk.utils import transaction_from_function
@@ -95,7 +95,9 @@ def patch_get_request_handler() -> None:
                 if has_span_streaming_enabled(client.options):
                     current_span = current_scope.streamed_span
 
-                    if not isinstance(current_span, NoOpStreamedSpan):
+                    if isinstance(current_span, StreamedSpan) and not isinstance(
+                        current_span, NoOpStreamedSpan
+                    ):
                         segment = current_span._segment
                         segment._update_active_thread()
 

--- a/sentry_sdk/integrations/fastapi.py
+++ b/sentry_sdk/integrations/fastapi.py
@@ -5,7 +5,7 @@ from functools import wraps
 import sentry_sdk
 from sentry_sdk.integrations import DidNotEnable
 from sentry_sdk.scope import should_send_default_pii
-from sentry_sdk.traces import NoOpStreamedSpan, StreamedSpan
+from sentry_sdk.traces import NoOpStreamedSpan
 from sentry_sdk.tracing import SOURCE_FOR_STYLE, TransactionSource
 from sentry_sdk.tracing_utils import has_span_streaming_enabled
 from sentry_sdk.utils import transaction_from_function
@@ -90,13 +90,15 @@ def patch_get_request_handler() -> None:
             @wraps(old_call)
             def _sentry_call(*args: "Any", **kwargs: "Any") -> "Any":
                 current_scope = sentry_sdk.get_current_scope()
-                current_span = current_scope.span
 
-                if isinstance(current_span, StreamedSpan) and not isinstance(
-                    current_span, NoOpStreamedSpan
-                ):
-                    segment = current_span._segment
-                    segment._update_active_thread()
+                client = sentry_sdk.get_client()
+                if has_span_streaming_enabled(client.options):
+                    current_span = current_scope.streamed_span
+
+                    if not isinstance(current_span, NoOpStreamedSpan):
+                        segment = current_span._segment
+                        segment._update_active_thread()
+
                 elif current_scope.transaction is not None:
                     current_scope.transaction.update_active_thread()
 

--- a/sentry_sdk/integrations/starlette.py
+++ b/sentry_sdk/integrations/starlette.py
@@ -21,7 +21,7 @@ from sentry_sdk.integrations._wsgi_common import (
 )
 from sentry_sdk.integrations.asgi import SentryAsgiMiddleware
 from sentry_sdk.scope import should_send_default_pii
-from sentry_sdk.traces import NoOpStreamedSpan, StreamedSpan
+from sentry_sdk.traces import NoOpStreamedSpan, StreamedSpan, _get_current_streamed_span
 from sentry_sdk.tracing import (
     SOURCE_FOR_STYLE,
     TransactionSource,
@@ -254,7 +254,7 @@ def _serialize_request_body_data(data: "Any") -> str:
 def _set_request_body_data_on_streaming_segment(
     info: "Optional[Dict[str, Any]]",
 ) -> None:
-    current_span = sentry_sdk.get_current_streamed_span()
+    current_span = _get_current_streamed_span()
     if (
         info
         and "data" in info

--- a/sentry_sdk/integrations/starlette.py
+++ b/sentry_sdk/integrations/starlette.py
@@ -545,19 +545,22 @@ def patch_request_response() -> None:
 
             @functools.wraps(old_func)
             def _sentry_sync_func(*args: "Any", **kwargs: "Any") -> "Any":
-                integration = sentry_sdk.get_client().get_integration(
-                    StarletteIntegration
-                )
+                client = sentry_sdk.get_client()
+
+                integration = client.get_integration(StarletteIntegration)
                 if integration is None:
                     return old_func(*args, **kwargs)
 
                 current_scope = sentry_sdk.get_current_scope()
-                current_span = current_scope.span
 
-                if isinstance(current_span, StreamedSpan) and not isinstance(
-                    current_span, NoOpStreamedSpan
-                ):
-                    current_span._segment._update_active_thread()
+                span_streaming = has_span_streaming_enabled(client.options)
+                if span_streaming:
+                    current_span = current_scope.streamed_span
+
+                    if isinstance(current_span, StreamedSpan) and not isinstance(
+                        current_span, NoOpStreamedSpan
+                    ):
+                        current_span._segment._update_active_thread()
                 elif current_scope.transaction is not None:
                     current_scope.transaction.update_active_thread()
 

--- a/sentry_sdk/integrations/starlette.py
+++ b/sentry_sdk/integrations/starlette.py
@@ -254,7 +254,7 @@ def _serialize_request_body_data(data: "Any") -> str:
 def _set_request_body_data_on_streaming_segment(
     info: "Optional[Dict[str, Any]]",
 ) -> None:
-    current_span = sentry_sdk.get_current_span()
+    current_span = sentry_sdk.get_current_streamed_span()
     if (
         info
         and "data" in info

--- a/sentry_sdk/scope.py
+++ b/sentry_sdk/scope.py
@@ -1278,7 +1278,7 @@ class Scope:
         if parent_span is _DEFAULT_PARENT_SPAN or isinstance(
             parent_span, NoOpStreamedSpan
         ):
-            parent_span = self.streamed_span  # type: ignore
+            parent_span = self.streamed_span
 
         # If no eligible parent_span was provided and there is no currently
         # active span, this is a segment

--- a/sentry_sdk/scope.py
+++ b/sentry_sdk/scope.py
@@ -877,8 +877,13 @@ class Scope:
             session.update(user=value)
 
     @property
-    def span(self) -> "Optional[Union[Span, StreamedSpan]]":
+    def span(self) -> "Optional[Span]":
         """Get/set current tracing span or transaction."""
+        return self._span
+
+    @property
+    def streamed_span(self) -> "Optional[StreamedSpan]":
+        """Get/set current tracing span."""
         return self._span
 
     @span.setter

--- a/sentry_sdk/scope.py
+++ b/sentry_sdk/scope.py
@@ -580,13 +580,19 @@ class Scope:
         """
         client = self.get_client()
 
+        if not has_tracing_enabled(client.options):
+            return self.get_active_propagation_context().to_traceparent()
+
+        span_streaming = has_span_streaming_enabled(client.options)
         # If we have an active span, return traceparent from there
         if (
-            has_tracing_enabled(client.options)
+            span_streaming
             and self.streamed_span is not None
-            and not isinstance(self.span, NoOpStreamedSpan)
+            and not isinstance(self.streamed_span, NoOpStreamedSpan)
         ):
             return self.streamed_span._to_traceparent()
+        elif not span_streaming and self.span is not None:
+            return self.span._to_traceparent()
 
         # else return traceparent from the propagation context
         return self.get_active_propagation_context().to_traceparent()
@@ -598,13 +604,19 @@ class Scope:
         """
         client = self.get_client()
 
+        if not has_tracing_enabled(client.options):
+            return self.get_active_propagation_context().get_baggage()
+
+        span_streaming = has_span_streaming_enabled(client.options)
         # If we have an active span, return baggage from there
         if (
-            has_tracing_enabled(client.options)
+            span_streaming
             and self.streamed_span is not None
-            and not isinstance(self.span, NoOpStreamedSpan)
+            and not isinstance(self.streamed_span, NoOpStreamedSpan)
         ):
             return self.streamed_span._to_baggage()
+        elif not span_streaming and self.span is not None:
+            return self.span._to_baggage()
 
         # else return baggage from the propagation context
         return self.get_active_propagation_context().get_baggage()

--- a/sentry_sdk/scope.py
+++ b/sentry_sdk/scope.py
@@ -680,7 +680,9 @@ class Scope:
             return
 
         span = kwargs.pop("span", None)
-        span = span or self.span
+        if not span:
+            span_streaming = has_span_streaming_enabled(client.options)
+            span = self.streamed_span if span_streaming else self.span
 
         if (
             has_tracing_enabled(client.options)

--- a/sentry_sdk/scope.py
+++ b/sentry_sdk/scope.py
@@ -583,10 +583,10 @@ class Scope:
         # If we have an active span, return traceparent from there
         if (
             has_tracing_enabled(client.options)
-            and self.span is not None
+            and self.streamed_span is not None
             and not isinstance(self.span, NoOpStreamedSpan)
         ):
-            return self.span._to_traceparent()
+            return self.streamed_span._to_traceparent()
 
         # else return traceparent from the propagation context
         return self.get_active_propagation_context().to_traceparent()
@@ -601,10 +601,10 @@ class Scope:
         # If we have an active span, return baggage from there
         if (
             has_tracing_enabled(client.options)
-            and self.span is not None
+            and self.streamed_span is not None
             and not isinstance(self.span, NoOpStreamedSpan)
         ):
-            return self.span._to_baggage()
+            return self.streamed_span._to_baggage()
 
         # else return baggage from the propagation context
         return self.get_active_propagation_context().get_baggage()

--- a/sentry_sdk/scope.py
+++ b/sentry_sdk/scope.py
@@ -1278,7 +1278,7 @@ class Scope:
         if parent_span is _DEFAULT_PARENT_SPAN or isinstance(
             parent_span, NoOpStreamedSpan
         ):
-            parent_span = self.span  # type: ignore
+            parent_span = self.streamed_span  # type: ignore
 
         # If no eligible parent_span was provided and there is no currently
         # active span, this is a segment

--- a/sentry_sdk/scope.py
+++ b/sentry_sdk/scope.py
@@ -879,15 +879,10 @@ class Scope:
     @property
     def span(self) -> "Optional[Span]":
         """Get/set current tracing span or transaction."""
-        return self._span
-
-    @property
-    def streamed_span(self) -> "Optional[StreamedSpan]":
-        """Get/set current tracing span."""
-        return self._span
+        return self._span if isinstance(self._span, Span) else None
 
     @span.setter
-    def span(self, span: "Optional[Union[Span, StreamedSpan]]") -> None:
+    def span(self, span: "Optional[Span]") -> None:
         self._span = span
         # XXX: this differs from the implementation in JS, there Scope.setSpan
         # does not set Scope._transactionName.
@@ -897,6 +892,15 @@ class Scope:
                 self._transaction = transaction.name
                 if transaction.source:
                     self._transaction_info["source"] = transaction.source
+
+    @property
+    def streamed_span(self) -> "Optional[StreamedSpan]":
+        """Get/set current tracing span."""
+        return self._span if isinstance(self._span, StreamedSpan) else None
+
+    @streamed_span.setter
+    def streamed_span(self, span: "Optional[StreamedSpan]") -> None:
+        self._span = span
 
         # Also set _transaction and _transaction_info in streaming mode as this
         # is used for populating events and linking them to segments

--- a/sentry_sdk/traces.py
+++ b/sentry_sdk/traces.py
@@ -761,7 +761,10 @@ def _get_current_streamed_span(
     scope: "Optional[sentry_sdk.Scope]" = None,
 ) -> "Optional[StreamedSpan]":
     """
-    Returns the currently active span if there is one running, otherwise `None`
+    Returns the currently active span on the scope if the span is a `StreamedSpan`, otherwise `None`.
+
+    This function will only return a non-`None` value when the streaming trace lifecycle is enabled.
+    To enable the lifecycle, pass `_experiments={"trace_lifecycle": "stream"}` to `sentry.init()`.
     """
     scope = scope or sentry_sdk.get_current_scope()
     current_span = scope.streamed_span

--- a/sentry_sdk/traces.py
+++ b/sentry_sdk/traces.py
@@ -755,3 +755,14 @@ def trace(
         return decorator(func)
     else:
         return decorator
+
+
+def _get_current_streamed_span(
+    scope: "Optional[sentry_sdk.Scope]" = None,
+) -> "Optional[StreamedSpan]":
+    """
+    Returns the currently active span if there is one running, otherwise `None`
+    """
+    scope = scope or sentry_sdk.get_current_scope()
+    current_span = scope.streamed_span
+    return current_span

--- a/sentry_sdk/traces.py
+++ b/sentry_sdk/traces.py
@@ -341,8 +341,8 @@ class StreamedSpan:
 
     def _start(self) -> None:
         if self._active:
-            old_span = self._scope.span
-            self._scope.span = self
+            old_span = self._scope.streamed_span
+            self._scope.streamed_span = self
             self._previous_span_on_scope = old_span
 
     def _end(self, end_timestamp: "Optional[Union[float, datetime]]" = None) -> None:
@@ -360,7 +360,7 @@ class StreamedSpan:
             with capture_internal_exceptions():
                 old_span = self._previous_span_on_scope
                 del self._previous_span_on_scope
-                self._scope.span = old_span
+                self._scope.streamed_span = old_span
 
         # Set attributes from the segment. These are set on span end on purpose
         # so that we have the best chance to capture the segment's final name
@@ -586,8 +586,8 @@ class NoOpStreamedSpan(StreamedSpan):
         if self._scope is None:
             return
 
-        old_span = self._scope.span
-        self._scope.span = self
+        old_span = self._scope.streamed_span
+        self._scope.streamed_span = self
         self._previous_span_on_scope = old_span
 
     def _end(self, end_timestamp: "Optional[Union[float, datetime]]" = None) -> None:
@@ -610,7 +610,7 @@ class NoOpStreamedSpan(StreamedSpan):
             with capture_internal_exceptions():
                 old_span = self._previous_span_on_scope
                 del self._previous_span_on_scope
-                self._scope.span = old_span
+                self._scope.streamed_span = old_span
 
         self._finished = True
 

--- a/sentry_sdk/tracing_utils.py
+++ b/sentry_sdk/tracing_utils.py
@@ -35,6 +35,7 @@ from sentry_sdk.utils import (
     _module_in_list,
 )
 from sentry_sdk.tracing import Span as LegacySpan
+from sentry_sdk.traces import _get_current_streamed_span
 
 from typing import TYPE_CHECKING
 
@@ -1203,17 +1204,6 @@ def get_current_span(
     return current_span
 
 
-def get_current_streamed_span(
-    scope: "Optional[sentry_sdk.Scope]" = None,
-) -> "Optional[StreamedSpan]":
-    """
-    Returns the currently active span if there is one running, otherwise `None`
-    """
-    scope = scope or sentry_sdk.get_current_scope()
-    current_span = scope.streamed_span
-    return current_span
-
-
 def set_span_errored(span: "Optional[Union[Span, StreamedSpan]]" = None) -> None:
     """
     Set the status of the current or given span to INTERNAL_ERROR.
@@ -1221,7 +1211,14 @@ def set_span_errored(span: "Optional[Union[Span, StreamedSpan]]" = None) -> None
     """
     from sentry_sdk.traces import StreamedSpan, SpanStatus
 
-    span = span or get_current_span()
+    client = sentry_sdk.get_client()
+
+    if not span:
+        span = (
+            _get_current_streamed_span()
+            if has_span_streaming_enabled(client.options)
+            else sentry_sdk.get_current_span()
+        )
 
     if span is not None:
         if isinstance(span, Span):

--- a/sentry_sdk/tracing_utils.py
+++ b/sentry_sdk/tracing_utils.py
@@ -35,7 +35,6 @@ from sentry_sdk.utils import (
     _module_in_list,
 )
 from sentry_sdk.tracing import Span as LegacySpan
-from sentry_sdk.traces import _get_current_streamed_span
 
 from typing import TYPE_CHECKING
 
@@ -1209,7 +1208,7 @@ def set_span_errored(span: "Optional[Union[Span, StreamedSpan]]" = None) -> None
     Set the status of the current or given span to INTERNAL_ERROR.
     Also sets the status of the transaction (root span) to INTERNAL_ERROR.
     """
-    from sentry_sdk.traces import StreamedSpan, SpanStatus
+    from sentry_sdk.traces import StreamedSpan, SpanStatus, _get_current_streamed_span
 
     client = sentry_sdk.get_client()
 

--- a/sentry_sdk/tracing_utils.py
+++ b/sentry_sdk/tracing_utils.py
@@ -1194,12 +1194,23 @@ def create_streaming_span_decorator(
 
 def get_current_span(
     scope: "Optional[sentry_sdk.Scope]" = None,
-) -> "Optional[Union[Span, StreamedSpan]]":
+) -> "Optional[Span]":
     """
     Returns the currently active span if there is one running, otherwise `None`
     """
     scope = scope or sentry_sdk.get_current_scope()
     current_span = scope.span
+    return current_span
+
+
+def get_current_streamed_span(
+    scope: "Optional[sentry_sdk.Scope]" = None,
+) -> "Optional[StreamedSpan]":
+    """
+    Returns the currently active span if there is one running, otherwise `None`
+    """
+    scope = scope or sentry_sdk.get_current_scope()
+    current_span = scope.streamed_span
     return current_span
 
 

--- a/tests/integrations/celery/test_celery.py
+++ b/tests/integrations/celery/test_celery.py
@@ -7,7 +7,8 @@ from celery import Celery, VERSION
 from celery.bin import worker
 
 import sentry_sdk
-from sentry_sdk import start_transaction, get_current_span, get_current_streamed_span
+from sentry_sdk import start_transaction, get_current_span
+from sentry_sdk.traces import _get_current_streamed_span
 from sentry_sdk.integrations.celery import (
     CeleryIntegration,
     _wrap_task_run,
@@ -664,7 +665,7 @@ def test_sentry_propagate_traces_override(span_streaming, init_celery):
     @celery.task(name="dummy_task", bind=True)
     def dummy_task(self, message):
         trace_id = (
-            get_current_streamed_span().trace_id
+            _get_current_streamed_span().trace_id
             if span_streaming
             else get_current_span().trace_id
         )

--- a/tests/integrations/celery/test_celery.py
+++ b/tests/integrations/celery/test_celery.py
@@ -7,7 +7,7 @@ from celery import Celery, VERSION
 from celery.bin import worker
 
 import sentry_sdk
-from sentry_sdk import start_transaction, get_current_span
+from sentry_sdk import start_transaction, get_current_span, get_current_streamed_span
 from sentry_sdk.integrations.celery import (
     CeleryIntegration,
     _wrap_task_run,
@@ -663,7 +663,11 @@ def test_sentry_propagate_traces_override(span_streaming, init_celery):
 
     @celery.task(name="dummy_task", bind=True)
     def dummy_task(self, message):
-        trace_id = get_current_span().trace_id
+        trace_id = (
+            get_current_streamed_span().trace_id
+            if span_streaming
+            else get_current_span().trace_id
+        )
         return trace_id
 
     if span_streaming:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -21,6 +21,8 @@ from sentry_sdk import (
     get_isolation_scope,
 )
 
+from sentry_sdk.tracing import Span
+
 from sentry_sdk.client import Client, NonRecordingClient
 from tests.conftest import TestTransportWithOptions
 
@@ -40,7 +42,7 @@ def test_get_current_span_default_hub(sentry_init):
     assert get_current_span() is None
 
     scope = get_current_scope()
-    fake_span = mock.MagicMock()
+    fake_span = Span()
     scope.span = fake_span
 
     assert get_current_span() == fake_span


### PR DESCRIPTION
…atible

### Description
<!-- What changed and why? -->

Create streaming-lifecycle variants of the `tracing_utils.get_current_span()` function and the `Scope.span` property. The existing functions are narrowed to be backwards compatible for users of the transaction-based span lifecycle, allowing users to upgrade their SDK version without their type checkers raising errors.

Note that this breaks all current uses of these functions when the streaming lifecycle option is enabled (which is experimental). All call sites internal to the SDK are updated.

The `Scope.span` property returns `None` if a `StreamedSpan` is held, and `Scope.streamed_span` returns `None` if a `Span` is held on the scope.

#### Issues

Closes https://github.com/getsentry/sentry-python/issues/6166

#### Reminders
- Please add tests to validate your changes, and lint your code using `tox -e linters`.
- Add GH Issue ID _&_ Linear ID (if applicable)
- PR title should use [conventional commit](https://develop.sentry.dev/engineering-practices/commit-messages/#type) style (`feat:`, `fix:`, `ref:`, `meta:`)
- For external contributors: [CONTRIBUTING.md](https://github.com/getsentry/sentry-python/blob/master/CONTRIBUTING.md), [Sentry SDK development docs](https://develop.sentry.dev/sdk/), [Discord community](https://discord.gg/Ww9hbqr)
