### PR TITLE
ci: Enable Ruff import ordering

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -212,6 +212,7 @@ select = [
     "E",   # pycodestyle errors (same as flake8 default)
     "W",   # pycodestyle warnings (same as flake8 default)
     "F",   # Pyflakes (same as flake8 default)
+    "I",
     # Note: B and N rules are NOT enabled by default in flake8
     # They were only active through the plugins, which may not have been fully enabled
 ]

--- a/scripts/init_serverless_sdk.py
+++ b/scripts/init_serverless_sdk.py
@@ -7,13 +7,12 @@ Then the Handler function sstring should be replaced with
 """
 
 import os
-import sys
 import re
+import sys
+from typing import TYPE_CHECKING
 
 import sentry_sdk
 from sentry_sdk.integrations.aws_lambda import AwsLambdaIntegration
-
-from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from typing import Any

--- a/scripts/populate_tox/populate_tox.py
+++ b/scripts/populate_tox/populate_tox.py
@@ -4,35 +4,35 @@ This script populates tox.ini automatically using release data from PyPI.
 See scripts/populate_tox/README.md for more info.
 """
 
-import re
 import functools
 import hashlib
 import json
 import os
+import re
 import subprocess
 import sys
 import time
-from dataclasses import dataclass
 from bisect import bisect_left
 from collections import defaultdict
+from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone  # noqa: F401
 from importlib.metadata import PackageMetadata, distributions
-from packaging.specifiers import SpecifierSet
-from packaging.version import Version
 from pathlib import Path
 from typing import Optional, Union
+
+from packaging.specifiers import SpecifierSet
+from packaging.version import Version
 
 # Adding the scripts directory to PATH. This is necessary in order to be able
 # to import stuff from the split_tox_gh_actions script
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 import requests
-from jinja2 import Environment, FileSystemLoader
-from sentry_sdk.integrations import _MIN_VERSIONS
-
 from config import TEST_SUITE_CONFIG
+from jinja2 import Environment, FileSystemLoader
 from split_tox_gh_actions.split_tox_gh_actions import GROUPS
 
+from sentry_sdk.integrations import _MIN_VERSIONS
 
 # Set CUTOFF this to a datetime to ignore packages older than CUTOFF
 CUTOFF = None

--- a/scripts/ready_yet/main.py
+++ b/scripts/ready_yet/main.py
@@ -1,17 +1,14 @@
-import time
 import re
 import sys
-
-import requests
-
+import time
 from collections import defaultdict
-
 from pathlib import Path
 
+import requests
 from tox.config.cli.parse import get_options
-from tox.session.state import State
 from tox.config.sets import CoreConfigSet
 from tox.config.source.tox_ini import ToxIni
+from tox.session.state import State
 
 PYTHON_VERSION = "3.13"
 

--- a/scripts/test-lambda-locally/lambda_function.py
+++ b/scripts/test-lambda-locally/lambda_function.py
@@ -1,7 +1,7 @@
 import logging
 import os
-import sentry_sdk
 
+import sentry_sdk
 from sentry_sdk.integrations.aws_lambda import AwsLambdaIntegration
 from sentry_sdk.integrations.logging import LoggingIntegration
 

--- a/sentry_sdk/__init__.py
+++ b/sentry_sdk/__init__.py
@@ -1,11 +1,9 @@
-from sentry_sdk import profiler
-from sentry_sdk import metrics
-from sentry_sdk.scope import Scope
-from sentry_sdk.transport import Transport, HttpTransport
-from sentry_sdk.client import Client
-
+from sentry_sdk import metrics, profiler
 from sentry_sdk.api import *  # noqa
+from sentry_sdk.client import Client
 from sentry_sdk.consts import VERSION
