### PR TITLE
feat(litestar): Support span streaming

### DIFF
--- a/sentry_sdk/integrations/litestar.py
+++ b/sentry_sdk/integrations/litestar.py
@@ -2,7 +2,7 @@ from collections.abc import Set
 from copy import deepcopy
 
 import sentry_sdk
-from sentry_sdk.consts import OP
+from sentry_sdk.consts import OP, SPANDATA
 from sentry_sdk.integrations import (
     _DEFAULT_FAILED_REQUEST_STATUS_CODES,
     DidNotEnable,
@@ -12,6 +12,7 @@ from sentry_sdk.integrations.asgi import SentryAsgiMiddleware
 from sentry_sdk.integrations.logging import ignore_logger
 from sentry_sdk.scope import should_send_default_pii
 from sentry_sdk.tracing import SOURCE_FOR_STYLE, TransactionSource
+from sentry_sdk.tracing_utils import has_span_streaming_enabled
 from sentry_sdk.utils import (
     ensure_integration_enabled,
     event_from_exception,
@@ -157,52 +158,103 @@ def enable_span_for_middleware(middleware: "Middleware") -> "Middleware":
         receive: "Receive",
         send: "Send",
     ) -> None:
-        if sentry_sdk.get_client().get_integration(LitestarIntegration) is None:
+        client = sentry_sdk.get_client()
+        if client.get_integration(LitestarIntegration) is None:
             return await old_call(self, scope, receive, send)
 
         middleware_name = self.__class__.__name__
-        with sentry_sdk.start_span(
-            op=OP.MIDDLEWARE_LITESTAR,
-            name=middleware_name,
-            origin=LitestarIntegration.origin,
-        ) as middleware_span:
-            middleware_span.set_tag("litestar.middleware_name", middleware_name)
+        if has_span_streaming_enabled(client.options):
+            with sentry_sdk.traces.start_span(
+                name=middleware_name,
+                attributes={
+                    "sentry.op": OP.MIDDLEWARE_LITESTAR,
+                    "sentry.origin": LitestarIntegration.origin,
+                },
+            ) as middleware_span:
+                middleware_span.set_attribute(SPANDATA.MIDDLEWARE_NAME, middleware_name)
 
-            # Creating spans for the "receive" callback
-            async def _sentry_receive(
-                *args: "Any", **kwargs: "Any"
-            ) -> "Union[HTTPReceiveMessage, WebSocketReceiveMessage]":
-                if sentry_sdk.get_client().get_integration(LitestarIntegration) is None:
-                    return await receive(*args, **kwargs)
-                with sentry_sdk.start_span(
-                    op=OP.MIDDLEWARE_LITESTAR_RECEIVE,
-                    name=getattr(receive, "__qualname__", str(receive)),
-                    origin=LitestarIntegration.origin,
-                ) as span:
-                    span.set_tag("litestar.middleware_name", middleware_name)
-                    return await receive(*args, **kwargs)
+                # Creating spans for the "receive" callback
+                async def _sentry_receive(
+                    *args: "Any", **kwargs: "Any"
+                ) -> "Union[HTTPReceiveMessage, WebSocketReceiveMessage]":
+                    if client.get_integration(LitestarIntegration) is None:
+                        return await receive(*args, **kwargs)
+                    with sentry_sdk.traces.start_span(
+                        name=getattr(receive, "__qualname__", str(receive)),
+                        attributes={
+                            "sentry.op": OP.MIDDLEWARE_LITESTAR_RECEIVE,
+                            "sentry.origin": LitestarIntegration.origin,
+                        },
+                    ) as span:
+                        span.set_attribute(SPANDATA.MIDDLEWARE_NAME, middleware_name)
+                        return await receive(*args, **kwargs)
 
-            receive_name = getattr(receive, "__name__", str(receive))
-            receive_patched = receive_name == "_sentry_receive"
-            new_receive = _sentry_receive if not receive_patched else receive
+                receive_name = getattr(receive, "__name__", str(receive))
+                receive_patched = receive_name == "_sentry_receive"
+                new_receive = _sentry_receive if not receive_patched else receive
 
-            # Creating spans for the "send" callback
-            async def _sentry_send(message: "Message") -> None:
-                if sentry_sdk.get_client().get_integration(LitestarIntegration) is None:
-                    return await send(message)
-                with sentry_sdk.start_span(
-                    op=OP.MIDDLEWARE_LITESTAR_SEND,
-                    name=getattr(send, "__qualname__", str(send)),
-                    origin=LitestarIntegration.origin,
-                ) as span:
-                    span.set_tag("litestar.middleware_name", middleware_name)
-                    return await send(message)
+                # Creating spans for the "send" callback
+                async def _sentry_send(message: "Message") -> None:
+                    if client.get_integration(LitestarIntegration) is None:
+                        return await send(message)
+                    with sentry_sdk.traces.start_span(
+                        name=getattr(send, "__qualname__", str(send)),
+                        attributes={
+                            "sentry.op": OP.MIDDLEWARE_LITESTAR_SEND,
+                            "sentry.origin": LitestarIntegration.origin,
+                        },
+                    ) as span:
+                        span.set_attribute(SPANDATA.MIDDLEWARE_NAME, middleware_name)
+                        return await send(message)
 
-            send_name = getattr(send, "__name__", str(send))
-            send_patched = send_name == "_sentry_send"
-            new_send = _sentry_send if not send_patched else send
+                send_name = getattr(send, "__name__", str(send))
+                send_patched = send_name == "_sentry_send"
+                new_send = _sentry_send if not send_patched else send
 
-            return await old_call(self, scope, new_receive, new_send)
+                return await old_call(self, scope, new_receive, new_send)
+        else:
+            with sentry_sdk.start_span(
+                op=OP.MIDDLEWARE_LITESTAR,
+                name=middleware_name,
+                origin=LitestarIntegration.origin,
+            ) as middleware_span:
+                middleware_span.set_tag("litestar.middleware_name", middleware_name)
+
+                # Creating spans for the "receive" callback
+                async def _sentry_receive(
+                    *args: "Any", **kwargs: "Any"
+                ) -> "Union[HTTPReceiveMessage, WebSocketReceiveMessage]":
+                    if client.get_integration(LitestarIntegration) is None:
+                        return await receive(*args, **kwargs)
+                    with sentry_sdk.start_span(
+                        op=OP.MIDDLEWARE_LITESTAR_RECEIVE,
+                        name=getattr(receive, "__qualname__", str(receive)),
+                        origin=LitestarIntegration.origin,
+                    ) as span:
+                        span.set_tag("litestar.middleware_name", middleware_name)
+                        return await receive(*args, **kwargs)
+
+                receive_name = getattr(receive, "__name__", str(receive))
+                receive_patched = receive_name == "_sentry_receive"
+                new_receive = _sentry_receive if not receive_patched else receive
+
+                # Creating spans for the "send" callback
+                async def _sentry_send(message: "Message") -> None:
+                    if client.get_integration(LitestarIntegration) is None:
+                        return await send(message)
+                    with sentry_sdk.start_span(
+                        op=OP.MIDDLEWARE_LITESTAR_SEND,
+                        name=getattr(send, "__qualname__", str(send)),
+                        origin=LitestarIntegration.origin,
+                    ) as span:
+                        span.set_tag("litestar.middleware_name", middleware_name)
+                        return await send(message)
+
+                send_name = getattr(send, "__name__", str(send))
+                send_patched = send_name == "_sentry_send"
+                new_send = _sentry_send if not send_patched else send
+
+                return await old_call(self, scope, new_receive, new_send)
 
     not_yet_patched = old_call.__name__ not in ["_create_span_call"]
 

--- a/tests/integrations/litestar/test_litestar.py
+++ b/tests/integrations/litestar/test_litestar.py
@@ -13,8 +13,10 @@ from litestar.middleware.rate_limit import RateLimitConfig
 from litestar.middleware.session.server_side import ServerSideSessionConfig
 from litestar.testing import TestClient
 
+import sentry_sdk
 from sentry_sdk import capture_message
 from sentry_sdk.integrations.litestar import LitestarIntegration
+from tests.conftest import ApproxDict
 from tests.integrations.conftest import parametrize_test_configurable_status_codes
 
 
@@ -87,39 +89,66 @@ def litestar_app_factory(middleware=None, debug=True, exception_handlers=None):
         ),
     ],
 )
