### PR TITLE
ref: Use old sampling context format in span streaming

### DIFF
--- a/sentry_sdk/tracing_utils.py
+++ b/sentry_sdk/tracing_utils.py
@@ -1605,14 +1605,26 @@ def _make_sampling_decision(
     # If there's a traces_sampler, use that; otherwise use traces_sample_rate
     traces_sampler_defined = callable(client.options.get("traces_sampler"))
     if traces_sampler_defined:
+        if attributes is not None:
+            attributes = dict(attributes)
+        else:
+            attributes = {}
+
         sampling_context = {
-            "span_context": {
-                "name": name,
+            "transaction_context": {
                 "trace_id": propagation_context.trace_id,
+                "span_id": None,
                 "parent_span_id": propagation_context.parent_span_id,
-                "parent_sampled": propagation_context.parent_sampled,
-                "attributes": dict(attributes) if attributes else {},
+                "op": attributes.get("sentry.op"),
+                "name": name,
+                "description": name,
+                "start_timestamp": None,
+                "timestamp": None,
+                "source": attributes.get("sentry.segment.name.source"),
+                "sampled": None,
+                "data": attributes,
             },
+            "parent_sampled": propagation_context.parent_sampled,
         }
 
         if propagation_context.custom_sampling_context:

--- a/tests/integrations/asgi/test_asgi.py
+++ b/tests/integrations/asgi/test_asgi.py
@@ -944,23 +944,13 @@ async def test_transaction_name_in_traces_sampler(
     """
 
     def dummy_traces_sampler(sampling_context):
-        if span_streaming:
-            assert sampling_context["span_context"]["name"] == expected_transaction_name
-            assert (
-                sampling_context["span_context"]["attributes"][
-                    "sentry.segment.name.source"
-                ]
-                == expected_transaction_source
-            )
-        else:
-            assert (
-                sampling_context["transaction_context"]["name"]
-                == expected_transaction_name
-            )
-            assert (
-                sampling_context["transaction_context"]["source"]
-                == expected_transaction_source
-            )
+        assert (
+            sampling_context["transaction_context"]["name"] == expected_transaction_name
+        )
+        assert (
+            sampling_context["transaction_context"]["source"]
+            == expected_transaction_source
+        )
 
     sentry_init(
         traces_sampler=dummy_traces_sampler,

--- a/tests/integrations/wsgi/test_wsgi.py
+++ b/tests/integrations/wsgi/test_wsgi.py
@@ -488,37 +488,23 @@ def test_traces_sampler_gets_correct_values_in_sampling_context(
 
     client.get("/dogs/are/great/")
 
-    if span_streaming:
-        traces_sampler.assert_any_call(
-            DictionaryContaining(
-                {
-                    "span_context": DictionaryContaining(
-                        {
-                            "name": "generic WSGI request",
-                        },
-                    ),
-                    "wsgi_environ": DictionaryContaining(
-                        {
-                            "PATH_INFO": "/dogs/are/great/",
-                            "REQUEST_METHOD": "GET",
-                        },
-                    ),
-                }
-            )
+    traces_sampler.assert_any_call(
+        DictionaryContaining(
+            {
+                "transaction_context": DictionaryContaining(
+                    {
+                        "name": "generic WSGI request",
+                    },
+                ),
+                "wsgi_environ": DictionaryContaining(
+                    {
+                        "PATH_INFO": "/dogs/are/great/",
+                        "REQUEST_METHOD": "GET",
+                    },
+                ),
+            }
         )
-    else:
-        traces_sampler.assert_any_call(
-            DictionaryContaining(
-                {
-                    "wsgi_environ": DictionaryContaining(
-                        {
-                            "PATH_INFO": "/dogs/are/great/",
-                            "REQUEST_METHOD": "GET",
-                        },
-                    ),
-                }
-            )
-        )
+    )
 
 
 @pytest.mark.parametrize("span_streaming", [True, False])

--- a/tests/tracing/test_sampling.py
+++ b/tests/tracing/test_sampling.py
@@ -446,7 +446,7 @@ def test_custom_sampling_context(sentry_init):
 
 def test_custom_sampling_context_update_to_context_value_persists(sentry_init):
     def traces_sampler(sampling_context):
-        if sampling_context["span_context"]["attributes"]["first"] is True:
+        if sampling_context["transaction_context"]["data"]["first"] is True:
             assert sampling_context["custom_value"] == 1
         else:
             assert sampling_context["custom_value"] == 2

--- a/tests/tracing/test_span_streaming.py
+++ b/tests/tracing/test_span_streaming.py
@@ -104,7 +104,9 @@ def test_span_sampled_when_created(sentry_init, capture_items):
     # at start_span() time
 
     def traces_sampler(sampling_context):
-        assert "delayed_attribute" not in sampling_context["span_context"]["attributes"]
+        assert (
+            "delayed_attribute" not in sampling_context["transaction_context"]["data"]
+        )
         return 1.0
 
     sentry_init(
@@ -153,10 +155,11 @@ def test_start_span_attributes(sentry_init, capture_items):
 
 def test_start_span_attributes_in_traces_sampler(sentry_init, capture_items):
     def traces_sampler(sampling_context):
-        assert "attributes" in sampling_context["span_context"]
-        assert "my_attribute" in sampling_context["span_context"]["attributes"]
+        assert "data" in sampling_context["transaction_context"]
+        assert "my_attribute" in sampling_context["transaction_context"]["data"]
         assert (
-            sampling_context["span_context"]["attributes"]["my_attribute"] == "my_value"
+            sampling_context["transaction_context"]["data"]["my_attribute"]
+            == "my_value"
         )
         return 1.0
 
@@ -188,16 +191,16 @@ def test_sampling_context(sentry_init, capture_items):
     def traces_sampler(sampling_context):
         nonlocal received_trace_id
 
-        assert "trace_id" in sampling_context["span_context"]
-        received_trace_id = sampling_context["span_context"]["trace_id"]
+        assert "trace_id" in sampling_context["transaction_context"]
+        received_trace_id = sampling_context["transaction_context"]["trace_id"]
 
-        assert "parent_span_id" in sampling_context["span_context"]
-        assert sampling_context["span_context"]["parent_span_id"] is None
+        assert "parent_span_id" in sampling_context["transaction_context"]
+        assert sampling_context["transaction_context"]["parent_span_id"] is None
 
-        assert "parent_sampled" in sampling_context["span_context"]
-        assert sampling_context["span_context"]["parent_sampled"] is None
+        assert "parent_sampled" in sampling_context
+        assert sampling_context["parent_sampled"] is None
 
-        assert "attributes" in sampling_context["span_context"]
+        assert "data" in sampling_context["transaction_context"]
 
         return 1.0
 
@@ -428,10 +431,10 @@ def test_span_attributes_serialize_early(sentry_init, capture_items):
 
 def test_traces_sampler_drops_span(sentry_init, capture_items):
     def traces_sampler(sampling_context):
-        assert "attributes" in sampling_context["span_context"]
-        assert "drop" in sampling_context["span_context"]["attributes"]
+        assert "data" in sampling_context["transaction_context"]
+        assert "drop" in sampling_context["transaction_context"]["data"]
 
-        if sampling_context["span_context"]["attributes"]["drop"] is True:
+        if sampling_context["transaction_context"]["data"]["drop"] is True:
             return 0.0
 
         return 1.0
@@ -465,7 +468,7 @@ def test_traces_sampler_called_once_per_segment(sentry_init):
     def traces_sampler(sampling_context):
         nonlocal traces_sampler_called, span_name_in_traces_sampler
         traces_sampler_called += 1
-        span_name_in_traces_sampler = sampling_context["span_context"]["name"]
+        span_name_in_traces_sampler = sampling_context["transaction_context"]["name"]
         return 1.0
 
     sentry_init(


### PR DESCRIPTION
### Description
Reverting `sampling_context` to look like it used to in transaction-based tracing.

Caveat: There's a bunch of keys that are not populated in span streaming, mostly because they're not known at span start (`span_id`, `sampled`, etc.). I've kept them in as `None` as that's how the legacy path did it, too (rather than omitting them).

Note: When bumping the sdk version in sentry and seer to a version that has this change, the sampling_context code needs to change there, too.

#### Issues
resolves https://github.com/getsentry/sentry-python/issues/6846

#### Reminders
- Please add tests to validate your changes, and lint your code using `uv run ruff`.
- Add GH Issue ID _&_ Linear ID (if applicable)
- PR title should use [conventional commit](https://develop.sentry.dev/engineering-practices/commit-messages/#type) style (`feat:`, `fix:`, `ref:`, `meta:`)
- For external contributors: [CONTRIBUTING.md](https://github.com/getsentry/sentry-python/blob/master/CONTRIBUTING.md), [Sentry SDK development docs](https://develop.sentry.dev/sdk/), [Discord community](https://discord.gg/Ww9hbqr)
