### PR TITLE
fix(match_regex_list): handle empty string patterns without IndexError

### DIFF
--- a/sentry_sdk/utils.py
+++ b/sentry_sdk/utils.py
@@ -1736,6 +1736,8 @@ def match_regex_list(
         return False
 
     for item_matcher in regex_list:
+        if item_matcher == "":
+            continue
         if not substring_matching and item_matcher[-1] != "$":
             item_matcher += "$"
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -551,6 +551,7 @@ def test_include_source_context_when_serializing_frame(include_source_context):
         ["some-string", [], False],
         ["some-string", None, False],
         ["some-string", ["some-string"], True],
+        ["some-string", [""], False],
         ["some-string", ["some"], False],
         ["some-string", ["some$"], False],  # same as above
         ["some-string", ["some.*"], True],


### PR DESCRIPTION
An empty string pattern in the regex list causes an `IndexError: string index out of range` when `item_matcher[-1]` is accessed. This is reachable through integrations like Celery (`CeleryIntegration.exclude_beat_tasks`) when users accidentally configure an empty pattern.

Skip empty string patterns in the loop to prevent the crash. A pattern with no characters is a no-op anyway.

Closes #6504