+@pytest.mark.parametrize("span_streaming", [True, False])
 def test_catch_exceptions(
     sentry_init,
     capture_exceptions,
     capture_events,
+    capture_items,
     test_url,
     expected_error,
     expected_message,
     expected_tx_name,
+    span_streaming,
 ):
-    sentry_init(integrations=[LitestarIntegration()])
+    sentry_init(
+        integrations=[LitestarIntegration()],
+        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+    )
     litestar_app = litestar_app_factory()
-    exceptions = capture_exceptions()
-    events = capture_events()
-
     client = TestClient(litestar_app)
-    try:
-        client.get(test_url)
-    except Exception:
-        pass
+    exceptions = capture_exceptions()
+    if span_streaming:
+        items = capture_items("event")
 
-    (exc,) = exceptions
-    assert isinstance(exc, expected_error)
-    assert str(exc) == expected_message
+        try:
+            client.get(test_url)
+        except Exception:
+            pass
 
-    (event,) = events
+        (exc,) = exceptions
+        assert isinstance(exc, expected_error)
+        assert str(exc) == expected_message
+
+        (event,) = (item.payload for item in items)
+    else:
+        events = capture_events()
+
+        try:
+            client.get(test_url)
+        except Exception:
+            pass
+
+        (exc,) = exceptions
+        assert isinstance(exc, expected_error)
+        assert str(exc) == expected_message
+
+        (event,) = events
     assert expected_tx_name in event["transaction"]
     assert event["exception"]["values"][0]["mechanism"]["type"] == "litestar"
 
 
