### PR TITLE
feat(celery): preserve original signature on apply_async wrapper for autospec compatibility

### DIFF
--- a/sentry_sdk/integrations/celery/__init__.py
+++ b/sentry_sdk/integrations/celery/__init__.py
@@ -1,3 +1,4 @@
+import inspect
 import sys
 from collections.abc import Mapping
 from functools import wraps
@@ -308,6 +309,16 @@ def _wrap_task_run(f: "F") -> "F":
                 kwarg_headers, span, integration.monitor_beat_tasks
             )
             return f(*args, **kwargs)
+
+    # Preserve the wrapped function's signature on the wrapper so that
+    # tools that inspect the wrapper (e.g. ``mock.patch(..., autospec=True)``
+    # or IDE introspection) see the original ``apply_async`` signature
+    # rather than the wrapper's bare ``(*args, **kwargs)``. Mirrors the
+    # ``__signature__`` override added in #3178 for the ``trace`` decorator.
+    try:
+        apply_async.__signature__ = inspect.signature(f)  # type: ignore[attr-defined]
+    except (TypeError, ValueError):
+        pass
 
     return apply_async  # type: ignore
 

--- a/tests/integrations/celery/test_celery.py
+++ b/tests/integrations/celery/test_celery.py
@@ -1,3 +1,4 @@
+import inspect
 import threading
 from unittest import mock
 
@@ -1192,6 +1193,47 @@ def test_user_custom_headers_accessible_in_task(span_streaming, init_celery):
         assert received_headers.get(key) == value, (
             f"Custom header {key!r} not found in task.request.headers"
         )
+
+
+def test_wrap_task_run_preserves_signature(init_celery):
+    """
+    ``_wrap_task_run`` replaces ``Task.apply_async`` (and
+    ``Celery.send_task``) with a wrapper declared as
+    ``def apply_async(*args, **kwargs)``. ``@functools.wraps`` copies
+    ``__wrapped__``, so ``inspect.signature`` resolves through it, but
+    other introspection tools (e.g. ``inspect.getcallargs``) do not
+    follow ``__wrapped__`` and would otherwise see the wrapper's bare
+    ``(*args, **kwargs)``.
+
+    Setting ``wrapper.__signature__ = inspect.signature(f)`` keeps the
+    wrapped function's signature visible regardless of how callers
+    inspect the wrapper. This mirrors PR #3178, which applied the same
+    fix to the ``sentry_sdk.tracing.trace`` decorator.
+    """
+    from celery.app.task import Task
+
+    init_celery()
+
+    wrapped = getattr(Task.apply_async, "__wrapped__", None)
+    assert wrapped is not None, (
+        "_wrap_task_run did not run; Task.apply_async has no __wrapped__"
+    )
+
+    expected_sig = inspect.signature(wrapped)
+
+    # ``inspect.signature`` follows ``__wrapped__``, so this passes either
+    # way; included as a sanity check that the wrapped signature is the
+    # one we expect to be preserved.
+    assert inspect.signature(Task.apply_async) == expected_sig
+
+    # ``inspect.getcallargs`` does NOT follow ``__wrapped__``; it inspects
+    # the wrapper's own ``__code__`` unless ``__signature__`` is set. The
+    # fix makes ``getcallargs`` see the wrapped function's parameter
+    # names instead of {'args': (...), 'kwargs': {}}.
+    callargs = inspect.getcallargs(Task.apply_async, None, (1, 2), {})
+    assert "self" in callargs
+    assert callargs["args"] == (1, 2)
+    assert callargs["kwargs"] == {}
 
 
 @pytest.mark.skip(reason="placeholder so that forked test does not come last")


### PR DESCRIPTION
## Summary

`_wrap_task_run` replaces `Task.apply_async` (and `Celery.send_task`) with a wrapper declared as:

```python
@wraps(f)
def apply_async(*args, **kwargs):
    ...
```

`functools.wraps` copies `__wrapped__` onto the wrapper, so `inspect.signature` resolves through it. But other introspection tools that do not follow `__wrapped__` (e.g. `inspect.getcallargs`, IDE call-arg analysis, and some autospec-style test doubles built on `__code__` rather than `signature`) see the wrapper's bare `(*args, **kwargs)` and lose the original parameter names.

This change adds:

```python
try:
    apply_async.__signature__ = inspect.signature(f)
except (TypeError, ValueError):
    pass
```

after the wrapper is defined, making the wrapper signature-transparent to all introspection paths.

## Precedent

PR #3178 (fix `@sentry_sdk.tracing.trace` changing function signature, fixing #3177) applied this exact pattern to `func_with_tracing` in `sentry_sdk/tracing_utils.py`. The `_wrap_task_run` wrapper has the same shape; this PR brings it in line.

## Reproduction

```python
import inspect
from celery import Celery
import sentry_sdk
from sentry_sdk.integrations.celery import CeleryIntegration

sentry_sdk.init(integrations=[CeleryIntegration()])

celery = Celery("repro")

@celery.task
def my_task(x, y):
    return x + y

from celery.app.task import Task

# Before this PR: getcallargs sees the bare (*args, **kwargs):
#   {'args': (None, (1, 2), {}), 'kwargs': {}}
# After this PR: getcallargs binds parameter names from the wrapped function:
#   {'self': None, 'args': (1, 2), 'kwargs': {}, 'task_id': None, ...}
print(inspect.getcallargs(Task.apply_async, None, (1, 2), {}))
```

## Test

Added `test_wrap_task_run_preserves_signature` in `tests/integrations/celery/test_celery.py`. The test fails on `master` (sees `args`/`kwargs` placeholders) and passes with the fix (sees `self`, `args`, `kwargs` bound by name).

## Why this matters downstream

At Rover.com (rover.com, ~1M+ DAU pet-services marketplace), our test suite defaults every `mock.patch` to `autospec=True, spec_set=True` (1,046 test files use this convention). With `sentry-sdk` 1.x we carry a `FixSentryCeleryIntegration` integration that wraps the private `_wrap_apply_async` symbol just to force `wrapper.__signature__ = inspect.signature(<*args, **kwargs callable>)`. The same symbol exists in 2.x as `_wrap_task_run`, with the same gap. If this PR lands, that Rover-side monkey-patch can be deleted entirely on the next upgrade.

---

## General Notes

Filed without a pre-existing GitHub issue per the contribution guidelines note; happy to open one and reference it if maintainers prefer. PR is opened as a draft per the contribution standards.