### PR TITLE
ref: Stop returning `StreamedSpan` from `get_start_span_function()`

### DIFF
--- a/sentry_sdk/ai/utils.py
+++ b/sentry_sdk/ai/utils.py
@@ -13,7 +13,6 @@ if TYPE_CHECKING:
 
 import sentry_sdk
 from sentry_sdk.traces import StreamedSpan
-from sentry_sdk.tracing_utils import has_span_streaming_enabled
 from sentry_sdk.utils import logger
 
 MAX_GEN_AI_MESSAGE_BYTES = 20_000  # 20KB
@@ -538,13 +537,7 @@ def normalize_message_roles(messages: "list[dict[str, Any]]") -> "list[dict[str,
 
 
 def get_start_span_function() -> "Callable[..., Any]":
-    if has_span_streaming_enabled(sentry_sdk.get_client().options):
-        return sentry_sdk.traces.start_span
-
     current_span = sentry_sdk.get_current_span()
-    if isinstance(current_span, StreamedSpan):
-        # mypy
-        return sentry_sdk.traces.start_span
 
     transaction_exists = (
         current_span is not None and current_span.containing_transaction is not None


### PR DESCRIPTION
### Description
<!-- What changed and why? -->

The new `start_span()` API automatically promotes spans to segment spans if applicable.

There is no need for `get_start_span_function()` anymore.

#### Issues
<!--
* resolves: #1234
* resolves: LIN-1234
-->

#### Reminders
- Please add tests to validate your changes, and lint your code using `uv run ruff`.
- Add GH Issue ID _&_ Linear ID (if applicable)
- PR title should use [conventional commit](https://develop.sentry.dev/engineering-practices/commit-messages/#type) style (`feat:`, `fix:`, `ref:`, `meta:`)
- For external contributors: [CONTRIBUTING.md](https://github.com/getsentry/sentry-python/blob/master/CONTRIBUTING.md), [Sentry SDK development docs](https://develop.sentry.dev/sdk/), [Discord community](https://discord.gg/Ww9hbqr)