-def test_middleware_spans(sentry_init, capture_events):
+@pytest.mark.parametrize("span_streaming", [True, False])
+def test_middleware_spans(
+    sentry_init,
+    capture_events,
+    capture_items,
+    span_streaming,
+):
     sentry_init(
         traces_sample_rate=1.0,
         integrations=[LitestarIntegration()],
+        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
     )
 
     logging_config = LoggingMiddlewareConfig()
@@ -133,32 +162,61 @@ def test_middleware_spans(sentry_init, capture_events):
             rate_limit_config.middleware,
         ]
     )
-    events = capture_events()
-
     client = TestClient(
         litestar_app, raise_server_exceptions=False, base_url="http://testserver.local"
     )
-    client.get("/message")
+    if span_streaming:
+        items = capture_items("span")
 
-    (_, transaction_event) = events
+        client.get("/message")
 
-    expected = {"SessionMiddleware", "LoggingMiddleware", "RateLimitMiddleware"}
-    found = set()
+        sentry_sdk.flush()
+        spans = [item.payload for item in items]
 
-    litestar_spans = (
-        span
-        for span in transaction_event["spans"]
-        if span["op"] == "middleware.litestar"
-    )
+        expected = {"SessionMiddleware", "LoggingMiddleware", "RateLimitMiddleware"}
+        found = set()
 
-    for span in litestar_spans:
-        assert span["description"] in expected
-        assert span["description"] not in found
-        found.add(span["description"])
-        assert span["description"] == span["tags"]["litestar.middleware_name"]
+        litestar_spans = (
+            span
+            for span in spans
+            if span["attributes"]["sentry.op"] == "middleware.litestar"
+        )
+
+        for span in litestar_spans:
+            assert span["name"] in expected
+            assert span["name"] not in found
+            found.add(span["name"])
+            assert span["name"] == span["attributes"]["middleware.name"]
+    else:
+        events = capture_events()
+
+        client.get("/message")
+
+        (_, transaction_event) = events
+
+        expected = {"SessionMiddleware", "LoggingMiddleware", "RateLimitMiddleware"}
+        found = set()
+
+        litestar_spans = (
+            span
+            for span in transaction_event["spans"]
+            if span["op"] == "middleware.litestar"
+        )
+
+        for span in litestar_spans:
+            assert span["description"] in expected
+            assert span["description"] not in found
+            found.add(span["description"])
+            assert span["description"] == span["tags"]["litestar.middleware_name"]
 
 
-def test_middleware_callback_spans(sentry_init, capture_events):
+@pytest.mark.parametrize("span_streaming", [True, False])
+def test_middleware_callback_spans(
+    sentry_init,
+    capture_events,
+    capture_items,
+    span_streaming,
+):
     class SampleMiddleware(AbstractMiddleware):
         async def __call__(self, scope, receive, send) -> None:
             async def do_stuff(message):
