### PR TITLE
fix(strawberry): Wrap yields in try-except to ensure span cleanup

### DIFF
--- a/sentry_sdk/integrations/strawberry.py
+++ b/sentry_sdk/integrations/strawberry.py
@@ -258,12 +258,14 @@ class SentryAsyncExtension(SchemaExtension):
                 origin=StrawberryIntegration.origin,
             )
 
-        yield
-
-        if isinstance(validation_span, StreamedSpan):
-            validation_span.end()
-        else:
-            validation_span.finish()
+        # If an exception is raised during validation, we still need to close the span
+        try:
+            yield
+        finally:
+            if isinstance(validation_span, StreamedSpan):
+                validation_span.end()
+            else:
+                validation_span.finish()
 
     def on_parse(self) -> "Generator[None, None, None]":
         client = sentry_sdk.get_client()
@@ -284,12 +286,14 @@ class SentryAsyncExtension(SchemaExtension):
                 origin=StrawberryIntegration.origin,
             )
 
-        yield
-
-        if isinstance(parsing_span, StreamedSpan):
-            parsing_span.end()
-        else:
-            parsing_span.finish()
+        # If an exception is raised during parsing, we still need to close the span
+        try:
+            yield
+        finally:
+            if isinstance(parsing_span, StreamedSpan):
+                parsing_span.end()
+            else:
+                parsing_span.finish()
 
     def should_skip_tracing(
         self,


### PR DESCRIPTION
Ensures that validation and parsing spans are properly closed even if an exception is raised during these operations. Moves yield statements into try/finally blocks so span cleanup always happens.

This addresses a [comment](https://github.com/getsentry/sentry-python/pull/6308/changes#r3275807909) raised by a PR bot in the span-first conversion changes

Fixes PY-2425
Fixes #6309