### PR TITLE
fix(scope): Drop None user attribute values in set_user

### DIFF
--- a/sentry_sdk/scope.py
+++ b/sentry_sdk/scope.py
@@ -890,7 +890,14 @@ class Scope:
 
     def set_user(self, value: "Optional[Dict[str, Any]]") -> None:
         """Sets a user for the scope."""
-        self._user = value
+        if value is not None:
+            self._user = {}
+            for k, v in value.items():
+                if v is not None:
+                    self._user[k] = v
+        else:
+            self._user = None
+
         session = self.get_isolation_scope()._session
         if session is not None:
             session.update(user=value)

--- a/sentry_sdk/scope.py
+++ b/sentry_sdk/scope.py
@@ -890,13 +890,7 @@ class Scope:
 
     def set_user(self, value: "Optional[Dict[str, Any]]") -> None:
         """Sets a user for the scope."""
-        if value is not None:
-            self._user = {}
-            for k, v in value.items():
-                if v is not None:
-                    self._user[k] = v
-        else:
-            self._user = None
+        self._user = value
 
         session = self.get_isolation_scope()._session
         if session is not None:
@@ -1760,7 +1754,11 @@ class Scope:
             ("user.email", "email"),
             ("user.ip_address", "ip_address"),
         ):
-            if user_attribute in self._user and attribute_name not in attributes:
+            if (
+                user_attribute in self._user
+                and attribute_name not in attributes
+                and self._user[user_attribute] is not None
+            ):
                 attributes[attribute_name] = self._user[user_attribute]
 
     def _drop(self, cause: "Any", ty: str) -> "Optional[Any]":

--- a/tests/test_scope.py
+++ b/tests/test_scope.py
@@ -82,16 +82,27 @@ def test_set_user(sentry_init, capture_events):
 
 
 def test_set_user_none_values_are_dropped_when_copying_to_attributes(
-    sentry_init, capture_events
+    sentry_init, capture_items
 ):
-    sentry_init()
-    events = capture_events()
-
-    sentry_sdk.get_isolation_scope().set_user(
-        {"email": "ada@beans.com", "username": None}
+    sentry_init(
+        traces_sample_rate=1.0,
+        send_default_pii=True,
+        _experiments={"trace_lifecycle": "stream"},
     )
-    capture_exception(NameError())
-    assert events[-1]["user"] == {"email": "ada@beans.com"}
+    items = capture_items("span")
+
+    with sentry_sdk.traces.start_span(name="test_segment"):
+        sentry_sdk.get_isolation_scope().set_user(
+            {"email": "ada@beans.com", "username": None}
+        )
+        capture_exception(NameError())
+
+    sentry_sdk.flush()
+
+    segment = items[0].payload
+
+    assert "user.name" not in segment["attributes"]
+    assert segment["attributes"]["user.email"] == "ada@beans.com"
 
 
 def test_merging(sentry_init, capture_events):

--- a/tests/test_scope.py
+++ b/tests/test_scope.py
@@ -68,6 +68,32 @@ def test_scope_flags_copy():
     ]
 
 
+def test_set_user(sentry_init, capture_events):
+    sentry_init()
+    events = capture_events()
+
+    sentry_sdk.get_isolation_scope().set_user({"id": "42", "email": "bob@example.com"})
+    capture_exception(NameError())
+    assert events[-1]["user"] == {"id": "42", "email": "bob@example.com"}
+
+    sentry_sdk.get_isolation_scope().set_user(None)
+    capture_exception(NameError())
+    assert "user" not in events[-1]
+
+
+def test_set_user_none_values_are_dropped_when_copying_to_attributes(
+    sentry_init, capture_events
+):
+    sentry_init()
+    events = capture_events()
+
+    sentry_sdk.get_isolation_scope().set_user(
+        {"email": "ada@beans.com", "username": None}
+    )
+    capture_exception(NameError())
+    assert events[-1]["user"] == {"email": "ada@beans.com"}
+
+
 def test_merging(sentry_init, capture_events):
     sentry_init()
 


### PR DESCRIPTION
`set_user` previously stored None values verbatim in the user dict, which would send null attributes to Sentry. Now any key with a None value is filtered out before the dict is stored on the scope, so only meaningful user attributes are captured in events.

Fixes PY-2567
Fixes #6689 