### PR TITLE
feat(gcp): Add span streaming support to GCP Cloud Functions integration

### DIFF
--- a/sentry_sdk/integrations/gcp.py
+++ b/sentry_sdk/integrations/gcp.py
@@ -116,17 +116,31 @@ def _wrap_func(func: "F") -> "F":
                 "gcp_event": gcp_event,
             }
 
+            function_name = environ.get("FUNCTION_NAME", "<unknown GCP function>")
+
+            if environ.get("GCP_PROJECT"):
+                additional_attributes["gcp.project.id"] = environ.get("GCP_PROJECT")
+
+            if environ.get("FUNCTION_IDENTITY"):
+                additional_attributes["faas.identity"] = environ.get(
+                    "FUNCTION_IDENTITY"
+                )
+
+            if environ.get("ENTRY_POINT"):
+                additional_attributes["faas.entry_point"] = environ.get("ENTRY_POINT")
+
             if has_span_streaming_enabled(client.options):
                 sentry_sdk.traces.continue_trace(headers)
                 Scope.set_custom_sampling_context(sampling_context)
                 span_ctx = sentry_sdk.traces.start_span(
-                    name=environ.get("FUNCTION_NAME", "<unknown GCP function>"),
+                    name=function_name,
                     parent_span=None,
                     attributes={
                         "sentry.op": OP.FUNCTION_GCP,
                         "sentry.origin": GcpIntegration.origin,
                         "sentry.span.source": SegmentSource.COMPONENT,
                         "cloud.provider": CLOUD_PROVIDER.GCP,
+                        "faas.name": function_name,
                         **header_attributes,
                         **additional_attributes,
                     },

--- a/sentry_sdk/integrations/gcp.py
+++ b/sentry_sdk/integrations/gcp.py
@@ -102,7 +102,7 @@ def _wrap_func(func: "F") -> "F":
 
             if should_send_default_pii() and hasattr(gcp_event, "query_string"):
                 additional_attributes["url.query"] = gcp_event.query_string.decode(
-                    "utf-8"
+                    "utf-8", errors="replace"
                 )
 
             sampling_context = {
@@ -221,7 +221,9 @@ def _make_request_event_processor(
             request["method"] = gcp_event.method
 
         if hasattr(gcp_event, "query_string"):
-            request["query_string"] = gcp_event.query_string.decode("utf-8")
+            request["query_string"] = gcp_event.query_string.decode(
+                "utf-8", errors="replace"
+            )
 
         if hasattr(gcp_event, "headers"):
             request["headers"] = _filter_headers(gcp_event.headers)

--- a/sentry_sdk/integrations/gcp.py
+++ b/sentry_sdk/integrations/gcp.py
@@ -10,8 +10,11 @@ from sentry_sdk.api import continue_trace
 from sentry_sdk.consts import OP
 from sentry_sdk.integrations import Integration
 from sentry_sdk.integrations._wsgi_common import _filter_headers
-from sentry_sdk.scope import should_send_default_pii
+from sentry_sdk.integrations.cloud_resource_context import CLOUD_PROVIDER
+from sentry_sdk.scope import Scope, should_send_default_pii
+from sentry_sdk.traces import SegmentSource
 from sentry_sdk.tracing import TransactionSource
+from sentry_sdk.tracing_utils import has_span_streaming_enabled
 from sentry_sdk.utils import (
     AnnotatedValue,
     TimeoutThread,
@@ -82,16 +85,26 @@ def _wrap_func(func: "F") -> "F":
                     timeout_thread.start()
 
             headers = {}
+            header_attributes: "dict[str, Any]" = {}
             if hasattr(gcp_event, "headers"):
                 headers = gcp_event.headers
+                for header, header_value in _filter_headers(
+                    headers, use_annotated_value=False
+                ).items():
+                    header_attributes[f"http.request.header.{header.lower()}"] = (
+                        # header_value will always be a string because we set `use_annotated_value` to false above
+                        header_value
+                    )
 
-            transaction = continue_trace(
-                headers,
-                op=OP.FUNCTION_GCP,
-                name=environ.get("FUNCTION_NAME", ""),
-                source=TransactionSource.COMPONENT,
-                origin=GcpIntegration.origin,
-            )
+            additional_attributes = {}
+            if hasattr(gcp_event, "method"):
+                additional_attributes["http.request.method"] = gcp_event.method
+
+            if should_send_default_pii() and hasattr(gcp_event, "query_string"):
+                additional_attributes["url.query"] = gcp_event.query_string.decode(
+                    "utf-8"
+                )
+
             sampling_context = {
                 "gcp_env": {
                     "function_name": environ.get("FUNCTION_NAME"),
@@ -102,9 +115,36 @@ def _wrap_func(func: "F") -> "F":
                 },
                 "gcp_event": gcp_event,
             }
-            with sentry_sdk.start_transaction(
-                transaction, custom_sampling_context=sampling_context
-            ):
+
+            if has_span_streaming_enabled(client.options):
+                sentry_sdk.traces.continue_trace(headers)
+                Scope.set_custom_sampling_context(sampling_context)
+                span_ctx = sentry_sdk.traces.start_span(
+                    name=environ.get("FUNCTION_NAME", ""),
+                    parent_span=None,
+                    attributes={
+                        "sentry.op": OP.FUNCTION_GCP,
+                        "sentry.origin": GcpIntegration.origin,
+                        "sentry.span.source": SegmentSource.COMPONENT,
+                        "cloud.provider": CLOUD_PROVIDER.GCP,
+                        **header_attributes,
+                        **additional_attributes,
+                    },
+                )
+            else:
+                transaction = continue_trace(
+                    headers,
+                    op=OP.FUNCTION_GCP,
+                    name=environ.get("FUNCTION_NAME", ""),
+                    source=TransactionSource.COMPONENT,
+                    origin=GcpIntegration.origin,
+                )
+
+                span_ctx = sentry_sdk.start_transaction(
+                    transaction, custom_sampling_context=sampling_context
+                )
+
+            with span_ctx:
                 try:
                     return func(functionhandler, gcp_event, *args, **kwargs)
                 except Exception:

--- a/sentry_sdk/integrations/gcp.py
+++ b/sentry_sdk/integrations/gcp.py
@@ -120,7 +120,7 @@ def _wrap_func(func: "F") -> "F":
                 sentry_sdk.traces.continue_trace(headers)
                 Scope.set_custom_sampling_context(sampling_context)
                 span_ctx = sentry_sdk.traces.start_span(
-                    name=environ.get("FUNCTION_NAME", ""),
+                    name=environ.get("FUNCTION_NAME", "<unknown GCP function>"),
                     parent_span=None,
                     attributes={
                         "sentry.op": OP.FUNCTION_GCP,

--- a/tests/integrations/gcp/test_gcp.py
+++ b/tests/integrations/gcp/test_gcp.py
@@ -13,6 +13,8 @@ from textwrap import dedent
 
 import pytest
 
+from sentry_sdk.traces import SpanStatus
+
 FUNCTIONS_PRELUDE = """
 from unittest.mock import Mock
 import __main__ as gcp_functions
@@ -53,14 +55,19 @@ def event_processor(event):
     time.sleep(1)
     return event
 
-def envelope_processor(envelope):
-    (item,) = envelope.items
-    return item.get_bytes()
-
 class TestTransport(HttpTransport):
     def capture_envelope(self, envelope):
-        envelope_item = envelope_processor(envelope)
-        print("\\nENVELOPE: {}\\n".format(envelope_item.decode(\"utf-8\")))
+        for item in envelope.items:
+            if item.headers.get("type") == "span":
+                payload = item.payload.json
+                for span_item in payload.get("items", []):
+                    attrs = {k: v["value"] for k, v in span_item.get("attributes", {}).items()}
+                    span_data = {k: v for k, v in span_item.items() if k != "attributes"}
+                    span_data["attributes"] = attrs
+                    print("\\nSPAN: {}\\n".format(json.dumps(span_data)))
+            else:
+                envelope_bytes = item.get_bytes()
+                print("\\nENVELOPE: {}\\n".format(envelope_bytes.decode(\"utf-8\")))
 
 
 def init_sdk(timeout_warning=False, **extra_init_args):
@@ -82,6 +89,7 @@ def init_sdk(timeout_warning=False, **extra_init_args):
 def run_cloud_function():
     def inner(code, subprocess_kwargs=()):
         envelope_items = []
+        span_items = []
         return_value = None
 
         # STEP : Create a zip of cloud function
@@ -120,6 +128,9 @@ def run_cloud_function():
                 if line.startswith("ENVELOPE: "):
                     line = line[len("ENVELOPE: ") :]
                     envelope_items.append(json.loads(line))
+                elif line.startswith("SPAN: "):
+                    line = line[len("SPAN: ") :]
+                    span_items.append(json.loads(line))
                 elif line.startswith("RETURN VALUE: "):
                     line = line[len("RETURN VALUE: ") :]
                     return_value = json.loads(line)
@@ -128,13 +139,13 @@ def run_cloud_function():
 
             stream.close()
 
-        return envelope_items, return_value
+        return envelope_items, return_value, span_items
 
     return inner
 
 
 def test_handled_exception(run_cloud_function):
-    envelope_items, return_value = run_cloud_function(
+    envelope_items, return_value, _ = run_cloud_function(
         dedent(
             """
         functionhandler = None
@@ -161,7 +172,7 @@ def test_handled_exception(run_cloud_function):
 
 
 def test_unhandled_exception(run_cloud_function):
-    envelope_items, _ = run_cloud_function(
+    envelope_items, _, _ = run_cloud_function(
         dedent(
             """
         functionhandler = None
@@ -189,7 +200,7 @@ def test_unhandled_exception(run_cloud_function):
 
 
 def test_timeout_error(run_cloud_function):
-    envelope_items, _ = run_cloud_function(
+    envelope_items, _, _ = run_cloud_function(
         dedent(
             """
         functionhandler = None
@@ -223,7 +234,7 @@ def test_timeout_error(run_cloud_function):
 
 
 def test_performance_no_error(run_cloud_function):
-    envelope_items, _ = run_cloud_function(
+    envelope_items, _, _ = run_cloud_function(
         dedent(
             """
         functionhandler = None
@@ -249,7 +260,7 @@ def test_performance_no_error(run_cloud_function):
 
 
 def test_performance_error(run_cloud_function):
-    envelope_items, _ = run_cloud_function(
+    envelope_items, _, _ = run_cloud_function(
         dedent(
             """
         functionhandler = None
@@ -292,7 +303,7 @@ def test_traces_sampler_gets_correct_values_in_sampling_context(
 
     import inspect
 
-    _, return_value = run_cloud_function(
+    _, return_value, _ = run_cloud_function(
         dedent(
             """
             functionhandler = None
@@ -365,7 +376,7 @@ def test_error_has_new_trace_context_performance_enabled(run_cloud_function):
     """
     Check if an 'trace' context is added to errros and transactions when performance monitoring is enabled.
     """
-    envelope_items, _ = run_cloud_function(
+    envelope_items, _, _ = run_cloud_function(
         dedent(
             """
         functionhandler = None
@@ -406,7 +417,7 @@ def test_error_has_new_trace_context_performance_disabled(run_cloud_function):
     """
     Check if an 'trace' context is added to errros and transactions when performance monitoring is disabled.
     """
-    envelope_items, _ = run_cloud_function(
+    envelope_items, _, _ = run_cloud_function(
         dedent(
             """
         functionhandler = None
@@ -450,7 +461,7 @@ def test_error_has_existing_trace_context_performance_enabled(run_cloud_function
     parent_sampled = 1
     sentry_trace_header = "{}-{}-{}".format(trace_id, parent_span_id, parent_sampled)
 
-    envelope_items, _ = run_cloud_function(
+    envelope_items, _, _ = run_cloud_function(
         dedent(
             """
         functionhandler = None
@@ -503,7 +514,7 @@ def test_error_has_existing_trace_context_performance_disabled(run_cloud_functio
     parent_sampled = 1
     sentry_trace_header = "{}-{}-{}".format(trace_id, parent_span_id, parent_sampled)
 
-    envelope_items, _ = run_cloud_function(
+    envelope_items, _, _ = run_cloud_function(
         dedent(
             """
         functionhandler = None
@@ -543,7 +554,7 @@ def test_error_has_existing_trace_context_performance_disabled(run_cloud_functio
 
 
 def test_span_origin(run_cloud_function):
-    events, _ = run_cloud_function(
+    events, _, _ = run_cloud_function(
         dedent(
             """
         functionhandler = None
@@ -564,3 +575,186 @@ def test_span_origin(run_cloud_function):
     (event,) = events
 
     assert event["contexts"]["trace"]["origin"] == "auto.function.gcp"
+
+
+def test_span_streaming_no_error(run_cloud_function):
+    _, _, span_items = run_cloud_function(
+        dedent(
+            """
+        functionhandler = None
+        event = {}
+        def cloud_function(functionhandler, event):
+            return "test_string"
+        """
+        )
+        + FUNCTIONS_PRELUDE
+        + dedent(
+            """
+        init_sdk(traces_sample_rate=1.0, _experiments={"trace_lifecycle": "stream"})
+        gcp_functions.worker_v1.FunctionHandler.invoke_user_function(functionhandler, event)
+        """
+        )
+    )
+
+    assert len(span_items) == 1
+    segment_span = span_items[0]
+
+    assert segment_span["is_segment"] is True
+    assert segment_span["name"] == "Google Cloud function"
+    assert segment_span["attributes"]["sentry.op"] == "function.gcp"
+    assert segment_span["attributes"]["sentry.origin"] == "auto.function.gcp"
+    assert segment_span["attributes"]["sentry.span.source"] == "component"
+    assert segment_span["attributes"]["cloud.provider"] == "gcp"
+
+
+def test_span_streaming_error(run_cloud_function):
+    envelope_items, _, span_items = run_cloud_function(
+        dedent(
+            """
+        functionhandler = None
+        event = {}
+        def cloud_function(functionhandler, event):
+            raise Exception("something went wrong")
+        """
+        )
+        + FUNCTIONS_PRELUDE
+        + dedent(
+            """
+        init_sdk(traces_sample_rate=1.0, _experiments={"trace_lifecycle": "stream"})
+        gcp_functions.worker_v1.FunctionHandler.invoke_user_function(functionhandler, event)
+        """
+        )
+    )
+
+    assert envelope_items[0]["level"] == "error"
+    (exception,) = envelope_items[0]["exception"]["values"]
+    assert exception["type"] == "Exception"
+    assert exception["value"] == "something went wrong"
+    assert exception["mechanism"]["type"] == "gcp"
+    assert not exception["mechanism"]["handled"]
+
+    assert len(span_items) == 1
+    segment_span = span_items[0]
+    assert segment_span["is_segment"] is True
+    assert segment_span["name"] == "Google Cloud function"
+    assert segment_span["attributes"]["sentry.op"] == "function.gcp"
+    assert segment_span["attributes"]["sentry.origin"] == "auto.function.gcp"
+    assert segment_span["attributes"]["sentry.span.source"] == "component"
+    assert segment_span["attributes"]["cloud.provider"] == "gcp"
+    assert segment_span["status"] == SpanStatus.ERROR
+
+
+def test_span_streaming_existing_trace_context(run_cloud_function):
+    trace_id = "471a43a4192642f0b136d5159a501701"
+    parent_span_id = "6e8f22c393e68f19"
+    parent_sampled = 1
+    sentry_trace_header = "{}-{}-{}".format(trace_id, parent_span_id, parent_sampled)
+
+    envelope_items, _, span_items = run_cloud_function(
+        dedent(
+            """
+        functionhandler = None
+
+        from collections import namedtuple
+        GCPEvent = namedtuple("GCPEvent", ["headers"])
+        event = GCPEvent(headers={"sentry-trace": "%s"})
+
+        def cloud_function(functionhandler, event):
+            sentry_sdk.capture_message("hi")
+            return "ok"
+        """
+            % sentry_trace_header
+        )
+        + FUNCTIONS_PRELUDE
+        + dedent(
+            """
+        init_sdk(traces_sample_rate=1.0, _experiments={"trace_lifecycle": "stream"})
+        gcp_functions.worker_v1.FunctionHandler.invoke_user_function(functionhandler, event)
+        """
+        )
+    )
+
+    (msg_event,) = envelope_items
+    assert msg_event["contexts"]["trace"]["trace_id"] == trace_id
+
+    assert len(span_items) == 1
+    segment_span = span_items[0]
+    assert segment_span["is_segment"] is True
+    assert segment_span["trace_id"] == trace_id
+    assert segment_span["name"] == "Google Cloud function"
+    assert segment_span["attributes"]["sentry.op"] == "function.gcp"
+    assert segment_span["attributes"]["sentry.origin"] == "auto.function.gcp"
+    assert segment_span["attributes"]["sentry.span.source"] == "component"
+    assert segment_span["attributes"]["cloud.provider"] == "gcp"
+
+
+def test_span_streaming_request_attributes(run_cloud_function):
+    _, _, span_items = run_cloud_function(
+        dedent(
+            """
+        functionhandler = None
+
+        from collections import namedtuple
+        GCPEvent = namedtuple("GCPEvent", ["headers", "method", "query_string"])
+        event = GCPEvent(
+            headers={"content-type": "application/json", "accept": "text/html"},
+            method="POST",
+            query_string=b"foo=bar",
+        )
+
+        def cloud_function(functionhandler, event):
+            return "ok"
+        """
+        )
+        + FUNCTIONS_PRELUDE
+        + dedent(
+            """
+        init_sdk(traces_sample_rate=1.0, send_default_pii=True, _experiments={"trace_lifecycle": "stream"})
+        gcp_functions.worker_v1.FunctionHandler.invoke_user_function(functionhandler, event)
+        """
+        )
+    )
+
+    assert len(span_items) == 1
+    segment_span = span_items[0]
+    attrs = segment_span["attributes"]
+
+    assert attrs["http.request.method"] == "POST"
+    assert attrs["url.query"] == "foo=bar"
+    assert attrs["http.request.header.content-type"] == "application/json"
+    assert attrs["http.request.header.accept"] == "text/html"
+
+
+def test_span_streaming_no_query_string_without_pii(run_cloud_function):
+    _, _, span_items = run_cloud_function(
+        dedent(
+            """
+        functionhandler = None
+
+        from collections import namedtuple
+        GCPEvent = namedtuple("GCPEvent", ["headers", "method", "query_string"])
+        event = GCPEvent(
+            headers={},
+            method="GET",
+            query_string=b"secret=hunter2",
+        )
+
+        def cloud_function(functionhandler, event):
+            return "ok"
+        """
+        )
+        + FUNCTIONS_PRELUDE
+        + dedent(
+            """
+        init_sdk(traces_sample_rate=1.0, send_default_pii=False, _experiments={"trace_lifecycle": "stream"})
+        gcp_functions.worker_v1.FunctionHandler.invoke_user_function(functionhandler, event)
+        """
+        )
+    )
+
+    assert len(span_items) == 1
+    segment_span = span_items[0]
+    attrs = segment_span["attributes"]
+
+    assert "url.query" not in attrs
+    assert attrs["http.request.method"] == "GET"

--- a/tests/integrations/gcp/test_gcp.py
+++ b/tests/integrations/gcp/test_gcp.py
@@ -605,6 +605,10 @@ def test_span_streaming_no_error(run_cloud_function):
     assert segment_span["attributes"]["sentry.origin"] == "auto.function.gcp"
     assert segment_span["attributes"]["sentry.span.source"] == "component"
     assert segment_span["attributes"]["cloud.provider"] == "gcp"
+    assert segment_span["attributes"]["faas.name"] == "Google Cloud function"
+    assert segment_span["attributes"]["gcp.project.id"] == "serverless_project"
+    assert segment_span["attributes"]["faas.identity"] == "func_ID"
+    assert segment_span["attributes"]["faas.entry_point"] == "cloud_function"
 
 
 def test_span_streaming_error(run_cloud_function):
@@ -641,6 +645,10 @@ def test_span_streaming_error(run_cloud_function):
     assert segment_span["attributes"]["sentry.origin"] == "auto.function.gcp"
     assert segment_span["attributes"]["sentry.span.source"] == "component"
     assert segment_span["attributes"]["cloud.provider"] == "gcp"
+    assert segment_span["attributes"]["faas.name"] == "Google Cloud function"
+    assert segment_span["attributes"]["gcp.project.id"] == "serverless_project"
+    assert segment_span["attributes"]["faas.identity"] == "func_ID"
+    assert segment_span["attributes"]["faas.entry_point"] == "cloud_function"
     assert segment_span["status"] == SpanStatus.ERROR
 
 
@@ -686,6 +694,10 @@ def test_span_streaming_existing_trace_context(run_cloud_function):
     assert segment_span["attributes"]["sentry.origin"] == "auto.function.gcp"
     assert segment_span["attributes"]["sentry.span.source"] == "component"
     assert segment_span["attributes"]["cloud.provider"] == "gcp"
+    assert segment_span["attributes"]["faas.name"] == "Google Cloud function"
+    assert segment_span["attributes"]["gcp.project.id"] == "serverless_project"
+    assert segment_span["attributes"]["faas.identity"] == "func_ID"
+    assert segment_span["attributes"]["faas.entry_point"] == "cloud_function"
 
 
 def test_span_streaming_request_attributes(run_cloud_function):
@@ -723,6 +735,10 @@ def test_span_streaming_request_attributes(run_cloud_function):
     assert attrs["url.query"] == "foo=bar"
     assert attrs["http.request.header.content-type"] == "application/json"
     assert attrs["http.request.header.accept"] == "text/html"
+    assert attrs["faas.name"] == "Google Cloud function"
+    assert attrs["gcp.project.id"] == "serverless_project"
+    assert attrs["faas.identity"] == "func_ID"
+    assert attrs["faas.entry_point"] == "cloud_function"
 
 
 def test_span_streaming_no_query_string_without_pii(run_cloud_function):
@@ -758,3 +774,7 @@ def test_span_streaming_no_query_string_without_pii(run_cloud_function):
 
     assert "url.query" not in attrs
     assert attrs["http.request.method"] == "GET"
+    assert attrs["faas.name"] == "Google Cloud function"
+    assert attrs["gcp.project.id"] == "serverless_project"
+    assert attrs["faas.identity"] == "func_ID"
+    assert attrs["faas.entry_point"] == "cloud_function"


### PR DESCRIPTION
Migrate GCP integration to support spans-first tracing via the span streaming API.
The integration now supports both:
- Span streaming (new trace lifecycle)
- Traditional transaction-based approach (fallback)

Add request attributes to spans including headers, HTTP method, and query string.
Include cloud provider context and segment source in span metadata.

Add comprehensive tests for span streaming functionality including error handling,
trace context propagation, and PII filtering for query strings.

Fixes PY-2324 and #6022