### PR TITLE
fix(ai): handle Pydantic SDK objects in truncate_messages_by_size

### DIFF
--- a/sentry_sdk/ai/utils.py
+++ b/sentry_sdk/ai/utils.py
@@ -588,13 +588,21 @@ class _PydanticEncoder(json.JSONEncoder):
     def default(self, obj: "Any") -> "Any":
         if not inspect.isclass(obj) and hasattr(obj, "model_dump"):
             try:
-                return obj.model_dump()
+                # mode="json" returns only JSON-native types (converts datetime,
+                # Decimal, etc.) — fall back to plain model_dump() for Pydantic v1
+                # and custom classes that don't accept the kwarg.
+                return obj.model_dump(mode="json")
+            except TypeError:
+                try:
+                    return obj.model_dump()
+                except Exception:
+                    pass
             except Exception:
                 pass
         return super().default(obj)
 
 
-def _find_truncation_index(messages: "List[Dict[str, Any]]", max_bytes: int) -> int:
+def _find_truncation_index(messages: "List[Any]", max_bytes: int) -> int:
     """
     Find the index of the first message that would exceed the max bytes limit.
     Compute the individual message sizes, and return the index of the first message from the back
@@ -721,10 +729,10 @@ def redact_blob_message_parts(
 
 
 def truncate_messages_by_size(
-    messages: "List[Dict[str, Any]]",
+    messages: "List[Any]",
     max_bytes: int = MAX_GEN_AI_MESSAGE_BYTES,
     max_single_message_chars: int = MAX_SINGLE_MESSAGE_CONTENT_CHARS,
-) -> "Tuple[List[Dict[str, Any]], int]":
+) -> "Tuple[List[Any], int]":
     """
     Returns a truncated messages list, consisting of
     - the last message, with its content truncated to `max_single_message_chars` characters,

