### PR TITLE
fix(tracing): Skip child span creation in streaming path when no current span (databases)

### DIFF
--- a/sentry_sdk/integrations/aiomysql.py
+++ b/sentry_sdk/integrations/aiomysql.py
@@ -179,33 +179,34 @@ def _wrap_connect(f: Callable[..., Awaitable[T]]) -> Callable[..., Awaitable[T]]
                 "sentry.origin": AioMySQLIntegration.origin,
             } | breadcrumb_data
 
+            if sentry_sdk.traces.get_current_span() is None:
+                return await f(self)
+
             with sentry_sdk.traces.start_span(
                 name="connect", attributes=span_attributes
-            ) as span:
+            ):
                 with capture_internal_exceptions():
                     sentry_sdk.add_breadcrumb(
                         message="connect", category="query", data=breadcrumb_data
                     )
-                res = await f(self)
-        else:
-            connect_data = _get_connect_data(self)
+                return await f(self)
 
-            with sentry_sdk.start_span(
-                op=OP.DB,
-                name="connect",
-                origin=AioMySQLIntegration.origin,
-            ) as span:
-                _set_db_data(span, self)
+        connect_data = _get_connect_data(self)
 
-                with capture_internal_exceptions():
-                    sentry_sdk.add_breadcrumb(
-                        message="connect",
-                        category="query",
-                        data=connect_data,
-                    )
-                res = await f(self)
+        with sentry_sdk.start_span(
+            op=OP.DB,
+            name="connect",
+            origin=AioMySQLIntegration.origin,
+        ) as span:
+            _set_db_data(span, self)
 
-        return res
+            with capture_internal_exceptions():
+                sentry_sdk.add_breadcrumb(
+                    message="connect",
+                    category="query",
+                    data=connect_data,
+                )
+            return await f(self)
 
     return _inner
 

--- a/sentry_sdk/integrations/aiomysql.py
+++ b/sentry_sdk/integrations/aiomysql.py
@@ -174,11 +174,6 @@ def _wrap_connect(f: Callable[..., Awaitable[T]]) -> Callable[..., Awaitable[T]]
         if has_span_streaming_enabled(client.options):
             breadcrumb_data = _get_connect_data(self, use_streaming_keys=True)
 
