### PR TITLE
feat(cohere): Add span streaming support

### DIFF
--- a/sentry_sdk/integrations/cohere.py
+++ b/sentry_sdk/integrations/cohere.py
@@ -6,9 +6,11 @@ from sentry_sdk import consts
 from sentry_sdk.ai.monitoring import record_token_usage
 from sentry_sdk.ai.utils import get_start_span_function, set_data_normalized
 from sentry_sdk.consts import SPANDATA
+from sentry_sdk.traces import StreamedSpan
+from sentry_sdk.tracing_utils import has_span_streaming_enabled
 
 if TYPE_CHECKING:
-    from typing import Any, Callable, Iterator
+    from typing import Any, Callable, Iterator, Union
 
     from sentry_sdk.tracing import Span
 
@@ -90,9 +92,18 @@ def _capture_exception(exc: "Any") -> None:
     sentry_sdk.capture_event(event, hint=hint)
 
 
+def _end_span(span: "Any") -> None:
+    if isinstance(span, StreamedSpan):
+        span.end()
+    else:
+        span.__exit__(None, None, None)
+
+
 def _wrap_chat(f: "Callable[..., Any]", streaming: bool) -> "Callable[..., Any]":
     def collect_chat_response_fields(
-        span: "Span", res: "NonStreamedChatResponse", include_pii: bool
+        span: "Union[Span, StreamedSpan]",
+        res: "NonStreamedChatResponse",
+        include_pii: bool,
     ) -> None:
         if include_pii:
             if hasattr(res, "text"):
@@ -129,6 +140,9 @@ def _wrap_chat(f: "Callable[..., Any]", streaming: bool) -> "Callable[..., Any]"
     @wraps(f)
     def new_chat(*args: "Any", **kwargs: "Any") -> "Any":
         integration = sentry_sdk.get_client().get_integration(CohereIntegration)
+        is_span_streaming_enabled = has_span_streaming_enabled(
+            sentry_sdk.get_client().options
+        )
 
         if (
             integration is None
@@ -139,12 +153,21 @@ def _wrap_chat(f: "Callable[..., Any]", streaming: bool) -> "Callable[..., Any]"
 
         message = kwargs.get("message")
 
-        span = get_start_span_function()(
-            op=consts.OP.COHERE_CHAT_COMPLETIONS_CREATE,
-            name="cohere.client.Chat",
-            origin=CohereIntegration.origin,
-        )
-        span.__enter__()
+        if is_span_streaming_enabled:
+            span = sentry_sdk.traces.start_span(
+                name="cohere.client.Chat",
+                attributes={
+                    "sentry.op": consts.OP.COHERE_CHAT_COMPLETIONS_CREATE,
+                    "sentry.origin": CohereIntegration.origin,
+                },
+            )
+        else:
+            span = get_start_span_function()(
+                op=consts.OP.COHERE_CHAT_COMPLETIONS_CREATE,
+                name="cohere.client.Chat",
+                origin=CohereIntegration.origin,
+            )
+            span.__enter__()
         try:
             res = f(*args, **kwargs)
         except Exception as e:
@@ -152,6 +175,7 @@ def _wrap_chat(f: "Callable[..., Any]", streaming: bool) -> "Callable[..., Any]"
             with capture_internal_exceptions():
                 _capture_exception(e)
                 span.__exit__(*exc_info)
+
             reraise(*exc_info)
 
         with capture_internal_exceptions():
@@ -195,8 +219,7 @@ def _wrap_chat(f: "Callable[..., Any]", streaming: bool) -> "Callable[..., Any]"
                                     and integration.include_prompts,
                                 )
                             yield x
-
-                    span.__exit__(None, None, None)
+                    _end_span(span)
 
                 return new_iterator()
             elif isinstance(res, NonStreamedChatResponse):
@@ -206,11 +229,11 @@ def _wrap_chat(f: "Callable[..., Any]", streaming: bool) -> "Callable[..., Any]"
                     include_pii=should_send_default_pii()
                     and integration.include_prompts,
                 )
-                span.__exit__(None, None, None)
+                _end_span(span)
             else:
                 set_data_normalized(span, "unknown_response", True)
