### PR TITLE
fix(serializer): Don't call `__iter__` on arbitrary sequences

### DIFF
--- a/sentry_sdk/serializer.py
+++ b/sentry_sdk/serializer.py
@@ -1,6 +1,6 @@
 import math
 import sys
-from collections.abc import Mapping, Sequence, Set
+from collections.abc import Mapping
 from datetime import datetime
 from typing import TYPE_CHECKING
 
@@ -53,7 +53,7 @@ def add_global_repr_processor(processor: "ReprProcessor") -> None:
     global_repr_processors.append(processor)
 
 
-sequence_types: "List[type]" = [Sequence, Set]
+sequence_types: "List[type]" = [tuple, list, set]
 
 
 def add_repr_sequence_type(ty: type) -> None:

--- a/sentry_sdk/serializer.py
+++ b/sentry_sdk/serializer.py
@@ -53,7 +53,7 @@ def add_global_repr_processor(processor: "ReprProcessor") -> None:
     global_repr_processors.append(processor)
 
 
-sequence_types: "List[type]" = [tuple, list, set]
+sequence_types: "List[type]" = [tuple, list, set, frozenset]
 
 
 def add_repr_sequence_type(ty: type) -> None:

--- a/sentry_sdk/serializer.py
+++ b/sentry_sdk/serializer.py
@@ -53,7 +53,7 @@ def add_global_repr_processor(processor: "ReprProcessor") -> None:
     global_repr_processors.append(processor)
 
 
-sequence_types: "List[type]" = [tuple, list, set, frozenset]
+sequence_types: "List[type]" = [tuple, list, set, frozenset, bytes]
 
 
 def add_repr_sequence_type(ty: type) -> None:

--- a/sentry_sdk/serializer.py
+++ b/sentry_sdk/serializer.py
@@ -1,5 +1,6 @@
 import math
 import sys
+from array import array
 from collections.abc import Mapping
 from datetime import datetime
 from typing import TYPE_CHECKING
@@ -53,7 +54,7 @@ def add_global_repr_processor(processor: "ReprProcessor") -> None:
     global_repr_processors.append(processor)
 
 
-sequence_types: "List[type]" = [tuple, list, set, frozenset, bytes]
+sequence_types: "List[type]" = [tuple, list, set, frozenset, array]
 
 
 def add_repr_sequence_type(ty: type) -> None:

--- a/tests/test_serializer.py
+++ b/tests/test_serializer.py
@@ -180,3 +180,39 @@ def test_max_value_length(body_normalizer):
     result = body_normalizer(data, max_value_length=max_value_length)
 
     assert len(result["key"]) == max_value_length
+
+
+def test_serialize_local_vars():
+    # This was added to make sure we don't try to iterate over instances of
+    # custom classes with an __iter__ method due to potential side effects
+    class Custom:
+        def __init__(self, items):
+            self.items = items
+
+        def __len__(self):
+            return self.items.__len__()
+
+        def __getitem__(self, item):
+            return self.items.__getitem__(item)
+
+        def __iter__(self):
+            raise ValueError
+
+    local_vars = {
+        "str": "123",
+        "bytes": b"123",
+        "list": [1, 2, 3],
+        "set": {1, 2, 3},
+        "frozenset": frozenset([1, 2, 3]),
+        "custom": Custom([1, 2, 3]),
+    }
+
+    result = serialize(local_vars, is_vars=True)
+    assert result["str"] == "'123'"
+    assert result["bytes"] == "b'123'"
+    assert result["list"] == ["1", "2", "3"]
+    assert result["set"] == ["1", "2", "3"]
+    assert result["frozenset"] == ["1", "2", "3"]
+    assert result["custom"].startswith(
+        "<tests.test_serializer.test_serialize_local_vars.<locals>.Custom object at"
+    )

--- a/tests/test_serializer.py
+++ b/tests/test_serializer.py
@@ -1,4 +1,5 @@
 import re
+from array import array
 
 import pytest
 
@@ -204,6 +205,7 @@ def test_serialize_local_vars():
         "list": [1, 2, 3],
         "set": {1, 2, 3},
         "frozenset": frozenset([1, 2, 3]),
+        "array": array("l", [1, 2, 3]),
         "custom": Custom([1, 2, 3]),
     }
 
@@ -211,8 +213,9 @@ def test_serialize_local_vars():
     assert result["str"] == "'123'"
     assert result["bytes"] == "b'123'"
     assert result["list"] == ["1", "2", "3"]
-    assert result["set"] == ["1", "2", "3"]
-    assert result["frozenset"] == ["1", "2", "3"]
+    assert sorted(result["set"]) == ["1", "2", "3"]
+    assert sorted(result["frozenset"]) == ["1", "2", "3"]
+    assert result["array"] == ["1", "2", "3"]
     assert result["custom"].startswith(
         "<tests.test_serializer.test_serialize_local_vars.<locals>.Custom object at"
     )


### PR DESCRIPTION
### Description
The serializer will attempt to serialize whatever objects are thrown into it. This includes arbitrary local variables in folks' programs that might have all sorts of side-effects.

Notably, if an object is a [`Sequence`](https://docs.python.org/3/glossary.html#term-sequence) (it has `__iter__`, `__len__`, and `__getitem__`), we will try to `__iter__` over it. Which is potentially an unwise thing to do, as we know nothing about the object's custom `__iter__` implementation. It can, for example, [acquire a non-reentrant lock](https://github.com/getsentry/sentry-python/issues/5586). In some scenarios, this can lead to deadlocks caused by the SDK.

In this PR, the serializer is changed so that we don't try to `__iter__` over all `Sequence`s, just built-in stdlib ones. Of course, nothing is preventing folks from defining side-effecty lists, tuples and sets, but it's a bit less likely to happen than on a custom class. Custom sequences will now be simply `__repr__`'d.

#### Issues
- Closes https://github.com/getsentry/sentry-python/issues/5586
- Closes https://linear.app/getsentry/issue/PY-2124/deadlock-during-gc-with-sentry-opentelemetry-tornado-aiohttp

#### Reminders
- Please add tests to validate your changes, and lint your code using `tox -e linters`.
- Add GH Issue ID _&_ Linear ID (if applicable)
- PR title should use [conventional commit](https://develop.sentry.dev/engineering-practices/commit-messages/#type) style (`feat:`, `fix:`, `ref:`, `meta:`)
- For external contributors: [CONTRIBUTING.md](https://github.com/getsentry/sentry-python/blob/master/CONTRIBUTING.md), [Sentry SDK development docs](https://develop.sentry.dev/sdk/), [Discord community](https://discord.gg/Ww9hbqr)
