### PR TITLE
test(aiomysql): Add span streaming variants to aiomysql tests

### DIFF
--- a/tests/integrations/aiomysql/test_aiomysql.py
+++ b/tests/integrations/aiomysql/test_aiomysql.py
@@ -19,6 +19,7 @@ import aiomysql
 import pytest
 import pytest_asyncio
 
+import sentry_sdk
 from sentry_sdk import capture_message, start_transaction
 from sentry_sdk.consts import SPANDATA
 from sentry_sdk.integrations.aiomysql import AioMySQLIntegration
@@ -431,299 +432,617 @@ async def test_connection_pool(sentry_init, capture_events) -> None:
 
 
 @pytest.mark.asyncio
-async def test_query_source_disabled(sentry_init, capture_events):
+@pytest.mark.parametrize("span_streaming", [True, False])
+async def test_query_source_disabled(
+    sentry_init, capture_events, capture_items, span_streaming
+):
     sentry_options = {
         "integrations": [AioMySQLIntegration()],
         "traces_sample_rate": 1.0,
         "enable_db_query_source": False,
         "db_query_source_threshold_ms": 0,
+        "_experiments": {
+            "trace_lifecycle": "stream" if span_streaming else "static",
+        },
     }
 
     sentry_init(**sentry_options)
 
-    events = capture_events()
+    if span_streaming:
+        items = capture_items("span")
 
-    with start_transaction(name="test_transaction", sampled=True):
-        conn = await aiomysql.connect(**_connect_args())
+        with sentry_sdk.traces.start_span(name="test_segment"):
+            conn = await aiomysql.connect(**_connect_args())
 
-        async with conn.cursor() as cur:
-            await cur.execute(
-                "INSERT INTO users(name, password, dob) VALUES ('Alice', 'secret', '1990-12-25')",
-            )
+            async with conn.cursor() as cur:
+                await cur.execute(
+                    "INSERT INTO users(name, password, dob) VALUES ('Alice', 'secret', '1990-12-25')",
+                )
 
-        conn.close()
+            conn.close()
 
-    (event,) = events
+        sentry_sdk.flush()
 
-    span = event["spans"][-1]
-    assert span["description"].startswith("INSERT INTO")
+        spans = [item.payload for item in items]
 
-    data = span.get("data", {})
+        assert len(spans) == 3
 
-    assert SPANDATA.CODE_LINENO not in data
-    assert SPANDATA.CODE_NAMESPACE not in data
-    assert SPANDATA.CODE_FILEPATH not in data
-    assert SPANDATA.CODE_FUNCTION not in data
+        connect_span = spans[0]
+        insert_span = spans[1]
+        segment = spans[2]
+
+        assert segment["is_segment"] is True
+        assert connect_span["name"] == "connect"
+        assert insert_span["name"].startswith("INSERT INTO")
+
+        data = insert_span.get("attributes", {})
+
+        assert "code.line.number" not in data
+        assert "code.namespace" not in data
+        assert "code.file.path" not in data
+        assert "code.function" not in data
+    else:
+        events = capture_events()
+
+        with start_transaction(name="test_transaction", sampled=True):
+            conn = await aiomysql.connect(**_connect_args())
+
+            async with conn.cursor() as cur:
+                await cur.execute(
+                    "INSERT INTO users(name, password, dob) VALUES ('Alice', 'secret', '1990-12-25')",
+                )
+
+            conn.close()
+
+        (event,) = events
+
+        span = event["spans"][-1]
+        assert span["description"].startswith("INSERT INTO")
+        data = span.get("data", {})
+
+        assert SPANDATA.CODE_LINENO not in data
+        assert SPANDATA.CODE_NAMESPACE not in data
+        assert SPANDATA.CODE_FILEPATH not in data
+        assert SPANDATA.CODE_FUNCTION not in data
 
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("enable_db_query_source", [None, True])
+@pytest.mark.parametrize("span_streaming", [True, False])
 async def test_query_source_enabled(
-    sentry_init, capture_events, enable_db_query_source
+    sentry_init, capture_events, capture_items, enable_db_query_source, span_streaming
 ):
     sentry_options = {
         "integrations": [AioMySQLIntegration()],
         "traces_sample_rate": 1.0,
         "db_query_source_threshold_ms": 0,
+        "_experiments": {
+            "trace_lifecycle": "stream" if span_streaming else "static",
+        },
     }
     if enable_db_query_source is not None:
         sentry_options["enable_db_query_source"] = enable_db_query_source
 
     sentry_init(**sentry_options)
 
