### PR TITLE
fix(tracing): Skip child span creation in streaming path when no current span (django)

### DIFF
--- a/sentry_sdk/integrations/django/__init__.py
+++ b/sentry_sdk/integrations/django/__init__.py
@@ -724,6 +724,8 @@ def install_sql_hook() -> None:
 
         span_streaming = has_span_streaming_enabled(sentry_sdk.get_client().options)
         if span_streaming:
+            if sentry_sdk.traces.get_current_span() is None:
+                return real_connect(self)
             with sentry_sdk.traces.start_span(
                 name="connect",
                 attributes={
@@ -750,6 +752,8 @@ def install_sql_hook() -> None:
 
         span_streaming = has_span_streaming_enabled(sentry_sdk.get_client().options)
         if span_streaming:
+            if sentry_sdk.traces.get_current_span() is None:
+                return real_commit(self)
             with sentry_sdk.traces.start_span(
                 name=SPANNAME.DB_COMMIT,
                 attributes={
@@ -776,6 +780,8 @@ def install_sql_hook() -> None:
 
         span_streaming = has_span_streaming_enabled(sentry_sdk.get_client().options)
         if span_streaming:
+            if sentry_sdk.traces.get_current_span() is None:
+                return real_rollback(self)
             with sentry_sdk.traces.start_span(
                 name=SPANNAME.DB_ROLLBACK,
                 attributes={

--- a/sentry_sdk/integrations/django/asgi.py
+++ b/sentry_sdk/integrations/django/asgi.py
@@ -191,6 +191,8 @@ def wrap_async_view(callback: "Any") -> "Any":
             return await callback(request, *args, **kwargs)
 
         if span_streaming:
+            if sentry_sdk.traces.get_current_span() is None:
+                return await callback(request, *args, **kwargs)
             with sentry_sdk.traces.start_span(
                 name=request.resolver_match.view_name,
                 attributes={

--- a/sentry_sdk/integrations/django/caching.py
+++ b/sentry_sdk/integrations/django/caching.py
@@ -61,6 +61,8 @@ def _patch_cache_method(
 
         span_streaming = has_span_streaming_enabled(sentry_sdk.get_client().options)
         if span_streaming:
+            if sentry_sdk.traces.get_current_span() is None:
+                return original_method(*args, **kwargs)
             with sentry_sdk.traces.start_span(
                 name=description,
                 attributes={

--- a/sentry_sdk/integrations/django/middleware.py
+++ b/sentry_sdk/integrations/django/middleware.py
@@ -84,6 +84,8 @@ def _wrap_middleware(middleware: "Any", middleware_name: str) -> "Any":
         span_streaming = has_span_streaming_enabled(sentry_sdk.get_client().options)
         middleware_span: "Union[Span, StreamedSpan]"
         if span_streaming:
+            if sentry_sdk.traces.get_current_span() is None:
+                return None
             middleware_span = sentry_sdk.traces.start_span(
                 name=description,
                 attributes={

--- a/sentry_sdk/integrations/django/signals_handlers.py
+++ b/sentry_sdk/integrations/django/signals_handlers.py
@@ -68,6 +68,8 @@ def patch_signals() -> None:
                     sentry_sdk.get_client().options
                 )
                 if span_streaming:
+                    if sentry_sdk.traces.get_current_span() is None:
+                        return receiver(*args, **kwargs)
                     with sentry_sdk.traces.start_span(
                         name=signal_name,
                         attributes={
@@ -75,7 +77,7 @@ def patch_signals() -> None:
                             "sentry.origin": DjangoIntegration.origin,
                             SPANDATA.CODE_FUNCTION_NAME: signal_name,
                         },
-                    ) as span:
+                    ):
                         return receiver(*args, **kwargs)
                 else:
                     with sentry_sdk.start_span(

--- a/sentry_sdk/integrations/django/tasks.py
+++ b/sentry_sdk/integrations/django/tasks.py
@@ -35,6 +35,8 @@ def patch_tasks() -> None:
 
         span_streaming = has_span_streaming_enabled(sentry_sdk.get_client().options)
         if span_streaming:
+            if sentry_sdk.traces.get_current_span() is None:
+                return old_task_enqueue(self, *args, **kwargs)
             with sentry_sdk.traces.start_span(
                 name=name,
                 attributes={

--- a/sentry_sdk/integrations/django/templates.py
+++ b/sentry_sdk/integrations/django/templates.py
@@ -64,13 +64,15 @@ def patch_templates() -> None:
     def rendered_content(self: "SimpleTemplateResponse") -> str:
         span_streaming = has_span_streaming_enabled(sentry_sdk.get_client().options)
         if span_streaming:
+            if sentry_sdk.traces.get_current_span() is None:
+                return real_rendered_content.fget(self)
             with sentry_sdk.traces.start_span(
                 name=_get_template_name_description(self.template_name),
                 attributes={
                     "sentry.op": OP.TEMPLATE_RENDER,
                     "sentry.origin": DjangoIntegration.origin,
                 },
-            ) as span:
+            ):
                 return real_rendered_content.fget(self)
         else:
             with sentry_sdk.start_span(
@@ -109,13 +111,15 @@ def patch_templates() -> None:
         span_streaming = has_span_streaming_enabled(client.options)
 
         if span_streaming:
+            if sentry_sdk.traces.get_current_span() is None:
+                return real_render(request, template_name, context, *args, **kwargs)
             with sentry_sdk.traces.start_span(
                 name=_get_template_name_description(template_name),
                 attributes={
                     "sentry.op": OP.TEMPLATE_RENDER,
                     "sentry.origin": DjangoIntegration.origin,
                 },
-            ) as span:
+            ):
                 return real_render(request, template_name, context, *args, **kwargs)
         else:
             with sentry_sdk.start_span(

--- a/sentry_sdk/integrations/django/views.py
+++ b/sentry_sdk/integrations/django/views.py
@@ -34,6 +34,8 @@ def patch_views() -> None:
     def sentry_patched_render(self: "SimpleTemplateResponse") -> "Any":
         span_streaming = has_span_streaming_enabled(sentry_sdk.get_client().options)
         if span_streaming:
+            if sentry_sdk.traces.get_current_span() is None:
+                return old_render(self)
             with sentry_sdk.traces.start_span(
                 name="serialize response",
                 attributes={
@@ -108,6 +110,8 @@ def _wrap_sync_view(callback: "Any") -> "Any":
             return callback(request, *args, **kwargs)
 
         if span_streaming:
+            if sentry_sdk.traces.get_current_span() is None:
+                return callback(request, *args, **kwargs)
             with sentry_sdk.traces.start_span(
                 name=request.resolver_match.view_name,
                 attributes={

--- a/tests/integrations/django/asgi/test_asgi.py
+++ b/tests/integrations/django/asgi/test_asgi.py
@@ -1027,8 +1027,8 @@ async def test_transaction_http_method_custom(
         sentry_sdk.flush()
         spans = [item.payload for item in items]
 
-        assert spans[10]["attributes"][SPANDATA.HTTP_REQUEST_METHOD] == "OPTIONS"
-        assert spans[16]["attributes"][SPANDATA.HTTP_REQUEST_METHOD] == "HEAD"
+        assert spans[5]["attributes"][SPANDATA.HTTP_REQUEST_METHOD] == "OPTIONS"
+        assert spans[11]["attributes"][SPANDATA.HTTP_REQUEST_METHOD] == "HEAD"
     else:
         events = capture_events()
 

--- a/tests/integrations/django/test_basic.py
+++ b/tests/integrations/django/test_basic.py
@@ -2370,8 +2370,8 @@ def test_transaction_http_method_custom(
         sentry_sdk.flush()
         spans = [item.payload for item in items]
 
-        assert spans[4]["attributes"][SPANDATA.HTTP_REQUEST_METHOD] == "OPTIONS"
-        assert spans[7]["attributes"][SPANDATA.HTTP_REQUEST_METHOD] == "HEAD"
+        assert spans[2]["attributes"][SPANDATA.HTTP_REQUEST_METHOD] == "OPTIONS"
+        assert spans[5]["attributes"][SPANDATA.HTTP_REQUEST_METHOD] == "HEAD"
     else:
         events = capture_events()
 


### PR DESCRIPTION
## Summary
- When span streaming is enabled and there is no current span, Django integrations should not create new root segments for child-span operations
- Adds a `sentry_sdk.traces.get_current_span() is None` guard before creating spans in the streaming path
- Affected: django init, asgi, caching, middleware, signals_handlers, tasks, templates, views

Part of https://github.com/getsentry/sentry-python/issues/6819