### PR TITLE
Add .warden to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@ pip-wheel-metadata
 .claude/
 .serena
 .tool-versions
+.warden
 
 # for running AWS Lambda tests using AWS SAM
 sam.template.yaml


### PR DESCRIPTION
## Summary
- Add `.warden` directory to `.gitignore` so it doesn't get accidentally tracked when running warden locally

Closes https://github.com/getsentry/sentry-python/issues/6209

🤖 Generated with [Claude Code](https://claude.com/claude-code)