### PR TITLE
feat: Disable string truncation for events by default

### DIFF
--- a/sentry_sdk/consts.py
+++ b/sentry_sdk/consts.py
@@ -2,11 +2,7 @@ import itertools
 from enum import Enum
 from typing import TYPE_CHECKING
 
-# up top to prevent circular import due to integration import
-# This is more or less an arbitrary large-ish value for now, so that we allow
-# pretty long strings (like LLM prompts), but still have *some* upper limit
-# until we verify that removing the trimming completely is safe.
-DEFAULT_MAX_VALUE_LENGTH = 100_000
+DEFAULT_MAX_VALUE_LENGTH = None
 
 DEFAULT_MAX_STACK_FRAMES = 100
 DEFAULT_ADD_FULL_STACK = False
@@ -1233,7 +1229,7 @@ class ClientConstructor:
         ],
         functions_to_trace: "Sequence[Dict[str, str]]" = [],  # noqa: B006
         event_scrubber: "Optional[sentry_sdk.scrubber.EventScrubber]" = None,
-        max_value_length: int = DEFAULT_MAX_VALUE_LENGTH,
+        max_value_length: "Optional[int]" = DEFAULT_MAX_VALUE_LENGTH,
         enable_backpressure_handling: bool = True,
         error_sampler: "Optional[Callable[[Event, Hint], Union[float, bool]]]" = None,
         enable_db_query_source: bool = True,

--- a/sentry_sdk/serializer.py
+++ b/sentry_sdk/serializer.py
@@ -103,7 +103,7 @@ def serialize(event: "Dict[str, Any]", **kwargs: "Any") -> "Dict[str, Any]":
     * Annotating the payload with the _meta field whenever trimming happens.
 
     :param max_request_body_size: If set to "always", will never trim request bodies.
-    :param max_value_length: The max length to strip strings to, defaults to sentry_sdk.consts.DEFAULT_MAX_VALUE_LENGTH
+    :param max_value_length: The max length to strip strings to, or None to disable string truncation. Defaults to None.
     :param is_vars: If we're serializing vars early, we want to repr() things that are JSON-serializable to make their type more apparent. For example, it's useful to see the difference between a unicode-string and a bytestring when viewing a stacktrace.
     :param custom_repr: A custom repr function that runs before safe_repr on the object to be serialized. If it returns None or throws internally, we will fallback to safe_repr.
 

--- a/sentry_sdk/utils.py
+++ b/sentry_sdk/utils.py
@@ -40,7 +40,6 @@ from sentry_sdk._types import SENSITIVE_DATA_SUBSTITUTE, Annotated, AnnotatedVal
 from sentry_sdk.consts import (
     DEFAULT_ADD_FULL_STACK,
     DEFAULT_MAX_STACK_FRAMES,
-    DEFAULT_MAX_VALUE_LENGTH,
     EndpointType,
 )
 
