### PR TITLE
fix(asyncpg): Use Sentry span attribute name conventions

### DIFF
--- a/sentry_sdk/integrations/asyncpg.py
+++ b/sentry_sdk/integrations/asyncpg.py
@@ -211,9 +211,9 @@ def _wrap_connect_addr(
             span_attributes = {
                 "sentry.op": OP.DB,
                 "sentry.origin": AsyncPGIntegration.origin,
-                SPANDATA.DB_SYSTEM: "postgresql",
+                SPANDATA.DB_SYSTEM_NAME: "postgresql",
                 SPANDATA.DB_USER: user,
-                SPANDATA.DB_NAME: database,
+                SPANDATA.DB_NAMESPACE: database,
                 SPANDATA.DB_DRIVER_NAME: "asyncpg",
             }
             if addr:
@@ -261,23 +261,40 @@ def _wrap_connect_addr(
 
 
 def _set_db_data(span: "Union[Span, StreamedSpan]", conn: "Any") -> None:
-    set_value = span.set_attribute if isinstance(span, StreamedSpan) else span.set_data
-
-    set_value(SPANDATA.DB_SYSTEM, "postgresql")
-    set_value(SPANDATA.DB_DRIVER_NAME, "asyncpg")
-
     addr = conn._addr
-    if addr:
-        try:
-            set_value(SPANDATA.SERVER_ADDRESS, addr[0])
-            set_value(SPANDATA.SERVER_PORT, addr[1])
-        except IndexError:
-            pass
-
     database = conn._params.database
-    if database:
-        set_value(SPANDATA.DB_NAME, database)
-
     user = conn._params.user
-    if user:
-        set_value(SPANDATA.DB_USER, user)
+
+    if isinstance(span, StreamedSpan):
+        span.set_attribute(SPANDATA.DB_SYSTEM_NAME, "postgresql")
+        span.set_attribute(SPANDATA.DB_DRIVER_NAME, "asyncpg")
+        if addr:
+            try:
+                span.set_attribute(SPANDATA.SERVER_ADDRESS, addr[0])
+                span.set_attribute(SPANDATA.SERVER_PORT, addr[1])
+            except IndexError:
+                pass
+
+        if database:
+            span.set_attribute(SPANDATA.DB_NAMESPACE, database)
+
+        if user:
+            span.set_attribute(SPANDATA.DB_USER, user)
+    else:
+        # Remove this else block once we've completely migrated to streamed spans
+        # The use of deprecated attributes here is to ensure backwards compatibility
+        span.set_data(SPANDATA.DB_SYSTEM, "postgresql")
+        span.set_data(SPANDATA.DB_DRIVER_NAME, "asyncpg")
+
+        if addr:
+            try:
+                span.set_data(SPANDATA.SERVER_ADDRESS, addr[0])
+                span.set_data(SPANDATA.SERVER_PORT, addr[1])
+            except IndexError:
+                pass
+
+        if database:
+            span.set_data(SPANDATA.DB_NAME, database)
+
+        if user:
+            span.set_data(SPANDATA.DB_USER, user)

--- a/tests/integrations/asyncpg/test_asyncpg.py
+++ b/tests/integrations/asyncpg/test_asyncpg.py
@@ -58,6 +58,23 @@ CRUMBS_CONNECT = {
     "message": "connect",
     "type": "default",
 }
+CRUMBS_CONNECT_STREAMING = {
+    "category": "query",
+    "data": ApproxDict(
+        {
+            "sentry.op": "db",
+            "sentry.origin": "auto.db.asyncpg",
+            "db.system.name": "postgresql",
+            "db.namespace": PG_NAME,
+            "db.user": PG_USER,
+            "db.driver.name": "asyncpg",
+            "server.address": PG_HOST,
+            "server.port": PG_PORT,
+        }
+    ),
+    "message": "connect",
+    "type": "default",
+}
 
 
 @pytest_asyncio.fixture(autouse=True)
@@ -124,7 +141,8 @@ async def test_connect(
     for crumb in event["breadcrumbs"]["values"]:
         del crumb["timestamp"]
 
-    assert event["breadcrumbs"]["values"] == [CRUMBS_CONNECT]
+    expected_crumbs_connect = CRUMBS_CONNECT_STREAMING if span_streaming else CRUMBS_CONNECT
+    assert event["breadcrumbs"]["values"] == [expected_crumbs_connect]
 
 
 @pytest.mark.asyncio
@@ -176,8 +194,9 @@ async def test_execute(
     for crumb in event["breadcrumbs"]["values"]:
         del crumb["timestamp"]
 
+    expected_crumbs_connect = CRUMBS_CONNECT_STREAMING if span_streaming else CRUMBS_CONNECT
     assert event["breadcrumbs"]["values"] == [
-        CRUMBS_CONNECT,
+        expected_crumbs_connect,
         {
             "category": "query",
             "data": {},
@@ -245,8 +264,9 @@ async def test_execute_many(
     for crumb in event["breadcrumbs"]["values"]:
         del crumb["timestamp"]
 
+    expected_crumbs_connect = CRUMBS_CONNECT_STREAMING if span_streaming else CRUMBS_CONNECT
     assert event["breadcrumbs"]["values"] == [
-        CRUMBS_CONNECT,
+        expected_crumbs_connect,
         {
             "category": "query",
             "data": {"db.executemany": True},
@@ -1398,11 +1418,11 @@ async def test_cursor__bind_exec_creates_spans(
 
         assert bind_exec_span["attributes"]["sentry.origin"] == "auto.db.asyncpg"
         assert bind_exec_span["attributes"]["sentry.op"] == "db"
-        assert bind_exec_span["attributes"]["db.system"] == "postgresql"
+        assert bind_exec_span["attributes"]["db.system.name"] == "postgresql"
         assert bind_exec_span["attributes"]["db.driver.name"] == "asyncpg"
         assert bind_exec_span["attributes"]["server.address"] == PG_HOST
         assert bind_exec_span["attributes"]["server.port"] == PG_PORT
-        assert bind_exec_span["attributes"]["db.name"] == PG_NAME
+        assert bind_exec_span["attributes"]["db.namespace"] == PG_NAME
         assert bind_exec_span["attributes"]["db.user"] == PG_USER
     else:
         events = capture_events()

--- a/tests/integrations/asyncpg/test_asyncpg.py
+++ b/tests/integrations/asyncpg/test_asyncpg.py
@@ -141,7 +141,9 @@ async def test_connect(
     for crumb in event["breadcrumbs"]["values"]:
         del crumb["timestamp"]
 
-    expected_crumbs_connect = CRUMBS_CONNECT_STREAMING if span_streaming else CRUMBS_CONNECT
+    expected_crumbs_connect = (
+        CRUMBS_CONNECT_STREAMING if span_streaming else CRUMBS_CONNECT
+    )
     assert event["breadcrumbs"]["values"] == [expected_crumbs_connect]
 
 
@@ -194,7 +196,9 @@ async def test_execute(
     for crumb in event["breadcrumbs"]["values"]:
         del crumb["timestamp"]
 
-    expected_crumbs_connect = CRUMBS_CONNECT_STREAMING if span_streaming else CRUMBS_CONNECT
+    expected_crumbs_connect = (
+        CRUMBS_CONNECT_STREAMING if span_streaming else CRUMBS_CONNECT
+    )
     assert event["breadcrumbs"]["values"] == [
         expected_crumbs_connect,
         {
@@ -264,7 +268,9 @@ async def test_execute_many(
     for crumb in event["breadcrumbs"]["values"]:
         del crumb["timestamp"]
 
-    expected_crumbs_connect = CRUMBS_CONNECT_STREAMING if span_streaming else CRUMBS_CONNECT
+    expected_crumbs_connect = (
+        CRUMBS_CONNECT_STREAMING if span_streaming else CRUMBS_CONNECT
+    )
     assert event["breadcrumbs"]["values"] == [
         expected_crumbs_connect,
         {


### PR DESCRIPTION
## Summary
- Update asyncpg span attributes to use `db.system.name` and `db.namespace` instead of deprecated `db.system` and `db.name`
- Retain deprecated attribute names for non-streamed spans for backwards compatibility

Fixes PY-2424
Fixes #6299