### PR TITLE
fix(mcp): support MCP SDK v2 handler signature and removed request_ctx

### DIFF
--- a/sentry_sdk/integrations/mcp.py
+++ b/sentry_sdk/integrations/mcp.py
@@ -19,14 +19,20 @@ from sentry_sdk.integrations._wsgi_common import nullcontext
 from sentry_sdk.scope import should_send_default_pii
 from sentry_sdk.traces import StreamedSpan
 from sentry_sdk.tracing_utils import has_span_streaming_enabled
-from sentry_sdk.utils import safe_serialize
+from sentry_sdk.utils import package_version, safe_serialize
+
+MCP_PACKAGE_VERSION = package_version("mcp")
 
 try:
     from mcp.server.lowlevel import Server  # type: ignore[import-not-found]
-    from mcp.server.lowlevel.server import request_ctx  # type: ignore[import-not-found]
     from mcp.server.streamable_http import (  # type: ignore[import-not-found]
         StreamableHTTPServerTransport,
     )
+
+    if MCP_PACKAGE_VERSION and MCP_PACKAGE_VERSION < (2, 0, 0):
+        from mcp.server.lowlevel.server import (  # type: ignore[import-not-found]
+            request_ctx,
+        )
 except ImportError:
     raise DidNotEnable("MCP SDK not installed")
 
@@ -34,6 +40,16 @@ try:
     from fastmcp import FastMCP  # type: ignore[import-not-found]
 except ImportError:
     FastMCP = None
+
+if MCP_PACKAGE_VERSION and MCP_PACKAGE_VERSION >= (2, 0, 0):
+    try:
+        from mcp.server.context import (  # type: ignore[import-not-found]
+            ServerRequestContext,
+        )
+    except ImportError:
+        ServerRequestContext = None
+else:
+    ServerRequestContext = None
 
 
 if TYPE_CHECKING:
@@ -71,13 +87,15 @@ class MCPIntegration(Integration):
             _patch_fastmcp()
 
 
