### PR TITLE
ci: Add `--skip-version-update` option to `populate_tox.py`

### DIFF
--- a/scripts/populate_tox/populate_tox.py
+++ b/scripts/populate_tox/populate_tox.py
@@ -1191,7 +1191,6 @@ def get_existing_releases_to_test(integration: str) -> list[PackageVersion]:
                 match["python_versions"]
             )
             release.rendered_python_versions = match["python_versions"]
-            release.transitive_dependencies = []
             releases[release] = release
 
     return sorted(releases.values())
@@ -1216,7 +1215,12 @@ def get_releases_to_test(integration, package) -> list[Version] | None:
     # Pick a handful of the supported releases to actually test against
     # and fetch the PyPI data for each to determine which Python versions
     # to test it on
-    return pick_releases_to_test(integration, releases, latest_prerelease)
+    test_releases = pick_releases_to_test(integration, releases, latest_prerelease)
+
+    for release in test_releases:
+        _add_python_versions_to_release(integration, package, release)
+
+    return test_releases
 
 
 def parse_args() -> argparse.Namespace:
@@ -1315,8 +1319,8 @@ def main() -> dict[str, list]:
             if test_releases is None:
                 continue
 
+            # Only reads from cache when `integration in skip_version_updates`
             for release in test_releases:
-                _add_python_versions_to_release(integration, package, release)
                 if not release.python_versions:
                     print(f"  Release {release} has no Python versions, skipping.")
                     continue

--- a/scripts/populate_tox/populate_tox.py
+++ b/scripts/populate_tox/populate_tox.py
@@ -1166,7 +1166,7 @@ def _exit_if_pip_unavailable():
         raise exc
 
 
-def _parse_rendered_python_versions(rendered: str) -> list[ThreadedVersion]:
+def parse_rendered_python_versions(rendered: str) -> list[ThreadedVersion]:
     rendered = rendered.strip("{}")
     return [
         ThreadedVersion(
@@ -1187,7 +1187,7 @@ def get_existing_releases_to_test(integration: str) -> list[PackageVersion]:
             if match is None:
                 continue
             release = PackageVersion(match["version"])
-            release.python_versions = _parse_rendered_python_versions(
+            release.python_versions = parse_rendered_python_versions(
                 match["python_versions"]
             )
             release.rendered_python_versions = match["python_versions"]

--- a/scripts/populate_tox/populate_tox.py
+++ b/scripts/populate_tox/populate_tox.py
@@ -4,6 +4,7 @@ This script populates tox.ini automatically using release data from PyPI.
 See scripts/populate_tox/README.md for more info.
 """
 
+import argparse
 import functools
 import hashlib
 import json
@@ -1165,6 +1166,70 @@ def _exit_if_pip_unavailable():
         raise exc
 
 
+def _parse_rendered_python_versions(rendered: str) -> list[ThreadedVersion]:
+    rendered = rendered.strip("{}")
+    return [
+        ThreadedVersion(
+            version.removeprefix("py").removesuffix("t"), no_gil=version.endswith("t")
+        )
+        for version in rendered.split(",")
+    ]
+
+
+def get_existing_releases_to_test(integration: str) -> list[PackageVersion]:
+    version_pattern = re.compile(
+        rf"^\s*(?P<python_versions>\{{[^}}]+\}})-{re.escape(integration)}-v(?P<version>\S+)\s*$"
+    )
+    releases = {}
+    with open(TOX_FILE) as tox_file:
+        for line in tox_file:
+            match = version_pattern.match(line)
+            if match is None:
+                continue
+            release = PackageVersion(match["version"])
+            release.python_versions = _parse_rendered_python_versions(
+                match["python_versions"]
+            )
+            release.rendered_python_versions = match["python_versions"]
+            release.transitive_dependencies = []
+            releases[release] = release
+
+    return sorted(releases.values())
+
+
+def get_releases_to_test(integration, package) -> list[Version] | None:
+    # Fetch data for the main package
+    pypi_data = fetch_package(package)
+    if pypi_data is None:
+        print("Failed to fetch necessary data from PyPI. Aborting.")
+        sys.exit(1)
+
+    # Get the list of all supported releases
+    releases, latest_prerelease = get_supported_releases(integration, pypi_data)
+
+    if not releases:
+        print("  Found no supported releases.")
+        return None
+
+    _compare_min_version_with_defined(integration, releases)
+
+    # Pick a handful of the supported releases to actually test against
+    # and fetch the PyPI data for each to determine which Python versions
+    # to test it on
+    return pick_releases_to_test(integration, releases, latest_prerelease)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--skip-version-update",
+        nargs="*",
+        default=[],
+        help="Integrations to skip version updates for.",
+    )
+    return parser.parse_args()
+
+
 def main() -> dict[str, list]:
     """
     Generate tox.ini from the tox.jinja template.
@@ -1226,6 +1291,9 @@ def main() -> dict[str, list]:
                 "_accessed": False,
             }
 
+    args = parse_args()
+    skip_version_updates = set(args.skip_version_update)
+
     # Process packages
     packages = defaultdict(list)
 
@@ -1236,31 +1304,16 @@ def main() -> dict[str, list]:
 
             print(f"Processing {integration}...")
 
-            # Figure out the actual main package
             package, extra = _get_package_name(integration)
 
-            # Fetch data for the main package
-            pypi_data = fetch_package(package)
-            if pypi_data is None:
-                print("Failed to fetch necessary data from PyPI. Aborting.")
-                sys.exit(1)
+            test_releases = None
+            if integration in skip_version_updates:
+                test_releases = get_existing_releases_to_test(integration)
+            else:
+                test_releases = get_releases_to_test(integration, package)
 
-            # Get the list of all supported releases
-
-            releases, latest_prerelease = get_supported_releases(integration, pypi_data)
-
-            if not releases:
-                print("  Found no supported releases.")
+            if test_releases is None:
                 continue
-
-            _compare_min_version_with_defined(integration, releases)
-
-            # Pick a handful of the supported releases to actually test against
-            # and fetch the PyPI data for each to determine which Python versions
-            # to test it on
-            test_releases = pick_releases_to_test(
-                integration, releases, latest_prerelease
-            )
 
             for release in test_releases:
                 _add_python_versions_to_release(integration, package, release)


### PR DESCRIPTION
### Description
<!-- What changed and why? -->

Add an option to hold versions back in test suites for a specified set of integrations.

This allows us to merge PRs which require updating `tox.ini` when a version incompatibility would otherwise be pulled in.

#### Issues
<!--
* resolves: #1234
* resolves: LIN-1234
-->

#### Reminders
- Please add tests to validate your changes, and lint your code using `uv run ruff`.
- Add GH Issue ID _&_ Linear ID (if applicable)
- PR title should use [conventional commit](https://develop.sentry.dev/engineering-practices/commit-messages/#type) style (`feat:`, `fix:`, `ref:`, `meta:`)
- For external contributors: [CONTRIBUTING.md](https://github.com/getsentry/sentry-python/blob/master/CONTRIBUTING.md), [Sentry SDK development docs](https://develop.sentry.dev/sdk/), [Discord community](https://discord.gg/Ww9hbqr)
