### PR TITLE
feat(pyramid): Set user.id on spans when PII is enabled

### DIFF
--- a/sentry_sdk/integrations/pyramid.py
+++ b/sentry_sdk/integrations/pyramid.py
@@ -81,19 +81,17 @@ class PyramidIntegration(Integration):
             if integration is None:
                 return old_call_view(registry, request, *args, **kwargs)
 
-            current_scope = sentry_sdk.get_current_scope()
             _set_transaction_name_and_source(
-                current_scope, integration.transaction_style, request
+                sentry_sdk.get_current_scope(), integration.transaction_style, request
             )
 
-            if should_send_default_pii() and has_span_streaming_enabled(client.options):
-                current_span = current_scope.streamed_span
-                user_id = authenticated_userid(request)
-
-                if user_id and type(current_span) is StreamedSpan:
-                    current_span._segment.set_attribute("user.id", user_id)
-
             scope = sentry_sdk.get_isolation_scope()
+
+            if should_send_default_pii() and has_span_streaming_enabled(client.options):
+                user_id = authenticated_userid(request)
+                if user_id:
+                    scope.set_user({"id": user_id})
+
             scope.add_event_processor(
                 _make_event_processor(weakref.ref(request), integration)
             )

--- a/sentry_sdk/integrations/pyramid.py
+++ b/sentry_sdk/integrations/pyramid.py
@@ -9,7 +9,6 @@ from sentry_sdk.integrations._wsgi_common import RequestExtractor
 from sentry_sdk.integrations.wsgi import SentryWsgiMiddleware
 from sentry_sdk.scope import should_send_default_pii
 from sentry_sdk.traces import SOURCE_FOR_STYLE as SEGMENT_SOURCE_FOR_STYLE
-from sentry_sdk.traces import StreamedSpan
 from sentry_sdk.tracing import SOURCE_FOR_STYLE as TRANSACTION_SOURCE_FOR_STYLE
 from sentry_sdk.tracing_utils import has_span_streaming_enabled
 from sentry_sdk.utils import (

--- a/sentry_sdk/integrations/pyramid.py
+++ b/sentry_sdk/integrations/pyramid.py
@@ -9,6 +9,7 @@ from sentry_sdk.integrations._wsgi_common import RequestExtractor
 from sentry_sdk.integrations.wsgi import SentryWsgiMiddleware
 from sentry_sdk.scope import should_send_default_pii
 from sentry_sdk.traces import SOURCE_FOR_STYLE as SEGMENT_SOURCE_FOR_STYLE
+from sentry_sdk.traces import StreamedSpan
 from sentry_sdk.tracing import SOURCE_FOR_STYLE as TRANSACTION_SOURCE_FOR_STYLE
 from sentry_sdk.tracing_utils import has_span_streaming_enabled
 from sentry_sdk.utils import (
@@ -75,13 +76,23 @@ class PyramidIntegration(Integration):
         def sentry_patched_call_view(
             registry: "Any", request: "Request", *args: "Any", **kwargs: "Any"
         ) -> "Response":
-            integration = sentry_sdk.get_client().get_integration(PyramidIntegration)
+            client = sentry_sdk.get_client()
+            integration = client.get_integration(PyramidIntegration)
             if integration is None:
                 return old_call_view(registry, request, *args, **kwargs)
 
+            current_scope = sentry_sdk.get_current_scope()
             _set_transaction_name_and_source(
-                sentry_sdk.get_current_scope(), integration.transaction_style, request
+                current_scope, integration.transaction_style, request
             )
+
+            if should_send_default_pii() and has_span_streaming_enabled(client.options):
+                current_span = current_scope.streamed_span
+                user_id = authenticated_userid(request)
+
+                if user_id and type(current_span) is StreamedSpan:
+                    current_span._segment.set_attribute("user.id", user_id)
+
             scope = sentry_sdk.get_isolation_scope()
             scope.add_event_processor(
                 _make_event_processor(weakref.ref(request), integration)

--- a/tests/integrations/pyramid/test_pyramid.py
+++ b/tests/integrations/pyramid/test_pyramid.py
@@ -527,7 +527,12 @@ def test_tracing_error(
 
 @pytest.mark.parametrize("span_streaming", [True, False])
 def test_span_origin(
-    sentry_init, capture_events, capture_items, get_client, span_streaming
+    sentry_init,
+    pyramid_config,
+    capture_events,
+    capture_items,
+    get_client,
+    span_streaming,
 ):
     sentry_init(
         integrations=[PyramidIntegration()],
@@ -552,3 +557,42 @@ def test_span_origin(
     else:
         (_, event) = events
         assert event["contexts"]["trace"]["origin"] == "auto.http.pyramid"
+
+
+@pytest.mark.parametrize("send_default_pii", [True, False])
+def test_span_sets_user_id_on_segment(
+    sentry_init,
+    pyramid_config,
+    capture_items,
+    get_client,
+    send_default_pii,
+):
+    sentry_init(
+        integrations=[PyramidIntegration()],
+        traces_sample_rate=1.0,
+        send_default_pii=send_default_pii,
+        _experiments={"trace_lifecycle": "stream"},
+    )
+
+    class AuthenticationPolicy:
+        def authenticated_userid(self, request):
+            return "123-abc"
+
+    pyramid_config.set_authorization_policy(ACLAuthorizationPolicy())
+    pyramid_config.set_authentication_policy(AuthenticationPolicy())
+
+    items = capture_items("span")
+
+    client = get_client()
+    client.get("/message")
+
+    sentry_sdk.flush()
+    spans = [i.payload for i in items if i.type == "span"]
+
+    assert len(spans) == 1
+    (segment,) = spans
+
+    if send_default_pii:
+        assert segment["attributes"]["user.id"] == "123-abc"
+    else:
+        assert "user.id" not in segment["attributes"]


### PR DESCRIPTION
When span streaming is enabled and `send_default_pii` is true, set the `user.id` attribute on all spans using `scope.set_user` using the authenticated user ID from the Pyramid request.

Fixes #6605
Fixes PY-2542