-    events = capture_events()
+    if span_streaming:
+        items = capture_items("span")
 
-    with start_transaction(name="test_transaction", sampled=True):
-        conn = await aiomysql.connect(**_connect_args())
+        with sentry_sdk.traces.start_span(name="test_segment"):
+            conn = await aiomysql.connect(**_connect_args())
 
-        async with conn.cursor() as cur:
-            await cur.execute(
-                "INSERT INTO users(name, password, dob) VALUES ('Alice', 'secret', '1990-12-25')",
-            )
+            async with conn.cursor() as cur:
+                await cur.execute(
+                    "INSERT INTO users(name, password, dob) VALUES ('Alice', 'secret', '1990-12-25')",
+                )
 
-        conn.close()
+            conn.close()
 
-    (event,) = events
+        sentry_sdk.flush()
 
-    span = event["spans"][-1]
-    assert span["description"].startswith("INSERT INTO")
+        spans = [item.payload for item in items]
 
-    data = span.get("data", {})
+        assert len(spans) == 3
 
-    assert SPANDATA.CODE_LINENO in data
-    assert SPANDATA.CODE_NAMESPACE in data
-    assert SPANDATA.CODE_FILEPATH in data
-    assert SPANDATA.CODE_FUNCTION in data
+        connect_span = spans[0]
+        insert_span = spans[1]
+        segment = spans[2]
+
+        assert segment["is_segment"] is True
+        assert connect_span["name"] == "connect"
+        assert insert_span["name"].startswith("INSERT INTO")
+
+        data = insert_span.get("attributes", {})
+
+        assert "code.line.number" in data
+        assert "code.namespace" in data
+        assert "code.file.path" in data
+        assert "code.function" in data
+    else:
+        events = capture_events()
+
+        with start_transaction(name="test_transaction", sampled=True):
+            conn = await aiomysql.connect(**_connect_args())
+
+            async with conn.cursor() as cur:
+                await cur.execute(
+                    "INSERT INTO users(name, password, dob) VALUES ('Alice', 'secret', '1990-12-25')",
+                )
+
+            conn.close()
+
+        (event,) = events
+
+        span = event["spans"][-1]
+        assert span["description"].startswith("INSERT INTO")
+        data = span.get("data", {})
+
+        assert SPANDATA.CODE_LINENO in data
+        assert SPANDATA.CODE_NAMESPACE in data
+        assert SPANDATA.CODE_FILEPATH in data
+        assert SPANDATA.CODE_FUNCTION in data
 
 
 @pytest.mark.asyncio
-async def test_query_source(sentry_init, capture_events):
+@pytest.mark.parametrize("span_streaming", [True, False])
+async def test_query_source(sentry_init, capture_events, capture_items, span_streaming):
     sentry_init(
         integrations=[AioMySQLIntegration()],
         traces_sample_rate=1.0,
         enable_db_query_source=True,
         db_query_source_threshold_ms=0,
+        _experiments={
+            "trace_lifecycle": "stream" if span_streaming else "static",
+        },
     )
 
-    events = capture_events()
+    if span_streaming:
+        items = capture_items("span")
 
-    with start_transaction(name="test_transaction", sampled=True):
-        conn = await aiomysql.connect(**_connect_args())
+        with sentry_sdk.traces.start_span(name="test_segment"):
+            conn = await aiomysql.connect(**_connect_args())
 
