### PR TITLE
fix(tornado): Gate url.full, url.path, url.query on send_default_pii

### DIFF
--- a/sentry_sdk/integrations/tornado.py
+++ b/sentry_sdk/integrations/tornado.py
@@ -197,10 +197,12 @@ def _get_request_attributes(request: "Any") -> "Dict[str, Any]":
     for header, value in headers.items():
         attributes[f"{SPANDATA.HTTP_REQUEST_HEADER}.{header.lower()}"] = value
 
-    if request.query:
-        attributes[SPANDATA.URL_QUERY] = request.query
+    if should_send_default_pii():
+        attributes[SPANDATA.URL_FULL] = request.full_url()
+        attributes["url.path"] = request.path
 
-    attributes[SPANDATA.URL_FULL] = request.full_url()
+        if request.query:
+            attributes[SPANDATA.URL_QUERY] = request.query
 
     if request.protocol:
         attributes[SPANDATA.NETWORK_PROTOCOL_NAME] = request.protocol

--- a/tests/integrations/tornado/test_tornado.py
+++ b/tests/integrations/tornado/test_tornado.py
@@ -110,6 +110,7 @@ def test_basic(tornado_testcase, sentry_init, capture_events):
     assert not sentry_sdk.get_isolation_scope()._tags
 
 
+@pytest.mark.parametrize("send_pii", [True, False])
 @pytest.mark.parametrize("span_streaming", [True, False])
 @pytest.mark.parametrize(
     "handler,code",
@@ -126,10 +127,12 @@ def test_transactions(
     handler,
     code,
     span_streaming,
+    send_pii,
 ):
     sentry_init(
         integrations=[TornadoIntegration()],
         traces_sample_rate=1.0,
+        send_default_pii=send_pii,
         _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
     )
 
@@ -185,11 +188,18 @@ def test_transactions(
         assert server_segment["attributes"]["http.request.method"] == "POST"
         assert server_segment["attributes"]["http.request.body.data"] == "heyoo"
         assert server_segment["attributes"]["http.response.status_code"] == code
-        assert server_segment["attributes"]["url.query"] == "foo=bar"
-        assert server_segment["attributes"]["url.full"].endswith("/hi?foo=bar")
-        assert server_segment["attributes"]["url.full"].startswith("http://")
         assert server_segment["status"] == ("ok" if code == 200 else "error")
         assert client_segment["trace_id"] == server_segment["trace_id"]
+
+        if send_pii:
+            assert server_segment["attributes"]["url.query"] == "foo=bar"
+            assert server_segment["attributes"]["url.full"].endswith("/hi?foo=bar")
+            assert server_segment["attributes"]["url.full"].startswith("http://")
+            assert server_segment["attributes"]["url.path"] == "/hi"
+        else:
+            assert "url.query" not in server_segment["attributes"]
+            assert "url.full" not in server_segment["attributes"]
+            assert "url.path" not in server_segment["attributes"]
     else:
         if code == 200:
             client_tx, server_tx = events
@@ -227,7 +237,7 @@ def test_transactions(
 
         request = server_tx["request"]
         host = request["headers"]["Host"]
-        assert server_tx["request"] == {
+        expected_request = {
             "env": {"REMOTE_ADDR": "127.0.0.1"},
             "headers": {
                 "Accept-Encoding": "gzip",
@@ -239,6 +249,9 @@ def test_transactions(
             "data": {"heyoo": [""]},
             "url": "http://{host}/hi".format(host=host),
         }
+        if send_pii:
+            expected_request["cookies"] = {}
+        assert server_tx["request"] == expected_request
 
         assert (
             client_tx["contexts"]["trace"]["trace_id"]


### PR DESCRIPTION
Gates `url.full`, `url.path`, and `url.query` span attributes in the Tornado integration behind `send_default_pii`, consistent with the same fix applied to the aiohttp (#6650) and wsgi (#6654) integrations.

Adds a `send_pii` parametrize dimension to the transactions test to cover both the PII-on and PII-off paths explicitly.

Fixes PY-2556
Fixes #6661