@@ -172,45 +230,99 @@ def test_middleware_callback_spans(sentry_init, capture_events):
     sentry_init(
         traces_sample_rate=1.0,
         integrations=[LitestarIntegration()],
+        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
     )
+
     litestar_app = litestar_app_factory(middleware=[SampleMiddleware])
-    events = capture_events()
-
     client = TestClient(litestar_app, raise_server_exceptions=False)
-    client.get("/message")
+    if span_streaming:
+        items = capture_items("span")
 
-    (_, transaction_events) = events
+        client.get("/message")
 
-    expected_litestar_spans = [
-        {
-            "op": "middleware.litestar",
-            "description": "SampleMiddleware",
-            "tags": {"litestar.middleware_name": "SampleMiddleware"},
-        },
-        {
-            "op": "middleware.litestar.send",
-            "description": "SentryAsgiMiddleware._run_app.<locals>._sentry_wrapped_send",
-            "tags": {"litestar.middleware_name": "SampleMiddleware"},
-        },
-        {
-            "op": "middleware.litestar.send",
-            "description": "SentryAsgiMiddleware._run_app.<locals>._sentry_wrapped_send",
-            "tags": {"litestar.middleware_name": "SampleMiddleware"},
-        },
-    ]
+        spans = [item.payload for item in items]
 
-    def is_matching_span(expected_span, actual_span):
-        return (
-            expected_span["op"] == actual_span["op"]
-            and expected_span["description"] == actual_span["description"]
-            and expected_span["tags"] == actual_span["tags"]
+        expected_litestar_spans = [
+            {
+                "name": "SampleMiddleware",
+                "attributes": ApproxDict(
+                    {
+                        "middleware.name": "SampleMiddleware",
+                        "sentry.op": "middleware.litestar",
+                    },
+                ),
+            },
+            {
+                "name": "SentryAsgiMiddleware._run_app.<locals>._sentry_wrapped_send",
+                "attributes": ApproxDict(
+                    {
+                        "middleware.name": "SampleMiddleware",
+                        "sentry.op": "middleware.litestar.send",
+                    }
+                ),
+            },
+            {
+                "name": "SentryAsgiMiddleware._run_app.<locals>._sentry_wrapped_send",
+                "attributes": ApproxDict(
+                    {
+                        "middleware.name": "SampleMiddleware",
+                        "sentry.op": "middleware.litestar.send",
+                    }
+                ),
+            },
+        ]
+
+        def is_matching_span(expected_span, actual_span):
+            return (
+                expected_span["name"] == actual_span["name"]
+                and expected_span["attributes"] == actual_span["attributes"]
+            )
+
+        sentry_sdk.flush()
+        spans = [item.payload for item in items]
+        actual_litestar_spans = list(
+            span
+            for span in spans
+            if "middleware.litestar" in span["attributes"].get("sentry.op")
+        )
+    else:
+        events = capture_events()
+
+        client.get("/message")
+
+        (_, transaction_events) = events
+
+        expected_litestar_spans = [
+            {
+                "op": "middleware.litestar",
+                "description": "SampleMiddleware",
+                "tags": {"litestar.middleware_name": "SampleMiddleware"},
+            },
+            {
+                "op": "middleware.litestar.send",
+                "description": "SentryAsgiMiddleware._run_app.<locals>._sentry_wrapped_send",
+                "tags": {"litestar.middleware_name": "SampleMiddleware"},
+            },
+            {
+                "op": "middleware.litestar.send",
+                "description": "SentryAsgiMiddleware._run_app.<locals>._sentry_wrapped_send",
+                "tags": {"litestar.middleware_name": "SampleMiddleware"},
+            },
+        ]
+
+        def is_matching_span(expected_span, actual_span):
+            return (
+                expected_span["op"] == actual_span["op"]
+                and expected_span["description"] == actual_span["description"]
+                and expected_span["tags"] == actual_span["tags"]
+            )
+
+        actual_litestar_spans = list(
+            span
+            for span in transaction_events["spans"]
+            if "middleware.litestar" in span["op"]
         )
 
-    actual_litestar_spans = list(
-        span
-        for span in transaction_events["spans"]
-        if "middleware.litestar" in span["op"]
-    )
     assert len(actual_litestar_spans) == 3
 
     for expected_span in expected_litestar_spans:
@@ -220,7 +332,8 @@ def test_middleware_callback_spans(sentry_init, capture_events):
         )
 
 
