### PR TITLE
fix(openai-agents): Stop setting transaction status when child span fails

### DIFF
--- a/sentry_sdk/integrations/openai_agents/patches/agent_run.py
+++ b/sentry_sdk/integrations/openai_agents/patches/agent_run.py
@@ -114,7 +114,7 @@ async def _run_single_turn(
         return await original_run_single_turn(*args, **kwargs)
 
     try:
-        return await original_run_single_turn(*args, **kwargs)
+        result = await original_run_single_turn(*args, **kwargs)
     except Exception:
         exc_info = sys.exc_info()
         with capture_internal_exceptions():
@@ -123,6 +123,8 @@ async def _run_single_turn(
             span.__exit__(*exc_info)
             delattr(context_wrapper, "_sentry_agent_span")
         reraise(*exc_info)
+
+    return result
 
 
 async def _run_single_turn_streamed(
@@ -193,12 +195,14 @@ async def _run_single_turn_streamed(
         agent=agent,
     ):
         try:
-            return await original_run_single_turn_streamed(*args, **kwargs)
+            result = await original_run_single_turn_streamed(*args, **kwargs)
         except Exception:
             exc_info = sys.exc_info()
             with capture_internal_exceptions():
                 _close_streaming_workflow_span(agent)
             reraise(*exc_info)
+
+    return result
 
 
 async def _execute_handoffs(

--- a/sentry_sdk/integrations/openai_agents/patches/agent_run.py
+++ b/sentry_sdk/integrations/openai_agents/patches/agent_run.py
@@ -116,9 +116,13 @@ async def _run_single_turn(
     except Exception:
         exc_info = sys.exc_info()
         with capture_internal_exceptions():
-            update_invoke_agent_span(span=span, context=context_wrapper, agent=agent)
-            span.__exit__(*exc_info)
-            delattr(context_wrapper, "_sentry_agent_span")
+            span = getattr(context_wrapper, "_sentry_agent_span", None)
+            if span:
+                update_invoke_agent_span(
+                    span=span, context=context_wrapper, agent=agent
+                )
+                span.__exit__(*exc_info)
+                delattr(context_wrapper, "_sentry_agent_span")
         reraise(*exc_info)
 
     return result
@@ -192,9 +196,13 @@ async def _run_single_turn_streamed(
     except Exception:
         exc_info = sys.exc_info()
         with capture_internal_exceptions():
-            update_invoke_agent_span(span=span, context=context_wrapper, agent=agent)
-            span.__exit__(*exc_info)
-            delattr(context_wrapper, "_sentry_agent_span")
+            span = getattr(context_wrapper, "_sentry_agent_span", None)
+            if span:
+                update_invoke_agent_span(
+                    span=span, context=context_wrapper, agent=agent
+                )
+                span.__exit__(*exc_info)
+                delattr(context_wrapper, "_sentry_agent_span")
             _close_streaming_workflow_span(agent)
         reraise(*exc_info)
 

--- a/sentry_sdk/integrations/openai_agents/patches/agent_run.py
+++ b/sentry_sdk/integrations/openai_agents/patches/agent_run.py
@@ -69,7 +69,6 @@ def _maybe_start_agent_span(
                 update_invoke_agent_span(
                     span=span, context=context_wrapper, agent=agent
                 )
-
                 span.__exit__(None, None, None)
                 delattr(context_wrapper, "_sentry_agent_span")
 
@@ -118,7 +117,6 @@ async def _run_single_turn(
         exc_info = sys.exc_info()
         with capture_internal_exceptions():
             update_invoke_agent_span(span=span, context=context_wrapper, agent=agent)
-
             span.__exit__(*exc_info)
             delattr(context_wrapper, "_sentry_agent_span")
         reraise(*exc_info)

--- a/sentry_sdk/integrations/openai_agents/patches/agent_run.py
+++ b/sentry_sdk/integrations/openai_agents/patches/agent_run.py
@@ -66,13 +66,13 @@ def _maybe_start_agent_span(
         current_agent = _get_current_agent(context_wrapper)
         if current_agent and current_agent != agent:
             span = getattr(context_wrapper, "_sentry_agent_span", None)
-            if not span:
-                return
+            if span:
+                update_invoke_agent_span(
+                    span=span, context=context_wrapper, agent=agent
+                )
 
-            update_invoke_agent_span(span=span, context=context_wrapper, agent=agent)
-
-            span.__exit__(None, None, None)
-            delattr(context_wrapper, "_sentry_agent_span")
+                span.__exit__(None, None, None)
+                delattr(context_wrapper, "_sentry_agent_span")
 
     # Store the agent on the context wrapper so we can access it later
     context_wrapper._sentry_current_agent = agent

--- a/sentry_sdk/integrations/openai_agents/patches/agent_run.py
+++ b/sentry_sdk/integrations/openai_agents/patches/agent_run.py
@@ -272,7 +272,7 @@ async def _execute_final_output(
 
     if not agent or not context_wrapper or not _has_active_agent_span(context_wrapper):
         try:
-            result = await original_execute_final_output(*args, **kwargs)
+            return await original_execute_final_output(*args, **kwargs)
         finally:
             with capture_internal_exceptions():
                 # For streaming, close the workflow span (non-streaming uses context manager in _create_run_wrapper)

--- a/sentry_sdk/integrations/openai_agents/patches/agent_run.py
+++ b/sentry_sdk/integrations/openai_agents/patches/agent_run.py
@@ -6,7 +6,6 @@ from sentry_sdk.integrations import DidNotEnable
 from sentry_sdk.utils import capture_internal_exceptions, reraise
 
 from ..spans import (
-    _AgentInvocationSpanContext,
     handoff_span,
     invoke_agent_span,
     update_invoke_agent_span,
@@ -190,17 +189,16 @@ async def _run_single_turn_streamed(
     if span is None or span.timestamp is not None:
         return await original_run_single_turn_streamed(*args, **kwargs)
 
-    with _AgentInvocationSpanContext(
-        context_wrapper=context_wrapper,
-        agent=agent,
-    ):
-        try:
-            result = await original_run_single_turn_streamed(*args, **kwargs)
-        except Exception:
-            exc_info = sys.exc_info()
-            with capture_internal_exceptions():
-                _close_streaming_workflow_span(agent)
-            reraise(*exc_info)
+    try:
+        result = await original_run_single_turn_streamed(*args, **kwargs)
+    except Exception:
+        exc_info = sys.exc_info()
+        with capture_internal_exceptions():
+            update_invoke_agent_span(span=span, context=context_wrapper, agent=agent)
+            span.__exit__(*exc_info)
+            delattr(context_wrapper, "_sentry_agent_span")
+            _close_streaming_workflow_span(agent)
+        reraise(*exc_info)
 
     return result
 
@@ -238,18 +236,27 @@ async def _execute_handoffs(
                 _close_streaming_workflow_span(agent)
             reraise(*exc_info)
 
-    with _AgentInvocationSpanContext(
-        context_wrapper=context_wrapper,
-        agent=agent,
-    ):
-        # Call original method with all parameters
-        try:
-            result = await original_execute_handoffs(*args, **kwargs)
-        except Exception:
-            exc_info = sys.exc_info()
-            with capture_internal_exceptions():
-                _close_streaming_workflow_span(agent)
-            reraise(*exc_info)
+    # Call original method with all parameters
+    try:
+        result = await original_execute_handoffs(*args, **kwargs)
+    except Exception:
+        exc_info = sys.exc_info()
+        with capture_internal_exceptions():
+            _close_streaming_workflow_span(agent)
+            span = getattr(context_wrapper, "_sentry_agent_span", None)
+            if span:
+                update_invoke_agent_span(
+                    span=span, context=context_wrapper, agent=agent
+                )
+                span.__exit__(*exc_info)
+                delattr(context_wrapper, "_sentry_agent_span")
+        reraise(*exc_info)
+
+    span = getattr(context_wrapper, "_sentry_agent_span", None)
+    if span:
+        update_invoke_agent_span(span=span, context=context_wrapper, agent=agent)
+        span.__exit__(None, None, None)
+        delattr(context_wrapper, "_sentry_agent_span")
 
     return result
 
@@ -278,14 +285,28 @@ async def _execute_final_output(
                 # For streaming, close the workflow span (non-streaming uses context manager in _create_run_wrapper)
                 _close_streaming_workflow_span(agent)
 
-    with _AgentInvocationSpanContext(
-        context_wrapper=context_wrapper, agent=agent, output=final_output
-    ):
-        try:
-            result = await original_execute_final_output(*args, **kwargs)
-        finally:
-            with capture_internal_exceptions():
-                # For streaming, close the workflow span (non-streaming uses context manager in _create_run_wrapper)
-                _close_streaming_workflow_span(agent)
+    try:
+        result = await original_execute_final_output(*args, **kwargs)
+    except Exception:
+        exc_info = sys.exc_info()
+        with capture_internal_exceptions():
+            # For streaming, close the workflow span (non-streaming uses context manager in _create_run_wrapper)
+            _close_streaming_workflow_span(agent)
+            span = getattr(context_wrapper, "_sentry_agent_span", None)
+            if span:
+                update_invoke_agent_span(
+                    span=span, context=context_wrapper, agent=agent, output=final_output
+                )
+                span.__exit__(*exc_info)
+                delattr(context_wrapper, "_sentry_agent_span")
+        reraise(*exc_info)
+
+    span = getattr(context_wrapper, "_sentry_agent_span", None)
+    if span:
+        update_invoke_agent_span(
+            span=span, context=context_wrapper, agent=agent, output=final_output
+        )
+        span.__exit__(None, None, None)
+        delattr(context_wrapper, "_sentry_agent_span")
 
     return result

--- a/sentry_sdk/integrations/openai_agents/patches/agent_run.py
+++ b/sentry_sdk/integrations/openai_agents/patches/agent_run.py
@@ -65,9 +65,14 @@ def _maybe_start_agent_span(
     if _has_active_agent_span(context_wrapper):
         current_agent = _get_current_agent(context_wrapper)
         if current_agent and current_agent != agent:
-            _AgentInvocationSpanContext(
-                context_wrapper=context_wrapper, agent=current_agent
-            ).__exit__(None, None, None)
+            span = getattr(context_wrapper, "_sentry_agent_span", None)
+            if not span:
+                return
+
+            update_invoke_agent_span(span=span, context=context_wrapper, agent=agent)
+
+            span.__exit__(None, None, None)
+            delattr(context_wrapper, "_sentry_agent_span")
 
     # Store the agent on the context wrapper so we can access it later
     context_wrapper._sentry_current_agent = agent

--- a/sentry_sdk/integrations/openai_agents/patches/agent_run.py
+++ b/sentry_sdk/integrations/openai_agents/patches/agent_run.py
@@ -3,13 +3,13 @@ from typing import TYPE_CHECKING
 
 from sentry_sdk.consts import SPANDATA
 from sentry_sdk.integrations import DidNotEnable
-from sentry_sdk.tracing_utils import set_span_errored
 from sentry_sdk.utils import capture_internal_exceptions, reraise
 
 from ..spans import (
-    end_invoke_agent_span,
+    _AgentInvocationSpanContext,
     handoff_span,
     invoke_agent_span,
+    update_invoke_agent_span,
 )
 
 if TYPE_CHECKING:
@@ -65,7 +65,9 @@ def _maybe_start_agent_span(
     if _has_active_agent_span(context_wrapper):
         current_agent = _get_current_agent(context_wrapper)
         if current_agent and current_agent != agent:
-            end_invoke_agent_span(context_wrapper, current_agent)
+            _AgentInvocationSpanContext(
+                context_wrapper=context_wrapper, agent=current_agent
+            ).__exit__(None, None, None)
 
     # Store the agent on the context wrapper so we can access it later
     context_wrapper._sentry_current_agent = agent
@@ -103,15 +105,23 @@ async def _run_single_turn(
         context_wrapper, agent, should_run_agent_start_hooks, kwargs
     )
 
-    try:
-        result = await original_run_single_turn(*args, **kwargs)
-    except Exception:
-        if span is not None and span.timestamp is None:
-            set_span_errored(span)
-            end_invoke_agent_span(context_wrapper, agent)
-        reraise(*sys.exc_info())
+    if span is None or span.timestamp is not None:
+        return await original_run_single_turn(*args, **kwargs)
 
-    return result
+    try:
+        return await original_run_single_turn(*args, **kwargs)
+    except Exception:
+        exc_info = sys.exc_info()
+        with capture_internal_exceptions():
+            span = getattr(context_wrapper, "_sentry_agent_span", None)
+            if not span:
+                return
+
+            update_invoke_agent_span(span=span, context=context_wrapper, agent=agent)
+
+            span.__exit__(*exc_info)
+            delattr(context_wrapper, "_sentry_agent_span")
+        reraise(*exc_info)
 
 
 async def _run_single_turn_streamed(
@@ -174,18 +184,20 @@ async def _run_single_turn_streamed(
         is_streaming=True,
     )
 
-    try:
-        result = await original_run_single_turn_streamed(*args, **kwargs)
-    except Exception:
-        exc_info = sys.exc_info()
-        with capture_internal_exceptions():
-            if span is not None and span.timestamp is None:
-                set_span_errored(span)
-                end_invoke_agent_span(context_wrapper, agent)
-            _close_streaming_workflow_span(agent)
-        reraise(*exc_info)
+    if span is None or span.timestamp is not None:
+        return await original_run_single_turn_streamed(*args, **kwargs)
 
-    return result
+    with _AgentInvocationSpanContext(
+        context_wrapper=context_wrapper,
+        agent=agent,
+    ):
+        try:
+            return await original_run_single_turn_streamed(*args, **kwargs)
+        except Exception:
+            exc_info = sys.exc_info()
+            with capture_internal_exceptions():
+                _close_streaming_workflow_span(agent)
+            reraise(*exc_info)
 
 
 async def _execute_handoffs(
@@ -211,18 +223,30 @@ async def _execute_handoffs(
         handoff_agent_name = first_handoff.handoff.agent_name
         handoff_span(context_wrapper, agent, handoff_agent_name)
 
-    # Call original method with all parameters
-    try:
-        result = await original_execute_handoffs(*args, **kwargs)
-    except Exception:
-        exc_info = sys.exc_info()
-        with capture_internal_exceptions():
-            _close_streaming_workflow_span(agent)
-        reraise(*exc_info)
-    finally:
-        # End span for current agent after handoff processing is complete
-        if agent and context_wrapper and _has_active_agent_span(context_wrapper):
-            end_invoke_agent_span(context_wrapper, agent)
+    if not agent or not context_wrapper or not _has_active_agent_span(context_wrapper):
+        # Call original method with all parameters
+        try:
+            result = await original_execute_handoffs(*args, **kwargs)
+        except Exception:
+            exc_info = sys.exc_info()
+            with capture_internal_exceptions():
+                _close_streaming_workflow_span(agent)
+            reraise(*exc_info)
+
+        return result
+
+    with _AgentInvocationSpanContext(
+        context_wrapper=context_wrapper,
+        agent=agent,
+    ):
+        # Call original method with all parameters
+        try:
+            result = await original_execute_handoffs(*args, **kwargs)
+        except Exception:
+            exc_info = sys.exc_info()
+            with capture_internal_exceptions():
+                _close_streaming_workflow_span(agent)
+            reraise(*exc_info)
 
     return result
 
@@ -243,13 +267,22 @@ async def _execute_final_output(
     context_wrapper = kwargs.get("context_wrapper")
     final_output = kwargs.get("final_output")
 
-    try:
-        result = await original_execute_final_output(*args, **kwargs)
-    finally:
-        with capture_internal_exceptions():
-            if agent and context_wrapper and _has_active_agent_span(context_wrapper):
-                end_invoke_agent_span(context_wrapper, agent, final_output)
-            # For streaming, close the workflow span (non-streaming uses context manager in _create_run_wrapper)
-            _close_streaming_workflow_span(agent)
+    if not agent or not context_wrapper or not _has_active_agent_span(context_wrapper):
+        try:
+            result = await original_execute_final_output(*args, **kwargs)
+        finally:
+            with capture_internal_exceptions():
+                # For streaming, close the workflow span (non-streaming uses context manager in _create_run_wrapper)
+                _close_streaming_workflow_span(agent)
+
+    with _AgentInvocationSpanContext(
+        context_wrapper=context_wrapper, agent=agent, output=final_output
+    ):
+        try:
+            result = await original_execute_final_output(*args, **kwargs)
+        finally:
+            with capture_internal_exceptions():
+                # For streaming, close the workflow span (non-streaming uses context manager in _create_run_wrapper)
+                _close_streaming_workflow_span(agent)
 
     return result

--- a/sentry_sdk/integrations/openai_agents/patches/agent_run.py
+++ b/sentry_sdk/integrations/openai_agents/patches/agent_run.py
@@ -118,10 +118,6 @@ async def _run_single_turn(
     except Exception:
         exc_info = sys.exc_info()
         with capture_internal_exceptions():
-            span = getattr(context_wrapper, "_sentry_agent_span", None)
-            if not span:
-                return
-
             update_invoke_agent_span(span=span, context=context_wrapper, agent=agent)
 
             span.__exit__(*exc_info)
@@ -231,14 +227,12 @@ async def _execute_handoffs(
     if not agent or not context_wrapper or not _has_active_agent_span(context_wrapper):
         # Call original method with all parameters
         try:
-            result = await original_execute_handoffs(*args, **kwargs)
+            return await original_execute_handoffs(*args, **kwargs)
         except Exception:
             exc_info = sys.exc_info()
             with capture_internal_exceptions():
                 _close_streaming_workflow_span(agent)
             reraise(*exc_info)
-
-        return result
 
     with _AgentInvocationSpanContext(
         context_wrapper=context_wrapper,

--- a/sentry_sdk/integrations/openai_agents/patches/error_tracing.py
+++ b/sentry_sdk/integrations/openai_agents/patches/error_tracing.py
@@ -2,7 +2,7 @@ from functools import wraps
 from typing import TYPE_CHECKING
 
 import sentry_sdk
-from sentry_sdk.tracing_utils import set_span_errored
+from sentry_sdk.consts import SPANSTATUS
 
 if TYPE_CHECKING:
     from typing import Any
@@ -56,7 +56,7 @@ def _patch_error_tracing() -> None:
         # Set the current Sentry span to errored
         current_span = sentry_sdk.get_current_span()
         if current_span is not None:
-            set_span_errored(current_span)
+            current_span.set_status(SPANSTATUS.INTERNAL_ERROR)
 
         # Call the original function
         return original_attach_error(error, *args, **kwargs)

--- a/sentry_sdk/integrations/openai_agents/patches/runner.py
+++ b/sentry_sdk/integrations/openai_agents/patches/runner.py
@@ -4,10 +4,9 @@ from functools import wraps
 import sentry_sdk
 from sentry_sdk.consts import SPANDATA
 from sentry_sdk.integrations import DidNotEnable
-from sentry_sdk.tracing_utils import set_span_errored
 from sentry_sdk.utils import capture_internal_exceptions, reraise
 
-from ..spans import agent_workflow_span, end_invoke_agent_span
+from ..spans import agent_workflow_span, update_invoke_agent_span
 from ..utils import _capture_exception
 
 try:
@@ -66,8 +65,14 @@ def _create_run_wrapper(original_func: "Callable[..., Any]") -> "Callable[..., A
                                 invoke_agent_span is not None
                                 and invoke_agent_span.timestamp is None
                             ):
-                                set_span_errored(invoke_agent_span)
-                                end_invoke_agent_span(context_wrapper, agent)
+                                update_invoke_agent_span(
+                                    span=invoke_agent_span,
+                                    context=context_wrapper,
+                                    agent=agent,
+                                )
+
+                                invoke_agent_span.__exit__(*exc_info)
+                                delattr(context_wrapper, "_sentry_agent_span")
                     reraise(*exc_info)
                 except Exception as exc:
                     exc_info = sys.exc_info()
@@ -78,7 +83,20 @@ def _create_run_wrapper(original_func: "Callable[..., Any]") -> "Callable[..., A
                         _capture_exception(exc)
                     reraise(*exc_info)
 
-                end_invoke_agent_span(run_result.context_wrapper, agent)
+                invoke_agent_span = getattr(
+                    run_result.context_wrapper, "_sentry_agent_span", None
+                )
+                if not invoke_agent_span:
+                    return run_result
+
+                update_invoke_agent_span(
+                    span=invoke_agent_span,
+                    context=run_result.context_wrapper,
+                    agent=agent,
+                )
+
+                invoke_agent_span.__exit__(None, None, None)
+                delattr(run_result.context_wrapper, "_sentry_agent_span")
                 return run_result
 
     return wrapper

--- a/sentry_sdk/integrations/openai_agents/spans/__init__.py
+++ b/sentry_sdk/integrations/openai_agents/spans/__init__.py
@@ -3,7 +3,7 @@ from .ai_client import ai_client_span, update_ai_client_span  # noqa: F401
 from .execute_tool import execute_tool_span, update_execute_tool_span  # noqa: F401
 from .handoff import handoff_span  # noqa: F401
 from .invoke_agent import (
-    end_invoke_agent_span,  # noqa: F401
+    _AgentInvocationSpanContext,  # noqa: F401
     invoke_agent_span,  # noqa: F401
     update_invoke_agent_span,  # noqa: F401
 )

--- a/sentry_sdk/integrations/openai_agents/spans/__init__.py
+++ b/sentry_sdk/integrations/openai_agents/spans/__init__.py
@@ -3,7 +3,6 @@ from .ai_client import ai_client_span, update_ai_client_span  # noqa: F401
 from .execute_tool import execute_tool_span, update_execute_tool_span  # noqa: F401
 from .handoff import handoff_span  # noqa: F401
 from .invoke_agent import (
-    _AgentInvocationSpanContext,  # noqa: F401
     invoke_agent_span,  # noqa: F401
     update_invoke_agent_span,  # noqa: F401
 )

--- a/sentry_sdk/integrations/openai_agents/spans/invoke_agent.py
+++ b/sentry_sdk/integrations/openai_agents/spans/invoke_agent.py
@@ -9,13 +9,13 @@ from sentry_sdk.ai.utils import (
 )
 from sentry_sdk.consts import OP, SPANDATA
 from sentry_sdk.scope import should_send_default_pii
-from sentry_sdk.utils import capture_internal_exceptions, safe_serialize
+from sentry_sdk.utils import safe_serialize
 
 from ..consts import SPAN_ORIGIN
 from ..utils import _set_agent_data, _set_usage_data
 
 if TYPE_CHECKING:
-    from typing import Any, Optional
+    from typing import Any
 
     import agents
 
@@ -101,48 +101,3 @@ def update_invoke_agent_span(
     conv_id = getattr(agent, "_sentry_conversation_id", None)
     if conv_id:
         span.set_data(SPANDATA.GEN_AI_CONVERSATION_ID, conv_id)
-
-
-class _AgentInvocationSpanContext:
-    """
-    Sets accumulated data on the Invoke Agent span and finishes the span on exit.
-    Is a no-op if the context wrapper has no span set, i.e., when the span has already been finished.
-    """
-
-    def __init__(
-        self,
-        context_wrapper: "agents.RunContextWrapper",
-        agent: "agents.Agent",
-        output: "Optional[Any]" = None,
-    ) -> None:
-        self._context_wrapper = context_wrapper
-        self._agent = agent
-        self._output = output
-
-    def __enter__(self) -> "_AgentInvocationSpanContext":
-        return self
-
-    def __exit__(
-        self,
-        exc_type: "Optional[type[BaseException]]",
-        exc_val: "Optional[BaseException]",
-        exc_tb: "Optional[Any]",
-    ) -> None:
-        with capture_internal_exceptions():
-            # Clear the stored agent
-            if hasattr(self._context_wrapper, "_sentry_current_agent"):
-                delattr(self._context_wrapper, "_sentry_current_agent")
-
-            span = getattr(self._context_wrapper, "_sentry_agent_span", None)
-            if not span:
-                return
-
-            update_invoke_agent_span(
-                span=span,
-                context=self._context_wrapper,
-                agent=self._agent,
-                output=self._output,
-            )
-
-            span.__exit__(exc_type, exc_val, exc_tb)
-            delattr(self._context_wrapper, "_sentry_agent_span")

--- a/sentry_sdk/integrations/openai_agents/spans/invoke_agent.py
+++ b/sentry_sdk/integrations/openai_agents/spans/invoke_agent.py
@@ -9,7 +9,7 @@ from sentry_sdk.ai.utils import (
 )
 from sentry_sdk.consts import OP, SPANDATA
 from sentry_sdk.scope import should_send_default_pii
-from sentry_sdk.utils import safe_serialize
+from sentry_sdk.utils import capture_internal_exceptions, safe_serialize
 
 from ..consts import SPAN_ORIGIN
 from ..utils import _set_agent_data, _set_usage_data
@@ -85,37 +85,64 @@ def invoke_agent_span(
 
 
 def update_invoke_agent_span(
-    context: "agents.RunContextWrapper", agent: "agents.Agent", output: "Any"
+    span: "sentry_sdk.tracing.Span",
+    context: "agents.RunContextWrapper",
+    agent: "agents.Agent",
+    output: "Any" = None,
 ) -> None:
-    span = getattr(context, "_sentry_agent_span", None)
+    # Add aggregated usage data from context_wrapper
+    if hasattr(context, "usage"):
+        _set_usage_data(span, context.usage)
 
-    if span:
-        # Add aggregated usage data from context_wrapper
-        if hasattr(context, "usage"):
-            _set_usage_data(span, context.usage)
+    if should_send_default_pii():
+        set_data_normalized(span, SPANDATA.GEN_AI_RESPONSE_TEXT, output, unpack=False)
 
-        if should_send_default_pii():
-            set_data_normalized(
-                span, SPANDATA.GEN_AI_RESPONSE_TEXT, output, unpack=False
+    # Add conversation ID from agent
+    conv_id = getattr(agent, "_sentry_conversation_id", None)
+    if conv_id:
+        span.set_data(SPANDATA.GEN_AI_CONVERSATION_ID, conv_id)
+
+
+class _AgentInvocationSpanContext:
+    """
+    Sets accumulated data on the Invoke Agent span and finishes the span on exit.
+    Is a no-op if the context wrapper has no span set, i.e., when the span has already been finished.
+    """
+
+    def __init__(
+        self,
+        context_wrapper: "agents.RunContextWrapper",
+        agent: "agents.Agent",
+        output: "Optional[Any]" = None,
+    ) -> None:
+        self._context_wrapper = context_wrapper
+        self._agent = agent
+        self._output = output
+
+    def __enter__(self) -> "_AgentInvocationSpanContext":
+        return self
+
+    def __exit__(
+        self,
+        exc_type: "Optional[type[BaseException]]",
+        exc_val: "Optional[BaseException]",
+        exc_tb: "Optional[Any]",
+    ) -> None:
+        with capture_internal_exceptions():
+            # Clear the stored agent
+            if hasattr(self._context_wrapper, "_sentry_current_agent"):
+                delattr(self._context_wrapper, "_sentry_current_agent")
+
+            span = getattr(self._context_wrapper, "_sentry_agent_span", None)
+            if not span:
+                return
+
+            update_invoke_agent_span(
+                span=span,
+                context=self._context_wrapper,
+                agent=self._agent,
+                output=self._output,
             )
 
-        # Add conversation ID from agent
-        conv_id = getattr(agent, "_sentry_conversation_id", None)
-        if conv_id:
-            span.set_data(SPANDATA.GEN_AI_CONVERSATION_ID, conv_id)
-
-        span.__exit__(None, None, None)
-        delattr(context, "_sentry_agent_span")
-
-
-def end_invoke_agent_span(
-    context_wrapper: "agents.RunContextWrapper",
-    agent: "agents.Agent",
-    output: "Optional[Any]" = None,
-) -> None:
-    """End the agent invocation span"""
-    # Clear the stored agent
-    if hasattr(context_wrapper, "_sentry_current_agent"):
-        delattr(context_wrapper, "_sentry_current_agent")
-
-    update_invoke_agent_span(context_wrapper, agent, output)
+            span.__exit__(exc_type, exc_val, exc_tb)
+            delattr(self._context_wrapper, "_sentry_agent_span")

--- a/sentry_sdk/integrations/openai_agents/utils.py
+++ b/sentry_sdk/integrations/openai_agents/utils.py
@@ -17,7 +17,6 @@ from sentry_sdk.ai.utils import (
 from sentry_sdk.consts import OP, SPANDATA, SPANSTATUS
 from sentry_sdk.integrations import DidNotEnable
 from sentry_sdk.scope import should_send_default_pii
-from sentry_sdk.tracing_utils import set_span_errored
 from sentry_sdk.utils import event_from_exception, safe_serialize
 
 if TYPE_CHECKING:
@@ -35,8 +34,6 @@ except ImportError:
 
 
 def _capture_exception(exc: "Any") -> None:
-    set_span_errored()
-
     event, hint = event_from_exception(
         exc,
         client_options=sentry_sdk.get_client().options,

--- a/sentry_sdk/tracing_utils.py
+++ b/sentry_sdk/tracing_utils.py
@@ -20,7 +20,7 @@ except ImportError:
 from typing import TYPE_CHECKING
 
 import sentry_sdk
-from sentry_sdk.consts import OP, SPANDATA, SPANSTATUS, SPANTEMPLATE
+from sentry_sdk.consts import OP, SPANDATA, SPANTEMPLATE
 from sentry_sdk.utils import (
     _is_external_source,
     _is_in_project_root,
@@ -1199,33 +1199,6 @@ def get_current_span(
     scope = scope or sentry_sdk.get_current_scope()
     current_span = scope.span
     return current_span
-
-
-def set_span_errored(span: "Optional[Union[Span, StreamedSpan]]" = None) -> None:
-    """
-    Set the status of the current or given span to INTERNAL_ERROR.
-    Also sets the status of the transaction (root span) to INTERNAL_ERROR.
-    """
-    from sentry_sdk.traces import SpanStatus, StreamedSpan, _get_current_streamed_span
-
-    client = sentry_sdk.get_client()
-
-    if not span:
-        span = (
-            _get_current_streamed_span()
-            if has_span_streaming_enabled(client.options)
-            else sentry_sdk.get_current_span()
-        )
-
-    if span is not None:
-        if isinstance(span, Span):
-            span.set_status(SPANSTATUS.INTERNAL_ERROR)
-            if span.containing_transaction is not None:
-                span.containing_transaction.set_status(SPANSTATUS.INTERNAL_ERROR)
-        elif isinstance(span, StreamedSpan):
-            span.status = SpanStatus.ERROR
-            if span._segment is not None:
-                span._segment.status = SpanStatus.ERROR
 
 
 def _generate_sample_rand(


### PR DESCRIPTION
### Description
<!-- What changed and why? -->

Stop modifying the transaction, since the transaction may not be managed by `openai-agents`.

Stop finishing spans inside `update_invoke_agent_span()`. Change the function to accept a `span` parameter and finish the span at the call site with `Span.__exit__()`, passing in the exception tuple if relevant.

#### Issues
<!--
* resolves: #1234
* resolves: LIN-1234
-->

#### Reminders
- Please add tests to validate your changes, and lint your code using `tox -e linters`.
- Add GH Issue ID _&_ Linear ID (if applicable)
- PR title should use [conventional commit](https://develop.sentry.dev/engineering-practices/commit-messages/#type) style (`feat:`, `fix:`, `ref:`, `meta:`)
- For external contributors: [CONTRIBUTING.md](https://github.com/getsentry/sentry-python/blob/master/CONTRIBUTING.md), [Sentry SDK development docs](https://develop.sentry.dev/sdk/), [Discord community](https://discord.gg/Ww9hbqr)
