### PR TITLE
fix(stdlib): Instrument response body read for chunked HTTP responses

### DIFF
--- a/sentry_sdk/integrations/stdlib.py
+++ b/sentry_sdk/integrations/stdlib.py
@@ -197,6 +197,9 @@ def _install_httplib() -> None:
             span.set_http_status(int(rv.status))
             span.set_data("reason", rv.reason)
 
+        # getresponse doesn't include actually reading the response body. This
+        # is done in read(). So if the metadata/headers suggest there's a body to
+        # read, don't finish the span just yet, but save it for ending it later.
         has_body = rv.chunked or (rv.length is not None and rv.length > 0)
         if has_body:
             rv._sentrysdk_span = span  # type: ignore[attr-defined]
@@ -215,11 +218,16 @@ def _install_httplib() -> None:
             rv = real_read(self, *args, **kwargs)
             return rv
         finally:
+            # read() might be called multiple times to consume a single body,
+            # so we can't just end the span when read() is done. Instead,
+            # try to figure out whether the response body has been fully read.
             if self.fp is None or self.closed or not rv:
                 self._sentrysdk_span = None  # type: ignore[attr-defined]
                 _finish_span(span)
 
     def close(self: "HTTPResponse") -> None:
+        # We patch close() as a best effort fallback in case the span is not
+        # ended yet in getresponse() or read().
         span = getattr(self, "_sentrysdk_span", None)
 
         try:

--- a/sentry_sdk/integrations/stdlib.py
+++ b/sentry_sdk/integrations/stdlib.py
@@ -209,18 +209,14 @@ def _install_httplib() -> None:
         return rv
 
     def read(self: "HTTPResponse", *args: "Any", **kwargs: "Any") -> "Any":
-        span = getattr(self, "_sentrysdk_span", None)
-
-        if span is None:
-            return real_read(self, *args, **kwargs)
-
         try:
             return real_read(self, *args, **kwargs)
         finally:
+            span = getattr(self, "_sentrysdk_span", None)
             # read() might be called multiple times to consume a single body,
             # so we can't just end the span when read() is done. Instead,
             # try to figure out whether the response body has been fully read.
-            if self.fp is None or self.closed:
+            if span and self.fp is None or self.closed:
                 self._sentrysdk_span = None  # type: ignore[attr-defined]
                 _complete_span(span)
 

--- a/sentry_sdk/integrations/stdlib.py
+++ b/sentry_sdk/integrations/stdlib.py
@@ -214,6 +214,7 @@ def _install_httplib() -> None:
         if span is None:
             return real_read(self, *args, **kwargs)
 
+        rv = None
         try:
             rv = real_read(self, *args, **kwargs)
             return rv

--- a/sentry_sdk/integrations/stdlib.py
+++ b/sentry_sdk/integrations/stdlib.py
@@ -214,15 +214,13 @@ def _install_httplib() -> None:
         if span is None:
             return real_read(self, *args, **kwargs)
 
-        rv = None
         try:
-            rv = real_read(self, *args, **kwargs)
-            return rv
+            return real_read(self, *args, **kwargs)
         finally:
             # read() might be called multiple times to consume a single body,
             # so we can't just end the span when read() is done. Instead,
             # try to figure out whether the response body has been fully read.
-            if self.fp is None or self.closed or not rv:
+            if self.fp is None or self.closed:
                 self._sentrysdk_span = None  # type: ignore[attr-defined]
                 _finish_span(span)
 

--- a/sentry_sdk/integrations/stdlib.py
+++ b/sentry_sdk/integrations/stdlib.py
@@ -66,7 +66,7 @@ class StdlibIntegration(Integration):
             return event
 
 
-def _finish_span(span: "Union[Span, StreamedSpan]") -> None:
+def _complete_span(span: "Union[Span, StreamedSpan]") -> None:
     if isinstance(span, StreamedSpan):
         with capture_internal_exceptions():
             add_http_request_source(span)
@@ -186,7 +186,7 @@ def _install_httplib() -> None:
         try:
             rv = real_getresponse(self, *args, **kwargs)
         except BaseException:
-            _finish_span(span)
+            _complete_span(span)
             raise
 
         if isinstance(span, StreamedSpan):
@@ -204,7 +204,7 @@ def _install_httplib() -> None:
         if has_body:
             rv._sentrysdk_span = span  # type: ignore[attr-defined]
         else:
-            _finish_span(span)
+            _complete_span(span)
 
         return rv
 
@@ -222,7 +222,7 @@ def _install_httplib() -> None:
             # try to figure out whether the response body has been fully read.
             if self.fp is None or self.closed:
                 self._sentrysdk_span = None  # type: ignore[attr-defined]
-                _finish_span(span)
+                _complete_span(span)
 
     def close(self: "HTTPResponse") -> None:
         # We patch close() as a best effort fallback in case the span is not
@@ -234,7 +234,7 @@ def _install_httplib() -> None:
         finally:
             if span is not None:
                 self._sentrysdk_span = None  # type: ignore[attr-defined]
-                _finish_span(span)
+                _complete_span(span)
 
     HTTPConnection.putrequest = putrequest  # type: ignore[method-assign]
     HTTPConnection.getresponse = getresponse  # type: ignore[method-assign]

--- a/sentry_sdk/integrations/stdlib.py
+++ b/sentry_sdk/integrations/stdlib.py
@@ -216,14 +216,14 @@ def _install_httplib() -> None:
             # read() might be called multiple times to consume a single body,
             # so we can't just end the span when read() is done. Instead,
             # try to figure out whether the response body has been fully read.
-            if span and self.fp is None or self.closed:
+            if span and (self.fp is None or self.closed):
                 self._sentrysdk_span = None  # type: ignore[attr-defined]
                 _complete_span(span)
 
     def close(self: "HTTPResponse") -> None:
         # We patch close() as a best effort fallback in case the span is not
         # ended yet in getresponse() or read().
-    
+
         try:
             real_close(self)
         finally:

--- a/sentry_sdk/integrations/stdlib.py
+++ b/sentry_sdk/integrations/stdlib.py
@@ -227,11 +227,11 @@ def _install_httplib() -> None:
     def close(self: "HTTPResponse") -> None:
         # We patch close() as a best effort fallback in case the span is not
         # ended yet in getresponse() or read().
-        span = getattr(self, "_sentrysdk_span", None)
-
+    
         try:
             real_close(self)
         finally:
+            span = getattr(self, "_sentrysdk_span", None)
             if span is not None:
                 self._sentrysdk_span = None  # type: ignore[attr-defined]
                 _complete_span(span)

--- a/sentry_sdk/integrations/stdlib.py
+++ b/sentry_sdk/integrations/stdlib.py
@@ -241,7 +241,7 @@ def _install_httplib() -> None:
     HTTPConnection.putrequest = putrequest  # type: ignore[method-assign]
     HTTPConnection.getresponse = getresponse  # type: ignore[method-assign]
     HTTPResponse.read = read  # type: ignore[method-assign]
