### PR TITLE
ci(mcp): Pin mcp package to <2.0.0 while alphas are in flight

### DIFF
--- a/scripts/populate_tox/config.py
+++ b/scripts/populate_tox/config.py
@@ -303,6 +303,7 @@ TEST_SUITE_CONFIG = {
         "deps": {
             "*": ["pytest-asyncio"],
         },
+        "include": "<2.0.0",  # Alphas are currently being released, will come back to these before the release that's expected at the end of July 2026
     },
     "fastmcp": {
         "package": "fastmcp",


### PR DESCRIPTION
The `mcp` package is currently releasing 2.0 alpha versions. Pin the test suite to `<2.0.0` to avoid picking up unstable pre-releases until the stable 2.0 release expected at the end of July 2026.