### PR TITLE
fix(httpx2): Gate url.full, url.query on send_default_pii

### DIFF
--- a/sentry_sdk/integrations/httpx2.py
+++ b/sentry_sdk/integrations/httpx2.py
@@ -3,6 +3,7 @@ from typing import TYPE_CHECKING
 import sentry_sdk
 from sentry_sdk.consts import OP, SPANDATA
 from sentry_sdk.integrations import DidNotEnable, Integration
+from sentry_sdk.scope import should_send_default_pii
 from sentry_sdk.tracing import BAGGAGE_HEADER_NAME
 from sentry_sdk.tracing_utils import (
     add_http_request_source,
@@ -73,7 +74,7 @@ def _install_httpx2_client() -> None:
             ) as streamed_span:
                 attributes: "Attributes" = {}
 
-                if parsed_url is not None:
+                if parsed_url is not None and should_send_default_pii():
                     attributes["url.full"] = parsed_url.url
                     if parsed_url.query:
                         attributes["url.query"] = parsed_url.query
@@ -183,7 +184,7 @@ def _install_httpx2_async_client() -> None:
             ) as streamed_span:
                 attributes: "Attributes" = {}
 
-                if parsed_url is not None:
+                if parsed_url is not None and should_send_default_pii():
                     attributes["url.full"] = parsed_url.url
                     if parsed_url.query:
                         attributes["url.query"] = parsed_url.query

--- a/tests/integrations/httpx2/test_httpx2.py
+++ b/tests/integrations/httpx2/test_httpx2.py
@@ -1123,6 +1123,7 @@ def test_http_url_attributes_span_streaming(
     sentry_init(
         integrations=[Httpx2Integration()],
         traces_sample_rate=1.0,
+        send_default_pii=True,
         _experiments={"trace_lifecycle": "stream"},
     )
 
@@ -1158,6 +1159,7 @@ def test_http_url_attributes_no_query_or_fragment_span_streaming(
     sentry_init(
         integrations=[Httpx2Integration()],
         traces_sample_rate=1.0,
+        send_default_pii=True,
         _experiments={"trace_lifecycle": "stream"},
     )
 
@@ -1176,6 +1178,41 @@ def test_http_url_attributes_no_query_or_fragment_span_streaming(
 
     assert http_span["attributes"]["http.request.method"] == "GET"
     assert http_span["attributes"]["url.full"] == "http://example.com/"
+    assert "url.query" not in http_span["attributes"]
+    assert "url.fragment" not in http_span["attributes"]
+    assert http_span["attributes"]["http.response.status_code"] == 200
+
+
+@pytest.mark.parametrize(
+    "httpx2_client",
+    (httpx2.Client(), httpx2.AsyncClient()),
+)
+def test_http_url_attributes_pii_disabled_span_streaming(
+    sentry_init, capture_items, httpx2_client, httpx2_mock
+):
+    httpx2_mock.add_response()
+
+    sentry_init(
+        integrations=[Httpx2Integration()],
+        traces_sample_rate=1.0,
+        _experiments={"trace_lifecycle": "stream"},
+    )
+
+    items = capture_items("span")
+
+    url = "http://example.com/?foo=bar#frag"
+
+    if asyncio.iscoroutinefunction(httpx2_client.get):
+        asyncio.run(httpx2_client.get(url))
+    else:
+        httpx2_client.get(url)
+
+    sentry_sdk.flush()
+
+    http_span = _get_http_client_span(items)
+
+    assert http_span["attributes"]["http.request.method"] == "GET"
+    assert "url.full" not in http_span["attributes"]
     assert "url.query" not in http_span["attributes"]
     assert "url.fragment" not in http_span["attributes"]
     assert http_span["attributes"]["http.response.status_code"] == 200


### PR DESCRIPTION
`url.full` and `url.query` can contain sensitive data such as query parameters or credentials embedded in URLs. This gates both attributes behind `send_default_pii` in the httpx2 integration, matching the behavior already in place for aiohttp and wsgi.

Fixes PY-2559
Fixes #6669 