### PR TITLE
feat(rq): Set `messaging.destination.name` on consumer spans

### DIFF
--- a/sentry_sdk/integrations/rq.py
+++ b/sentry_sdk/integrations/rq.py
@@ -65,11 +65,11 @@ class RqIntegration(Integration):
 
         @functools.wraps(old_perform_job)
         def sentry_patched_perform_job(
-            self: "Any", job: "Job", *args: "Queue", **kwargs: "Any"
+            self: "Any", job: "Job", queue: "Queue", *args: "Any", **kwargs: "Any"
         ) -> bool:
             client = sentry_sdk.get_client()
             if client.get_integration(RqIntegration) is None:
-                return old_perform_job(self, job, *args, **kwargs)
+                return old_perform_job(self, job, queue, *args, **kwargs)
 
             with sentry_sdk.new_scope() as scope:
                 scope.clear_breadcrumbs()
@@ -93,18 +93,14 @@ class RqIntegration(Integration):
                             "sentry.origin": RqIntegration.origin,
                             "sentry.span.source": SegmentSource.TASK,
                             SPANDATA.MESSAGING_MESSAGE_ID: job.id,
+                            SPANDATA.MESSAGING_DESTINATION_NAME: queue.name,
                         },
                         parent_span=None,
                     ) as span:
                         if func_name is not None:
                             span.set_attribute(SPANDATA.CODE_FUNCTION_NAME, func_name)
 
-                        if args:
-                            span.set_attribute(
-                                SPANDATA.MESSAGING_DESTINATION_NAME, args[0].name
-                            )
-
-                        rv = old_perform_job(self, job, *args, **kwargs)
+                        rv = old_perform_job(self, job, queue, *args, **kwargs)
                 else:
                     transaction = continue_trace(
                         job.meta.get("_sentry_trace_headers") or {},
@@ -121,12 +117,9 @@ class RqIntegration(Integration):
                         transaction,
                         custom_sampling_context={"rq_job": job},
                     ) as span:
-                        if args:
-                            span.set_data(
-                                SPANDATA.MESSAGING_DESTINATION_NAME, args[0].name
-                            )
+                        span.set_data(SPANDATA.MESSAGING_DESTINATION_NAME, queue.name)
 
-                        rv = old_perform_job(self, job, *args, **kwargs)
+                        rv = old_perform_job(self, job, queue, *args, **kwargs)
 
             if self.is_horse:
                 # We're inside of a forked process and RQ is

--- a/sentry_sdk/integrations/rq.py
+++ b/sentry_sdk/integrations/rq.py
@@ -99,6 +99,11 @@ class RqIntegration(Integration):
                         if func_name is not None:
                             span.set_attribute(SPANDATA.CODE_FUNCTION_NAME, func_name)
 
+                        if args:
+                            span.set_attribute(
+                                SPANDATA.MESSAGING_DESTINATION_NAME, args[0].name
+                            )
+
                         rv = old_perform_job(self, job, *args, **kwargs)
                 else:
                     transaction = continue_trace(
@@ -115,7 +120,12 @@ class RqIntegration(Integration):
                     with sentry_sdk.start_transaction(
                         transaction,
                         custom_sampling_context={"rq_job": job},
-                    ):
+                    ) as span:
+                        if args:
+                            span.set_data(
+                                SPANDATA.MESSAGING_DESTINATION_NAME, args[0].name
+                            )
+
                         rv = old_perform_job(self, job, *args, **kwargs)
 
             if self.is_horse:

--- a/tests/integrations/rq/test_rq.py
+++ b/tests/integrations/rq/test_rq.py
@@ -416,6 +416,7 @@ def test_transaction_no_error(
 
         assert span["attributes"]["sentry.op"] == "queue.task.rq"
         assert span["name"] == "tests.integrations.rq.test_rq.do_trick"
+        assert span["attributes"][SPANDATA.MESSAGING_DESTINATION_NAME] == queue.name
     else:
         events = capture_events()
 
@@ -427,6 +428,10 @@ def test_transaction_no_error(
         assert envelope["type"] == "transaction"
         assert envelope["contexts"]["trace"]["op"] == "queue.task.rq"
         assert envelope["transaction"] == "tests.integrations.rq.test_rq.do_trick"
+        assert (
+            envelope["contexts"]["trace"]["data"][SPANDATA.MESSAGING_DESTINATION_NAME]
+            == queue.name
+        )
         assert envelope["extra"]["rq-job"] == DictionaryContaining(
             {
                 "args": ["Maisey"] if send_default_pii else SENSITIVE_DATA_SUBSTITUTE,

--- a/uv.lock
+++ b/uv.lock
@@ -6,6 +6,9 @@ resolution-markers = [
     "python_full_version < '3.15'",
 ]
 
+[options]
+prerelease-mode = "allow"
+
 [manifest]
 
 [manifest.dependency-groups]

--- a/uv.lock
+++ b/uv.lock
@@ -6,9 +6,6 @@ resolution-markers = [
     "python_full_version < '3.15'",
 ]
 
-[options]
-prerelease-mode = "allow"
-
 [manifest]
 
 [manifest.dependency-groups]


### PR DESCRIPTION
### Description
<!-- What changed and why? -->

Set `Queue.name` as the `messaging.destination.name` attribute to support description inference.

#### Issues
<!--
* resolves: #1234
* resolves: LIN-1234
-->
Closes https://github.com/getsentry/sentry-python/issues/6768

#### Reminders
- Please add tests to validate your changes, and lint your code using `uv run ruff`.
- Add GH Issue ID _&_ Linear ID (if applicable)
- PR title should use [conventional commit](https://develop.sentry.dev/engineering-practices/commit-messages/#type) style (`feat:`, `fix:`, `ref:`, `meta:`)
- For external contributors: [CONTRIBUTING.md](https://github.com/getsentry/sentry-python/blob/master/CONTRIBUTING.md), [Sentry SDK development docs](https://develop.sentry.dev/sdk/), [Discord community](https://discord.gg/Ww9hbqr)
