### PR TITLE
Revert "fix: Work around compromised transitive dependency (#6257)"

### DIFF
--- a/scripts/populate_tox/config.py
+++ b/scripts/populate_tox/config.py
@@ -310,7 +310,7 @@ TEST_SUITE_CONFIG = {
         "num_versions": 2,
     },
     "pydantic_ai": {
-        "package": "pydantic-ai-slim",
+        "package": "pydantic-ai",
         "deps": {
             "*": ["pytest-asyncio"],
         },

--- a/tox.ini
+++ b/tox.ini
@@ -477,11 +477,11 @@ deps =
     openai_agents-latest: openai-agents==0.17.0
     openai_agents: pytest-asyncio
 
-    pydantic_ai-v1.0.18: pydantic-ai-slim==1.0.18
-    pydantic_ai-v1.31.0: pydantic-ai-slim==1.31.0
-    pydantic_ai-v1.63.0: pydantic-ai-slim==1.63.0
-    pydantic_ai-v1.93.0: pydantic-ai-slim==1.93.0
-    pydantic_ai-latest: pydantic-ai-slim==1.93.0
+    pydantic_ai-v1.0.18: pydantic-ai==1.0.18
+    pydantic_ai-v1.31.0: pydantic-ai==1.31.0
+    pydantic_ai-v1.63.0: pydantic-ai==1.63.0
+    pydantic_ai-v1.93.0: pydantic-ai==1.93.0
+    pydantic_ai-latest: pydantic-ai==1.93.0
     pydantic_ai: pytest-asyncio
 
 


### PR DESCRIPTION
`mistralai` has been un-quarantined, so it should be installable again. (We're pulling it in via `pydantic-ai`.)

This reverts commit c1921a4c5df2f2c8bf66baca356c1cbe0440d350.