-def test_middleware_receive_send(sentry_init, capture_events):
+@pytest.mark.parametrize("span_streaming", [True, False])
+def test_middleware_receive_send(sentry_init, capture_items, span_streaming):
     class SampleReceiveSendMiddleware(AbstractMiddleware):
         async def __call__(self, scope, receive, send):
             message = await receive()
@@ -235,6 +348,7 @@ def test_middleware_receive_send(sentry_init, capture_events):
     sentry_init(
         traces_sample_rate=1.0,
         integrations=[LitestarIntegration()],
+        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
     )
     litestar_app = litestar_app_factory(middleware=[SampleReceiveSendMiddleware])
 
@@ -243,7 +357,13 @@ def test_middleware_receive_send(sentry_init, capture_events):
     client.get("/message")
 
 
-def test_middleware_partial_receive_send(sentry_init, capture_events):
+@pytest.mark.parametrize("span_streaming", [True, False])
+def test_middleware_partial_receive_send(
+    sentry_init,
+    capture_events,
+    capture_items,
+    span_streaming,
+):
     class SamplePartialReceiveSendMiddleware(AbstractMiddleware):
         async def __call__(self, scope, receive, send):
             message = await receive()
@@ -267,46 +387,106 @@ def test_middleware_partial_receive_send(sentry_init, capture_events):
     sentry_init(
         traces_sample_rate=1.0,
         integrations=[LitestarIntegration()],
+        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
     )
+
     litestar_app = litestar_app_factory(middleware=[SamplePartialReceiveSendMiddleware])
-    events = capture_events()
-
     client = TestClient(litestar_app, raise_server_exceptions=False)
-    # See SamplePartialReceiveSendMiddleware.__call__ above for assertions of correct behavior
-    client.get("/message")
 
-    (_, transaction_events) = events
+    if span_streaming:
+        items = capture_items("span")
 
-    expected_litestar_spans = [
-        {
-            "op": "middleware.litestar",
-            "description": "SamplePartialReceiveSendMiddleware",
-            "tags": {"litestar.middleware_name": "SamplePartialReceiveSendMiddleware"},
-        },
-        {
-            "op": "middleware.litestar.receive",
-            "description": "TestClientTransport.create_receive.<locals>.receive",
-            "tags": {"litestar.middleware_name": "SamplePartialReceiveSendMiddleware"},
-        },
-        {
-            "op": "middleware.litestar.send",
-            "description": "SentryAsgiMiddleware._run_app.<locals>._sentry_wrapped_send",
-            "tags": {"litestar.middleware_name": "SamplePartialReceiveSendMiddleware"},
-        },
-    ]
+        # See SamplePartialReceiveSendMiddleware.__call__ above for assertions of correct behavior
+        client.get("/message")
 
