### PR TITLE
Add option to drop scrubbed user IP addresses

### DIFF
--- a/sentry_sdk/scrubber.py
+++ b/sentry_sdk/scrubber.py
@@ -66,7 +66,6 @@ class EventScrubber:
         recursive: bool = False,
         send_default_pii: bool = False,
         pii_denylist: "Optional[List[str]]" = None,
-        remove_user_ip_address: bool = False,
     ) -> None:
         """
         A scrubber that goes through the event payload and removes sensitive data configured through denylists.
@@ -75,7 +74,6 @@ class EventScrubber:
         :param recursive: Whether to scrub the event payload recursively, default False.
         :param send_default_pii: Whether pii is sending is on, pii fields are not scrubbed.
         :param pii_denylist: The denylist to use for scrubbing when pii is not sent, defaults to DEFAULT_PII_DENYLIST.
-        :param remove_user_ip_address: Whether to remove ``user.ip_address`` instead of replacing it with ``[Filtered]``.
         """
         self.denylist = DEFAULT_DENYLIST.copy() if denylist is None else denylist
 
@@ -87,7 +85,6 @@ class EventScrubber:
 
         self.denylist = [x.lower() for x in self.denylist]
         self.recursive = recursive
-        self.remove_user_ip_address = remove_user_ip_address
 
     def scrub_list(self, lst: object) -> None:
         """
@@ -141,11 +138,7 @@ class EventScrubber:
         with capture_internal_exceptions():
             if "user" in event:
                 user = event["user"]
-                if (
-                    "ip_address" in self.denylist
-                    and self.remove_user_ip_address
-                    and isinstance(user, dict)
-                ):
+                if "ip_address" in self.denylist and isinstance(user, dict):
                     user.pop("ip_address", None)
                 self.scrub_dict(user)
 

--- a/sentry_sdk/scrubber.py
+++ b/sentry_sdk/scrubber.py
@@ -66,6 +66,7 @@ class EventScrubber:
         recursive: bool = False,
         send_default_pii: bool = False,
         pii_denylist: "Optional[List[str]]" = None,
+        remove_user_ip_address: bool = False,
     ) -> None:
         """
         A scrubber that goes through the event payload and removes sensitive data configured through denylists.
@@ -74,6 +75,7 @@ class EventScrubber:
         :param recursive: Whether to scrub the event payload recursively, default False.
         :param send_default_pii: Whether pii is sending is on, pii fields are not scrubbed.
         :param pii_denylist: The denylist to use for scrubbing when pii is not sent, defaults to DEFAULT_PII_DENYLIST.
+        :param remove_user_ip_address: Whether to remove ``user.ip_address`` instead of replacing it with ``[Filtered]``.
         """
         self.denylist = DEFAULT_DENYLIST.copy() if denylist is None else denylist
 
@@ -85,6 +87,7 @@ class EventScrubber:
 
         self.denylist = [x.lower() for x in self.denylist]
         self.recursive = recursive
+        self.remove_user_ip_address = remove_user_ip_address
 
     def scrub_list(self, lst: object) -> None:
         """
@@ -137,7 +140,14 @@ class EventScrubber:
     def scrub_user(self, event: "Event") -> None:
         with capture_internal_exceptions():
             if "user" in event:
-                self.scrub_dict(event["user"])
+                user = event["user"]
+                if (
+                    self.remove_user_ip_address
+                    and "ip_address" in self.denylist
+                    and isinstance(user, dict)
+                ):
+                    user.pop("ip_address", None)
+                self.scrub_dict(user)
 
     def scrub_breadcrumbs(self, event: "Event") -> None:
         with capture_internal_exceptions():

--- a/sentry_sdk/scrubber.py
+++ b/sentry_sdk/scrubber.py
@@ -142,8 +142,8 @@ class EventScrubber:
             if "user" in event:
                 user = event["user"]
                 if (
-                    self.remove_user_ip_address
-                    and "ip_address" in self.denylist
+                    "ip_address" in self.denylist
+                    and self.remove_user_ip_address
                     and isinstance(user, dict)
                 ):
                     user.pop("ip_address", None)

--- a/tests/new_scopes_compat/test_new_scopes_compat_event.py
+++ b/tests/new_scopes_compat/test_new_scopes_compat_event.py
@@ -102,7 +102,6 @@ def expected_error(integrations):
             "user": {
                 "id": "123",
                 "email": "jane.doe@example.com",
-                "ip_address": "[Filtered]",
             },
             "transaction": "test_transaction",
             "transaction_info": {"source": "custom"},
