### PR TITLE
fix: Stop unconditionally importing `contextvars`

### DIFF
--- a/sentry_sdk/utils.py
+++ b/sentry_sdk/utils.py
@@ -1,5 +1,4 @@
 import base64
-import contextvars
 import copy
 import json
 import linecache
@@ -1445,9 +1444,7 @@ requests.
 Please refer to https://docs.sentry.io/platforms/python/contextvars/ for more information.
 """
 
-_is_sentry_internal_task = contextvars.ContextVar(
-    "is_sentry_internal_task", default=False
-)
+_is_sentry_internal_task = ContextVar("is_sentry_internal_task", default=False)
 
 # These exceptions won't set the span status to error if they occur. Use
 # register_control_flow_exception to add to this list

--- a/sentry_sdk/utils.py
+++ b/sentry_sdk/utils.py
@@ -84,29 +84,6 @@ logger = logging.getLogger("sentry_sdk.errors")
 
 _installed_modules = None
 
-_is_sentry_internal_task = contextvars.ContextVar(
-    "is_sentry_internal_task", default=False
-)
-
-# These exceptions won't set the span status to error if they occur. Use
-# register_control_flow_exception to add to this list
-_control_flow_exception_classes: "set[type]" = set()
-
-
-def is_internal_task() -> bool:
-    return _is_sentry_internal_task.get()
-
-
-@contextmanager
-def mark_sentry_task_internal() -> "Generator[None, None, None]":
-    """Context manager to mark a task as Sentry internal."""
-    token = _is_sentry_internal_task.set(True)
-    try:
-        yield
-    finally:
-        _is_sentry_internal_task.reset(token)
-
-
 BASE64_ALPHABET = re.compile(r"^[a-zA-Z0-9/+=]*$")
 
 FALSY_ENV_VALUES = frozenset(("false", "f", "n", "no", "off", "0"))
@@ -1467,6 +1444,28 @@ requests.
 
 Please refer to https://docs.sentry.io/platforms/python/contextvars/ for more information.
 """
+
+_is_sentry_internal_task = contextvars.ContextVar(
+    "is_sentry_internal_task", default=False
+)
+
+# These exceptions won't set the span status to error if they occur. Use
+# register_control_flow_exception to add to this list
+_control_flow_exception_classes: "set[type]" = set()
+
+
+def is_internal_task() -> bool:
+    return _is_sentry_internal_task.get()
+
+
+@contextmanager
+def mark_sentry_task_internal() -> "Generator[None, None, None]":
+    """Context manager to mark a task as Sentry internal."""
+    token = _is_sentry_internal_task.set(True)
+    try:
+        yield
+    finally:
+        _is_sentry_internal_task.reset(token)
 
 
 def qualname_from_function(func: "Callable[..., Any]") -> "Optional[str]":


### PR DESCRIPTION
### Description
<!-- What changed and why? -->

Fix regression from https://github.com/getsentry/sentry-python/commit/26044097d4e32dc0e12ed559130904f644317455.

`contextvars` was added to the standard library in Python 3.7, and `sentry-sdk` does not declare any dependencies which allow it to resolve `contextvars` at import time.

#### Issues
<!--
* resolves: #1234
* resolves: LIN-1234
-->

#### Reminders
- Please add tests to validate your changes, and lint your code using `uv run ruff`.
- Add GH Issue ID _&_ Linear ID (if applicable)
- PR title should use [conventional commit](https://develop.sentry.dev/engineering-practices/commit-messages/#type) style (`feat:`, `fix:`, `ref:`, `meta:`)
- For external contributors: [CONTRIBUTING.md](https://github.com/getsentry/sentry-python/blob/master/CONTRIBUTING.md), [Sentry SDK development docs](https://develop.sentry.dev/sdk/), [Discord community](https://discord.gg/Ww9hbqr)