-    def is_matching_span(expected_span, actual_span):
-        return (
-            expected_span["op"] == actual_span["op"]
-            and actual_span["description"].startswith(expected_span["description"])
-            and expected_span["tags"] == actual_span["tags"]
+        sentry_sdk.flush()
+        spans = [item.payload for item in items]
+
+        expected_litestar_spans = [
+            {
+                "name": "SamplePartialReceiveSendMiddleware",
+                "attributes": ApproxDict(
+                    {
+                        "middleware.name": "SamplePartialReceiveSendMiddleware",
+                        "sentry.op": "middleware.litestar",
+                    }
+                ),
+            },
+            {
+                "name": "TestClientTransport.create_receive.<locals>.receive",
+                "attributes": ApproxDict(
+                    {
+                        "middleware.name": "SamplePartialReceiveSendMiddleware",
+                        "sentry.op": "middleware.litestar.receive",
+                    }
+                ),
+            },
+            {
+                "name": "SentryAsgiMiddleware._run_app.<locals>._sentry_wrapped_send",
+                "attributes": ApproxDict(
+                    {
+                        "middleware.name": "SamplePartialReceiveSendMiddleware",
+                        "sentry.op": "middleware.litestar.send",
+                    }
+                ),
+            },
+        ]
+
+        def is_matching_span(expected_span, actual_span):
+            return (
+                actual_span["name"].startswith(expected_span["name"])
+                and expected_span["attributes"] == actual_span["attributes"]
+            )
+
+        actual_litestar_spans = list(
+            span
+            for span in spans
+            if "middleware.litestar" in span["attributes"].get("sentry.op")
         )
+    else:
+        events = capture_events()
 
-    actual_litestar_spans = list(
-        span
-        for span in transaction_events["spans"]
-        if "middleware.litestar" in span["op"]
-    )
+        # See SamplePartialReceiveSendMiddleware.__call__ above for assertions of correct behavior
+        client.get("/message")
+
+        (_, transaction_events) = events
+
+        expected_litestar_spans = [
+            {
+                "op": "middleware.litestar",
+                "description": "SamplePartialReceiveSendMiddleware",
+                "tags": {
+                    "litestar.middleware_name": "SamplePartialReceiveSendMiddleware"
+                },
+            },
+            {
+                "op": "middleware.litestar.receive",
+                "description": "TestClientTransport.create_receive.<locals>.receive",
+                "tags": {
+                    "litestar.middleware_name": "SamplePartialReceiveSendMiddleware"
+                },
+            },
+            {
+                "op": "middleware.litestar.send",
+                "description": "SentryAsgiMiddleware._run_app.<locals>._sentry_wrapped_send",
+                "tags": {
+                    "litestar.middleware_name": "SamplePartialReceiveSendMiddleware"
+                },
+            },
+        ]
+
+        def is_matching_span(expected_span, actual_span):
+            return (
+                expected_span["op"] == actual_span["op"]
+                and actual_span["description"].startswith(expected_span["description"])
+                and expected_span["tags"] == actual_span["tags"]
+            )
+
+        actual_litestar_spans = list(
+            span
+            for span in transaction_events["spans"]
+            if "middleware.litestar" in span["op"]
+        )
     assert len(actual_litestar_spans) == 3
 
     for expected_span in expected_litestar_spans:
@@ -316,10 +496,17 @@ def test_middleware_partial_receive_send(sentry_init, capture_events):
         )
 
 
-def test_span_origin(sentry_init, capture_events):
+@pytest.mark.parametrize("span_streaming", [True, False])
+def test_span_origin(
+    sentry_init,
+    capture_events,
+    capture_items,
+    span_streaming,
+):
     sentry_init(
         integrations=[LitestarIntegration()],
         traces_sample_rate=1.0,
+        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
     )
 
     logging_config = LoggingMiddlewareConfig()
@@ -333,18 +520,31 @@ def test_span_origin(sentry_init, capture_events):
             rate_limit_config.middleware,
         ]
     )
-    events = capture_events()
-
     client = TestClient(
         litestar_app, raise_server_exceptions=False, base_url="http://testserver.local"
     )
-    client.get("/message")
+    if span_streaming:
+        items = capture_items("span")
 
-    (_, event) = events
+        client.get("/message")
 