-                span.__exit__(None, None, None)
-            return res
+                _end_span(span)
+        return res
 
     return new_chat
 
@@ -222,11 +245,26 @@ def _wrap_embed(f: "Callable[..., Any]") -> "Callable[..., Any]":
         if integration is None:
             return f(*args, **kwargs)
 
-        with get_start_span_function()(
-            op=consts.OP.COHERE_EMBEDDINGS_CREATE,
-            name="Cohere Embedding Creation",
-            origin=CohereIntegration.origin,
-        ) as span:
+        is_span_streaming_enabled = has_span_streaming_enabled(
+            sentry_sdk.get_client().options
+        )
+
+        if is_span_streaming_enabled:
+            span_ctx = sentry_sdk.traces.start_span(
+                name="Cohere Embedding Creation",
+                attributes={
+                    "sentry.op": consts.OP.COHERE_EMBEDDINGS_CREATE,
+                    "sentry.origin": CohereIntegration.origin,
+                },
+            )
+        else:
+            span_ctx = get_start_span_function()(
+                op=consts.OP.COHERE_EMBEDDINGS_CREATE,
+                name="Cohere Embedding Creation",
+                origin=CohereIntegration.origin,
+            )
+
+        with span_ctx as span:
             if "texts" in kwargs and (
                 should_send_default_pii() and integration.include_prompts
             ):

--- a/tests/integrations/cohere/test_cohere.py
+++ b/tests/integrations/cohere/test_cohere.py
@@ -6,24 +6,31 @@ import pytest
 from cohere import ChatMessage, Client
 from httpx import Client as HTTPXClient
 
+import sentry_sdk
 from sentry_sdk import start_transaction
 from sentry_sdk.consts import SPANDATA
 from sentry_sdk.integrations.cohere import CohereIntegration
 
 
+@pytest.mark.parametrize("span_streaming", [True, False])
 @pytest.mark.parametrize(
     "send_default_pii, include_prompts",
     [(True, True), (True, False), (False, True), (False, False)],
 )
 def test_nonstreaming_chat(
-    sentry_init, capture_events, send_default_pii, include_prompts
+    sentry_init,
+    capture_events,
+    capture_items,
+    send_default_pii,
+    include_prompts,
+    span_streaming,
 ):
     sentry_init(
         integrations=[CohereIntegration(include_prompts=include_prompts)],
         traces_sample_rate=1.0,
         send_default_pii=send_default_pii,
+        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
     )
-    events = capture_events()
 
     client = Client(api_key="z")
     HTTPXClient.request = mock.Mock(
@@ -41,51 +48,99 @@ def test_nonstreaming_chat(
         )
     )
 
-    with start_transaction(name="cohere tx"):
-        response = client.chat(
-            model="some-model",
-            chat_history=[ChatMessage(role="SYSTEM", message="some context")],
-            message="hello",
-        ).text
+    if span_streaming:
+        items = capture_items("span")
 
-    assert response == "the model response"
-    tx = events[0]
-    assert tx["type"] == "transaction"
-    span = tx["spans"][0]
-    assert span["op"] == "ai.chat_completions.create.cohere"
-    assert span["data"][SPANDATA.AI_MODEL_ID] == "some-model"
+        with start_transaction(name="cohere tx"):
+            response = client.chat(
+                model="some-model",
+                chat_history=[ChatMessage(role="SYSTEM", message="some context")],
+                message="hello",
+            ).text
 
