### PR TITLE
feat(starlite): Set name and source on request span when streaming

### DIFF
--- a/sentry_sdk/integrations/starlite.py
+++ b/sentry_sdk/integrations/starlite.py
@@ -256,7 +256,7 @@ def patch_http_route_handle() -> None:
             name = _DEFAULT_TRANSACTION_NAME
             source = TransactionSource.ROUTE
 
-        sentry_sdk.get_current_scope().set_transaction_name(name, source)
+        sentry_sdk.set_transaction_name(name, source)
 
         def event_processor(event: "Event", _: "Hint") -> "Event":
             request_info = event.get("request", {})

--- a/sentry_sdk/integrations/starlite.py
+++ b/sentry_sdk/integrations/starlite.py
@@ -238,9 +238,27 @@ def patch_http_route_handle() -> None:
 
         request_data = await body
 
-        def event_processor(event: "Event", _: "Hint") -> "Event":
-            route_handler = scope.get("route_handler")
+        route_handler = scope.get("route_handler")
 
+        func = None
+        if route_handler.name is not None:
+            name = route_handler.name
+        elif isinstance(route_handler.fn, Ref):
+            func = route_handler.fn.value
+        else:
+            func = route_handler.fn
+        if func is not None:
+            name = transaction_from_function(func)
+
+        source = SOURCE_FOR_STYLE["endpoint"]
+
+        if not name:
+            name = _DEFAULT_TRANSACTION_NAME
+            source = TransactionSource.ROUTE
+
+        sentry_sdk.get_current_scope().set_transaction_name(name, source)
+
+        def event_processor(event: "Event", _: "Hint") -> "Event":
             request_info = event.get("request", {})
             request_info["content_length"] = len(scope.get("_body", b""))
             if should_send_default_pii():
@@ -248,29 +266,7 @@ def patch_http_route_handle() -> None:
             if request_data is not None:
                 request_info["data"] = request_data
 
-            func = None
-            if route_handler.name is not None:
-                tx_name = route_handler.name
-            elif isinstance(route_handler.fn, Ref):
-                func = route_handler.fn.value
-            else:
-                func = route_handler.fn
-            if func is not None:
-                tx_name = transaction_from_function(func)
-
-            tx_info = {"source": SOURCE_FOR_STYLE["endpoint"]}
-
-            if not tx_name:
-                tx_name = _DEFAULT_TRANSACTION_NAME
-                tx_info = {"source": TransactionSource.ROUTE}
-
-            event.update(
-                {
-                    "request": deepcopy(request_info),
-                    "transaction": tx_name,
-                    "transaction_info": tx_info,
-                }
-            )
+            event["request"] = deepcopy(request_info)
             return event
 
         sentry_scope._name = StarliteIntegration.identifier

--- a/sentry_sdk/integrations/starlite.py
+++ b/sentry_sdk/integrations/starlite.py
@@ -257,6 +257,7 @@ def patch_http_route_handle() -> None:
             source = TransactionSource.ROUTE
 
         sentry_sdk.set_transaction_name(name, source)
+        sentry_scope.set_transaction_name(name, source)
 
         def event_processor(event: "Event", _: "Hint") -> "Event":
             request_info = event.get("request", {})