-    assert event["contexts"]["trace"]["origin"] == "auto.http.litestar"
-    for span in event["spans"]:
-        assert span["origin"] == "auto.http.litestar"
+        sentry_sdk.flush()
+        spans = [item.payload for item in items]
+
+        for span in spans:
+            if span["attributes"]["sentry.origin"] == "auto.http.httpx":
+                continue
+            assert span["attributes"]["sentry.origin"] == "auto.http.litestar"
+    else:
+        events = capture_events()
+
+        client.get("/message")
+
+        (_, event) = events
+
+        assert event["contexts"]["trace"]["origin"] == "auto.http.litestar"
+        for span in event["spans"]:
+            assert span["origin"] == "auto.http.litestar"
 
 
 @pytest.mark.parametrize(
@@ -358,8 +558,14 @@ def test_span_origin(sentry_init, capture_events):
         "send_default_pii=False",
     ],
 )
+@pytest.mark.parametrize("span_streaming", [True, False])
 def test_litestar_scope_user_on_exception_event(
-    sentry_init, capture_exceptions, capture_events, is_send_default_pii
+    sentry_init,
+    capture_exceptions,
+    capture_events,
+    capture_items,
+    is_send_default_pii,
+    span_streaming,
 ):
     class TestUserMiddleware(AbstractMiddleware):
         async def __call__(self, scope, receive, send):