@@ -137,7 +136,6 @@ def expected_error(integrations):
             },
             "platform": "python",
             "_meta": {
-                "user": {"ip_address": {"": {"rem": [["!config", "s"]]}}},
                 "extra": {
                     "should_be_removed_by_event_scrubber": {
                         "": {"rem": [["!config", "s"]]}
@@ -207,7 +205,6 @@ def expected_transaction(integrations):
             "user": {
                 "id": "123",
                 "email": "jane.doe@example.com",
-                "ip_address": "[Filtered]",
             },
             "extra": {
                 "extra1": "extra1_value",
@@ -226,7 +223,6 @@ def expected_transaction(integrations):
             },
             "platform": "python",
             "_meta": {
-                "user": {"ip_address": {"": {"rem": [["!config", "s"]]}}},
                 "extra": {
                     "should_be_removed_by_event_scrubber": {
                         "": {"rem": [["!config", "s"]]}

--- a/tests/test_scrubber.py
+++ b/tests/test_scrubber.py
@@ -89,7 +89,7 @@ def test_ip_address_not_scrubbed_when_pii_enabled(sentry_init, capture_events):
     }
 
 
-def test_user_ip_address_scrubbed_when_pii_disabled(sentry_init, capture_events):
+def test_user_ip_address_removed_when_pii_disabled(sentry_init, capture_events):
     sentry_init()
     events = capture_events()
 
@@ -103,12 +103,12 @@ def test_user_ip_address_scrubbed_when_pii_disabled(sentry_init, capture_events)
 
     (event,) = events
 
-    assert event["user"] == {"id": "42", "ip_address": "[Filtered]"}
-    assert event["_meta"]["user"] == {"ip_address": {"": {"rem": [["!config", "s"]]}}}
+    assert event["user"] == {"id": "42"}
+    assert "user" not in event.get("_meta", {})
 
 
-def test_user_ip_address_removed_when_configured(sentry_init, capture_events):
-    sentry_init(event_scrubber=EventScrubber(remove_user_ip_address=True))
+def test_user_ip_address_not_removed_when_pii_enabled(sentry_init, capture_events):
+    sentry_init(send_default_pii=True)
     events = capture_events()
 
     try:
@@ -121,7 +121,7 @@ def test_user_ip_address_removed_when_configured(sentry_init, capture_events):
 
     (event,) = events
 
-    assert event["user"] == {"id": "42"}
+    assert event["user"] == {"id": "42", "ip_address": "127.0.0.1"}
     assert "user" not in event.get("_meta", {})
 
 

--- a/tests/test_scrubber.py
+++ b/tests/test_scrubber.py
@@ -89,6 +89,42 @@ def test_ip_address_not_scrubbed_when_pii_enabled(sentry_init, capture_events):
     }
 
 
+def test_user_ip_address_scrubbed_when_pii_disabled(sentry_init, capture_events):
+    sentry_init()
+    events = capture_events()
+
+    try:
+        1 / 0
+    except ZeroDivisionError:
+        ev, _hint = event_from_exception(sys.exc_info())
+        ev["user"] = {"id": "42", "ip_address": "127.0.0.1"}
+
+        capture_event(ev)
+
+    (event,) = events
+
+    assert event["user"] == {"id": "42", "ip_address": "[Filtered]"}
+    assert event["_meta"]["user"] == {"ip_address": {"": {"rem": [["!config", "s"]]}}}
+
+
+def test_user_ip_address_removed_when_configured(sentry_init, capture_events):
+    sentry_init(event_scrubber=EventScrubber(remove_user_ip_address=True))
+    events = capture_events()
+
+    try:
+        1 / 0
+    except ZeroDivisionError:
+        ev, _hint = event_from_exception(sys.exc_info())
+        ev["user"] = {"id": "42", "ip_address": "127.0.0.1"}
+
+        capture_event(ev)
+
+    (event,) = events
+
+    assert event["user"] == {"id": "42"}
+    assert "user" not in event.get("_meta", {})
+
+
 def test_stack_var_scrubbing(sentry_init, capture_events):
     sentry_init()
     events = capture_events()


### PR DESCRIPTION
## Summary

Fixes #5701 by adding an EventScrubber option to remove `user.ip_address` instead of replacing it with `[Filtered]`.

This avoids emitting `[Filtered]` in a field Relay expects to be a valid IP address, while preserving the existing default behavior for backward compatibility. By default, `user.ip_address` is still scrubbed through the normal scrubber path and keeps the `_meta` annotation.

## Testing

- `python -m pytest tests/test_scrubber.py tests/new_scopes_compat/test_new_scopes_compat_event.py -q`
- `ruff check sentry_sdk/scrubber.py tests/test_scrubber.py`
- `ruff format --check sentry_sdk/scrubber.py tests/test_scrubber.py`
- `git diff --check`