### PR TITLE
perf(traces): Cache valid span statuses in a module-level frozenset

### DIFF
--- a/sentry_sdk/traces.py
+++ b/sentry_sdk/traces.py
@@ -60,6 +60,9 @@ class SpanStatus(str, Enum):
         return self.value
 
 
+_VALID_SPAN_STATUSES = frozenset(e.value for e in SpanStatus)
+
+
 # Segment source, see
 # https://getsentry.github.io/sentry-conventions/generated/attributes/sentry.html#sentryspansource
 class SegmentSource(str, Enum):
@@ -430,7 +433,7 @@ class StreamedSpan:
         if isinstance(status, Enum):
             status = status.value
 
-        if status not in {e.value for e in SpanStatus}:
+        if status not in _VALID_SPAN_STATUSES:
             logger.debug(
                 f'[Tracing] Unsupported span status {status}. Expected one of: "ok", "error"'
             )


### PR DESCRIPTION
The `status` setter on `StreamedSpan` was reconstructing a set from the `SpanStatus` enum on every invocation. In high-throughput tracing workloads this is a hot path, so caching the values in a module-level `frozenset` avoids repeated allocations.

Fixes #6207
Fixes PY-2403

---

Using the following benchmarking script:

```python
import timeit
from enum import Enum

class SpanStatus(str, Enum):
    OK = "ok"
    ERROR = "error"


# Approach 1: Current — rebuild set every call
def check_current(status):
    return status not in {e.value for e in SpanStatus}


# Approach 2: Module-level frozenset
_VALID = frozenset(e.value for e in SpanStatus)

def check_frozenset(status):
    return status not in _VALID


N = 100_000
REPEATS = 5

for label, fn in [
    ("current (set comprehension)", check_current),
    ("frozenset lookup",            check_frozenset),
]:
    # Test with a valid status (common path)
    times = timeit.repeat(lambda: fn("ok"), number=N, repeat=REPEATS)
    best = min(times)
    per_call_ns = (best / N) * 1e9
    print(f"{label:30s}  valid    {best:.4f}s / {N} calls  ({per_call_ns:.0f} ns/call)")

    # Test with an invalid status (rare path)
    times = timeit.repeat(lambda: fn("bogus"), number=N, repeat=REPEATS)
    best = min(times)
    per_call_ns = (best / N) * 1e9
    print(f"{label:30s}  invalid  {best:.4f}s / {N} calls  ({per_call_ns:.0f} ns/call)")
```

I was able to confirm the small bump in performance with this change:

Run 1:
```
current (set comprehension)     valid    0.0375s / 100000 calls  (375 ns/call)
current (set comprehension)     invalid  0.0379s / 100000 calls  (379 ns/call)
frozenset lookup                valid    0.0031s / 100000 calls  (31 ns/call)
frozenset lookup                invalid  0.0029s / 100000 calls  (29 ns/call)
```

Run 2:
```
current (set comprehension)     valid    0.0308s / 100000 calls  (308 ns/call)
current (set comprehension)     invalid  0.0311s / 100000 calls  (311 ns/call)
frozenset lookup                valid    0.0024s / 100000 calls  (24 ns/call)
frozenset lookup                invalid  0.0025s / 100000 calls  (25 ns/call)
```

Run 3:
```
current (set comprehension)     valid    0.0312s / 100000 calls  (312 ns/call)
current (set comprehension)     invalid  0.0312s / 100000 calls  (312 ns/call)
frozenset lookup                valid    0.0025s / 100000 calls  (25 ns/call)
frozenset lookup                invalid  0.0024s / 100000 calls  (24 ns/call)
```