@@ -371,22 +577,37 @@ def test_litestar_scope_user_on_exception_event(
             await self.app(scope, receive, send)
 
     sentry_init(
-        integrations=[LitestarIntegration()], send_default_pii=is_send_default_pii
+        integrations=[LitestarIntegration()],
+        send_default_pii=is_send_default_pii,
+        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
     )
+
     litestar_app = litestar_app_factory(middleware=[TestUserMiddleware])
-    exceptions = capture_exceptions()
-    events = capture_events()
-
-    # This request intentionally raises an exception
     client = TestClient(litestar_app)
-    try:
-        client.get("/some_url")
-    except Exception:
-        pass
+    exceptions = capture_exceptions()
+    if span_streaming:
+        items = capture_items("event")
 
-    assert len(exceptions) == 1
-    assert len(events) == 1
-    (event,) = events
+        # This request intentionally raises an exception
+        try:
+            client.get("/some_url")
+        except Exception:
+            pass
+
+        assert len(exceptions) == 1
+        (event,) = (item.payload for item in items)
+    else:
+        events = capture_events()
+
+        # This request intentionally raises an exception
+        try:
+            client.get("/some_url")
+        except Exception:
+            pass
+
+        assert len(exceptions) == 1
+        assert len(events) == 1
+        (event,) = events
 
     if is_send_default_pii:
         assert "user" in event
@@ -400,21 +621,25 @@ def test_litestar_scope_user_on_exception_event(
 
 
 @parametrize_test_configurable_status_codes
+@pytest.mark.parametrize("span_streaming", [True, False])
 def test_configurable_status_codes_handler(
     sentry_init,
     capture_events,
+    capture_items,
     failed_request_status_codes,
     status_code,
     expected_error,
+    span_streaming,
 ):
     integration_kwargs = (
         {"failed_request_status_codes": failed_request_status_codes}
         if failed_request_status_codes is not None
         else {}
     )
-    sentry_init(integrations=[LitestarIntegration(**integration_kwargs)])
-
-    events = capture_events()
+    sentry_init(
+        integrations=[LitestarIntegration(**integration_kwargs)],
+        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+    )
 
     @get("/error")
     async def error() -> None:
@@ -422,27 +647,42 @@ def test_configurable_status_codes_handler(
 
     app = Litestar([error])
     client = TestClient(app)
-    client.get("/error")
+
+    if span_streaming:
+        items = capture_items("event")
+
+        client.get("/error")
+
+        events = [item.payload for item in items]
+    else:
+        events = capture_events()
+
+        client.get("/error")
 
     assert len(events) == int(expected_error)
 
 
 @parametrize_test_configurable_status_codes
+@pytest.mark.parametrize("span_streaming", [True, False])
 def test_configurable_status_codes_middleware(
     sentry_init,
     capture_events,
+    capture_items,
     failed_request_status_codes,
     status_code,
     expected_error,
+    span_streaming,
 ):
     integration_kwargs = (
         {"failed_request_status_codes": failed_request_status_codes}
         if failed_request_status_codes is not None
         else {}
     )
-    sentry_init(integrations=[LitestarIntegration(**integration_kwargs)])
 
-    events = capture_events()
+    sentry_init(
+        integrations=[LitestarIntegration(**integration_kwargs)],
+        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+    )
 
     def create_raising_middleware(app):
         async def raising_middleware(scope, receive, send):
@@ -455,18 +695,32 @@ def test_configurable_status_codes_middleware(
 
     app = Litestar([error], middleware=[create_raising_middleware])
     client = TestClient(app)
-    client.get("/error")
+
+    if span_streaming:
+        items = capture_items("event")
+
+        client.get("/error")
+
+        events = [item.payload for item in items]
+    else:
+        events = capture_events()
+
+        client.get("/error")
 
     assert len(events) == int(expected_error)
 
 
+@pytest.mark.parametrize("span_streaming", [True, False])
 def test_catch_non_http_exceptions_in_middleware(
     sentry_init,
     capture_events,
+    capture_items,
+    span_streaming,
 ):
-    sentry_init(integrations=[LitestarIntegration()])
-
-    events = capture_events()
+    sentry_init(
+        integrations=[LitestarIntegration()],
+        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+    )
 
     def create_raising_middleware(app):
         async def raising_middleware(scope, receive, send):
@@ -480,10 +734,22 @@ def test_catch_non_http_exceptions_in_middleware(
     app = Litestar([error], middleware=[create_raising_middleware])
     client = TestClient(app)
 
-    try:
-        client.get("/error")
-    except RuntimeError:
-        pass
+    if span_streaming:
+        items = capture_items("event")
+
+        try:
+            client.get("/error")
+        except RuntimeError:
+            pass
+
+        events = [item.payload for item in items]
+    else:
+        events = capture_events()
+
+        try:
+            client.get("/error")
+        except RuntimeError:
+            pass
 
     assert len(events) == 1
     event_exception = events[0]["exception"]["values"][0]


### PR DESCRIPTION
### Description
<!-- What changed and why? -->

In the streaming path, use

- `middleware.name` instead of `litestar.middleware_name`

## Adapting Tests

sed commands used for converting specific attributes:

- sed -i '' 's/"litestar.middleware_name"/"middleware.name"/g'

`sed` commands used for converting event capture:

- sed -i '' 's/capture_events,/capture_items,/g'
- sed -i '' 's/events = capture_events()/items = capture_items("event", "transaction", "span")/g'
- sed -i '' 's/transaction_event\["spans"\]/spans/g'
- sed -i '' 's/transaction_events\["spans"\]/spans/g'
- sed -i '' 's/(_, transaction_event) = events/spans = [item.payload for item in items if item.type == "span"]/g'
- sed -i '' 's/(_, transaction_events) = events/spans = [item.payload for item in items if item.type == "span"]/g'
- sed -i '' 's/(event,) = events/(event,) = (item.payload for item in items if item.type == "event")/g'
- sed -i '' 's/"tags"/"attributes"/g'
- sed -i '' 's/event\["spans"\]/spans/g'

`sed` commands used for converting `op`:

- sed -i '' 's/\["op"\]/\["attributes"\]\["sentry.op"\]/g'
- sed -i '' 's/"op"/"sentry.op"/g'

`sed` commands used for converting origin:

- sed -i '' 's/\["origin"\]/["attributes"]["sentry.origin"]/g'

`sed` commands used for converting `description`:

- sed -i '' 's/description/name/g' 


#### Issues

Closes https://github.com/getsentry/sentry-python/issues/6035

#### Reminders
- Please add tests to validate your changes, and lint your code using `uv run ruff`.
- Add GH Issue ID _&_ Linear ID (if applicable)
- PR title should use [conventional commit](https://develop.sentry.dev/engineering-practices/commit-messages/#type) style (`feat:`, `fix:`, `ref:`, `meta:`)
- For external contributors: [CONTRIBUTING.md](https://github.com/getsentry/sentry-python/blob/master/CONTRIBUTING.md), [Sentry SDK development docs](https://develop.sentry.dev/sdk/), [Discord community](https://discord.gg/Ww9hbqr)
