### PR TITLE
chore: Deprecate OpenTelemetryIntegration in favor of OTLPIntegration and no-op for span first

### DIFF
--- a/sentry_sdk/integrations/opentelemetry/integration.py
+++ b/sentry_sdk/integrations/opentelemetry/integration.py
@@ -4,10 +4,17 @@ are experimental and not suitable for production use. They may be changed or
 removed at any time without prior notice.
 """
 
+import warnings
+from typing import TYPE_CHECKING
+
 from sentry_sdk.integrations import DidNotEnable, Integration
 from sentry_sdk.integrations.opentelemetry.propagator import SentryPropagator
 from sentry_sdk.integrations.opentelemetry.span_processor import SentrySpanProcessor
+from sentry_sdk.tracing_utils import has_span_streaming_enabled
 from sentry_sdk.utils import logger
+
+if TYPE_CHECKING:
+    from typing import Any, Dict, Optional
 
 try:
     from opentelemetry import trace
@@ -34,9 +41,24 @@ class OpenTelemetryIntegration(Integration):
 
     @staticmethod
     def setup_once() -> None:
-        logger.warning(
-            "[OTel] Initializing highly experimental OpenTelemetry support. "
-            "Use at your own risk."
+        pass
+
+    def setup_once_with_options(
+        self, options: "Optional[Dict[str, Any]]" = None
+    ) -> None:
+        if has_span_streaming_enabled(options):
+            logger.warning(
+                "[OTel] OpenTelemetryIntegration is not compatible with span streaming "
+                "(trace_lifecycle='stream') and will be disabled."
+            )
+            return
+
+        warnings.warn(
+            "OpenTelemetryIntegration is deprecated. "
+            "Please use OTLPIntegration instead: "
+            "https://docs.sentry.io/platforms/python/integrations/otlp/",
+            DeprecationWarning,
+            stacklevel=2,
         )
 
         _setup_sentry_tracing()

--- a/tests/integrations/opentelemetry/test_experimental.py
+++ b/tests/integrations/opentelemetry/test_experimental.py
@@ -2,46 +2,56 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from sentry_sdk.integrations.opentelemetry.integration import OpenTelemetryIntegration
+
 
 @pytest.mark.forked
 def test_integration_enabled_if_option_is_on(sentry_init, reset_integrations):
-    mocked_setup_once = MagicMock()
+    mocked_setup_sentry_tracing = MagicMock()
 
     with patch(
-        "sentry_sdk.integrations.opentelemetry.integration.OpenTelemetryIntegration.setup_once",
-        mocked_setup_once,
+        "sentry_sdk.integrations.opentelemetry.integration._setup_sentry_tracing",
+        mocked_setup_sentry_tracing,
     ):
-        sentry_init(
-            _experiments={
-                "otel_powered_performance": True,
-            },
-        )
-        mocked_setup_once.assert_called_once()
+        with pytest.warns(DeprecationWarning):
+            sentry_init(_experiments={"otel_powered_performance": True})
+        mocked_setup_sentry_tracing.assert_called_once()
 
 
 @pytest.mark.forked
 def test_integration_not_enabled_if_option_is_off(sentry_init, reset_integrations):
-    mocked_setup_once = MagicMock()
+    mocked_setup_sentry_tracing = MagicMock()
 
     with patch(
-        "sentry_sdk.integrations.opentelemetry.integration.OpenTelemetryIntegration.setup_once",
-        mocked_setup_once,
+        "sentry_sdk.integrations.opentelemetry.integration._setup_sentry_tracing",
+        mocked_setup_sentry_tracing,
     ):
-        sentry_init(
-            _experiments={
-                "otel_powered_performance": False,
-            },
-        )
-        mocked_setup_once.assert_not_called()
+        sentry_init(_experiments={"otel_powered_performance": False})
+        mocked_setup_sentry_tracing.assert_not_called()
 
 
 @pytest.mark.forked
 def test_integration_not_enabled_if_option_is_missing(sentry_init, reset_integrations):
-    mocked_setup_once = MagicMock()
+    mocked_setup_sentry_tracing = MagicMock()
 
     with patch(
-        "sentry_sdk.integrations.opentelemetry.integration.OpenTelemetryIntegration.setup_once",
-        mocked_setup_once,
+        "sentry_sdk.integrations.opentelemetry.integration._setup_sentry_tracing",
+        mocked_setup_sentry_tracing,
     ):
         sentry_init()
-        mocked_setup_once.assert_not_called()
+        mocked_setup_sentry_tracing.assert_not_called()
+
+
+@pytest.mark.forked
+def test_integration_disabled_with_span_streaming(sentry_init, reset_integrations):
+    mocked_setup_sentry_tracing = MagicMock()
+
+    with patch(
+        "sentry_sdk.integrations.opentelemetry.integration._setup_sentry_tracing",
+        mocked_setup_sentry_tracing,
+    ):
+        sentry_init(
+            integrations=[OpenTelemetryIntegration()],
+            _experiments={"trace_lifecycle": "stream"},
+        )
+        mocked_setup_sentry_tracing.assert_not_called()


### PR DESCRIPTION
#### Issues

* resolves: #6043
* resolves: PY-2345