### PR TITLE
fix(typing): Add `@sentry_sdk.traces.trace` overloads to fix typing

### DIFF
--- a/sentry_sdk/traces.py
+++ b/sentry_sdk/traces.py
@@ -37,6 +37,7 @@ if TYPE_CHECKING:
         Callable,
         Iterator,
         Optional,
+        overload,
         ParamSpec,
         TypeVar,
         Union,
@@ -701,6 +702,23 @@ class NoOpStreamedSpan(StreamedSpan):
     @property
     def timestamp(self) -> "Optional[datetime]":
         return None
+
+
+if TYPE_CHECKING:
+
+    @overload
+    def trace(
+        func: "Callable[P, R]",
+    ) -> "Callable[P, R]": ...
+
+    @overload
+    def trace(
+        func: None = None,
+        *,
+        name: "Optional[str]" = None,
+        attributes: "Optional[dict[str, Any]]" = None,
+        active: bool = True,
+    ) -> "Callable[[Callable[P, R]], Callable[P, R]]": ...
 
 
 def trace(


### PR DESCRIPTION
Changing `sentry_sdk.trace` to `sentry_sdk.traces.trace` introduced a whole avalanche of [typing issues](https://github.com/getsentry/seer/actions/runs/25495762136/job/74814929830?pr=6291).

Adding the overloads we have for the original `trace`.