### PR TITLE
fix: Use proto version 2 to fix backfilled user agent and IP

### DIFF
--- a/sentry_sdk/_batcher.py
+++ b/sentry_sdk/_batcher.py
@@ -153,9 +153,14 @@ class Batcher(Generic[T]):
                 },
                 payload=PayloadRef(
                     json={
+                        "ingest_settings": {
+                            "infer_ip": "never",
+                            "infer_user_agent": "never",
+                        },
+                        "version": 2,
                         "items": [
                             self._to_transport_format(item) for item in self._buffer
-                        ]
+                        ],
                     }
                 ),
             )

--- a/sentry_sdk/_batcher.py
+++ b/sentry_sdk/_batcher.py
@@ -153,10 +153,6 @@ class Batcher(Generic[T]):
                 },
                 payload=PayloadRef(
                     json={
-                        "ingest_settings": {
-                            "infer_ip": "never",
-                            "infer_user_agent": "never",
-                        },
                         "version": 2,
                         "items": [
                             self._to_transport_format(item) for item in self._buffer

--- a/sentry_sdk/_log_batcher.py
+++ b/sentry_sdk/_log_batcher.py
@@ -45,7 +45,12 @@ class LogBatcher(Batcher["Log"]):
             headers={
                 "item_count": 1,
             },
-            payload=PayloadRef(json={"items": [self._to_transport_format(item)]}),
+            payload=PayloadRef(
+                json={
+                    "version": 2,
+                    "items": [self._to_transport_format(item)],
+                }
+            ),
         )
 
         self._record_lost_func(

--- a/sentry_sdk/_span_batcher.py
+++ b/sentry_sdk/_span_batcher.py
@@ -224,10 +224,6 @@ class SpanBatcher(Batcher["StreamedSpan"]):
                             },
                             payload=PayloadRef(
                                 json={
-                                    "ingest_settings": {
-                                        "infer_ip": "never",
-                                        "infer_user_agent": "never",
-                                    },
                                     "version": 2,
                                     "items": [
                                         self._to_transport_format(spans[j])

--- a/sentry_sdk/_span_batcher.py
+++ b/sentry_sdk/_span_batcher.py
@@ -224,10 +224,15 @@ class SpanBatcher(Batcher["StreamedSpan"]):
                             },
                             payload=PayloadRef(
                                 json={
+                                    "ingest_settings": {
+                                        "infer_ip": "never",
+                                        "infer_user_agent": "never",
+                                    },
+                                    "version": 2,
                                     "items": [
                                         self._to_transport_format(spans[j])
                                         for j in range(start, end)
-                                    ]
+                                    ],
                                 }
                             ),
                         )

--- a/tests/test_logs.py
+++ b/tests/test_logs.py
@@ -545,6 +545,7 @@ def test_batcher_drops_logs(sentry_init, monkeypatch):
             "content_type": "application/vnd.sentry.items.log+json",
         }
         assert item.payload.json == {
+            "version": 2,
             "items": [
                 {
                     "body": "This is a 'info' log...",
@@ -583,7 +584,7 @@ def test_batcher_drops_logs(sentry_init, monkeypatch):
                         },
                     },
                 }
-            ]
+            ],
         }
 
 

--- a/tests/test_logs.py
+++ b/tests/test_logs.py
@@ -466,6 +466,7 @@ def test_transport_format(sentry_init, capture_envelopes):
         "content_type": "application/vnd.sentry.items.log+json",
     }
     assert item.payload.json == {
+        "version": 2,
         "items": [
             {
                 "body": "This is a log...",
@@ -504,7 +505,7 @@ def test_transport_format(sentry_init, capture_envelopes):
                     },
                 },
             }
-        ]
+        ],
     }
 
 

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -267,6 +267,7 @@ def test_transport_format(sentry_init, capture_envelopes):
         "content_type": "application/vnd.sentry.items.trace-metric+json",
     }
     assert item.payload.json == {
+        "version": 2,
         "items": [
             {
                 "name": "test.counter",
@@ -297,7 +298,7 @@ def test_transport_format(sentry_init, capture_envelopes):
                     },
                 },
             }
-        ]
+        ],
     }
 
 

--- a/tests/tracing/test_span_batcher.py
+++ b/tests/tracing/test_span_batcher.py
@@ -406,6 +406,7 @@ def test_transport_format(sentry_init, capture_envelopes):
         "content_type": "application/vnd.sentry.items.span.v2+json",
     }
     assert item.payload.json == {
+        "version": 2,
         "items": [
             {
                 "trace_id": mock.ANY,
@@ -417,7 +418,7 @@ def test_transport_format(sentry_init, capture_envelopes):
                 "end_timestamp": mock.ANY,
                 "attributes": mock.ANY,
             }
-        ]
+        ],
     }
     for attribute, value in item.payload.json["items"][0]["attributes"].items():
         assert isinstance(attribute, str)


### PR DESCRIPTION
### Description
Turn off user agent and user IP inference in Relay as it doesn't fill in the correct data for backend SDKs.

`"version": 2` implies `"ingest_settings": {"infer_ip": "never", "infer_user_agent": "never"}`, as those are the default values for the settings in version 2. I'm not including the values in the item payload to keep it a bit slimmer. 

Spec: https://develop.sentry.dev/sdk/telemetry/metrics/#version-and-ingest_settings-properties (for metrics, but applies to logs and spans v2 as well; docs rework pending with https://github.com/getsentry/sentry-docs/pull/17725)

#### Issues
* closes https://linear.app/getsentry/issue/PY-2413/send-ingest-settings
* closes https://github.com/getsentry/sentry-python/issues/6255

#### Reminders
- Please add tests to validate your changes, and lint your code using `tox -e linters`.
- Add GH Issue ID _&_ Linear ID (if applicable)
- PR title should use [conventional commit](https://develop.sentry.dev/engineering-practices/commit-messages/#type) style (`feat:`, `fix:`, `ref:`, `meta:`)
- For external contributors: [CONTRIBUTING.md](https://github.com/getsentry/sentry-python/blob/master/CONTRIBUTING.md), [Sentry SDK development docs](https://develop.sentry.dev/sdk/), [Discord community](https://discord.gg/Ww9hbqr)
