### PR TITLE
fix: Work around compromised transitive dependency

### DIFF
--- a/scripts/populate_tox/config.py
+++ b/scripts/populate_tox/config.py
@@ -310,7 +310,7 @@ TEST_SUITE_CONFIG = {
         "num_versions": 2,
     },
     "pydantic_ai": {
-        "package": "pydantic-ai",
+        "package": "pydantic-ai-slim",
         "deps": {
             "*": ["pytest-asyncio"],
         },

--- a/tox.ini
+++ b/tox.ini
@@ -477,11 +477,11 @@ deps =
     openai_agents-latest: openai-agents==0.17.0
     openai_agents: pytest-asyncio
 
-    pydantic_ai-v1.0.18: pydantic-ai==1.0.18
-    pydantic_ai-v1.31.0: pydantic-ai==1.31.0
-    pydantic_ai-v1.63.0: pydantic-ai==1.63.0
-    pydantic_ai-v1.93.0: pydantic-ai==1.93.0
-    pydantic_ai-latest: pydantic-ai==1.93.0
+    pydantic_ai-v1.0.18: pydantic-ai-slim==1.0.18
+    pydantic_ai-v1.31.0: pydantic-ai-slim==1.31.0
+    pydantic_ai-v1.63.0: pydantic-ai-slim==1.63.0
+    pydantic_ai-v1.93.0: pydantic-ai-slim==1.93.0
+    pydantic_ai-latest: pydantic-ai-slim==1.93.0
     pydantic_ai: pytest-asyncio
 
 


### PR DESCRIPTION
- `mistralai` [might have been compromised](https://github.com/mistralai/client-python/issues/524). It's been quarantined by PyPI, so it can't be installed at all.
- The base Pydantic AI package `pydantic-ai` [installs](https://github.com/pydantic/pydantic-ai/issues/5382) `pydantic-ai-slim` with a bunch of extras for all sort of AI providers, including `mistralai`.
- Our test suite fails because we attempt to install `pydantic-ai`, which then tries to pull in `mistralai` transitively.

Even though there's now a new release of `pydantic-ai` without the dependency, older versions still have it, and we still want to test against a variety of versions in our test suite.

The fix: don't install `pydantic-ai`, but instead install `pydantic-ai-slim` directly, at least for now until `mistralai` is restored.