### PR TITLE
ci: Raise `update-tox` timeout to 20 minutes

### DIFF
--- a/.github/workflows/update-tox.yml
+++ b/.github/workflows/update-tox.yml
@@ -11,7 +11,7 @@ jobs:
     name: Update test matrix
     if: github.ref == 'refs/heads/master'
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 20
 
     permissions:
       contents: write


### PR DESCRIPTION
### Description
<!-- What changed and why? -->

A run with an empty cache takes 14 minutes in https://github.com/getsentry/toxgen-testbed/pull/1 

#### Issues
<!--
* resolves: #1234
* resolves: LIN-1234
-->

#### Reminders
- Please add tests to validate your changes, and lint your code using `uv run ruff`.
- Add GH Issue ID _&_ Linear ID (if applicable)
- PR title should use [conventional commit](https://develop.sentry.dev/engineering-practices/commit-messages/#type) style (`feat:`, `fix:`, `ref:`, `meta:`)
- For external contributors: [CONTRIBUTING.md](https://github.com/getsentry/sentry-python/blob/master/CONTRIBUTING.md), [Sentry SDK development docs](https://develop.sentry.dev/sdk/), [Discord community](https://discord.gg/Ww9hbqr)