-    HTTPResponse.close = close  # type: ignore[method-assign]
+    HTTPResponse.close = close  # type: ignore[assignment,method-assign]
 
 
 def _init_argument(

--- a/sentry_sdk/integrations/stdlib.py
+++ b/sentry_sdk/integrations/stdlib.py
@@ -2,7 +2,7 @@ import os
 import subprocess
 import sys
 import platform
-from http.client import HTTPConnection
+from http.client import HTTPConnection, HTTPResponse
 
 import sentry_sdk
 from sentry_sdk.consts import OP, SPANDATA
@@ -66,9 +66,22 @@ class StdlibIntegration(Integration):
             return event
 
 
+def _finish_span(span: "Union[Span, StreamedSpan]") -> None:
+    if isinstance(span, StreamedSpan):
+        with capture_internal_exceptions():
+            add_http_request_source(span)
+        span.end()
+    else:
+        span.finish()
+        with capture_internal_exceptions():
+            add_http_request_source(span)
+
+
 def _install_httplib() -> None:
     real_putrequest = HTTPConnection.putrequest
     real_getresponse = HTTPConnection.getresponse
+    real_read = HTTPResponse.read
+    real_close = HTTPResponse.close
 
     def putrequest(
         self: "HTTPConnection", method: str, url: str, *args: "Any", **kwargs: "Any"
@@ -172,29 +185,54 @@ def _install_httplib() -> None:
 
         try:
             rv = real_getresponse(self, *args, **kwargs)
+        except BaseException:
+            _finish_span(span)
+            raise
 
-            if isinstance(span, StreamedSpan):
-                status_code = int(rv.status)
-                span.status = "error" if status_code >= 400 else "ok"
-                span.set_attribute("http.response.status_code", status_code)
-            else:
-                span.set_http_status(int(rv.status))
-                span.set_data("reason", rv.reason)
-        finally:
-            if isinstance(span, StreamedSpan):
-                with capture_internal_exceptions():
-                    add_http_request_source(span)
-                span.end()
-            else:
-                span.finish()
+        if isinstance(span, StreamedSpan):
+            status_code = int(rv.status)
+            span.status = "error" if status_code >= 400 else "ok"
+            span.set_attribute("http.response.status_code", status_code)
+        else:
+            span.set_http_status(int(rv.status))
+            span.set_data("reason", rv.reason)
 
-                with capture_internal_exceptions():
-                    add_http_request_source(span)
+        has_body = rv.chunked or (rv.length is not None and rv.length > 0)
+        if has_body:
+            rv._sentrysdk_span = span  # type: ignore[attr-defined]
+        else:
+            _finish_span(span)
 
         return rv
 
+    def read(self: "HTTPResponse", *args: "Any", **kwargs: "Any") -> "Any":
+        span = getattr(self, "_sentrysdk_span", None)
+
+        if span is None:
+            return real_read(self, *args, **kwargs)
+
+        try:
+            rv = real_read(self, *args, **kwargs)
+            return rv
+        finally:
+            if self.fp is None or self.closed or not rv:
+                self._sentrysdk_span = None  # type: ignore[attr-defined]
+                _finish_span(span)
+
+    def close(self: "HTTPResponse") -> None:
+        span = getattr(self, "_sentrysdk_span", None)
+
+        try:
+            real_close(self)
+        finally:
+            if span is not None:
+                self._sentrysdk_span = None  # type: ignore[attr-defined]
+                _finish_span(span)
+
     HTTPConnection.putrequest = putrequest  # type: ignore[method-assign]
     HTTPConnection.getresponse = getresponse  # type: ignore[method-assign]
+    HTTPResponse.read = read  # type: ignore[method-assign]
+    HTTPResponse.close = close  # type: ignore[method-assign]
 
 
 def _init_argument(

--- a/tests/integrations/stdlib/test_httplib.py
+++ b/tests/integrations/stdlib/test_httplib.py
@@ -1,6 +1,7 @@
 import os
 import socket
 import datetime
+import time
 from http.client import HTTPConnection, HTTPSConnection
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from socket import SocketIO
@@ -1161,3 +1162,86 @@ def test_proxy_http_tunnel(
         assert span["data"][SPANDATA.HTTP_METHOD] == "GET"
         assert span["data"][SPANDATA.NETWORK_PEER_ADDRESS] == "localhost"
         assert span["data"][SPANDATA.NETWORK_PEER_PORT] == PROXY_PORT
+
+
+CHUNK_DELAY = 0.1
+NUM_CHUNKS = 3
+
+
+class ChunkedResponseHandler(BaseHTTPRequestHandler):
+    def do_GET(self):
+        self.send_response(200)
+        self.send_header("Transfer-Encoding", "chunked")
+        self.end_headers()
+        for _ in range(NUM_CHUNKS):
+            chunk = b"x" * 100
+            self.wfile.write(f"{len(chunk):x}\r\n".encode() + chunk + b"\r\n")
+            self.wfile.flush()
+            time.sleep(CHUNK_DELAY)
+        self.wfile.write(b"0\r\n\r\n")
+
+    def log_message(self, *args):
+        pass
+
+
+def create_chunked_server():
+    port = get_free_port()
+    server = HTTPServer(("localhost", port), ChunkedResponseHandler)
+    thread = Thread(target=server.serve_forever)
+    thread.daemon = True
+    thread.start()
+    return port
+
+
+CHUNKED_PORT = create_chunked_server()
+
+
+@pytest.mark.parametrize("span_streaming", [True, False])
+def test_chunked_response_span_covers_body_read(
+    sentry_init,
+    capture_events,
+    capture_items,
+    span_streaming,
+):
+    sentry_init(
+        traces_sample_rate=1.0,
+        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+    )
+
+    min_expected_duration = CHUNK_DELAY * NUM_CHUNKS
+
+    if span_streaming:
+        items = capture_items("span")
+
+        with sentry_sdk.traces.start_span(name="custom parent"):
+            conn = HTTPConnection("localhost", CHUNKED_PORT)
+            conn.request("GET", "/chunked")
+            response = conn.getresponse()
+            response.read()
+
+        sentry_sdk.flush()
+        spans = [item.payload for item in items if item.type == "span"]
+        (span,) = (
+            span
+            for span in spans
+            if span["attributes"].get("sentry.origin") == "auto.http.stdlib.httplib"
+        )
+
+        duration = span["end_timestamp"] - span["start_timestamp"]
+        assert duration >= min_expected_duration
+    else:
+        events = capture_events()
+
+        with start_transaction(name="test_chunked"):
+            conn = HTTPConnection("localhost", CHUNKED_PORT)
+            conn.request("GET", "/chunked")
+            response = conn.getresponse()
+            response.read()
+
+        (event,) = events
+        (span,) = event["spans"]
+
+        start = datetime.datetime.fromisoformat(span["start_timestamp"])
+        end = datetime.datetime.fromisoformat(span["timestamp"])
+        duration = (end - start).total_seconds()
+        assert duration >= min_expected_duration

--- a/tests/integrations/stdlib/test_httplib.py
+++ b/tests/integrations/stdlib/test_httplib.py
@@ -1241,9 +1241,8 @@ def test_chunked_response_span_covers_body_read(
         (event,) = events
         (span,) = event["spans"]
 
-        start = datetime.datetime.fromisoformat(
-            span["start_timestamp"].replace("Z", "+00:00")
-        )
-        end = datetime.datetime.fromisoformat(span["timestamp"].replace("Z", "+00:00"))
+        fmt = "%Y-%m-%dT%H:%M:%S.%fZ"
+        start = datetime.datetime.strptime(span["start_timestamp"], fmt)
+        end = datetime.datetime.strptime(span["timestamp"], fmt)
         duration = (end - start).total_seconds()
         assert duration >= min_expected_duration

--- a/tests/integrations/stdlib/test_httplib.py
+++ b/tests/integrations/stdlib/test_httplib.py
@@ -1219,14 +1219,9 @@ def test_chunked_response_span_covers_body_read(
             response.read()
 
         sentry_sdk.flush()
-        spans = [item.payload for item in items if item.type == "span"]
-        (span,) = (
-            span
-            for span in spans
-            if span["attributes"].get("sentry.origin") == "auto.http.stdlib.httplib"
-        )
+        http_span, parent_span = [item.payload for item in items]
 
-        duration = span["end_timestamp"] - span["start_timestamp"]
+        duration = http_span["end_timestamp"] - http_span["start_timestamp"]
         assert duration >= min_expected_duration
     else:
         events = capture_events()

--- a/tests/integrations/stdlib/test_httplib.py
+++ b/tests/integrations/stdlib/test_httplib.py
@@ -45,6 +45,37 @@ def create_mock_proxy_server():
 
 PROXY_PORT = create_mock_proxy_server()
 
+CHUNK_DELAY = 0.1
+NUM_CHUNKS = 3
+
+
+class ChunkedResponseHandler(BaseHTTPRequestHandler):
+    def do_GET(self):
+        self.send_response(200)
+        self.send_header("Transfer-Encoding", "chunked")
+        self.end_headers()
+        for _ in range(NUM_CHUNKS):
+            chunk = b"x" * 100
+            self.wfile.write(f"{len(chunk):x}\r\n".encode() + chunk + b"\r\n")
+            self.wfile.flush()
+            time.sleep(CHUNK_DELAY)
+        self.wfile.write(b"0\r\n\r\n")
+
+    def log_message(self, *args):
+        pass
+
+
+def create_chunked_server():
+    port = get_free_port()
+    server = HTTPServer(("localhost", port), ChunkedResponseHandler)
+    thread = Thread(target=server.serve_forever)
+    thread.daemon = True
+    thread.start()
+    return port
+
+
+CHUNKED_PORT = create_chunked_server()
+
 
 def test_crumb_capture(sentry_init, capture_events):
     sentry_init(integrations=[StdlibIntegration()])
@@ -1162,38 +1193,6 @@ def test_proxy_http_tunnel(
         assert span["data"][SPANDATA.HTTP_METHOD] == "GET"
         assert span["data"][SPANDATA.NETWORK_PEER_ADDRESS] == "localhost"
         assert span["data"][SPANDATA.NETWORK_PEER_PORT] == PROXY_PORT
-
-
-CHUNK_DELAY = 0.1
-NUM_CHUNKS = 3
-
-
-class ChunkedResponseHandler(BaseHTTPRequestHandler):
-    def do_GET(self):
-        self.send_response(200)
-        self.send_header("Transfer-Encoding", "chunked")
-        self.end_headers()
-        for _ in range(NUM_CHUNKS):
-            chunk = b"x" * 100
-            self.wfile.write(f"{len(chunk):x}\r\n".encode() + chunk + b"\r\n")
-            self.wfile.flush()
-            time.sleep(CHUNK_DELAY)
-        self.wfile.write(b"0\r\n\r\n")
-
-    def log_message(self, *args):
-        pass
-
-
-def create_chunked_server():
-    port = get_free_port()
-    server = HTTPServer(("localhost", port), ChunkedResponseHandler)
-    thread = Thread(target=server.serve_forever)
-    thread.daemon = True
-    thread.start()
-    return port
-
-
-CHUNKED_PORT = create_chunked_server()
 
 
 @pytest.mark.parametrize("span_streaming", [True, False])

--- a/tests/integrations/stdlib/test_httplib.py
+++ b/tests/integrations/stdlib/test_httplib.py
@@ -1241,7 +1241,9 @@ def test_chunked_response_span_covers_body_read(
         (event,) = events
         (span,) = event["spans"]
 
-        start = datetime.datetime.fromisoformat(span["start_timestamp"])
-        end = datetime.datetime.fromisoformat(span["timestamp"])
+        start = datetime.datetime.fromisoformat(
+            span["start_timestamp"].replace("Z", "+00:00")
+        )
+        end = datetime.datetime.fromisoformat(span["timestamp"].replace("Z", "+00:00"))
         duration = (end - start).total_seconds()
         assert duration >= min_expected_duration


### PR DESCRIPTION
The HTTP client span in the stdlib integration was finishing in `getresponse()`, which only waits for response headers, not the actual response. For chunked or large responses, the actual data transfer happens during `read()`, leaving that time uninstrumented.

Defer span completion to `HTTPResponse.read()` for responses with a body (chunked or Content-Length > 0), with `HTTPResponse.close()` as a safety net for responses that are never read.

⚠️ Note that this means we might report some requests to be longer than they actually were, since in some cases we only close them once the GC gets to them (and `close()` is called). In a sense we're essentially flipping the current situation (where we report requests to be much shorter than they are, since they don't include the response part) -- but the current situation was incorrect for all spans, while this `close()` fallback should hopefully only kick in for edge cases.

Responses with no body (Content-Length: 0, HEAD, 204, 304) still finish the span immediately in `getresponse()`.

* Closes https://github.com/getsentry/sentry-python/issues/2277
* Closes https://linear.app/getsentry/issue/PY-159/sentry-does-not-fully-instrument-requests-library-requests