-def _get_active_http_scopes() -> (
-    "Optional[Tuple[Optional[sentry_sdk.Scope], Optional[sentry_sdk.Scope]]]"
-):
-    try:
-        ctx = request_ctx.get()
-    except LookupError:
-        return None
+def _get_active_http_scopes(
+    ctx: "Optional[Any]" = None,
+) -> "Optional[Tuple[Optional[sentry_sdk.Scope], Optional[sentry_sdk.Scope]]]":
+    if MCP_PACKAGE_VERSION and MCP_PACKAGE_VERSION < (2, 0, 0):
+        if ctx is None:
+            try:
+                ctx = request_ctx.get()
+            except LookupError:
+                return None
 
     if (
         ctx is None
@@ -93,7 +111,9 @@ def _get_active_http_scopes() -> (
     )
 
 
-def _get_request_context_data() -> "tuple[Optional[str], Optional[str], str]":
+def _get_request_context_data(
+    ctx: "Optional[Any]" = None,
+) -> "tuple[Optional[str], Optional[str], str]":
     """
     Extract request ID, session ID, and MCP transport type from the request context.
 
@@ -106,31 +126,28 @@ def _get_request_context_data() -> "tuple[Optional[str], Optional[str], str]":
     request_id: "Optional[str]" = None
     session_id: "Optional[str]" = None
     mcp_transport: str = "stdio"
+    if MCP_PACKAGE_VERSION and MCP_PACKAGE_VERSION < (2, 0, 0):
+        if ctx is None:
+            try:
+                ctx = request_ctx.get()
+            except LookupError:
+                return request_id, session_id, mcp_transport
 
-    try:
-        ctx = request_ctx.get()
-
-        if ctx is not None:
-            request_id = ctx.request_id
-            if hasattr(ctx, "request") and ctx.request is not None:
-                request = ctx.request
-                # Detect transport type by checking request characteristics
-                if hasattr(request, "query_params") and request.query_params.get(
-                    "session_id"
-                ):
-                    # SSE transport uses query parameter
-                    mcp_transport = "sse"
-                    session_id = request.query_params.get("session_id")
-                elif hasattr(request, "headers") and request.headers.get(
-                    "mcp-session-id"
-                ):
-                    # StreamableHTTP transport uses header
-                    mcp_transport = "http"
-                    session_id = request.headers.get("mcp-session-id")
-
-    except LookupError:
-        # No request context available - default to stdio
-        pass
+    if ctx is not None:
+        request_id = ctx.request_id
+        if hasattr(ctx, "request") and ctx.request is not None:
+            request = ctx.request
+            # Detect transport type by checking request characteristics
+            if hasattr(request, "query_params") and request.query_params.get(
+                "session_id"
+            ):
+                # SSE transport uses query parameter
+                mcp_transport = "sse"
+                session_id = request.query_params.get("session_id")
+            elif hasattr(request, "headers") and request.headers.get("mcp-session-id"):
+                # StreamableHTTP transport uses header
+                mcp_transport = "http"
+                session_id = request.headers.get("mcp-session-id")
 
     return request_id, session_id, mcp_transport
 
@@ -204,12 +221,23 @@ def _extract_tool_result_content(result: "Any") -> "Any":
     Extract meaningful content from MCP tool result.
 
     Tool handlers can return:
+    - CallToolResult (mcp v2+): Has .content list and optional .structured_content
     - tuple (UnstructuredContent, StructuredContent): Return the structured content (dict)
     - dict (StructuredContent): Return as-is
-    - Iterable (UnstructuredContent): Extract text from content blocks
+    - list/Iterable (UnstructuredContent): Extract text from content blocks
     """
     if result is None:
         return None
+
+    # Handle v2 CallToolResult-like objects (has .content list attribute)
+    if hasattr(result, "content") and isinstance(
+        getattr(result, "content", None), list
+    ):
+        # This is only present when a tool declares an output_schema
+        structured = getattr(result, "structured_content", None)
+        if structured is not None:
+            return structured
+        return _extract_text_from_content_blocks(result.content)
 
     # Handle CombinationContent: tuple of (UnstructuredContent, StructuredContent)
     if isinstance(result, tuple) and len(result) == 2:
@@ -221,22 +249,23 @@ def _extract_tool_result_content(result: "Any") -> "Any":
         return result
 
     # Handle UnstructuredContent: iterable of ContentBlock objects
-    # Try to extract text content
     if hasattr(result, "__iter__") and not isinstance(result, (str, bytes, dict)):
-        texts = []
-        try:
-            for item in result:
-                # Try to get text attribute from ContentBlock objects
-                if hasattr(item, "text"):
-                    texts.append(item.text)
-                elif isinstance(item, dict) and "text" in item:
-                    texts.append(item["text"])
-        except Exception:
-            # If extraction fails, return the original
-            return result
-        return " ".join(texts) if texts else result
+        return _extract_text_from_content_blocks(result)
 
     return result
+
+
+def _extract_text_from_content_blocks(content_blocks: "Any") -> "Any":
+    texts = []
+    try:
+        for item in content_blocks:
+            if hasattr(item, "text"):
+                texts.append(item.text)
+            elif isinstance(item, dict) and "text" in item:
+                texts.append(item["text"])
+    except Exception:
+        return content_blocks
+    return " ".join(texts) if texts else content_blocks
 
 
 def _set_span_output_data(
@@ -336,20 +365,54 @@ def _set_span_output_data(
 # Handler data preparation and wrapping
 
 
-def _prepare_handler_data(
+def _is_v2_context(original_args: "tuple[Any, ...]") -> bool:
+    """Check if original_args contains a v2 ServerRequestContext as the first element."""
+    return (
+        ServerRequestContext is not None
+        and bool(original_args)
+        and isinstance(original_args[0], ServerRequestContext)
+    )
+
+
+def _extract_handler_data_from_params(
+    handler_type: str,
+    params: "Any",
+) -> "tuple[str, dict[str, Any]]":
+    """
+    Extract handler name and arguments from a v2 typed params object.
+
+    In MCP SDK v2, handlers receive (ctx, params) where params is a typed
+    Pydantic model (CallToolRequestParams, GetPromptRequestParams, etc.).
+    """
+    if handler_type == "tool":
+        handler_name = getattr(params, "name", "unknown")
+        arguments = getattr(params, "arguments", None) or {}
+    elif handler_type == "prompt":
+        handler_name = getattr(params, "name", "unknown")
+        arguments = getattr(params, "arguments", None) or {}
+        arguments = {"name": handler_name, **arguments}
+    else:  # resource
+        handler_name = str(getattr(params, "uri", "unknown"))
+        arguments = {}
+
+    return handler_name, arguments
+
+
+def _extract_handler_data_from_args(
     handler_type: str,
     original_args: "tuple[Any, ...]",
     original_kwargs: "Optional[dict[str, Any]]" = None,
-) -> "tuple[str, dict[str, Any], str, str, str, Optional[str]]":
+) -> "tuple[str, dict[str, Any]]":
     """
-    Prepare common handler data for both async and sync wrappers.
+    Extract handler name and arguments from v1 positional args.
 
-    Returns:
-        Tuple of (handler_name, arguments, span_data_key, span_name, mcp_method_name, result_data_key)
+    In MCP SDK v1, handlers receive positional args:
+    - Tool: (tool_name, arguments)
+    - Prompt: (name, arguments)
+    - Resource: (uri,)
     """
     original_kwargs = original_kwargs or {}
 
-    # Extract handler-specific data based on handler type
     if handler_type == "tool":
         if original_args:
             handler_name = original_args[0]
@@ -374,7 +437,6 @@ def _prepare_handler_data(
         elif original_kwargs.get("arguments"):
             arguments = original_kwargs["arguments"]
 
-        # Include name in arguments dict for span data
         arguments = {"name": handler_name, **(arguments or {})}
 
     else:  # resource
@@ -386,7 +448,39 @@ def _prepare_handler_data(
 
         arguments = {}
 
-    # Get span configuration
+    return handler_name, arguments
+
+
+def _prepare_handler_data(
+    handler_type: str,
+    original_args: "tuple[Any, ...]",
+    original_kwargs: "Optional[dict[str, Any]]" = None,
+    params: "Optional[Any]" = None,
+) -> "tuple[str, dict[str, Any], str, str, str, Optional[str]]":
+    """
+    Prepare common handler data for both v1 and v2 MCP SDK.
+
+    Args:
+        handler_type: "tool", "prompt", or "resource"
+        original_args: Original positional args (v1 path)
+        original_kwargs: Original keyword args (v1 path)
+        params: Typed params object from v2 ServerRequestContext path
+
+    Returns:
+        Tuple of (handler_name, arguments, span_data_key, span_name, mcp_method_name, result_data_key)
+    """
+    if params is not None:
+        handler_name, arguments = _extract_handler_data_from_params(
+            handler_type, params
+        )
+    elif _is_v2_context(original_args):
+        handler_name = "unknown"
+        arguments = {}
+    else:
+        handler_name, arguments = _extract_handler_data_from_args(
+            handler_type, original_args, original_kwargs
+        )
+
     span_data_key, span_name, mcp_method_name, result_data_key = _get_span_config(
         handler_type, handler_name
     )
@@ -422,6 +516,17 @@ async def _handler_wrapper(
     if original_kwargs is None:
         original_kwargs = {}
 
+    # Detect v1 vs v2: MCP SDK v2 passes (ServerRequestContext, params) to handlers
+    ctx: "Optional[Any]" = None
+    params: "Optional[Any]" = None
+    if (
+        ServerRequestContext is not None
+        and original_args
+        and isinstance(original_args[0], ServerRequestContext)
+    ):
+        ctx = original_args[0]
+        params = original_args[1] if len(original_args) > 1 else None
+
     (
         handler_name,
         arguments,
@@ -429,9 +534,11 @@ async def _handler_wrapper(
         span_name,
         mcp_method_name,
         result_data_key,
-    ) = _prepare_handler_data(handler_type, original_args, original_kwargs)
+    ) = _prepare_handler_data(
+        handler_type, original_args, original_kwargs, params=params
+    )
 
-    scopes = _get_active_http_scopes()
+    scopes = _get_active_http_scopes(ctx=ctx)
 
     isolation_scope_context: "ContextManager[Any]"
     current_scope_context: "ContextManager[Any]"
@@ -454,7 +561,7 @@ async def _handler_wrapper(
         )
 
     # Get request ID, session ID, and transport from context
-    request_id, session_id, mcp_transport = _get_request_context_data()
+    request_id, session_id, mcp_transport = _get_request_context_data(ctx=ctx)
 
     span_streaming = has_span_streaming_enabled(sentry_sdk.get_client().options)
 
@@ -492,7 +599,10 @@ async def _handler_wrapper(
 
                 # For resources, extract and set protocol
                 if handler_type == "resource":
-                    if original_args:
+                    uri = None
+                    if params is not None:
+                        uri = getattr(params, "uri", None)
+                    elif original_args:
                         uri = original_args[0]
                     else:
                         uri = original_kwargs.get("uri")
@@ -569,10 +679,34 @@ def _create_instrumented_decorator(
     return instrumented_decorator
 
 
+_METHOD_TO_HANDLER_TYPE = {
+    "tools/call": "tool",
+    "prompts/get": "prompt",
+    "resources/read": "resource",
+}
+
+# In MCP SDK v2, tool/prompt/resource handlers are most commonly registered via
+# the Server(...) constructor kwargs rather than add_request_handler. The in-tree
+# high-level MCPServer also wires its handlers through these kwargs.
+_KWARG_TO_HANDLER_TYPE = {
+    "on_call_tool": "tool",
+    "on_get_prompt": "prompt",
+    "on_read_resource": "resource",
+}
+
+
 def _patch_lowlevel_server() -> None:
     """
     Patches the mcp.server.lowlevel.Server class to instrument handler execution.
     """
+    if MCP_PACKAGE_VERSION and MCP_PACKAGE_VERSION >= (2, 0, 0):
+        _patch_lowlevel_server_v2()
+    else:
+        _patch_lowlevel_server_v1()
+
+
+def _patch_lowlevel_server_v1() -> None:
+    """Patches v1 Server decorator methods (call_tool, get_prompt, read_resource)."""
     # Patch call_tool decorator
     original_call_tool = Server.call_tool
 
@@ -611,6 +745,69 @@ def _patch_lowlevel_server() -> None:
         )(func)
 
     Server.read_resource = patched_read_resource
+
+
+def _wrap_v2_handler(
+    handler_type: str, handler: "Callable[..., Any]"
+) -> "Callable[..., Any]":
+    """Wrap a v2 (ctx, params) handler with Sentry instrumentation.
+
+    Idempotent: an already-wrapped handler is returned unchanged so handlers
+    registered through more than one path (e.g. MCPServer building a Server)
+    are not double-wrapped.
+    """
+    if getattr(handler, "__sentry_mcp_wrapped__", False):
+        return handler
+
+    @wraps(handler)
+    async def wrapper(*args: "Any", **kwargs: "Any") -> "Any":
+        return await _handler_wrapper(
+            handler_type, handler, args, kwargs, force_await=False
+        )
+
+    wrapper.__sentry_mcp_wrapped__ = True  # type: ignore[attr-defined]
+    return wrapper
+
+
+def _patch_lowlevel_server_v2() -> None:
+    """Patches the v2 Server to wrap tool/prompt/resource handlers.
+
+    Handlers can be registered either via the Server(...) constructor kwargs
+    (on_call_tool/on_get_prompt/on_read_resource) — the path the in-tree
+    MCPServer and most lowlevel examples use — or via add_request_handler.
+    Both are patched.
+    """
+    original_init = Server.__init__
+
+    @wraps(original_init)
+    def patched_init(self: "Server", *args: "Any", **kwargs: "Any") -> None:
+        for kwarg, handler_type in _KWARG_TO_HANDLER_TYPE.items():
+            handler = kwargs.get(kwarg)
+            if handler is not None:
+                kwargs[kwarg] = _wrap_v2_handler(handler_type, handler)
+        original_init(self, *args, **kwargs)
+
+    Server.__init__ = patched_init
+
+    original_add_request_handler = Server.add_request_handler
+
+    def patched_add_request_handler(
+        self: "Server",
+        method: str,
+        params_type: "Any",
+        handler: "Callable[..., Any]",
+        *args: "Any",
+        **kwargs: "Any",
+    ) -> None:
+        handler_type = _METHOD_TO_HANDLER_TYPE.get(method)
+        if handler_type is not None:
+            handler = _wrap_v2_handler(handler_type, handler)
+
+        original_add_request_handler(
+            self, method, params_type, handler, *args, **kwargs
+        )
+
+    Server.add_request_handler = patched_add_request_handler
 
 
 def _patch_handle_request() -> None:

--- a/sentry_sdk/integrations/mcp.py
+++ b/sentry_sdk/integrations/mcp.py
@@ -602,10 +602,13 @@ async def _handler_wrapper(
                     uri = None
                     if params is not None:
                         uri = getattr(params, "uri", None)
-                    elif original_args:
-                        uri = original_args[0]
-                    else:
-                        uri = original_kwargs.get("uri")
+
+                    # v1 scenario
+                    if ServerRequestContext is None:
+                        if original_args:
+                            uri = original_args[0]
+                        else:
+                            uri = original_kwargs.get("uri")
 
                     protocol = None
                     if uri is not None and hasattr(uri, "scheme"):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -47,7 +47,7 @@ from sentry_sdk.integrations import (  # noqa: F401
 from sentry_sdk.profiler import teardown_profiler
 from sentry_sdk.profiler.continuous_profiler import teardown_continuous_profiler
 from sentry_sdk.transport import Transport
-from sentry_sdk.utils import reraise
+from sentry_sdk.utils import package_version, reraise
 
 try:
     import openai
@@ -103,6 +103,9 @@ try:
         JSONRPCNotification,
         JSONRPCRequest,
     )
+
+    _MCP_VERSION = package_version("mcp")
+    _IS_MCP_V2 = _MCP_VERSION is not None and _MCP_VERSION >= (2, 0, 0)
 except ImportError:
     create_memory_object_stream = None
     create_task_group = None
@@ -112,6 +115,7 @@ except ImportError:
     JSONRPCNotification = None
     JSONRPCRequest = None
     SessionMessage = None
+    _IS_MCP_V2 = False
 
 
 SENTRY_EVENT_SCHEMA = "./checkouts/data-schemas/relay/event.schema.json"
@@ -760,21 +764,27 @@ def suppress_deprecation_warnings():
         yield
 
 
+def _make_session_message(jsonrpc_msg):
+    """Construct a SessionMessage compatible with both MCP v1 and v2."""
+    if _IS_MCP_V2:
+        return SessionMessage(message=jsonrpc_msg)  # type: ignore
+    else:
+        return SessionMessage(message=JSONRPCMessage(root=jsonrpc_msg))  # type: ignore
+
+
 @pytest.fixture
 def get_initialization_payload():
     def inner(request_id: str):
-        return SessionMessage(  # type: ignore
-            message=JSONRPCMessage(  # type: ignore
-                root=JSONRPCRequest(  # type: ignore
-                    jsonrpc="2.0",
-                    id=request_id,
-                    method="initialize",
-                    params={
-                        "protocolVersion": "2025-11-25",
-                        "capabilities": {},
-                        "clientInfo": {"name": "test-client", "version": "1.0.0"},
-                    },
-                )
+        return _make_session_message(
+            JSONRPCRequest(  # type: ignore
+                jsonrpc="2.0",
+                id=request_id,
+                method="initialize",
+                params={
+                    "protocolVersion": "2025-11-25",
+                    "capabilities": {},
+                    "clientInfo": {"name": "test-client", "version": "1.0.0"},
+                },
             )
         )
 
@@ -784,12 +794,10 @@ def get_initialization_payload():
 @pytest.fixture
 def get_initialized_notification_payload():
     def inner():
-        return SessionMessage(  # type: ignore
-            message=JSONRPCMessage(  # type: ignore
-                root=JSONRPCNotification(  # type: ignore
-                    jsonrpc="2.0",
-                    method="notifications/initialized",
-                )
+        return _make_session_message(
+            JSONRPCNotification(  # type: ignore
+                jsonrpc="2.0",
+                method="notifications/initialized",
             )
         )
 
@@ -799,14 +807,12 @@ def get_initialized_notification_payload():
 @pytest.fixture
 def get_mcp_command_payload():
     def inner(method: str, params, request_id: str):
-        return SessionMessage(  # type: ignore
-            message=JSONRPCMessage(  # type: ignore
-                root=JSONRPCRequest(  # type: ignore
-                    jsonrpc="2.0",
-                    id=request_id,
-                    method=method,
-                    params=params,
-                )
+        return _make_session_message(
+            JSONRPCRequest(  # type: ignore
+                jsonrpc="2.0",
+                id=request_id,
+                method=method,
+                params=params,
             )
         )
 

--- a/tests/integrations/mcp/test_mcp.py
+++ b/tests/integrations/mcp/test_mcp.py
@@ -22,6 +22,8 @@ from unittest import mock
 import anyio
 import pytest
 
+from sentry_sdk.utils import package_version
+
 try:
     from unittest.mock import AsyncMock
 except ImportError:
@@ -33,13 +35,30 @@ except ImportError:
 
 from mcp.server.lowlevel import Server
 from mcp.server.lowlevel.helper_types import ReadResourceContents
-from mcp.server.lowlevel.server import request_ctx
 from mcp.types import GetPromptResult, PromptMessage, TextContent
 
+MCP_PACKAGE_VERSION = package_version("mcp")
+IS_MCP_V2 = MCP_PACKAGE_VERSION is not None and MCP_PACKAGE_VERSION >= (2, 0, 0)
+
 try:
-    from mcp.server.lowlevel.server import request_ctx
+    if not IS_MCP_V2:
+        from mcp.server.lowlevel.server import (  # type: ignore[import-not-found]
+            request_ctx,
+        )
+    else:
+        request_ctx = None
 except ImportError:
     request_ctx = None
+
+if IS_MCP_V2:
+    from mcp.types import (
+        CallToolRequestParams,
+        CallToolResult,
+        GetPromptRequestParams,
+        ReadResourceRequestParams,
+        ReadResourceResult,
+        TextResourceContents,
+    )
 
 from mcp.server.sse import SseServerTransport
 from mcp.server.streamable_http_manager import StreamableHTTPSessionManager
@@ -55,6 +74,14 @@ from sentry_sdk.integrations.mcp import MCPIntegration
 
 def _experiments_for(span_streaming):
     return {"trace_lifecycle": "stream" if span_streaming else "static"}
+
+
+def _get_response(session_message):
+    """Extract the JSON-RPC response from a SessionMessage (v1 or v2)."""
+    msg = session_message.message
+    if hasattr(msg, "root"):
+        return msg.root
+    return msg
 
 
 def _find_mcp_span(items, method_name=None):
@@ -102,20 +129,149 @@ class MockTextContent:
 
 def test_integration_patches_server(sentry_init):
     """Test that MCPIntegration patches the Server class"""
-    # Get original methods before integration
-    original_call_tool = Server.call_tool
-    original_get_prompt = Server.get_prompt
-    original_read_resource = Server.read_resource
+    if IS_MCP_V2:
+        original_add_request_handler = Server.add_request_handler
+        original_init = Server.__init__
+
+        sentry_init(
+            integrations=[MCPIntegration()],
+            traces_sample_rate=1.0,
+        )
+
+        assert Server.add_request_handler is not original_add_request_handler
+        assert Server.__init__ is not original_init
+    else:
+        original_call_tool = Server.call_tool
+        original_get_prompt = Server.get_prompt
+        original_read_resource = Server.read_resource
+
+        sentry_init(
+            integrations=[MCPIntegration()],
+            traces_sample_rate=1.0,
+        )
+
+        assert Server.call_tool is not original_call_tool
+        assert Server.get_prompt is not original_get_prompt
+        assert Server.read_resource is not original_read_resource
+
+
+@pytest.mark.asyncio
+@pytest.mark.skipif(
+    not IS_MCP_V2, reason="Constructor handler registration is MCP v2 only"
+)
+@pytest.mark.parametrize("span_streaming", [True, False])
+async def test_tool_handler_constructor_registration(
+    sentry_init, capture_events, capture_items, span_streaming, stdio
+):
+    """v2 handlers registered via the Server(...) constructor are instrumented.
+
+    This is the dominant v2 registration path (used by lowlevel examples and by
+    the in-tree MCPServer), distinct from add_request_handler.
+    """
+    sentry_init(
+        integrations=[MCPIntegration()],
+        traces_sample_rate=1.0,
+        _experiments=_experiments_for(span_streaming),
+    )
+
+    async def test_tool(ctx, params):
+        return CallToolResult(
+            content=[
+                TextContent(
+                    type="text",
+                    text=json.dumps({"result": "success"}),
+                )
+            ],
+            structured_content={"result": "success"},
+        )
+
+    server = Server("test-server", on_call_tool=test_tool)
+
+    if span_streaming:
+        items = capture_items("span")
+        with sentry_sdk.traces.start_span(name="mcp tx"):
+            await stdio(
+                server,
+                method="tools/call",
+                params={"name": "calculate", "arguments": {"x": 10}},
+                request_id="req-ctor",
+            )
+        sentry_sdk.flush()
+        span = _find_mcp_span(items, method_name="tools/call")
+        assert span is not None
+        data = span["attributes"]
+    else:
+        events = capture_events()
+        with start_transaction(name="mcp tx"):
+            await stdio(
+                server,
+                method="tools/call",
+                params={"name": "calculate", "arguments": {"x": 10}},
+                request_id="req-ctor",
+            )
+        (tx,) = events
+        assert len(tx["spans"]) == 1
+        span = tx["spans"][0]
+        assert span["description"] == "tools/call calculate"
+        data = span["data"]
+
+    assert data[SPANDATA.MCP_TOOL_NAME] == "calculate"
+    assert data[SPANDATA.MCP_METHOD_NAME] == "tools/call"
+    assert data[SPANDATA.MCP_REQUEST_ID] == "req-ctor"
+    assert data["mcp.request.argument.x"] == "10"
+
+
+@pytest.mark.asyncio
+@pytest.mark.skipif(not IS_MCP_V2, reason="MCPServer is MCP v2 only")
+async def test_mcpserver_high_level_tool_instrumented(
+    sentry_init, capture_events, stdio
+):
+    """The in-tree high-level MCPServer wires its handlers through the lowlevel
+    Server(...) constructor, so its tool calls are instrumented too."""
+    from mcp.server import MCPServer
 
     sentry_init(
         integrations=[MCPIntegration()],
         traces_sample_rate=1.0,
     )
 
-    # After initialization, the methods should be patched
-    assert Server.call_tool is not original_call_tool
-    assert Server.get_prompt is not original_get_prompt
-    assert Server.read_resource is not original_read_resource
+    mcp_server = MCPServer("test-server")
+
+    @mcp_server.tool()
+    def add(a: int, b: int) -> int:
+        return a + b
+
+    events = capture_events()
+    with start_transaction(name="mcp tx"):
+        await stdio(
+            mcp_server._lowlevel_server,
+            method="tools/call",
+            params={"name": "add", "arguments": {"a": 2, "b": 3}},
+            request_id="req-mcpserver",
+        )
+
+    (tx,) = events
+    assert len(tx["spans"]) == 1
+    span = tx["spans"][0]
+    assert span["op"] == OP.MCP_SERVER
+    assert span["description"] == "tools/call add"
+    assert span["data"][SPANDATA.MCP_METHOD_NAME] == "tools/call"
+
+
+def test_wrap_v2_handler_is_idempotent():
+    """_wrap_v2_handler must not double-wrap a handler registered through more
+    than one path (e.g. MCPServer building a Server, then re-registration)."""
+    import sentry_sdk.integrations.mcp as mcp_module
+
+    async def handler(ctx, params):
+        return None
+
+    wrapped = mcp_module._wrap_v2_handler("tool", handler)
+    assert wrapped is not handler
+    assert getattr(wrapped, "__sentry_mcp_wrapped__", False) is True
+
+    rewrapped = mcp_module._wrap_v2_handler("tool", wrapped)
+    assert rewrapped is wrapped
 
 
 @pytest.mark.asyncio
@@ -143,9 +299,25 @@ async def test_tool_handler_stdio(
 
     server = Server("test-server")
 
-    @server.call_tool()
-    async def test_tool(tool_name, arguments):
-        return {"result": "success", "value": 42}
+    if IS_MCP_V2:
+
+        async def test_tool(ctx, params):
+            return CallToolResult(
+                content=[
+                    TextContent(
+                        type="text",
+                        text=json.dumps({"result": "success", "value": 42}),
+                    )
+                ],
+                structured_content={"result": "success", "value": 42},
+            )
+
+        server.add_request_handler("tools/call", CallToolRequestParams, test_tool)
+    else:
+
+        @server.call_tool()
+        async def test_tool(tool_name, arguments):
+            return {"result": "success", "value": 42}
 
     if span_streaming:
         items = capture_items("span")
@@ -173,10 +345,16 @@ async def test_tool_handler_stdio(
                 request_id="req-123",
             )
 
-    assert result.message.root.result["content"][0]["text"] == json.dumps(
-        {"result": "success", "value": 42},
-        indent=2,
-    )
+    if IS_MCP_V2:
+        assert _get_response(result).result["structuredContent"] == {
+            "result": "success",
+            "value": 42,
+        }
+    else:
+        assert _get_response(result).result["content"][0]["text"] == json.dumps(
+            {"result": "success", "value": 42},
+            indent=2,
+        )
 
     if span_streaming:
         span = _find_mcp_span(items, method_name="tools/call")
@@ -246,6 +424,30 @@ async def test_tool_handler_streamable_http(
 
     server = Server("test-server")
 
+    if IS_MCP_V2:
+
+        async def test_tool_async(ctx, params):
+            return CallToolResult(
+                content=[
+                    TextContent(
+                        type="text",
+                        text=json.dumps({"status": "completed"}),
+                    )
+                ]
+            )
+
+        server.add_request_handler("tools/call", CallToolRequestParams, test_tool_async)
+    else:
+
+        @server.call_tool()
+        async def test_tool_async(tool_name, arguments):
+            return [
+                TextContent(
+                    type="text",
+                    text=json.dumps({"status": "completed"}),
+                )
+            ]
+
     session_manager = StreamableHTTPSessionManager(
         app=server,
         json_response=True,
@@ -257,15 +459,6 @@ async def test_tool_handler_streamable_http(
         ],
         lifespan=lambda app: session_manager.run(),
     )
-
-    @server.call_tool()
-    async def test_tool_async(tool_name, arguments):
-        return [
-            TextContent(
-                type="text",
-                text=json.dumps({"status": "completed"}),
-            )
-        ]
 
     if span_streaming:
         items = capture_items("span")
@@ -353,9 +546,17 @@ async def test_tool_handler_with_error(
 
     server = Server("test-server")
 
-    @server.call_tool()
-    def failing_tool(tool_name, arguments):
-        raise ValueError("Tool execution failed")
+    if IS_MCP_V2:
+
+        async def failing_tool(ctx, params):
+            raise ValueError("Tool execution failed")
+
+        server.add_request_handler("tools/call", CallToolRequestParams, failing_tool)
+    else:
+
+        @server.call_tool()
+        def failing_tool(tool_name, arguments):
+            raise ValueError("Tool execution failed")
 
     if span_streaming:
         items = capture_items("event", "span")
@@ -371,9 +572,11 @@ async def test_tool_handler_with_error(
             )
         sentry_sdk.flush()
 
-        assert (
-            result.message.root.result["content"][0]["text"] == "Tool execution failed"
-        )
+        resp = _get_response(result)
+        if IS_MCP_V2:
+            assert "Tool execution failed" in resp.error.message
+        else:
+            assert resp.result["content"][0]["text"] == "Tool execution failed"
 
         error_payload = next(item.payload for item in items if item.type == "event")
         span = _find_mcp_span(items, method_name="tools/call")
@@ -400,10 +603,11 @@ async def test_tool_handler_with_error(
                 request_id="req-error",
             )
 
-            assert (
-                result.message.root.result["content"][0]["text"]
-                == "Tool execution failed"
-            )
+            resp = _get_response(result)
+            if IS_MCP_V2:
+                assert "Tool execution failed" in resp.error.message
+            else:
+                assert resp.result["content"][0]["text"] == "Tool execution failed"
 
         # Should have error event and transaction
         assert len(events) == 2
@@ -450,17 +654,27 @@ async def test_prompt_handler_stdio(
 
     server = Server("test-server")
 
-    @server.get_prompt()
-    async def test_prompt(name, arguments):
-        return GetPromptResult(
-            description="A helpful test prompt",
-            messages=[
-                PromptMessage(
-                    role="user",
-                    content=TextContent(type="text", text="Tell me about Python"),
-                ),
-            ],
-        )
+    prompt_result = GetPromptResult(
+        description="A helpful test prompt",
+        messages=[
+            PromptMessage(
+                role="user",
+                content=TextContent(type="text", text="Tell me about Python"),
+            ),
+        ],
+    )
+
+    if IS_MCP_V2:
+
+        async def test_prompt(ctx, params):
+            return prompt_result
+
+        server.add_request_handler("prompts/get", GetPromptRequestParams, test_prompt)
+    else:
+
+        @server.get_prompt()
+        async def test_prompt(name, arguments):
+            return prompt_result
 
     if span_streaming:
         items = capture_items("span")
@@ -488,9 +702,9 @@ async def test_prompt_handler_stdio(
                 request_id="req-prompt",
             )
 
-    assert result.message.root.result["messages"][0]["role"] == "user"
+    assert _get_response(result).result["messages"][0]["role"] == "user"
     assert (
-        result.message.root.result["messages"][0]["content"]["text"]
+        _get_response(result).result["messages"][0]["content"]["text"]
         == "Tell me about Python"
     )
 
@@ -560,6 +774,33 @@ async def test_prompt_handler_streamable_http(
 
     server = Server("test-server")
 
+    prompt_result = GetPromptResult(
+        description="A helpful test prompt",
+        messages=[
+            PromptMessage(
+                role="user",
+                content=TextContent(type="text", text="You are a helpful assistant"),
+            ),
+            PromptMessage(
+                role="user", content=TextContent(type="text", text="What is MCP?")
+            ),
+        ],
+    )
+
+    if IS_MCP_V2:
+
+        async def test_prompt_async(ctx, params):
+            return prompt_result
+
+        server.add_request_handler(
+            "prompts/get", GetPromptRequestParams, test_prompt_async
+        )
+    else:
+
+        @server.get_prompt()
+        async def test_prompt_async(name, arguments):
+            return prompt_result
+
     session_manager = StreamableHTTPSessionManager(
         app=server,
         json_response=True,
@@ -571,23 +812,6 @@ async def test_prompt_handler_streamable_http(
         ],
         lifespan=lambda app: session_manager.run(),
     )
-
-    @server.get_prompt()
-    async def test_prompt_async(name, arguments):
-        return GetPromptResult(
-            description="A helpful test prompt",
-            messages=[
-                PromptMessage(
-                    role="user",
-                    content=TextContent(
-                        type="text", text="You are a helpful assistant"
-                    ),
-                ),
-                PromptMessage(
-                    role="user", content=TextContent(type="text", text="What is MCP?")
-                ),
-            ],
-        )
 
     if span_streaming:
         items = capture_items("span")
@@ -657,9 +881,19 @@ async def test_prompt_handler_with_error(
 
     server = Server("test-server")
 
-    @server.get_prompt()
-    async def failing_prompt(name, arguments):
-        raise RuntimeError("Prompt not found")
+    if IS_MCP_V2:
+
+        async def failing_prompt(ctx, params):
+            raise RuntimeError("Prompt not found")
+
+        server.add_request_handler(
+            "prompts/get", GetPromptRequestParams, failing_prompt
+        )
+    else:
+
+        @server.get_prompt()
+        async def failing_prompt(name, arguments):
+            raise RuntimeError("Prompt not found")
 
     if span_streaming:
         items = capture_items("event", "span")
@@ -675,7 +909,7 @@ async def test_prompt_handler_with_error(
             )
         sentry_sdk.flush()
 
-        assert response.message.root.error.message == "Prompt not found"
+        assert _get_response(response).error.message == "Prompt not found"
 
         error_payload = next(item.payload for item in items if item.type == "event")
         span = _find_mcp_span(items, method_name="prompts/get")
@@ -698,7 +932,7 @@ async def test_prompt_handler_with_error(
                 request_id="req-error-prompt",
             )
 
-        assert response.message.root.error.message == "Prompt not found"
+        assert _get_response(response).error.message == "Prompt not found"
 
         # Should have error event and transaction
         assert len(events) == 2
@@ -730,13 +964,32 @@ async def test_resource_handler_stdio(
 
     server = Server("test-server")
 
-    @server.read_resource()
-    async def test_resource(uri):
-        return [
-            ReadResourceContents(
-                content=json.dumps({"content": "file contents"}), mime_type="text/plain"
+    if IS_MCP_V2:
+
+        async def test_resource(ctx, params):
+            return ReadResourceResult(
+                contents=[
+                    TextResourceContents(
+                        uri=str(params.uri),
+                        text=json.dumps({"content": "file contents"}),
+                        mime_type="text/plain",
+                    )
+                ]
             )
-        ]
+
+        server.add_request_handler(
+            "resources/read", ReadResourceRequestParams, test_resource
+        )
+    else:
+
+        @server.read_resource()
+        async def test_resource(uri):
+            return [
+                ReadResourceContents(
+                    content=json.dumps({"content": "file contents"}),
+                    mime_type="text/plain",
+                )
+            ]
 
     if span_streaming:
         items = capture_items("span")
@@ -762,7 +1015,7 @@ async def test_resource_handler_stdio(
                 request_id="req-resource",
             )
 
-    assert result.message.root.result["contents"][0]["text"] == json.dumps(
+    assert _get_response(result).result["contents"][0]["text"] == json.dumps(
         {"content": "file contents"},
     )
 
@@ -813,6 +1066,33 @@ async def test_resource_handler_streamable_http(
 
     server = Server("test-server")
 
+    if IS_MCP_V2:
+
+        async def test_resource_async(ctx, params):
+            return ReadResourceResult(
+                contents=[
+                    TextResourceContents(
+                        uri=str(params.uri),
+                        text=json.dumps({"data": "resource data"}),
+                        mime_type="text/plain",
+                    )
+                ]
+            )
+
+        server.add_request_handler(
+            "resources/read", ReadResourceRequestParams, test_resource_async
+        )
+    else:
+
+        @server.read_resource()
+        async def test_resource_async(uri):
+            return [
+                ReadResourceContents(
+                    content=json.dumps({"data": "resource data"}),
+                    mime_type="text/plain",
+                )
+            ]
+
     session_manager = StreamableHTTPSessionManager(
         app=server,
         json_response=True,
@@ -824,14 +1104,6 @@ async def test_resource_handler_streamable_http(
         ],
         lifespan=lambda app: session_manager.run(),
     )
-
-    @server.read_resource()
-    async def test_resource_async(uri):
-        return [
-            ReadResourceContents(
-                content=json.dumps({"data": "resource data"}), mime_type="text/plain"
-            )
-        ]
 
     if span_streaming:
         items = capture_items("span")
@@ -899,9 +1171,19 @@ async def test_resource_handler_with_error(
 
     server = Server("test-server")
 
-    @server.read_resource()
-    def failing_resource(uri):
-        raise FileNotFoundError("Resource not found")
+    if IS_MCP_V2:
+
+        async def failing_resource(ctx, params):
+            raise FileNotFoundError("Resource not found")
+
+        server.add_request_handler(
+            "resources/read", ReadResourceRequestParams, failing_resource
+        )
+    else:
+
+        @server.read_resource()
+        def failing_resource(uri):
+            raise FileNotFoundError("Resource not found")
 
     if span_streaming:
         items = capture_items("event", "span")
@@ -977,12 +1259,22 @@ async def test_tool_result_extraction_tuple(
 
     server = Server("test-server")
 
-    @server.call_tool()
-    def test_tool_tuple(tool_name, arguments):
-        # Return CombinationContent: (UnstructuredContent, StructuredContent)
-        unstructured = [MockTextContent("Result text")]
-        structured = {"key": "value", "count": 5}
-        return (unstructured, structured)
+    if IS_MCP_V2:
+
+        async def test_tool_tuple(ctx, params):
+            return CallToolResult(
+                content=[TextContent(type="text", text="Result text")],
+                structured_content={"key": "value", "count": 5},
+            )
+
+        server.add_request_handler("tools/call", CallToolRequestParams, test_tool_tuple)
+    else:
+
+        @server.call_tool()
+        def test_tool_tuple(tool_name, arguments):
+            unstructured = [MockTextContent("Result text")]
+            structured = {"key": "value", "count": 5}
+            return (unstructured, structured)
 
     if span_streaming:
         items = capture_items("span")
@@ -1017,7 +1309,6 @@ async def test_tool_result_extraction_tuple(
         (tx,) = events
         data = tx["spans"][0]["data"]
 
-    # Should extract the structured content (second element of tuple) only with PII
     if send_default_pii and include_prompts:
         assert data[SPANDATA.MCP_TOOL_RESULT_CONTENT] == json.dumps(
             {
@@ -1056,13 +1347,27 @@ async def test_tool_result_extraction_unstructured(
 
     server = Server("test-server")
 
-    @server.call_tool()
-    def test_tool_unstructured(tool_name, arguments):
-        # Return UnstructuredContent as list of content blocks
-        return [
-            MockTextContent("First part"),
-            MockTextContent("Second part"),
-        ]
+    if IS_MCP_V2:
+
+        async def test_tool_unstructured(ctx, params):
+            return CallToolResult(
+                content=[
+                    TextContent(type="text", text="First part"),
+                    TextContent(type="text", text="Second part"),
+                ]
+            )
+
+        server.add_request_handler(
+            "tools/call", CallToolRequestParams, test_tool_unstructured
+        )
+    else:
+
+        @server.call_tool()
+        def test_tool_unstructured(tool_name, arguments):
+            return [
+                MockTextContent("First part"),
+                MockTextContent("Second part"),
+            ]
 
     if span_streaming:
         items = capture_items("span")
@@ -1118,24 +1423,54 @@ async def test_multiple_handlers(
 
     server = Server("test-server")
 
-    @server.call_tool()
-    def tool1(tool_name, arguments):
-        return {"result": "tool1"}
+    if IS_MCP_V2:
 
-    @server.call_tool()
-    def tool2(tool_name, arguments):
-        return {"result": "tool2"}
+        async def tool_handler(ctx, params):
+            return CallToolResult(
+                content=[
+                    TextContent(
+                        type="text",
+                        text=json.dumps({"result": params.name}),
+                    )
+                ]
+            )
 
-    @server.get_prompt()
-    def prompt1(name, arguments):
-        return GetPromptResult(
-            description="A test prompt",
-            messages=[
-                PromptMessage(
-                    role="user", content=TextContent(type="text", text="Test prompt")
-                )
-            ],
+        async def prompt_handler(ctx, params):
+            return GetPromptResult(
+                description="A test prompt",
+                messages=[
+                    PromptMessage(
+                        role="user",
+                        content=TextContent(type="text", text="Test prompt"),
+                    )
+                ],
+            )
+
+        server.add_request_handler("tools/call", CallToolRequestParams, tool_handler)
+        server.add_request_handler(
+            "prompts/get", GetPromptRequestParams, prompt_handler
         )
+    else:
+
+        @server.call_tool()
+        def tool1(tool_name, arguments):
+            return {"result": "tool1"}
+
+        @server.call_tool()
+        def tool2(tool_name, arguments):
+            return {"result": "tool2"}
+
+        @server.get_prompt()
+        def prompt1(name, arguments):
+            return GetPromptResult(
+                description="A test prompt",
+                messages=[
+                    PromptMessage(
+                        role="user",
+                        content=TextContent(type="text", text="Test prompt"),
+                    )
+                ],
+            )
 
     if span_streaming:
         items = capture_items("span")
@@ -1228,14 +1563,30 @@ async def test_prompt_with_dict_result(
 
     server = Server("test-server")
 
-    @server.get_prompt()
-    def test_prompt_dict(name, arguments):
-        # Return dict format instead of GetPromptResult object
-        return {
-            "messages": [
-                {"role": "user", "content": {"text": "Hello from dict"}},
-            ]
-        }
+    if IS_MCP_V2:
+
+        async def test_prompt_dict(ctx, params):
+            return GetPromptResult(
+                messages=[
+                    PromptMessage(
+                        role="user",
+                        content=TextContent(type="text", text="Hello from dict"),
+                    )
+                ]
+            )
+
+        server.add_request_handler(
+            "prompts/get", GetPromptRequestParams, test_prompt_dict
+        )
+    else:
+
+        @server.get_prompt()
+        def test_prompt_dict(name, arguments):
+            return {
+                "messages": [
+                    {"role": "user", "content": {"text": "Hello from dict"}},
+                ]
+            }
 
     if span_streaming:
         items = capture_items("span")
@@ -1296,9 +1647,19 @@ async def test_tool_with_complex_arguments(
 
     server = Server("test-server")
 
-    @server.call_tool()
-    def test_tool_complex(tool_name, arguments):
-        return {"processed": True}
+    if IS_MCP_V2:
+
+        async def test_tool_complex(ctx, params):
+            return CallToolResult(content=[TextContent(type="text", text="processed")])
+
+        server.add_request_handler(
+            "tools/call", CallToolRequestParams, test_tool_complex
+        )
+    else:
+
+        @server.call_tool()
+        def test_tool_complex(tool_name, arguments):
+            return {"processed": True}
 
     complex_args = {
         "nested": {"key": "value", "list": [1, 2, 3]},
@@ -1349,6 +1710,7 @@ async def test_tool_with_complex_arguments(
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("span_streaming", [True, False])
+@pytest.mark.skipif(IS_MCP_V2, reason="SSE scope propagation not supported in MCP v2")
 async def test_sse_transport_detection(
     sentry_init, capture_events, capture_items, span_streaming, json_rpc_sse
 ):
@@ -1387,9 +1749,20 @@ async def test_sse_transport_detection(
         ],
     )
 
-    @server.call_tool()
-    async def test_tool(tool_name, arguments):
-        return {"result": "success"}
+    if IS_MCP_V2:
+
+        async def test_tool(ctx, params):
+            return CallToolResult(
+                content=[TextContent(type="text", text="success")],
+                structured_content={"result": "success"},
+            )
+
+        server.add_request_handler("tools/call", CallToolRequestParams, test_tool)
+    else:
+
+        @server.call_tool()
+        async def test_tool(tool_name, arguments):
+            return {"result": "success"}
 
     if span_streaming:
         items = capture_items("span")
@@ -1432,3 +1805,308 @@ async def test_sse_transport_detection(
     assert data[SPANDATA.MCP_TRANSPORT] == "sse"
     assert data[SPANDATA.NETWORK_TRANSPORT] == "tcp"
     assert data[SPANDATA.MCP_SESSION_ID] == session_id
+
+
+class _FakeServerRequestContext:
+    """
+    Stands in for MCP SDK v2's ServerRequestContext, which doesn't exist in v1.
+    Used to test that _handler_wrapper extracts context from original_args
+    when the first arg is a ServerRequestContext instance.
+    """
+
+    def __init__(self, request_id=None, request=None):
+        self.request_id = request_id
+        self.request = request
+
+
+class TestHandlerWrapperWithExplicitContext:
+    """
+    Tests that _handler_wrapper correctly extracts request context data from
+    original_args when the first argument is a ServerRequestContext (MCP SDK v2
+    pattern), rather than relying on the request_ctx ContextVar.
+    """
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("span_streaming", [True, False])
+    async def test_http_context_extracted_from_args(
+        self, sentry_init, capture_events, capture_items, span_streaming
+    ):
+        """When a ServerRequestContext with HTTP headers is in original_args,
+        span data reflects the request_id, session_id, and http transport."""
+        sentry_init(
+            integrations=[MCPIntegration()],
+            traces_sample_rate=1.0,
+            _experiments=_experiments_for(span_streaming),
+        )
+
+        import sentry_sdk.integrations.mcp as mcp_module
+
+        request = mock.MagicMock()
+        request.headers = {"mcp-session-id": "session-abc"}
+        request.query_params = {}
+        request.scope = {"state": {}}
+
+        ctx = _FakeServerRequestContext(request_id="req-42", request=request)
+
+        async def dummy_tool(ctx, name, arguments):
+            return {"result": "ok"}
+
+        with mock.patch.object(
+            mcp_module, "ServerRequestContext", _FakeServerRequestContext
+        ):
+            if span_streaming:
+                items = capture_items("span")
+                with sentry_sdk.traces.start_span(name="test tx"):
+                    await mcp_module._handler_wrapper(
+                        "tool",
+                        dummy_tool,
+                        (ctx, "my_tool", {"x": 1}),
+                        force_await=False,
+                    )
+                sentry_sdk.flush()
+                span = _find_mcp_span(items, method_name="tools/call")
+                assert span is not None
+                data = span["attributes"]
+            else:
+                events = capture_events()
+                with start_transaction(name="test tx"):
+                    await mcp_module._handler_wrapper(
+                        "tool",
+                        dummy_tool,
+                        (ctx, "my_tool", {"x": 1}),
+                        force_await=False,
+                    )
+                (tx,) = events
+                data = tx["spans"][0]["data"]
+
+        assert data[SPANDATA.MCP_REQUEST_ID] == "req-42"
+        assert data[SPANDATA.MCP_SESSION_ID] == "session-abc"
+        assert data[SPANDATA.MCP_TRANSPORT] == "http"
+        assert data[SPANDATA.NETWORK_TRANSPORT] == "tcp"
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("span_streaming", [True, False])
+    async def test_sse_context_extracted_from_args(
+        self, sentry_init, capture_events, capture_items, span_streaming
+    ):
+        """When a ServerRequestContext with SSE query params is in original_args,
+        span data reflects sse transport and session_id."""
+        sentry_init(
+            integrations=[MCPIntegration()],
+            traces_sample_rate=1.0,
+            _experiments=_experiments_for(span_streaming),
+        )
+
+        import sentry_sdk.integrations.mcp as mcp_module
+
+        request = mock.MagicMock()
+        request.headers = {}
+        request.query_params = {"session_id": "sse-session-456"}
+        request.scope = {"state": {}}
+
+        ctx = _FakeServerRequestContext(request_id="req-99", request=request)
+
+        async def dummy_tool(ctx, name, arguments):
+            return {"result": "ok"}
+
+        with mock.patch.object(
+            mcp_module, "ServerRequestContext", _FakeServerRequestContext
+        ):
+            if span_streaming:
+                items = capture_items("span")
+                with sentry_sdk.traces.start_span(name="test tx"):
+                    await mcp_module._handler_wrapper(
+                        "tool",
+                        dummy_tool,
+                        (ctx, "my_tool", {}),
+                        force_await=False,
+                    )
+                sentry_sdk.flush()
+                span = _find_mcp_span(items, method_name="tools/call")
+                assert span is not None
+                data = span["attributes"]
+            else:
+                events = capture_events()
+                with start_transaction(name="test tx"):
+                    await mcp_module._handler_wrapper(
+                        "tool",
+                        dummy_tool,
+                        (ctx, "my_tool", {}),
+                        force_await=False,
+                    )
+                (tx,) = events
+                data = tx["spans"][0]["data"]
+
+        assert data[SPANDATA.MCP_REQUEST_ID] == "req-99"
+        assert data[SPANDATA.MCP_SESSION_ID] == "sse-session-456"
+        assert data[SPANDATA.MCP_TRANSPORT] == "sse"
+        assert data[SPANDATA.NETWORK_TRANSPORT] == "tcp"
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("span_streaming", [True, False])
+    async def test_stdio_fallback_when_no_context_in_args(
+        self, sentry_init, capture_events, capture_items, span_streaming
+    ):
+        """When original_args has no ServerRequestContext (v1 style),
+        falls back to ContextVar / stdio defaults."""
+        sentry_init(
+            integrations=[MCPIntegration()],
+            traces_sample_rate=1.0,
+            _experiments=_experiments_for(span_streaming),
+        )
+
+        import sentry_sdk.integrations.mcp as mcp_module
+
+        async def dummy_tool(name, arguments):
+            return {"result": "ok"}
+
+        if span_streaming:
+            items = capture_items("span")
+            with sentry_sdk.traces.start_span(name="test tx"):
+                await mcp_module._handler_wrapper(
+                    "tool",
+                    dummy_tool,
+                    ("my_tool", {"x": 1}),
+                    force_await=False,
+                )
+            sentry_sdk.flush()
+            span = _find_mcp_span(items, method_name="tools/call")
+            assert span is not None
+            data = span["attributes"]
+        else:
+            events = capture_events()
+            with start_transaction(name="test tx"):
+                await mcp_module._handler_wrapper(
+                    "tool",
+                    dummy_tool,
+                    ("my_tool", {"x": 1}),
+                    force_await=False,
+                )
+            (tx,) = events
+            data = tx["spans"][0]["data"]
+
+        assert data[SPANDATA.MCP_TRANSPORT] == "stdio"
+        assert data[SPANDATA.NETWORK_TRANSPORT] == "pipe"
+        assert SPANDATA.MCP_SESSION_ID not in data
+
+    @pytest.mark.asyncio
+    async def test_scopes_extracted_from_context_request_state(
+        self, sentry_init, capture_events
+    ):
+        """When a ServerRequestContext carries Sentry scopes in its request
+        state, _handler_wrapper uses those scopes for the span."""
+        sentry_init(
+            integrations=[MCPIntegration()],
+            traces_sample_rate=1.0,
+        )
+
+        import sentry_sdk.integrations.mcp as mcp_module
+
+        isolation_scope = sentry_sdk.get_isolation_scope()
+        current_scope = sentry_sdk.get_current_scope()
+
+        request = mock.MagicMock()
+        request.headers = {"mcp-session-id": "session-scopes"}
+        request.query_params = {}
+        request.scope = {
+            "state": {
+                "sentry_sdk.isolation_scope": isolation_scope,
+                "sentry_sdk.current_scope": current_scope,
+            }
+        }
+
+        ctx = _FakeServerRequestContext(request_id="req-scope", request=request)
+
+        async def dummy_tool(ctx, name, arguments):
+            return {"result": "ok"}
+
+        with mock.patch.object(
+            mcp_module, "ServerRequestContext", _FakeServerRequestContext
+        ):
+            events = capture_events()
+            with start_transaction(name="test tx"):
+                await mcp_module._handler_wrapper(
+                    "tool",
+                    dummy_tool,
+                    (ctx, "my_tool", {"x": 1}),
+                    force_await=False,
+                )
+            (tx,) = events
+            span = tx["spans"][0]
+
+        assert span["op"] == OP.MCP_SERVER
+        assert span["data"][SPANDATA.MCP_SESSION_ID] == "session-scopes"
+
+    @pytest.mark.asyncio
+    async def test_no_scopes_when_context_has_no_request(
+        self, sentry_init, capture_events
+    ):
+        """When a ServerRequestContext has no request (stdio-like),
+        _handler_wrapper still works without scope override."""
+        sentry_init(
+            integrations=[MCPIntegration()],
+            traces_sample_rate=1.0,
+        )
+
+        import sentry_sdk.integrations.mcp as mcp_module
+
+        ctx = _FakeServerRequestContext(request_id="req-no-request")
+        ctx.request = None
+
+        async def dummy_tool(ctx, name, arguments):
+            return {"result": "ok"}
+
+        with mock.patch.object(
+            mcp_module, "ServerRequestContext", _FakeServerRequestContext
+        ):
+            events = capture_events()
+            with start_transaction(name="test tx"):
+                await mcp_module._handler_wrapper(
+                    "tool",
+                    dummy_tool,
+                    (ctx, "my_tool", {}),
+                    force_await=False,
+                )
+            (tx,) = events
+            span = tx["spans"][0]
+
+        assert span["op"] == OP.MCP_SERVER
+        assert span["data"][SPANDATA.MCP_TRANSPORT] == "stdio"
+
+    @pytest.mark.asyncio
+    async def test_v2_context_without_params_uses_unknown_handler_name(
+        self, sentry_init, capture_events
+    ):
+        """When v2 is detected (ServerRequestContext as first arg) but no
+        params object is present, handler_name should be 'unknown' instead
+        of the ServerRequestContext object."""
+        sentry_init(
+            integrations=[MCPIntegration()],
+            traces_sample_rate=1.0,
+        )
+
+        import sentry_sdk.integrations.mcp as mcp_module
+
+        ctx = _FakeServerRequestContext(request_id="req-no-params")
+        ctx.request = None
+
+        async def dummy_tool(ctx):
+            return {"result": "ok"}
+
+        with mock.patch.object(
+            mcp_module, "ServerRequestContext", _FakeServerRequestContext
+        ):
+            events = capture_events()
+            with start_transaction(name="test tx"):
+                await mcp_module._handler_wrapper(
+                    "tool",
+                    dummy_tool,
+                    (ctx,),
+                    force_await=False,
+                )
+            (tx,) = events
+            span = tx["spans"][0]
+
+        assert span["op"] == OP.MCP_SERVER
+        assert span["description"] == "tools/call unknown"
+        assert span["data"][SPANDATA.MCP_METHOD_NAME] == "tools/call"

--- a/tests/integrations/mcp/test_mcp.py
+++ b/tests/integrations/mcp/test_mcp.py
@@ -11,8 +11,9 @@ This test suite covers:
 - Span data validation
 - Origin tracking
 
-The tests mock the MCP server components and request context to verify
-that the integration properly instruments MCP handlers with Sentry spans.
+The tests drive real MCP servers over the stdio, StreamableHTTP, and SSE
+transports to verify that the integration properly instruments MCP handlers
+with Sentry spans.
 """
 
 import asyncio
@@ -1807,306 +1808,188 @@ async def test_sse_transport_detection(
     assert data[SPANDATA.MCP_SESSION_ID] == session_id
 
 
-class _FakeServerRequestContext:
+@pytest.mark.asyncio
+@pytest.mark.parametrize("span_streaming", [True, False])
+@pytest.mark.skipif(not IS_MCP_V2, reason="MCP v2 SSE transport detection")
+async def test_sse_transport_detection_v2(
+    sentry_init, capture_events, capture_items, span_streaming, json_rpc_sse
+):
+    """Test that SSE transport is detected on MCP v2.
+
+    In v2 the request context is carried by the ServerRequestContext built per
+    request (request=metadata.request_context), and the SSE session id rides the
+    `?session_id=` query parameter.
+
+    Note: only transport/session detection is asserted. Sentry scope propagation
+    is wired through StreamableHTTPServerTransport.handle_request, not SSE, so the
+    SSE path does not get scope override.
     """
-    Stands in for MCP SDK v2's ServerRequestContext, which doesn't exist in v1.
-    Used to test that _handler_wrapper extracts context from original_args
-    when the first arg is a ServerRequestContext instance.
+    sentry_init(
+        integrations=[MCPIntegration()],
+        traces_sample_rate=1.0,
+        _experiments=_experiments_for(span_streaming),
+    )
+
+    server = Server("test-server")
+    sse = SseServerTransport("/messages/")
+
+    sse_connection_closed = asyncio.Event()
+
+    async def handle_sse(request):
+        async with sse.connect_sse(
+            request.scope, request.receive, request._send
+        ) as streams:
+            async with anyio.create_task_group() as tg:
+
+                async def run_server():
+                    await server.run(
+                        streams[0], streams[1], server.create_initialization_options()
+                    )
+
+                tg.start_soon(run_server)
+
+        sse_connection_closed.set()
+        return Response()
+
+    app = Starlette(
+        routes=[
+            Route("/sse", endpoint=handle_sse, methods=["GET"]),
+            Mount("/messages/", app=sse.handle_post_message),
+        ],
+    )
+
+    async def test_tool(ctx, params):
+        return CallToolResult(
+            content=[TextContent(type="text", text="success")],
+            structured_content={"result": "success"},
+        )
+
+    server.add_request_handler("tools/call", CallToolRequestParams, test_tool)
+
+    if span_streaming:
+        items = capture_items("span")
+    else:
+        events = capture_events()
+
+    keep_sse_alive = asyncio.Event()
+    app_task, session_id, result = await json_rpc_sse(
+        app,
+        method="tools/call",
+        params={
+            "name": "sse_tool",
+            "arguments": {},
+        },
+        request_id="req-sse-v2",
+        keep_sse_alive=keep_sse_alive,
+    )
+
+    await sse_connection_closed.wait()
+    await app_task
+
+    assert result["result"]["structuredContent"] == {"result": "success"}
+
+    if span_streaming:
+        sentry_sdk.flush()
+        span = _find_mcp_span(items, method_name="tools/call")
+        assert span is not None
+        data = span["attributes"]
+    else:
+        # v2 SSE does not propagate Sentry scopes (only StreamableHTTP does), so
+        # the handler runs without an active transaction and the MCP span becomes
+        # its own root transaction (data lives on the trace context) rather than a
+        # child span of the "/sse" request transaction. Accept either shape.
+        data = None
+        for event in events:
+            if event.get("type") != "transaction":
+                continue
+            trace = event["contexts"]["trace"]
+            if (
+                trace.get("op") == OP.MCP_SERVER
+                and trace.get("data", {}).get(SPANDATA.MCP_METHOD_NAME) == "tools/call"
+            ):
+                data = trace["data"]
+                break
+            for span in event.get("spans", []):
+                if span["data"].get(SPANDATA.MCP_METHOD_NAME) == "tools/call":
+                    data = span["data"]
+                    break
+            if data is not None:
+                break
+        assert data is not None
+
+    assert data[SPANDATA.MCP_TRANSPORT] == "sse"
+    assert data[SPANDATA.NETWORK_TRANSPORT] == "tcp"
+    assert data[SPANDATA.MCP_SESSION_ID] == session_id
+
+
+@pytest.mark.asyncio
+async def test_streamable_http_scope_propagation(sentry_init, capture_events, json_rpc):
+    """Errors raised inside an HTTP handler attach to the MCP transaction's trace.
+
+    StreamableHTTPServerTransport.handle_request stashes the active isolation and
+    current scopes in the ASGI scope state; the handler wrapper then re-activates
+    them so the span (and any captured error) belongs to the same trace as the
+    HTTP request.
     """
+    sentry_init(
+        integrations=[MCPIntegration()],
+        traces_sample_rate=1.0,
+    )
 
-    def __init__(self, request_id=None, request=None):
-        self.request_id = request_id
-        self.request = request
+    server = Server("test-server")
 
+    if IS_MCP_V2:
 
-class TestHandlerWrapperWithExplicitContext:
-    """
-    Tests that _handler_wrapper correctly extracts request context data from
-    original_args when the first argument is a ServerRequestContext (MCP SDK v2
-    pattern), rather than relying on the request_ctx ContextVar.
-    """
+        async def failing_tool(ctx, params):
+            raise ValueError("Tool execution failed")
 
-    @pytest.mark.asyncio
-    @pytest.mark.parametrize("span_streaming", [True, False])
-    async def test_http_context_extracted_from_args(
-        self, sentry_init, capture_events, capture_items, span_streaming
-    ):
-        """When a ServerRequestContext with HTTP headers is in original_args,
-        span data reflects the request_id, session_id, and http transport."""
-        sentry_init(
-            integrations=[MCPIntegration()],
-            traces_sample_rate=1.0,
-            _experiments=_experiments_for(span_streaming),
+        server.add_request_handler("tools/call", CallToolRequestParams, failing_tool)
+    else:
+
+        @server.call_tool()
+        def failing_tool(tool_name, arguments):
+            raise ValueError("Tool execution failed")
+
+    session_manager = StreamableHTTPSessionManager(
+        app=server,
+        json_response=True,
+    )
+
+    app = Starlette(
+        routes=[
+            Mount("/mcp", app=session_manager.handle_request),
+        ],
+        lifespan=lambda app: session_manager.run(),
+    )
+
+    events = capture_events()
+    json_rpc(
+        app,
+        method="tools/call",
+        params={"name": "bad_tool", "arguments": {}},
+        request_id="req-scope",
+    )
+
+    error_events = [e for e in events if e.get("type") != "transaction"]
+    mcp_transactions = [
+        e
+        for e in events
+        if e.get("type") == "transaction"
+        and any(
+            span["data"].get(SPANDATA.MCP_METHOD_NAME) == "tools/call"
+            for span in e.get("spans", [])
         )
+    ]
 
-        import sentry_sdk.integrations.mcp as mcp_module
+    assert len(error_events) == 1
+    assert len(mcp_transactions) == 1
 
-        request = mock.MagicMock()
-        request.headers = {"mcp-session-id": "session-abc"}
-        request.query_params = {}
-        request.scope = {"state": {}}
+    error_event = error_events[0]
+    assert error_event["exception"]["values"][0]["type"] == "ValueError"
 
-        ctx = _FakeServerRequestContext(request_id="req-42", request=request)
-
-        async def dummy_tool(ctx, name, arguments):
-            return {"result": "ok"}
-
-        with mock.patch.object(
-            mcp_module, "ServerRequestContext", _FakeServerRequestContext
-        ):
-            if span_streaming:
-                items = capture_items("span")
-                with sentry_sdk.traces.start_span(name="test tx"):
-                    await mcp_module._handler_wrapper(
-                        "tool",
-                        dummy_tool,
-                        (ctx, "my_tool", {"x": 1}),
-                        force_await=False,
-                    )
-                sentry_sdk.flush()
-                span = _find_mcp_span(items, method_name="tools/call")
-                assert span is not None
-                data = span["attributes"]
-            else:
-                events = capture_events()
-                with start_transaction(name="test tx"):
-                    await mcp_module._handler_wrapper(
-                        "tool",
-                        dummy_tool,
-                        (ctx, "my_tool", {"x": 1}),
-                        force_await=False,
-                    )
-                (tx,) = events
-                data = tx["spans"][0]["data"]
-
-        assert data[SPANDATA.MCP_REQUEST_ID] == "req-42"
-        assert data[SPANDATA.MCP_SESSION_ID] == "session-abc"
-        assert data[SPANDATA.MCP_TRANSPORT] == "http"
-        assert data[SPANDATA.NETWORK_TRANSPORT] == "tcp"
-
-    @pytest.mark.asyncio
-    @pytest.mark.parametrize("span_streaming", [True, False])
-    async def test_sse_context_extracted_from_args(
-        self, sentry_init, capture_events, capture_items, span_streaming
-    ):
-        """When a ServerRequestContext with SSE query params is in original_args,
-        span data reflects sse transport and session_id."""
-        sentry_init(
-            integrations=[MCPIntegration()],
-            traces_sample_rate=1.0,
-            _experiments=_experiments_for(span_streaming),
-        )
-
-        import sentry_sdk.integrations.mcp as mcp_module
-
-        request = mock.MagicMock()
-        request.headers = {}
-        request.query_params = {"session_id": "sse-session-456"}
-        request.scope = {"state": {}}
-
-        ctx = _FakeServerRequestContext(request_id="req-99", request=request)
-
-        async def dummy_tool(ctx, name, arguments):
-            return {"result": "ok"}
-
-        with mock.patch.object(
-            mcp_module, "ServerRequestContext", _FakeServerRequestContext
-        ):
-            if span_streaming:
-                items = capture_items("span")
-                with sentry_sdk.traces.start_span(name="test tx"):
-                    await mcp_module._handler_wrapper(
-                        "tool",
-                        dummy_tool,
-                        (ctx, "my_tool", {}),
-                        force_await=False,
-                    )
-                sentry_sdk.flush()
-                span = _find_mcp_span(items, method_name="tools/call")
-                assert span is not None
-                data = span["attributes"]
-            else:
-                events = capture_events()
-                with start_transaction(name="test tx"):
-                    await mcp_module._handler_wrapper(
-                        "tool",
-                        dummy_tool,
-                        (ctx, "my_tool", {}),
-                        force_await=False,
-                    )
-                (tx,) = events
-                data = tx["spans"][0]["data"]
-
-        assert data[SPANDATA.MCP_REQUEST_ID] == "req-99"
-        assert data[SPANDATA.MCP_SESSION_ID] == "sse-session-456"
-        assert data[SPANDATA.MCP_TRANSPORT] == "sse"
-        assert data[SPANDATA.NETWORK_TRANSPORT] == "tcp"
-
-    @pytest.mark.asyncio
-    @pytest.mark.parametrize("span_streaming", [True, False])
-    async def test_stdio_fallback_when_no_context_in_args(
-        self, sentry_init, capture_events, capture_items, span_streaming
-    ):
-        """When original_args has no ServerRequestContext (v1 style),
-        falls back to ContextVar / stdio defaults."""
-        sentry_init(
-            integrations=[MCPIntegration()],
-            traces_sample_rate=1.0,
-            _experiments=_experiments_for(span_streaming),
-        )
-
-        import sentry_sdk.integrations.mcp as mcp_module
-
-        async def dummy_tool(name, arguments):
-            return {"result": "ok"}
-
-        if span_streaming:
-            items = capture_items("span")
-            with sentry_sdk.traces.start_span(name="test tx"):
-                await mcp_module._handler_wrapper(
-                    "tool",
-                    dummy_tool,
-                    ("my_tool", {"x": 1}),
-                    force_await=False,
-                )
-            sentry_sdk.flush()
-            span = _find_mcp_span(items, method_name="tools/call")
-            assert span is not None
-            data = span["attributes"]
-        else:
-            events = capture_events()
-            with start_transaction(name="test tx"):
-                await mcp_module._handler_wrapper(
-                    "tool",
-                    dummy_tool,
-                    ("my_tool", {"x": 1}),
-                    force_await=False,
-                )
-            (tx,) = events
-            data = tx["spans"][0]["data"]
-
-        assert data[SPANDATA.MCP_TRANSPORT] == "stdio"
-        assert data[SPANDATA.NETWORK_TRANSPORT] == "pipe"
-        assert SPANDATA.MCP_SESSION_ID not in data
-
-    @pytest.mark.asyncio
-    async def test_scopes_extracted_from_context_request_state(
-        self, sentry_init, capture_events
-    ):
-        """When a ServerRequestContext carries Sentry scopes in its request
-        state, _handler_wrapper uses those scopes for the span."""
-        sentry_init(
-            integrations=[MCPIntegration()],
-            traces_sample_rate=1.0,
-        )
-
-        import sentry_sdk.integrations.mcp as mcp_module
-
-        isolation_scope = sentry_sdk.get_isolation_scope()
-        current_scope = sentry_sdk.get_current_scope()
-
-        request = mock.MagicMock()
-        request.headers = {"mcp-session-id": "session-scopes"}
-        request.query_params = {}
-        request.scope = {
-            "state": {
-                "sentry_sdk.isolation_scope": isolation_scope,
-                "sentry_sdk.current_scope": current_scope,
-            }
-        }
-
-        ctx = _FakeServerRequestContext(request_id="req-scope", request=request)
-
-        async def dummy_tool(ctx, name, arguments):
-            return {"result": "ok"}
-
-        with mock.patch.object(
-            mcp_module, "ServerRequestContext", _FakeServerRequestContext
-        ):
-            events = capture_events()
-            with start_transaction(name="test tx"):
-                await mcp_module._handler_wrapper(
-                    "tool",
-                    dummy_tool,
-                    (ctx, "my_tool", {"x": 1}),
-                    force_await=False,
-                )
-            (tx,) = events
-            span = tx["spans"][0]
-
-        assert span["op"] == OP.MCP_SERVER
-        assert span["data"][SPANDATA.MCP_SESSION_ID] == "session-scopes"
-
-    @pytest.mark.asyncio
-    async def test_no_scopes_when_context_has_no_request(
-        self, sentry_init, capture_events
-    ):
-        """When a ServerRequestContext has no request (stdio-like),
-        _handler_wrapper still works without scope override."""
-        sentry_init(
-            integrations=[MCPIntegration()],
-            traces_sample_rate=1.0,
-        )
-
-        import sentry_sdk.integrations.mcp as mcp_module
-
-        ctx = _FakeServerRequestContext(request_id="req-no-request")
-        ctx.request = None
-
-        async def dummy_tool(ctx, name, arguments):
-            return {"result": "ok"}
-
-        with mock.patch.object(
-            mcp_module, "ServerRequestContext", _FakeServerRequestContext
-        ):
-            events = capture_events()
-            with start_transaction(name="test tx"):
-                await mcp_module._handler_wrapper(
-                    "tool",
-                    dummy_tool,
-                    (ctx, "my_tool", {}),
-                    force_await=False,
-                )
-            (tx,) = events
-            span = tx["spans"][0]
-
-        assert span["op"] == OP.MCP_SERVER
-        assert span["data"][SPANDATA.MCP_TRANSPORT] == "stdio"
-
-    @pytest.mark.asyncio
-    async def test_v2_context_without_params_uses_unknown_handler_name(
-        self, sentry_init, capture_events
-    ):
-        """When v2 is detected (ServerRequestContext as first arg) but no
-        params object is present, handler_name should be 'unknown' instead
-        of the ServerRequestContext object."""
-        sentry_init(
-            integrations=[MCPIntegration()],
-            traces_sample_rate=1.0,
-        )
-
-        import sentry_sdk.integrations.mcp as mcp_module
-
-        ctx = _FakeServerRequestContext(request_id="req-no-params")
-        ctx.request = None
-
-        async def dummy_tool(ctx):
-            return {"result": "ok"}
-
-        with mock.patch.object(
-            mcp_module, "ServerRequestContext", _FakeServerRequestContext
-        ):
-            events = capture_events()
-            with start_transaction(name="test tx"):
-                await mcp_module._handler_wrapper(
-                    "tool",
-                    dummy_tool,
-                    (ctx,),
-                    force_await=False,
-                )
-            (tx,) = events
-            span = tx["spans"][0]
-
-        assert span["op"] == OP.MCP_SERVER
-        assert span["description"] == "tools/call unknown"
-        assert span["data"][SPANDATA.MCP_METHOD_NAME] == "tools/call"
+    # The captured error shares the trace of the MCP transaction, proving the
+    # handler executed under the propagated request scope.
+    assert (
+        error_event["contexts"]["trace"]["trace_id"]
+        == mcp_transactions[0]["contexts"]["trace"]["trace_id"]
+    )

--- a/tests/integrations/mcp/test_mcp.py
+++ b/tests/integrations/mcp/test_mcp.py
@@ -259,20 +259,61 @@ async def test_mcpserver_high_level_tool_instrumented(
     assert span["data"][SPANDATA.MCP_METHOD_NAME] == "tools/call"
 
 
-def test_wrap_v2_handler_is_idempotent():
-    """_wrap_v2_handler must not double-wrap a handler registered through more
-    than one path (e.g. MCPServer building a Server, then re-registration)."""
-    import sentry_sdk.integrations.mcp as mcp_module
+@pytest.mark.asyncio
+@pytest.mark.skipif(
+    not IS_MCP_V2, reason="Constructor handler registration is MCP v2 only"
+)
+@pytest.mark.parametrize("span_streaming", [True, False])
+async def test_wrapping_handler_is_idempotent(
+    sentry_init, capture_events, capture_items, span_streaming, stdio
+):
+    """Re-registering an already-wrapped handler via add_request_handler must
+    not double-wrap — invoking it should produce exactly one MCP span."""
+    sentry_init(
+        integrations=[MCPIntegration()],
+        traces_sample_rate=1.0,
+        _experiments=_experiments_for(span_streaming),
+    )
 
-    async def handler(ctx, params):
-        return None
+    async def test_tool(ctx, params):
+        return CallToolResult(
+            content=[TextContent(type="text", text="ok")],
+            structured_content={"result": "ok"},
+        )
 
-    wrapped = mcp_module._wrap_v2_handler("tool", handler)
-    assert wrapped is not handler
-    assert getattr(wrapped, "__sentry_mcp_wrapped__", False) is True
+    server = Server("test-server", on_call_tool=test_tool)
+    entry = server.get_request_handler("tools/call")
+    server.add_request_handler("tools/call", CallToolRequestParams, entry.handler)
 
-    rewrapped = mcp_module._wrap_v2_handler("tool", wrapped)
-    assert rewrapped is wrapped
+    if span_streaming:
+        items = capture_items("span")
+        with sentry_sdk.traces.start_span(name="mcp tx"):
+            await stdio(
+                server,
+                method="tools/call",
+                params={"name": "add", "arguments": {}},
+                request_id="req-idempotent",
+            )
+        sentry_sdk.flush()
+        mcp_spans = [
+            item.payload
+            for item in items
+            if item.type == "span"
+            and item.payload.get("attributes", {}).get("sentry.op") == OP.MCP_SERVER
+        ]
+    else:
+        events = capture_events()
+        with start_transaction(name="mcp tx"):
+            await stdio(
+                server,
+                method="tools/call",
+                params={"name": "add", "arguments": {}},
+                request_id="req-idempotent",
+            )
+        (tx,) = events
+        mcp_spans = [s for s in tx["spans"] if s["op"] == OP.MCP_SERVER]
+
+    assert len(mcp_spans) == 1
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
MCP SDK v2 changed handler signatures from (name, arguments) to
(ctx, params) and removed the request_ctx ContextVar. Add version
detection to patch the correct entry-points (Server.__init__ and
add_request_handler for v2, decorator methods for v1), extract
request context from the ServerRequestContext argument directly,
and update tests to work with both SDK versions.

Migration notes for MCP SDK v2 can be found here:
- https://github.com/modelcontextprotocol/python-sdk/releases/tag/v2.0.0a1
- https://github.com/modelcontextprotocol/python-sdk/blob/main/docs/migration.md

What this PR does not do:
- address all breaking changes outlined in the migration guide. This is meant to fix the test failures on https://github.com/getsentry/sentry-python/pull/6567 while still being comprehensive enough to make sense for the next developer who continues the migration.

This was tested on the branch in https://github.com/getsentry/sentry-python/pull/6567 to confirm it doesn't introduce regressions while addressing the v2 breaking change.

Fixes PY-2532
Fixes https://github.com/getsentry/sentry-python/issues/6574