### PR TITLE
ref: Make `set_custom_sampling_context()` a classmethod

### DIFF
--- a/sentry_sdk/integrations/aiohttp.py
+++ b/sentry_sdk/integrations/aiohttp.py
@@ -16,7 +16,7 @@ from sentry_sdk.integrations._wsgi_common import (
     request_body_within_bounds,
 )
 from sentry_sdk.integrations.logging import ignore_logger
-from sentry_sdk.scope import should_send_default_pii
+from sentry_sdk.scope import should_send_default_pii, Scope
 from sentry_sdk.sessions import track_session
 from sentry_sdk.traces import (
     SOURCE_FOR_STYLE as SEGMENT_SOURCE_FOR_STYLE,
@@ -139,9 +139,7 @@ class AioHttpIntegration(Integration):
                     span_ctx: "ContextManager[Union[Span, StreamedSpan]]"
                     if is_span_streaming_enabled:
                         sentry_sdk.traces.continue_trace(headers)
-                        sentry_sdk.get_current_scope().set_custom_sampling_context(
-                            {"aiohttp_request": request}
-                        )
+                        Scope.set_custom_sampling_context({"aiohttp_request": request})
 
                         header_attributes: "dict[str, Any]" = {}
                         for header, header_value in _filter_headers(

--- a/sentry_sdk/integrations/asgi.py
+++ b/sentry_sdk/integrations/asgi.py
@@ -46,6 +46,7 @@ from sentry_sdk.utils import (
     capture_internal_exceptions,
     qualname_from_function,
 )
+from sentry_sdk.scope import Scope
 
 from typing import TYPE_CHECKING
 
@@ -257,9 +258,7 @@ class SentryAsgiMiddleware:
                             ):
                                 sentry_sdk.traces.continue_trace(_get_headers(scope))
 
-                                sentry_scope.set_custom_sampling_context(
-                                    {"asgi_scope": scope}
-                                )
+                                Scope.set_custom_sampling_context({"asgi_scope": scope})
 
                                 attributes["sentry.op"] = f"{ty}.server"
                                 segment = sentry_sdk.traces.start_span(
@@ -270,9 +269,7 @@ class SentryAsgiMiddleware:
                         else:
                             sentry_sdk.traces.new_trace()
 
-                            sentry_scope.set_custom_sampling_context(
-                                {"asgi_scope": scope}
-                            )
+                            Scope.set_custom_sampling_context({"asgi_scope": scope})
 
                             attributes["sentry.op"] = OP.HTTP_SERVER
                             segment = sentry_sdk.traces.start_span(

--- a/sentry_sdk/integrations/celery/__init__.py
+++ b/sentry_sdk/integrations/celery/__init__.py
@@ -14,7 +14,7 @@ from sentry_sdk.integrations.celery.beat import (
 )
 from sentry_sdk.integrations.celery.utils import _now_seconds_since_epoch
 from sentry_sdk.integrations.logging import ignore_logger
-from sentry_sdk.scope import should_send_default_pii
+from sentry_sdk.scope import should_send_default_pii, Scope
 from sentry_sdk.traces import StreamedSpan, _get_current_streamed_span
 from sentry_sdk.tracing import BAGGAGE_HEADER_NAME, Span, TransactionSource
 from sentry_sdk.tracing_utils import Baggage, has_span_streaming_enabled
@@ -361,7 +361,7 @@ def _wrap_tracer(task: "Any", f: "F") -> "F":
                 headers = args[3].get("headers") or {}
                 if span_streaming:
                     sentry_sdk.traces.continue_trace(headers)
-                    scope.set_custom_sampling_context(custom_sampling_context)
+                    Scope.set_custom_sampling_context(custom_sampling_context)
                     span = sentry_sdk.traces.start_span(
                         name=task_name,
                         parent_span=None,  # make this a segment

--- a/sentry_sdk/integrations/wsgi.py
+++ b/sentry_sdk/integrations/wsgi.py
@@ -11,7 +11,7 @@ from sentry_sdk.integrations._wsgi_common import (
     _filter_headers,
     nullcontext,
 )
-from sentry_sdk.scope import should_send_default_pii, use_isolation_scope
+from sentry_sdk.scope import should_send_default_pii, use_isolation_scope, Scope
 from sentry_sdk.sessions import track_session
 from sentry_sdk.traces import StreamedSpan, SegmentSource
 from sentry_sdk.tracing import Span, TransactionSource
@@ -132,7 +132,7 @@ class SentryWsgiMiddleware:
                             sentry_sdk.traces.continue_trace(
                                 dict(_get_headers(environ))
                             )
-                            scope.set_custom_sampling_context({"wsgi_environ": environ})
+                            Scope.set_custom_sampling_context({"wsgi_environ": environ})
 
                             span_ctx = sentry_sdk.traces.start_span(
                                 name=_DEFAULT_TRANSACTION_NAME,

--- a/sentry_sdk/scope.py
+++ b/sentry_sdk/scope.py
@@ -719,10 +719,11 @@ class Scope:
             isolation_scope._propagation_context = PropagationContext()
         return isolation_scope._propagation_context
 
+    @classmethod
     def set_custom_sampling_context(
-        self, custom_sampling_context: "dict[str, Any]"
+        cls, custom_sampling_context: "dict[str, Any]"
     ) -> None:
-        self.get_current_scope().get_active_propagation_context()._set_custom_sampling_context(
+        cls.get_current_scope().get_active_propagation_context()._set_custom_sampling_context(
             custom_sampling_context
         )
 


### PR DESCRIPTION
### Description
<!-- What changed and why? -->

Remove uncertainty about which scope to call `set_custom_sampling_context()` on since the method always operates on the current scope. Allow users to call the method directly on the class.

#### Issues
<!--
* resolves: #1234
* resolves: LIN-1234
-->

#### Reminders
- Please add tests to validate your changes, and lint your code using `tox -e linters`.
- Add GH Issue ID _&_ Linear ID (if applicable)
- PR title should use [conventional commit](https://develop.sentry.dev/engineering-practices/commit-messages/#type) style (`feat:`, `fix:`, `ref:`, `meta:`)
- For external contributors: [CONTRIBUTING.md](https://github.com/getsentry/sentry-python/blob/master/CONTRIBUTING.md), [Sentry SDK development docs](https://develop.sentry.dev/sdk/), [Discord community](https://discord.gg/Ww9hbqr)
