### PR TITLE
test(pyramid): Add span streaming support to integration tests

### DIFF
--- a/sentry_sdk/integrations/pyramid.py
+++ b/sentry_sdk/integrations/pyramid.py
@@ -8,7 +8,9 @@ from sentry_sdk.integrations import DidNotEnable, Integration
 from sentry_sdk.integrations._wsgi_common import RequestExtractor
 from sentry_sdk.integrations.wsgi import SentryWsgiMiddleware
 from sentry_sdk.scope import should_send_default_pii
-from sentry_sdk.tracing import SOURCE_FOR_STYLE
+from sentry_sdk.traces import SOURCE_FOR_STYLE as SEGMENT_SOURCE_FOR_STYLE
+from sentry_sdk.tracing import SOURCE_FOR_STYLE as TRANSACTION_SOURCE_FOR_STYLE
+from sentry_sdk.tracing_utils import has_span_streaming_enabled
 from sentry_sdk.utils import (
     capture_internal_exceptions,
     ensure_integration_enabled,
@@ -157,9 +159,17 @@ def _set_transaction_name_and_source(
             "route_name": request.matched_route.name,
             "route_pattern": request.matched_route.pattern,
         }
+        is_span_streaming_enabled = has_span_streaming_enabled(
+            sentry_sdk.get_client().options
+        )
+        source = (
+            SEGMENT_SOURCE_FOR_STYLE[transaction_style]
+            if is_span_streaming_enabled
+            else TRANSACTION_SOURCE_FOR_STYLE[transaction_style]
+        )
         scope.set_transaction_name(
             name_for_style[transaction_style],
-            source=SOURCE_FOR_STYLE[transaction_style],
+            source=source,
         )
     except Exception:
         pass

--- a/tests/integrations/pyramid/test_pyramid.py
+++ b/tests/integrations/pyramid/test_pyramid.py
@@ -526,7 +526,9 @@ def test_tracing_error(
 
 
 @pytest.mark.parametrize("span_streaming", [True, False])
-def test_span_origin(sentry_init, capture_events, capture_items, get_client, span_streaming):
+def test_span_origin(
+    sentry_init, capture_events, capture_items, get_client, span_streaming
+):
     sentry_init(
         integrations=[PyramidIntegration()],
         traces_sample_rate=1.0,

--- a/tests/integrations/pyramid/test_pyramid.py
+++ b/tests/integrations/pyramid/test_pyramid.py
@@ -9,9 +9,11 @@ from pyramid.authorization import ACLAuthorizationPolicy
 from pyramid.response import Response
 from werkzeug.test import Client
 
+import sentry_sdk
 from sentry_sdk import add_breadcrumb, capture_message
 from sentry_sdk.integrations.pyramid import PyramidIntegration
 from sentry_sdk.serializer import MAX_DATABAG_BREADTH
+from sentry_sdk.traces import SpanStatus
 from tests.conftest import unpack_werkzeug_response
 
 try:
@@ -126,6 +128,7 @@ def test_has_context(route, get_client, sentry_init, capture_events):
     assert event["transaction"] == "hi2"
 
 
+@pytest.mark.parametrize("span_streaming", [True, False])
 @pytest.mark.parametrize(
     "url,transaction_style,expected_transaction,expected_source",
     [
@@ -139,20 +142,38 @@ def test_transaction_style(
     sentry_init,
     get_client,
     capture_events,
+    capture_items,
     url,
     transaction_style,
     expected_transaction,
     expected_source,
+    span_streaming,
 ):
-    sentry_init(integrations=[PyramidIntegration(transaction_style=transaction_style)])
+    sentry_init(
+        integrations=[PyramidIntegration(transaction_style=transaction_style)],
+        traces_sample_rate=1.0,
+        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+    )
 
-    events = capture_events()
+    if span_streaming:
+        items = capture_items("event", "span")
+    else:
+        events = capture_events()
+
     client = get_client()
     client.get(url)
 
-    (event,) = events
-    assert event["transaction"] == expected_transaction
-    assert event["transaction_info"] == {"source": expected_source}
+    if span_streaming:
+        sentry_sdk.flush()
+        spans = [i.payload for i in items if i.type == "span"]
+        assert len(spans) == 1
+        (segment,) = spans
+        assert segment["name"] == expected_transaction
+        assert segment["attributes"]["sentry.span.source"] == expected_source
+    else:
+        (_, transaction_event) = events
+        assert transaction_event["transaction"] == expected_transaction
+        assert transaction_event["transaction_info"] == {"source": expected_source}
 
 
 @pytest.mark.parametrize("max_value_length", [1024, None])
@@ -453,16 +474,79 @@ def test_tween_ok(sentry_init, pyramid_config, capture_exceptions, route, get_cl
     assert not errors
 
 
-def test_span_origin(sentry_init, capture_events, get_client):
+@pytest.mark.parametrize("span_streaming", [True, False])
+def test_tracing_error(
+    sentry_init, capture_events, capture_items, route, get_client, span_streaming
+):
     sentry_init(
         integrations=[PyramidIntegration()],
         traces_sample_rate=1.0,
+        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
     )
-    events = capture_events()
+
+    if span_streaming:
+        items = capture_items("event", "span")
+    else:
+        events = capture_events()
+
+    @route("/tracing-error")
+    def tracing_error(request):
+        1 / 0
+
+    client = get_client()
+    with pytest.raises(ZeroDivisionError):
+        client.get("/tracing-error")
+
+    if span_streaming:
+        sentry_sdk.flush()
+        spans = [i.payload for i in items if i.type == "span"]
+        error_events = [i.payload for i in items if i.type == "event"]
+
+        assert len(spans) == 1
+        assert len(error_events) == 1
+
+        (segment,) = spans
+        (error_event,) = error_events
+
+        assert segment["name"] == "tracing_error"
+        assert segment["status"] == SpanStatus.ERROR
+        assert segment["attributes"]["sentry.origin"] == "auto.http.pyramid"
+
+        assert error_event["exception"]["values"][-1]["type"] == "ZeroDivisionError"
+        assert error_event["exception"]["values"][-1]["mechanism"]["type"] == "pyramid"
+    else:
+        error_event, transaction_event = events
+
+        assert transaction_event["type"] == "transaction"
+        assert transaction_event["transaction"] == "tracing_error"
+        assert transaction_event["contexts"]["trace"]["status"] == "internal_error"
+
+        assert error_event["exception"]["values"][-1]["type"] == "ZeroDivisionError"
+        assert error_event["exception"]["values"][-1]["mechanism"]["type"] == "pyramid"
+
+
+@pytest.mark.parametrize("span_streaming", [True, False])
+def test_span_origin(sentry_init, capture_events, capture_items, get_client, span_streaming):
+    sentry_init(
+        integrations=[PyramidIntegration()],
+        traces_sample_rate=1.0,
+        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+    )
+
+    if span_streaming:
+        items = capture_items("event", "span")
+    else:
+        events = capture_events()
 
     client = get_client()
     client.get("/message")
 
-    (_, event) = events
-
-    assert event["contexts"]["trace"]["origin"] == "auto.http.pyramid"
+    if span_streaming:
+        sentry_sdk.flush()
+        spans = [i.payload for i in items if i.type == "span"]
+        assert len(spans) == 1
+        (segment,) = spans
+        assert segment["attributes"]["sentry.origin"] == "auto.http.pyramid"
+    else:
+        (_, event) = events
+        assert event["contexts"]["trace"]["origin"] == "auto.http.pyramid"


### PR DESCRIPTION
This integration gets span streaming automatically via the SentryWsgiMiddleware and the branching logic in helper methods like `set_transaction_name`.

Added test coverage to confirm span streaming works as expected.

Fixes PY-2350
Fixes #6048