### PR TITLE
docs: fix typos

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -198,7 +198,7 @@ lldb -- ../../uwsgi/uwsgi --pythonpath "$PWD/.venv/lib/python3.14/site-packages"
 
 ### Troubleshooting "module not found" error in relation to the `sentry-sdk` when it's installed in editable mode
 
-If you are trying to debug a Django applicaton such as that described above, and have the Sentry SDK installed in editable mode in the Django project, you will likely encounter this error because the editable package is not being found in the uWSGI's python path. To fix this, the above command needs to be updated to include a `--pythonpath` argument that passes in where your local `sentry-python` codebase is:
+If you are trying to debug a Django application such as that described above, and have the Sentry SDK installed in editable mode in the Django project, you will likely encounter this error because the editable package is not being found in the uWSGI's python path. To fix this, the above command needs to be updated to include a `--pythonpath` argument that passes in where your local `sentry-python` codebase is:
 
 ```bash
 lldb -- ../../uwsgi/uwsgi --pythonpath "$PWD/.venv/lib/python3.14/site-packages" \

--- a/tests/profiler/test_transaction_profiler.py
+++ b/tests/profiler/test_transaction_profiler.py
@@ -608,7 +608,7 @@ def test_thread_scheduler_no_thread_on_shutdown(scheduler_class):
     # setup but no profiles started so still no threads
     assert len(get_scheduler_threads(scheduler)) == 0
 
-    # mock RuntimeError as if the 3.12 intepreter was shutting down
+    # mock RuntimeError as if the 3.12 interpreter was shutting down
     with mock.patch(
         "threading.Thread.start",
         side_effect=RuntimeError("can't create new thread at interpreter shutdown"),


### PR DESCRIPTION
## Summary
- Fix a small set of spelling mistakes in documentation/comments.
- Keep the change scoped to text-only cleanup.

## Validation
- git diff --check