### PR TITLE
fix(rq): Restore `functools.wraps()` for patched functions

### DIFF
--- a/sentry_sdk/integrations/rq.py
+++ b/sentry_sdk/integrations/rq.py
@@ -1,3 +1,4 @@
+import functools
 import weakref
 
 import sentry_sdk
@@ -62,6 +63,7 @@ class RqIntegration(Integration):
 
         old_perform_job = worker_cls.perform_job
 
+        @functools.wraps(old_perform_job)
         def sentry_patched_perform_job(
             self: "Any", job: "Job", *args: "Queue", **kwargs: "Any"
         ) -> bool:
@@ -146,6 +148,7 @@ class RqIntegration(Integration):
 
         old_enqueue_job = Queue.enqueue_job
 
+        @functools.wraps(old_enqueue_job)
         def sentry_patched_enqueue_job(
             self: "Queue", job: "Any", **kwargs: "Any"
         ) -> "Any":


### PR DESCRIPTION
### Description
<!-- What changed and why? -->

Fix regression introduced in https://github.com/getsentry/sentry-python/pull/6493 because I didn't realize `ensure_integration_enabled` also wraps the patched function.

#### Issues
<!--
* resolves: #1234
* resolves: LIN-1234
-->

#### Reminders
- Please add tests to validate your changes, and lint your code using `uv run ruff`.
- Add GH Issue ID _&_ Linear ID (if applicable)
- PR title should use [conventional commit](https://develop.sentry.dev/engineering-practices/commit-messages/#type) style (`feat:`, `fix:`, `ref:`, `meta:`)
- For external contributors: [CONTRIBUTING.md](https://github.com/getsentry/sentry-python/blob/master/CONTRIBUTING.md), [Sentry SDK development docs](https://develop.sentry.dev/sdk/), [Discord community](https://discord.gg/Ww9hbqr)
