### PR TITLE
fix: replace asyncio.iscoroutinefunction with inspect on Python 3.12+

### DIFF
--- a/sentry_sdk/integrations/asgi.py
+++ b/sentry_sdk/integrations/asgi.py
@@ -66,9 +66,13 @@ _DEFAULT_TRANSACTION_NAME = "generic ASGI request"
 TRANSACTION_STYLE_VALUES = ("endpoint", "url")
 
 
+# Originally vendored from uvicorn._compat (see
+# https://github.com/Kludex/uvicorn/blob/b224045f5900b7f766743bcb16ba9fc3adea2606/uvicorn/_compat.py#L10-L13),
+# but the version gate has been updated from >= (3, 14) to >= (3, 12):
 # asyncio.iscoroutinefunction() was deprecated in Python 3.12 and is slated for
-# removal in 3.16.  inspect.iscoroutinefunction() behaves identically on 3.12+
-# because the legacy _is_coroutine marker was removed in the same release.
+# removal in 3.16.  The legacy _is_coroutine marker it additionally checked was
+# also removed in 3.12, making inspect.iscoroutinefunction() a full drop-in
+# replacement from 3.12 onward.
 if sys.version_info >= (3, 12):
     from inspect import iscoroutinefunction
 else:

--- a/sentry_sdk/integrations/asgi.py
+++ b/sentry_sdk/integrations/asgi.py
@@ -66,8 +66,10 @@ _DEFAULT_TRANSACTION_NAME = "generic ASGI request"
 TRANSACTION_STYLE_VALUES = ("endpoint", "url")
 
 
-# Vendored: https://github.com/Kludex/uvicorn/blob/b224045f5900b7f766743bcb16ba9fc3adea2606/uvicorn/_compat.py#L10-L13
-if sys.version_info >= (3, 14):
+# asyncio.iscoroutinefunction() was deprecated in Python 3.12 and is slated for
+# removal in 3.16.  inspect.iscoroutinefunction() behaves identically on 3.12+
+# because the legacy _is_coroutine marker was removed in the same release.
+if sys.version_info >= (3, 12):
     from inspect import iscoroutinefunction
 else:
     from asyncio import iscoroutinefunction

--- a/sentry_sdk/integrations/django/views.py
+++ b/sentry_sdk/integrations/django/views.py
@@ -1,4 +1,5 @@
 import functools
+import sys
 from typing import TYPE_CHECKING
 
 import sentry_sdk
@@ -10,10 +11,17 @@ if TYPE_CHECKING:
     from typing import Any
 
 
-try:
-    from asyncio import iscoroutinefunction
-except ImportError:
-    iscoroutinefunction = None  # type: ignore
+# asyncio.iscoroutinefunction() was deprecated in Python 3.12 and is slated for
+# removal in 3.16.  inspect.iscoroutinefunction() is available since Python 3.1
+# and is a full drop-in replacement on 3.12+ (the legacy _is_coroutine marker
+# that asyncio additionally checked was removed in the same release).
+if sys.version_info >= (3, 12):
+    from inspect import iscoroutinefunction
+else:
+    try:
+        from asyncio import iscoroutinefunction
+    except ImportError:
+        iscoroutinefunction = None  # type: ignore[assignment]
 
 
 try:

--- a/sentry_sdk/integrations/fastapi.py
+++ b/sentry_sdk/integrations/fastapi.py
@@ -36,7 +36,10 @@ _DEFAULT_TRANSACTION_NAME = "generic FastAPI request"
 
 
 # Vendored: https://github.com/Kludex/starlette/blob/0a29b5ccdcbd1285c75c4fdb5d62ae1d244a21b0/starlette/_utils.py#L11-L17
-if sys.version_info >= (3, 13):  # pragma: no cover
+# asyncio.iscoroutinefunction() was deprecated in Python 3.12 (removal in 3.16).
+# The legacy _is_coroutine marker it additionally checked was also removed in 3.12,
+# so inspect.iscoroutinefunction() is a full drop-in replacement from 3.12 onward.
+if sys.version_info >= (3, 12):  # pragma: no cover
     from inspect import iscoroutinefunction
 else:
     from asyncio import iscoroutinefunction

