### PR TITLE
fix: Avoid split propagation context on empty `continue_trace()`

### DIFF
--- a/sentry_sdk/traces.py
+++ b/sentry_sdk/traces.py
@@ -200,12 +200,13 @@ def continue_trace(incoming: "dict[str, Any]") -> None:
     # used to be set there in non-span-first mode. But in span first mode, we
     # start spans on the current scope, regardless of type, like JS does, so we
     # need to set the propagation context there.
-    sentry_sdk.get_isolation_scope().generate_propagation_context(
+    isolation_scope = sentry_sdk.get_isolation_scope()
+    current_scope = sentry_sdk.get_current_scope()
+
+    isolation_scope.generate_propagation_context(
         incoming,
     )
-    sentry_sdk.get_current_scope().generate_propagation_context(
-        incoming,
-    )
+    current_scope._propagation_context = isolation_scope._propagation_context
 
 
 def new_trace() -> None:


### PR DESCRIPTION
### Description
<!-- What changed and why? -->

#### Issues
<!--
* resolves: #1234
* resolves: LIN-1234
-->

#### Reminders
- Please add tests to validate your changes, and lint your code using `uv run ruff`.
- Add GH Issue ID _&_ Linear ID (if applicable)
- PR title should use [conventional commit](https://develop.sentry.dev/engineering-practices/commit-messages/#type) style (`feat:`, `fix:`, `ref:`, `meta:`)
- For external contributors: [CONTRIBUTING.md](https://github.com/getsentry/sentry-python/blob/master/CONTRIBUTING.md), [Sentry SDK development docs](https://develop.sentry.dev/sdk/), [Discord community](https://discord.gg/Ww9hbqr)
