### PR TITLE
fix(tracing): Set `sentry.op` to function in new trace decorator

### DIFF
--- a/sentry_sdk/tracing_utils.py
+++ b/sentry_sdk/tracing_utils.py
@@ -1113,7 +1113,7 @@ def create_streaming_span_decorator(
         """
         Decorator to create a span for the given function.
         """
-        new_attributes = attributes or {}
+        new_attributes = dict(attributes) if attributes else {}
         if "sentry.op" not in new_attributes:
             new_attributes["sentry.op"] = OP.FUNCTION
 

--- a/sentry_sdk/tracing_utils.py
+++ b/sentry_sdk/tracing_utils.py
@@ -1113,6 +1113,9 @@ def create_streaming_span_decorator(
         """
         Decorator to create a span for the given function.
         """
+        new_attributes = attributes or {}
+        if "sentry.op" not in new_attributes:
+            new_attributes["sentry.op"] = OP.FUNCTION
 
         @functools.wraps(f)
         async def async_wrapper(*args: "Any", **kwargs: "Any") -> "Any":
@@ -1127,7 +1130,7 @@ def create_streaming_span_decorator(
             span_name = name or qualname_from_function(f) or ""
 
             with start_streaming_span(
-                name=span_name, attributes=attributes, active=active
+                name=span_name, attributes=new_attributes, active=active
             ):
                 result = await f(*args, **kwargs)
                 return result
@@ -1150,7 +1153,7 @@ def create_streaming_span_decorator(
             span_name = name or qualname_from_function(f) or ""
 
             with start_streaming_span(
-                name=span_name, attributes=attributes, active=active
+                name=span_name, attributes=new_attributes, active=active
             ):
                 return f(*args, **kwargs)
 

--- a/tests/tracing/test_decorator.py
+++ b/tests/tracing/test_decorator.py
@@ -110,6 +110,7 @@ def test_trace_decorator_span_streaming(sentry_init, capture_items):
         span["name"]
         == "test_decorator.test_trace_decorator_span_streaming.<locals>.traced_function"
     )
+    assert span["attributes"]["sentry.op"] == "function"
     assert span["status"] == "ok"
 
 
@@ -136,6 +137,7 @@ def test_trace_decorator_arguments_span_streaming(sentry_init, capture_items):
 
     assert span["name"] == "traced"
     assert span["attributes"]["traced.attribute"] == 123
+    assert span["attributes"]["sentry.op"] == "function"
     assert span["status"] == "ok"
 
 
@@ -193,6 +195,7 @@ async def test_trace_decorator_async_span_streaming(sentry_init, capture_items):
         span["name"]
         == "test_decorator.test_trace_decorator_async_span_streaming.<locals>.traced_function"
     )
+    assert span["attributes"]["sentry.op"] == "function"
     assert span["status"] == "ok"
 
 
@@ -222,6 +225,7 @@ async def test_trace_decorator_async_arguments_span_streaming(
 
     assert span["name"] == "traced"
     assert span["attributes"]["traced.attribute"] == 123
+    assert span["attributes"]["sentry.op"] == "function"
     assert span["status"] == "ok"
 
 


### PR DESCRIPTION
### Description
We weren't setting `sentry.op` in spans created with the `@sentry_sdk.traces.trace` decorator, so they'd show up with a fallback name in the product.

#### Issues
Closes https://github.com/getsentry/sentry-python/issues/6795

#### Reminders
- Please add tests to validate your changes, and lint your code using `uv run ruff`.
- Add GH Issue ID _&_ Linear ID (if applicable)
- PR title should use [conventional commit](https://develop.sentry.dev/engineering-practices/commit-messages/#type) style (`feat:`, `fix:`, `ref:`, `meta:`)
- For external contributors: [CONTRIBUTING.md](https://github.com/getsentry/sentry-python/blob/master/CONTRIBUTING.md), [Sentry SDK development docs](https://develop.sentry.dev/sdk/), [Discord community](https://discord.gg/Ww9hbqr)
