### PR TITLE
feat(django): Add user attributes in span streaming

### DIFF
--- a/sentry_sdk/consts.py
+++ b/sentry_sdk/consts.py
@@ -978,10 +978,28 @@ class SPANDATA:
     Example: "MainThread"
     """
 
+    USER_EMAIL = "user.email"
+    """
+    User email address.
+    Example: "test@example.com"
+    """
+
+    USER_ID = "user.id"
+    """
+    Unique identifier of the user.
+    Example: "S-1-5-21-202424912787-2692429404-2351956786-1000"
+    """
+
     USER_IP_ADDRESS = "user.ip_address"
     """
     The IP address of the user that triggered the request.
     Example: "10.1.2.80"
+    """
+
+    USER_NAME = "user.name"
+    """
+    Short name or login/username of the user.
+    Example: "j.smith"
     """
 
     URL_FULL = "url.full"

--- a/sentry_sdk/integrations/django/__init__.py
+++ b/sentry_sdk/integrations/django/__init__.py
@@ -458,7 +458,8 @@ def _attempt_resolve_again(
 
 
 def _after_get_response(request: "WSGIRequest") -> None:
-    integration = sentry_sdk.get_client().get_integration(DjangoIntegration)
+    client = sentry_sdk.get_client()
+    integration = client.get_integration(DjangoIntegration)
     if integration is None:
         return
 
@@ -467,7 +468,7 @@ def _after_get_response(request: "WSGIRequest") -> None:
     if integration.transaction_style == "url":
         _attempt_resolve_again(request, scope, integration.transaction_style)
 
-    span_streaming = has_span_streaming_enabled(sentry_sdk.get_client().options)
+    span_streaming = has_span_streaming_enabled(client.options)
     if span_streaming and should_send_default_pii():
         user = getattr(request, "user", None)
 

--- a/sentry_sdk/integrations/django/__init__.py
+++ b/sentry_sdk/integrations/django/__init__.py
@@ -479,14 +479,8 @@ def _after_get_response(request: "WSGIRequest") -> None:
         elif is_lazy:
             return
 
-        if (
-            user is None
-            or not is_authenticated(user)
-            or type(scope.streamed_span) is not StreamedSpan
-        ):
+        if user is None or not is_authenticated(user):
             return
-
-        segment_span = scope.streamed_span._segment
 
         user_id = None
         try:
@@ -494,7 +488,7 @@ def _after_get_response(request: "WSGIRequest") -> None:
         except Exception:
             pass
         if user_id is not None:
-            segment_span.set_attribute(SPANDATA.USER_ID, user_id)
+            scope.set_attribute(SPANDATA.USER_ID, user_id)
 
         user_email = None
         try:
@@ -502,7 +496,7 @@ def _after_get_response(request: "WSGIRequest") -> None:
         except Exception:
             pass
         if user_email is not None:
-            segment_span.set_attribute(SPANDATA.USER_EMAIL, user_email)
+            scope.set_attribute(SPANDATA.USER_EMAIL, user_email)
 
         username = None
         try:
@@ -510,7 +504,7 @@ def _after_get_response(request: "WSGIRequest") -> None:
         except Exception:
             pass
         if username is not None:
-            segment_span.set_attribute(SPANDATA.USER_NAME, username)
+            scope.set_attribute(SPANDATA.USER_NAME, username)
 
 
 def _patch_get_response() -> None:

--- a/sentry_sdk/integrations/django/__init__.py
+++ b/sentry_sdk/integrations/django/__init__.py
@@ -40,6 +40,7 @@ try:
     from django.conf import settings
     from django.conf import settings as django_settings
     from django.core import signals
+    from django.utils.functional import SimpleLazyObject
 
     try:
         from django.urls import resolve
@@ -463,6 +464,40 @@ def _after_get_response(request: "WSGIRequest") -> None:
 
     scope = sentry_sdk.get_current_scope()
     _attempt_resolve_again(request, scope, integration.transaction_style)
+
+    span_streaming = has_span_streaming_enabled(sentry_sdk.get_client().options)
+    if span_streaming:
+        user = getattr(request, "user", None)
+
+        # Evaluating a SimpleLazyObject in an async view can raise django.core.exceptions.SynchronousOnlyOperation.
+        # Exit early if the user has not been materialized yet.
+        is_lazy = isinstance(user, SimpleLazyObject)
+        if is_lazy and hasattr(request, "_cached_user"):
+            user = request._cached_user
+        elif is_lazy:
+            return
+
+        if user is None or not is_authenticated(user):
+            return
+
+        segment_span = scope.streamed_span._segment
+        try:
+            user_id = str(user.pk)
+        except Exception:
+            pass
+        segment_span.set_attribute(SPANDATA.USER_ID, user_id)
+
+        try:
+            user_email = user.email
+        except Exception:
+            pass
+        segment_span.set_attribute(SPANDATA.USER_EMAIL, user_email)
+
+        try:
+            username = user.get_username()
+        except Exception:
+            pass
+        segment_span.set_attribute(SPANDATA.USER_NAME, username)
 
 
 def _patch_get_response() -> None:

--- a/sentry_sdk/integrations/django/__init__.py
+++ b/sentry_sdk/integrations/django/__init__.py
@@ -477,7 +477,11 @@ def _after_get_response(request: "WSGIRequest") -> None:
         elif is_lazy:
             return
 
-        if user is None or not is_authenticated(user) or scope.streamed_span is None:
+        if (
+            user is None
+            or not is_authenticated(user)
+            or type(scope.streamed_span) is not StreamedSpan
+        ):
             return
 
         segment_span = scope.streamed_span._segment

--- a/sentry_sdk/integrations/django/__init__.py
+++ b/sentry_sdk/integrations/django/__init__.py
@@ -477,7 +477,7 @@ def _after_get_response(request: "WSGIRequest") -> None:
         elif is_lazy:
             return
 
-        if user is None or not is_authenticated(user):
+        if user is None or not is_authenticated(user) or scope.streamed_span is None:
             return
 
         segment_span = scope.streamed_span._segment

--- a/sentry_sdk/integrations/django/__init__.py
+++ b/sentry_sdk/integrations/django/__init__.py
@@ -468,7 +468,7 @@ def _after_get_response(request: "WSGIRequest") -> None:
         _attempt_resolve_again(request, scope, integration.transaction_style)
 
     span_streaming = has_span_streaming_enabled(sentry_sdk.get_client().options)
-    if span_streaming:
+    if span_streaming and should_send_default_pii():
         user = getattr(request, "user", None)
 
         # Evaluating a SimpleLazyObject in an async view can raise django.core.exceptions.SynchronousOnlyOperation.
@@ -487,23 +487,30 @@ def _after_get_response(request: "WSGIRequest") -> None:
             return
 
         segment_span = scope.streamed_span._segment
+
+        user_id = None
         try:
             user_id = str(user.pk)
         except Exception:
             pass
-        segment_span.set_attribute(SPANDATA.USER_ID, user_id)
+        if user_id is not None:
+            segment_span.set_attribute(SPANDATA.USER_ID, user_id)
 
+        user_email = None
         try:
             user_email = user.email
         except Exception:
             pass
-        segment_span.set_attribute(SPANDATA.USER_EMAIL, user_email)
+        if user_email is not None:
+            segment_span.set_attribute(SPANDATA.USER_EMAIL, user_email)
 
+        username = None
         try:
             username = user.get_username()
         except Exception:
             pass
-        segment_span.set_attribute(SPANDATA.USER_NAME, username)
+        if username is not None:
+            segment_span.set_attribute(SPANDATA.USER_NAME, username)
 
 
 def _patch_get_response() -> None:

--- a/sentry_sdk/integrations/django/__init__.py
+++ b/sentry_sdk/integrations/django/__init__.py
@@ -463,9 +463,8 @@ def _after_get_response(request: "WSGIRequest") -> None:
     if integration is None:
         return
 
-    scope = sentry_sdk.get_current_scope()
-
     if integration.transaction_style == "url":
+        scope = sentry_sdk.get_current_scope()
         _attempt_resolve_again(request, scope, integration.transaction_style)
 
     span_streaming = has_span_streaming_enabled(client.options)
@@ -499,7 +498,7 @@ def _after_get_response(request: "WSGIRequest") -> None:
         except Exception:
             pass
 
-        scope.set_user(user_info)
+        sentry_sdk.set_user(user_info)
 
 
 def _patch_get_response() -> None:

--- a/sentry_sdk/integrations/django/__init__.py
+++ b/sentry_sdk/integrations/django/__init__.py
@@ -459,11 +459,13 @@ def _attempt_resolve_again(
 
 def _after_get_response(request: "WSGIRequest") -> None:
     integration = sentry_sdk.get_client().get_integration(DjangoIntegration)
-    if integration is None or integration.transaction_style != "url":
+    if integration is None:
         return
 
     scope = sentry_sdk.get_current_scope()
-    _attempt_resolve_again(request, scope, integration.transaction_style)
+
+    if integration.transaction_style == "url":
+        _attempt_resolve_again(request, scope, integration.transaction_style)
 
     span_streaming = has_span_streaming_enabled(sentry_sdk.get_client().options)
     if span_streaming:

--- a/sentry_sdk/integrations/django/__init__.py
+++ b/sentry_sdk/integrations/django/__init__.py
@@ -482,29 +482,23 @@ def _after_get_response(request: "WSGIRequest") -> None:
         if user is None or not is_authenticated(user):
             return
 
-        user_id = None
+        user_info = {}
         try:
-            user_id = str(user.pk)
+            user_info["id"] = str(user.pk)
         except Exception:
             pass
-        if user_id is not None:
-            scope.set_attribute(SPANDATA.USER_ID, user_id)
 
-        user_email = None
         try:
-            user_email = user.email
+            user_info["email"] = user.email
         except Exception:
             pass
-        if user_email is not None:
-            scope.set_attribute(SPANDATA.USER_EMAIL, user_email)
 
-        username = None
         try:
-            username = user.get_username()
+            user_info["username"] = user.get_username()
         except Exception:
             pass
-        if username is not None:
-            scope.set_attribute(SPANDATA.USER_NAME, username)
+
+        scope.set_user(user_info)
 
 
 def _patch_get_response() -> None:

--- a/tests/integrations/django/test_basic.py
+++ b/tests/integrations/django/test_basic.py
@@ -532,7 +532,7 @@ def test_user_captured(
 
 @pytest.mark.forked
 @pytest_mark_django_db_decorator()
-def test_materialized_user_captured_on_segment_span(
+def test_materialized_user_captured(
     sentry_init,
     client,
     capture_events,

--- a/tests/integrations/django/test_basic.py
+++ b/tests/integrations/django/test_basic.py
@@ -532,6 +532,39 @@ def test_user_captured(
 
 @pytest.mark.forked
 @pytest_mark_django_db_decorator()
+def test_materialized_user_captured_on_segment_span(
+    sentry_init,
+    client,
+    capture_events,
+    capture_items,
+):
+    sentry_init(
+        integrations=[DjangoIntegration()],
+        send_default_pii=True,
+        traces_sample_rate=1.0,
+        _experiments={"trace_lifecycle": "stream"},
+    )
+
+    content, status, headers = unpack_werkzeug_response(client.get(reverse("mylogin")))
+    assert content == b"ok"
+
+    items = capture_items("span")
+
+    content, status, headers = unpack_werkzeug_response(
+        client.get(reverse("template_test"))
+    )
+
+    sentry_sdk.flush()
+    spans = [item.payload for item in items]
+    (span,) = (span for span in spans if span["name"] == "/template-test")
+
+    assert span["attributes"][SPANDATA.USER_ID] == "1"
+    assert span["attributes"][SPANDATA.USER_EMAIL] == "lennon@thebeatles.com"
+    assert span["attributes"][SPANDATA.USER_NAME] == "john"
+
+
+@pytest.mark.forked
+@pytest_mark_django_db_decorator()
 @pytest.mark.parametrize("span_streaming", [True, False])
 def test_queryset_repr(
     sentry_init,


### PR DESCRIPTION
### Description
<!-- What changed and why? -->

Adapt logic for extracting user information from [`_set_user_info()`](https://github.com/getsentry/sentry-python/blob/3bbd78d4fe3a2803839d8091ecc435136bd83363/sentry_sdk/integrations/django/__init__.py#L585) to run after `BaseHandler.get_response`.

Do not set user attributes if the user is an instance of `SimpleLazyObject` and the underlying user object has not been cached yet. Bailing early ensures that we avoid the exception reported in https://github.com/getsentry/sentry-python/issues/5274.

#### Issues

Contributes to https://github.com/getsentry/sentry-python/issues/6201

#### Reminders
- Please add tests to validate your changes, and lint your code using `uv run ruff`.
- Add GH Issue ID _&_ Linear ID (if applicable)
- PR title should use [conventional commit](https://develop.sentry.dev/engineering-practices/commit-messages/#type) style (`feat:`, `fix:`, `ref:`, `meta:`)
- For external contributors: [CONTRIBUTING.md](https://github.com/getsentry/sentry-python/blob/master/CONTRIBUTING.md), [Sentry SDK development docs](https://develop.sentry.dev/sdk/), [Discord community](https://discord.gg/Ww9hbqr)
