### PR TITLE
ref: Rename `_get_current_streamed_span`

### DIFF
--- a/sentry_sdk/api.py
+++ b/sentry_sdk/api.py
@@ -8,7 +8,8 @@ from sentry_sdk._init_implementation import init
 from sentry_sdk.consts import INSTRUMENTER
 from sentry_sdk.crons import monitor
 from sentry_sdk.scope import Scope, _ScopeManager, isolation_scope, new_scope
-from sentry_sdk.traces import StreamedSpan, _get_current_streamed_span
+from sentry_sdk.traces import StreamedSpan
+from sentry_sdk.traces import get_current_span as _get_current_streamed_span
 from sentry_sdk.tracing import NoOpSpan, Transaction, trace
 
 if TYPE_CHECKING:

--- a/sentry_sdk/feature_flags.py
+++ b/sentry_sdk/feature_flags.py
@@ -65,7 +65,7 @@ def add_feature_flag(flag: str, result: bool) -> None:
     flags.set(flag, result)
 
     if has_span_streaming_enabled(client.options):
-        span = sentry_sdk.traces._get_current_streamed_span()
+        span = sentry_sdk.traces.get_current_span()
         if span and isinstance(span, sentry_sdk.traces.StreamedSpan):
             span.set_attribute(f"flag.evaluation.{flag}", result)
 