-            span_attributes: dict[str, Any] = {
-                "sentry.op": OP.DB,
-                "sentry.origin": AioMySQLIntegration.origin,
-            } | breadcrumb_data
-
             with capture_internal_exceptions():
                 sentry_sdk.add_breadcrumb(
                     message="connect", category="query", data=breadcrumb_data
@@ -186,6 +181,11 @@ def _wrap_connect(f: Callable[..., Awaitable[T]]) -> Callable[..., Awaitable[T]]
 
             if sentry_sdk.traces.get_current_span() is None:
                 return await f(self)
+
+            span_attributes: dict[str, Any] = {
+                "sentry.op": OP.DB,
+                "sentry.origin": AioMySQLIntegration.origin,
+            } | breadcrumb_data
 
             with sentry_sdk.traces.start_span(
                 name="connect", attributes=span_attributes

--- a/sentry_sdk/integrations/aiomysql.py
+++ b/sentry_sdk/integrations/aiomysql.py
@@ -179,16 +179,17 @@ def _wrap_connect(f: Callable[..., Awaitable[T]]) -> Callable[..., Awaitable[T]]
                 "sentry.origin": AioMySQLIntegration.origin,
             } | breadcrumb_data
 
+            with capture_internal_exceptions():
+                sentry_sdk.add_breadcrumb(
+                    message="connect", category="query", data=breadcrumb_data
+                )
+
             if sentry_sdk.traces.get_current_span() is None:
                 return await f(self)
 
             with sentry_sdk.traces.start_span(
                 name="connect", attributes=span_attributes
             ):
-                with capture_internal_exceptions():
-                    sentry_sdk.add_breadcrumb(
-                        message="connect", category="query", data=breadcrumb_data
-                    )
                 return await f(self)
 
         connect_data = _get_connect_data(self)

--- a/sentry_sdk/integrations/asyncpg.py
+++ b/sentry_sdk/integrations/asyncpg.py
@@ -235,39 +235,39 @@ def _wrap_connect_addr(
                 except IndexError:
                     pass
 
+            if sentry_sdk.traces.get_current_span() is None:
+                return await f(*args, **kwargs)
+
             with sentry_sdk.traces.start_span(
                 name="connect", attributes=span_attributes
-            ) as span:
+            ):
                 with capture_internal_exceptions():
                     sentry_sdk.add_breadcrumb(
                         message="connect", category="query", data=span_attributes
                     )
-                res = await f(*args, **kwargs)
+                return await f(*args, **kwargs)
 
-        else:
-            with sentry_sdk.start_span(
-                op=OP.DB,
-                name="connect",
-                origin=AsyncPGIntegration.origin,
-            ) as span:
-                span.set_data(SPANDATA.DB_SYSTEM, "postgresql")
-                if addr:
-                    try:
-                        span.set_data(SPANDATA.SERVER_ADDRESS, addr[0])
-                        span.set_data(SPANDATA.SERVER_PORT, addr[1])
-                    except IndexError:
-                        pass
-                span.set_data(SPANDATA.DB_NAME, database)
-                span.set_data(SPANDATA.DB_USER, user)
-                span.set_data(SPANDATA.DB_DRIVER_NAME, "asyncpg")
+        with sentry_sdk.start_span(
+            op=OP.DB,
+            name="connect",
+            origin=AsyncPGIntegration.origin,
+        ) as span:
+            span.set_data(SPANDATA.DB_SYSTEM, "postgresql")
+            if addr:
+                try:
+                    span.set_data(SPANDATA.SERVER_ADDRESS, addr[0])
+                    span.set_data(SPANDATA.SERVER_PORT, addr[1])
+                except IndexError:
+                    pass
+            span.set_data(SPANDATA.DB_NAME, database)
+            span.set_data(SPANDATA.DB_USER, user)
+            span.set_data(SPANDATA.DB_DRIVER_NAME, "asyncpg")
 
-                with capture_internal_exceptions():
-                    sentry_sdk.add_breadcrumb(
-                        message="connect", category="query", data=span._data
-                    )
-                res = await f(*args, **kwargs)
-
-        return res
+            with capture_internal_exceptions():
+                sentry_sdk.add_breadcrumb(
+                    message="connect", category="query", data=span._data
+                )
+            return await f(*args, **kwargs)
 
     return _inner
 

--- a/sentry_sdk/integrations/asyncpg.py
+++ b/sentry_sdk/integrations/asyncpg.py
@@ -235,16 +235,17 @@ def _wrap_connect_addr(
                 except IndexError:
                     pass
 
+            with capture_internal_exceptions():
+                sentry_sdk.add_breadcrumb(
+                    message="connect", category="query", data=span_attributes
+                )
+
             if sentry_sdk.traces.get_current_span() is None:
                 return await f(*args, **kwargs)
 
             with sentry_sdk.traces.start_span(
                 name="connect", attributes=span_attributes
             ):
-                with capture_internal_exceptions():
-                    sentry_sdk.add_breadcrumb(
-                        message="connect", category="query", data=span_attributes
-                    )
                 return await f(*args, **kwargs)
 
         with sentry_sdk.start_span(

--- a/sentry_sdk/integrations/clickhouse_driver.py
+++ b/sentry_sdk/integrations/clickhouse_driver.py
@@ -85,14 +85,16 @@ def _wrap_start(f: "Callable[P, T]") -> "Callable[P, T]":
         params = args[3] if len(args) > 3 else kwargs.get("params")
 
         if has_span_streaming_enabled(client.options):
-            span = sentry_sdk.traces.start_span(
-                name=query,  # type: ignore
-                attributes={
-                    "sentry.op": OP.DB,
-                    "sentry.origin": ClickhouseDriverIntegration.origin,
-                    SPANDATA.DB_QUERY_TEXT: str(query),
-                },
-            )
+            span = None
+            if sentry_sdk.traces.get_current_span() is not None:
+                span = sentry_sdk.traces.start_span(
+                    name=query,  # type: ignore
+                    attributes={
+                        "sentry.op": OP.DB,
+                        "sentry.origin": ClickhouseDriverIntegration.origin,
+                        SPANDATA.DB_QUERY_TEXT: str(query),
+                    },
+                )
         else:
             span = sentry_sdk.start_span(
                 op=OP.DB,
@@ -110,7 +112,8 @@ def _wrap_start(f: "Callable[P, T]") -> "Callable[P, T]":
 
         connection._sentry_span = span  # type: ignore[attr-defined]
 
-        _set_db_data(span, connection)
+        if span is not None:
+            _set_db_data(span, connection)
 
         # run the original code
         ret = f(*args, **kwargs)

--- a/sentry_sdk/integrations/pymongo.py
+++ b/sentry_sdk/integrations/pymongo.py
@@ -152,9 +152,6 @@ class CommandTracer(monitoring.CommandListener):
             query = json.dumps(command, default=str)
 
             if has_span_streaming_enabled(client.options):
-                if sentry_sdk.traces.get_current_span() is None:
-                    return
-
                 span_first_data = {
                     "db.operation.name": operation_name,
                     "db.collection.name": collection_name,
@@ -164,10 +161,6 @@ class CommandTracer(monitoring.CommandListener):
                     **db_data,
                 }
 
-                span = sentry_sdk.traces.start_span(
-                    name=query, attributes=span_first_data
-                )
-
                 with capture_internal_exceptions():
                     sentry_sdk.add_breadcrumb(
                         message=query,
@@ -175,6 +168,13 @@ class CommandTracer(monitoring.CommandListener):
                         type=OP.DB,
                         data=span_first_data,
                     )
+
+                if sentry_sdk.traces.get_current_span() is None:
+                    return
+
+                span = sentry_sdk.traces.start_span(
+                    name=query, attributes=span_first_data
+                )
 
             else:
                 tags = {

--- a/sentry_sdk/integrations/pymongo.py
+++ b/sentry_sdk/integrations/pymongo.py
@@ -152,6 +152,9 @@ class CommandTracer(monitoring.CommandListener):
             query = json.dumps(command, default=str)
 
             if has_span_streaming_enabled(client.options):
+                if sentry_sdk.traces.get_current_span() is None:
+                    return
+
                 span_first_data = {
                     "db.operation.name": operation_name,
                     "db.collection.name": collection_name,

--- a/sentry_sdk/integrations/redis/_async_common.py
+++ b/sentry_sdk/integrations/redis/_async_common.py
@@ -46,6 +46,8 @@ def patch_redis_async_pipeline(
 
         span: "Union[Span, StreamedSpan]"
         if span_streaming:
+            if sentry_sdk.traces.get_current_span() is None:
+                return await old_execute(self, *args, **kwargs)
             span = sentry_sdk.traces.start_span(
                 name="redis.pipeline.execute",
                 attributes={
@@ -102,6 +104,9 @@ def patch_redis_async_client(
             return await old_execute_command(self, name, *args, **kwargs)
 
         span_streaming = has_span_streaming_enabled(client.options)
+
+        if span_streaming and sentry_sdk.traces.get_current_span() is None:
+            return await old_execute_command(self, name, *args, **kwargs)
 
         cache_properties = _compile_cache_span_properties(
             name,

--- a/sentry_sdk/integrations/redis/_sync_common.py
+++ b/sentry_sdk/integrations/redis/_sync_common.py
@@ -43,6 +43,8 @@ def patch_redis_pipeline(
 
         span: "Union[Span, StreamedSpan]"
         if span_streaming:
+            if sentry_sdk.traces.get_current_span() is None:
+                return old_execute(self, *args, **kwargs)
             span = sentry_sdk.traces.start_span(
                 name="redis.pipeline.execute",
                 attributes={
@@ -101,6 +103,9 @@ def patch_redis_client(
             return old_execute_command(self, name, *args, **kwargs)
 
         span_streaming = has_span_streaming_enabled(client.options)
+
+        if span_streaming and sentry_sdk.traces.get_current_span() is None:
+            return old_execute_command(self, name, *args, **kwargs)
 
         cache_properties = _compile_cache_span_properties(
             name,


### PR DESCRIPTION
## Summary
- When span streaming is enabled and there is no current span, database integrations should not create new root segments for child-span operations
- Adds a `sentry_sdk.traces.get_current_span() is None` guard before creating spans in the streaming path
- Affected integrations: aiomysql, asyncpg, clickhouse_driver, pymongo, redis

Part of https://github.com/getsentry/sentry-python/issues/6819