### PR TITLE
feat(argv): Support span streaming

### DIFF
--- a/sentry_sdk/traces.py
+++ b/sentry_sdk/traces.py
@@ -7,6 +7,7 @@ You can enable span streaming mode via
 sentry_sdk.init(_experiments={"trace_lifecycle": "stream"}).
 """
 
+import sys
 import uuid
 import warnings
 from datetime import datetime, timedelta, timezone
@@ -306,6 +307,8 @@ class StreamedSpan:
         self._start_profile()
         self._set_profile_id(get_profiler_id())
 
+        self._set_segment_attributes()
+
         self._start()
 
     def __repr__(self) -> str:
@@ -563,6 +566,12 @@ class StreamedSpan:
         try_autostart_continuous_profiler()
 
         self._continuous_profile = try_profile_lifecycle_trace_start()
+
+    def _set_segment_attributes(self) -> None:
+        if not self._is_segment():
+            return
+
+        self.set_attribute("process.command_args", sys.argv)
 
 
 class NoOpStreamedSpan(StreamedSpan):

--- a/tests/tracing/test_span_streaming.py
+++ b/tests/tracing/test_span_streaming.py
@@ -1533,6 +1533,7 @@ def test_default_attributes(sentry_init, capture_envelopes):
     assert item.payload.json["items"][0]["attributes"] == {
         "thread.id": {"value": mock.ANY, "type": "string"},
         "thread.name": {"value": "MainThread", "type": "string"},
+        "process.command_args": {"value": mock.ANY, "type": "array"},
         "sentry.segment.id": {"value": mock.ANY, "type": "string"},
         "sentry.segment.name": {"value": "test", "type": "string"},
         "sentry.sdk.name": {"value": "sentry.python", "type": "string"},


### PR DESCRIPTION
### Description
Reintroducing the argv integration port from https://github.com/getsentry/sentry-python/pull/6147. Work on full support for array attributes in the product is still ongoing, but at least the trace will now load (the attribute won't be displayed), so we're not breaking anything with this change.

#### Issues
- Closes https://github.com/getsentry/sentry-python/issues/5998
- Closes https://linear.app/getsentry/issue/PY-2300/migrate-argv-to-span-first

#### Reminders
- Please add tests to validate your changes, and lint your code using `tox -e linters`.
- Add GH Issue ID _&_ Linear ID (if applicable)
- PR title should use [conventional commit](https://develop.sentry.dev/engineering-practices/commit-messages/#type) style (`feat:`, `fix:`, `ref:`, `meta:`)
- For external contributors: [CONTRIBUTING.md](https://github.com/getsentry/sentry-python/blob/master/CONTRIBUTING.md), [Sentry SDK development docs](https://develop.sentry.dev/sdk/), [Discord community](https://discord.gg/Ww9hbqr)
