### PR TITLE
test: Respect context manager lifecycles in `fake_record_sql_queries`

### DIFF
--- a/tests/integrations/django/test_db_query_data.py
+++ b/tests/integrations/django/test_db_query_data.py
@@ -346,17 +346,16 @@ def test_no_query_source_if_duration_too_short(sentry_init, client, capture_even
 
     class fake_record_sql_queries:  # noqa: N801
         def __init__(self, *args, **kwargs):
-            with record_sql_queries(*args, **kwargs) as span:
-                self.span = span
-
-            self.span.start_timestamp = datetime(2024, 1, 1, microsecond=0)
-            self.span.timestamp = datetime(2024, 1, 1, microsecond=99999)
+            self._ctx_mgr = record_sql_queries(*args, **kwargs)
 
         def __enter__(self):
+            self.span = self._ctx_mgr.__enter__()
+            self.span.start_timestamp = datetime(2024, 1, 1, microsecond=0)
             return self.span
 
         def __exit__(self, type, value, traceback):
-            pass
+            self._ctx_mgr.__exit__(type, value, traceback)
+            self.span.timestamp = datetime(2024, 1, 1, microsecond=99999)
 
     with mock.patch(
         "sentry_sdk.integrations.django.record_sql_queries",
@@ -404,17 +403,16 @@ def test_query_source_if_duration_over_threshold(sentry_init, client, capture_ev
 
     class fake_record_sql_queries:  # noqa: N801
         def __init__(self, *args, **kwargs):
-            with record_sql_queries(*args, **kwargs) as span:
-                self.span = span
-
-            self.span.start_timestamp = datetime(2024, 1, 1, microsecond=0)
-            self.span.timestamp = datetime(2024, 1, 1, microsecond=101000)
+            self._ctx_mgr = record_sql_queries(*args, **kwargs)
 
         def __enter__(self):
+            self.span = self._ctx_mgr.__enter__()
+            self.span.start_timestamp = datetime(2024, 1, 1, microsecond=0)
             return self.span
 
         def __exit__(self, type, value, traceback):
-            pass
+            self._ctx_mgr.__exit__(type, value, traceback)
+            self.span.timestamp = datetime(2024, 1, 1, microsecond=101000)
 
     with mock.patch(
         "sentry_sdk.integrations.django.record_sql_queries",

--- a/tests/integrations/sqlalchemy/test_sqlalchemy.py
+++ b/tests/integrations/sqlalchemy/test_sqlalchemy.py
@@ -934,25 +934,19 @@ def test_no_query_source_if_duration_too_short(
 
             class fake_record_sql_queries:  # noqa: N801
                 def __init__(self, *args, **kwargs):
-                    with record_sql_queries_supporting_streaming(
+                    self._ctx_mgr = record_sql_queries_supporting_streaming(
                         *args, **kwargs
-                    ) as span:
-                        self.span = span
-
-                    if span_streaming:
-                        self.span._start_timestamp = datetime(2024, 1, 1, microsecond=0)
-                        self.span._end_timestamp = datetime(
-                            2024, 1, 1, microsecond=99999
-                        )
-                    else:
-                        self.span.start_timestamp = datetime(2024, 1, 1, microsecond=0)
-                        self.span.timestamp = datetime(2024, 1, 1, microsecond=99999)
+                    )
 
                 def __enter__(self):
+                    self.span = self._ctx_mgr.__enter__()
+                    self.span._start_timestamp = datetime(2024, 1, 1, microsecond=0)
+                    self.span._end_timestamp = datetime(2024, 1, 1, microsecond=99999)
                     return self.span
 
                 def __exit__(self, type, value, traceback):
-                    pass
+                    self.span._end_timestamp = None
+                    self._ctx_mgr.__exit__(type, value, traceback)
 
             with mock.patch(
                 "sentry_sdk.integrations.sqlalchemy.record_sql_queries_supporting_streaming",
@@ -1000,25 +994,18 @@ def test_no_query_source_if_duration_too_short(
 
             class fake_record_sql_queries:  # noqa: N801
                 def __init__(self, *args, **kwargs):
-                    with record_sql_queries_supporting_streaming(
+                    self._ctx_mgr = record_sql_queries_supporting_streaming(
                         *args, **kwargs
-                    ) as span:
-                        self.span = span
-
-                    if span_streaming:
-                        self.span._start_timestamp = datetime(2024, 1, 1, microsecond=0)
-                        self.span._end_timestamp = datetime(
-                            2024, 1, 1, microsecond=99999
-                        )
-                    else:
-                        self.span.start_timestamp = datetime(2024, 1, 1, microsecond=0)
-                        self.span.timestamp = datetime(2024, 1, 1, microsecond=99999)
+                    )
 
                 def __enter__(self):
+                    self.span = self._ctx_mgr.__enter__()
+                    self.span.start_timestamp = datetime(2024, 1, 1, microsecond=0)
                     return self.span
 
                 def __exit__(self, type, value, traceback):
-                    pass
+                    self._ctx_mgr.__exit__(type, value, traceback)
+                    self.span.timestamp = datetime(2024, 1, 1, microsecond=99999)
 
             with mock.patch(
                 "sentry_sdk.integrations.sqlalchemy.record_sql_queries_supporting_streaming",
@@ -1159,19 +1146,18 @@ def test_query_source_if_duration_over_threshold(
 
             class fake_record_sql_queries:  # noqa: N801
                 def __init__(self, *args, **kwargs):
-                    with record_sql_queries_supporting_streaming(
+                    self._ctx_mgr = record_sql_queries_supporting_streaming(
                         *args, **kwargs
-                    ) as span:
-                        self.span = span
-
-                    self.span.start_timestamp = datetime(2024, 1, 1, microsecond=0)
-                    self.span.timestamp = datetime(2024, 1, 1, microsecond=101000)
+                    )
 
                 def __enter__(self):
+                    self.span = self._ctx_mgr.__enter__()
+                    self.span.start_timestamp = datetime(2024, 1, 1, microsecond=0)
                     return self.span
 
                 def __exit__(self, type, value, traceback):
-                    pass
+                    self._ctx_mgr.__exit__(type, value, traceback)
+                    self.span.timestamp = datetime(2024, 1, 1, microsecond=101000)
 
             with mock.patch(
                 "sentry_sdk.integrations.sqlalchemy.record_sql_queries_supporting_streaming",


### PR DESCRIPTION
### Description
<!-- What changed and why? -->

In the static trace lifecycle, set `span.start_timestamp` and `span.timestamp` immediately after `__enter__` and `__exit__` are called, respectively.

In the streaming trace lifecycle, set both`span._start_timestam` and `span._end_timestamp` immediately after `__enter__` is called, as the query source is added inside the context manager. Then reset `span._end_timestamp` immediately before `__exit__`, as otherwise the span is not captured.

#### Issues
<!--
* resolves: #1234
* resolves: LIN-1234
-->

#### Reminders
- Please add tests to validate your changes, and lint your code using `tox -e linters`.
- Add GH Issue ID _&_ Linear ID (if applicable)
- PR title should use [conventional commit](https://develop.sentry.dev/engineering-practices/commit-messages/#type) style (`feat:`, `fix:`, `ref:`, `meta:`)
- For external contributors: [CONTRIBUTING.md](https://github.com/getsentry/sentry-python/blob/master/CONTRIBUTING.md), [Sentry SDK development docs](https://develop.sentry.dev/sdk/), [Discord community](https://discord.gg/Ww9hbqr)