-    if send_default_pii and include_prompts:
-        assert (
-            '{"role": "system", "content": "some context"}'
-            in span["data"][SPANDATA.AI_INPUT_MESSAGES]
-        )
-        assert (
-            '{"role": "user", "content": "hello"}'
-            in span["data"][SPANDATA.AI_INPUT_MESSAGES]
-        )
-        assert "the model response" in span["data"][SPANDATA.AI_RESPONSES]
+        assert response == "the model response"
+        sentry_sdk.flush()
+
+        assert len(items) == 1
+        span = items[0].payload
+
+        assert span["attributes"]["sentry.op"] == "ai.chat_completions.create.cohere"
+        assert span["attributes"][SPANDATA.AI_MODEL_ID] == "some-model"
+
+        if send_default_pii and include_prompts:
+            assert (
+                '{"role": "system", "content": "some context"}'
+                in span["attributes"][SPANDATA.AI_INPUT_MESSAGES]
+            )
+            assert (
+                '{"role": "user", "content": "hello"}'
+                in span["attributes"][SPANDATA.AI_INPUT_MESSAGES]
+            )
+            assert "the model response" in span["attributes"][SPANDATA.AI_RESPONSES]
+        else:
+            assert SPANDATA.AI_INPUT_MESSAGES not in span["attributes"]
+            assert SPANDATA.AI_RESPONSES not in span["attributes"]
+
+        assert span["attributes"]["gen_ai.usage.output_tokens"] == 10
+        assert span["attributes"]["gen_ai.usage.input_tokens"] == 20
+        assert span["attributes"]["gen_ai.usage.total_tokens"] == 30
     else:
-        assert SPANDATA.AI_INPUT_MESSAGES not in span["data"]
-        assert SPANDATA.AI_RESPONSES not in span["data"]
+        events = capture_events()
 
-    assert span["data"]["gen_ai.usage.output_tokens"] == 10
-    assert span["data"]["gen_ai.usage.input_tokens"] == 20
-    assert span["data"]["gen_ai.usage.total_tokens"] == 30
+        with start_transaction(name="cohere tx"):
+            response = client.chat(
+                model="some-model",
+                chat_history=[ChatMessage(role="SYSTEM", message="some context")],
+                message="hello",
+            ).text
+
+        assert response == "the model response"
+        tx = events[0]
+        assert tx["type"] == "transaction"
+        assert len(tx["spans"]) == 1
+        span = tx["spans"][0]
+        assert span["op"] == "ai.chat_completions.create.cohere"
+        assert span["data"][SPANDATA.AI_MODEL_ID] == "some-model"
+
+        if send_default_pii and include_prompts:
+            assert (
+                '{"role": "system", "content": "some context"}'
+                in span["data"][SPANDATA.AI_INPUT_MESSAGES]
+            )
+            assert (
+                '{"role": "user", "content": "hello"}'
+                in span["data"][SPANDATA.AI_INPUT_MESSAGES]
+            )
+            assert "the model response" in span["data"][SPANDATA.AI_RESPONSES]
+        else:
+            assert SPANDATA.AI_INPUT_MESSAGES not in span["data"]
+            assert SPANDATA.AI_RESPONSES not in span["data"]
+
+        assert span["data"]["gen_ai.usage.output_tokens"] == 10
+        assert span["data"]["gen_ai.usage.input_tokens"] == 20
+        assert span["data"]["gen_ai.usage.total_tokens"] == 30
 
 
 # noinspection PyTypeChecker
+@pytest.mark.parametrize("span_streaming", [True, False])
 @pytest.mark.parametrize(
     "send_default_pii, include_prompts",
     [(True, True), (True, False), (False, True), (False, False)],
 )
-def test_streaming_chat(sentry_init, capture_events, send_default_pii, include_prompts):
+def test_streaming_chat(
+    sentry_init,
+    capture_events,
+    capture_items,
+    send_default_pii,
+    include_prompts,
+    span_streaming,
+):
     sentry_init(
         integrations=[CohereIntegration(include_prompts=include_prompts)],
         traces_sample_rate=1.0,
         send_default_pii=send_default_pii,
+        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
     )
-    events = capture_events()
 
     client = Client(api_key="z")
     HTTPXClient.send = mock.Mock(
@@ -115,40 +170,83 @@ def test_streaming_chat(sentry_init, capture_events, send_default_pii, include_p
         )
     )
 
