### PR TITLE
ref(tracing): No-op and emit warning in `start_transaction` with the streaming trace lifecycle

### DIFF
--- a/sentry_sdk/scope.py
+++ b/sentry_sdk/scope.py
@@ -1141,9 +1141,16 @@ class Scope:
             constructor. See :py:class:`sentry_sdk.tracing.Transaction` for
             available arguments.
         """
-        kwargs.setdefault("scope", self)
-
         client = self.get_client()
+        if has_span_streaming_enabled(client.options):
+            warnings.warn(
+                "Scope.start_transaction is not available in streaming mode.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            return NoOpSpan()
+
+        kwargs.setdefault("scope", self)
 
         configuration_instrumenter = client.options["instrumenter"]
 

--- a/tests/integrations/anthropic/test_anthropic.py
+++ b/tests/integrations/anthropic/test_anthropic.py
@@ -170,8 +170,8 @@ def test_nonstreaming_create_message(
                 span["attributes"][SPANDATA.GEN_AI_RESPONSE_TEXT] == "Hi, I'm Claude."
             )
         else:
-            assert SPANDATA.GEN_AI_REQUEST_MESSAGES not in span
-            assert SPANDATA.GEN_AI_RESPONSE_TEXT not in span
+            assert SPANDATA.GEN_AI_REQUEST_MESSAGES not in span["attributes"]
+            assert SPANDATA.GEN_AI_RESPONSE_TEXT not in span["attributes"]
 
         assert span["attributes"][SPANDATA.GEN_AI_USAGE_INPUT_TOKENS] == 10
         assert span["attributes"][SPANDATA.GEN_AI_USAGE_OUTPUT_TOKENS] == 20

--- a/tests/integrations/anthropic/test_anthropic.py
+++ b/tests/integrations/anthropic/test_anthropic.py
@@ -170,8 +170,8 @@ def test_nonstreaming_create_message(
                 span["attributes"][SPANDATA.GEN_AI_RESPONSE_TEXT] == "Hi, I'm Claude."
             )
         else:
-            assert SPANDATA.GEN_AI_REQUEST_MESSAGES not in spans[1]["attributes"]
-            assert SPANDATA.GEN_AI_RESPONSE_TEXT not in spans[1]["attributes"]
+            assert SPANDATA.GEN_AI_REQUEST_MESSAGES not in span
+            assert SPANDATA.GEN_AI_RESPONSE_TEXT not in span
 
         assert span["attributes"][SPANDATA.GEN_AI_USAGE_INPUT_TOKENS] == 10
         assert span["attributes"][SPANDATA.GEN_AI_USAGE_OUTPUT_TOKENS] == 20

--- a/tests/integrations/anthropic/test_anthropic.py
+++ b/tests/integrations/anthropic/test_anthropic.py
@@ -69,7 +69,6 @@ from sentry_sdk.integrations.anthropic import (
     _transform_anthropic_content_block,
 )
 from sentry_sdk.integrations.stdlib import StdlibIntegration
-from sentry_sdk.traces import SpanStatus
 from sentry_sdk.utils import package_version
 
 ANTHROPIC_VERSION = package_version("anthropic")
@@ -571,65 +570,7 @@ def test_streaming_create_message(
         },
     ]
 
-    if span_streaming:
-        items = capture_items("span")
-
-        with mock.patch.object(
-            client._client,
-            "send",
-            return_value=response,
-        ) as _, sentry_sdk.traces.start_span(name="anthropic"):
-            message = client.messages.create(
-                max_tokens=1024, messages=messages, model="model", stream=True
-            )
-
-            for _ in message:
-                pass
-
-        sentry_sdk.flush()
-        spans = [item.payload for item in items if item.type == "span"]
-        assert spans[1]["name"] == "anthropic"
-        span = next(
-            span for span in spans if span["attributes"]["sentry.op"] == OP.GEN_AI_CHAT
-        )
-
-        assert span["attributes"]["sentry.op"] == OP.GEN_AI_CHAT
-        assert span["name"] == "chat model"
-        assert span["attributes"][SPANDATA.GEN_AI_SYSTEM] == "anthropic"
-        assert span["attributes"][SPANDATA.GEN_AI_OPERATION_NAME] == "chat"
-        assert span["attributes"][SPANDATA.GEN_AI_REQUEST_MODEL] == "model"
-
-        if send_default_pii and include_prompts:
-            assert json.loads(span["attributes"][SPANDATA.GEN_AI_REQUEST_MESSAGES]) == [
-                {
-                    "role": "user",
-                    "content": "Message demonstrating the absence of truncation.",
-                },
-                {
-                    "role": "user",
-                    "content": "Hello, Claude",
-                },
-            ]
-            assert (
-                span["attributes"][SPANDATA.GEN_AI_RESPONSE_TEXT] == "Hi! I'm Claude!"
-            )
-
-        else:
-            assert SPANDATA.GEN_AI_REQUEST_MESSAGES not in span["attributes"]
-            assert SPANDATA.GEN_AI_RESPONSE_TEXT not in span["attributes"]
-
-        assert span["attributes"][SPANDATA.GEN_AI_USAGE_INPUT_TOKENS] == 10
-        assert span["attributes"][SPANDATA.GEN_AI_USAGE_OUTPUT_TOKENS] == 10
-        assert span["attributes"][SPANDATA.GEN_AI_USAGE_TOTAL_TOKENS] == 20
-        assert span["attributes"][SPANDATA.GEN_AI_RESPONSE_STREAMING] is True
-        assert (
-            span["attributes"][SPANDATA.GEN_AI_RESPONSE_ID]
-            == "msg_01XFDUDYJgAACzvnptvVoYEL"
-        )
-        assert span["attributes"][SPANDATA.GEN_AI_RESPONSE_FINISH_REASONS] == [
-            "max_tokens"
-        ]
-    elif stream_gen_ai_spans:
+    if span_streaming or stream_gen_ai_spans:
         items = capture_items("transaction", "span")
 
         with mock.patch.object(
@@ -805,51 +746,7 @@ def test_streaming_create_message_close(
         }
     ]
 
-    if span_streaming:
-        items = capture_items("transaction", "span")
-
-        with mock.patch.object(
-            client._client,
-            "send",
-            return_value=response,
-        ) as _, sentry_sdk.traces.start_span(name="anthropic"):
-            messages = client.messages.create(
-                max_tokens=1024, messages=messages, model="model", stream=True
-            )
-
-            for _ in range(4):
-                next(messages)
-
-            messages.close()
-
-        sentry_sdk.flush()
-        spans = [item.payload for item in items if item.type == "span"]
-        assert spans[1]["name"] == "anthropic"
-        span = next(
-            span for span in spans if span["attributes"]["sentry.op"] == OP.GEN_AI_CHAT
-        )
-
-        assert span["attributes"]["sentry.op"] == OP.GEN_AI_CHAT
-        assert span["name"] == "chat model"
-        assert span["attributes"][SPANDATA.GEN_AI_SYSTEM] == "anthropic"
-        assert span["attributes"][SPANDATA.GEN_AI_OPERATION_NAME] == "chat"
-        assert span["attributes"][SPANDATA.GEN_AI_REQUEST_MODEL] == "model"
-
-        assert (
-            span["attributes"][SPANDATA.GEN_AI_REQUEST_MESSAGES]
-            == '[{"role": "user", "content": "Hello, Claude"}]'
-        )
-        assert span["attributes"][SPANDATA.GEN_AI_RESPONSE_TEXT] == "Hi!"
-
-        assert span["attributes"][SPANDATA.GEN_AI_USAGE_INPUT_TOKENS] == 10
-        assert span["attributes"][SPANDATA.GEN_AI_USAGE_OUTPUT_TOKENS] == 20
-        assert span["attributes"][SPANDATA.GEN_AI_USAGE_TOTAL_TOKENS] == 30
-        assert span["attributes"][SPANDATA.GEN_AI_RESPONSE_STREAMING] is True
-        assert (
-            span["attributes"][SPANDATA.GEN_AI_RESPONSE_ID]
-            == "msg_01XFDUDYJgAACzvnptvVoYEL"
-        )
-    elif stream_gen_ai_spans:
+    if span_streaming or stream_gen_ai_spans:
         items = capture_items("transaction", "span")
 
         with mock.patch.object(
@@ -1006,52 +903,7 @@ def test_streaming_create_message_api_error(
         }
     ]
 
-    if span_streaming:
-        items = capture_items("transaction", "span")
-
-        with pytest.raises(APIStatusError), mock.patch.object(
-            client._client,
-            "send",
-            return_value=response,
-        ) as _, sentry_sdk.traces.start_span(name="anthropic"):
-            message = client.messages.create(
-                max_tokens=1024, messages=messages, model="model", stream=True
-            )
-
-            for _ in message:
-                pass
-
-        sentry_sdk.flush()
-        spans = [item.payload for item in items if item.type == "span"]
-        assert spans[1]["name"] == "anthropic"
-        assert spans[1]["status"] == SpanStatus.ERROR
-        span = next(
-            span for span in spans if span["attributes"]["sentry.op"] == OP.GEN_AI_CHAT
-        )
-
-        assert span["attributes"]["sentry.op"] == OP.GEN_AI_CHAT
-        assert span["name"] == "chat model"
-        assert span["attributes"][SPANDATA.GEN_AI_SYSTEM] == "anthropic"
-        assert span["attributes"][SPANDATA.GEN_AI_OPERATION_NAME] == "chat"
-        assert span["attributes"][SPANDATA.GEN_AI_REQUEST_MODEL] == "model"
-
-        assert (
-            span["attributes"][SPANDATA.GEN_AI_REQUEST_MESSAGES]
-            == '[{"role": "user", "content": "Hello, Claude"}]'
-        )
-        assert span["attributes"][SPANDATA.GEN_AI_RESPONSE_TEXT] == "Hi!"
-
-        assert span["attributes"][SPANDATA.GEN_AI_USAGE_INPUT_TOKENS] == 10
-        assert span["attributes"][SPANDATA.GEN_AI_USAGE_OUTPUT_TOKENS] == 20
-        assert span["attributes"][SPANDATA.GEN_AI_USAGE_TOTAL_TOKENS] == 30
-        assert span["attributes"][SPANDATA.GEN_AI_RESPONSE_STREAMING] is True
-        assert (
-            span["attributes"][SPANDATA.GEN_AI_RESPONSE_ID]
-            == "msg_01XFDUDYJgAACzvnptvVoYEL"
-        )
-
-        assert span["status"] == "error"
-    elif stream_gen_ai_spans:
+    if span_streaming or stream_gen_ai_spans:
         items = capture_items("transaction", "span")
 
         with pytest.raises(APIStatusError), mock.patch.object(
@@ -1226,65 +1078,7 @@ def test_stream_messages(
         },
     ]
 
-    if span_streaming:
-        items = capture_items("transaction", "span")
-
-        with mock.patch.object(
-            client._client,
-            "send",
-            return_value=response,
-        ) as _, sentry_sdk.traces.start_span(name="anthropic"), client.messages.stream(
-            max_tokens=1024,
-            messages=messages,
-            model="model",
-        ) as stream:
-            for event in stream:
-                pass
-
-        sentry_sdk.flush()
-        spans = [item.payload for item in items if item.type == "span"]
-        assert spans[1]["name"] == "anthropic"
-        span = next(
-            span for span in spans if span["attributes"]["sentry.op"] == OP.GEN_AI_CHAT
-        )
-
-        assert span["attributes"]["sentry.op"] == OP.GEN_AI_CHAT
-        assert span["name"] == "chat model"
-        assert span["attributes"][SPANDATA.GEN_AI_SYSTEM] == "anthropic"
-        assert span["attributes"][SPANDATA.GEN_AI_OPERATION_NAME] == "chat"
-        assert span["attributes"][SPANDATA.GEN_AI_REQUEST_MODEL] == "model"
-
-        if send_default_pii and include_prompts:
-            assert json.loads(span["attributes"][SPANDATA.GEN_AI_REQUEST_MESSAGES]) == [
-                {
-                    "role": "user",
-                    "content": "Message demonstrating the absence of truncation.",
-                },
-                {
-                    "role": "user",
-                    "content": "Hello, Claude",
-                },
-            ]
-            assert (
-                span["attributes"][SPANDATA.GEN_AI_RESPONSE_TEXT] == "Hi! I'm Claude!"
-            )
-
-        else:
-            assert SPANDATA.GEN_AI_REQUEST_MESSAGES not in span["attributes"]
-            assert SPANDATA.GEN_AI_RESPONSE_TEXT not in span["attributes"]
-
-        assert span["attributes"][SPANDATA.GEN_AI_USAGE_INPUT_TOKENS] == 10
-        assert span["attributes"][SPANDATA.GEN_AI_USAGE_OUTPUT_TOKENS] == 10
-        assert span["attributes"][SPANDATA.GEN_AI_USAGE_TOTAL_TOKENS] == 20
-        assert span["attributes"][SPANDATA.GEN_AI_RESPONSE_STREAMING] is True
-        assert (
-            span["attributes"][SPANDATA.GEN_AI_RESPONSE_ID]
-            == "msg_01XFDUDYJgAACzvnptvVoYEL"
-        )
-        assert span["attributes"][SPANDATA.GEN_AI_RESPONSE_FINISH_REASONS] == [
-            "max_tokens"
-        ]
-    elif stream_gen_ai_spans:
+    if span_streaming or stream_gen_ai_spans:
         items = capture_items("transaction", "span")
 
         with mock.patch.object(
@@ -1459,55 +1253,7 @@ def test_stream_messages_close(
         }
     ]
 
-    if span_streaming:
-        items = capture_items("transaction", "span")
-
-        with mock.patch.object(
-            client._client,
-            "send",
-            return_value=response,
-        ) as _, sentry_sdk.traces.start_span(name="anthropic"), client.messages.stream(
-            max_tokens=1024,
-            messages=messages,
-            model="model",
-        ) as stream:
-            for _ in range(4):
-                next(stream)
-
-            # New versions add TextEvent, so consume one more event.
-            if TextEvent is not None and isinstance(next(stream), TextEvent):
-                next(stream)
-
-            stream.close()
-
-        sentry_sdk.flush()
-        spans = [item.payload for item in items if item.type == "span"]
-        assert spans[1]["name"] == "anthropic"
-        span = next(
-            span for span in spans if span["attributes"]["sentry.op"] == OP.GEN_AI_CHAT
-        )
-
-        assert span["attributes"]["sentry.op"] == OP.GEN_AI_CHAT
-        assert span["name"] == "chat model"
-        assert span["attributes"][SPANDATA.GEN_AI_SYSTEM] == "anthropic"
-        assert span["attributes"][SPANDATA.GEN_AI_OPERATION_NAME] == "chat"
-        assert span["attributes"][SPANDATA.GEN_AI_REQUEST_MODEL] == "model"
-
-        assert (
-            span["attributes"][SPANDATA.GEN_AI_REQUEST_MESSAGES]
-            == '[{"role": "user", "content": "Hello, Claude"}]'
-        )
-        assert span["attributes"][SPANDATA.GEN_AI_RESPONSE_TEXT] == "Hi!"
-
-        assert span["attributes"][SPANDATA.GEN_AI_USAGE_INPUT_TOKENS] == 10
-        assert span["attributes"][SPANDATA.GEN_AI_USAGE_OUTPUT_TOKENS] == 20
-        assert span["attributes"][SPANDATA.GEN_AI_USAGE_TOTAL_TOKENS] == 30
-        assert span["attributes"][SPANDATA.GEN_AI_RESPONSE_STREAMING] is True
-        assert (
-            span["attributes"][SPANDATA.GEN_AI_RESPONSE_ID]
-            == "msg_01XFDUDYJgAACzvnptvVoYEL"
-        )
-    elif stream_gen_ai_spans:
+    if span_streaming or stream_gen_ai_spans:
         items = capture_items("transaction", "span")
 
         with mock.patch.object(
@@ -1672,52 +1418,7 @@ def test_stream_messages_api_error(
         }
     ]
 
-    if span_streaming:
-        items = capture_items("transaction", "span")
-
-        with pytest.raises(APIStatusError), mock.patch.object(
-            client._client,
-            "send",
-            return_value=response,
-        ) as _, sentry_sdk.traces.start_span(name="anthropic"), client.messages.stream(
-            max_tokens=1024,
-            messages=messages,
-            model="model",
-        ) as stream:
-            for event in stream:
-                pass
-
-        sentry_sdk.flush()
-        spans = [item.payload for item in items if item.type == "span"]
-        assert spans[1]["name"] == "anthropic"
-        assert spans[1]["status"] == SpanStatus.ERROR
-        span = next(
-            span for span in spans if span["attributes"]["sentry.op"] == OP.GEN_AI_CHAT
-        )
-
-        assert span["attributes"]["sentry.op"] == OP.GEN_AI_CHAT
-        assert span["name"] == "chat model"
-        assert span["attributes"][SPANDATA.GEN_AI_SYSTEM] == "anthropic"
-        assert span["attributes"][SPANDATA.GEN_AI_OPERATION_NAME] == "chat"
-        assert span["attributes"][SPANDATA.GEN_AI_REQUEST_MODEL] == "model"
-
-        assert (
-            span["attributes"][SPANDATA.GEN_AI_REQUEST_MESSAGES]
-            == '[{"role": "user", "content": "Hello, Claude"}]'
-        )
-        assert span["attributes"][SPANDATA.GEN_AI_RESPONSE_TEXT] == "Hi!"
-
-        assert span["attributes"][SPANDATA.GEN_AI_USAGE_INPUT_TOKENS] == 10
-        assert span["attributes"][SPANDATA.GEN_AI_USAGE_OUTPUT_TOKENS] == 20
-        assert span["attributes"][SPANDATA.GEN_AI_USAGE_TOTAL_TOKENS] == 30
-        assert span["attributes"][SPANDATA.GEN_AI_RESPONSE_STREAMING] is True
-        assert (
-            span["attributes"][SPANDATA.GEN_AI_RESPONSE_ID]
-            == "msg_01XFDUDYJgAACzvnptvVoYEL"
-        )
-
-        assert span["status"] == "error"
-    elif stream_gen_ai_spans:
+    if span_streaming or stream_gen_ai_spans:
         items = capture_items("transaction", "span")
 
         with pytest.raises(APIStatusError), mock.patch.object(
@@ -2136,50 +1837,7 @@ async def test_streaming_create_message_async_close(
         }
     ]
 
-    if span_streaming:
-        items = capture_items("span")
-
-        with mock.patch.object(
-            client._client,
-            "send",
-            return_value=response,
-        ) as _, sentry_sdk.traces.start_span(name="anthropic"):
-            messages = await client.messages.create(
-                max_tokens=1024, messages=messages, model="model", stream=True
-            )
-
-            for _ in range(4):
-                await messages.__anext__()
-            await messages.close()
-
-        sentry_sdk.flush()
-        spans = [item.payload for item in items if item.type == "span"]
-        assert spans[1]["name"] == "anthropic"
-        span = next(
-            span for span in spans if span["attributes"]["sentry.op"] == OP.GEN_AI_CHAT
-        )
-
-        assert span["attributes"]["sentry.op"] == OP.GEN_AI_CHAT
-        assert span["name"] == "chat model"
-        assert span["attributes"][SPANDATA.GEN_AI_SYSTEM] == "anthropic"
-        assert span["attributes"][SPANDATA.GEN_AI_OPERATION_NAME] == "chat"
-        assert span["attributes"][SPANDATA.GEN_AI_REQUEST_MODEL] == "model"
-
-        assert (
-            span["attributes"][SPANDATA.GEN_AI_REQUEST_MESSAGES]
-            == '[{"role": "user", "content": "Hello, Claude"}]'
-        )
-        assert span["attributes"][SPANDATA.GEN_AI_RESPONSE_TEXT] == "Hi!"
-
-        assert span["attributes"][SPANDATA.GEN_AI_USAGE_INPUT_TOKENS] == 10
-        assert span["attributes"][SPANDATA.GEN_AI_USAGE_OUTPUT_TOKENS] == 20
-        assert span["attributes"][SPANDATA.GEN_AI_USAGE_TOTAL_TOKENS] == 30
-        assert span["attributes"][SPANDATA.GEN_AI_RESPONSE_STREAMING] is True
-        assert (
-            span["attributes"][SPANDATA.GEN_AI_RESPONSE_ID]
-            == "msg_01XFDUDYJgAACzvnptvVoYEL"
-        )
-    elif stream_gen_ai_spans:
+    if span_streaming or stream_gen_ai_spans:
         items = capture_items("transaction", "span")
 
         with mock.patch.object(
@@ -2338,52 +1996,7 @@ async def test_streaming_create_message_async_api_error(
         }
     ]
 
-    if span_streaming:
-        items = capture_items("transaction", "span")
-
-        with pytest.raises(APIStatusError), mock.patch.object(
-            client._client,
-            "send",
-            return_value=response,
-        ) as _, sentry_sdk.traces.start_span(name="anthropic"):
-            message = await client.messages.create(
-                max_tokens=1024, messages=messages, model="model", stream=True
-            )
-
-            async for _ in message:
-                pass
-
-        sentry_sdk.flush()
-        spans = [item.payload for item in items if item.type == "span"]
-        assert spans[1]["name"] == "anthropic"
-        assert spans[1]["status"] == SpanStatus.ERROR
-        span = next(
-            span for span in spans if span["attributes"]["sentry.op"] == OP.GEN_AI_CHAT
-        )
-
-        assert span["attributes"]["sentry.op"] == OP.GEN_AI_CHAT
-        assert span["name"] == "chat model"
-        assert span["attributes"][SPANDATA.GEN_AI_SYSTEM] == "anthropic"
-        assert span["attributes"][SPANDATA.GEN_AI_OPERATION_NAME] == "chat"
-        assert span["attributes"][SPANDATA.GEN_AI_REQUEST_MODEL] == "model"
-
-        assert (
-            span["attributes"][SPANDATA.GEN_AI_REQUEST_MESSAGES]
-            == '[{"role": "user", "content": "Hello, Claude"}]'
-        )
-        assert span["attributes"][SPANDATA.GEN_AI_RESPONSE_TEXT] == "Hi!"
-
-        assert span["attributes"][SPANDATA.GEN_AI_USAGE_INPUT_TOKENS] == 10
-        assert span["attributes"][SPANDATA.GEN_AI_USAGE_OUTPUT_TOKENS] == 20
-        assert span["attributes"][SPANDATA.GEN_AI_USAGE_TOTAL_TOKENS] == 30
-        assert span["attributes"][SPANDATA.GEN_AI_RESPONSE_STREAMING] is True
-        assert (
-            span["attributes"][SPANDATA.GEN_AI_RESPONSE_ID]
-            == "msg_01XFDUDYJgAACzvnptvVoYEL"
-        )
-
-        assert span["status"] == "error"
-    elif stream_gen_ai_spans:
+    if span_streaming or stream_gen_ai_spans:
         items = capture_items("transaction", "span")
 
         with pytest.raises(APIStatusError), mock.patch.object(
@@ -2795,53 +2408,7 @@ async def test_stream_messages_async_api_error(
         }
     ]
 
-    if span_streaming:
-        items = capture_items("transaction", "span")
-
-        with pytest.raises(APIStatusError), mock.patch.object(
-            client._client,
-            "send",
-            return_value=response,
-        ) as _, sentry_sdk.traces.start_span(name="anthropic"):
-            async with client.messages.stream(
-                max_tokens=1024,
-                messages=messages,
-                model="model",
-            ) as stream:
-                async for event in stream:
-                    pass
-
-        sentry_sdk.flush()
-        spans = [item.payload for item in items if item.type == "span"]
-        assert spans[1]["name"] == "anthropic"
-        assert spans[1]["status"] == SpanStatus.ERROR
-        span = next(
-            span for span in spans if span["attributes"]["sentry.op"] == OP.GEN_AI_CHAT
-        )
-
-        assert span["attributes"]["sentry.op"] == OP.GEN_AI_CHAT
-        assert span["name"] == "chat model"
-        assert span["attributes"][SPANDATA.GEN_AI_SYSTEM] == "anthropic"
-        assert span["attributes"][SPANDATA.GEN_AI_OPERATION_NAME] == "chat"
-        assert span["attributes"][SPANDATA.GEN_AI_REQUEST_MODEL] == "model"
-
-        assert (
-            span["attributes"][SPANDATA.GEN_AI_REQUEST_MESSAGES]
-            == '[{"role": "user", "content": "Hello, Claude"}]'
-        )
-        assert span["attributes"][SPANDATA.GEN_AI_RESPONSE_TEXT] == "Hi!"
-
-        assert span["attributes"][SPANDATA.GEN_AI_USAGE_INPUT_TOKENS] == 10
-        assert span["attributes"][SPANDATA.GEN_AI_USAGE_OUTPUT_TOKENS] == 20
-        assert span["attributes"][SPANDATA.GEN_AI_USAGE_TOTAL_TOKENS] == 30
-        assert span["attributes"][SPANDATA.GEN_AI_RESPONSE_STREAMING] is True
-        assert (
-            span["attributes"][SPANDATA.GEN_AI_RESPONSE_ID]
-            == "msg_01XFDUDYJgAACzvnptvVoYEL"
-        )
-
-        assert span["status"] == "error"
-    elif stream_gen_ai_spans:
+    if span_streaming or stream_gen_ai_spans:
         items = capture_items("transaction", "span")
 
         with pytest.raises(APIStatusError), mock.patch.object(
@@ -3007,58 +2574,7 @@ async def test_stream_messages_async_close(
         }
     ]
 
-    if span_streaming:
-        items = capture_items("transaction", "span")
-
-        with mock.patch.object(
-            client._client,
-            "send",
-            return_value=response,
-        ) as _, sentry_sdk.traces.start_span(name="anthropic"):
-            async with client.messages.stream(
-                max_tokens=1024,
-                messages=messages,
-                model="model",
-            ) as stream:
-                for _ in range(4):
-                    await stream.__anext__()
-
-                # New versions add TextEvent, so consume one more event.
-                if TextEvent is not None and isinstance(
-                    await stream.__anext__(), TextEvent
-                ):
-                    await stream.__anext__()
-
-                await stream.close()
-
-        sentry_sdk.flush()
-        spans = [item.payload for item in items if item.type == "span"]
-        assert spans[1]["name"] == "anthropic"
-        span = next(
-            span for span in spans if span["attributes"]["sentry.op"] == OP.GEN_AI_CHAT
-        )
-
-        assert span["attributes"]["sentry.op"] == OP.GEN_AI_CHAT
-        assert span["name"] == "chat model"
-        assert span["attributes"][SPANDATA.GEN_AI_SYSTEM] == "anthropic"
-        assert span["attributes"][SPANDATA.GEN_AI_OPERATION_NAME] == "chat"
-        assert span["attributes"][SPANDATA.GEN_AI_REQUEST_MODEL] == "model"
-
-        assert (
-            span["attributes"][SPANDATA.GEN_AI_REQUEST_MESSAGES]
-            == '[{"role": "user", "content": "Hello, Claude"}]'
-        )
-        assert span["attributes"][SPANDATA.GEN_AI_RESPONSE_TEXT] == "Hi!"
-
-        assert span["attributes"][SPANDATA.GEN_AI_USAGE_INPUT_TOKENS] == 10
-        assert span["attributes"][SPANDATA.GEN_AI_USAGE_OUTPUT_TOKENS] == 20
-        assert span["attributes"][SPANDATA.GEN_AI_USAGE_TOTAL_TOKENS] == 30
-        assert span["attributes"][SPANDATA.GEN_AI_RESPONSE_STREAMING] is True
-        assert (
-            span["attributes"][SPANDATA.GEN_AI_RESPONSE_ID]
-            == "msg_01XFDUDYJgAACzvnptvVoYEL"
-        )
-    elif stream_gen_ai_spans:
+    if span_streaming or stream_gen_ai_spans:
         items = capture_items("transaction", "span")
 
         with mock.patch.object(
@@ -4770,28 +4286,7 @@ def test_anthropic_message_role_mapping(
 
     test_messages = [test_message]
 
-    if span_streaming:
-        items = capture_items("span")
-
-        with sentry_sdk.traces.start_span(name="anthropic tx"):
-            client.messages.create(
-                model="claude-3-opus", max_tokens=10, messages=test_messages
-            )
-
-        sentry_sdk.flush()
-        span = next(item.payload for item in items if item.type == "span")
-
-        # Verify that the span was created correctly
-        assert span["attributes"]["sentry.op"] == "gen_ai.chat"
-        assert span["attributes"][SPANDATA.GEN_AI_SYSTEM] == "anthropic"
-        assert span["attributes"][SPANDATA.GEN_AI_OPERATION_NAME] == "chat"
-        assert SPANDATA.GEN_AI_REQUEST_MESSAGES in span["attributes"]
-
-        # Parse the stored messages
-        stored_messages = json.loads(
-            span["attributes"][SPANDATA.GEN_AI_REQUEST_MESSAGES]
-        )
-    elif stream_gen_ai_spans:
+    if span_streaming or stream_gen_ai_spans:
         items = capture_items("span")
 
         with start_transaction(name="anthropic tx"):

--- a/tests/integrations/anthropic/test_anthropic.py
+++ b/tests/integrations/anthropic/test_anthropic.py
@@ -68,6 +68,8 @@ from sentry_sdk.integrations.anthropic import (
     _set_output_data,
     _transform_anthropic_content_block,
 )
+from sentry_sdk.integrations.stdlib import StdlibIntegration
+from sentry_sdk.traces import SpanStatus
 from sentry_sdk.utils import package_version
 
 ANTHROPIC_VERSION = package_version("anthropic")
@@ -105,6 +107,7 @@ def test_nonstreaming_create_message(
 ):
     sentry_init(
         integrations=[AnthropicIntegration(include_prompts=include_prompts)],
+        disabled_integrations=[StdlibIntegration],
         traces_sample_rate=1.0,
         send_default_pii=send_default_pii,
         stream_gen_ai_spans=stream_gen_ai_spans,
@@ -125,7 +128,63 @@ def test_nonstreaming_create_message(
         },
     ]
 
-    if span_streaming or stream_gen_ai_spans:
+    if span_streaming:
+        items = capture_items("transaction", "span")
+
+        with sentry_sdk.traces.start_span(name="anthropic"):
+            response = client.messages.create(
+                max_tokens=1024, messages=messages, model="model"
+            )
+
+        assert response == EXAMPLE_MESSAGE
+        usage = response.usage
+
+        assert usage.input_tokens == 10
+        assert usage.output_tokens == 20
+
+        sentry_sdk.flush()
+        spans = [item.payload for item in items if item.type == "span"]
+        assert len(spans) == 2
+
+        assert spans[1]["name"] == "anthropic"
+        (span, _) = spans
+
+        assert span["attributes"]["sentry.op"] == OP.GEN_AI_CHAT
+        assert span["name"] == "chat model"
+        assert span["attributes"][SPANDATA.GEN_AI_SYSTEM] == "anthropic"
+        assert span["attributes"][SPANDATA.GEN_AI_OPERATION_NAME] == "chat"
+        assert span["attributes"][SPANDATA.GEN_AI_REQUEST_MODEL] == "model"
+
+        if send_default_pii and include_prompts:
+            assert json.loads(span["attributes"][SPANDATA.GEN_AI_REQUEST_MESSAGES]) == [
+                {
+                    "role": "user",
+                    "content": "Message demonstrating the absence of truncation.",
+                },
+                {
+                    "role": "user",
+                    "content": "Hello, Claude",
+                },
+            ]
+            assert (
+                span["attributes"][SPANDATA.GEN_AI_RESPONSE_TEXT] == "Hi, I'm Claude."
+            )
+        else:
+            assert SPANDATA.GEN_AI_REQUEST_MESSAGES not in spans[1]["attributes"]
+            assert SPANDATA.GEN_AI_RESPONSE_TEXT not in spans[1]["attributes"]
+
+        assert span["attributes"][SPANDATA.GEN_AI_USAGE_INPUT_TOKENS] == 10
+        assert span["attributes"][SPANDATA.GEN_AI_USAGE_OUTPUT_TOKENS] == 20
+        assert span["attributes"][SPANDATA.GEN_AI_USAGE_TOTAL_TOKENS] == 30
+        assert span["attributes"][SPANDATA.GEN_AI_RESPONSE_STREAMING] is False
+        assert (
+            span["attributes"][SPANDATA.GEN_AI_RESPONSE_ID]
+            == "msg_01XFDUDYJgAACzvnptvVoYEL"
+        )
+        assert span["attributes"][SPANDATA.GEN_AI_RESPONSE_FINISH_REASONS] == [
+            "end_turn"
+        ]
+    elif stream_gen_ai_spans:
         items = capture_items("transaction", "span")
 
         with start_transaction(name="anthropic"):
@@ -254,6 +313,7 @@ async def test_nonstreaming_create_message_async(
 ):
     sentry_init(
         integrations=[AnthropicIntegration(include_prompts=include_prompts)],
+        disabled_integrations=[StdlibIntegration],
         traces_sample_rate=1.0,
         send_default_pii=send_default_pii,
         stream_gen_ai_spans=stream_gen_ai_spans,
@@ -274,7 +334,61 @@ async def test_nonstreaming_create_message_async(
         },
     ]
 
-    if span_streaming or stream_gen_ai_spans:
+    if span_streaming:
+        items = capture_items("transaction", "span")
+
+        with sentry_sdk.traces.start_span(name="anthropic"):
+            response = await client.messages.create(
+                max_tokens=1024, messages=messages, model="model"
+            )
+
+        assert response == EXAMPLE_MESSAGE
+        usage = response.usage
+
+        assert usage.input_tokens == 10
+        assert usage.output_tokens == 20
+
+        sentry_sdk.flush()
+        spans = [item.payload for item in items if item.type == "span"]
+        assert len(spans) == 2
+
+        assert spans[1]["name"] == "anthropic"
+        (span, _) = spans
+
+        assert span["attributes"]["sentry.op"] == OP.GEN_AI_CHAT
+        assert span["name"] == "chat model"
+        assert span["attributes"][SPANDATA.GEN_AI_SYSTEM] == "anthropic"
+        assert span["attributes"][SPANDATA.GEN_AI_OPERATION_NAME] == "chat"
+        assert span["attributes"][SPANDATA.GEN_AI_REQUEST_MODEL] == "model"
+
+        if send_default_pii and include_prompts:
+            assert json.loads(span["attributes"][SPANDATA.GEN_AI_REQUEST_MESSAGES]) == [
+                {
+                    "role": "user",
+                    "content": "Message demonstrating the absence of truncation.",
+                },
+                {
+                    "role": "user",
+                    "content": "Hello, Claude",
+                },
+            ]
+            assert (
+                span["attributes"][SPANDATA.GEN_AI_RESPONSE_TEXT] == "Hi, I'm Claude."
+            )
+        else:
+            assert SPANDATA.GEN_AI_REQUEST_MESSAGES not in span["attributes"]
+            assert SPANDATA.GEN_AI_RESPONSE_TEXT not in span["attributes"]
+
+        assert span["attributes"][SPANDATA.GEN_AI_USAGE_INPUT_TOKENS] == 10
+        assert span["attributes"][SPANDATA.GEN_AI_USAGE_OUTPUT_TOKENS] == 20
+        assert span["attributes"][SPANDATA.GEN_AI_USAGE_TOTAL_TOKENS] == 30
+        assert span["attributes"][SPANDATA.GEN_AI_RESPONSE_STREAMING] is False
+        assert (
+            span["attributes"][SPANDATA.GEN_AI_RESPONSE_ID]
+            == "msg_01XFDUDYJgAACzvnptvVoYEL"
+        )
+
+    elif stream_gen_ai_spans:
         items = capture_items("transaction", "span")
 
         with start_transaction(name="anthropic"):
@@ -439,6 +553,7 @@ def test_streaming_create_message(
 
     sentry_init(
         integrations=[AnthropicIntegration(include_prompts=include_prompts)],
+        disabled_integrations=[StdlibIntegration],
         traces_sample_rate=1.0,
         send_default_pii=send_default_pii,
         stream_gen_ai_spans=stream_gen_ai_spans,
@@ -456,7 +571,65 @@ def test_streaming_create_message(
         },
     ]
 
-    if span_streaming or stream_gen_ai_spans:
+    if span_streaming:
+        items = capture_items("span")
+
+        with mock.patch.object(
+            client._client,
+            "send",
+            return_value=response,
+        ) as _, sentry_sdk.traces.start_span(name="anthropic"):
+            message = client.messages.create(
+                max_tokens=1024, messages=messages, model="model", stream=True
+            )
+
+            for _ in message:
+                pass
+
+        sentry_sdk.flush()
+        spans = [item.payload for item in items if item.type == "span"]
+        assert spans[1]["name"] == "anthropic"
+        span = next(
+            span for span in spans if span["attributes"]["sentry.op"] == OP.GEN_AI_CHAT
+        )
+
+        assert span["attributes"]["sentry.op"] == OP.GEN_AI_CHAT
+        assert span["name"] == "chat model"
+        assert span["attributes"][SPANDATA.GEN_AI_SYSTEM] == "anthropic"
+        assert span["attributes"][SPANDATA.GEN_AI_OPERATION_NAME] == "chat"
+        assert span["attributes"][SPANDATA.GEN_AI_REQUEST_MODEL] == "model"
+
+        if send_default_pii and include_prompts:
+            assert json.loads(span["attributes"][SPANDATA.GEN_AI_REQUEST_MESSAGES]) == [
+                {
+                    "role": "user",
+                    "content": "Message demonstrating the absence of truncation.",
+                },
+                {
+                    "role": "user",
+                    "content": "Hello, Claude",
+                },
+            ]
+            assert (
+                span["attributes"][SPANDATA.GEN_AI_RESPONSE_TEXT] == "Hi! I'm Claude!"
+            )
+
+        else:
+            assert SPANDATA.GEN_AI_REQUEST_MESSAGES not in span["attributes"]
+            assert SPANDATA.GEN_AI_RESPONSE_TEXT not in span["attributes"]
+
+        assert span["attributes"][SPANDATA.GEN_AI_USAGE_INPUT_TOKENS] == 10
+        assert span["attributes"][SPANDATA.GEN_AI_USAGE_OUTPUT_TOKENS] == 10
+        assert span["attributes"][SPANDATA.GEN_AI_USAGE_TOTAL_TOKENS] == 20
+        assert span["attributes"][SPANDATA.GEN_AI_RESPONSE_STREAMING] is True
+        assert (
+            span["attributes"][SPANDATA.GEN_AI_RESPONSE_ID]
+            == "msg_01XFDUDYJgAACzvnptvVoYEL"
+        )
+        assert span["attributes"][SPANDATA.GEN_AI_RESPONSE_FINISH_REASONS] == [
+            "max_tokens"
+        ]
+    elif stream_gen_ai_spans:
         items = capture_items("transaction", "span")
 
         with mock.patch.object(
@@ -618,6 +791,7 @@ def test_streaming_create_message_close(
 
     sentry_init(
         integrations=[AnthropicIntegration(include_prompts=True)],
+        disabled_integrations=[StdlibIntegration],
         traces_sample_rate=1.0,
         send_default_pii=True,
         stream_gen_ai_spans=stream_gen_ai_spans,
@@ -631,7 +805,51 @@ def test_streaming_create_message_close(
         }
     ]
 
-    if span_streaming or stream_gen_ai_spans:
+    if span_streaming:
+        items = capture_items("transaction", "span")
+
+        with mock.patch.object(
+            client._client,
+            "send",
+            return_value=response,
+        ) as _, sentry_sdk.traces.start_span(name="anthropic"):
+            messages = client.messages.create(
+                max_tokens=1024, messages=messages, model="model", stream=True
+            )
+
+            for _ in range(4):
+                next(messages)
+
+            messages.close()
+
+        sentry_sdk.flush()
+        spans = [item.payload for item in items if item.type == "span"]
+        assert spans[1]["name"] == "anthropic"
+        span = next(
+            span for span in spans if span["attributes"]["sentry.op"] == OP.GEN_AI_CHAT
+        )
+
+        assert span["attributes"]["sentry.op"] == OP.GEN_AI_CHAT
+        assert span["name"] == "chat model"
+        assert span["attributes"][SPANDATA.GEN_AI_SYSTEM] == "anthropic"
+        assert span["attributes"][SPANDATA.GEN_AI_OPERATION_NAME] == "chat"
+        assert span["attributes"][SPANDATA.GEN_AI_REQUEST_MODEL] == "model"
+
+        assert (
+            span["attributes"][SPANDATA.GEN_AI_REQUEST_MESSAGES]
+            == '[{"role": "user", "content": "Hello, Claude"}]'
+        )
+        assert span["attributes"][SPANDATA.GEN_AI_RESPONSE_TEXT] == "Hi!"
+
+        assert span["attributes"][SPANDATA.GEN_AI_USAGE_INPUT_TOKENS] == 10
+        assert span["attributes"][SPANDATA.GEN_AI_USAGE_OUTPUT_TOKENS] == 20
+        assert span["attributes"][SPANDATA.GEN_AI_USAGE_TOTAL_TOKENS] == 30
+        assert span["attributes"][SPANDATA.GEN_AI_RESPONSE_STREAMING] is True
+        assert (
+            span["attributes"][SPANDATA.GEN_AI_RESPONSE_ID]
+            == "msg_01XFDUDYJgAACzvnptvVoYEL"
+        )
+    elif stream_gen_ai_spans:
         items = capture_items("transaction", "span")
 
         with mock.patch.object(
@@ -774,6 +992,7 @@ def test_streaming_create_message_api_error(
 
     sentry_init(
         integrations=[AnthropicIntegration(include_prompts=True)],
+        disabled_integrations=[StdlibIntegration],
         traces_sample_rate=1.0,
         send_default_pii=True,
         stream_gen_ai_spans=stream_gen_ai_spans,
@@ -787,7 +1006,52 @@ def test_streaming_create_message_api_error(
         }
     ]
 
-    if span_streaming or stream_gen_ai_spans:
+    if span_streaming:
+        items = capture_items("transaction", "span")
+
+        with pytest.raises(APIStatusError), mock.patch.object(
+            client._client,
+            "send",
+            return_value=response,
+        ) as _, sentry_sdk.traces.start_span(name="anthropic"):
+            message = client.messages.create(
+                max_tokens=1024, messages=messages, model="model", stream=True
+            )
+
+            for _ in message:
+                pass
+
+        sentry_sdk.flush()
+        spans = [item.payload for item in items if item.type == "span"]
+        assert spans[1]["name"] == "anthropic"
+        assert spans[1]["status"] == SpanStatus.ERROR
+        span = next(
+            span for span in spans if span["attributes"]["sentry.op"] == OP.GEN_AI_CHAT
+        )
+
+        assert span["attributes"]["sentry.op"] == OP.GEN_AI_CHAT
+        assert span["name"] == "chat model"
+        assert span["attributes"][SPANDATA.GEN_AI_SYSTEM] == "anthropic"
+        assert span["attributes"][SPANDATA.GEN_AI_OPERATION_NAME] == "chat"
+        assert span["attributes"][SPANDATA.GEN_AI_REQUEST_MODEL] == "model"
+
+        assert (
+            span["attributes"][SPANDATA.GEN_AI_REQUEST_MESSAGES]
+            == '[{"role": "user", "content": "Hello, Claude"}]'
+        )
+        assert span["attributes"][SPANDATA.GEN_AI_RESPONSE_TEXT] == "Hi!"
+
+        assert span["attributes"][SPANDATA.GEN_AI_USAGE_INPUT_TOKENS] == 10
+        assert span["attributes"][SPANDATA.GEN_AI_USAGE_OUTPUT_TOKENS] == 20
+        assert span["attributes"][SPANDATA.GEN_AI_USAGE_TOTAL_TOKENS] == 30
+        assert span["attributes"][SPANDATA.GEN_AI_RESPONSE_STREAMING] is True
+        assert (
+            span["attributes"][SPANDATA.GEN_AI_RESPONSE_ID]
+            == "msg_01XFDUDYJgAACzvnptvVoYEL"
+        )
+
+        assert span["status"] == "error"
+    elif stream_gen_ai_spans:
         items = capture_items("transaction", "span")
 
         with pytest.raises(APIStatusError), mock.patch.object(
@@ -832,6 +1096,7 @@ def test_streaming_create_message_api_error(
         )
 
         assert span["status"] == "error"
+        assert event["contexts"]["trace"]["status"] == "internal_error"
     else:
         events = capture_events()
 
@@ -877,7 +1142,7 @@ def test_streaming_create_message_api_error(
 
         assert span["status"] == "internal_error"
         assert span["tags"]["status"] == "internal_error"
-    assert event["contexts"]["trace"]["status"] == "internal_error"
+        assert event["contexts"]["trace"]["status"] == "internal_error"
 
 
 @pytest.mark.parametrize("span_streaming", [True, False])
@@ -943,6 +1208,7 @@ def test_stream_messages(
 
     sentry_init(
         integrations=[AnthropicIntegration(include_prompts=include_prompts)],
+        disabled_integrations=[StdlibIntegration],
         traces_sample_rate=1.0,
         send_default_pii=send_default_pii,
         stream_gen_ai_spans=stream_gen_ai_spans,
@@ -960,7 +1226,65 @@ def test_stream_messages(
         },
     ]
 
-    if span_streaming or stream_gen_ai_spans:
+    if span_streaming:
+        items = capture_items("transaction", "span")
+
+        with mock.patch.object(
+            client._client,
+            "send",
+            return_value=response,
+        ) as _, sentry_sdk.traces.start_span(name="anthropic"), client.messages.stream(
+            max_tokens=1024,
+            messages=messages,
+            model="model",
+        ) as stream:
+            for event in stream:
+                pass
+
+        sentry_sdk.flush()
+        spans = [item.payload for item in items if item.type == "span"]
+        assert spans[1]["name"] == "anthropic"
+        span = next(
+            span for span in spans if span["attributes"]["sentry.op"] == OP.GEN_AI_CHAT
+        )
+
+        assert span["attributes"]["sentry.op"] == OP.GEN_AI_CHAT
+        assert span["name"] == "chat model"
+        assert span["attributes"][SPANDATA.GEN_AI_SYSTEM] == "anthropic"
+        assert span["attributes"][SPANDATA.GEN_AI_OPERATION_NAME] == "chat"
+        assert span["attributes"][SPANDATA.GEN_AI_REQUEST_MODEL] == "model"
+
+        if send_default_pii and include_prompts:
+            assert json.loads(span["attributes"][SPANDATA.GEN_AI_REQUEST_MESSAGES]) == [
+                {
+                    "role": "user",
+                    "content": "Message demonstrating the absence of truncation.",
+                },
+                {
+                    "role": "user",
+                    "content": "Hello, Claude",
+                },
+            ]
+            assert (
+                span["attributes"][SPANDATA.GEN_AI_RESPONSE_TEXT] == "Hi! I'm Claude!"
+            )
+
+        else:
+            assert SPANDATA.GEN_AI_REQUEST_MESSAGES not in span["attributes"]
+            assert SPANDATA.GEN_AI_RESPONSE_TEXT not in span["attributes"]
+
+        assert span["attributes"][SPANDATA.GEN_AI_USAGE_INPUT_TOKENS] == 10
+        assert span["attributes"][SPANDATA.GEN_AI_USAGE_OUTPUT_TOKENS] == 10
+        assert span["attributes"][SPANDATA.GEN_AI_USAGE_TOTAL_TOKENS] == 20
+        assert span["attributes"][SPANDATA.GEN_AI_RESPONSE_STREAMING] is True
+        assert (
+            span["attributes"][SPANDATA.GEN_AI_RESPONSE_ID]
+            == "msg_01XFDUDYJgAACzvnptvVoYEL"
+        )
+        assert span["attributes"][SPANDATA.GEN_AI_RESPONSE_FINISH_REASONS] == [
+            "max_tokens"
+        ]
+    elif stream_gen_ai_spans:
         items = capture_items("transaction", "span")
 
         with mock.patch.object(
@@ -1121,6 +1445,7 @@ def test_stream_messages_close(
 
     sentry_init(
         integrations=[AnthropicIntegration(include_prompts=True)],
+        disabled_integrations=[StdlibIntegration],
         traces_sample_rate=1.0,
         send_default_pii=True,
         stream_gen_ai_spans=stream_gen_ai_spans,
@@ -1134,7 +1459,55 @@ def test_stream_messages_close(
         }
     ]
 
-    if span_streaming or stream_gen_ai_spans:
+    if span_streaming:
+        items = capture_items("transaction", "span")
+
+        with mock.patch.object(
+            client._client,
+            "send",
+            return_value=response,
+        ) as _, sentry_sdk.traces.start_span(name="anthropic"), client.messages.stream(
+            max_tokens=1024,
+            messages=messages,
+            model="model",
+        ) as stream:
+            for _ in range(4):
+                next(stream)
+
+            # New versions add TextEvent, so consume one more event.
+            if TextEvent is not None and isinstance(next(stream), TextEvent):
+                next(stream)
+
+            stream.close()
+
+        sentry_sdk.flush()
+        spans = [item.payload for item in items if item.type == "span"]
+        assert spans[1]["name"] == "anthropic"
+        span = next(
+            span for span in spans if span["attributes"]["sentry.op"] == OP.GEN_AI_CHAT
+        )
+
+        assert span["attributes"]["sentry.op"] == OP.GEN_AI_CHAT
+        assert span["name"] == "chat model"
+        assert span["attributes"][SPANDATA.GEN_AI_SYSTEM] == "anthropic"
+        assert span["attributes"][SPANDATA.GEN_AI_OPERATION_NAME] == "chat"
+        assert span["attributes"][SPANDATA.GEN_AI_REQUEST_MODEL] == "model"
+
+        assert (
+            span["attributes"][SPANDATA.GEN_AI_REQUEST_MESSAGES]
+            == '[{"role": "user", "content": "Hello, Claude"}]'
+        )
+        assert span["attributes"][SPANDATA.GEN_AI_RESPONSE_TEXT] == "Hi!"
+
+        assert span["attributes"][SPANDATA.GEN_AI_USAGE_INPUT_TOKENS] == 10
+        assert span["attributes"][SPANDATA.GEN_AI_USAGE_OUTPUT_TOKENS] == 20
+        assert span["attributes"][SPANDATA.GEN_AI_USAGE_TOTAL_TOKENS] == 30
+        assert span["attributes"][SPANDATA.GEN_AI_RESPONSE_STREAMING] is True
+        assert (
+            span["attributes"][SPANDATA.GEN_AI_RESPONSE_ID]
+            == "msg_01XFDUDYJgAACzvnptvVoYEL"
+        )
+    elif stream_gen_ai_spans:
         items = capture_items("transaction", "span")
 
         with mock.patch.object(
@@ -1285,6 +1658,7 @@ def test_stream_messages_api_error(
 
     sentry_init(
         integrations=[AnthropicIntegration(include_prompts=True)],
+        disabled_integrations=[StdlibIntegration],
         traces_sample_rate=1.0,
         send_default_pii=True,
         stream_gen_ai_spans=stream_gen_ai_spans,
@@ -1298,7 +1672,52 @@ def test_stream_messages_api_error(
         }
     ]
 
-    if span_streaming or stream_gen_ai_spans:
+    if span_streaming:
+        items = capture_items("transaction", "span")
+
+        with pytest.raises(APIStatusError), mock.patch.object(
+            client._client,
+            "send",
+            return_value=response,
+        ) as _, sentry_sdk.traces.start_span(name="anthropic"), client.messages.stream(
+            max_tokens=1024,
+            messages=messages,
+            model="model",
+        ) as stream:
+            for event in stream:
+                pass
+
+        sentry_sdk.flush()
+        spans = [item.payload for item in items if item.type == "span"]
+        assert spans[1]["name"] == "anthropic"
+        assert spans[1]["status"] == SpanStatus.ERROR
+        span = next(
+            span for span in spans if span["attributes"]["sentry.op"] == OP.GEN_AI_CHAT
+        )
+
+        assert span["attributes"]["sentry.op"] == OP.GEN_AI_CHAT
+        assert span["name"] == "chat model"
+        assert span["attributes"][SPANDATA.GEN_AI_SYSTEM] == "anthropic"
+        assert span["attributes"][SPANDATA.GEN_AI_OPERATION_NAME] == "chat"
+        assert span["attributes"][SPANDATA.GEN_AI_REQUEST_MODEL] == "model"
+
+        assert (
+            span["attributes"][SPANDATA.GEN_AI_REQUEST_MESSAGES]
+            == '[{"role": "user", "content": "Hello, Claude"}]'
+        )
+        assert span["attributes"][SPANDATA.GEN_AI_RESPONSE_TEXT] == "Hi!"
+
+        assert span["attributes"][SPANDATA.GEN_AI_USAGE_INPUT_TOKENS] == 10
+        assert span["attributes"][SPANDATA.GEN_AI_USAGE_OUTPUT_TOKENS] == 20
+        assert span["attributes"][SPANDATA.GEN_AI_USAGE_TOTAL_TOKENS] == 30
+        assert span["attributes"][SPANDATA.GEN_AI_RESPONSE_STREAMING] is True
+        assert (
+            span["attributes"][SPANDATA.GEN_AI_RESPONSE_ID]
+            == "msg_01XFDUDYJgAACzvnptvVoYEL"
+        )
+
+        assert span["status"] == "error"
+    elif stream_gen_ai_spans:
         items = capture_items("transaction", "span")
 
         with pytest.raises(APIStatusError), mock.patch.object(
@@ -1344,6 +1763,7 @@ def test_stream_messages_api_error(
         )
 
         assert span["status"] == "error"
+        assert event["contexts"]["trace"]["status"] == "internal_error"
     else:
         events = capture_events()
 
@@ -1389,7 +1809,7 @@ def test_stream_messages_api_error(
 
         assert span["status"] == "internal_error"
         assert span["tags"]["status"] == "internal_error"
-    assert event["contexts"]["trace"]["status"] == "internal_error"
+        assert event["contexts"]["trace"]["status"] == "internal_error"
 
 
 @pytest.mark.parametrize("span_streaming", [True, False])
@@ -1459,6 +1879,7 @@ async def test_streaming_create_message_async(
 
     sentry_init(
         integrations=[AnthropicIntegration(include_prompts=include_prompts)],
+        disabled_integrations=[StdlibIntegration],
         traces_sample_rate=1.0,
         default_integrations=False,
         send_default_pii=send_default_pii,
@@ -1477,7 +1898,65 @@ async def test_streaming_create_message_async(
         },
     ]
 
-    if span_streaming or stream_gen_ai_spans:
+    if span_streaming:
+        items = capture_items("transaction", "span")
+
+        with mock.patch.object(
+            client._client,
+            "send",
+            return_value=response,
+        ) as _, sentry_sdk.traces.start_span(name="anthropic"):
+            message = await client.messages.create(
+                max_tokens=1024, messages=messages, model="model", stream=True
+            )
+
+            async for _ in message:
+                pass
+
+        sentry_sdk.flush()
+        spans = [item.payload for item in items if item.type == "span"]
+        assert len(spans) == 2
+
+        assert spans[1]["name"] == "anthropic"
+        (span, _) = spans
+
+        assert span["attributes"]["sentry.op"] == OP.GEN_AI_CHAT
+        assert span["name"] == "chat model"
+        assert span["attributes"][SPANDATA.GEN_AI_SYSTEM] == "anthropic"
+        assert span["attributes"][SPANDATA.GEN_AI_OPERATION_NAME] == "chat"
+        assert span["attributes"][SPANDATA.GEN_AI_REQUEST_MODEL] == "model"
+
+        if send_default_pii and include_prompts:
+            assert json.loads(span["attributes"][SPANDATA.GEN_AI_REQUEST_MESSAGES]) == [
+                {
+                    "role": "user",
+                    "content": "Message demonstrating the absence of truncation.",
+                },
+                {
+                    "role": "user",
+                    "content": "Hello, Claude",
+                },
+            ]
+            assert (
+                span["attributes"][SPANDATA.GEN_AI_RESPONSE_TEXT] == "Hi! I'm Claude!"
+            )
+
+        else:
+            assert SPANDATA.GEN_AI_REQUEST_MESSAGES not in span["attributes"]
+            assert SPANDATA.GEN_AI_RESPONSE_TEXT not in span["attributes"]
+
+        assert span["attributes"][SPANDATA.GEN_AI_USAGE_INPUT_TOKENS] == 10
+        assert span["attributes"][SPANDATA.GEN_AI_USAGE_OUTPUT_TOKENS] == 10
+        assert span["attributes"][SPANDATA.GEN_AI_USAGE_TOTAL_TOKENS] == 20
+        assert span["attributes"][SPANDATA.GEN_AI_RESPONSE_STREAMING] is True
+        assert (
+            span["attributes"][SPANDATA.GEN_AI_RESPONSE_ID]
+            == "msg_01XFDUDYJgAACzvnptvVoYEL"
+        )
+        assert span["attributes"][SPANDATA.GEN_AI_RESPONSE_FINISH_REASONS] == [
+            "max_tokens"
+        ]
+    elif stream_gen_ai_spans:
         items = capture_items("transaction", "span")
 
         with mock.patch.object(
@@ -1643,6 +2122,7 @@ async def test_streaming_create_message_async_close(
 
     sentry_init(
         integrations=[AnthropicIntegration(include_prompts=True)],
+        disabled_integrations=[StdlibIntegration],
         traces_sample_rate=1.0,
         send_default_pii=True,
         stream_gen_ai_spans=stream_gen_ai_spans,
@@ -1656,7 +2136,50 @@ async def test_streaming_create_message_async_close(
         }
     ]
 
-    if span_streaming or stream_gen_ai_spans:
+    if span_streaming:
+        items = capture_items("span")
+
+        with mock.patch.object(
+            client._client,
+            "send",
+            return_value=response,
+        ) as _, sentry_sdk.traces.start_span(name="anthropic"):
+            messages = await client.messages.create(
+                max_tokens=1024, messages=messages, model="model", stream=True
+            )
+
+            for _ in range(4):
+                await messages.__anext__()
+            await messages.close()
+
+        sentry_sdk.flush()
+        spans = [item.payload for item in items if item.type == "span"]
+        assert spans[1]["name"] == "anthropic"
+        span = next(
+            span for span in spans if span["attributes"]["sentry.op"] == OP.GEN_AI_CHAT
+        )
+
+        assert span["attributes"]["sentry.op"] == OP.GEN_AI_CHAT
+        assert span["name"] == "chat model"
+        assert span["attributes"][SPANDATA.GEN_AI_SYSTEM] == "anthropic"
+        assert span["attributes"][SPANDATA.GEN_AI_OPERATION_NAME] == "chat"
+        assert span["attributes"][SPANDATA.GEN_AI_REQUEST_MODEL] == "model"
+
+        assert (
+            span["attributes"][SPANDATA.GEN_AI_REQUEST_MESSAGES]
+            == '[{"role": "user", "content": "Hello, Claude"}]'
+        )
+        assert span["attributes"][SPANDATA.GEN_AI_RESPONSE_TEXT] == "Hi!"
+
+        assert span["attributes"][SPANDATA.GEN_AI_USAGE_INPUT_TOKENS] == 10
+        assert span["attributes"][SPANDATA.GEN_AI_USAGE_OUTPUT_TOKENS] == 20
+        assert span["attributes"][SPANDATA.GEN_AI_USAGE_TOTAL_TOKENS] == 30
+        assert span["attributes"][SPANDATA.GEN_AI_RESPONSE_STREAMING] is True
+        assert (
+            span["attributes"][SPANDATA.GEN_AI_RESPONSE_ID]
+            == "msg_01XFDUDYJgAACzvnptvVoYEL"
+        )
+    elif stream_gen_ai_spans:
         items = capture_items("transaction", "span")
 
         with mock.patch.object(
@@ -1801,6 +2324,7 @@ async def test_streaming_create_message_async_api_error(
 
     sentry_init(
         integrations=[AnthropicIntegration(include_prompts=True)],
+        disabled_integrations=[StdlibIntegration],
         traces_sample_rate=1.0,
         send_default_pii=True,
         stream_gen_ai_spans=stream_gen_ai_spans,
@@ -1814,7 +2338,52 @@ async def test_streaming_create_message_async_api_error(
         }
     ]
 
-    if span_streaming or stream_gen_ai_spans:
+    if span_streaming:
+        items = capture_items("transaction", "span")
+
+        with pytest.raises(APIStatusError), mock.patch.object(
+            client._client,
+            "send",
+            return_value=response,
+        ) as _, sentry_sdk.traces.start_span(name="anthropic"):
+            message = await client.messages.create(
+                max_tokens=1024, messages=messages, model="model", stream=True
+            )
+
+            async for _ in message:
+                pass
+
+        sentry_sdk.flush()
+        spans = [item.payload for item in items if item.type == "span"]
+        assert spans[1]["name"] == "anthropic"
+        assert spans[1]["status"] == SpanStatus.ERROR
+        span = next(
+            span for span in spans if span["attributes"]["sentry.op"] == OP.GEN_AI_CHAT
+        )
+
+        assert span["attributes"]["sentry.op"] == OP.GEN_AI_CHAT
+        assert span["name"] == "chat model"
+        assert span["attributes"][SPANDATA.GEN_AI_SYSTEM] == "anthropic"
+        assert span["attributes"][SPANDATA.GEN_AI_OPERATION_NAME] == "chat"
+        assert span["attributes"][SPANDATA.GEN_AI_REQUEST_MODEL] == "model"
+
+        assert (
+            span["attributes"][SPANDATA.GEN_AI_REQUEST_MESSAGES]
+            == '[{"role": "user", "content": "Hello, Claude"}]'
+        )
+        assert span["attributes"][SPANDATA.GEN_AI_RESPONSE_TEXT] == "Hi!"
+
+        assert span["attributes"][SPANDATA.GEN_AI_USAGE_INPUT_TOKENS] == 10
+        assert span["attributes"][SPANDATA.GEN_AI_USAGE_OUTPUT_TOKENS] == 20
+        assert span["attributes"][SPANDATA.GEN_AI_USAGE_TOTAL_TOKENS] == 30
+        assert span["attributes"][SPANDATA.GEN_AI_RESPONSE_STREAMING] is True
+        assert (
+            span["attributes"][SPANDATA.GEN_AI_RESPONSE_ID]
+            == "msg_01XFDUDYJgAACzvnptvVoYEL"
+        )
+
+        assert span["status"] == "error"
+    elif stream_gen_ai_spans:
         items = capture_items("transaction", "span")
 
         with pytest.raises(APIStatusError), mock.patch.object(
@@ -1860,6 +2429,7 @@ async def test_streaming_create_message_async_api_error(
         )
 
         assert span["status"] == "error"
+        assert event["contexts"]["trace"]["status"] == "internal_error"
     else:
         events = capture_events()
 
@@ -1905,7 +2475,7 @@ async def test_streaming_create_message_async_api_error(
 
         assert span["status"] == "internal_error"
         assert span["tags"]["status"] == "internal_error"
-    assert event["contexts"]["trace"]["status"] == "internal_error"
+        assert event["contexts"]["trace"]["status"] == "internal_error"
 
 
 @pytest.mark.parametrize("span_streaming", [True, False])
@@ -1975,6 +2545,7 @@ async def test_stream_message_async(
 
     sentry_init(
         integrations=[AnthropicIntegration(include_prompts=include_prompts)],
+        disabled_integrations=[StdlibIntegration],
         traces_sample_rate=1.0,
         send_default_pii=send_default_pii,
         stream_gen_ai_spans=stream_gen_ai_spans,
@@ -1992,7 +2563,63 @@ async def test_stream_message_async(
         },
     ]
 
-    if span_streaming or stream_gen_ai_spans:
+    if span_streaming:
+        items = capture_items("transaction", "span")
+
+        with mock.patch.object(
+            client._client,
+            "send",
+            return_value=response,
+        ) as _, sentry_sdk.traces.start_span(name="anthropic"):
+            async with client.messages.stream(
+                max_tokens=1024,
+                messages=messages,
+                model="model",
+            ) as stream:
+                async for event in stream:
+                    pass
+
+        sentry_sdk.flush()
+        spans = [item.payload for item in items if item.type == "span"]
+        assert len(spans) == 2
+
+        assert spans[1]["name"] == "anthropic"
+        (span, _) = spans
+
+        assert span["attributes"]["sentry.op"] == OP.GEN_AI_CHAT
+        assert span["name"] == "chat model"
+        assert span["attributes"][SPANDATA.GEN_AI_SYSTEM] == "anthropic"
+        assert span["attributes"][SPANDATA.GEN_AI_OPERATION_NAME] == "chat"
+        assert span["attributes"][SPANDATA.GEN_AI_REQUEST_MODEL] == "model"
+
+        if send_default_pii and include_prompts:
+            assert json.loads(span["attributes"][SPANDATA.GEN_AI_REQUEST_MESSAGES]) == [
+                {
+                    "role": "user",
+                    "content": "Message demonstrating the absence of truncation.",
+                },
+                {
+                    "role": "user",
+                    "content": "Hello, Claude",
+                },
+            ]
+            assert (
+                span["attributes"][SPANDATA.GEN_AI_RESPONSE_TEXT] == "Hi! I'm Claude!"
+            )
+
+        else:
+            assert SPANDATA.GEN_AI_REQUEST_MESSAGES not in span["attributes"]
+            assert SPANDATA.GEN_AI_RESPONSE_TEXT not in span["attributes"]
+
+        assert span["attributes"][SPANDATA.GEN_AI_USAGE_INPUT_TOKENS] == 10
+        assert span["attributes"][SPANDATA.GEN_AI_USAGE_OUTPUT_TOKENS] == 10
+        assert span["attributes"][SPANDATA.GEN_AI_USAGE_TOTAL_TOKENS] == 20
+        assert span["attributes"][SPANDATA.GEN_AI_RESPONSE_STREAMING] is True
+        assert (
+            span["attributes"][SPANDATA.GEN_AI_RESPONSE_ID]
+            == "msg_01XFDUDYJgAACzvnptvVoYEL"
+        )
+    elif stream_gen_ai_spans:
         items = capture_items("transaction", "span")
 
         with mock.patch.object(
@@ -2154,6 +2781,7 @@ async def test_stream_messages_async_api_error(
 
     sentry_init(
         integrations=[AnthropicIntegration(include_prompts=True)],
+        disabled_integrations=[StdlibIntegration],
         traces_sample_rate=1.0,
         send_default_pii=True,
         stream_gen_ai_spans=stream_gen_ai_spans,
@@ -2167,7 +2795,53 @@ async def test_stream_messages_async_api_error(
         }
     ]
 
-    if span_streaming or stream_gen_ai_spans:
+    if span_streaming:
+        items = capture_items("transaction", "span")
+
+        with pytest.raises(APIStatusError), mock.patch.object(
+            client._client,
+            "send",
+            return_value=response,
+        ) as _, sentry_sdk.traces.start_span(name="anthropic"):
+            async with client.messages.stream(
+                max_tokens=1024,
+                messages=messages,
+                model="model",
+            ) as stream:
+                async for event in stream:
+                    pass
+
+        sentry_sdk.flush()
+        spans = [item.payload for item in items if item.type == "span"]
+        assert spans[1]["name"] == "anthropic"
+        assert spans[1]["status"] == SpanStatus.ERROR
+        span = next(
+            span for span in spans if span["attributes"]["sentry.op"] == OP.GEN_AI_CHAT
+        )
+
+        assert span["attributes"]["sentry.op"] == OP.GEN_AI_CHAT
+        assert span["name"] == "chat model"
+        assert span["attributes"][SPANDATA.GEN_AI_SYSTEM] == "anthropic"
+        assert span["attributes"][SPANDATA.GEN_AI_OPERATION_NAME] == "chat"
+        assert span["attributes"][SPANDATA.GEN_AI_REQUEST_MODEL] == "model"
+
+        assert (
+            span["attributes"][SPANDATA.GEN_AI_REQUEST_MESSAGES]
+            == '[{"role": "user", "content": "Hello, Claude"}]'
+        )
+        assert span["attributes"][SPANDATA.GEN_AI_RESPONSE_TEXT] == "Hi!"
+
+        assert span["attributes"][SPANDATA.GEN_AI_USAGE_INPUT_TOKENS] == 10
+        assert span["attributes"][SPANDATA.GEN_AI_USAGE_OUTPUT_TOKENS] == 20
+        assert span["attributes"][SPANDATA.GEN_AI_USAGE_TOTAL_TOKENS] == 30
+        assert span["attributes"][SPANDATA.GEN_AI_RESPONSE_STREAMING] is True
+        assert (
+            span["attributes"][SPANDATA.GEN_AI_RESPONSE_ID]
+            == "msg_01XFDUDYJgAACzvnptvVoYEL"
+        )
+
+        assert span["status"] == "error"
+    elif stream_gen_ai_spans:
         items = capture_items("transaction", "span")
 
         with pytest.raises(APIStatusError), mock.patch.object(
@@ -2260,7 +2934,7 @@ async def test_stream_messages_async_api_error(
 
         assert span["status"] == "internal_error"
         assert span["tags"]["status"] == "internal_error"
-    assert event["contexts"]["trace"]["status"] == "internal_error"
+        assert event["contexts"]["trace"]["status"] == "internal_error"
 
 
 @pytest.mark.parametrize("span_streaming", [True, False])
@@ -2319,6 +2993,7 @@ async def test_stream_messages_async_close(
 
     sentry_init(
         integrations=[AnthropicIntegration(include_prompts=True)],
+        disabled_integrations=[StdlibIntegration],
         traces_sample_rate=1.0,
         send_default_pii=True,
         stream_gen_ai_spans=stream_gen_ai_spans,
@@ -2332,7 +3007,58 @@ async def test_stream_messages_async_close(
         }
     ]
 
-    if span_streaming or stream_gen_ai_spans:
+    if span_streaming:
+        items = capture_items("transaction", "span")
+
+        with mock.patch.object(
+            client._client,
+            "send",
+            return_value=response,
+        ) as _, sentry_sdk.traces.start_span(name="anthropic"):
+            async with client.messages.stream(
+                max_tokens=1024,
+                messages=messages,
+                model="model",
+            ) as stream:
+                for _ in range(4):
+                    await stream.__anext__()
+
+                # New versions add TextEvent, so consume one more event.
+                if TextEvent is not None and isinstance(
+                    await stream.__anext__(), TextEvent
+                ):
+                    await stream.__anext__()
+
+                await stream.close()
+
+        sentry_sdk.flush()
+        spans = [item.payload for item in items if item.type == "span"]
+        assert spans[1]["name"] == "anthropic"
+        span = next(
+            span for span in spans if span["attributes"]["sentry.op"] == OP.GEN_AI_CHAT
+        )
+
+        assert span["attributes"]["sentry.op"] == OP.GEN_AI_CHAT
+        assert span["name"] == "chat model"
+        assert span["attributes"][SPANDATA.GEN_AI_SYSTEM] == "anthropic"
+        assert span["attributes"][SPANDATA.GEN_AI_OPERATION_NAME] == "chat"
+        assert span["attributes"][SPANDATA.GEN_AI_REQUEST_MODEL] == "model"
+
+        assert (
+            span["attributes"][SPANDATA.GEN_AI_REQUEST_MESSAGES]
+            == '[{"role": "user", "content": "Hello, Claude"}]'
+        )
+        assert span["attributes"][SPANDATA.GEN_AI_RESPONSE_TEXT] == "Hi!"
+
+        assert span["attributes"][SPANDATA.GEN_AI_USAGE_INPUT_TOKENS] == 10
+        assert span["attributes"][SPANDATA.GEN_AI_USAGE_OUTPUT_TOKENS] == 20
+        assert span["attributes"][SPANDATA.GEN_AI_USAGE_TOTAL_TOKENS] == 30
+        assert span["attributes"][SPANDATA.GEN_AI_RESPONSE_STREAMING] is True
+        assert (
+            span["attributes"][SPANDATA.GEN_AI_RESPONSE_ID]
+            == "msg_01XFDUDYJgAACzvnptvVoYEL"
+        )
+    elif stream_gen_ai_spans:
         items = capture_items("transaction", "span")
 
         with mock.patch.object(
@@ -2535,6 +3261,7 @@ def test_streaming_create_message_with_input_json_delta(
 
     sentry_init(
         integrations=[AnthropicIntegration(include_prompts=include_prompts)],
+        disabled_integrations=[StdlibIntegration],
         traces_sample_rate=1.0,
         send_default_pii=send_default_pii,
         stream_gen_ai_spans=stream_gen_ai_spans,
@@ -2548,7 +3275,53 @@ def test_streaming_create_message_with_input_json_delta(
         }
     ]
 
-    if span_streaming or stream_gen_ai_spans:
+    if span_streaming:
+        items = capture_items("transaction", "span")
+
+        with mock.patch.object(
+            client._client,
+            "send",
+            return_value=response,
+        ) as _, sentry_sdk.traces.start_span(name="anthropic"):
+            message = client.messages.create(
+                max_tokens=1024, messages=messages, model="model", stream=True
+            )
+
+            for _ in message:
+                pass
+
+        sentry_sdk.flush()
+        spans = [item.payload for item in items if item.type == "span"]
+        assert len(spans) == 2
+
+        assert spans[1]["name"] == "anthropic"
+        (span, _) = spans
+
+        assert span["attributes"]["sentry.op"] == OP.GEN_AI_CHAT
+        assert span["name"] == "chat model"
+        assert span["attributes"][SPANDATA.GEN_AI_SYSTEM] == "anthropic"
+        assert span["attributes"][SPANDATA.GEN_AI_OPERATION_NAME] == "chat"
+        assert span["attributes"][SPANDATA.GEN_AI_REQUEST_MODEL] == "model"
+
+        if send_default_pii and include_prompts:
+            assert (
+                span["attributes"][SPANDATA.GEN_AI_REQUEST_MESSAGES]
+                == '[{"role": "user", "content": "What is the weather like in San Francisco?"}]'
+            )
+            assert (
+                span["attributes"][SPANDATA.GEN_AI_RESPONSE_TEXT]
+                == '{"location": "San Francisco, CA"}'
+            )
+        else:
+            assert SPANDATA.GEN_AI_REQUEST_MESSAGES not in span["attributes"]
+            assert SPANDATA.GEN_AI_RESPONSE_TEXT not in span["attributes"]
+
+        assert span["attributes"][SPANDATA.GEN_AI_USAGE_INPUT_TOKENS] == 366
+        assert span["attributes"][SPANDATA.GEN_AI_USAGE_OUTPUT_TOKENS] == 41
+        assert span["attributes"][SPANDATA.GEN_AI_USAGE_TOTAL_TOKENS] == 407
+        assert span["attributes"][SPANDATA.GEN_AI_RESPONSE_STREAMING] is True
+
+    elif stream_gen_ai_spans:
         items = capture_items("transaction", "span")
 
         with mock.patch.object(
@@ -2741,6 +3514,7 @@ def test_stream_messages_with_input_json_delta(
 
     sentry_init(
         integrations=[AnthropicIntegration(include_prompts=include_prompts)],
+        disabled_integrations=[StdlibIntegration],
         traces_sample_rate=1.0,
         send_default_pii=send_default_pii,
         stream_gen_ai_spans=stream_gen_ai_spans,
@@ -2754,7 +3528,53 @@ def test_stream_messages_with_input_json_delta(
         }
     ]
 
-    if span_streaming or stream_gen_ai_spans:
+    if span_streaming:
+        items = capture_items("transaction", "span")
+
+        with mock.patch.object(
+            client._client,
+            "send",
+            return_value=response,
+        ) as _, sentry_sdk.traces.start_span(name="anthropic"), client.messages.stream(
+            max_tokens=1024,
+            messages=messages,
+            model="model",
+        ) as stream:
+            for event in stream:
+                pass
+
+        sentry_sdk.flush()
+        spans = [item.payload for item in items if item.type == "span"]
+        assert len(spans) == 2
+
+        assert spans[1]["name"] == "anthropic"
+        (span, _) = spans
+
+        assert span["attributes"]["sentry.op"] == OP.GEN_AI_CHAT
+        assert span["name"] == "chat model"
+        assert span["attributes"][SPANDATA.GEN_AI_SYSTEM] == "anthropic"
+        assert span["attributes"][SPANDATA.GEN_AI_OPERATION_NAME] == "chat"
+        assert span["attributes"][SPANDATA.GEN_AI_REQUEST_MODEL] == "model"
+
+        if send_default_pii and include_prompts:
+            assert (
+                span["attributes"][SPANDATA.GEN_AI_REQUEST_MESSAGES]
+                == '[{"role": "user", "content": "What is the weather like in San Francisco?"}]'
+            )
+            assert (
+                span["attributes"][SPANDATA.GEN_AI_RESPONSE_TEXT]
+                == '{"location": "San Francisco, CA"}'
+            )
+        else:
+            assert SPANDATA.GEN_AI_REQUEST_MESSAGES not in span["attributes"]
+            assert SPANDATA.GEN_AI_RESPONSE_TEXT not in span["attributes"]
+
+        assert span["attributes"][SPANDATA.GEN_AI_USAGE_INPUT_TOKENS] == 366
+        assert span["attributes"][SPANDATA.GEN_AI_USAGE_OUTPUT_TOKENS] == 41
+        assert span["attributes"][SPANDATA.GEN_AI_USAGE_TOTAL_TOKENS] == 407
+        assert span["attributes"][SPANDATA.GEN_AI_RESPONSE_STREAMING] is True
+
+    elif stream_gen_ai_spans:
         items = capture_items("transaction", "span")
 
         with mock.patch.object(
@@ -2953,6 +3773,7 @@ async def test_streaming_create_message_with_input_json_delta_async(
 
     sentry_init(
         integrations=[AnthropicIntegration(include_prompts=include_prompts)],
+        disabled_integrations=[StdlibIntegration],
         traces_sample_rate=1.0,
         send_default_pii=send_default_pii,
         stream_gen_ai_spans=stream_gen_ai_spans,
@@ -2966,7 +3787,54 @@ async def test_streaming_create_message_with_input_json_delta_async(
         }
     ]
 
-    if span_streaming or stream_gen_ai_spans:
+    if span_streaming:
+        items = capture_items("transaction", "span")
+
+        with mock.patch.object(
+            client._client,
+            "send",
+            return_value=response,
+        ) as _, sentry_sdk.traces.start_span(name="anthropic"):
+            message = await client.messages.create(
+                max_tokens=1024, messages=messages, model="model", stream=True
+            )
+
+            async for _ in message:
+                pass
+
+        sentry_sdk.flush()
+        spans = [item.payload for item in items if item.type == "span"]
+        assert len(spans) == 2
+
+        assert spans[1]["name"] == "anthropic"
+        (span, _) = spans
+
+        assert span["attributes"]["sentry.op"] == OP.GEN_AI_CHAT
+        assert span["name"] == "chat model"
+        assert span["attributes"][SPANDATA.GEN_AI_SYSTEM] == "anthropic"
+        assert span["attributes"][SPANDATA.GEN_AI_OPERATION_NAME] == "chat"
+        assert span["attributes"][SPANDATA.GEN_AI_REQUEST_MODEL] == "model"
+
+        if send_default_pii and include_prompts:
+            assert (
+                span["attributes"][SPANDATA.GEN_AI_REQUEST_MESSAGES]
+                == '[{"role": "user", "content": "What is the weather like in San Francisco?"}]'
+            )
+            assert (
+                span["attributes"][SPANDATA.GEN_AI_RESPONSE_TEXT]
+                == '{"location": "San Francisco, CA"}'
+            )
+
+        else:
+            assert SPANDATA.GEN_AI_REQUEST_MESSAGES not in span["attributes"]
+            assert SPANDATA.GEN_AI_RESPONSE_TEXT not in span["attributes"]
+
+        assert span["attributes"][SPANDATA.GEN_AI_USAGE_INPUT_TOKENS] == 366
+        assert span["attributes"][SPANDATA.GEN_AI_USAGE_OUTPUT_TOKENS] == 41
+        assert span["attributes"][SPANDATA.GEN_AI_USAGE_TOTAL_TOKENS] == 407
+        assert span["attributes"][SPANDATA.GEN_AI_RESPONSE_STREAMING] is True
+
+    elif stream_gen_ai_spans:
         items = capture_items("transaction", "span")
 
         with mock.patch.object(
@@ -3167,6 +4035,7 @@ async def test_stream_message_with_input_json_delta_async(
 
     sentry_init(
         integrations=[AnthropicIntegration(include_prompts=include_prompts)],
+        disabled_integrations=[StdlibIntegration],
         traces_sample_rate=1.0,
         send_default_pii=send_default_pii,
         stream_gen_ai_spans=stream_gen_ai_spans,
@@ -3180,7 +4049,54 @@ async def test_stream_message_with_input_json_delta_async(
         }
     ]
 
-    if span_streaming or stream_gen_ai_spans:
+    if span_streaming:
+        items = capture_items("transaction", "span")
+
+        with mock.patch.object(
+            client._client,
+            "send",
+            return_value=response,
+        ) as _, sentry_sdk.traces.start_span(name="anthropic"):
+            async with client.messages.stream(
+                max_tokens=1024,
+                messages=messages,
+                model="model",
+            ) as stream:
+                async for event in stream:
+                    pass
+
+        sentry_sdk.flush()
+        spans = [item.payload for item in items if item.type == "span"]
+        assert len(spans) == 2
+
+        assert spans[1]["name"] == "anthropic"
+        (span, _) = spans
+
+        assert span["attributes"]["sentry.op"] == OP.GEN_AI_CHAT
+        assert span["name"] == "chat model"
+        assert span["attributes"][SPANDATA.GEN_AI_SYSTEM] == "anthropic"
+        assert span["attributes"][SPANDATA.GEN_AI_OPERATION_NAME] == "chat"
+        assert span["attributes"][SPANDATA.GEN_AI_REQUEST_MODEL] == "model"
+
+        if send_default_pii and include_prompts:
+            assert (
+                span["attributes"][SPANDATA.GEN_AI_REQUEST_MESSAGES]
+                == '[{"role": "user", "content": "What is the weather like in San Francisco?"}]'
+            )
+            assert (
+                span["attributes"][SPANDATA.GEN_AI_RESPONSE_TEXT]
+                == '{"location": "San Francisco, CA"}'
+            )
+        else:
+            assert SPANDATA.GEN_AI_REQUEST_MESSAGES not in span["attributes"]
+            assert SPANDATA.GEN_AI_RESPONSE_TEXT not in span["attributes"]
+
+        assert span["attributes"][SPANDATA.GEN_AI_USAGE_INPUT_TOKENS] == 366
+        assert span["attributes"][SPANDATA.GEN_AI_USAGE_OUTPUT_TOKENS] == 41
+        assert span["attributes"][SPANDATA.GEN_AI_USAGE_TOTAL_TOKENS] == 407
+        assert span["attributes"][SPANDATA.GEN_AI_RESPONSE_STREAMING] is True
+
+    elif stream_gen_ai_spans:
         items = capture_items("transaction", "span")
 
         with mock.patch.object(
@@ -3289,6 +4205,7 @@ def test_exception_message_create(
 ):
     sentry_init(
         integrations=[AnthropicIntegration()],
+        disabled_integrations=[StdlibIntegration],
         traces_sample_rate=1.0,
         stream_gen_ai_spans=stream_gen_ai_spans,
         _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
@@ -3352,11 +4269,39 @@ def test_span_status_error(
 ):
     sentry_init(
         integrations=[AnthropicIntegration()],
+        disabled_integrations=[StdlibIntegration],
         traces_sample_rate=1.0,
         stream_gen_ai_spans=stream_gen_ai_spans,
         _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
     )
-    if span_streaming or stream_gen_ai_spans:
+
+    if span_streaming:
+        items = capture_items("event", "span")
+
+        with sentry_sdk.traces.start_span(name="anthropic"):
+            client = Anthropic(api_key="z")
+            client.messages._post = mock.Mock(
+                side_effect=AnthropicError("API rate limit reached")
+            )
+            with pytest.raises(AnthropicError):
+                client.messages.create(
+                    model="some-model",
+                    messages=[
+                        {"role": "system", "content": "I'm throwing an exception"}
+                    ],
+                    max_tokens=1024,
+                )
+
+        (error,) = (item.payload for item in items if item.type == "event")
+        assert error["level"] == "error"
+
+        sentry_sdk.flush()
+        spans = [item.payload for item in items if item.type == "span"]
+        assert spans[0]["status"] == "error"
+        assert spans[0]["attributes"][SPANDATA.GEN_AI_SYSTEM] == "anthropic"
+        assert spans[0]["attributes"][SPANDATA.GEN_AI_OPERATION_NAME] == "chat"
+
+    elif stream_gen_ai_spans:
         items = capture_items("event", "span")
 
         with start_transaction(name="anthropic"):
@@ -3418,11 +4363,37 @@ async def test_span_status_error_async(
 ):
     sentry_init(
         integrations=[AnthropicIntegration()],
+        disabled_integrations=[StdlibIntegration],
         traces_sample_rate=1.0,
         stream_gen_ai_spans=stream_gen_ai_spans,
         _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
     )
-    if span_streaming or stream_gen_ai_spans:
+    if span_streaming:
+        items = capture_items("event", "span")
+
+        with sentry_sdk.traces.start_span(name="anthropic"):
+            client = AsyncAnthropic(api_key="z")
+            client.messages._post = AsyncMock(
+                side_effect=AnthropicError("API rate limit reached")
+            )
+            with pytest.raises(AnthropicError):
+                await client.messages.create(
+                    model="some-model",
+                    messages=[
+                        {"role": "system", "content": "I'm throwing an exception"}
+                    ],
+                    max_tokens=1024,
+                )
+
+        (error,) = (item.payload for item in items if item.type == "event")
+        assert error["level"] == "error"
+
+        sentry_sdk.flush()
+        spans = [item.payload for item in items if item.type == "span"]
+        assert spans[0]["status"] == "error"
+        assert spans[0]["attributes"][SPANDATA.GEN_AI_SYSTEM] == "anthropic"
+        assert spans[0]["attributes"][SPANDATA.GEN_AI_OPERATION_NAME] == "chat"
+    elif stream_gen_ai_spans:
         items = capture_items("event", "span")
 
         with start_transaction(name="anthropic"):
@@ -3484,6 +4455,7 @@ async def test_exception_message_create_async(
 ):
     sentry_init(
         integrations=[AnthropicIntegration()],
+        disabled_integrations=[StdlibIntegration],
         traces_sample_rate=1.0,
         stream_gen_ai_spans=stream_gen_ai_spans,
         _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
@@ -3547,6 +4519,7 @@ def test_span_origin(
 ):
     sentry_init(
         integrations=[AnthropicIntegration()],
+        disabled_integrations=[StdlibIntegration],
         traces_sample_rate=1.0,
         stream_gen_ai_spans=stream_gen_ai_spans,
         _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
@@ -3562,7 +4535,20 @@ def test_span_origin(
         }
     ]
 
-    if span_streaming or stream_gen_ai_spans:
+    if span_streaming:
+        items = capture_items("transaction", "span")
+
+        with sentry_sdk.traces.start_span(name="anthropic"):
+            client.messages.create(max_tokens=1024, messages=messages, model="model")
+
+        sentry_sdk.flush()
+        spans = [item.payload for item in items if item.type == "span"]
+        assert spans[1]["attributes"]["sentry.origin"] == "manual"
+        assert spans[0]["attributes"]["sentry.origin"] == "auto.ai.anthropic"
+        assert spans[0]["attributes"][SPANDATA.GEN_AI_SYSTEM] == "anthropic"
+        assert spans[0]["attributes"][SPANDATA.GEN_AI_OPERATION_NAME] == "chat"
+
+    elif stream_gen_ai_spans:
         items = capture_items("transaction", "span")
 
         with start_transaction(name="anthropic"):
@@ -3601,6 +4587,7 @@ async def test_span_origin_async(
 ):
     sentry_init(
         integrations=[AnthropicIntegration()],
+        disabled_integrations=[StdlibIntegration],
         traces_sample_rate=1.0,
         stream_gen_ai_spans=stream_gen_ai_spans,
         _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
@@ -3616,7 +4603,21 @@ async def test_span_origin_async(
         }
     ]
 
-    if span_streaming or stream_gen_ai_spans:
+    if span_streaming:
+        items = capture_items("transaction", "span")
+
+        with sentry_sdk.traces.start_span(name="anthropic"):
+            await client.messages.create(
+                max_tokens=1024, messages=messages, model="model"
+            )
+
+        sentry_sdk.flush()
+        spans = [item.payload for item in items if item.type == "span"]
+        assert spans[1]["attributes"]["sentry.origin"] == "manual"
+        assert spans[0]["attributes"]["sentry.origin"] == "auto.ai.anthropic"
+        assert spans[0]["attributes"][SPANDATA.GEN_AI_SYSTEM] == "anthropic"
+        assert spans[0]["attributes"][SPANDATA.GEN_AI_OPERATION_NAME] == "chat"
+    elif stream_gen_ai_spans:
         items = capture_items("transaction", "span")
 
         with start_transaction(name="anthropic"):
@@ -3685,6 +4686,7 @@ def test_collect_ai_data_with_input_json_delta(span_streaming):
 def test_set_output_data_with_input_json_delta(sentry_init):
     sentry_init(
         integrations=[AnthropicIntegration(include_prompts=True)],
+        disabled_integrations=[StdlibIntegration],
         traces_sample_rate=1.0,
         send_default_pii=True,
     )
@@ -3743,6 +4745,7 @@ def test_anthropic_message_role_mapping(
     """Test that Anthropic integration properly maps message roles like 'ai' to 'assistant'"""
     sentry_init(
         integrations=[AnthropicIntegration(include_prompts=True)],
+        disabled_integrations=[StdlibIntegration],
         traces_sample_rate=1.0,
         send_default_pii=True,
         stream_gen_ai_spans=stream_gen_ai_spans,
@@ -3767,7 +4770,28 @@ def test_anthropic_message_role_mapping(
 
     test_messages = [test_message]
 
-    if span_streaming or stream_gen_ai_spans:
+    if span_streaming:
+        items = capture_items("span")
+
+        with sentry_sdk.traces.start_span(name="anthropic tx"):
+            client.messages.create(
+                model="claude-3-opus", max_tokens=10, messages=test_messages
+            )
+
+        sentry_sdk.flush()
+        span = next(item.payload for item in items if item.type == "span")
+
+        # Verify that the span was created correctly
+        assert span["attributes"]["sentry.op"] == "gen_ai.chat"
+        assert span["attributes"][SPANDATA.GEN_AI_SYSTEM] == "anthropic"
+        assert span["attributes"][SPANDATA.GEN_AI_OPERATION_NAME] == "chat"
+        assert SPANDATA.GEN_AI_REQUEST_MESSAGES in span["attributes"]
+
+        # Parse the stored messages
+        stored_messages = json.loads(
+            span["attributes"][SPANDATA.GEN_AI_REQUEST_MESSAGES]
+        )
+    elif stream_gen_ai_spans:
         items = capture_items("span")
 
         with start_transaction(name="anthropic tx"):
@@ -3815,6 +4839,7 @@ def test_anthropic_message_truncation(sentry_init, capture_events):
     """Test that large messages are truncated properly in Anthropic integration."""
     sentry_init(
         integrations=[AnthropicIntegration(include_prompts=True)],
+        disabled_integrations=[StdlibIntegration],
         traces_sample_rate=1.0,
         send_default_pii=True,
         stream_gen_ai_spans=False,
@@ -3868,6 +4893,7 @@ async def test_anthropic_message_truncation_async(sentry_init, capture_events):
     """Test that large messages are truncated properly in Anthropic integration."""
     sentry_init(
         integrations=[AnthropicIntegration(include_prompts=True)],
+        disabled_integrations=[StdlibIntegration],
         traces_sample_rate=1.0,
         send_default_pii=True,
         stream_gen_ai_spans=False,
@@ -3939,6 +4965,7 @@ def test_nonstreaming_create_message_with_system_prompt(
     """Test that system prompts are properly captured in GEN_AI_REQUEST_MESSAGES."""
     sentry_init(
         integrations=[AnthropicIntegration(include_prompts=include_prompts)],
+        disabled_integrations=[StdlibIntegration],
         traces_sample_rate=1.0,
         send_default_pii=send_default_pii,
         stream_gen_ai_spans=stream_gen_ai_spans,
@@ -3955,7 +4982,68 @@ def test_nonstreaming_create_message_with_system_prompt(
         }
     ]
 
-    if span_streaming or stream_gen_ai_spans:
+    if span_streaming:
+        items = capture_items("transaction", "span")
+
+        with sentry_sdk.traces.start_span(name="anthropic"):
+            response = client.messages.create(
+                max_tokens=1024,
+                messages=messages,
+                model="model",
+                system="You are a helpful assistant.",
+            )
+
+        assert response == EXAMPLE_MESSAGE
+        usage = response.usage
+
+        assert usage.input_tokens == 10
+        assert usage.output_tokens == 20
+
+        sentry_sdk.flush()
+        spans = [item.payload for item in items if item.type == "span"]
+        assert len(spans) == 2
+
+        assert spans[1]["name"] == "anthropic"
+        (span, _) = spans
+
+        assert span["attributes"]["sentry.op"] == OP.GEN_AI_CHAT
+        assert span["name"] == "chat model"
+        assert span["attributes"][SPANDATA.GEN_AI_SYSTEM] == "anthropic"
+        assert span["attributes"][SPANDATA.GEN_AI_OPERATION_NAME] == "chat"
+        assert span["attributes"][SPANDATA.GEN_AI_REQUEST_MODEL] == "model"
+
+        if send_default_pii and include_prompts:
+            assert SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS in span["attributes"]
+            system_instructions = json.loads(
+                span["attributes"][SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS]
+            )
+            assert system_instructions == [
+                {"type": "text", "content": "You are a helpful assistant."}
+            ]
+
+            assert SPANDATA.GEN_AI_REQUEST_MESSAGES in span["attributes"]
+            stored_messages = json.loads(
+                span["attributes"][SPANDATA.GEN_AI_REQUEST_MESSAGES]
+            )
+            assert len(stored_messages) == 1
+            assert stored_messages[0]["role"] == "user"
+            assert stored_messages[0]["content"] == "Hello, Claude"
+            assert (
+                span["attributes"][SPANDATA.GEN_AI_RESPONSE_TEXT] == "Hi, I'm Claude."
+            )
+        else:
+            assert SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS not in span["attributes"]
+            assert SPANDATA.GEN_AI_REQUEST_MESSAGES not in span["attributes"]
+            assert SPANDATA.GEN_AI_RESPONSE_TEXT not in span["attributes"]
+
+        assert span["attributes"][SPANDATA.GEN_AI_USAGE_INPUT_TOKENS] == 10
+        assert span["attributes"][SPANDATA.GEN_AI_USAGE_OUTPUT_TOKENS] == 20
+        assert span["attributes"][SPANDATA.GEN_AI_USAGE_TOTAL_TOKENS] == 30
+        assert span["attributes"][SPANDATA.GEN_AI_RESPONSE_STREAMING] is False
+        assert span["attributes"][SPANDATA.GEN_AI_RESPONSE_FINISH_REASONS] == [
+            "end_turn"
+        ]
+    elif stream_gen_ai_spans:
         items = capture_items("transaction", "span")
 
         with start_transaction(name="anthropic"):
@@ -4100,6 +5188,7 @@ async def test_nonstreaming_create_message_with_system_prompt_async(
     """Test that system prompts are properly captured in GEN_AI_REQUEST_MESSAGES (async)."""
     sentry_init(
         integrations=[AnthropicIntegration(include_prompts=include_prompts)],
+        disabled_integrations=[StdlibIntegration],
         traces_sample_rate=1.0,
         send_default_pii=send_default_pii,
         stream_gen_ai_spans=stream_gen_ai_spans,
@@ -4116,7 +5205,68 @@ async def test_nonstreaming_create_message_with_system_prompt_async(
         }
     ]
 
-    if span_streaming or stream_gen_ai_spans:
+    if span_streaming:
+        items = capture_items("transaction", "span")
+
+        with sentry_sdk.traces.start_span(name="anthropic"):
+            response = await client.messages.create(
+                max_tokens=1024,
+                messages=messages,
+                model="model",
+                system="You are a helpful assistant.",
+            )
+
+        assert response == EXAMPLE_MESSAGE
+        usage = response.usage
+
+        assert usage.input_tokens == 10
+        assert usage.output_tokens == 20
+
+        sentry_sdk.flush()
+        spans = [item.payload for item in items if item.type == "span"]
+        assert len(spans) == 2
+
+        assert spans[1]["name"] == "anthropic"
+        (span, _) = spans
+
+        assert span["attributes"]["sentry.op"] == OP.GEN_AI_CHAT
+        assert span["name"] == "chat model"
+        assert span["attributes"][SPANDATA.GEN_AI_SYSTEM] == "anthropic"
+        assert span["attributes"][SPANDATA.GEN_AI_OPERATION_NAME] == "chat"
+        assert span["attributes"][SPANDATA.GEN_AI_REQUEST_MODEL] == "model"
+
+        if send_default_pii and include_prompts:
+            assert SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS in span["attributes"]
+            system_instructions = json.loads(
+                span["attributes"][SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS]
+            )
+            assert system_instructions == [
+                {"type": "text", "content": "You are a helpful assistant."}
+            ]
+
+            assert SPANDATA.GEN_AI_REQUEST_MESSAGES in span["attributes"]
+            stored_messages = json.loads(
+                span["attributes"][SPANDATA.GEN_AI_REQUEST_MESSAGES]
+            )
+            assert len(stored_messages) == 1
+            assert stored_messages[0]["role"] == "user"
+            assert stored_messages[0]["content"] == "Hello, Claude"
+            assert (
+                span["attributes"][SPANDATA.GEN_AI_RESPONSE_TEXT] == "Hi, I'm Claude."
+            )
+        else:
+            assert SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS not in span["attributes"]
+            assert SPANDATA.GEN_AI_REQUEST_MESSAGES not in span["attributes"]
+            assert SPANDATA.GEN_AI_RESPONSE_TEXT not in span["attributes"]
+
+        assert span["attributes"][SPANDATA.GEN_AI_USAGE_INPUT_TOKENS] == 10
+        assert span["attributes"][SPANDATA.GEN_AI_USAGE_OUTPUT_TOKENS] == 20
+        assert span["attributes"][SPANDATA.GEN_AI_USAGE_TOTAL_TOKENS] == 30
+        assert span["attributes"][SPANDATA.GEN_AI_RESPONSE_STREAMING] is False
+        assert span["attributes"][SPANDATA.GEN_AI_RESPONSE_FINISH_REASONS] == [
+            "end_turn"
+        ]
+    elif stream_gen_ai_spans:
         items = capture_items("transaction", "span")
 
         with start_transaction(name="anthropic"):
@@ -4301,6 +5451,7 @@ def test_streaming_create_message_with_system_prompt(
 
     sentry_init(
         integrations=[AnthropicIntegration(include_prompts=include_prompts)],
+        disabled_integrations=[StdlibIntegration],
         traces_sample_rate=1.0,
         send_default_pii=send_default_pii,
         stream_gen_ai_spans=stream_gen_ai_spans,
@@ -4314,7 +5465,69 @@ def test_streaming_create_message_with_system_prompt(
         }
     ]
 
-    if span_streaming or stream_gen_ai_spans:
+    if span_streaming:
+        items = capture_items("transaction", "span")
+
+        with mock.patch.object(
+            client._client,
+            "send",
+            return_value=response,
+        ) as _, sentry_sdk.traces.start_span(name="anthropic"):
+            message = client.messages.create(
+                max_tokens=1024,
+                messages=messages,
+                model="model",
+                stream=True,
+                system="You are a helpful assistant.",
+            )
+
+            for _ in message:
+                pass
+
+        sentry_sdk.flush()
+        spans = [item.payload for item in items if item.type == "span"]
+        assert len(spans) == 2
+
+        assert spans[1]["name"] == "anthropic"
+        (span, _) = spans
+
+        assert span["attributes"]["sentry.op"] == OP.GEN_AI_CHAT
+        assert span["name"] == "chat model"
+        assert span["attributes"][SPANDATA.GEN_AI_SYSTEM] == "anthropic"
+        assert span["attributes"][SPANDATA.GEN_AI_OPERATION_NAME] == "chat"
+        assert span["attributes"][SPANDATA.GEN_AI_REQUEST_MODEL] == "model"
+
+        if send_default_pii and include_prompts:
+            assert SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS in span["attributes"]
+            system_instructions = json.loads(
+                span["attributes"][SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS]
+            )
+            assert system_instructions == [
+                {"type": "text", "content": "You are a helpful assistant."}
+            ]
+
+            assert SPANDATA.GEN_AI_REQUEST_MESSAGES in span["attributes"]
+            stored_messages = json.loads(
+                span["attributes"][SPANDATA.GEN_AI_REQUEST_MESSAGES]
+            )
+            assert len(stored_messages) == 1
+            assert stored_messages[0]["role"] == "user"
+            assert stored_messages[0]["content"] == "Hello, Claude"
+            assert (
+                span["attributes"][SPANDATA.GEN_AI_RESPONSE_TEXT] == "Hi! I'm Claude!"
+            )
+
+        else:
+            assert SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS not in span["attributes"]
+            assert SPANDATA.GEN_AI_REQUEST_MESSAGES not in span["attributes"]
+            assert SPANDATA.GEN_AI_RESPONSE_TEXT not in span["attributes"]
+
+        assert span["attributes"][SPANDATA.GEN_AI_USAGE_INPUT_TOKENS] == 10
+        assert span["attributes"][SPANDATA.GEN_AI_USAGE_OUTPUT_TOKENS] == 10
+        assert span["attributes"][SPANDATA.GEN_AI_USAGE_TOTAL_TOKENS] == 20
+        assert span["attributes"][SPANDATA.GEN_AI_RESPONSE_STREAMING] is True
+
+    elif stream_gen_ai_spans:
         items = capture_items("transaction", "span")
 
         with mock.patch.object(
@@ -4502,6 +5715,7 @@ def test_stream_messages_with_system_prompt(
 
     sentry_init(
         integrations=[AnthropicIntegration(include_prompts=include_prompts)],
+        disabled_integrations=[StdlibIntegration],
         traces_sample_rate=1.0,
         send_default_pii=send_default_pii,
         stream_gen_ai_spans=stream_gen_ai_spans,
@@ -4515,7 +5729,64 @@ def test_stream_messages_with_system_prompt(
         }
     ]
 
-    if span_streaming or stream_gen_ai_spans:
+    if span_streaming:
+        items = capture_items("transaction", "span")
+
+        with mock.patch.object(
+            client._client,
+            "send",
+            return_value=response,
+        ) as _, sentry_sdk.traces.start_span(name="anthropic"), client.messages.stream(
+            max_tokens=1024,
+            messages=messages,
+            model="model",
+            system="You are a helpful assistant.",
+        ) as stream:
+            for event in stream:
+                pass
+
+        sentry_sdk.flush()
+        spans = [item.payload for item in items if item.type == "span"]
+        assert len(spans) == 2
+
+        assert spans[1]["name"] == "anthropic"
+        (span, _) = spans
+
+        assert span["attributes"]["sentry.op"] == OP.GEN_AI_CHAT
+        assert span["name"] == "chat model"
+        assert span["attributes"][SPANDATA.GEN_AI_SYSTEM] == "anthropic"
+        assert span["attributes"][SPANDATA.GEN_AI_OPERATION_NAME] == "chat"
+        assert span["attributes"][SPANDATA.GEN_AI_REQUEST_MODEL] == "model"
+
+        if send_default_pii and include_prompts:
+            assert SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS in span["attributes"]
+            system_instructions = json.loads(
+                span["attributes"][SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS]
+            )
+            assert system_instructions == [
+                {"type": "text", "content": "You are a helpful assistant."}
+            ]
+            assert SPANDATA.GEN_AI_REQUEST_MESSAGES in span["attributes"]
+            stored_messages = json.loads(
+                span["attributes"][SPANDATA.GEN_AI_REQUEST_MESSAGES]
+            )
+            assert len(stored_messages) == 1
+            assert stored_messages[0]["role"] == "user"
+            assert stored_messages[0]["content"] == "Hello, Claude"
+            assert (
+                span["attributes"][SPANDATA.GEN_AI_RESPONSE_TEXT] == "Hi! I'm Claude!"
+            )
+        else:
+            assert SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS not in span["attributes"]
+            assert SPANDATA.GEN_AI_REQUEST_MESSAGES not in span["attributes"]
+            assert SPANDATA.GEN_AI_RESPONSE_TEXT not in span["attributes"]
+
+        assert span["attributes"][SPANDATA.GEN_AI_USAGE_INPUT_TOKENS] == 10
+        assert span["attributes"][SPANDATA.GEN_AI_USAGE_OUTPUT_TOKENS] == 10
+        assert span["attributes"][SPANDATA.GEN_AI_USAGE_TOTAL_TOKENS] == 20
+        assert span["attributes"][SPANDATA.GEN_AI_RESPONSE_STREAMING] is True
+
+    elif stream_gen_ai_spans:
         items = capture_items("transaction", "span")
 
         with mock.patch.object(
@@ -4696,6 +5967,7 @@ async def test_stream_message_with_system_prompt_async(
 
     sentry_init(
         integrations=[AnthropicIntegration(include_prompts=include_prompts)],
+        disabled_integrations=[StdlibIntegration],
         traces_sample_rate=1.0,
         send_default_pii=send_default_pii,
         stream_gen_ai_spans=stream_gen_ai_spans,
@@ -4709,7 +5981,66 @@ async def test_stream_message_with_system_prompt_async(
         }
     ]
 
-    if span_streaming or stream_gen_ai_spans:
+    if span_streaming:
+        items = capture_items("transaction", "span")
+
+        with mock.patch.object(
+            client._client,
+            "send",
+            return_value=response,
+        ) as _, sentry_sdk.traces.start_span(name="anthropic"):
+            async with client.messages.stream(
+                max_tokens=1024,
+                messages=messages,
+                model="model",
+                system="You are a helpful assistant.",
+            ) as stream:
+                async for event in stream:
+                    pass
+
+        sentry_sdk.flush()
+        spans = [item.payload for item in items if item.type == "span"]
+        assert len(spans) == 2
+
+        assert spans[1]["name"] == "anthropic"
+        (span, _) = spans
+
+        assert span["attributes"]["sentry.op"] == OP.GEN_AI_CHAT
+        assert span["name"] == "chat model"
+        assert span["attributes"][SPANDATA.GEN_AI_SYSTEM] == "anthropic"
+        assert span["attributes"][SPANDATA.GEN_AI_OPERATION_NAME] == "chat"
+        assert span["attributes"][SPANDATA.GEN_AI_REQUEST_MODEL] == "model"
+
+        if send_default_pii and include_prompts:
+            assert SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS in span["attributes"]
+            system_instructions = json.loads(
+                span["attributes"][SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS]
+            )
+            assert system_instructions == [
+                {"type": "text", "content": "You are a helpful assistant."}
+            ]
+
+            assert SPANDATA.GEN_AI_REQUEST_MESSAGES in span["attributes"]
+            stored_messages = json.loads(
+                span["attributes"][SPANDATA.GEN_AI_REQUEST_MESSAGES]
+            )
+            assert len(stored_messages) == 1
+            assert stored_messages[0]["role"] == "user"
+            assert stored_messages[0]["content"] == "Hello, Claude"
+            assert (
+                span["attributes"][SPANDATA.GEN_AI_RESPONSE_TEXT] == "Hi! I'm Claude!"
+            )
+        else:
+            assert SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS not in span["attributes"]
+            assert SPANDATA.GEN_AI_REQUEST_MESSAGES not in span["attributes"]
+            assert SPANDATA.GEN_AI_RESPONSE_TEXT not in span["attributes"]
+
+        assert span["attributes"][SPANDATA.GEN_AI_USAGE_INPUT_TOKENS] == 10
+        assert span["attributes"][SPANDATA.GEN_AI_USAGE_OUTPUT_TOKENS] == 10
+        assert span["attributes"][SPANDATA.GEN_AI_USAGE_TOTAL_TOKENS] == 20
+        assert span["attributes"][SPANDATA.GEN_AI_RESPONSE_STREAMING] is True
+
+    elif stream_gen_ai_spans:
         items = capture_items("transaction", "span")
 
         with mock.patch.object(
@@ -4895,6 +6226,7 @@ async def test_streaming_create_message_with_system_prompt_async(
 
     sentry_init(
         integrations=[AnthropicIntegration(include_prompts=include_prompts)],
+        disabled_integrations=[StdlibIntegration],
         traces_sample_rate=1.0,
         send_default_pii=send_default_pii,
         stream_gen_ai_spans=stream_gen_ai_spans,
@@ -4908,7 +6240,70 @@ async def test_streaming_create_message_with_system_prompt_async(
         }
     ]
 
-    if span_streaming or stream_gen_ai_spans:
+    if span_streaming:
+        items = capture_items("transaction", "span")
+
+        with mock.patch.object(
+            client._client,
+            "send",
+            return_value=response,
+        ) as _, sentry_sdk.traces.start_span(name="anthropic"):
+            message = await client.messages.create(
+                max_tokens=1024,
+                messages=messages,
+                model="model",
+                stream=True,
+                system="You are a helpful assistant.",
+            )
+
+            async for _ in message:
+                pass
+
+        sentry_sdk.flush()
+        spans = [item.payload for item in items if item.type == "span"]
+
+        assert spans[1]["name"] == "anthropic"
+        assert len(spans) == 2
+        (span, _) = spans
+
+        assert span["attributes"]["sentry.op"] == OP.GEN_AI_CHAT
+        assert span["name"] == "chat model"
+        assert span["attributes"][SPANDATA.GEN_AI_SYSTEM] == "anthropic"
+        assert span["attributes"][SPANDATA.GEN_AI_OPERATION_NAME] == "chat"
+        assert span["attributes"][SPANDATA.GEN_AI_REQUEST_MODEL] == "model"
+
+        if send_default_pii and include_prompts:
+            assert SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS in span["attributes"]
+            system_instructions = json.loads(
+                span["attributes"][SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS]
+            )
+            assert system_instructions == [
+                {"type": "text", "content": "You are a helpful assistant."}
+            ]
+
+            assert SPANDATA.GEN_AI_REQUEST_MESSAGES in span["attributes"]
+            stored_messages = json.loads(
+                span["attributes"][SPANDATA.GEN_AI_REQUEST_MESSAGES]
+            )
+
+            assert len(stored_messages) == 1
+            assert stored_messages[0]["role"] == "user"
+            assert stored_messages[0]["content"] == "Hello, Claude"
+            assert (
+                span["attributes"][SPANDATA.GEN_AI_RESPONSE_TEXT] == "Hi! I'm Claude!"
+            )
+
+        else:
+            assert SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS not in span["attributes"]
+            assert SPANDATA.GEN_AI_REQUEST_MESSAGES not in span["attributes"]
+            assert SPANDATA.GEN_AI_RESPONSE_TEXT not in span["attributes"]
+
+        assert span["attributes"][SPANDATA.GEN_AI_USAGE_INPUT_TOKENS] == 10
+        assert span["attributes"][SPANDATA.GEN_AI_USAGE_OUTPUT_TOKENS] == 10
+        assert span["attributes"][SPANDATA.GEN_AI_USAGE_TOTAL_TOKENS] == 20
+        assert span["attributes"][SPANDATA.GEN_AI_RESPONSE_STREAMING] is True
+
+    elif stream_gen_ai_spans:
         items = capture_items("transaction", "span")
 
         with mock.patch.object(
@@ -5043,6 +6438,7 @@ def test_system_prompt_with_complex_structure(
     """Test that complex system prompt structures (list of text blocks) are properly captured."""
     sentry_init(
         integrations=[AnthropicIntegration(include_prompts=True)],
+        disabled_integrations=[StdlibIntegration],
         traces_sample_rate=1.0,
         send_default_pii=True,
         stream_gen_ai_spans=stream_gen_ai_spans,
@@ -5065,7 +6461,44 @@ def test_system_prompt_with_complex_structure(
         }
     ]
 
-    if span_streaming or stream_gen_ai_spans:
+    if span_streaming:
+        items = capture_items("span")
+
+        with sentry_sdk.traces.start_span(name="anthropic"):
+            response = client.messages.create(
+                max_tokens=1024, messages=messages, model="model", system=system_prompt
+            )
+
+        assert response == EXAMPLE_MESSAGE
+
+        sentry_sdk.flush()
+        spans = [item.payload for item in items]
+        assert len(spans) == 2
+
+        assert spans[1]["name"] == "anthropic"
+        (span, _) = spans
+
+        assert span["attributes"][SPANDATA.GEN_AI_SYSTEM] == "anthropic"
+        assert span["attributes"][SPANDATA.GEN_AI_OPERATION_NAME] == "chat"
+
+        assert SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS in span["attributes"]
+        system_instructions = json.loads(
+            span["attributes"][SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS]
+        )
+
+        # System content should be a list of text blocks
+        assert isinstance(system_instructions, list)
+        assert system_instructions == [
+            {"type": "text", "content": "You are a helpful assistant."},
+            {"type": "text", "content": "Be concise and clear."},
+        ]
+
+        assert SPANDATA.GEN_AI_REQUEST_MESSAGES in span["attributes"]
+        stored_messages = json.loads(
+            span["attributes"][SPANDATA.GEN_AI_REQUEST_MESSAGES]
+        )
+
+    elif stream_gen_ai_spans:
         items = capture_items("span")
 
         with start_transaction(name="anthropic"):
@@ -5337,6 +6770,7 @@ def test_message_with_base64_image(sentry_init, capture_events):
     """Test that messages with base64 images are properly captured."""
     sentry_init(
         integrations=[AnthropicIntegration(include_prompts=True)],
+        disabled_integrations=[StdlibIntegration],
         traces_sample_rate=1.0,
         send_default_pii=True,
         stream_gen_ai_spans=False,
@@ -5397,6 +6831,7 @@ def test_message_with_url_image(
     """Test that messages with URL-referenced images are properly captured."""
     sentry_init(
         integrations=[AnthropicIntegration(include_prompts=True)],
+        disabled_integrations=[StdlibIntegration],
         traces_sample_rate=1.0,
         send_default_pii=True,
         stream_gen_ai_spans=stream_gen_ai_spans,
@@ -5468,6 +6903,7 @@ def test_message_with_file_image(
     """Test that messages with file_id-referenced images are properly captured."""
     sentry_init(
         integrations=[AnthropicIntegration(include_prompts=True)],
+        disabled_integrations=[StdlibIntegration],
         traces_sample_rate=1.0,
         send_default_pii=True,
         stream_gen_ai_spans=stream_gen_ai_spans,
@@ -5532,6 +6968,7 @@ def test_message_with_base64_pdf(sentry_init, capture_events):
     """Test that messages with base64-encoded PDF documents are properly captured."""
     sentry_init(
         integrations=[AnthropicIntegration(include_prompts=True)],
+        disabled_integrations=[StdlibIntegration],
         traces_sample_rate=1.0,
         send_default_pii=True,
         stream_gen_ai_spans=False,
@@ -5586,6 +7023,7 @@ def test_message_with_url_pdf(
     """Test that messages with URL-referenced PDF documents are properly captured."""
     sentry_init(
         integrations=[AnthropicIntegration(include_prompts=True)],
+        disabled_integrations=[StdlibIntegration],
         traces_sample_rate=1.0,
         send_default_pii=True,
         stream_gen_ai_spans=stream_gen_ai_spans,
@@ -5657,6 +7095,7 @@ def test_message_with_file_document(
     """Test that messages with file_id-referenced documents are properly captured."""
     sentry_init(
         integrations=[AnthropicIntegration(include_prompts=True)],
+        disabled_integrations=[StdlibIntegration],
         traces_sample_rate=1.0,
         send_default_pii=True,
         stream_gen_ai_spans=stream_gen_ai_spans,
@@ -5721,6 +7160,7 @@ def test_message_with_mixed_content(sentry_init, capture_events):
     """Test that messages with mixed content (text, images, documents) are properly captured."""
     sentry_init(
         integrations=[AnthropicIntegration(include_prompts=True)],
+        disabled_integrations=[StdlibIntegration],
         traces_sample_rate=1.0,
         send_default_pii=True,
         stream_gen_ai_spans=False,
@@ -5805,6 +7245,7 @@ def test_message_with_multiple_images_different_formats(sentry_init, capture_eve
     """Test that messages with multiple images of different source types are handled."""
     sentry_init(
         integrations=[AnthropicIntegration(include_prompts=True)],
+        disabled_integrations=[StdlibIntegration],
         traces_sample_rate=1.0,
         send_default_pii=True,
         stream_gen_ai_spans=False,
@@ -5889,6 +7330,7 @@ def test_binary_content_not_stored_when_pii_disabled(
     """Test that binary content is not stored when send_default_pii is False."""
     sentry_init(
         integrations=[AnthropicIntegration(include_prompts=True)],
+        disabled_integrations=[StdlibIntegration],
         traces_sample_rate=1.0,
         send_default_pii=False,
         stream_gen_ai_spans=stream_gen_ai_spans,
@@ -5953,6 +7395,7 @@ def test_binary_content_not_stored_when_prompts_disabled(
     """Test that binary content is not stored when include_prompts is False."""
     sentry_init(
         integrations=[AnthropicIntegration(include_prompts=False)],
+        disabled_integrations=[StdlibIntegration],
         traces_sample_rate=1.0,
         send_default_pii=True,
         stream_gen_ai_spans=stream_gen_ai_spans,
@@ -6017,6 +7460,7 @@ def test_cache_tokens_nonstreaming(
     """Test cache read/write tokens are tracked for non-streaming responses."""
     sentry_init(
         integrations=[AnthropicIntegration()],
+        disabled_integrations=[StdlibIntegration],
         traces_sample_rate=1.0,
         stream_gen_ai_spans=stream_gen_ai_spans,
         _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
@@ -6099,6 +7543,7 @@ def test_input_tokens_include_cache_write_nonstreaming(
     """
     sentry_init(
         integrations=[AnthropicIntegration()],
+        disabled_integrations=[StdlibIntegration],
         traces_sample_rate=1.0,
         stream_gen_ai_spans=stream_gen_ai_spans,
         _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
@@ -6185,6 +7630,7 @@ def test_input_tokens_include_cache_read_nonstreaming(
     """
     sentry_init(
         integrations=[AnthropicIntegration()],
+        disabled_integrations=[StdlibIntegration],
         traces_sample_rate=1.0,
         stream_gen_ai_spans=stream_gen_ai_spans,
         _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
@@ -6295,6 +7741,7 @@ def test_input_tokens_include_cache_read_streaming(
 
     sentry_init(
         integrations=[AnthropicIntegration()],
+        disabled_integrations=[StdlibIntegration],
         traces_sample_rate=1.0,
         stream_gen_ai_spans=stream_gen_ai_spans,
         _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
@@ -6398,6 +7845,7 @@ def test_stream_messages_input_tokens_include_cache_read_streaming(
 
     sentry_init(
         integrations=[AnthropicIntegration()],
+        disabled_integrations=[StdlibIntegration],
         traces_sample_rate=1.0,
         stream_gen_ai_spans=stream_gen_ai_spans,
         _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
@@ -6469,6 +7917,7 @@ def test_input_tokens_unchanged_without_caching(
     """
     sentry_init(
         integrations=[AnthropicIntegration()],
+        disabled_integrations=[StdlibIntegration],
         traces_sample_rate=1.0,
         stream_gen_ai_spans=stream_gen_ai_spans,
         _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
@@ -6565,6 +8014,7 @@ def test_cache_tokens_streaming(
 
     sentry_init(
         integrations=[AnthropicIntegration()],
+        disabled_integrations=[StdlibIntegration],
         traces_sample_rate=1.0,
         stream_gen_ai_spans=stream_gen_ai_spans,
         _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
@@ -6663,6 +8113,7 @@ def test_stream_messages_cache_tokens(
 
     sentry_init(
         integrations=[AnthropicIntegration()],
+        disabled_integrations=[StdlibIntegration],
         traces_sample_rate=1.0,
         stream_gen_ai_spans=stream_gen_ai_spans,
         _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},

--- a/tests/integrations/anthropic/test_anthropic.py
+++ b/tests/integrations/anthropic/test_anthropic.py
@@ -69,6 +69,7 @@ from sentry_sdk.integrations.anthropic import (
     _transform_anthropic_content_block,
 )
 from sentry_sdk.integrations.stdlib import StdlibIntegration
+from sentry_sdk.traces import SpanStatus
 from sentry_sdk.utils import package_version
 
 ANTHROPIC_VERSION = package_version("anthropic")
@@ -570,7 +571,65 @@ def test_streaming_create_message(
         },
     ]
 
-    if span_streaming or stream_gen_ai_spans:
+    if span_streaming:
+        items = capture_items("transaction", "span")
+
+        with mock.patch.object(
+            client._client,
+            "send",
+            return_value=response,
+        ) as _, sentry_sdk.traces.start_span(name="anthropic"):
+            message = client.messages.create(
+                max_tokens=1024, messages=messages, model="model", stream=True
+            )
+
+            for _ in message:
+                pass
+
+        sentry_sdk.flush()
+        spans = [item.payload for item in items if item.type == "span"]
+        assert spans[1]["name"] == "anthropic"
+        span = next(
+            span for span in spans if span["attributes"]["sentry.op"] == OP.GEN_AI_CHAT
+        )
+
+        assert span["attributes"]["sentry.op"] == OP.GEN_AI_CHAT
+        assert span["name"] == "chat model"
+        assert span["attributes"][SPANDATA.GEN_AI_SYSTEM] == "anthropic"
+        assert span["attributes"][SPANDATA.GEN_AI_OPERATION_NAME] == "chat"
+        assert span["attributes"][SPANDATA.GEN_AI_REQUEST_MODEL] == "model"
+
+        if send_default_pii and include_prompts:
+            assert json.loads(span["attributes"][SPANDATA.GEN_AI_REQUEST_MESSAGES]) == [
+                {
+                    "role": "user",
+                    "content": "Message demonstrating the absence of truncation.",
+                },
+                {
+                    "role": "user",
+                    "content": "Hello, Claude",
+                },
+            ]
+            assert (
+                span["attributes"][SPANDATA.GEN_AI_RESPONSE_TEXT] == "Hi! I'm Claude!"
+            )
+
+        else:
+            assert SPANDATA.GEN_AI_REQUEST_MESSAGES not in span["attributes"]
+            assert SPANDATA.GEN_AI_RESPONSE_TEXT not in span["attributes"]
+
+        assert span["attributes"][SPANDATA.GEN_AI_USAGE_INPUT_TOKENS] == 10
+        assert span["attributes"][SPANDATA.GEN_AI_USAGE_OUTPUT_TOKENS] == 10
+        assert span["attributes"][SPANDATA.GEN_AI_USAGE_TOTAL_TOKENS] == 20
+        assert span["attributes"][SPANDATA.GEN_AI_RESPONSE_STREAMING] is True
+        assert (
+            span["attributes"][SPANDATA.GEN_AI_RESPONSE_ID]
+            == "msg_01XFDUDYJgAACzvnptvVoYEL"
+        )
+        assert span["attributes"][SPANDATA.GEN_AI_RESPONSE_FINISH_REASONS] == [
+            "max_tokens"
+        ]
+    elif stream_gen_ai_spans:
         items = capture_items("transaction", "span")
 
         with mock.patch.object(
@@ -746,7 +805,51 @@ def test_streaming_create_message_close(
         }
     ]
 
-    if span_streaming or stream_gen_ai_spans:
+    if span_streaming:
+        items = capture_items("transaction", "span")
+
+        with mock.patch.object(
+            client._client,
+            "send",
+            return_value=response,
+        ) as _, sentry_sdk.traces.start_span(name="anthropic"):
+            messages = client.messages.create(
+                max_tokens=1024, messages=messages, model="model", stream=True
+            )
+
+            for _ in range(4):
+                next(messages)
+
+            messages.close()
+
+        sentry_sdk.flush()
+        spans = [item.payload for item in items if item.type == "span"]
+        assert spans[1]["name"] == "anthropic"
+        span = next(
+            span for span in spans if span["attributes"]["sentry.op"] == OP.GEN_AI_CHAT
+        )
+
+        assert span["attributes"]["sentry.op"] == OP.GEN_AI_CHAT
+        assert span["name"] == "chat model"
+        assert span["attributes"][SPANDATA.GEN_AI_SYSTEM] == "anthropic"
+        assert span["attributes"][SPANDATA.GEN_AI_OPERATION_NAME] == "chat"
+        assert span["attributes"][SPANDATA.GEN_AI_REQUEST_MODEL] == "model"
+
+        assert (
+            span["attributes"][SPANDATA.GEN_AI_REQUEST_MESSAGES]
+            == '[{"role": "user", "content": "Hello, Claude"}]'
+        )
+        assert span["attributes"][SPANDATA.GEN_AI_RESPONSE_TEXT] == "Hi!"
+
+        assert span["attributes"][SPANDATA.GEN_AI_USAGE_INPUT_TOKENS] == 10
+        assert span["attributes"][SPANDATA.GEN_AI_USAGE_OUTPUT_TOKENS] == 20
+        assert span["attributes"][SPANDATA.GEN_AI_USAGE_TOTAL_TOKENS] == 30
+        assert span["attributes"][SPANDATA.GEN_AI_RESPONSE_STREAMING] is True
+        assert (
+            span["attributes"][SPANDATA.GEN_AI_RESPONSE_ID]
+            == "msg_01XFDUDYJgAACzvnptvVoYEL"
+        )
+    elif stream_gen_ai_spans:
         items = capture_items("transaction", "span")
 
         with mock.patch.object(
@@ -903,7 +1006,52 @@ def test_streaming_create_message_api_error(
         }
     ]
 
-    if span_streaming or stream_gen_ai_spans:
+    if span_streaming:
+        items = capture_items("transaction", "span")
+
+        with pytest.raises(APIStatusError), mock.patch.object(
+            client._client,
+            "send",
+            return_value=response,
+        ) as _, sentry_sdk.traces.start_span(name="anthropic"):
+            message = client.messages.create(
+                max_tokens=1024, messages=messages, model="model", stream=True
+            )
+
+            for _ in message:
+                pass
+
+        sentry_sdk.flush()
+        spans = [item.payload for item in items if item.type == "span"]
+        assert spans[1]["name"] == "anthropic"
+        assert spans[1]["status"] == SpanStatus.ERROR
+        span = next(
+            span for span in spans if span["attributes"]["sentry.op"] == OP.GEN_AI_CHAT
+        )
+
+        assert span["attributes"]["sentry.op"] == OP.GEN_AI_CHAT
+        assert span["name"] == "chat model"
+        assert span["attributes"][SPANDATA.GEN_AI_SYSTEM] == "anthropic"
+        assert span["attributes"][SPANDATA.GEN_AI_OPERATION_NAME] == "chat"
+        assert span["attributes"][SPANDATA.GEN_AI_REQUEST_MODEL] == "model"
+
+        assert (
+            span["attributes"][SPANDATA.GEN_AI_REQUEST_MESSAGES]
+            == '[{"role": "user", "content": "Hello, Claude"}]'
+        )
+        assert span["attributes"][SPANDATA.GEN_AI_RESPONSE_TEXT] == "Hi!"
+
+        assert span["attributes"][SPANDATA.GEN_AI_USAGE_INPUT_TOKENS] == 10
+        assert span["attributes"][SPANDATA.GEN_AI_USAGE_OUTPUT_TOKENS] == 20
+        assert span["attributes"][SPANDATA.GEN_AI_USAGE_TOTAL_TOKENS] == 30
+        assert span["attributes"][SPANDATA.GEN_AI_RESPONSE_STREAMING] is True
+        assert (
+            span["attributes"][SPANDATA.GEN_AI_RESPONSE_ID]
+            == "msg_01XFDUDYJgAACzvnptvVoYEL"
+        )
+
+        assert span["status"] == "error"
+    elif stream_gen_ai_spans:
         items = capture_items("transaction", "span")
 
         with pytest.raises(APIStatusError), mock.patch.object(
@@ -1078,7 +1226,65 @@ def test_stream_messages(
         },
     ]
 
-    if span_streaming or stream_gen_ai_spans:
+    if span_streaming:
+        items = capture_items("transaction", "span")
+
+        with mock.patch.object(
+            client._client,
+            "send",
+            return_value=response,
+        ) as _, sentry_sdk.traces.start_span(name="anthropic"), client.messages.stream(
+            max_tokens=1024,
+            messages=messages,
+            model="model",
+        ) as stream:
+            for event in stream:
+                pass
+
+        sentry_sdk.flush()
+        spans = [item.payload for item in items if item.type == "span"]
+        assert spans[1]["name"] == "anthropic"
+        span = next(
+            span for span in spans if span["attributes"]["sentry.op"] == OP.GEN_AI_CHAT
+        )
+
+        assert span["attributes"]["sentry.op"] == OP.GEN_AI_CHAT
+        assert span["name"] == "chat model"
+        assert span["attributes"][SPANDATA.GEN_AI_SYSTEM] == "anthropic"
+        assert span["attributes"][SPANDATA.GEN_AI_OPERATION_NAME] == "chat"
+        assert span["attributes"][SPANDATA.GEN_AI_REQUEST_MODEL] == "model"
+
+        if send_default_pii and include_prompts:
+            assert json.loads(span["attributes"][SPANDATA.GEN_AI_REQUEST_MESSAGES]) == [
+                {
+                    "role": "user",
+                    "content": "Message demonstrating the absence of truncation.",
+                },
+                {
+                    "role": "user",
+                    "content": "Hello, Claude",
+                },
+            ]
+            assert (
+                span["attributes"][SPANDATA.GEN_AI_RESPONSE_TEXT] == "Hi! I'm Claude!"
+            )
+
+        else:
+            assert SPANDATA.GEN_AI_REQUEST_MESSAGES not in span["attributes"]
+            assert SPANDATA.GEN_AI_RESPONSE_TEXT not in span["attributes"]
+
+        assert span["attributes"][SPANDATA.GEN_AI_USAGE_INPUT_TOKENS] == 10
+        assert span["attributes"][SPANDATA.GEN_AI_USAGE_OUTPUT_TOKENS] == 10
+        assert span["attributes"][SPANDATA.GEN_AI_USAGE_TOTAL_TOKENS] == 20
+        assert span["attributes"][SPANDATA.GEN_AI_RESPONSE_STREAMING] is True
+        assert (
+            span["attributes"][SPANDATA.GEN_AI_RESPONSE_ID]
+            == "msg_01XFDUDYJgAACzvnptvVoYEL"
+        )
+        assert span["attributes"][SPANDATA.GEN_AI_RESPONSE_FINISH_REASONS] == [
+            "max_tokens"
+        ]
+    elif stream_gen_ai_spans:
         items = capture_items("transaction", "span")
 
         with mock.patch.object(
@@ -1253,7 +1459,55 @@ def test_stream_messages_close(
         }
     ]
 
-    if span_streaming or stream_gen_ai_spans:
+    if span_streaming:
+        items = capture_items("transaction", "span")
+
+        with mock.patch.object(
+            client._client,
+            "send",
+            return_value=response,
+        ) as _, sentry_sdk.traces.start_span(name="anthropic"), client.messages.stream(
+            max_tokens=1024,
+            messages=messages,
+            model="model",
+        ) as stream:
+            for _ in range(4):
+                next(stream)
+
+            # New versions add TextEvent, so consume one more event.
+            if TextEvent is not None and isinstance(next(stream), TextEvent):
+                next(stream)
+
+            stream.close()
+
+        sentry_sdk.flush()
+        spans = [item.payload for item in items if item.type == "span"]
+        assert spans[1]["name"] == "anthropic"
+        span = next(
+            span for span in spans if span["attributes"]["sentry.op"] == OP.GEN_AI_CHAT
+        )
+
+        assert span["attributes"]["sentry.op"] == OP.GEN_AI_CHAT
+        assert span["name"] == "chat model"
+        assert span["attributes"][SPANDATA.GEN_AI_SYSTEM] == "anthropic"
+        assert span["attributes"][SPANDATA.GEN_AI_OPERATION_NAME] == "chat"
+        assert span["attributes"][SPANDATA.GEN_AI_REQUEST_MODEL] == "model"
+
+        assert (
+            span["attributes"][SPANDATA.GEN_AI_REQUEST_MESSAGES]
+            == '[{"role": "user", "content": "Hello, Claude"}]'
+        )
+        assert span["attributes"][SPANDATA.GEN_AI_RESPONSE_TEXT] == "Hi!"
+
+        assert span["attributes"][SPANDATA.GEN_AI_USAGE_INPUT_TOKENS] == 10
+        assert span["attributes"][SPANDATA.GEN_AI_USAGE_OUTPUT_TOKENS] == 20
+        assert span["attributes"][SPANDATA.GEN_AI_USAGE_TOTAL_TOKENS] == 30
+        assert span["attributes"][SPANDATA.GEN_AI_RESPONSE_STREAMING] is True
+        assert (
+            span["attributes"][SPANDATA.GEN_AI_RESPONSE_ID]
+            == "msg_01XFDUDYJgAACzvnptvVoYEL"
+        )
+    elif stream_gen_ai_spans:
         items = capture_items("transaction", "span")
 
         with mock.patch.object(
@@ -1418,7 +1672,52 @@ def test_stream_messages_api_error(
         }
     ]
 
-    if span_streaming or stream_gen_ai_spans:
+    if span_streaming:
+        items = capture_items("transaction", "span")
+
+        with pytest.raises(APIStatusError), mock.patch.object(
+            client._client,
+            "send",
+            return_value=response,
+        ) as _, sentry_sdk.traces.start_span(name="anthropic"), client.messages.stream(
+            max_tokens=1024,
+            messages=messages,
+            model="model",
+        ) as stream:
+            for event in stream:
+                pass
+
+        sentry_sdk.flush()
+        spans = [item.payload for item in items if item.type == "span"]
+        assert spans[1]["name"] == "anthropic"
+        assert spans[1]["status"] == SpanStatus.ERROR
+        span = next(
+            span for span in spans if span["attributes"]["sentry.op"] == OP.GEN_AI_CHAT
+        )
+
+        assert span["attributes"]["sentry.op"] == OP.GEN_AI_CHAT
+        assert span["name"] == "chat model"
+        assert span["attributes"][SPANDATA.GEN_AI_SYSTEM] == "anthropic"
+        assert span["attributes"][SPANDATA.GEN_AI_OPERATION_NAME] == "chat"
+        assert span["attributes"][SPANDATA.GEN_AI_REQUEST_MODEL] == "model"
+
+        assert (
+            span["attributes"][SPANDATA.GEN_AI_REQUEST_MESSAGES]
+            == '[{"role": "user", "content": "Hello, Claude"}]'
+        )
+        assert span["attributes"][SPANDATA.GEN_AI_RESPONSE_TEXT] == "Hi!"
+
+        assert span["attributes"][SPANDATA.GEN_AI_USAGE_INPUT_TOKENS] == 10
+        assert span["attributes"][SPANDATA.GEN_AI_USAGE_OUTPUT_TOKENS] == 20
+        assert span["attributes"][SPANDATA.GEN_AI_USAGE_TOTAL_TOKENS] == 30
+        assert span["attributes"][SPANDATA.GEN_AI_RESPONSE_STREAMING] is True
+        assert (
+            span["attributes"][SPANDATA.GEN_AI_RESPONSE_ID]
+            == "msg_01XFDUDYJgAACzvnptvVoYEL"
+        )
+
+        assert span["status"] == "error"
+    elif stream_gen_ai_spans:
         items = capture_items("transaction", "span")
 
         with pytest.raises(APIStatusError), mock.patch.object(
@@ -1837,7 +2136,50 @@ async def test_streaming_create_message_async_close(
         }
     ]
 
-    if span_streaming or stream_gen_ai_spans:
+    if span_streaming:
+        items = capture_items("transaction", "span")
+
+        with mock.patch.object(
+            client._client,
+            "send",
+            return_value=response,
+        ) as _, sentry_sdk.traces.start_span(name="anthropic"):
+            messages = await client.messages.create(
+                max_tokens=1024, messages=messages, model="model", stream=True
+            )
+
+            for _ in range(4):
+                await messages.__anext__()
+            await messages.close()
+
+        sentry_sdk.flush()
+        spans = [item.payload for item in items if item.type == "span"]
+        assert spans[1]["name"] == "anthropic"
+        span = next(
+            span for span in spans if span["attributes"]["sentry.op"] == OP.GEN_AI_CHAT
+        )
+
+        assert span["attributes"]["sentry.op"] == OP.GEN_AI_CHAT
+        assert span["name"] == "chat model"
+        assert span["attributes"][SPANDATA.GEN_AI_SYSTEM] == "anthropic"
+        assert span["attributes"][SPANDATA.GEN_AI_OPERATION_NAME] == "chat"
+        assert span["attributes"][SPANDATA.GEN_AI_REQUEST_MODEL] == "model"
+
+        assert (
+            span["attributes"][SPANDATA.GEN_AI_REQUEST_MESSAGES]
+            == '[{"role": "user", "content": "Hello, Claude"}]'
+        )
+        assert span["attributes"][SPANDATA.GEN_AI_RESPONSE_TEXT] == "Hi!"
+
+        assert span["attributes"][SPANDATA.GEN_AI_USAGE_INPUT_TOKENS] == 10
+        assert span["attributes"][SPANDATA.GEN_AI_USAGE_OUTPUT_TOKENS] == 20
+        assert span["attributes"][SPANDATA.GEN_AI_USAGE_TOTAL_TOKENS] == 30
+        assert span["attributes"][SPANDATA.GEN_AI_RESPONSE_STREAMING] is True
+        assert (
+            span["attributes"][SPANDATA.GEN_AI_RESPONSE_ID]
+            == "msg_01XFDUDYJgAACzvnptvVoYEL"
+        )
+    elif stream_gen_ai_spans:
         items = capture_items("transaction", "span")
 
         with mock.patch.object(
@@ -1996,7 +2338,52 @@ async def test_streaming_create_message_async_api_error(
         }
     ]
 
-    if span_streaming or stream_gen_ai_spans:
+    if span_streaming:
+        items = capture_items("transaction", "span")
+
+        with pytest.raises(APIStatusError), mock.patch.object(
+            client._client,
+            "send",
+            return_value=response,
+        ) as _, sentry_sdk.traces.start_span(name="anthropic"):
+            message = await client.messages.create(
+                max_tokens=1024, messages=messages, model="model", stream=True
+            )
+
+            async for _ in message:
+                pass
+
+        sentry_sdk.flush()
+        spans = [item.payload for item in items if item.type == "span"]
+        assert spans[1]["name"] == "anthropic"
+        assert spans[1]["status"] == SpanStatus.ERROR
+        span = next(
+            span for span in spans if span["attributes"]["sentry.op"] == OP.GEN_AI_CHAT
+        )
+
+        assert span["attributes"]["sentry.op"] == OP.GEN_AI_CHAT
+        assert span["name"] == "chat model"
+        assert span["attributes"][SPANDATA.GEN_AI_SYSTEM] == "anthropic"
+        assert span["attributes"][SPANDATA.GEN_AI_OPERATION_NAME] == "chat"
+        assert span["attributes"][SPANDATA.GEN_AI_REQUEST_MODEL] == "model"
+
+        assert (
+            span["attributes"][SPANDATA.GEN_AI_REQUEST_MESSAGES]
+            == '[{"role": "user", "content": "Hello, Claude"}]'
+        )
+        assert span["attributes"][SPANDATA.GEN_AI_RESPONSE_TEXT] == "Hi!"
+
+        assert span["attributes"][SPANDATA.GEN_AI_USAGE_INPUT_TOKENS] == 10
+        assert span["attributes"][SPANDATA.GEN_AI_USAGE_OUTPUT_TOKENS] == 20
+        assert span["attributes"][SPANDATA.GEN_AI_USAGE_TOTAL_TOKENS] == 30
+        assert span["attributes"][SPANDATA.GEN_AI_RESPONSE_STREAMING] is True
+        assert (
+            span["attributes"][SPANDATA.GEN_AI_RESPONSE_ID]
+            == "msg_01XFDUDYJgAACzvnptvVoYEL"
+        )
+
+        assert span["status"] == "error"
+    elif stream_gen_ai_spans:
         items = capture_items("transaction", "span")
 
         with pytest.raises(APIStatusError), mock.patch.object(
@@ -2408,7 +2795,52 @@ async def test_stream_messages_async_api_error(
         }
     ]
 
-    if span_streaming or stream_gen_ai_spans:
+    if span_streaming:
+        items = capture_items("transaction", "span")
+
+        with pytest.raises(APIStatusError), mock.patch.object(
+            client._client,
+            "send",
+            return_value=response,
+        ) as _, sentry_sdk.traces.start_span(name="anthropic"):
+            async with client.messages.stream(
+                max_tokens=1024,
+                messages=messages,
+                model="model",
+            ) as stream:
+                async for event in stream:
+                    pass
+
+        sentry_sdk.flush()
+        spans = [item.payload for item in items if item.type == "span"]
+        assert spans[1]["name"] == "anthropic"
+        span = next(
+            span for span in spans if span["attributes"]["sentry.op"] == OP.GEN_AI_CHAT
+        )
+
+        assert span["attributes"]["sentry.op"] == OP.GEN_AI_CHAT
+        assert span["name"] == "chat model"
+        assert span["attributes"][SPANDATA.GEN_AI_SYSTEM] == "anthropic"
+        assert span["attributes"][SPANDATA.GEN_AI_OPERATION_NAME] == "chat"
+        assert span["attributes"][SPANDATA.GEN_AI_REQUEST_MODEL] == "model"
+
+        assert (
+            span["attributes"][SPANDATA.GEN_AI_REQUEST_MESSAGES]
+            == '[{"role": "user", "content": "Hello, Claude"}]'
+        )
+        assert span["attributes"][SPANDATA.GEN_AI_RESPONSE_TEXT] == "Hi!"
+
+        assert span["attributes"][SPANDATA.GEN_AI_USAGE_INPUT_TOKENS] == 10
+        assert span["attributes"][SPANDATA.GEN_AI_USAGE_OUTPUT_TOKENS] == 20
+        assert span["attributes"][SPANDATA.GEN_AI_USAGE_TOTAL_TOKENS] == 30
+        assert span["attributes"][SPANDATA.GEN_AI_RESPONSE_STREAMING] is True
+        assert (
+            span["attributes"][SPANDATA.GEN_AI_RESPONSE_ID]
+            == "msg_01XFDUDYJgAACzvnptvVoYEL"
+        )
+
+        assert span["status"] == "error"
+    elif stream_gen_ai_spans:
         items = capture_items("transaction", "span")
 
         with pytest.raises(APIStatusError), mock.patch.object(
@@ -2423,9 +2855,6 @@ async def test_stream_messages_async_api_error(
             ) as stream:
                 async for event in stream:
                     pass
-
-        (event,) = (item.payload for item in items if item.type == "transaction")
-        assert event["transaction"] == "anthropic"
 
         sentry_sdk.flush()
         spans = [item.payload for item in items if item.type == "span"]
@@ -2574,7 +3003,58 @@ async def test_stream_messages_async_close(
         }
     ]
 
-    if span_streaming or stream_gen_ai_spans:
+    if span_streaming:
+        items = capture_items("transaction", "span")
+
+        with mock.patch.object(
+            client._client,
+            "send",
+            return_value=response,
+        ) as _, sentry_sdk.traces.start_span(name="anthropic"):
+            async with client.messages.stream(
+                max_tokens=1024,
+                messages=messages,
+                model="model",
+            ) as stream:
+                for _ in range(4):
+                    await stream.__anext__()
+
+                # New versions add TextEvent, so consume one more event.
+                if TextEvent is not None and isinstance(
+                    await stream.__anext__(), TextEvent
+                ):
+                    await stream.__anext__()
+
+                await stream.close()
+
+        sentry_sdk.flush()
+        spans = [item.payload for item in items if item.type == "span"]
+        assert spans[1]["name"] == "anthropic"
+        span = next(
+            span for span in spans if span["attributes"]["sentry.op"] == OP.GEN_AI_CHAT
+        )
+
+        assert span["attributes"]["sentry.op"] == OP.GEN_AI_CHAT
+        assert span["name"] == "chat model"
+        assert span["attributes"][SPANDATA.GEN_AI_SYSTEM] == "anthropic"
+        assert span["attributes"][SPANDATA.GEN_AI_OPERATION_NAME] == "chat"
+        assert span["attributes"][SPANDATA.GEN_AI_REQUEST_MODEL] == "model"
+
+        assert (
+            span["attributes"][SPANDATA.GEN_AI_REQUEST_MESSAGES]
+            == '[{"role": "user", "content": "Hello, Claude"}]'
+        )
+        assert span["attributes"][SPANDATA.GEN_AI_RESPONSE_TEXT] == "Hi!"
+
+        assert span["attributes"][SPANDATA.GEN_AI_USAGE_INPUT_TOKENS] == 10
+        assert span["attributes"][SPANDATA.GEN_AI_USAGE_OUTPUT_TOKENS] == 20
+        assert span["attributes"][SPANDATA.GEN_AI_USAGE_TOTAL_TOKENS] == 30
+        assert span["attributes"][SPANDATA.GEN_AI_RESPONSE_STREAMING] is True
+        assert (
+            span["attributes"][SPANDATA.GEN_AI_RESPONSE_ID]
+            == "msg_01XFDUDYJgAACzvnptvVoYEL"
+        )
+    elif stream_gen_ai_spans:
         items = capture_items("transaction", "span")
 
         with mock.patch.object(
@@ -2597,9 +3077,6 @@ async def test_stream_messages_async_close(
                     await stream.__anext__()
 
                 await stream.close()
-
-        (event,) = (item.payload for item in items if item.type == "transaction")
-        assert event["transaction"] == "anthropic"
 
         sentry_sdk.flush()
         spans = [item.payload for item in items if item.type == "span"]

--- a/tests/integrations/google_genai/test_google_genai.py
+++ b/tests/integrations/google_genai/test_google_genai.py
@@ -147,7 +147,77 @@ def test_nonstreaming_generate_content(
     # Mock the HTTP response at the _api_client.request() level
     mock_http_response = create_mock_http_response(EXAMPLE_API_RESPONSE_JSON)
 
-    if span_streaming or stream_gen_ai_spans:
+    if span_streaming:
+        items = capture_items("transaction", "span")
+
+        with mock.patch.object(
+            mock_genai_client._api_client,
+            "request",
+            return_value=mock_http_response,
+        ), sentry_sdk.traces.start_span(name="google_genai"):
+            config = create_test_config(temperature=0.7, max_output_tokens=100)
+            mock_genai_client.models.generate_content(
+                model="gemini-1.5-flash",
+                contents=[
+                    "Message demonstrating the absence of truncation.",
+                    "Tell me a joke",
+                ],
+                config=config,
+            )
+
+        sentry_sdk.flush()
+        spans = [item.payload for item in items if item.type == "span"]
+        assert len(spans) == 2
+        assert spans[1]["name"] == "google_genai"
+        chat_span = next(item.payload for item in items if item.type == "span")
+
+        # Check chat span
+        assert chat_span["attributes"]["sentry.op"] == OP.GEN_AI_CHAT
+        assert chat_span["name"] == "chat gemini-1.5-flash"
+        assert chat_span["attributes"][SPANDATA.GEN_AI_OPERATION_NAME] == "chat"
+        assert chat_span["attributes"][SPANDATA.GEN_AI_SYSTEM] == "gcp.gemini"
+        assert (
+            chat_span["attributes"][SPANDATA.GEN_AI_REQUEST_MODEL] == "gemini-1.5-flash"
+        )
+
+        if send_default_pii and include_prompts:
+            assert json.loads(
+                chat_span["attributes"][SPANDATA.GEN_AI_REQUEST_MESSAGES]
+            ) == [
+                {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "text",
+                            "text": "Message demonstrating the absence of truncation.",
+                        },
+                        {
+                            "type": "text",
+                            "text": "Tell me a joke",
+                        },
+                    ],
+                }
+            ]
+
+            # Response text is stored as a JSON array
+            response_text = chat_span["attributes"][SPANDATA.GEN_AI_RESPONSE_TEXT]
+
+            # Parse the JSON array
+            response_texts = json.loads(response_text)
+            assert response_texts == ["Hello! How can I help you today?"]
+        else:
+            assert SPANDATA.GEN_AI_RESPONSE_TEXT not in chat_span["attributes"]
+
+        # Check token usage
+        assert chat_span["attributes"][SPANDATA.GEN_AI_USAGE_INPUT_TOKENS] == 10
+        # Output tokens now include reasoning tokens: candidates_token_count (20) + thoughts_token_count (3) = 23
+        assert chat_span["attributes"][SPANDATA.GEN_AI_USAGE_OUTPUT_TOKENS] == 23
+        assert chat_span["attributes"][SPANDATA.GEN_AI_USAGE_TOTAL_TOKENS] == 30
+        assert chat_span["attributes"][SPANDATA.GEN_AI_USAGE_INPUT_TOKENS_CACHED] == 5
+        assert (
+            chat_span["attributes"][SPANDATA.GEN_AI_USAGE_OUTPUT_TOKENS_REASONING] == 3
+        )
+    elif stream_gen_ai_spans:
         items = capture_items("transaction", "span")
 
         with mock.patch.object(
@@ -867,7 +937,26 @@ def test_span_origin(
 
     mock_http_response = create_mock_http_response(EXAMPLE_API_RESPONSE_JSON)
 
-    if span_streaming or stream_gen_ai_spans:
+    if span_streaming:
+        items = capture_items("span", "transaction")
+
+        with mock.patch.object(
+            mock_genai_client._api_client, "request", return_value=mock_http_response
+        ), sentry_sdk.traces.start_span(name="google_genai"):
+            config = create_test_config()
+            mock_genai_client.models.generate_content(
+                model="gemini-1.5-flash", contents="Test origin", config=config
+            )
+
+        sentry_sdk.flush()
+        spans = [item.payload for item in items if item.type == "span"]
+        for span in spans:
+            if span["is_segment"] is True:
+                assert span["attributes"]["sentry.origin"] == "manual"
+                continue
+
+            assert span["attributes"]["sentry.origin"] == "auto.ai.google_genai"
+    elif stream_gen_ai_spans:
         items = capture_items("span", "transaction")
 
         with mock.patch.object(
@@ -1596,7 +1685,56 @@ def test_embed_content(
     # Mock the HTTP response at the _api_client.request() level
     mock_http_response = create_mock_http_response(EXAMPLE_EMBED_RESPONSE_JSON)
 
-    if span_streaming or stream_gen_ai_spans:
+    if span_streaming:
+        items = capture_items("transaction", "span")
+
+        with mock.patch.object(
+            mock_genai_client._api_client,
+            "request",
+            return_value=mock_http_response,
+        ), sentry_sdk.traces.start_span(name="google_genai_embeddings"):
+            mock_genai_client.models.embed_content(
+                model="text-embedding-004",
+                contents=[
+                    "What is your name?",
+                    "What is your favorite color?",
+                ],
+            )
+
+        # Should have 1 span for embeddings
+        sentry_sdk.flush()
+        spans = [item.payload for item in items if item.type == "span"]
+        assert len(spans) == 2
+        assert spans[1]["name"] == "google_genai_embeddings"
+        (embed_span, _) = spans
+
+        # Check embeddings span
+        assert embed_span["attributes"]["sentry.op"] == OP.GEN_AI_EMBEDDINGS
+        assert embed_span["name"] == "embeddings text-embedding-004"
+        assert embed_span["attributes"][SPANDATA.GEN_AI_OPERATION_NAME] == "embeddings"
+        assert embed_span["attributes"][SPANDATA.GEN_AI_SYSTEM] == "gcp.gemini"
+        assert (
+            embed_span["attributes"][SPANDATA.GEN_AI_REQUEST_MODEL]
+            == "text-embedding-004"
+        )
+
+        # Check input texts if PII is allowed
+        if send_default_pii and include_prompts:
+            input_texts = json.loads(
+                embed_span["attributes"][SPANDATA.GEN_AI_EMBEDDINGS_INPUT]
+            )
+            assert input_texts == [
+                "What is your name?",
+                "What is your favorite color?",
+            ]
+        else:
+            assert SPANDATA.GEN_AI_EMBEDDINGS_INPUT not in embed_span["attributes"]
+
+        # Check usage data (sum of token counts from statistics: 10 + 15 = 25)
+        # Note: Only available in newer versions with ContentEmbeddingStatistics
+        if SPANDATA.GEN_AI_USAGE_INPUT_TOKENS in embed_span["attributes"]:
+            assert embed_span["attributes"][SPANDATA.GEN_AI_USAGE_INPUT_TOKENS] == 25
+    elif stream_gen_ai_spans:
         items = capture_items("transaction", "span")
 
         with mock.patch.object(
@@ -1931,7 +2069,25 @@ def test_embed_content_span_origin(
     )
 
     mock_http_response = create_mock_http_response(EXAMPLE_EMBED_RESPONSE_JSON)
-    if span_streaming or stream_gen_ai_spans:
+    if span_streaming:
+        items = capture_items("transaction", "span")
+        with mock.patch.object(
+            mock_genai_client._api_client, "request", return_value=mock_http_response
+        ), sentry_sdk.traces.start_span(name="google_genai_embeddings"):
+            mock_genai_client.models.embed_content(
+                model="text-embedding-004",
+                contents=["Test origin"],
+            )
+
+        sentry_sdk.flush()
+        spans = [item.payload for item in items if item.type == "span"]
+        for span in spans:
+            if span["is_segment"] is True:
+                assert span["attributes"]["sentry.origin"] == "manual"
+                continue
+
+            assert span["attributes"]["sentry.origin"] == "auto.ai.google_genai"
+    elif stream_gen_ai_spans:
         items = capture_items("transaction", "span")
         with mock.patch.object(
             mock_genai_client._api_client, "request", return_value=mock_http_response
@@ -1999,7 +2155,56 @@ async def test_async_embed_content(
     # Mock the async HTTP response
     mock_http_response = create_mock_http_response(EXAMPLE_EMBED_RESPONSE_JSON)
 
-    if span_streaming or stream_gen_ai_spans:
+    if span_streaming:
+        items = capture_items("transaction", "span")
+
+        with mock.patch.object(
+            mock_genai_client._api_client,
+            "async_request",
+            return_value=mock_http_response,
+        ), sentry_sdk.traces.start_span(name="google_genai_embeddings_async"):
+            await mock_genai_client.aio.models.embed_content(
+                model="text-embedding-004",
+                contents=[
+                    "What is your name?",
+                    "What is your favorite color?",
+                ],
+            )
+
+        # Should have 1 span for embeddings
+        sentry_sdk.flush()
+        spans = [item.payload for item in items if item.type == "span"]
+        assert len(spans) == 2
+        assert spans[1]["name"] == "google_genai_embeddings_async"
+        (embed_span, _) = spans
+
+        # Check embeddings span
+        assert embed_span["attributes"]["sentry.op"] == OP.GEN_AI_EMBEDDINGS
+        assert embed_span["name"] == "embeddings text-embedding-004"
+        assert embed_span["attributes"][SPANDATA.GEN_AI_OPERATION_NAME] == "embeddings"
+        assert embed_span["attributes"][SPANDATA.GEN_AI_SYSTEM] == "gcp.gemini"
+        assert (
+            embed_span["attributes"][SPANDATA.GEN_AI_REQUEST_MODEL]
+            == "text-embedding-004"
+        )
+
+        # Check input texts if PII is allowed
+        if send_default_pii and include_prompts:
+            input_texts = json.loads(
+                embed_span["attributes"][SPANDATA.GEN_AI_EMBEDDINGS_INPUT]
+            )
+            assert input_texts == [
+                "What is your name?",
+                "What is your favorite color?",
+            ]
+        else:
+            assert SPANDATA.GEN_AI_EMBEDDINGS_INPUT not in embed_span["attributes"]
+
+        # Check usage data (sum of token counts from statistics: 10 + 15 = 25)
+        # Note: Only available in newer versions with ContentEmbeddingStatistics
+        if SPANDATA.GEN_AI_USAGE_INPUT_TOKENS in embed_span["attributes"]:
+            assert embed_span["attributes"][SPANDATA.GEN_AI_USAGE_INPUT_TOKENS] == 25
+    elif stream_gen_ai_spans:
         items = capture_items("transaction", "span")
 
         with mock.patch.object(
@@ -2348,7 +2553,29 @@ async def test_async_embed_content_span_origin(
 
     mock_http_response = create_mock_http_response(EXAMPLE_EMBED_RESPONSE_JSON)
 
-    if span_streaming or stream_gen_ai_spans:
+    if span_streaming:
+        items = capture_items("transaction", "span")
+
+        with mock.patch.object(
+            mock_genai_client._api_client,
+            "async_request",
+            return_value=mock_http_response,
+        ), sentry_sdk.traces.start_span(name="google_genai_embeddings_async"):
+            await mock_genai_client.aio.models.embed_content(
+                model="text-embedding-004",
+                contents=["Test origin"],
+            )
+
+        sentry_sdk.flush()
+        spans = [item.payload for item in items if item.type == "span"]
+        for span in spans:
+            if span["is_segment"] is True:
+                assert span["attributes"]["sentry.origin"] == "manual"
+                continue
+
+            assert span["attributes"]["sentry.origin"] == "auto.ai.google_genai"
+
+    elif stream_gen_ai_spans:
         items = capture_items("transaction", "span")
 
         with mock.patch.object(

--- a/tests/integrations/langchain/test_langchain.py
+++ b/tests/integrations/langchain/test_langchain.py
@@ -287,7 +287,39 @@ def test_langchain_text_completion(
         openai_api_key="badkey",
     )
 
-    if span_streaming or stream_gen_ai_spans:
+    if span_streaming:
+        items = capture_items("transaction", "span")
+
+        with patch.object(
+            model.client._client._client,
+            "send",
+            return_value=model_response,
+        ) as _, sentry_sdk.traces.start_span(name="custom parent"):
+            input_text = "What is the capital of France?"
+            model.invoke(input_text, config={"run_name": "my-snazzy-pipeline"})
+
+        sentry_sdk.flush()
+        spans = [item.payload for item in items if item.type == "span"]
+        llm_spans = [
+            span
+            for span in spans
+            if span["attributes"].get("sentry.op") == "gen_ai.text_completion"
+        ]
+        assert len(llm_spans) > 0
+
+        llm_span = llm_spans[0]
+        assert llm_span["name"] == "text_completion gpt-3.5-turbo"
+        assert llm_span["attributes"]["gen_ai.system"] == "openai"
+        assert llm_span["attributes"]["gen_ai.function_id"] == "my-snazzy-pipeline"
+        assert llm_span["attributes"]["gen_ai.request.model"] == "gpt-3.5-turbo"
+        assert (
+            llm_span["attributes"]["gen_ai.response.text"]
+            == "The capital of France is Paris."
+        )
+        assert llm_span["attributes"]["gen_ai.usage.total_tokens"] == 25
+        assert llm_span["attributes"]["gen_ai.usage.input_tokens"] == 10
+        assert llm_span["attributes"]["gen_ai.usage.output_tokens"] == 15
+    elif stream_gen_ai_spans:
         items = capture_items("transaction", "span")
 
         with patch.object(
@@ -599,7 +631,75 @@ def test_langchain_create_agent(
         name="word_length_agent",
     )
 
-    if span_streaming or stream_gen_ai_spans:
+    if span_streaming:
+        items = capture_items("transaction", "span")
+
+        with patch.object(
+            llm.client._client._client,
+            "send",
+            return_value=model_response,
+        ) as _, sentry_sdk.traces.start_span(name="custom parent"):
+            agent.invoke(
+                {
+                    "messages": [
+                        HumanMessage(
+                            content="Message demonstrating the absence of truncation."
+                        ),
+                        HumanMessage(content="How many letters in the word eudca"),
+                    ],
+                },
+            )
+
+        sentry_sdk.flush()
+        spans = [item.payload for item in items if item.type == "span"]
+        assert spans[2]["attributes"]["sentry.origin"] == "manual"
+        chat_spans = list(
+            x for x in spans if x["attributes"].get("sentry.op") == "gen_ai.chat"
+        )
+        assert len(chat_spans) == 1
+        assert chat_spans[0]["attributes"]["sentry.origin"] == "auto.ai.langchain"
+
+        assert chat_spans[0]["attributes"]["gen_ai.system"] == "openai-chat"
+        assert chat_spans[0]["attributes"]["gen_ai.agent.name"] == "word_length_agent"
+
+        assert chat_spans[0]["attributes"]["gen_ai.usage.input_tokens"] == 10
+        assert chat_spans[0]["attributes"]["gen_ai.usage.output_tokens"] == 20
+        assert chat_spans[0]["attributes"]["gen_ai.usage.total_tokens"] == 30
+
+        if send_default_pii and include_prompts:
+            assert (
+                chat_spans[0]["attributes"][SPANDATA.GEN_AI_RESPONSE_TEXT]
+                == "Hello, how can I help you?"
+            )
+
+            assert json.loads(
+                chat_spans[0]["attributes"][SPANDATA.GEN_AI_REQUEST_MESSAGES]
+            ) == [
+                {
+                    "role": "user",
+                    "content": "Message demonstrating the absence of truncation.",
+                },
+                {
+                    "role": "user",
+                    "content": "How many letters in the word eudca",
+                },
+            ]
+
+            assert expected_system_instructions == json.loads(
+                chat_spans[0]["attributes"][SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS]
+            )
+        else:
+            assert SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS not in chat_spans[0].get(
+                "attributes", {}
+            )
+            assert SPANDATA.GEN_AI_REQUEST_MESSAGES not in chat_spans[0].get(
+                "attributes", {}
+            )
+            assert SPANDATA.GEN_AI_RESPONSE_TEXT not in chat_spans[0].get(
+                "attributes", {}
+            )
+
+    elif stream_gen_ai_spans:
         items = capture_items("transaction", "span")
 
         with patch.object(
@@ -818,14 +918,14 @@ def test_tool_execution_span(
         name="word_length_agent",
     )
 
-    if span_streaming or stream_gen_ai_spans:
+    if span_streaming:
         items = capture_items("transaction", "span")
 
         with patch.object(
             llm.client._client._client,
             "send",
             side_effect=[tool_response, final_response],
-        ) as _, start_transaction():
+        ) as _, sentry_sdk.traces.start_span(name="custom parent"):
             agent.invoke(
                 {
                     "messages": [
@@ -834,12 +934,115 @@ def test_tool_execution_span(
                 },
             )
 
-        tx = next(item.payload for item in items if item.type == "transaction")
-        assert tx["type"] == "transaction"
-        assert tx["contexts"]["trace"]["origin"] == "manual"
+        sentry_sdk.flush()
+        spans = [item.payload for item in items if item.type == "span"]
+        assert spans[3]["attributes"]["sentry.origin"] == "manual"
+        chat_spans = list(
+            x for x in spans if x["attributes"].get("sentry.op") == "gen_ai.chat"
+        )
+        assert len(chat_spans) == 2
+
+        tool_exec_spans = list(
+            x
+            for x in spans
+            if x["attributes"].get("sentry.op") == "gen_ai.execute_tool"
+        )
+        assert len(tool_exec_spans) == 1
+        tool_exec_span = tool_exec_spans[0]
+
+        assert chat_spans[0]["attributes"]["sentry.origin"] == "auto.ai.langchain"
+        assert chat_spans[1]["attributes"]["sentry.origin"] == "auto.ai.langchain"
+        assert tool_exec_span["attributes"]["sentry.origin"] == "auto.ai.langchain"
+
+        assert chat_spans[0]["attributes"]["gen_ai.agent.name"] == "word_length_agent"
+        assert chat_spans[1]["attributes"]["gen_ai.agent.name"] == "word_length_agent"
+        assert tool_exec_span["attributes"]["gen_ai.agent.name"] == "word_length_agent"
+
+        assert chat_spans[0]["attributes"]["gen_ai.usage.input_tokens"] == 142
+        assert chat_spans[0]["attributes"]["gen_ai.usage.output_tokens"] == 50
+        assert chat_spans[0]["attributes"]["gen_ai.usage.total_tokens"] == 192
+        assert chat_spans[0]["attributes"]["gen_ai.system"] == "openai-chat"
+
+        assert chat_spans[1]["attributes"]["gen_ai.usage.input_tokens"] == 89
+        assert chat_spans[1]["attributes"]["gen_ai.usage.output_tokens"] == 28
+        assert chat_spans[1]["attributes"]["gen_ai.usage.total_tokens"] == 117
+        assert chat_spans[1]["attributes"]["gen_ai.system"] == "openai-chat"
+
+        if send_default_pii and include_prompts:
+            assert "word" in tool_exec_span["attributes"][SPANDATA.GEN_AI_TOOL_INPUT]
+
+            assert "5" in chat_spans[1]["attributes"][SPANDATA.GEN_AI_RESPONSE_TEXT]
+
+            # Verify tool calls are recorded when PII is enabled
+            assert SPANDATA.GEN_AI_RESPONSE_TOOL_CALLS in chat_spans[0].get(
+                "attributes", {}
+            ), (
+                "Tool calls should be recorded when send_default_pii=True and include_prompts=True"
+            )
+            tool_calls_data = chat_spans[0]["attributes"][
+                SPANDATA.GEN_AI_RESPONSE_TOOL_CALLS
+            ]
+            assert isinstance(tool_calls_data, str)
+            assert "get_word_length" in tool_calls_data
+        else:
+            assert SPANDATA.GEN_AI_REQUEST_MESSAGES not in chat_spans[0].get(
+                "attributes", {}
+            )
+            assert SPANDATA.GEN_AI_RESPONSE_TEXT not in chat_spans[0].get(
+                "attributes", {}
+            )
+            assert SPANDATA.GEN_AI_REQUEST_MESSAGES not in chat_spans[1].get(
+                "attributes", {}
+            )
+            assert SPANDATA.GEN_AI_RESPONSE_TEXT not in chat_spans[1].get(
+                "attributes", {}
+            )
+            assert SPANDATA.GEN_AI_TOOL_INPUT not in tool_exec_span.get(
+                "attributes", {}
+            )
+            assert SPANDATA.GEN_AI_TOOL_OUTPUT not in tool_exec_span.get(
+                "attributes", {}
+            )
+
+            # Verify tool calls are NOT recorded when PII is disabled
+            assert SPANDATA.GEN_AI_RESPONSE_TOOL_CALLS not in chat_spans[0].get(
+                "attributes", {}
+            ), (
+                f"Tool calls should NOT be recorded when send_default_pii={send_default_pii} "
+                f"and include_prompts={include_prompts}"
+            )
+            assert SPANDATA.GEN_AI_RESPONSE_TOOL_CALLS not in chat_spans[1].get(
+                "attributes", {}
+            ), (
+                f"Tool calls should NOT be recorded when send_default_pii={send_default_pii} "
+                f"and include_prompts={include_prompts}"
+            )
+
+        # Verify that available tools are always recorded regardless of PII settings
+        for chat_span in chat_spans:
+            tools_data = chat_span["attributes"][
+                SPANDATA.GEN_AI_REQUEST_AVAILABLE_TOOLS
+            ]
+            assert "get_word_length" in tools_data
+    elif stream_gen_ai_spans:
+        items = capture_items("transaction", "span")
+
+        with patch.object(
+            llm.client._client._client,
+            "send",
+            side_effect=[tool_response, final_response],
+        ) as _, sentry_sdk.traces.start_span(name="custom parent"):
+            agent.invoke(
+                {
+                    "messages": [
+                        HumanMessage(content="How many letters in the word eudca"),
+                    ],
+                },
+            )
 
         sentry_sdk.flush()
         spans = [item.payload for item in items if item.type == "span"]
+        assert spans[4]["attributes"]["sentry.origin"] == "manual"
         chat_spans = list(
             x for x in spans if x["attributes"]["sentry.op"] == "gen_ai.chat"
         )
@@ -1084,7 +1287,123 @@ def test_langchain_openai_tools_agent_no_prompts(
 
     agent_executor = AgentExecutor(agent=agent, tools=[get_word_length], verbose=True)
 
-    if span_streaming or stream_gen_ai_spans:
+    if span_streaming:
+        items = capture_items("transaction", "span")
+
+        with patch.object(
+            llm.client._client._client,
+            "send",
+            side_effect=[tool_response, final_response],
+        ) as _, sentry_sdk.traces.start_span(name="custom parent"):
+            list(
+                agent_executor.invoke(
+                    {"input": "How many letters in the word eudca"},
+                    {"run_name": "my-snazzy-pipeline"},
+                )
+            )
+
+        sentry_sdk.flush()
+        spans = [item.payload for item in items if item.type == "span"]
+        assert spans[4]["attributes"]["sentry.origin"] == "manual"
+        invoke_agent_span = next(
+            x
+            for x in spans
+            if x["attributes"].get("sentry.op") == "gen_ai.invoke_agent"
+        )
+        chat_spans = list(
+            x for x in spans if x["attributes"].get("sentry.op") == "gen_ai.chat"
+        )
+        tool_exec_span = next(
+            x
+            for x in spans
+            if x["attributes"].get("sentry.op") == "gen_ai.execute_tool"
+        )
+
+        assert len(chat_spans) == 2
+
+        assert invoke_agent_span["attributes"]["sentry.origin"] == "auto.ai.langchain"
+        assert chat_spans[0]["attributes"]["sentry.origin"] == "auto.ai.langchain"
+        assert chat_spans[1]["attributes"]["sentry.origin"] == "auto.ai.langchain"
+        assert tool_exec_span["attributes"]["sentry.origin"] == "auto.ai.langchain"
+
+        assert (
+            invoke_agent_span["attributes"]["gen_ai.function_id"]
+            == "my-snazzy-pipeline"
+        )
+
+        # We can't guarantee anything about the "shape" of the langchain execution graph
+        assert (
+            len(
+                list(
+                    x
+                    for x in spans
+                    if x["attributes"].get("sentry.op") == "gen_ai.chat"
+                )
+            )
+            > 0
+        )
+
+        # Token usage is only available in newer versions of langchain (v0.2+)
+        # where usage_metadata is supported on AIMessageChunk
+        if "gen_ai.usage.input_tokens" in chat_spans[0]["attributes"]:
+            assert chat_spans[0]["attributes"]["gen_ai.usage.input_tokens"] == 142
+            assert chat_spans[0]["attributes"]["gen_ai.usage.output_tokens"] == 50
+            assert chat_spans[0]["attributes"]["gen_ai.usage.total_tokens"] == 192
+
+        if "gen_ai.usage.input_tokens" in chat_spans[1]["attributes"]:
+            assert chat_spans[1]["attributes"]["gen_ai.usage.input_tokens"] == 89
+            assert chat_spans[1]["attributes"]["gen_ai.usage.output_tokens"] == 28
+            assert chat_spans[1]["attributes"]["gen_ai.usage.total_tokens"] == 117
+
+        assert SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS not in chat_spans[0].get(
+            "attributes", {}
+        )
+        assert SPANDATA.GEN_AI_REQUEST_MESSAGES not in chat_spans[0].get(
+            "attributes", {}
+        )
+        assert SPANDATA.GEN_AI_RESPONSE_TEXT not in chat_spans[0].get("attributes", {})
+        assert SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS not in chat_spans[1].get(
+            "attributes", {}
+        )
+        assert SPANDATA.GEN_AI_REQUEST_MESSAGES not in chat_spans[1].get(
+            "attributes", {}
+        )
+        assert SPANDATA.GEN_AI_RESPONSE_TEXT not in chat_spans[1].get("attributes", {})
+        assert SPANDATA.GEN_AI_TOOL_INPUT not in tool_exec_span.get("attributes", {})
+        assert SPANDATA.GEN_AI_TOOL_OUTPUT not in tool_exec_span.get("attributes", {})
+
+        # Verify tool calls are NOT recorded when PII is disabled
+        assert SPANDATA.GEN_AI_RESPONSE_TOOL_CALLS not in chat_spans[0].get(
+            "attributes", {}
+        ), (
+            f"Tool calls should NOT be recorded when send_default_pii={send_default_pii} "
+            f"and include_prompts={include_prompts}"
+        )
+        assert SPANDATA.GEN_AI_RESPONSE_TOOL_CALLS not in chat_spans[1].get(
+            "attributes", {}
+        ), (
+            f"Tool calls should NOT be recorded when send_default_pii={send_default_pii} "
+            f"and include_prompts={include_prompts}"
+        )
+
+        # Verify finish_reasons is always an array of strings
+        assert chat_spans[0]["attributes"][SPANDATA.GEN_AI_RESPONSE_FINISH_REASONS] == [
+            "function_call"
+        ]
+        assert chat_spans[1]["attributes"][SPANDATA.GEN_AI_RESPONSE_FINISH_REASONS] == [
+            "stop"
+        ]
+
+        # Verify that available tools are always recorded regardless of PII settings
+        for chat_span in chat_spans:
+            tools_data = chat_span["attributes"][
+                SPANDATA.GEN_AI_REQUEST_AVAILABLE_TOOLS
+            ]
+            assert tools_data is not None, (
+                "Available tools should always be recorded regardless of PII settings"
+            )
+            assert "get_word_length" in tools_data
+    elif stream_gen_ai_spans:
         items = capture_items("transaction", "span")
 
         with patch.object(
@@ -1389,7 +1708,122 @@ def test_langchain_openai_tools_agent(
 
     agent_executor = AgentExecutor(agent=agent, tools=[get_word_length], verbose=True)
 
-    if span_streaming or stream_gen_ai_spans:
+    if span_streaming:
+        items = capture_items("transaction", "span")
+
+        with patch.object(
+            llm.client._client._client,
+            "send",
+            side_effect=[tool_response, final_response],
+        ) as _, sentry_sdk.traces.start_span(name="custom parent"):
+            list(
+                agent_executor.stream(
+                    {
+                        "input": [
+                            "Message demonstrating the absence of truncation.",
+                            "How many letters in the word eudca",
+                        ]
+                    }
+                )
+            )
+
+        sentry_sdk.flush()
+        spans = [item.payload for item in items if item.type == "span"]
+        assert spans[3]["attributes"]["sentry.origin"] == "manual"
+        invoke_agent_span = next(
+            x
+            for x in spans
+            if x["attributes"].get("sentry.op") == "gen_ai.invoke_agent"
+        )
+        chat_spans = list(
+            x for x in spans if x["attributes"].get("sentry.op") == "gen_ai.chat"
+        )
+        tool_exec_span = next(
+            x
+            for x in spans
+            if x["attributes"].get("sentry.op") == "gen_ai.execute_tool"
+        )
+
+        assert len(chat_spans) == 2
+
+        assert invoke_agent_span["attributes"]["sentry.origin"] == "auto.ai.langchain"
+        assert chat_spans[0]["attributes"]["sentry.origin"] == "auto.ai.langchain"
+        assert chat_spans[1]["attributes"]["sentry.origin"] == "auto.ai.langchain"
+        assert tool_exec_span["attributes"]["sentry.origin"] == "auto.ai.langchain"
+
+        # We can't guarantee anything about the "shape" of the langchain execution graph
+        assert (
+            len(list(x for x in spans if x["attributes"]["sentry.op"] == "gen_ai.chat"))
+            > 0
+        )
+
+        # Token usage is only available in newer versions of langchain (v0.2+)
+        # where usage_metadata is supported on AIMessageChunk
+        if "gen_ai.usage.input_tokens" in chat_spans[0]["attributes"]:
+            assert chat_spans[0]["attributes"]["gen_ai.usage.input_tokens"] == 142
+            assert chat_spans[0]["attributes"]["gen_ai.usage.output_tokens"] == 50
+            assert chat_spans[0]["attributes"]["gen_ai.usage.total_tokens"] == 192
+
+        if "gen_ai.usage.input_tokens" in chat_spans[1]["attributes"]:
+            assert chat_spans[1]["attributes"]["gen_ai.usage.input_tokens"] == 89
+            assert chat_spans[1]["attributes"]["gen_ai.usage.output_tokens"] == 28
+            assert chat_spans[1]["attributes"]["gen_ai.usage.total_tokens"] == 117
+
+        assert "5" in chat_spans[0]["attributes"][SPANDATA.GEN_AI_RESPONSE_TEXT]
+        assert "word" in tool_exec_span["attributes"][SPANDATA.GEN_AI_TOOL_INPUT]
+        assert 5 == int(tool_exec_span["attributes"][SPANDATA.GEN_AI_TOOL_OUTPUT])
+
+        assert json.loads(
+            chat_spans[0]["attributes"][SPANDATA.GEN_AI_REQUEST_MESSAGES]
+        ) == [
+            {
+                "role": "user",
+                "content": "['Message demonstrating the absence of truncation.', 'How many letters in the word eudca']",
+            }
+        ]
+
+        assert expected_system_instructions == json.loads(
+            chat_spans[0]["attributes"][SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS]
+        )
+
+        assert "5" in chat_spans[1]["attributes"][SPANDATA.GEN_AI_RESPONSE_TEXT]
+
+        # Verify tool calls are recorded when PII is enabled
+        assert SPANDATA.GEN_AI_RESPONSE_TOOL_CALLS in chat_spans[0].get(
+            "attributes", {}
+        ), (
+            "Tool calls should be recorded when send_default_pii=True and include_prompts=True"
+        )
+        tool_calls_data = chat_spans[0]["attributes"][
+            SPANDATA.GEN_AI_RESPONSE_TOOL_CALLS
+        ]
+
+        assert isinstance(tool_calls_data, (list, str))  # Could be serialized
+        if isinstance(tool_calls_data, str):
+            assert "get_word_length" in tool_calls_data
+        elif isinstance(tool_calls_data, list) and len(tool_calls_data) > 0:
+            # Check if tool calls contain expected function name
+            tool_call_str = str(tool_calls_data)
+            assert "get_word_length" in tool_call_str
+
+        # Verify finish_reasons is always an array of strings
+        assert chat_spans[0]["attributes"][SPANDATA.GEN_AI_RESPONSE_FINISH_REASONS] == [
+            "function_call"
+        ]
+        assert chat_spans[1]["attributes"][SPANDATA.GEN_AI_RESPONSE_FINISH_REASONS] == [
+            "stop"
+        ]
+
+        # Verify that available tools are always recorded regardless of PII settings
+        for chat_span in chat_spans:
+            tools_data = chat_span["attributes"][
+                SPANDATA.GEN_AI_REQUEST_AVAILABLE_TOOLS
+            ]
+            assert tools_data is not None, (
+                "Available tools should always be recorded regardless of PII settings"
+            )
+            assert "get_word_length" in tools_data
+    elif stream_gen_ai_spans:
         items = capture_items("transaction", "span")
 
         with patch.object(
@@ -1771,7 +2205,116 @@ def test_langchain_openai_tools_agent_stream_no_prompts(
 
     agent_executor = AgentExecutor(agent=agent, tools=[get_word_length], verbose=True)
 
-    if span_streaming or stream_gen_ai_spans:
+    if span_streaming:
+        items = capture_items("transaction", "span")
+
+        with patch.object(
+            llm.client._client._client,
+            "send",
+            side_effect=[tool_response, final_response],
+        ) as _, sentry_sdk.traces.start_span(name="custom parent"):
+            list(
+                agent_executor.stream(
+                    {"input": "How many letters in the word eudca"},
+                    {"run_name": "my-snazzy-pipeline"},
+                )
+            )
+
+        sentry_sdk.flush()
+        spans = [item.payload for item in items if item.type == "span"]
+        assert spans[3]["attributes"]["sentry.origin"] == "manual"
+        invoke_agent_span = next(
+            x for x in spans if x["attributes"]["sentry.op"] == "gen_ai.invoke_agent"
+        )
+        chat_spans = list(
+            x for x in spans if x["attributes"]["sentry.op"] == "gen_ai.chat"
+        )
+        tool_exec_span = next(
+            x for x in spans if x["attributes"]["sentry.op"] == "gen_ai.execute_tool"
+        )
+
+        assert len(chat_spans) == 2
+
+        assert invoke_agent_span["attributes"]["sentry.origin"] == "auto.ai.langchain"
+        assert chat_spans[0]["attributes"]["sentry.origin"] == "auto.ai.langchain"
+        assert chat_spans[1]["attributes"]["sentry.origin"] == "auto.ai.langchain"
+        assert tool_exec_span["attributes"]["sentry.origin"] == "auto.ai.langchain"
+
+        assert (
+            invoke_agent_span["attributes"]["gen_ai.function_id"]
+            == "my-snazzy-pipeline"
+        )
+
+        sentry_sdk.flush()
+        spans = [item.payload for item in items if item.type == "span"]
+        # We can't guarantee anything about the "shape" of the langchain execution graph
+        assert (
+            len(list(x for x in spans if x["attributes"]["sentry.op"] == "gen_ai.chat"))
+            > 0
+        )
+
+        # Token usage is only available in newer versions of langchain (v0.2+)
+        # where usage_metadata is supported on AIMessageChunk
+        if "gen_ai.usage.input_tokens" in chat_spans[0]["attributes"]:
+            assert chat_spans[0]["attributes"]["gen_ai.usage.input_tokens"] == 142
+            assert chat_spans[0]["attributes"]["gen_ai.usage.output_tokens"] == 50
+            assert chat_spans[0]["attributes"]["gen_ai.usage.total_tokens"] == 192
+
+        if "gen_ai.usage.input_tokens" in chat_spans[1]["attributes"]:
+            assert chat_spans[1]["attributes"]["gen_ai.usage.input_tokens"] == 89
+            assert chat_spans[1]["attributes"]["gen_ai.usage.output_tokens"] == 28
+            assert chat_spans[1]["attributes"]["gen_ai.usage.total_tokens"] == 117
+
+        assert SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS not in chat_spans[0].get(
+            "attributes", {}
+        )
+        assert SPANDATA.GEN_AI_REQUEST_MESSAGES not in chat_spans[0].get(
+            "attributes", {}
+        )
+        assert SPANDATA.GEN_AI_RESPONSE_TEXT not in chat_spans[0].get("attributes", {})
+        assert SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS not in chat_spans[1].get(
+            "attributes", {}
+        )
+        assert SPANDATA.GEN_AI_REQUEST_MESSAGES not in chat_spans[1].get(
+            "attributes", {}
+        )
+        assert SPANDATA.GEN_AI_RESPONSE_TEXT not in chat_spans[1].get("attributes", {})
+        assert SPANDATA.GEN_AI_TOOL_INPUT not in tool_exec_span.get("attributes", {})
+        assert SPANDATA.GEN_AI_TOOL_OUTPUT not in tool_exec_span.get("attributes", {})
+
+        # Verify tool calls are NOT recorded when PII is disabled
+        assert SPANDATA.GEN_AI_RESPONSE_TOOL_CALLS not in chat_spans[0].get(
+            "attributes", {}
+        ), (
+            f"Tool calls should NOT be recorded when send_default_pii={send_default_pii} "
+            f"and include_prompts={include_prompts}"
+        )
+        assert SPANDATA.GEN_AI_RESPONSE_TOOL_CALLS not in chat_spans[1].get(
+            "attributes", {}
+        ), (
+            f"Tool calls should NOT be recorded when send_default_pii={send_default_pii} "
+            f"and include_prompts={include_prompts}"
+        )
+
+        # Verify finish_reasons is always an array of strings
+        assert chat_spans[0]["attributes"][SPANDATA.GEN_AI_RESPONSE_FINISH_REASONS] == [
+            "function_call"
+        ]
+        assert chat_spans[1]["attributes"][SPANDATA.GEN_AI_RESPONSE_FINISH_REASONS] == [
+            "stop"
+        ]
+
+        # Verify that available tools are always recorded regardless of PII settings
+        for chat_span in chat_spans:
+            tools_data = chat_span["attributes"][
+                SPANDATA.GEN_AI_REQUEST_AVAILABLE_TOOLS
+            ]
+
+            assert tools_data is not None, (
+                "Available tools should always be recorded regardless of PII settings"
+            )
+            assert "get_word_length" in tools_data
+    elif stream_gen_ai_spans:
         items = capture_items("transaction", "span")
 
         with patch.object(
@@ -2080,7 +2623,124 @@ def test_langchain_openai_tools_agent_stream(
 
     agent_executor = AgentExecutor(agent=agent, tools=[get_word_length], verbose=True)
 
-    if span_streaming or stream_gen_ai_spans:
+    if span_streaming:
+        items = capture_items("transaction", "span")
+
+        with patch.object(
+            llm.client._client._client,
+            "send",
+            side_effect=[tool_response, final_response],
+        ) as _, sentry_sdk.traces.start_span(name="custom parent"):
+            list(
+                agent_executor.stream(
+                    {
+                        "input": [
+                            "Message demonstrating the absence of truncation.",
+                            "How many letters in the word eudca",
+                        ]
+                    },
+                    {"run_name": "my-snazzy-pipeline"},
+                )
+            )
+
+        sentry_sdk.flush()
+        spans = [item.payload for item in items if item.type == "span"]
+        assert spans[3]["attributes"]["sentry.origin"] == "manual"
+        invoke_agent_span = next(
+            x for x in spans if x["attributes"]["sentry.op"] == "gen_ai.invoke_agent"
+        )
+        chat_spans = list(
+            x for x in spans if x["attributes"]["sentry.op"] == "gen_ai.chat"
+        )
+        tool_exec_span = next(
+            x for x in spans if x["attributes"]["sentry.op"] == "gen_ai.execute_tool"
+        )
+
+        assert len(chat_spans) == 2
+
+        assert invoke_agent_span["attributes"]["sentry.origin"] == "auto.ai.langchain"
+        assert chat_spans[0]["attributes"]["sentry.origin"] == "auto.ai.langchain"
+        assert chat_spans[1]["attributes"]["sentry.origin"] == "auto.ai.langchain"
+        assert tool_exec_span["attributes"]["sentry.origin"] == "auto.ai.langchain"
+
+        assert (
+            invoke_agent_span["attributes"]["gen_ai.function_id"]
+            == "my-snazzy-pipeline"
+        )
+
+        # We can't guarantee anything about the "shape" of the langchain execution graph
+        assert (
+            len(list(x for x in spans if x["attributes"]["sentry.op"] == "gen_ai.chat"))
+            > 0
+        )
+
+        # Token usage is only available in newer versions of langchain (v0.2+)
+        # where usage_metadata is supported on AIMessageChunk
+        if "gen_ai.usage.input_tokens" in chat_spans[0]["attributes"]:
+            assert chat_spans[0]["attributes"]["gen_ai.usage.input_tokens"] == 142
+            assert chat_spans[0]["attributes"]["gen_ai.usage.output_tokens"] == 50
+            assert chat_spans[0]["attributes"]["gen_ai.usage.total_tokens"] == 192
+
+        if "gen_ai.usage.input_tokens" in chat_spans[1]["attributes"]:
+            assert chat_spans[1]["attributes"]["gen_ai.usage.input_tokens"] == 89
+            assert chat_spans[1]["attributes"]["gen_ai.usage.output_tokens"] == 28
+            assert chat_spans[1]["attributes"]["gen_ai.usage.total_tokens"] == 117
+
+        assert "5" in chat_spans[0]["attributes"][SPANDATA.GEN_AI_RESPONSE_TEXT]
+        assert "word" in tool_exec_span["attributes"][SPANDATA.GEN_AI_TOOL_INPUT]
+        assert 5 == int(tool_exec_span["attributes"][SPANDATA.GEN_AI_TOOL_OUTPUT])
+
+        assert json.loads(
+            chat_spans[0]["attributes"][SPANDATA.GEN_AI_REQUEST_MESSAGES]
+        ) == [
+            {
+                "role": "user",
+                "content": "['Message demonstrating the absence of truncation.', 'How many letters in the word eudca']",
+            }
+        ]
+
+        assert expected_system_instructions == json.loads(
+            chat_spans[0]["attributes"][SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS]
+        )
+
+        assert "5" in chat_spans[1]["attributes"][SPANDATA.GEN_AI_RESPONSE_TEXT]
+
+        # Verify tool calls are recorded when PII is enabled
+        assert SPANDATA.GEN_AI_RESPONSE_TOOL_CALLS in chat_spans[0].get(
+            "attributes", {}
+        ), (
+            "Tool calls should be recorded when send_default_pii=True and include_prompts=True"
+        )
+        tool_calls_data = chat_spans[0]["attributes"][
+            SPANDATA.GEN_AI_RESPONSE_TOOL_CALLS
+        ]
+
+        assert isinstance(tool_calls_data, (list, str))  # Could be serialized
+        if isinstance(tool_calls_data, str):
+            assert "get_word_length" in tool_calls_data
+        elif isinstance(tool_calls_data, list) and len(tool_calls_data) > 0:
+            # Check if tool calls contain expected function name
+            tool_call_str = str(tool_calls_data)
+            assert "get_word_length" in tool_call_str
+
+        # Verify finish_reasons is always an array of strings
+        assert chat_spans[0]["attributes"][SPANDATA.GEN_AI_RESPONSE_FINISH_REASONS] == [
+            "function_call"
+        ]
+        assert chat_spans[1]["attributes"][SPANDATA.GEN_AI_RESPONSE_FINISH_REASONS] == [
+            "stop"
+        ]
+
+        # Verify that available tools are always recorded regardless of PII settings
+        for chat_span in chat_spans:
+            tools_data = chat_span["attributes"][
+                SPANDATA.GEN_AI_REQUEST_AVAILABLE_TOOLS
+            ]
+            assert tools_data is not None, (
+                "Available tools should always be recorded regardless of PII settings"
+            )
+            assert "get_word_length" in tools_data
+    elif stream_gen_ai_spans:
         items = capture_items("transaction", "span")
 
         with patch.object(
@@ -2353,7 +3013,31 @@ def test_langchain_openai_tools_agent_stream_with_config(
 
     agent_executor = AgentExecutor(agent=agent, tools=[get_word_length], verbose=True)
 
-    if span_streaming or stream_gen_ai_spans:
+    if span_streaming:
+        items = capture_items("transaction", "span")
+
+        with patch.object(
+            llm.client._client._client,
+            "send",
+            side_effect=[tool_response, final_response],
+        ) as _, sentry_sdk.traces.start_span(name="custom parent"):
+            list(
+                agent_executor.stream(
+                    {"input": "How many letters in the word eudca"},
+                )
+            )
+
+        sentry_sdk.flush()
+        spans = [item.payload for item in items if item.type == "span"]
+        assert spans[4]["attributes"]["sentry.origin"] == "manual"
+        invoke_agent_span = next(
+            x for x in spans if x["attributes"]["sentry.op"] == "gen_ai.invoke_agent"
+        )
+        assert (
+            invoke_agent_span["attributes"]["gen_ai.function_id"]
+            == "my-snazzy-pipeline"
+        )
+    elif stream_gen_ai_spans:
         items = capture_items("transaction", "span")
 
         with patch.object(
@@ -2506,7 +3190,45 @@ def test_span_status_error(
         stream_gen_ai_spans=stream_gen_ai_spans,
         _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
     )
-    if span_streaming or stream_gen_ai_spans:
+
+    if span_streaming:
+        items = capture_items("event", "transaction", "span")
+
+        with start_transaction(name="test"):
+            prompt = ChatPromptTemplate.from_messages(
+                [
+                    (
+                        "system",
+                        "You are very powerful assistant, but don't know current events",
+                    ),
+                    ("user", "{input}"),
+                    MessagesPlaceholder(variable_name="agent_scratchpad"),
+                ]
+            )
+            llm = MockOpenAI(
+                model_name="gpt-3.5-turbo",
+                temperature=0,
+                openai_api_key="badkey",
+            )
+            agent = create_openai_tools_agent(llm, [get_word_length], prompt)
+
+            agent_executor = AgentExecutor(
+                agent=agent, tools=[get_word_length], verbose=True
+            )
+
+            with pytest.raises(ValueError):
+                list(
+                    agent_executor.stream(
+                        {"input": "How many letters in the word eudca"}
+                    )
+                )
+
+        (error,) = (item.payload for item in items if item.type == "event")
+        assert error["level"] == "error"
+        sentry_sdk.flush()
+        spans = [item.payload for item in items if item.type == "span"]
+        assert spans[0]["status"] == "error"
+    elif stream_gen_ai_spans:
         items = capture_items("event", "transaction", "span")
 
         with start_transaction(name="test"):

--- a/tests/integrations/langchain/test_langchain.py
+++ b/tests/integrations/langchain/test_langchain.py
@@ -29,6 +29,7 @@ from sentry_sdk.integrations.langchain import (
     _transform_langchain_content_block,
     _transform_langchain_message_content,
 )
+from sentry_sdk.integrations.stdlib import StdlibIntegration
 from sentry_sdk.utils import package_version
 
 try:
@@ -252,6 +253,7 @@ def test_langchain_text_completion(
                 include_prompts=True,
             )
         ],
+        disabled_integrations=[StdlibIntegration],
         traces_sample_rate=1.0,
         send_default_pii=True,
         stream_gen_ai_spans=stream_gen_ai_spans,
@@ -406,6 +408,7 @@ def test_langchain_chat_with_run_name(
                 include_prompts=True,
             )
         ],
+        disabled_integrations=[StdlibIntegration],
         traces_sample_rate=1.0,
         send_default_pii=True,
         stream_gen_ai_spans=stream_gen_ai_spans,
@@ -499,6 +502,7 @@ def test_langchain_tool_call_with_run_name(
                 include_prompts=True,
             )
         ],
+        disabled_integrations=[StdlibIntegration],
         traces_sample_rate=1.0,
         send_default_pii=True,
         stream_gen_ai_spans=stream_gen_ai_spans,
@@ -604,6 +608,7 @@ def test_langchain_create_agent(
                 include_prompts=include_prompts,
             )
         ],
+        disabled_integrations=[StdlibIntegration],
         traces_sample_rate=1.0,
         send_default_pii=send_default_pii,
         stream_gen_ai_spans=stream_gen_ai_spans,
@@ -850,6 +855,7 @@ def test_tool_execution_span(
                 include_prompts=include_prompts,
             )
         ],
+        disabled_integrations=[StdlibIntegration],
         traces_sample_rate=1.0,
         send_default_pii=send_default_pii,
         stream_gen_ai_spans=stream_gen_ai_spans,
@@ -936,7 +942,7 @@ def test_tool_execution_span(
 
         sentry_sdk.flush()
         spans = [item.payload for item in items if item.type == "span"]
-        assert spans[3]["attributes"]["sentry.origin"] == "manual"
+        assert spans[4]["attributes"]["sentry.origin"] == "manual"
         chat_spans = list(
             x for x in spans if x["attributes"].get("sentry.op") == "gen_ai.chat"
         )
@@ -1042,7 +1048,6 @@ def test_tool_execution_span(
 
         sentry_sdk.flush()
         spans = [item.payload for item in items if item.type == "span"]
-        assert spans[4]["attributes"]["sentry.origin"] == "manual"
         chat_spans = list(
             x for x in spans if x["attributes"]["sentry.op"] == "gen_ai.chat"
         )
@@ -1245,6 +1250,7 @@ def test_langchain_openai_tools_agent_no_prompts(
                 include_prompts=include_prompts,
             )
         ],
+        disabled_integrations=[StdlibIntegration],
         traces_sample_rate=1.0,
         send_default_pii=send_default_pii,
         stream_gen_ai_spans=stream_gen_ai_spans,
@@ -1666,6 +1672,7 @@ def test_langchain_openai_tools_agent(
                 include_prompts=True,
             )
         ],
+        disabled_integrations=[StdlibIntegration],
         traces_sample_rate=1.0,
         send_default_pii=True,
         stream_gen_ai_spans=stream_gen_ai_spans,
@@ -1729,7 +1736,7 @@ def test_langchain_openai_tools_agent(
 
         sentry_sdk.flush()
         spans = [item.payload for item in items if item.type == "span"]
-        assert spans[3]["attributes"]["sentry.origin"] == "manual"
+        assert spans[4]["attributes"]["sentry.origin"] == "manual"
         invoke_agent_span = next(
             x
             for x in spans
@@ -1753,7 +1760,13 @@ def test_langchain_openai_tools_agent(
 
         # We can't guarantee anything about the "shape" of the langchain execution graph
         assert (
-            len(list(x for x in spans if x["attributes"]["sentry.op"] == "gen_ai.chat"))
+            len(
+                list(
+                    x
+                    for x in spans
+                    if x["attributes"].get("sentry.op") == "gen_ai.chat"
+                )
+            )
             > 0
         )
 
@@ -2040,6 +2053,7 @@ def test_langchain_openai_tools_agent_with_config(
                 include_prompts=True,
             )
         ],
+        disabled_integrations=[StdlibIntegration],
         traces_sample_rate=1.0,
         send_default_pii=True,
         stream_gen_ai_spans=stream_gen_ai_spans,
@@ -2084,7 +2098,33 @@ def test_langchain_openai_tools_agent_with_config(
 
     agent_executor = AgentExecutor(agent=agent, tools=[get_word_length], verbose=True)
 
-    if span_streaming or stream_gen_ai_spans:
+    if span_streaming:
+        items = capture_items("transaction", "span")
+
+        with patch.object(
+            llm.client._client._client,
+            "send",
+            side_effect=[tool_response, final_response],
+        ) as _, sentry_sdk.traces.start_span(name="custom parent"):
+            list(
+                agent_executor.invoke(
+                    {"input": "How many letters in the word eudca"},
+                )
+            )
+
+        sentry_sdk.flush()
+        spans = [item.payload for item in items if item.type == "span"]
+        assert spans[4]["attributes"]["sentry.origin"] == "manual"
+        invoke_agent_span = next(
+            x
+            for x in spans
+            if x["attributes"].get("sentry.op") == "gen_ai.invoke_agent"
+        )
+        assert (
+            invoke_agent_span["attributes"]["gen_ai.function_id"]
+            == "my-snazzy-pipeline"
+        )
+    elif stream_gen_ai_spans:
         items = capture_items("transaction", "span")
 
         with patch.object(
@@ -2163,6 +2203,7 @@ def test_langchain_openai_tools_agent_stream_no_prompts(
                 include_prompts=include_prompts,
             )
         ],
+        disabled_integrations=[StdlibIntegration],
         traces_sample_rate=1.0,
         send_default_pii=send_default_pii,
         stream_gen_ai_spans=stream_gen_ai_spans,
@@ -2222,15 +2263,19 @@ def test_langchain_openai_tools_agent_stream_no_prompts(
 
         sentry_sdk.flush()
         spans = [item.payload for item in items if item.type == "span"]
-        assert spans[3]["attributes"]["sentry.origin"] == "manual"
+        assert spans[4]["attributes"]["sentry.origin"] == "manual"
         invoke_agent_span = next(
-            x for x in spans if x["attributes"]["sentry.op"] == "gen_ai.invoke_agent"
+            x
+            for x in spans
+            if x["attributes"].get("sentry.op") == "gen_ai.invoke_agent"
         )
         chat_spans = list(
-            x for x in spans if x["attributes"]["sentry.op"] == "gen_ai.chat"
+            x for x in spans if x["attributes"].get("sentry.op") == "gen_ai.chat"
         )
         tool_exec_span = next(
-            x for x in spans if x["attributes"]["sentry.op"] == "gen_ai.execute_tool"
+            x
+            for x in spans
+            if x["attributes"].get("sentry.op") == "gen_ai.execute_tool"
         )
 
         assert len(chat_spans) == 2
@@ -2249,7 +2294,13 @@ def test_langchain_openai_tools_agent_stream_no_prompts(
         spans = [item.payload for item in items if item.type == "span"]
         # We can't guarantee anything about the "shape" of the langchain execution graph
         assert (
-            len(list(x for x in spans if x["attributes"]["sentry.op"] == "gen_ai.chat"))
+            len(
+                list(
+                    x
+                    for x in spans
+                    if x["attributes"].get("sentry.op") == "gen_ai.chat"
+                )
+            )
             > 0
         )
 
@@ -2581,6 +2632,7 @@ def test_langchain_openai_tools_agent_stream(
                 include_prompts=True,
             )
         ],
+        disabled_integrations=[StdlibIntegration],
         traces_sample_rate=1.0,
         send_default_pii=True,
         stream_gen_ai_spans=stream_gen_ai_spans,
@@ -2645,15 +2697,19 @@ def test_langchain_openai_tools_agent_stream(
 
         sentry_sdk.flush()
         spans = [item.payload for item in items if item.type == "span"]
-        assert spans[3]["attributes"]["sentry.origin"] == "manual"
+        assert spans[4]["attributes"]["sentry.origin"] == "manual"
         invoke_agent_span = next(
-            x for x in spans if x["attributes"]["sentry.op"] == "gen_ai.invoke_agent"
+            x
+            for x in spans
+            if x["attributes"].get("sentry.op") == "gen_ai.invoke_agent"
         )
         chat_spans = list(
-            x for x in spans if x["attributes"]["sentry.op"] == "gen_ai.chat"
+            x for x in spans if x["attributes"].get("sentry.op") == "gen_ai.chat"
         )
         tool_exec_span = next(
-            x for x in spans if x["attributes"]["sentry.op"] == "gen_ai.execute_tool"
+            x
+            for x in spans
+            if x["attributes"].get("sentry.op") == "gen_ai.execute_tool"
         )
 
         assert len(chat_spans) == 2
@@ -2670,7 +2726,13 @@ def test_langchain_openai_tools_agent_stream(
 
         # We can't guarantee anything about the "shape" of the langchain execution graph
         assert (
-            len(list(x for x in spans if x["attributes"]["sentry.op"] == "gen_ai.chat"))
+            len(
+                list(
+                    x
+                    for x in spans
+                    if x["attributes"].get("sentry.op") == "gen_ai.chat"
+                )
+            )
             > 0
         )
 
@@ -2969,6 +3031,7 @@ def test_langchain_openai_tools_agent_stream_with_config(
                 include_prompts=True,
             )
         ],
+        disabled_integrations=[StdlibIntegration],
         traces_sample_rate=1.0,
         send_default_pii=True,
         stream_gen_ai_spans=stream_gen_ai_spans,
@@ -3116,6 +3179,7 @@ def test_langchain_error(
 
     sentry_init(
         integrations=[LangchainIntegration(include_prompts=True)],
+        disabled_integrations=[StdlibIntegration],
         traces_sample_rate=1.0,
         send_default_pii=True,
         stream_gen_ai_spans=stream_gen_ai_spans,
@@ -3186,6 +3250,7 @@ def test_span_status_error(
 
     sentry_init(
         integrations=[LangchainIntegration(include_prompts=True)],
+        disabled_integrations=[StdlibIntegration],
         traces_sample_rate=1.0,
         stream_gen_ai_spans=stream_gen_ai_spans,
         _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
@@ -3349,7 +3414,9 @@ def test_manual_callback_no_duplication(sentry_init):
             return {}
 
     sentry_init(
-        integrations=[LangchainIntegration()], _experiments={"gen_ai_as_v2_spans": True}
+        integrations=[LangchainIntegration()],
+        disabled_integrations=[StdlibIntegration],
+        _experiments={"gen_ai_as_v2_spans": True},
     )
 
     # Create a manual SentryLangchainCallback
@@ -3390,6 +3457,7 @@ def test_span_map_is_instance_variable():
 def test_langchain_callback_manager(sentry_init):
     sentry_init(
         integrations=[LangchainIntegration()],
+        disabled_integrations=[StdlibIntegration],
         traces_sample_rate=1.0,
     )
     local_manager = BaseCallbackManager(handlers=[])
@@ -3422,6 +3490,7 @@ def test_langchain_callback_manager(sentry_init):
 def test_langchain_callback_manager_with_sentry_callback(sentry_init):
     sentry_init(
         integrations=[LangchainIntegration()],
+        disabled_integrations=[StdlibIntegration],
         traces_sample_rate=1.0,
     )
     sentry_callback = SentryLangchainCallback(0, False)
@@ -3454,6 +3523,7 @@ def test_langchain_callback_manager_with_sentry_callback(sentry_init):
 def test_langchain_callback_list(sentry_init):
     sentry_init(
         integrations=[LangchainIntegration()],
+        disabled_integrations=[StdlibIntegration],
         traces_sample_rate=1.0,
     )
     local_callbacks = []
@@ -3486,6 +3556,7 @@ def test_langchain_callback_list(sentry_init):
 def test_langchain_callback_list_existing_callback(sentry_init):
     sentry_init(
         integrations=[LangchainIntegration()],
+        disabled_integrations=[StdlibIntegration],
         traces_sample_rate=1.0,
     )
     sentry_callback = SentryLangchainCallback(0, False)
@@ -3554,6 +3625,7 @@ def test_langchain_message_role_mapping(
 
     sentry_init(
         integrations=[LangchainIntegration(include_prompts=True)],
+        disabled_integrations=[StdlibIntegration],
         traces_sample_rate=1.0,
         send_default_pii=True,
         stream_gen_ai_spans=stream_gen_ai_spans,
@@ -3740,6 +3812,7 @@ def test_langchain_message_truncation(sentry_init, capture_events):
 
     sentry_init(
         integrations=[LangchainIntegration(include_prompts=True)],
+        disabled_integrations=[StdlibIntegration],
         traces_sample_rate=1.0,
         send_default_pii=True,
         stream_gen_ai_spans=False,
@@ -3841,6 +3914,7 @@ def test_langchain_embeddings_sync(
 
     sentry_init(
         integrations=[LangchainIntegration(include_prompts=include_prompts)],
+        disabled_integrations=[StdlibIntegration],
         traces_sample_rate=1.0,
         send_default_pii=send_default_pii,
         stream_gen_ai_spans=stream_gen_ai_spans,
@@ -3991,6 +4065,7 @@ def test_langchain_embeddings_embed_query(
 
     sentry_init(
         integrations=[LangchainIntegration(include_prompts=include_prompts)],
+        disabled_integrations=[StdlibIntegration],
         traces_sample_rate=1.0,
         send_default_pii=send_default_pii,
         stream_gen_ai_spans=stream_gen_ai_spans,
@@ -4132,6 +4207,7 @@ async def test_langchain_embeddings_async(
 
     sentry_init(
         integrations=[LangchainIntegration(include_prompts=include_prompts)],
+        disabled_integrations=[StdlibIntegration],
         traces_sample_rate=1.0,
         send_default_pii=send_default_pii,
         stream_gen_ai_spans=stream_gen_ai_spans,
@@ -4285,6 +4361,7 @@ async def test_langchain_embeddings_aembed_query(
 
     sentry_init(
         integrations=[LangchainIntegration(include_prompts=True)],
+        disabled_integrations=[StdlibIntegration],
         traces_sample_rate=1.0,
         send_default_pii=True,
         stream_gen_ai_spans=stream_gen_ai_spans,
@@ -4405,6 +4482,7 @@ def test_langchain_embeddings_no_model_name(
 
     sentry_init(
         integrations=[LangchainIntegration(include_prompts=False)],
+        disabled_integrations=[StdlibIntegration],
         traces_sample_rate=1.0,
         stream_gen_ai_spans=stream_gen_ai_spans,
         _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
@@ -4508,6 +4586,7 @@ def test_langchain_embeddings_integration_disabled(
         pytest.skip("langchain_openai not installed")
 
     sentry_init(
+        disabled_integrations=[StdlibIntegration],
         traces_sample_rate=1.0,
         stream_gen_ai_spans=stream_gen_ai_spans,
         _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
@@ -4583,6 +4662,7 @@ def test_langchain_embeddings_multiple_providers(
 
     sentry_init(
         integrations=[LangchainIntegration(include_prompts=True)],
+        disabled_integrations=[StdlibIntegration],
         traces_sample_rate=1.0,
         send_default_pii=True,
         stream_gen_ai_spans=stream_gen_ai_spans,
@@ -4694,6 +4774,7 @@ def test_langchain_embeddings_error_handling(sentry_init, capture_events):
 
     sentry_init(
         integrations=[LangchainIntegration(include_prompts=True)],
+        disabled_integrations=[StdlibIntegration],
         traces_sample_rate=1.0,
         send_default_pii=True,
     )
@@ -4740,6 +4821,7 @@ def test_langchain_embeddings_multiple_calls(
 
     sentry_init(
         integrations=[LangchainIntegration(include_prompts=True)],
+        disabled_integrations=[StdlibIntegration],
         traces_sample_rate=1.0,
         send_default_pii=True,
         stream_gen_ai_spans=stream_gen_ai_spans,
@@ -4868,6 +4950,7 @@ def test_langchain_embeddings_span_hierarchy(
 
     sentry_init(
         integrations=[LangchainIntegration(include_prompts=True)],
+        disabled_integrations=[StdlibIntegration],
         traces_sample_rate=1.0,
         send_default_pii=True,
         stream_gen_ai_spans=stream_gen_ai_spans,
@@ -5026,6 +5109,7 @@ def test_langchain_embeddings_with_list_and_string_inputs(
 
     sentry_init(
         integrations=[LangchainIntegration(include_prompts=True)],
+        disabled_integrations=[StdlibIntegration],
         traces_sample_rate=1.0,
         send_default_pii=True,
         stream_gen_ai_spans=stream_gen_ai_spans,
@@ -5152,6 +5236,7 @@ def test_langchain_response_model_extraction(
 ):
     sentry_init(
         integrations=[LangchainIntegration(include_prompts=True)],
+        disabled_integrations=[StdlibIntegration],
         traces_sample_rate=1.0,
         send_default_pii=True,
         stream_gen_ai_spans=stream_gen_ai_spans,
@@ -5512,6 +5597,7 @@ def test_langchain_ai_system_detection(
 ):
     sentry_init(
         integrations=[LangchainIntegration()],
+        disabled_integrations=[StdlibIntegration],
         traces_sample_rate=1.0,
         stream_gen_ai_spans=stream_gen_ai_spans,
         _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},

--- a/tests/integrations/litellm/test_litellm.py
+++ b/tests/integrations/litellm/test_litellm.py
@@ -398,7 +398,59 @@ async def test_async_nonstreaming_chat_completion(
         request_headers={"X-Stainless-Raw-Response": "true"},
     )
 
-    if span_streaming or stream_gen_ai_spans:
+    if span_streaming:
+        items = capture_items("transaction", "span")
+
+        with mock.patch.object(
+            client.completions._client._client,
+            "send",
+            return_value=model_response,
+        ), sentry_sdk.traces.start_span(name="litellm test"):
+            await litellm.acompletion(
+                model="gpt-3.5-turbo",
+                messages=messages,
+                client=client,
+            )
+
+            await GLOBAL_LOGGING_WORKER.flush()
+            await asyncio.sleep(0.5)
+
+        sentry_sdk.flush()
+        spans = [item.payload for item in items if item.type == "span"]
+        assert spans[2]["name"] == "litellm test"
+        chat_spans = list(
+            x
+            for x in spans
+            if x["attributes"].get("sentry.op") == OP.GEN_AI_CHAT
+            and x["attributes"].get("sentry.origin") == "auto.ai.litellm"
+        )
+        assert len(chat_spans) == 1
+        span = chat_spans[0]
+
+        assert span["attributes"]["sentry.op"] == OP.GEN_AI_CHAT
+        assert span["name"] == "chat gpt-3.5-turbo"
+        assert span["attributes"][SPANDATA.GEN_AI_REQUEST_MODEL] == "gpt-3.5-turbo"
+        assert span["attributes"][SPANDATA.GEN_AI_RESPONSE_MODEL] == "gpt-3.5-turbo"
+        assert span["attributes"][SPANDATA.GEN_AI_SYSTEM] == "openai"
+        assert span["attributes"][SPANDATA.GEN_AI_OPERATION_NAME] == "chat"
+
+        if send_default_pii and include_prompts:
+            assert json.loads(span["attributes"][SPANDATA.GEN_AI_REQUEST_MESSAGES]) == [
+                {
+                    "role": "user",
+                    "content": "Message demonstrating the absence of truncation.",
+                },
+                {"role": "user", "content": "Hello!"},
+            ]
+            assert SPANDATA.GEN_AI_RESPONSE_TEXT in span["attributes"]
+        else:
+            assert SPANDATA.GEN_AI_REQUEST_MESSAGES not in span["attributes"]
+            assert SPANDATA.GEN_AI_RESPONSE_TEXT not in span["attributes"]
+
+        assert span["attributes"][SPANDATA.GEN_AI_USAGE_INPUT_TOKENS] == 10
+        assert span["attributes"][SPANDATA.GEN_AI_USAGE_OUTPUT_TOKENS] == 20
+        assert span["attributes"][SPANDATA.GEN_AI_USAGE_TOTAL_TOKENS] == 30
+    elif stream_gen_ai_spans:
         items = capture_items("transaction", "span")
 
         with mock.patch.object(

--- a/tests/integrations/litellm/test_litellm.py
+++ b/tests/integrations/litellm/test_litellm.py
@@ -1987,7 +1987,78 @@ async def test_async_multiple_providers(
         request_headers={"X-Stainless-Raw-Response": "true"},
     )
 
-    if span_streaming or stream_gen_ai_spans:
+    if span_streaming:
+        items = capture_items("transaction", "span")
+
+        with mock.patch.object(
+            openai_client.completions._client._client,
+            "send",
+            return_value=openai_model_response,
+        ), sentry_sdk.traces.start_span(name="test gpt-3.5-turbo"):
+            await litellm.acompletion(
+                model="gpt-3.5-turbo",
+                messages=messages,
+                client=openai_client,
+            )
+
+            await GLOBAL_LOGGING_WORKER.flush()
+            await asyncio.sleep(0.5)
+
+        _reset_litellm_executor()
+
+        anthropic_client = AsyncHTTPHandler()
+        anthropic_model_response = get_model_response(
+            nonstreaming_anthropic_model_response,
+            serialize_pydantic=True,
+            request_headers={"X-Stainless-Raw-Response": "True"},
+        )
+
+        with mock.patch.object(
+            anthropic_client,
+            "post",
+            return_value=anthropic_model_response,
+        ), sentry_sdk.traces.start_span(name="test claude-3-opus-20240229"):
+            await litellm.acompletion(
+                model="claude-3-opus-20240229",
+                messages=messages,
+                client=anthropic_client,
+                api_key="test-key",
+            )
+
+            await GLOBAL_LOGGING_WORKER.flush()
+            await asyncio.sleep(0.5)
+
+        _reset_litellm_executor()
+
+        gemini_client = AsyncHTTPHandler()
+        gemini_model_response = get_model_response(
+            nonstreaming_google_genai_model_response,
+            serialize_pydantic=True,
+        )
+
+        with mock.patch.object(
+            gemini_client,
+            "post",
+            return_value=gemini_model_response,
+        ), sentry_sdk.traces.start_span(name="test gemini/gemini-pro"):
+            await litellm.acompletion(
+                model="gemini/gemini-pro",
+                messages=messages,
+                client=gemini_client,
+                api_key="test-key",
+            )
+
+            await GLOBAL_LOGGING_WORKER.flush()
+            await asyncio.sleep(0.5)
+
+        sentry_sdk.flush()
+        spans = [item.payload for item in items if item.type == "span"]
+        for span in spans:
+            if span["is_segment"] is True:
+                continue
+            # The provider should be detected by litellm.get_llm_provider
+            assert SPANDATA.GEN_AI_SYSTEM in span["attributes"]
+    elif stream_gen_ai_spans:
         items = capture_items("transaction", "span")
 
         with mock.patch.object(

--- a/tests/integrations/litellm/test_litellm.py
+++ b/tests/integrations/litellm/test_litellm.py
@@ -190,7 +190,58 @@ def test_nonstreaming_chat_completion(
         request_headers={"X-Stainless-Raw-Response": "true"},
     )
 
-    if span_streaming or stream_gen_ai_spans:
+    if span_streaming:
+        items = capture_items("transaction", "span")
+
+        with mock.patch.object(
+            client.completions._client._client,
+            "send",
+            return_value=model_response,
+        ), sentry_sdk.traces.start_span(name="litellm test"):
+            litellm.completion(
+                model="gpt-3.5-turbo",
+                messages=messages,
+                client=client,
+            )
+
+            litellm_utils.executor.shutdown(wait=True)
+
+        sentry_sdk.flush()
+        spans = [item.payload for item in items if item.type == "span"]
+        assert spans[2]["name"] == "litellm test"
+        chat_spans = list(
+            x
+            for x in spans
+            if x["attributes"].get("sentry.op") == OP.GEN_AI_CHAT
+            and x["attributes"].get("sentry.origin") == "auto.ai.litellm"
+        )
+        assert len(chat_spans) == 1
+        span = chat_spans[0]
+
+        assert span["attributes"]["sentry.op"] == OP.GEN_AI_CHAT
+        assert span["name"] == "chat gpt-3.5-turbo"
+        assert span["attributes"][SPANDATA.GEN_AI_REQUEST_MODEL] == "gpt-3.5-turbo"
+        assert span["attributes"][SPANDATA.GEN_AI_RESPONSE_MODEL] == "gpt-3.5-turbo"
+        assert span["attributes"][SPANDATA.GEN_AI_SYSTEM] == "openai"
+        assert span["attributes"][SPANDATA.GEN_AI_OPERATION_NAME] == "chat"
+
+        if send_default_pii and include_prompts:
+            assert json.loads(span["attributes"][SPANDATA.GEN_AI_REQUEST_MESSAGES]) == [
+                {
+                    "role": "user",
+                    "content": "Message demonstrating the absence of truncation.",
+                },
+                {"role": "user", "content": "Hello!"},
+            ]
+            assert SPANDATA.GEN_AI_RESPONSE_TEXT in span["attributes"]
+        else:
+            assert SPANDATA.GEN_AI_REQUEST_MESSAGES not in span["attributes"]
+            assert SPANDATA.GEN_AI_RESPONSE_TEXT not in span["attributes"]
+
+        assert span["attributes"][SPANDATA.GEN_AI_USAGE_INPUT_TOKENS] == 10
+        assert span["attributes"][SPANDATA.GEN_AI_USAGE_OUTPUT_TOKENS] == 20
+        assert span["attributes"][SPANDATA.GEN_AI_USAGE_TOTAL_TOKENS] == 30
+    elif stream_gen_ai_spans:
         items = capture_items("transaction", "span")
 
         with mock.patch.object(

--- a/tests/integrations/openai/test_openai.py
+++ b/tests/integrations/openai/test_openai.py
@@ -3026,7 +3026,19 @@ def test_span_origin_nonstreaming_chat(
         )
     )
 
-    if span_streaming or stream_gen_ai_spans:
+    if span_streaming:
+        items = capture_items("transaction", "span")
+
+        with sentry_sdk.traces.start_span(name="openai tx"):
+            client.chat.completions.create(
+                model="some-model", messages=[{"role": "system", "content": "hello"}]
+            )
+
+        sentry_sdk.flush()
+        spans = [item.payload for item in items if item.type == "span"]
+        assert spans[1]["attributes"]["sentry.origin"] == "manual"
+        assert spans[0]["attributes"]["sentry.origin"] == "auto.ai.openai"
+    elif stream_gen_ai_spans:
         items = capture_items("transaction", "span")
 
         with start_transaction(name="openai tx"):
@@ -3088,7 +3100,19 @@ async def test_span_origin_nonstreaming_chat_async(
         )
     )
 
-    if span_streaming or stream_gen_ai_spans:
+    if span_streaming:
+        items = capture_items("transaction", "span")
+
+        with sentry_sdk.traces.start_span(name="openai tx"):
+            await client.chat.completions.create(
+                model="some-model", messages=[{"role": "system", "content": "hello"}]
+            )
+
+        sentry_sdk.flush()
+        spans = [item.payload for item in items if item.type == "span"]
+        assert spans[1]["attributes"]["sentry.origin"] == "manual"
+        assert spans[0]["attributes"]["sentry.origin"] == "auto.ai.openai"
+    elif stream_gen_ai_spans:
         items = capture_items("transaction", "span")
 
         with start_transaction(name="openai tx"):
@@ -3171,7 +3195,22 @@ def test_span_origin_streaming_chat(
         ),
     ]
 
-    if span_streaming or stream_gen_ai_spans:
+    if span_streaming:
+        items = capture_items("transaction", "span")
+
+        client.chat.completions._post = mock.Mock(return_value=returned_stream)
+        with sentry_sdk.traces.start_span(name="openai tx"):
+            response_stream = client.chat.completions.create(
+                model="some-model", messages=[{"role": "system", "content": "hello"}]
+            )
+
+            "".join(map(lambda x: x.choices[0].delta.content, response_stream))
+
+        sentry_sdk.flush()
+        spans = [item.payload for item in items if item.type == "span"]
+        assert spans[1]["attributes"]["sentry.origin"] == "manual"
+        assert spans[0]["attributes"]["sentry.origin"] == "auto.ai.openai"
+    elif stream_gen_ai_spans:
         items = capture_items("transaction", "span")
 
         client.chat.completions._post = mock.Mock(return_value=returned_stream)
@@ -3268,7 +3307,23 @@ async def test_span_origin_streaming_chat_async(
 
     client.chat.completions._post = AsyncMock(return_value=returned_stream)
 
-    if span_streaming or stream_gen_ai_spans:
+    if span_streaming:
+        items = capture_items("transaction", "span")
+
+        with sentry_sdk.traces.start_span(name="openai tx"):
+            response_stream = await client.chat.completions.create(
+                model="some-model", messages=[{"role": "system", "content": "hello"}]
+            )
+            async for _ in response_stream:
+                pass
+
+            # "".join(map(lambda x: x.choices[0].delta.content, response_stream))
+
+        sentry_sdk.flush()
+        spans = [item.payload for item in items if item.type == "span"]
+        assert spans[1]["attributes"]["sentry.origin"] == "manual"
+        assert spans[0]["attributes"]["sentry.origin"] == "auto.ai.openai"
+    elif stream_gen_ai_spans:
         items = capture_items("transaction", "span")
 
         with start_transaction(name="openai tx"):
@@ -3335,7 +3390,17 @@ def test_span_origin_embeddings(
 
     client.embeddings._post = mock.Mock(return_value=returned_embedding)
 
-    if span_streaming or stream_gen_ai_spans:
+    if span_streaming:
+        items = capture_items("transaction", "span")
+
+        with sentry_sdk.traces.start_span(name="openai tx"):
+            client.embeddings.create(input="hello", model="text-embedding-3-large")
+
+        sentry_sdk.flush()
+        spans = [item.payload for item in items if item.type == "span"]
+        assert spans[1]["attributes"]["sentry.origin"] == "manual"
+        assert spans[0]["attributes"]["sentry.origin"] == "auto.ai.openai"
+    elif stream_gen_ai_spans:
         items = capture_items("transaction", "span")
 
         with start_transaction(name="openai tx"):
@@ -3391,7 +3456,19 @@ async def test_span_origin_embeddings_async(
 
     client.embeddings._post = AsyncMock(return_value=returned_embedding)
 
-    if span_streaming or stream_gen_ai_spans:
+    if span_streaming:
+        items = capture_items("transaction", "span")
+
+        with sentry_sdk.traces.start_span(name="openai tx"):
+            await client.embeddings.create(
+                input="hello", model="text-embedding-3-large"
+            )
+
+        sentry_sdk.flush()
+        spans = [item.payload for item in items if item.type == "span"]
+        assert spans[1]["attributes"]["sentry.origin"] == "manual"
+        assert spans[0]["attributes"]["sentry.origin"] == "auto.ai.openai"
+    elif stream_gen_ai_spans:
         items = capture_items("transaction", "span")
 
         with start_transaction(name="openai tx"):


### PR DESCRIPTION
### Description
<!-- What changed and why? -->

Mirror the deprecation warning in `Scope.start_span()`. The API is not available when the streaming trace lifecycle is used.

Adapt tests that wrongly assert on transactions when the lifecycle is enabled.

#### Issues
<!--
* resolves: #1234
* resolves: LIN-1234
-->

#### Reminders
- Please add tests to validate your changes, and lint your code using `uv run ruff`.
- Add GH Issue ID _&_ Linear ID (if applicable)
- PR title should use [conventional commit](https://develop.sentry.dev/engineering-practices/commit-messages/#type) style (`feat:`, `fix:`, `ref:`, `meta:`)
- For external contributors: [CONTRIBUTING.md](https://github.com/getsentry/sentry-python/blob/master/CONTRIBUTING.md), [Sentry SDK development docs](https://develop.sentry.dev/sdk/), [Discord community](https://discord.gg/Ww9hbqr)