-        async with conn.cursor() as cur:
-            await cur.execute(
-                "INSERT INTO users(name, password, dob) VALUES ('Alice', 'secret', '1990-12-25')",
-            )
+            async with conn.cursor() as cur:
+                await cur.execute(
+                    "INSERT INTO users(name, password, dob) VALUES ('Alice', 'secret', '1990-12-25')",
+                )
 
-        conn.close()
+            conn.close()
 
-    (event,) = events
+        sentry_sdk.flush()
 
-    span = event["spans"][-1]
-    assert span["description"].startswith("INSERT INTO")
+        spans = [item.payload for item in items]
 
-    data = span.get("data", {})
+        assert len(spans) == 3
 
-    assert SPANDATA.CODE_LINENO in data
-    assert SPANDATA.CODE_NAMESPACE in data
-    assert SPANDATA.CODE_FILEPATH in data
-    assert SPANDATA.CODE_FUNCTION in data
+        connect_span = spans[0]
+        insert_span = spans[1]
+        segment = spans[2]
 
-    assert type(data.get(SPANDATA.CODE_LINENO)) == int
-    assert data.get(SPANDATA.CODE_LINENO) > 0
-    assert (
-        data.get(SPANDATA.CODE_NAMESPACE) == "tests.integrations.aiomysql.test_aiomysql"
-    )
-    assert data.get(SPANDATA.CODE_FILEPATH).endswith(
-        "tests/integrations/aiomysql/test_aiomysql.py"
-    )
+        assert segment["is_segment"] is True
+        assert connect_span["name"] == "connect"
+        assert insert_span["name"].startswith("INSERT INTO")
 
-    is_relative_path = data.get(SPANDATA.CODE_FILEPATH)[0] != os.sep
-    assert is_relative_path
+        data = insert_span.get("attributes", {})
 
-    assert data.get(SPANDATA.CODE_FUNCTION) == "test_query_source"
+        assert "code.line.number" in data
+        assert "code.namespace" in data
+        assert "code.file.path" in data
+        assert "code.function" in data
+
+        assert type(data.get("code.line.number")) == int
+        assert data.get("code.line.number") > 0
+        assert data.get("code.namespace") == "tests.integrations.aiomysql.test_aiomysql"
+        assert data.get("code.file.path").endswith(
+            "tests/integrations/aiomysql/test_aiomysql.py"
+        )
+
+        is_relative_path = data.get("code.file.path")[0] != os.sep
+        assert is_relative_path
+
+        assert data.get("code.function") == "test_query_source"
+    else:
+        events = capture_events()
+
+        with start_transaction(name="test_transaction", sampled=True):
+            conn = await aiomysql.connect(**_connect_args())
+
+            async with conn.cursor() as cur:
+                await cur.execute(
+                    "INSERT INTO users(name, password, dob) VALUES ('Alice', 'secret', '1990-12-25')",
+                )
+
+            conn.close()
+
+        (event,) = events
+
+        span = event["spans"][-1]
+        assert span["description"].startswith("INSERT INTO")
+
+        data = span.get("data", {})
+
+        assert SPANDATA.CODE_LINENO in data
+        assert SPANDATA.CODE_NAMESPACE in data
+        assert SPANDATA.CODE_FILEPATH in data
+        assert SPANDATA.CODE_FUNCTION in data
+
+        assert type(data.get(SPANDATA.CODE_LINENO)) == int
+        assert data.get(SPANDATA.CODE_LINENO) > 0
+        assert (
+            data.get(SPANDATA.CODE_NAMESPACE)
+            == "tests.integrations.aiomysql.test_aiomysql"
+        )
+        assert data.get(SPANDATA.CODE_FILEPATH).endswith(
+            "tests/integrations/aiomysql/test_aiomysql.py"
+        )
+
+        is_relative_path = data.get(SPANDATA.CODE_FILEPATH)[0] != os.sep
+        assert is_relative_path
+
+        assert data.get(SPANDATA.CODE_FUNCTION) == "test_query_source"
 
 
 @pytest.mark.asyncio