-    with start_transaction(name="cohere tx"):
-        responses = list(
-            client.chat_stream(
-                model="some-model",
-                chat_history=[ChatMessage(role="SYSTEM", message="some context")],
-                message="hello",
+    if span_streaming:
+        items = capture_items("span")
+
+        with start_transaction(name="cohere tx"):
+            responses = list(
+                client.chat_stream(
+                    model="some-model",
+                    chat_history=[ChatMessage(role="SYSTEM", message="some context")],
+                    message="hello",
+                )
             )
-        )
-        response_string = responses[-1].response.text
+            response_string = responses[-1].response.text
 
-    assert response_string == "the model response"
-    tx = events[0]
-    assert tx["type"] == "transaction"
-    span = tx["spans"][0]
-    assert span["op"] == "ai.chat_completions.create.cohere"
-    assert span["data"][SPANDATA.AI_MODEL_ID] == "some-model"
+        assert response_string == "the model response"
+        sentry_sdk.flush()
 
-    if send_default_pii and include_prompts:
-        assert (
-            '{"role": "system", "content": "some context"}'
-            in span["data"][SPANDATA.AI_INPUT_MESSAGES]
-        )
-        assert (
-            '{"role": "user", "content": "hello"}'
-            in span["data"][SPANDATA.AI_INPUT_MESSAGES]
-        )
-        assert "the model response" in span["data"][SPANDATA.AI_RESPONSES]
+        assert len(items) == 1
+        span = items[0].payload
+
+        assert span["attributes"]["sentry.op"] == "ai.chat_completions.create.cohere"
+        assert span["attributes"][SPANDATA.AI_MODEL_ID] == "some-model"
+
+        if send_default_pii and include_prompts:
+            assert (
+                '{"role": "system", "content": "some context"}'
+                in span["attributes"][SPANDATA.AI_INPUT_MESSAGES]
+            )
+            assert (
+                '{"role": "user", "content": "hello"}'
+                in span["attributes"][SPANDATA.AI_INPUT_MESSAGES]
+            )
+            assert "the model response" in span["attributes"][SPANDATA.AI_RESPONSES]
+        else:
+            assert SPANDATA.AI_INPUT_MESSAGES not in span["attributes"]
+            assert SPANDATA.AI_RESPONSES not in span["attributes"]
+
+        assert span["attributes"]["gen_ai.usage.output_tokens"] == 10
+        assert span["attributes"]["gen_ai.usage.input_tokens"] == 20
+        assert span["attributes"]["gen_ai.usage.total_tokens"] == 30
     else:
-        assert SPANDATA.AI_INPUT_MESSAGES not in span["data"]
-        assert SPANDATA.AI_RESPONSES not in span["data"]
+        events = capture_events()
 
-    assert span["data"]["gen_ai.usage.output_tokens"] == 10
-    assert span["data"]["gen_ai.usage.input_tokens"] == 20
-    assert span["data"]["gen_ai.usage.total_tokens"] == 30
+        with start_transaction(name="cohere tx"):
+            responses = list(
+                client.chat_stream(
+                    model="some-model",
+                    chat_history=[ChatMessage(role="SYSTEM", message="some context")],
+                    message="hello",
+                )
+            )
+            response_string = responses[-1].response.text
+
+        assert response_string == "the model response"
+        tx = events[0]
+        assert tx["type"] == "transaction"
+        assert len(tx["spans"]) == 1
+        span = tx["spans"][0]
+        assert span["op"] == "ai.chat_completions.create.cohere"
+        assert span["data"][SPANDATA.AI_MODEL_ID] == "some-model"
+
+        if send_default_pii and include_prompts:
+            assert (
+                '{"role": "system", "content": "some context"}'
+                in span["data"][SPANDATA.AI_INPUT_MESSAGES]
+            )
+            assert (
+                '{"role": "user", "content": "hello"}'
+                in span["data"][SPANDATA.AI_INPUT_MESSAGES]
+            )
+            assert "the model response" in span["data"][SPANDATA.AI_RESPONSES]
+        else:
+            assert SPANDATA.AI_INPUT_MESSAGES not in span["data"]
+            assert SPANDATA.AI_RESPONSES not in span["data"]
+
+        assert span["data"]["gen_ai.usage.output_tokens"] == 10
+        assert span["data"]["gen_ai.usage.input_tokens"] == 20
+        assert span["data"]["gen_ai.usage.total_tokens"] == 30
 
 
 def test_bad_chat(sentry_init, capture_events):
@@ -185,17 +283,48 @@ def test_span_status_error(sentry_init, capture_events):
     assert transaction["spans"][0]["tags"]["status"] == "internal_error"
 
 
+def test_span_status_error_streaming(sentry_init, capture_events, capture_items):
+    sentry_init(
+        integrations=[CohereIntegration()],
+        traces_sample_rate=1.0,
+        _experiments={"trace_lifecycle": "stream"},
+    )
+    items = capture_items("span")
+
+    client = Client(api_key="z")
+    HTTPXClient.request = mock.Mock(
+        side_effect=httpx.HTTPError("API rate limit reached")
+    )
+    with start_transaction(name="test"):
+        with pytest.raises(httpx.HTTPError):
+            client.chat(model="some-model", message="hello")
+
+    sentry_sdk.flush()
+
+    assert len(items) == 1
+    span = items[0].payload
+    assert span["status"] == "error"
+
+
+@pytest.mark.parametrize("span_streaming", [True, False])
 @pytest.mark.parametrize(
     "send_default_pii, include_prompts",
     [(True, True), (True, False), (False, True), (False, False)],
 )
-def test_embed(sentry_init, capture_events, send_default_pii, include_prompts):
+def test_embed(
+    sentry_init,
+    capture_events,
+    capture_items,
+    send_default_pii,
+    include_prompts,
+    span_streaming,
+):
     sentry_init(
         integrations=[CohereIntegration(include_prompts=include_prompts)],
         traces_sample_rate=1.0,
         send_default_pii=send_default_pii,
+        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
     )
-    events = capture_events()
 
     client = Client(api_key="z")
     HTTPXClient.request = mock.Mock(
@@ -215,22 +344,46 @@ def test_embed(sentry_init, capture_events, send_default_pii, include_prompts):
         )
     )
 
