### PR TITLE
feat(huey): Set `messaging.destination.name` on producer spans

### DIFF
--- a/sentry_sdk/integrations/huey.py
+++ b/sentry_sdk/integrations/huey.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING
 
 import sentry_sdk
 from sentry_sdk.api import continue_trace, get_baggage, get_traceparent
-from sentry_sdk.consts import OP, SPANSTATUS
+from sentry_sdk.consts import OP, SPANDATA, SPANSTATUS
 from sentry_sdk.integrations import DidNotEnable, Integration
 from sentry_sdk.scope import should_send_default_pii
 from sentry_sdk.traces import SegmentSource, SpanStatus, StreamedSpan
@@ -86,6 +86,7 @@ def patch_enqueue() -> None:
                 attributes={
                     "sentry.op": OP.QUEUE_SUBMIT_HUEY,
                     "sentry.origin": HueyIntegration.origin,
+                    SPANDATA.MESSAGING_DESTINATION_NAME: self.name,
                 },
             )
         else:
@@ -94,6 +95,7 @@ def patch_enqueue() -> None:
                 name=span_name,
                 origin=HueyIntegration.origin,
             )
+            span_ctx.set_data(SPANDATA.MESSAGING_DESTINATION_NAME, self.name)
 
         no_headers_types = (PeriodicTask,) + tuple(
             t for t in [HueyGroup, HueyChord] if t is not None

--- a/tests/integrations/huey/test_huey.py
+++ b/tests/integrations/huey/test_huey.py
@@ -7,7 +7,7 @@ from huey.exceptions import CancelExecution, RetryTask
 
 import sentry_sdk
 from sentry_sdk import start_transaction
-from sentry_sdk.consts import OP
+from sentry_sdk.consts import OP, SPANDATA
 from sentry_sdk.integrations.huey import HueyIntegration
 from sentry_sdk.traces import SegmentSource, SpanStatus
 from sentry_sdk.utils import parse_version
@@ -97,6 +97,9 @@ def test_task_transaction_or_segment(
         enqueue_span, execute_span = payloads
 
         assert enqueue_span["attributes"]["sentry.op"] == OP.QUEUE_SUBMIT_HUEY
+        assert (
+            enqueue_span["attributes"][SPANDATA.MESSAGING_DESTINATION_NAME] == huey.name
+        )
         assert execute_span["is_segment"]
         assert execute_span["attributes"]["sentry.op"] == OP.QUEUE_TASK_HUEY
         assert execute_span["name"] == "division"
@@ -308,6 +311,7 @@ def test_huey_enqueue(init_huey, capture_events):
     assert len(event["spans"])
     assert event["spans"][0]["op"] == "queue.submit.huey"
     assert event["spans"][0]["description"] == "different_task_name"
+    assert event["spans"][0]["data"][SPANDATA.MESSAGING_DESTINATION_NAME] == huey.name
 
 
 def test_huey_propagate_trace(init_huey, capture_events):

--- a/uv.lock
+++ b/uv.lock
@@ -6,9 +6,6 @@ resolution-markers = [
     "python_full_version < '3.15'",
 ]
 
-[options]
-prerelease-mode = "allow"
-
 [manifest]
 
 [manifest.dependency-groups]


### PR DESCRIPTION
### Description
<!-- What changed and why? -->

Set `Huey.name` as the `messaging.destination.name` attribute to support description inference.

#### Issues
<!--
* resolves: #1234
* resolves: LIN-1234
-->

#### Reminders
- Please add tests to validate your changes, and lint your code using `uv run ruff`.
- Add GH Issue ID _&_ Linear ID (if applicable)
- PR title should use [conventional commit](https://develop.sentry.dev/engineering-practices/commit-messages/#type) style (`feat:`, `fix:`, `ref:`, `meta:`)
- For external contributors: [CONTRIBUTING.md](https://github.com/getsentry/sentry-python/blob/master/CONTRIBUTING.md), [Sentry SDK development docs](https://develop.sentry.dev/sdk/), [Discord community](https://discord.gg/Ww9hbqr)