@@ -754,7 +753,7 @@ def single_exception_from_error_tuple(
     if client_options is None:
         include_local_variables = True
         include_source_context = True
-        max_value_length = DEFAULT_MAX_VALUE_LENGTH  # fallback
+        max_value_length = None  # fallback
         custom_repr = None
     else:
         include_local_variables = client_options["include_local_variables"]
@@ -1268,11 +1267,8 @@ def _get_size_in_bytes(value: str) -> "Optional[int]":
 def strip_string(
     value: str, max_length: "Optional[int]" = None
 ) -> "Union[AnnotatedValue, str]":
-    if not value:
+    if not value or max_length is None:
         return value
-
-    if max_length is None:
-        max_length = DEFAULT_MAX_VALUE_LENGTH
 
     byte_size = _get_size_in_bytes(value)
     text_size = len(value)

--- a/tests/integrations/bottle/test_bottle.py
+++ b/tests/integrations/bottle/test_bottle.py
@@ -9,7 +9,6 @@ from werkzeug.test import Client
 from werkzeug.wrappers import Response
 
 from sentry_sdk import capture_message
-from sentry_sdk.consts import DEFAULT_MAX_VALUE_LENGTH
 from sentry_sdk.integrations.bottle import BottleIntegration
 from sentry_sdk.integrations.logging import LoggingIntegration
 from sentry_sdk.serializer import MAX_DATABAG_BREADTH
@@ -122,10 +121,17 @@ def test_errors(
     assert event["exception"]["values"][0]["mechanism"]["handled"] is False
 
 
-def test_large_json_request(sentry_init, capture_events, app, get_client):
-    sentry_init(integrations=[BottleIntegration()], max_request_body_size="always")
+@pytest.mark.parametrize("max_value_length", [1024, None])
+def test_large_json_request(
+    sentry_init, capture_events, app, get_client, max_value_length
+):
+    sentry_init(
+        integrations=[BottleIntegration()],
+        max_request_body_size="always",
+        max_value_length=max_value_length,
+    )
 
-    data = {"foo": {"bar": "a" * (DEFAULT_MAX_VALUE_LENGTH + 10)}}
+    data = {"foo": {"bar": "a" * (1034)}}
 
     @app.route("/", method="POST")
     def index():
@@ -145,15 +151,17 @@ def test_large_json_request(sentry_init, capture_events, app, get_client):
     assert response[1] == "200 OK"
 
     (event,) = events
-    assert event["_meta"]["request"]["data"]["foo"]["bar"] == {
-        "": {
-            "len": DEFAULT_MAX_VALUE_LENGTH + 10,
-            "rem": [
-                ["!limit", "x", DEFAULT_MAX_VALUE_LENGTH - 3, DEFAULT_MAX_VALUE_LENGTH]
-            ],
+
+    if max_value_length:
+        assert event["_meta"]["request"]["data"]["foo"]["bar"] == {
+            "": {
+                "len": 1034,
+                "rem": [["!limit", "x", 1021, 1024]],
+            }
         }
-    }
-    assert len(event["request"]["data"]["foo"]["bar"]) == DEFAULT_MAX_VALUE_LENGTH
+        assert len(event["request"]["data"]["foo"]["bar"]) == 1024
+    else:
+        assert len(event["request"]["data"]["foo"]["bar"]) == 1034
 
 
 @pytest.mark.parametrize("data", [{}, []], ids=["empty-dict", "empty-list"])
@@ -180,10 +188,17 @@ def test_empty_json_request(sentry_init, capture_events, app, data, get_client):
     assert event["request"]["data"] == data
 
 
-def test_medium_formdata_request(sentry_init, capture_events, app, get_client):
-    sentry_init(integrations=[BottleIntegration()], max_request_body_size="always")
+@pytest.mark.parametrize("max_value_length", [1024, None])
+def test_medium_formdata_request(
+    sentry_init, capture_events, app, get_client, max_value_length
+):
+    sentry_init(
+        integrations=[BottleIntegration()],
+        max_request_body_size="always",
+        max_value_length=max_value_length,
+    )
 
-    data = {"foo": "a" * (DEFAULT_MAX_VALUE_LENGTH + 10)}
+    data = {"foo": "a" * (1034)}
 
     @app.route("/", method="POST")
     def index():
@@ -200,15 +215,17 @@ def test_medium_formdata_request(sentry_init, capture_events, app, get_client):
     assert response[1] == "200 OK"
 
     (event,) = events
-    assert event["_meta"]["request"]["data"]["foo"] == {
-        "": {
-            "len": DEFAULT_MAX_VALUE_LENGTH + 10,
-            "rem": [
-                ["!limit", "x", DEFAULT_MAX_VALUE_LENGTH - 3, DEFAULT_MAX_VALUE_LENGTH]
-            ],
+
+    if max_value_length:
+        assert event["_meta"]["request"]["data"]["foo"] == {
+            "": {
+                "len": 1034,
+                "rem": [["!limit", "x", 1021, 1024]],
+            }
         }
-    }
-    assert len(event["request"]["data"]["foo"]) == DEFAULT_MAX_VALUE_LENGTH
+        assert len(event["request"]["data"]["foo"]) == 1024
+    else:
+        assert len(event["request"]["data"]["foo"]) == 1034
 
 
 @pytest.mark.parametrize("input_char", ["a", b"a"])
@@ -242,11 +259,16 @@ def test_too_large_raw_request(
     assert not event["request"]["data"]
 
 
-def test_files_and_form(sentry_init, capture_events, app, get_client):
-    sentry_init(integrations=[BottleIntegration()], max_request_body_size="always")
+@pytest.mark.parametrize("max_value_length", [1024, None])
+def test_files_and_form(sentry_init, capture_events, app, get_client, max_value_length):
+    sentry_init(
+        integrations=[BottleIntegration()],
+        max_request_body_size="always",
+        max_value_length=max_value_length,
+    )
 
     data = {
-        "foo": "a" * (DEFAULT_MAX_VALUE_LENGTH + 10),
+        "foo": "a" * (1034),
         "file": (BytesIO(b"hello"), "hello.txt"),
     }
 
@@ -267,15 +289,16 @@ def test_files_and_form(sentry_init, capture_events, app, get_client):
     assert response[1] == "200 OK"
 
     (event,) = events
-    assert event["_meta"]["request"]["data"]["foo"] == {
-        "": {
-            "len": DEFAULT_MAX_VALUE_LENGTH + 10,
-            "rem": [
-                ["!limit", "x", DEFAULT_MAX_VALUE_LENGTH - 3, DEFAULT_MAX_VALUE_LENGTH]
-            ],
+    if max_value_length:
+        assert event["_meta"]["request"]["data"]["foo"] == {
+            "": {
+                "len": 1034,
+                "rem": [["!limit", "x", 1021, 1024]],
+            }
         }
-    }
-    assert len(event["request"]["data"]["foo"]) == DEFAULT_MAX_VALUE_LENGTH
+        assert len(event["request"]["data"]["foo"]) == 1024
+    else:
+        assert len(event["request"]["data"]["foo"]) == 1034
 
     assert event["_meta"]["request"]["data"]["file"] == {
         "": {

--- a/tests/integrations/falcon/test_falcon.py
+++ b/tests/integrations/falcon/test_falcon.py
@@ -5,7 +5,6 @@ import falcon.testing
 import pytest
 
 import sentry_sdk
-from sentry_sdk.consts import DEFAULT_MAX_VALUE_LENGTH
 from sentry_sdk.integrations.falcon import FalconIntegration
 from sentry_sdk.integrations.logging import LoggingIntegration
 from sentry_sdk.utils import parse_version
@@ -206,10 +205,15 @@ def test_http_status(sentry_init, capture_exceptions, capture_events):
     assert len(events) == 0
 
 
-def test_falcon_large_json_request(sentry_init, capture_events):
-    sentry_init(integrations=[FalconIntegration()], max_request_body_size="always")
+@pytest.mark.parametrize("max_value_length", [1024, None])
+def test_falcon_large_json_request(sentry_init, capture_events, max_value_length):
+    sentry_init(
+        integrations=[FalconIntegration()],
+        max_request_body_size="always",
+        max_value_length=max_value_length,
+    )
 
-    data = {"foo": {"bar": "a" * (DEFAULT_MAX_VALUE_LENGTH + 10)}}
+    data = {"foo": {"bar": "a" * (1034)}}
 
     class Resource:
         def on_post(self, req, resp):
@@ -227,15 +231,16 @@ def test_falcon_large_json_request(sentry_init, capture_events):
     assert response.status == falcon.HTTP_200
 
     (event,) = events
-    assert event["_meta"]["request"]["data"]["foo"]["bar"] == {
-        "": {
-            "len": DEFAULT_MAX_VALUE_LENGTH + 10,
-            "rem": [
-                ["!limit", "x", DEFAULT_MAX_VALUE_LENGTH - 3, DEFAULT_MAX_VALUE_LENGTH]
-            ],
+    if max_value_length:
+        assert event["_meta"]["request"]["data"]["foo"]["bar"] == {
+            "": {
+                "len": 1034,
+                "rem": [["!limit", "x", 1021, 1024]],
+            }
         }
-    }
-    assert len(event["request"]["data"]["foo"]["bar"]) == DEFAULT_MAX_VALUE_LENGTH
+        assert len(event["request"]["data"]["foo"]["bar"]) == 1024
+    else:
+        assert len(event["request"]["data"]["foo"]["bar"]) == 1034
 
 
 @pytest.mark.parametrize("data", [{}, []], ids=["empty-dict", "empty-list"])

--- a/tests/integrations/flask/test_flask.py
+++ b/tests/integrations/flask/test_flask.py
@@ -27,7 +27,6 @@ from sentry_sdk import (
     capture_message,
     set_tag,
 )
-from sentry_sdk.consts import DEFAULT_MAX_VALUE_LENGTH
 from sentry_sdk.integrations.logging import LoggingIntegration
 from sentry_sdk.serializer import MAX_DATABAG_BREADTH
 
@@ -247,12 +246,15 @@ def test_flask_login_configured(
         assert event["user"]["id"] == str(user_id)
 
 
-def test_flask_large_json_request(sentry_init, capture_events, app):
+@pytest.mark.parametrize("max_value_length", [1024, None])
+def test_flask_large_json_request(sentry_init, capture_events, app, max_value_length):
     sentry_init(
-        integrations=[flask_sentry.FlaskIntegration()], max_request_body_size="always"
+        integrations=[flask_sentry.FlaskIntegration()],
+        max_request_body_size="always",
+        max_value_length=max_value_length,
     )
 
-    data = {"foo": {"bar": "a" * (DEFAULT_MAX_VALUE_LENGTH + 10)}}
+    data = {"foo": {"bar": "a" * (1034)}}
 
     @app.route("/", methods=["POST"])
     def index():
@@ -269,15 +271,16 @@ def test_flask_large_json_request(sentry_init, capture_events, app):
     assert response.status_code == 200
 
     (event,) = events
-    assert event["_meta"]["request"]["data"]["foo"]["bar"] == {
-        "": {
-            "len": DEFAULT_MAX_VALUE_LENGTH + 10,
-            "rem": [
-                ["!limit", "x", DEFAULT_MAX_VALUE_LENGTH - 3, DEFAULT_MAX_VALUE_LENGTH]
-            ],
+    if max_value_length:
+        assert event["_meta"]["request"]["data"]["foo"]["bar"] == {
+            "": {
+                "len": 1034,
+                "rem": [["!limit", "x", 1021, 1024]],
+            }
         }
-    }
-    assert len(event["request"]["data"]["foo"]["bar"]) == DEFAULT_MAX_VALUE_LENGTH
+        assert len(event["request"]["data"]["foo"]["bar"]) == 1024
+    else:
+        assert len(event["request"]["data"]["foo"]["bar"]) == 1034
 
 
 def test_flask_session_tracking(sentry_init, capture_envelopes, app):
@@ -342,12 +345,17 @@ def test_flask_empty_json_request(sentry_init, capture_events, app, data):
     assert event["request"]["data"] == data
 
 
-def test_flask_medium_formdata_request(sentry_init, capture_events, app):
+@pytest.mark.parametrize("max_value_length", [1024, None])
+def test_flask_medium_formdata_request(
+    sentry_init, capture_events, app, max_value_length
+):
     sentry_init(
-        integrations=[flask_sentry.FlaskIntegration()], max_request_body_size="always"
+        integrations=[flask_sentry.FlaskIntegration()],
+        max_request_body_size="always",
+        max_value_length=max_value_length,
     )
 
-    data = {"foo": "a" * (DEFAULT_MAX_VALUE_LENGTH + 10)}
+    data = {"foo": "a" * (1034)}
 
     @app.route("/", methods=["POST"])
     def index():
@@ -368,15 +376,16 @@ def test_flask_medium_formdata_request(sentry_init, capture_events, app):
     assert response.status_code == 200
 
     (event,) = events
-    assert event["_meta"]["request"]["data"]["foo"] == {
-        "": {
-            "len": DEFAULT_MAX_VALUE_LENGTH + 10,
-            "rem": [
-                ["!limit", "x", DEFAULT_MAX_VALUE_LENGTH - 3, DEFAULT_MAX_VALUE_LENGTH]
-            ],
+    if max_value_length:
+        assert event["_meta"]["request"]["data"]["foo"] == {
+            "": {
+                "len": 1034,
+                "rem": [["!limit", "x", 1021, 1024]],
+            }
         }
-    }
-    assert len(event["request"]["data"]["foo"]) == DEFAULT_MAX_VALUE_LENGTH
+        assert len(event["request"]["data"]["foo"]) == 1024
+    else:
+        assert len(event["request"]["data"]["foo"]) == 1034
 
 
 def test_flask_formdata_request_appear_transaction_body(
@@ -450,13 +459,16 @@ def test_flask_too_large_raw_request(sentry_init, input_char, capture_events, ap
     assert not event["request"]["data"]
 
 
-def test_flask_files_and_form(sentry_init, capture_events, app):
+@pytest.mark.parametrize("max_value_length", [1024, None])
+def test_flask_files_and_form(sentry_init, capture_events, app, max_value_length):
     sentry_init(
-        integrations=[flask_sentry.FlaskIntegration()], max_request_body_size="always"
+        integrations=[flask_sentry.FlaskIntegration()],
+        max_request_body_size="always",
+        max_value_length=max_value_length,
     )
 
     data = {
-        "foo": "a" * (DEFAULT_MAX_VALUE_LENGTH + 10),
+        "foo": "a" * (1034),
         "file": (BytesIO(b"hello"), "hello.txt"),
     }
 
@@ -479,15 +491,16 @@ def test_flask_files_and_form(sentry_init, capture_events, app):
     assert response.status_code == 200
 
     (event,) = events
-    assert event["_meta"]["request"]["data"]["foo"] == {
-        "": {
-            "len": DEFAULT_MAX_VALUE_LENGTH + 10,
-            "rem": [
-                ["!limit", "x", DEFAULT_MAX_VALUE_LENGTH - 3, DEFAULT_MAX_VALUE_LENGTH]
-            ],
+    if max_value_length:
+        assert event["_meta"]["request"]["data"]["foo"] == {
+            "": {
+                "len": 1034,
+                "rem": [["!limit", "x", 1021, 1024]],
+            }
         }
-    }
-    assert len(event["request"]["data"]["foo"]) == DEFAULT_MAX_VALUE_LENGTH
+        assert len(event["request"]["data"]["foo"]) == 1024
+    else:
+        assert len(event["request"]["data"]["foo"]) == 1034
 
     assert event["_meta"]["request"]["data"]["file"] == {"": {"rem": [["!raw", "x"]]}}
     assert not event["request"]["data"]["file"]

--- a/tests/integrations/pyramid/test_pyramid.py
+++ b/tests/integrations/pyramid/test_pyramid.py
@@ -10,7 +10,6 @@ from pyramid.response import Response
 from werkzeug.test import Client
 
 from sentry_sdk import add_breadcrumb, capture_message
-from sentry_sdk.consts import DEFAULT_MAX_VALUE_LENGTH
 from sentry_sdk.integrations.pyramid import PyramidIntegration
 from sentry_sdk.serializer import MAX_DATABAG_BREADTH
 from tests.conftest import unpack_werkzeug_response
@@ -156,10 +155,17 @@ def test_transaction_style(
     assert event["transaction_info"] == {"source": expected_source}
 
 
-def test_large_json_request(sentry_init, capture_events, route, get_client):
-    sentry_init(integrations=[PyramidIntegration()], max_request_body_size="always")
+@pytest.mark.parametrize("max_value_length", [1024, None])
+def test_large_json_request(
+    sentry_init, capture_events, route, get_client, max_value_length
+):
+    sentry_init(
+        integrations=[PyramidIntegration()],
+        max_request_body_size="always",
+        max_value_length=max_value_length,
+    )
 
-    data = {"foo": {"bar": "a" * (DEFAULT_MAX_VALUE_LENGTH + 10)}}
+    data = {"foo": {"bar": "a" * (1034)}}
 
     @route("/")
     def index(request):
@@ -175,15 +181,17 @@ def test_large_json_request(sentry_init, capture_events, route, get_client):
     client.post("/", content_type="application/json", data=json.dumps(data))
 
     (event,) = events
-    assert event["_meta"]["request"]["data"]["foo"]["bar"] == {
-        "": {
-            "len": DEFAULT_MAX_VALUE_LENGTH + 10,
-            "rem": [
-                ["!limit", "x", DEFAULT_MAX_VALUE_LENGTH - 3, DEFAULT_MAX_VALUE_LENGTH]
-            ],
+
+    if max_value_length:
+        assert event["_meta"]["request"]["data"]["foo"]["bar"] == {
+            "": {
+                "len": 1034,
+                "rem": [["!limit", "x", 1021, 1024]],
+            }
         }
-    }
-    assert len(event["request"]["data"]["foo"]["bar"]) == DEFAULT_MAX_VALUE_LENGTH
+        assert len(event["request"]["data"]["foo"]["bar"]) == 1024
+    else:
+        assert len(event["request"]["data"]["foo"]["bar"]) == 1034
 
 
 @pytest.mark.parametrize("data", [{}, []], ids=["empty-dict", "empty-list"])
@@ -233,11 +241,18 @@ def test_json_not_truncated_if_max_request_body_size_is_always(
     assert event["request"]["data"] == data
 
 
-def test_files_and_form(sentry_init, capture_events, route, get_client):
-    sentry_init(integrations=[PyramidIntegration()], max_request_body_size="always")
+@pytest.mark.parametrize("max_value_length", [1024, None])
+def test_files_and_form(
+    sentry_init, capture_events, route, get_client, max_value_length
+):
+    sentry_init(
+        integrations=[PyramidIntegration()],
+        max_request_body_size="always",
+        max_value_length=max_value_length,
+    )
 
     data = {
-        "foo": "a" * (DEFAULT_MAX_VALUE_LENGTH + 10),
+        "foo": "a" * (1034),
         "file": (BytesIO(b"hello"), "hello.txt"),
     }
 
@@ -252,15 +267,16 @@ def test_files_and_form(sentry_init, capture_events, route, get_client):
     client.post("/", data=data)
 
     (event,) = events
-    assert event["_meta"]["request"]["data"]["foo"] == {
-        "": {
-            "len": DEFAULT_MAX_VALUE_LENGTH + 10,
-            "rem": [
-                ["!limit", "x", DEFAULT_MAX_VALUE_LENGTH - 3, DEFAULT_MAX_VALUE_LENGTH]
-            ],
+    if max_value_length:
+        assert event["_meta"]["request"]["data"]["foo"] == {
+            "": {
+                "len": 1034,
+                "rem": [["!limit", "x", 1021, 1024]],
+            }
         }
-    }
-    assert len(event["request"]["data"]["foo"]) == DEFAULT_MAX_VALUE_LENGTH
+        assert len(event["request"]["data"]["foo"]) == 1024
+    else:
+        assert len(event["request"]["data"]["foo"]) == 1034
 
     assert event["_meta"]["request"]["data"]["file"] == {"": {"rem": [["!raw", "x"]]}}
     assert not event["request"]["data"]["file"]

--- a/tests/integrations/sqlalchemy/test_sqlalchemy.py
+++ b/tests/integrations/sqlalchemy/test_sqlalchemy.py
@@ -10,7 +10,7 @@ from sqlalchemy.orm import relationship, sessionmaker
 
 import sentry_sdk
 from sentry_sdk import capture_message, start_transaction
-from sentry_sdk.consts import DEFAULT_MAX_VALUE_LENGTH, SPANDATA
+from sentry_sdk.consts import SPANDATA
 from sentry_sdk.integrations.sqlalchemy import SqlalchemyIntegration
 from sentry_sdk.serializer import MAX_EVENT_BYTES
 from sentry_sdk.tracing_utils import record_sql_queries_supporting_streaming
@@ -357,14 +357,16 @@ def test_long_sql_query_preserved(
         assert description.endswith("SELECT 98 UNION SELECT 99")
 
 
-def test_large_event_not_truncated(sentry_init, capture_events):
+@pytest.mark.parametrize("max_value_length", [1024, None])
+def test_large_event_not_truncated(sentry_init, capture_events, max_value_length):
     sentry_init(
         traces_sample_rate=1,
         integrations=[SqlalchemyIntegration()],
+        max_value_length=max_value_length,
     )
     events = capture_events()
 
-    long_str = "x" * (DEFAULT_MAX_VALUE_LENGTH + 10)
+    long_str = "x" * (1034)
 
     scope = sentry_sdk.get_isolation_scope()
 
@@ -401,18 +403,19 @@ def test_large_event_not_truncated(sentry_init, capture_events):
     assert description.startswith("SELECT 0")
     assert description.endswith("SELECT 98 UNION SELECT 99")
 
-    # Smoke check that truncation of other fields has not changed.
-    assert len(event["message"]) == DEFAULT_MAX_VALUE_LENGTH
+    if max_value_length:
+        # Smoke check that truncation of other fields has not changed.
+        assert len(event["message"]) == 1024
 
-    # The _meta for other truncated fields should be there as well.
-    assert event["_meta"]["message"] == {
-        "": {
-            "len": DEFAULT_MAX_VALUE_LENGTH + 10,
-            "rem": [
-                ["!limit", "x", DEFAULT_MAX_VALUE_LENGTH - 3, DEFAULT_MAX_VALUE_LENGTH]
-            ],
+        # The _meta for other truncated fields should be there as well.
+        assert event["_meta"]["message"] == {
+            "": {
+                "len": 1034,
+                "rem": [["!limit", "x", 1021, 1024]],
+            }
         }
-    }
+    else:
+        assert len(event["message"]) == 1034
 
 
 @pytest.mark.parametrize("span_streaming", [True, False])

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -24,7 +24,7 @@ from sentry_sdk import (
     start_transaction,
 )
 from sentry_sdk._compat import PY38
-from sentry_sdk.consts import DEFAULT_MAX_BREADCRUMBS, DEFAULT_MAX_VALUE_LENGTH
+from sentry_sdk.consts import DEFAULT_MAX_BREADCRUMBS
 from sentry_sdk.integrations.asyncio import AsyncioIntegration
 from sentry_sdk.integrations.executing import ExecutingIntegration
 from sentry_sdk.serializer import MAX_DATABAG_BREADTH
@@ -803,19 +803,19 @@ def test_databag_depth_stripping(sentry_init, capture_events):
 
 
 def test_databag_string_stripping(sentry_init, capture_events):
-    sentry_init()
+    sentry_init(max_value_length=1024)
     events = capture_events()
 
     del events[:]
     try:
-        a = "A" * DEFAULT_MAX_VALUE_LENGTH * 10  # noqa
+        a = "A" * 10240  # noqa
         1 / 0
     except Exception:
         capture_exception()
 
     (event,) = events
 
-    assert len(json.dumps(event)) < DEFAULT_MAX_VALUE_LENGTH * 10
+    assert len(json.dumps(event)) < 10240
 
 
 def test_databag_breadth_stripping(sentry_init, capture_events):
@@ -1102,25 +1102,13 @@ def test_multiple_positional_args(sentry_init):
     assert "Only single positional argument is expected" in str(exinfo.value)
 
 
-@pytest.mark.parametrize(
-    "sdk_options, expected_data_length",
-    [
-        ({}, DEFAULT_MAX_VALUE_LENGTH),
-        (
-            {"max_value_length": DEFAULT_MAX_VALUE_LENGTH + 1000},
-            DEFAULT_MAX_VALUE_LENGTH + 1000,
-        ),
-    ],
-)
-def test_max_value_length_option(
-    sentry_init, capture_events, sdk_options, expected_data_length
-):
-    sentry_init(sdk_options)
+def test_max_value_length_option(sentry_init, capture_events):
+    sentry_init(max_value_length=2024)
     events = capture_events()
 
-    capture_message("a" * (DEFAULT_MAX_VALUE_LENGTH + 2000))
+    capture_message("a" * (3024))
 
-    assert len(events[0]["message"]) == expected_data_length
+    assert len(events[0]["message"]) == 2024
 
 
 @pytest.mark.parametrize(

--- a/tests/test_serializer.py
+++ b/tests/test_serializer.py
@@ -2,7 +2,6 @@ import re
 
 import pytest
 
-from sentry_sdk.consts import DEFAULT_MAX_VALUE_LENGTH
 from sentry_sdk.serializer import MAX_DATABAG_BREADTH, MAX_DATABAG_DEPTH, serialize
 
 try:
@@ -166,12 +165,12 @@ def test_no_trimming_if_max_request_body_size_is_always(body_normalizer):
     assert result == data
 
 
-def test_max_value_length_default(body_normalizer):
-    data = {"key": "a" * (DEFAULT_MAX_VALUE_LENGTH * 10)}
+def test_no_value_truncation_by_default(body_normalizer):
+    data = {"key": "a" * (10240)}
 
     result = body_normalizer(data)
 
-    assert len(result["key"]) == DEFAULT_MAX_VALUE_LENGTH  # fallback max length
+    assert len(result["key"]) == 10240  # fallback max length
 
 
 def test_max_value_length(body_normalizer):


### PR DESCRIPTION
### Description
<!-- What changed and why? -->

Remove the default string limit applied when serializing envelopes by changing
`max_value_length` to default to `None`. Setting`max_value_length` to `None` disables string truncation.

This follows the earlier limit increase in https://github.com/getsentry/sentry-python/pull/4632.

Replace `DEFAULT_MAX_VALUE_LENGTH` with the value 1024 in tests, which was the original limit.

#### Issues

Closes SDK-1246

#### Reminders
- Please add tests to validate your changes, and lint your code using `tox -e linters`.
- Add GH Issue ID _&_ Linear ID (if applicable)
- PR title should use [conventional commit](https://develop.sentry.dev/engineering-practices/commit-messages/#type) style (`feat:`, `fix:`, `ref:`, `meta:`)
- For external contributors: [CONTRIBUTING.md](https://github.com/getsentry/sentry-python/blob/master/CONTRIBUTING.md), [Sentry SDK development docs](https://develop.sentry.dev/sdk/), [Discord community](https://discord.gg/Ww9hbqr)
