### PR TITLE
ref(wsgi): Remove unused segment name setting

### DIFF
--- a/sentry_sdk/integrations/asgi.py
+++ b/sentry_sdk/integrations/asgi.py
@@ -367,27 +367,6 @@ class SentryAsgiMiddleware:
                                 self._capture_request_exception(exc)
                             reraise(*exc_info)
 
-                        finally:
-                            if isinstance(span, StreamedSpan):
-                                already_set = (
-                                    span is not None
-                                    and span.name != _DEFAULT_TRANSACTION_NAME
-                                    and span.get_attributes().get("sentry.span.source")
-                                    in [
-                                        SegmentSource.COMPONENT.value,
-                                        SegmentSource.ROUTE.value,
-                                        SegmentSource.CUSTOM.value,
-                                    ]
-                                )
-                                with capture_internal_exceptions():
-                                    if not already_set:
-                                        name, source = (
-                                            self._get_segment_name_and_source(
-                                                self.transaction_style, scope
-                                            )
-                                        )
-                                        span.name = name
-                                        span.set_attribute("sentry.span.source", source)
         finally:
             _asgi_middleware_applied.set(False)
 

--- a/sentry_sdk/integrations/asgi.py
+++ b/sentry_sdk/integrations/asgi.py
@@ -367,6 +367,27 @@ class SentryAsgiMiddleware:
                                 self._capture_request_exception(exc)
                             reraise(*exc_info)
 
+                        finally:
+                            if isinstance(span, StreamedSpan):
+                                already_set = (
+                                    span is not None
+                                    and span.name != _DEFAULT_TRANSACTION_NAME
+                                    and span.get_attributes().get("sentry.span.source")
+                                    in [
+                                        SegmentSource.COMPONENT.value,
+                                        SegmentSource.ROUTE.value,
+                                        SegmentSource.CUSTOM.value,
+                                    ]
+                                )
+                                with capture_internal_exceptions():
+                                    if not already_set:
+                                        name, source = (
+                                            self._get_segment_name_and_source(
+                                                self.transaction_style, scope
+                                            )
+                                        )
+                                        span.name = name
+                                        span.set_attribute("sentry.span.source", source)
         finally:
             _asgi_middleware_applied.set(False)
 

--- a/sentry_sdk/integrations/wsgi.py
+++ b/sentry_sdk/integrations/wsgi.py
@@ -174,7 +174,6 @@ class SentryWsgiMiddleware:
                             )
                         except BaseException:
                             reraise(*_capture_exception())
-
         finally:
             _wsgi_middleware_applied.set(False)
 

--- a/sentry_sdk/integrations/wsgi.py
+++ b/sentry_sdk/integrations/wsgi.py
@@ -174,24 +174,7 @@ class SentryWsgiMiddleware:
                             )
                         except BaseException:
                             reraise(*_capture_exception())
-                        finally:
-                            if isinstance(span, StreamedSpan):
-                                already_set = (
-                                    span.name != _DEFAULT_TRANSACTION_NAME
-                                    and span.get_attributes().get("sentry.span.source")
-                                    in [
-                                        SegmentSource.COMPONENT.value,
-                                        SegmentSource.ROUTE.value,
-                                        SegmentSource.CUSTOM.value,
-                                    ]
-                                )
-                                if not already_set:
-                                    with capture_internal_exceptions():
-                                        span.name = _DEFAULT_TRANSACTION_NAME
-                                        span.set_attribute(
-                                            "sentry.span.source",
-                                            SegmentSource.ROUTE.value,
-                                        )
+
         finally:
             _wsgi_middleware_applied.set(False)
 


### PR DESCRIPTION
### Description
In span first, there is logic in the WSGI integration that sets the segment name and the source attribute to a generic default at the end of a segment span's lifecycle, unless the name/source have been set explicitly.

This logic is unnecessary. We create the segment with the default name and source, so there's no reason to rename again at the end. If the segment was renamed during its lifetime, that's the name we want to keep; the default is just a fallback.

#### Issues
<!--
* resolves: #1234
* resolves: LIN-1234
-->

#### Reminders
- Please add tests to validate your changes, and lint your code using `tox -e linters`.
- Add GH Issue ID _&_ Linear ID (if applicable)
- PR title should use [conventional commit](https://develop.sentry.dev/engineering-practices/commit-messages/#type) style (`feat:`, `fix:`, `ref:`, `meta:`)
- For external contributors: [CONTRIBUTING.md](https://github.com/getsentry/sentry-python/blob/master/CONTRIBUTING.md), [Sentry SDK development docs](https://develop.sentry.dev/sdk/), [Discord community](https://discord.gg/Ww9hbqr)
