### PR TITLE
chore: Emit warnings when post-sampling in span first

### DIFF
--- a/sentry_sdk/client.py
+++ b/sentry_sdk/client.py
@@ -363,6 +363,12 @@ def _get_options(*args: "Optional[str]", **kwargs: "Any") -> "Dict[str, Any]":
             stacklevel=2,
         )
 
+    if rv["trace_ignore_status_codes"] and has_span_streaming_enabled(rv):
+        warnings.warn(
+            "The `trace_ignore_status_codes` parameter is ignored in span streaming mode.",
+            stacklevel=2,
+        )
+
     return rv
 
 

--- a/sentry_sdk/consts.py
+++ b/sentry_sdk/consts.py
@@ -1705,6 +1705,8 @@ class ClientConstructor:
             If `trace_ignore_status_codes` is not provided, requests with any status code
             may be traced.
 
+            This option has no effect in span streaming mode (`trace_lifecycle="stream"`).
+
         :param strict_trace_continuation: If set to `True`, the SDK will only continue a trace if the `org_id` of the incoming trace found in the
            `baggage` header matches the `org_id` of the current Sentry client and only if BOTH are present.
 

--- a/sentry_sdk/integrations/sanic.py
+++ b/sentry_sdk/integrations/sanic.py
@@ -71,13 +71,6 @@ class SanicIntegration(Integration):
         """
         self._unsampled_statuses = unsampled_statuses or set()
 
-        client = sentry_sdk.get_client()
-        if self._unsampled_statuses and has_span_streaming_enabled(client.options):
-            warnings.warn(
-                "The unsampled_statuses SanicIntegration option has no effect when span streaming is active.",
-                stacklevel=2,
-            )
-
     @staticmethod
     def setup_once() -> None:
         SanicIntegration.version = parse_version(SANIC_VERSION)
@@ -242,6 +235,13 @@ async def _context_exit(
                     span.status = "error" if response_status >= 400 else "ok"
 
                 span.end()
+
+                if integration._unsampled_statuses:
+                    warnings.warn(
+                        "The unsampled_statuses SanicIntegration option has no effect when span streaming is active.",
+                        stacklevel=2,
+                    )
+
             else:
                 span.set_http_status(response_status)
                 span.sampled &= (

--- a/sentry_sdk/integrations/sanic.py
+++ b/sentry_sdk/integrations/sanic.py
@@ -236,7 +236,7 @@ async def _context_exit(
 
                 span.end()
 
-                if integration._unsampled_statuses:
+                if integration and integration._unsampled_statuses:
                     warnings.warn(
                         "The unsampled_statuses SanicIntegration option has no effect when span streaming is active.",
                         stacklevel=2,

--- a/sentry_sdk/integrations/sanic.py
+++ b/sentry_sdk/integrations/sanic.py
@@ -179,6 +179,16 @@ async def _context_enter(request: "Request") -> None:
     scope.add_event_processor(_make_request_processor(weak_request))
 
     if is_span_streaming_enabled:
+        integration = client.get_integration(SanicIntegration)
+        if (
+            isinstance(integration, SanicIntegration)
+            and integration._unsampled_statuses
+        ):
+            warnings.warn(
+                "The `unsampled_statuses` option of SanicIntegration has no effect when span streaming is enabled.",
+                stacklevel=2,
+            )
+
         sentry_sdk.traces.continue_trace(dict(request.headers))
         scope.set_custom_sampling_context({"sanic_request": request})
 
@@ -235,12 +245,6 @@ async def _context_exit(
                     span.status = "error" if response_status >= 400 else "ok"
 
                 span.end()
-
-                if integration and integration._unsampled_statuses:
-                    warnings.warn(
-                        "The unsampled_statuses SanicIntegration option has no effect when span streaming is active.",
-                        stacklevel=2,
-                    )
 
             else:
                 span.set_http_status(response_status)

--- a/sentry_sdk/integrations/sanic.py
+++ b/sentry_sdk/integrations/sanic.py
@@ -1,4 +1,5 @@
 import sys
+import warnings
 import weakref
 from inspect import isawaitable
 from typing import TYPE_CHECKING
@@ -69,6 +70,13 @@ class SanicIntegration(Integration):
         HTTP statuses, including 404.
         """
         self._unsampled_statuses = unsampled_statuses or set()
+
+        client = sentry_sdk.get_client()
+        if self._unsampled_statuses and has_span_streaming_enabled(client.options):
+            warnings.warn(
+                "The unsampled_statuses SanicIntegration option has no effect when span streaming is active.",
+                stacklevel=2,
+            )
 
     @staticmethod
     def setup_once() -> None:


### PR DESCRIPTION
### Description
In span first, it's no longer possible to unsample spans at span end. Add a warning to all places that currently allow this.

#### Issues
- Closes https://linear.app/getsentry/issue/PY-2489/emit-warnings-if-using-post-sampling-in-span-first
- Closes https://github.com/getsentry/sentry-python/issues/6388

#### Reminders
- Please add tests to validate your changes, and lint your code using `uv run ruff`.
- Add GH Issue ID _&_ Linear ID (if applicable)
- PR title should use [conventional commit](https://develop.sentry.dev/engineering-practices/commit-messages/#type) style (`feat:`, `fix:`, `ref:`, `meta:`)
- For external contributors: [CONTRIBUTING.md](https://github.com/getsentry/sentry-python/blob/master/CONTRIBUTING.md), [Sentry SDK development docs](https://develop.sentry.dev/sdk/), [Discord community](https://discord.gg/Ww9hbqr)
