### PR TITLE
ref: Rename `_timestamp` to `_end_timestamp`

### DIFF
--- a/sentry_sdk/_span_batcher.py
+++ b/sentry_sdk/_span_batcher.py
@@ -168,8 +168,8 @@ class SpanBatcher(Batcher["StreamedSpan"]):
             "start_timestamp": item._start_timestamp.timestamp(),
         }
 
-        if item._timestamp:
-            res["end_timestamp"] = item._timestamp.timestamp()
+        if item._end_timestamp:
+            res["end_timestamp"] = item._end_timestamp.timestamp()
 
         if item._parent_span_id:
             res["parent_span_id"] = item._parent_span_id

--- a/sentry_sdk/traces.py
+++ b/sentry_sdk/traces.py
@@ -244,7 +244,7 @@ class StreamedSpan:
         "_parent_sampled",
         "_start_timestamp",
         "_start_timestamp_monotonic_ns",
-        "_timestamp",
+        "_end_timestamp",
         "_status",
         "_scope",
         "_previous_span_on_scope",

--- a/sentry_sdk/traces.py
+++ b/sentry_sdk/traces.py
@@ -479,7 +479,7 @@ class StreamedSpan:
         return self._start_timestamp
 
     @property
-    def timestamp(self) -> "Optional[datetime]":
+    def end_timestamp(self) -> "Optional[datetime]":
         return self._end_timestamp
 
     def _is_segment(self) -> bool:
@@ -699,7 +699,7 @@ class NoOpStreamedSpan(StreamedSpan):
         return None
 
     @property
-    def timestamp(self) -> "Optional[datetime]":
+    def end_timestamp(self) -> "Optional[datetime]":
         return None
 
 

--- a/sentry_sdk/traces.py
+++ b/sentry_sdk/traces.py
@@ -291,7 +291,7 @@ class StreamedSpan:
         self._sample_rate = sample_rate
 
         self._start_timestamp = datetime.now(timezone.utc)
-        self._timestamp: "Optional[datetime]" = None
+        self._end_timestamp: "Optional[datetime]" = None
 
         # profiling depends on this value and requires that
         # it is measured in nanoseconds
@@ -327,7 +327,7 @@ class StreamedSpan:
     def __exit__(
         self, ty: "Optional[Any]", value: "Optional[Any]", tb: "Optional[Any]"
     ) -> None:
-        if self._timestamp is not None:
+        if self._end_timestamp is not None:
             # This span is already finished, ignore
             return
 
@@ -361,7 +361,7 @@ class StreamedSpan:
             self._previous_span_on_scope = old_span
 
     def _end(self, end_timestamp: "Optional[Union[float, datetime]]" = None) -> None:
-        if self._timestamp is not None:
+        if self._end_timestamp is not None:
             # This span is already finished, ignore.
             return
 
@@ -392,15 +392,15 @@ class StreamedSpan:
                     pass
 
             if isinstance(end_timestamp, datetime):
-                self._timestamp = end_timestamp
+                self._end_timestamp = end_timestamp
             else:
                 logger.debug(
                     "[Tracing] Failed to set end_timestamp. Using current time instead."
                 )
 
-        if self._timestamp is None:
+        if self._end_timestamp is None:
             elapsed = nanosecond_time() - self._start_timestamp_monotonic_ns
