### PR TITLE
fix(pydantic-ai): Stop setting transaction status when child span fails

### DIFF
--- a/sentry_sdk/integrations/pydantic_ai/utils.py
+++ b/sentry_sdk/integrations/pydantic_ai/utils.py
@@ -4,7 +4,6 @@ from typing import TYPE_CHECKING
 import sentry_sdk
 from sentry_sdk.consts import SPANDATA
 from sentry_sdk.scope import should_send_default_pii
-from sentry_sdk.tracing_utils import set_span_errored
 from sentry_sdk.utils import event_from_exception, safe_serialize
 
 if TYPE_CHECKING:
@@ -207,8 +206,6 @@ def _set_available_tools(span: "sentry_sdk.tracing.Span", agent: "Any") -> None:
 
 
 def _capture_exception(exc: "Any", handled: bool = False) -> None:
-    set_span_errored()
-
     event, hint = event_from_exception(
         exc,
         client_options=sentry_sdk.get_client().options,


### PR DESCRIPTION
### Description
<!-- What changed and why? -->

Stop modifying the transaction, since the transaction may not be managed by Pydantic AI.

#### Issues
<!--
* resolves: #1234
* resolves: LIN-1234
-->

#### Reminders
- Please add tests to validate your changes, and lint your code using `tox -e linters`.
- Add GH Issue ID _&_ Linear ID (if applicable)
- PR title should use [conventional commit](https://develop.sentry.dev/engineering-practices/commit-messages/#type) style (`feat:`, `fix:`, `ref:`, `meta:`)
- For external contributors: [CONTRIBUTING.md](https://github.com/getsentry/sentry-python/blob/master/CONTRIBUTING.md), [Sentry SDK development docs](https://develop.sentry.dev/sdk/), [Discord community](https://discord.gg/Ww9hbqr)