-async def test_no_query_source_if_duration_too_short(sentry_init, capture_events):
+@pytest.mark.parametrize("span_streaming", [True, False])
+async def test_no_query_source_if_duration_too_short(
+    sentry_init, capture_events, capture_items, span_streaming
+):
     sentry_init(
         integrations=[AioMySQLIntegration()],
         traces_sample_rate=1.0,
         enable_db_query_source=True,
         db_query_source_threshold_ms=100,
+        _experiments={
+            "trace_lifecycle": "stream" if span_streaming else "static",
+        },
     )
 
-    events = capture_events()
-
-    with start_transaction(name="test_transaction", sampled=True):
-        conn = await aiomysql.connect(**_connect_args())
+    if span_streaming:
+        items = capture_items("span")
 
         @contextmanager
-        def fake_record_sql_queries(*args, **kwargs):
+        def fake_record_sql_queries_streaming(*args, **kwargs):
             with record_sql_queries(*args, **kwargs) as span:
                 pass
-            span.start_timestamp = datetime.datetime(2024, 1, 1, microsecond=0)
-            span.timestamp = datetime.datetime(2024, 1, 1, microsecond=99999)
+            span._start_timestamp = datetime.datetime(2024, 1, 1, microsecond=0)
+            span._end_timestamp = datetime.datetime(2024, 1, 1, microsecond=99999)
             yield span
 
-        async with conn.cursor() as cur:
-            with mock.patch(
-                "sentry_sdk.integrations.aiomysql.record_sql_queries",
-                fake_record_sql_queries,
-            ):
-                await cur.execute(
-                    "INSERT INTO users(name, password, dob) VALUES ('Alice', 'secret', '1990-12-25')",
-                )
+        with sentry_sdk.traces.start_span(name="test_segment"):
+            conn = await aiomysql.connect(**_connect_args())
 
-        conn.close()
+            async with conn.cursor() as cur:
+                with mock.patch(
+                    "sentry_sdk.integrations.aiomysql.record_sql_queries",
+                    fake_record_sql_queries_streaming,
+                ):
+                    await cur.execute(
+                        "INSERT INTO users(name, password, dob) VALUES ('Alice', 'secret', '1990-12-25')",
+                    )
 
-    (event,) = events
+            conn.close()
 
-    span = event["spans"][-1]
-    assert span["description"].startswith("INSERT INTO")
+        sentry_sdk.flush()
 
-    data = span.get("data", {})
+        spans = [item.payload for item in items]
 
-    assert SPANDATA.CODE_LINENO not in data
-    assert SPANDATA.CODE_NAMESPACE not in data
-    assert SPANDATA.CODE_FILEPATH not in data
-    assert SPANDATA.CODE_FUNCTION not in data
+        assert len(spans) == 3
+
+        connect_span = spans[0]
+        insert_span = spans[1]
+        segment = spans[2]
+
+        assert segment["name"] == "test_segment"
+        assert insert_span["name"].startswith("INSERT INTO")
+        assert connect_span["name"] == "connect"
+        data = insert_span.get("attributes", {})
+
+        assert "code.line.number" not in data
+        assert "code.namespace" not in data
+        assert "code.file.path" not in data
+        assert "code.function" not in data
+    else:
+        events = capture_events()
+
+        with start_transaction(name="test_transaction", sampled=True):
+            conn = await aiomysql.connect(**_connect_args())
+
+            @contextmanager
+            def fake_record_sql_queries(*args, **kwargs):
+                with record_sql_queries(*args, **kwargs) as span:
+                    pass
+                span.start_timestamp = datetime.datetime(2024, 1, 1, microsecond=0)
+                span.timestamp = datetime.datetime(2024, 1, 1, microsecond=99999)
+                yield span
+
+            async with conn.cursor() as cur:
+                with mock.patch(
+                    "sentry_sdk.integrations.aiomysql.record_sql_queries",
+                    fake_record_sql_queries,
+                ):
+                    await cur.execute(
+                        "INSERT INTO users(name, password, dob) VALUES ('Alice', 'secret', '1990-12-25')",
+                    )
+
+            conn.close()
+
+        (event,) = events
+
+        span = event["spans"][-1]
+        assert span["description"].startswith("INSERT INTO")
+
+        data = span.get("data", {})
+
+        assert SPANDATA.CODE_LINENO not in data
+        assert SPANDATA.CODE_NAMESPACE not in data
+        assert SPANDATA.CODE_FILEPATH not in data
+        assert SPANDATA.CODE_FUNCTION not in data
 
 
 @pytest.mark.asyncio