--- a/sentry_sdk/integrations/fastapi.py
+++ b/sentry_sdk/integrations/fastapi.py
@@ -35,7 +35,9 @@ except ImportError:
 _DEFAULT_TRANSACTION_NAME = "generic FastAPI request"
 
 
-# Vendored: https://github.com/Kludex/starlette/blob/0a29b5ccdcbd1285c75c4fdb5d62ae1d244a21b0/starlette/_utils.py#L11-L17
+# Originally vendored from starlette._utils (see
+# https://github.com/Kludex/starlette/blob/0a29b5ccdcbd1285c75c4fdb5d62ae1d244a21b0/starlette/_utils.py#L11-L17),
+# but the version gate has been updated from >= (3, 13) to >= (3, 12):
 # asyncio.iscoroutinefunction() was deprecated in Python 3.12 (removal in 3.16).
 # The legacy _is_coroutine marker it additionally checked was also removed in 3.12,
 # so inspect.iscoroutinefunction() is a full drop-in replacement from 3.12 onward.

--- a/sentry_sdk/integrations/starlette.py
+++ b/sentry_sdk/integrations/starlette.py
@@ -80,7 +80,9 @@ except ImportError:
     multipart = None
 
 
-# Vendored: https://github.com/Kludex/starlette/blob/0a29b5ccdcbd1285c75c4fdb5d62ae1d244a21b0/starlette/_utils.py#L11-L17
+# Originally vendored from starlette._utils (see
+# https://github.com/Kludex/starlette/blob/0a29b5ccdcbd1285c75c4fdb5d62ae1d244a21b0/starlette/_utils.py#L11-L17),
+# but the version gate has been updated from >= (3, 13) to >= (3, 12):
 # asyncio.iscoroutinefunction() was deprecated in Python 3.12 (removal in 3.16).
 # The legacy _is_coroutine marker it additionally checked was also removed in 3.12,
 # so inspect.iscoroutinefunction() is a full drop-in replacement from 3.12 onward.

--- a/sentry_sdk/integrations/starlette.py
+++ b/sentry_sdk/integrations/starlette.py
@@ -81,7 +81,10 @@ except ImportError:
 
 
 # Vendored: https://github.com/Kludex/starlette/blob/0a29b5ccdcbd1285c75c4fdb5d62ae1d244a21b0/starlette/_utils.py#L11-L17
-if sys.version_info >= (3, 13):  # pragma: no cover
+# asyncio.iscoroutinefunction() was deprecated in Python 3.12 (removal in 3.16).
+# The legacy _is_coroutine marker it additionally checked was also removed in 3.12,
+# so inspect.iscoroutinefunction() is a full drop-in replacement from 3.12 onward.
+if sys.version_info >= (3, 12):  # pragma: no cover
     from inspect import iscoroutinefunction
 else:
     from asyncio import iscoroutinefunction


### PR DESCRIPTION
## Summary

Fixes #6085.

`asyncio.iscoroutinefunction()` was deprecated in Python 3.12 and is slated for removal in Python 3.16. The legacy `_is_coroutine` marker that it additionally checked (beyond `inspect.iscoroutinefunction`) was also removed in Python 3.12, making `inspect.iscoroutinefunction()` a full drop-in replacement from 3.12 onward.

Before this change, four integration files triggered `DeprecationWarning` on Python 3.12–3.14:

| File | Issue |
|---|---|
| `integrations/asgi.py` | Used `>= (3, 14)` as the cutoff — Python 3.12 and 3.13 users got warnings |
| `integrations/starlette.py` | Used `>= (3, 13)` — Python 3.12 users got warnings |
| `integrations/fastapi.py` | Used `>= (3, 13)` — Python 3.12 users got warnings |
| `integrations/django/views.py` | No version guard at all — always imported from `asyncio`, warnings on every call on 3.12+ |

All four now use `inspect.iscoroutinefunction` on Python >= 3.12. The `asyncio` fallback is kept for Python < 3.12 where the `_is_coroutine` marker behaviour still matters.

## Test plan

- [x] Verified zero `DeprecationWarning` from sentry-python code on Python 3.14 (using `-W error::DeprecationWarning`)
- [x] `tests/integrations/asgi/` — 113 passed
- [x] `tests/integrations/starlette/` — passed (included in the 113 above)
- [x] `tests/integrations/django/test_middleware.py` — 3 passed
- [x] `ruff check` — no lint errors on all 4 changed files