### PR TITLE
fix(pydantic-ai): Only use hooks when `ModelRequestContext.model` exists

### DIFF
--- a/sentry_sdk/integrations/pydantic_ai/__init__.py
+++ b/sentry_sdk/integrations/pydantic_ai/__init__.py
@@ -1,7 +1,7 @@
 import functools
 
 from sentry_sdk.integrations import DidNotEnable, Integration
-from sentry_sdk.utils import capture_internal_exceptions
+from sentry_sdk.utils import capture_internal_exceptions, package_version
 
 try:
     import pydantic_ai  # type: ignore # noqa: F401
@@ -164,8 +164,16 @@ class PydanticAIIntegration(Integration):
             Hooks = None
             PydanticAIIntegration.are_request_hooks_available = False
 
-        if Hooks is None:
+        # ModelRequestContext.model added in https://github.com/pydantic/pydantic-ai/commit/f1260dfe09907f17688eee1646daf898fc428d4c
+        PYDANTIC_AI_VERSION = package_version("pydantic-ai")
+        if PYDANTIC_AI_VERSION is not None and PYDANTIC_AI_VERSION < (
+            1,
+            73,
+        ):
             _patch_graph_nodes()
+            return
+
+        if Hooks is None:
             return
 
         hooks = Hooks()

--- a/sentry_sdk/integrations/pydantic_ai/__init__.py
+++ b/sentry_sdk/integrations/pydantic_ai/__init__.py
@@ -1,7 +1,7 @@
 import functools
 
 from sentry_sdk.integrations import DidNotEnable, Integration
-from sentry_sdk.utils import capture_internal_exceptions, package_version
+from sentry_sdk.utils import capture_internal_exceptions, parse_version
 
 try:
     import pydantic_ai  # type: ignore # noqa: F401
@@ -10,6 +10,7 @@ except ImportError:
     raise DidNotEnable("pydantic-ai not installed")
 
 
