### PR TITLE
fix(openai-agents): Use `name`, not `description` in `start_span`

### DIFF
--- a/sentry_sdk/integrations/openai_agents/spans/ai_client.py
+++ b/sentry_sdk/integrations/openai_agents/spans/ai_client.py
@@ -31,7 +31,7 @@ def ai_client_span(
 
     span = sentry_sdk.start_span(
         op=OP.GEN_AI_CHAT,
-        description=f"chat {model_name}",
+        name=f"chat {model_name}",
         origin=SPAN_ORIGIN,
     )
     # TODO-anton: remove hardcoded stuff and replace something that also works for embedding and so on

--- a/sentry_sdk/integrations/openai_agents/utils.py
+++ b/sentry_sdk/integrations/openai_agents/utils.py
@@ -224,7 +224,7 @@ def _create_mcp_execute_tool_spans(
         if output.__class__.__name__ == "McpCall":
             with sentry_sdk.start_span(
                 op=OP.GEN_AI_EXECUTE_TOOL,
-                description=f"execute_tool {output.name}",
+                name=f"execute_tool {output.name}",
                 start_timestamp=span.start_timestamp,
             ) as execute_tool_span:
                 execute_tool_span.set_data(SPANDATA.GEN_AI_TOOL_NAME, output.name)


### PR DESCRIPTION
We're using the `name` argument to `start_span` throughout the SDK. There are only two places where we still use the deprecated `description` arg instead. Fix those.

This aligns these two spans with equivalent spans from other AI integrations which all use `name`.