--- a/tests/integrations/starlite/test_starlite.py
+++ b/tests/integrations/starlite/test_starlite.py
@@ -157,8 +157,7 @@ def test_transaction_name_and_source(
             pass
 
         sentry_sdk.flush()
-        spans = [item.payload for item in items if item.type == "span"]
-
+        spans = [item.payload for item in items]
         spans = [span for span in spans if span["name"] == expected_tx_name]
         assert len(spans) == 1
         assert spans[0]["attributes"]["sentry.span.source"] == "component"

--- a/tests/integrations/starlite/test_starlite.py
+++ b/tests/integrations/starlite/test_starlite.py
@@ -158,7 +158,7 @@ def test_transaction_name_and_source(
 
         sentry_sdk.flush()
         spans = [item.payload for item in items]
-        spans = [span for span in spans if span["name"] == expected_tx_name]
+        spans = [span for span in spans if expected_tx_name in span["name"]]
         assert len(spans) == 1
         assert spans[0]["attributes"]["sentry.span.source"] == "component"
     else:
@@ -170,7 +170,7 @@ def test_transaction_name_and_source(
             pass
 
         (_, transaction) = events
-        assert transaction["transaction"] == expected_tx_name
+        assert expected_tx_name in transaction["transaction"]
         assert transaction["transaction_info"] == {"source": "component"}
 
 

--- a/tests/integrations/starlite/test_starlite.py
+++ b/tests/integrations/starlite/test_starlite.py
@@ -112,6 +112,69 @@ def test_catch_exceptions(
     assert event["exception"]["values"][0]["mechanism"]["type"] == "starlite"
 
 
+@pytest.mark.parametrize(
+    "test_url,expected_tx_name",
+    [
+        (
+            "/some_url",
+            "tests.integrations.starlite.test_starlite.starlite_app_factory.<locals>.homepage_handler",
+        ),
+        (
+            "/custom_error",
+            "custom_name",
+        ),
+        (
+            "/controller/error",
+            "partial(<function tests.integrations.starlite.test_starlite.starlite_app_factory.<locals>.MyController.controller_error>)",
+        ),
+    ],
+)
+@pytest.mark.parametrize("span_streaming", [True, False])
+def test_transaction_name_and_source(
+    sentry_init,
+    capture_events,
+    test_url,
+    expected_tx_name,
+    capture_items,
+    span_streaming,
+):
+    sentry_init(
+        traces_sample_rate=1.0,
+        integrations=[StarliteIntegration()],
+        _experiments={
+            "trace_lifecycle": "stream" if span_streaming else "static",
+        },
+    )
+    starlite_app = starlite_app_factory()
+    client = TestClient(starlite_app)
+
+    if span_streaming:
+        items = capture_items("span")
+
+        try:
+            client.get(test_url)
+        except Exception:
+            pass
+
+        sentry_sdk.flush()
+        spans = [item.payload for item in items if item.type == "span"]
+
+        spans = [span for span in spans if span["name"] == expected_tx_name]
+        assert len(spans) == 1
+        assert spans[0]["attributes"]["sentry.span.source"] == "component"
+    else:
+        events = capture_events()
+
+        try:
+            client.get(test_url)
+        except Exception:
+            pass
+
+        (_, transaction) = events
+        assert transaction["transaction"] == expected_tx_name
+        assert transaction["transaction_info"] == {"source": "component"}
+
+
 @pytest.mark.parametrize("span_streaming", [True, False])
 def test_middleware_spans(sentry_init, capture_events, capture_items, span_streaming):
     sentry_init(


### PR DESCRIPTION
### Description
<!-- What changed and why? -->

Call `Scope.set_transaction_name()` on isolation and current scopes instead of manually overwriting event fields in an event processor.

Using the function ensures that the name and the `sentry.span.source` attribute are set on the segment span when the streaming trace lifecycle is enabled.

#### Issues
<!--
* resolves: #1234
* resolves: LIN-1234
-->

#### Reminders
- Please add tests to validate your changes, and lint your code using `uv run ruff`.
- Add GH Issue ID _&_ Linear ID (if applicable)
- PR title should use [conventional commit](https://develop.sentry.dev/engineering-practices/commit-messages/#type) style (`feat:`, `fix:`, `ref:`, `meta:`)
- For external contributors: [CONTRIBUTING.md](https://github.com/getsentry/sentry-python/blob/master/CONTRIBUTING.md), [Sentry SDK development docs](https://develop.sentry.dev/sdk/), [Discord community](https://discord.gg/Ww9hbqr)
