### PR TITLE
ci: use ghcr image mirrors for postgres and redis services

### DIFF
--- a/.github/workflows/test-integrations-dbs.yml
+++ b/.github/workflows/test-integrations-dbs.yml
@@ -21,7 +21,7 @@ jobs:
         os: [ubuntu-22.04]
     services:
       postgres:
-        image: postgres
+        image: ghcr.io/getsentry/image-mirror-library-postgres:17-alpine
         env:
           POSTGRES_PASSWORD: sentry
         # Set health checks to wait until postgres has started

--- a/.github/workflows/test-integrations-tasks.yml
+++ b/.github/workflows/test-integrations-tasks.yml
@@ -21,7 +21,7 @@ jobs:
         os: [ubuntu-22.04]
     services:
       redis:
-        image: redis
+        image: ghcr.io/getsentry/image-mirror-library-redis:7.0.8-bullseye
         options: >-
           --health-cmd "redis-cli ping"
           --health-interval 10s

--- a/.github/workflows/test-integrations-web-1.yml
+++ b/.github/workflows/test-integrations-web-1.yml
@@ -21,7 +21,7 @@ jobs:
         os: [ubuntu-22.04]
     services:
       postgres:
-        image: postgres
+        image: ghcr.io/getsentry/image-mirror-library-postgres:17-alpine
         env:
           POSTGRES_PASSWORD: sentry
         # Set health checks to wait until postgres has started

--- a/scripts/split_tox_gh_actions/templates/test_group.jinja
+++ b/scripts/split_tox_gh_actions/templates/test_group.jinja
@@ -17,7 +17,7 @@
       {% endif %}
       {% if needs_postgres %}
       postgres:
-        image: postgres
+        image: ghcr.io/getsentry/image-mirror-library-postgres:17-alpine
         env:
           POSTGRES_PASSWORD: sentry
         # Set health checks to wait until postgres has started
@@ -32,7 +32,7 @@
       {% endif %}
       {% if needs_redis %}
       redis:
-        image: redis
+        image: ghcr.io/getsentry/image-mirror-library-redis:7.0.8-bullseye
         options: >-
           --health-cmd "redis-cli ping"
           --health-interval 10s


### PR DESCRIPTION
Replaces Docker Hub image references in CI with their `ghcr.io/getsentry/image-mirror-*` equivalents, consistent with how `getsentry/sentry` pulls service containers.

## Changes

- `postgres` → `ghcr.io/getsentry/image-mirror-library-postgres:17-alpine`
- `redis` → `ghcr.io/getsentry/image-mirror-library-redis:7.0.8-bullseye`

`mysql` and `docker:dind` are not available in the getsentry mirror ([getsentry/image-mirror](https://github.com/getsentry/image-mirror)) so those are left unchanged.

The change is made in the Jinja template (`scripts/split_tox_gh_actions/templates/test_group.jinja`); the three generated workflow files (`test-integrations-dbs.yml`, `test-integrations-tasks.yml`, `test-integrations-web-1.yml`) are regenerated by running `python scripts/split_tox_gh_actions/split_tox_gh_actions.py`.

---
[View Session in Sentry](https://sentry.sentry.io/traces/?project=4510944073809921&query=gen_ai.conversation.id%3A%22slack%3AC09M26BC6A1%3A1781169862.709999%22)