### PR TITLE
ref(tests): Replace custom `envelopes_to_x` helpers with `capture_items`

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -358,7 +358,7 @@ def capture_items(monkeypatch):
                 if types and item.type not in types:
                     continue
 
-                if item.type in ("metric", "log", "span"):
+                if item.type in ("trace_metric", "log", "span"):
                     for i in item.payload.json["items"]:
                         t = {k: v for k, v in i.items() if k != "attributes"}
                         t["attributes"] = {

--- a/tests/integrations/logging/test_logging.py
+++ b/tests/integrations/logging/test_logging.py
@@ -12,7 +12,6 @@ from sentry_sdk.integrations.logging import (
     unignore_logger,
     unignore_logger_for_sentry_logs,
 )
-from tests.test_logs import envelopes_to_logs
 
 other_logger = logging.getLogger("testfoo")
 logger = logging.getLogger(__name__)
@@ -271,12 +270,10 @@ def test_ignore_logger_wildcard(sentry_init, capture_events, request):
     assert event["logentry"]["formatted"] == "hi"
 
 
-def test_ignore_logger_does_not_affect_sentry_logs(
-    sentry_init, capture_envelopes, request
-):
+def test_ignore_logger_does_not_affect_sentry_logs(sentry_init, capture_items, request):
     """ignore_logger should suppress events/breadcrumbs but not Sentry Logs."""
     sentry_init(enable_logs=True)
-    envelopes = capture_envelopes()
+    items = capture_items("log")
 
     ignore_logger("testfoo")
     request.addfinalizer(lambda: unignore_logger("testfoo"))
@@ -284,15 +281,18 @@ def test_ignore_logger_does_not_affect_sentry_logs(
     other_logger.error("hi")
     get_client().flush()
 
-    logs = envelopes_to_logs(envelopes)
+    logs = [item.payload for item in items]
     assert len(logs) == 1
     assert logs[0]["body"] == "hi"
 
 
-def test_ignore_logger_for_sentry_logs(sentry_init, capture_envelopes, request):
+def test_ignore_logger_for_sentry_logs(
+    sentry_init, capture_envelopes, capture_items, request
+):
     """ignore_logger_for_sentry_logs should suppress Sentry Logs but not events."""
     sentry_init(enable_logs=True)
     envelopes = capture_envelopes()
+    items = capture_items("log")
 
     ignore_logger_for_sentry_logs("testfoo")
     request.addfinalizer(lambda: unignore_logger_for_sentry_logs("testfoo"))
@@ -305,7 +305,7 @@ def test_ignore_logger_for_sentry_logs(sentry_init, capture_envelopes, request):
     assert len(event_envelopes) == 1
 
     # But no Sentry Logs
-    logs = envelopes_to_logs(envelopes)
+    logs = [item.payload for item in items]
     assert len(logs) == 0
 
 
@@ -347,18 +347,18 @@ def test_logging_dictionary_args(sentry_init, capture_events):
     assert event["logentry"]["params"] == {"foo": "bar", "bar": "baz"}
 
 
-def test_sentry_logs_warning(sentry_init, capture_envelopes):
+def test_sentry_logs_warning(sentry_init, capture_items):
     """
     The python logger module should create 'warn' sentry logs if the flag is on.
     """
     sentry_init(enable_logs=True)
-    envelopes = capture_envelopes()
+    items = capture_items("log")
 
     python_logger = logging.Logger("test-logger")
     python_logger.warning("this is %s a template %s", "1", "2")
 
     get_client().flush()
-    logs = envelopes_to_logs(envelopes)
+    logs = [item.payload for item in items]
     attrs = logs[0]["attributes"]
     assert attrs["sentry.message.template"] == "this is %s a template %s"
     assert "code.file.path" in attrs
@@ -368,8 +368,8 @@ def test_sentry_logs_warning(sentry_init, capture_envelopes):
     assert attrs["sentry.message.parameter.0"] == "1"
     assert attrs["sentry.message.parameter.1"] == "2"
     assert attrs["sentry.origin"] == "auto.log.stdlib"
-    assert logs[0]["severity_number"] == 13
-    assert logs[0]["severity_text"] == "warn"
+    assert logs[0]["attributes"]["sentry.severity_number"] == 13
+    assert logs[0]["attributes"]["sentry.severity_text"] == "warn"
 
 
 def test_sentry_logs_debug(sentry_init, capture_envelopes):
@@ -404,12 +404,13 @@ def test_no_log_infinite_loop(sentry_init, capture_envelopes):
     assert len(envelopes) == 1
 
 
-def test_logging_errors(sentry_init, capture_envelopes):
+def test_logging_errors(sentry_init, capture_envelopes, capture_items):
     """
     The python logger module should be able to log errors without erroring
     """
     sentry_init(enable_logs=True)
     envelopes = capture_envelopes()
+    items = capture_items("log")
 
     python_logger = logging.Logger("test-logger")
     python_logger.error(Exception("test exc 1"))
@@ -421,13 +422,13 @@ def test_logging_errors(sentry_init, capture_envelopes):
     error_event_2 = envelopes[1].items[0].payload.json
     assert error_event_2["level"] == "error"
 
-    logs = envelopes_to_logs(envelopes)
-    assert logs[0]["severity_text"] == "error"
+    logs = [item.payload for item in items]
+    assert logs[0]["attributes"]["sentry.severity_text"] == "error"
     assert "sentry.message.template" not in logs[0]["attributes"]
     assert "sentry.message.parameter.0" not in logs[0]["attributes"]
     assert "code.line.number" in logs[0]["attributes"]
 
-    assert logs[1]["severity_text"] == "error"
+    assert logs[1]["attributes"]["sentry.severity_text"] == "error"
     assert logs[1]["attributes"]["sentry.message.template"] == "error is %s"
     assert logs[1]["attributes"]["sentry.message.parameter.0"] in (
         "Exception('test exc 2')",
@@ -438,7 +439,7 @@ def test_logging_errors(sentry_init, capture_envelopes):
     assert len(logs) == 2
 
 
-def test_log_strips_project_root(sentry_init, capture_envelopes):
+def test_log_strips_project_root(sentry_init, capture_items):
     """
     The python logger should strip project roots from the log record path
     """
@@ -446,7 +447,7 @@ def test_log_strips_project_root(sentry_init, capture_envelopes):
         enable_logs=True,
         project_root="/custom/test",
     )
-    envelopes = capture_envelopes()
+    items = capture_items("log")
 
     python_logger = logging.Logger("test-logger")
     python_logger.handle(
@@ -462,18 +463,18 @@ def test_log_strips_project_root(sentry_init, capture_envelopes):
     )
     get_client().flush()
 
-    logs = envelopes_to_logs(envelopes)
+    logs = [item.payload for item in items]
     assert len(logs) == 1
     attrs = logs[0]["attributes"]
     assert attrs["code.file.path"] == "blah/path.py"
 
 
-def test_logger_with_all_attributes(sentry_init, capture_envelopes):
+def test_logger_with_all_attributes(sentry_init, capture_items):
     """
     The python logger should be able to log all attributes, including extra data.
     """
     sentry_init(enable_logs=True)
-    envelopes = capture_envelopes()
+    items = capture_items("log")
 
     python_logger = logging.Logger("test-logger")
     python_logger.warning(
@@ -483,7 +484,7 @@ def test_logger_with_all_attributes(sentry_init, capture_envelopes):
     )
     get_client().flush()
 
-    logs = envelopes_to_logs(envelopes)
+    logs = [item.payload for item in items]
 
     assert "span_id" in logs[0]
     assert logs[0]["span_id"] is None
@@ -544,12 +545,12 @@ def test_logger_with_all_attributes(sentry_init, capture_envelopes):
     }
 
 
-def test_sentry_logs_named_parameters(sentry_init, capture_envelopes):
+def test_sentry_logs_named_parameters(sentry_init, capture_items):
     """
     The python logger module should capture named parameters from dictionary arguments in Sentry logs.
     """
     sentry_init(enable_logs=True)
-    envelopes = capture_envelopes()
+    items = capture_items("log")
 
     python_logger = logging.Logger("test-logger")
     python_logger.info(
@@ -564,7 +565,7 @@ def test_sentry_logs_named_parameters(sentry_init, capture_envelopes):
     )
 
     get_client().flush()
-    logs = envelopes_to_logs(envelopes)
+    logs = [item.payload for item in items]
 
     assert len(logs) == 1
     attrs = logs[0]["attributes"]
@@ -585,16 +586,16 @@ def test_sentry_logs_named_parameters(sentry_init, capture_envelopes):
     # Check other standard attributes
     assert attrs["logger.name"] == "test-logger"
     assert attrs["sentry.origin"] == "auto.log.stdlib"
-    assert logs[0]["severity_number"] == 9  # info level
-    assert logs[0]["severity_text"] == "info"
+    assert logs[0]["attributes"]["sentry.severity_number"] == 9  # info level
+    assert logs[0]["attributes"]["sentry.severity_text"] == "info"
 
 
-def test_sentry_logs_named_parameters_complex_values(sentry_init, capture_envelopes):
+def test_sentry_logs_named_parameters_complex_values(sentry_init, capture_items):
     """
     The python logger module should handle complex values in named parameters using safe_repr.
     """
     sentry_init(enable_logs=True)
-    envelopes = capture_envelopes()
+    items = capture_items("log")
 
     python_logger = logging.Logger("test-logger")
     complex_object = {"nested": {"data": [1, 2, 3]}, "tuple": (4, 5, 6)}
@@ -607,7 +608,7 @@ def test_sentry_logs_named_parameters_complex_values(sentry_init, capture_envelo
     )
 
     get_client().flush()
-    logs = envelopes_to_logs(envelopes)
+    logs = [item.payload for item in items]
 
     assert len(logs) == 1
     attrs = logs[0]["attributes"]
@@ -623,18 +624,18 @@ def test_sentry_logs_named_parameters_complex_values(sentry_init, capture_envelo
     assert "data" in complex_param
 
 
-def test_sentry_logs_no_parameters_no_template(sentry_init, capture_envelopes):
+def test_sentry_logs_no_parameters_no_template(sentry_init, capture_items):
     """
     There shouldn't be a template if there are no parameters.
     """
     sentry_init(enable_logs=True)
-    envelopes = capture_envelopes()
+    items = capture_items("log")
 
     python_logger = logging.Logger("test-logger")
     python_logger.warning("Warning about something without any parameters.")
 
     get_client().flush()
-    logs = envelopes_to_logs(envelopes)
+    logs = [item.payload for item in items]
 
     assert len(logs) == 1
 

--- a/tests/integrations/loguru/test_loguru.py
+++ b/tests/integrations/loguru/test_loguru.py
@@ -8,7 +8,6 @@ from loguru._recattrs import RecordFile, RecordLevel
 import sentry_sdk
 from sentry_sdk.consts import VERSION
 from sentry_sdk.integrations.loguru import LoguruIntegration, LoggingLevels
-from tests.test_logs import envelopes_to_logs
 
 logger.remove(0)  # don't print to console
 
@@ -136,18 +135,18 @@ def test_event_format(sentry_init, capture_events, uninstall_integration, reques
 
 
 def test_sentry_logs_warning(
-    sentry_init, capture_envelopes, uninstall_integration, request
+    sentry_init, capture_items, uninstall_integration, request
 ):
     uninstall_integration("loguru")
     request.addfinalizer(logger.remove)
 
     sentry_init(enable_logs=True)
-    envelopes = capture_envelopes()
+    items = capture_items("log")
 
     logger.warning("this is {} a {}", "just", "template")
 
     sentry_sdk.get_client().flush()
-    logs = envelopes_to_logs(envelopes)
+    logs = [item.payload for item in items]
 
     attrs = logs[0]["attributes"]
     assert "code.file.path" in attrs
@@ -155,8 +154,8 @@ def test_sentry_logs_warning(
     assert attrs["logger.name"] == "tests.integrations.loguru.test_loguru"
     assert attrs["sentry.environment"] == "production"
     assert attrs["sentry.origin"] == "auto.log.loguru"
-    assert logs[0]["severity_number"] == 13
-    assert logs[0]["severity_text"] == "warn"
+    assert logs[0]["attributes"]["sentry.severity_number"] == 13
+    assert logs[0]["attributes"]["sentry.severity_text"] == "warn"
 
 
 def test_sentry_logs_debug(
@@ -174,9 +173,7 @@ def test_sentry_logs_debug(
     assert len(envelopes) == 0
 
 
-def test_sentry_log_levels(
-    sentry_init, capture_envelopes, uninstall_integration, request
-):
+def test_sentry_log_levels(sentry_init, capture_items, uninstall_integration, request):
     uninstall_integration("loguru")
     request.addfinalizer(logger.remove)
 
@@ -184,7 +181,7 @@ def test_sentry_log_levels(
         integrations=[LoguruIntegration(sentry_logs_level=LoggingLevels.SUCCESS)],
         enable_logs=True,
     )
-    envelopes = capture_envelopes()
+    items = capture_items("log")
 
     logger.trace("this is a log")
     logger.debug("this is a log")
@@ -195,21 +192,21 @@ def test_sentry_log_levels(
     logger.critical("this is a log")
 
     sentry_sdk.get_client().flush()
-    logs = envelopes_to_logs(envelopes)
+    logs = [item.payload for item in items]
     assert len(logs) == 4
 
-    assert logs[0]["severity_number"] == 11
-    assert logs[0]["severity_text"] == "info"
-    assert logs[1]["severity_number"] == 13
-    assert logs[1]["severity_text"] == "warn"
-    assert logs[2]["severity_number"] == 17
-    assert logs[2]["severity_text"] == "error"
-    assert logs[3]["severity_number"] == 21
-    assert logs[3]["severity_text"] == "fatal"
+    assert logs[0]["attributes"]["sentry.severity_number"] == 11
+    assert logs[0]["attributes"]["sentry.severity_text"] == "info"
+    assert logs[1]["attributes"]["sentry.severity_number"] == 13
+    assert logs[1]["attributes"]["sentry.severity_text"] == "warn"
+    assert logs[2]["attributes"]["sentry.severity_number"] == 17
+    assert logs[2]["attributes"]["sentry.severity_text"] == "error"
+    assert logs[3]["attributes"]["sentry.severity_number"] == 21
+    assert logs[3]["attributes"]["sentry.severity_text"] == "fatal"
 
 
 def test_disable_loguru_logs(
-    sentry_init, capture_envelopes, uninstall_integration, request
+    sentry_init, capture_items, uninstall_integration, request
 ):
     uninstall_integration("loguru")
     request.addfinalizer(logger.remove)
@@ -218,7 +215,7 @@ def test_disable_loguru_logs(
         integrations=[LoguruIntegration(sentry_logs_level=None)],
         enable_logs=True,
     )
-    envelopes = capture_envelopes()
+    items = capture_items("log")
 
     logger.trace("this is a log")
     logger.debug("this is a log")
@@ -229,12 +226,12 @@ def test_disable_loguru_logs(
     logger.critical("this is a log")
 
     sentry_sdk.get_client().flush()
-    logs = envelopes_to_logs(envelopes)
+    logs = [item.payload for item in items]
     assert len(logs) == 0
 
 
 def test_disable_sentry_logs(
-    sentry_init, capture_envelopes, uninstall_integration, request
+    sentry_init, capture_items, uninstall_integration, request
 ):
     uninstall_integration("loguru")
     request.addfinalizer(logger.remove)
@@ -242,7 +239,7 @@ def test_disable_sentry_logs(
     sentry_init(
         _experiments={"enable_logs": False},
     )
-    envelopes = capture_envelopes()
+    items = capture_items("log")
 
     logger.trace("this is a log")
     logger.debug("this is a log")
@@ -253,7 +250,7 @@ def test_disable_sentry_logs(
     logger.critical("this is a log")
 
     sentry_sdk.get_client().flush()
-    logs = envelopes_to_logs(envelopes)
+    logs = [item.payload for item in items]
     assert len(logs) == 0
 
 
@@ -279,13 +276,16 @@ def test_no_log_infinite_loop(
     assert len(envelopes) == 1
 
 
-def test_logging_errors(sentry_init, capture_envelopes, uninstall_integration, request):
+def test_logging_errors(
+    sentry_init, capture_envelopes, capture_items, uninstall_integration, request
+):
     """We're able to log errors without erroring."""
     uninstall_integration("loguru")
     request.addfinalizer(logger.remove)
 
     sentry_init(enable_logs=True)
     envelopes = capture_envelopes()
+    items = capture_items("log")
 
     logger.error(Exception("test exc 1"))
     logger.error("error is %s", Exception("test exc 2"))
@@ -296,18 +296,18 @@ def test_logging_errors(sentry_init, capture_envelopes, uninstall_integration, r
     error_event_2 = envelopes[1].items[0].payload.json
     assert error_event_2["level"] == "error"
 
-    logs = envelopes_to_logs(envelopes)
-    assert logs[0]["severity_text"] == "error"
+    logs = [item.payload for item in items]
+    assert logs[0]["attributes"]["sentry.severity_text"] == "error"
     assert "code.line.number" in logs[0]["attributes"]
 
-    assert logs[1]["severity_text"] == "error"
+    assert logs[1]["attributes"]["sentry.severity_text"] == "error"
     assert "code.line.number" in logs[1]["attributes"]
 
     assert len(logs) == 2
 
 
 def test_log_strips_project_root(
-    sentry_init, capture_envelopes, uninstall_integration, request
+    sentry_init, capture_items, uninstall_integration, request
 ):
     uninstall_integration("loguru")
     request.addfinalizer(logger.remove)
@@ -316,7 +316,7 @@ def test_log_strips_project_root(
         enable_logs=True,
         project_root="/custom/test",
     )
-    envelopes = capture_envelopes()
+    items = capture_items("log")
 
     class FakeMessage:
         def __init__(self, *args, **kwargs):
@@ -349,14 +349,14 @@ def test_log_strips_project_root(
 
     sentry_sdk.get_client().flush()
 
-    logs = envelopes_to_logs(envelopes)
+    logs = [item.payload for item in items]
     assert len(logs) == 1
     attrs = logs[0]["attributes"]
     assert attrs["code.file.path"] == "blah/path.py"
 
 
 def test_log_keeps_full_path_if_not_in_project_root(
-    sentry_init, capture_envelopes, uninstall_integration, request
+    sentry_init, capture_items, uninstall_integration, request
 ):
     uninstall_integration("loguru")
     request.addfinalizer(logger.remove)
@@ -365,7 +365,7 @@ def test_log_keeps_full_path_if_not_in_project_root(
         enable_logs=True,
         project_root="/custom/test",
     )
-    envelopes = capture_envelopes()
+    items = capture_items("log")
 
     class FakeMessage:
         def __init__(self, *args, **kwargs):
@@ -398,25 +398,25 @@ def test_log_keeps_full_path_if_not_in_project_root(
 
     sentry_sdk.get_client().flush()
 
-    logs = envelopes_to_logs(envelopes)
+    logs = [item.payload for item in items]
     assert len(logs) == 1
     attrs = logs[0]["attributes"]
     assert attrs["code.file.path"] == "/blah/path.py"
 
 
 def test_logger_with_all_attributes(
-    sentry_init, capture_envelopes, uninstall_integration, request
+    sentry_init, capture_items, uninstall_integration, request
 ):
     uninstall_integration("loguru")
     request.addfinalizer(logger.remove)
 
     sentry_init(enable_logs=True)
-    envelopes = capture_envelopes()
+    items = capture_items("log")
 
     logger.warning("log #{}", 1)
     sentry_sdk.get_client().flush()
 
-    logs = envelopes_to_logs(envelopes)
+    logs = [item.payload for item in items]
 
     assert "span_id" in logs[0]
     assert logs[0]["span_id"] is None
@@ -473,7 +473,7 @@ def test_logger_with_all_attributes(
 
 
 def test_logger_capture_parameters_from_args(
-    sentry_init, capture_envelopes, uninstall_integration, request
+    sentry_init, capture_items, uninstall_integration, request
 ):
     # This is currently not supported as regular args don't get added to extra
     # (which we use for populating parameters). Adding this test to make that
@@ -482,106 +482,106 @@ def test_logger_capture_parameters_from_args(
     request.addfinalizer(logger.remove)
 
     sentry_init(enable_logs=True)
-    envelopes = capture_envelopes()
+    items = capture_items("log")
 
     logger.warning("Task ID: {}", 123)
 
     sentry_sdk.get_client().flush()
 
-    logs = envelopes_to_logs(envelopes)
+    logs = [item.payload for item in items]
 
     attributes = logs[0]["attributes"]
     assert "sentry.message.parameter.0" not in attributes
 
 
 def test_logger_capture_parameters_from_kwargs(
-    sentry_init, capture_envelopes, uninstall_integration, request
+    sentry_init, capture_items, uninstall_integration, request
 ):
     uninstall_integration("loguru")
     request.addfinalizer(logger.remove)
 
     sentry_init(enable_logs=True)
-    envelopes = capture_envelopes()
+    items = capture_items("log")
 
     logger.warning("Task ID: {task_id}", task_id=123)
 
     sentry_sdk.get_client().flush()
 
-    logs = envelopes_to_logs(envelopes)
+    logs = [item.payload for item in items]
 
     attributes = logs[0]["attributes"]
     assert attributes["sentry.message.parameter.task_id"] == 123
 
 
 def test_logger_capture_parameters_from_contextualize(
-    sentry_init, capture_envelopes, uninstall_integration, request
+    sentry_init, capture_items, uninstall_integration, request
 ):
     uninstall_integration("loguru")
     request.addfinalizer(logger.remove)
 
     sentry_init(enable_logs=True)
-    envelopes = capture_envelopes()
+    items = capture_items("log")
 
     with logger.contextualize(task_id=123):
         logger.warning("Log")
 
     sentry_sdk.get_client().flush()
 
-    logs = envelopes_to_logs(envelopes)
+    logs = [item.payload for item in items]
 
     attributes = logs[0]["attributes"]
     assert attributes["sentry.message.parameter.task_id"] == 123
 
 
 def test_logger_capture_parameters_from_bind(
-    sentry_init, capture_envelopes, uninstall_integration, request
+    sentry_init, capture_items, uninstall_integration, request
 ):
     uninstall_integration("loguru")
     request.addfinalizer(logger.remove)
 
     sentry_init(enable_logs=True)
-    envelopes = capture_envelopes()
+    items = capture_items("log")
 
     logger.bind(task_id=123).warning("Log")
     sentry_sdk.get_client().flush()
 
-    logs = envelopes_to_logs(envelopes)
+    logs = [item.payload for item in items]
 
     attributes = logs[0]["attributes"]
     assert attributes["sentry.message.parameter.task_id"] == 123
 
 
 def test_logger_capture_parameters_from_patch(
-    sentry_init, capture_envelopes, uninstall_integration, request
+    sentry_init, capture_items, uninstall_integration, request
 ):
     uninstall_integration("loguru")
     request.addfinalizer(logger.remove)
 
     sentry_init(enable_logs=True)
-    envelopes = capture_envelopes()
+    items = capture_items("log")
 
     logger.patch(lambda record: record["extra"].update(task_id=123)).warning("Log")
     sentry_sdk.get_client().flush()
 
-    logs = envelopes_to_logs(envelopes)
+    logs = [item.payload for item in items]
 
     attributes = logs[0]["attributes"]
     assert attributes["sentry.message.parameter.task_id"] == 123
 
 
 def test_no_parameters_no_template(
-    sentry_init, capture_envelopes, uninstall_integration, request
+    sentry_init, capture_items, uninstall_integration, request
 ):
     uninstall_integration("loguru")
     request.addfinalizer(logger.remove)
 
     sentry_init(enable_logs=True)
-    envelopes = capture_envelopes()
+    items = capture_items("log")
 
     logger.warning("Logging a hardcoded warning")
     sentry_sdk.get_client().flush()
 
-    logs = envelopes_to_logs(envelopes)
+    logs = [item.payload for item in items]
 
     attributes = logs[0]["attributes"]
     assert "sentry.message.template" not in attributes

--- a/tests/test_attributes.py
+++ b/tests/test_attributes.py
@@ -1,12 +1,10 @@
 import sentry_sdk
 
-from tests.test_metrics import envelopes_to_metrics
 
-
-def test_top_level_api(sentry_init, capture_envelopes):
+def test_top_level_api(sentry_init, capture_items):
     sentry_init()
 
-    envelopes = capture_envelopes()
+    items = capture_items("trace_metric")
 
     sentry_sdk.set_attribute("set", "value")
     sentry_sdk.set_attribute("removed", "value")
@@ -17,14 +15,14 @@ def test_top_level_api(sentry_init, capture_envelopes):
     sentry_sdk.metrics.count("test", 1)
     sentry_sdk.get_client().flush()
 
-    metrics = envelopes_to_metrics(envelopes)
+    metrics = [item.payload for item in items]
     (metric,) = metrics
 
     assert metric["attributes"]["set"] == "value"
     assert "removed" not in metric["attributes"]
 
 
-def test_scope_precedence(sentry_init, capture_envelopes):
+def test_scope_precedence(sentry_init, capture_items):
     # Order of precedence, from most important to least:
     # 1. telemetry attributes (directly supplying attributes on creation or using set_attribute)
     # 2. current scope attributes
@@ -32,7 +30,7 @@ def test_scope_precedence(sentry_init, capture_envelopes):
     # 4. global scope attributes
     sentry_init()
 
-    envelopes = capture_envelopes()
+    items = capture_items("trace_metric")
 
     global_scope = sentry_sdk.get_global_scope()
     global_scope.set_attribute("global.attribute", "global")
@@ -49,7 +47,7 @@ def test_scope_precedence(sentry_init, capture_envelopes):
     sentry_sdk.metrics.count("test", 1)
     sentry_sdk.get_client().flush()
 
-    metrics = envelopes_to_metrics(envelopes)
+    metrics = [item.payload for item in items]
     (metric,) = metrics
 
     assert metric["attributes"]["global.attribute"] == "global"
@@ -59,7 +57,7 @@ def test_scope_precedence(sentry_init, capture_envelopes):
     assert metric["attributes"]["overwritten.attribute"] == "current"
 
 
-def test_telemetry_precedence(sentry_init, capture_envelopes):
+def test_telemetry_precedence(sentry_init, capture_items):
     # Order of precedence, from most important to least:
     # 1. telemetry attributes (directly supplying attributes on creation or using set_attribute)
     # 2. current scope attributes
@@ -67,7 +65,7 @@ def test_telemetry_precedence(sentry_init, capture_envelopes):
     # 4. global scope attributes
     sentry_init()
 
-    envelopes = capture_envelopes()
+    items = capture_items("trace_metric")
 
     global_scope = sentry_sdk.get_global_scope()
     global_scope.set_attribute("global.attribute", "global")
@@ -92,7 +90,7 @@ def test_telemetry_precedence(sentry_init, capture_envelopes):
 
     sentry_sdk.get_client().flush()
 
-    metrics = envelopes_to_metrics(envelopes)
+    metrics = [item.payload for item in items]
     (metric,) = metrics
 
     assert metric["attributes"]["global.attribute"] == "global"
@@ -103,10 +101,10 @@ def test_telemetry_precedence(sentry_init, capture_envelopes):
     assert metric["attributes"]["overwritten.attribute"] == "telemetry"
 
 
-def test_attribute_out_of_scope(sentry_init, capture_envelopes):
+def test_attribute_out_of_scope(sentry_init, capture_items):
     sentry_init()
 
-    envelopes = capture_envelopes()
+    items = capture_items("trace_metric")
 
     with sentry_sdk.new_scope() as scope:
         scope.set_attribute("outofscope.attribute", "out of scope")
@@ -115,16 +113,16 @@ def test_attribute_out_of_scope(sentry_init, capture_envelopes):
 
     sentry_sdk.get_client().flush()
 
-    metrics = envelopes_to_metrics(envelopes)
+    metrics = [item.payload for item in items]
     (metric,) = metrics
 
     assert "outofscope.attribute" not in metric["attributes"]
 
 
-def test_remove_attribute(sentry_init, capture_envelopes):
+def test_remove_attribute(sentry_init, capture_items):
     sentry_init()
 
-    envelopes = capture_envelopes()
+    items = capture_items("trace_metric")
 
     with sentry_sdk.new_scope() as scope:
         scope.set_attribute("some.attribute", 123)
@@ -134,13 +132,13 @@ def test_remove_attribute(sentry_init, capture_envelopes):
 
     sentry_sdk.get_client().flush()
 
-    metrics = envelopes_to_metrics(envelopes)
+    metrics = [item.payload for item in items]
     (metric,) = metrics
 
     assert "some.attribute" not in metric["attributes"]
 
 
-def test_scope_attributes_preserialized(sentry_init, capture_envelopes):
+def test_scope_attributes_preserialized(sentry_init, capture_items):
     def before_send_metric(metric, _):
         # Scope attrs show up serialized in before_send
         assert isinstance(metric["attributes"]["instance"], str)
@@ -150,7 +148,7 @@ def test_scope_attributes_preserialized(sentry_init, capture_envelopes):
 
     sentry_init(before_send_metric=before_send_metric)
 
-    envelopes = capture_envelopes()
+    items = capture_items("trace_metric")
 
     class Cat:
         pass
@@ -170,7 +168,7 @@ def test_scope_attributes_preserialized(sentry_init, capture_envelopes):
 
     sentry_sdk.get_client().flush()
 
-    metrics = envelopes_to_metrics(envelopes)
+    metrics = [item.payload for item in items]
     (metric,) = metrics
 
     # Attrs originally from the scope are serialized when sent

--- a/tests/test_logs.py
+++ b/tests/test_logs.py
@@ -1,63 +1,19 @@
-import json
 import logging
 import os
 import sys
 import time
-from typing import List, Any, Mapping, Union
+
 import pytest
 from unittest import mock
 
 import sentry_sdk
 import sentry_sdk.logger
 from sentry_sdk import get_client
-from sentry_sdk.envelope import Envelope
-from sentry_sdk.types import Log
 from sentry_sdk.consts import SPANDATA, VERSION
 
 minimum_python_37 = pytest.mark.skipif(
     sys.version_info < (3, 7), reason="Asyncio tests need Python >= 3.7"
 )
-
-
-def otel_attributes_to_dict(otel_attrs: "Mapping[str, Any]") -> "Mapping[str, Any]":
-    def _convert_attr(attr: "Mapping[str, Union[str, float, bool]]") -> "Any":
-        if attr["type"] == "boolean":
-            return attr["value"]
-        if attr["type"] == "double":
-            return attr["value"]
-        if attr["type"] == "integer":
-            return attr["value"]
-        if attr["value"].startswith("{"):
-            try:
-                return json.loads(attr["value"])
-            except ValueError:
-                pass
-        return str(attr["value"])
-
-    return {k: _convert_attr(v) for (k, v) in otel_attrs.items()}
-
-
-def envelopes_to_logs(envelopes: List[Envelope]) -> List[Log]:
-    res: "List[Log]" = []
-    for envelope in envelopes:
-        for item in envelope.items:
-            if item.type == "log":
-                for log_json in item.payload.json["items"]:
-                    log: "Log" = {
-                        "severity_text": log_json["attributes"]["sentry.severity_text"][
-                            "value"
-                        ],
-                        "severity_number": int(
-                            log_json["attributes"]["sentry.severity_number"]["value"]
-                        ),
-                        "body": log_json["body"],
-                        "attributes": otel_attributes_to_dict(log_json["attributes"]),
-                        "time_unix_nano": int(float(log_json["timestamp"]) * 1e9),
-                        "trace_id": log_json["trace_id"],
-                        "span_id": log_json.get("span_id"),
-                    }
-                    res.append(log)
-    return res
 
 
 @minimum_python_37
@@ -80,9 +36,9 @@ def test_logs_disabled_by_default(sentry_init, capture_envelopes):
 
 
 @minimum_python_37
-def test_logs_basics(sentry_init, capture_envelopes):
+def test_logs_basics(sentry_init, capture_items):
     sentry_init(enable_logs=True)
-    envelopes = capture_envelopes()
+    items = capture_items("log")
 
     sentry_sdk.logger.trace("This is a 'trace' log...")
     sentry_sdk.logger.debug("This is a 'debug' log...")
@@ -92,44 +48,44 @@ def test_logs_basics(sentry_init, capture_envelopes):
     sentry_sdk.logger.fatal("This is a 'fatal' log...")
 
     get_client().flush()
-    logs = envelopes_to_logs(envelopes)
-    assert logs[0].get("severity_text") == "trace"
-    assert logs[0].get("severity_number") == 1
+    logs = [item.payload for item in items]
+    assert logs[0]["attributes"]["sentry.severity_text"] == "trace"
+    assert logs[0]["attributes"]["sentry.severity_number"] == 1
 
-    assert logs[1].get("severity_text") == "debug"
-    assert logs[1].get("severity_number") == 5
+    assert logs[1]["attributes"]["sentry.severity_text"] == "debug"
+    assert logs[1]["attributes"]["sentry.severity_number"] == 5
 
-    assert logs[2].get("severity_text") == "info"
-    assert logs[2].get("severity_number") == 9
+    assert logs[2]["attributes"]["sentry.severity_text"] == "info"
+    assert logs[2]["attributes"]["sentry.severity_number"] == 9
 
-    assert logs[3].get("severity_text") == "warn"
-    assert logs[3].get("severity_number") == 13
+    assert logs[3]["attributes"]["sentry.severity_text"] == "warn"
+    assert logs[3]["attributes"]["sentry.severity_number"] == 13
 
-    assert logs[4].get("severity_text") == "error"
-    assert logs[4].get("severity_number") == 17
+    assert logs[4]["attributes"]["sentry.severity_text"] == "error"
+    assert logs[4]["attributes"]["sentry.severity_number"] == 17
 
-    assert logs[5].get("severity_text") == "fatal"
-    assert logs[5].get("severity_number") == 21
+    assert logs[5]["attributes"]["sentry.severity_text"] == "fatal"
+    assert logs[5]["attributes"]["sentry.severity_number"] == 21
 
 
 @minimum_python_37
-def test_logs_experimental_option_still_works(sentry_init, capture_envelopes):
+def test_logs_experimental_option_still_works(sentry_init, capture_items):
     sentry_init(_experiments={"enable_logs": True})
-    envelopes = capture_envelopes()
+    items = capture_items("log")
 
     sentry_sdk.logger.error("This is an error log...")
 
     get_client().flush()
 
-    logs = envelopes_to_logs(envelopes)
+    logs = [item.payload for item in items]
     assert len(logs) == 1
 
-    assert logs[0].get("severity_text") == "error"
-    assert logs[0].get("severity_number") == 17
+    assert logs[0]["attributes"]["sentry.severity_text"] == "error"
+    assert logs[0]["attributes"]["sentry.severity_number"] == 17
 
 
 @minimum_python_37
-def test_logs_before_send_log(sentry_init, capture_envelopes):
+def test_logs_before_send_log(sentry_init, capture_items):
     before_log_called = False
 
     def _before_log(record, hint):
@@ -156,7 +112,7 @@ def test_logs_before_send_log(sentry_init, capture_envelopes):
         enable_logs=True,
         before_send_log=_before_log,
     )
-    envelopes = capture_envelopes()
+    items = capture_items("log")
 
     sentry_sdk.logger.trace("This is a 'trace' log...")
     sentry_sdk.logger.debug("This is a 'debug' log...")
@@ -166,19 +122,19 @@ def test_logs_before_send_log(sentry_init, capture_envelopes):
     sentry_sdk.logger.fatal("This is a 'fatal' log...")
 
     get_client().flush()
-    logs = envelopes_to_logs(envelopes)
+    logs = [item.payload for item in items]
     assert len(logs) == 4
 
-    assert logs[0]["severity_text"] == "trace"
-    assert logs[1]["severity_text"] == "debug"
-    assert logs[2]["severity_text"] == "info"
-    assert logs[3]["severity_text"] == "warn"
+    assert logs[0]["attributes"]["sentry.severity_text"] == "trace"
+    assert logs[1]["attributes"]["sentry.severity_text"] == "debug"
+    assert logs[2]["attributes"]["sentry.severity_text"] == "info"
+    assert logs[3]["attributes"]["sentry.severity_text"] == "warn"
     assert before_log_called is True
 
 
 @minimum_python_37
 def test_logs_before_send_log_experimental_option_still_works(
-    sentry_init, capture_envelopes
+    sentry_init, capture_items
 ):
     before_log_called = False
 
@@ -194,25 +150,25 @@ def test_logs_before_send_log_experimental_option_still_works(
             "before_send_log": _before_log,
         },
     )
-    envelopes = capture_envelopes()
+    items = capture_items("log")
 
     sentry_sdk.logger.error("This is an error log...")
 
     get_client().flush()
-    logs = envelopes_to_logs(envelopes)
+    logs = [item.payload for item in items]
     assert len(logs) == 1
 
-    assert logs[0]["severity_text"] == "error"
+    assert logs[0]["attributes"]["sentry.severity_text"] == "error"
     assert before_log_called is True
 
 
 @minimum_python_37
-def test_logs_attributes(sentry_init, capture_envelopes):
+def test_logs_attributes(sentry_init, capture_items):
     """
     Passing arbitrary attributes to log messages.
     """
     sentry_init(enable_logs=True, server_name="test-server")
-    envelopes = capture_envelopes()
+    items = capture_items("log")
 
     attrs = {
         "attr_int": 1,
@@ -226,7 +182,7 @@ def test_logs_attributes(sentry_init, capture_envelopes):
     )
 
     get_client().flush()
-    logs = envelopes_to_logs(envelopes)
+    logs = [item.payload for item in items]
     assert logs[0]["body"] == "The recorded value was 'some value'"
 
     for k, v in attrs.items():
@@ -241,12 +197,12 @@ def test_logs_attributes(sentry_init, capture_envelopes):
 
 
 @minimum_python_37
-def test_logs_message_params(sentry_init, capture_envelopes):
+def test_logs_message_params(sentry_init, capture_items):
     """
     This is the official way of how to pass vars to log messages.
     """
     sentry_init(enable_logs=True)
-    envelopes = capture_envelopes()
+    items = capture_items("log")
 
     sentry_sdk.logger.warning("The recorded value was '{int_var}'", int_var=1)
     sentry_sdk.logger.warning("The recorded value was '{float_var}'", float_var=2.0)
@@ -260,7 +216,7 @@ def test_logs_message_params(sentry_init, capture_envelopes):
     sentry_sdk.logger.warning("The recorded value was hardcoded.")
 
     get_client().flush()
-    logs = envelopes_to_logs(envelopes)
+    logs = [item.payload for item in items]
 
     assert logs[0]["body"] == "The recorded value was '1'"
     assert logs[0]["attributes"]["sentry.message.parameter.int_var"] == 1
@@ -308,55 +264,55 @@ def test_logs_message_params(sentry_init, capture_envelopes):
 
 
 @minimum_python_37
-def test_logs_tied_to_transactions(sentry_init, capture_envelopes):
+def test_logs_tied_to_transactions(sentry_init, capture_items):
     """
     Log messages are also tied to transactions.
     """
     sentry_init(enable_logs=True, traces_sample_rate=1.0)
-    envelopes = capture_envelopes()
+    items = capture_items("log")
 
     with sentry_sdk.start_transaction(name="test-transaction") as trx:
         sentry_sdk.logger.warning("This is a log tied to a transaction")
 
     get_client().flush()
-    logs = envelopes_to_logs(envelopes)
+    logs = [item.payload for item in items]
 
     assert "span_id" in logs[0]
     assert logs[0]["span_id"] == trx.span_id
 
 
 @minimum_python_37
-def test_logs_no_span_id_without_active_span(sentry_init, capture_envelopes):
+def test_logs_no_span_id_without_active_span(sentry_init, capture_items):
     """
     Per the metrics spec, span_id is only attached when a span is active
     when the telemetry is emitted. The propagation context's synthesized
     span_id must not be used as a fallback.
     """
     sentry_init(enable_logs=True)
-    envelopes = capture_envelopes()
+    items = capture_items("log")
 
     sentry_sdk.logger.warning("This is a log without an active span")
 
     get_client().flush()
-    logs = envelopes_to_logs(envelopes)
+    logs = [item.payload for item in items]
     assert logs[0]["trace_id"] is not None
     assert logs[0]["span_id"] is None
 
 
 @minimum_python_37
-def test_logs_tied_to_spans(sentry_init, capture_envelopes):
+def test_logs_tied_to_spans(sentry_init, capture_items):
     """
     Log messages are also tied to spans.
     """
     sentry_init(enable_logs=True, traces_sample_rate=1.0)
-    envelopes = capture_envelopes()
+    items = capture_items("log")
 
     with sentry_sdk.start_transaction(name="test-transaction"):
         with sentry_sdk.start_span(name="test-span") as span:
             sentry_sdk.logger.warning("This is a log tied to a span")
 
     get_client().flush()
-    logs = envelopes_to_logs(envelopes)
+    logs = [item.payload for item in items]
     assert logs[0]["span_id"] == span.span_id
 
 
@@ -380,18 +336,18 @@ def test_auto_flush_logs_after_100(sentry_init, capture_envelopes):
 
 
 @minimum_python_37
-def test_log_user_attributes(sentry_init, capture_envelopes):
+def test_log_user_attributes(sentry_init, capture_items):
     """User attributes are sent if enable_logs is True and send_default_pii is True."""
     sentry_init(enable_logs=True, send_default_pii=True)
 
     sentry_sdk.set_user({"id": "1", "email": "test@example.com", "username": "test"})
-    envelopes = capture_envelopes()
+    items = capture_items("log")
 
     sentry_sdk.logger.warning("Hello, world!")
 
     get_client().flush()
 
-    logs = envelopes_to_logs(envelopes)
+    logs = [item.payload for item in items]
     (log,) = logs
 
     # Check that all expected user attributes are present.
@@ -403,18 +359,18 @@ def test_log_user_attributes(sentry_init, capture_envelopes):
 
 
 @minimum_python_37
-def test_log_no_user_attributes_if_no_pii(sentry_init, capture_envelopes):
+def test_log_no_user_attributes_if_no_pii(sentry_init, capture_items):
     """User attributes are not if PII sending is off."""
     sentry_init(enable_logs=True, send_default_pii=False)
 
     sentry_sdk.set_user({"id": "1", "email": "test@example.com", "username": "test"})
-    envelopes = capture_envelopes()
+    items = capture_items("log")
 
     sentry_sdk.logger.warning("Hello, world!")
 
     get_client().flush()
 
-    logs = envelopes_to_logs(envelopes)
+    logs = [item.payload for item in items]
     (log,) = logs
 
     assert "user.id" not in log["attributes"]
@@ -462,14 +418,14 @@ def test_auto_flush_logs_after_5s(sentry_init, capture_envelopes):
     ],
 )
 def test_logs_with_literal_braces(
-    sentry_init, capture_envelopes, message, expected_body, params
+    sentry_init, capture_items, message, expected_body, params
 ):
     """
     Test that log messages with literal braces (like JSON) work without crashing.
     This is a regression test for issue #4975.
     """
     sentry_init(enable_logs=True)
-    envelopes = capture_envelopes()
+    items = capture_items("log")
 
     if params:
         sentry_sdk.logger.info(message, **params)
@@ -477,7 +433,7 @@ def test_logs_with_literal_braces(
         sentry_sdk.logger.info(message)
 
     get_client().flush()
-    logs = envelopes_to_logs(envelopes)
+    logs = [item.payload for item in items]
 
     assert len(logs) == 1
     assert logs[0]["body"] == expected_body
@@ -631,10 +587,10 @@ def test_batcher_drops_logs(sentry_init, monkeypatch):
 
 
 @minimum_python_37
-def test_log_gets_attributes_from_scopes(sentry_init, capture_envelopes):
+def test_log_gets_attributes_from_scopes(sentry_init, capture_items):
     sentry_init(enable_logs=True)
 
-    envelopes = capture_envelopes()
+    items = capture_items("log")
 
     global_scope = sentry_sdk.get_global_scope()
     global_scope.set_attribute("global.attribute", "value")
@@ -647,7 +603,7 @@ def test_log_gets_attributes_from_scopes(sentry_init, capture_envelopes):
 
     get_client().flush()
 
-    logs = envelopes_to_logs(envelopes)
+    logs = [item.payload for item in items]
     (log1, log2) = logs
 
     assert log1["attributes"]["global.attribute"] == "value"
@@ -658,10 +614,10 @@ def test_log_gets_attributes_from_scopes(sentry_init, capture_envelopes):
 
 
 @minimum_python_37
-def test_log_attributes_override_scope_attributes(sentry_init, capture_envelopes):
+def test_log_attributes_override_scope_attributes(sentry_init, capture_items):
     sentry_init(enable_logs=True)
 
-    envelopes = capture_envelopes()
+    items = capture_items("log")
 
     with sentry_sdk.new_scope() as scope:
         scope.set_attribute("durable.attribute", "value1")
@@ -672,7 +628,7 @@ def test_log_attributes_override_scope_attributes(sentry_init, capture_envelopes
 
     get_client().flush()
 
-    logs = envelopes_to_logs(envelopes)
+    logs = [item.payload for item in items]
     (log,) = logs
 
     assert log["attributes"]["durable.attribute"] == "value1"
@@ -736,7 +692,7 @@ def test_log_array_attributes(sentry_init, capture_envelopes):
 
 
 @minimum_python_37
-def test_attributes_preserialized_in_before_send(sentry_init, capture_envelopes):
+def test_attributes_preserialized_in_before_send(sentry_init, capture_items):
     """We don't surface user-held references to objects in attributes."""
 
     def before_send_log(log, _):
@@ -749,7 +705,7 @@ def test_attributes_preserialized_in_before_send(sentry_init, capture_envelopes)
 
     sentry_init(enable_logs=True, before_send_log=before_send_log)
 
-    envelopes = capture_envelopes()
+    items = capture_items("log")
 
     class Cat:
         pass
@@ -769,7 +725,7 @@ def test_attributes_preserialized_in_before_send(sentry_init, capture_envelopes)
 
     get_client().flush()
 
-    logs = envelopes_to_logs(envelopes)
+    logs = [item.payload for item in items]
     (log,) = logs
 
     assert isinstance(log["attributes"]["instance"], str)

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,38 +1,12 @@
 import os
 import sys
-from typing import List
 from unittest import mock
 
 import pytest
 
 import sentry_sdk
 from sentry_sdk import get_client
-from sentry_sdk.envelope import Envelope
-from sentry_sdk.types import Metric
 from sentry_sdk.consts import SPANDATA, VERSION
-
-
-def envelopes_to_metrics(envelopes: "List[Envelope]") -> "List[Metric]":
-    res = []  # type: List[Metric]
-    for envelope in envelopes:
-        for item in envelope.items:
-            if item.type == "trace_metric":
-                for metric_json in item.payload.json["items"]:
-                    metric: "Metric" = {
-                        "timestamp": metric_json["timestamp"],
-                        "trace_id": metric_json["trace_id"],
-                        "span_id": metric_json.get("span_id"),
-                        "name": metric_json["name"],
-                        "type": metric_json["type"],
-                        "value": metric_json["value"],
-                        "unit": metric_json.get("unit"),
-                        "attributes": {
-                            k: v["value"]
-                            for (k, v) in metric_json["attributes"].items()
-                        },
-                    }
-                    res.append(metric)
-    return res
 
 
 def test_metrics_disabled(sentry_init, capture_envelopes):
@@ -47,23 +21,23 @@ def test_metrics_disabled(sentry_init, capture_envelopes):
     assert len(envelopes) == 0
 
 
-def test_metrics_basics(sentry_init, capture_envelopes):
+def test_metrics_basics(sentry_init, capture_items):
     sentry_init()
-    envelopes = capture_envelopes()
+    items = capture_items("trace_metric")
 
     sentry_sdk.metrics.count("test.counter", 1)
     sentry_sdk.metrics.gauge("test.gauge", 42, unit="millisecond")
     sentry_sdk.metrics.distribution("test.distribution", 200, unit="second")
 
     get_client().flush()
-    metrics = envelopes_to_metrics(envelopes)
+    metrics = [item.payload for item in items]
 
     assert len(metrics) == 3
 
     assert metrics[0]["name"] == "test.counter"
     assert metrics[0]["type"] == "counter"
     assert metrics[0]["value"] == 1.0
-    assert metrics[0]["unit"] is None
+    assert "unit" not in metrics[0]
     assert "sentry.sdk.name" in metrics[0]["attributes"]
     assert "sentry.sdk.version" in metrics[0]["attributes"]
 
@@ -78,15 +52,15 @@ def test_metrics_basics(sentry_init, capture_envelopes):
     assert metrics[2]["unit"] == "second"
 
 
-def test_metrics_experimental_option(sentry_init, capture_envelopes):
+def test_metrics_experimental_option(sentry_init, capture_items):
     sentry_init()
-    envelopes = capture_envelopes()
+    items = capture_items("trace_metric")
 
     sentry_sdk.metrics.count("test.counter", 5)
 
     get_client().flush()
 
-    metrics = envelopes_to_metrics(envelopes)
+    metrics = [item.payload for item in items]
     assert len(metrics) == 1
 
     assert metrics[0]["name"] == "test.counter"
@@ -94,9 +68,9 @@ def test_metrics_experimental_option(sentry_init, capture_envelopes):
     assert metrics[0]["value"] == 5.0
 
 
-def test_metrics_with_attributes(sentry_init, capture_envelopes):
+def test_metrics_with_attributes(sentry_init, capture_items):
     sentry_init(release="1.0.0", environment="test", server_name="test-server")
-    envelopes = capture_envelopes()
+    items = capture_items("trace_metric")
 
     sentry_sdk.metrics.count(
         "test.counter", 1, attributes={"endpoint": "/api/test", "status": "success"}
@@ -104,7 +78,7 @@ def test_metrics_with_attributes(sentry_init, capture_envelopes):
 
     get_client().flush()
 
-    metrics = envelopes_to_metrics(envelopes)
+    metrics = [item.payload for item in items]
     assert len(metrics) == 1
 
     assert metrics[0]["attributes"]["endpoint"] == "/api/test"
@@ -117,9 +91,9 @@ def test_metrics_with_attributes(sentry_init, capture_envelopes):
     assert metrics[0]["attributes"]["sentry.sdk.version"] == VERSION
 
 
-def test_metrics_with_user(sentry_init, capture_envelopes):
+def test_metrics_with_user(sentry_init, capture_items):
     sentry_init(send_default_pii=True)
-    envelopes = capture_envelopes()
+    items = capture_items("trace_metric")
 
     sentry_sdk.set_user(
         {"id": "user-123", "email": "test@example.com", "username": "testuser"}
@@ -128,7 +102,7 @@ def test_metrics_with_user(sentry_init, capture_envelopes):
 
     get_client().flush()
 
-    metrics = envelopes_to_metrics(envelopes)
+    metrics = [item.payload for item in items]
     assert len(metrics) == 1
 
     assert metrics[0]["attributes"]["user.id"] == "user-123"
@@ -136,9 +110,9 @@ def test_metrics_with_user(sentry_init, capture_envelopes):
     assert metrics[0]["attributes"]["user.name"] == "testuser"
 
 
-def test_metrics_no_user_if_pii_off(sentry_init, capture_envelopes):
+def test_metrics_no_user_if_pii_off(sentry_init, capture_items):
     sentry_init(send_default_pii=False)
-    envelopes = capture_envelopes()
+    items = capture_items("trace_metric")
 
     sentry_sdk.set_user(
         {"id": "user-123", "email": "test@example.com", "username": "testuser"}
@@ -147,7 +121,7 @@ def test_metrics_no_user_if_pii_off(sentry_init, capture_envelopes):
 
     get_client().flush()
 
-    metrics = envelopes_to_metrics(envelopes)
+    metrics = [item.payload for item in items]
     assert len(metrics) == 1
 
     assert "user.id" not in metrics[0]["attributes"]
@@ -155,16 +129,16 @@ def test_metrics_no_user_if_pii_off(sentry_init, capture_envelopes):
     assert "user.name" not in metrics[0]["attributes"]
 
 
-def test_metrics_with_span(sentry_init, capture_envelopes):
+def test_metrics_with_span(sentry_init, capture_items):
     sentry_init(traces_sample_rate=1.0)
-    envelopes = capture_envelopes()
+    items = capture_items("trace_metric")
 
     with sentry_sdk.start_transaction(op="test", name="test-span") as transaction:
         sentry_sdk.metrics.count("test.span.counter", 1)
 
     get_client().flush()
 
-    metrics = envelopes_to_metrics(envelopes)
+    metrics = [item.payload for item in items]
     assert len(metrics) == 1
 
     assert metrics[0]["trace_id"] is not None
@@ -172,16 +146,16 @@ def test_metrics_with_span(sentry_init, capture_envelopes):
     assert metrics[0]["span_id"] == transaction.span_id
 
 
-def test_metrics_tracing_without_performance(sentry_init, capture_envelopes):
+def test_metrics_tracing_without_performance(sentry_init, capture_items):
     sentry_init()
-    envelopes = capture_envelopes()
+    items = capture_items("trace_metric")
 
     with sentry_sdk.isolation_scope() as isolation_scope:
         sentry_sdk.metrics.count("test.span.counter", 1)
 
     get_client().flush()
 
-    metrics = envelopes_to_metrics(envelopes)
+    metrics = [item.payload for item in items]
     assert len(metrics) == 1
 
     propagation_context = isolation_scope._propagation_context
@@ -190,10 +164,10 @@ def test_metrics_tracing_without_performance(sentry_init, capture_envelopes):
     # Per the metrics spec, span_id is only attached when a span is
     # active when the metric is emitted. The propagation context's
     # synthesized span_id must not be used as a fallback.
-    assert metrics[0]["span_id"] is None
+    assert "span_id" not in metrics[0]
 
 
-def test_metrics_before_send(sentry_init, capture_envelopes):
+def test_metrics_before_send(sentry_init, capture_items):
     before_metric_called = False
 
     def _before_metric(record, hint):
@@ -219,20 +193,20 @@ def test_metrics_before_send(sentry_init, capture_envelopes):
     sentry_init(
         before_send_metric=_before_metric,
     )
-    envelopes = capture_envelopes()
+    items = capture_items("trace_metric")
 
     sentry_sdk.metrics.count("test.skip", 1)
     sentry_sdk.metrics.count("test.keep", 1)
 
     get_client().flush()
 
-    metrics = envelopes_to_metrics(envelopes)
+    metrics = [item.payload for item in items]
     assert len(metrics) == 1
     assert metrics[0]["name"] == "test.keep"
     assert before_metric_called
 
 
-def test_metrics_experimental_before_send(sentry_init, capture_envelopes):
+def test_metrics_experimental_before_send(sentry_init, capture_items):
     before_metric_called = False
 
     def _before_metric(record, hint):
@@ -260,14 +234,14 @@ def test_metrics_experimental_before_send(sentry_init, capture_envelopes):
             "before_send_metric": _before_metric,
         },
     )
-    envelopes = capture_envelopes()
+    items = capture_items("trace_metric")
 
     sentry_sdk.metrics.count("test.skip", 1)
     sentry_sdk.metrics.count("test.keep", 1)
 
     get_client().flush()
 
-    metrics = envelopes_to_metrics(envelopes)
+    metrics = [item.payload for item in items]
     assert len(metrics) == 1
     assert metrics[0]["name"] == "test.keep"
     assert before_metric_called
@@ -351,10 +325,10 @@ def test_batcher_drops_metrics(sentry_init, monkeypatch):
         assert lost_event_call == ("queue_overflow", "trace_metric", 1)
 
 
-def test_metric_gets_attributes_from_scopes(sentry_init, capture_envelopes):
+def test_metric_gets_attributes_from_scopes(sentry_init, capture_items):
     sentry_init()
 
-    envelopes = capture_envelopes()
+    items = capture_items("trace_metric")
 
     global_scope = sentry_sdk.get_global_scope()
     global_scope.set_attribute("global.attribute", "value")
@@ -367,7 +341,7 @@ def test_metric_gets_attributes_from_scopes(sentry_init, capture_envelopes):
 
     get_client().flush()
 
-    metrics = envelopes_to_metrics(envelopes)
+    metrics = [item.payload for item in items]
     (metric1, metric2) = metrics
 
     assert metric1["attributes"]["global.attribute"] == "value"
@@ -377,10 +351,10 @@ def test_metric_gets_attributes_from_scopes(sentry_init, capture_envelopes):
     assert "current.attribute" not in metric2["attributes"]
 
 
-def test_metric_attributes_override_scope_attributes(sentry_init, capture_envelopes):
+def test_metric_attributes_override_scope_attributes(sentry_init, capture_items):
     sentry_init()
 
-    envelopes = capture_envelopes()
+    items = capture_items("trace_metric")
 
     with sentry_sdk.new_scope() as scope:
         scope.set_attribute("durable.attribute", "value1")
@@ -389,7 +363,7 @@ def test_metric_attributes_override_scope_attributes(sentry_init, capture_envelo
 
     get_client().flush()
 
-    metrics = envelopes_to_metrics(envelopes)
+    metrics = [item.payload for item in items]
     (metric,) = metrics
 
     assert metric["attributes"]["durable.attribute"] == "value1"
@@ -452,7 +426,7 @@ def test_log_array_attributes(sentry_init, capture_envelopes):
     }
 
 
-def test_attributes_preserialized_in_before_send(sentry_init, capture_envelopes):
+def test_attributes_preserialized_in_before_send(sentry_init, capture_items):
     """We don't surface user-held references to objects in attributes."""
 
     def before_send_metric(metric, _):
@@ -465,7 +439,7 @@ def test_attributes_preserialized_in_before_send(sentry_init, capture_envelopes)
 
     sentry_init(before_send_metric=before_send_metric)
 
-    envelopes = capture_envelopes()
+    items = capture_items("trace_metric")
 
     class Cat:
         pass
@@ -486,7 +460,7 @@ def test_attributes_preserialized_in_before_send(sentry_init, capture_envelopes)
 
     get_client().flush()
 
-    metrics = envelopes_to_metrics(envelopes)
+    metrics = [item.payload for item in items]
     (metric,) = metrics
 
     assert isinstance(metric["attributes"]["instance"], str)

--- a/tests/tracing/test_span_streaming.py
+++ b/tests/tracing/test_span_streaming.py
@@ -4,7 +4,6 @@ import re
 import sys
 import time
 from unittest import mock
-from typing import Any
 
 import pytest
 
@@ -18,36 +17,13 @@ minimum_python_38 = pytest.mark.skipif(
 )
 
 
-def envelopes_to_spans(envelopes):
-    res: "list[dict[str, Any]]" = []
-    for envelope in envelopes:
-        for item in envelope.items:
-            if item.type == "span":
-                for span_json in item.payload.json["items"]:
-                    span = {
-                        "start_timestamp": span_json["start_timestamp"],
-                        "end_timestamp": span_json.get("end_timestamp"),
-                        "trace_id": span_json["trace_id"],
-                        "span_id": span_json["span_id"],
-                        "name": span_json["name"],
-                        "status": span_json["status"],
-                        "is_segment": span_json["is_segment"],
-                        "parent_span_id": span_json.get("parent_span_id"),
-                        "attributes": {
-                            k: v["value"] for (k, v) in span_json["attributes"].items()
-                        },
-                    }
-                    res.append(span)
-    return res
-
-
-def test_start_span(sentry_init, capture_envelopes):
+def test_start_span(sentry_init, capture_items):
     sentry_init(
         traces_sample_rate=1.0,
         _experiments={"trace_lifecycle": "stream"},
     )
 
-    events = capture_envelopes()
+    items = capture_items("span")
 
     with sentry_sdk.traces.start_span(name="segment") as segment:
         assert segment._is_segment() is True
@@ -56,7 +32,7 @@ def test_start_span(sentry_init, capture_envelopes):
             assert child._segment == segment
 
     sentry_sdk.get_client().flush()
-    spans = envelopes_to_spans(events)
+    spans = [item.payload for item in items]
 
     assert len(spans) == 2
     child, segment = spans
@@ -67,7 +43,7 @@ def test_start_span(sentry_init, capture_envelopes):
     assert child["attributes"]["sentry.segment.name"] == "segment"
 
     assert segment["is_segment"] is True
-    assert segment["parent_span_id"] is None
+    assert "parent_span_id" not in segment
     assert child["is_segment"] is False
     assert child["parent_span_id"] == segment["span_id"]
     assert child["trace_id"] == segment["trace_id"]
@@ -81,13 +57,13 @@ def test_start_span(sentry_init, capture_envelopes):
     assert segment["status"] == "ok"
 
 
-def test_start_span_no_context_manager(sentry_init, capture_envelopes):
+def test_start_span_no_context_manager(sentry_init, capture_items):
     sentry_init(
         traces_sample_rate=1.0,
         _experiments={"trace_lifecycle": "stream"},
     )
 
-    events = capture_envelopes()
+    items = capture_items("span")
 
     segment = sentry_sdk.traces.start_span(name="segment")
     child = sentry_sdk.traces.start_span(name="child")
@@ -96,7 +72,7 @@ def test_start_span_no_context_manager(sentry_init, capture_envelopes):
     segment.end()
 
     sentry_sdk.get_client().flush()
-    spans = envelopes_to_spans(events)
+    spans = [item.payload for item in items]
 
     assert len(spans) == 2
     child, segment = spans
@@ -120,7 +96,7 @@ def test_start_span_no_context_manager(sentry_init, capture_envelopes):
     assert segment["status"] == "ok"
 
 
-def test_span_sampled_when_created(sentry_init, capture_envelopes):
+def test_span_sampled_when_created(sentry_init, capture_items):
     # Test that if a span is created without the context manager, it is sampled
     # at start_span() time
 
@@ -133,14 +109,14 @@ def test_span_sampled_when_created(sentry_init, capture_envelopes):
         _experiments={"trace_lifecycle": "stream"},
     )
 
-    events = capture_envelopes()
+    items = capture_items("span")
 
     segment = sentry_sdk.traces.start_span(name="segment")
     segment.set_attribute("delayed_attribute", 12)
     segment.end()
 
     sentry_sdk.get_client().flush()
-    spans = envelopes_to_spans(events)
+    spans = [item.payload for item in items]
 
     assert len(spans) == 1
     (segment,) = spans
@@ -149,13 +125,13 @@ def test_span_sampled_when_created(sentry_init, capture_envelopes):
     assert segment["attributes"]["delayed_attribute"] == 12
 
 
-def test_start_span_attributes(sentry_init, capture_envelopes):
+def test_start_span_attributes(sentry_init, capture_items):
     sentry_init(
         traces_sample_rate=1.0,
         _experiments={"trace_lifecycle": "stream"},
     )
 
-    events = capture_envelopes()
+    items = capture_items("span")
 
     with sentry_sdk.traces.start_span(
         name="segment", attributes={"my_attribute": "my_value"}
@@ -163,7 +139,7 @@ def test_start_span_attributes(sentry_init, capture_envelopes):
         ...
 
     sentry_sdk.get_client().flush()
-    spans = envelopes_to_spans(events)
+    spans = [item.payload for item in items]
 
     assert len(spans) == 1
     (span,) = spans
@@ -172,7 +148,7 @@ def test_start_span_attributes(sentry_init, capture_envelopes):
     assert span["attributes"]["my_attribute"] == "my_value"
 
 
-def test_start_span_attributes_in_traces_sampler(sentry_init, capture_envelopes):
+def test_start_span_attributes_in_traces_sampler(sentry_init, capture_items):
     def traces_sampler(sampling_context):
         assert "attributes" in sampling_context["span_context"]
         assert "my_attribute" in sampling_context["span_context"]["attributes"]
@@ -186,7 +162,7 @@ def test_start_span_attributes_in_traces_sampler(sentry_init, capture_envelopes)
         _experiments={"trace_lifecycle": "stream"},
     )
 
-    events = capture_envelopes()
+    items = capture_items("span")
 
     with sentry_sdk.traces.start_span(
         name="segment", attributes={"my_attribute": "my_value"}
@@ -194,7 +170,7 @@ def test_start_span_attributes_in_traces_sampler(sentry_init, capture_envelopes)
         ...
 
     sentry_sdk.get_client().flush()
-    spans = envelopes_to_spans(events)
+    spans = [item.payload for item in items]
 
     assert len(spans) == 1
     (span,) = spans
@@ -203,7 +179,7 @@ def test_start_span_attributes_in_traces_sampler(sentry_init, capture_envelopes)
     assert span["attributes"]["my_attribute"] == "my_value"
 
 
-def test_sampling_context(sentry_init, capture_envelopes):
+def test_sampling_context(sentry_init, capture_items):
     received_trace_id = None
 
     def traces_sampler(sampling_context):
@@ -227,7 +203,7 @@ def test_sampling_context(sentry_init, capture_envelopes):
         _experiments={"trace_lifecycle": "stream"},
     )
 
-    events = capture_envelopes()
+    items = capture_items("span")
 
     with sentry_sdk.traces.start_span(name="span") as span:
         trace_id = span._trace_id
@@ -235,7 +211,7 @@ def test_sampling_context(sentry_init, capture_envelopes):
     assert received_trace_id == trace_id
 
     sentry_sdk.get_client().flush()
-    spans = envelopes_to_spans(events)
+    spans = [item.payload for item in items]
 
     assert len(spans) == 1
 
@@ -296,13 +272,13 @@ def test_custom_sampling_context_update_to_context_value_persists(sentry_init):
         ...
 
 
-def test_span_attributes(sentry_init, capture_envelopes):
+def test_span_attributes(sentry_init, capture_items):
     sentry_init(
         traces_sample_rate=1.0,
         _experiments={"trace_lifecycle": "stream"},
     )
 
-    events = capture_envelopes()
+    items = capture_items("span")
 
     with sentry_sdk.traces.start_span(
         name="segment", attributes={"attribute1": "value"}
@@ -318,7 +294,7 @@ def test_span_attributes(sentry_init, capture_envelopes):
         assert attributes["attribute4"] is False
 
     sentry_sdk.get_client().flush()
-    spans = envelopes_to_spans(events)
+    spans = [item.payload for item in items]
 
     assert len(spans) == 1
     (span,) = spans
@@ -330,13 +306,13 @@ def test_span_attributes(sentry_init, capture_envelopes):
     assert span["attributes"]["attribute4"] is False
 
 
-def test_span_attributes_serialize_early(sentry_init, capture_envelopes):
+def test_span_attributes_serialize_early(sentry_init, capture_items):
     sentry_init(
         traces_sample_rate=1.0,
         _experiments={"trace_lifecycle": "stream"},
     )
 
-    events = capture_envelopes()
+    items = capture_items("span")
 
     class Class:
         pass
@@ -357,7 +333,7 @@ def test_span_attributes_serialize_early(sentry_init, capture_envelopes):
         assert "Class" in attributes["attribute2"]
 
     sentry_sdk.get_client().flush()
-    spans = envelopes_to_spans(events)
+    spans = [item.payload for item in items]
 
     assert len(spans) == 1
     (span,) = spans
@@ -366,7 +342,7 @@ def test_span_attributes_serialize_early(sentry_init, capture_envelopes):
     assert "Class" in span["attributes"]["attribute2"]
 
 
-def test_traces_sampler_drops_span(sentry_init, capture_envelopes):
+def test_traces_sampler_drops_span(sentry_init, capture_items):
     def traces_sampler(sampling_context):
         assert "attributes" in sampling_context["span_context"]
         assert "drop" in sampling_context["span_context"]["attributes"]
@@ -381,7 +357,7 @@ def test_traces_sampler_drops_span(sentry_init, capture_envelopes):
         _experiments={"trace_lifecycle": "stream"},
     )
 
-    events = capture_envelopes()
+    items = capture_items("span")
 
     with sentry_sdk.traces.start_span(name="dropped", attributes={"drop": True}):
         ...
@@ -389,7 +365,7 @@ def test_traces_sampler_drops_span(sentry_init, capture_envelopes):
         ...
 
     sentry_sdk.get_client().flush()
-    spans = envelopes_to_spans(events)
+    spans = [item.payload for item in items]
 
     assert len(spans) == 1
     (span,) = spans
@@ -424,13 +400,13 @@ def test_traces_sampler_called_once_per_segment(sentry_init):
     assert span_name_in_traces_sampler == segment.name
 
 
-def test_start_inactive_span(sentry_init, capture_envelopes):
+def test_start_inactive_span(sentry_init, capture_items):
     sentry_init(
         traces_sample_rate=1.0,
         _experiments={"trace_lifecycle": "stream"},
     )
 
-    events = capture_envelopes()
+    items = capture_items("span")
 
     with sentry_sdk.traces.start_span(name="segment") as segment:
         with sentry_sdk.traces.start_span(name="child1", active=False):
@@ -439,7 +415,7 @@ def test_start_inactive_span(sentry_init, capture_envelopes):
                 pass
 
     sentry_sdk.get_client().flush()
-    spans = envelopes_to_spans(events)
+    spans = [item.payload for item in items]
 
     assert len(spans) == 3
     child2, child1, segment = spans
@@ -461,13 +437,13 @@ def test_start_inactive_span(sentry_init, capture_envelopes):
     assert child2["trace_id"] == segment["trace_id"]
 
 
-def test_start_span_override_parent(sentry_init, capture_envelopes):
+def test_start_span_override_parent(sentry_init, capture_items):
     sentry_init(
         traces_sample_rate=1.0,
         _experiments={"trace_lifecycle": "stream"},
     )
 
-    events = capture_envelopes()
+    items = capture_items("span")
 
     with sentry_sdk.traces.start_span(name="segment") as segment:
         with sentry_sdk.traces.start_span(name="child1"):
@@ -475,7 +451,7 @@ def test_start_span_override_parent(sentry_init, capture_envelopes):
                 pass
 
     sentry_sdk.get_client().flush()
-    spans = envelopes_to_spans(events)
+    spans = [item.payload for item in items]
 
     assert len(spans) == 3
     child2, child1, segment = spans
@@ -500,13 +476,13 @@ def test_start_span_override_parent(sentry_init, capture_envelopes):
     assert child2["trace_id"] == segment["trace_id"]
 
 
-def test_sibling_segments(sentry_init, capture_envelopes):
+def test_sibling_segments(sentry_init, capture_items):
     sentry_init(
         traces_sample_rate=1.0,
         _experiments={"trace_lifecycle": "stream"},
     )
 
-    events = capture_envelopes()
+    items = capture_items("span")
 
     with sentry_sdk.traces.start_span(name="segment1"):
         ...
@@ -515,7 +491,7 @@ def test_sibling_segments(sentry_init, capture_envelopes):
         ...
 
     sentry_sdk.get_client().flush()
-    spans = envelopes_to_spans(events)
+    spans = [item.payload for item in items]
 
     assert len(spans) == 2
     segment1, segment2 = spans
@@ -523,23 +499,23 @@ def test_sibling_segments(sentry_init, capture_envelopes):
     assert segment1["name"] == "segment1"
     assert segment1["attributes"]["sentry.segment.name"] == "segment1"
     assert segment1["is_segment"] is True
-    assert segment1["parent_span_id"] is None
+    assert "parent_span_id" not in segment1
 
     assert segment2["name"] == "segment2"
     assert segment2["attributes"]["sentry.segment.name"] == "segment2"
     assert segment2["is_segment"] is True
-    assert segment2["parent_span_id"] is None
+    assert "parent_span_id" not in segment2
 
     assert segment1["trace_id"] == segment2["trace_id"]
 
 
-def test_sibling_segments_new_trace(sentry_init, capture_envelopes):
+def test_sibling_segments_new_trace(sentry_init, capture_items):
     sentry_init(
         traces_sample_rate=1.0,
         _experiments={"trace_lifecycle": "stream"},
     )
 
-    events = capture_envelopes()
+    items = capture_items("span")
 
     with sentry_sdk.traces.start_span(name="segment1"):
         ...
@@ -550,7 +526,7 @@ def test_sibling_segments_new_trace(sentry_init, capture_envelopes):
         ...
 
     sentry_sdk.get_client().flush()
-    spans = envelopes_to_spans(events)
+    spans = [item.payload for item in items]
 
     assert len(spans) == 2
     segment1, segment2 = spans
@@ -558,24 +534,24 @@ def test_sibling_segments_new_trace(sentry_init, capture_envelopes):
     assert segment1["name"] == "segment1"
     assert segment1["attributes"]["sentry.segment.name"] == "segment1"
     assert segment1["is_segment"] is True
-    assert segment1["parent_span_id"] is None
+    assert "parent_span_id" not in segment1
 
     assert segment2["name"] == "segment2"
     assert segment2["attributes"]["sentry.segment.name"] == "segment2"
     assert segment2["is_segment"] is True
-    assert segment2["parent_span_id"] is None
+    assert "parent_span_id" not in segment2
 
     assert segment1["trace_id"] != segment2["trace_id"]
 
 
-def test_continue_trace_sampled(sentry_init, capture_envelopes):
+def test_continue_trace_sampled(sentry_init, capture_items):
     sentry_init(
         # parent sampling decision takes precedence over traces_sample_rate
         traces_sample_rate=0.0,
         _experiments={"trace_lifecycle": "stream"},
     )
 
-    events = capture_envelopes()
+    items = capture_items("span")
 
     trace_id = "0af7651916cd43dd8448eb211c80319c"
     parent_span_id = "b7ad6b7169203331"
@@ -598,7 +574,7 @@ def test_continue_trace_sampled(sentry_init, capture_envelopes):
     assert span._sample_rand == float(sample_rand)
 
     sentry_sdk.get_client().flush()
-    spans = envelopes_to_spans(events)
+    spans = [item.payload for item in items]
 
     assert len(spans) == 1
     (segment,) = spans
@@ -608,14 +584,14 @@ def test_continue_trace_sampled(sentry_init, capture_envelopes):
     assert segment["trace_id"] == trace_id
 
 
-def test_continue_trace_unsampled(sentry_init, capture_envelopes):
+def test_continue_trace_unsampled(sentry_init, capture_items):
     sentry_init(
         # parent sampling decision takes precedence over traces_sample_rate
         traces_sample_rate=1.0,
         _experiments={"trace_lifecycle": "stream"},
     )
 
-    events = capture_envelopes()
+    items = capture_items("span")
 
     trace_id = "0af7651916cd43dd8448eb211c80319c"
     parent_span_id = "b7ad6b7169203331"
@@ -638,20 +614,20 @@ def test_continue_trace_unsampled(sentry_init, capture_envelopes):
     assert span.span_id == "0000000000000000"
 
     sentry_sdk.get_client().flush()
-    spans = envelopes_to_spans(events)
+    spans = [item.payload for item in items]
 
     assert len(spans) == 0
 
 
 def test_unsampled_spans_produce_client_report(
-    sentry_init, capture_envelopes, capture_record_lost_event_calls
+    sentry_init, capture_items, capture_record_lost_event_calls
 ):
     sentry_init(
         traces_sample_rate=0.0,
         _experiments={"trace_lifecycle": "stream"},
     )
 
-    envelopes = capture_envelopes()
+    items = capture_items("span")
     record_lost_event_calls = capture_record_lost_event_calls()
 
     with sentry_sdk.traces.start_span(name="segment"):
@@ -662,7 +638,7 @@ def test_unsampled_spans_produce_client_report(
 
     sentry_sdk.get_client().flush()
 
-    spans = envelopes_to_spans(envelopes)
+    spans = [item.payload for item in items]
     assert not spans
 
     assert record_lost_event_calls == [
@@ -673,14 +649,14 @@ def test_unsampled_spans_produce_client_report(
 
 
 def test_no_client_reports_if_tracing_is_off(
-    sentry_init, capture_envelopes, capture_record_lost_event_calls
+    sentry_init, capture_items, capture_record_lost_event_calls
 ):
     sentry_init(
         traces_sample_rate=None,
         _experiments={"trace_lifecycle": "stream"},
     )
 
-    envelopes = capture_envelopes()
+    items = capture_items("span")
     record_lost_event_calls = capture_record_lost_event_calls()
 
     with sentry_sdk.traces.start_span(name="segment"):
@@ -691,19 +667,19 @@ def test_no_client_reports_if_tracing_is_off(
 
     sentry_sdk.get_client().flush()
 
-    spans = envelopes_to_spans(envelopes)
+    spans = [item.payload for item in items]
     assert not spans
     assert not record_lost_event_calls
 
 
-def test_continue_trace_no_sample_rand(sentry_init, capture_envelopes):
+def test_continue_trace_no_sample_rand(sentry_init, capture_items):
     sentry_init(
         # parent sampling decision takes precedence over traces_sample_rate
         traces_sample_rate=0.0,
         _experiments={"trace_lifecycle": "stream"},
     )
 
-    events = capture_envelopes()
+    items = capture_items("span")
 
     trace_id = "0af7651916cd43dd8448eb211c80319c"
     parent_span_id = "b7ad6b7169203331"
@@ -725,7 +701,7 @@ def test_continue_trace_no_sample_rand(sentry_init, capture_envelopes):
     assert isinstance(span._sample_rand, float)
 
     sentry_sdk.get_client().flush()
-    spans = envelopes_to_spans(events)
+    spans = [item.payload for item in items]
 
     assert len(spans) == 1
     (segment,) = spans
@@ -796,13 +772,13 @@ def test_outgoing_traceparent_and_baggage_when_noop_span_is_active(
         assert baggage_items["sentry-trace_id"] == propagation_trace_id
 
 
-def test_trace_decorator(sentry_init, capture_envelopes):
+def test_trace_decorator(sentry_init, capture_items):
     sentry_init(
         traces_sample_rate=1.0,
         _experiments={"trace_lifecycle": "stream"},
     )
 
-    events = capture_envelopes()
+    items = capture_items("span")
 
     @sentry_sdk.traces.trace
     def traced_function(): ...
@@ -810,7 +786,7 @@ def test_trace_decorator(sentry_init, capture_envelopes):
     traced_function()
 
     sentry_sdk.get_client().flush()
-    spans = envelopes_to_spans(events)
+    spans = [item.payload for item in items]
 
     assert len(spans) == 1
     (span,) = spans
@@ -822,13 +798,13 @@ def test_trace_decorator(sentry_init, capture_envelopes):
     assert span["status"] == "ok"
 
 
-def test_trace_decorator_arguments(sentry_init, capture_envelopes):
+def test_trace_decorator_arguments(sentry_init, capture_items):
     sentry_init(
         traces_sample_rate=1.0,
         _experiments={"trace_lifecycle": "stream"},
     )
 
-    events = capture_envelopes()
+    items = capture_items("span")
 
     @sentry_sdk.traces.trace(name="traced", attributes={"traced.attribute": 123})
     def traced_function(): ...
@@ -836,7 +812,7 @@ def test_trace_decorator_arguments(sentry_init, capture_envelopes):
     traced_function()
 
     sentry_sdk.get_client().flush()
-    spans = envelopes_to_spans(events)
+    spans = [item.payload for item in items]
 
     assert len(spans) == 1
     (span,) = spans
@@ -846,13 +822,13 @@ def test_trace_decorator_arguments(sentry_init, capture_envelopes):
     assert span["status"] == "ok"
 
 
-def test_trace_decorator_inactive(sentry_init, capture_envelopes):
+def test_trace_decorator_inactive(sentry_init, capture_items):
     sentry_init(
         traces_sample_rate=1.0,
         _experiments={"trace_lifecycle": "stream"},
     )
 
-    events = capture_envelopes()
+    items = capture_items("span")
 
     @sentry_sdk.traces.trace(name="outer", active=False)
     def traced_function():
@@ -862,25 +838,25 @@ def test_trace_decorator_inactive(sentry_init, capture_envelopes):
     traced_function()
 
     sentry_sdk.get_client().flush()
-    spans = envelopes_to_spans(events)
+    spans = [item.payload for item in items]
 
     assert len(spans) == 2
     (span1, span2) = spans
 
     assert span1["name"] == "inner"
-    assert span1["parent_span_id"] != span2["span_id"]
+    assert span1.get("parent_span_id") != span2["span_id"]
 
     assert span2["name"] == "outer"
 
 
 @minimum_python_38
-def test_trace_decorator_async(sentry_init, capture_envelopes):
+def test_trace_decorator_async(sentry_init, capture_items):
     sentry_init(
         traces_sample_rate=1.0,
         _experiments={"trace_lifecycle": "stream"},
     )
 
-    events = capture_envelopes()
+    items = capture_items("span")
 
     @sentry_sdk.traces.trace
     async def traced_function(): ...
@@ -888,7 +864,7 @@ def test_trace_decorator_async(sentry_init, capture_envelopes):
     asyncio.run(traced_function())
 
     sentry_sdk.get_client().flush()
-    spans = envelopes_to_spans(events)
+    spans = [item.payload for item in items]
 
     assert len(spans) == 1
     (span,) = spans
@@ -901,13 +877,13 @@ def test_trace_decorator_async(sentry_init, capture_envelopes):
 
 
 @minimum_python_38
-def test_trace_decorator_async_arguments(sentry_init, capture_envelopes):
+def test_trace_decorator_async_arguments(sentry_init, capture_items):
     sentry_init(
         traces_sample_rate=1.0,
         _experiments={"trace_lifecycle": "stream"},
     )
 
-    events = capture_envelopes()
+    items = capture_items("span")
 
     @sentry_sdk.traces.trace(name="traced", attributes={"traced.attribute": 123})
     async def traced_function(): ...
@@ -915,7 +891,7 @@ def test_trace_decorator_async_arguments(sentry_init, capture_envelopes):
     asyncio.run(traced_function())
 
     sentry_sdk.get_client().flush()
-    spans = envelopes_to_spans(events)
+    spans = [item.payload for item in items]
 
     assert len(spans) == 1
     (span,) = spans
@@ -926,13 +902,13 @@ def test_trace_decorator_async_arguments(sentry_init, capture_envelopes):
 
 
 @minimum_python_38
-def test_trace_decorator_async_inactive(sentry_init, capture_envelopes):
+def test_trace_decorator_async_inactive(sentry_init, capture_items):
     sentry_init(
         traces_sample_rate=1.0,
         _experiments={"trace_lifecycle": "stream"},
     )
 
-    events = capture_envelopes()
+    items = capture_items("span")
 
     @sentry_sdk.traces.trace(name="outer", active=False)
     async def traced_function():
@@ -942,24 +918,24 @@ def test_trace_decorator_async_inactive(sentry_init, capture_envelopes):
     asyncio.run(traced_function())
 
     sentry_sdk.get_client().flush()
-    spans = envelopes_to_spans(events)
+    spans = [item.payload for item in items]
 
     assert len(spans) == 2
     (span1, span2) = spans
 
     assert span1["name"] == "inner"
-    assert span1["parent_span_id"] != span2["span_id"]
+    assert span1.get("parent_span_id") != span2["span_id"]
 
     assert span2["name"] == "outer"
 
 
-def test_set_span_status(sentry_init, capture_envelopes):
+def test_set_span_status(sentry_init, capture_items):
     sentry_init(
         traces_sample_rate=1.0,
         _experiments={"trace_lifecycle": "stream"},
     )
 
-    events = capture_envelopes()
+    items = capture_items("span")
 
     with sentry_sdk.traces.start_span(name="span") as span:
         span.status = SpanStatus.ERROR
@@ -968,7 +944,7 @@ def test_set_span_status(sentry_init, capture_envelopes):
         span.status = "error"
 
     sentry_sdk.get_client().flush()
-    spans = envelopes_to_spans(events)
+    spans = [item.payload for item in items]
 
     assert len(spans) == 2
     (span1, span2) = spans
@@ -977,20 +953,20 @@ def test_set_span_status(sentry_init, capture_envelopes):
     assert span2["status"] == "error"
 
 
-def test_set_span_status_on_error(sentry_init, capture_envelopes):
+def test_set_span_status_on_error(sentry_init, capture_items):
     sentry_init(
         traces_sample_rate=1.0,
         _experiments={"trace_lifecycle": "stream"},
     )
 
-    events = capture_envelopes()
+    items = capture_items("span")
 
     with pytest.raises(ValueError):
         with sentry_sdk.traces.start_span(name="span") as span:
             raise ValueError("oh no!")
 
     sentry_sdk.get_client().flush()
-    spans = envelopes_to_spans(events)
+    spans = [item.payload for item in items]
 
     assert len(spans) == 1
     (span,) = spans
@@ -998,19 +974,19 @@ def test_set_span_status_on_error(sentry_init, capture_envelopes):
     assert span["status"] == "error"
 
 
-def test_set_span_status_on_ignored_span(sentry_init, capture_envelopes):
+def test_set_span_status_on_ignored_span(sentry_init, capture_items):
     sentry_init(
         traces_sample_rate=1.0,
         _experiments={"trace_lifecycle": "stream", "ignore_spans": ["ignored"]},
     )
 
-    events = capture_envelopes()
+    items = capture_items("span")
 
     with sentry_sdk.traces.start_span(name="ignored") as span:
         span.status = "error"
 
     sentry_sdk.get_client().flush()
-    spans = envelopes_to_spans(events)
+    spans = [item.payload for item in items]
 
     assert len(spans) == 0
 
@@ -1099,7 +1075,7 @@ def test_set_span_status_on_ignored_span(sentry_init, capture_envelopes):
     ],
 )
 def test_ignore_spans(
-    sentry_init, capture_envelopes, ignore_spans, name, attributes, ignored
+    sentry_init, capture_items, ignore_spans, name, attributes, ignored
 ):
     sentry_init(
         traces_sample_rate=1.0,
@@ -1109,7 +1085,7 @@ def test_ignore_spans(
         },
     )
 
-    events = capture_envelopes()
+    items = capture_items("span")
 
     with sentry_sdk.traces.start_span(name=name, attributes=attributes) as span:
         if ignored:
@@ -1120,7 +1096,7 @@ def test_ignore_spans(
             assert isinstance(span, StreamedSpan)
 
     sentry_sdk.get_client().flush()
-    spans = envelopes_to_spans(events)
+    spans = [item.payload for item in items]
 
     if ignored:
         assert len(spans) == 0
@@ -1131,7 +1107,7 @@ def test_ignore_spans(
 
 
 def test_ignore_spans_basic(
-    sentry_init, capture_envelopes, capture_record_lost_event_calls
+    sentry_init, capture_items, capture_record_lost_event_calls
 ):
     sentry_init(
         traces_sample_rate=1.0,
@@ -1141,7 +1117,7 @@ def test_ignore_spans_basic(
         },
     )
 
-    events = capture_envelopes()
+    items = capture_items("span")
     lost_event_calls = capture_record_lost_event_calls()
 
     with sentry_sdk.traces.start_span(name="ignored") as ignored_span:
@@ -1152,19 +1128,19 @@ def test_ignore_spans_basic(
 
     sentry_sdk.get_client().flush()
 
-    spans = envelopes_to_spans(events)
+    spans = [item.payload for item in items]
 
     assert len(spans) == 1
     (span,) = spans
     assert span["name"] == "not ignored"
-    assert span["parent_span_id"] is None
+    assert "parent_span_id" not in span
 
     assert len(lost_event_calls) == 1
     assert lost_event_calls[0] == ("ignored", "span", None, 1)
 
 
 def test_ignore_spans_ignored_segment_drops_whole_tree(
-    sentry_init, capture_envelopes, capture_record_lost_event_calls
+    sentry_init, capture_items, capture_record_lost_event_calls
 ):
     # Ignored segments should drop the whole span tree.
     sentry_init(
@@ -1175,7 +1151,7 @@ def test_ignore_spans_ignored_segment_drops_whole_tree(
         },
     )
 
-    events = capture_envelopes()
+    items = capture_items("span")
     lost_event_calls = capture_record_lost_event_calls()
 
     with sentry_sdk.traces.start_span(name="ignored") as ignored_span:
@@ -1191,7 +1167,7 @@ def test_ignore_spans_ignored_segment_drops_whole_tree(
                 assert isinstance(span2, NoOpStreamedSpan)
 
     sentry_sdk.get_client().flush()
-    spans = envelopes_to_spans(events)
+    spans = [item.payload for item in items]
 
     assert len(spans) == 0
 
@@ -1201,7 +1177,7 @@ def test_ignore_spans_ignored_segment_drops_whole_tree(
 
 
 def test_ignore_spans_ignored_segment_drops_whole_tree_explicit_parent_span(
-    sentry_init, capture_envelopes, capture_record_lost_event_calls
+    sentry_init, capture_items, capture_record_lost_event_calls
 ):
     # Ignored segments should drop the whole span tree.
     sentry_init(
@@ -1212,7 +1188,7 @@ def test_ignore_spans_ignored_segment_drops_whole_tree_explicit_parent_span(
         },
     )
 
-    events = capture_envelopes()
+    items = capture_items("span")
     lost_event_calls = capture_record_lost_event_calls()
 
     ignored_span = sentry_sdk.traces.start_span(name="ignored")
@@ -1233,7 +1209,7 @@ def test_ignore_spans_ignored_segment_drops_whole_tree_explicit_parent_span(
 
     sentry_sdk.get_client().flush()
 
-    spans = envelopes_to_spans(events)
+    spans = [item.payload for item in items]
 
     assert len(spans) == 0
 
@@ -1243,7 +1219,7 @@ def test_ignore_spans_ignored_segment_drops_whole_tree_explicit_parent_span(
 
 
 def test_ignore_spans_set_ignored_child_span_as_parent(
-    sentry_init, capture_envelopes, capture_record_lost_event_calls
+    sentry_init, capture_items, capture_record_lost_event_calls
 ):
     # Ignored non-segment spans should NOT drop the whole subtree under them.
     sentry_init(
@@ -1254,7 +1230,7 @@ def test_ignore_spans_set_ignored_child_span_as_parent(
         },
     )
 
-    events = capture_envelopes()
+    items = capture_items("span")
     lost_event_calls = capture_record_lost_event_calls()
 
     with sentry_sdk.traces.start_span(name="segment") as segment:
@@ -1271,7 +1247,7 @@ def test_ignore_spans_set_ignored_child_span_as_parent(
                     assert span._parent_span_id == segment.span_id
 
     sentry_sdk.get_client().flush()
-    spans = envelopes_to_spans(events)
+    spans = [item.payload for item in items]
 
     assert len(spans) == 2
     (child, segment) = spans
@@ -1285,7 +1261,7 @@ def test_ignore_spans_set_ignored_child_span_as_parent(
 
 
 def test_ignore_spans_set_ignored_child_span_as_parent_explicit_parent_span(
-    sentry_init, capture_envelopes, capture_record_lost_event_calls
+    sentry_init, capture_items, capture_record_lost_event_calls
 ):
     # Ignored non-segment spans should NOT drop the whole subtree under them.
     sentry_init(
@@ -1296,7 +1272,7 @@ def test_ignore_spans_set_ignored_child_span_as_parent_explicit_parent_span(
         },
     )
 
-    events = capture_envelopes()
+    items = capture_items("span")
     lost_event_calls = capture_record_lost_event_calls()
 
     segment = sentry_sdk.traces.start_span(name="segment")
@@ -1325,7 +1301,7 @@ def test_ignore_spans_set_ignored_child_span_as_parent_explicit_parent_span(
     segment.end()
 
     sentry_sdk.get_client().flush()
-    spans = envelopes_to_spans(events)
+    spans = [item.payload for item in items]
 
     assert len(spans) == 2
     (child, segment) = spans
@@ -1338,7 +1314,7 @@ def test_ignore_spans_set_ignored_child_span_as_parent_explicit_parent_span(
         assert lost_event_call == ("ignored", "span", None, 1)
 
 
-def test_ignore_spans_reparenting(sentry_init, capture_envelopes):
+def test_ignore_spans_reparenting(sentry_init, capture_items):
     sentry_init(
         traces_sample_rate=1.0,
         _experiments={
@@ -1347,7 +1323,7 @@ def test_ignore_spans_reparenting(sentry_init, capture_envelopes):
         },
     )
 
-    events = capture_envelopes()
+    items = capture_items("span")
 
     with sentry_sdk.traces.start_span(name="segment") as span1:
         assert span1.sampled is True
@@ -1368,7 +1344,7 @@ def test_ignore_spans_reparenting(sentry_init, capture_envelopes):
                         assert span5._parent_span_id == span3.span_id
 
     sentry_sdk.get_client().flush()
-    spans = envelopes_to_spans(events)
+    spans = [item.payload for item in items]
 
     assert len(spans) == 3
     (span5, span3, span1) = spans
@@ -1380,14 +1356,14 @@ def test_ignore_spans_reparenting(sentry_init, capture_envelopes):
 
 
 def test_ignored_spans_produce_client_report(
-    sentry_init, capture_envelopes, capture_record_lost_event_calls
+    sentry_init, capture_items, capture_record_lost_event_calls
 ):
     sentry_init(
         traces_sample_rate=1.0,
         _experiments={"trace_lifecycle": "stream", "ignore_spans": ["ignored"]},
     )
 
-    envelopes = capture_envelopes()
+    items = capture_items("span")
     record_lost_event_calls = capture_record_lost_event_calls()
 
     with sentry_sdk.traces.start_span(name="ignored"):
@@ -1398,7 +1374,7 @@ def test_ignored_spans_produce_client_report(
 
     sentry_sdk.get_client().flush()
 
-    spans = envelopes_to_spans(envelopes)
+    spans = [item.payload for item in items]
     assert not spans
 
     # All three spans will be ignored since the segment is ignored
@@ -1411,7 +1387,7 @@ def test_ignored_spans_produce_client_report(
 
 @mock.patch("sentry_sdk.profiler.continuous_profiler.DEFAULT_SAMPLING_FREQUENCY", 21)
 def test_segment_span_has_profiler_id(
-    sentry_init, capture_envelopes, teardown_profiling
+    sentry_init, capture_items, capture_envelopes, teardown_profiling
 ):
     sentry_init(
         traces_sample_rate=1.0,
@@ -1423,6 +1399,7 @@ def test_segment_span_has_profiler_id(
             "continuous_profiling_auto_start": True,
         },
     )
+    items = capture_items("span")
     envelopes = capture_envelopes()
 
     with sentry_sdk.traces.start_span(name="profiled segment"):
@@ -1431,7 +1408,7 @@ def test_segment_span_has_profiler_id(
     sentry_sdk.get_client().flush()
     time.sleep(0.3)  # wait for profiler to flush
 
-    spans = envelopes_to_spans(envelopes)
+    spans = [item.payload for item in items]
     assert len(spans) == 1
     assert "sentry.profiler_id" in spans[0]["attributes"]
 
@@ -1445,7 +1422,7 @@ def test_segment_span_has_profiler_id(
 
 
 def test_segment_span_no_profiler_id_when_unsampled(
-    sentry_init, capture_envelopes, teardown_profiling
+    sentry_init, capture_items, capture_envelopes, teardown_profiling
 ):
     sentry_init(
         traces_sample_rate=1.0,
@@ -1457,6 +1434,7 @@ def test_segment_span_no_profiler_id_when_unsampled(
             "continuous_profiling_auto_start": True,
         },
     )
+    items = capture_items("span")
     envelopes = capture_envelopes()
 
     with sentry_sdk.traces.start_span(name="segment"):
@@ -1465,7 +1443,7 @@ def test_segment_span_no_profiler_id_when_unsampled(
     sentry_sdk.get_client().flush()
     time.sleep(0.2)
 
-    spans = envelopes_to_spans(envelopes)
+    spans = [item.payload for item in items]
     assert len(spans) == 1
     assert "sentry.profiler_id" not in spans[0]["attributes"]
 


### PR DESCRIPTION
We had multiple `envelopes_to_x` helpers around in tests for unwrapping metrics, logs, and spans. Replace them all with `capture_items`, which has the added benefit of being more true to the actual payload leaving the SDK, unlike `envelopes_to_x`, which used to modify some fields (setting them to `None` if they were not present, for instance).
