### PR TITLE
fix: handle empty string in match_regex_list to prevent IndexError

### DIFF
--- a/sentry_sdk/utils.py
+++ b/sentry_sdk/utils.py
@@ -1740,6 +1740,8 @@ def match_regex_list(
         return False
 
     for item_matcher in regex_list:
+        if not item_matcher:
+            continue
         if not substring_matching and item_matcher[-1] != "$":
             item_matcher += "$"
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -556,6 +556,8 @@ def test_include_source_context_when_serializing_frame(include_source_context):
         ["some-string", ["some.*"], True],
         ["some-string", ["Some"], False],  # we do case sensitive matching
         ["some-string", [".*string$"], True],
+        ["some-string", [""], False],  # empty string in list should not crash
+        ["", [""], False],  # both empty should not crash
     ],
 )
 def test_match_regex_list(item, regex_list, expected_result):


### PR DESCRIPTION
### Description

When `match_regex_list` receives a pattern list containing an empty string, `item_matcher[-1]` raises `IndexError` because empty strings have no characters. This is reachable from the Celery integration when `CeleryIntegration.exclude_beat_tasks` contains an empty string.

Fix: skip empty strings in the iteration loop before the `[-1]` access.

#### Issues

* resolves: #6504

#### Reminders

- [x] Added tests to validate changes
- [x] Conventional commit format in PR title