### PR TITLE
test: Add streaming propagation tests

### DIFF
--- a/tests/tracing/test_propagation.py
+++ b/tests/tracing/test_propagation.py
@@ -31,6 +31,15 @@ def test_span_in_transaction(sentry_init):
             next(span.iter_headers())
 
 
+def test_span_in_transaction_span_streaming(sentry_init):
+    sentry_init(traces_sample_rate=1.0, _experiments={"trace_lifecycle": "stream"})
+
+    with sentry_sdk.traces.start_span(name="test"):
+        with sentry_sdk.traces.start_span(name="test2") as span:
+            # Ensure the headers are there
+            next(span._iter_headers())
+
+
 def test_span_in_span_in_transaction(sentry_init):
     sentry_init(traces_sample_rate=1.0)
 
@@ -39,3 +48,13 @@ def test_span_in_span_in_transaction(sentry_init):
             with sentry_sdk.start_span(op="test3") as span_inner:
                 # Ensure the headers are there
                 next(span_inner.iter_headers())
+
+
+def test_span_in_span_in_transaction_span_streaming(sentry_init):
+    sentry_init(traces_sample_rate=1.0, _experiments={"trace_lifecycle": "stream"})
+
+    with sentry_sdk.traces.start_span(name="test"):
+        with sentry_sdk.traces.start_span(name="test2"):
+            with sentry_sdk.traces.start_span(name="test3") as span_inner:
+                # Ensure the headers are there
+                next(span_inner._iter_headers())


### PR DESCRIPTION
### Description
Some tests in this file were testing the unsupported case of using a top-level `start_span` (instead of `start_transaction`) and checking that the resulting span then doesn't produce propagation headers. As this case now has no counterpart in span streaming, I didn't port those tests.

#### Issues
Part of https://github.com/getsentry/sentry-python/issues/5395

#### Reminders
- Please add tests to validate your changes, and lint your code using `uv run ruff`.
- Add GH Issue ID _&_ Linear ID (if applicable)
- PR title should use [conventional commit](https://develop.sentry.dev/engineering-practices/commit-messages/#type) style (`feat:`, `fix:`, `ref:`, `meta:`)
- For external contributors: [CONTRIBUTING.md](https://github.com/getsentry/sentry-python/blob/master/CONTRIBUTING.md), [Sentry SDK development docs](https://develop.sentry.dev/sdk/), [Discord community](https://discord.gg/Ww9hbqr)
