### PR TITLE
fix(boto3): Guard setting method

### DIFF
--- a/sentry_sdk/integrations/boto3.py
+++ b/sentry_sdk/integrations/boto3.py
@@ -99,7 +99,8 @@ def _sentry_request_created(
 
         span.set_tag("aws.service_id", service_id.hyphenize())
         span.set_tag("aws.operation_name", operation_name)
-        span.set_data(SPANDATA.HTTP_METHOD, request.method)
+        if request.method is not None:
+            span.set_data(SPANDATA.HTTP_METHOD, request.method)
 
     # We do it in order for subsequent http calls/retries be
     # attached to this span.


### PR DESCRIPTION
### Description
Check that `request.method` is not `None` before setting it. We do this in the span streaming path but not in legacy tracing.

#### Issues
- Closes https://linear.app/getsentry/issue/PY-2406/guard-setting-requestmethod-in-boto3-integration
- Closes https://github.com/getsentry/sentry-python/issues/6212

#### Reminders
- Please add tests to validate your changes, and lint your code using `tox -e linters`.
- Add GH Issue ID _&_ Linear ID (if applicable)
- PR title should use [conventional commit](https://develop.sentry.dev/engineering-practices/commit-messages/#type) style (`feat:`, `fix:`, `ref:`, `meta:`)
- For external contributors: [CONTRIBUTING.md](https://github.com/getsentry/sentry-python/blob/master/CONTRIBUTING.md), [Sentry SDK development docs](https://develop.sentry.dev/sdk/), [Discord community](https://discord.gg/Ww9hbqr)