-    with start_transaction(name="cohere tx"):
-        response = client.embed(texts=["hello"], model="text-embedding-3-large")
+    if span_streaming:
+        items = capture_items("span")
 
-    assert len(response.embeddings[0]) == 3
+        with start_transaction(name="cohere tx"):
+            response = client.embed(texts=["hello"], model="text-embedding-3-large")
 
-    tx = events[0]
-    assert tx["type"] == "transaction"
-    span = tx["spans"][0]
-    assert span["op"] == "ai.embeddings.create.cohere"
-    if send_default_pii and include_prompts:
-        assert "hello" in span["data"][SPANDATA.AI_INPUT_MESSAGES]
+        assert len(response.embeddings[0]) == 3
+        sentry_sdk.flush()
+
+        assert len(items) == 1
+        span = items[0].payload
+
+        assert span["attributes"]["sentry.op"] == "ai.embeddings.create.cohere"
+        if send_default_pii and include_prompts:
+            assert "hello" in span["attributes"][SPANDATA.AI_INPUT_MESSAGES]
+        else:
+            assert SPANDATA.AI_INPUT_MESSAGES not in span["attributes"]
+
+        assert span["attributes"]["gen_ai.usage.input_tokens"] == 10
+        assert span["attributes"]["gen_ai.usage.total_tokens"] == 10
     else:
-        assert SPANDATA.AI_INPUT_MESSAGES not in span["data"]
+        events = capture_events()
 
-    assert span["data"]["gen_ai.usage.input_tokens"] == 10
-    assert span["data"]["gen_ai.usage.total_tokens"] == 10
+        with start_transaction(name="cohere tx"):
+            response = client.embed(texts=["hello"], model="text-embedding-3-large")
+
+        assert len(response.embeddings[0]) == 3
+
+        tx = events[0]
+        assert tx["type"] == "transaction"
+        assert len(tx["spans"]) == 1
+        span = tx["spans"][0]
+        assert span["op"] == "ai.embeddings.create.cohere"
+        if send_default_pii and include_prompts:
+            assert "hello" in span["data"][SPANDATA.AI_INPUT_MESSAGES]
+        else:
+            assert SPANDATA.AI_INPUT_MESSAGES not in span["data"]
+
+        assert span["data"]["gen_ai.usage.input_tokens"] == 10
+        assert span["data"]["gen_ai.usage.total_tokens"] == 10
 
 
 def test_span_origin_chat(sentry_init, capture_events):


### PR DESCRIPTION
Enable the Cohere integration to use span streaming when configured. Add support for both StreamedSpan and traditional span lifecycle patterns.

Fixes PY-2315
Fixes #6013