### PR TITLE
test(openai-agents): Deduplicate by removing `node.callspec.id` matching

### DIFF
--- a/tests/integrations/openai_agents/test_openai_agents.py
+++ b/tests/integrations/openai_agents/test_openai_agents.py
@@ -323,6 +323,22 @@ async def test_agent_invocation_span_no_pii(
         ),
         (
             "You are a coding assistant that talks like a pirate.",
+            ("Test input"),
+            [
+                {
+                    "type": "text",
+                    "content": "You are a coding assistant that talks like a pirate.",
+                },
+            ],
+            [
+                {
+                    "content": [{"text": "Test input", "type": "text"}],
+                    "role": "user",
+                },
+            ],
+        ),
+        (
+            "You are a coding assistant that talks like a pirate.",
             [
                 {
                     "role": "system",
@@ -863,6 +879,22 @@ def test_agent_invocation_span_sync_no_pii(
             None,
             ("Test input"),
             None,
+            [
+                {
+                    "content": [{"text": "Test input", "type": "text"}],
+                    "role": "user",
+                },
+            ],
+        ),
+        (
+            "You are a coding assistant that talks like a pirate.",
+            ("Test input"),
+            [
+                {
+                    "type": "text",
+                    "content": "You are a coding assistant that talks like a pirate.",
+                },
+            ],
             [
                 {
                     "content": [{"text": "Test input", "type": "text"}],

--- a/tests/integrations/openai_agents/test_openai_agents.py
+++ b/tests/integrations/openai_agents/test_openai_agents.py
@@ -308,17 +308,21 @@ async def test_agent_invocation_span_no_pii(
 @pytest.mark.parametrize("stream_gen_ai_spans", [True, False])
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    "instructions",
-    (
-        None,
-        "You are a coding assistant that talks like a pirate.",
-    ),
-)
-@pytest.mark.parametrize(
-    "input",
+    "instructions,input,expected_system_instructions,expected_request_messages",
     [
-        pytest.param("Test input", id="string"),
-        pytest.param(
+        (
+            None,
+            ("Test input"),
+            None,
+            [
+                {
+                    "content": [{"text": "Test input", "type": "text"}],
+                    "role": "user",
+                },
+            ],
+        ),
+        (
+            "You are a coding assistant that talks like a pirate.",
             [
                 {
                     "role": "system",
@@ -333,9 +337,28 @@ async def test_agent_invocation_span_no_pii(
                     "content": "Test input",
                 },
             ],
-            id="blocks_no_type",
+            [
+                {
+                    "type": "text",
+                    "content": "You are a coding assistant that talks like a pirate.",
+                },
+                {"type": "text", "content": "You are a helpful assistant."},
+            ],
+            [
+                {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "text",
+                            "text": "Message demonstrating the absence of truncation.",
+                        }
+                    ],
+                },
+                {"role": "user", "content": [{"type": "text", "text": "Test input"}]},
+            ],
         ),
-        pytest.param(
+        (
+            "You are a coding assistant that talks like a pirate.",
             [
                 {
                     "type": "message",
@@ -353,9 +376,28 @@ async def test_agent_invocation_span_no_pii(
                     "content": "Test input",
                 },
             ],
-            id="blocks",
+            [
+                {
+                    "type": "text",
+                    "content": "You are a coding assistant that talks like a pirate.",
+                },
+                {"type": "text", "content": "You are a helpful assistant."},
+            ],
+            [
+                {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "text",
+                            "text": "Message demonstrating the absence of truncation.",
+                        }
+                    ],
+                },
+                {"role": "user", "content": [{"type": "text", "text": "Test input"}]},
+            ],
         ),
-        pytest.param(
+        (
+            "You are a coding assistant that talks like a pirate.",
             [
                 {
                     "role": "system",
@@ -373,9 +415,29 @@ async def test_agent_invocation_span_no_pii(
                     "content": "Test input",
                 },
             ],
-            id="parts_no_type",
+            [
+                {
+                    "type": "text",
+                    "content": "You are a coding assistant that talks like a pirate.",
+                },
+                {"type": "text", "content": "You are a helpful assistant."},
+                {"type": "text", "content": "Be concise and clear."},
+            ],
+            [
+                {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "text",
+                            "text": "Message demonstrating the absence of truncation.",
+                        }
+                    ],
+                },
+                {"role": "user", "content": [{"type": "text", "text": "Test input"}]},
+            ],
         ),
-        pytest.param(
+        (
+            "You are a coding assistant that talks like a pirate.",
             [
                 {
                     "type": "message",
@@ -396,7 +458,26 @@ async def test_agent_invocation_span_no_pii(
                     "content": "Test input",
                 },
             ],
-            id="parts",
+            [
+                {
+                    "type": "text",
+                    "content": "You are a coding assistant that talks like a pirate.",
+                },
+                {"type": "text", "content": "You are a helpful assistant."},
+                {"type": "text", "content": "Be concise and clear."},
+            ],
+            [
+                {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "text",
+                            "text": "Message demonstrating the absence of truncation.",
+                        }
+                    ],
+                },
+                {"role": "user", "content": [{"type": "text", "text": "Test input"}]},
+            ],
         ),
     ],
 )
@@ -408,7 +489,8 @@ async def test_agent_invocation_span(
     nonstreaming_responses_model_response,
     instructions,
     input,
-    request,
+    expected_system_instructions,
+    expected_request_messages,
     get_model_response,
     stream_gen_ai_spans,
 ):
@@ -457,236 +539,17 @@ async def test_agent_invocation_span(
 
         assert invoke_agent_span["name"] == "invoke_agent test_agent"
 
-        # Only first case checks "gen_ai.request.messages" until further input handling work.
-        param_id = request.node.callspec.id
-        if "string" in param_id and instructions is None:  # type: ignore
+        if expected_system_instructions is None:
             assert "gen_ai.system_instructions" not in ai_client_span["attributes"]
-
-            assert invoke_agent_span["attributes"][
-                "gen_ai.request.messages"
-            ] == safe_serialize(
-                [
-                    {
-                        "content": [{"text": "Test input", "type": "text"}],
-                        "role": "user",
-                    },
-                ]
-            )
-        elif "string" in param_id:
-            assert ai_client_span["attributes"][
-                "gen_ai.system_instructions"
-            ] == safe_serialize(
-                [
-                    {
-                        "type": "text",
-                        "content": "You are a coding assistant that talks like a pirate.",
-                    },
-                ]
-            )
-        elif "blocks_no_type" in param_id and instructions is None:  # type: ignore
-            assert ai_client_span["attributes"][
-                "gen_ai.system_instructions"
-            ] == safe_serialize(
-                [
-                    {"type": "text", "content": "You are a helpful assistant."},
-                ]
-            )
-
-            assert json.loads(
-                ai_client_span["attributes"][SPANDATA.GEN_AI_REQUEST_MESSAGES]
-            ) == [
-                {
-                    "role": "user",
-                    "content": [
-                        {
-                            "type": "text",
-                            "text": "Message demonstrating the absence of truncation.",
-                        }
-                    ],
-                },
-                {"role": "user", "content": [{"type": "text", "text": "Test input"}]},
-            ]
-        elif "blocks_no_type" in param_id:
-            assert ai_client_span["attributes"][
-                "gen_ai.system_instructions"
-            ] == safe_serialize(
-                [
-                    {
-                        "type": "text",
-                        "content": "You are a coding assistant that talks like a pirate.",
-                    },
-                    {"type": "text", "content": "You are a helpful assistant."},
-                ]
-            )
-
-            assert json.loads(
-                ai_client_span["attributes"][SPANDATA.GEN_AI_REQUEST_MESSAGES]
-            ) == [
-                {
-                    "role": "user",
-                    "content": [
-                        {
-                            "type": "text",
-                            "text": "Message demonstrating the absence of truncation.",
-                        }
-                    ],
-                },
-                {"role": "user", "content": [{"type": "text", "text": "Test input"}]},
-            ]
-        elif "blocks" in param_id and instructions is None:  # type: ignore
-            assert ai_client_span["attributes"][
-                "gen_ai.system_instructions"
-            ] == safe_serialize(
-                [
-                    {"type": "text", "content": "You are a helpful assistant."},
-                ]
-            )
-
-            assert json.loads(
-                ai_client_span["attributes"][SPANDATA.GEN_AI_REQUEST_MESSAGES]
-            ) == [
-                {
-                    "role": "user",
-                    "content": [
-                        {
-                            "type": "text",
-                            "text": "Message demonstrating the absence of truncation.",
-                        }
-                    ],
-                },
-                {"role": "user", "content": [{"type": "text", "text": "Test input"}]},
-            ]
-        elif "blocks" in param_id:
-            assert ai_client_span["attributes"][
-                "gen_ai.system_instructions"
-            ] == safe_serialize(
-                [
-                    {
-                        "type": "text",
-                        "content": "You are a coding assistant that talks like a pirate.",
-                    },
-                    {"type": "text", "content": "You are a helpful assistant."},
-                ]
-            )
-
-            assert json.loads(
-                ai_client_span["attributes"][SPANDATA.GEN_AI_REQUEST_MESSAGES]
-            ) == [
-                {
-                    "role": "user",
-                    "content": [
-                        {
-                            "type": "text",
-                            "text": "Message demonstrating the absence of truncation.",
-                        }
-                    ],
-                },
-                {"role": "user", "content": [{"type": "text", "text": "Test input"}]},
-            ]
-        elif "parts_no_type" in param_id and instructions is None:
-            assert ai_client_span["attributes"][
-                "gen_ai.system_instructions"
-            ] == safe_serialize(
-                [
-                    {"type": "text", "content": "You are a helpful assistant."},
-                    {"type": "text", "content": "Be concise and clear."},
-                ]
-            )
-
-            assert json.loads(
-                ai_client_span["attributes"][SPANDATA.GEN_AI_REQUEST_MESSAGES]
-            ) == [
-                {
-                    "role": "user",
-                    "content": [
-                        {
-                            "type": "text",
-                            "text": "Message demonstrating the absence of truncation.",
-                        }
-                    ],
-                },
-                {"role": "user", "content": [{"type": "text", "text": "Test input"}]},
-            ]
-        elif "parts_no_type" in param_id:
-            assert ai_client_span["attributes"][
-                "gen_ai.system_instructions"
-            ] == safe_serialize(
-                [
-                    {
-                        "type": "text",
-                        "content": "You are a coding assistant that talks like a pirate.",
-                    },
-                    {"type": "text", "content": "You are a helpful assistant."},
-                    {"type": "text", "content": "Be concise and clear."},
-                ]
-            )
-
-            assert json.loads(
-                ai_client_span["attributes"][SPANDATA.GEN_AI_REQUEST_MESSAGES]
-            ) == [
-                {
-                    "role": "user",
-                    "content": [
-                        {
-                            "type": "text",
-                            "text": "Message demonstrating the absence of truncation.",
-                        }
-                    ],
-                },
-                {"role": "user", "content": [{"type": "text", "text": "Test input"}]},
-            ]
-        elif instructions is None:  # type: ignore
-            assert ai_client_span["attributes"][
-                "gen_ai.system_instructions"
-            ] == safe_serialize(
-                [
-                    {"type": "text", "content": "You are a helpful assistant."},
-                    {"type": "text", "content": "Be concise and clear."},
-                ]
-            )
-
-            assert json.loads(
-                ai_client_span["attributes"][SPANDATA.GEN_AI_REQUEST_MESSAGES]
-            ) == [
-                {
-                    "role": "user",
-                    "content": [
-                        {
-                            "type": "text",
-                            "text": "Message demonstrating the absence of truncation.",
-                        }
-                    ],
-                },
-                {"role": "user", "content": [{"type": "text", "text": "Test input"}]},
-            ]
         else:
             assert ai_client_span["attributes"][
                 "gen_ai.system_instructions"
-            ] == safe_serialize(
-                [
-                    {
-                        "type": "text",
-                        "content": "You are a coding assistant that talks like a pirate.",
-                    },
-                    {"type": "text", "content": "You are a helpful assistant."},
-                    {"type": "text", "content": "Be concise and clear."},
-                ]
-            )
+            ] == safe_serialize(expected_system_instructions)
 
-            assert json.loads(
-                ai_client_span["attributes"][SPANDATA.GEN_AI_REQUEST_MESSAGES]
-            ) == [
-                {
-                    "role": "user",
-                    "content": [
-                        {
-                            "type": "text",
-                            "text": "Message demonstrating the absence of truncation.",
-                        }
-                    ],
-                },
-                {"role": "user", "content": [{"type": "text", "text": "Test input"}]},
-            ]
+        assert (
+            json.loads(ai_client_span["attributes"][SPANDATA.GEN_AI_REQUEST_MESSAGES])
+            == expected_request_messages
+        )
 
         assert (
             invoke_agent_span["attributes"]["gen_ai.response.text"]
@@ -744,117 +607,17 @@ async def test_agent_invocation_span(
 
         assert invoke_agent_span["description"] == "invoke_agent test_agent"
 
-        # Only first case checks "gen_ai.request.messages" until further input handling work.
-        param_id = request.node.callspec.id
-        if "string" in param_id and instructions is None:  # type: ignore
+        if expected_system_instructions is None:
             assert "gen_ai.system_instructions" not in ai_client_span["data"]
-
-            assert invoke_agent_span["data"][
-                "gen_ai.request.messages"
-            ] == safe_serialize(
-                [
-                    {
-                        "content": [{"text": "Test input", "type": "text"}],
-                        "role": "user",
-                    },
-                ]
-            )
-
-        elif "string" in param_id:
-            assert ai_client_span["data"][
-                "gen_ai.system_instructions"
-            ] == safe_serialize(
-                [
-                    {
-                        "type": "text",
-                        "content": "You are a coding assistant that talks like a pirate.",
-                    },
-                ]
-            )
-        elif "blocks_no_type" in param_id and instructions is None:  # type: ignore
-            assert ai_client_span["data"][
-                "gen_ai.system_instructions"
-            ] == safe_serialize(
-                [
-                    {"type": "text", "content": "You are a helpful assistant."},
-                ]
-            )
-        elif "blocks_no_type" in param_id:
-            assert ai_client_span["data"][
-                "gen_ai.system_instructions"
-            ] == safe_serialize(
-                [
-                    {
-                        "type": "text",
-                        "content": "You are a coding assistant that talks like a pirate.",
-                    },
-                    {"type": "text", "content": "You are a helpful assistant."},
-                ]
-            )
-        elif "blocks" in param_id and instructions is None:  # type: ignore
-            assert ai_client_span["data"][
-                "gen_ai.system_instructions"
-            ] == safe_serialize(
-                [
-                    {"type": "text", "content": "You are a helpful assistant."},
-                ]
-            )
-        elif "blocks" in param_id:
-            assert ai_client_span["data"][
-                "gen_ai.system_instructions"
-            ] == safe_serialize(
-                [
-                    {
-                        "type": "text",
-                        "content": "You are a coding assistant that talks like a pirate.",
-                    },
-                    {"type": "text", "content": "You are a helpful assistant."},
-                ]
-            )
-        elif "parts_no_type" in param_id and instructions is None:
-            assert ai_client_span["data"][
-                "gen_ai.system_instructions"
-            ] == safe_serialize(
-                [
-                    {"type": "text", "content": "You are a helpful assistant."},
-                    {"type": "text", "content": "Be concise and clear."},
-                ]
-            )
-        elif "parts_no_type" in param_id:
-            assert ai_client_span["data"][
-                "gen_ai.system_instructions"
-            ] == safe_serialize(
-                [
-                    {
-                        "type": "text",
-                        "content": "You are a coding assistant that talks like a pirate.",
-                    },
-                    {"type": "text", "content": "You are a helpful assistant."},
-                    {"type": "text", "content": "Be concise and clear."},
-                ]
-            )
-        elif instructions is None:  # type: ignore
-            assert ai_client_span["data"][
-                "gen_ai.system_instructions"
-            ] == safe_serialize(
-                [
-                    {"type": "text", "content": "You are a helpful assistant."},
-                    {"type": "text", "content": "Be concise and clear."},
-                ]
-            )
         else:
             assert ai_client_span["data"][
                 "gen_ai.system_instructions"
-            ] == safe_serialize(
-                [
-                    {
-                        "type": "text",
-                        "content": "You are a coding assistant that talks like a pirate.",
-                    },
-                    {"type": "text", "content": "You are a helpful assistant."},
-                    {"type": "text", "content": "Be concise and clear."},
-                ]
-            )
+            ] == safe_serialize(expected_system_instructions)
+
+        assert (
+            json.loads(ai_client_span["data"][SPANDATA.GEN_AI_REQUEST_MESSAGES])
+            == expected_request_messages[-1:]
+        )
 
         assert (
             invoke_agent_span["data"]["gen_ai.response.text"]
@@ -1094,17 +857,21 @@ def test_agent_invocation_span_sync_no_pii(
 
 @pytest.mark.parametrize("stream_gen_ai_spans", [True, False])
 @pytest.mark.parametrize(
-    "instructions",
-    (
-        None,
-        "You are a coding assistant that talks like a pirate.",
-    ),
-)
-@pytest.mark.parametrize(
-    "input",
+    "instructions,input,expected_system_instructions,expected_request_messages",
     [
-        pytest.param("Test input", id="string"),
-        pytest.param(
+        (
+            None,
+            ("Test input"),
+            None,
+            [
+                {
+                    "content": [{"text": "Test input", "type": "text"}],
+                    "role": "user",
+                },
+            ],
+        ),
+        (
+            "You are a coding assistant that talks like a pirate.",
             [
                 {
                     "role": "system",
@@ -1119,9 +886,28 @@ def test_agent_invocation_span_sync_no_pii(
                     "content": "Test input",
                 },
             ],
-            id="blocks_no_type",
+            [
+                {
+                    "type": "text",
+                    "content": "You are a coding assistant that talks like a pirate.",
+                },
+                {"type": "text", "content": "You are a helpful assistant."},
+            ],
+            [
+                {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "text",
+                            "text": "Message demonstrating the absence of truncation.",
+                        }
+                    ],
+                },
+                {"role": "user", "content": [{"type": "text", "text": "Test input"}]},
+            ],
         ),
-        pytest.param(
+        (
+            "You are a coding assistant that talks like a pirate.",
             [
                 {
                     "type": "message",
@@ -1139,9 +925,28 @@ def test_agent_invocation_span_sync_no_pii(
                     "content": "Test input",
                 },
             ],
-            id="blocks",
+            [
+                {
+                    "type": "text",
+                    "content": "You are a coding assistant that talks like a pirate.",
+                },
+                {"type": "text", "content": "You are a helpful assistant."},
+            ],
+            [
+                {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "text",
+                            "text": "Message demonstrating the absence of truncation.",
+                        }
+                    ],
+                },
+                {"role": "user", "content": [{"type": "text", "text": "Test input"}]},
+            ],
         ),
-        pytest.param(
+        (
+            "You are a coding assistant that talks like a pirate.",
             [
                 {
                     "role": "system",
@@ -1159,9 +964,29 @@ def test_agent_invocation_span_sync_no_pii(
                     "content": "Test input",
                 },
             ],
-            id="parts_no_type",
+            [
+                {
+                    "type": "text",
+                    "content": "You are a coding assistant that talks like a pirate.",
+                },
+                {"type": "text", "content": "You are a helpful assistant."},
+                {"type": "text", "content": "Be concise and clear."},
+            ],
+            [
+                {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "text",
+                            "text": "Message demonstrating the absence of truncation.",
+                        }
+                    ],
+                },
+                {"role": "user", "content": [{"type": "text", "text": "Test input"}]},
+            ],
         ),
-        pytest.param(
+        (
+            "You are a coding assistant that talks like a pirate.",
             [
                 {
                     "type": "message",
@@ -1182,7 +1007,26 @@ def test_agent_invocation_span_sync_no_pii(
                     "content": "Test input",
                 },
             ],
-            id="parts",
+            [
+                {
+                    "type": "text",
+                    "content": "You are a coding assistant that talks like a pirate.",
+                },
+                {"type": "text", "content": "You are a helpful assistant."},
+                {"type": "text", "content": "Be concise and clear."},
+            ],
+            [
+                {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "text",
+                            "text": "Message demonstrating the absence of truncation.",
+                        }
+                    ],
+                },
+                {"role": "user", "content": [{"type": "text", "text": "Test input"}]},
+            ],
         ),
     ],
 )
@@ -1194,7 +1038,8 @@ def test_agent_invocation_span_sync(
     nonstreaming_responses_model_response,
     instructions,
     input,
-    request,
+    expected_system_instructions,
+    expected_request_messages,
     get_model_response,
     stream_gen_ai_spans,
     sync_event_loop,
@@ -1261,224 +1106,17 @@ def test_agent_invocation_span_sync(
         assert ai_client_span["attributes"]["gen_ai.request.temperature"] == 0.7
         assert ai_client_span["attributes"]["gen_ai.request.top_p"] == 1.0
 
-        param_id = request.node.callspec.id
-        if "string" in param_id and instructions is None:  # type: ignore
+        if expected_system_instructions is None:
             assert "gen_ai.system_instructions" not in ai_client_span["attributes"]
-        elif "string" in param_id:
-            assert ai_client_span["attributes"][
-                "gen_ai.system_instructions"
-            ] == safe_serialize(
-                [
-                    {
-                        "type": "text",
-                        "content": "You are a coding assistant that talks like a pirate.",
-                    },
-                ]
-            )
-        elif "blocks_no_type" in param_id and instructions is None:  # type: ignore
-            assert ai_client_span["attributes"][
-                "gen_ai.system_instructions"
-            ] == safe_serialize(
-                [
-                    {"type": "text", "content": "You are a helpful assistant."},
-                ]
-            )
-
-            assert json.loads(
-                ai_client_span["attributes"][SPANDATA.GEN_AI_REQUEST_MESSAGES]
-            ) == [
-                {
-                    "role": "user",
-                    "content": [
-                        {
-                            "type": "text",
-                            "text": "Message demonstrating the absence of truncation.",
-                        }
-                    ],
-                },
-                {"role": "user", "content": [{"type": "text", "text": "Test input"}]},
-            ]
-        elif "blocks_no_type" in param_id:
-            assert ai_client_span["attributes"][
-                "gen_ai.system_instructions"
-            ] == safe_serialize(
-                [
-                    {
-                        "type": "text",
-                        "content": "You are a coding assistant that talks like a pirate.",
-                    },
-                    {"type": "text", "content": "You are a helpful assistant."},
-                ]
-            )
-
-            assert json.loads(
-                ai_client_span["attributes"][SPANDATA.GEN_AI_REQUEST_MESSAGES]
-            ) == [
-                {
-                    "role": "user",
-                    "content": [
-                        {
-                            "type": "text",
-                            "text": "Message demonstrating the absence of truncation.",
-                        }
-                    ],
-                },
-                {"role": "user", "content": [{"type": "text", "text": "Test input"}]},
-            ]
-        elif "blocks" in param_id and instructions is None:  # type: ignore
-            assert ai_client_span["attributes"][
-                "gen_ai.system_instructions"
-            ] == safe_serialize(
-                [
-                    {"type": "text", "content": "You are a helpful assistant."},
-                ]
-            )
-
-            assert json.loads(
-                ai_client_span["attributes"][SPANDATA.GEN_AI_REQUEST_MESSAGES]
-            ) == [
-                {
-                    "role": "user",
-                    "content": [
-                        {
-                            "type": "text",
-                            "text": "Message demonstrating the absence of truncation.",
-                        }
-                    ],
-                },
-                {"role": "user", "content": [{"type": "text", "text": "Test input"}]},
-            ]
-        elif "blocks" in param_id:
-            assert ai_client_span["attributes"][
-                "gen_ai.system_instructions"
-            ] == safe_serialize(
-                [
-                    {
-                        "type": "text",
-                        "content": "You are a coding assistant that talks like a pirate.",
-                    },
-                    {"type": "text", "content": "You are a helpful assistant."},
-                ]
-            )
-
-            assert json.loads(
-                ai_client_span["attributes"][SPANDATA.GEN_AI_REQUEST_MESSAGES]
-            ) == [
-                {
-                    "role": "user",
-                    "content": [
-                        {
-                            "type": "text",
-                            "text": "Message demonstrating the absence of truncation.",
-                        }
-                    ],
-                },
-                {"role": "user", "content": [{"type": "text", "text": "Test input"}]},
-            ]
-        elif "parts_no_type" in param_id and instructions is None:
-            assert ai_client_span["attributes"][
-                "gen_ai.system_instructions"
-            ] == safe_serialize(
-                [
-                    {"type": "text", "content": "You are a helpful assistant."},
-                    {"type": "text", "content": "Be concise and clear."},
-                ]
-            )
-
-            assert json.loads(
-                ai_client_span["attributes"][SPANDATA.GEN_AI_REQUEST_MESSAGES]
-            ) == [
-                {
-                    "role": "user",
-                    "content": [
-                        {
-                            "type": "text",
-                            "text": "Message demonstrating the absence of truncation.",
-                        }
-                    ],
-                },
-                {"role": "user", "content": [{"type": "text", "text": "Test input"}]},
-            ]
-        elif "parts_no_type" in param_id:
-            assert ai_client_span["attributes"][
-                "gen_ai.system_instructions"
-            ] == safe_serialize(
-                [
-                    {
-                        "type": "text",
-                        "content": "You are a coding assistant that talks like a pirate.",
-                    },
-                    {"type": "text", "content": "You are a helpful assistant."},
-                    {"type": "text", "content": "Be concise and clear."},
-                ]
-            )
-
-            assert json.loads(
-                ai_client_span["attributes"][SPANDATA.GEN_AI_REQUEST_MESSAGES]
-            ) == [
-                {
-                    "role": "user",
-                    "content": [
-                        {
-                            "type": "text",
-                            "text": "Message demonstrating the absence of truncation.",
-                        }
-                    ],
-                },
-                {"role": "user", "content": [{"type": "text", "text": "Test input"}]},
-            ]
-        elif instructions is None:  # type: ignore
-            assert ai_client_span["attributes"][
-                "gen_ai.system_instructions"
-            ] == safe_serialize(
-                [
-                    {"type": "text", "content": "You are a helpful assistant."},
-                    {"type": "text", "content": "Be concise and clear."},
-                ]
-            )
-
-            assert json.loads(
-                ai_client_span["attributes"][SPANDATA.GEN_AI_REQUEST_MESSAGES]
-            ) == [
-                {
-                    "role": "user",
-                    "content": [
-                        {
-                            "type": "text",
-                            "text": "Message demonstrating the absence of truncation.",
-                        }
-                    ],
-                },
-                {"role": "user", "content": [{"type": "text", "text": "Test input"}]},
-            ]
         else:
             assert ai_client_span["attributes"][
                 "gen_ai.system_instructions"
-            ] == safe_serialize(
-                [
-                    {
-                        "type": "text",
-                        "content": "You are a coding assistant that talks like a pirate.",
-                    },
-                    {"type": "text", "content": "You are a helpful assistant."},
-                    {"type": "text", "content": "Be concise and clear."},
-                ]
-            )
+            ] == safe_serialize(expected_system_instructions)
 
-            assert json.loads(
-                ai_client_span["attributes"][SPANDATA.GEN_AI_REQUEST_MESSAGES]
-            ) == [
-                {
-                    "role": "user",
-                    "content": [
-                        {
-                            "type": "text",
-                            "text": "Message demonstrating the absence of truncation.",
-                        }
-                    ],
-                },
-                {"role": "user", "content": [{"type": "text", "text": "Test input"}]},
-            ]
+        assert (
+            json.loads(ai_client_span["attributes"][SPANDATA.GEN_AI_REQUEST_MESSAGES])
+            == expected_request_messages
+        )
     else:
         with patch.object(
             agent.model._client._client,
@@ -1528,104 +1166,12 @@ def test_agent_invocation_span_sync(
         assert ai_client_span["data"]["gen_ai.request.temperature"] == 0.7
         assert ai_client_span["data"]["gen_ai.request.top_p"] == 1.0
 
-        param_id = request.node.callspec.id
-        if "string" in param_id and instructions is None:  # type: ignore
+        if expected_system_instructions is None:
             assert "gen_ai.system_instructions" not in ai_client_span["data"]
-        elif "string" in param_id:
-            assert ai_client_span["data"][
-                "gen_ai.system_instructions"
-            ] == safe_serialize(
-                [
-                    {
-                        "type": "text",
-                        "content": "You are a coding assistant that talks like a pirate.",
-                    },
-                ]
-            )
-        elif "blocks_no_type" in param_id and instructions is None:  # type: ignore
-            assert ai_client_span["data"][
-                "gen_ai.system_instructions"
-            ] == safe_serialize(
-                [
-                    {"type": "text", "content": "You are a helpful assistant."},
-                ]
-            )
-        elif "blocks_no_type" in param_id:
-            assert ai_client_span["data"][
-                "gen_ai.system_instructions"
-            ] == safe_serialize(
-                [
-                    {
-                        "type": "text",
-                        "content": "You are a coding assistant that talks like a pirate.",
-                    },
-                    {"type": "text", "content": "You are a helpful assistant."},
-                ]
-            )
-        elif "blocks" in param_id and instructions is None:  # type: ignore
-            assert ai_client_span["data"][
-                "gen_ai.system_instructions"
-            ] == safe_serialize(
-                [
-                    {"type": "text", "content": "You are a helpful assistant."},
-                ]
-            )
-        elif "blocks" in param_id:
-            assert ai_client_span["data"][
-                "gen_ai.system_instructions"
-            ] == safe_serialize(
-                [
-                    {
-                        "type": "text",
-                        "content": "You are a coding assistant that talks like a pirate.",
-                    },
-                    {"type": "text", "content": "You are a helpful assistant."},
-                ]
-            )
-        elif "parts_no_type" in param_id and instructions is None:
-            assert ai_client_span["data"][
-                "gen_ai.system_instructions"
-            ] == safe_serialize(
-                [
-                    {"type": "text", "content": "You are a helpful assistant."},
-                    {"type": "text", "content": "Be concise and clear."},
-                ]
-            )
-        elif "parts_no_type" in param_id:
-            assert ai_client_span["data"][
-                "gen_ai.system_instructions"
-            ] == safe_serialize(
-                [
-                    {
-                        "type": "text",
-                        "content": "You are a coding assistant that talks like a pirate.",
-                    },
-                    {"type": "text", "content": "You are a helpful assistant."},
-                    {"type": "text", "content": "Be concise and clear."},
-                ]
-            )
-        elif instructions is None:  # type: ignore
-            assert ai_client_span["data"][
-                "gen_ai.system_instructions"
-            ] == safe_serialize(
-                [
-                    {"type": "text", "content": "You are a helpful assistant."},
-                    {"type": "text", "content": "Be concise and clear."},
-                ]
-            )
         else:
             assert ai_client_span["data"][
                 "gen_ai.system_instructions"
-            ] == safe_serialize(
-                [
-                    {
-                        "type": "text",
-                        "content": "You are a coding assistant that talks like a pirate.",
-                    },
-                    {"type": "text", "content": "You are a helpful assistant."},
-                    {"type": "text", "content": "Be concise and clear."},
-                ]
-            )
+            ] == safe_serialize(expected_system_instructions)
 
 
 @pytest.mark.parametrize("stream_gen_ai_spans", [True, False])


### PR DESCRIPTION
### Description
<!-- What changed and why? -->

Jointly parametrize on instructions, input and the expected value of the `gen_ai.system_instructions` and `gen_ai.request.messages` attributes

Only keep one test case for `None` system instructions.

#### Issues
<!--
* resolves: #1234
* resolves: LIN-1234
-->

#### Reminders
- Please add tests to validate your changes, and lint your code using `tox -e linters`.
- Add GH Issue ID _&_ Linear ID (if applicable)
- PR title should use [conventional commit](https://develop.sentry.dev/engineering-practices/commit-messages/#type) style (`feat:`, `fix:`, `ref:`, `meta:`)
- For external contributors: [CONTRIBUTING.md](https://github.com/getsentry/sentry-python/blob/master/CONTRIBUTING.md), [Sentry SDK development docs](https://develop.sentry.dev/sdk/), [Discord community](https://discord.gg/Ww9hbqr)
