### PR TITLE
(test): need to include the alpha tag for mcp package inclusion

### DIFF
--- a/scripts/populate_tox/config.py
+++ b/scripts/populate_tox/config.py
@@ -303,7 +303,7 @@ TEST_SUITE_CONFIG = {
         "deps": {
             "*": ["pytest-asyncio"],
         },
-        "include": "<2.0.0",  # Alphas are currently being released, will come back to these before the release that's expected at the end of July 2026
+        "include": "<2.0.0a1",  # Alphas are currently being released, will come back to these before the release that's expected at the end of July 2026
     },
     "fastmcp": {
         "package": "fastmcp",


### PR DESCRIPTION
### Description
The initial PR #6687 doesn't correctly ignore alpha tags because `2.0.0a` < `2.0.0`. Update the conditional to make sure these alpha versions are filtered out