### PR TITLE
fix(user): Set `user.ip_address` on telemetry if present

### DIFF
--- a/sentry_sdk/scope.py
+++ b/sentry_sdk/scope.py
@@ -1741,6 +1741,7 @@ class Scope:
             ("user.id", "id"),
             ("user.name", "username"),
             ("user.email", "email"),
+            ("user.ip_address", "ip_address"),
         ):
             if user_attribute in self._user and attribute_name not in attributes:
                 attributes[attribute_name] = self._user[user_attribute]

--- a/tests/test_attributes.py
+++ b/tests/test_attributes.py
@@ -174,3 +174,41 @@ def test_scope_attributes_preserialized(sentry_init, capture_items):
     # Attrs originally from the scope are serialized when sent
     assert isinstance(metric["attributes"]["instance"], str)
     assert isinstance(metric["attributes"]["dictionary"], str)
+
+
+def test_user_attributes(sentry_init, capture_items):
+    sentry_init(
+        traces_sample_rate=1.0,
+        send_default_pii=True,
+        _experiments={
+            "trace_lifecycle": "stream",
+        },
+    )
+
+    items = capture_items("trace_metric", "span")
+
+    sentry_sdk.set_user(
+        {
+            "id": "123456",
+            "username": "username",
+            "email": "username@example.com",
+            "ip_address": "127.0.0.1",
+        }
+    )
+
+    with sentry_sdk.traces.start_span(name="login"):
+        sentry_sdk.metrics.count("test", 1)
+
+    sentry_sdk.get_client().flush()
+
+    metric, span = [item.payload for item in items]
+
+    assert metric["attributes"]["user.id"] == "123456"
+    assert metric["attributes"]["user.name"] == "username"
+    assert metric["attributes"]["user.email"] == "username@example.com"
+    assert metric["attributes"]["user.ip_address"] == "127.0.0.1"
+
+    assert span["attributes"]["user.id"] == "123456"
+    assert span["attributes"]["user.name"] == "username"
+    assert span["attributes"]["user.email"] == "username@example.com"
+    assert span["attributes"]["user.ip_address"] == "127.0.0.1"


### PR DESCRIPTION
### Description
If user data is set on scope, we should materialize it onto attributes-based telemetry (metrics, logs, spans v2) at the end. The code for that was there and working, but we were omitting `ip_address`.

#### Issues
<!--
* resolves: #1234
* resolves: LIN-1234
-->

#### Reminders
- Please add tests to validate your changes, and lint your code using `uv run ruff`.
- Add GH Issue ID _&_ Linear ID (if applicable)
- PR title should use [conventional commit](https://develop.sentry.dev/engineering-practices/commit-messages/#type) style (`feat:`, `fix:`, `ref:`, `meta:`)
- For external contributors: [CONTRIBUTING.md](https://github.com/getsentry/sentry-python/blob/master/CONTRIBUTING.md), [Sentry SDK development docs](https://develop.sentry.dev/sdk/), [Discord community](https://discord.gg/Ww9hbqr)