--- a/sentry_sdk/ai/utils.py
+++ b/sentry_sdk/ai/utils.py
@@ -578,6 +578,22 @@ def _truncate_single_message_content_if_present(
     return message
 
 
+class _PydanticEncoder(json.JSONEncoder):
+    """JSON encoder that serializes Pydantic models via model_dump().
+
+    This allows json.dumps() to handle OpenAI/LiteLLM SDK objects such as
+    ResponseFunctionToolCall that callers pass back in follow-up requests.
+    """
+
+    def default(self, obj: "Any") -> "Any":
+        if not inspect.isclass(obj) and hasattr(obj, "model_dump"):
+            try:
+                return obj.model_dump()
+            except Exception:
+                pass
+        return super().default(obj)
+
+
 def _find_truncation_index(messages: "List[Dict[str, Any]]", max_bytes: int) -> int:
     """
     Find the index of the first message that would exceed the max bytes limit.
@@ -586,7 +602,11 @@ def _find_truncation_index(messages: "List[Dict[str, Any]]", max_bytes: int) -> 
     """
     running_sum = 0
     for idx in range(len(messages) - 1, -1, -1):
-        size = len(json.dumps(messages[idx], separators=(",", ":")).encode("utf-8"))
+        size = len(
+            json.dumps(
+                messages[idx], cls=_PydanticEncoder, separators=(",", ":")
+            ).encode("utf-8")
+        )
         running_sum += size
         if running_sum > max_bytes:
             return idx + 1
@@ -715,7 +735,7 @@ def truncate_messages_by_size(
     In the single message case, the serialized message size may exceed `max_bytes`, because
     truncation is based only on character count in that case.
     """
-    serialized_json = json.dumps(messages, separators=(",", ":"))
+    serialized_json = json.dumps(messages, cls=_PydanticEncoder, separators=(",", ":"))
     current_size = len(serialized_json.encode("utf-8"))
 
     if current_size <= max_bytes:

--- a/tests/test_ai_monitoring.py
+++ b/tests/test_ai_monitoring.py
@@ -440,8 +440,11 @@ class TestTruncateMessagesBySize:
             {"type": "function_call_output", "call_id": "call_abc123", "output": "ok"},
         ]
 
-        # Must not raise TypeError: Object of type FakePydanticModel is not JSON serializable
-        result, truncation_index = truncate_messages_by_size(messages)
+        # Pass an explicit limit well above the test payload so the assertion is
+        # deterministic regardless of the default constant's value.
+        result, truncation_index = truncate_messages_by_size(
+            messages, max_bytes=100_000
+        )
 
         assert truncation_index == 0
         assert isinstance(result, list)

--- a/tests/test_ai_monitoring.py
+++ b/tests/test_ai_monitoring.py
@@ -411,6 +411,45 @@ class TestTruncateMessagesBySize:
 
         assert result[0]["content"] is content
 
+    def test_pydantic_objects_in_message_list_do_not_raise(self):
+        """Regression test for #5350.
+
+        OpenAI's Responses API returns Pydantic objects (e.g. ResponseFunctionToolCall)
+        that callers pass back in follow-up requests.  truncate_messages_by_size() must
+        not raise TypeError when the messages list contains such objects.
+        """
+
+        class FakePydanticModel:
+            """Minimal stand-in for any pydantic BaseModel with model_dump()."""
+
+            def __init__(self, **kwargs):
+                self._data = kwargs
+
+            def model_dump(self):
+                return self._data
+
+        tool_call = FakePydanticModel(
+            type="function_call",
+            call_id="call_abc123",
+            name="notify_team",
+            arguments='{"message": "hello"}',
+        )
+        messages = [
+            {"role": "user", "content": "Please notify the team"},
+            tool_call,  # Pydantic-like object mixed into the list
+            {"type": "function_call_output", "call_id": "call_abc123", "output": "ok"},
+        ]
+
+        # Must not raise TypeError: Object of type FakePydanticModel is not JSON serializable
+        result, truncation_index = truncate_messages_by_size(messages)
+
+        assert truncation_index == 0
+        assert isinstance(result, list)
+        assert len(result) == 3
+        # The Pydantic object is preserved as-is in the returned list;
+        # the fix only ensures json.dumps() can serialize it for size measurement.
+        assert result[1] is tool_call
+
 
 class TestTruncateAndAnnotateMessages:
     def test_only_keeps_last_message(self, sample_messages):


### PR DESCRIPTION
## Summary

Fixes #5350.

OpenAI's Responses API returns Pydantic model instances (e.g. `ResponseFunctionToolCall`) that callers pass back as items in the `input` list of follow-up requests. `truncate_messages_by_size()` called `json.dumps(messages)` directly without any special handling, so a messages list containing such an object raised:

```
TypeError: Object of type ResponseFunctionToolCall is not JSON serializable
```

This is the same class of bug as the `Omit`/`NotGiven` handling done previously — the OpenAI integration assumes inputs are plain Python dicts, but the SDK passes Pydantic objects through the instrumentation path.

## Fix

Introduce `_PydanticEncoder`, a `JSONEncoder` subclass that serializes Pydantic models via `model_dump()`. It is used in the two `json.dumps()` calls inside `truncate_messages_by_size()` and `_find_truncation_index()` — only for byte-size measurement. The returned `messages` list is left unchanged (Pydantic objects are preserved as-is). This avoids the `TypeError` without altering the data the caller gets back.

The SDK already has `_normalize_data()` which handles Pydantic objects, but using it here would stringify `None` values to `"None"` (a pre-existing behaviour), which would break the existing `test_single_message_truncation_non_str_non_list_content` test. The encoder approach is more targeted.

## Test plan

- [x] New regression test `test_pydantic_objects_in_message_list_do_not_raise` — verifies a Pydantic-like object in the messages list does not raise `TypeError`
- [x] `TestTruncateMessagesBySize` — all 15 tests pass (including pre-existing `None` / int / bool content tests)
- [x] `ruff check` + `ruff format` — clean