### PR TITLE
fix(langchain): Catch `TypeError` on `langchain.agents` import

### DIFF
--- a/sentry_sdk/integrations/langchain.py
+++ b/sentry_sdk/integrations/langchain.py
@@ -61,7 +61,8 @@ except ImportError:
     try:
         # <v1
         from langchain.agents import AgentExecutor
-    except ImportError:
+    # Catch TypeError due to changes in type hint evaluation order: https://github.com/pydantic/pydantic/issues/13036
+    except (ImportError, TypeError):
         AgentExecutor = None
 
 


### PR DESCRIPTION
### Description
<!-- What changed and why? -->

Stack trace when importing `langchain.agents` with the reporter's package versions:

```
Traceback (most recent call last):
  File "/repro/repro.py", line 18, in main
    from langchain.agents import AgentExecutor
  File "/usr/local/lib/python3.14/site-packages/langchain/agents/__init__.py", line 40, in <module>
    from langchain.agents.agent import (
    ...<6 lines>...
    )
  File "/usr/local/lib/python3.14/site-packages/langchain/agents/agent.py", line 50, in <module>
    from langchain.chains.base import Chain
  File "/usr/local/lib/python3.14/site-packages/langchain/chains/base.py", line 50, in <module>
    class Chain(RunnableSerializable[dict[str, Any], dict[str, Any]], ABC):
    ...<715 lines>...
            return [self(inputs, callbacks=callbacks) for inputs in input_list]
  File "/usr/local/lib/python3.14/site-packages/pydantic/_internal/_model_construction.py", line 243, in __new__
    set_model_fields(cls, config_wrapper=config_wrapper, ns_resolver=ns_resolver)
    ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.14/site-packages/pydantic/_internal/_model_construction.py", line 579, in set_model_fields
    fields, pydantic_extra_info, class_vars = collect_model_fields(
                                              ~~~~~~~~~~~~~~~~~~~~^
        cls, config_wrapper, ns_resolver, typevars_map=typevars_map
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
  File "/usr/local/lib/python3.14/site-packages/pydantic/_internal/_fields.py", line 265, in collect_model_fields
    type_hints = _typing_extra.get_model_type_hints(cls, ns_resolver=ns_resolver)
  File "/usr/local/lib/python3.14/site-packages/pydantic/_internal/_typing_extra.py", line 368, in get_model_type_hints
    hints[name] = try_eval_type(value, globalns, localns)
                  ~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.14/site-packages/pydantic/_internal/_typing_extra.py", line 423, in try_eval_type
    return eval_type_backport(value, globalns, localns), True
           ~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.14/site-packages/pydantic/_internal/_typing_extra.py", line 474, in eval_type_backport
    return _eval_type_backport(value, globalns, localns, type_params)
  File "/usr/local/lib/python3.14/site-packages/pydantic/_internal/_typing_extra.py", line 511, in _eval_type_backport
    return _eval_type(value, globalns, localns, type_params)
  File "/usr/local/lib/python3.14/site-packages/pydantic/_internal/_typing_extra.py", line 543, in _eval_type
    evaluated = typing._eval_type(  # type: ignore
        value,
    ...<9 lines>...
        prefer_fwd_module=True,
    )
  File "/usr/local/lib/python3.14/typing.py", line 461, in _eval_type
    return evaluate_forward_ref(t, globals=globalns, locals=localns,
                                type_params=type_params, owner=owner,
                                _recursive_guard=recursive_guard, format=format)
  File "/usr/local/lib/python3.14/typing.py", line 1000, in evaluate_forward_ref
    value = forward_ref.evaluate(globals=globals, locals=locals,
                                 type_params=type_params, owner=owner, format=format)
  File "/usr/local/lib/python3.14/annotationlib.py", line 205, in evaluate
    return eval(code, globals=globals, locals=locals)
  File "<string>", line 1, in <module>
TypeError: 'function' object is not subscriptable
Unable to evaluate type annotation 'Optional[dict[str, Any]]'.
```

#### Issues

Closes https://github.com/getsentry/sentry-python/issues/6265

#### Reminders
- Please add tests to validate your changes, and lint your code using `tox -e linters`.
- Add GH Issue ID _&_ Linear ID (if applicable)
- PR title should use [conventional commit](https://develop.sentry.dev/engineering-practices/commit-messages/#type) style (`feat:`, `fix:`, `ref:`, `meta:`)
- For external contributors: [CONTRIBUTING.md](https://github.com/getsentry/sentry-python/blob/master/CONTRIBUTING.md), [Sentry SDK development docs](https://develop.sentry.dev/sdk/), [Discord community](https://discord.gg/Ww9hbqr)
