### PR TITLE
fix: remove universal bdist_wheel option from setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -113,5 +113,4 @@ setup(
         "Programming Language :: Python :: 3.14",
         "Topic :: Software Development :: Libraries :: Python Modules",
     ],
-    options={"bdist_wheel": {"universal": "1"}},
 )


### PR DESCRIPTION
Removes the deprecated  bdist_wheel option from setup.py.

Fixes #6121

The  option for bdist_wheel is no longer needed since the package dropped Python 2 support. This option caused setuptools to produce a universal wheel which is inappropriate for a Python 3-only package.