### PR TITLE
ci: Reuse Django test database across forked tests

### DIFF
--- a/scripts/populate_tox/tox.jinja
+++ b/scripts/populate_tox/tox.jinja
@@ -221,6 +221,13 @@ setenv =
     py3.6: COVERAGE_RCFILE=.coveragerc36
 
     django: DJANGO_SETTINGS_MODULE=tests.integrations.django.myapp.settings
+    # @pytest.mark.forked django_db tests run pytest-django's session-scoped
+    # database setup in each child process, so without --reuse-db every fork
+    # creates and migrates its own test database (~1s per test on postgres).
+    # A stable per-env database name lets all forks of an env share one
+    # database while keeping parallel tox envs from colliding.
+    django: PYTEST_ADDOPTS=--reuse-db --no-migrations
+    django: SENTRY_PYTHON_TEST_POSTGRES_NAME={env:SENTRY_PYTHON_TEST_POSTGRES_NAME:myapp_db_{envname}}
     spark-v{3.0.3,3.5.6}: JAVA_HOME=/usr/lib/jvm/temurin-11-jdk-amd64
 
     # Ray 2.43+ auto-detects `uv run` drivers and spawns workers via uv,

--- a/tests/integrations/django/conftest.py
+++ b/tests/integrations/django/conftest.py
@@ -1,0 +1,21 @@
+import pytest_django
+
+# pytest-django versions without `databases` support on the django_db marker
+# (see `pytest_mark_django_db_decorator` in utils.py) only flush the default
+# database between transactional tests, so rows written to the secondary
+# postgres database would survive into the next test when the test database
+# is reused. Disable --reuse-db there; those envs fall back to recreating
+# the database in every forked test.
+_reuse_db_supported = False
+try:
+    pytest_django_version = tuple(map(int, pytest_django.__version__.split(".")))
+    _reuse_db_supported = pytest_django_version > (4, 2, 0)
+except ValueError:
+    _reuse_db_supported = "dev" in pytest_django.__version__
+except AttributeError:
+    pass
+
+
+def pytest_configure(config):
+    if not _reuse_db_supported and getattr(config.option, "reuse_db", False):
+        config.option.reuse_db = False

--- a/tox.ini
+++ b/tox.ini
@@ -18606,6 +18606,13 @@ setenv =
     py3.6: COVERAGE_RCFILE=.coveragerc36
 
     django: DJANGO_SETTINGS_MODULE=tests.integrations.django.myapp.settings
+    # @pytest.mark.forked django_db tests run pytest-django's session-scoped
+    # database setup in each child process, so without --reuse-db every fork
+    # creates and migrates its own test database (~1s per test on postgres).
+    # A stable per-env database name lets all forks of an env share one
+    # database while keeping parallel tox envs from colliding.
+    django: PYTEST_ADDOPTS=--reuse-db --no-migrations
+    django: SENTRY_PYTHON_TEST_POSTGRES_NAME={env:SENTRY_PYTHON_TEST_POSTGRES_NAME:myapp_db_{envname}}
     spark-v{3.0.3,3.5.6}: JAVA_HOME=/usr/lib/jvm/temurin-11-jdk-amd64
 
     # Ray 2.43+ auto-detects `uv run` drivers and spawns workers via uv,


### PR DESCRIPTION
The `Test django` step dominates the Web 1 CI job: ~7.5 of its ~9 minutes on the slowest Python versions. Per-test durations from the CI junit artifacts show why — the ~110 postgres-backed tests each cost a uniform ~1s while everything else runs in ≤0.2s. Those tests are marked `@pytest.mark.forked`, so pytest-django's session-scoped database setup runs in every child process: each forked test creates and migrates its own postgres database from scratch (that's also why `myapp/settings.py` names the database `myapp_db_{os.getpid()}`).

Django tox envs now pass `--reuse-db --no-migrations` and get a stable per-env database name, so all forks of an env share one database and build its tables directly from models instead of running migrations. Parallel tox envs still can't collide since the name includes `{envname}`, and an externally set `SENTRY_PYTHON_TEST_POSTGRES_NAME` still wins. The test app has no migrations of its own (all DB tests use `django.contrib.auth`), so skipping migrations changes nothing about the schema under test.

One compatibility carve-out: pytest-django < 4.3 has no `databases` support on the `django_db` marker (the same limitation `utils.pytest_mark_django_db_decorator` works around), so it never flushes the secondary postgres database between transactional tests — reusing the database there leaks rows across forked tests and fails with duplicate-key errors. A new `tests/integrations/django/conftest.py` turns `--reuse-db` back off for those envs (Django 1.11/2.2), which just keeps their previous per-fork behavior.

Locally this cuts a Django env from ~92s to ~55s even without postgres (the sqlite path pays the same per-fork setup); the CI effect is larger since the ~1s/test cost is postgres-bound. Test outcomes are unchanged. `tox.ini` was regenerated from `tox.jinja` with all integration versions frozen, so the diff is only the new setenv block.