### PR TITLE
ci: Use `package-ecosystem: uv` in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,6 @@
 version: 2
 updates:
-- package-ecosystem: pip
+- package-ecosystem: uv
   directory: "/"
   schedule:
     interval: weekly


### PR DESCRIPTION
This should make dependabot update `uv.lock` when bumping versions