### PR TITLE
feat(huey): Set `messaging.destination.name` on consumer spans

### DIFF
--- a/sentry_sdk/integrations/huey.py
+++ b/sentry_sdk/integrations/huey.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING
 
 import sentry_sdk
 from sentry_sdk.api import continue_trace, get_baggage, get_traceparent
-from sentry_sdk.consts import OP, SPANSTATUS
+from sentry_sdk.consts import OP, SPANDATA, SPANSTATUS
 from sentry_sdk.integrations import DidNotEnable, Integration
 from sentry_sdk.scope import should_send_default_pii
 from sentry_sdk.traces import SegmentSource, SpanStatus, StreamedSpan
@@ -211,6 +211,7 @@ def patch_execute() -> None:
                         "sentry.op": OP.QUEUE_TASK_HUEY,
                         "sentry.origin": HueyIntegration.origin,
                         "sentry.span.source": SegmentSource.TASK,
+                        SPANDATA.MESSAGING_DESTINATION_NAME: self.name,
                         "messaging.message.id": task.id,
                         "messaging.message.system": "huey",
                         "messaging.message.retry.count": (task.default_retries or 0)
@@ -228,6 +229,7 @@ def patch_execute() -> None:
                 )
                 transaction.set_status(SPANSTATUS.OK)
                 span_ctx = sentry_sdk.start_transaction(transaction)
+                span_ctx.set_data(SPANDATA.MESSAGING_DESTINATION_NAME, self.name)
 
             if not getattr(task, "_sentry_is_patched", False):
                 task.execute = _wrap_task_execute(task.execute)

--- a/tests/integrations/huey/test_huey.py
+++ b/tests/integrations/huey/test_huey.py
@@ -7,7 +7,7 @@ from huey.exceptions import CancelExecution, RetryTask
 
 import sentry_sdk
 from sentry_sdk import start_transaction
-from sentry_sdk.consts import OP
+from sentry_sdk.consts import OP, SPANDATA
 from sentry_sdk.integrations.huey import HueyIntegration
 from sentry_sdk.traces import SegmentSource, SpanStatus
 from sentry_sdk.utils import parse_version
@@ -99,6 +99,9 @@ def test_task_transaction_or_segment(
         assert enqueue_span["attributes"]["sentry.op"] == OP.QUEUE_SUBMIT_HUEY
         assert execute_span["is_segment"]
         assert execute_span["attributes"]["sentry.op"] == OP.QUEUE_TASK_HUEY
+        assert (
+            execute_span["attributes"][SPANDATA.MESSAGING_DESTINATION_NAME] == huey.name
+        )
         assert execute_span["name"] == "division"
         assert execute_span["status"] == (
             SpanStatus.ERROR if task_fails else SpanStatus.OK
@@ -118,6 +121,10 @@ def test_task_transaction_or_segment(
         assert event["type"] == "transaction"
         assert event["transaction"] == "division"
         assert event["transaction_info"] == {"source": "task"}
+        assert (
+            event["contexts"]["trace"]["data"][SPANDATA.MESSAGING_DESTINATION_NAME]
+            == huey.name
+        )
 
         if task_fails:
             assert event["contexts"]["trace"]["status"] == "internal_error"

--- a/uv.lock
+++ b/uv.lock
@@ -6,9 +6,6 @@ resolution-markers = [
     "python_full_version < '3.15'",
 ]
 
-[options]
-prerelease-mode = "allow"
-
 [manifest]
 
 [manifest.dependency-groups]


### PR DESCRIPTION
### Description
<!-- What changed and why? -->

Set `Huey.name` as the messaging.destination.name attribute to support description inference.

#### Issues
<!--
* resolves: #1234
* resolves: LIN-1234
-->

#### Reminders
- Please add tests to validate your changes, and lint your code using `uv run ruff`.
- Add GH Issue ID _&_ Linear ID (if applicable)
- PR title should use [conventional commit](https://develop.sentry.dev/engineering-practices/commit-messages/#type) style (`feat:`, `fix:`, `ref:`, `meta:`)
- For external contributors: [CONTRIBUTING.md](https://github.com/getsentry/sentry-python/blob/master/CONTRIBUTING.md), [Sentry SDK development docs](https://develop.sentry.dev/sdk/), [Discord community](https://discord.gg/Ww9hbqr)
