### PR TITLE
feat: Allow integrations to define control flow exceptions

### DIFF
--- a/sentry_sdk/integrations/aiohttp.py
+++ b/sentry_sdk/integrations/aiohttp.py
@@ -42,13 +42,13 @@ from sentry_sdk.utils import (
     HAS_REAL_CONTEXTVARS,
     SENSITIVE_DATA_SUBSTITUTE,
     AnnotatedValue,
+    _register_control_flow_exception,
     capture_internal_exceptions,
     ensure_integration_enabled,
     event_from_exception,
     logger,
     parse_url,
     parse_version,
-    register_control_flow_exception,
     reraise,
     transaction_from_function,
 )
@@ -107,7 +107,7 @@ class AioHttpIntegration(Integration):
         # In the aiohttp integration, all of their HTTP responses are Exceptions.
         # Because they have to be raised and handled by the framework, we need this check so
         # that we don't accidentally overwrite a status of "ok" with "error".
-        register_control_flow_exception(HTTPException)
+        _register_control_flow_exception(HTTPException)
 
         if not HAS_REAL_CONTEXTVARS:
             # We better have contextvars or we're going to leak state between

--- a/sentry_sdk/integrations/aiohttp.py
+++ b/sentry_sdk/integrations/aiohttp.py
@@ -48,6 +48,7 @@ from sentry_sdk.utils import (
     logger,
     parse_url,
     parse_version,
+    register_control_flow_exception,
     reraise,
     transaction_from_function,
 )
@@ -102,6 +103,11 @@ class AioHttpIntegration(Integration):
     def setup_once() -> None:
         version = parse_version(AIOHTTP_VERSION)
         _check_minimum_version(AioHttpIntegration, version)
+
+        # In the aiohttp integration, all of their HTTP responses are Exceptions.
+        # Because they have to be raised and handled by the framework, we need this check so
+        # that we don't accidentally overwrite a status of "ok" with "error".
+        register_control_flow_exception(HTTPException)
 
         if not HAS_REAL_CONTEXTVARS:
             # We better have contextvars or we're going to leak state between

--- a/sentry_sdk/integrations/aiohttp.py
+++ b/sentry_sdk/integrations/aiohttp.py
@@ -104,11 +104,6 @@ class AioHttpIntegration(Integration):
         version = parse_version(AIOHTTP_VERSION)
         _check_minimum_version(AioHttpIntegration, version)
 
-        # In the aiohttp integration, all of their HTTP responses are Exceptions.
-        # Because they have to be raised and handled by the framework, we need this check so
-        # that we don't accidentally overwrite a status of "ok" with "error".
-        _register_control_flow_exception(HTTPException)
-
         if not HAS_REAL_CONTEXTVARS:
             # We better have contextvars or we're going to leak state between
             # requests.
@@ -116,6 +111,12 @@ class AioHttpIntegration(Integration):
                 "The aiohttp integration for Sentry requires Python 3.7+ "
                 " or aiocontextvars package." + CONTEXTVARS_ERROR_MESSAGE
             )
+
+        # In the aiohttp integration, all of their HTTP responses are Exceptions.
+        # Because they have to be raised and handled by the framework, we need to
+        # register the exceptions as control flow exceptions so that we don't
+        # accidentally overwrite a status of "ok" with "error".
+        _register_control_flow_exception(HTTPException)
 
         ignore_logger("aiohttp.server")
 

--- a/sentry_sdk/utils.py
+++ b/sentry_sdk/utils.py
@@ -27,11 +27,6 @@ except ImportError:
     # Python 3.10 and below
     BaseExceptionGroup = None  # type: ignore
 
-try:
-    from aiohttp.web_exceptions import HTTPException as AIOHttpHttpException
-except ImportError:
-    AIOHttpHttpException = None
-
 from typing import TYPE_CHECKING
 
 import sentry_sdk
@@ -92,6 +87,10 @@ _installed_modules = None
 _is_sentry_internal_task = contextvars.ContextVar(
     "is_sentry_internal_task", default=False
 )
+
+# These exceptions won't set the span status to error if they occur. Use
+# register_control_flow_exception to add to this list
+_control_flow_exceptions = []
 
 
 def is_internal_task() -> bool:
@@ -1983,15 +1982,16 @@ def get_current_thread_meta(
     return None, None
 
 
+def register_control_flow_exception(exc_type: type) -> None:
+    _control_flow_exceptions.append(exc_type)
+
+
 def should_be_treated_as_error(ty: "Any", value: "Any") -> bool:
     if ty == SystemExit and hasattr(value, "code") and value.code in (0, None):
         # https://docs.python.org/3/library/exceptions.html#SystemExit
         return False
 
-    # In the aiohttp integration, all of their HTTP responses are Exceptions.
-    # Because they have to be raised and handled by the framework, we need this check so
-    # that we don't accidentally overwrite a status of "ok" with "error" here.
-    if AIOHttpHttpException and isinstance(value, AIOHttpHttpException):
+    if ty in _control_flow_exceptions:
         return False
 
     return True

--- a/sentry_sdk/utils.py
+++ b/sentry_sdk/utils.py
@@ -90,7 +90,7 @@ _is_sentry_internal_task = contextvars.ContextVar(
 
 # These exceptions won't set the span status to error if they occur. Use
 # register_control_flow_exception to add to this list
-_control_flow_exceptions = []
+_control_flow_exception_classes: "list[type]" = []
 
 
 def is_internal_task() -> bool:
@@ -1983,7 +1983,7 @@ def get_current_thread_meta(
 
 
 def register_control_flow_exception(exc_type: type) -> None:
-    _control_flow_exceptions.append(exc_type)
+    _control_flow_exception_classes.append(exc_type)
 
 
 def should_be_treated_as_error(ty: "Any", value: "Any") -> bool:
@@ -1991,7 +1991,7 @@ def should_be_treated_as_error(ty: "Any", value: "Any") -> bool:
         # https://docs.python.org/3/library/exceptions.html#SystemExit
         return False
 
-    if ty in _control_flow_exceptions:
+    if issubclass(ty, tuple(_control_flow_exception_classes)):
         return False
 
     return True

--- a/sentry_sdk/utils.py
+++ b/sentry_sdk/utils.py
@@ -1982,7 +1982,7 @@ def get_current_thread_meta(
     return None, None
 
 
-def register_control_flow_exception(exc_type: type) -> None:
+def _register_control_flow_exception(exc_type: type) -> None:
     _control_flow_exception_classes.append(exc_type)
 
 


### PR DESCRIPTION
### Description
Some frameworks we're integrating with use specific exception types for control flow. If we encounter them, we should not set the status of the current span to error.

Implement a global ignore list that each integration can populate with control flow exceptions known to it, so that whenever a span finishes, it has access to the list and can decide whether the exception that occurred constitutes an error or not.

#### Issues
- Closes https://github.com/getsentry/sentry-python/issues/6408
- Closes https://linear.app/getsentry/issue/PY-2492

#### Reminders
- Please add tests to validate your changes, and lint your code using `tox -e linters`.
- Add GH Issue ID _&_ Linear ID (if applicable)
- PR title should use [conventional commit](https://develop.sentry.dev/engineering-practices/commit-messages/#type) style (`feat:`, `fix:`, `ref:`, `meta:`)
- For external contributors: [CONTRIBUTING.md](https://github.com/getsentry/sentry-python/blob/master/CONTRIBUTING.md), [Sentry SDK development docs](https://develop.sentry.dev/sdk/), [Discord community](https://discord.gg/Ww9hbqr)