+from sentry_sdk.scope import Scope
+from sentry_sdk.transport import HttpTransport, Transport
 
 __all__ = [  # noqa
     "Hub",

--- a/sentry_sdk/__init__.py
+++ b/sentry_sdk/__init__.py
@@ -1,9 +1,11 @@
 from sentry_sdk import metrics, profiler
-from sentry_sdk.api import *  # noqa
-from sentry_sdk.client import Client
+
+from sentry_sdk.scope import Scope  # isort: skip
+from sentry_sdk.client import Client  # isort: skip
 from sentry_sdk.consts import VERSION
-from sentry_sdk.scope import Scope
 from sentry_sdk.transport import HttpTransport, Transport
+
+from sentry_sdk.api import *  # noqa # isort: skip
 
 __all__ = [  # noqa
     "Hub",

--- a/sentry_sdk/_batcher.py
+++ b/sentry_sdk/_batcher.py
@@ -1,15 +1,15 @@
 import os
 import random
 import threading
-from datetime import datetime, timezone
-from typing import TYPE_CHECKING, TypeVar, Generic
 import weakref
+from datetime import datetime, timezone
+from typing import TYPE_CHECKING, Generic, TypeVar
 
-from sentry_sdk.utils import format_timestamp
 from sentry_sdk.envelope import Envelope, Item, PayloadRef
+from sentry_sdk.utils import format_timestamp
 
 if TYPE_CHECKING:
-    from typing import Optional, Callable, Any
+    from typing import Any, Callable, Optional
 
 T = TypeVar("T")
 

--- a/sentry_sdk/_compat.py
+++ b/sentry_sdk/_compat.py
@@ -1,10 +1,8 @@
 import sys
-
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from typing import Any
-    from typing import TypeVar
+    from typing import Any, TypeVar
 
     T = TypeVar("T")
 

--- a/sentry_sdk/_init_implementation.py
+++ b/sentry_sdk/_init_implementation.py
@@ -1,5 +1,4 @@
 import warnings
-
 from typing import TYPE_CHECKING
 
 import sentry_sdk

--- a/sentry_sdk/_log_batcher.py
+++ b/sentry_sdk/_log_batcher.py
@@ -1,11 +1,12 @@
 from typing import TYPE_CHECKING
 
 from sentry_sdk._batcher import Batcher
-from sentry_sdk.utils import serialize_attribute
 from sentry_sdk.envelope import Item, PayloadRef
+from sentry_sdk.utils import serialize_attribute
 
 if TYPE_CHECKING:
     from typing import Any
+
     from sentry_sdk._types import Log
 
 

--- a/sentry_sdk/_metrics_batcher.py
+++ b/sentry_sdk/_metrics_batcher.py
@@ -5,6 +5,7 @@ from sentry_sdk.utils import serialize_attribute
 
 if TYPE_CHECKING:
     from typing import Any
+
     from sentry_sdk._types import Metric
 
 

--- a/sentry_sdk/_queue.py
+++ b/sentry_sdk/_queue.py
@@ -72,10 +72,8 @@ Agreement.
 """
 
 import threading
-
 from collections import deque
 from time import time
-
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:

--- a/sentry_sdk/_span_batcher.py
+++ b/sentry_sdk/_span_batcher.py
@@ -1,11 +1,11 @@
+import os
 import random
 import threading
 import time
+import weakref
 from collections import defaultdict
 from datetime import datetime, timezone
-import os
 from typing import TYPE_CHECKING
-import weakref
 
 from sentry_sdk._batcher import Batcher
 from sentry_sdk.envelope import Envelope, Item, PayloadRef
@@ -13,6 +13,7 @@ from sentry_sdk.utils import format_timestamp, serialize_attribute
 
 if TYPE_CHECKING:
     from typing import Any, Callable, Optional
+
     from sentry_sdk.traces import StreamedSpan
 
 

--- a/sentry_sdk/_werkzeug.py
+++ b/sentry_sdk/_werkzeug.py
@@ -35,10 +35,7 @@ SUCH DAMAGE.
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from typing import Dict
-    from typing import Iterator
-    from typing import Tuple
-    from typing import Optional
+    from typing import Dict, Iterator, Optional, Tuple
 
 
 #

--- a/sentry_sdk/ai/__init__.py
+++ b/sentry_sdk/ai/__init__.py
@@ -1,8 +1,8 @@
 from .utils import (
-    set_data_normalized,  # noqa: F401
     GEN_AI_MESSAGE_ROLE_MAPPING,  # noqa: F401
     GEN_AI_MESSAGE_ROLE_REVERSE_MAPPING,  # noqa: F401
     normalize_message_role,  # noqa: F401
     normalize_message_roles,  # noqa: F401
     set_conversation_id,  # noqa: F401
+    set_data_normalized,  # noqa: F401
 )

--- a/sentry_sdk/ai/_openai_completions_api.py
+++ b/sentry_sdk/ai/_openai_completions_api.py
@@ -1,16 +1,16 @@
 from collections.abc import Iterable
-
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from sentry_sdk._types import TextPart
     from typing import Union
 
     from openai.types.chat import (
+        ChatCompletionContentPartParam,
         ChatCompletionMessageParam,
         ChatCompletionSystemMessageParam,
-        ChatCompletionContentPartParam,
     )
+
+    from sentry_sdk._types import TextPart
 
 
 def _is_system_instruction(message: "ChatCompletionMessageParam") -> bool:

--- a/sentry_sdk/ai/_openai_responses_api.py
+++ b/sentry_sdk/ai/_openai_responses_api.py
@@ -3,7 +3,7 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from typing import Union
 
-    from openai.types.responses import ResponseInputParam, ResponseInputItemParam
+    from openai.types.responses import ResponseInputItemParam, ResponseInputParam
 
 
 def _is_system_instruction(message: "ResponseInputItemParam") -> bool:

--- a/sentry_sdk/ai/monitoring.py
+++ b/sentry_sdk/ai/monitoring.py
@@ -1,19 +1,18 @@
 import inspect
 import sys
 from functools import wraps
-
-from sentry_sdk.ai.utils import _set_span_data_attribute
-from sentry_sdk.consts import SPANDATA
-import sentry_sdk.utils
-from sentry_sdk import start_span
-from sentry_sdk.tracing import Span
-from sentry_sdk.traces import StreamedSpan
-from sentry_sdk.utils import ContextVar, reraise, capture_internal_exceptions
-
 from typing import TYPE_CHECKING
 
+import sentry_sdk.utils
+from sentry_sdk import start_span
+from sentry_sdk.ai.utils import _set_span_data_attribute
+from sentry_sdk.consts import SPANDATA
+from sentry_sdk.traces import StreamedSpan
+from sentry_sdk.tracing import Span
+from sentry_sdk.utils import ContextVar, capture_internal_exceptions, reraise
+
 if TYPE_CHECKING:
-    from typing import Optional, Callable, Awaitable, Any, Union, TypeVar
+    from typing import Any, Awaitable, Callable, Optional, TypeVar, Union
 
     F = TypeVar("F", bound=Union[Callable[..., Any], Callable[..., Awaitable[Any]]])
 

--- a/sentry_sdk/ai/utils.py
+++ b/sentry_sdk/ai/utils.py
@@ -12,9 +12,9 @@ if TYPE_CHECKING:
     from sentry_sdk.tracing import Span
 
 import sentry_sdk
-from sentry_sdk.utils import logger
 from sentry_sdk.traces import StreamedSpan
 from sentry_sdk.tracing_utils import has_span_streaming_enabled
+from sentry_sdk.utils import logger
 
 MAX_GEN_AI_MESSAGE_BYTES = 20_000  # 20KB
 # Maximum characters when only a single message is left after bytes truncation

--- a/sentry_sdk/api.py
+++ b/sentry_sdk/api.py
@@ -1,43 +1,43 @@
 import inspect
 import warnings
 from contextlib import contextmanager
+from typing import TYPE_CHECKING
 
-from sentry_sdk import tracing_utils, Client
+from sentry_sdk import Client, tracing_utils
 from sentry_sdk._init_implementation import init
 from sentry_sdk.consts import INSTRUMENTER
-from sentry_sdk.scope import Scope, _ScopeManager, new_scope, isolation_scope
+from sentry_sdk.crons import monitor
+from sentry_sdk.scope import Scope, _ScopeManager, isolation_scope, new_scope
 from sentry_sdk.traces import StreamedSpan, _get_current_streamed_span
 from sentry_sdk.tracing import NoOpSpan, Transaction, trace
-from sentry_sdk.crons import monitor
-
-from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from collections.abc import Mapping
-
-    from typing import Any
-    from typing import Dict
-    from typing import Generator
-    from typing import Optional
-    from typing import overload
-    from typing import Callable
-    from typing import TypeVar
-    from typing import ContextManager
-    from typing import Union
+    from typing import (
+        Any,
+        Callable,
+        ContextManager,
+        Dict,
+        Generator,
+        Optional,
+        TypeVar,
+        Union,
+        overload,
+    )
 
     from typing_extensions import Unpack
 
-    from sentry_sdk.client import BaseClient
     from sentry_sdk._types import (
-        Event,
-        Hint,
         Breadcrumb,
         BreadcrumbHint,
+        Event,
         ExcInfo,
-        MeasurementUnit,
+        Hint,
         LogLevelStr,
+        MeasurementUnit,
         SamplingContext,
     )
+    from sentry_sdk.client import BaseClient
     from sentry_sdk.traces import StreamedSpan
     from sentry_sdk.tracing import Span, TransactionKwargs
 

--- a/sentry_sdk/api.py
+++ b/sentry_sdk/api.py
@@ -3,7 +3,7 @@ import warnings
 from contextlib import contextmanager
 from typing import TYPE_CHECKING
 
-from sentry_sdk import Client, tracing_utils
+from sentry_sdk import tracing_utils, Client  # isort: skip
 from sentry_sdk._init_implementation import init
 from sentry_sdk.consts import INSTRUMENTER
 from sentry_sdk.crons import monitor

--- a/sentry_sdk/attachments.py
+++ b/sentry_sdk/attachments.py
@@ -1,12 +1,11 @@
-import os
 import mimetypes
+import os
+from typing import TYPE_CHECKING
 
 from sentry_sdk.envelope import Item, PayloadRef
 
-from typing import TYPE_CHECKING
-
 if TYPE_CHECKING:
-    from typing import Optional, Union, Callable
+    from typing import Callable, Optional, Union
 
 
 class Attachment:

--- a/sentry_sdk/client.py
+++ b/sentry_sdk/client.py
@@ -1,82 +1,78 @@
+import json
 import os
-import uuid
 import random
 import socket
-from collections.abc import Mapping, Iterable
+import uuid
+import warnings
+from collections.abc import Iterable, Mapping
 from datetime import datetime, timezone
 from importlib import import_module
-from typing import TYPE_CHECKING, List, Dict, cast, overload
-import warnings
-import json
+from typing import TYPE_CHECKING, Dict, List, cast, overload
 
 from sentry_sdk._compat import check_uwsgi_thread_support
 from sentry_sdk._metrics_batcher import MetricsBatcher
 from sentry_sdk._span_batcher import SpanBatcher
+from sentry_sdk.consts import (
+    DEFAULT_MAX_VALUE_LENGTH,
+    DEFAULT_OPTIONS,
+    INSTRUMENTER,
+    SPANDATA,
+    SPANSTATUS,
+    VERSION,
+    ClientConstructor,
+)
+from sentry_sdk.envelope import Envelope, Item, PayloadRef
+from sentry_sdk.integrations import _DEFAULT_INTEGRATIONS, setup_integrations
+from sentry_sdk.integrations.dedupe import DedupeIntegration
+from sentry_sdk.monitor import Monitor
+from sentry_sdk.profiler.continuous_profiler import setup_continuous_profiler
+from sentry_sdk.profiler.transaction_profiler import (
+    Profile,
+    has_profiling_enabled,
+    setup_profiler,
+)
+from sentry_sdk.scrubber import EventScrubber
+from sentry_sdk.serializer import serialize
+from sentry_sdk.sessions import SessionFlusher
+from sentry_sdk.traces import SpanStatus
+from sentry_sdk.tracing import trace
+from sentry_sdk.tracing_utils import has_span_streaming_enabled
+from sentry_sdk.transport import (
+    AsyncHttpTransport,
+    HttpTransportCore,
+    make_transport,
+)
 from sentry_sdk.utils import (
     AnnotatedValue,
     ContextVar,
     capture_internal_exceptions,
     current_stacktrace,
+    datetime_from_isoformat,
     env_to_bool,
     format_timestamp,
-    get_sdk_name,
-    get_type_name,
-    get_default_release,
-    handle_in_app,
-    logger,
     get_before_send_log,
     get_before_send_metric,
+    get_default_release,
+    get_sdk_name,
+    get_type_name,
+    handle_in_app,
     has_logs_enabled,
     has_metrics_enabled,
+    logger,
 )
-from sentry_sdk.serializer import serialize
-from sentry_sdk.tracing import trace
-from sentry_sdk.traces import SpanStatus
-from sentry_sdk.tracing_utils import has_span_streaming_enabled
-from sentry_sdk.transport import (
-    HttpTransportCore,
-    make_transport,
-    AsyncHttpTransport,
-)
-from sentry_sdk.consts import (
-    SPANDATA,
-    SPANSTATUS,
-    DEFAULT_MAX_VALUE_LENGTH,
-    DEFAULT_OPTIONS,
-    INSTRUMENTER,
-    VERSION,
-    ClientConstructor,
-)
-from sentry_sdk.integrations import _DEFAULT_INTEGRATIONS, setup_integrations
-from sentry_sdk.integrations.dedupe import DedupeIntegration
-from sentry_sdk.sessions import SessionFlusher
-from sentry_sdk.envelope import Envelope, Item, PayloadRef
-from sentry_sdk.profiler.continuous_profiler import setup_continuous_profiler
-from sentry_sdk.profiler.transaction_profiler import (
-    has_profiling_enabled,
-    Profile,
-    setup_profiler,
-)
-from sentry_sdk.scrubber import EventScrubber
-from sentry_sdk.monitor import Monitor
-from sentry_sdk.utils import datetime_from_isoformat
 
 if TYPE_CHECKING:
-    from typing import Any
-    from typing import Callable
-    from typing import Optional
-    from typing import Sequence
-    from typing import Type
-    from typing import Union
-    from typing import TypeVar
+    from typing import Any, Callable, Optional, Sequence, Type, TypeVar, Union
 
+    from sentry_sdk._log_batcher import LogBatcher
+    from sentry_sdk._metrics_batcher import MetricsBatcher
     from sentry_sdk._types import (
         Event,
+        EventDataCategory,
         Hint,
-        SDKInfo,
         Log,
         Metric,
-        EventDataCategory,
+        SDKInfo,
         SerializedAttributeValue,
     )
     from sentry_sdk.integrations import Integration
@@ -84,9 +80,7 @@ if TYPE_CHECKING:
     from sentry_sdk.session import Session
     from sentry_sdk.spotlight import SpotlightClient
     from sentry_sdk.traces import StreamedSpan
-    from sentry_sdk.transport import Transport, Item
-    from sentry_sdk._log_batcher import LogBatcher
-    from sentry_sdk._metrics_batcher import MetricsBatcher
+    from sentry_sdk.transport import Item, Transport
     from sentry_sdk.utils import Dsn
 
     I = TypeVar("I", bound=Integration)  # noqa: E741

--- a/sentry_sdk/crons/__init__.py
+++ b/sentry_sdk/crons/__init__.py
@@ -2,7 +2,6 @@ from sentry_sdk.crons.api import capture_checkin
 from sentry_sdk.crons.consts import MonitorStatus
 from sentry_sdk.crons.decorator import monitor
 
-
 __all__ = [
     "capture_checkin",
     "MonitorStatus",

--- a/sentry_sdk/crons/api.py
+++ b/sentry_sdk/crons/api.py
@@ -1,12 +1,12 @@
 import uuid
+from typing import TYPE_CHECKING
 
 import sentry_sdk
 from sentry_sdk.utils import logger
 
-from typing import TYPE_CHECKING
-
 if TYPE_CHECKING:
     from typing import Optional
+
     from sentry_sdk._types import Event, MonitorConfig
 
 

--- a/sentry_sdk/crons/decorator.py
+++ b/sentry_sdk/crons/decorator.py
@@ -1,11 +1,10 @@
 from functools import wraps
 from inspect import iscoroutinefunction
+from typing import TYPE_CHECKING
 
 from sentry_sdk.crons import capture_checkin
 from sentry_sdk.crons.consts import MonitorStatus
 from sentry_sdk.utils import now
-
-from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from collections.abc import Awaitable, Callable
@@ -20,6 +19,7 @@ if TYPE_CHECKING:
         cast,
         overload,
     )
+
     from sentry_sdk._types import MonitorConfig
 
     P = ParamSpec("P")

--- a/sentry_sdk/debug.py
+++ b/sentry_sdk/debug.py
@@ -1,11 +1,11 @@
-import sys
 import logging
+import sys
 import warnings
+from logging import LogRecord
 
 from sentry_sdk import get_client
 from sentry_sdk.client import _client_init_debug
 from sentry_sdk.utils import logger
-from logging import LogRecord
 
 
 class _DebugFilter(logging.Filter):

--- a/sentry_sdk/envelope.py
+++ b/sentry_sdk/envelope.py
@@ -1,19 +1,13 @@
 import io
 import json
 import mimetypes
-
-from sentry_sdk.session import Session
-from sentry_sdk.utils import json_dumps, capture_internal_exceptions
-
 from typing import TYPE_CHECKING
 
+from sentry_sdk.session import Session
+from sentry_sdk.utils import capture_internal_exceptions, json_dumps
+
 if TYPE_CHECKING:
-    from typing import Any
-    from typing import Optional
-    from typing import Union
-    from typing import Dict
-    from typing import List
-    from typing import Iterator
+    from typing import Any, Dict, Iterator, List, Optional, Union
 
     from sentry_sdk._types import Event, EventDataCategory
 

--- a/sentry_sdk/feature_flags.py
+++ b/sentry_sdk/feature_flags.py
@@ -1,11 +1,11 @@
 import copy
+from threading import Lock
+from typing import TYPE_CHECKING, Any
+
 import sentry_sdk
 from sentry_sdk._lru_cache import LRUCache
 from sentry_sdk.tracing import Span
 from sentry_sdk.tracing_utils import has_span_streaming_enabled
-from threading import Lock
-
-from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from typing import TypedDict

--- a/sentry_sdk/integrations/_asgi_common.py
+++ b/sentry_sdk/integrations/_asgi_common.py
@@ -1,15 +1,12 @@
 import urllib
-
-from sentry_sdk.scope import should_send_default_pii
-from sentry_sdk.integrations._wsgi_common import _filter_headers
-
 from typing import TYPE_CHECKING
 
+from sentry_sdk.integrations._wsgi_common import _filter_headers
+from sentry_sdk.scope import should_send_default_pii
+
 if TYPE_CHECKING:
-    from typing import Any
-    from typing import Dict
-    from typing import Optional
-    from typing import Union
+    from typing import Any, Dict, Optional, Union
+
     from typing_extensions import Literal
 
     from sentry_sdk.utils import AnnotatedValue

--- a/sentry_sdk/integrations/_wsgi_common.py
+++ b/sentry_sdk/integrations/_wsgi_common.py
@@ -1,5 +1,5 @@
-from contextlib import contextmanager
 import json
+from contextlib import contextmanager
 from copy import deepcopy
 
 import sentry_sdk
@@ -18,13 +18,8 @@ except ImportError:
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from typing import Any
-    from typing import Dict
-    from typing import Iterator
-    from typing import Mapping
-    from typing import MutableMapping
-    from typing import Optional
-    from typing import Union
+    from typing import Any, Dict, Iterator, Mapping, MutableMapping, Optional, Union
+
     from sentry_sdk._types import Event, HttpStatusCodeRange
 
 

--- a/sentry_sdk/integrations/aiohttp.py
+++ b/sentry_sdk/integrations/aiohttp.py
@@ -16,7 +16,7 @@ from sentry_sdk.integrations._wsgi_common import (
     request_body_within_bounds,
 )
 from sentry_sdk.integrations.logging import ignore_logger
-from sentry_sdk.scope import should_send_default_pii, Scope
+from sentry_sdk.scope import Scope, should_send_default_pii
 from sentry_sdk.sessions import track_session
 from sentry_sdk.traces import (
     SOURCE_FOR_STYLE as SEGMENT_SOURCE_FOR_STYLE,

--- a/sentry_sdk/integrations/anthropic.py
+++ b/sentry_sdk/integrations/anthropic.py
@@ -1,5 +1,5 @@
-import sys
 import json
+import sys
 from collections.abc import Iterable
 from functools import wraps
 from typing import TYPE_CHECKING
@@ -8,21 +8,21 @@ import sentry_sdk
 from sentry_sdk.ai.monitoring import record_token_usage
 from sentry_sdk.ai.utils import (
     GEN_AI_ALLOWED_MESSAGE_ROLES,
-    set_data_normalized,
-    normalize_message_roles,
-    truncate_and_annotate_messages,
     get_start_span_function,
+    normalize_message_roles,
+    set_data_normalized,
     transform_anthropic_content_part,
+    truncate_and_annotate_messages,
 )
 from sentry_sdk.consts import OP, SPANDATA
-from sentry_sdk.integrations import _check_minimum_version, DidNotEnable, Integration
+from sentry_sdk.integrations import DidNotEnable, Integration, _check_minimum_version
 from sentry_sdk.scope import should_send_default_pii
 from sentry_sdk.utils import (
     capture_internal_exceptions,
     event_from_exception,
     package_version,
-    safe_serialize,
     reraise,
+    safe_serialize,
 )
 
 try:
@@ -36,22 +36,21 @@ try:
     except ImportError:
         Omit = None
 
-    from anthropic import Stream, AsyncStream
-    from anthropic.resources import AsyncMessages, Messages
+    from anthropic import AsyncStream, Stream
     from anthropic.lib.streaming import (
-        MessageStreamManager,
-        MessageStream,
-        AsyncMessageStreamManager,
         AsyncMessageStream,
+        AsyncMessageStreamManager,
+        MessageStream,
+        MessageStreamManager,
     )
-
+    from anthropic.resources import AsyncMessages, Messages
     from anthropic.types import (
-        MessageStartEvent,
-        MessageDeltaEvent,
-        MessageStopEvent,
-        ContentBlockStartEvent,
         ContentBlockDeltaEvent,
+        ContentBlockStartEvent,
         ContentBlockStopEvent,
+        MessageDeltaEvent,
+        MessageStartEvent,
+        MessageStopEvent,
     )
 
     if TYPE_CHECKING:
@@ -63,22 +62,23 @@ if TYPE_CHECKING:
     from typing import (
         Any,
         AsyncIterator,
+        Awaitable,
+        Callable,
         Iterator,
         Optional,
         Union,
-        Callable,
-        Awaitable,
     )
-    from sentry_sdk.tracing import Span
-    from sentry_sdk._types import TextPart
 
     from anthropic.types import (
-        RawMessageStreamEvent,
         MessageParam,
         ModelParam,
+        RawMessageStreamEvent,
         TextBlockParam,
         ToolUnionParam,
     )
+
+    from sentry_sdk._types import TextPart
+    from sentry_sdk.tracing import Span
 
 
 class _RecordedUsage:

--- a/sentry_sdk/integrations/argv.py
+++ b/sentry_sdk/integrations/argv.py
@@ -1,10 +1,9 @@
 import sys
+from typing import TYPE_CHECKING
 
 import sentry_sdk
 from sentry_sdk.integrations import Integration
 from sentry_sdk.scope import add_global_event_processor
-
-from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from typing import Optional

--- a/sentry_sdk/integrations/ariadne.py
+++ b/sentry_sdk/integrations/ariadne.py
@@ -1,10 +1,10 @@
 from importlib import import_module
 
 import sentry_sdk
-from sentry_sdk import get_client, capture_event
-from sentry_sdk.integrations import _check_minimum_version, DidNotEnable, Integration
-from sentry_sdk.integrations.logging import ignore_logger
+from sentry_sdk import capture_event, get_client
+from sentry_sdk.integrations import DidNotEnable, Integration, _check_minimum_version
 from sentry_sdk.integrations._wsgi_common import request_body_within_bounds
+from sentry_sdk.integrations.logging import ignore_logger
 from sentry_sdk.scope import should_send_default_pii
 from sentry_sdk.utils import (
     capture_internal_exceptions,
@@ -24,8 +24,15 @@ from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from typing import Any, Dict, List, Optional
-    from ariadne.types import GraphQLError, GraphQLResult, GraphQLSchema, QueryParser  # type: ignore
+
+    from ariadne.types import (  # type: ignore
+        GraphQLError,
+        GraphQLResult,
+        GraphQLSchema,
+        QueryParser,
+    )
     from graphql.language.ast import DocumentNode
+
     from sentry_sdk._types import Event, EventProcessor
 
 

--- a/sentry_sdk/integrations/arq.py
+++ b/sentry_sdk/integrations/arq.py
@@ -2,23 +2,23 @@ import sys
 
 import sentry_sdk
 from sentry_sdk.consts import OP, SPANSTATUS
-from sentry_sdk.integrations import _check_minimum_version, DidNotEnable, Integration
+from sentry_sdk.integrations import DidNotEnable, Integration, _check_minimum_version
 from sentry_sdk.integrations.logging import ignore_logger
 from sentry_sdk.scope import should_send_default_pii
 from sentry_sdk.tracing import Transaction, TransactionSource
 from sentry_sdk.utils import (
+    SENSITIVE_DATA_SUBSTITUTE,
     capture_internal_exceptions,
     ensure_integration_enabled,
     event_from_exception,
-    SENSITIVE_DATA_SUBSTITUTE,
     parse_version,
     reraise,
 )
 
 try:
     import arq.worker
-    from arq.version import VERSION as ARQ_VERSION
     from arq.connections import ArqRedis
+    from arq.version import VERSION as ARQ_VERSION
     from arq.worker import JobExecutionFailed, Retry, RetryJob, Worker
 except ImportError:
     raise DidNotEnable("Arq is not installed")
@@ -28,12 +28,12 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from typing import Any, Dict, Optional, Union
 
-    from sentry_sdk._types import EventProcessor, Event, ExcInfo, Hint
-
     from arq.cron import CronJob
     from arq.jobs import Job
     from arq.typing import WorkerCoroutine
     from arq.worker import Function
+
+    from sentry_sdk._types import Event, EventProcessor, ExcInfo, Hint
 
 ARQ_CONTROL_FLOW_EXCEPTIONS = (JobExecutionFailed, Retry, RetryJob)
 

--- a/sentry_sdk/integrations/asgi.py
+++ b/sentry_sdk/integrations/asgi.py
@@ -4,10 +4,11 @@ An ASGI middleware.
 Based on Tom Christie's `sentry-asgi <https://github.com/encode/sentry-asgi>`.
 """
 
-import sys
 import inspect
+import sys
 from copy import deepcopy
 from functools import partial
+from typing import TYPE_CHECKING
 
 import sentry_sdk
 from sentry_sdk.api import continue_trace
@@ -22,11 +23,14 @@ from sentry_sdk.integrations._wsgi_common import (
     DEFAULT_HTTP_METHODS_TO_CAPTURE,
     nullcontext,
 )
+from sentry_sdk.scope import Scope
 from sentry_sdk.sessions import track_session
 from sentry_sdk.traces import (
-    StreamedSpan,
-    SegmentSource,
     SOURCE_FOR_STYLE as SEGMENT_SOURCE_FOR_STYLE,
+)
+from sentry_sdk.traces import (
+    SegmentSource,
+    StreamedSpan,
 )
 from sentry_sdk.tracing import (
     SOURCE_FOR_STYLE,
@@ -35,28 +39,20 @@ from sentry_sdk.tracing import (
 )
 from sentry_sdk.tracing_utils import has_span_streaming_enabled
 from sentry_sdk.utils import (
-    ContextVar,
-    event_from_exception,
-    HAS_REAL_CONTEXTVARS,
     CONTEXTVARS_ERROR_MESSAGE,
-    logger,
-    transaction_from_function,
+    HAS_REAL_CONTEXTVARS,
+    ContextVar,
     _get_installed_modules,
-    reraise,
     capture_internal_exceptions,
+    event_from_exception,
+    logger,
     qualname_from_function,
+    reraise,
+    transaction_from_function,
 )
-from sentry_sdk.scope import Scope
-
-from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from typing import Any
-    from typing import ContextManager
-    from typing import Dict
-    from typing import Optional
-    from typing import Tuple
-    from typing import Union
+    from typing import Any, ContextManager, Dict, Optional, Tuple, Union
 
     from sentry_sdk._types import Attributes, Event, Hint
     from sentry_sdk.tracing import Span

--- a/sentry_sdk/integrations/atexit.py
+++ b/sentry_sdk/integrations/atexit.py
@@ -1,15 +1,14 @@
+import atexit
 import os
 import sys
-import atexit
-
-import sentry_sdk
-from sentry_sdk.utils import logger
-from sentry_sdk.integrations import Integration
 from typing import TYPE_CHECKING
 
+import sentry_sdk
+from sentry_sdk.integrations import Integration
+from sentry_sdk.utils import logger
+
 if TYPE_CHECKING:
-    from typing import Any
-    from typing import Optional
+    from typing import Any, Optional
 
 
 def default_callback(pending: int, timeout: int) -> None:

--- a/sentry_sdk/integrations/aws_lambda.py
+++ b/sentry_sdk/integrations/aws_lambda.py
@@ -5,33 +5,29 @@ import sys
 from copy import deepcopy
 from datetime import datetime, timedelta, timezone
 from os import environ
+from typing import TYPE_CHECKING
 
 import sentry_sdk
 from sentry_sdk.api import continue_trace
 from sentry_sdk.consts import OP
+from sentry_sdk.integrations import Integration
+from sentry_sdk.integrations._wsgi_common import _filter_headers
 from sentry_sdk.scope import should_send_default_pii
 from sentry_sdk.tracing import TransactionSource
 from sentry_sdk.utils import (
     AnnotatedValue,
+    TimeoutThread,
     capture_internal_exceptions,
     ensure_integration_enabled,
     event_from_exception,
     logger,
-    TimeoutThread,
     reraise,
 )
-from sentry_sdk.integrations import Integration
-from sentry_sdk.integrations._wsgi_common import _filter_headers
-
-from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from typing import Any
-    from typing import TypeVar
-    from typing import Callable
-    from typing import Optional
+    from typing import Any, Callable, Optional, TypeVar
 
-    from sentry_sdk._types import EventProcessor, Event, Hint
+    from sentry_sdk._types import Event, EventProcessor, Hint
 
     F = TypeVar("F", bound=Callable[..., Any])
 

--- a/sentry_sdk/integrations/beam.py
+++ b/sentry_sdk/integrations/beam.py
@@ -1,6 +1,7 @@
 import sys
 import types
 from functools import wraps
+from typing import TYPE_CHECKING
 
 import sentry_sdk
 from sentry_sdk.integrations import Integration
@@ -12,13 +13,8 @@ from sentry_sdk.utils import (
     reraise,
 )
 
-from typing import TYPE_CHECKING
-
 if TYPE_CHECKING:
-    from typing import Any
-    from typing import Iterator
-    from typing import TypeVar
-    from typing import Callable
+    from typing import Any, Callable, Iterator, TypeVar
 
     from sentry_sdk._types import ExcInfo
 

--- a/sentry_sdk/integrations/boto3.py
+++ b/sentry_sdk/integrations/boto3.py
@@ -1,10 +1,11 @@
 from functools import partial
+from typing import TYPE_CHECKING
 
 import sentry_sdk
 from sentry_sdk.consts import OP, SPANDATA
-from sentry_sdk.integrations import _check_minimum_version, Integration, DidNotEnable
-from sentry_sdk.tracing import Span
+from sentry_sdk.integrations import DidNotEnable, Integration, _check_minimum_version
 from sentry_sdk.traces import StreamedSpan
+from sentry_sdk.tracing import Span
 from sentry_sdk.tracing_utils import has_span_streaming_enabled
 from sentry_sdk.utils import (
     capture_internal_exceptions,
@@ -12,22 +13,16 @@ from sentry_sdk.utils import (
     parse_version,
 )
 
-from typing import TYPE_CHECKING
-
 if TYPE_CHECKING:
-    from typing import Any
-    from typing import Dict
-    from typing import Optional
-    from typing import Type
-    from typing import Union
+    from typing import Any, Dict, Optional, Type, Union
 
     from botocore.model import ServiceId
 
 try:
     from botocore import __version__ as BOTOCORE_VERSION
+    from botocore.awsrequest import AWSRequest
     from botocore.client import BaseClient
     from botocore.response import StreamingBody
-    from botocore.awsrequest import AWSRequest
 except ImportError:
     raise DidNotEnable("botocore is not installed")
 

--- a/sentry_sdk/integrations/bottle.py
+++ b/sentry_sdk/integrations/bottle.py
@@ -1,6 +1,15 @@
 import functools
+from typing import TYPE_CHECKING
 
 import sentry_sdk
+from sentry_sdk.integrations import (
+    _DEFAULT_FAILED_REQUEST_STATUS_CODES,
+    DidNotEnable,
+    Integration,
+    _check_minimum_version,
+)
+from sentry_sdk.integrations._wsgi_common import RequestExtractor
+from sentry_sdk.integrations.wsgi import SentryWsgiMiddleware
 from sentry_sdk.tracing import SOURCE_FOR_STYLE
 from sentry_sdk.utils import (
     capture_internal_exceptions,
@@ -9,36 +18,27 @@ from sentry_sdk.utils import (
     parse_version,
     transaction_from_function,
 )
-from sentry_sdk.integrations import (
-    Integration,
-    DidNotEnable,
-    _DEFAULT_FAILED_REQUEST_STATUS_CODES,
-    _check_minimum_version,
-)
-from sentry_sdk.integrations.wsgi import SentryWsgiMiddleware
-from sentry_sdk.integrations._wsgi_common import RequestExtractor
-
-from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from collections.abc import Set
+    from typing import Any, Callable, Dict, Optional
 
-    from sentry_sdk.integrations.wsgi import _ScopedResponse
-    from typing import Any
-    from typing import Dict
-    from typing import Callable
-    from typing import Optional
     from bottle import FileUpload, FormsDict, LocalRequest  # type: ignore
 
-    from sentry_sdk._types import EventProcessor, Event
+    from sentry_sdk._types import Event, EventProcessor
+    from sentry_sdk.integrations.wsgi import _ScopedResponse
 
 try:
     from bottle import (
         Bottle,
         HTTPResponse,
         Route,
-        request as bottle_request,
+    )
+    from bottle import (
         __version__ as BOTTLE_VERSION,
+    )
+    from bottle import (
+        request as bottle_request,
     )
 except ImportError:
     raise DidNotEnable("Bottle not installed")

--- a/sentry_sdk/integrations/celery/__init__.py
+++ b/sentry_sdk/integrations/celery/__init__.py
@@ -1,12 +1,13 @@
 import sys
 from collections.abc import Mapping
 from functools import wraps
+from typing import TYPE_CHECKING
 
 import sentry_sdk
 from sentry_sdk import isolation_scope
 from sentry_sdk.api import continue_trace
-from sentry_sdk.consts import OP, SPANSTATUS, SPANDATA
-from sentry_sdk.integrations import _check_minimum_version, Integration, DidNotEnable
+from sentry_sdk.consts import OP, SPANDATA, SPANSTATUS
+from sentry_sdk.integrations import DidNotEnable, Integration, _check_minimum_version
 from sentry_sdk.integrations.celery.beat import (
     _patch_beat_apply_entry,
     _patch_redbeat_apply_async,
@@ -14,7 +15,7 @@ from sentry_sdk.integrations.celery.beat import (
 )
 from sentry_sdk.integrations.celery.utils import _now_seconds_since_epoch
 from sentry_sdk.integrations.logging import ignore_logger
-from sentry_sdk.scope import should_send_default_pii, Scope
+from sentry_sdk.scope import Scope, should_send_default_pii
 from sentry_sdk.traces import StreamedSpan, _get_current_streamed_span
 from sentry_sdk.tracing import BAGGAGE_HEADER_NAME, Span, TransactionSource
 from sentry_sdk.tracing_utils import Baggage, has_span_streaming_enabled
@@ -25,17 +26,10 @@ from sentry_sdk.utils import (
     reraise,
 )
 
-from typing import TYPE_CHECKING
-
 if TYPE_CHECKING:
-    from typing import Any
-    from typing import Callable
-    from typing import List
-    from typing import Optional
-    from typing import TypeVar
-    from typing import Union
+    from typing import Any, Callable, List, Optional, TypeVar, Union
 
-    from sentry_sdk._types import EventProcessor, Event, Hint, ExcInfo
+    from sentry_sdk._types import Event, EventProcessor, ExcInfo, Hint
 
     F = TypeVar("F", bound=Callable[..., Any])
 

--- a/sentry_sdk/integrations/celery/beat.py
+++ b/sentry_sdk/integrations/celery/beat.py
@@ -1,5 +1,7 @@
+from typing import TYPE_CHECKING
+
 import sentry_sdk
-from sentry_sdk.crons import capture_checkin, MonitorStatus
+from sentry_sdk.crons import MonitorStatus, capture_checkin
 from sentry_sdk.integrations import DidNotEnable
 from sentry_sdk.integrations.celery.utils import (
     _get_humanized_interval,
@@ -10,11 +12,10 @@ from sentry_sdk.utils import (
     match_regex_list,
 )
 
-from typing import TYPE_CHECKING
-
 if TYPE_CHECKING:
     from collections.abc import Callable
     from typing import Any, Optional, TypeVar, Union
+
     from sentry_sdk._types import (
         MonitorConfig,
         MonitorConfigScheduleType,
@@ -25,13 +26,13 @@ if TYPE_CHECKING:
 
 
 try:
-    from celery import Task, Celery  # type: ignore
+    from celery import Celery, Task  # type: ignore
     from celery.beat import Scheduler  # type: ignore
     from celery.schedules import crontab, schedule  # type: ignore
     from celery.signals import (  # type: ignore
         task_failure,
-        task_success,
         task_retry,
+        task_success,
     )
 except ImportError:
     raise DidNotEnable("Celery not installed")

--- a/sentry_sdk/integrations/celery/utils.py
+++ b/sentry_sdk/integrations/celery/utils.py
@@ -3,6 +3,7 @@ from typing import TYPE_CHECKING, cast
 
 if TYPE_CHECKING:
     from typing import Tuple
+
     from sentry_sdk._types import MonitorConfigScheduleUnit
 
 

--- a/sentry_sdk/integrations/chalice.py
+++ b/sentry_sdk/integrations/chalice.py
@@ -2,7 +2,7 @@ import sys
 from functools import wraps
 
 import sentry_sdk
-from sentry_sdk.integrations import Integration, DidNotEnable
+from sentry_sdk.integrations import DidNotEnable, Integration
 from sentry_sdk.integrations.aws_lambda import _make_request_event_processor
 from sentry_sdk.tracing import TransactionSource
 from sentry_sdk.utils import (
@@ -14,19 +14,18 @@ from sentry_sdk.utils import (
 
 try:
     import chalice  # type: ignore
-    from chalice import __version__ as CHALICE_VERSION
     from chalice import Chalice, ChaliceViewError
-    from chalice.app import EventSourceHandler as ChaliceEventSourceHandler  # type: ignore
+    from chalice import __version__ as CHALICE_VERSION
+    from chalice.app import (
+        EventSourceHandler as ChaliceEventSourceHandler,  # type: ignore
+    )
 except ImportError:
     raise DidNotEnable("Chalice is not installed")
 
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from typing import Any
-    from typing import Dict
-    from typing import TypeVar
-    from typing import Callable
+    from typing import Any, Callable, Dict, TypeVar
 
     F = TypeVar("F", bound=Callable[..., Any])
 

--- a/sentry_sdk/integrations/chalice.py
+++ b/sentry_sdk/integrations/chalice.py
@@ -17,7 +17,7 @@ try:
     from chalice import Chalice, ChaliceViewError
     from chalice import __version__ as CHALICE_VERSION
     from chalice.app import (  # type: ignore
-        EventSourceHandler as ChaliceEventSourceHandler,  
+        EventSourceHandler as ChaliceEventSourceHandler,
     )
 except ImportError:
     raise DidNotEnable("Chalice is not installed")

--- a/sentry_sdk/integrations/chalice.py
+++ b/sentry_sdk/integrations/chalice.py
@@ -16,8 +16,8 @@ try:
     import chalice  # type: ignore
     from chalice import Chalice, ChaliceViewError
     from chalice import __version__ as CHALICE_VERSION
-    from chalice.app import (
-        EventSourceHandler as ChaliceEventSourceHandler,  # type: ignore
+    from chalice.app import (  # type: ignore
+        EventSourceHandler as ChaliceEventSourceHandler,  
     )
 except ImportError:
     raise DidNotEnable("Chalice is not installed")

--- a/sentry_sdk/integrations/clickhouse_driver.py
+++ b/sentry_sdk/integrations/clickhouse_driver.py
@@ -1,18 +1,18 @@
+from typing import TYPE_CHECKING, TypeVar
+
 import sentry_sdk
 from sentry_sdk.consts import OP, SPANDATA
-from sentry_sdk.integrations import _check_minimum_version, Integration, DidNotEnable
-from sentry_sdk.tracing import Span
+from sentry_sdk.integrations import DidNotEnable, Integration, _check_minimum_version
 from sentry_sdk.scope import should_send_default_pii
+from sentry_sdk.tracing import Span
 from sentry_sdk.utils import capture_internal_exceptions, ensure_integration_enabled
-
-from typing import TYPE_CHECKING, TypeVar
 
 # Hack to get new Python features working in older versions
 # without introducing a hard dependency on `typing_extensions`
 # from: https://stackoverflow.com/a/71944042/300572
 if TYPE_CHECKING:
     from collections.abc import Iterator
-    from typing import Any, ParamSpec, Callable
+    from typing import Any, Callable, ParamSpec
 else:
     # Fake ParamSpec
     class ParamSpec:
@@ -32,7 +32,9 @@ else:
 try:
     from clickhouse_driver import VERSION  # type: ignore[import-not-found]
     from clickhouse_driver.client import Client  # type: ignore[import-not-found]
-    from clickhouse_driver.connection import Connection  # type: ignore[import-not-found]
+    from clickhouse_driver.connection import (
+        Connection,  # type: ignore[import-not-found]
+    )
 
 except ImportError:
     raise DidNotEnable("clickhouse-driver not installed.")

--- a/sentry_sdk/integrations/clickhouse_driver.py
+++ b/sentry_sdk/integrations/clickhouse_driver.py
@@ -33,7 +33,7 @@ try:
     from clickhouse_driver import VERSION  # type: ignore[import-not-found]
     from clickhouse_driver.client import Client  # type: ignore[import-not-found]
     from clickhouse_driver.connection import (  # type: ignore[import-not-found]
-        Connection,  
+        Connection,
     )
 
 except ImportError:

--- a/sentry_sdk/integrations/clickhouse_driver.py
+++ b/sentry_sdk/integrations/clickhouse_driver.py
@@ -32,8 +32,8 @@ else:
 try:
     from clickhouse_driver import VERSION  # type: ignore[import-not-found]
     from clickhouse_driver.client import Client  # type: ignore[import-not-found]
-    from clickhouse_driver.connection import (
-        Connection,  # type: ignore[import-not-found]
+    from clickhouse_driver.connection import (  # type: ignore[import-not-found]
+        Connection,  
     )
 
 except ImportError:

--- a/sentry_sdk/integrations/cloud_resource_context.py
+++ b/sentry_sdk/integrations/cloud_resource_context.py
@@ -1,11 +1,11 @@
 import json
+from typing import TYPE_CHECKING
+
 import urllib3
 
-from sentry_sdk.integrations import Integration
 from sentry_sdk.api import set_context
+from sentry_sdk.integrations import Integration
 from sentry_sdk.utils import logger
-
-from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from typing import Dict

--- a/sentry_sdk/integrations/cohere.py
+++ b/sentry_sdk/integrations/cohere.py
@@ -1,31 +1,30 @@
 import sys
 from functools import wraps
+from typing import TYPE_CHECKING
 
 from sentry_sdk import consts
 from sentry_sdk.ai.monitoring import record_token_usage
-from sentry_sdk.consts import SPANDATA
 from sentry_sdk.ai.utils import set_data_normalized
-
-from typing import TYPE_CHECKING
-
+from sentry_sdk.consts import SPANDATA
 from sentry_sdk.tracing_utils import set_span_errored
 
 if TYPE_CHECKING:
     from typing import Any, Callable, Iterator
+
     from sentry_sdk.tracing import Span
 
 import sentry_sdk
-from sentry_sdk.scope import should_send_default_pii
 from sentry_sdk.integrations import DidNotEnable, Integration
+from sentry_sdk.scope import should_send_default_pii
 from sentry_sdk.utils import capture_internal_exceptions, event_from_exception, reraise
 
 try:
-    from cohere.client import Client
-    from cohere.base_client import BaseCohere
     from cohere import (
         ChatStreamEndEvent,
         NonStreamedChatResponse,
     )
+    from cohere.base_client import BaseCohere
+    from cohere.client import Client
 
     if TYPE_CHECKING:
         from cohere import StreamedChatResponse

--- a/sentry_sdk/integrations/dedupe.py
+++ b/sentry_sdk/integrations/dedupe.py
@@ -1,11 +1,10 @@
 import weakref
+from typing import TYPE_CHECKING
 
 import sentry_sdk
-from sentry_sdk.utils import ContextVar, logger
 from sentry_sdk.integrations import Integration
 from sentry_sdk.scope import add_global_event_processor
-
-from typing import TYPE_CHECKING
+from sentry_sdk.utils import ContextVar, logger
 
 if TYPE_CHECKING:
     from typing import Optional

--- a/sentry_sdk/integrations/django/__init__.py
+++ b/sentry_sdk/integrations/django/__init__.py
@@ -6,35 +6,35 @@ from importlib import import_module
 
 import sentry_sdk
 from sentry_sdk.consts import OP, SPANDATA, SPANNAME
+from sentry_sdk.integrations import DidNotEnable, Integration, _check_minimum_version
+from sentry_sdk.integrations._wsgi_common import (
+    DEFAULT_HTTP_METHODS_TO_CAPTURE,
+    RequestExtractor,
+)
+from sentry_sdk.integrations.logging import ignore_logger
+from sentry_sdk.integrations.wsgi import SentryWsgiMiddleware
 from sentry_sdk.scope import add_global_event_processor, should_send_default_pii
 from sentry_sdk.serializer import add_global_repr_processor, add_repr_sequence_type
 from sentry_sdk.tracing import SOURCE_FOR_STYLE, TransactionSource
 from sentry_sdk.tracing_utils import add_query_source, record_sql_queries
 from sentry_sdk.utils import (
-    AnnotatedValue,
-    HAS_REAL_CONTEXTVARS,
     CONTEXTVARS_ERROR_MESSAGE,
+    HAS_REAL_CONTEXTVARS,
     SENSITIVE_DATA_SUBSTITUTE,
-    logger,
+    AnnotatedValue,
     capture_internal_exceptions,
     ensure_integration_enabled,
     event_from_exception,
+    logger,
     transaction_from_function,
     walk_exception_chain,
-)
-from sentry_sdk.integrations import _check_minimum_version, Integration, DidNotEnable
-from sentry_sdk.integrations.logging import ignore_logger
-from sentry_sdk.integrations.wsgi import SentryWsgiMiddleware
-from sentry_sdk.integrations._wsgi_common import (
-    DEFAULT_HTTP_METHODS_TO_CAPTURE,
-    RequestExtractor,
 )
 
 try:
     from django import VERSION as DJANGO_VERSION
+    from django.conf import settings
     from django.conf import settings as django_settings
     from django.core import signals
-    from django.conf import settings
 
     try:
         from django.urls import resolve
@@ -55,14 +55,14 @@ try:
 except ImportError:
     raise DidNotEnable("Django not installed")
 
-from sentry_sdk.integrations.django.transactions import LEGACY_RESOLVER
+from sentry_sdk.integrations.django.middleware import patch_django_middlewares
+from sentry_sdk.integrations.django.signals_handlers import patch_signals
+from sentry_sdk.integrations.django.tasks import patch_tasks
 from sentry_sdk.integrations.django.templates import (
     get_template_frame_from_exception,
     patch_templates,
 )
-from sentry_sdk.integrations.django.middleware import patch_django_middlewares
-from sentry_sdk.integrations.django.signals_handlers import patch_signals
-from sentry_sdk.integrations.django.tasks import patch_tasks
+from sentry_sdk.integrations.django.transactions import LEGACY_RESOLVER
 from sentry_sdk.integrations.django.views import patch_views
 
 if DJANGO_VERSION[:2] > (1, 8):
@@ -73,21 +73,16 @@ else:
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from typing import Any
-    from typing import Callable
-    from typing import Dict
-    from typing import Optional
-    from typing import Union
-    from typing import List
+    from typing import Any, Callable, Dict, List, Optional, Union
 
     from django.core.handlers.wsgi import WSGIRequest
-    from django.http.response import HttpResponse
     from django.http.request import QueryDict
+    from django.http.response import HttpResponse
     from django.utils.datastructures import MultiValueDict
 
-    from sentry_sdk.tracing import Span
+    from sentry_sdk._types import Event, EventProcessor, Hint, NotImplementedType
     from sentry_sdk.integrations.wsgi import _ScopedResponse
-    from sentry_sdk._types import Event, Hint, EventProcessor, NotImplementedType
+    from sentry_sdk.tracing import Span
 
 
 if DJANGO_VERSION < (1, 10):

--- a/sentry_sdk/integrations/django/asgi.py
+++ b/sentry_sdk/integrations/django/asgi.py
@@ -9,12 +9,12 @@ Since this file contains `async def` it is conditionally imported in
 import asyncio
 import functools
 import inspect
+from typing import TYPE_CHECKING
 
 from django.core.handlers.wsgi import WSGIRequest
 
 import sentry_sdk
 from sentry_sdk.consts import OP
-
 from sentry_sdk.integrations.asgi import SentryAsgiMiddleware
 from sentry_sdk.scope import should_send_default_pii
 from sentry_sdk.utils import (
@@ -22,10 +22,8 @@ from sentry_sdk.utils import (
     ensure_integration_enabled,
 )
 
-from typing import TYPE_CHECKING
-
 if TYPE_CHECKING:
-    from typing import Any, Callable, Union, TypeVar
+    from typing import Any, Callable, TypeVar, Union
 
     from django.core.handlers.asgi import ASGIRequest
     from django.http.response import HttpResponse

--- a/sentry_sdk/integrations/django/caching.py
+++ b/sentry_sdk/integrations/django/caching.py
@@ -1,23 +1,20 @@
 import functools
 from typing import TYPE_CHECKING
-from sentry_sdk.integrations.redis.utils import _get_safe_key, _key_as_string
-from urllib3.util import parse_url as urlparse
 
 from django import VERSION as DJANGO_VERSION
 from django.core.cache import CacheHandler
+from urllib3.util import parse_url as urlparse
 
 import sentry_sdk
 from sentry_sdk.consts import OP, SPANDATA
+from sentry_sdk.integrations.redis.utils import _get_safe_key, _key_as_string
 from sentry_sdk.utils import (
     capture_internal_exceptions,
     ensure_integration_enabled,
 )
 
-
 if TYPE_CHECKING:
-    from typing import Any
-    from typing import Callable
-    from typing import Optional
+    from typing import Any, Callable, Optional
 
 
 METHODS_TO_INSTRUMENT = [

--- a/sentry_sdk/integrations/django/middleware.py
+++ b/sentry_sdk/integrations/django/middleware.py
@@ -3,6 +3,7 @@ Create spans from Django middleware invocations
 """
 
 from functools import wraps
+from typing import TYPE_CHECKING
 
 from django import VERSION as DJANGO_VERSION
 
@@ -10,17 +11,12 @@ import sentry_sdk
 from sentry_sdk.consts import OP
 from sentry_sdk.utils import (
     ContextVar,
-    transaction_from_function,
     capture_internal_exceptions,
+    transaction_from_function,
 )
 
-from typing import TYPE_CHECKING
-
 if TYPE_CHECKING:
-    from typing import Any
-    from typing import Callable
-    from typing import Optional
-    from typing import TypeVar
+    from typing import Any, Callable, Optional, TypeVar
 
     from sentry_sdk.tracing import Span
 

--- a/sentry_sdk/integrations/django/signals_handlers.py
+++ b/sentry_sdk/integrations/django/signals_handlers.py
@@ -1,12 +1,11 @@
 from functools import wraps
+from typing import TYPE_CHECKING
 
 from django.dispatch import Signal
 
 import sentry_sdk
 from sentry_sdk.consts import OP
 from sentry_sdk.integrations.django import DJANGO_VERSION
-
-from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from collections.abc import Callable

--- a/sentry_sdk/integrations/django/templates.py
+++ b/sentry_sdk/integrations/django/templates.py
@@ -1,21 +1,16 @@
 import functools
+from typing import TYPE_CHECKING
 
+from django import VERSION as DJANGO_VERSION
 from django.template import TemplateSyntaxError
 from django.utils.safestring import mark_safe
-from django import VERSION as DJANGO_VERSION
 
 import sentry_sdk
 from sentry_sdk.consts import OP
 from sentry_sdk.utils import ensure_integration_enabled
 
-from typing import TYPE_CHECKING
-
 if TYPE_CHECKING:
-    from typing import Any
-    from typing import Dict
-    from typing import Optional
-    from typing import Iterator
-    from typing import Tuple
+    from typing import Any, Dict, Iterator, Optional, Tuple
 
 try:
     # support Django 1.9
@@ -58,6 +53,7 @@ def _get_template_name_description(template_name: str) -> str:
 
 def patch_templates() -> None:
     from django.template.response import SimpleTemplateResponse
+
     from sentry_sdk.integrations.django import DjangoIntegration
 
     real_rendered_content = SimpleTemplateResponse.rendered_content

--- a/sentry_sdk/integrations/django/transactions.py
+++ b/sentry_sdk/integrations/django/transactions.py
@@ -6,18 +6,13 @@ in use.
 """
 
 import re
-
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from django.urls.resolvers import URLResolver
-    from typing import Dict
-    from typing import List
-    from typing import Optional
-    from django.urls.resolvers import URLPattern
-    from typing import Tuple
-    from typing import Union
     from re import Pattern
+    from typing import Dict, List, Optional, Tuple, Union
+
+    from django.urls.resolvers import URLPattern, URLResolver
 
 from django import VERSION as DJANGO_VERSION
 

--- a/sentry_sdk/integrations/django/views.py
+++ b/sentry_sdk/integrations/django/views.py
@@ -1,9 +1,8 @@
 import functools
+from typing import TYPE_CHECKING
 
 import sentry_sdk
 from sentry_sdk.consts import OP
-
-from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from typing import Any
@@ -24,6 +23,7 @@ except (ImportError, SyntaxError):
 def patch_views() -> None:
     from django.core.handlers.base import BaseHandler
     from django.template.response import SimpleTemplateResponse
+
     from sentry_sdk.integrations.django import DjangoIntegration
 
     old_make_view_atomic = BaseHandler.make_view_atomic

--- a/sentry_sdk/integrations/dramatiq.py
+++ b/sentry_sdk/integrations/dramatiq.py
@@ -1,9 +1,10 @@
 import json
+from typing import TypeVar
 
 import sentry_sdk
-from sentry_sdk.consts import OP, SPANSTATUS
 from sentry_sdk.api import continue_trace, get_baggage, get_traceparent
-from sentry_sdk.integrations import Integration, DidNotEnable
+from sentry_sdk.consts import OP, SPANSTATUS
+from sentry_sdk.integrations import DidNotEnable, Integration
 from sentry_sdk.integrations._wsgi_common import request_body_within_bounds
 from sentry_sdk.tracing import (
     BAGGAGE_HEADER_NAME,
@@ -15,15 +16,14 @@ from sentry_sdk.utils import (
     capture_internal_exceptions,
     event_from_exception,
 )
-from typing import TypeVar
 
 R = TypeVar("R")
 
 try:
     from dramatiq.broker import Broker
-    from dramatiq.middleware import Middleware, default_middleware
     from dramatiq.errors import Retry
     from dramatiq.message import Message
+    from dramatiq.middleware import Middleware, default_middleware
 except ImportError:
     raise DidNotEnable("Dramatiq is not installed")
 
@@ -31,6 +31,7 @@ from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from typing import Any, Callable, Dict, Optional, Union
+
     from sentry_sdk._types import Event, Hint
 
 

--- a/sentry_sdk/integrations/excepthook.py
+++ b/sentry_sdk/integrations/excepthook.py
@@ -1,21 +1,16 @@
 import sys
+from typing import TYPE_CHECKING
 
 import sentry_sdk
+from sentry_sdk.integrations import Integration
 from sentry_sdk.utils import (
     capture_internal_exceptions,
     event_from_exception,
 )
-from sentry_sdk.integrations import Integration
-
-from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from typing import Callable
-    from typing import Any
-    from typing import Type
-    from typing import Optional
-
     from types import TracebackType
+    from typing import Any, Callable, Optional, Type
 
     Excepthook = Callable[
         [Type[BaseException], BaseException, Optional[TracebackType]],

--- a/sentry_sdk/integrations/executing.py
+++ b/sentry_sdk/integrations/executing.py
@@ -1,9 +1,9 @@
-import sentry_sdk
-from sentry_sdk.integrations import Integration, DidNotEnable
-from sentry_sdk.scope import add_global_event_processor
-from sentry_sdk.utils import walk_exception_chain, iter_stacks
-
 from typing import TYPE_CHECKING
+
+import sentry_sdk
+from sentry_sdk.integrations import DidNotEnable, Integration
+from sentry_sdk.scope import add_global_event_processor
+from sentry_sdk.utils import iter_stacks, walk_exception_chain
 
 if TYPE_CHECKING:
     from typing import Optional

--- a/sentry_sdk/integrations/falcon.py
+++ b/sentry_sdk/integrations/falcon.py
@@ -1,5 +1,7 @@
+from typing import TYPE_CHECKING
+
 import sentry_sdk
-from sentry_sdk.integrations import _check_minimum_version, Integration, DidNotEnable
+from sentry_sdk.integrations import DidNotEnable, Integration, _check_minimum_version
 from sentry_sdk.integrations._wsgi_common import RequestExtractor
 from sentry_sdk.integrations.wsgi import SentryWsgiMiddleware
 from sentry_sdk.tracing import SOURCE_FOR_STYLE
@@ -10,12 +12,8 @@ from sentry_sdk.utils import (
     parse_version,
 )
 
-from typing import TYPE_CHECKING
-
 if TYPE_CHECKING:
-    from typing import Any
-    from typing import Dict
-    from typing import Optional
+    from typing import Any, Dict, Optional
 
     from sentry_sdk._types import Event, EventProcessor
 
@@ -24,7 +22,6 @@ if TYPE_CHECKING:
 
 try:
     import falcon  # type: ignore
-
     from falcon import __version__ as FALCON_VERSION
 except ImportError:
     raise DidNotEnable("Falcon not installed")
@@ -46,7 +43,9 @@ except ImportError:
 _FALCON_UNSET: "Optional[object]" = None
 if FALCON3:  # falcon.request._UNSET is only available in Falcon 3.0+
     with capture_internal_exceptions():
-        from falcon.request import _UNSET as _FALCON_UNSET  # type: ignore[import-not-found, no-redef]
+        from falcon.request import (
+            _UNSET as _FALCON_UNSET,  # type: ignore[import-not-found, no-redef]
+        )
 
 
 class FalconRequestExtractor(RequestExtractor):

--- a/sentry_sdk/integrations/falcon.py
+++ b/sentry_sdk/integrations/falcon.py
@@ -43,8 +43,8 @@ except ImportError:
 _FALCON_UNSET: "Optional[object]" = None
 if FALCON3:  # falcon.request._UNSET is only available in Falcon 3.0+
     with capture_internal_exceptions():
-        from falcon.request import (
-            _UNSET as _FALCON_UNSET,  # type: ignore[import-not-found, no-redef]
+        from falcon.request import (  # type: ignore[import-not-found, no-redef]
+            _UNSET as _FALCON_UNSET,  
         )
 
 

--- a/sentry_sdk/integrations/falcon.py
+++ b/sentry_sdk/integrations/falcon.py
@@ -44,7 +44,7 @@ _FALCON_UNSET: "Optional[object]" = None
 if FALCON3:  # falcon.request._UNSET is only available in Falcon 3.0+
     with capture_internal_exceptions():
         from falcon.request import (  # type: ignore[import-not-found, no-redef]
-            _UNSET as _FALCON_UNSET,  
+            _UNSET as _FALCON_UNSET,
         )
 
 

--- a/sentry_sdk/integrations/flask.py
+++ b/sentry_sdk/integrations/flask.py
@@ -1,5 +1,7 @@
+from typing import TYPE_CHECKING
+
 import sentry_sdk
-from sentry_sdk.integrations import _check_minimum_version, DidNotEnable, Integration
+from sentry_sdk.integrations import DidNotEnable, Integration, _check_minimum_version
 from sentry_sdk.integrations._wsgi_common import (
     DEFAULT_HTTP_METHODS_TO_CAPTURE,
     RequestExtractor,
@@ -14,14 +16,13 @@ from sentry_sdk.utils import (
     package_version,
 )
 
-from typing import TYPE_CHECKING
-
 if TYPE_CHECKING:
     from typing import Any, Callable, Dict, Union
 
+    from werkzeug.datastructures import FileStorage, ImmutableMultiDict
+
     from sentry_sdk._types import Event, EventProcessor
     from sentry_sdk.integrations.wsgi import _ScopedResponse
-    from werkzeug.datastructures import FileStorage, ImmutableMultiDict
 
 
 try:

--- a/sentry_sdk/integrations/gcp.py
+++ b/sentry_sdk/integrations/gcp.py
@@ -3,6 +3,7 @@ import sys
 from copy import deepcopy
 from datetime import datetime, timedelta, timezone
 from os import environ
+from typing import TYPE_CHECKING
 
 import sentry_sdk
 from sentry_sdk.api import continue_trace
@@ -13,26 +14,21 @@ from sentry_sdk.scope import should_send_default_pii
 from sentry_sdk.tracing import TransactionSource
 from sentry_sdk.utils import (
     AnnotatedValue,
+    TimeoutThread,
     capture_internal_exceptions,
     event_from_exception,
     logger,
-    TimeoutThread,
     reraise,
 )
-
-from typing import TYPE_CHECKING
 
 # Constants
 TIMEOUT_WARNING_BUFFER = 1.5  # Buffer time required to send timeout warning to Sentry
 MILLIS_TO_SECONDS = 1000.0
 
 if TYPE_CHECKING:
-    from typing import Any
-    from typing import TypeVar
-    from typing import Callable
-    from typing import Optional
+    from typing import Any, Callable, Optional, TypeVar
 
-    from sentry_sdk._types import EventProcessor, Event, Hint
+    from sentry_sdk._types import Event, EventProcessor, Hint
 
     F = TypeVar("F", bound=Callable[..., Any])
 

--- a/sentry_sdk/integrations/gnu_backtrace.py
+++ b/sentry_sdk/integrations/gnu_backtrace.py
@@ -1,14 +1,14 @@
 import re
+from typing import TYPE_CHECKING
 
 import sentry_sdk
 from sentry_sdk.integrations import Integration
 from sentry_sdk.scope import add_global_event_processor
 from sentry_sdk.utils import capture_internal_exceptions
 
-from typing import TYPE_CHECKING
-
 if TYPE_CHECKING:
     from typing import Any
+
     from sentry_sdk._types import Event
 
 # function is everything between index at @

--- a/sentry_sdk/integrations/google_genai/__init__.py
+++ b/sentry_sdk/integrations/google_genai/__init__.py
@@ -9,30 +9,29 @@ from typing import (
 
 import sentry_sdk
 from sentry_sdk.ai.utils import get_start_span_function
-from sentry_sdk.integrations import DidNotEnable, Integration
 from sentry_sdk.consts import OP, SPANDATA
+from sentry_sdk.integrations import DidNotEnable, Integration
 from sentry_sdk.tracing import SPANSTATUS
 
-
 try:
-    from google.genai.models import Models, AsyncModels
+    from google.genai.models import AsyncModels, Models
 except ImportError:
     raise DidNotEnable("google-genai not installed")
 
 
-from .consts import IDENTIFIER, ORIGIN, GEN_AI_SYSTEM
+from .consts import GEN_AI_SYSTEM, IDENTIFIER, ORIGIN
+from .streaming import (
+    accumulate_streaming_response,
+    set_span_data_for_streaming_response,
+)
 from .utils import (
-    set_span_data_for_request,
-    set_span_data_for_response,
     _capture_exception,
-    prepare_generate_content_args,
     prepare_embed_content_args,
+    prepare_generate_content_args,
     set_span_data_for_embed_request,
     set_span_data_for_embed_response,
-)
-from .streaming import (
-    set_span_data_for_streaming_response,
-    accumulate_streaming_response,
+    set_span_data_for_request,
+    set_span_data_for_response,
 )
 
 

--- a/sentry_sdk/integrations/google_genai/streaming.py
+++ b/sentry_sdk/integrations/google_genai/streaming.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Any, List, TypedDict, Optional
+from typing import TYPE_CHECKING, Any, List, Optional, TypedDict
 
 from sentry_sdk.ai.utils import set_data_normalized
 from sentry_sdk.consts import SPANDATA
@@ -6,17 +6,19 @@ from sentry_sdk.scope import should_send_default_pii
 from sentry_sdk.utils import (
     safe_serialize,
 )
+
 from .utils import (
-    extract_tool_calls,
-    extract_finish_reasons,
-    extract_contents_text,
-    extract_usage_data,
     UsageData,
+    extract_contents_text,
+    extract_finish_reasons,
+    extract_tool_calls,
+    extract_usage_data,
 )
 
 if TYPE_CHECKING:
-    from sentry_sdk.tracing import Span
     from google.genai.types import GenerateContentResponse
+
+    from sentry_sdk.tracing import Span
 
 
 class AccumulatedResponse(TypedDict):

--- a/sentry_sdk/integrations/google_genai/utils.py
+++ b/sentry_sdk/integrations/google_genai/utils.py
@@ -1,28 +1,30 @@
 import copy
-import json
 import inspect
+import json
 from functools import wraps
-from .consts import ORIGIN, TOOL_ATTRIBUTES_MAP, GEN_AI_SYSTEM
-from sentry_sdk._types import BLOB_DATA_SUBSTITUTE
+from itertools import chain
 from typing import (
     TYPE_CHECKING,
-    Iterable,
     Any,
     Callable,
+    Dict,
+    Iterable,
     List,
     Optional,
-    Union,
     TypedDict,
-    Dict,
+    Union,
 )
 
+from google.genai.types import Content, GenerateContentConfig, Part, PartDict
+
 import sentry_sdk
+from sentry_sdk._types import BLOB_DATA_SUBSTITUTE
 from sentry_sdk.ai.utils import (
-    set_data_normalized,
-    truncate_and_annotate_messages,
-    normalize_message_roles,
-    transform_google_content_part,
     get_modality_from_mime_type,
+    normalize_message_roles,
+    set_data_normalized,
+    transform_google_content_part,
+    truncate_and_annotate_messages,
 )
 from sentry_sdk.consts import OP, SPANDATA
 from sentry_sdk.scope import should_send_default_pii
@@ -31,21 +33,22 @@ from sentry_sdk.utils import (
     event_from_exception,
     safe_serialize,
 )
-from google.genai.types import GenerateContentConfig, Part, Content, PartDict
-from itertools import chain
+
+from .consts import GEN_AI_SYSTEM, ORIGIN, TOOL_ATTRIBUTES_MAP
 
 if TYPE_CHECKING:
-    from sentry_sdk.tracing import Span
-    from sentry_sdk._types import TextPart
     from google.genai.types import (
-        GenerateContentResponse,
         ContentListUnion,
-        ContentUnionDict,
-        Tool,
-        Model,
-        EmbedContentResponse,
         ContentUnion,
+        ContentUnionDict,
+        EmbedContentResponse,
+        GenerateContentResponse,
+        Model,
+        Tool,
     )
+
+    from sentry_sdk._types import TextPart
+    from sentry_sdk.tracing import Span
 
 _is_PIL_available = False
 try:

--- a/sentry_sdk/integrations/gql.py
+++ b/sentry_sdk/integrations/gql.py
@@ -1,23 +1,27 @@
 import sentry_sdk
+from sentry_sdk.integrations import DidNotEnable, Integration, _check_minimum_version
+from sentry_sdk.scope import should_send_default_pii
 from sentry_sdk.utils import (
-    event_from_exception,
     ensure_integration_enabled,
+    event_from_exception,
     parse_version,
 )
 
-from sentry_sdk.integrations import _check_minimum_version, DidNotEnable, Integration
-from sentry_sdk.scope import should_send_default_pii
-
 try:
     import gql  # type: ignore[import-not-found]
+    from gql.transport import (  # type: ignore[import-not-found]
+        AsyncTransport,
+        Transport,
+    )
+    from gql.transport.exceptions import (
+        TransportQueryError,  # type: ignore[import-not-found]
+    )
     from graphql import (
-        print_ast,
-        get_operation_ast,
         DocumentNode,
         VariableDefinitionNode,
+        get_operation_ast,
+        print_ast,
     )
-    from gql.transport import Transport, AsyncTransport  # type: ignore[import-not-found]
-    from gql.transport.exceptions import TransportQueryError  # type: ignore[import-not-found]
 
     try:
         # gql 4.0+
@@ -32,6 +36,7 @@ from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from typing import Any, Dict, Tuple, Union
+
     from sentry_sdk._types import Event, EventProcessor
 
     EventDataType = Dict[str, Union[str, Tuple[VariableDefinitionNode, ...]]]

--- a/sentry_sdk/integrations/gql.py
+++ b/sentry_sdk/integrations/gql.py
@@ -14,7 +14,7 @@ try:
         Transport,
     )
     from gql.transport.exceptions import (  # type: ignore[import-not-found]
-        TransportQueryError,  
+        TransportQueryError,
     )
     from graphql import (
         DocumentNode,

--- a/sentry_sdk/integrations/gql.py
+++ b/sentry_sdk/integrations/gql.py
@@ -13,8 +13,8 @@ try:
         AsyncTransport,
         Transport,
     )
-    from gql.transport.exceptions import (
-        TransportQueryError,  # type: ignore[import-not-found]
+    from gql.transport.exceptions import (  # type: ignore[import-not-found]
+        TransportQueryError,  
     )
     from graphql import (
         DocumentNode,

--- a/sentry_sdk/integrations/graphene.py
+++ b/sentry_sdk/integrations/graphene.py
@@ -2,7 +2,7 @@ from contextlib import contextmanager
 
 import sentry_sdk
 from sentry_sdk.consts import OP
-from sentry_sdk.integrations import _check_minimum_version, DidNotEnable, Integration
+from sentry_sdk.integrations import DidNotEnable, Integration, _check_minimum_version
 from sentry_sdk.scope import should_send_default_pii
 from sentry_sdk.utils import (
     capture_internal_exceptions,
@@ -21,9 +21,11 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from collections.abc import Generator
     from typing import Any, Dict, Union
+
     from graphene.language.source import Source  # type: ignore
     from graphql.execution import ExecutionResult
     from graphql.type import GraphQLSchema
+
     from sentry_sdk._types import Event
 
 

--- a/sentry_sdk/integrations/grpc/__init__.py
+++ b/sentry_sdk/integrations/grpc/__init__.py
@@ -1,13 +1,11 @@
 from functools import wraps
+from typing import TYPE_CHECKING, Any, Optional, Sequence
 
-from sentry_sdk.integrations import Integration
+from sentry_sdk.integrations import DidNotEnable, Integration
 from sentry_sdk.utils import parse_version
-from sentry_sdk.integrations import DidNotEnable
 
 from .client import ClientInterceptor
 from .server import ServerInterceptor
-
-from typing import TYPE_CHECKING, Any, Optional, Sequence
 
 try:
     import grpc
@@ -15,13 +13,13 @@ try:
     from grpc.aio import Channel as AsyncChannel
     from grpc.aio import Server as AsyncServer
 
-    from .aio.server import ServerInterceptor as AsyncServerInterceptor
-    from .aio.client import (
-        SentryUnaryUnaryClientInterceptor as AsyncUnaryUnaryClientInterceptor,
-    )
     from .aio.client import (
         SentryUnaryStreamClientInterceptor as AsyncUnaryStreamClientIntercetor,
     )
+    from .aio.client import (
+        SentryUnaryUnaryClientInterceptor as AsyncUnaryUnaryClientInterceptor,
+    )
+    from .aio.server import ServerInterceptor as AsyncServerInterceptor
 except ImportError:
     raise DidNotEnable("grpcio is not installed.")
 
@@ -29,7 +27,7 @@ except ImportError:
 # without introducing a hard dependency on `typing_extensions`
 # from: https://stackoverflow.com/a/71944042/300572
 if TYPE_CHECKING:
-    from typing import ParamSpec, Callable
+    from typing import Callable, ParamSpec
 else:
     # Fake ParamSpec
     class ParamSpec:

--- a/sentry_sdk/integrations/grpc/aio/__init__.py
+++ b/sentry_sdk/integrations/grpc/aio/__init__.py
@@ -1,5 +1,5 @@
-from .server import ServerInterceptor
 from .client import ClientInterceptor
+from .server import ServerInterceptor
 
 __all__ = [
     "ClientInterceptor",

--- a/sentry_sdk/integrations/grpc/aio/client.py
+++ b/sentry_sdk/integrations/grpc/aio/client.py
@@ -1,4 +1,4 @@
-from typing import Callable, Union, AsyncIterable, Any
+from typing import Any, AsyncIterable, Callable, Union
 
 import sentry_sdk
 from sentry_sdk.consts import OP, SPANDATA
@@ -7,15 +7,15 @@ from sentry_sdk.integrations.grpc.consts import SPAN_ORIGIN
 from sentry_sdk.tracing_utils import has_span_streaming_enabled
 
 try:
-    from grpc.aio import (
-        UnaryUnaryClientInterceptor,
-        UnaryStreamClientInterceptor,
-        ClientCallDetails,
-        UnaryUnaryCall,
-        UnaryStreamCall,
-        Metadata,
-    )
     from google.protobuf.message import Message
+    from grpc.aio import (
+        ClientCallDetails,
+        Metadata,
+        UnaryStreamCall,
+        UnaryStreamClientInterceptor,
+        UnaryUnaryCall,
+        UnaryUnaryClientInterceptor,
+    )
 except ImportError:
     raise DidNotEnable("grpcio is not installed")
 

--- a/sentry_sdk/integrations/grpc/aio/server.py
+++ b/sentry_sdk/integrations/grpc/aio/server.py
@@ -1,12 +1,12 @@
+from typing import TYPE_CHECKING
+
 import sentry_sdk
 from sentry_sdk.consts import OP
 from sentry_sdk.integrations import DidNotEnable
 from sentry_sdk.integrations.grpc.consts import SPAN_ORIGIN
 from sentry_sdk.tracing import TransactionSource
-from sentry_sdk.utils import event_from_exception
 from sentry_sdk.tracing_utils import has_span_streaming_enabled
-
-from typing import TYPE_CHECKING
+from sentry_sdk.utils import event_from_exception
 
 if TYPE_CHECKING:
     from collections.abc import Awaitable, Callable

--- a/sentry_sdk/integrations/grpc/client.py
+++ b/sentry_sdk/integrations/grpc/client.py
@@ -1,20 +1,20 @@
+from typing import TYPE_CHECKING
+
 import sentry_sdk
 from sentry_sdk.consts import OP, SPANDATA
 from sentry_sdk.integrations import DidNotEnable
 from sentry_sdk.integrations.grpc.consts import SPAN_ORIGIN
 from sentry_sdk.tracing_utils import has_span_streaming_enabled
 
-from typing import TYPE_CHECKING
-
 if TYPE_CHECKING:
-    from typing import Any, Callable, Iterator, Iterable, Union
+    from typing import Any, Callable, Iterable, Iterator, Union
 
 try:
     import grpc
-    from grpc import ClientCallDetails, Call
+    from google.protobuf.message import Message
+    from grpc import Call, ClientCallDetails
     from grpc._interceptor import _UnaryOutcome
     from grpc.aio._interceptor import UnaryStreamCall
-    from google.protobuf.message import Message
 except ImportError:
     raise DidNotEnable("grpcio is not installed")
 

--- a/sentry_sdk/integrations/grpc/server.py
+++ b/sentry_sdk/integrations/grpc/server.py
@@ -1,3 +1,5 @@
+from typing import TYPE_CHECKING
+
 import sentry_sdk
 from sentry_sdk.consts import OP
 from sentry_sdk.integrations import DidNotEnable
@@ -5,15 +7,14 @@ from sentry_sdk.integrations.grpc.consts import SPAN_ORIGIN
 from sentry_sdk.tracing import TransactionSource
 from sentry_sdk.tracing_utils import has_span_streaming_enabled
 
-from typing import TYPE_CHECKING
-
 if TYPE_CHECKING:
     from typing import Callable, Optional
+
     from google.protobuf.message import Message
 
 try:
     import grpc
-    from grpc import ServicerContext, HandlerCallDetails, RpcMethodHandler
+    from grpc import HandlerCallDetails, RpcMethodHandler, ServicerContext
 except ImportError:
     raise DidNotEnable("grpcio is not installed")
 

--- a/sentry_sdk/integrations/httpx.py
+++ b/sentry_sdk/integrations/httpx.py
@@ -1,12 +1,14 @@
+from typing import TYPE_CHECKING
+
 import sentry_sdk
 from sentry_sdk.consts import OP, SPANDATA
-from sentry_sdk.integrations import Integration, DidNotEnable
+from sentry_sdk.integrations import DidNotEnable, Integration
 from sentry_sdk.tracing import BAGGAGE_HEADER_NAME
 from sentry_sdk.tracing_utils import (
     add_http_request_source,
-    should_propagate_trace,
     add_sentry_baggage_to_headers,
     has_span_streaming_enabled,
+    should_propagate_trace,
 )
 from sentry_sdk.utils import (
     SENSITIVE_DATA_SUBSTITUTE,
@@ -16,10 +18,9 @@ from sentry_sdk.utils import (
     parse_url,
 )
 
-from typing import TYPE_CHECKING
-
 if TYPE_CHECKING:
     from typing import Any
+
     from sentry_sdk._types import Attributes
 
 

--- a/sentry_sdk/integrations/huey.py
+++ b/sentry_sdk/integrations/huey.py
@@ -1,5 +1,6 @@
 import sys
 from datetime import datetime
+from typing import TYPE_CHECKING
 
 import sentry_sdk
 from sentry_sdk.api import continue_trace, get_baggage, get_traceparent
@@ -12,25 +13,23 @@ from sentry_sdk.tracing import (
     TransactionSource,
 )
 from sentry_sdk.utils import (
+    SENSITIVE_DATA_SUBSTITUTE,
     capture_internal_exceptions,
     ensure_integration_enabled,
     event_from_exception,
-    SENSITIVE_DATA_SUBSTITUTE,
     reraise,
 )
 
-from typing import TYPE_CHECKING
-
 if TYPE_CHECKING:
-    from typing import Any, Callable, Optional, Union, TypeVar
+    from typing import Any, Callable, Optional, TypeVar, Union
 
-    from sentry_sdk._types import EventProcessor, Event, Hint
+    from sentry_sdk._types import Event, EventProcessor, Hint
     from sentry_sdk.utils import ExcInfo
 
     F = TypeVar("F", bound=Callable[..., Any])
 
 try:
-    from huey.api import Huey, Result, ResultGroup, Task, PeriodicTask
+    from huey.api import Huey, PeriodicTask, Result, ResultGroup, Task
     from huey.exceptions import CancelExecution, RetryTask, TaskLockedException
 except ImportError:
     raise DidNotEnable("Huey is not installed")

--- a/sentry_sdk/integrations/langchain.py
+++ b/sentry_sdk/integrations/langchain.py
@@ -78,7 +78,7 @@ except ImportError:
 
 try:
     from langchain_google_vertexai import (  # type: ignore[import-not-found]
-        VertexAIEmbeddings,  
+        VertexAIEmbeddings,
     )
 except ImportError:
     VertexAIEmbeddings = None
@@ -95,14 +95,14 @@ except ImportError:
 
 try:
     from langchain_mistralai import (  # type: ignore[import-not-found]
-        MistralAIEmbeddings,  
+        MistralAIEmbeddings,
     )
 except ImportError:
     MistralAIEmbeddings = None
 
 try:
     from langchain_huggingface import (  # type: ignore[import-not-found]
-        HuggingFaceEmbeddings,  
+        HuggingFaceEmbeddings,
     )
 except ImportError:
     HuggingFaceEmbeddings = None

--- a/sentry_sdk/integrations/langchain.py
+++ b/sentry_sdk/integrations/langchain.py
@@ -77,8 +77,8 @@ except ImportError:
     AzureOpenAIEmbeddings = None
 
 try:
-    from langchain_google_vertexai import (
-        VertexAIEmbeddings,  # type: ignore[import-not-found]
+    from langchain_google_vertexai import (  # type: ignore[import-not-found]
+        VertexAIEmbeddings,  
     )
 except ImportError:
     VertexAIEmbeddings = None
@@ -94,15 +94,15 @@ except ImportError:
     CohereEmbeddings = None
 
 try:
-    from langchain_mistralai import (
-        MistralAIEmbeddings,  # type: ignore[import-not-found]
+    from langchain_mistralai import (  # type: ignore[import-not-found]
+        MistralAIEmbeddings,  
     )
 except ImportError:
     MistralAIEmbeddings = None
 
 try:
-    from langchain_huggingface import (
-        HuggingFaceEmbeddings,  # type: ignore[import-not-found]
+    from langchain_huggingface import (  # type: ignore[import-not-found]
+        HuggingFaceEmbeddings,  
     )
 except ImportError:
     HuggingFaceEmbeddings = None

--- a/sentry_sdk/integrations/langchain.py
+++ b/sentry_sdk/integrations/langchain.py
@@ -1,6 +1,6 @@
 import itertools
-import sys
 import json
+import sys
 import warnings
 from collections import OrderedDict
 from functools import wraps
@@ -13,8 +13,8 @@ from sentry_sdk.ai.utils import (
     get_start_span_function,
     normalize_message_roles,
     set_data_normalized,
-    truncate_and_annotate_messages,
     transform_content_part,
+    truncate_and_annotate_messages,
 )
 from sentry_sdk.consts import OP, SPANDATA
 from sentry_sdk.integrations import DidNotEnable, Integration
@@ -35,8 +35,8 @@ if TYPE_CHECKING:
     )
     from uuid import UUID
 
-    from sentry_sdk.tracing import Span
     from sentry_sdk._types import TextPart
+    from sentry_sdk.tracing import Span
 
 
 try:
@@ -77,7 +77,9 @@ except ImportError:
     AzureOpenAIEmbeddings = None
 
 try:
-    from langchain_google_vertexai import VertexAIEmbeddings  # type: ignore[import-not-found]
+    from langchain_google_vertexai import (
+        VertexAIEmbeddings,  # type: ignore[import-not-found]
+    )
 except ImportError:
     VertexAIEmbeddings = None
 
@@ -92,12 +94,16 @@ except ImportError:
     CohereEmbeddings = None
 
 try:
-    from langchain_mistralai import MistralAIEmbeddings  # type: ignore[import-not-found]
+    from langchain_mistralai import (
+        MistralAIEmbeddings,  # type: ignore[import-not-found]
+    )
 except ImportError:
     MistralAIEmbeddings = None
 
 try:
-    from langchain_huggingface import HuggingFaceEmbeddings  # type: ignore[import-not-found]
+    from langchain_huggingface import (
+        HuggingFaceEmbeddings,  # type: ignore[import-not-found]
+    )
 except ImportError:
     HuggingFaceEmbeddings = None
 

--- a/sentry_sdk/integrations/langgraph.py
+++ b/sentry_sdk/integrations/langgraph.py
@@ -3,15 +3,14 @@ from typing import Any, Callable, List, Optional
 
 import sentry_sdk
 from sentry_sdk.ai.utils import (
-    set_data_normalized,
     normalize_message_roles,
+    set_data_normalized,
     truncate_and_annotate_messages,
 )
 from sentry_sdk.consts import OP, SPANDATA
 from sentry_sdk.integrations import DidNotEnable, Integration
 from sentry_sdk.scope import should_send_default_pii
 from sentry_sdk.utils import safe_serialize
-
 
 try:
     from langgraph.graph import StateGraph

--- a/sentry_sdk/integrations/launchdarkly.py
+++ b/sentry_sdk/integrations/launchdarkly.py
@@ -8,11 +8,11 @@ try:
     from ldclient.hook import Hook, Metadata
 
     if TYPE_CHECKING:
-        from ldclient import LDClient
-        from ldclient.hook import EvaluationSeriesContext
-        from ldclient.evaluation import EvaluationDetail
-
         from typing import Any
+
+        from ldclient import LDClient
+        from ldclient.evaluation import EvaluationDetail
+        from ldclient.hook import EvaluationSeriesContext
 except ImportError:
     raise DidNotEnable("LaunchDarkly is not installed")
 

--- a/sentry_sdk/integrations/litellm.py
+++ b/sentry_sdk/integrations/litellm.py
@@ -7,9 +7,9 @@ from sentry_sdk.ai.monitoring import record_token_usage
 from sentry_sdk.ai.utils import (
     get_start_span_function,
     set_data_normalized,
-    truncate_and_annotate_messages,
     transform_openai_content_part,
     truncate_and_annotate_embedding_inputs,
+    truncate_and_annotate_messages,
 )
 from sentry_sdk.consts import SPANDATA
 from sentry_sdk.integrations import DidNotEnable, Integration
@@ -17,12 +17,12 @@ from sentry_sdk.scope import should_send_default_pii
 from sentry_sdk.utils import event_from_exception
 
 if TYPE_CHECKING:
-    from typing import Any, Dict, List
     from datetime import datetime
+    from typing import Any, Dict, List
 
 try:
     import litellm  # type: ignore[import-not-found]
-    from litellm import input_callback, success_callback, failure_callback
+    from litellm import failure_callback, input_callback, success_callback
 except ImportError:
     raise DidNotEnable("LiteLLM not installed")
 

--- a/sentry_sdk/integrations/litestar.py
+++ b/sentry_sdk/integrations/litestar.py
@@ -11,7 +11,7 @@ from sentry_sdk.integrations import (
 from sentry_sdk.integrations.asgi import SentryAsgiMiddleware
 from sentry_sdk.integrations.logging import ignore_logger
 from sentry_sdk.scope import should_send_default_pii
-from sentry_sdk.tracing import TransactionSource, SOURCE_FOR_STYLE
+from sentry_sdk.tracing import SOURCE_FOR_STYLE, TransactionSource
 from sentry_sdk.utils import (
     ensure_integration_enabled,
     event_from_exception,
@@ -19,12 +19,12 @@ from sentry_sdk.utils import (
 )
 
 try:
-    from litestar import Request, Litestar  # type: ignore
+    from litestar import Litestar, Request  # type: ignore
+    from litestar.data_extractors import ConnectionDataExtractor  # type: ignore
+    from litestar.exceptions import HTTPException  # type: ignore
     from litestar.handlers.base import BaseRouteHandler  # type: ignore
     from litestar.middleware import DefineMiddleware  # type: ignore
     from litestar.routes.http import HTTPRoute  # type: ignore
-    from litestar.data_extractors import ConnectionDataExtractor  # type: ignore
-    from litestar.exceptions import HTTPException  # type: ignore
 except ImportError:
     raise DidNotEnable("Litestar is not installed")
 
@@ -32,18 +32,22 @@ from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from typing import Any, Optional, Union
-    from litestar.types.asgi_types import ASGIApp  # type: ignore
+
+    from litestar.middleware import MiddlewareProtocol
     from litestar.types import (  # type: ignore
         HTTPReceiveMessage,
         HTTPScope,
         Message,
         Middleware,
         Receive,
-        Scope as LitestarScope,
         Send,
         WebSocketReceiveMessage,
     )
-    from litestar.middleware import MiddlewareProtocol
+    from litestar.types import (
+        Scope as LitestarScope,
+    )
+    from litestar.types.asgi_types import ASGIApp  # type: ignore
+
     from sentry_sdk._types import Event, Hint
 
 _DEFAULT_TRANSACTION_NAME = "generic Litestar request"

--- a/sentry_sdk/integrations/logging.py
+++ b/sentry_sdk/integrations/logging.py
@@ -2,28 +2,25 @@ import logging
 import sys
 from datetime import datetime, timezone
 from fnmatch import fnmatch
+from typing import TYPE_CHECKING
 
 import sentry_sdk
 from sentry_sdk.client import BaseClient
+from sentry_sdk.integrations import Integration
 from sentry_sdk.logger import _log_level_to_otel
 from sentry_sdk.utils import (
+    capture_internal_exceptions,
+    current_stacktrace,
+    event_from_exception,
+    has_logs_enabled,
     safe_repr,
     to_string,
-    event_from_exception,
-    current_stacktrace,
-    capture_internal_exceptions,
-    has_logs_enabled,
 )
-from sentry_sdk.integrations import Integration
-
-from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from collections.abc import MutableMapping
     from logging import LogRecord
-    from typing import Any
-    from typing import Dict
-    from typing import Optional
+    from typing import Any, Dict, Optional
 
 DEFAULT_LEVEL = logging.INFO
 DEFAULT_EVENT_LEVEL = logging.ERROR

--- a/sentry_sdk/integrations/loguru.py
+++ b/sentry_sdk/integrations/loguru.py
@@ -1,7 +1,8 @@
 import enum
+from typing import TYPE_CHECKING
 
 import sentry_sdk
-from sentry_sdk.integrations import Integration, DidNotEnable
+from sentry_sdk.integrations import DidNotEnable, Integration
 from sentry_sdk.integrations.logging import (
     BreadcrumbHandler,
     EventHandler,
@@ -9,8 +10,6 @@ from sentry_sdk.integrations.logging import (
 )
 from sentry_sdk.logger import _log_level_to_otel
 from sentry_sdk.utils import has_logs_enabled, safe_repr
-
-from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from logging import LogRecord

--- a/sentry_sdk/integrations/mcp.py
+++ b/sentry_sdk/integrations/mcp.py
@@ -24,8 +24,8 @@ from sentry_sdk.utils import safe_serialize
 try:
     from mcp.server.lowlevel import Server  # type: ignore[import-not-found]
     from mcp.server.lowlevel.server import request_ctx  # type: ignore[import-not-found]
-    from mcp.server.streamable_http import (
-        StreamableHTTPServerTransport,  # type: ignore[import-not-found]
+    from mcp.server.streamable_http import (  # type: ignore[import-not-found]
+        StreamableHTTPServerTransport,  
     )
 except ImportError:
     raise DidNotEnable("MCP SDK not installed")

--- a/sentry_sdk/integrations/mcp.py
+++ b/sentry_sdk/integrations/mcp.py
@@ -25,7 +25,7 @@ try:
     from mcp.server.lowlevel import Server  # type: ignore[import-not-found]
     from mcp.server.lowlevel.server import request_ctx  # type: ignore[import-not-found]
     from mcp.server.streamable_http import (  # type: ignore[import-not-found]
-        StreamableHTTPServerTransport,  
+        StreamableHTTPServerTransport,
     )
 except ImportError:
     raise DidNotEnable("MCP SDK not installed")

--- a/sentry_sdk/integrations/mcp.py
+++ b/sentry_sdk/integrations/mcp.py
@@ -14,17 +14,19 @@ from typing import TYPE_CHECKING
 import sentry_sdk
 from sentry_sdk.ai.utils import _set_span_data_attribute, get_start_span_function
 from sentry_sdk.consts import OP, SPANDATA
-from sentry_sdk.integrations import Integration, DidNotEnable
+from sentry_sdk.integrations import DidNotEnable, Integration
+from sentry_sdk.integrations._wsgi_common import nullcontext
+from sentry_sdk.scope import should_send_default_pii
 from sentry_sdk.traces import StreamedSpan
 from sentry_sdk.tracing_utils import has_span_streaming_enabled
 from sentry_sdk.utils import safe_serialize
-from sentry_sdk.scope import should_send_default_pii
-from sentry_sdk.integrations._wsgi_common import nullcontext
 
 try:
     from mcp.server.lowlevel import Server  # type: ignore[import-not-found]
     from mcp.server.lowlevel.server import request_ctx  # type: ignore[import-not-found]
-    from mcp.server.streamable_http import StreamableHTTPServerTransport  # type: ignore[import-not-found]
+    from mcp.server.streamable_http import (
+        StreamableHTTPServerTransport,  # type: ignore[import-not-found]
+    )
 except ImportError:
     raise DidNotEnable("MCP SDK not installed")
 
@@ -35,11 +37,12 @@ except ImportError:
 
 
 if TYPE_CHECKING:
-    from typing import Any, Callable, Optional, Tuple, Union, ContextManager
+    from typing import Any, Callable, ContextManager, Optional, Tuple, Union
 
-    from sentry_sdk.tracing import Span
-    from sentry_sdk.traces import StreamedSpan
     from starlette.types import Receive, Scope, Send  # type: ignore[import-not-found]
+
+    from sentry_sdk.traces import StreamedSpan
+    from sentry_sdk.tracing import Span
 
 
 class MCPIntegration(Integration):

--- a/sentry_sdk/integrations/modules.py
+++ b/sentry_sdk/integrations/modules.py
@@ -1,12 +1,13 @@
+from typing import TYPE_CHECKING
+
 import sentry_sdk
 from sentry_sdk.integrations import Integration
 from sentry_sdk.scope import add_global_event_processor
 from sentry_sdk.utils import _get_installed_modules
 
-from typing import TYPE_CHECKING
-
 if TYPE_CHECKING:
     from typing import Any
+
     from sentry_sdk._types import Event
 
 

--- a/sentry_sdk/integrations/openai.py
+++ b/sentry_sdk/integrations/openai.py
@@ -1,27 +1,34 @@
-import sys
 import json
+import sys
 import time
-from functools import wraps
 from collections.abc import Iterable
+from functools import wraps
+from typing import TYPE_CHECKING
 
 import sentry_sdk
 from sentry_sdk import consts
-from sentry_sdk.ai.monitoring import record_token_usage
-from sentry_sdk.ai.utils import (
-    set_data_normalized,
-    normalize_message_roles,
-    truncate_and_annotate_messages,
-    truncate_and_annotate_embedding_inputs,
+from sentry_sdk.ai._openai_completions_api import (
+    _get_system_instructions as _get_system_instructions_completions,
+)
+from sentry_sdk.ai._openai_completions_api import (
+    _get_text_items,
+    _transform_system_instructions,
 )
 from sentry_sdk.ai._openai_completions_api import (
     _is_system_instruction as _is_system_instruction_completions,
-    _get_system_instructions as _get_system_instructions_completions,
-    _transform_system_instructions,
-    _get_text_items,
+)
+from sentry_sdk.ai._openai_responses_api import (
+    _get_system_instructions as _get_system_instructions_responses,
 )
 from sentry_sdk.ai._openai_responses_api import (
     _is_system_instruction as _is_system_instruction_responses,
-    _get_system_instructions as _get_system_instructions_responses,
+)
+from sentry_sdk.ai.monitoring import record_token_usage
+from sentry_sdk.ai.utils import (
+    normalize_message_roles,
+    set_data_normalized,
+    truncate_and_annotate_embedding_inputs,
+    truncate_and_annotate_messages,
 )
 from sentry_sdk.consts import SPANDATA
 from sentry_sdk.integrations import DidNotEnable, Integration
@@ -29,34 +36,33 @@ from sentry_sdk.scope import should_send_default_pii
 from sentry_sdk.utils import (
     capture_internal_exceptions,
     event_from_exception,
-    safe_serialize,
     reraise,
+    safe_serialize,
 )
-
-from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from typing import (
         Any,
+        AsyncIterator,
+        Callable,
+        Iterable,
+        Iterator,
         List,
         Optional,
-        Callable,
-        AsyncIterator,
-        Iterator,
         Union,
-        Iterable,
     )
-    from sentry_sdk.tracing import Span
-    from sentry_sdk._types import TextPart
 
-    from openai.types.responses.response_usage import ResponseUsage
+    from openai import Omit
+    from openai.types import CompletionUsage
     from openai.types.responses import (
         ResponseInputParam,
-        SequenceNotStr,
         ResponseStreamEvent,
+        SequenceNotStr,
     )
-    from openai.types import CompletionUsage
-    from openai import Omit
+    from openai.types.responses.response_usage import ResponseUsage
+
+    from sentry_sdk._types import TextPart
+    from sentry_sdk.tracing import Span
 
 try:
     try:
@@ -69,15 +75,14 @@ try:
     except ImportError:
         Omit = None
 
-    from openai.resources.chat.completions import Completions, AsyncCompletions
-    from openai.resources import Embeddings, AsyncEmbeddings
-
-    from openai import Stream, AsyncStream
+    from openai import AsyncStream, Stream
+    from openai.resources import AsyncEmbeddings, Embeddings
+    from openai.resources.chat.completions import AsyncCompletions, Completions
 
     if TYPE_CHECKING:
         from openai.types.chat import (
-            ChatCompletionMessageParam,
             ChatCompletionChunk,
+            ChatCompletionMessageParam,
         )
 except ImportError:
     raise DidNotEnable("OpenAI not installed")
@@ -85,7 +90,7 @@ except ImportError:
 RESPONSES_API_ENABLED = True
 try:
     # responses API support was introduced in v1.66.0
-    from openai.resources.responses import Responses, AsyncResponses
+    from openai.resources.responses import AsyncResponses, Responses
     from openai.types.responses.response_completed_event import ResponseCompletedEvent
 except ImportError:
     RESPONSES_API_ENABLED = False

--- a/sentry_sdk/integrations/openai_agents/__init__.py
+++ b/sentry_sdk/integrations/openai_agents/__init__.py
@@ -1,18 +1,18 @@
+from functools import wraps
+
 from sentry_sdk.integrations import DidNotEnable, Integration
 from sentry_sdk.utils import parse_version
 
-from functools import wraps
-
 from .patches import (
-    _get_model,
+    _create_run_streamed_wrapper,
+    _create_run_wrapper,
+    _execute_final_output,
+    _execute_handoffs,
     _get_all_tools,
+    _get_model,
+    _patch_error_tracing,
     _run_single_turn,
     _run_single_turn_streamed,
-    _execute_handoffs,
-    _create_run_wrapper,
-    _create_run_streamed_wrapper,
-    _execute_final_output,
-    _patch_error_tracing,
 )
 
 try:

--- a/sentry_sdk/integrations/openai_agents/patches/__init__.py
+++ b/sentry_sdk/integrations/openai_agents/patches/__init__.py
@@ -1,10 +1,10 @@
-from .models import _get_model  # noqa: F401
-from .tools import _get_all_tools  # noqa: F401
-from .runner import _create_run_wrapper, _create_run_streamed_wrapper  # noqa: F401
 from .agent_run import (
+    _execute_final_output,  # noqa: F401
+    _execute_handoffs,  # noqa: F401
     _run_single_turn,  # noqa: F401
     _run_single_turn_streamed,  # noqa: F401
-    _execute_handoffs,  # noqa: F401
-    _execute_final_output,  # noqa: F401
 )
 from .error_tracing import _patch_error_tracing  # noqa: F401
+from .models import _get_model  # noqa: F401
+from .runner import _create_run_streamed_wrapper, _create_run_wrapper  # noqa: F401
+from .tools import _get_all_tools  # noqa: F401

--- a/sentry_sdk/integrations/openai_agents/patches/agent_run.py
+++ b/sentry_sdk/integrations/openai_agents/patches/agent_run.py
@@ -1,23 +1,23 @@
 import sys
+from typing import TYPE_CHECKING
 
 from sentry_sdk.consts import SPANDATA
 from sentry_sdk.integrations import DidNotEnable
+from sentry_sdk.tracing_utils import set_span_errored
 from sentry_sdk.utils import capture_internal_exceptions, reraise
+
 from ..spans import (
-    invoke_agent_span,
     end_invoke_agent_span,
     handoff_span,
+    invoke_agent_span,
 )
-from sentry_sdk.tracing_utils import set_span_errored
-
-from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from typing import Any, Optional, Callable, Awaitable
-
-    from sentry_sdk.tracing import Span
+    from typing import Any, Awaitable, Callable, Optional
 
     from agents.run_internal.run_steps import SingleStepResult
+
+    from sentry_sdk.tracing import Span
 
 try:
     import agents

--- a/sentry_sdk/integrations/openai_agents/patches/error_tracing.py
+++ b/sentry_sdk/integrations/openai_agents/patches/error_tracing.py
@@ -1,9 +1,8 @@
 from functools import wraps
+from typing import TYPE_CHECKING
 
 import sentry_sdk
 from sentry_sdk.tracing_utils import set_span_errored
-
-from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from typing import Any

--- a/sentry_sdk/integrations/openai_agents/patches/models.py
+++ b/sentry_sdk/integrations/openai_agents/patches/models.py
@@ -1,24 +1,23 @@
 import copy
 import time
 from functools import wraps
-
-from sentry_sdk.integrations import DidNotEnable
-
-from ..spans import ai_client_span, update_ai_client_span
+from typing import TYPE_CHECKING
 
 import sentry_sdk
 from sentry_sdk.consts import SPANDATA
-from sentry_sdk.utils import logger
+from sentry_sdk.integrations import DidNotEnable
 from sentry_sdk.tracing import BAGGAGE_HEADER_NAME
 from sentry_sdk.tracing_utils import (
-    should_propagate_trace,
     add_sentry_baggage_to_headers,
+    should_propagate_trace,
 )
+from sentry_sdk.utils import logger
 
-from typing import TYPE_CHECKING
+from ..spans import ai_client_span, update_ai_client_span
 
 if TYPE_CHECKING:
     from typing import Any, Callable, Optional
+
     from sentry_sdk.tracing import Span
 
 try:

--- a/sentry_sdk/integrations/openai_agents/patches/runner.py
+++ b/sentry_sdk/integrations/openai_agents/patches/runner.py
@@ -4,8 +4,8 @@ from functools import wraps
 import sentry_sdk
 from sentry_sdk.consts import SPANDATA
 from sentry_sdk.integrations import DidNotEnable
-from sentry_sdk.utils import capture_internal_exceptions, reraise
 from sentry_sdk.tracing_utils import set_span_errored
+from sentry_sdk.utils import capture_internal_exceptions, reraise
 
 from ..spans import agent_workflow_span, end_invoke_agent_span
 from ..utils import _capture_exception

--- a/sentry_sdk/integrations/openai_agents/patches/tools.py
+++ b/sentry_sdk/integrations/openai_agents/patches/tools.py
@@ -1,13 +1,12 @@
 from functools import wraps
+from typing import TYPE_CHECKING
 
 from sentry_sdk.integrations import DidNotEnable
 
 from ..spans import execute_tool_span, update_execute_tool_span
 
-from typing import TYPE_CHECKING
-
 if TYPE_CHECKING:
-    from typing import Any, Callable, Awaitable
+    from typing import Any, Awaitable, Callable
 
 try:
     import agents

--- a/sentry_sdk/integrations/openai_agents/spans/__init__.py
+++ b/sentry_sdk/integrations/openai_agents/spans/__init__.py
@@ -3,7 +3,7 @@ from .ai_client import ai_client_span, update_ai_client_span  # noqa: F401
 from .execute_tool import execute_tool_span, update_execute_tool_span  # noqa: F401
 from .handoff import handoff_span  # noqa: F401
 from .invoke_agent import (
+    end_invoke_agent_span,  # noqa: F401
     invoke_agent_span,  # noqa: F401
     update_invoke_agent_span,  # noqa: F401
-    end_invoke_agent_span,  # noqa: F401
 )

--- a/sentry_sdk/integrations/openai_agents/spans/agent_workflow.py
+++ b/sentry_sdk/integrations/openai_agents/spans/agent_workflow.py
@@ -1,9 +1,9 @@
+from typing import TYPE_CHECKING
+
 import sentry_sdk
 from sentry_sdk.ai.utils import get_start_span_function
 
 from ..consts import SPAN_ORIGIN
-
-from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     import agents

--- a/sentry_sdk/integrations/openai_agents/spans/ai_client.py
+++ b/sentry_sdk/integrations/openai_agents/spans/ai_client.py
@@ -1,20 +1,21 @@
+from typing import TYPE_CHECKING
+
 import sentry_sdk
 from sentry_sdk.consts import OP, SPANDATA
 
 from ..consts import SPAN_ORIGIN
 from ..utils import (
+    _create_mcp_execute_tool_spans,
     _set_agent_data,
     _set_input_data,
     _set_output_data,
     _set_usage_data,
-    _create_mcp_execute_tool_spans,
 )
 
-from typing import TYPE_CHECKING
-
 if TYPE_CHECKING:
-    from agents import Agent
     from typing import Any, Optional
+
+    from agents import Agent
 
 
 def ai_client_span(

--- a/sentry_sdk/integrations/openai_agents/spans/execute_tool.py
+++ b/sentry_sdk/integrations/openai_agents/spans/execute_tool.py
@@ -1,3 +1,5 @@
+from typing import TYPE_CHECKING
+
 import sentry_sdk
 from sentry_sdk.consts import OP, SPANDATA, SPANSTATUS
 from sentry_sdk.scope import should_send_default_pii
@@ -5,11 +7,10 @@ from sentry_sdk.scope import should_send_default_pii
 from ..consts import SPAN_ORIGIN
 from ..utils import _set_agent_data
 
-from typing import TYPE_CHECKING
-
 if TYPE_CHECKING:
-    import agents
     from typing import Any
+
+    import agents
 
 
 def execute_tool_span(

--- a/sentry_sdk/integrations/openai_agents/spans/handoff.py
+++ b/sentry_sdk/integrations/openai_agents/spans/handoff.py
@@ -1,9 +1,9 @@
+from typing import TYPE_CHECKING
+
 import sentry_sdk
 from sentry_sdk.consts import OP, SPANDATA
 
 from ..consts import SPAN_ORIGIN
-
-from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     import agents

--- a/sentry_sdk/integrations/openai_agents/spans/invoke_agent.py
+++ b/sentry_sdk/integrations/openai_agents/spans/invoke_agent.py
@@ -1,8 +1,10 @@
+from typing import TYPE_CHECKING
+
 import sentry_sdk
 from sentry_sdk.ai.utils import (
     get_start_span_function,
-    set_data_normalized,
     normalize_message_roles,
+    set_data_normalized,
     truncate_and_annotate_messages,
 )
 from sentry_sdk.consts import OP, SPANDATA
@@ -12,11 +14,10 @@ from sentry_sdk.utils import safe_serialize
 from ..consts import SPAN_ORIGIN
 from ..utils import _set_agent_data, _set_usage_data
 
-from typing import TYPE_CHECKING
-
 if TYPE_CHECKING:
-    import agents
     from typing import Any, Optional
+
+    import agents
 
 
 def invoke_agent_span(

--- a/sentry_sdk/integrations/openai_agents/utils.py
+++ b/sentry_sdk/integrations/openai_agents/utils.py
@@ -1,29 +1,29 @@
 import json
+from typing import TYPE_CHECKING
 
 import sentry_sdk
+from sentry_sdk.ai._openai_completions_api import _transform_system_instructions
+from sentry_sdk.ai._openai_responses_api import (
+    _get_system_instructions,
+    _is_system_instruction,
+)
 from sentry_sdk.ai.utils import (
     GEN_AI_ALLOWED_MESSAGE_ROLES,
+    normalize_message_role,
     normalize_message_roles,
     set_data_normalized,
-    normalize_message_role,
     truncate_and_annotate_messages,
 )
-from sentry_sdk.consts import SPANDATA, SPANSTATUS, OP
+from sentry_sdk.consts import OP, SPANDATA, SPANSTATUS
 from sentry_sdk.integrations import DidNotEnable
 from sentry_sdk.scope import should_send_default_pii
 from sentry_sdk.tracing_utils import set_span_errored
 from sentry_sdk.utils import event_from_exception, safe_serialize
-from sentry_sdk.ai._openai_completions_api import _transform_system_instructions
-from sentry_sdk.ai._openai_responses_api import (
-    _is_system_instruction,
-    _get_system_instructions,
-)
-
-from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from typing import Any
-    from agents import Usage, TResponseInputItem
+
+    from agents import TResponseInputItem, Usage
 
     from sentry_sdk._types import TextPart
 

--- a/sentry_sdk/integrations/opentelemetry/__init__.py
+++ b/sentry_sdk/integrations/opentelemetry/__init__.py
@@ -1,5 +1,5 @@
-from sentry_sdk.integrations.opentelemetry.span_processor import SentrySpanProcessor
 from sentry_sdk.integrations.opentelemetry.propagator import SentryPropagator
+from sentry_sdk.integrations.opentelemetry.span_processor import SentrySpanProcessor
 
 __all__ = [
     "SentryPropagator",

--- a/sentry_sdk/integrations/opentelemetry/integration.py
+++ b/sentry_sdk/integrations/opentelemetry/integration.py
@@ -17,7 +17,9 @@ except ImportError:
     raise DidNotEnable("opentelemetry not installed")
 
 try:
-    from opentelemetry.instrumentation.django import DjangoInstrumentor  # type: ignore[import-not-found]
+    from opentelemetry.instrumentation.django import (
+        DjangoInstrumentor,  # type: ignore[import-not-found]
+    )
 except ImportError:
     DjangoInstrumentor = None
 

--- a/sentry_sdk/integrations/opentelemetry/integration.py
+++ b/sentry_sdk/integrations/opentelemetry/integration.py
@@ -17,8 +17,8 @@ except ImportError:
     raise DidNotEnable("opentelemetry not installed")
 
 try:
-    from opentelemetry.instrumentation.django import (
-        DjangoInstrumentor,  # type: ignore[import-not-found]
+    from opentelemetry.instrumentation.django import (  # type: ignore[import-not-found]
+        DjangoInstrumentor,  
     )
 except ImportError:
     DjangoInstrumentor = None

--- a/sentry_sdk/integrations/opentelemetry/integration.py
+++ b/sentry_sdk/integrations/opentelemetry/integration.py
@@ -18,7 +18,7 @@ except ImportError:
 
 try:
     from opentelemetry.instrumentation.django import (  # type: ignore[import-not-found]
-        DjangoInstrumentor,  
+        DjangoInstrumentor,
     )
 except ImportError:
     DjangoInstrumentor = None

--- a/sentry_sdk/integrations/opentelemetry/span_processor.py
+++ b/sentry_sdk/integrations/opentelemetry/span_processor.py
@@ -2,6 +2,8 @@ from datetime import datetime, timezone
 from time import time
 from typing import TYPE_CHECKING, cast
 
+from urllib3.util import parse_url as urlparse
+
 from sentry_sdk import get_client, start_transaction
 from sentry_sdk.consts import INSTRUMENTER, SPANSTATUS
 from sentry_sdk.integrations import DidNotEnable
@@ -10,19 +12,19 @@ from sentry_sdk.integrations.opentelemetry.consts import (
     SENTRY_TRACE_KEY,
 )
 from sentry_sdk.scope import add_global_event_processor
-from sentry_sdk.tracing import Transaction, Span as SentrySpan
-
-from urllib3.util import parse_url as urlparse
+from sentry_sdk.tracing import Span as SentrySpan
+from sentry_sdk.tracing import Transaction
 
 try:
     from opentelemetry.context import get_value
-    from opentelemetry.sdk.trace import SpanProcessor, ReadableSpan as OTelSpan
+    from opentelemetry.sdk.trace import ReadableSpan as OTelSpan
+    from opentelemetry.sdk.trace import SpanProcessor
     from opentelemetry.semconv.trace import SpanAttributes
     from opentelemetry.trace import (
+        SpanKind,
         format_span_id,
         format_trace_id,
         get_current_span,
-        SpanKind,
     )
     from opentelemetry.trace.span import (
         INVALID_SPAN_ID,
@@ -33,8 +35,10 @@ except ImportError:
 
 if TYPE_CHECKING:
     from typing import Any, Optional, Union
+
     from opentelemetry import context as context_api
     from opentelemetry.trace import SpanContext
+
     from sentry_sdk._types import Event, Hint
 
 OPEN_TELEMETRY_CONTEXT = "otel"

--- a/sentry_sdk/integrations/otlp.py
+++ b/sentry_sdk/integrations/otlp.py
@@ -1,57 +1,54 @@
-from sentry_sdk import get_client, capture_event
-from sentry_sdk.integrations import Integration, DidNotEnable
-from sentry_sdk.scope import register_external_propagation_context
-from sentry_sdk.utils import (
-    Dsn,
-    logger,
-    event_from_exception,
-    capture_internal_exceptions,
-)
+from sentry_sdk import capture_event, get_client
 from sentry_sdk.consts import VERSION, EndpointType
-from sentry_sdk.tracing_utils import Baggage
+from sentry_sdk.integrations import DidNotEnable, Integration
+from sentry_sdk.scope import register_external_propagation_context
 from sentry_sdk.tracing import (
     BAGGAGE_HEADER_NAME,
     SENTRY_TRACE_HEADER_NAME,
 )
+from sentry_sdk.tracing_utils import Baggage
+from sentry_sdk.utils import (
+    Dsn,
+    capture_internal_exceptions,
+    event_from_exception,
+    logger,
+)
 
 try:
-    from opentelemetry.propagate import set_global_textmap
-    from opentelemetry.sdk.trace import TracerProvider, Span
-    from opentelemetry.sdk.trace.export import BatchSpanProcessor
-    from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
-
-    from opentelemetry.trace import (
-        get_current_span,
-        get_tracer_provider,
-        set_tracer_provider,
-        format_trace_id,
-        format_span_id,
-        SpanContext,
-        INVALID_SPAN_ID,
-        INVALID_TRACE_ID,
-    )
-
     from opentelemetry.context import (
         Context,
         get_current,
         get_value,
     )
-
+    from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+    from opentelemetry.propagate import set_global_textmap
     from opentelemetry.propagators.textmap import (
         CarrierT,
         Setter,
         default_setter,
     )
+    from opentelemetry.sdk.trace import Span, TracerProvider
+    from opentelemetry.sdk.trace.export import BatchSpanProcessor
+    from opentelemetry.trace import (
+        INVALID_SPAN_ID,
+        INVALID_TRACE_ID,
+        SpanContext,
+        format_span_id,
+        format_trace_id,
+        get_current_span,
+        get_tracer_provider,
+        set_tracer_provider,
+    )
 
-    from sentry_sdk.integrations.opentelemetry.propagator import SentryPropagator
     from sentry_sdk.integrations.opentelemetry.consts import SENTRY_BAGGAGE_KEY
+    from sentry_sdk.integrations.opentelemetry.propagator import SentryPropagator
 except ImportError:
     raise DidNotEnable("opentelemetry-distro[otlp] is not installed")
 
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from typing import Optional, Dict, Any, Tuple
+    from typing import Any, Dict, Optional, Tuple
 
 
 def otel_propagation_context() -> "Optional[Tuple[str, str]]":

--- a/sentry_sdk/integrations/pure_eval.py
+++ b/sentry_sdk/integrations/pure_eval.py
@@ -1,16 +1,15 @@
 import ast
+from typing import TYPE_CHECKING
 
 import sentry_sdk
 from sentry_sdk import serializer
-from sentry_sdk.integrations import Integration, DidNotEnable
+from sentry_sdk.integrations import DidNotEnable, Integration
 from sentry_sdk.scope import add_global_event_processor
-from sentry_sdk.utils import walk_exception_chain, iter_stacks
-
-from typing import TYPE_CHECKING
+from sentry_sdk.utils import iter_stacks, walk_exception_chain
 
 if TYPE_CHECKING:
-    from typing import Optional, Dict, Any, Tuple, List
     from types import FrameType
+    from typing import Any, Dict, List, Optional, Tuple
 
     from sentry_sdk._types import Event, Hint
 

--- a/sentry_sdk/integrations/pydantic_ai/__init__.py
+++ b/sentry_sdk/integrations/pydantic_ai/__init__.py
@@ -10,21 +10,21 @@ except ImportError:
     raise DidNotEnable("pydantic-ai not installed")
 
 
+from typing import TYPE_CHECKING
+
 from .patches import (
     _patch_agent_run,
     _patch_graph_nodes,
     _patch_tool_execution,
 )
-
 from .spans.ai_client import ai_client_span, update_ai_client_span
-
-from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from typing import Any
+
     from pydantic_ai import ModelRequestContext, RunContext
-    from pydantic_ai.messages import ModelResponse  # type: ignore
     from pydantic_ai.capabilities import Hooks  # type: ignore
+    from pydantic_ai.messages import ModelResponse  # type: ignore
 
 
 def register_hooks(hooks: "Hooks") -> None:

--- a/sentry_sdk/integrations/pydantic_ai/patches/agent_run.py
+++ b/sentry_sdk/integrations/pydantic_ai/patches/agent_run.py
@@ -1,5 +1,6 @@
 import sys
 from functools import wraps
+from typing import TYPE_CHECKING
 
 import sentry_sdk
 from sentry_sdk.integrations import DidNotEnable
@@ -7,8 +8,6 @@ from sentry_sdk.utils import capture_internal_exceptions, reraise
 
 from ..spans import invoke_agent_span, update_invoke_agent_span
 from ..utils import _capture_exception, pop_agent, push_agent
-
-from typing import TYPE_CHECKING
 
 try:
     from pydantic_ai.agent import Agent  # type: ignore

--- a/sentry_sdk/integrations/pydantic_ai/patches/tools.py
+++ b/sentry_sdk/integrations/pydantic_ai/patches/tools.py
@@ -1,14 +1,13 @@
 import sys
 from functools import wraps
+from typing import TYPE_CHECKING
 
-from sentry_sdk.integrations import DidNotEnable
 import sentry_sdk
+from sentry_sdk.integrations import DidNotEnable
 from sentry_sdk.utils import capture_internal_exceptions, reraise
 
 from ..spans import execute_tool_span, update_execute_tool_span
 from ..utils import _capture_exception, get_current_agent
-
-from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from typing import Any

--- a/sentry_sdk/integrations/pydantic_ai/spans/ai_client.py
+++ b/sentry_sdk/integrations/pydantic_ai/spans/ai_client.py
@@ -1,4 +1,5 @@
 import json
+from typing import TYPE_CHECKING
 
 import sentry_sdk
 from sentry_sdk.ai.utils import (
@@ -11,11 +12,11 @@ from sentry_sdk.utils import safe_serialize
 
 from ..consts import SPAN_ORIGIN
 from ..utils import (
+    _get_model_name,
     _set_agent_data,
     _set_available_tools,
     _set_model_data,
     _should_send_prompts,
-    _get_model_name,
     get_current_agent,
     get_is_streaming,
 )
@@ -25,23 +26,23 @@ from .utils import (
     _set_usage_data,
 )
 
-from typing import TYPE_CHECKING
-
 if TYPE_CHECKING:
-    from typing import Any, List, Dict
+    from typing import Any, Dict, List
+
     from pydantic_ai.messages import ModelMessage, SystemPromptPart  # type: ignore
+
     from sentry_sdk._types import TextPart as SentryTextPart
 
 try:
     from pydantic_ai.messages import (
         BaseToolCallPart,
         BaseToolReturnPart,
-        SystemPromptPart,
-        UserPromptPart,
-        TextPart,
-        ThinkingPart,
         BinaryContent,
         ImageUrl,
+        SystemPromptPart,
+        TextPart,
+        ThinkingPart,
+        UserPromptPart,
     )
 except ImportError:
     # Fallback if these classes are not available

--- a/sentry_sdk/integrations/pydantic_ai/spans/execute_tool.py
+++ b/sentry_sdk/integrations/pydantic_ai/spans/execute_tool.py
@@ -1,3 +1,5 @@
+from typing import TYPE_CHECKING
+
 import sentry_sdk
 from sentry_sdk.consts import OP, SPANDATA
 from sentry_sdk.utils import safe_serialize
@@ -5,10 +7,9 @@ from sentry_sdk.utils import safe_serialize
 from ..consts import SPAN_ORIGIN
 from ..utils import _set_agent_data, _should_send_prompts
 
-from typing import TYPE_CHECKING
-
 if TYPE_CHECKING:
     from typing import Any, Optional
+
     from pydantic_ai._tool_manager import ToolDefinition  # type: ignore
 
 

--- a/sentry_sdk/integrations/pydantic_ai/spans/invoke_agent.py
+++ b/sentry_sdk/integrations/pydantic_ai/spans/invoke_agent.py
@@ -1,3 +1,5 @@
+from typing import TYPE_CHECKING
+
 import sentry_sdk
 from sentry_sdk.ai.utils import (
     get_start_span_function,
@@ -19,8 +21,6 @@ from .utils import (
     _serialize_image_url_item,
     _set_usage_data,
 )
-
-from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from typing import Any

--- a/sentry_sdk/integrations/pydantic_ai/spans/utils.py
+++ b/sentry_sdk/integrations/pydantic_ai/spans/utils.py
@@ -1,16 +1,16 @@
 """Utility functions for PydanticAI span instrumentation."""
 
+from typing import TYPE_CHECKING
+
 import sentry_sdk
 from sentry_sdk._types import BLOB_DATA_SUBSTITUTE
+from sentry_sdk.ai.consts import DATA_URL_BASE64_REGEX
 from sentry_sdk.ai.utils import get_modality_from_mime_type
 from sentry_sdk.consts import SPANDATA
 
-from sentry_sdk.ai.consts import DATA_URL_BASE64_REGEX
-
-from typing import TYPE_CHECKING
-
 if TYPE_CHECKING:
-    from typing import Union, Dict, Any
+    from typing import Any, Dict, Union
+
     from pydantic_ai.usage import RequestUsage, RunUsage  # type: ignore
 
 

--- a/sentry_sdk/integrations/pydantic_ai/utils.py
+++ b/sentry_sdk/integrations/pydantic_ai/utils.py
@@ -1,11 +1,11 @@
-import sentry_sdk
 from contextvars import ContextVar
+from typing import TYPE_CHECKING
+
+import sentry_sdk
 from sentry_sdk.consts import SPANDATA
 from sentry_sdk.scope import should_send_default_pii
 from sentry_sdk.tracing_utils import set_span_errored
 from sentry_sdk.utils import event_from_exception, safe_serialize
-
-from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from typing import Any, Optional

--- a/sentry_sdk/integrations/pyramid.py
+++ b/sentry_sdk/integrations/pyramid.py
@@ -4,7 +4,7 @@ import sys
 import weakref
 
 import sentry_sdk
-from sentry_sdk.integrations import Integration, DidNotEnable
+from sentry_sdk.integrations import DidNotEnable, Integration
 from sentry_sdk.integrations._wsgi_common import RequestExtractor
 from sentry_sdk.integrations.wsgi import SentryWsgiMiddleware
 from sentry_sdk.scope import should_send_default_pii
@@ -25,17 +25,15 @@ except ImportError:
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
+    from typing import Any, Callable, Dict, Optional
+
     from pyramid.response import Response
-    from typing import Any
-    from sentry_sdk.integrations.wsgi import _ScopedResponse
-    from typing import Callable
-    from typing import Dict
-    from typing import Optional
     from webob.cookies import RequestCookies
     from webob.request import _FieldStorageWithFile
 
-    from sentry_sdk.utils import ExcInfo
     from sentry_sdk._types import Event, EventProcessor
+    from sentry_sdk.integrations.wsgi import _ScopedResponse
+    from sentry_sdk.utils import ExcInfo
 
 
 if getattr(Request, "authenticated_userid", None):

--- a/sentry_sdk/integrations/pyreqwest.py
+++ b/sentry_sdk/integrations/pyreqwest.py
@@ -1,12 +1,15 @@
+from contextlib import contextmanager
+from typing import Any, Generator
+
 import sentry_sdk
 from sentry_sdk import start_span
 from sentry_sdk.consts import OP, SPANDATA
-from sentry_sdk.integrations import Integration, DidNotEnable
+from sentry_sdk.integrations import DidNotEnable, Integration
 from sentry_sdk.tracing import BAGGAGE_HEADER_NAME
 from sentry_sdk.tracing_utils import (
-    should_propagate_trace,
     add_http_request_source,
     add_sentry_baggage_to_headers,
+    should_propagate_trace,
 )
 from sentry_sdk.utils import (
     SENSITIVE_DATA_SUBSTITUTE,
@@ -15,18 +18,21 @@ from sentry_sdk.utils import (
     parse_url,
 )
 
-from contextlib import contextmanager
-from typing import Any, Generator
-
 try:
-    from pyreqwest.client import ClientBuilder, SyncClientBuilder  # type: ignore[import-not-found]
-    from pyreqwest.request import (  # type: ignore[import-not-found]
-        Request,
-        OneOffRequestBuilder,
-        SyncOneOffRequestBuilder,
+    from pyreqwest.client import (  # type: ignore[import-not-found]
+        ClientBuilder,
+        SyncClientBuilder,
     )
     from pyreqwest.middleware import Next, SyncNext  # type: ignore[import-not-found]
-    from pyreqwest.response import Response, SyncResponse  # type: ignore[import-not-found]
+    from pyreqwest.request import (  # type: ignore[import-not-found]
+        OneOffRequestBuilder,
+        Request,
+        SyncOneOffRequestBuilder,
+    )
+    from pyreqwest.response import (  # type: ignore[import-not-found]
+        Response,
+        SyncResponse,
+    )
 except ImportError:
     raise DidNotEnable("pyreqwest not installed or incompatible version installed")
 

--- a/sentry_sdk/integrations/quart.py
+++ b/sentry_sdk/integrations/quart.py
@@ -2,6 +2,7 @@ import asyncio
 import inspect
 import sys
 from functools import wraps
+from typing import TYPE_CHECKING
 
 import sentry_sdk
 from sentry_sdk.integrations import DidNotEnable, Integration
@@ -14,11 +15,9 @@ from sentry_sdk.utils import (
     ensure_integration_enabled,
     event_from_exception,
 )
-from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from typing import Any
-    from typing import Union
+    from typing import Any, Union
 
     from sentry_sdk._types import Event, EventProcessor
 
@@ -29,10 +28,10 @@ except ImportError:
 
 try:
     from quart import (  # type: ignore
+        Quart,
+        Request,
         has_request_context,
         has_websocket_context,
-        Request,
-        Quart,
         request,
         websocket,
     )

--- a/sentry_sdk/integrations/ray.py
+++ b/sentry_sdk/integrations/ray.py
@@ -1,10 +1,10 @@
-import inspect
 import functools
+import inspect
 import sys
 
 import sentry_sdk
 from sentry_sdk.consts import OP, SPANSTATUS
-from sentry_sdk.integrations import _check_minimum_version, DidNotEnable, Integration
+from sentry_sdk.integrations import DidNotEnable, Integration, _check_minimum_version
 from sentry_sdk.tracing import TransactionSource
 from sentry_sdk.utils import (
     event_from_exception,
@@ -25,6 +25,7 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from collections.abc import Callable
     from typing import Any, Optional
+
     from sentry_sdk.utils import ExcInfo
 
 

--- a/sentry_sdk/integrations/redis/__init__.py
+++ b/sentry_sdk/integrations/redis/__init__.py
@@ -1,14 +1,13 @@
 import warnings
+from typing import TYPE_CHECKING
 
-from sentry_sdk.integrations import Integration, DidNotEnable
+from sentry_sdk.integrations import DidNotEnable, Integration
 from sentry_sdk.integrations.redis.consts import _DEFAULT_MAX_DATA_SIZE
 from sentry_sdk.integrations.redis.rb import _patch_rb
 from sentry_sdk.integrations.redis.redis import _patch_redis
 from sentry_sdk.integrations.redis.redis_cluster import _patch_redis_cluster
 from sentry_sdk.integrations.redis.redis_py_cluster_legacy import _patch_rediscluster
 from sentry_sdk.utils import logger
-
-from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from typing import Optional

--- a/sentry_sdk/integrations/redis/_async_common.py
+++ b/sentry_sdk/integrations/redis/_async_common.py
@@ -1,3 +1,5 @@
+from typing import TYPE_CHECKING
+
 import sentry_sdk
 from sentry_sdk.consts import OP
 from sentry_sdk.integrations.redis.consts import SPAN_ORIGIN
@@ -14,14 +16,14 @@ from sentry_sdk.tracing import Span
 from sentry_sdk.tracing_utils import has_span_streaming_enabled
 from sentry_sdk.utils import capture_internal_exceptions
 
-from typing import TYPE_CHECKING
-
 if TYPE_CHECKING:
     from collections.abc import Callable
     from typing import Any, Optional, Union
-    from sentry_sdk.traces import StreamedSpan
+
     from redis.asyncio.client import Pipeline, StrictRedis
     from redis.asyncio.cluster import ClusterPipeline, RedisCluster
+
+    from sentry_sdk.traces import StreamedSpan
 
 
 def patch_redis_async_pipeline(

--- a/sentry_sdk/integrations/redis/_sync_common.py
+++ b/sentry_sdk/integrations/redis/_sync_common.py
@@ -1,3 +1,5 @@
+from typing import TYPE_CHECKING
+
 import sentry_sdk
 from sentry_sdk.consts import OP
 from sentry_sdk.integrations.redis.consts import SPAN_ORIGIN
@@ -14,11 +16,10 @@ from sentry_sdk.tracing import Span
 from sentry_sdk.tracing_utils import has_span_streaming_enabled
 from sentry_sdk.utils import capture_internal_exceptions
 
-from typing import TYPE_CHECKING
-
 if TYPE_CHECKING:
     from collections.abc import Callable
     from typing import Any, Optional, Union
+
     from sentry_sdk.traces import StreamedSpan
 
 

--- a/sentry_sdk/integrations/redis/modules/caches.py
+++ b/sentry_sdk/integrations/redis/modules/caches.py
@@ -13,9 +13,10 @@ SET_COMMANDS = ("set", "setex")
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
+    from typing import Any, Optional, Union
+
     from sentry_sdk.integrations.redis import RedisIntegration
     from sentry_sdk.tracing import Span
-    from typing import Any, Optional, Union
 
 
 def _get_op(name: str) -> "Optional[str]":

--- a/sentry_sdk/integrations/redis/modules/queries.py
+++ b/sentry_sdk/integrations/redis/modules/queries.py
@@ -2,18 +2,20 @@
 Code used for the Queries module in Sentry
 """
 
+from typing import TYPE_CHECKING
+
 from sentry_sdk.consts import OP, SPANDATA
 from sentry_sdk.integrations.redis.utils import _get_safe_command
 from sentry_sdk.traces import StreamedSpan
 from sentry_sdk.utils import capture_internal_exceptions
 
-from typing import TYPE_CHECKING
-
 if TYPE_CHECKING:
+    from typing import Any, Union
+
     from redis import Redis
+
     from sentry_sdk.integrations.redis import RedisIntegration
     from sentry_sdk.tracing import Span
-    from typing import Any, Union
 
 
 def _compile_db_span_properties(

--- a/sentry_sdk/integrations/redis/redis.py
+++ b/sentry_sdk/integrations/redis/redis.py
@@ -4,13 +4,13 @@ Instrumentation for Redis
 https://github.com/redis/redis-py
 """
 
+from typing import TYPE_CHECKING
+
 from sentry_sdk.integrations.redis._sync_common import (
     patch_redis_client,
     patch_redis_pipeline,
 )
 from sentry_sdk.integrations.redis.modules.queries import _set_db_data
-
-from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from typing import Any, Sequence

--- a/sentry_sdk/integrations/redis/redis_cluster.py
+++ b/sentry_sdk/integrations/redis/redis_cluster.py
@@ -5,24 +5,27 @@ This is part of the main redis-py client.
 https://github.com/redis/redis-py/blob/master/redis/cluster.py
 """
 
+from typing import TYPE_CHECKING
+
 from sentry_sdk.integrations.redis._sync_common import (
     patch_redis_client,
     patch_redis_pipeline,
 )
 from sentry_sdk.integrations.redis.modules.queries import _set_db_data_on_span
 from sentry_sdk.integrations.redis.utils import _parse_rediscluster_command
-
 from sentry_sdk.utils import capture_internal_exceptions
-
-from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from typing import Any, Union
+
     from redis import RedisCluster
     from redis.asyncio.cluster import (
-        RedisCluster as AsyncRedisCluster,
         ClusterPipeline as AsyncClusterPipeline,
     )
+    from redis.asyncio.cluster import (
+        RedisCluster as AsyncRedisCluster,
+    )
+
     from sentry_sdk.traces import StreamedSpan
     from sentry_sdk.tracing import Span
 

--- a/sentry_sdk/integrations/redis/utils.py
+++ b/sentry_sdk/integrations/redis/utils.py
@@ -1,3 +1,5 @@
+from typing import TYPE_CHECKING
+
 from sentry_sdk.consts import SPANDATA
 from sentry_sdk.integrations.redis.consts import (
     _COMMANDS_INCLUDING_SENSITIVE_DATA,
@@ -10,8 +12,6 @@ from sentry_sdk.scope import should_send_default_pii
 from sentry_sdk.traces import StreamedSpan
 from sentry_sdk.tracing import Span
 from sentry_sdk.utils import SENSITIVE_DATA_SUBSTITUTE
-
-from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from typing import Any, Optional, Sequence, Union

--- a/sentry_sdk/integrations/rq.py
+++ b/sentry_sdk/integrations/rq.py
@@ -1,9 +1,9 @@
 import weakref
 
 import sentry_sdk
-from sentry_sdk.consts import OP
 from sentry_sdk.api import continue_trace
-from sentry_sdk.integrations import _check_minimum_version, DidNotEnable, Integration
+from sentry_sdk.consts import OP
+from sentry_sdk.integrations import DidNotEnable, Integration, _check_minimum_version
 from sentry_sdk.integrations.logging import ignore_logger
 from sentry_sdk.scope import should_send_default_pii
 from sentry_sdk.tracing import TransactionSource
@@ -17,11 +17,11 @@ from sentry_sdk.utils import (
 )
 
 try:
+    from rq.job import JobStatus
     from rq.queue import Queue
     from rq.timeouts import JobTimeoutException
     from rq.version import VERSION as RQ_VERSION
     from rq.worker import Worker
-    from rq.job import JobStatus
 except ImportError:
     raise DidNotEnable("RQ not installed")
 
@@ -38,10 +38,10 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from typing import Any, Callable
 
+    from rq.job import Job
+
     from sentry_sdk._types import Event, EventProcessor
     from sentry_sdk.utils import ExcInfo
-
-    from rq.job import Job
 
 
 class RqIntegration(Integration):

--- a/sentry_sdk/integrations/sanic.py
+++ b/sentry_sdk/integrations/sanic.py
@@ -1,46 +1,42 @@
 import sys
 import weakref
 from inspect import isawaitable
+from typing import TYPE_CHECKING
 from urllib.parse import urlsplit
 
 import sentry_sdk
 from sentry_sdk import continue_trace
 from sentry_sdk.consts import OP
-from sentry_sdk.integrations import _check_minimum_version, Integration, DidNotEnable
+from sentry_sdk.integrations import DidNotEnable, Integration, _check_minimum_version
 from sentry_sdk.integrations._wsgi_common import RequestExtractor, _filter_headers
 from sentry_sdk.integrations.logging import ignore_logger
 from sentry_sdk.tracing import TransactionSource
 from sentry_sdk.utils import (
+    CONTEXTVARS_ERROR_MESSAGE,
+    HAS_REAL_CONTEXTVARS,
     capture_internal_exceptions,
     ensure_integration_enabled,
     event_from_exception,
-    HAS_REAL_CONTEXTVARS,
-    CONTEXTVARS_ERROR_MESSAGE,
     parse_version,
     reraise,
 )
 
-from typing import TYPE_CHECKING
-
 if TYPE_CHECKING:
     from collections.abc import Container
-    from typing import Any
-    from typing import Callable
-    from typing import Optional
-    from typing import Union
-    from typing import Dict
+    from typing import Any, Callable, Dict, Optional, Union
 
     from sanic.request import Request, RequestParameters
     from sanic.response import BaseHTTPResponse
-
-    from sentry_sdk._types import Event, EventProcessor, ExcInfo, Hint
     from sanic.router import Route
 
+    from sentry_sdk._types import Event, EventProcessor, ExcInfo, Hint
+
 try:
-    from sanic import Sanic, __version__ as SANIC_VERSION
+    from sanic import Sanic
+    from sanic import __version__ as SANIC_VERSION
     from sanic.exceptions import SanicException
-    from sanic.router import Router
     from sanic.handlers import ErrorHandler
+    from sanic.router import Router
 except ImportError:
     raise DidNotEnable("Sanic not installed")
 

--- a/sentry_sdk/integrations/socket.py
+++ b/sentry_sdk/integrations/socket.py
@@ -7,7 +7,7 @@ from sentry_sdk.integrations import Integration
 
 if MYPY:
     from socket import AddressFamily, SocketKind
-    from typing import Tuple, Optional, Union, List
+    from typing import List, Optional, Tuple, Union
 
 __all__ = ["SocketIntegration"]
 

--- a/sentry_sdk/integrations/spark/spark_driver.py
+++ b/sentry_sdk/integrations/spark/spark_driver.py
@@ -1,15 +1,15 @@
+from typing import TYPE_CHECKING
+
 import sentry_sdk
 from sentry_sdk.integrations import Integration
 from sentry_sdk.utils import capture_internal_exceptions, ensure_integration_enabled
 
-from typing import TYPE_CHECKING
-
 if TYPE_CHECKING:
-    from typing import Any
-    from typing import Optional
+    from typing import Any, Optional
+
+    from pyspark import SparkContext
 
     from sentry_sdk._types import Event, Hint
-    from pyspark import SparkContext
 
 
 class SparkIntegration(Integration):

--- a/sentry_sdk/integrations/spark/spark_worker.py
+++ b/sentry_sdk/integrations/spark/spark_worker.py
@@ -1,22 +1,20 @@
 import sys
+from typing import TYPE_CHECKING
 
 import sentry_sdk
 from sentry_sdk.integrations import Integration
 from sentry_sdk.utils import (
     capture_internal_exceptions,
+    event_hint_with_exc_info,
     exc_info_from_error,
     single_exception_from_error_tuple,
     walk_exception_chain,
-    event_hint_with_exc_info,
 )
 
-from typing import TYPE_CHECKING
-
 if TYPE_CHECKING:
-    from typing import Any
-    from typing import Optional
+    from typing import Any, Optional
 
-    from sentry_sdk._types import ExcInfo, Event, Hint
+    from sentry_sdk._types import Event, ExcInfo, Hint
 
 
 class SparkWorkerIntegration(Integration):

--- a/sentry_sdk/integrations/sqlalchemy.py
+++ b/sentry_sdk/integrations/sqlalchemy.py
@@ -1,5 +1,7 @@
-from sentry_sdk.consts import SPANSTATUS, SPANDATA
-from sentry_sdk.integrations import _check_minimum_version, Integration, DidNotEnable
+from sentry_sdk.consts import SPANDATA, SPANSTATUS
+from sentry_sdk.integrations import DidNotEnable, Integration, _check_minimum_version
+from sentry_sdk.traces import SpanStatus, StreamedSpan
+from sentry_sdk.tracing import Span
 from sentry_sdk.tracing_utils import (
     add_query_source,
     record_sql_queries_supporting_streaming,
@@ -9,23 +11,18 @@ from sentry_sdk.utils import (
     ensure_integration_enabled,
     parse_version,
 )
-from sentry_sdk.traces import StreamedSpan, SpanStatus
-from sentry_sdk.tracing import Span
 
 try:
+    from sqlalchemy import __version__ as SQLALCHEMY_VERSION  # type: ignore
     from sqlalchemy.engine import Engine  # type: ignore
     from sqlalchemy.event import listen  # type: ignore
-    from sqlalchemy import __version__ as SQLALCHEMY_VERSION  # type: ignore
 except ImportError:
     raise DidNotEnable("SQLAlchemy not installed.")
 
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from typing import Any
-    from typing import ContextManager
-    from typing import Optional
-    from typing import Union
+    from typing import Any, ContextManager, Optional, Union
 
 
 class SqlalchemyIntegration(Integration):

--- a/sentry_sdk/integrations/starlette.py
+++ b/sentry_sdk/integrations/starlette.py
@@ -22,8 +22,7 @@ from sentry_sdk.integrations._wsgi_common import (
 )
 from sentry_sdk.integrations.asgi import SentryAsgiMiddleware
 from sentry_sdk.scope import should_send_default_pii
-from sentry_sdk.traces import _get_current_streamed_span
-from sentry_sdk.traces import StreamedSpan
+from sentry_sdk.traces import StreamedSpan, _get_current_streamed_span
 from sentry_sdk.tracing import (
     SOURCE_FOR_STYLE,
     TransactionSource,

--- a/sentry_sdk/integrations/starlite.py
+++ b/sentry_sdk/integrations/starlite.py
@@ -13,13 +13,17 @@ from sentry_sdk.utils import (
 )
 
 try:
+    from pydantic import BaseModel  # type: ignore
     from starlite import Request, Starlite, State  # type: ignore
     from starlite.handlers.base import BaseRouteHandler  # type: ignore
     from starlite.middleware import DefineMiddleware  # type: ignore
     from starlite.plugins.base import get_plugin_for_value  # type: ignore
     from starlite.routes.http import HTTPRoute  # type: ignore
-    from starlite.utils import ConnectionDataExtractor, is_async_callable, Ref  # type: ignore
-    from pydantic import BaseModel  # type: ignore
+    from starlite.utils import (  # type: ignore
+        ConnectionDataExtractor,
+        Ref,
+        is_async_callable,
+    )
 except ImportError:
     raise DidNotEnable("Starlite is not installed")
 
@@ -27,6 +31,8 @@ from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from typing import Any, Optional, Union
+
+    from starlite import MiddlewareProtocol
     from starlite.types import (  # type: ignore
         ASGIApp,
         Hint,
@@ -35,11 +41,13 @@ if TYPE_CHECKING:
         Message,
         Middleware,
         Receive,
-        Scope as StarliteScope,
         Send,
         WebSocketReceiveMessage,
     )
-    from starlite import MiddlewareProtocol
+    from starlite.types import (
+        Scope as StarliteScope,
+    )
+
     from sentry_sdk._types import Event
 
 

--- a/sentry_sdk/integrations/statsig.py
+++ b/sentry_sdk/integrations/statsig.py
@@ -1,8 +1,8 @@
 from functools import wraps
-from typing import Any, TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from sentry_sdk.feature_flags import add_feature_flag
-from sentry_sdk.integrations import Integration, DidNotEnable, _check_minimum_version
+from sentry_sdk.integrations import DidNotEnable, Integration, _check_minimum_version
 from sentry_sdk.utils import parse_version
 
 try:

--- a/sentry_sdk/integrations/stdlib.py
+++ b/sentry_sdk/integrations/stdlib.py
@@ -1,20 +1,21 @@
 import os
+import platform
 import subprocess
 import sys
-import platform
 from http.client import HTTPConnection, HTTPResponse
+from typing import TYPE_CHECKING
 
 import sentry_sdk
 from sentry_sdk.consts import OP, SPANDATA
 from sentry_sdk.integrations import Integration
 from sentry_sdk.scope import add_global_event_processor
-from sentry_sdk.tracing import Span
 from sentry_sdk.traces import StreamedSpan
+from sentry_sdk.tracing import Span
 from sentry_sdk.tracing_utils import (
     EnvironHeaders,
-    should_propagate_trace,
     add_http_request_source,
     has_span_streaming_enabled,
+    should_propagate_trace,
 )
 from sentry_sdk.utils import (
     SENSITIVE_DATA_SUBSTITUTE,
@@ -22,19 +23,12 @@ from sentry_sdk.utils import (
     ensure_integration_enabled,
     is_sentry_url,
     logger,
-    safe_repr,
     parse_url,
+    safe_repr,
 )
 
-from typing import TYPE_CHECKING
-
 if TYPE_CHECKING:
-    from typing import Any
-    from typing import Callable
-    from typing import Dict
-    from typing import Optional
-    from typing import List
-    from typing import Union
+    from typing import Any, Callable, Dict, List, Optional, Union
 
     from sentry_sdk._types import Event, Hint
 

--- a/sentry_sdk/integrations/strawberry.py
+++ b/sentry_sdk/integrations/strawberry.py
@@ -5,7 +5,7 @@ from inspect import isawaitable
 
 import sentry_sdk
 from sentry_sdk.consts import OP
-from sentry_sdk.integrations import _check_minimum_version, Integration, DidNotEnable
+from sentry_sdk.integrations import DidNotEnable, Integration, _check_minimum_version
 from sentry_sdk.integrations.logging import ignore_logger
 from sentry_sdk.scope import should_send_default_pii
 from sentry_sdk.tracing import TransactionSource
@@ -38,6 +38,8 @@ except ImportError:
 try:
     from strawberry.extensions.tracing import (
         SentryTracingExtension as StrawberrySentryAsyncExtension,
+    )
+    from strawberry.extensions.tracing import (
         SentryTracingExtensionSync as StrawberrySentrySyncExtension,
     )
 except ImportError:
@@ -48,9 +50,11 @@ from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from typing import Any, Callable, Generator, List, Optional
+
     from graphql import GraphQLError, GraphQLResolveInfo
     from strawberry.http import GraphQLHTTPResponse
     from strawberry.types import ExecutionContext
+
     from sentry_sdk._types import Event, EventProcessor
 
 

--- a/sentry_sdk/integrations/sys_exit.py
+++ b/sentry_sdk/integrations/sys_exit.py
@@ -2,9 +2,9 @@ import functools
 import sys
 
 import sentry_sdk
-from sentry_sdk.utils import capture_internal_exceptions, event_from_exception
-from sentry_sdk.integrations import Integration
 from sentry_sdk._types import TYPE_CHECKING
+from sentry_sdk.integrations import Integration
+from sentry_sdk.utils import capture_internal_exceptions, event_from_exception
 
 if TYPE_CHECKING:
     from collections.abc import Callable

--- a/sentry_sdk/integrations/threading.py
+++ b/sentry_sdk/integrations/threading.py
@@ -1,26 +1,22 @@
 import sys
 import warnings
+from concurrent.futures import Future, ThreadPoolExecutor
 from functools import wraps
 from threading import Thread, current_thread
-from concurrent.futures import ThreadPoolExecutor, Future
+from typing import TYPE_CHECKING
 
 import sentry_sdk
 from sentry_sdk.integrations import Integration
 from sentry_sdk.scope import use_isolation_scope, use_scope
 from sentry_sdk.utils import (
-    event_from_exception,
     capture_internal_exceptions,
+    event_from_exception,
     logger,
     reraise,
 )
 
-from typing import TYPE_CHECKING
-
 if TYPE_CHECKING:
-    from typing import Any
-    from typing import TypeVar
-    from typing import Callable
-    from typing import Optional
+    from typing import Any, Callable, Optional, TypeVar
 
     from sentry_sdk._types import ExcInfo
 

--- a/sentry_sdk/integrations/tornado.py
+++ b/sentry_sdk/integrations/tornado.py
@@ -1,43 +1,39 @@
-import weakref
 import contextlib
+import weakref
 from inspect import iscoroutinefunction
 
 import sentry_sdk
 from sentry_sdk.api import continue_trace
 from sentry_sdk.consts import OP
-from sentry_sdk.scope import should_send_default_pii
-from sentry_sdk.tracing import TransactionSource
-from sentry_sdk.utils import (
-    HAS_REAL_CONTEXTVARS,
-    CONTEXTVARS_ERROR_MESSAGE,
-    ensure_integration_enabled,
-    event_from_exception,
-    capture_internal_exceptions,
-    transaction_from_function,
-)
-from sentry_sdk.integrations import _check_minimum_version, Integration, DidNotEnable
+from sentry_sdk.integrations import DidNotEnable, Integration, _check_minimum_version
 from sentry_sdk.integrations._wsgi_common import (
     RequestExtractor,
     _filter_headers,
     _is_json_content_type,
 )
 from sentry_sdk.integrations.logging import ignore_logger
+from sentry_sdk.scope import should_send_default_pii
+from sentry_sdk.tracing import TransactionSource
+from sentry_sdk.utils import (
+    CONTEXTVARS_ERROR_MESSAGE,
+    HAS_REAL_CONTEXTVARS,
+    capture_internal_exceptions,
+    ensure_integration_enabled,
+    event_from_exception,
+    transaction_from_function,
+)
 
 try:
     from tornado import version_info as TORNADO_VERSION
-    from tornado.web import RequestHandler, HTTPError
     from tornado.gen import coroutine
+    from tornado.web import HTTPError, RequestHandler
 except ImportError:
     raise DidNotEnable("Tornado not installed")
 
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from typing import Any
-    from typing import Optional
-    from typing import Dict
-    from typing import Callable
-    from typing import Generator
+    from typing import Any, Callable, Dict, Generator, Optional
 
     from sentry_sdk._types import Event, EventProcessor
 

--- a/sentry_sdk/integrations/trytond.py
+++ b/sentry_sdk/integrations/trytond.py
@@ -1,8 +1,7 @@
 import sentry_sdk
-from sentry_sdk.integrations import Integration
+from sentry_sdk.integrations import DidNotEnable, Integration
 from sentry_sdk.integrations.wsgi import SentryWsgiMiddleware
 from sentry_sdk.utils import ensure_integration_enabled, event_from_exception
-from sentry_sdk.integrations import DidNotEnable
 
 try:
     from trytond.exceptions import TrytonException  # type: ignore

--- a/sentry_sdk/integrations/typer.py
+++ b/sentry_sdk/integrations/typer.py
@@ -1,19 +1,15 @@
+from typing import TYPE_CHECKING
+
 import sentry_sdk
+from sentry_sdk.integrations import DidNotEnable, Integration
 from sentry_sdk.utils import (
     capture_internal_exceptions,
     event_from_exception,
 )
-from sentry_sdk.integrations import Integration, DidNotEnable
-
-from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from typing import Callable
-    from typing import Any
-    from typing import Type
-    from typing import Optional
-
     from types import TracebackType
+    from typing import Any, Callable, Optional, Type
 
     Excepthook = Callable[
         [Type[BaseException], BaseException, Optional[TracebackType]],

--- a/sentry_sdk/integrations/unleash.py
+++ b/sentry_sdk/integrations/unleash.py
@@ -2,7 +2,7 @@ from functools import wraps
 from typing import Any
 
 from sentry_sdk.feature_flags import add_feature_flag
-from sentry_sdk.integrations import Integration, DidNotEnable
+from sentry_sdk.integrations import DidNotEnable, Integration
 
 try:
     from UnleashClient import UnleashClient

--- a/sentry_sdk/integrations/unraisablehook.py
+++ b/sentry_sdk/integrations/unraisablehook.py
@@ -1,17 +1,15 @@
 import sys
+from typing import TYPE_CHECKING
 
 import sentry_sdk
+from sentry_sdk.integrations import Integration
 from sentry_sdk.utils import (
     capture_internal_exceptions,
     event_from_exception,
 )
-from sentry_sdk.integrations import Integration
-
-from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from typing import Callable
-    from typing import Any
+    from typing import Any, Callable
 
 
 class UnraisablehookIntegration(Integration):

--- a/sentry_sdk/integrations/wsgi.py
+++ b/sentry_sdk/integrations/wsgi.py
@@ -11,9 +11,9 @@ from sentry_sdk.integrations._wsgi_common import (
     _filter_headers,
     nullcontext,
 )
-from sentry_sdk.scope import should_send_default_pii, use_isolation_scope, Scope
+from sentry_sdk.scope import Scope, should_send_default_pii, use_isolation_scope
 from sentry_sdk.sessions import track_session
-from sentry_sdk.traces import StreamedSpan, SegmentSource
+from sentry_sdk.traces import SegmentSource, StreamedSpan
 from sentry_sdk.tracing import Span, TransactionSource
 from sentry_sdk.tracing_utils import has_span_streaming_enabled
 from sentry_sdk.utils import (

--- a/sentry_sdk/logger.py
+++ b/sentry_sdk/logger.py
@@ -1,10 +1,10 @@
 # NOTE: this is the logger sentry exposes to users, not some generic logger.
 import functools
 import time
-from typing import Any, TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import sentry_sdk
-from sentry_sdk.utils import format_attribute, capture_internal_exceptions
+from sentry_sdk.utils import capture_internal_exceptions, format_attribute
 
 if TYPE_CHECKING:
     from sentry_sdk._types import Attributes

--- a/sentry_sdk/metrics.py
+++ b/sentry_sdk/metrics.py
@@ -1,5 +1,5 @@
 import time
-from typing import Any, Optional, TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, Optional
 
 import sentry_sdk
 from sentry_sdk.utils import format_attribute

--- a/sentry_sdk/monitor.py
+++ b/sentry_sdk/monitor.py
@@ -1,12 +1,11 @@
 import os
 import time
 import weakref
-from threading import Thread, Lock
+from threading import Lock, Thread
+from typing import TYPE_CHECKING
 
 import sentry_sdk
 from sentry_sdk.utils import logger
-
-from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from typing import Optional

--- a/sentry_sdk/profiler/__init__.py
+++ b/sentry_sdk/profiler/__init__.py
@@ -7,10 +7,10 @@ from sentry_sdk.profiler.continuous_profiler import (
 from sentry_sdk.profiler.transaction_profiler import (
     MAX_PROFILE_DURATION_NS,
     PROFILE_MINIMUM_SAMPLES,
+    GeventScheduler,
     Profile,
     Scheduler,
     ThreadScheduler,
-    GeventScheduler,
     has_profiling_enabled,
     setup_profiler,
     teardown_profiler,
@@ -18,10 +18,10 @@ from sentry_sdk.profiler.transaction_profiler import (
 from sentry_sdk.profiler.utils import (
     DEFAULT_SAMPLING_FREQUENCY,
     MAX_STACK_DEPTH,
-    get_frame_name,
     extract_frame,
     extract_stack,
     frame_id,
+    get_frame_name,
 )
 
 __all__ = [

--- a/sentry_sdk/profiler/continuous_profiler.py
+++ b/sentry_sdk/profiler/continuous_profiler.py
@@ -8,10 +8,11 @@ import uuid
 import warnings
 from collections import deque
 from datetime import datetime, timezone
+from typing import TYPE_CHECKING
 
+from sentry_sdk._lru_cache import LRUCache
 from sentry_sdk.consts import VERSION
 from sentry_sdk.envelope import Envelope
-from sentry_sdk._lru_cache import LRUCache
 from sentry_sdk.profiler.utils import (
     DEFAULT_SAMPLING_FREQUENCY,
     extract_stack,
@@ -24,27 +25,19 @@ from sentry_sdk.utils import (
     set_in_app_in_frames,
 )
 
-from typing import TYPE_CHECKING
-
 if TYPE_CHECKING:
-    from typing import Any
-    from typing import Callable
-    from typing import Deque
-    from typing import Dict
-    from typing import List
-    from typing import Optional
-    from typing import Set
-    from typing import Type
-    from typing import Union
+    from typing import Any, Callable, Deque, Dict, List, Optional, Set, Type, Union
+
     from typing_extensions import TypedDict
+
     from sentry_sdk._types import ContinuousProfilerMode, SDKInfo
     from sentry_sdk.profiler.utils import (
         ExtractedSample,
         FrameId,
-        StackId,
-        ThreadId,
         ProcessedFrame,
         ProcessedStack,
+        StackId,
+        ThreadId,
     )
 
     ProcessedSample = TypedDict(

--- a/sentry_sdk/profiler/transaction_profiler.py
+++ b/sentry_sdk/profiler/transaction_profiler.py
@@ -36,6 +36,7 @@ import uuid
 import warnings
 from abc import ABC, abstractmethod
 from collections import deque
+from typing import TYPE_CHECKING
 
 import sentry_sdk
 from sentry_sdk._lru_cache import LRUCache
@@ -54,29 +55,21 @@ from sentry_sdk.utils import (
     set_in_app_in_frames,
 )
 
-from typing import TYPE_CHECKING
-
 if TYPE_CHECKING:
-    from typing import Any
-    from typing import Callable
-    from typing import Deque
-    from typing import Dict
-    from typing import List
-    from typing import Optional
-    from typing import Set
-    from typing import Type
+    from typing import Any, Callable, Deque, Dict, List, Optional, Set, Type
+
     from typing_extensions import TypedDict
 
+    from sentry_sdk._types import Event, ProfilerMode, SamplingContext
     from sentry_sdk.profiler.utils import (
-        ProcessedStack,
-        ProcessedFrame,
-        ProcessedThreadMetadata,
+        ExtractedSample,
         FrameId,
+        ProcessedFrame,
+        ProcessedStack,
+        ProcessedThreadMetadata,
         StackId,
         ThreadId,
-        ExtractedSample,
     )
-    from sentry_sdk._types import Event, SamplingContext, ProfilerMode
 
     ProcessedSample = TypedDict(
         "ProcessedSample",

--- a/sentry_sdk/profiler/utils.py
+++ b/sentry_sdk/profiler/utils.py
@@ -1,20 +1,17 @@
 import os
 from collections import deque
+from typing import TYPE_CHECKING
 
 from sentry_sdk._compat import PY311
 from sentry_sdk.utils import filename_for_module
 
-from typing import TYPE_CHECKING
-
 if TYPE_CHECKING:
-    from sentry_sdk._lru_cache import LRUCache
     from types import FrameType
-    from typing import Deque
-    from typing import List
-    from typing import Optional
-    from typing import Sequence
-    from typing import Tuple
+    from typing import Deque, List, Optional, Sequence, Tuple
+
     from typing_extensions import TypedDict
+
+    from sentry_sdk._lru_cache import LRUCache
 
     ThreadId = str
 

--- a/sentry_sdk/scrubber.py
+++ b/sentry_sdk/scrubber.py
@@ -1,14 +1,15 @@
+from typing import TYPE_CHECKING, Dict, List, cast
+
 from sentry_sdk.utils import (
-    capture_internal_exceptions,
     AnnotatedValue,
+    capture_internal_exceptions,
     iter_event_frames,
 )
 
-from typing import TYPE_CHECKING, cast, List, Dict
-
 if TYPE_CHECKING:
-    from sentry_sdk._types import Event
     from typing import Optional
+
+    from sentry_sdk._types import Event
 
 
 DEFAULT_DENYLIST = [

--- a/sentry_sdk/serializer.py
+++ b/sentry_sdk/serializer.py
@@ -1,7 +1,8 @@
-import sys
 import math
+import sys
 from collections.abc import Mapping, Sequence, Set
 from datetime import datetime
+from typing import TYPE_CHECKING
 
 from sentry_sdk.utils import (
     AnnotatedValue,
@@ -12,19 +13,9 @@ from sentry_sdk.utils import (
     strip_string,
 )
 
-from typing import TYPE_CHECKING
-
 if TYPE_CHECKING:
     from types import TracebackType
-
-    from typing import Any
-    from typing import Callable
-    from typing import ContextManager
-    from typing import Dict
-    from typing import List
-    from typing import Optional
-    from typing import Type
-    from typing import Union
+    from typing import Any, Callable, ContextManager, Dict, List, Optional, Type, Union
 
     from sentry_sdk._types import NotImplementedType
 

--- a/sentry_sdk/session.py
+++ b/sentry_sdk/session.py
@@ -1,15 +1,11 @@
 import uuid
 from datetime import datetime, timezone
+from typing import TYPE_CHECKING
 
 from sentry_sdk.utils import format_timestamp
 
-from typing import TYPE_CHECKING
-
 if TYPE_CHECKING:
-    from typing import Optional
-    from typing import Union
-    from typing import Any
-    from typing import Dict
+    from typing import Any, Dict, Optional, Union
 
     from sentry_sdk._types import SessionStatus
 

--- a/sentry_sdk/sessions.py
+++ b/sentry_sdk/sessions.py
@@ -1,23 +1,16 @@
 import os
 import warnings
-from threading import Thread, Lock, Event
 from contextlib import contextmanager
+from threading import Event, Lock, Thread
+from typing import TYPE_CHECKING
 
 import sentry_sdk
 from sentry_sdk.envelope import Envelope
 from sentry_sdk.session import Session
 from sentry_sdk.utils import format_timestamp
 
-from typing import TYPE_CHECKING
-
 if TYPE_CHECKING:
-    from typing import Any
-    from typing import Callable
-    from typing import Dict
-    from typing import Generator
-    from typing import List
-    from typing import Optional
-    from typing import Union
+    from typing import Any, Callable, Dict, Generator, List, Optional, Union
 
 
 def is_auto_session_tracking_enabled(

--- a/sentry_sdk/spotlight.py
+++ b/sentry_sdk/spotlight.py
@@ -1,31 +1,27 @@
 import io
 import logging
 import os
+import sys
 import time
+import urllib.error
 import urllib.parse
 import urllib.request
-import urllib.error
-import urllib3
-import sys
-
 from itertools import chain, product
-
 from typing import TYPE_CHECKING
 
-if TYPE_CHECKING:
-    from typing import Any
-    from typing import Callable
-    from typing import Dict
-    from typing import Optional
-    from typing import Self
+import urllib3
 
+if TYPE_CHECKING:
+    from typing import Any, Callable, Dict, Optional, Self
+
+from sentry_sdk.envelope import Envelope
+from sentry_sdk.utils import (
+    capture_internal_exceptions,
+    env_to_bool,
+)
 from sentry_sdk.utils import (
     logger as sentry_logger,
-    env_to_bool,
-    capture_internal_exceptions,
 )
-from sentry_sdk.envelope import Envelope
-
 
 logger = logging.getLogger("spotlight")
 
@@ -95,9 +91,9 @@ class SpotlightClient:
 
 
 try:
-    from django.utils.deprecation import MiddlewareMixin
-    from django.http import HttpResponseServerError, HttpResponse, HttpRequest
     from django.conf import settings
+    from django.http import HttpRequest, HttpResponse, HttpResponseServerError
+    from django.utils.deprecation import MiddlewareMixin
 
     SPOTLIGHT_JS_ENTRY_PATH = "/assets/main.js"
     SPOTLIGHT_JS_SNIPPET_PATTERN = (

--- a/sentry_sdk/traces.py
+++ b/sentry_sdk/traces.py
@@ -37,10 +37,10 @@ if TYPE_CHECKING:
         Callable,
         Iterator,
         Optional,
-        overload,
         ParamSpec,
         TypeVar,
         Union,
+        overload,
     )
 
     from sentry_sdk._types import Attributes, AttributeValue

--- a/sentry_sdk/tracing_utils.py
+++ b/sentry_sdk/tracing_utils.py
@@ -325,7 +325,7 @@ def add_source(
         except Exception:
             lineno = None
         if lineno is not None:
-            if isinstance(span, LegacySpan):
+            if isinstance(span, Span):
                 span.set_data(SPANDATA.CODE_LINENO, lineno)
             else:
                 span.set_attribute("code.line.number", lineno)
@@ -335,7 +335,7 @@ def add_source(
         except Exception:
             namespace = None
         if namespace is not None:
-            if isinstance(span, LegacySpan):
+            if isinstance(span, Span):
                 span.set_data(SPANDATA.CODE_NAMESPACE, namespace)
             else:
                 span.set_attribute(SPANDATA.CODE_NAMESPACE, namespace)
@@ -349,7 +349,7 @@ def add_source(
             else:
                 in_app_path = filepath
 
-            if isinstance(span, LegacySpan):
+            if isinstance(span, Span):
                 span.set_data(SPANDATA.CODE_FILEPATH, in_app_path)
             else:
                 if in_app_path is not None:
@@ -361,7 +361,7 @@ def add_source(
             code_function = None
 
         if code_function is not None:
-            if isinstance(span, LegacySpan):
+            if isinstance(span, Span):
                 span.set_data(SPANDATA.CODE_FUNCTION, frame.f_code.co_name)
             else:
                 span.set_attribute(SPANDATA.CODE_FUNCTION, frame.f_code.co_name)
@@ -377,9 +377,9 @@ def add_query_source(
     if not client.is_active():
         return
 
-    if isinstance(span, LegacySpan):
+    if isinstance(span, Span):
         # In the StreamedSpan case, we need to add the extra span information before
-        # the span finishes, so it's expected that this will be None. In the LegacySpan case,
+        # the span finishes, so it's expected that this will be None. In the Span case,
         # it should already be finished.
         if span.timestamp is None:
             return
@@ -423,9 +423,9 @@ def add_http_request_source(
     if not client.is_active():
         return
 
-    if isinstance(span, LegacySpan):
+    if isinstance(span, Span):
         # In the StreamedSpan case, we need to add the extra span information before
-        # the span finishes, so it's expected that this will be None. In the LegacySpan case,
+        # the span finishes, so it's expected that this will be None. In the Span case,
         # it should already be finished.
         if span.timestamp is None:
             return
@@ -1723,7 +1723,7 @@ from sentry_sdk.tracing import (
     SENTRY_TRACE_HEADER_NAME,
 )
 from sentry_sdk.tracing import (
-    Span as LegacySpan,
+    Span
 )
 
 if TYPE_CHECKING:

--- a/sentry_sdk/tracing_utils.py
+++ b/sentry_sdk/tracing_utils.py
@@ -1721,9 +1721,7 @@ from sentry_sdk.tracing import (
     BAGGAGE_HEADER_NAME,
     LOW_QUALITY_TRANSACTION_SOURCES,
     SENTRY_TRACE_HEADER_NAME,
-)
-from sentry_sdk.tracing import (
-    Span
+    Span,
 )
 
 if TYPE_CHECKING:

--- a/sentry_sdk/tracing_utils.py
+++ b/sentry_sdk/tracing_utils.py
@@ -21,7 +21,6 @@ from typing import TYPE_CHECKING
 
 import sentry_sdk
 from sentry_sdk.consts import OP, SPANDATA, SPANSTATUS, SPANTEMPLATE
-from sentry_sdk.tracing import Span as LegacySpan
 from sentry_sdk.utils import (
     _is_external_source,
     _is_in_project_root,
@@ -1722,7 +1721,9 @@ from sentry_sdk.tracing import (
     BAGGAGE_HEADER_NAME,
     LOW_QUALITY_TRANSACTION_SOURCES,
     SENTRY_TRACE_HEADER_NAME,
-    Span,
+)
+from sentry_sdk.tracing import (
+    Span as LegacySpan,
 )
 
 if TYPE_CHECKING:

--- a/sentry_sdk/tracing_utils.py
+++ b/sentry_sdk/tracing_utils.py
@@ -4,12 +4,12 @@ import inspect
 import os
 import re
 import sys
+import uuid
 import warnings
 from collections.abc import Mapping, MutableMapping
 from datetime import datetime, timedelta, timezone
 from random import Random
 from urllib.parse import quote, unquote
-import uuid
 
 try:
     from re import Pattern
@@ -17,37 +17,30 @@ except ImportError:
     # 3.6
     from typing import Pattern
 
+from typing import TYPE_CHECKING
+
 import sentry_sdk
 from sentry_sdk.consts import OP, SPANDATA, SPANSTATUS, SPANTEMPLATE
+from sentry_sdk.tracing import Span as LegacySpan
 from sentry_sdk.utils import (
+    _is_external_source,
+    _is_in_project_root,
+    _module_in_list,
     capture_internal_exceptions,
     filename_for_module,
+    is_sentry_url,
+    is_valid_sample_rate,
     logger,
     match_regex_list,
     qualname_from_function,
     safe_repr,
     to_string,
     try_convert,
-    is_sentry_url,
-    is_valid_sample_rate,
-    _is_external_source,
-    _is_in_project_root,
-    _module_in_list,
 )
-from sentry_sdk.tracing import Span as LegacySpan
-
-from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from typing import Any
-    from typing import Dict
-    from typing import Generator
-    from typing import Optional
-    from typing import Union
-    from typing import Iterator
-    from typing import Tuple
-
     from types import FrameType
+    from typing import Any, Dict, Generator, Iterator, Optional, Tuple, Union
 
     from sentry_sdk._types import Attributes
 
@@ -1214,7 +1207,7 @@ def set_span_errored(span: "Optional[Union[Span, StreamedSpan]]" = None) -> None
     Set the status of the current or given span to INTERNAL_ERROR.
     Also sets the status of the transaction (root span) to INTERNAL_ERROR.
     """
-    from sentry_sdk.traces import StreamedSpan, SpanStatus, _get_current_streamed_span
+    from sentry_sdk.traces import SpanStatus, StreamedSpan, _get_current_streamed_span
 
     client = sentry_sdk.get_client()
 
@@ -1718,16 +1711,18 @@ def is_ignored_span(name: str, attributes: "Optional[Attributes]") -> bool:
 
 
 # Circular imports
+from sentry_sdk.traces import (
+    LOW_QUALITY_SEGMENT_SOURCES,
+    StreamedSpan,
+)
+from sentry_sdk.traces import (
+    start_span as start_streaming_span,
+)
 from sentry_sdk.tracing import (
     BAGGAGE_HEADER_NAME,
     LOW_QUALITY_TRANSACTION_SOURCES,
     SENTRY_TRACE_HEADER_NAME,
     Span,
-)
-from sentry_sdk.traces import (
-    LOW_QUALITY_SEGMENT_SOURCES,
-    StreamedSpan,
-    start_span as start_streaming_span,
 )
 
 if TYPE_CHECKING:

--- a/sentry_sdk/types.py
+++ b/sentry_sdk/types.py
@@ -19,9 +19,9 @@ if TYPE_CHECKING:
         EventDataCategory,
         Hint,
         Log,
+        Metric,
         MonitorConfig,
         SamplingContext,
-        Metric,
     )
 else:
     from typing import Any

--- a/sentry_sdk/worker.py
+++ b/sentry_sdk/worker.py
@@ -1,19 +1,16 @@
-from abc import ABC, abstractmethod
 import asyncio
 import os
 import threading
-
+from abc import ABC, abstractmethod
 from time import sleep, time
-from sentry_sdk._queue import Queue, FullError
-from sentry_sdk.utils import logger, mark_sentry_task_internal
-from sentry_sdk.consts import DEFAULT_QUEUE_SIZE
-
 from typing import TYPE_CHECKING
 
+from sentry_sdk._queue import FullError, Queue
+from sentry_sdk.consts import DEFAULT_QUEUE_SIZE
+from sentry_sdk.utils import logger, mark_sentry_task_internal
+
 if TYPE_CHECKING:
-    from typing import Any
-    from typing import Optional
-    from typing import Callable
+    from typing import Any, Callable, Optional
 
 
 _TERMINATOR = object()

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,8 @@ Sentry-Python - Sentry SDK for Python
 """
 
 import os
-from setuptools import setup, find_packages
+
+from setuptools import find_packages, setup
 
 here = os.path.abspath(os.path.dirname(__file__))
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,23 +1,23 @@
-import json
-import os
 import asyncio
-from urllib.parse import urlparse, parse_qs
-import socket
-import warnings
-import brotli
 import gzip
 import io
-from dataclasses import dataclass
-from threading import Thread
-from contextlib import contextmanager
-from http.server import BaseHTTPRequestHandler, HTTPServer
-from unittest import mock
+import json
+import os
+import socket
+import warnings
 from collections import namedtuple
+from contextlib import contextmanager
+from dataclasses import dataclass
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from threading import Thread
+from unittest import mock
+from urllib.parse import parse_qs, urlparse
 
+import brotli
+import jsonschema
 import pytest
 from pytest_localserver.http import WSGIServer
 from werkzeug.wrappers import Request, Response
-import jsonschema
 
 try:
     from starlette.testclient import TestClient
@@ -67,21 +67,25 @@ except ImportError:
     google = None
 
 
-from tests import _warning_recorder, _warning_recorder_mgr
-
 from typing import TYPE_CHECKING
 
+from tests import _warning_recorder, _warning_recorder_mgr
+
 if TYPE_CHECKING:
-    from typing import Any, Callable, MutableMapping, Optional
     from collections.abc import Iterator
+    from typing import Any, Callable, MutableMapping, Optional
 
 try:
     from httpx import (
         ASGITransport,
-        Request as HttpxRequest,
-        Response as HttpxResponse,
         AsyncByteStream,
         AsyncClient,
+    )
+    from httpx import (
+        Request as HttpxRequest,
+    )
+    from httpx import (
+        Response as HttpxResponse,
     )
 except ImportError:
     ASGITransport = None
@@ -92,13 +96,13 @@ except ImportError:
 
 
 try:
-    from anyio import create_memory_object_stream, create_task_group, EndOfStream
+    from anyio import EndOfStream, create_memory_object_stream, create_task_group
+    from mcp.shared.message import SessionMessage
     from mcp.types import (
         JSONRPCMessage,
         JSONRPCNotification,
         JSONRPCRequest,
     )
-    from mcp.shared.message import SessionMessage
 except ImportError:
     create_memory_object_stream = None
     create_task_group = None

--- a/tests/integrations/aiohttp/__init__.py
+++ b/tests/integrations/aiohttp/__init__.py
@@ -1,5 +1,6 @@
 import os
 import sys
+
 import pytest
 
 pytest.importorskip("aiohttp")

--- a/tests/integrations/anthropic/test_anthropic.py
+++ b/tests/integrations/anthropic/test_anthropic.py
@@ -1,6 +1,7 @@
-import pytest
-from unittest import mock
 import json
+from unittest import mock
+
+import pytest
 
 try:
     from unittest.mock import AsyncMock
@@ -21,8 +22,8 @@ from anthropic.types.message_delta_event import MessageDeltaEvent
 from anthropic.types.message_start_event import MessageStartEvent
 
 try:
-    from anthropic.types import ErrorResponse, OverloadedError
     from anthropic import APIStatusError
+    from anthropic.types import ErrorResponse, OverloadedError
 except ImportError:
     ErrorResponse = None
     OverloadedError = None
@@ -54,19 +55,18 @@ try:
 except ImportError:
     from anthropic.types.content_block import ContentBlock as TextBlock
 
-from sentry_sdk import start_transaction, start_span
+from sentry_sdk import start_span, start_transaction
 from sentry_sdk._types import BLOB_DATA_SUBSTITUTE
+from sentry_sdk.ai.utils import transform_content_part, transform_message_content
 from sentry_sdk.consts import OP, SPANDATA
 from sentry_sdk.integrations.anthropic import (
     AnthropicIntegration,
-    _set_output_data,
     _collect_ai_data,
-    _transform_anthropic_content_block,
     _RecordedUsage,
+    _set_output_data,
+    _transform_anthropic_content_block,
 )
-from sentry_sdk.ai.utils import transform_content_part, transform_message_content
 from sentry_sdk.utils import package_version
-
 
 ANTHROPIC_VERSION = package_version("anthropic")
 

--- a/tests/integrations/ariadne/test_ariadne.py
+++ b/tests/integrations/ariadne/test_ariadne.py
@@ -1,8 +1,8 @@
-from ariadne import gql, graphql_sync, ObjectType, QueryType, make_executable_schema
+from ariadne import ObjectType, QueryType, gql, graphql_sync, make_executable_schema
 from ariadne.asgi import GraphQL
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
-from flask import Flask, request, jsonify
+from flask import Flask, jsonify, request
 
 from sentry_sdk.integrations.ariadne import AriadneIntegration
 from sentry_sdk.integrations.fastapi import FastApiIntegration

--- a/tests/integrations/arq/test_arq.py
+++ b/tests/integrations/arq/test_arq.py
@@ -1,18 +1,16 @@
 import asyncio
 from datetime import timedelta
 
-import pytest
-
-from sentry_sdk import get_client, start_transaction
-from sentry_sdk.integrations.arq import ArqIntegration
-
 import arq.worker
+import pytest
 from arq import cron
 from arq.connections import ArqRedis
 from arq.jobs import Job
 from arq.utils import timestamp_ms
-
 from fakeredis.aioredis import FakeRedis
+
+from sentry_sdk import get_client, start_transaction
+from sentry_sdk.integrations.arq import ArqIntegration
 
 
 def async_partial(async_fn, *args, **kwargs):

--- a/tests/integrations/asgi/test_asgi.py
+++ b/tests/integrations/asgi/test_asgi.py
@@ -1,13 +1,13 @@
 from collections import Counter
 
 import pytest
+from async_asgi_testclient import TestClient
+
 import sentry_sdk
 from sentry_sdk import capture_message
-from sentry_sdk.tracing import TransactionSource
-from sentry_sdk.integrations._asgi_common import _get_ip, _get_headers
+from sentry_sdk.integrations._asgi_common import _get_headers, _get_ip
 from sentry_sdk.integrations.asgi import SentryAsgiMiddleware, _looks_like_asgi3
-
-from async_asgi_testclient import TestClient
+from sentry_sdk.tracing import TransactionSource
 
 
 @pytest.fixture

--- a/tests/integrations/asyncpg/__init__.py
+++ b/tests/integrations/asyncpg/__init__.py
@@ -1,5 +1,6 @@
 import os
 import sys
+
 import pytest
 
 pytest.importorskip("asyncpg")

--- a/tests/integrations/aws_lambda/lambda_functions_with_embedded_sdk/RaiseErrorPerformanceDisabled/index.py
+++ b/tests/integrations/aws_lambda/lambda_functions_with_embedded_sdk/RaiseErrorPerformanceDisabled/index.py
@@ -1,7 +1,7 @@
 import os
+
 import sentry_sdk
 from sentry_sdk.integrations.aws_lambda import AwsLambdaIntegration
-
 
 sentry_sdk.init(
     dsn=os.environ.get("SENTRY_DSN"),

--- a/tests/integrations/aws_lambda/lambda_functions_with_embedded_sdk/RaiseErrorPerformanceEnabled/index.py
+++ b/tests/integrations/aws_lambda/lambda_functions_with_embedded_sdk/RaiseErrorPerformanceEnabled/index.py
@@ -1,7 +1,7 @@
 import os
+
 import sentry_sdk
 from sentry_sdk.integrations.aws_lambda import AwsLambdaIntegration
-
 
 sentry_sdk.init(
     dsn=os.environ.get("SENTRY_DSN"),

--- a/tests/integrations/aws_lambda/lambda_functions_with_embedded_sdk/TracesSampler/index.py
+++ b/tests/integrations/aws_lambda/lambda_functions_with_embedded_sdk/TracesSampler/index.py
@@ -1,5 +1,6 @@
 import json
 import os
+
 import sentry_sdk
 from sentry_sdk.integrations.aws_lambda import AwsLambdaIntegration
 

--- a/tests/integrations/aws_lambda/test_aws_lambda.py
+++ b/tests/integrations/aws_lambda/test_aws_lambda.py
@@ -1,18 +1,16 @@
-import boto3
-import docker
 import json
-import pytest
 import subprocess
 import tempfile
 import time
-import yaml
-
 from unittest import mock
 
+import boto3
+import docker
+import pytest
+import yaml
 from aws_cdk import App
 
-from .utils import LocalLambdaStack, SentryServerForTesting, SAM_PORT
-
+from .utils import SAM_PORT, LocalLambdaStack, SentryServerForTesting
 
 DOCKER_NETWORK_NAME = "lambda-test-network"
 SAM_TEMPLATE_FILE = "sam.template.yaml"

--- a/tests/integrations/aws_lambda/utils.py
+++ b/tests/integrations/aws_lambda/utils.py
@@ -1,25 +1,24 @@
 import gzip
 import json
 import os
-import shutil
-import subprocess
-import requests
-import sys
-import time
-import threading
-import socket
 import platform
+import shutil
+import socket
+import subprocess
+import sys
+import threading
+import time
 
+import requests
+import uvicorn
 from aws_cdk import (
     CfnResource,
     Stack,
 )
 from constructs import Construct
 from fastapi import FastAPI, Request
-import uvicorn
 
-from scripts.build_aws_lambda_layer import build_packaged_zip, DIST_PATH
-
+from scripts.build_aws_lambda_layer import DIST_PATH, build_packaged_zip
 
 LAMBDA_FUNCTION_DIR = "./tests/integrations/aws_lambda/lambda_functions/"
 LAMBDA_FUNCTION_WITH_EMBEDDED_SDK_DIR = (

--- a/tests/integrations/beam/test_beam.py
+++ b/tests/integrations/beam/test_beam.py
@@ -1,19 +1,18 @@
-import pytest
 import inspect
 
 import dill
+import pytest
+from apache_beam.runners.common import DoFnContext, DoFnInvoker
+from apache_beam.transforms.core import CallableWrapperDoFn, DoFn, ParDo, _DoFnParam
+from apache_beam.typehints.decorators import getcallargs_forhints
+from apache_beam.typehints.trivial_inference import instance_to_type
+from apache_beam.utils.windowed_value import WindowedValue
 
 from sentry_sdk.integrations.beam import (
     BeamIntegration,
-    _wrap_task_call,
     _wrap_inspect_call,
+    _wrap_task_call,
 )
-
-from apache_beam.typehints.trivial_inference import instance_to_type
-from apache_beam.typehints.decorators import getcallargs_forhints
-from apache_beam.transforms.core import DoFn, ParDo, _DoFnParam, CallableWrapperDoFn
-from apache_beam.runners.common import DoFnInvoker, DoFnContext
-from apache_beam.utils.windowed_value import WindowedValue
 
 try:
     from apache_beam.runners.common import OutputHandler

--- a/tests/integrations/boto3/__init__.py
+++ b/tests/integrations/boto3/__init__.py
@@ -1,5 +1,6 @@
-import pytest
 import os
+
+import pytest
 
 pytest.importorskip("boto3")
 xml_fixture_path = os.path.dirname(os.path.abspath(__file__))

--- a/tests/integrations/boto3/aws_mock.py
+++ b/tests/integrations/boto3/aws_mock.py
@@ -1,4 +1,5 @@
 from io import BytesIO
+
 from botocore.awsrequest import AWSResponse
 
 

--- a/tests/integrations/boto3/test_s3.py
+++ b/tests/integrations/boto3/test_s3.py
@@ -9,7 +9,6 @@ from tests.conftest import ApproxDict
 from tests.integrations.boto3 import read_fixture
 from tests.integrations.boto3.aws_mock import MockResponse
 
-
 session = boto3.Session(
     aws_access_key_id="-",
     aws_secret_access_key="-",

--- a/tests/integrations/bottle/test_bottle.py
+++ b/tests/integrations/bottle/test_bottle.py
@@ -1,17 +1,18 @@
 import json
-import pytest
 import logging
-
 from io import BytesIO
-from bottle import Bottle, debug as set_debug, abort, redirect, HTTPResponse
+
+import pytest
+from bottle import Bottle, HTTPResponse, abort, redirect
+from bottle import debug as set_debug
+from werkzeug.test import Client
+from werkzeug.wrappers import Response
+
 from sentry_sdk import capture_message
 from sentry_sdk.consts import DEFAULT_MAX_VALUE_LENGTH
 from sentry_sdk.integrations.bottle import BottleIntegration
-from sentry_sdk.serializer import MAX_DATABAG_BREADTH
-
 from sentry_sdk.integrations.logging import LoggingIntegration
-from werkzeug.test import Client
-from werkzeug.wrappers import Response
+from sentry_sdk.serializer import MAX_DATABAG_BREADTH
 
 
 @pytest.fixture(scope="function")

--- a/tests/integrations/celery/integration_tests/test_celery_beat_cron_monitoring.py
+++ b/tests/integrations/celery/integration_tests/test_celery_beat_cron_monitoring.py
@@ -1,13 +1,11 @@
 import os
 import sys
-import pytest
 
+import pytest
 from celery.contrib.testing.worker import start_worker
 
 from sentry_sdk.utils import logger
-
 from tests.integrations.celery.integration_tests import run_beat
-
 
 REDIS_SERVER = "redis://127.0.0.1:6379"
 REDIS_DB = 15

--- a/tests/integrations/celery/test_celery.py
+++ b/tests/integrations/celery/test_celery.py
@@ -1,19 +1,19 @@
 import threading
-import kombu
 from unittest import mock
 
+import kombu
 import pytest
-from celery import Celery, VERSION
+from celery import VERSION, Celery
 from celery.bin import worker
 
 import sentry_sdk
-from sentry_sdk import start_transaction, get_current_span
-from sentry_sdk.traces import _get_current_streamed_span
+from sentry_sdk import get_current_span, start_transaction
 from sentry_sdk.integrations.celery import (
     CeleryIntegration,
     _wrap_task_run,
 )
 from sentry_sdk.integrations.celery.beat import _get_headers
+from sentry_sdk.traces import _get_current_streamed_span
 from sentry_sdk.utils import SENSITIVE_DATA_SUBSTITUTE
 from tests.conftest import ApproxDict
 
@@ -507,18 +507,18 @@ def test_newrelic_interference(init_celery, newrelic_order, celery_invocation):
     def instrument_newrelic():
         try:
             # older newrelic versions
+            import celery.app.trace as celery_trace_module
             from newrelic.hooks.application_celery import (
                 instrument_celery_execute_trace,
             )
-            import celery.app.trace as celery_trace_module
 
             assert hasattr(celery_trace_module, "build_tracer")
             instrument_celery_execute_trace(celery_trace_module)
 
         except ImportError:
             # newer newrelic versions
-            from newrelic.hooks.application_celery import instrument_celery_app_base
             import celery.app as celery_app_module
+            from newrelic.hooks.application_celery import instrument_celery_app_base
 
             assert hasattr(celery_app_module, "Celery")
             assert hasattr(celery_app_module.Celery, "send_task")

--- a/tests/integrations/celery/test_update_celery_task_headers.py
+++ b/tests/integrations/celery/test_update_celery_task_headers.py
@@ -1,13 +1,12 @@
-from copy import copy
 import itertools
-import pytest
-
+from copy import copy
 from unittest import mock
 
-from sentry_sdk.integrations.celery import _update_celery_task_headers
-import sentry_sdk
-from sentry_sdk.tracing_utils import Baggage
+import pytest
 
+import sentry_sdk
+from sentry_sdk.integrations.celery import _update_celery_task_headers
+from sentry_sdk.tracing_utils import Baggage
 
 BAGGAGE_VALUE = (
     "sentry-trace_id=771a43a4192642f0b136d5159a501700,"

--- a/tests/integrations/chalice/test_chalice.py
+++ b/tests/integrations/chalice/test_chalice.py
@@ -1,13 +1,13 @@
-import pytest
 import time
-from chalice import Chalice, BadRequestError
+
+import pytest
+from chalice import BadRequestError, Chalice
 from chalice.local import LambdaContext, LocalGateway
+from pytest_chalice.handlers import RequestHandler
 
 from sentry_sdk import capture_message
 from sentry_sdk.integrations.chalice import CHALICE_VERSION, ChaliceIntegration
 from sentry_sdk.utils import parse_version
-
-from pytest_chalice.handlers import RequestHandler
 
 
 def _generate_lambda_context(self):

--- a/tests/integrations/clickhouse_driver/test_clickhouse_driver.py
+++ b/tests/integrations/clickhouse_driver/test_clickhouse_driver.py
@@ -8,7 +8,7 @@ docker run -d -p 18123:8123 -p9000:9000 --name clickhouse-test --ulimit nofile=2
 import clickhouse_driver
 from clickhouse_driver import Client, connect
 
-from sentry_sdk import start_transaction, capture_message
+from sentry_sdk import capture_message, start_transaction
 from sentry_sdk.integrations.clickhouse_driver import ClickhouseDriverIntegration
 from tests.conftest import ApproxDict
 

--- a/tests/integrations/cohere/test_cohere.py
+++ b/tests/integrations/cohere/test_cohere.py
@@ -1,15 +1,14 @@
 import json
+from unittest import mock  # python 3.3 and above
 
 import httpx
 import pytest
-from cohere import Client, ChatMessage
+from cohere import ChatMessage, Client
+from httpx import Client as HTTPXClient
 
 from sentry_sdk import start_transaction
 from sentry_sdk.consts import SPANDATA
 from sentry_sdk.integrations.cohere import CohereIntegration
-
-from unittest import mock  # python 3.3 and above
-from httpx import Client as HTTPXClient
 
 
 @pytest.mark.parametrize(

--- a/tests/integrations/conftest.py
+++ b/tests/integrations/conftest.py
@@ -1,4 +1,5 @@
 import pytest
+
 import sentry_sdk
 
 

--- a/tests/integrations/django/__init__.py
+++ b/tests/integrations/django/__init__.py
@@ -1,5 +1,6 @@
 import os
 import sys
+
 import pytest
 
 pytest.importorskip("django")

--- a/tests/integrations/django/asgi/test_asgi.py
+++ b/tests/integrations/django/asgi/test_asgi.py
@@ -1,14 +1,15 @@
-import base64
-import sys
-import json
-import inspect
 import asyncio
+import base64
+import inspect
+import json
 import os
+import sys
 from unittest import mock
 
 import django
 import pytest
 from channels.testing import HttpCommunicator
+
 from sentry_sdk import capture_message
 from sentry_sdk.integrations.django import DjangoIntegration
 from sentry_sdk.integrations.django.asgi import _asgi_middleware_mixin_factory

--- a/tests/integrations/django/myapp/asgi.py
+++ b/tests/integrations/django/myapp/asgi.py
@@ -4,6 +4,7 @@ defined in the ASGI_APPLICATION setting.
 """
 
 import os
+
 import django
 from channels.routing import get_default_application
 

--- a/tests/integrations/django/myapp/middleware.py
+++ b/tests/integrations/django/myapp/middleware.py
@@ -2,6 +2,7 @@ import django
 
 if django.VERSION >= (3, 1):
     import asyncio
+
     from django.utils.decorators import sync_and_async_middleware
 
     @sync_and_async_middleware

--- a/tests/integrations/django/myapp/urls.py
+++ b/tests/integrations/django/myapp/urls.py
@@ -23,8 +23,9 @@ except ImportError:
         return url("^{}$".format(path), *args, **kwargs)
 
 
-from . import views
 from django_helpers import views as helper_views
+
+from . import views
 
 urlpatterns = [
     path("view-exc", views.view_exc, name="view_exc"),

--- a/tests/integrations/django/myapp/views.py
+++ b/tests/integrations/django/myapp/views.py
@@ -2,10 +2,10 @@ import asyncio
 import json
 import threading
 
-from django.db import transaction
 from django.contrib.auth import login
 from django.contrib.auth.models import User
 from django.core.exceptions import PermissionDenied
+from django.db import transaction
 from django.dispatch import Signal
 from django.http import HttpResponse, HttpResponseNotFound, HttpResponseServerError
 from django.shortcuts import render
@@ -15,7 +15,6 @@ from django.utils.decorators import method_decorator
 from django.views.decorators.cache import cache_page
 from django.views.decorators.csrf import csrf_exempt
 from django.views.generic import ListView
-
 
 from tests.integrations.django.myapp.signals import (
     myapp_custom_signal,

--- a/tests/integrations/django/test_basic.py
+++ b/tests/integrations/django/test_basic.py
@@ -1,23 +1,20 @@
 import inspect
 import json
 import os
-import pytest
 import re
 import sys
-
 from functools import partial
 from unittest.mock import patch
 
-from werkzeug.test import Client
-
+import pytest
 from django import VERSION as DJANGO_VERSION
-
 from django.contrib.auth.models import User
 from django.core.management import execute_from_command_line
-from django.db.utils import OperationalError, ProgrammingError, DataError
+from django.db.utils import DataError, OperationalError, ProgrammingError
 from django.http.request import RawPostDataException
 from django.template.context import make_context
 from django.utils.functional import SimpleLazyObject
+from werkzeug.test import Client
 
 try:
     from django.urls import reverse
@@ -25,8 +22,8 @@ except ImportError:
     from django.core.urlresolvers import reverse
 
 import sentry_sdk
+from sentry_sdk import capture_exception, capture_message
 from sentry_sdk._compat import PY310
-from sentry_sdk import capture_message, capture_exception
 from sentry_sdk.consts import SPANDATA
 from sentry_sdk.integrations.django import (
     DjangoIntegration,
@@ -38,8 +35,8 @@ from sentry_sdk.integrations.executing import ExecutingIntegration
 from sentry_sdk.profiler.utils import get_frame_name
 from sentry_sdk.tracing import Span
 from tests.conftest import unpack_werkzeug_response
-from tests.integrations.django.myapp.wsgi import application
 from tests.integrations.django.myapp.signals import myapp_custom_signal_silenced
+from tests.integrations.django.myapp.wsgi import application
 from tests.integrations.django.utils import pytest_mark_django_db_decorator
 
 DJANGO_VERSION = DJANGO_VERSION[:2]

--- a/tests/integrations/django/test_cache_module.py
+++ b/tests/integrations/django/test_cache_module.py
@@ -17,7 +17,6 @@ from sentry_sdk.integrations.django.caching import _get_span_description
 from tests.integrations.django.myapp.wsgi import application
 from tests.integrations.django.utils import pytest_mark_django_db_decorator
 
-
 DJANGO_VERSION = DJANGO_VERSION[:2]
 
 

--- a/tests/integrations/django/test_data_scrubbing.py
+++ b/tests/integrations/django/test_data_scrubbing.py
@@ -1,5 +1,4 @@
 import pytest
-
 from werkzeug.test import Client
 
 from sentry_sdk.integrations.django import DjangoIntegration

--- a/tests/integrations/django/test_db_query_data.py
+++ b/tests/integrations/django/test_db_query_data.py
@@ -1,9 +1,8 @@
 import os
-
-import pytest
 from datetime import datetime
 from unittest import mock
 
+import pytest
 from django import VERSION as DJANGO_VERSION
 from django.db import connections
 
@@ -18,10 +17,9 @@ from sentry_sdk import start_transaction
 from sentry_sdk.consts import SPANDATA
 from sentry_sdk.integrations.django import DjangoIntegration
 from sentry_sdk.tracing_utils import record_sql_queries
-
 from tests.conftest import unpack_werkzeug_response
-from tests.integrations.django.utils import pytest_mark_django_db_decorator
 from tests.integrations.django.myapp.wsgi import application
+from tests.integrations.django.utils import pytest_mark_django_db_decorator
 
 
 @pytest.fixture

--- a/tests/integrations/django/test_db_transactions.py
+++ b/tests/integrations/django/test_db_transactions.py
@@ -1,10 +1,10 @@
-import os
-import pytest
 import itertools
+import os
 from datetime import datetime
 
-from django.db import connections
+import pytest
 from django.contrib.auth.models import User
+from django.db import connections
 
 try:
     from django.urls import reverse
@@ -16,9 +16,8 @@ from werkzeug.test import Client
 from sentry_sdk import start_transaction
 from sentry_sdk.consts import SPANDATA, SPANNAME
 from sentry_sdk.integrations.django import DjangoIntegration
-
-from tests.integrations.django.utils import pytest_mark_django_db_decorator
 from tests.integrations.django.myapp.wsgi import application
+from tests.integrations.django.utils import pytest_mark_django_db_decorator
 
 
 @pytest.fixture

--- a/tests/integrations/django/test_tasks.py
+++ b/tests/integrations/django/test_tasks.py
@@ -1,9 +1,8 @@
 import pytest
 
 import sentry_sdk
-from sentry_sdk.integrations.django import DjangoIntegration
 from sentry_sdk.consts import OP
-
+from sentry_sdk.integrations.django import DjangoIntegration
 
 try:
     from django.tasks import task

--- a/tests/integrations/django/test_transactions.py
+++ b/tests/integrations/django/test_transactions.py
@@ -1,19 +1,19 @@
 from unittest import mock
 
-import pytest
 import django
+import pytest
 from django.utils.translation import pgettext_lazy
-
 
 # django<2.0 has only `url` with regex based patterns.
 # django>=2.0 renames `url` to `re_path`, and additionally introduces `path`
 # for new style URL patterns, e.g. <int:article_id>.
 if django.VERSION >= (2, 0):
+    from django.conf.urls import include
     from django.urls import path, re_path
     from django.urls.converters import PathConverter
-    from django.conf.urls import include
 else:
-    from django.conf.urls import url as re_path, include
+    from django.conf.urls import include
+    from django.conf.urls import url as re_path
 
 if django.VERSION < (1, 9):
     included_url_conf = (re_path(r"^foo/bar/(?P<param>[\w]+)", lambda x: ""),), "", ""
@@ -21,7 +21,6 @@ else:
     included_url_conf = ((re_path(r"^foo/bar/(?P<param>[\w]+)", lambda x: ""),), "")
 
 from sentry_sdk.integrations.django.transactions import RavenResolver
-
 
 example_url_conf = (
     re_path(r"^api/(?P<project_id>[\w_-]+)/store/$", lambda x: ""),

--- a/tests/integrations/django/utils.py
+++ b/tests/integrations/django/utils.py
@@ -3,7 +3,6 @@ from functools import partial
 import pytest
 import pytest_django
 
-
 # Hack to prevent from experimental feature introduced in version `4.3.0` in `pytest-django` that
 # requires explicit database allow from failing the test
 pytest_mark_django_db_decorator = partial(pytest.mark.django_db)

--- a/tests/integrations/excepthook/test_excepthook.py
+++ b/tests/integrations/excepthook/test_excepthook.py
@@ -1,9 +1,8 @@
-import pytest
-import sys
 import subprocess
-
+import sys
 from textwrap import dedent
 
+import pytest
 
 TEST_PARAMETERS = [("", "HttpTransport")]
 

--- a/tests/integrations/falcon/test_falcon.py
+++ b/tests/integrations/falcon/test_falcon.py
@@ -1,15 +1,14 @@
 import logging
 
-import pytest
-
 import falcon
 import falcon.testing
+import pytest
+
 import sentry_sdk
 from sentry_sdk.consts import DEFAULT_MAX_VALUE_LENGTH
 from sentry_sdk.integrations.falcon import FalconIntegration
 from sentry_sdk.integrations.logging import LoggingIntegration
 from sentry_sdk.utils import parse_version
-
 
 try:
     import falcon.asgi

--- a/tests/integrations/fastapi/test_fastapi.py
+++ b/tests/integrations/fastapi/test_fastapi.py
@@ -1,15 +1,15 @@
 import json
 import logging
-import pytest
 import threading
 import warnings
 from unittest import mock
 
 import fastapi
+import pytest
 import starlette
 from fastapi import FastAPI, HTTPException, Request
-from fastapi.testclient import TestClient
 from fastapi.middleware.trustedhost import TrustedHostMiddleware
+from fastapi.testclient import TestClient
 
 import sentry_sdk
 from sentry_sdk import capture_message
@@ -18,7 +18,6 @@ from sentry_sdk.integrations.asgi import SentryAsgiMiddleware
 from sentry_sdk.integrations.fastapi import FastApiIntegration
 from sentry_sdk.integrations.starlette import StarletteIntegration
 from sentry_sdk.utils import parse_version
-
 
 FASTAPI_VERSION = parse_version(fastapi.__version__)
 STARLETTE_VERSION = parse_version(starlette.__version__)

--- a/tests/integrations/fastmcp/test_fastmcp.py
+++ b/tests/integrations/fastmcp/test_fastmcp.py
@@ -21,11 +21,13 @@ to properly trigger Sentry instrumentation and span creation. This ensures
 accurate testing of the integration's behavior in real MCP Server scenarios.
 """
 
-import anyio
 import asyncio
 import json
-import pytest
 from unittest import mock
+
+import anyio
+import pytest
+
 import sentry_sdk
 
 try:
@@ -37,12 +39,12 @@ except ImportError:
             return super(AsyncMock, self).__call__(*args, **kwargs)
 
 
-from sentry_sdk import start_transaction
-from sentry_sdk.consts import SPANDATA, OP
-from sentry_sdk.integrations.mcp import MCPIntegration
-
 from mcp.server.sse import SseServerTransport
 from mcp.server.streamable_http_manager import StreamableHTTPSessionManager
+
+from sentry_sdk import start_transaction
+from sentry_sdk.consts import OP, SPANDATA
+from sentry_sdk.integrations.mcp import MCPIntegration
 
 try:
     from fastmcp.prompts import Message
@@ -50,9 +52,9 @@ except ImportError:
     Message = None
 
 
+from starlette.applications import Starlette
 from starlette.responses import Response
 from starlette.routing import Mount, Route
-from starlette.applications import Starlette
 
 # Try to import both FastMCP implementations
 try:

--- a/tests/integrations/flask/test_flask.py
+++ b/tests/integrations/flask/test_flask.py
@@ -1,16 +1,16 @@
 import json
-import re
 import logging
+import re
 from io import BytesIO
 
 import pytest
 from flask import (
     Flask,
     Response,
-    request,
     abort,
-    stream_with_context,
     render_template_string,
+    request,
+    stream_with_context,
 )
 from flask.views import View
 from flask_login import LoginManager, login_user
@@ -23,14 +23,13 @@ except ImportError:
 import sentry_sdk
 import sentry_sdk.integrations.flask as flask_sentry
 from sentry_sdk import (
-    set_tag,
-    capture_message,
     capture_exception,
+    capture_message,
+    set_tag,
 )
 from sentry_sdk.consts import DEFAULT_MAX_VALUE_LENGTH
 from sentry_sdk.integrations.logging import LoggingIntegration
 from sentry_sdk.serializer import MAX_DATABAG_BREADTH
-
 
 login_manager = LoginManager()
 

--- a/tests/integrations/gcp/__init__.py
+++ b/tests/integrations/gcp/__init__.py
@@ -1,6 +1,6 @@
-import pytest
 import os
 
+import pytest
 
 if "gcp" not in os.environ.get("TOX_ENV_NAME", ""):
     pytest.skip("GCP tests only run in GCP environment", allow_module_level=True)

--- a/tests/integrations/gcp/test_gcp.py
+++ b/tests/integrations/gcp/test_gcp.py
@@ -4,15 +4,14 @@
 """
 
 import json
-from textwrap import dedent
-import tempfile
-import sys
+import os
+import os.path
 import subprocess
+import sys
+import tempfile
+from textwrap import dedent
 
 import pytest
-import os.path
-import os
-
 
 FUNCTIONS_PRELUDE = """
 from unittest.mock import Mock

--- a/tests/integrations/google_genai/test_google_genai.py
+++ b/tests/integrations/google_genai/test_google_genai.py
@@ -1,7 +1,7 @@
 import json
-import pytest
 from unittest import mock
 
+import pytest
 from google import genai
 from google.genai import types as genai_types
 from google.genai.types import Content, Part

--- a/tests/integrations/gql/test_gql.py
+++ b/tests/integrations/gql/test_gql.py
@@ -1,11 +1,9 @@
 import pytest
-
 import responses
-from gql import gql
-from gql import Client
-from gql import __version__
+from gql import Client, __version__, gql
 from gql.transport.exceptions import TransportQueryError
 from gql.transport.requests import RequestsHTTPTransport
+
 from sentry_sdk.integrations.gql import GQLIntegration
 from sentry_sdk.utils import parse_version
 

--- a/tests/integrations/graphene/test_graphene.py
+++ b/tests/integrations/graphene/test_graphene.py
@@ -1,8 +1,8 @@
 import pytest
 from fastapi import FastAPI, Request
 from fastapi.testclient import TestClient
-from flask import Flask, request, jsonify
-from graphene import ObjectType, String, Schema
+from flask import Flask, jsonify, request
+from graphene import ObjectType, Schema, String
 
 from sentry_sdk.consts import OP
 from sentry_sdk.integrations.fastapi import FastApiIntegration

--- a/tests/integrations/grpc/grpc_test_service_pb2.pyi
+++ b/tests/integrations/grpc/grpc_test_service_pb2.pyi
@@ -1,6 +1,8 @@
+from typing import ClassVar as _ClassVar
+from typing import Optional as _Optional
+
 from google.protobuf import descriptor as _descriptor
 from google.protobuf import message as _message
-from typing import ClassVar as _ClassVar, Optional as _Optional
 
 DESCRIPTOR: _descriptor.FileDescriptor
 

--- a/tests/integrations/grpc/test_grpc.py
+++ b/tests/integrations/grpc/test_grpc.py
@@ -1,18 +1,17 @@
-import grpc
-import pytest
-
 from concurrent import futures
 from typing import List, Optional, Tuple
-
 from unittest import mock
 from unittest.mock import Mock
 
+import grpc
+import pytest
+
 import sentry_sdk
 from sentry_sdk import start_span, start_transaction
-from sentry_sdk.tracing_utils import has_span_streaming_enabled
 from sentry_sdk.consts import OP
 from sentry_sdk.integrations.grpc import GRPCIntegration
 from sentry_sdk.integrations.grpc.client import ClientInterceptor
+from sentry_sdk.tracing_utils import has_span_streaming_enabled
 from tests.conftest import ApproxDict
 from tests.integrations.grpc.grpc_test_service_pb2 import gRPCTestMessage
 from tests.integrations.grpc.grpc_test_service_pb2_grpc import (

--- a/tests/integrations/grpc/test_grpc_aio.py
+++ b/tests/integrations/grpc/test_grpc_aio.py
@@ -1,15 +1,16 @@
 import asyncio
+from typing import Optional
+from unittest import mock
 
 import grpc
 import pytest
 import pytest_asyncio
-from unittest import mock
 
 import sentry_sdk
 from sentry_sdk import start_span, start_transaction
-from sentry_sdk.tracing_utils import has_span_streaming_enabled
 from sentry_sdk.consts import OP
 from sentry_sdk.integrations.grpc import GRPCIntegration
+from sentry_sdk.tracing_utils import has_span_streaming_enabled
 from tests.conftest import ApproxDict
 from tests.integrations.grpc.grpc_test_service_pb2 import gRPCTestMessage
 from tests.integrations.grpc.grpc_test_service_pb2_grpc import (
@@ -17,8 +18,6 @@ from tests.integrations.grpc.grpc_test_service_pb2_grpc import (
     gRPCTestServiceServicer,
     gRPCTestServiceStub,
 )
-
-from typing import Optional
 
 
 @pytest_asyncio.fixture(scope="function")

--- a/tests/integrations/httpx/__init__.py
+++ b/tests/integrations/httpx/__init__.py
@@ -1,5 +1,6 @@
 import os
 import sys
+
 import pytest
 
 pytest.importorskip("httpx")

--- a/tests/integrations/httpx/test_httpx.py
+++ b/tests/integrations/httpx/test_httpx.py
@@ -1,5 +1,5 @@
-import os
 import asyncio
+import os
 from unittest import mock
 
 import httpx

--- a/tests/integrations/huey/test_huey.py
+++ b/tests/integrations/huey/test_huey.py
@@ -1,14 +1,13 @@
-import pytest
 from decimal import DivisionByZero
 
-from sentry_sdk import start_transaction
-from sentry_sdk.integrations.huey import HueyIntegration
-from sentry_sdk.utils import parse_version
-
+import pytest
 from huey import __version__ as HUEY_VERSION
 from huey.api import MemoryHuey, Result
 from huey.exceptions import RetryTask
 
+from sentry_sdk import start_transaction
+from sentry_sdk.integrations.huey import HueyIntegration
+from sentry_sdk.utils import parse_version
 
 HUEY_VERSION = parse_version(HUEY_VERSION)
 

--- a/tests/integrations/huggingface_hub/test_huggingface_hub.py
+++ b/tests/integrations/huggingface_hub/test_huggingface_hub.py
@@ -2,14 +2,13 @@ import re
 from typing import TYPE_CHECKING
 from unittest import mock
 
-from sentry_sdk.utils import safe_serialize
 import pytest
 import responses
 from huggingface_hub import InferenceClient
 
 import sentry_sdk
 from sentry_sdk.integrations.huggingface_hub import HuggingfaceHubIntegration
-from sentry_sdk.utils import package_version
+from sentry_sdk.utils import package_version, safe_serialize
 
 try:
     from huggingface_hub.utils._errors import HfHubHTTPError

--- a/tests/integrations/langchain/test_langchain.py
+++ b/tests/integrations/langchain/test_langchain.py
@@ -1,5 +1,5 @@
 import json
-from typing import List, Optional, Any, Iterator
+from typing import Any, Iterator, List, Optional
 from unittest import mock
 from unittest.mock import Mock, patch
 
@@ -12,37 +12,39 @@ try:
     from langchain_openai import ChatOpenAI, OpenAI
 except ImportError:
     # Langchain < 0.2
-    from langchain_community.llms import OpenAI
     from langchain_community.chat_models import ChatOpenAI
+    from langchain_community.llms import OpenAI
 
 from langchain_core.callbacks import BaseCallbackManager, CallbackManagerForLLMRun
-from langchain_core.messages import BaseMessage, AIMessageChunk
+from langchain_core.language_models.chat_models import BaseChatModel
+from langchain_core.messages import AIMessageChunk, BaseMessage
 from langchain_core.outputs import ChatGenerationChunk, ChatResult
 from langchain_core.runnables import RunnableConfig
-from langchain_core.language_models.chat_models import BaseChatModel
 
 import sentry_sdk
 from sentry_sdk import start_transaction
-from sentry_sdk.utils import package_version
 from sentry_sdk.integrations.langchain import (
     LangchainIntegration,
     SentryLangchainCallback,
     _transform_langchain_content_block,
     _transform_langchain_message_content,
 )
+from sentry_sdk.utils import package_version
 
 try:
     # langchain v1+
-    from langchain.tools import tool
     from langchain.agents import create_agent
-    from langchain_classic.agents import AgentExecutor, create_openai_tools_agent  # type: ignore[import-not-found]
+    from langchain.tools import tool
+    from langchain_classic.agents import (  # type: ignore[import-not-found]
+        AgentExecutor,
+        create_openai_tools_agent,
+    )
 except ImportError:
     # langchain <v1
-    from langchain.agents import tool, AgentExecutor, create_openai_tools_agent
+    from langchain.agents import AgentExecutor, create_openai_tools_agent, tool
 
-from langchain_core.prompts import ChatPromptTemplate, MessagesPlaceholder
 from langchain_core.messages import HumanMessage, SystemMessage
-
+from langchain_core.prompts import ChatPromptTemplate, MessagesPlaceholder
 from openai.types.chat.chat_completion_chunk import (
     ChatCompletionChunk,
     Choice,
@@ -50,14 +52,11 @@ from openai.types.chat.chat_completion_chunk import (
     ChoiceDeltaToolCall,
     ChoiceDeltaToolCallFunction,
 )
-
 from openai.types.completion import Completion
 from openai.types.completion_choice import CompletionChoice
-
 from openai.types.completion_usage import (
     CompletionUsage,
 )
-
 from openai.types.responses import (
     ResponseUsage,
 )
@@ -2993,7 +2992,7 @@ def test_langchain_message_role_normalization_units():
 
 def test_langchain_message_truncation(sentry_init, capture_events):
     """Test that large messages are truncated properly in Langchain integration."""
-    from langchain_core.outputs import LLMResult, Generation
+    from langchain_core.outputs import Generation, LLMResult
 
     sentry_init(
         integrations=[LangchainIntegration(include_prompts=True)],
@@ -3807,7 +3806,7 @@ def test_langchain_embeddings_multiple_providers(
 ):
     """Test that embeddings work with different providers."""
     try:
-        from langchain_openai import OpenAIEmbeddings, AzureOpenAIEmbeddings
+        from langchain_openai import AzureOpenAIEmbeddings, OpenAIEmbeddings
     except ImportError:
         pytest.skip("langchain_openai not installed")
 

--- a/tests/integrations/langgraph/test_langgraph.py
+++ b/tests/integrations/langgraph/test_langgraph.py
@@ -5,7 +5,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from sentry_sdk import start_transaction
-from sentry_sdk.consts import SPANDATA, OP
+from sentry_sdk.consts import OP, SPANDATA
 
 
 def mock_langgraph_imports():
@@ -31,9 +31,9 @@ mock_state_graph, mock_pregel = mock_langgraph_imports()
 from sentry_sdk.integrations.langgraph import (  # noqa: E402
     LanggraphIntegration,
     _parse_langgraph_messages,
-    _wrap_state_graph_compile,
-    _wrap_pregel_invoke,
     _wrap_pregel_ainvoke,
+    _wrap_pregel_invoke,
+    _wrap_state_graph_compile,
 )
 
 

--- a/tests/integrations/launchdarkly/test_launchdarkly.py
+++ b/tests/integrations/launchdarkly/test_launchdarkly.py
@@ -3,16 +3,15 @@ import sys
 
 import ldclient
 import pytest
-
 from ldclient import LDClient
 from ldclient.config import Config
 from ldclient.context import Context
 from ldclient.integrations.test_data import TestData
 
 import sentry_sdk
+from sentry_sdk import start_span, start_transaction
 from sentry_sdk.integrations import DidNotEnable
 from sentry_sdk.integrations.launchdarkly import LaunchDarklyIntegration
-from sentry_sdk import start_span, start_transaction
 from tests.conftest import ApproxDict
 
 

--- a/tests/integrations/litellm/test_litellm.py
+++ b/tests/integrations/litellm/test_litellm.py
@@ -1,10 +1,11 @@
+import asyncio
 import base64
 import json
-import pytest
 import time
-import asyncio
-from unittest import mock
 from datetime import datetime
+from unittest import mock
+
+import pytest
 
 try:
     from unittest.mock import AsyncMock
@@ -20,30 +21,30 @@ try:
 except ImportError:
     pytest.skip("litellm not installed", allow_module_level=True)
 
-from sentry_sdk import start_transaction
-from sentry_sdk.consts import OP, SPANDATA
-from sentry_sdk._types import BLOB_DATA_SUBSTITUTE
-from sentry_sdk.integrations.litellm import (
-    LiteLLMIntegration,
-    _convert_message_parts,
-    _input_callback,
-    _success_callback,
-    _failure_callback,
-)
-from sentry_sdk.utils import package_version
-
-from openai import OpenAI, AsyncOpenAI
-from openai.types import CompletionUsage
-
 from concurrent.futures import ThreadPoolExecutor
 
 import litellm.utils as litellm_utils
-from litellm.litellm_core_utils import streaming_handler
-from litellm.litellm_core_utils import thread_pool_executor
-from litellm.litellm_core_utils import litellm_logging
+from litellm.litellm_core_utils import (
+    litellm_logging,
+    streaming_handler,
+    thread_pool_executor,
+)
 from litellm.litellm_core_utils.logging_worker import GLOBAL_LOGGING_WORKER
-from litellm.llms.custom_httpx.http_handler import HTTPHandler, AsyncHTTPHandler
+from litellm.llms.custom_httpx.http_handler import AsyncHTTPHandler, HTTPHandler
+from openai import AsyncOpenAI, OpenAI
+from openai.types import CompletionUsage
 
+from sentry_sdk import start_transaction
+from sentry_sdk._types import BLOB_DATA_SUBSTITUTE
+from sentry_sdk.consts import OP, SPANDATA
+from sentry_sdk.integrations.litellm import (
+    LiteLLMIntegration,
+    _convert_message_parts,
+    _failure_callback,
+    _input_callback,
+    _success_callback,
+)
+from sentry_sdk.utils import package_version
 
 LITELLM_VERSION = package_version("litellm")
 

--- a/tests/integrations/litestar/test_litestar.py
+++ b/tests/integrations/litestar/test_litestar.py
@@ -1,15 +1,11 @@
 from __future__ import annotations
+
 import functools
-
-from litestar.exceptions import HTTPException
-import pytest
-
-from sentry_sdk import capture_message
-from sentry_sdk.integrations.litestar import LitestarIntegration
-
 from typing import Any
 
-from litestar import Litestar, get, Controller
+import pytest
+from litestar import Controller, Litestar, get
+from litestar.exceptions import HTTPException
 from litestar.logging.config import LoggingConfig
 from litestar.middleware import AbstractMiddleware
 from litestar.middleware.logging import LoggingMiddlewareConfig
@@ -17,6 +13,8 @@ from litestar.middleware.rate_limit import RateLimitConfig
 from litestar.middleware.session.server_side import ServerSideSessionConfig
 from litestar.testing import TestClient
 
+from sentry_sdk import capture_message
+from sentry_sdk.integrations.litestar import LitestarIntegration
 from tests.integrations.conftest import parametrize_test_configurable_status_codes
 
 

--- a/tests/integrations/loguru/test_loguru.py
+++ b/tests/integrations/loguru/test_loguru.py
@@ -1,5 +1,5 @@
-from unittest.mock import MagicMock, patch
 import re
+from unittest.mock import MagicMock, patch
 
 import pytest
 from loguru import logger
@@ -7,7 +7,7 @@ from loguru._recattrs import RecordFile, RecordLevel
 
 import sentry_sdk
 from sentry_sdk.consts import VERSION
-from sentry_sdk.integrations.loguru import LoguruIntegration, LoggingLevels
+from sentry_sdk.integrations.loguru import LoggingLevels, LoguruIntegration
 
 logger.remove(0)  # don't print to console
 

--- a/tests/integrations/mcp/test_mcp.py
+++ b/tests/integrations/mcp/test_mcp.py
@@ -15,12 +15,12 @@ The tests mock the MCP server components and request context to verify
 that the integration properly instruments MCP handlers with Sentry spans.
 """
 
-import anyio
 import asyncio
-
-import pytest
 import json
 from unittest import mock
+
+import anyio
+import pytest
 
 try:
     from unittest.mock import AsyncMock
@@ -32,25 +32,25 @@ except ImportError:
 
 
 from mcp.server.lowlevel import Server
+from mcp.server.lowlevel.helper_types import ReadResourceContents
 from mcp.server.lowlevel.server import request_ctx
 from mcp.types import GetPromptResult, PromptMessage, TextContent
-from mcp.server.lowlevel.helper_types import ReadResourceContents
 
 try:
     from mcp.server.lowlevel.server import request_ctx
 except ImportError:
     request_ctx = None
 
-import sentry_sdk
-from sentry_sdk import start_transaction
-from sentry_sdk.consts import SPANDATA, OP
-from sentry_sdk.integrations.mcp import MCPIntegration
-
 from mcp.server.sse import SseServerTransport
 from mcp.server.streamable_http_manager import StreamableHTTPSessionManager
-from starlette.routing import Mount, Route
 from starlette.applications import Starlette
 from starlette.responses import Response
+from starlette.routing import Mount, Route
+
+import sentry_sdk
+from sentry_sdk import start_transaction
+from sentry_sdk.consts import OP, SPANDATA
+from sentry_sdk.integrations.mcp import MCPIntegration
 
 
 def _experiments_for(span_streaming):

--- a/tests/integrations/modules/test_modules.py
+++ b/tests/integrations/modules/test_modules.py
@@ -1,5 +1,4 @@
 import sentry_sdk
-
 from sentry_sdk.integrations.modules import ModulesIntegration
 
 

--- a/tests/integrations/openai/test_openai.py
+++ b/tests/integrations/openai/test_openai.py
@@ -1,4 +1,5 @@
 import json
+
 import pytest
 
 from sentry_sdk.utils import package_version
@@ -8,22 +9,28 @@ try:
 except ImportError:
     NOT_GIVEN = None
 try:
-    from openai import omit
-    from openai import Omit
+    from openai import Omit, omit
 except ImportError:
     omit = None
     Omit = None
 
-from openai import AsyncOpenAI, OpenAI, AsyncStream, Stream, OpenAIError
+from openai import AsyncOpenAI, AsyncStream, OpenAI, OpenAIError, Stream
 from openai.types import CompletionUsage, CreateEmbeddingResponse, Embedding
-from openai.types.chat import ChatCompletionMessage, ChatCompletionChunk
+from openai.types.chat import ChatCompletionChunk, ChatCompletionMessage
 from openai.types.chat.chat_completion import Choice
-from openai.types.chat.chat_completion_chunk import ChoiceDelta, Choice as DeltaChoice
+from openai.types.chat.chat_completion_chunk import Choice as DeltaChoice
+from openai.types.chat.chat_completion_chunk import ChoiceDelta
 from openai.types.create_embedding_response import Usage as EmbeddingTokenUsage
 
 SKIP_RESPONSES_TESTS = False
 
 try:
+    from openai.types.responses import (
+        Response,
+        ResponseOutputMessage,
+        ResponseOutputText,
+        ResponseUsage,
+    )
     from openai.types.responses.response_completed_event import ResponseCompletedEvent
     from openai.types.responses.response_created_event import ResponseCreatedEvent
     from openai.types.responses.response_text_delta_event import ResponseTextDeltaEvent
@@ -31,25 +38,19 @@ try:
         InputTokensDetails,
         OutputTokensDetails,
     )
-    from openai.types.responses import (
-        Response,
-        ResponseUsage,
-        ResponseOutputMessage,
-        ResponseOutputText,
-    )
 except ImportError:
     SKIP_RESPONSES_TESTS = True
 
+from unittest import mock  # python 3.3 and above
+
 from sentry_sdk import start_transaction
-from sentry_sdk.consts import SPANDATA, OP
+from sentry_sdk.consts import OP, SPANDATA
 from sentry_sdk.integrations.openai import (
     OpenAIIntegration,
     _calculate_completions_token_usage,
     _calculate_responses_token_usage,
 )
 from sentry_sdk.utils import safe_serialize
-
-from unittest import mock  # python 3.3 and above
 
 try:
     from unittest.mock import AsyncMock

--- a/tests/integrations/openai_agents/test_openai_agents.py
+++ b/tests/integrations/openai_agents/test_openai_agents.py
@@ -1,55 +1,52 @@
 import asyncio
-import pytest
-from unittest.mock import MagicMock, patch
-import os
 import json
 import logging
-import httpx
-
-import sentry_sdk
-from sentry_sdk import start_span
-from sentry_sdk.consts import SPANDATA, OP
-from sentry_sdk.integrations.logging import LoggingIntegration
-from sentry_sdk.integrations.openai_agents import OpenAIAgentsIntegration
-from sentry_sdk.integrations.openai_agents.utils import _set_input_data, safe_serialize
-from sentry_sdk.utils import parse_version, package_version
-
-from openai import AsyncOpenAI, InternalServerError
-from agents.models.openai_responses import OpenAIResponsesModel
-
+import os
 from unittest import mock
+from unittest.mock import MagicMock, patch
 
 import agents
+import httpx
+import pytest
 from agents import (
     Agent,
     ModelResponse,
-    Usage,
     ModelSettings,
+    Usage,
 )
+from agents.exceptions import MaxTurnsExceeded, ModelBehaviorError
 from agents.items import (
     McpCall,
+    ResponseFunctionToolCall,
     ResponseOutputMessage,
     ResponseOutputText,
-    ResponseFunctionToolCall,
 )
+from agents.models.openai_responses import OpenAIResponsesModel
 from agents.tool import HostedMCPTool
-from agents.exceptions import MaxTurnsExceeded, ModelBehaviorError
 from agents.version import __version__ as OPENAI_AGENTS_VERSION
+from openai import AsyncOpenAI, InternalServerError
+
+import sentry_sdk
+from sentry_sdk import start_span
+from sentry_sdk.consts import OP, SPANDATA
+from sentry_sdk.integrations.logging import LoggingIntegration
+from sentry_sdk.integrations.openai_agents import OpenAIAgentsIntegration
+from sentry_sdk.integrations.openai_agents.utils import _set_input_data, safe_serialize
+from sentry_sdk.utils import package_version, parse_version
 
 OPENAI_VERSION = package_version("openai")
 
 from openai.types.responses import (
+    Response,
+    ResponseCompletedEvent,
     ResponseCreatedEvent,
     ResponseTextDeltaEvent,
-    ResponseCompletedEvent,
-    Response,
     ResponseUsage,
 )
 from openai.types.responses.response_usage import (
     InputTokensDetails,
     OutputTokensDetails,
 )
-
 
 test_run_config = agents.RunConfig(tracing_disabled=True)
 
@@ -3761,8 +3758,8 @@ def test_openai_agents_message_role_mapping(
 
     get_response_kwargs = {"input": [test_message]}
 
-    from sentry_sdk.integrations.openai_agents.utils import _set_input_data
     from sentry_sdk import start_span
+    from sentry_sdk.integrations.openai_agents.utils import _set_input_data
 
     with start_span(op="test") as span:
         _set_input_data(span, get_response_kwargs)

--- a/tests/integrations/openfeature/test_openfeature.py
+++ b/tests/integrations/openfeature/test_openfeature.py
@@ -2,7 +2,6 @@ import concurrent.futures as cf
 import sys
 
 import pytest
-
 from openfeature import api
 from openfeature.provider.in_memory_provider import InMemoryFlag, InMemoryProvider
 

--- a/tests/integrations/opentelemetry/test_entry_points.py
+++ b/tests/integrations/opentelemetry/test_entry_points.py
@@ -3,6 +3,7 @@ import os
 from unittest.mock import patch
 
 from opentelemetry import propagate
+
 from sentry_sdk.integrations.opentelemetry import SentryPropagator
 
 

--- a/tests/integrations/opentelemetry/test_propagator.py
+++ b/tests/integrations/opentelemetry/test_propagator.py
@@ -1,8 +1,7 @@
-import pytest
-
 from unittest import mock
 from unittest.mock import MagicMock
 
+import pytest
 from opentelemetry.context import get_current
 from opentelemetry.trace import (
     SpanContext,

--- a/tests/integrations/opentelemetry/test_span_processor.py
+++ b/tests/integrations/opentelemetry/test_span_processor.py
@@ -4,16 +4,16 @@ from unittest import mock
 from unittest.mock import MagicMock
 
 import pytest
-from opentelemetry.trace import SpanKind, SpanContext, Status, StatusCode
+from opentelemetry.trace import SpanContext, SpanKind, Status, StatusCode
 
 import sentry_sdk
 from sentry_sdk.integrations.opentelemetry.span_processor import (
     SentrySpanProcessor,
     link_trace_context_to_error_event,
 )
-from sentry_sdk.utils import Dsn
 from sentry_sdk.tracing import Span, Transaction
 from sentry_sdk.tracing_utils import extract_sentrytrace_data
+from sentry_sdk.utils import Dsn
 
 
 def test_is_sentry_span():

--- a/tests/integrations/otlp/test_otlp.py
+++ b/tests/integrations/otlp/test_otlp.py
@@ -1,25 +1,23 @@
 import pytest
 import responses
-
 from opentelemetry import trace
+from opentelemetry.context import attach, detach
+from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+from opentelemetry.propagate import get_global_textmap, set_global_textmap
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import BatchSpanProcessor
 from opentelemetry.trace import (
-    get_tracer_provider,
-    set_tracer_provider,
     ProxyTracerProvider,
     format_span_id,
     format_trace_id,
     get_current_span,
+    get_tracer_provider,
+    set_tracer_provider,
 )
-from opentelemetry.context import attach, detach
-from opentelemetry.propagate import get_global_textmap, set_global_textmap
 from opentelemetry.util._once import Once
-from opentelemetry.sdk.trace import TracerProvider
-from opentelemetry.sdk.trace.export import BatchSpanProcessor
-from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
 
 from sentry_sdk.integrations.otlp import OTLPIntegration, SentryOTLPPropagator
 from sentry_sdk.scope import get_external_propagation_context
-
 
 original_propagator = get_global_textmap()
 

--- a/tests/integrations/pydantic_ai/test_pydantic_ai.py
+++ b/tests/integrations/pydantic_ai/test_pydantic_ai.py
@@ -1,10 +1,15 @@
 import asyncio
 import json
-import pytest
+from typing import Annotated
 from unittest.mock import MagicMock
 
-from typing import Annotated
+import pytest
 from pydantic import Field
+from pydantic_ai import Agent
+from pydantic_ai.exceptions import ModelRetry, UnexpectedModelBehavior
+from pydantic_ai.messages import BinaryContent, ImageUrl, UserPromptPart
+from pydantic_ai.models.function import FunctionModel
+from pydantic_ai.usage import RequestUsage
 
 import sentry_sdk
 from sentry_sdk._types import BLOB_DATA_SUBSTITUTE
@@ -12,11 +17,6 @@ from sentry_sdk.consts import SPANDATA
 from sentry_sdk.integrations.pydantic_ai import PydanticAIIntegration
 from sentry_sdk.integrations.pydantic_ai.spans.ai_client import _set_input_messages
 from sentry_sdk.integrations.pydantic_ai.spans.utils import _set_usage_data
-from pydantic_ai import Agent
-from pydantic_ai.messages import BinaryContent, ImageUrl, UserPromptPart
-from pydantic_ai.usage import RequestUsage
-from pydantic_ai.exceptions import ModelRetry, UnexpectedModelBehavior
-from pydantic_ai.models.function import FunctionModel
 
 
 @pytest.fixture
@@ -1749,9 +1749,11 @@ async def test_mcp_tool_execution_spans(
     pytest.importorskip("mcp")
 
     from unittest.mock import MagicMock
-    from pydantic_ai.mcp import MCPServerStdio
+
     from pydantic_ai import Agent
+    from pydantic_ai.mcp import MCPServerStdio
     from pydantic_ai.toolsets.combined import CombinedToolset
+
     import sentry_sdk
 
     # Create mock MCP server
@@ -1827,8 +1829,8 @@ async def test_mcp_tool_execution_spans(
 
             # Create a mock tool that simulates an MCP tool from CombinedToolset
             from pydantic_ai._run_context import RunContext
-            from pydantic_ai.result import RunUsage
             from pydantic_ai.models.test import TestModel
+            from pydantic_ai.result import RunUsage
             from pydantic_ai.toolsets.combined import _CombinedToolsetTool
 
             ctx = RunContext(
@@ -1878,8 +1880,8 @@ async def test_mcp_tool_execution_spans(
 
             # Create a mock tool that simulates an MCP tool from CombinedToolset
             from pydantic_ai._run_context import RunContext
-            from pydantic_ai.result import RunUsage
             from pydantic_ai.models.test import TestModel
+            from pydantic_ai.result import RunUsage
             from pydantic_ai.toolsets.combined import _CombinedToolsetTool
 
             ctx = RunContext(
@@ -2229,6 +2231,7 @@ async def test_model_name_extraction_with_callable(sentry_init, capture_items):
     Test model name extraction when model has a callable name() method.
     """
     from unittest.mock import MagicMock
+
     from sentry_sdk.integrations.pydantic_ai.utils import _get_model_name
 
     sentry_init(
@@ -2255,6 +2258,7 @@ async def test_model_name_extraction_fallback_to_str(sentry_init, capture_items)
     Test model name extraction falls back to str() when no name attribute exists.
     """
     from unittest.mock import MagicMock
+
     from sentry_sdk.integrations.pydantic_ai.utils import _get_model_name
 
     sentry_init(
@@ -2281,8 +2285,9 @@ async def test_model_settings_object_style(sentry_init, capture_items):
     """
     Test that object-style model settings (non-dict) are handled correctly.
     """
-    import sentry_sdk
     from unittest.mock import MagicMock
+
+    import sentry_sdk
     from sentry_sdk.integrations.pydantic_ai.utils import _set_model_data
 
     sentry_init(
@@ -2702,8 +2707,9 @@ async def test_model_response_without_parts(sentry_init, capture_items):
     """
     Test handling of model response without parts attribute.
     """
-    import sentry_sdk
     from unittest.mock import MagicMock
+
+    import sentry_sdk
     from sentry_sdk.integrations.pydantic_ai.spans.ai_client import _set_output_data
 
     sentry_init(
@@ -2762,8 +2768,9 @@ async def test_available_tools_error_handling(sentry_init, capture_items):
     """
     Test that _set_available_tools handles errors gracefully.
     """
-    import sentry_sdk
     from unittest.mock import MagicMock
+
+    import sentry_sdk
     from sentry_sdk.integrations.pydantic_ai.utils import _set_available_tools
 
     sentry_init(
@@ -2817,8 +2824,9 @@ async def test_set_usage_data_with_partial_fields(sentry_init, capture_items):
     """
     Test that _set_usage_data handles usage with only some fields.
     """
-    import sentry_sdk
     from unittest.mock import MagicMock
+
+    import sentry_sdk
     from sentry_sdk.integrations.pydantic_ai.spans.ai_client import _set_usage_data
 
     sentry_init(
@@ -2905,8 +2913,9 @@ async def test_message_parts_with_list_content(sentry_init, capture_items):
     """
     Test that message parts with list content are handled correctly.
     """
-    import sentry_sdk
     from unittest.mock import MagicMock
+
+    import sentry_sdk
 
     sentry_init(
         integrations=[PydanticAIIntegration()],
@@ -2940,8 +2949,9 @@ async def test_output_data_with_text_and_tool_calls(sentry_init, capture_items):
     """
     Test that _set_output_data handles both text and tool calls in response.
     """
-    import sentry_sdk
     from unittest.mock import MagicMock
+
+    import sentry_sdk
     from sentry_sdk.integrations.pydantic_ai.spans.ai_client import _set_output_data
 
     sentry_init(
@@ -2979,8 +2989,9 @@ async def test_output_data_error_handling(sentry_init, capture_items):
     """
     Test that _set_output_data handles errors in formatting gracefully.
     """
-    import sentry_sdk
     from unittest.mock import MagicMock
+
+    import sentry_sdk
     from sentry_sdk.integrations.pydantic_ai.spans.ai_client import _set_output_data
 
     sentry_init(
@@ -3011,9 +3022,11 @@ async def test_message_with_system_prompt_part(sentry_init, capture_items):
     """
     Test that SystemPromptPart is handled with correct role.
     """
-    import sentry_sdk
     from unittest.mock import MagicMock
+
     from pydantic_ai import messages
+
+    import sentry_sdk
 
     sentry_init(
         integrations=[PydanticAIIntegration()],
@@ -3047,8 +3060,9 @@ async def test_message_with_instructions(sentry_init, capture_items):
     """
     Test that messages with instructions field are handled correctly.
     """
-    import sentry_sdk
     from unittest.mock import MagicMock
+
+    import sentry_sdk
 
     sentry_init(
         integrations=[PydanticAIIntegration()],
@@ -3108,8 +3122,9 @@ async def test_set_output_data_without_prompts(sentry_init, capture_items):
     """
     Test that _set_output_data respects _should_send_prompts().
     """
-    import sentry_sdk
     from unittest.mock import MagicMock
+
+    import sentry_sdk
     from sentry_sdk.integrations.pydantic_ai.spans.ai_client import _set_output_data
 
     sentry_init(
@@ -3138,6 +3153,7 @@ async def test_get_model_name_with_exception_in_callable(sentry_init, capture_it
     Test that _get_model_name handles exceptions in name() callable.
     """
     from unittest.mock import MagicMock
+
     from sentry_sdk.integrations.pydantic_ai.utils import _get_model_name
 
     sentry_init(
@@ -3199,8 +3215,9 @@ async def test_set_model_data_with_system(sentry_init, capture_items):
     """
     Test that _set_model_data captures system from model.
     """
-    import sentry_sdk
     from unittest.mock import MagicMock
+
+    import sentry_sdk
     from sentry_sdk.integrations.pydantic_ai.utils import _set_model_data
 
     sentry_init(
@@ -3230,8 +3247,9 @@ async def test_set_model_data_from_agent_scope(sentry_init, capture_items):
     """
     Test that _set_model_data retrieves model from agent in scope when not passed.
     """
-    import sentry_sdk
     from unittest.mock import MagicMock
+
+    import sentry_sdk
     from sentry_sdk.integrations.pydantic_ai.utils import _set_model_data
 
     sentry_init(
@@ -3339,8 +3357,9 @@ async def test_set_agent_data_from_scope(sentry_init, capture_items):
     """
     Test that _set_agent_data retrieves agent from scope when not passed.
     """
-    import sentry_sdk
     from unittest.mock import MagicMock
+
+    import sentry_sdk
     from sentry_sdk.integrations.pydantic_ai.utils import _set_agent_data
 
     sentry_init(
@@ -3371,8 +3390,9 @@ async def test_set_agent_data_without_name(sentry_init, capture_items):
     """
     Test that _set_agent_data handles agent without name attribute.
     """
-    import sentry_sdk
     from unittest.mock import MagicMock
+
+    import sentry_sdk
     from sentry_sdk.integrations.pydantic_ai.utils import _set_agent_data
 
     sentry_init(
@@ -3401,8 +3421,9 @@ async def test_set_available_tools_without_toolset(sentry_init, capture_items):
     """
     Test that _set_available_tools handles agent without toolset.
     """
-    import sentry_sdk
     from unittest.mock import MagicMock
+
+    import sentry_sdk
     from sentry_sdk.integrations.pydantic_ai.utils import _set_available_tools
 
     sentry_init(
@@ -3431,8 +3452,9 @@ async def test_set_available_tools_with_schema(sentry_init, capture_items):
     """
     Test that _set_available_tools extracts tool schema correctly.
     """
-    import sentry_sdk
     from unittest.mock import MagicMock
+
+    import sentry_sdk
     from sentry_sdk.integrations.pydantic_ai.utils import _set_available_tools
 
     sentry_init(
@@ -3647,8 +3669,9 @@ async def test_invoke_agent_span_with_callable_instruction(sentry_init, capture_
     """
     Test that invoke_agent_span skips callable instructions correctly.
     """
-    import sentry_sdk
     from unittest.mock import MagicMock
+
+    import sentry_sdk
     from sentry_sdk.integrations.pydantic_ai.spans.invoke_agent import invoke_agent_span
 
     sentry_init(
@@ -3680,8 +3703,9 @@ async def test_invoke_agent_span_with_string_instructions(sentry_init, capture_i
     """
     Test that invoke_agent_span handles string instructions (not list).
     """
-    import sentry_sdk
     from unittest.mock import MagicMock
+
+    import sentry_sdk
     from sentry_sdk.integrations.pydantic_ai.spans.invoke_agent import invoke_agent_span
 
     sentry_init(
@@ -3736,8 +3760,9 @@ async def test_ai_client_span_gets_agent_from_scope(sentry_init, capture_items):
     """
     Test that ai_client_span gets agent from scope when not passed.
     """
-    import sentry_sdk
     from unittest.mock import MagicMock
+
+    import sentry_sdk
     from sentry_sdk.integrations.pydantic_ai.spans.ai_client import ai_client_span
 
     sentry_init(

--- a/tests/integrations/pyramid/test_pyramid.py
+++ b/tests/integrations/pyramid/test_pyramid.py
@@ -4,17 +4,16 @@ from io import BytesIO
 
 import pyramid.testing
 import pytest
+from packaging.version import Version
 from pyramid.authorization import ACLAuthorizationPolicy
 from pyramid.response import Response
-from packaging.version import Version
 from werkzeug.test import Client
 
-from sentry_sdk import capture_message, add_breadcrumb
+from sentry_sdk import add_breadcrumb, capture_message
 from sentry_sdk.consts import DEFAULT_MAX_VALUE_LENGTH
 from sentry_sdk.integrations.pyramid import PyramidIntegration
 from sentry_sdk.serializer import MAX_DATABAG_BREADTH
 from tests.conftest import unpack_werkzeug_response
-
 
 try:
     from importlib.metadata import version

--- a/tests/integrations/pyreqwest/__init__.py
+++ b/tests/integrations/pyreqwest/__init__.py
@@ -1,5 +1,6 @@
 import os
 import sys
+
 import pytest
 
 pytest.importorskip("pyreqwest")

--- a/tests/integrations/pyreqwest/test_pyreqwest.py
+++ b/tests/integrations/pyreqwest/test_pyreqwest.py
@@ -4,8 +4,8 @@ from contextlib import contextmanager
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from threading import Thread
 from unittest import mock
-import pytest
 
+import pytest
 from pyreqwest.client import ClientBuilder, SyncClientBuilder
 from pyreqwest.simple.request import pyreqwest_get as async_pyreqwest_get
 from pyreqwest.simple.sync_request import pyreqwest_get as sync_pyreqwest_get

--- a/tests/integrations/quart/test_quart.py
+++ b/tests/integrations/quart/test_quart.py
@@ -7,13 +7,13 @@ from unittest import mock
 import pytest
 
 import sentry_sdk
+import sentry_sdk.integrations.quart as quart_sentry
 from sentry_sdk import (
-    set_tag,
-    capture_message,
     capture_exception,
+    capture_message,
+    set_tag,
 )
 from sentry_sdk.integrations.logging import LoggingIntegration
-import sentry_sdk.integrations.quart as quart_sentry
 
 
 def quart_app_factory():

--- a/tests/integrations/ray/test_ray.py
+++ b/tests/integrations/ray/test_ray.py
@@ -1,9 +1,9 @@
 import json
 import os
-import pytest
 import shutil
 import uuid
 
+import pytest
 import ray
 
 import sentry_sdk

--- a/tests/integrations/redis/asyncio/test_redis_asyncio.py
+++ b/tests/integrations/redis/asyncio/test_redis_asyncio.py
@@ -1,12 +1,11 @@
 import pytest
+from fakeredis.aioredis import FakeRedis
 
 import sentry_sdk
 from sentry_sdk import capture_message, start_transaction
 from sentry_sdk.consts import SPANDATA
 from sentry_sdk.integrations.redis import RedisIntegration
 from tests.conftest import ApproxDict
-
-from fakeredis.aioredis import FakeRedis
 
 
 @pytest.mark.asyncio

--- a/tests/integrations/redis/cluster/test_redis_cluster.py
+++ b/tests/integrations/redis/cluster/test_redis_cluster.py
@@ -1,13 +1,12 @@
 import pytest
+import redis
 
 import sentry_sdk
 from sentry_sdk import capture_message
-from sentry_sdk.consts import SPANDATA
 from sentry_sdk.api import start_transaction
+from sentry_sdk.consts import SPANDATA
 from sentry_sdk.integrations.redis import RedisIntegration
 from tests.conftest import ApproxDict
-
-import redis
 
 
 @pytest.fixture(autouse=True)

--- a/tests/integrations/redis/cluster_asyncio/test_redis_cluster_asyncio.py
+++ b/tests/integrations/redis/cluster_asyncio/test_redis_cluster_asyncio.py
@@ -1,12 +1,11 @@
 import pytest
+from redis.asyncio import cluster
 
 import sentry_sdk
 from sentry_sdk import capture_message, start_transaction
 from sentry_sdk.consts import SPANDATA
 from sentry_sdk.integrations.redis import RedisIntegration
 from tests.conftest import ApproxDict
-
-from redis.asyncio import cluster
 
 
 async def fake_initialize(*_, **__):

--- a/tests/integrations/redis/test_redis.py
+++ b/tests/integrations/redis/test_redis.py
@@ -8,7 +8,6 @@ from sentry_sdk import capture_message, start_transaction
 from sentry_sdk.consts import SPANDATA
 from sentry_sdk.integrations.redis import RedisIntegration
 
-
 MOCK_CONNECTION_POOL = mock.MagicMock()
 MOCK_CONNECTION_POOL.connection_kwargs = {
     "host": "localhost",

--- a/tests/integrations/redis/test_redis_cache_module.py
+++ b/tests/integrations/redis/test_redis_cache_module.py
@@ -1,16 +1,14 @@
 import uuid
 
-import pytest
-
 import fakeredis
+import pytest
 from fakeredis import FakeStrictRedis
 
+import sentry_sdk
 from sentry_sdk.consts import SPANDATA
 from sentry_sdk.integrations.redis import RedisIntegration
 from sentry_sdk.integrations.redis.utils import _get_safe_key, _key_as_string
 from sentry_sdk.utils import parse_version
-import sentry_sdk
-
 
 FAKEREDIS_VERSION = parse_version(fakeredis.__version__)
 

--- a/tests/integrations/redis/test_redis_cache_module_async.py
+++ b/tests/integrations/redis/test_redis_cache_module_async.py
@@ -14,10 +14,9 @@ if FakeRedisAsync is None:
         allow_module_level=True,
     )
 
+import sentry_sdk
 from sentry_sdk.integrations.redis import RedisIntegration
 from sentry_sdk.utils import parse_version
-import sentry_sdk
-
 
 FAKEREDIS_VERSION = parse_version(fakeredis.__version__)
 

--- a/tests/integrations/redis_py_cluster_legacy/test_redis_py_cluster_legacy.py
+++ b/tests/integrations/redis_py_cluster_legacy/test_redis_py_cluster_legacy.py
@@ -9,7 +9,6 @@ from sentry_sdk.consts import SPANDATA
 from sentry_sdk.integrations.redis import RedisIntegration
 from tests.conftest import ApproxDict
 
-
 MOCK_CONNECTION_POOL = mock.MagicMock()
 MOCK_CONNECTION_POOL.connection_kwargs = {
     "host": "localhost",

--- a/tests/integrations/rust_tracing/test_rust_tracing.py
+++ b/tests/integrations/rust_tracing/test_rust_tracing.py
@@ -1,17 +1,17 @@
-from unittest import mock
-import pytest
-
 from string import Template
 from typing import Dict
+from unittest import mock
+
+import pytest
 
 import sentry_sdk
+from sentry_sdk import capture_message, start_transaction
 from sentry_sdk.integrations.rust_tracing import (
+    EventTypeMapping,
     RustTracingIntegration,
     RustTracingLayer,
     RustTracingLevel,
-    EventTypeMapping,
 )
-from sentry_sdk import start_transaction, capture_message
 
 
 def _test_event_type_mapping(metadata: Dict[str, object]) -> EventTypeMapping:

--- a/tests/integrations/sanic/test_sanic.py
+++ b/tests/integrations/sanic/test_sanic.py
@@ -6,15 +6,15 @@ import sys
 from unittest.mock import Mock
 
 import pytest
+from sanic import Sanic, request, response
+from sanic import __version__ as SANIC_VERSION_RAW
+from sanic.exceptions import SanicException
+from sanic.response import HTTPResponse
 
 import sentry_sdk
 from sentry_sdk import capture_message
 from sentry_sdk.integrations.sanic import SanicIntegration
 from sentry_sdk.tracing import TransactionSource
-
-from sanic import Sanic, request, response, __version__ as SANIC_VERSION_RAW
-from sanic.response import HTTPResponse
-from sanic.exceptions import SanicException
 
 try:
     from sanic_testing import TestManager
@@ -29,7 +29,7 @@ except ImportError:
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from collections.abc import Iterable, Container
+    from collections.abc import Container, Iterable
     from typing import Any, Optional
 
 SANIC_VERSION = tuple(map(int, SANIC_VERSION_RAW.split(".")))

--- a/tests/integrations/spark/test_spark.py
+++ b/tests/integrations/spark/test_spark.py
@@ -1,19 +1,17 @@
-import pytest
 import sys
 from unittest.mock import patch
 
-from sentry_sdk.integrations.spark.spark_driver import (
-    _set_app_properties,
-    _start_sentry_listener,
-    SentryListener,
-    SparkIntegration,
-)
-from sentry_sdk.integrations.spark.spark_worker import SparkWorkerIntegration
-
+import pytest
+from py4j.protocol import Py4JJavaError
 from pyspark import SparkConf, SparkContext
 
-from py4j.protocol import Py4JJavaError
-
+from sentry_sdk.integrations.spark.spark_driver import (
+    SentryListener,
+    SparkIntegration,
+    _set_app_properties,
+    _start_sentry_listener,
+)
+from sentry_sdk.integrations.spark.spark_worker import SparkWorkerIntegration
 
 ################
 # DRIVER TESTS #
@@ -311,9 +309,8 @@ def test_sentry_listener_on_stage_completed_failure(
 
 
 def test_spark_worker(monkeypatch, sentry_init, capture_events, capture_exceptions):
-    import pyspark.worker as original_worker
     import pyspark.daemon as original_daemon
-
+    import pyspark.worker as original_worker
     from pyspark.taskcontext import TaskContext
 
     task_context = TaskContext._getOrCreate()

--- a/tests/integrations/sqlalchemy/__init__.py
+++ b/tests/integrations/sqlalchemy/__init__.py
@@ -1,5 +1,6 @@
 import os
 import sys
+
 import pytest
 
 pytest.importorskip("sqlalchemy")

--- a/tests/integrations/sqlalchemy/test_sqlalchemy.py
+++ b/tests/integrations/sqlalchemy/test_sqlalchemy.py
@@ -3,11 +3,10 @@ from datetime import datetime
 from unittest import mock
 
 import pytest
-from sqlalchemy import Column, ForeignKey, Integer, String, create_engine
+from sqlalchemy import Column, ForeignKey, Integer, String, create_engine, text
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import relationship, sessionmaker
-from sqlalchemy import text
 
 import sentry_sdk
 from sentry_sdk import capture_message, start_transaction

--- a/tests/integrations/starlette/test_starlette.py
+++ b/tests/integrations/starlette/test_starlette.py
@@ -10,16 +10,6 @@ import warnings
 from unittest import mock
 
 import pytest
-
-import sentry_sdk
-from sentry_sdk import capture_message, get_baggage, get_traceparent
-from sentry_sdk.integrations.asgi import SentryAsgiMiddleware
-from sentry_sdk.integrations.starlette import (
-    StarletteIntegration,
-    StarletteRequestExtractor,
-)
-from sentry_sdk.utils import parse_version
-
 import starlette
 from starlette.authentication import (
     AuthCredentials,
@@ -32,8 +22,16 @@ from starlette.middleware import Middleware
 from starlette.middleware.authentication import AuthenticationMiddleware
 from starlette.middleware.trustedhost import TrustedHostMiddleware
 from starlette.testclient import TestClient
-from tests.integrations.conftest import parametrize_test_configurable_status_codes
 
+import sentry_sdk
+from sentry_sdk import capture_message, get_baggage, get_traceparent
+from sentry_sdk.integrations.asgi import SentryAsgiMiddleware
+from sentry_sdk.integrations.starlette import (
+    StarletteIntegration,
+    StarletteRequestExtractor,
+)
+from sentry_sdk.utils import parse_version
+from tests.integrations.conftest import parametrize_test_configurable_status_codes
 
 STARLETTE_VERSION = parse_version(starlette.__version__)
 

--- a/tests/integrations/starlite/test_starlite.py
+++ b/tests/integrations/starlite/test_starlite.py
@@ -1,17 +1,16 @@
 from __future__ import annotations
+
 import functools
-
-import pytest
-
-from sentry_sdk import capture_message
-from sentry_sdk.integrations.starlite import StarliteIntegration
-
 from typing import Any, Dict
 
-from starlite import AbstractMiddleware, LoggingConfig, Starlite, get, Controller
+import pytest
+from starlite import AbstractMiddleware, Controller, LoggingConfig, Starlite, get
 from starlite.middleware import LoggingMiddlewareConfig, RateLimitConfig
 from starlite.middleware.session.memory_backend import MemoryBackendConfig
 from starlite.testing import TestClient
+
+from sentry_sdk import capture_message
+from sentry_sdk.integrations.starlite import StarliteIntegration
 
 
 def starlite_app_factory(middleware=None, debug=True, exception_handlers=None):

--- a/tests/integrations/statsig/test_statsig.py
+++ b/tests/integrations/statsig/test_statsig.py
@@ -1,17 +1,17 @@
 import concurrent.futures as cf
 import sys
 from contextlib import contextmanager
-from statsig import statsig
-from statsig.statsig_user import StatsigUser
 from random import random
 from unittest.mock import Mock
-from sentry_sdk import start_span, start_transaction
-from tests.conftest import ApproxDict
 
 import pytest
+from statsig import statsig
+from statsig.statsig_user import StatsigUser
 
 import sentry_sdk
+from sentry_sdk import start_span, start_transaction
 from sentry_sdk.integrations.statsig import StatsigIntegration
+from tests.conftest import ApproxDict
 
 
 @contextmanager

--- a/tests/integrations/stdlib/test_httplib.py
+++ b/tests/integrations/stdlib/test_httplib.py
@@ -1,22 +1,21 @@
+import datetime
 import os
 import socket
-import datetime
 import time
 from http.client import HTTPConnection, HTTPSConnection
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from socket import SocketIO
 from threading import Thread
+from unittest import mock
 from urllib.error import HTTPError
 from urllib.request import urlopen
-from unittest import mock
 
 import pytest
 
 import sentry_sdk
-from sentry_sdk import capture_message, start_transaction, continue_trace
+from sentry_sdk import capture_message, continue_trace, start_transaction
 from sentry_sdk.consts import MATCH_ALL, SPANDATA
 from sentry_sdk.integrations.stdlib import StdlibIntegration
-
 from tests.conftest import ApproxDict, create_mock_http_server, get_free_port
 
 PORT = create_mock_http_server()

--- a/tests/integrations/stdlib/test_subprocess.py
+++ b/tests/integrations/stdlib/test_subprocess.py
@@ -1,5 +1,4 @@
 import os
-import sentry_sdk
 import platform
 import subprocess
 import sys
@@ -7,6 +6,7 @@ from collections.abc import Mapping
 
 import pytest
 
+import sentry_sdk
 from sentry_sdk import capture_message, start_transaction
 from sentry_sdk.consts import SPANDATA
 from sentry_sdk.integrations.stdlib import StdlibIntegration

--- a/tests/integrations/strawberry/test_strawberry.py
+++ b/tests/integrations/strawberry/test_strawberry.py
@@ -1,5 +1,6 @@
-import pytest
 from typing import AsyncGenerator, Optional
+
+import pytest
 
 strawberry = pytest.importorskip("strawberry")
 pytest.importorskip("fastapi")
@@ -17,9 +18,9 @@ from sentry_sdk.integrations.fastapi import FastApiIntegration
 from sentry_sdk.integrations.flask import FlaskIntegration
 from sentry_sdk.integrations.starlette import StarletteIntegration
 from sentry_sdk.integrations.strawberry import (
-    StrawberryIntegration,
     SentryAsyncExtension,
     SentrySyncExtension,
+    StrawberryIntegration,
 )
 from tests.conftest import ApproxDict
 

--- a/tests/integrations/tornado/test_tornado.py
+++ b/tests/integrations/tornado/test_tornado.py
@@ -1,13 +1,12 @@
 import json
 
 import pytest
+from tornado.testing import AsyncHTTPTestCase
+from tornado.web import Application, HTTPError, RequestHandler
 
 import sentry_sdk
-from sentry_sdk import start_transaction, capture_message
+from sentry_sdk import capture_message, start_transaction
 from sentry_sdk.integrations.tornado import TornadoIntegration
-
-from tornado.web import RequestHandler, Application, HTTPError
-from tornado.testing import AsyncHTTPTestCase
 
 
 @pytest.fixture

--- a/tests/integrations/trytond/test_trytond.py
+++ b/tests/integrations/trytond/test_trytond.py
@@ -2,14 +2,12 @@ import json
 import unittest.mock
 
 import pytest
-
 import trytond
+from trytond.exceptions import LoginException
 from trytond.exceptions import TrytonException as TrytondBaseException
 from trytond.exceptions import UserError as TrytondUserError
 from trytond.exceptions import UserWarning as TrytondUserWarning
-from trytond.exceptions import LoginException
 from trytond.wsgi import app as trytond_app
-
 from werkzeug.test import Client
 
 from sentry_sdk.integrations.trytond import TrytondWSGIIntegration

--- a/tests/integrations/typer/test_typer.py
+++ b/tests/integrations/typer/test_typer.py
@@ -1,8 +1,8 @@
 import subprocess
 import sys
 from textwrap import dedent
-import pytest
 
+import pytest
 from typer.testing import CliRunner
 
 runner = CliRunner()

--- a/tests/integrations/unleash/test_unleash.py
+++ b/tests/integrations/unleash/test_unleash.py
@@ -2,15 +2,15 @@ import concurrent.futures as cf
 import sys
 from random import random
 from unittest import mock
-from UnleashClient import UnleashClient
 
 import pytest
+from UnleashClient import UnleashClient
 
 import sentry_sdk
-from sentry_sdk.integrations.unleash import UnleashIntegration
 from sentry_sdk import start_span, start_transaction
-from tests.integrations.unleash.testutils import mock_unleash_client
+from sentry_sdk.integrations.unleash import UnleashIntegration
 from tests.conftest import ApproxDict
+from tests.integrations.unleash.testutils import mock_unleash_client
 
 
 def test_is_enabled(sentry_init, capture_events, uninstall_integration):

--- a/tests/integrations/unleash/testutils.py
+++ b/tests/integrations/unleash/testutils.py
@@ -1,4 +1,5 @@
 from contextlib import contextmanager
+
 from UnleashClient import UnleashClient
 
 

--- a/tests/integrations/unraisablehook/test_unraisablehook.py
+++ b/tests/integrations/unraisablehook/test_unraisablehook.py
@@ -1,9 +1,8 @@
-import pytest
-import sys
 import subprocess
-
+import sys
 from textwrap import dedent
 
+import pytest
 
 TEST_PARAMETERS = [
     ("", "HttpTransport"),

--- a/tests/new_scopes_compat/conftest.py
+++ b/tests/new_scopes_compat/conftest.py
@@ -1,4 +1,5 @@
 import pytest
+
 import sentry_sdk
 
 

--- a/tests/new_scopes_compat/test_new_scopes_compat_event.py
+++ b/tests/new_scopes_compat/test_new_scopes_compat_event.py
@@ -1,12 +1,11 @@
-import pytest
-
 from unittest import mock
+
+import pytest
 
 import sentry_sdk
 from sentry_sdk.hub import Hub
 from sentry_sdk.integrations import iter_default_integrations
-from sentry_sdk.scrubber import EventScrubber, DEFAULT_DENYLIST
-
+from sentry_sdk.scrubber import DEFAULT_DENYLIST, EventScrubber
 
 """
 Those tests are meant to check the compatibility of the new scopes in SDK 2.0 with the old Hub/Scope system in SDK 1.x.

--- a/tests/profiler/test_continuous_profiler.py
+++ b/tests/profiler/test_continuous_profiler.py
@@ -8,13 +8,13 @@ import pytest
 import sentry_sdk
 from sentry_sdk.consts import VERSION
 from sentry_sdk.profiler.continuous_profiler import (
-    is_profile_session_sampled,
     get_profiler_id,
+    is_profile_session_sampled,
     setup_continuous_profiler,
-    start_profiler,
     start_profile_session,
-    stop_profiler,
+    start_profiler,
     stop_profile_session,
+    stop_profiler,
 )
 from tests.conftest import ApproxDict
 

--- a/tests/profiler/test_transaction_profiler.py
+++ b/tests/profiler/test_transaction_profiler.py
@@ -1,6 +1,5 @@
 import inspect
 import os
-import sentry_sdk
 import sys
 import threading
 import time
@@ -10,7 +9,9 @@ from unittest import mock
 
 import pytest
 
+import sentry_sdk
 from sentry_sdk import start_transaction
+from sentry_sdk._lru_cache import LRUCache
 from sentry_sdk.profiler.transaction_profiler import (
     GeventScheduler,
     Profile,
@@ -24,7 +25,6 @@ from sentry_sdk.profiler.utils import (
     frame_id,
     get_frame_name,
 )
-from sentry_sdk._lru_cache import LRUCache
 
 try:
     import gevent

--- a/tests/test_ai_integration_deactivation.py
+++ b/tests/test_ai_integration_deactivation.py
@@ -3,7 +3,6 @@ import pytest
 from sentry_sdk import get_client
 from sentry_sdk.integrations import _INTEGRATION_DEACTIVATES
 
-
 try:
     from sentry_sdk.integrations.langchain import LangchainIntegration
 

--- a/tests/test_ai_monitoring.py
+++ b/tests/test_ai_monitoring.py
@@ -2,25 +2,25 @@ import pytest
 
 import sentry_sdk
 from sentry_sdk._types import (
-    AnnotatedValue,
     BLOB_DATA_SUBSTITUTE,
+    AnnotatedValue,
 )
 from sentry_sdk.ai.monitoring import ai_track
 from sentry_sdk.ai.utils import (
     MAX_GEN_AI_MESSAGE_BYTES,
     MAX_SINGLE_MESSAGE_CONTENT_CHARS,
-    truncate_and_annotate_messages,
-    truncate_messages_by_size,
     _find_truncation_index,
+    get_modality_from_mime_type,
     parse_data_uri,
     redact_blob_message_parts,
-    get_modality_from_mime_type,
-    transform_openai_content_part,
     transform_anthropic_content_part,
-    transform_google_content_part,
-    transform_generic_content_part,
     transform_content_part,
+    transform_generic_content_part,
+    transform_google_content_part,
     transform_message_content,
+    transform_openai_content_part,
+    truncate_and_annotate_messages,
+    truncate_messages_by_size,
 )
 from sentry_sdk.utils import safe_serialize
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,29 +1,27 @@
-import pytest
-
 import re
 from unittest import mock
+
+import pytest
 
 import sentry_sdk
 from sentry_sdk import (
     capture_exception,
+    configure_scope,
     continue_trace,
     get_baggage,
     get_client,
+    get_current_scope,
     get_current_span,
+    get_global_scope,
+    get_isolation_scope,
     get_traceparent,
     is_initialized,
-    start_transaction,
-    set_tags,
-    configure_scope,
     push_scope,
-    get_global_scope,
-    get_current_scope,
-    get_isolation_scope,
+    set_tags,
+    start_transaction,
 )
-
-from sentry_sdk.tracing import Span
-
 from sentry_sdk.client import Client, NonRecordingClient
+from sentry_sdk.tracing import Span
 from tests.conftest import TestTransportWithOptions
 
 

--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -7,24 +7,23 @@ import time
 from collections import Counter
 
 import pytest
-from sentry_sdk.client import Client
-from sentry_sdk.utils import datetime_from_isoformat
 
 import sentry_sdk
 import sentry_sdk.scope
 from sentry_sdk import (
-    get_client,
-    push_scope,
+    Hub,
+    add_breadcrumb,
     capture_event,
     capture_exception,
     capture_message,
-    start_transaction,
-    last_event_id,
-    add_breadcrumb,
+    get_client,
     isolation_scope,
+    last_event_id,
     new_scope,
-    Hub,
+    push_scope,
+    start_transaction,
 )
+from sentry_sdk.client import Client
 from sentry_sdk.integrations import (
     _AUTO_ENABLING_INTEGRATIONS,
     _DEFAULT_INTEGRATIONS,
@@ -35,8 +34,8 @@ from sentry_sdk.integrations import (
 from sentry_sdk.integrations.logging import LoggingIntegration
 from sentry_sdk.integrations.stdlib import StdlibIntegration
 from sentry_sdk.scope import add_global_event_processor
-from sentry_sdk.utils import get_sdk_name, reraise
 from sentry_sdk.tracing_utils import has_tracing_enabled
+from sentry_sdk.utils import datetime_from_isoformat, get_sdk_name, reraise
 
 
 class NoOpIntegration(Integration):

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,6 +1,6 @@
 import contextlib
-import os
 import json
+import os
 import subprocess
 import sys
 import time
@@ -13,24 +13,24 @@ import pytest
 
 import sentry_sdk
 from sentry_sdk import (
-    Hub,
     Client,
+    Hub,
     add_breadcrumb,
-    configure_scope,
-    capture_message,
-    capture_exception,
     capture_event,
+    capture_exception,
+    capture_message,
+    configure_scope,
     set_tag,
     start_transaction,
 )
-from sentry_sdk.spotlight import DEFAULT_SPOTLIGHT_URL
-from sentry_sdk.utils import capture_internal_exception
-from sentry_sdk.integrations.executing import ExecutingIntegration
-from sentry_sdk.integrations.asyncio import AsyncioIntegration
-from sentry_sdk.transport import Transport, AsyncHttpTransport
-from sentry_sdk.serializer import MAX_DATABAG_BREADTH
-from sentry_sdk.consts import DEFAULT_MAX_BREADCRUMBS, DEFAULT_MAX_VALUE_LENGTH
 from sentry_sdk._compat import PY38
+from sentry_sdk.consts import DEFAULT_MAX_BREADCRUMBS, DEFAULT_MAX_VALUE_LENGTH
+from sentry_sdk.integrations.asyncio import AsyncioIntegration
+from sentry_sdk.integrations.executing import ExecutingIntegration
+from sentry_sdk.serializer import MAX_DATABAG_BREADTH
+from sentry_sdk.spotlight import DEFAULT_SPOTLIGHT_URL
+from sentry_sdk.transport import AsyncHttpTransport, Transport
+from sentry_sdk.utils import capture_internal_exception
 
 try:
     import gevent  # noqa: F401
@@ -48,6 +48,7 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from collections.abc import Callable
     from typing import Any, Optional, Union
+
     from sentry_sdk._types import Event
 
 

--- a/tests/test_crons.py
+++ b/tests/test_crons.py
@@ -4,7 +4,6 @@ from unittest import mock
 import pytest
 
 import sentry_sdk
-
 from sentry_sdk.crons import capture_checkin
 
 

--- a/tests/test_envelope.py
+++ b/tests/test_envelope.py
@@ -1,7 +1,7 @@
+import sentry_sdk.client
+from sentry_sdk import capture_event
 from sentry_sdk.envelope import Envelope, Item, PayloadRef
 from sentry_sdk.session import Session
-from sentry_sdk import capture_event
-import sentry_sdk.client
 
 
 def generate_transaction_item():

--- a/tests/test_exceptiongroup.py
+++ b/tests/test_exceptiongroup.py
@@ -1,8 +1,8 @@
 import sys
+
 import pytest
 
 from sentry_sdk.utils import event_from_exception
-
 
 try:
     # Python 3.11

--- a/tests/test_feature_flags.py
+++ b/tests/test_feature_flags.py
@@ -1,13 +1,13 @@
 import concurrent.futures as cf
-import sys
 import copy
+import sys
 import threading
 
 import pytest
 
 import sentry_sdk
-from sentry_sdk.feature_flags import add_feature_flag, FlagBuffer
 from sentry_sdk import start_span, start_transaction
+from sentry_sdk.feature_flags import FlagBuffer, add_feature_flag
 from tests.conftest import ApproxDict
 
 

--- a/tests/test_gevent.py
+++ b/tests/test_gevent.py
@@ -2,10 +2,10 @@ import logging
 import pickle
 from datetime import datetime, timezone
 
+import pytest
+
 import sentry_sdk
 from sentry_sdk._compat import PY37, PY38
-
-import pytest
 from tests.conftest import CapturingServer
 
 pytest.importorskip("gevent")

--- a/tests/test_logs.py
+++ b/tests/test_logs.py
@@ -2,9 +2,9 @@ import logging
 import os
 import sys
 import time
+from unittest import mock
 
 import pytest
-from unittest import mock
 
 import sentry_sdk
 import sentry_sdk.logger

--- a/tests/test_propagationcontext.py
+++ b/tests/test_propagationcontext.py
@@ -5,7 +5,6 @@ import pytest
 
 from sentry_sdk.tracing_utils import PropagationContext
 
-
 SAMPLED_FLAG = {
     None: "",
     False: "-0",

--- a/tests/test_scope.py
+++ b/tests/test_scope.py
@@ -1,7 +1,8 @@
 import copy
 import os
-import pytest
 from unittest import mock
+
+import pytest
 
 import sentry_sdk
 from sentry_sdk import (
@@ -13,11 +14,11 @@ from sentry_sdk.client import Client, NonRecordingClient
 from sentry_sdk.scope import (
     Scope,
     ScopeType,
-    use_isolation_scope,
-    use_scope,
-    should_send_default_pii,
     register_external_propagation_context,
     remove_external_propagation_context,
+    should_send_default_pii,
+    use_isolation_scope,
+    use_scope,
 )
 
 

--- a/tests/test_scrubber.py
+++ b/tests/test_scrubber.py
@@ -1,11 +1,10 @@
-import sys
 import logging
+import sys
 
-from sentry_sdk import capture_exception, capture_event, start_transaction, start_span
-from sentry_sdk.utils import event_from_exception
+from sentry_sdk import capture_event, capture_exception, start_span, start_transaction
 from sentry_sdk.scrubber import EventScrubber
+from sentry_sdk.utils import event_from_exception
 from tests.conftest import ApproxDict
-
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.DEBUG)

--- a/tests/test_serializer.py
+++ b/tests/test_serializer.py
@@ -6,8 +6,8 @@ from sentry_sdk.consts import DEFAULT_MAX_VALUE_LENGTH
 from sentry_sdk.serializer import MAX_DATABAG_BREADTH, MAX_DATABAG_DEPTH, serialize
 
 try:
-    from hypothesis import given
     import hypothesis.strategies as st
+    from hypothesis import given
 except ImportError:
     pass
 else:

--- a/tests/test_shadowed_module.py
+++ b/tests/test_shadowed_module.py
@@ -1,9 +1,10 @@
-import sys
 import ast
-import types
-import pkgutil
 import importlib
 import pathlib
+import pkgutil
+import sys
+import types
+
 import pytest
 
 from sentry_sdk import integrations

--- a/tests/test_tracing_utils.py
+++ b/tests/test_tracing_utils.py
@@ -1,11 +1,12 @@
-import pytest
 from dataclasses import asdict, dataclass
-from typing import Optional, List
+from typing import List, Optional
+
+import pytest
 
 from sentry_sdk.tracing_utils import (
+    Baggage,
     _should_be_included,
     _should_continue_trace,
-    Baggage,
 )
 from tests.conftest import TestTransportWithOptions
 

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -1,6 +1,7 @@
 import sys
 
 import pytest
+
 from sentry_sdk.types import Event, Hint
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,40 +1,40 @@
-import threading
 import re
 import sys
-from datetime import timedelta, datetime, timezone
+import threading
+from datetime import datetime, timedelta, timezone
 from unittest import mock
 
 import pytest
 
 import sentry_sdk
-from sentry_sdk.integrations import Integration
 from sentry_sdk._queue import Queue
+from sentry_sdk.integrations import Integration
 from sentry_sdk.utils import (
     Components,
     Dsn,
+    _get_installed_modules,
     datetime_from_isoformat,
+    ensure_integration_enabled,
     env_to_bool,
+    exc_info_from_error,
     format_timestamp,
     get_current_thread_meta,
     get_default_release,
     get_error_message,
     get_git_revision,
+    get_lines_from_file,
+    is_sentry_url,
     is_valid_sample_rate,
     logger,
     match_regex_list,
+    package_version,
     parse_url,
     parse_version,
+    safe_serialize,
     safe_str,
     sanitize_url,
     serialize_frame,
-    is_sentry_url,
-    _get_installed_modules,
-    ensure_integration_enabled,
     to_string,
-    exc_info_from_error,
-    get_lines_from_file,
-    package_version,
-    safe_serialize,
 )
 
 

--- a/tests/tracing/test_ignore_status_codes.py
+++ b/tests/tracing/test_ignore_status_codes.py
@@ -1,9 +1,9 @@
-import sentry_sdk
-from sentry_sdk import start_transaction, start_span
+from collections import Counter
 
 import pytest
 
-from collections import Counter
+import sentry_sdk
+from sentry_sdk import start_span, start_transaction
 
 
 def test_no_ignored_codes(sentry_init, capture_events):

--- a/tests/tracing/test_integration_tests.py
+++ b/tests/tracing/test_integration_tests.py
@@ -9,9 +9,9 @@ import pytest
 import sentry_sdk
 from sentry_sdk import (
     capture_message,
+    continue_trace,
     start_span,
     start_transaction,
-    continue_trace,
 )
 from sentry_sdk.consts import SPANSTATUS
 from sentry_sdk.transport import Transport

--- a/tests/tracing/test_misc.py
+++ b/tests/tracing/test_misc.py
@@ -1,12 +1,13 @@
-import pytest
 import gc
-import uuid
 import os
+import uuid
 from unittest import mock
 from unittest.mock import MagicMock
 
+import pytest
+
 import sentry_sdk
-from sentry_sdk import start_span, start_transaction, set_measurement
+from sentry_sdk import set_measurement, start_span, start_transaction
 from sentry_sdk.consts import MATCH_ALL
 from sentry_sdk.tracing import Span, Transaction
 from sentry_sdk.tracing_utils import should_propagate_trace

--- a/tests/tracing/test_propagation.py
+++ b/tests/tracing/test_propagation.py
@@ -1,5 +1,6 @@
-import sentry_sdk
 import pytest
+
+import sentry_sdk
 
 
 def test_standalone_span_iter_headers(sentry_init):

--- a/tests/tracing/test_sampling.py
+++ b/tests/tracing/test_sampling.py
@@ -5,7 +5,7 @@ from unittest import mock
 import pytest
 
 import sentry_sdk
-from sentry_sdk import start_span, start_transaction, capture_exception
+from sentry_sdk import capture_exception, start_span, start_transaction
 from sentry_sdk.tracing_utils import Baggage
 from sentry_sdk.utils import logger
 

--- a/tests/tracing/test_span_origin.py
+++ b/tests/tracing/test_span_origin.py
@@ -1,4 +1,4 @@
-from sentry_sdk import start_transaction, start_span
+from sentry_sdk import start_span, start_transaction
 
 
 def test_span_origin_manual(sentry_init, capture_events):

--- a/tests/tracing/test_span_streaming.py
+++ b/tests/tracing/test_span_streaming.py
@@ -10,7 +10,6 @@ import sentry_sdk
 from sentry_sdk.profiler.continuous_profiler import get_profiler_id
 from sentry_sdk.traces import NoOpStreamedSpan, SpanStatus, StreamedSpan
 
-
 minimum_python_38 = pytest.mark.skipif(
     sys.version_info < (3, 8), reason="Asyncio tests need Python >= 3.8"
 )

--- a/tests/utils/test_contextvars.py
+++ b/tests/utils/test_contextvars.py
@@ -1,7 +1,8 @@
-import pytest
 import random
 import time
 from unittest import mock
+
+import pytest
 
 
 def _run_contextvar_threaded_test():
@@ -9,7 +10,6 @@ def _run_contextvar_threaded_test():
 
     # Need to explicitly call _get_contextvars because the SDK has already
     # decided upon gevent on import.
-
     from sentry_sdk import utils
 
     _, ContextVar = utils._get_contextvars()  # noqa: N806

--- a/tests/utils/test_general.py
+++ b/tests/utils/test_general.py
@@ -1,29 +1,27 @@
-import sys
 import os
+import sys
 
 import pytest
+
 from sentry_sdk.ai.utils import _normalize_data
-
-
+from sentry_sdk.consts import EndpointType
 from sentry_sdk.utils import (
+    AnnotatedValue,
     BadDsn,
     Dsn,
-    safe_repr,
     exceptions_from_error_tuple,
     filename_for_module,
-    iter_event_stacktraces,
-    to_base64,
     from_base64,
+    iter_event_stacktraces,
+    safe_repr,
     set_in_app_in_frames,
     strip_string,
-    AnnotatedValue,
+    to_base64,
 )
-from sentry_sdk.consts import EndpointType
-
 
 try:
-    from hypothesis import given
     import hypothesis.strategies as st
+    from hypothesis import given
 except ImportError:
     pass
 else:


### PR DESCRIPTION
### Description
<!-- What changed and why? -->

Add "I" to the `[tool.ruff.lint]` section in `pyproject.toml`.

To prevent the introduction of circular imports:
- Add `isort: skip` to `sentry_sdk/__init__.py`.
- Consolidate `LegacySpan` import in `tracing_utils.py` with import at the end of the file.

Run 

```bash
ruff check --fix
```

#### Issues
<!--
* resolves: #1234
* resolves: LIN-1234
-->

#### Reminders
- Please add tests to validate your changes, and lint your code using `tox -e linters`.
- Add GH Issue ID _&_ Linear ID (if applicable)
- PR title should use [conventional commit](https://develop.sentry.dev/engineering-practices/commit-messages/#type) style (`feat:`, `fix:`, `ref:`, `meta:`)
- For external contributors: [CONTRIBUTING.md](https://github.com/getsentry/sentry-python/blob/master/CONTRIBUTING.md), [Sentry SDK development docs](https://develop.sentry.dev/sdk/), [Discord community](https://discord.gg/Ww9hbqr)
