### PR TITLE
chore: Update Renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -43,7 +43,7 @@
         "/^scripts\\/split_tox_gh_actions\\/templates\\/(test_group|test_orchestrator)\\.jinja$/"
       ],
       "matchStrings": [
-        "(?<depName>[A-Za-z0-9_.-]+\\/[A-Za-z0-9_.-]+(?:\\/[A-Za-z0-9_.-]+)*)@(?<currentDigest>[a-f0-9]{40})[ \\t]+#[ \\t]+(?<currentValue>v?\\d+(?:\\.\\d+){0,2})"
+        "(?<depName>[A-Za-z0-9-]+\\/[A-Za-z0-9_.-]+(?:\\/[A-Za-z0-9_.-]+)*)@(?<currentDigest>[a-f0-9]{40})[ \\t]+#[ \\t]+(?<currentValue>v?\\d+(?:\\.\\d+){0,2})"
       ],
       "datasourceTemplate": "github-tags",
       "versioningTemplate": "github-actions",
@@ -56,7 +56,7 @@
         "/^scripts\\/split_tox_gh_actions\\/templates\\/test_group\\.jinja$/"
       ],
       "matchStrings": [
-        "(?<depName>ghcr\\.io\\/getsentry\\/image-mirror-library-[A-Za-z0-9_.-]+):(?<currentValue>[A-Za-z0-9_.-]+)"
+        "(?<depName>ghcr\\.io\\/getsentry\\/image-mirror-library-[a-z0-9_.-]+):(?<currentValue>[A-Za-z0-9_.-]+)"
       ],
       "datasourceTemplate": "docker",
       "versioningTemplate": "docker",

