### PR TITLE
fix(tracing): Skip child span creation in streaming path when no current span (AI/LLM)

### DIFF
--- a/sentry_sdk/integrations/anthropic.py
+++ b/sentry_sdk/integrations/anthropic.py
@@ -640,6 +640,8 @@ def _sentry_patched_create_sync(f: "Any", *args: "Any", **kwargs: "Any") -> "Any
 
     span_streaming = has_span_streaming_enabled(sentry_sdk.get_client().options)
     if span_streaming:
+        if sentry_sdk.traces.get_current_span() is None:
+            return f(*args, **kwargs)
         span = sentry_sdk.traces.start_span(
             name=f"chat {model}".strip(),
             attributes={
@@ -738,6 +740,8 @@ async def _sentry_patched_create_async(
 
     span_streaming = has_span_streaming_enabled(sentry_sdk.get_client().options)
     if span_streaming:
+        if sentry_sdk.traces.get_current_span() is None:
+            return await f(*args, **kwargs)
         span = sentry_sdk.traces.start_span(
             name=f"chat {model}".strip(),
             attributes={
@@ -982,6 +986,8 @@ def _wrap_message_stream_manager_enter(f: "Any") -> "Any":
             return f(self)
 
         if has_span_streaming_enabled(client.options):
+            if sentry_sdk.traces.get_current_span() is None:
+                return f(self)
             span = sentry_sdk.traces.start_span(
                 name="chat" if self._model is None else f"chat {self._model}".strip(),
                 attributes={
@@ -1089,6 +1095,8 @@ def _wrap_async_message_stream_manager_aenter(f: "Any") -> "Any":
             return await f(self)
 
         if has_span_streaming_enabled(client.options):
+            if sentry_sdk.traces.get_current_span() is None:
+                return await f(self)
             span = sentry_sdk.traces.start_span(
                 name="chat" if self._model is None else f"chat {self._model}".strip(),
                 attributes={

--- a/sentry_sdk/integrations/cohere.py
+++ b/sentry_sdk/integrations/cohere.py
@@ -17,7 +17,11 @@ if TYPE_CHECKING:
 import sentry_sdk
 from sentry_sdk.integrations import DidNotEnable, Integration
 from sentry_sdk.scope import should_send_default_pii
-from sentry_sdk.utils import capture_internal_exceptions, event_from_exception, reraise
+from sentry_sdk.utils import (
+    capture_internal_exceptions,
+    event_from_exception,
+    reraise,
+)
 
 try:
     from cohere import (
@@ -154,6 +158,8 @@ def _wrap_chat(f: "Callable[..., Any]", streaming: bool) -> "Callable[..., Any]"
         message = kwargs.get("message")
 
         if is_span_streaming_enabled:
+            if sentry_sdk.traces.get_current_span() is None:
+                return f(*args, **kwargs)
             span = sentry_sdk.traces.start_span(
                 name="cohere.client.Chat",
                 attributes={
@@ -250,6 +256,8 @@ def _wrap_embed(f: "Callable[..., Any]") -> "Callable[..., Any]":
         )
 
         if is_span_streaming_enabled:
+            if sentry_sdk.traces.get_current_span() is None:
+                return f(*args, **kwargs)
             span_ctx = sentry_sdk.traces.start_span(
                 name="Cohere Embedding Creation",
                 attributes={

--- a/sentry_sdk/integrations/google_genai/__init__.py
+++ b/sentry_sdk/integrations/google_genai/__init__.py
@@ -76,17 +76,19 @@ def _wrap_generate_content_stream(f: "Callable[..., Any]") -> "Callable[..., Any
         _model, contents, model_name = prepare_generate_content_args(args, kwargs)
 
         if has_span_streaming_enabled(client.options):
-            chat_span = sentry_sdk.traces.start_span(
-                name=f"chat {model_name}",
-                attributes={
-                    "sentry.op": OP.GEN_AI_CHAT,
-                    "sentry.origin": ORIGIN,
-                    SPANDATA.GEN_AI_OPERATION_NAME: "chat",
-                    SPANDATA.GEN_AI_SYSTEM: GEN_AI_SYSTEM,
-                    SPANDATA.GEN_AI_REQUEST_MODEL: model_name,
-                    SPANDATA.GEN_AI_RESPONSE_STREAMING: True,
-                },
-            )
+            chat_span = None
+            if sentry_sdk.traces.get_current_span() is not None:
+                chat_span = sentry_sdk.traces.start_span(
+                    name=f"chat {model_name}",
+                    attributes={
+                        "sentry.op": OP.GEN_AI_CHAT,
+                        "sentry.origin": ORIGIN,
+                        SPANDATA.GEN_AI_OPERATION_NAME: "chat",
+                        SPANDATA.GEN_AI_SYSTEM: GEN_AI_SYSTEM,
+                        SPANDATA.GEN_AI_REQUEST_MODEL: model_name,
+                        SPANDATA.GEN_AI_RESPONSE_STREAMING: True,
+                    },
+                )
         else:
             chat_span = get_start_span_function()(
                 op=OP.GEN_AI_CHAT,
@@ -100,7 +102,10 @@ def _wrap_generate_content_stream(f: "Callable[..., Any]") -> "Callable[..., Any
             chat_span.set_data(SPANDATA.GEN_AI_REQUEST_MODEL, model_name)
             chat_span.set_data(SPANDATA.GEN_AI_RESPONSE_STREAMING, True)
 
-        set_span_data_for_request(chat_span, integration, model_name, contents, kwargs)
+        if chat_span is not None:
+            set_span_data_for_request(
+                chat_span, integration, model_name, contents, kwargs
+            )
 
         try:
             stream = f(self, *args, **kwargs)
@@ -114,25 +119,28 @@ def _wrap_generate_content_stream(f: "Callable[..., Any]") -> "Callable[..., Any
                         yield chunk
                 except Exception as exc:
                     _capture_exception(exc)
-                    if isinstance(chat_span, StreamedSpan):
-                        chat_span.status = SpanStatus.ERROR
-                    else:
-                        chat_span.set_status(SPANSTATUS.INTERNAL_ERROR)
+                    if chat_span is not None:
+                        if isinstance(chat_span, StreamedSpan):
+                            chat_span.status = SpanStatus.ERROR
+                        else:
+                            chat_span.set_status(SPANSTATUS.INTERNAL_ERROR)
                     raise
                 finally:
-                    # Accumulate all chunks and set final response data on spans
-                    if chunks:
-                        accumulated_response = accumulate_streaming_response(chunks)
-                        set_span_data_for_streaming_response(
-                            chat_span, integration, accumulated_response
-                        )
-                    chat_span.__exit__(None, None, None)
+                    if chat_span is not None:
+                        # Accumulate all chunks and set final response data on spans
+                        if chunks:
+                            accumulated_response = accumulate_streaming_response(chunks)
+                            set_span_data_for_streaming_response(
+                                chat_span, integration, accumulated_response
+                            )
+                        chat_span.__exit__(None, None, None)
 
             return new_iterator()
 
         except Exception as exc:
             _capture_exception(exc)
-            chat_span.__exit__(None, None, None)
+            if chat_span is not None:
+                chat_span.__exit__(None, None, None)
             raise
 
     return new_generate_content_stream
@@ -153,17 +161,19 @@ def _wrap_async_generate_content_stream(
         _model, contents, model_name = prepare_generate_content_args(args, kwargs)
 
         if has_span_streaming_enabled(client.options):
-            chat_span = sentry_sdk.traces.start_span(
-                name=f"chat {model_name}",
-                attributes={
-                    "sentry.op": OP.GEN_AI_CHAT,
-                    "sentry.origin": ORIGIN,
-                    SPANDATA.GEN_AI_OPERATION_NAME: "chat",
-                    SPANDATA.GEN_AI_SYSTEM: GEN_AI_SYSTEM,
-                    SPANDATA.GEN_AI_REQUEST_MODEL: model_name,
-                    SPANDATA.GEN_AI_RESPONSE_STREAMING: True,
-                },
-            )
+            chat_span = None
+            if sentry_sdk.traces.get_current_span() is not None:
+                chat_span = sentry_sdk.traces.start_span(
+                    name=f"chat {model_name}",
+                    attributes={
+                        "sentry.op": OP.GEN_AI_CHAT,
+                        "sentry.origin": ORIGIN,
+                        SPANDATA.GEN_AI_OPERATION_NAME: "chat",
+                        SPANDATA.GEN_AI_SYSTEM: GEN_AI_SYSTEM,
+                        SPANDATA.GEN_AI_REQUEST_MODEL: model_name,
+                        SPANDATA.GEN_AI_RESPONSE_STREAMING: True,
+                    },
+                )
         else:
             chat_span = get_start_span_function()(
                 op=OP.GEN_AI_CHAT,
@@ -177,7 +187,10 @@ def _wrap_async_generate_content_stream(
             chat_span.set_data(SPANDATA.GEN_AI_REQUEST_MODEL, model_name)
             chat_span.set_data(SPANDATA.GEN_AI_RESPONSE_STREAMING, True)
 
-        set_span_data_for_request(chat_span, integration, model_name, contents, kwargs)
+        if chat_span is not None:
+            set_span_data_for_request(
+                chat_span, integration, model_name, contents, kwargs
+            )
 
         try:
             stream = await f(self, *args, **kwargs)
@@ -191,25 +204,28 @@ def _wrap_async_generate_content_stream(
                         yield chunk
                 except Exception as exc:
                     _capture_exception(exc)
-                    if isinstance(chat_span, StreamedSpan):
-                        chat_span.status = SpanStatus.ERROR
-                    else:
-                        chat_span.set_status(SPANSTATUS.INTERNAL_ERROR)
+                    if chat_span is not None:
+                        if isinstance(chat_span, StreamedSpan):
+                            chat_span.status = SpanStatus.ERROR
+                        else:
+                            chat_span.set_status(SPANSTATUS.INTERNAL_ERROR)
                     raise
                 finally:
-                    # Accumulate all chunks and set final response data on spans
-                    if chunks:
-                        accumulated_response = accumulate_streaming_response(chunks)
-                        set_span_data_for_streaming_response(
-                            chat_span, integration, accumulated_response
-                        )
-                    chat_span.__exit__(None, None, None)
+                    if chat_span is not None:
+                        # Accumulate all chunks and set final response data on spans
+                        if chunks:
+                            accumulated_response = accumulate_streaming_response(chunks)
+                            set_span_data_for_streaming_response(
+                                chat_span, integration, accumulated_response
+                            )
+                        chat_span.__exit__(None, None, None)
 
             return new_async_iterator()
 
         except Exception as exc:
             _capture_exception(exc)
-            chat_span.__exit__(None, None, None)
+            if chat_span is not None:
+                chat_span.__exit__(None, None, None)
             raise
 
     return new_async_generate_content_stream
@@ -226,6 +242,9 @@ def _wrap_generate_content(f: "Callable[..., Any]") -> "Callable[..., Any]":
         model, contents, model_name = prepare_generate_content_args(args, kwargs)
 
         if has_span_streaming_enabled(client.options):
+            if sentry_sdk.traces.get_current_span() is None:
+                return f(self, *args, **kwargs)
+
             with sentry_sdk.traces.start_span(
                 name=f"chat {model_name}",
                 attributes={
@@ -290,6 +309,9 @@ def _wrap_async_generate_content(f: "Callable[..., Any]") -> "Callable[..., Any]
         model, contents, model_name = prepare_generate_content_args(args, kwargs)
 
         if has_span_streaming_enabled(client.options):
+            if sentry_sdk.traces.get_current_span() is None:
+                return await f(self, *args, **kwargs)
+
             with sentry_sdk.traces.start_span(
                 name=f"chat {model_name}",
                 attributes={
@@ -350,6 +372,9 @@ def _wrap_embed_content(f: "Callable[..., Any]") -> "Callable[..., Any]":
         model_name, contents = prepare_embed_content_args(args, kwargs)
 
         if has_span_streaming_enabled(client.options):
+            if sentry_sdk.traces.get_current_span() is None:
+                return f(self, *args, **kwargs)
+
             with sentry_sdk.traces.start_span(
                 name=f"embeddings {model_name}",
                 attributes={
@@ -410,6 +435,9 @@ def _wrap_async_embed_content(f: "Callable[..., Any]") -> "Callable[..., Any]":
         model_name, contents = prepare_embed_content_args(args, kwargs)
 
         if has_span_streaming_enabled(client.options):
+            if sentry_sdk.traces.get_current_span() is None:
+                return await f(self, *args, **kwargs)
+
             with sentry_sdk.traces.start_span(
                 name=f"embeddings {model_name}",
                 attributes={

--- a/sentry_sdk/integrations/google_genai/utils.py
+++ b/sentry_sdk/integrations/google_genai/utils.py
@@ -36,6 +36,7 @@ from sentry_sdk.tracing_utils import (
 from sentry_sdk.utils import (
     capture_internal_exceptions,
     event_from_exception,
+    nullcontext,
     safe_serialize,
 )
 
@@ -671,10 +672,12 @@ def _capture_tool_input(
 
 def _create_tool_span(
     tool_name: str, tool_doc: "Optional[str]"
-) -> "Union[Span, StreamedSpan]":
+) -> "Union[Span, StreamedSpan, nullcontext[None]]":
     """Create a span for tool execution."""
     span_streaming = has_span_streaming_enabled(sentry_sdk.get_client().options)
     if span_streaming:
+        if sentry_sdk.traces.get_current_span() is None:
+            return nullcontext()
         span = sentry_sdk.traces.start_span(
             name=f"execute_tool {tool_name}",
             attributes={
@@ -712,22 +715,30 @@ def wrapped_tool(tool: "Tool | Callable[..., Any]") -> "Tool | Callable[..., Any
         @wraps(tool)
         async def async_wrapped(*args: "Any", **kwargs: "Any") -> "Any":
             with _create_tool_span(tool_name, tool_doc) as span:
-                set_on_span = (
-                    span.set_attribute
-                    if isinstance(span, StreamedSpan)
-                    else span.set_data
-                )
-                # Capture tool input
-                tool_input = _capture_tool_input(args, kwargs, tool)
-                with capture_internal_exceptions():
-                    set_on_span(SPANDATA.GEN_AI_TOOL_INPUT, safe_serialize(tool_input))
+                if span is not None:
+                    set_on_span = (
+                        span.set_attribute
+                        if isinstance(span, StreamedSpan)
+                        else span.set_data
+                    )
+                    # Capture tool input
+                    tool_input = _capture_tool_input(args, kwargs, tool)
+                    with capture_internal_exceptions():
+                        set_on_span(
+                            SPANDATA.GEN_AI_TOOL_INPUT,
+                            safe_serialize(tool_input),
+                        )
 
                 try:
                     result = await tool(*args, **kwargs)
 
                     # Capture tool output
-                    with capture_internal_exceptions():
-                        set_on_span(SPANDATA.GEN_AI_TOOL_OUTPUT, safe_serialize(result))
+                    if span is not None:
+                        with capture_internal_exceptions():
+                            set_on_span(
+                                SPANDATA.GEN_AI_TOOL_OUTPUT,
+                                safe_serialize(result),
+                            )
 
                     return result
                 except Exception as exc:
@@ -740,22 +751,30 @@ def wrapped_tool(tool: "Tool | Callable[..., Any]") -> "Tool | Callable[..., Any
         @wraps(tool)
         def sync_wrapped(*args: "Any", **kwargs: "Any") -> "Any":
             with _create_tool_span(tool_name, tool_doc) as span:
-                set_on_span = (
-                    span.set_attribute
-                    if isinstance(span, StreamedSpan)
-                    else span.set_data
-                )
-                # Capture tool input
-                tool_input = _capture_tool_input(args, kwargs, tool)
-                with capture_internal_exceptions():
-                    set_on_span(SPANDATA.GEN_AI_TOOL_INPUT, safe_serialize(tool_input))
+                if span is not None:
+                    set_on_span = (
+                        span.set_attribute
+                        if isinstance(span, StreamedSpan)
+                        else span.set_data
+                    )
+                    # Capture tool input
+                    tool_input = _capture_tool_input(args, kwargs, tool)
+                    with capture_internal_exceptions():
+                        set_on_span(
+                            SPANDATA.GEN_AI_TOOL_INPUT,
+                            safe_serialize(tool_input),
+                        )
 
                 try:
                     result = tool(*args, **kwargs)
 
                     # Capture tool output
-                    with capture_internal_exceptions():
-                        set_on_span(SPANDATA.GEN_AI_TOOL_OUTPUT, safe_serialize(result))
+                    if span is not None:
+                        with capture_internal_exceptions():
+                            set_on_span(
+                                SPANDATA.GEN_AI_TOOL_OUTPUT,
+                                safe_serialize(result),
+                            )
 
                     return result
                 except Exception as exc:

--- a/sentry_sdk/integrations/huggingface_hub.py
+++ b/sentry_sdk/integrations/huggingface_hub.py
@@ -93,6 +93,8 @@ def _wrap_huggingface_task(f: "Callable[..., Any]", op: str) -> "Callable[..., A
 
         span: "Union[Span, StreamedSpan]"
         if has_span_streaming_enabled(sentry_sdk.get_client().options):
+            if sentry_sdk.traces.get_current_span() is None:
+                return f(*args, **kwargs)
             span = sentry_sdk.traces.start_span(
                 name=f"{operation_name} {model}",
                 attributes={

--- a/sentry_sdk/integrations/langchain.py
+++ b/sentry_sdk/integrations/langchain.py
@@ -296,7 +296,7 @@ class SentryLangchainCallback(BaseCallbackHandler):  # type: ignore[misc]
         op: str,
         name: str,
         origin: str,
-    ) -> "Union[sentry_sdk.tracing.Span, StreamedSpan]":
+    ) -> "Optional[Union[sentry_sdk.tracing.Span, StreamedSpan]]":
         span = None
         if parent_id:
             parent_span: "Optional[Union[sentry_sdk.tracing.Span, StreamedSpan]]" = (
@@ -318,17 +318,20 @@ class SentryLangchainCallback(BaseCallbackHandler):  # type: ignore[misc]
 
         if span is None:
             span_streaming = has_span_streaming_enabled(sentry_sdk.get_client().options)
-            span = (
-                sentry_sdk.traces.start_span(
-                    name=name,
-                    attributes={
-                        "sentry.op": op,
-                        "sentry.origin": origin,
-                    },
-                )
-                if span_streaming
-                else sentry_sdk.start_span(op=op, name=name, origin=origin)
-            )
+            if span_streaming:
+                if sentry_sdk.traces.get_current_span() is not None:
+                    span = sentry_sdk.traces.start_span(
+                        name=name,
+                        attributes={
+                            "sentry.op": op,
+                            "sentry.origin": origin,
+                        },
+                    )
+            else:
+                span = sentry_sdk.start_span(op=op, name=name, origin=origin)
+
+        if span is None:
+            return None
 
         span.__enter__()
         self.span_map[run_id] = span
@@ -375,6 +378,8 @@ class SentryLangchainCallback(BaseCallbackHandler):  # type: ignore[misc]
                 name=f"text_completion {model}".strip(),
                 origin=LangchainIntegration.origin,
             )
+            if span is None:
+                return
 
             set_on_span = (
                 span.set_attribute if isinstance(span, StreamedSpan) else span.set_data
@@ -455,6 +460,8 @@ class SentryLangchainCallback(BaseCallbackHandler):  # type: ignore[misc]
                 name=f"chat {model}".strip(),
                 origin=LangchainIntegration.origin,
             )
+            if span is None:
+                return
 
             set_on_span = (
                 span.set_attribute if isinstance(span, StreamedSpan) else span.set_data
@@ -672,6 +679,8 @@ class SentryLangchainCallback(BaseCallbackHandler):  # type: ignore[misc]
                 name=f"execute_tool {tool_name}".strip(),
                 origin=LangchainIntegration.origin,
             )
+            if span is None:
+                return
 
             set_on_span = (
                 span.set_attribute if isinstance(span, StreamedSpan) else span.set_data
@@ -1020,6 +1029,9 @@ def _wrap_agent_executor_invoke(f: "Callable[..., Any]") -> "Callable[..., Any]"
         run_name, tools = _get_request_data(self, args, kwargs)
 
         if has_span_streaming_enabled(client.options):
+            if sentry_sdk.traces.get_current_span() is None:
+                return f(self, *args, **kwargs)
+
             with sentry_sdk.traces.start_span(
                 name=f"invoke_agent {run_name}" if run_name else "invoke_agent",
                 attributes={
@@ -1135,17 +1147,19 @@ def _wrap_agent_executor_stream(f: "Callable[..., Any]") -> "Callable[..., Any]"
         run_name, tools = _get_request_data(self, args, kwargs)
 
         if has_span_streaming_enabled(client.options):
-            span = sentry_sdk.traces.start_span(
-                name=f"invoke_agent {run_name}" if run_name else "invoke_agent",
-                attributes={
-                    "sentry.op": OP.GEN_AI_INVOKE_AGENT,
-                    "sentry.origin": LangchainIntegration.origin,
-                    SPANDATA.GEN_AI_OPERATION_NAME: "invoke_agent",
-                    SPANDATA.GEN_AI_RESPONSE_STREAMING: True,
-                },
-            )
+            span = None
+            if sentry_sdk.traces.get_current_span() is not None:
+                span = sentry_sdk.traces.start_span(
+                    name=f"invoke_agent {run_name}" if run_name else "invoke_agent",
+                    attributes={
+                        "sentry.op": OP.GEN_AI_INVOKE_AGENT,
+                        "sentry.origin": LangchainIntegration.origin,
+                        SPANDATA.GEN_AI_OPERATION_NAME: "invoke_agent",
+                        SPANDATA.GEN_AI_RESPONSE_STREAMING: True,
+                    },
+                )
 
-            if run_name:
+            if span is not None and run_name:
                 span.set_attribute(SPANDATA.GEN_AI_FUNCTION_ID, run_name)
         else:
             start_span_function = get_start_span_function()
@@ -1163,33 +1177,37 @@ def _wrap_agent_executor_stream(f: "Callable[..., Any]") -> "Callable[..., Any]"
             if run_name:
                 span.set_data(SPANDATA.GEN_AI_FUNCTION_ID, run_name)
 
-        _set_tools_on_span(span, tools)
+        if span is not None:
+            _set_tools_on_span(span, tools)
 
-        input = args[0].get("input") if len(args) >= 1 else None
-        if (
-            input is not None
-            and should_send_default_pii()
-            and integration.include_prompts
-        ):
-            normalized_messages = normalize_message_roles([input])
+            input = args[0].get("input") if len(args) >= 1 else None
+            if (
+                input is not None
+                and should_send_default_pii()
+                and integration.include_prompts
+            ):
+                normalized_messages = normalize_message_roles([input])
 
-            client = sentry_sdk.get_client()
-            scope = sentry_sdk.get_current_scope()
-            messages_data = (
-                truncate_and_annotate_messages(normalized_messages, span, scope)
-                if should_truncate_gen_ai_input(client.options)
-                else normalized_messages
-            )
-            if messages_data is not None:
-                set_data_normalized(
-                    span,
-                    SPANDATA.GEN_AI_REQUEST_MESSAGES,
-                    messages_data,
-                    unpack=False,
+                client = sentry_sdk.get_client()
+                scope = sentry_sdk.get_current_scope()
+                messages_data = (
+                    truncate_and_annotate_messages(normalized_messages, span, scope)
+                    if should_truncate_gen_ai_input(client.options)
+                    else normalized_messages
                 )
+                if messages_data is not None:
+                    set_data_normalized(
+                        span,
+                        SPANDATA.GEN_AI_REQUEST_MESSAGES,
+                        messages_data,
+                        unpack=False,
+                    )
 
         # Run the agent
         result = f(self, *args, **kwargs)
+
+        if span is None:
+            return result
 
         old_iterator = result
 
@@ -1287,6 +1305,9 @@ def _wrap_embedding_method(f: "Callable[..., Any]") -> "Callable[..., Any]":
         model_name = getattr(self, "model", None) or getattr(self, "model_name", None)
 
         if has_span_streaming_enabled(client.options):
+            if sentry_sdk.traces.get_current_span() is None:
+                return f(self, *args, **kwargs)
+
             with sentry_sdk.traces.start_span(
                 name=f"embeddings {model_name}" if model_name else "embeddings",
                 attributes={
@@ -1308,7 +1329,10 @@ def _wrap_embedding_method(f: "Callable[..., Any]") -> "Callable[..., Any]":
                     # Normalize to list format
                     texts = input_data if isinstance(input_data, list) else [input_data]
                     set_data_normalized(
-                        span, SPANDATA.GEN_AI_EMBEDDINGS_INPUT, texts, unpack=False
+                        span,
+                        SPANDATA.GEN_AI_EMBEDDINGS_INPUT,
+                        texts,
+                        unpack=False,
                     )
 
                 result = f(self, *args, **kwargs)
@@ -1357,6 +1381,9 @@ def _wrap_async_embedding_method(f: "Callable[..., Any]") -> "Callable[..., Any]
         model_name = getattr(self, "model", None) or getattr(self, "model_name", None)
 
         if has_span_streaming_enabled(client.options):
+            if sentry_sdk.traces.get_current_span() is None:
+                return await f(self, *args, **kwargs)
+
             with sentry_sdk.traces.start_span(
                 name=f"embeddings {model_name}" if model_name else "embeddings",
                 attributes={
@@ -1378,7 +1405,10 @@ def _wrap_async_embedding_method(f: "Callable[..., Any]") -> "Callable[..., Any]
                     # Normalize to list format
                     texts = input_data if isinstance(input_data, list) else [input_data]
                     set_data_normalized(
-                        span, SPANDATA.GEN_AI_EMBEDDINGS_INPUT, texts, unpack=False
+                        span,
+                        SPANDATA.GEN_AI_EMBEDDINGS_INPUT,
+                        texts,
+                        unpack=False,
                     )
 
                 result = await f(self, *args, **kwargs)

--- a/sentry_sdk/integrations/langgraph.py
+++ b/sentry_sdk/integrations/langgraph.py
@@ -174,6 +174,9 @@ def _wrap_pregel_invoke(f: "Callable[..., Any]") -> "Callable[..., Any]":
         )
 
         if has_span_streaming_enabled(client.options):
+            if sentry_sdk.traces.get_current_span() is None:
+                return f(self, *args, **kwargs)
+
             with sentry_sdk.traces.start_span(
                 name=span_name,
                 attributes={
@@ -286,6 +289,9 @@ def _wrap_pregel_ainvoke(f: "Callable[..., Any]") -> "Callable[..., Any]":
         )
 
         if has_span_streaming_enabled(client.options):
+            if sentry_sdk.traces.get_current_span() is None:
+                return await f(self, *args, **kwargs)
+
             with sentry_sdk.traces.start_span(
                 name=span_name,
                 attributes={

--- a/sentry_sdk/integrations/litellm.py
+++ b/sentry_sdk/integrations/litellm.py
@@ -99,6 +99,8 @@ def _input_callback(kwargs: "Dict[str, Any]") -> None:
 
     # Start a new span/transaction
     if has_span_streaming_enabled(client.options):
+        if sentry_sdk.traces.get_current_span() is None:
+            return
         span = sentry_sdk.traces.start_span(
             name=f"{operation} {model}",
             attributes={

--- a/sentry_sdk/integrations/openai.py
+++ b/sentry_sdk/integrations/openai.py
@@ -729,6 +729,9 @@ def _new_sync_chat_completion(f: "Any", *args: "Any", **kwargs: "Any") -> "Any":
     is_streaming_response = kwargs.get("stream", False) or False
 
     if has_span_streaming_enabled(client.options):
+        if sentry_sdk.traces.get_current_span() is None:
+            return f(*args, **kwargs)
+
         span = sentry_sdk.traces.start_span(
             name=f"chat {model}",
             attributes={
@@ -810,6 +813,9 @@ async def _new_async_chat_completion(f: "Any", *args: "Any", **kwargs: "Any") ->
     is_streaming_response = kwargs.get("stream", False) or False
 
     if has_span_streaming_enabled(client.options):
+        if sentry_sdk.traces.get_current_span() is None:
+            return await f(*args, **kwargs)
+
         span = sentry_sdk.traces.start_span(
             name=f"chat {model}",
             attributes={
@@ -1227,6 +1233,9 @@ def _new_sync_embeddings_create(f: "Any", *args: "Any", **kwargs: "Any") -> "Any
     model = kwargs.get("model")
 
     if has_span_streaming_enabled(client.options):
+        if sentry_sdk.traces.get_current_span() is None:
+            return f(*args, **kwargs)
+
         with sentry_sdk.traces.start_span(
             name=f"embeddings {model}",
             attributes={
@@ -1285,6 +1294,9 @@ async def _new_async_embeddings_create(
     model = kwargs.get("model")
 
     if has_span_streaming_enabled(client.options):
+        if sentry_sdk.traces.get_current_span() is None:
+            return await f(*args, **kwargs)
+
         with sentry_sdk.traces.start_span(
             name=f"embeddings {model}",
             attributes={
@@ -1368,6 +1380,9 @@ def _new_sync_responses_create(f: "Any", *args: "Any", **kwargs: "Any") -> "Any"
     is_streaming_response = kwargs.get("stream", False) or False
 
     if has_span_streaming_enabled(client.options):
+        if sentry_sdk.traces.get_current_span() is None:
+            return f(*args, **kwargs)
+
         span = sentry_sdk.traces.start_span(
             name=f"responses {model}",
             attributes={
@@ -1438,6 +1453,9 @@ async def _new_async_responses_create(f: "Any", *args: "Any", **kwargs: "Any") -
     is_streaming_response = kwargs.get("stream", False) or False
 
     if has_span_streaming_enabled(client.options):
+        if sentry_sdk.traces.get_current_span() is None:
+            return await f(*args, **kwargs)
+
         span = sentry_sdk.traces.start_span(
             name=f"responses {model}",
             attributes={


### PR DESCRIPTION
## Summary
- When span streaming is enabled and there is no current span, AI/LLM integrations should not create new root segments for child-span operations
- Adds a `sentry_sdk.traces.get_current_span() is None` guard before creating spans in the streaming path
- Affected integrations: anthropic, cohere, openai, google_genai, huggingface_hub, langchain, langgraph, litellm

## Test plan
- [ ] Existing tests pass
- [ ] Verify that in streaming mode, no orphan root segments are created for AI/LLM calls when there's no active span

🤖 Generated with [Claude Code](https://claude.com/claude-code)