### PR TITLE
fix(utils): handle image_url string shorthand in _is_image_type_with_blob_content

### DIFF
--- a/sentry_sdk/ai/utils.py
+++ b/sentry_sdk/ai/utils.py
@@ -609,7 +609,12 @@ def _is_image_type_with_blob_content(item: "Dict[str, Any]") -> bool:
     if item.get("type") != "image_url":
         return False
 
-    image_url = item.get("image_url", {}).get("url", "")
+    image_url_val = item.get("image_url")
+    image_url = (
+        image_url_val.get("url", "")
+        if isinstance(image_url_val, dict)
+        else (image_url_val or "")
+    )
     data_url_match = DATA_URL_BASE64_REGEX.match(image_url)
 
     return bool(data_url_match)
@@ -694,7 +699,10 @@ def redact_blob_message_parts(
                     if item.get("type") == "blob":
                         item["content"] = BLOB_DATA_SUBSTITUTE
                     elif _is_image_type_with_blob_content(item):
-                        item["image_url"]["url"] = BLOB_DATA_SUBSTITUTE
+                        if isinstance(item["image_url"], dict):
+                            item["image_url"]["url"] = BLOB_DATA_SUBSTITUTE
+                        else:
+                            item["image_url"] = BLOB_DATA_SUBSTITUTE
 
     return messages_copy
 

--- a/tests/test_ai_monitoring.py
+++ b/tests/test_ai_monitoring.py
@@ -923,6 +923,23 @@ class TestRedactBlobMessageParts:
         # Should return same list since no blobs
         assert result is messages
 
+    def test_redact_blob_message_parts_image_url_string_shorthand(self):
+        """image_url as a plain string (OpenAI shorthand) must not raise AttributeError"""
+        messages = [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "What is in this image?"},
+                    {
+                        "type": "image_url",
+                        "image_url": "data:image/jpeg;base64,/9j/abc123==",
+                    },
+                ],
+            }
+        ]
+        result = redact_blob_message_parts(messages)
+        assert result[0]["content"][1]["image_url"] == "[Blob substitute]"
+
 
 class TestParseDataUri:
     def test_parses_base64_image_data_uri(self):


### PR DESCRIPTION
## What's broken

`_is_image_type_with_blob_content` crashes with `AttributeError: 'str' object has no attribute 'get'` when `image_url` is a plain string shorthand (e.g. `{"type": "image_url", "image_url": "data:image/jpeg;base64,..."}`) instead of a dict. The OpenAI API supports this form and `transform_openai_content_part` in the same file documents it. Any call to `redact_blob_message_parts` — which is invoked from `truncate_and_annotate_messages` across the OpenAI, LiteLLM, Anthropic, LangChain, pydantic-ai, and openai-agents integrations when `send_default_pii=True` — would crash on such input.

## Why it happens

`item.get("image_url", {})` returns the raw string when the value is a string, and the subsequent `.get("url", "")` call fails because strings have no `.get` method.

## Fix

Check `isinstance(image_url_val, dict)` before calling `.get("url", "")`, falling back to using the string directly. The same guard is applied to the redaction path at line 702 where `item["image_url"]["url"]` would also fail on a string.

## Test

Added `test_redact_blob_message_parts_image_url_string_shorthand` to `TestRedactBlobMessageParts` which passes a message with the string shorthand form and asserts it is redacted to `[Blob substitute]` without raising.

Fixes #6477