### PR TITLE
fix(serializer): avoid copying large Mapping locals before trimming

### DIFF
--- a/sentry_sdk/serializer.py
+++ b/sentry_sdk/serializer.py
@@ -3,6 +3,7 @@ import sys
 from array import array
 from collections.abc import Mapping
 from datetime import datetime
+from itertools import islice
 from typing import TYPE_CHECKING
 
 from sentry_sdk.utils import (
@@ -301,14 +302,18 @@ class _Serializer:
         elif isinstance(obj, Mapping):
             # Create temporary copy here to avoid calling too much code that
             # might mutate our dictionary while we're still iterating over it.
-            obj = dict(obj.items())
+            obj_len = len(obj)
+            if isinstance(remaining_breadth, int):
+                obj = dict(islice(obj.items(), remaining_breadth + 1))
+            else:
+                obj = dict(obj.items())
 
             rv_dict: "Dict[str, Any]" = {}
             i = 0
 
             for k, v in obj.items():
                 if remaining_breadth is not None and i >= remaining_breadth:
-                    self._annotate(len=len(obj))
+                    self._annotate(len=obj_len)
                     break
 
                 str_k = str(k)

--- a/tests/test_serializer.py
+++ b/tests/test_serializer.py
@@ -1,6 +1,7 @@
 import gc
 import re
 from array import array
+from collections.abc import Mapping
 
 import pytest
 
@@ -151,6 +152,34 @@ def test_trim_databag_breadth(body_normalizer):
     assert len(result) == MAX_DATABAG_BREADTH
     for key, value in result.items():
         assert data.get(key) == value
+
+
+def test_trim_databag_breadth_does_not_copy_entire_mapping(body_normalizer):
+    class CountingMapping(Mapping):
+        def __init__(self, size):
+            self.data = {"key{}".format(i): "value{}".format(i) for i in range(size)}
+            self.iterated = 0
+            self.lookups = 0
+
+        def __len__(self):
+            return len(self.data)
+
+        def __iter__(self):
+            for key in self.data:
+                self.iterated += 1
+                yield key
+
+        def __getitem__(self, key):
+            self.lookups += 1
+            return self.data[key]
+
+    data = CountingMapping(MAX_DATABAG_BREADTH + 5)
+
+    result = body_normalizer(data)
+
+    assert len(result) == MAX_DATABAG_BREADTH
+    assert data.iterated == MAX_DATABAG_BREADTH + 1
+    assert data.lookups == MAX_DATABAG_BREADTH + 1
 
 
 def test_no_trimming_if_max_request_body_size_is_always(body_normalizer):


### PR DESCRIPTION
fix(serializer): avoid copying large Mapping locals before trimming

`_Serializer._serialize_node_impl()` now limits the temporary copy
to at most `remaining_breadth + 1` pairs when breadth is bounded,
while keeping the existing full-copy path for unbounded breadth.
This avoids O(len(mapping)) work on huge locals that will be trimmed
anyway (especially frame locals during exception capture).

- Added a regression test using a counting `Mapping` to prove
  the serializer only iterates/lookups the bounded prefix + 1.
- Preserves mutation safety during iteration via `dict()` copy.
- `_annotate(len=...)` now reports the original length, not the
  truncated copy size.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

Closes #6773
