### PR TITLE
ref(grpc): Use `SegmentSource` constants for streamed spans

### DIFF
--- a/sentry_sdk/integrations/grpc/aio/server.py
+++ b/sentry_sdk/integrations/grpc/aio/server.py
@@ -4,6 +4,7 @@ import sentry_sdk
 from sentry_sdk.consts import OP
 from sentry_sdk.integrations import DidNotEnable
 from sentry_sdk.integrations.grpc.consts import SPAN_ORIGIN
+from sentry_sdk.traces import SegmentSource
 from sentry_sdk.tracing import TransactionSource
 from sentry_sdk.tracing_utils import has_span_streaming_enabled
 from sentry_sdk.utils import event_from_exception
@@ -66,7 +67,7 @@ class ServerInterceptor(grpc.aio.ServerInterceptor):  # type: ignore
                             name=name,
                             attributes={
                                 "sentry.op": OP.GRPC_SERVER,
-                                "sentry.span.source": TransactionSource.CUSTOM.value,
+                                "sentry.span.source": SegmentSource.CUSTOM.value,
                                 "sentry.origin": SPAN_ORIGIN,
                             },
                             parent_span=None,

--- a/sentry_sdk/integrations/grpc/server.py
+++ b/sentry_sdk/integrations/grpc/server.py
@@ -4,6 +4,7 @@ import sentry_sdk
 from sentry_sdk.consts import OP
 from sentry_sdk.integrations import DidNotEnable
 from sentry_sdk.integrations.grpc.consts import SPAN_ORIGIN
+from sentry_sdk.traces import SegmentSource
 from sentry_sdk.tracing import TransactionSource
 from sentry_sdk.tracing_utils import has_span_streaming_enabled
 
@@ -57,7 +58,7 @@ class ServerInterceptor(grpc.ServerInterceptor):  # type: ignore
                             name=name,
                             attributes={
                                 "sentry.op": OP.GRPC_SERVER,
-                                "sentry.span.source": TransactionSource.CUSTOM.value,
+                                "sentry.span.source": SegmentSource.CUSTOM.value,
                                 "sentry.origin": SPAN_ORIGIN,
                             },
                             parent_span=None,


### PR DESCRIPTION
### Description
<!-- What changed and why? -->

#### Issues
<!--
* resolves: #1234
* resolves: LIN-1234
-->

#### Reminders
- Please add tests to validate your changes, and lint your code using `uv run ruff`.
- Add GH Issue ID _&_ Linear ID (if applicable)
- PR title should use [conventional commit](https://develop.sentry.dev/engineering-practices/commit-messages/#type) style (`feat:`, `fix:`, `ref:`, `meta:`)
- For external contributors: [CONTRIBUTING.md](https://github.com/getsentry/sentry-python/blob/master/CONTRIBUTING.md), [Sentry SDK development docs](https://develop.sentry.dev/sdk/), [Discord community](https://discord.gg/Ww9hbqr)
