### PR TITLE
fix(logs): coerce mixed-type arrays to string arrays instead of dropping them

### DIFF
--- a/sentry_sdk/utils.py
+++ b/sentry_sdk/utils.py
@@ -2142,10 +2142,17 @@ def format_attribute(val: "Any") -> "AttributeValue":
         ty = type(val[0])
         if ty in (str, int, float, bool) and all(type(v) is ty for v in val):
             return copy.deepcopy(val)
+        # Mixed-type or non-primitive list: preserve the array structure by
+        # coercing each element to a string. This matches sentry-javascript
+        # behaviour and avoids silently collapsing the whole array into a
+        # single string attribute value.
+        return [v if isinstance(v, str) else safe_repr(v) for v in val]
     elif isinstance(val, tuple):
         ty = type(val[0])
         if ty in (str, int, float, bool) and all(type(v) is ty for v in val):
             return list(val)
+        # Same treatment for tuples with mixed/non-primitive elements.
+        return [v if isinstance(v, str) else safe_repr(v) for v in val]
 
     return safe_repr(val)
 


### PR DESCRIPTION
## Problem

`format_attribute` converts user-supplied values into an `AttributeValue` before they are transmitted. When a list or tuple contained **mixed types** (e.g. `[1, "two", 3]`) or **non-primitive elements**, the entire list was collapsed into a single `safe_repr()` string:

```python
[1, "two", 3]    →  "[1, 'two', 3]"   # type: "string"  ← array silently lost
[obj1, obj2]     →  "[<Obj ...>, ...]"  # type: "string"  ← same
```

This diverges from the sentry-javascript SDK (which preserves the array by coercing elements to strings) and was reported as ["Logs: array attribute values are silently dropped"](https://github.com/getsentry/sentry-python/issues/XXXX).

## Fix

When the uniform-type check fails, instead of falling back to `safe_repr(list)`, map each element individually — keeping `str` elements unchanged and calling `safe_repr()` only on non-string items — and return the result as a `list[str]`:

```python
[1, "two", 3]  →  ["1", "two", "3"]   # type: "array"  ✓
[obj1, obj2]   →  ["repr(obj1)", "repr(obj2)"]  # type: "array"  ✓
```

The same fix is applied to tuples.

## Behaviour table

| Input | Before | After |
|---|---|---|
| `[1, 2, 3]` | `[1, 2, 3]` (array) ✓ | `[1, 2, 3]` (array) ✓ |
| `["a", "b"]` | `["a", "b"]` (array) ✓ | `["a", "b"]` (array) ✓ |
| `[1, "two", 3]` | `"[1, 'two', 3]"` (string) ✗ | `["1", "two", "3"]` (array) ✓ |
| `[obj1, obj2]` | `"[<Obj...>, ...]"` (string) ✗ | `["<Obj...>", "..."]` (array) ✓ |
| `[]` | `[]` (array) ✓ | `[]` (array) ✓ |