--- a/renovate.json
+++ b/renovate.json
@@ -15,18 +15,14 @@
   },
   "packageRules": [
     {
-      "description": "Group package updates.",
+      "description": "Disable pyproject.toml version updates.",
       "matchManagers": ["pep621"],
-      "groupName": "Packages",
-      "groupSlug": "packages",
-      "separateMajorMinor": false,
-      "separateMinorPatch": false,
-      "separateMultipleMajor": false
+      "matchUpdateTypes": ["major", "minor", "patch", "pin"],
+      "enabled": false
     },
     {
       "description": "Group GitHub Actions updates.",
       "matchManagers": ["custom.regex", "github-actions"],
-      "matchDatasources": ["github-tags"],
       "groupName": "GitHub Actions",
       "groupSlug": "github-actions",
       "separateMajorMinor": false,
@@ -37,16 +33,16 @@
   "customManagers": [
     {
       "customType": "regex",
-      "description": "Update GitHub Actions in test_group.jinja",
+      "description": "Update GitHub Actions in templates.",
       "managerFilePatterns": [
         "/^scripts\\/split_tox_gh_actions\\/templates\\/(test_group|test_orchestrator)\\.jinja$/"
       ],
       "matchStrings": [
-        "(?<indent>\\s+(?:-\\s+)?uses:\\s+)(?<depName>[A-Za-z0-9_.-]+\\/[A-Za-z0-9_.-]+(?:\\/[A-Za-z0-9_.-]+)*)@(?<currentDigest>[a-f0-9]{40})\\s+#\\s+(?<currentValue>v?\\d+(?:\\.\\d+){0,2})"
+        "(?<depName>[A-Za-z0-9_.-]+\\/[A-Za-z0-9_.-]+(?:\\/[A-Za-z0-9_.-]+)*)@(?<currentDigest>[a-f0-9]{40})[ \\t]+#[ \\t]+(?<currentValue>v?\\d+(?:\\.\\d+){0,2})"
       ],
       "datasourceTemplate": "github-tags",
-      "versioningTemplate": "semver-coerced",
-      "autoReplaceStringTemplate": "{{{indent}}}{{{depName}}}@{{{newDigest}}} # {{{newValue}}}"
+      "versioningTemplate": "github-actions",
+      "autoReplaceStringTemplate": "{{{depName}}}@{{{newDigest}}} # {{{newValue}}}"
     }
   ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -51,7 +51,7 @@
     },
     {
       "customType": "regex",
-      "description": "Update Docker (some) Docker images in templates.",
+      "description": "Update (some) Docker images in templates.",
       "managerFilePatterns": [
         "/^scripts\\/split_tox_gh_actions\\/templates\\/test_group\\.jinja$/"
       ],

--- a/renovate.json
+++ b/renovate.json
@@ -7,8 +7,7 @@
     "uv.lock",
     "scripts/split_tox_gh_actions/templates/test_group.jinja",
     "scripts/split_tox_gh_actions/templates/test_orchestrator.jinja",
-    ".github/workflows/test.yml",
-    ".github/workflows/test-integrations-*.yml"
+    ".github/workflows/*.yml"
   ],
   "lockFileMaintenance": {
     "enabled": true
@@ -18,6 +17,12 @@
       "description": "Disable pyproject.toml version updates.",
       "matchManagers": ["pep621"],
       "matchUpdateTypes": ["major", "minor", "patch", "pin"],
+      "enabled": false
+    },
+    {
+      "description": "Disable Ubuntu image updates.",
+      "matchManagers": ["github-actions"],
+      "matchDatasources": ["github-runners"],
       "enabled": false
     },
     {
@@ -43,6 +48,19 @@
       "datasourceTemplate": "github-tags",
       "versioningTemplate": "github-actions",
       "autoReplaceStringTemplate": "{{{depName}}}@{{{newDigest}}} # {{{newValue}}}"
+    },
+    {
+      "customType": "regex",
+      "description": "Update Docker (some) Docker images in templates.",
+      "managerFilePatterns": [
+        "/^scripts\\/split_tox_gh_actions\\/templates\\/test_group\\.jinja$/"
+      ],
+      "matchStrings": [
+        "(?<depName>ghcr\\.io\\/getsentry\\/image-mirror-library-[A-Za-z0-9_.-]+):(?<currentValue>[A-Za-z0-9_.-]+)"
+      ],
+      "datasourceTemplate": "docker",
+      "versioningTemplate": "docker",
+      "autoReplaceStringTemplate": "{{{depName}}}:{{{newValue}}}"
     }
   ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -26,10 +26,10 @@
       "enabled": false
     },
     {
-      "description": "Group GitHub Actions updates.",
+      "description": "Group GitHub workflow updates.",
       "matchManagers": ["custom.regex", "github-actions"],
-      "groupName": "GitHub Actions",
-      "groupSlug": "github-actions",
+      "groupName": "GitHub Workflows",
+      "groupSlug": "github-workflows",
       "separateMajorMinor": false,
       "separateMinorPatch": false,
       "separateMultipleMajor": false


### PR DESCRIPTION
### Description
<!-- What changed and why? -->

Based on iterating on my fork: https://github.com/alexander-alderman-webb/sentry-python/pulls?q=sort%3Aupdated-desc+is%3Apr+state%3Aopen+

Groups GitHub workflow updates and `uv.locks` refreshes in separate groups. Uses a regular expression to update Jinja workflow templates.

#### Issues
<!--
* resolves: #1234
* resolves: LIN-1234
-->

#### Reminders
- Please add tests to validate your changes, and lint your code using `uv run ruff`.
- Add GH Issue ID _&_ Linear ID (if applicable)
- PR title should use [conventional commit](https://develop.sentry.dev/engineering-practices/commit-messages/#type) style (`feat:`, `fix:`, `ref:`, `meta:`)
- For external contributors: [CONTRIBUTING.md](https://github.com/getsentry/sentry-python/blob/master/CONTRIBUTING.md), [Sentry SDK development docs](https://develop.sentry.dev/sdk/), [Discord community](https://discord.gg/Ww9hbqr)