-async def test_query_source_if_duration_over_threshold(sentry_init, capture_events):
+@pytest.mark.parametrize("span_streaming", [True, False])
+async def test_query_source_if_duration_over_threshold(
+    sentry_init, capture_events, capture_items, span_streaming
+):
     sentry_init(
         integrations=[AioMySQLIntegration()],
         traces_sample_rate=1.0,
         enable_db_query_source=True,
         db_query_source_threshold_ms=100,
+        _experiments={
+            "trace_lifecycle": "stream" if span_streaming else "static",
+        },
     )
 
-    events = capture_events()
-
-    with start_transaction(name="test_transaction", sampled=True):
-        conn = await aiomysql.connect(**_connect_args())
+    if span_streaming:
+        items = capture_items("span")
 
         @contextmanager
-        def fake_record_sql_queries(*args, **kwargs):
+        def fake_record_sql_queries_streaming(*args, **kwargs):
             with record_sql_queries(*args, **kwargs) as span:
-                pass
-            span.start_timestamp = datetime.datetime(2024, 1, 1, microsecond=0)
-            span.timestamp = datetime.datetime(2024, 1, 1, microsecond=100001)
-            yield span
+                span._start_timestamp = datetime.datetime(
+                    2024, 1, 1, microsecond=0, tzinfo=datetime.timezone.utc
+                )
+                yield span
 