--- a/sentry_sdk/integrations/celery/__init__.py
+++ b/sentry_sdk/integrations/celery/__init__.py
@@ -16,7 +16,7 @@ from sentry_sdk.integrations.celery.beat import (
 from sentry_sdk.integrations.celery.utils import _now_seconds_since_epoch
 from sentry_sdk.integrations.logging import ignore_logger
 from sentry_sdk.scope import Scope, should_send_default_pii
-from sentry_sdk.traces import StreamedSpan, _get_current_streamed_span
+from sentry_sdk.traces import StreamedSpan, get_current_span
 from sentry_sdk.tracing import BAGGAGE_HEADER_NAME, Span, TransactionSource
 from sentry_sdk.tracing_utils import Baggage, has_span_streaming_enabled
 from sentry_sdk.utils import (
@@ -286,7 +286,7 @@ def _wrap_task_run(f: "F") -> "F":
 
         span_mgr: "Union[StreamedSpan, Span, NoOpMgr]" = NoOpMgr()
         if span_streaming:
-            if not task_started_from_beat and _get_current_streamed_span() is not None:
+            if not task_started_from_beat and get_current_span() is not None:
                 span_mgr = sentry_sdk.traces.start_span(
                     name=task_name,
                     attributes={
@@ -567,7 +567,7 @@ def _patch_producer_publish() -> None:
 
         span: "Union[StreamedSpan, Span, None]" = None
         if span_streaming:
-            if _get_current_streamed_span() is not None:
+            if get_current_span() is not None:
                 span = sentry_sdk.traces.start_span(
                     name=task_name,
                     attributes={

--- a/sentry_sdk/integrations/starlette.py
+++ b/sentry_sdk/integrations/starlette.py
@@ -22,7 +22,7 @@ from sentry_sdk.integrations._wsgi_common import (
 )
 from sentry_sdk.integrations.asgi import SentryAsgiMiddleware
 from sentry_sdk.scope import should_send_default_pii
-from sentry_sdk.traces import StreamedSpan, _get_current_streamed_span
+from sentry_sdk.traces import StreamedSpan, get_current_span
 from sentry_sdk.tracing import (
     SOURCE_FOR_STYLE,
     TransactionSource,
@@ -254,7 +254,7 @@ def _serialize_request_body_data(data: "Any") -> str:
 def _set_request_body_data_on_streaming_segment(
     info: "Optional[Dict[str, Any]]",
 ) -> None:
-    current_span = _get_current_streamed_span()
+    current_span = get_current_span()
     if info and "data" in info and type(current_span) is StreamedSpan:
         with capture_internal_exceptions():
             current_span._segment.set_attribute(

--- a/sentry_sdk/traces.py
+++ b/sentry_sdk/traces.py
@@ -827,7 +827,7 @@ def trace(
         return decorator
 
 
-def _get_current_streamed_span(
+def get_current_span(
     scope: "Optional[sentry_sdk.Scope]" = None,
 ) -> "Optional[StreamedSpan]":
     """

--- a/tests/integrations/celery/test_celery.py
+++ b/tests/integrations/celery/test_celery.py
@@ -8,13 +8,13 @@ from celery import VERSION, Celery
 from celery.bin import worker
 
 import sentry_sdk
+import sentry_sdk.traces
 from sentry_sdk import get_current_span, start_transaction
 from sentry_sdk.integrations.celery import (
     CeleryIntegration,
     _wrap_task_run,
 )
 from sentry_sdk.integrations.celery.beat import _get_headers
-from sentry_sdk.traces import _get_current_streamed_span
 from sentry_sdk.utils import SENSITIVE_DATA_SUBSTITUTE
 from tests.conftest import ApproxDict
 
@@ -667,7 +667,7 @@ def test_sentry_propagate_traces_override(span_streaming, init_celery):
     @celery.task(name="dummy_task", bind=True)
     def dummy_task(self, message):
         trace_id = (
-            _get_current_streamed_span().trace_id
+            sentry_sdk.traces.get_current_span().trace_id
             if span_streaming
             else get_current_span().trace_id
         )

--- a/tests/integrations/rust_tracing/test_rust_tracing.py
+++ b/tests/integrations/rust_tracing/test_rust_tracing.py
@@ -87,15 +87,13 @@ def test_on_new_span_on_close(
         with sentry_sdk.traces.start_span(name="custom parent"):
             rust_tracing.new_span(RustTracingLevel.Info, 3)
 
-            sentry_first_rust_span = sentry_sdk.traces._get_current_streamed_span()
+            sentry_first_rust_span = sentry_sdk.traces.get_current_span()
             rust_first_rust_span = rust_tracing.spans[3]
 
             assert sentry_first_rust_span == rust_first_rust_span
 
             rust_tracing.close_span(3)
-            assert (
-                sentry_sdk.traces._get_current_streamed_span() != sentry_first_rust_span
-            )
+            assert sentry_sdk.traces.get_current_span() != sentry_first_rust_span
 
         sentry_sdk.flush()
         spans = [item.payload for item in items if item.type == "span"]
@@ -173,16 +171,16 @@ def test_nested_on_new_span_on_close(
     if span_streaming:
         items = capture_items("event", "transaction", "span")
         with sentry_sdk.traces.start_span(name="custom parent"):
-            original_sentry_span = sentry_sdk.traces._get_current_streamed_span()
+            original_sentry_span = sentry_sdk.traces.get_current_span()
 
             rust_tracing.new_span(RustTracingLevel.Info, 3, index_arg=10)
-            sentry_first_rust_span = sentry_sdk.traces._get_current_streamed_span()
+            sentry_first_rust_span = sentry_sdk.traces.get_current_span()
             rust_first_rust_span = rust_tracing.spans[3]
 
             # Use a different `index_arg` value for the inner span to help
             # distinguish the two at the end of the test
             rust_tracing.new_span(RustTracingLevel.Info, 5, index_arg=9)
-            sentry_second_rust_span = sentry_sdk.traces._get_current_streamed_span()
+            sentry_second_rust_span = sentry_sdk.traces.get_current_span()
             rust_second_rust_span = rust_tracing.spans[5]
 
             assert rust_second_rust_span == sentry_second_rust_span
@@ -190,15 +188,13 @@ def test_nested_on_new_span_on_close(
             rust_tracing.close_span(5)
 
             # Ensure the current sentry span was moved back to the parent
-            sentry_span_after_close = sentry_sdk.traces._get_current_streamed_span()
+            sentry_span_after_close = sentry_sdk.traces.get_current_span()
             assert sentry_span_after_close == sentry_first_rust_span
             assert sentry_span_after_close == rust_first_rust_span
 
             rust_tracing.close_span(3)
 
-            assert (
-                sentry_sdk.traces._get_current_streamed_span() == original_sentry_span
-            )
+            assert sentry_sdk.traces.get_current_span() == original_sentry_span
 
         sentry_sdk.flush()
         spans = [item.payload for item in items if item.type == "span"]
@@ -312,10 +308,10 @@ def test_on_new_span_without_transaction(sentry_init, span_streaming):
     )
 
     if span_streaming:
-        assert sentry_sdk.traces._get_current_streamed_span() is None
+        assert sentry_sdk.traces.get_current_span() is None
 
         rust_tracing.new_span(RustTracingLevel.Info, 3)
-        current_span = sentry_sdk.traces._get_current_streamed_span()
+        current_span = sentry_sdk.traces.get_current_span()
         assert current_span is not None
         assert current_span._segment is current_span
     else:
@@ -584,24 +580,22 @@ def test_span_filter(
     if span_streaming:
         items = capture_items("event", "transaction", "span")
         with sentry_sdk.traces.start_span(name="custom parent"):
-            original_sentry_span = sentry_sdk.traces._get_current_streamed_span()
+            original_sentry_span = sentry_sdk.traces.get_current_span()
 
             # Span is not ignored
             rust_tracing.new_span(RustTracingLevel.Info, 3, index_arg=10)
-            info_span = sentry_sdk.traces._get_current_streamed_span()
+            info_span = sentry_sdk.traces.get_current_span()
 
             # Span is ignored, current span should remain the same
             rust_tracing.new_span(RustTracingLevel.Trace, 5, index_arg=9)
-            assert sentry_sdk.traces._get_current_streamed_span() == info_span
+            assert sentry_sdk.traces.get_current_span() == info_span
 
             # Closing the filtered span should leave the current span alone
             rust_tracing.close_span(5)
-            assert sentry_sdk.traces._get_current_streamed_span() == info_span
+            assert sentry_sdk.traces.get_current_span() == info_span
 
             rust_tracing.close_span(3)
-            assert (
-                sentry_sdk.traces._get_current_streamed_span() == original_sentry_span
-            )
+            assert sentry_sdk.traces.get_current_span() == original_sentry_span
 
         sentry_sdk.flush()
         spans = [item.payload for item in items if item.type == "span"]
@@ -652,16 +646,12 @@ def test_record(sentry_init, span_streaming):
         with sentry_sdk.traces.start_span(name="custom parent"):
             rust_tracing.new_span(RustTracingLevel.Info, 3)
 
-            span_before_record = (
-                sentry_sdk.traces._get_current_streamed_span()._to_json()
-            )
+            span_before_record = sentry_sdk.traces.get_current_span()._to_json()
             assert span_before_record["attributes"]["version"] == "None"
 
             rust_tracing.record(3)
 
-            span_after_record = (
-                sentry_sdk.traces._get_current_streamed_span()._to_json()
-            )
+            span_after_record = sentry_sdk.traces.get_current_span()._to_json()
             assert span_after_record["attributes"]["version"] == "memoized"
     else:
         with start_transaction():
@@ -699,18 +689,14 @@ def test_record_in_ignored_span(sentry_init, span_streaming):
         with sentry_sdk.traces.start_span(name="custom parent"):
             rust_tracing.new_span(RustTracingLevel.Info, 3)
 
-            span_before_record = (
-                sentry_sdk.traces._get_current_streamed_span()._to_json()
-            )
+            span_before_record = sentry_sdk.traces.get_current_span()._to_json()
             assert span_before_record["attributes"]["version"] == "None"
 
             rust_tracing.new_span(RustTracingLevel.Trace, 5)
             rust_tracing.record(5)
 
             # `on_record()` should not do anything to the current Sentry span if the associated Rust span was ignored
-            span_after_record = (
-                sentry_sdk.traces._get_current_streamed_span()._to_json()
-            )
+            span_after_record = sentry_sdk.traces.get_current_span()._to_json()
             assert span_after_record["attributes"]["version"] == "None"
     else:
         with start_transaction():
@@ -764,9 +750,7 @@ def test_include_tracing_fields(
         with sentry_sdk.traces.start_span(name="custom parent"):
             rust_tracing.new_span(RustTracingLevel.Info, 3)
 
-            span_before_record = (
-                sentry_sdk.traces._get_current_streamed_span()._to_json()
-            )
+            span_before_record = sentry_sdk.traces.get_current_span()._to_json()
             if tracing_fields_expected:
                 assert span_before_record["attributes"]["version"] == "None"
             else:
@@ -774,9 +758,7 @@ def test_include_tracing_fields(
 
             rust_tracing.record(3)
 
-            span_after_record = (
-                sentry_sdk.traces._get_current_streamed_span()._to_json()
-            )
+            span_after_record = sentry_sdk.traces.get_current_span()._to_json()
 
             if tracing_fields_expected:
                 assert span_after_record["attributes"] == {


### PR DESCRIPTION
### Description
Follow the existing convention of defining the future top-level API functions in `traces.py` under their future names

#### Issues
<!--
* resolves: #1234
* resolves: LIN-1234
-->

#### Reminders
- Please add tests to validate your changes, and lint your code using `uv run ruff`.
- Add GH Issue ID _&_ Linear ID (if applicable)
- PR title should use [conventional commit](https://develop.sentry.dev/engineering-practices/commit-messages/#type) style (`feat:`, `fix:`, `ref:`, `meta:`)
- For external contributors: [CONTRIBUTING.md](https://github.com/getsentry/sentry-python/blob/master/CONTRIBUTING.md), [Sentry SDK development docs](https://develop.sentry.dev/sdk/), [Discord community](https://discord.gg/Ww9hbqr)
