### PR TITLE
fix(strawberry): Fix `AttributeError` on `graphql_span` in `resolve`

### DIFF
--- a/sentry_sdk/integrations/strawberry.py
+++ b/sentry_sdk/integrations/strawberry.py
@@ -119,9 +119,9 @@ def _patch_schema_init() -> None:
         ]
 
         # add our extension
-        extensions.append(
+        extensions = [
             SentryAsyncExtension if should_use_async_extension else SentrySyncExtension
-        )
+        ] + extensions
 
         kwargs["extensions"] = extensions
 
@@ -263,7 +263,7 @@ class SentryAsyncExtension(SchemaExtension):
 
         field_path = "{}.{}".format(info.parent_type, info.field_name)
 
-        with self.graphql_span.start_child(
+        with sentry_sdk.start_span(
             op=OP.GRAPHQL_RESOLVE,
             name="resolving {}".format(field_path),
             origin=StrawberryIntegration.origin,
@@ -290,7 +290,7 @@ class SentrySyncExtension(SentryAsyncExtension):
 
         field_path = "{}.{}".format(info.parent_type, info.field_name)
 
-        with self.graphql_span.start_child(
+        with sentry_sdk.start_span(
             op=OP.GRAPHQL_RESOLVE,
             name="resolving {}".format(field_path),
             origin=StrawberryIntegration.origin,

--- a/sentry_sdk/integrations/strawberry.py
+++ b/sentry_sdk/integrations/strawberry.py
@@ -152,7 +152,7 @@ class SentryAsyncExtension(SchemaExtension):
         return hashlib.md5(query.encode("utf-8")).hexdigest()
 
     def on_operation(self) -> "Generator[None, None, None]":
-        self._operation_name = self.execution_context.operation_name
+        operation_name = self.execution_context.operation_name
 
         operation_type = "query"
         op = OP.GRAPHQL_QUERY
@@ -168,13 +168,13 @@ class SentryAsyncExtension(SchemaExtension):
             op = OP.GRAPHQL_SUBSCRIPTION
 
         description = operation_type
-        if self._operation_name:
-            description += " {}".format(self._operation_name)
+        if operation_name:
+            description += " {}".format(operation_name)
 
         sentry_sdk.add_breadcrumb(
             category="graphql.operation",
             data={
-                "operation_name": self._operation_name,
+                "operation_name": operation_name,
                 "operation_type": operation_type,
             },
         )
@@ -183,31 +183,31 @@ class SentryAsyncExtension(SchemaExtension):
         event_processor = _make_request_event_processor(self.execution_context)
         scope.add_event_processor(event_processor)
 
-        self.graphql_span = sentry_sdk.start_span(
+        graphql_span = sentry_sdk.start_span(
             op=op,
             name=description,
             origin=StrawberryIntegration.origin,
         )
-        self.graphql_span.__enter__()
+        graphql_span.__enter__()
 
-        self.graphql_span.set_data("graphql.operation.type", operation_type)
-        self.graphql_span.set_data("graphql.operation.name", self._operation_name)
+        graphql_span.set_data("graphql.operation.type", operation_type)
+        graphql_span.set_data("graphql.operation.name", operation_name)
         if should_send_default_pii():
-            self.graphql_span.set_data("graphql.document", self.execution_context.query)
-        self.graphql_span.set_data("graphql.resource_name", self._resource_name)
+            graphql_span.set_data("graphql.document", self.execution_context.query)
+        graphql_span.set_data("graphql.resource_name", self._resource_name)
 
         yield
 
-        transaction = self.graphql_span.containing_transaction
+        transaction = graphql_span.containing_transaction
         if transaction and self.execution_context.operation_name:
             transaction.name = self.execution_context.operation_name
             transaction.source = TransactionSource.COMPONENT
             transaction.op = op
 
-        self.graphql_span.__exit__(None, None, None)
+        graphql_span.__exit__(None, None, None)
 
     def on_validate(self) -> "Generator[None, None, None]":
-        self.validation_span = sentry_sdk.start_span(
+        validation_span = sentry_sdk.start_span(
             op=OP.GRAPHQL_VALIDATE,
             name="validation",
             origin=StrawberryIntegration.origin,
@@ -215,10 +215,10 @@ class SentryAsyncExtension(SchemaExtension):
 
         yield
 
-        self.validation_span.finish()
+        validation_span.finish()
 
     def on_parse(self) -> "Generator[None, None, None]":
-        self.parsing_span = sentry_sdk.start_span(
+        parsing_span = sentry_sdk.start_span(
             op=OP.GRAPHQL_PARSE,
             name="parsing",
             origin=StrawberryIntegration.origin,
@@ -226,7 +226,7 @@ class SentryAsyncExtension(SchemaExtension):
 
         yield
 
-        self.parsing_span.finish()
+        parsing_span.finish()
 
     def should_skip_tracing(
         self,

--- a/sentry_sdk/integrations/strawberry.py
+++ b/sentry_sdk/integrations/strawberry.py
@@ -207,7 +207,7 @@ class SentryAsyncExtension(SchemaExtension):
         self.graphql_span.__exit__(None, None, None)
 
     def on_validate(self) -> "Generator[None, None, None]":
-        self.validation_span = self.graphql_span.start_child(
+        self.validation_span = sentry_sdk.start_span(
             op=OP.GRAPHQL_VALIDATE,
             name="validation",
             origin=StrawberryIntegration.origin,
@@ -218,7 +218,7 @@ class SentryAsyncExtension(SchemaExtension):
         self.validation_span.finish()
 
     def on_parse(self) -> "Generator[None, None, None]":
-        self.parsing_span = self.graphql_span.start_child(
+        self.parsing_span = sentry_sdk.start_span(
             op=OP.GRAPHQL_PARSE,
             name="parsing",
             origin=StrawberryIntegration.origin,


### PR DESCRIPTION
Strawberry's `MiddlewareManager` is cached on the schema, so `resolve()` runs on stale extension instances from the first request. Use `start_span()` instead of `self.graphql_span.start_child()` so resolve spans parent correctly via the scope rather than relying on instance state.

Also prepend (rather than append) the Sentry extension so it wraps all other extensions as the outermost layer and captures the whole request.

Also make all instance variables that are only used in one method local.

### Description
<!-- What changed and why? -->

#### Issues

- Closes https://github.com/getsentry/sentry-python/issues/4991
- Closes https://linear.app/getsentry/issue/PY-1919/strawberry-uncaught-exception

#### Reminders
- Please add tests to validate your changes, and lint your code using `tox -e linters`.
- Add GH Issue ID _&_ Linear ID (if applicable)
- PR title should use [conventional commit](https://develop.sentry.dev/engineering-practices/commit-messages/#type) style (`feat:`, `fix:`, `ref:`, `meta:`)
- For external contributors: [CONTRIBUTING.md](https://github.com/getsentry/sentry-python/blob/master/CONTRIBUTING.md), [Sentry SDK development docs](https://develop.sentry.dev/sdk/), [Discord community](https://discord.gg/Ww9hbqr)