-        async with conn.cursor() as cur:
-            with mock.patch(
-                "sentry_sdk.integrations.aiomysql.record_sql_queries",
-                fake_record_sql_queries,
-            ):
+        with sentry_sdk.traces.start_span(name="test_segment"):
+            conn = await aiomysql.connect(**_connect_args())
+
+            async with conn.cursor() as cur:
+                with mock.patch(
+                    "sentry_sdk.integrations.aiomysql.record_sql_queries",
+                    fake_record_sql_queries_streaming,
+                ):
+                    await cur.execute(
+                        "INSERT INTO users(name, password, dob) VALUES ('Alice', 'secret', '1990-12-25')",
+                    )
+
+            conn.close()
+
+        sentry_sdk.flush()
+
+        spans = [item.payload for item in items]
+
+        assert len(spans) == 3
+
+        connect_span = spans[0]
+        insert_span = spans[1]
+        segment = spans[2]
+
+        assert segment["name"] == "test_segment"
+        assert insert_span["name"].startswith("INSERT INTO")
+        assert connect_span["name"] == "connect"
+
+        data = insert_span.get("attributes", {})
+
+        assert "code.line.number" in data
+        assert "code.namespace" in data
+        assert "code.file.path" in data
+        assert "code.function" in data
+
+        assert type(data.get("code.line.number")) == int
+        assert data.get("code.line.number") > 0
+        assert data.get("code.namespace") == "tests.integrations.aiomysql.test_aiomysql"
+        assert data.get("code.file.path").endswith(
+            "tests/integrations/aiomysql/test_aiomysql.py"
+        )
+
+        is_relative_path = data.get("code.file.path")[0] != os.sep
+        assert is_relative_path
+
+        assert (
+            data.get("code.function") == "test_query_source_if_duration_over_threshold"
+        )
+    else:
+        events = capture_events()
+
+        with start_transaction(name="test_transaction", sampled=True):
+            conn = await aiomysql.connect(**_connect_args())
+
+            @contextmanager
+            def fake_record_sql_queries(*args, **kwargs):
+                with record_sql_queries(*args, **kwargs) as span:
+                    pass
+                span.start_timestamp = datetime.datetime(2024, 1, 1, microsecond=0)
+                span.timestamp = datetime.datetime(2024, 1, 1, microsecond=100001)
+                yield span
+
+            async with conn.cursor() as cur:
+                with mock.patch(
+                    "sentry_sdk.integrations.aiomysql.record_sql_queries",
+                    fake_record_sql_queries,
+                ):
+                    await cur.execute(
+                        "INSERT INTO users(name, password, dob) VALUES ('Alice', 'secret', '1990-12-25')",
+                    )
+
+            conn.close()
+
+        (event,) = events
+
+        span = event["spans"][-1]
+        assert span["description"].startswith("INSERT INTO")
+
+        data = span.get("data", {})
+
+        assert SPANDATA.CODE_LINENO in data
+        assert SPANDATA.CODE_NAMESPACE in data
+        assert SPANDATA.CODE_FILEPATH in data
+        assert SPANDATA.CODE_FUNCTION in data
+
+        assert type(data.get(SPANDATA.CODE_LINENO)) == int
+        assert data.get(SPANDATA.CODE_LINENO) > 0
+        assert (
+            data.get(SPANDATA.CODE_NAMESPACE)
+            == "tests.integrations.aiomysql.test_aiomysql"
+        )
+        assert data.get(SPANDATA.CODE_FILEPATH).endswith(
+            "tests/integrations/aiomysql/test_aiomysql.py"
+        )
+
+        is_relative_path = data.get(SPANDATA.CODE_FILEPATH)[0] != os.sep
+        assert is_relative_path
+
+        assert (
+            data.get(SPANDATA.CODE_FUNCTION)
+            == "test_query_source_if_duration_over_threshold"
+        )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("span_streaming", [True, False])
+async def test_span_origin(sentry_init, capture_events, capture_items, span_streaming):
+    sentry_init(
+        integrations=[AioMySQLIntegration()],
+        traces_sample_rate=1.0,
+        _experiments={
+            "trace_lifecycle": "stream" if span_streaming else "static",
+        },
+    )
+
+    if span_streaming:
+        items = capture_items("span")
+
+        with sentry_sdk.traces.start_span(name="test_segment"):
+            conn = await aiomysql.connect(**_connect_args())
+
+            async with conn.cursor() as cur:
+                await cur.execute("SELECT 1")
+                await cur.execute("SELECT 2")
+
+            conn.close()
+
+        sentry_sdk.flush()
+
+        spans = [item.payload for item in items]
+
+        non_segment_spans = [s for s in spans if not s.get("is_segment")]
+        segment_spans = [s for s in spans if s.get("is_segment")]
+
+        assert len(segment_spans) == 1
+        assert segment_spans[0]["attributes"]["sentry.origin"] == "manual"
+
+        for span in non_segment_spans:
+            assert span["attributes"]["sentry.origin"] == "auto.db.aiomysql"
+    else:
+        events = capture_events()
+
+        with start_transaction(name="test_transaction"):
+            conn = await aiomysql.connect(**_connect_args())
+
+            async with conn.cursor() as cur:
+                await cur.execute("SELECT 1")
+                await cur.execute("SELECT 2")
+
+            conn.close()
+
+        (event,) = events
+
+        assert event["contexts"]["trace"]["origin"] == "manual"
+
+        for span in event["spans"]:
+            assert span["origin"] == "auto.db.aiomysql"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("span_streaming", [True, False])
+async def test_multiline_query_description_normalized(
+    sentry_init, capture_events, capture_items, span_streaming
+):
+    sentry_init(
+        integrations=[AioMySQLIntegration()],
+        traces_sample_rate=1.0,
+        _experiments={
+            "trace_lifecycle": "stream" if span_streaming else "static",
+        },
+    )
+
+    if span_streaming:
+        items = capture_items("span")
+
+        with sentry_sdk.traces.start_span(name="test_segment"):
+            conn = await aiomysql.connect(**_connect_args())
+
+            async with conn.cursor() as cur:
                 await cur.execute(
-                    "INSERT INTO users(name, password, dob) VALUES ('Alice', 'secret', '1990-12-25')",
+                    """
+                    SELECT
+                        id,
+                        name
+                    FROM
+                        users
+                    WHERE
+                        name = 'Alice'
+                    """
                 )
 
