### PR TITLE
feat(arq): Set `messaging.destination.name` on consumer spans

### DIFF
--- a/sentry_sdk/integrations/arq.py
+++ b/sentry_sdk/integrations/arq.py
@@ -119,7 +119,11 @@ def patch_run_job() -> None:
                         SPANDATA.MESSAGING_MESSAGE_ID: job_id,
                     },
                     parent_span=None,
-                ):
+                ) as span:
+                    if self.queue_name is not None:
+                        span.set_attribute(
+                            SPANDATA.MESSAGING_DESTINATION_NAME, self.queue_name
+                        )
                     return await old_run_job(self, job_id, score)
 
             transaction = Transaction(
@@ -130,7 +134,9 @@ def patch_run_job() -> None:
                 origin=ArqIntegration.origin,
             )
 
-            with sentry_sdk.start_transaction(transaction):
+            with sentry_sdk.start_transaction(transaction) as span:
+                if self.queue_name is not None:
+                    span.set_data(SPANDATA.MESSAGING_DESTINATION_NAME, self.queue_name)
                 return await old_run_job(self, job_id, score)
 
     Worker.run_job = _sentry_run_job

--- a/tests/integrations/arq/test_arq.py
+++ b/tests/integrations/arq/test_arq.py
@@ -11,6 +11,7 @@ from fakeredis.aioredis import FakeRedis
 
 import sentry_sdk
 from sentry_sdk import get_client, start_transaction
+from sentry_sdk.consts import SPANDATA
 from sentry_sdk.integrations.arq import ArqIntegration
 
 
@@ -364,6 +365,10 @@ async def test_job_transaction(
 
         division_span = next(span for span in task_spans if span["name"] == "division")
         assert division_span["attributes"]["sentry.span.source"] == "task"
+        assert (
+            division_span["attributes"][SPANDATA.MESSAGING_DESTINATION_NAME]
+            == worker.queue_name
+        )
 
         assert any(span["name"] == "cron:division" for span in task_spans)
     else:
@@ -410,6 +415,10 @@ async def test_job_transaction(
         assert func_event["type"] == "transaction"
         assert func_event["transaction"] == "division"
         assert func_event["transaction_info"] == {"source": "task"}
+        assert (
+            func_event["contexts"]["trace"]["data"][SPANDATA.MESSAGING_DESTINATION_NAME]
+            == worker.queue_name
+        )
 
         assert "arq_task_id" in func_event["tags"]
         assert "arq_task_retry" in func_event["tags"]

--- a/uv.lock
+++ b/uv.lock
@@ -6,6 +6,9 @@ resolution-markers = [
     "python_full_version < '3.15'",
 ]
 
+[options]
+prerelease-mode = "allow"
+
 [manifest]
 
 [manifest.dependency-groups]

--- a/uv.lock
+++ b/uv.lock
@@ -6,9 +6,6 @@ resolution-markers = [
     "python_full_version < '3.15'",
 ]
 
-[options]
-prerelease-mode = "allow"
-
 [manifest]
 
 [manifest.dependency-groups]


### PR DESCRIPTION
### Description
<!-- What changed and why? -->

Set `Worker.queue_name`  as the `messaging.destination.name` attribute to support description inference.

#### Issues

Closes https://github.com/getsentry/sentry-python/issues/6766

#### Reminders
- Please add tests to validate your changes, and lint your code using `uv run ruff`.
- Add GH Issue ID _&_ Linear ID (if applicable)
- PR title should use [conventional commit](https://develop.sentry.dev/engineering-practices/commit-messages/#type) style (`feat:`, `fix:`, `ref:`, `meta:`)
- For external contributors: [CONTRIBUTING.md](https://github.com/getsentry/sentry-python/blob/master/CONTRIBUTING.md), [Sentry SDK development docs](https://develop.sentry.dev/sdk/), [Discord community](https://discord.gg/Ww9hbqr)
