### PR TITLE
fix(django): trace cache.add operations

### DIFF
--- a/sentry_sdk/integrations/django/caching.py
+++ b/sentry_sdk/integrations/django/caching.py
@@ -19,6 +19,7 @@ if TYPE_CHECKING:
 
 
 METHODS_TO_INSTRUMENT = [
+    "add",
     "set",
     "set_many",
     "get",
@@ -52,7 +53,7 @@ def _patch_cache_method(
         address: "Optional[str]",
         port: "Optional[int]",
     ) -> "Any":
-        is_set_operation = method_name.startswith("set")
+        is_set_operation = method_name.startswith("set") or method_name == "add"
         is_get_method = method_name == "get"
         is_get_many_method = method_name == "get_many"
 

--- a/tests/integrations/django/test_cache_module.py
+++ b/tests/integrations/django/test_cache_module.py
@@ -4,6 +4,7 @@ import uuid
 
 import pytest
 from django import VERSION as DJANGO_VERSION
+from django.core.cache import cache
 from werkzeug.test import Client
 
 try:
@@ -540,6 +541,56 @@ def test_cache_spans_templatetag(
         )
         assert second_event["spans"][0]["data"]["cache.hit"]
         assert second_event["spans"][0]["data"]["cache.item_size"] == 51
+
+
+@pytest.mark.forked
+@pytest.mark.parametrize("span_streaming", [True, False])
+def test_cache_spans_add(
+    sentry_init,
+    capture_events,
+    capture_items,
+    use_django_caching,
+    span_streaming,
+):
+    sentry_init(
+        integrations=[
+            DjangoIntegration(
+                cache_spans=True,
+                middleware_spans=False,
+                signals_spans=False,
+            )
+        ],
+        traces_sample_rate=1.0,
+        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+    )
+
+    if span_streaming:
+        items = capture_items("span")
+
+        with sentry_sdk.start_transaction(name="cache-add", op="test"):
+            assert cache.add("cache-add-key", "value")
+
+        sentry_sdk.flush()
+        spans = [item.payload for item in items if item.type == "span"]
+        assert len(spans) == 1
+        assert spans[0]["attributes"]["sentry.op"] == "cache.put"
+        assert spans[0]["name"] == "cache-add-key"
+        assert spans[0]["attributes"]["cache.key"] == ["cache-add-key"]
+        assert spans[0]["attributes"]["cache.item_size"] == 5
+    else:
+        events = capture_events()
+
+        with sentry_sdk.start_transaction(name="cache-add", op="test"):
+            assert cache.add("cache-add-key", "value")
+
+        sentry_sdk.flush()
+        assert len(events) == 1
+        spans = events[0]["spans"]
+        assert len(spans) == 1
+        assert spans[0]["op"] == "cache.put"
+        assert spans[0]["description"] == "cache-add-key"
+        assert spans[0]["data"]["cache.key"] == ["cache-add-key"]
+        assert spans[0]["data"]["cache.item_size"] == 5
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Refs #6402

`cache.add()` was a blind spot. `cache.set()` emitted `cache.put`, `cache.add()` emitted nothing. kinda odd for a normal Django cache write path.

Repro
```py
from django.core.cache import cache
import sentry_sdk
from sentry_sdk.integrations.django import DjangoIntegration

sentry_sdk.init(
    integrations=[DjangoIntegration(cache_spans=True)],
    traces_sample_rate=1.0,
)

with sentry_sdk.start_transaction(name="t", op="test"):
    cache.add("k", "value")
```

Before this patch: no cache span.
After this patch: one `cache.put` span for `cache.add()`.

What changed
- instrument `cache.add()`
- treat it as `cache.put`
- add a regression test for static + stream mode

Tested
- `tox -e py3.12-django-v4.2.30 -- -k test_cache_spans_add`

I also checked a wider Django cache test slice, but this env doesnt have the repo's local Postgres test service, so the db-marked Django tests bail early.
