### PR TITLE
fix: skip empty patterns in match_regex_list to prevent IndexError

### DIFF
--- a/sentry_sdk/utils.py
+++ b/sentry_sdk/utils.py
@@ -1736,6 +1736,9 @@ def match_regex_list(
         return False
 
     for item_matcher in regex_list:
+        if not item_matcher:
+            continue
+
         if not substring_matching and item_matcher[-1] != "$":
             item_matcher += "$"
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -556,6 +556,9 @@ def test_include_source_context_when_serializing_frame(include_source_context):
         ["some-string", ["some.*"], True],
         ["some-string", ["Some"], False],  # we do case sensitive matching
         ["some-string", [".*string$"], True],
+        ["some-string", [""], False],  # empty pattern should not match
+        ["some-string", ["", "some-string"], True],  # empty pattern skipped, second matches
+        ["some-string", ["", ""], False],  # all empty patterns, no match
     ],
 )
 def test_match_regex_list(item, regex_list, expected_result):


### PR DESCRIPTION
Fixes #6504

`match_regex_list` indexes `item_matcher[-1]` to check for `$` suffix. When the pattern list contains an empty string, `""[-1]` raises `IndexError: string index out of range`.

This is reachable from `CeleryIntegration.exclude_beat_tasks` when user configures an empty string in the pattern list.

Skip empty patterns with `if not item_matcher: continue` before the index check. Empty strings cannot match anything, so this is the correct behavior.

Three test cases added:
- `[""]` single empty pattern → no match
- `["", "some-string"]` empty then valid → matches valid
- `["", ""]` all empty → no match