### PR TITLE
test: Add span origin span streaming tests

### DIFF
--- a/tests/tracing/test_span_origin.py
+++ b/tests/tracing/test_span_origin.py
@@ -1,12 +1,12 @@
-from sentry_sdk import start_span, start_transaction
+import sentry_sdk
 
 
 def test_span_origin_manual(sentry_init, capture_events):
     sentry_init(traces_sample_rate=1.0)
     events = capture_events()
 
-    with start_transaction(name="hi"):
-        with start_span(op="foo", name="bar"):
+    with sentry_sdk.start_transaction(name="hi"):
+        with sentry_sdk.start_span(op="foo", name="bar"):
             pass
 
     (event,) = events
@@ -20,12 +20,12 @@ def test_span_origin_custom(sentry_init, capture_events):
     sentry_init(traces_sample_rate=1.0)
     events = capture_events()
 
-    with start_transaction(name="hi"):
-        with start_span(op="foo", name="bar", origin="foo.foo2.foo3"):
+    with sentry_sdk.start_transaction(name="hi"):
+        with sentry_sdk.start_span(op="foo", name="bar", origin="foo.foo2.foo3"):
             pass
 
-    with start_transaction(name="ho", origin="ho.ho2.ho3"):
-        with start_span(op="baz", name="qux", origin="baz.baz2.baz3"):
+    with sentry_sdk.start_transaction(name="ho", origin="ho.ho2.ho3"):
+        with sentry_sdk.start_span(op="baz", name="qux", origin="baz.baz2.baz3"):
             pass
 
     (first_transaction, second_transaction) = events
@@ -36,3 +36,41 @@ def test_span_origin_custom(sentry_init, capture_events):
 
     assert second_transaction["contexts"]["trace"]["origin"] == "ho.ho2.ho3"
     assert second_transaction["spans"][0]["origin"] == "baz.baz2.baz3"
+
+
+def test_span_origin_manual_span_streaming(sentry_init, capture_items):
+    sentry_init(_experiments={"trace_lifecycle": "stream"}, traces_sample_rate=1.0)
+    items = capture_items("span")
+
+    with sentry_sdk.traces.start_span(name="hi"):
+        pass
+
+    sentry_sdk.flush()
+
+    (span,) = [item.payload for item in items]
+
+    assert len(items) == 1
+    assert span["attributes"]["sentry.origin"] == "manual"
+
+
+def test_span_origin_custom_span_streaming(sentry_init, capture_items):
+    sentry_init(_experiments={"trace_lifecycle": "stream"}, traces_sample_rate=1.0)
+    items = capture_items("span")
+
+    with sentry_sdk.traces.start_span(
+        name="hi", attributes={"sentry.origin": "foo.foo2.foo3"}
+    ):
+        pass
+
+    with sentry_sdk.traces.start_span(
+        name="ho", attributes={"sentry.origin": "baz.baz2.baz3"}
+    ):
+        pass
+
+    sentry_sdk.flush()
+
+    (span1, span2) = [item.payload for item in items]
+
+    assert len(items) == 2
+    assert span1["attributes"]["sentry.origin"] == "foo.foo2.foo3"
+    assert span2["attributes"]["sentry.origin"] == "baz.baz2.baz3"


### PR DESCRIPTION
### Description
Span origin is just a regular attribute in span streaming, so it might not actually need separate tests. However, the case where we check that it's set to `manual` by default makes sense to cover, so added streaming counterparts to the two existing origin tests.

#### Issues
Part of https://github.com/getsentry/sentry-python/issues/5395

#### Reminders
- Please add tests to validate your changes, and lint your code using `uv run ruff`.
- Add GH Issue ID _&_ Linear ID (if applicable)
- PR title should use [conventional commit](https://develop.sentry.dev/engineering-practices/commit-messages/#type) style (`feat:`, `fix:`, `ref:`, `meta:`)
- For external contributors: [CONTRIBUTING.md](https://github.com/getsentry/sentry-python/blob/master/CONTRIBUTING.md), [Sentry SDK development docs](https://develop.sentry.dev/sdk/), [Discord community](https://discord.gg/Ww9hbqr)