+from importlib.metadata import PackageNotFoundError, version
 from typing import TYPE_CHECKING
 
 from .patches import (
@@ -165,8 +166,16 @@ class PydanticAIIntegration(Integration):
             PydanticAIIntegration.are_request_hooks_available = False
 
         # ModelRequestContext.model added in https://github.com/pydantic/pydantic-ai/commit/f1260dfe09907f17688eee1646daf898fc428d4c
-        PYDANTIC_AI_VERSION = package_version("pydantic-ai")
-        if PYDANTIC_AI_VERSION is not None and PYDANTIC_AI_VERSION < (
+        try:
+            PYDANTIC_AI_VERSION = version("pydantic-ai-slim")
+        except PackageNotFoundError:
+            return
+
+        PYDANTIC_AI_VERSION = parse_version(PYDANTIC_AI_VERSION)
+        if PYDANTIC_AI_VERSION is None:
+            return
+
+        if PYDANTIC_AI_VERSION < (
             1,
             73,
         ):

--- a/sentry_sdk/integrations/pydantic_ai/__init__.py
+++ b/sentry_sdk/integrations/pydantic_ai/__init__.py
@@ -168,12 +168,14 @@ class PydanticAIIntegration(Integration):
         try:
             PYDANTIC_AI_VERSION = version("pydantic-ai-slim")
         except PackageNotFoundError:
-            _patch_graph_nodes()
+            return
+
+        PYDANTIC_AI_VERSION = parse_version(PYDANTIC_AI_VERSION)
+        if PYDANTIC_AI_VERSION is None:
             return
 
         # ModelRequestContext.model added in https://github.com/pydantic/pydantic-ai/commit/f1260dfe09907f17688eee1646daf898fc428d4c
-        PYDANTIC_AI_VERSION = parse_version(PYDANTIC_AI_VERSION)
-        if PYDANTIC_AI_VERSION is None or PYDANTIC_AI_VERSION < (
+        if PYDANTIC_AI_VERSION < (
             1,
             73,
         ):

--- a/sentry_sdk/integrations/pydantic_ai/__init__.py
+++ b/sentry_sdk/integrations/pydantic_ai/__init__.py
@@ -159,12 +159,7 @@ class PydanticAIIntegration(Integration):
         _patch_agent_run()
         _patch_tool_execution()
 
-        try:
-            from pydantic_ai.capabilities import Hooks
-        except ImportError:
-            Hooks = None
-            PydanticAIIntegration.are_request_hooks_available = False
-
+        PydanticAIIntegration.using_request_hooks = False
         try:
             PYDANTIC_AI_VERSION = version("pydantic-ai-slim")
         except PackageNotFoundError:
@@ -182,8 +177,12 @@ class PydanticAIIntegration(Integration):
             _patch_graph_nodes()
             return
 
-        if Hooks is None:
+        try:
+            from pydantic_ai.capabilities import Hooks
+        except ImportError:
+            Hooks = None
             return
 
+        PydanticAIIntegration.using_request_hooks = True
         hooks = Hooks()
         register_hooks(hooks)

--- a/sentry_sdk/integrations/pydantic_ai/__init__.py
+++ b/sentry_sdk/integrations/pydantic_ai/__init__.py
@@ -180,7 +180,6 @@ class PydanticAIIntegration(Integration):
         try:
             from pydantic_ai.capabilities import Hooks
         except ImportError:
-            Hooks = None
             return
 
         PydanticAIIntegration.using_request_hooks = True

--- a/sentry_sdk/integrations/pydantic_ai/__init__.py
+++ b/sentry_sdk/integrations/pydantic_ai/__init__.py
@@ -165,7 +165,6 @@ class PydanticAIIntegration(Integration):
             Hooks = None
             PydanticAIIntegration.are_request_hooks_available = False
 
-        # ModelRequestContext.model added in https://github.com/pydantic/pydantic-ai/commit/f1260dfe09907f17688eee1646daf898fc428d4c
         try:
             PYDANTIC_AI_VERSION = version("pydantic-ai-slim")
         except PackageNotFoundError:
@@ -175,6 +174,7 @@ class PydanticAIIntegration(Integration):
         if PYDANTIC_AI_VERSION is None:
             return
 
+        # ModelRequestContext.model added in https://github.com/pydantic/pydantic-ai/commit/f1260dfe09907f17688eee1646daf898fc428d4c
         if PYDANTIC_AI_VERSION < (
             1,
             73,

--- a/sentry_sdk/integrations/pydantic_ai/__init__.py
+++ b/sentry_sdk/integrations/pydantic_ai/__init__.py
@@ -129,7 +129,7 @@ class PydanticAIIntegration(Integration):
 
     identifier = "pydantic_ai"
     origin = f"auto.ai.{identifier}"
-    are_request_hooks_available = True
+    using_request_hooks = False
 
     def __init__(
         self, include_prompts: bool = True, handled_tool_call_exceptions: bool = True

--- a/sentry_sdk/integrations/pydantic_ai/__init__.py
+++ b/sentry_sdk/integrations/pydantic_ai/__init__.py
@@ -168,14 +168,12 @@ class PydanticAIIntegration(Integration):
         try:
             PYDANTIC_AI_VERSION = version("pydantic-ai-slim")
         except PackageNotFoundError:
-            return
-
-        PYDANTIC_AI_VERSION = parse_version(PYDANTIC_AI_VERSION)
-        if PYDANTIC_AI_VERSION is None:
+            _patch_graph_nodes()
             return
 
         # ModelRequestContext.model added in https://github.com/pydantic/pydantic-ai/commit/f1260dfe09907f17688eee1646daf898fc428d4c
-        if PYDANTIC_AI_VERSION < (
+        PYDANTIC_AI_VERSION = parse_version(PYDANTIC_AI_VERSION)
+        if PYDANTIC_AI_VERSION is None or PYDANTIC_AI_VERSION < (
             1,
             73,
         ):

--- a/sentry_sdk/integrations/pydantic_ai/patches/agent_run.py
+++ b/sentry_sdk/integrations/pydantic_ai/patches/agent_run.py
@@ -109,7 +109,7 @@ def _create_run_wrapper(
             model = kwargs.get("model")
             model_settings = kwargs.get("model_settings")
 
-            if PydanticAIIntegration.are_request_hooks_available:
+            if PydanticAIIntegration.using_request_hooks:
                 metadata = kwargs.get("metadata")
                 if metadata is None:
                     kwargs["metadata"] = {"_sentry_span": None}
@@ -158,7 +158,7 @@ def _create_streaming_wrapper(
         model = kwargs.get("model")
         model_settings = kwargs.get("model_settings")
 
-        if PydanticAIIntegration.are_request_hooks_available:
+        if PydanticAIIntegration.using_request_hooks:
             metadata = kwargs.get("metadata")
             if metadata is None:
                 kwargs["metadata"] = {"_sentry_span": None}


### PR DESCRIPTION
### Description
<!-- What changed and why? -->

Prevent

```bash
AttributeError: 'ModelRequestContext' object has no attribute 'model'
```

raised, e.g., with version 1.71.0 of Pydantic AI in the generated test suite of https://github.com/getsentry/sentry-python/pull/6437

#### Issues
<!--
* resolves: #1234
* resolves: LIN-1234
-->

#### Reminders
- Please add tests to validate your changes, and lint your code using `uv run ruff`.
- Add GH Issue ID _&_ Linear ID (if applicable)
- PR title should use [conventional commit](https://develop.sentry.dev/engineering-practices/commit-messages/#type) style (`feat:`, `fix:`, `ref:`, `meta:`)
- For external contributors: [CONTRIBUTING.md](https://github.com/getsentry/sentry-python/blob/master/CONTRIBUTING.md), [Sentry SDK development docs](https://develop.sentry.dev/sdk/), [Discord community](https://discord.gg/Ww9hbqr)