-        conn.close()
+            conn.close()
 
-    (event,) = events
+        sentry_sdk.flush()
 
-    span = event["spans"][-1]
-    assert span["description"].startswith("INSERT INTO")
+        spans = [item.payload for item in items]
 
-    data = span.get("data", {})
+        select_spans = [
+            s
+            for s in spans
+            if not s.get("is_segment") and "SELECT" in s.get("name", "")
+        ]
+        assert len(select_spans) == 1
+        assert (
+            select_spans[0]["name"] == "SELECT id, name FROM users WHERE name = 'Alice'"
+        )
+    else:
+        events = capture_events()
 
-    assert SPANDATA.CODE_LINENO in data
-    assert SPANDATA.CODE_NAMESPACE in data
-    assert SPANDATA.CODE_FILEPATH in data
-    assert SPANDATA.CODE_FUNCTION in data
+        with start_transaction(name="test_transaction"):
+            conn = await aiomysql.connect(**_connect_args())
 
-    assert type(data.get(SPANDATA.CODE_LINENO)) == int
-    assert data.get(SPANDATA.CODE_LINENO) > 0
-    assert (
-        data.get(SPANDATA.CODE_NAMESPACE) == "tests.integrations.aiomysql.test_aiomysql"
-    )
-    assert data.get(SPANDATA.CODE_FILEPATH).endswith(
-        "tests/integrations/aiomysql/test_aiomysql.py"
-    )
+            async with conn.cursor() as cur:
+                await cur.execute(
+                    """
+                    SELECT
+                        id,
+                        name
+                    FROM
+                        users
+                    WHERE
+                        name = 'Alice'
+                    """
+                )
 
-    is_relative_path = data.get(SPANDATA.CODE_FILEPATH)[0] != os.sep
-    assert is_relative_path
+            conn.close()
 
-    assert (
-        data.get(SPANDATA.CODE_FUNCTION)
-        == "test_query_source_if_duration_over_threshold"
-    )
+        (event,) = events
 
-
-@pytest.mark.asyncio
-async def test_span_origin(sentry_init, capture_events):
-    sentry_init(
-        integrations=[AioMySQLIntegration()],
-        traces_sample_rate=1.0,
-    )
-
-    events = capture_events()
-
-    with start_transaction(name="test_transaction"):
-        conn = await aiomysql.connect(**_connect_args())
-
-        async with conn.cursor() as cur:
-            await cur.execute("SELECT 1")
-            await cur.execute("SELECT 2")
-
-        conn.close()
-
-    (event,) = events
-
-    assert event["contexts"]["trace"]["origin"] == "manual"
-
-    for span in event["spans"]:
-        assert span["origin"] == "auto.db.aiomysql"
-
-
-@pytest.mark.asyncio
-async def test_multiline_query_description_normalized(sentry_init, capture_events):
-    sentry_init(
-        integrations=[AioMySQLIntegration()],
-        traces_sample_rate=1.0,
-    )
-    events = capture_events()
-
-    with start_transaction(name="test_transaction"):
-        conn = await aiomysql.connect(**_connect_args())
-
-        async with conn.cursor() as cur:
-            await cur.execute(
-                """
-                SELECT
-                    id,
-                    name
-                FROM
-                    users
-                WHERE
-                    name = 'Alice'
-                """
-            )
-
-        conn.close()
-
-    (event,) = events
-
-    spans = [
-        s
-        for s in event["spans"]
-        if s["op"] == "db" and "SELECT" in s.get("description", "")
-    ]
-    assert len(spans) == 1
-    assert spans[0]["description"] == "SELECT id, name FROM users WHERE name = 'Alice'"
+        spans = [
+            s
+            for s in event["spans"]
+            if s["op"] == "db" and "SELECT" in s.get("description", "")
+        ]
+        assert len(spans) == 1
+        assert (
+            spans[0]["description"] == "SELECT id, name FROM users WHERE name = 'Alice'"
+        )
 
 
 @pytest.mark.asyncio
