### PR TITLE
ci: Remove `pip` from `requirements-testing.txt`

### DIFF
--- a/requirements-testing.txt
+++ b/requirements-testing.txt
@@ -1,4 +1,3 @@
-pip
 pytest>=6.0.0
 tomli;python_version<"3.11"  # Only needed for pytest on Python < 3.11
 pytest-cov


### PR DESCRIPTION
### Description
<!-- What changed and why? -->

Remove the package from `requirements-testing.txt` and add the package as a dependency to only the test suites that rely on the package (if applicable).

This is part of environment cleanup before moving the remaining testing dependencies to a uv dependency group.

#### Issues
<!--
* resolves: #1234
* resolves: LIN-1234
-->

#### Reminders
- Please add tests to validate your changes, and lint your code using `uv run ruff`.
- Add GH Issue ID _&_ Linear ID (if applicable)
- PR title should use [conventional commit](https://develop.sentry.dev/engineering-practices/commit-messages/#type) style (`feat:`, `fix:`, `ref:`, `meta:`)
- For external contributors: [CONTRIBUTING.md](https://github.com/getsentry/sentry-python/blob/master/CONTRIBUTING.md), [Sentry SDK development docs](https://develop.sentry.dev/sdk/), [Discord community](https://discord.gg/Ww9hbqr)
