### PR TITLE
fix: Set transaction source for unsampled streamed spans

### DIFF
--- a/sentry_sdk/scope.py
+++ b/sentry_sdk/scope.py
@@ -849,6 +849,10 @@ class Scope:
     def set_transaction_name(self, name: str, source: "Optional[str]" = None) -> None:
         """Set the transaction name and optionally the transaction source."""
         self._transaction = name
+
+        if source:
+            self._transaction_info["source"] = source
+
         if self._span:
             if isinstance(self._span, NoOpStreamedSpan):
                 return
@@ -864,9 +868,6 @@ class Scope:
                 self._span.containing_transaction.name = name
                 if source:
                     self._span.containing_transaction.source = source
-
-        if source:
-            self._transaction_info["source"] = source
 
     @_attr_setter
     def user(self, value: "Optional[Dict[str, Any]]") -> None:


### PR DESCRIPTION
### Description
<!-- What changed and why? -->

Set the transaction source that is attached to events before the early return for `NoOpStreamedSpan`.

Enables creating a streaming lifecycle version of `tests/integrations/django/test_basic.py::test_transaction_style`.

#### Issues
<!--
* resolves: #1234
* resolves: LIN-1234
-->

#### Reminders
- Please add tests to validate your changes, and lint your code using `tox -e linters`.
- Add GH Issue ID _&_ Linear ID (if applicable)
- PR title should use [conventional commit](https://develop.sentry.dev/engineering-practices/commit-messages/#type) style (`feat:`, `fix:`, `ref:`, `meta:`)
- For external contributors: [CONTRIBUTING.md](https://github.com/getsentry/sentry-python/blob/master/CONTRIBUTING.md), [Sentry SDK development docs](https://develop.sentry.dev/sdk/), [Discord community](https://discord.gg/Ww9hbqr)
