### PR TITLE
ci: Remove `brotli` from `requirements-testing.txt`

### DIFF
--- a/requirements-testing.txt
+++ b/requirements-testing.txt
@@ -14,5 +14,4 @@ pysocks
 socksio
 httpcore[http2]
 setuptools
-Brotli
 docker

--- a/scripts/populate_tox/tox.jinja
+++ b/scripts/populate_tox/tox.jinja
@@ -79,6 +79,7 @@ deps =
 
     # === Common ===
     py3.8-common: hypothesis
+    common: brotli
     common: pytest-asyncio
     common: httpcore[asyncio]
     # See https://github.com/pytest-dev/pytest/issues/9621
@@ -97,6 +98,7 @@ deps =
     # for justification of the upper bound on pytest
     {py3.6,py3.7}-gevent: pytest<7.0.0
     {py3.8,py3.9,py3.10,py3.11,py3.12}-gevent: pytest
+    gevent: brotli
     gevent: pytest-asyncio
     gevent: setuptools<82
     {py3.10,py3.11}-gevent: zope.event<5.0.0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,7 +13,11 @@ from threading import Thread
 from unittest import mock
 from urllib.parse import parse_qs, urlparse
 
-import brotli
+try:
+    import brotli
+except ImportError:
+    brotli = None
+
 import jsonschema
 import pytest
 from pytest_localserver.http import WSGIServer
@@ -1641,6 +1645,7 @@ class CapturingServer(WSGIServer):
             rdr = gzip.GzipFile(fileobj=io.BytesIO(request.data))
             compressed = True
         elif content_encoding == "br":
+            assert brotli is not None
             rdr = io.BytesIO(brotli.decompress(request.data))
             compressed = True
         else:

--- a/tox.ini
+++ b/tox.ini
@@ -402,6 +402,7 @@ deps =
 
     # === Common ===
     py3.8-common: hypothesis
+    common: brotli
     common: pytest-asyncio
     common: httpcore[asyncio]
     # See https://github.com/pytest-dev/pytest/issues/9621
@@ -420,6 +421,7 @@ deps =
     # for justification of the upper bound on pytest
     {py3.6,py3.7}-gevent: pytest<7.0.0
     {py3.8,py3.9,py3.10,py3.11,py3.12}-gevent: pytest
+    gevent: brotli
     gevent: pytest-asyncio
     gevent: setuptools<82
     {py3.10,py3.11}-gevent: zope.event<5.0.0


### PR DESCRIPTION
### Description
<!-- What changed and why? -->

Remove the package from `requirements-testing.txt` and add the package as a dependency to only the test suites that rely on the package (if applicable).

This is part of environment cleanup before moving the remaining testing dependencies to a uv dependency group.

#### Issues
<!--
* resolves: #1234
* resolves: LIN-1234
-->

#### Reminders
- Please add tests to validate your changes, and lint your code using `uv run ruff`.
- Add GH Issue ID _&_ Linear ID (if applicable)
- PR title should use [conventional commit](https://develop.sentry.dev/engineering-practices/commit-messages/#type) style (`feat:`, `fix:`, `ref:`, `meta:`)
- For external contributors: [CONTRIBUTING.md](https://github.com/getsentry/sentry-python/blob/master/CONTRIBUTING.md), [Sentry SDK development docs](https://develop.sentry.dev/sdk/), [Discord community](https://discord.gg/Ww9hbqr)
