### PR TITLE
test: Assert presence of profile chunks after session shutdown

### DIFF
--- a/tests/profiler/test_continuous_profiler.py
+++ b/tests/profiler/test_continuous_profiler.py
@@ -243,10 +243,6 @@ def assert_single_transaction_without_profile_chunks(envelopes):
         pytest.param(get_client_options(False), id="experiment"),
     ],
 )
-@mock.patch(
-    "sentry_sdk.profiler.continuous_profiler.ProfileBuffer.should_flush",
-    lambda a, b: True,
-)  # Force flushing profile of first transaction.
 def test_continuous_profiler_auto_start_and_manual_stop(
     sentry_init,
     capture_envelopes,
@@ -270,13 +266,10 @@ def test_continuous_profiler_auto_start_and_manual_stop(
         with sentry_sdk.start_span(op="op"):
             pass
 
-    # Wait so profiles are captured before assertions.
-    sentry_sdk.profiler.continuous_profiler._scheduler.teardown()
-
-    assert_single_transaction_with_profile_chunks(envelopes, thread)
-
     for _ in range(3):
         stop_profiler_func()
+
+        assert_single_transaction_with_profile_chunks(envelopes, thread)
 
         envelopes.clear()
 
@@ -292,9 +285,11 @@ def test_continuous_profiler_auto_start_and_manual_stop(
 
         with sentry_sdk.start_transaction(name="profiling"):
             with sentry_sdk.start_span(op="op"):
-                time.sleep(0.05)
+                pass
 
-        assert_single_transaction_with_profile_chunks(envelopes, thread)
+    stop_profiler_func()
+
+    assert_single_transaction_with_profile_chunks(envelopes, thread)
 
 
 @pytest.mark.parametrize(
@@ -431,11 +426,11 @@ def test_continuous_profiler_manual_start_and_stop_unsampled(
 
     with sentry_sdk.start_transaction(name="profiling"):
         with sentry_sdk.start_span(op="op"):
-            time.sleep(0.05)
-
-    assert_single_transaction_without_profile_chunks(envelopes)
+            pass
 
     stop_profiler_func()
+
+    assert_single_transaction_without_profile_chunks(envelopes)
 
 
 @pytest.mark.parametrize(
@@ -629,7 +624,6 @@ def test_continuous_profiler_manual_start_and_stop_noop_when_using_trace_lifecyl
         mock_teardown.assert_not_called()
 
 
-@mock.patch("sentry_sdk.profiler.continuous_profiler.PROFILE_BUFFER_SECONDS", 0.01)
 def test_continuous_profiler_run_does_not_null_buffer(
     sentry_init,
     capture_envelopes,
@@ -662,8 +656,7 @@ def test_continuous_profiler_run_does_not_null_buffer(
     envelopes.clear()
     with sentry_sdk.start_transaction(name="profiling"):
         with sentry_sdk.start_span(op="op"):
-            time.sleep(0.1)
-    assert_single_transaction_with_profile_chunks(envelopes, thread)
+            pass
 
     # Get the scheduler and create a sentinel buffer.
     # We'll call run() directly to verify it doesn't null out self.buffer.
@@ -672,6 +665,8 @@ def test_continuous_profiler_run_does_not_null_buffer(
 
     # Stop the profiler so the thread exits cleanly
     stop_profiler()
+
+    assert_single_transaction_with_profile_chunks(envelopes, thread)
 
     # Now set up a fresh buffer and mark the scheduler as not running
     # (simulating the state right after ensure_running() created a new buffer


### PR DESCRIPTION
### Description
<!-- What changed and why? -->

Follows on from https://github.com/getsentry/sentry-python/pull/6174 as other tests started flaking due to the same cause. The race is that assertions run before profiles reach the transport on the thread.

For example, in https://github.com/getsentry/sentry-python/actions/runs/25435862082/job/74613765358?pr=6193, the traceback is

```
=================================== FAILURES ===================================
______________ test_continuous_profiler_run_does_not_null_buffer _______________
tests/profiler/test_continuous_profiler.py:666: in test_continuous_profiler_run_does_not_null_buffer
    assert_single_transaction_with_profile_chunks(envelopes, thread)
tests/profiler/test_continuous_profiler.py:147: in assert_single_transaction_with_profile_chunks
    assert len(items["profile_chunk"]) > 0
E   assert 0 > 0
E    +  where 0 = len([])
```

#### Issues
<!--
* resolves: #1234
* resolves: LIN-1234
-->

#### Reminders
- Please add tests to validate your changes, and lint your code using `tox -e linters`.
- Add GH Issue ID _&_ Linear ID (if applicable)
- PR title should use [conventional commit](https://develop.sentry.dev/engineering-practices/commit-messages/#type) style (`feat:`, `fix:`, `ref:`, `meta:`)
- For external contributors: [CONTRIBUTING.md](https://github.com/getsentry/sentry-python/blob/master/CONTRIBUTING.md), [Sentry SDK development docs](https://develop.sentry.dev/sdk/), [Discord community](https://discord.gg/Ww9hbqr)
