### PR TITLE
fix(asgi): Add url.path to ASGI request span attributes

### DIFF
--- a/sentry_sdk/integrations/_asgi_common.py
+++ b/sentry_sdk/integrations/_asgi_common.py
@@ -135,6 +135,9 @@ def _get_request_attributes(asgi_scope: "Any") -> "dict[str, Any]":
                 if query_string is not None
                 else url_without_query_string
             )
+            attributes["url.path"] = asgi_scope.get("root_path", "") + asgi_scope.get(
+                "path", ""
+            )
 
     client = asgi_scope.get("client")
     if client and should_send_default_pii():

--- a/tests/integrations/asgi/test_asgi.py
+++ b/tests/integrations/asgi/test_asgi.py
@@ -221,6 +221,7 @@ async def test_capture_transaction(
                 span["attributes"]["url.full"]
                 == "http://localhost/some_url?somevalue=123"
             )
+            assert span["attributes"]["url.path"] == "/some_url"
             assert span["attributes"]["http.query"] == "somevalue=123"
 
     else:
@@ -240,6 +241,30 @@ async def test_capture_transaction(
             "query_string": "somevalue=123",
             "url": "http://localhost/some_url",
         }
+
+
+@pytest.mark.asyncio
+async def test_capture_transaction_with_root_path(
+    sentry_init,
+    asgi3_app,
+    capture_items,
+):
+    sentry_init(
+        send_default_pii=True,
+        traces_sample_rate=1.0,
+        _experiments={"trace_lifecycle": "stream"},
+    )
+    app = SentryAsgiMiddleware(asgi3_app)
+
+    async with TestClient(app, scope={"root_path": "/api"}) as client:
+        items = capture_items("span")
+        await client.get("/some_url")
+
+    sentry_sdk.flush()
+
+    assert len(items) == 1
+    span = items[0].payload
+    assert span["attributes"]["url.path"] == "/api/some_url"
 
 
 @pytest.mark.asyncio

--- a/tests/integrations/quart/test_quart.py
+++ b/tests/integrations/quart/test_quart.py
@@ -822,6 +822,7 @@ async def test_span_streaming_request_attributes_no_pii(sentry_init, capture_ite
     assert "http.request.header.host" in segment["attributes"]
 
     assert "url.full" not in segment["attributes"]
+    assert "url.path" not in segment["attributes"]
     assert "url.query" not in segment["attributes"]
     assert "client.address" not in segment["attributes"]
     assert "user.ip_address" not in segment["attributes"]
@@ -854,6 +855,7 @@ async def test_span_streaming_request_attributes_with_pii(sentry_init, capture_i
     assert (
         segment["attributes"]["url.full"] == "http://localhost/message?foo=bar&baz=qux"
     )
+    assert segment["attributes"]["url.path"] == "/message"
     assert segment["attributes"]["url.query"] == "foo=bar&baz=qux"
     assert "client.address" in segment["attributes"]
     assert "user.ip_address" in segment["attributes"]


### PR DESCRIPTION
The ASGI integration was not setting `url.path` on streamed request spans. Add it by combining `root_path` and `path` from the ASGI scope, which correctly handles sub-mounted apps where `root_path` is non-empty.

Fixes PY-2551
Fixes #6651