@@ -772,30 +1091,64 @@ async def test_before_send_transaction_sees_normalized_description(
 
 
 @pytest.mark.asyncio
-async def test_db_data_on_spans(sentry_init, capture_events):
+@pytest.mark.parametrize("span_streaming", [True, False])
+async def test_db_data_on_spans(
+    sentry_init, capture_events, capture_items, span_streaming
+):
     """Test that database connection data is properly set on spans."""
     sentry_init(
         integrations=[AioMySQLIntegration()],
         traces_sample_rate=1.0,
+        _experiments={
+            "trace_lifecycle": "stream" if span_streaming else "static",
+        },
     )
-    events = capture_events()
 
-    with start_transaction(name="test_transaction"):
-        conn = await aiomysql.connect(**_connect_args())
+    if span_streaming:
+        items = capture_items("span")
 
-        async with conn.cursor() as cur:
-            await cur.execute("SELECT 1")
+        with sentry_sdk.traces.start_span(name="test_segment"):
+            conn = await aiomysql.connect(**_connect_args())
 
-        conn.close()
+            async with conn.cursor() as cur:
+                await cur.execute("SELECT 1")
 
-    (event,) = events
+            conn.close()
 
-    db_spans = [s for s in event["spans"] if s["op"] == "db"]
-    assert len(db_spans) > 0
+        sentry_sdk.flush()
 
-    query_span = [s for s in db_spans if "SELECT" in s.get("description", "")][0]
-    assert query_span["data"].get(SPANDATA.DB_SYSTEM) == "mysql"
-    assert query_span["data"].get(SPANDATA.SERVER_ADDRESS) == MYSQL_HOST
-    assert query_span["data"].get(SPANDATA.SERVER_PORT) == MYSQL_PORT
-    assert query_span["data"].get(SPANDATA.DB_NAME) == MYSQL_DB
-    assert query_span["data"].get(SPANDATA.DB_USER) == MYSQL_USER
+        spans = [item.payload for item in items]
+
+        query_span = [
+            s
+            for s in spans
+            if not s.get("is_segment") and "SELECT" in s.get("name", "")
+        ][0]
+        data = query_span.get("attributes", {})
+        assert data.get(SPANDATA.DB_SYSTEM_NAME) == "mysql"
+        assert data.get(SPANDATA.SERVER_ADDRESS) == MYSQL_HOST
+        assert data.get(SPANDATA.SERVER_PORT) == MYSQL_PORT
+        assert data.get(SPANDATA.DB_NAMESPACE) == MYSQL_DB
+        assert data.get(SPANDATA.DB_USER) == MYSQL_USER
+    else:
+        events = capture_events()
+
+        with start_transaction(name="test_transaction"):
+            conn = await aiomysql.connect(**_connect_args())
+
+            async with conn.cursor() as cur:
+                await cur.execute("SELECT 1")
+
+            conn.close()
+
+        (event,) = events
+
+        db_spans = [s for s in event["spans"] if s["op"] == "db"]
+        assert len(db_spans) > 0
+
+        query_span = [s for s in db_spans if "SELECT" in s.get("description", "")][0]
+        assert query_span["data"].get(SPANDATA.DB_SYSTEM) == "mysql"
+        assert query_span["data"].get(SPANDATA.SERVER_ADDRESS) == MYSQL_HOST
+        assert query_span["data"].get(SPANDATA.SERVER_PORT) == MYSQL_PORT
+        assert query_span["data"].get(SPANDATA.DB_NAME) == MYSQL_DB
+        assert query_span["data"].get(SPANDATA.DB_USER) == MYSQL_USER


### PR DESCRIPTION
Parametrize existing aiomysql tests with span_streaming to cover both
static and stream trace lifecycle modes.

Fixes PY-2523
Fixes #6539