### PR TITLE
fix(langchain): Stop setting transaction status when child span fails

### DIFF
--- a/sentry_sdk/integrations/langchain.py
+++ b/sentry_sdk/integrations/langchain.py
@@ -19,7 +19,7 @@ from sentry_sdk.ai.utils import (
 from sentry_sdk.consts import OP, SPANDATA
 from sentry_sdk.integrations import DidNotEnable, Integration
 from sentry_sdk.scope import should_send_default_pii
-from sentry_sdk.tracing_utils import _get_value, set_span_errored
+from sentry_sdk.tracing_utils import _get_value
 from sentry_sdk.utils import capture_internal_exceptions, logger
 
 if TYPE_CHECKING:
@@ -273,11 +273,10 @@ class SentryLangchainCallback(BaseCallbackHandler):  # type: ignore[misc]
 
             span_data = self.span_map[run_id]
             span = span_data.span
-            set_span_errored(span)
 
             sentry_sdk.capture_exception(error, span.scope)
 
-            span.__exit__(None, None, None)
+            span.__exit__(type(error), error, error.__traceback__)
             del self.span_map[run_id]
 
     def _normalize_langchain_message(self, message: "BaseMessage") -> "Any":
@@ -1112,13 +1111,13 @@ def _wrap_agent_executor_stream(f: "Callable[..., Any]") -> "Callable[..., Any]"
                     and integration.include_prompts
                 ):
                     set_data_normalized(span, SPANDATA.GEN_AI_RESPONSE_TEXT, output)
+
+                span.__exit__(None, None, None)
             except Exception:
                 exc_info = sys.exc_info()
-                set_span_errored(span)
+                with capture_internal_exceptions():
+                    span.__exit__(*exc_info)
                 raise
-            finally:
-                # Ensure cleanup happens even if iterator is abandoned or fails
-                span.__exit__(*exc_info)
 
         async def new_iterator_async() -> "AsyncIterator[Any]":
             exc_info: "tuple[Any, Any, Any]" = (None, None, None)
@@ -1137,9 +1136,12 @@ def _wrap_agent_executor_stream(f: "Callable[..., Any]") -> "Callable[..., Any]"
                     and integration.include_prompts
                 ):
                     set_data_normalized(span, SPANDATA.GEN_AI_RESPONSE_TEXT, output)
+
+                span.__exit__(None, None, None)
             except Exception:
                 exc_info = sys.exc_info()
-                set_span_errored(span)
+                with capture_internal_exceptions():
+                    span.__exit__(*exc_info)
                 raise
             finally:
                 # Ensure cleanup happens even if iterator is abandoned or fails

--- a/sentry_sdk/integrations/langchain.py
+++ b/sentry_sdk/integrations/langchain.py
@@ -1143,9 +1143,6 @@ def _wrap_agent_executor_stream(f: "Callable[..., Any]") -> "Callable[..., Any]"
                 with capture_internal_exceptions():
                     span.__exit__(*exc_info)
                 raise
-            finally:
-                # Ensure cleanup happens even if iterator is abandoned or fails
-                span.__exit__(*exc_info)
 
         if str(type(result)) == "<class 'async_generator'>":
             result = new_iterator_async()

--- a/tests/integrations/langchain/test_langchain.py
+++ b/tests/integrations/langchain/test_langchain.py
@@ -2561,8 +2561,6 @@ def test_span_status_error(
         assert transaction["spans"][0]["status"] == "internal_error"
         assert transaction["spans"][0]["tags"]["status"] == "internal_error"
 
-    assert transaction["contexts"]["trace"]["status"] == "internal_error"
-
 
 def test_manual_callback_no_duplication(sentry_init):
     """


### PR DESCRIPTION
### Description
<!-- What changed and why? -->

Stop modifying the transaction, since the transaction may not be managed by langchain.

#### Issues
<!--
* resolves: #1234
* resolves: LIN-1234
-->

#### Reminders
- Please add tests to validate your changes, and lint your code using `tox -e linters`.
- Add GH Issue ID _&_ Linear ID (if applicable)
- PR title should use [conventional commit](https://develop.sentry.dev/engineering-practices/commit-messages/#type) style (`feat:`, `fix:`, `ref:`, `meta:`)
- For external contributors: [CONTRIBUTING.md](https://github.com/getsentry/sentry-python/blob/master/CONTRIBUTING.md), [Sentry SDK development docs](https://develop.sentry.dev/sdk/), [Discord community](https://discord.gg/Ww9hbqr)
