### PR TITLE
ci: Prevent `grpcio-tools` source builds when generating test matrices

### DIFF
--- a/scripts/populate_tox/populate_tox.py
+++ b/scripts/populate_tox/populate_tox.py
@@ -228,7 +228,7 @@ def fetch_package_dependencies(
         "install",
         f"{package}=={version}",
         "--only-binary",
-        "apache-beam",  # Prevent source install due to missing PEP 658 metadata on sdists.
+        "apache-beam",  # Prevent source builds that hang CI.
         "--dry-run",
         "--ignore-installed",
         "--report",

--- a/scripts/populate_tox/populate_tox.py
+++ b/scripts/populate_tox/populate_tox.py
@@ -228,7 +228,7 @@ def fetch_package_dependencies(
         "install",
         f"{package}=={version}",
         "--only-binary",
-        "apache-beam",  # Prevent source builds that hang CI.
+        "grpcio-tools",  # Prevent source builds that hang CI. grpcio-tools is a build-time dependency pinned by apache-beam.
         "--dry-run",
         "--ignore-installed",
         "--report",

--- a/scripts/populate_tox/populate_tox.py
+++ b/scripts/populate_tox/populate_tox.py
@@ -227,6 +227,8 @@ def fetch_package_dependencies(
         "pip",
         "install",
         f"{package}=={version}",
+        "--only-binary",
+        "apache-beam",  # Prevent source install due to missing PEP 658 metadata on sdists.
         "--dry-run",
         "--ignore-installed",
         "--report",


### PR DESCRIPTION
### Description
<!-- What changed and why? -->

Avoid hanging the `update-tox` job: https://github.com/getsentry/sentry-python/actions/runs/26821086603

#### Issues
<!--
* resolves: #1234
* resolves: LIN-1234
-->

#### Reminders
- Please add tests to validate your changes, and lint your code using `uv run ruff`.
- Add GH Issue ID _&_ Linear ID (if applicable)
- PR title should use [conventional commit](https://develop.sentry.dev/engineering-practices/commit-messages/#type) style (`feat:`, `fix:`, `ref:`, `meta:`)
- For external contributors: [CONTRIBUTING.md](https://github.com/getsentry/sentry-python/blob/master/CONTRIBUTING.md), [Sentry SDK development docs](https://develop.sentry.dev/sdk/), [Discord community](https://discord.gg/Ww9hbqr)
