### PR TITLE
test(django): Check transaction annotations on transaction events

### DIFF
--- a/tests/integrations/django/test_basic.py
+++ b/tests/integrations/django/test_basic.py
@@ -730,7 +730,8 @@ def test_transaction_style(
     content, status, headers = unpack_werkzeug_response(client.get(client_url))
     assert content == expected_response
 
-    (_, transaction) = events
+    (error, transaction) = events
+    assert error["transaction"] == expected_transaction
     assert transaction["transaction"] == expected_transaction
     assert transaction["transaction_info"] == {"source": expected_source}
 

--- a/tests/integrations/django/test_basic.py
+++ b/tests/integrations/django/test_basic.py
@@ -723,15 +723,16 @@ def test_transaction_style(
 ):
     sentry_init(
         integrations=[DjangoIntegration(transaction_style=transaction_style)],
+        traces_sample_rate=1.0,
         send_default_pii=True,
     )
     events = capture_events()
     content, status, headers = unpack_werkzeug_response(client.get(client_url))
     assert content == expected_response
 
-    (event,) = events
-    assert event["transaction"] == expected_transaction
-    assert event["transaction_info"] == {"source": expected_source}
+    (_, transaction) = events
+    assert transaction["transaction"] == expected_transaction
+    assert transaction["transaction_info"] == {"source": expected_source}
 
 
 def test_request_body(sentry_init, client, capture_events):


### PR DESCRIPTION
### Description
<!-- What changed and why? -->

Assert that the `transaction_info` field has the expected value on a transaction event instead of an error event.

#### Issues
<!--
* resolves: #1234
* resolves: LIN-1234
-->

#### Reminders
- Please add tests to validate your changes, and lint your code using `tox -e linters`.
- Add GH Issue ID _&_ Linear ID (if applicable)
- PR title should use [conventional commit](https://develop.sentry.dev/engineering-practices/commit-messages/#type) style (`feat:`, `fix:`, `ref:`, `meta:`)
- For external contributors: [CONTRIBUTING.md](https://github.com/getsentry/sentry-python/blob/master/CONTRIBUTING.md), [Sentry SDK development docs](https://develop.sentry.dev/sdk/), [Discord community](https://discord.gg/Ww9hbqr)
