### PR TITLE
feat(dramatiq): Set `messaging.destination.name` on consumer spans

### DIFF
--- a/sentry_sdk/integrations/dramatiq.py
+++ b/sentry_sdk/integrations/dramatiq.py
@@ -3,7 +3,7 @@ from typing import TypeVar
 
 import sentry_sdk
 from sentry_sdk.api import continue_trace, get_baggage, get_traceparent
-from sentry_sdk.consts import OP, SPANSTATUS
+from sentry_sdk.consts import OP, SPANDATA, SPANSTATUS
 from sentry_sdk.integrations import DidNotEnable, Integration
 from sentry_sdk.integrations._wsgi_common import request_body_within_bounds
 from sentry_sdk.traces import SegmentSource
@@ -140,6 +140,7 @@ class SentryMiddleware(Middleware):  # type: ignore[misc]
                     "sentry.op": OP.QUEUE_TASK_DRAMATIQ,
                     "sentry.origin": DramatiqIntegration.origin,
                     "sentry.span.source": SegmentSource.TASK.value,
+                    SPANDATA.MESSAGING_DESTINATION_NAME: message.queue_name,
                 },
                 parent_span=None,
             )
@@ -160,6 +161,9 @@ class SentryMiddleware(Middleware):  # type: ignore[misc]
                 source=TransactionSource.TASK,
             )
             transaction.__enter__()
+            transaction.set_data(
+                SPANDATA.MESSAGING_DESTINATION_NAME, message.queue_name
+            )
             message._sentry_span_ctx = transaction
 
     def after_process_message(

--- a/tests/integrations/dramatiq/test_dramatiq.py
+++ b/tests/integrations/dramatiq/test_dramatiq.py
@@ -7,7 +7,7 @@ from dramatiq.middleware import Middleware, SkipMessage
 
 import sentry_sdk
 from sentry_sdk import start_transaction
-from sentry_sdk.consts import SPANSTATUS
+from sentry_sdk.consts import SPANDATA, SPANSTATUS
 from sentry_sdk.integrations.dramatiq import DramatiqIntegration
 from sentry_sdk.integrations.logging import ignore_logger
 from sentry_sdk.tracing import Transaction, TransactionSource
@@ -172,6 +172,10 @@ def test_task_transaction(
         assert segment["is_segment"] is True
         assert segment["attributes"]["sentry.op"] == "queue.task.dramatiq"
         assert segment["attributes"]["sentry.span.source"] == "task"
+        assert (
+            segment["attributes"][SPANDATA.MESSAGING_DESTINATION_NAME]
+            == dummy_actor.queue_name
+        )
         assert segment["status"] == ("error" if task_fails else "ok")
     else:
         if task_fails:
@@ -184,6 +188,10 @@ def test_task_transaction(
         assert event["type"] == "transaction"
         assert event["transaction"] == "dummy_actor"
         assert event["transaction_info"] == {"source": TransactionSource.TASK}
+        assert (
+            event["contexts"]["trace"]["data"][SPANDATA.MESSAGING_DESTINATION_NAME]
+            == dummy_actor.queue_name
+        )
         assert event["contexts"]["trace"]["status"] == expected_span_status
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -6,9 +6,6 @@ resolution-markers = [
     "python_full_version < '3.15'",
 ]
 
-[options]
-prerelease-mode = "allow"
-
 [manifest]
 
 [manifest.dependency-groups]


### PR DESCRIPTION
### Description
<!-- What changed and why? -->

Set `Message.queue_name` as the `messaging.destination.name` attribute to support description inference.

#### Issues
Closes https://github.com/getsentry/sentry-python/issues/6775

#### Reminders
- Please add tests to validate your changes, and lint your code using `uv run ruff`.
- Add GH Issue ID _&_ Linear ID (if applicable)
- PR title should use [conventional commit](https://develop.sentry.dev/engineering-practices/commit-messages/#type) style (`feat:`, `fix:`, `ref:`, `meta:`)
- For external contributors: [CONTRIBUTING.md](https://github.com/getsentry/sentry-python/blob/master/CONTRIBUTING.md), [Sentry SDK development docs](https://develop.sentry.dev/sdk/), [Discord community](https://discord.gg/Ww9hbqr)
