### PR TITLE
test(logging): Fix flaky test_logging_captured_warnings

### DIFF
--- a/tests/integrations/logging/test_logging.py
+++ b/tests/integrations/logging/test_logging.py
@@ -223,9 +223,12 @@ def test_logging_captured_warnings(sentry_init, capture_events, recwarn):
     assert events[1]["logentry"]["message"] == events[1]["logentry"]["formatted"]
     assert events[1]["logentry"]["params"] == []
 
-    # Using recwarn suppresses the "third" warning in the test output
-    assert len(recwarn) == 1
-    assert str(recwarn[0].message) == "third"
+    # "third" is emitted after captureWarnings(False), so it is not captured
+    # by Sentry and instead surfaces as a normal warning. Using recwarn also
+    # suppresses it in the test output. Filter by message rather than asserting
+    # on the total count, since unrelated warnings from other tests can leak in.
+    third_warnings = [w for w in recwarn if str(w.message) == "third"]
+    assert len(third_warnings) == 1
 
 
 def test_ignore_logger(sentry_init, capture_events, request):


### PR DESCRIPTION
## Summary

Fixes a flaky failure in `tests/integrations/logging/test_logging.py::test_logging_captured_warnings` seen in CI (`assert len(recwarn) == 1` failing with `assert 2 == 1`).

## Root cause

The `recwarn` fixture records **every** warning emitted during the test. The test asserted the total count was exactly 1, which holds in isolation and in file order, but fails in the full `tests` suite when an unrelated warning leaks in from another module (warning filter/registry state is process-global). Whether it reproduces depends on test ordering.

## Fix

Filter `recwarn` for the specific `"third"` warning the test actually cares about instead of asserting on the total count. This preserves the test's intent — verifying that `"third"` (emitted after `captureWarnings(False)`) is not captured by Sentry but surfaces as a normal warning — while being immune to stray warnings from other tests.
