### PR TITLE
fix(tracing): Skip child span creation in streaming path when no current span (misc)

### DIFF
--- a/sentry_sdk/integrations/asyncio.py
+++ b/sentry_sdk/integrations/asyncio.py
@@ -155,13 +155,14 @@ def patch_asyncio() -> None:
                 with sentry_sdk.isolation_scope():
                     if task_spans:
                         if is_span_streaming_enabled:
-                            span_ctx = sentry_sdk.traces.start_span(
-                                name=get_name(coro),
-                                attributes={
-                                    "sentry.op": OP.FUNCTION,
-                                    "sentry.origin": AsyncioIntegration.origin,
-                                },
-                            )
+                            if sentry_sdk.traces.get_current_span() is not None:
+                                span_ctx = sentry_sdk.traces.start_span(
+                                    name=get_name(coro),
+                                    attributes={
+                                        "sentry.op": OP.FUNCTION,
+                                        "sentry.origin": AsyncioIntegration.origin,
+                                    },
+                                )
                         else:
                             span_ctx = sentry_sdk.start_span(
                                 op=OP.FUNCTION,

--- a/sentry_sdk/integrations/grpc/aio/client.py
+++ b/sentry_sdk/integrations/grpc/aio/client.py
@@ -52,6 +52,13 @@ class SentryUnaryUnaryClientInterceptor(ClientInterceptor, UnaryUnaryClientInter
 
         span_streaming = has_span_streaming_enabled(sentry_sdk.get_client().options)
         if span_streaming:
+            if sentry_sdk.traces.get_current_span() is None:
+                client_call_details = (
+                    self._update_client_call_details_metadata_from_scope(
+                        client_call_details
+                    )
+                )
+                return await continuation(client_call_details, request)
             with sentry_sdk.traces.start_span(
                 name="unary unary call to %s" % method.decode(),
                 attributes={
@@ -107,6 +114,13 @@ class SentryUnaryStreamClientInterceptor(
 
         span_streaming = has_span_streaming_enabled(sentry_sdk.get_client().options)
         if span_streaming:
+            if sentry_sdk.traces.get_current_span() is None:
+                client_call_details = (
+                    self._update_client_call_details_metadata_from_scope(
+                        client_call_details
+                    )
+                )
+                return await continuation(client_call_details, request)
             with sentry_sdk.traces.start_span(
                 name="unary stream call to %s" % method.decode(),
                 attributes={

--- a/sentry_sdk/integrations/grpc/client.py
+++ b/sentry_sdk/integrations/grpc/client.py
@@ -33,6 +33,13 @@ class ClientInterceptor(
 
         span_streaming = has_span_streaming_enabled(sentry_sdk.get_client().options)
         if span_streaming:
+            if sentry_sdk.traces.get_current_span() is None:
+                client_call_details = (
+                    self._update_client_call_details_metadata_from_scope(
+                        client_call_details
+                    )
+                )
+                return continuation(client_call_details, request)
             with sentry_sdk.traces.start_span(
                 name="unary unary call to %s" % method,
                 attributes={
@@ -84,6 +91,13 @@ class ClientInterceptor(
         span_streaming = has_span_streaming_enabled(sentry_sdk.get_client().options)
         response: "UnaryStreamCall"
         if span_streaming:
+            if sentry_sdk.traces.get_current_span() is None:
+                client_call_details = (
+                    self._update_client_call_details_metadata_from_scope(
+                        client_call_details
+                    )
+                )
+                return continuation(client_call_details, request)
             with sentry_sdk.traces.start_span(
                 name="unary stream call to %s" % method,
                 attributes={

--- a/sentry_sdk/integrations/mcp.py
+++ b/sentry_sdk/integrations/mcp.py
@@ -567,15 +567,18 @@ async def _handler_wrapper(
     # Start span and execute
     with isolation_scope_context:
         with current_scope_context:
-            span_mgr: "Union[Span, StreamedSpan]"
+            span_mgr: "Union[Span, StreamedSpan, ContextManager[None]]"
             if span_streaming:
-                span_mgr = sentry_sdk.traces.start_span(
-                    name=span_name,
-                    attributes={
-                        "sentry.op": OP.MCP_SERVER,
-                        "sentry.origin": MCPIntegration.origin,
-                    },
-                )
+                if sentry_sdk.traces.get_current_span() is not None:
+                    span_mgr = sentry_sdk.traces.start_span(
+                        name=span_name,
+                        attributes={
+                            "sentry.op": OP.MCP_SERVER,
+                            "sentry.origin": MCPIntegration.origin,
+                        },
+                    )
+                else:
+                    span_mgr = nullcontext()
             else:
                 span_mgr = get_start_span_function()(
                     op=OP.MCP_SERVER,
@@ -584,40 +587,41 @@ async def _handler_wrapper(
                 )
 
             with span_mgr as span:
-                # Set input span data
-                _set_span_input_data(
-                    span,
-                    handler_name,
-                    span_data_key,
-                    mcp_method_name,
-                    arguments,
-                    request_id,
-                    session_id,
-                    mcp_transport,
-                )
+                if span is not None:
+                    # Set input span data
+                    _set_span_input_data(
+                        span,
+                        handler_name,
+                        span_data_key,
+                        mcp_method_name,
+                        arguments,
+                        request_id,
+                        session_id,
+                        mcp_transport,
+                    )
 
-                # For resources, extract and set protocol
-                if handler_type == "resource":
-                    uri = None
-                    if params is not None:
-                        uri = getattr(params, "uri", None)
+                    # For resources, extract and set protocol
+                    if handler_type == "resource":
+                        uri = None
+                        if params is not None:
+                            uri = getattr(params, "uri", None)
 
-                    # v1 scenario
-                    if ServerRequestContext is None:
-                        if original_args:
-                            uri = original_args[0]
-                        else:
-                            uri = original_kwargs.get("uri")
+                        # v1 scenario
+                        if ServerRequestContext is None:
+                            if original_args:
+                                uri = original_args[0]
+                            else:
+                                uri = original_kwargs.get("uri")
 
-                    protocol = None
-                    if uri is not None and hasattr(uri, "scheme"):
-                        protocol = uri.scheme
-                    elif handler_name and "://" in handler_name:
-                        protocol = handler_name.split("://")[0]
-                    if protocol:
-                        _set_span_data_attribute(
-                            span, SPANDATA.MCP_RESOURCE_PROTOCOL, protocol
-                        )
+                        protocol = None
+                        if uri is not None and hasattr(uri, "scheme"):
+                            protocol = uri.scheme
+                        elif handler_name and "://" in handler_name:
+                            protocol = handler_name.split("://")[0]
+                        if protocol:
+                            _set_span_data_attribute(
+                                span, SPANDATA.MCP_RESOURCE_PROTOCOL, protocol
+                            )
 
                 try:
                     # Execute the async handler
@@ -630,14 +634,15 @@ async def _handler_wrapper(
 
                 except Exception as e:
                     # Set error flag for tools
-                    if handler_type == "tool":
+                    if span is not None and handler_type == "tool":
                         _set_span_data_attribute(
                             span, SPANDATA.MCP_TOOL_RESULT_IS_ERROR, True
                         )
                     sentry_sdk.capture_exception(e)
                     raise
 
-                _set_span_output_data(span, result, result_data_key, handler_type)
+                if span is not None:
+                    _set_span_output_data(span, result, result_data_key, handler_type)
 
     return result
 

--- a/sentry_sdk/integrations/rust_tracing.py
+++ b/sentry_sdk/integrations/rust_tracing.py
@@ -208,6 +208,9 @@ class RustTracingLayer:
 
         span_streaming = has_span_streaming_enabled(sentry_sdk.get_client().options)
         if span_streaming:
+            if sentry_sdk.traces.get_current_span() is None:
+                return None
+
             sentry_span = sentry_sdk.traces.start_span(
                 name=sentry_span_name,
                 attributes={

--- a/sentry_sdk/integrations/socket.py
+++ b/sentry_sdk/integrations/socket.py
@@ -57,6 +57,9 @@ def _patch_create_connection() -> None:
             return real_create_connection(address, timeout, source_address)
 
         if has_span_streaming_enabled(client.options):
+            if sentry_sdk.traces.get_current_span() is None:
+                return real_create_connection(address, timeout, source_address)
+
             with sentry_sdk.traces.start_span(
                 name=_get_span_description(address[0], address[1]),
                 attributes={
@@ -105,6 +108,9 @@ def _patch_getaddrinfo() -> None:
             return real_getaddrinfo(host, port, family, type, proto, flags)
 
         if has_span_streaming_enabled(client.options):
+            if sentry_sdk.traces.get_current_span() is None:
+                return real_getaddrinfo(host, port, family, type, proto, flags)
+
             with sentry_sdk.traces.start_span(
                 name=_get_span_description(host, port),
                 attributes={

--- a/tests/integrations/grpc/test_grpc_aio.py
+++ b/tests/integrations/grpc/test_grpc_aio.py
@@ -100,7 +100,7 @@ async def test_noop_for_unimplemented_method(
 
         sentry_sdk.flush()
         spans = [item.payload for item in items]
-        assert len(spans) == 1  # Only client span present.
+        assert len(spans) == 0  # No client span created without an active span.
     else:
         events = capture_events()
 

--- a/tests/integrations/rust_tracing/test_rust_tracing.py
+++ b/tests/integrations/rust_tracing/test_rust_tracing.py
@@ -309,10 +309,10 @@ def test_on_new_span_without_transaction(sentry_init, span_streaming):
     if span_streaming:
         assert sentry_sdk.traces.get_current_span() is None
 
+        # In streaming mode we do not create an orphan root segment when there
+        # is no active span
         rust_tracing.new_span(RustTracingLevel.Info, 3)
-        current_span = sentry_sdk.traces.get_current_span()
-        assert current_span is not None
-        assert current_span._segment is current_span
+        assert sentry_sdk.traces.get_current_span() is None
     else:
         assert sentry_sdk.get_current_span() is None
 


### PR DESCRIPTION
## Summary
- When span streaming is enabled and there is no current span, integrations should not create new root segments for child-span operations
- Adds a `sentry_sdk.traces.get_current_span() is None` guard before creating spans in the streaming path
- Affected integrations: socket, grpc (client), asyncio, mcp, rust_tracing

## Test plan
- [ ] Existing tests pass
- [ ] Verify that in streaming mode, no orphan root segments are created when there's no active span

🤖 Generated with [Claude Code](https://claude.com/claude-code)