-            self._timestamp = self._start_timestamp + timedelta(
+            self._end_timestamp = self._start_timestamp + timedelta(
                 microseconds=elapsed / 1000
             )
 
@@ -480,7 +480,7 @@ class StreamedSpan:
 
     @property
     def timestamp(self) -> "Optional[datetime]":
-        return self._timestamp
+        return self._end_timestamp
 
     def _is_segment(self) -> bool:
         return self._segment is self

--- a/sentry_sdk/tracing_utils.py
+++ b/sentry_sdk/tracing_utils.py
@@ -399,9 +399,12 @@ def add_query_source(
     if not should_add_query_source:
         return
 
-    end_timestamp = (
-        datetime.now(timezone.utc) if span.end_timestamp is None else span.end_timestamp
-    )
+    if isinstance(span, StreamedSpan):
+        end_timestamp = span.end_timestamp
+    else:
+        end_timestamp = span.timestamp
+
+    end_timestamp = end_timestamp or datetime.now(timezone.utc)
 
     duration = end_timestamp - span.start_timestamp
     threshold = client.options.get("db_query_source_threshold_ms", 0)
@@ -442,9 +445,12 @@ def add_http_request_source(
     if not should_add_request_source:
         return
 
-    end_timestamp = (
-        datetime.now(timezone.utc) if span.end_timestamp is None else span.end_timestamp
-    )
+    if isinstance(span, StreamedSpan):
+        end_timestamp = span.end_timestamp
+    else:
+        end_timestamp = span.timestamp
+
+    end_timestamp = end_timestamp or datetime.now(timezone.utc)
 
     duration = end_timestamp - span.start_timestamp
     threshold = client.options.get("http_request_source_threshold_ms", 0)

--- a/sentry_sdk/tracing_utils.py
+++ b/sentry_sdk/tracing_utils.py
@@ -400,7 +400,7 @@ def add_query_source(
         return
 
     end_timestamp = (
-        datetime.now(timezone.utc) if span.timestamp is None else span.timestamp
+        datetime.now(timezone.utc) if span.end_timestamp is None else span.end_timestamp
     )
 
     duration = end_timestamp - span.start_timestamp
@@ -443,7 +443,7 @@ def add_http_request_source(
         return
 
     end_timestamp = (
-        datetime.now(timezone.utc) if span.timestamp is None else span.timestamp
+        datetime.now(timezone.utc) if span.end_timestamp is None else span.end_timestamp
     )
 
     duration = end_timestamp - span.start_timestamp

--- a/tests/integrations/sqlalchemy/test_sqlalchemy.py
+++ b/tests/integrations/sqlalchemy/test_sqlalchemy.py
@@ -939,7 +939,9 @@ def test_no_query_source_if_duration_too_short(
 
                     if span_streaming:
                         self.span._start_timestamp = datetime(2024, 1, 1, microsecond=0)
-                        self.span._timestamp = datetime(2024, 1, 1, microsecond=99999)
+                        self.span._end_timestamp = datetime(
+                            2024, 1, 1, microsecond=99999
+                        )
                     else:
                         self.span.start_timestamp = datetime(2024, 1, 1, microsecond=0)
                         self.span.timestamp = datetime(2024, 1, 1, microsecond=99999)
@@ -1003,7 +1005,9 @@ def test_no_query_source_if_duration_too_short(
 
                     if span_streaming:
                         self.span._start_timestamp = datetime(2024, 1, 1, microsecond=0)
-                        self.span._timestamp = datetime(2024, 1, 1, microsecond=99999)
+                        self.span._end_timestamp = datetime(
+                            2024, 1, 1, microsecond=99999
+                        )
                     else:
                         self.span.start_timestamp = datetime(2024, 1, 1, microsecond=0)
                         self.span.timestamp = datetime(2024, 1, 1, microsecond=99999)
@@ -1082,7 +1086,7 @@ def test_query_source_if_duration_over_threshold(
                         self.span = span
 
                     self.span._start_timestamp = datetime(2024, 1, 1, microsecond=0)
-                    self.span._timestamp = datetime(2024, 1, 1, microsecond=101000)
+                    self.span._end_timestamp = datetime(2024, 1, 1, microsecond=101000)
 
                 def __enter__(self):
                     return self.span

--- a/tests/integrations/stdlib/test_httplib.py
+++ b/tests/integrations/stdlib/test_httplib.py
@@ -873,9 +873,9 @@ def test_no_request_source_if_duration_too_short(
     def add_http_request_source_with_pinned_timestamps(span):
         if span_streaming:
             span._start_timestamp = datetime.datetime(2024, 1, 1, microsecond=0)
-            span._timestamp = datetime.datetime(2024, 1, 1, microsecond=99999)
+            span._end_timestamp = datetime.datetime(2024, 1, 1, microsecond=99999)
             result = add_http_request_source(span)
-            span._timestamp = None
+            span._end_timestamp = None
             return result
         else:
             span.start_timestamp = datetime.datetime(2024, 1, 1, microsecond=0)
@@ -947,9 +947,9 @@ def test_request_source_if_duration_over_threshold(
     def add_http_request_source_with_pinned_timestamps(span):
         if span_streaming:
             span._start_timestamp = datetime.datetime(2024, 1, 1, microsecond=0)
-            span._timestamp = datetime.datetime(2024, 1, 1, microsecond=100001)
+            span._end_timestamp = datetime.datetime(2024, 1, 1, microsecond=100001)
             result = add_http_request_source(span)
-            span._timestamp = None
+            span._end_timestamp = None
             return result
         else:
             span.start_timestamp = datetime.datetime(2024, 1, 1, microsecond=0)


### PR DESCRIPTION
The field capturing the end timestamp of a span used to be called `timestamp` in legacy mode (on the `Span` class), with `start_timestamp` as its counterpart.

In span streaming, we originally followed the same convention on the new `StreamedSpan` class, but there's actually no reason to and it'd be better to use `end_timestamp` instead:
- the field on the serialized span v2 is actually called `end_timestamp`
- `end_timestamp` is a clearer name in general, and complements `start_timestamp` nicely
