### PR TITLE
test(pydantic-ai): Create event loop before invoking sync methods

### DIFF
--- a/tests/integrations/pydantic_ai/test_pydantic_ai.py
+++ b/tests/integrations/pydantic_ai/test_pydantic_ai.py
@@ -55,6 +55,20 @@ def get_test_agent_with_settings():
     return inner
 
 
+@pytest.fixture
+def sync_event_loop():
+    # Pydantic AI creates an event loop and doesn't close it in synchronous methods.
+    # Run with "-X tracemalloc=25 -W default::ResourceWarning" to reproduce.
+    # https://github.com/pydantic/pydantic-ai/commit/a58dd47f9cd6494665e47bf7cf71fccbfce2c0dd
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
+    try:
+        yield loop
+    finally:
+        loop.close()
+        asyncio.set_event_loop(None)
+
+
 @pytest.mark.parametrize("span_streaming", [True, False])
 @pytest.mark.parametrize("stream_gen_ai_spans", [True, False])
 @pytest.mark.asyncio
@@ -284,6 +298,7 @@ def test_agent_run_sync(
     get_test_agent,
     stream_gen_ai_spans,
     span_streaming,
+    sync_event_loop,
 ):
     """
     Test that the integration creates spans for sync agent runs.
@@ -381,6 +396,7 @@ def test_agent_run_sync_model_error(
     capture_items,
     stream_gen_ai_spans,
     span_streaming,
+    sync_event_loop,
 ):
     sentry_init(
         integrations=[PydanticAIIntegration()],
@@ -1985,7 +2001,7 @@ async def test_context_cleanup_after_run(sentry_init, get_test_agent):
     assert "pydantic_ai_agent" not in scope._contexts
 
 
-def test_context_cleanup_after_run_sync(sentry_init, get_test_agent):
+def test_context_cleanup_after_run_sync(sentry_init, get_test_agent, sync_event_loop):
     """
     Test that the pydantic_ai_agent context is properly cleaned up after sync agent execution.
     """

--- a/tests/integrations/pydantic_ai/test_pydantic_ai.py
+++ b/tests/integrations/pydantic_ai/test_pydantic_ai.py
@@ -57,7 +57,7 @@ def get_test_agent_with_settings():
 
 @pytest.fixture
 def sync_event_loop():
-    # Pydantic AI creates an event loop and doesn't close it in synchronous methods.
+    # Pydantic AI creates an event loop if there is none and doesn't close it in synchronous methods.
     # Run with "-X tracemalloc=25 -W default::ResourceWarning" to reproduce.
     # https://github.com/pydantic/pydantic-ai/commit/a58dd47f9cd6494665e47bf7cf71fccbfce2c0dd
     loop = asyncio.new_event_loop()


### PR DESCRIPTION
### Description
<!-- What changed and why? -->

To see for yourself, replace

https://github.com/getsentry/sentry-python/blob/7f724ec6b362012bf641b7d0b61a4fe746aaf15a/tox.ini#L1116

with 

```bash
python -X tracemalloc=25 -m pytest -W default::ResourceWarning -W error::pytest.PytestUnraisableExceptionWarning {env:TESTPATH:{env:_TESTPATH}} -o junit_suite_name={envname} {posargs}
```

Tracemalloc output indicating that Pydantic AI doesn't clean up loop:

```bash
  Object allocated at:
    File "/Users/alex/code/sentry-repos/isort-sentry-python/.tox/py3.14t-pydantic_ai-v2.0.0b4/lib/python3.14t/site-packages/pluggy/_manager.py", line 120
      return self._inner_hookexec(hook_name, methods, kwargs, firstresult)
    File "/Users/alex/code/sentry-repos/isort-sentry-python/.tox/py3.14t-pydantic_ai-v2.0.0b4/lib/python3.14t/site-packages/pluggy/_callers.py", line 121
      res = hook_impl.function(*args)
    File "/Users/alex/code/sentry-repos/isort-sentry-python/.tox/py3.14t-pydantic_ai-v2.0.0b4/lib/python3.14t/site-packages/_pytest/main.py", line 396
      item.config.hook.pytest_runtest_protocol(item=item, nextitem=nextitem)
    File "/Users/alex/code/sentry-repos/isort-sentry-python/.tox/py3.14t-pydantic_ai-v2.0.0b4/lib/python3.14t/site-packages/pluggy/_hooks.py", line 512
      return self._hookexec(self.name, self._hookimpls.copy(), kwargs, firstresult)
    File "/Users/alex/code/sentry-repos/isort-sentry-python/.tox/py3.14t-pydantic_ai-v2.0.0b4/lib/python3.14t/site-packages/pluggy/_manager.py", line 120
      return self._inner_hookexec(hook_name, methods, kwargs, firstresult)
    File "/Users/alex/code/sentry-repos/isort-sentry-python/.tox/py3.14t-pydantic_ai-v2.0.0b4/lib/python3.14t/site-packages/pluggy/_callers.py", line 121
      res = hook_impl.function(*args)
    File "/Users/alex/code/sentry-repos/isort-sentry-python/.tox/py3.14t-pydantic_ai-v2.0.0b4/lib/python3.14t/site-packages/_pytest/runner.py", line 118
      runtestprotocol(item, nextitem=nextitem)
    File "/Users/alex/code/sentry-repos/isort-sentry-python/.tox/py3.14t-pydantic_ai-v2.0.0b4/lib/python3.14t/site-packages/_pytest/runner.py", line 137
      reports.append(call_and_report(item, "call", log))
    File "/Users/alex/code/sentry-repos/isort-sentry-python/.tox/py3.14t-pydantic_ai-v2.0.0b4/lib/python3.14t/site-packages/_pytest/runner.py", line 244
      call = CallInfo.from_call(
    File "/Users/alex/code/sentry-repos/isort-sentry-python/.tox/py3.14t-pydantic_ai-v2.0.0b4/lib/python3.14t/site-packages/_pytest/runner.py", line 353
      result: TResult | None = func()
    File "/Users/alex/code/sentry-repos/isort-sentry-python/.tox/py3.14t-pydantic_ai-v2.0.0b4/lib/python3.14t/site-packages/_pytest/runner.py", line 245
      lambda: runtest_hook(item=item, **kwds),
    File "/Users/alex/code/sentry-repos/isort-sentry-python/.tox/py3.14t-pydantic_ai-v2.0.0b4/lib/python3.14t/site-packages/pluggy/_hooks.py", line 512
      return self._hookexec(self.name, self._hookimpls.copy(), kwargs, firstresult)
    File "/Users/alex/code/sentry-repos/isort-sentry-python/.tox/py3.14t-pydantic_ai-v2.0.0b4/lib/python3.14t/site-packages/pluggy/_manager.py", line 120
      return self._inner_hookexec(hook_name, methods, kwargs, firstresult)
    File "/Users/alex/code/sentry-repos/isort-sentry-python/.tox/py3.14t-pydantic_ai-v2.0.0b4/lib/python3.14t/site-packages/pluggy/_callers.py", line 121
      res = hook_impl.function(*args)
    File "/Users/alex/code/sentry-repos/isort-sentry-python/.tox/py3.14t-pydantic_ai-v2.0.0b4/lib/python3.14t/site-packages/_pytest/runner.py", line 179
      item.runtest()
    File "/Users/alex/code/sentry-repos/isort-sentry-python/.tox/py3.14t-pydantic_ai-v2.0.0b4/lib/python3.14t/site-packages/_pytest/python.py", line 1720
      self.ihook.pytest_pyfunc_call(pyfuncitem=self)
    File "/Users/alex/code/sentry-repos/isort-sentry-python/.tox/py3.14t-pydantic_ai-v2.0.0b4/lib/python3.14t/site-packages/pluggy/_hooks.py", line 512
      return self._hookexec(self.name, self._hookimpls.copy(), kwargs, firstresult)
    File "/Users/alex/code/sentry-repos/isort-sentry-python/.tox/py3.14t-pydantic_ai-v2.0.0b4/lib/python3.14t/site-packages/pluggy/_manager.py", line 120
      return self._inner_hookexec(hook_name, methods, kwargs, firstresult)
    File "/Users/alex/code/sentry-repos/isort-sentry-python/.tox/py3.14t-pydantic_ai-v2.0.0b4/lib/python3.14t/site-packages/pluggy/_callers.py", line 121
      res = hook_impl.function(*args)
    File "/Users/alex/code/sentry-repos/isort-sentry-python/.tox/py3.14t-pydantic_ai-v2.0.0b4/lib/python3.14t/site-packages/_pytest/python.py", line 166
      result = testfunction(**testargs)
    File "/Users/alex/code/sentry-repos/isort-sentry-python/tests/integrations/pydantic_ai/test_pydantic_ai.py", line 2015
      test_agent.run_sync("Test input")
    File "/Users/alex/code/sentry-repos/isort-sentry-python/.tox/py3.14t-pydantic_ai-v2.0.0b4/lib/python3.14t/site-packages/pydantic_ai/agent/abstract.py", line 549
      return _utils.get_event_loop().run_until_complete(
    File "/Users/alex/code/sentry-repos/isort-sentry-python/.tox/py3.14t-pydantic_ai-v2.0.0b4/lib/python3.14t/site-packages/pydantic_ai/_utils.py", line 797
      event_loop = asyncio.new_event_loop()
    File "/opt/homebrew/Cellar/python-freethreading/3.14.0/Frameworks/PythonT.framework/Versions/3.14/lib/python3.14t/asyncio/events.py", line 844
      return _get_event_loop_policy().new_event_loop()
    File "/opt/homebrew/Cellar/python-freethreading/3.14.0/Frameworks/PythonT.framework/Versions/3.14/lib/python3.14t/asyncio/events.py", line 732
      return self._loop_factory()
```

#### Issues
<!--
* resolves: #1234
* resolves: LIN-1234
-->

#### Reminders
- Please add tests to validate your changes, and lint your code using `uv run ruff`.
- Add GH Issue ID _&_ Linear ID (if applicable)
- PR title should use [conventional commit](https://develop.sentry.dev/engineering-practices/commit-messages/#type) style (`feat:`, `fix:`, `ref:`, `meta:`)
- For external contributors: [CONTRIBUTING.md](https://github.com/getsentry/sentry-python/blob/master/CONTRIBUTING.md), [Sentry SDK development docs](https://develop.sentry.dev/sdk/), [Discord community](https://discord.gg/Ww9hbqr)
