### PR TITLE
test(openai-agents): Add `pytest.mark.asyncio` to sync tests

### DIFF
--- a/tests/integrations/openai_agents/test_openai_agents.py
+++ b/tests/integrations/openai_agents/test_openai_agents.py
@@ -945,7 +945,7 @@ async def test_client_span_custom_model(
 
 @pytest.mark.parametrize("stream_gen_ai_spans", [True, False])
 @pytest.mark.asyncio
-def test_agent_invocation_span_sync_no_pii(
+async def test_agent_invocation_span_sync_no_pii(
     sentry_init,
     capture_events,
     capture_items,
@@ -1172,7 +1172,7 @@ def test_agent_invocation_span_sync_no_pii(
         ),
     ],
 )
-def test_agent_invocation_span_sync(
+async def test_agent_invocation_span_sync(
     sentry_init,
     capture_events,
     capture_items,

--- a/tests/integrations/openai_agents/test_openai_agents.py
+++ b/tests/integrations/openai_agents/test_openai_agents.py
@@ -944,6 +944,7 @@ async def test_client_span_custom_model(
 
 
 @pytest.mark.parametrize("stream_gen_ai_spans", [True, False])
+@pytest.mark.asyncio
 def test_agent_invocation_span_sync_no_pii(
     sentry_init,
     capture_events,
@@ -1077,6 +1078,7 @@ def test_agent_invocation_span_sync_no_pii(
 
 
 @pytest.mark.parametrize("stream_gen_ai_spans", [True, False])
+@pytest.mark.asyncio
 @pytest.mark.parametrize(
     "instructions",
     (


### PR DESCRIPTION
### Description
<!-- What changed and why? -->

`AgentRunner.run_sync()` requires a running event loop. See https://github.com/openai/openai-agents-python/blob/6d5b888f6f57b8356398bea883b45172fec54b95/src/agents/run.py#L1596-L1598

#### Issues
<!--
* resolves: #1234
* resolves: LIN-1234
-->

#### Reminders
- Please add tests to validate your changes, and lint your code using `tox -e linters`.
- Add GH Issue ID _&_ Linear ID (if applicable)
- PR title should use [conventional commit](https://develop.sentry.dev/engineering-practices/commit-messages/#type) style (`feat:`, `fix:`, `ref:`, `meta:`)
- For external contributors: [CONTRIBUTING.md](https://github.com/getsentry/sentry-python/blob/master/CONTRIBUTING.md), [Sentry SDK development docs](https://develop.sentry.dev/sdk/), [Discord community](https://discord.gg/Ww9hbqr)
