### PR TITLE
ref: Use top-level `trace_lifecycle` and `ignore_spans` options in tests

### DIFF
--- a/tests/integrations/aiohttp/test_aiohttp.py
+++ b/tests/integrations/aiohttp/test_aiohttp.py
@@ -1145,7 +1145,7 @@ async def test_tracing_span_streaming(
         integrations=[AioHttpIntegration()],
         traces_sample_rate=1.0,
         send_default_pii=send_pii,
-        _experiments={"trace_lifecycle": "stream"},
+        trace_lifecycle="stream",
     )
 
     async def hello(request):
@@ -1215,7 +1215,7 @@ async def test_sensitive_header_scrubbing_span_streaming(
     sentry_init(
         integrations=[AioHttpIntegration()],
         traces_sample_rate=1.0,
-        _experiments={"trace_lifecycle": "stream"},
+        trace_lifecycle="stream",
     )
 
     async def hello(request):
@@ -1262,7 +1262,7 @@ async def test_sensitive_header_passthrough_with_pii_span_streaming(
         integrations=[AioHttpIntegration()],
         traces_sample_rate=1.0,
         send_default_pii=True,
-        _experiments={"trace_lifecycle": "stream"},
+        trace_lifecycle="stream",
     )
 
     async def hello(request):
@@ -1300,7 +1300,7 @@ async def test_url_query_attribute_span_streaming(
         integrations=[AioHttpIntegration()],
         traces_sample_rate=1.0,
         send_default_pii=send_pii,
-        _experiments={"trace_lifecycle": "stream"},
+        trace_lifecycle="stream",
     )
 
     async def hello(request):
@@ -1357,7 +1357,7 @@ async def test_transaction_style_span_streaming(
     sentry_init(
         integrations=[AioHttpIntegration(transaction_style=transaction_style)],
         traces_sample_rate=1.0,
-        _experiments={"trace_lifecycle": "stream"},
+        trace_lifecycle="stream",
     )
 
     async def hello(request):
@@ -1387,7 +1387,7 @@ async def test_server_error_span_streaming(sentry_init, aiohttp_client, capture_
     sentry_init(
         integrations=[AioHttpIntegration()],
         traces_sample_rate=1.0,
-        _experiments={"trace_lifecycle": "stream"},
+        trace_lifecycle="stream",
     )
 
     async def hello(request):
@@ -1428,7 +1428,7 @@ async def test_http_exception_span_streaming(
     sentry_init(
         integrations=[AioHttpIntegration()],
         traces_sample_rate=1.0,
-        _experiments={"trace_lifecycle": "stream"},
+        trace_lifecycle="stream",
     )
 
     async def hello(request):
@@ -1460,7 +1460,7 @@ async def test_http_exception_ok_status_not_overridden_span_streaming(
     sentry_init(
         integrations=[AioHttpIntegration()],
         traces_sample_rate=1.0,
-        _experiments={"trace_lifecycle": "stream"},
+        trace_lifecycle="stream",
     )
 
     async def hello(request):
@@ -1494,7 +1494,7 @@ async def test_outgoing_client_span_span_streaming(
         integrations=[AioHttpIntegration()],
         traces_sample_rate=1.0,
         send_default_pii=send_pii,
-        _experiments={"trace_lifecycle": "stream"},
+        trace_lifecycle="stream",
     )
 
     async def handler(request):
@@ -1555,7 +1555,7 @@ async def test_outgoing_trace_headers_span_streaming(
     sentry_init(
         integrations=[AioHttpIntegration()],
         traces_sample_rate=1.0,
-        _experiments={"trace_lifecycle": "stream"},
+        trace_lifecycle="stream",
     )
 
     async def handler(request):
@@ -1589,7 +1589,7 @@ async def test_user_ip_address_on_all_spans(
         integrations=[AioHttpIntegration()],
         traces_sample_rate=1.0,
         send_default_pii=send_default_pii,
-        _experiments={"trace_lifecycle": "stream"},
+        trace_lifecycle="stream",
     )
 
     async def hello(request):

--- a/tests/integrations/anthropic/test_anthropic.py
+++ b/tests/integrations/anthropic/test_anthropic.py
@@ -108,7 +108,7 @@ def test_nonstreaming_create_message(
         traces_sample_rate=1.0,
         send_default_pii=send_default_pii,
         stream_gen_ai_spans=stream_gen_ai_spans,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     client = Anthropic(api_key="z")
@@ -257,7 +257,7 @@ async def test_nonstreaming_create_message_async(
         traces_sample_rate=1.0,
         send_default_pii=send_default_pii,
         stream_gen_ai_spans=stream_gen_ai_spans,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     client = AsyncAnthropic(api_key="z")
@@ -442,7 +442,7 @@ def test_streaming_create_message(
         traces_sample_rate=1.0,
         send_default_pii=send_default_pii,
         stream_gen_ai_spans=stream_gen_ai_spans,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     messages = [
@@ -621,7 +621,7 @@ def test_streaming_create_message_close(
         traces_sample_rate=1.0,
         send_default_pii=True,
         stream_gen_ai_spans=stream_gen_ai_spans,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     messages = [
@@ -777,7 +777,7 @@ def test_streaming_create_message_api_error(
         traces_sample_rate=1.0,
         send_default_pii=True,
         stream_gen_ai_spans=stream_gen_ai_spans,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     messages = [
@@ -946,7 +946,7 @@ def test_stream_messages(
         traces_sample_rate=1.0,
         send_default_pii=send_default_pii,
         stream_gen_ai_spans=stream_gen_ai_spans,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     messages = [
@@ -1124,7 +1124,7 @@ def test_stream_messages_close(
         traces_sample_rate=1.0,
         send_default_pii=True,
         stream_gen_ai_spans=stream_gen_ai_spans,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     messages = [
@@ -1288,7 +1288,7 @@ def test_stream_messages_api_error(
         traces_sample_rate=1.0,
         send_default_pii=True,
         stream_gen_ai_spans=stream_gen_ai_spans,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     messages = [
@@ -1463,7 +1463,7 @@ async def test_streaming_create_message_async(
         default_integrations=False,
         send_default_pii=send_default_pii,
         stream_gen_ai_spans=stream_gen_ai_spans,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     messages = [
@@ -1646,7 +1646,7 @@ async def test_streaming_create_message_async_close(
         traces_sample_rate=1.0,
         send_default_pii=True,
         stream_gen_ai_spans=stream_gen_ai_spans,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     messages = [
@@ -1804,7 +1804,7 @@ async def test_streaming_create_message_async_api_error(
         traces_sample_rate=1.0,
         send_default_pii=True,
         stream_gen_ai_spans=stream_gen_ai_spans,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     messages = [
@@ -1978,7 +1978,7 @@ async def test_stream_message_async(
         traces_sample_rate=1.0,
         send_default_pii=send_default_pii,
         stream_gen_ai_spans=stream_gen_ai_spans,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     messages = [
@@ -2157,7 +2157,7 @@ async def test_stream_messages_async_api_error(
         traces_sample_rate=1.0,
         send_default_pii=True,
         stream_gen_ai_spans=stream_gen_ai_spans,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     messages = [
@@ -2322,7 +2322,7 @@ async def test_stream_messages_async_close(
         traces_sample_rate=1.0,
         send_default_pii=True,
         stream_gen_ai_spans=stream_gen_ai_spans,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     messages = [
@@ -2538,7 +2538,7 @@ def test_streaming_create_message_with_input_json_delta(
         traces_sample_rate=1.0,
         send_default_pii=send_default_pii,
         stream_gen_ai_spans=stream_gen_ai_spans,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     messages = [
@@ -2744,7 +2744,7 @@ def test_stream_messages_with_input_json_delta(
         traces_sample_rate=1.0,
         send_default_pii=send_default_pii,
         stream_gen_ai_spans=stream_gen_ai_spans,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     messages = [
@@ -2956,7 +2956,7 @@ async def test_streaming_create_message_with_input_json_delta_async(
         traces_sample_rate=1.0,
         send_default_pii=send_default_pii,
         stream_gen_ai_spans=stream_gen_ai_spans,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     messages = [
@@ -3170,7 +3170,7 @@ async def test_stream_message_with_input_json_delta_async(
         traces_sample_rate=1.0,
         send_default_pii=send_default_pii,
         stream_gen_ai_spans=stream_gen_ai_spans,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     messages = [
@@ -3291,7 +3291,7 @@ def test_exception_message_create(
         integrations=[AnthropicIntegration()],
         traces_sample_rate=1.0,
         stream_gen_ai_spans=stream_gen_ai_spans,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     client = Anthropic(api_key="z")
@@ -3354,7 +3354,7 @@ def test_span_status_error(
         integrations=[AnthropicIntegration()],
         traces_sample_rate=1.0,
         stream_gen_ai_spans=stream_gen_ai_spans,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
     if span_streaming or stream_gen_ai_spans:
         items = capture_items("event", "span")
@@ -3420,7 +3420,7 @@ async def test_span_status_error_async(
         integrations=[AnthropicIntegration()],
         traces_sample_rate=1.0,
         stream_gen_ai_spans=stream_gen_ai_spans,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
     if span_streaming or stream_gen_ai_spans:
         items = capture_items("event", "span")
@@ -3486,7 +3486,7 @@ async def test_exception_message_create_async(
         integrations=[AnthropicIntegration()],
         traces_sample_rate=1.0,
         stream_gen_ai_spans=stream_gen_ai_spans,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     client = AsyncAnthropic(api_key="z")
@@ -3549,7 +3549,7 @@ def test_span_origin(
         integrations=[AnthropicIntegration()],
         traces_sample_rate=1.0,
         stream_gen_ai_spans=stream_gen_ai_spans,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     client = Anthropic(api_key="z")
@@ -3603,7 +3603,7 @@ async def test_span_origin_async(
         integrations=[AnthropicIntegration()],
         traces_sample_rate=1.0,
         stream_gen_ai_spans=stream_gen_ai_spans,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     client = AsyncAnthropic(api_key="z")
@@ -3746,7 +3746,7 @@ def test_anthropic_message_role_mapping(
         traces_sample_rate=1.0,
         send_default_pii=True,
         stream_gen_ai_spans=stream_gen_ai_spans,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     client = Anthropic(api_key="z")
@@ -3942,7 +3942,7 @@ def test_nonstreaming_create_message_with_system_prompt(
         traces_sample_rate=1.0,
         send_default_pii=send_default_pii,
         stream_gen_ai_spans=stream_gen_ai_spans,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     client = Anthropic(api_key="z")
@@ -4103,7 +4103,7 @@ async def test_nonstreaming_create_message_with_system_prompt_async(
         traces_sample_rate=1.0,
         send_default_pii=send_default_pii,
         stream_gen_ai_spans=stream_gen_ai_spans,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     client = AsyncAnthropic(api_key="z")
@@ -4304,7 +4304,7 @@ def test_streaming_create_message_with_system_prompt(
         traces_sample_rate=1.0,
         send_default_pii=send_default_pii,
         stream_gen_ai_spans=stream_gen_ai_spans,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     messages = [
@@ -4505,7 +4505,7 @@ def test_stream_messages_with_system_prompt(
         traces_sample_rate=1.0,
         send_default_pii=send_default_pii,
         stream_gen_ai_spans=stream_gen_ai_spans,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     messages = [
@@ -4699,7 +4699,7 @@ async def test_stream_message_with_system_prompt_async(
         traces_sample_rate=1.0,
         send_default_pii=send_default_pii,
         stream_gen_ai_spans=stream_gen_ai_spans,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     messages = [
@@ -4898,7 +4898,7 @@ async def test_streaming_create_message_with_system_prompt_async(
         traces_sample_rate=1.0,
         send_default_pii=send_default_pii,
         stream_gen_ai_spans=stream_gen_ai_spans,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     messages = [
@@ -5046,7 +5046,7 @@ def test_system_prompt_with_complex_structure(
         traces_sample_rate=1.0,
         send_default_pii=True,
         stream_gen_ai_spans=stream_gen_ai_spans,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     client = Anthropic(api_key="z")
@@ -5400,7 +5400,7 @@ def test_message_with_url_image(
         traces_sample_rate=1.0,
         send_default_pii=True,
         stream_gen_ai_spans=stream_gen_ai_spans,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     client = Anthropic(api_key="z")
@@ -5471,7 +5471,7 @@ def test_message_with_file_image(
         traces_sample_rate=1.0,
         send_default_pii=True,
         stream_gen_ai_spans=stream_gen_ai_spans,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     client = Anthropic(api_key="z")
@@ -5589,7 +5589,7 @@ def test_message_with_url_pdf(
         traces_sample_rate=1.0,
         send_default_pii=True,
         stream_gen_ai_spans=stream_gen_ai_spans,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     client = Anthropic(api_key="z")
@@ -5660,7 +5660,7 @@ def test_message_with_file_document(
         traces_sample_rate=1.0,
         send_default_pii=True,
         stream_gen_ai_spans=stream_gen_ai_spans,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     client = Anthropic(api_key="z")
@@ -5892,7 +5892,7 @@ def test_binary_content_not_stored_when_pii_disabled(
         traces_sample_rate=1.0,
         send_default_pii=False,
         stream_gen_ai_spans=stream_gen_ai_spans,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     client = Anthropic(api_key="z")
@@ -5956,7 +5956,7 @@ def test_binary_content_not_stored_when_prompts_disabled(
         traces_sample_rate=1.0,
         send_default_pii=True,
         stream_gen_ai_spans=stream_gen_ai_spans,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     client = Anthropic(api_key="z")
@@ -6019,7 +6019,7 @@ def test_cache_tokens_nonstreaming(
         integrations=[AnthropicIntegration()],
         traces_sample_rate=1.0,
         stream_gen_ai_spans=stream_gen_ai_spans,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     client = Anthropic(api_key="z")
@@ -6101,7 +6101,7 @@ def test_input_tokens_include_cache_write_nonstreaming(
         integrations=[AnthropicIntegration()],
         traces_sample_rate=1.0,
         stream_gen_ai_spans=stream_gen_ai_spans,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     client = Anthropic(api_key="z")
@@ -6187,7 +6187,7 @@ def test_input_tokens_include_cache_read_nonstreaming(
         integrations=[AnthropicIntegration()],
         traces_sample_rate=1.0,
         stream_gen_ai_spans=stream_gen_ai_spans,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     client = Anthropic(api_key="z")
@@ -6297,7 +6297,7 @@ def test_input_tokens_include_cache_read_streaming(
         integrations=[AnthropicIntegration()],
         traces_sample_rate=1.0,
         stream_gen_ai_spans=stream_gen_ai_spans,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     if span_streaming or stream_gen_ai_spans:
@@ -6400,7 +6400,7 @@ def test_stream_messages_input_tokens_include_cache_read_streaming(
         integrations=[AnthropicIntegration()],
         traces_sample_rate=1.0,
         stream_gen_ai_spans=stream_gen_ai_spans,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     if span_streaming or stream_gen_ai_spans:
@@ -6471,7 +6471,7 @@ def test_input_tokens_unchanged_without_caching(
         integrations=[AnthropicIntegration()],
         traces_sample_rate=1.0,
         stream_gen_ai_spans=stream_gen_ai_spans,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     client = Anthropic(api_key="z")
@@ -6567,7 +6567,7 @@ def test_cache_tokens_streaming(
         integrations=[AnthropicIntegration()],
         traces_sample_rate=1.0,
         stream_gen_ai_spans=stream_gen_ai_spans,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     if span_streaming or stream_gen_ai_spans:
@@ -6665,7 +6665,7 @@ def test_stream_messages_cache_tokens(
         integrations=[AnthropicIntegration()],
         traces_sample_rate=1.0,
         stream_gen_ai_spans=stream_gen_ai_spans,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     if span_streaming or stream_gen_ai_spans:

--- a/tests/integrations/arq/test_arq.py
+++ b/tests/integrations/arq/test_arq.py
@@ -63,7 +63,7 @@ def init_arq(sentry_init):
             integrations=[ArqIntegration()],
             traces_sample_rate=1.0,
             send_default_pii=True,
-            _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+            trace_lifecycle="stream" if span_streaming else "static",
         )
 
         server = FakeRedis()
@@ -110,7 +110,7 @@ def init_arq_with_dict_settings(sentry_init):
             integrations=[ArqIntegration()],
             traces_sample_rate=1.0,
             send_default_pii=True,
-            _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+            trace_lifecycle="stream" if span_streaming else "static",
         )
 
         server = FakeRedis()
@@ -160,7 +160,7 @@ def init_arq_with_kwarg_settings(sentry_init):
             integrations=[ArqIntegration()],
             traces_sample_rate=1.0,
             send_default_pii=True,
-            _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+            trace_lifecycle="stream" if span_streaming else "static",
         )
 
         server = FakeRedis()

--- a/tests/integrations/asgi/test_asgi.py
+++ b/tests/integrations/asgi/test_asgi.py
@@ -1042,7 +1042,7 @@ async def test_user_ip_address_on_all_spans(
     sentry_init(
         send_default_pii=send_default_pii,
         traces_sample_rate=1.0,
-        _experiments={"trace_lifecycle": "stream"},
+        trace_lifecycle="stream",
     )
     sentry_app = SentryAsgiMiddleware(app)
 

--- a/tests/integrations/asyncpg/test_asyncpg.py
+++ b/tests/integrations/asyncpg/test_asyncpg.py
@@ -1456,7 +1456,7 @@ async def test_cursor_fetch_methods_create_spans(
         traces_sample_rate=1.0,
         enable_db_query_source=True,
         db_query_source_threshold_ms=0,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     if span_streaming:

--- a/tests/integrations/aws_lambda/lambda_functions_with_embedded_sdk/BasicOkSpanStreaming/index.py
+++ b/tests/integrations/aws_lambda/lambda_functions_with_embedded_sdk/BasicOkSpanStreaming/index.py
@@ -7,7 +7,7 @@ sentry_sdk.init(
     dsn=os.environ.get("SENTRY_DSN"),
     traces_sample_rate=1.0,
     integrations=[AwsLambdaIntegration()],
-    _experiments={"trace_lifecycle": "stream"},
+    trace_lifecycle="stream",
 )
 
 

--- a/tests/integrations/aws_lambda/lambda_functions_with_embedded_sdk/BasicOkSpanStreamingPii/index.py
+++ b/tests/integrations/aws_lambda/lambda_functions_with_embedded_sdk/BasicOkSpanStreamingPii/index.py
@@ -8,7 +8,7 @@ sentry_sdk.init(
     traces_sample_rate=1.0,
     send_default_pii=True,
     integrations=[AwsLambdaIntegration()],
-    _experiments={"trace_lifecycle": "stream"},
+    trace_lifecycle="stream",
 )
 
 

--- a/tests/integrations/aws_lambda/lambda_functions_with_embedded_sdk/RaiseErrorSpanStreaming/index.py
+++ b/tests/integrations/aws_lambda/lambda_functions_with_embedded_sdk/RaiseErrorSpanStreaming/index.py
@@ -7,7 +7,7 @@ sentry_sdk.init(
     dsn=os.environ.get("SENTRY_DSN"),
     traces_sample_rate=1.0,
     integrations=[AwsLambdaIntegration()],
-    _experiments={"trace_lifecycle": "stream"},
+    trace_lifecycle="stream",
 )
 
 

--- a/tests/integrations/boto3/test_s3.py
+++ b/tests/integrations/boto3/test_s3.py
@@ -28,7 +28,7 @@ def test_basic(
         # disabled because session.resource() or s3.Bucket() result in a subprocess span for a
         # shell that runs "uname -p 2> /dev/null" on Python 3.7 with boto3 version 1.12.49.
         default_integrations=False,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     s3 = session.resource("s3")
@@ -85,7 +85,7 @@ def test_streaming(
         traces_sample_rate=1.0,
         integrations=[Boto3Integration()],
         send_default_pii=send_default_pii,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     s3 = session.resource("s3")
@@ -187,7 +187,7 @@ def test_streaming_close(
     sentry_init(
         traces_sample_rate=1.0,
         integrations=[Boto3Integration()],
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     s3 = session.resource("s3")
@@ -243,7 +243,7 @@ def test_omit_url_data_if_parsing_fails(
         traces_sample_rate=1.0,
         integrations=[Boto3Integration()],
         send_default_pii=True,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     s3 = session.resource("s3")
@@ -329,7 +329,7 @@ def test_span_origin(
     sentry_init(
         traces_sample_rate=1.0,
         integrations=[Boto3Integration()],
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     s3 = session.resource("s3")

--- a/tests/integrations/bottle/test_bottle.py
+++ b/tests/integrations/bottle/test_bottle.py
@@ -474,7 +474,7 @@ def test_span_origin(
     sentry_init(
         integrations=[BottleIntegration()],
         traces_sample_rate=1.0,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     if span_streaming:
@@ -577,7 +577,7 @@ def test_span_streaming_basic(sentry_init, capture_items):
     sentry_init(
         integrations=[BottleIntegration()],
         traces_sample_rate=1.0,
-        _experiments={"trace_lifecycle": "stream"},
+        trace_lifecycle="stream",
     )
     items = capture_items("span")
 
@@ -628,7 +628,7 @@ def test_span_streaming_transaction_style(
     sentry_init(
         integrations=[BottleIntegration(transaction_style=transaction_style)],
         traces_sample_rate=1.0,
-        _experiments={"trace_lifecycle": "stream"},
+        trace_lifecycle="stream",
     )
     items = capture_items("span")
 
@@ -666,7 +666,7 @@ def test_span_streaming_with_error(sentry_init, capture_items):
     sentry_init(
         integrations=[BottleIntegration()],
         traces_sample_rate=1.0,
-        _experiments={"trace_lifecycle": "stream"},
+        trace_lifecycle="stream",
     )
     items = capture_items("event", "span")
 
@@ -727,7 +727,7 @@ def test_span_streaming_http_error_status(
     sentry_init(
         integrations=[BottleIntegration()],
         traces_sample_rate=1.0,
-        _experiments={"trace_lifecycle": "stream"},
+        trace_lifecycle="stream",
     )
     items = capture_items("span")
 
@@ -775,7 +775,7 @@ def test_span_streaming_failed_request_status_codes(
     sentry_init(
         integrations=[BottleIntegration(**integration_kwargs)],
         traces_sample_rate=1.0,
-        _experiments={"trace_lifecycle": "stream"},
+        trace_lifecycle="stream",
     )
     items = capture_items("event", "span")
 

--- a/tests/integrations/celery/test_celery.py
+++ b/tests/integrations/celery/test_celery.py
@@ -134,7 +134,7 @@ def test_simple_with_performance(
     celery = init_celery(
         traces_sample_rate=1.0,
         send_default_pii=send_default_pii,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     @celery.task(name="dummy_task")
@@ -244,7 +244,7 @@ def test_transaction_events(
 ):
     celery = init_celery(
         traces_sample_rate=1.0,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     @celery.task(name="dummy_task")
@@ -553,7 +553,7 @@ def test_traces_sampler_gets_task_info_in_sampling_context(
     traces_sampler = mock.Mock(return_value=1.0)
     celery = init_celery(
         traces_sampler=traces_sampler,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     @celery.task(name="dog_walk")
@@ -661,7 +661,7 @@ def test_sentry_propagate_traces_override(span_streaming, init_celery):
         propagate_traces=True,
         traces_sample_rate=1.0,
         release="abcdef",
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     @celery.task(name="dummy_task", bind=True)
@@ -749,7 +749,7 @@ def test_messaging_destination_name_default_exchange(
 ):
     celery_app = init_celery(
         traces_sample_rate=1.0,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
     mock_request.delivery_info = {"routing_key": routing_key, "exchange": ""}
 
@@ -786,7 +786,7 @@ def test_messaging_destination_name_nondefault_exchange(
     """
     celery_app = init_celery(
         traces_sample_rate=1.0,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
     mock_request.delivery_info = {"routing_key": "celery", "exchange": "custom"}
 
@@ -811,7 +811,7 @@ def test_messaging_destination_name_nondefault_exchange(
 def test_messaging_id(span_streaming, init_celery, capture_events, capture_items):
     celery = init_celery(
         traces_sample_rate=1.0,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     @celery.task
@@ -835,7 +835,7 @@ def test_messaging_id(span_streaming, init_celery, capture_events, capture_items
 def test_retry_count_zero(span_streaming, init_celery, capture_events, capture_items):
     celery = init_celery(
         traces_sample_rate=1.0,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     @celery.task()
@@ -864,7 +864,7 @@ def test_retry_count_nonzero(
 
     celery = init_celery(
         traces_sample_rate=1.0,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     @celery.task()
@@ -891,7 +891,7 @@ def test_messaging_system(
 ):
     celery = init_celery(
         traces_sample_rate=1.0,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     # Does not need to be a real URL, since we use always eager
@@ -929,7 +929,7 @@ def test_producer_span_data(
     sentry_init(
         integrations=[CeleryIntegration()],
         traces_sample_rate=1.0,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
     celery = Celery(__name__, broker=f"{system}://example.com")  # noqa: E231
 
@@ -974,7 +974,7 @@ def test_producer_span_data(
 def test_receive_latency(span_streaming, init_celery, capture_events, capture_items):
     celery = init_celery(
         traces_sample_rate=1.0,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     @celery.task()
@@ -1004,7 +1004,7 @@ def tests_span_origin_consumer(
 ):
     celery = init_celery(
         traces_sample_rate=1.0,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
     celery.conf.broker_url = "redis://example.com"  # noqa: E231
 
@@ -1044,7 +1044,7 @@ def tests_span_origin_producer(
     sentry_init(
         integrations=[CeleryIntegration()],
         traces_sample_rate=1.0,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
     celery = Celery(__name__, broker="redis://example.com")  # noqa: E231
 
@@ -1095,7 +1095,7 @@ def test_send_task_wrapped(
     sentry_init(
         integrations=[CeleryIntegration()],
         traces_sample_rate=1.0,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
     celery = Celery(__name__, broker="redis://example.com")  # noqa: E231
 
@@ -1169,7 +1169,7 @@ def test_user_custom_headers_accessible_in_task(span_streaming, init_celery):
     """
     celery = init_celery(
         traces_sample_rate=1.0,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     @celery.task(name="custom_headers_task", bind=True)

--- a/tests/integrations/chalice/test_chalice.py
+++ b/tests/integrations/chalice/test_chalice.py
@@ -179,7 +179,7 @@ def _make_span_streaming_app(sentry_init):
     sentry_init(
         integrations=[ChaliceIntegration()],
         traces_sample_rate=1.0,
-        _experiments={"trace_lifecycle": "stream"},
+        trace_lifecycle="stream",
     )
     app = Chalice(app_name="sentry_chalice")
 

--- a/tests/integrations/clickhouse_driver/test_clickhouse_driver.py
+++ b/tests/integrations/clickhouse_driver/test_clickhouse_driver.py
@@ -1499,7 +1499,7 @@ def test_span_origin(
     sentry_init(
         integrations=[ClickhouseDriverIntegration()],
         traces_sample_rate=1.0,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
     if span_streaming:
         items = capture_items("span")

--- a/tests/integrations/cohere/test_cohere.py
+++ b/tests/integrations/cohere/test_cohere.py
@@ -29,7 +29,7 @@ def test_nonstreaming_chat(
         integrations=[CohereIntegration(include_prompts=include_prompts)],
         traces_sample_rate=1.0,
         send_default_pii=send_default_pii,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     client = Client(api_key="z")
@@ -139,7 +139,7 @@ def test_streaming_chat(
         integrations=[CohereIntegration(include_prompts=include_prompts)],
         traces_sample_rate=1.0,
         send_default_pii=send_default_pii,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     client = Client(api_key="z")
@@ -287,7 +287,7 @@ def test_span_status_error_streaming(sentry_init, capture_events, capture_items)
     sentry_init(
         integrations=[CohereIntegration()],
         traces_sample_rate=1.0,
-        _experiments={"trace_lifecycle": "stream"},
+        trace_lifecycle="stream",
     )
     items = capture_items("span")
 
@@ -323,7 +323,7 @@ def test_embed(
         integrations=[CohereIntegration(include_prompts=include_prompts)],
         traces_sample_rate=1.0,
         send_default_pii=send_default_pii,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     client = Client(api_key="z")

--- a/tests/integrations/django/asgi/test_asgi.py
+++ b/tests/integrations/django/asgi/test_asgi.py
@@ -55,7 +55,7 @@ async def test_basic(
     sentry_init(
         integrations=[DjangoIntegration()],
         send_default_pii=True,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     import channels  # type: ignore[import-not-found]
@@ -162,7 +162,7 @@ async def test_async_views(
     sentry_init(
         integrations=[DjangoIntegration()],
         send_default_pii=True,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     comm = HttpCommunicator(application, "GET", "/async_message")
@@ -217,7 +217,7 @@ async def test_active_thread_id(
         integrations=[DjangoIntegration(middleware_spans=middleware_spans)],
         traces_sample_rate=1.0,
         profiles_sample_rate=1.0,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     comm = HttpCommunicator(application, "GET", endpoint)
@@ -453,7 +453,7 @@ async def test_has_trace_if_performance_enabled(
     sentry_init(
         integrations=[DjangoIntegration()],
         traces_sample_rate=1.0,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     comm = HttpCommunicator(asgi_application, "GET", "/view-exc-with-msg")
@@ -509,7 +509,7 @@ async def test_has_trace_if_performance_disabled(
 ):
     sentry_init(
         integrations=[DjangoIntegration()],
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     comm = HttpCommunicator(asgi_application, "GET", "/view-exc-with-msg")
@@ -560,7 +560,7 @@ async def test_trace_from_headers_if_performance_enabled(
     sentry_init(
         integrations=[DjangoIntegration()],
         traces_sample_rate=1.0,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     trace_id = "582b43a4192642f0b136d5159a501701"
@@ -621,7 +621,7 @@ async def test_trace_from_headers_if_performance_disabled(
 ):
     sentry_init(
         integrations=[DjangoIntegration()],
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     trace_id = "582b43a4192642f0b136d5159a501701"
@@ -779,7 +779,7 @@ async def test_asgi_request_body(
     sentry_init(
         integrations=[DjangoIntegration()],
         send_default_pii=send_default_pii,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     comm = HttpCommunicator(
@@ -900,7 +900,7 @@ async def test_async_view(
     sentry_init(
         integrations=[DjangoIntegration()],
         traces_sample_rate=1.0,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     comm = HttpCommunicator(application, "GET", "/simple_async_view")
@@ -943,7 +943,7 @@ async def test_transaction_http_method_default(
     sentry_init(
         integrations=[DjangoIntegration()],
         traces_sample_rate=1.0,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
     if span_streaming:
         items = capture_items("span")
@@ -1007,7 +1007,7 @@ async def test_transaction_http_method_custom(
             )
         ],
         traces_sample_rate=1.0,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
     if span_streaming:
         items = capture_items("span")

--- a/tests/integrations/django/test_basic.py
+++ b/tests/integrations/django/test_basic.py
@@ -59,7 +59,7 @@ def test_view_exceptions(
     sentry_init(
         integrations=[DjangoIntegration()],
         send_default_pii=True,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
     exceptions = capture_exceptions()
     if span_streaming:
@@ -101,7 +101,7 @@ def test_ensures_x_forwarded_header_is_honored_in_sdk_when_enabled_in_django(
     sentry_init(
         integrations=[DjangoIntegration()],
         send_default_pii=True,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
     exceptions = capture_exceptions()
     if span_streaming:
@@ -140,7 +140,7 @@ def test_ensures_x_forwarded_header_is_not_honored_when_unenabled_in_django(
     sentry_init(
         integrations=[DjangoIntegration()],
         send_default_pii=True,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
     exceptions = capture_exceptions()
     if span_streaming:
@@ -181,7 +181,7 @@ def test_request_captured(
     sentry_init(
         integrations=[DjangoIntegration()],
         send_default_pii=True,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
     if span_streaming:
         items = capture_items("event")
@@ -233,7 +233,7 @@ def test_transaction_with_class_view(
     sentry_init(
         integrations=[DjangoIntegration(transaction_style="function_name")],
         send_default_pii=True,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
     if span_streaming:
         items = capture_items("event")
@@ -273,7 +273,7 @@ def test_has_trace_if_performance_enabled(
             )
         ],
         traces_sample_rate=1.0,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
     if span_streaming:
         items = capture_items("event", "span")
@@ -332,7 +332,7 @@ def test_has_trace_if_performance_disabled(
 ):
     sentry_init(
         integrations=[DjangoIntegration()],
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
     if span_streaming:
         items = capture_items("event")
@@ -375,7 +375,7 @@ def test_trace_from_headers_if_performance_enabled(
             )
         ],
         traces_sample_rate=1.0,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     trace_id = "582b43a4192642f0b136d5159a501701"
@@ -442,7 +442,7 @@ def test_trace_from_headers_if_performance_disabled(
                 http_methods_to_capture=("HEAD",),
             )
         ],
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     trace_id = "582b43a4192642f0b136d5159a501701"
@@ -489,7 +489,7 @@ def test_user_captured(
     sentry_init(
         integrations=[DjangoIntegration()],
         send_default_pii=True,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
     if span_streaming:
         items = capture_items("event")
@@ -542,7 +542,7 @@ def test_materialized_user_captured(
         integrations=[DjangoIntegration()],
         send_default_pii=True,
         traces_sample_rate=1.0,
-        _experiments={"trace_lifecycle": "stream"},
+        trace_lifecycle="stream",
     )
 
     content, status, headers = unpack_werkzeug_response(client.get(reverse("mylogin")))
@@ -574,7 +574,7 @@ def test_queryset_repr(
 ):
     sentry_init(
         integrations=[DjangoIntegration()],
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     User.objects.create_user("john", "lennon@thebeatles.com", "johnpassword")
@@ -618,7 +618,7 @@ def test_context_nested_queryset_repr(
 ):
     sentry_init(
         integrations=[DjangoIntegration()],
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
     User.objects.create_user("john", "lennon@thebeatles.com", "johnpassword")
     if span_streaming:
@@ -658,7 +658,7 @@ def test_custom_error_handler_request_context(
 ):
     sentry_init(
         integrations=[DjangoIntegration()],
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
     if span_streaming:
         items = capture_items("event")
@@ -830,7 +830,7 @@ def test_response_trace(
     sentry_init(
         integrations=[DjangoIntegration()],
         traces_sample_rate=1.0,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
     if span_streaming:
         items = capture_items("span")
@@ -1035,7 +1035,7 @@ def test_django_connect_trace(
         integrations=[DjangoIntegration()],
         send_default_pii=True,
         traces_sample_rate=1.0,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     from django.db import connections
@@ -1098,7 +1098,7 @@ def test_django_connect_breadcrumbs(
     sentry_init(
         integrations=[DjangoIntegration()],
         send_default_pii=True,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     from django.db import connections
@@ -1151,7 +1151,7 @@ def test_db_connection_span_data(
         integrations=[DjangoIntegration()],
         send_default_pii=True,
         traces_sample_rate=1.0,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     from django.db import connections
@@ -1265,7 +1265,7 @@ def test_transaction_style(
         integrations=[DjangoIntegration(transaction_style=transaction_style)],
         traces_sample_rate=1.0,
         send_default_pii=True,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
     if span_streaming:
         items = capture_items("event", "span")
@@ -1303,7 +1303,7 @@ def test_request_body(
 ):
     sentry_init(
         integrations=[DjangoIntegration()],
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
     if span_streaming:
         items = capture_items("event")
@@ -1380,7 +1380,7 @@ def test_read_request(
 ):
     sentry_init(
         integrations=[DjangoIntegration()],
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
     if span_streaming:
         items = capture_items("event")
@@ -1424,7 +1424,7 @@ def test_request_body_already_read(
 ):
     sentry_init(
         integrations=[DjangoIntegration()],
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     class MockExtractor(DjangoRequestExtractor):
@@ -1473,7 +1473,7 @@ def test_template_tracing_meta(
 ):
     sentry_init(
         integrations=[DjangoIntegration()],
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
     if span_streaming:
         items = capture_items("event")
@@ -1515,7 +1515,7 @@ def test_template_exception(
 ):
     sentry_init(
         integrations=[DjangoIntegration()] + with_executing_integration,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
     if span_streaming:
         items = capture_items("event")
@@ -1599,7 +1599,7 @@ def test_rest_framework_basic(
     sentry_init(
         integrations=[DjangoIntegration()],
         send_default_pii=True,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
     if span_streaming:
         exceptions = capture_exceptions()
@@ -1659,7 +1659,7 @@ def test_does_not_capture_403(
 
     sentry_init(
         integrations=[DjangoIntegration()],
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
     if span_streaming:
         items = capture_items("event", "transaction", "span")
@@ -1689,7 +1689,7 @@ def test_render_spans(
     sentry_init(
         integrations=[DjangoIntegration()],
         traces_sample_rate=1.0,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
     if span_streaming:
         views_tests = [
@@ -1788,7 +1788,7 @@ def test_middleware_spans(
             DjangoIntegration(middleware_spans=True, signals_spans=False),
         ],
         traces_sample_rate=1.0,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
     if span_streaming:
         items = capture_items("event", "span")
@@ -1875,7 +1875,7 @@ def test_middleware_spans_disabled(
             DjangoIntegration(signals_spans=False),
         ],
         traces_sample_rate=1.0,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
     if span_streaming:
         items = capture_items("event", "span")
@@ -1914,7 +1914,7 @@ def test_signals_spans(
             DjangoIntegration(middleware_spans=False),
         ],
         traces_sample_rate=1.0,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
     if span_streaming:
         items = capture_items("event", "span")
@@ -1980,7 +1980,7 @@ def test_signals_spans_disabled(
             DjangoIntegration(middleware_spans=False, signals_spans=False),
         ],
         traces_sample_rate=1.0,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
     if span_streaming:
         items = capture_items("event", "span")
@@ -2025,7 +2025,7 @@ def test_signals_spans_filtering(
             ),
         ],
         traces_sample_rate=1.0,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
     if span_streaming:
         items = capture_items("span")
@@ -2148,7 +2148,7 @@ def test_custom_urlconf_middleware(
     sentry_init(
         integrations=[DjangoIntegration(middleware_spans=middleware_spans)],
         traces_sample_rate=1.0,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     if span_streaming:
@@ -2266,7 +2266,7 @@ def test_span_origin(
             )
         ],
         traces_sample_rate=1.0,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
     signal_span_found = False
     if span_streaming:
@@ -2314,7 +2314,7 @@ def test_transaction_http_method_default(
     sentry_init(
         integrations=[DjangoIntegration()],
         traces_sample_rate=1.0,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
     if span_streaming:
         items = capture_items("span")
@@ -2358,7 +2358,7 @@ def test_transaction_http_method_custom(
             )
         ],
         traces_sample_rate=1.0,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
     if span_streaming:
         items = capture_items("span")

--- a/tests/integrations/django/test_cache_module.py
+++ b/tests/integrations/django/test_cache_module.py
@@ -110,7 +110,7 @@ def test_cache_spans_disabled_middleware(
             )
         ],
         traces_sample_rate=1.0,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
     if span_streaming:
         items = capture_items("span")
@@ -153,7 +153,7 @@ def test_cache_spans_disabled_decorator(
             )
         ],
         traces_sample_rate=1.0,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
     if span_streaming:
         items = capture_items("span")
@@ -196,7 +196,7 @@ def test_cache_spans_disabled_templatetag(
             )
         ],
         traces_sample_rate=1.0,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
     if span_streaming:
         items = capture_items("span")
@@ -239,7 +239,7 @@ def test_cache_spans_middleware(
             )
         ],
         traces_sample_rate=1.0,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     client.application.load_middleware()
@@ -361,7 +361,7 @@ def test_cache_spans_decorator(
             )
         ],
         traces_sample_rate=1.0,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
     if span_streaming:
         items = capture_items("span")
@@ -461,7 +461,7 @@ def test_cache_spans_templatetag(
             )
         ],
         traces_sample_rate=1.0,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
     if span_streaming:
         items = capture_items("span")
@@ -598,7 +598,7 @@ def test_cache_spans_location_with_port(
             )
         ],
         traces_sample_rate=1.0,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
     if span_streaming:
         items = capture_items("span")
@@ -651,7 +651,7 @@ def test_cache_spans_location_without_port(
             )
         ],
         traces_sample_rate=1.0,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
     if span_streaming:
         items = capture_items("span")
@@ -700,7 +700,7 @@ def test_cache_spans_location_with_cluster(
             )
         ],
         traces_sample_rate=1.0,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
     if span_streaming:
         items = capture_items("span")
@@ -748,7 +748,7 @@ def test_cache_spans_item_size(
             )
         ],
         traces_sample_rate=1.0,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
     if span_streaming:
         items = capture_items("span")
@@ -827,7 +827,7 @@ def test_cache_spans_get_custom_default(
             )
         ],
         traces_sample_rate=1.0,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     id = os.getpid()
@@ -940,7 +940,7 @@ def test_cache_spans_get_many(
             )
         ],
         traces_sample_rate=1.0,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     id = os.getpid()
@@ -1043,7 +1043,7 @@ def test_cache_spans_set_many(
             )
         ],
         traces_sample_rate=1.0,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     id = os.getpid()
@@ -1116,7 +1116,7 @@ def test_span_origin_cache(
             )
         ],
         traces_sample_rate=1.0,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
     cache_span_found = False
     if span_streaming:

--- a/tests/integrations/django/test_data_scrubbing.py
+++ b/tests/integrations/django/test_data_scrubbing.py
@@ -29,7 +29,7 @@ def test_scrub_django_session_cookies_removed(
     sentry_init(
         integrations=[DjangoIntegration()],
         send_default_pii=False,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
     items = capture_items("event")
     werkzeug_set_cookie(client, "localhost", "sessionid", "123")
@@ -53,7 +53,7 @@ def test_scrub_django_session_cookies_filtered(
     sentry_init(
         integrations=[DjangoIntegration()],
         send_default_pii=True,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
     items = capture_items("event")
     werkzeug_set_cookie(client, "localhost", "sessionid", "123")
@@ -85,7 +85,7 @@ def test_scrub_django_custom_session_cookies_filtered(
     sentry_init(
         integrations=[DjangoIntegration()],
         send_default_pii=True,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
     items = capture_items("event")
     werkzeug_set_cookie(client, "localhost", "my_sess", "123")

--- a/tests/integrations/django/test_db_query_data.py
+++ b/tests/integrations/django/test_db_query_data.py
@@ -46,7 +46,7 @@ def test_query_source_disabled(
         "traces_sample_rate": 1.0,
         "enable_db_query_source": False,
         "db_query_source_threshold_ms": 0,
-        "_experiments": {"trace_lifecycle": "stream" if span_streaming else "static"},
+        "trace_lifecycle": "stream" if span_streaming else "static",
     }
 
     sentry_init(**sentry_options)
@@ -120,7 +120,7 @@ def test_query_source_enabled(
         "send_default_pii": True,
         "traces_sample_rate": 1.0,
         "db_query_source_threshold_ms": 0,
-        "_experiments": {"trace_lifecycle": "stream" if span_streaming else "static"},
+        "trace_lifecycle": "stream" if span_streaming else "static",
     }
 
     if enable_db_query_source is not None:
@@ -196,7 +196,7 @@ def test_query_source(
         traces_sample_rate=1.0,
         enable_db_query_source=True,
         db_query_source_threshold_ms=0,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     if "postgres" not in connections:
@@ -304,7 +304,7 @@ def test_query_source_with_module_in_search_path(
         traces_sample_rate=1.0,
         enable_db_query_source=True,
         db_query_source_threshold_ms=0,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     if "postgres" not in connections:
@@ -398,7 +398,7 @@ def test_query_source_with_in_app_exclude(
         enable_db_query_source=True,
         db_query_source_threshold_ms=0,
         in_app_exclude=["tests.integrations.django.myapp.views"],
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     if "postgres" not in connections:
@@ -520,7 +520,7 @@ def test_query_source_with_in_app_include(
         enable_db_query_source=True,
         db_query_source_threshold_ms=0,
         in_app_include=["django"],
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     if "postgres" not in connections:
@@ -614,7 +614,7 @@ def test_no_query_source_if_duration_too_short(
         traces_sample_rate=1.0,
         enable_db_query_source=True,
         db_query_source_threshold_ms=100,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     if "postgres" not in connections:
@@ -720,7 +720,7 @@ def test_query_source_if_duration_over_threshold(
         traces_sample_rate=1.0,
         enable_db_query_source=True,
         db_query_source_threshold_ms=100,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     if "postgres" not in connections:
@@ -855,7 +855,7 @@ def test_db_span_origin_execute(
     sentry_init(
         integrations=[DjangoIntegration()],
         traces_sample_rate=1.0,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     if "postgres" not in connections:
@@ -908,7 +908,7 @@ def test_db_span_origin_executemany(
     sentry_init(
         integrations=[DjangoIntegration()],
         traces_sample_rate=1.0,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     if "postgres" not in connections:

--- a/tests/integrations/django/test_db_transactions.py
+++ b/tests/integrations/django/test_db_transactions.py
@@ -39,7 +39,7 @@ def test_db_transaction_spans_disabled_no_autocommit(
     sentry_init(
         integrations=[DjangoIntegration()],
         traces_sample_rate=1.0,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     if "postgres" not in connections:
@@ -285,7 +285,7 @@ def test_db_transaction_spans_disabled_atomic(
     sentry_init(
         integrations=[DjangoIntegration()],
         traces_sample_rate=1.0,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     if "postgres" not in connections:
@@ -513,7 +513,7 @@ def test_db_no_autocommit_execute(
     sentry_init(
         integrations=[DjangoIntegration(db_transaction_spans=True)],
         traces_sample_rate=1.0,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     if "postgres" not in connections:
@@ -625,7 +625,7 @@ def test_db_no_autocommit_executemany(
     sentry_init(
         integrations=[DjangoIntegration(db_transaction_spans=True)],
         traces_sample_rate=1.0,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
     if span_streaming:
         items = capture_items("span")
@@ -795,7 +795,7 @@ def test_db_no_autocommit_rollback_execute(
     sentry_init(
         integrations=[DjangoIntegration(db_transaction_spans=True)],
         traces_sample_rate=1.0,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     if "postgres" not in connections:
@@ -908,7 +908,7 @@ def test_db_no_autocommit_rollback_executemany(
     sentry_init(
         integrations=[DjangoIntegration(db_transaction_spans=True)],
         traces_sample_rate=1.0,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
     if span_streaming:
         items = capture_items("span")
@@ -1077,7 +1077,7 @@ def test_db_atomic_execute(
     sentry_init(
         integrations=[DjangoIntegration(db_transaction_spans=True)],
         traces_sample_rate=1.0,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     if "postgres" not in connections:
@@ -1190,7 +1190,7 @@ def test_db_atomic_executemany(
         integrations=[DjangoIntegration(db_transaction_spans=True)],
         send_default_pii=True,
         traces_sample_rate=1.0,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
     if span_streaming:
         items = capture_items("span")
@@ -1351,7 +1351,7 @@ def test_db_atomic_rollback_execute(
         integrations=[DjangoIntegration(db_transaction_spans=True)],
         send_default_pii=True,
         traces_sample_rate=1.0,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     if "postgres" not in connections:
@@ -1466,7 +1466,7 @@ def test_db_atomic_rollback_executemany(
         integrations=[DjangoIntegration(db_transaction_spans=True)],
         send_default_pii=True,
         traces_sample_rate=1.0,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
     if span_streaming:
         items = capture_items("span")
@@ -1632,7 +1632,7 @@ def test_db_atomic_execute_exception(
         integrations=[DjangoIntegration(db_transaction_spans=True)],
         send_default_pii=True,
         traces_sample_rate=1.0,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     if "postgres" not in connections:
@@ -1746,7 +1746,7 @@ def test_db_atomic_executemany_exception(
         integrations=[DjangoIntegration(db_transaction_spans=True)],
         send_default_pii=True,
         traces_sample_rate=1.0,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
     if span_streaming:
         items = capture_items("span")

--- a/tests/integrations/django/test_tasks.py
+++ b/tests/integrations/django/test_tasks.py
@@ -63,7 +63,7 @@ def test_task_span_is_created(
     sentry_init(
         integrations=[DjangoIntegration()],
         traces_sample_rate=1.0,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
     if span_streaming:
         items = capture_items("span")
@@ -140,7 +140,7 @@ def test_task_enqueue_with_kwargs(
     sentry_init(
         integrations=[DjangoIntegration()],
         traces_sample_rate=1.0,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
     if span_streaming:
         items = capture_items("span")
@@ -198,7 +198,7 @@ def test_task_error_reporting(
     sentry_init(
         integrations=[DjangoIntegration()],
         traces_sample_rate=1.0,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
     if span_streaming:
         items = capture_items("span")
@@ -265,7 +265,7 @@ def test_multiple_task_enqueues_create_multiple_spans(
     sentry_init(
         integrations=[DjangoIntegration()],
         traces_sample_rate=1.0,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
     if span_streaming:
         items = capture_items("span")

--- a/tests/integrations/dramatiq/test_dramatiq.py
+++ b/tests/integrations/dramatiq/test_dramatiq.py
@@ -79,7 +79,7 @@ def test_that_a_single_error_is_captured(broker, worker, capture_events, fail_fa
         (
             {
                 "traces_sample_rate": 1.0,
-                "_experiments": {"trace_lifecycle": "stream"},
+                "trace_lifecycle": "stream",
             },
             SPANSTATUS.INTERNAL_ERROR,
             False,
@@ -88,7 +88,7 @@ def test_that_a_single_error_is_captured(broker, worker, capture_events, fail_fa
         (
             {
                 "traces_sample_rate": 1.0,
-                "_experiments": {"trace_lifecycle": "stream"},
+                "trace_lifecycle": "stream",
             },
             SPANSTATUS.OK,
             False,
@@ -97,7 +97,7 @@ def test_that_a_single_error_is_captured(broker, worker, capture_events, fail_fa
         (
             {
                 "traces_sample_rate": 1.0,
-                "_experiments": {"trace_lifecycle": "stream"},
+                "trace_lifecycle": "stream",
             },
             SPANSTATUS.INTERNAL_ERROR,
             True,
@@ -106,7 +106,7 @@ def test_that_a_single_error_is_captured(broker, worker, capture_events, fail_fa
         (
             {
                 "traces_sample_rate": 1.0,
-                "_experiments": {"trace_lifecycle": "stream"},
+                "trace_lifecycle": "stream",
             },
             SPANSTATUS.OK,
             True,
@@ -202,7 +202,7 @@ def test_task_transaction(
         (
             {
                 "traces_sample_rate": 1.0,
-                "_experiments": {"trace_lifecycle": "stream"},
+                "trace_lifecycle": "stream",
             },
             True,
         ),
@@ -519,7 +519,7 @@ def test_that_retry_exceptions_are_not_captured(
         (
             {
                 "traces_sample_rate": 1.0,
-                "_experiments": {"trace_lifecycle": "stream"},
+                "trace_lifecycle": "stream",
             },
             True,
         ),

--- a/tests/integrations/falcon/test_falcon.py
+++ b/tests/integrations/falcon/test_falcon.py
@@ -74,7 +74,7 @@ def test_has_context(
 ):
     sentry_init(
         integrations=[FalconIntegration()],
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     client = make_client()
@@ -122,7 +122,7 @@ def test_transaction_style(
     sentry_init(
         integrations=[integration],
         traces_sample_rate=1.0,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     client = make_client()
@@ -165,7 +165,7 @@ def test_unhandled_errors(
 ):
     sentry_init(
         integrations=[FalconIntegration()],
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     class Resource:
@@ -216,7 +216,7 @@ def test_raised_5xx_errors(
 ):
     sentry_init(
         integrations=[FalconIntegration()],
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     class Resource:
@@ -261,7 +261,7 @@ def test_raised_4xx_errors(
 ):
     sentry_init(
         integrations=[FalconIntegration()],
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     class Resource:
@@ -298,7 +298,7 @@ def test_http_status(
     """
     sentry_init(
         integrations=[FalconIntegration()],
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     class Resource:
@@ -337,7 +337,7 @@ def test_falcon_large_json_request(
         integrations=[FalconIntegration()],
         max_request_body_size="always",
         max_value_length=max_value_length,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     data = {"foo": {"bar": "a" * (1034)}}
@@ -390,7 +390,7 @@ def test_falcon_empty_json_request(
 ):
     sentry_init(
         integrations=[FalconIntegration()],
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     class Resource:
@@ -430,7 +430,7 @@ def test_falcon_raw_data_request(
 ):
     sentry_init(
         integrations=[FalconIntegration()],
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     class Resource:
@@ -470,7 +470,7 @@ def test_logging(
 ):
     sentry_init(
         integrations=[FalconIntegration(), LoggingIntegration(event_level="ERROR")],
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     logger = logging.getLogger()
@@ -533,7 +533,7 @@ def test_error_in_errorhandler(
 ):
     sentry_init(
         integrations=[FalconIntegration()],
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     app = falcon.API()
@@ -579,7 +579,7 @@ def test_bad_request_not_captured(
 ):
     sentry_init(
         integrations=[FalconIntegration()],
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     app = falcon.API()
@@ -611,7 +611,7 @@ def test_does_not_leak_scope(
 ):
     sentry_init(
         integrations=[FalconIntegration()],
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     app = falcon.API()
@@ -661,7 +661,7 @@ def test_falcon_not_breaking_asgi(sentry_init, span_streaming):
     """
     sentry_init(
         integrations=[FalconIntegration()],
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     asgi_app = falcon.asgi.App()
@@ -690,7 +690,7 @@ def test_falcon_custom_error_handler(
     """
     sentry_init(
         integrations=[FalconIntegration()],
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     app = make_app()
@@ -717,7 +717,7 @@ def test_span_origin(
     sentry_init(
         integrations=[FalconIntegration()],
         traces_sample_rate=1.0,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     client = make_client()
@@ -770,7 +770,7 @@ def test_falcon_request_media(sentry_init, span_streaming):
 
     sentry_init(
         integrations=[FalconIntegration()],
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     try:

--- a/tests/integrations/fastapi/test_fastapi.py
+++ b/tests/integrations/fastapi/test_fastapi.py
@@ -508,7 +508,7 @@ def test_active_thread_id_span_streaming(sentry_init, capture_items, endpoint):
         auto_enabling_integrations=False,  # Ensure httpx is not auto-enabled; its legacy start_span interferes with streaming mode
         integrations=[StarletteIntegration(), FastApiIntegration()],
         traces_sample_rate=1.0,
-        _experiments={"trace_lifecycle": "stream"},
+        trace_lifecycle="stream",
     )
     app = fastapi_app_factory()
 

--- a/tests/integrations/fastmcp/test_fastmcp.py
+++ b/tests/integrations/fastmcp/test_fastmcp.py
@@ -293,7 +293,7 @@ async def test_fastmcp_tool_sync(
         integrations=[MCPIntegration(include_prompts=include_prompts)],
         traces_sample_rate=1.0,
         send_default_pii=send_default_pii,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     mcp = FastMCP("Test Server")
@@ -405,7 +405,7 @@ async def test_fastmcp_tool_async(
         integrations=[MCPIntegration(include_prompts=include_prompts)],
         traces_sample_rate=1.0,
         send_default_pii=send_default_pii,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     mcp = FastMCP("Test Server")
@@ -526,7 +526,7 @@ async def test_fastmcp_tool_with_error(
     sentry_init(
         integrations=[MCPIntegration()],
         traces_sample_rate=1.0,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     mcp = FastMCP("Test Server")
@@ -622,7 +622,7 @@ async def test_fastmcp_multiple_tools(
     sentry_init(
         integrations=[MCPIntegration()],
         traces_sample_rate=1.0,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     mcp = FastMCP("Test Server")
@@ -761,7 +761,7 @@ async def test_fastmcp_tool_with_complex_return(
         integrations=[MCPIntegration(include_prompts=True)],
         traces_sample_rate=1.0,
         send_default_pii=True,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     mcp = FastMCP("Test Server")
@@ -866,7 +866,7 @@ async def test_fastmcp_prompt_sync(
         integrations=[MCPIntegration(include_prompts=include_prompts)],
         traces_sample_rate=1.0,
         send_default_pii=send_default_pii,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     mcp = FastMCP("Test Server")
@@ -1058,7 +1058,7 @@ async def test_fastmcp_resource_sync(
     sentry_init(
         integrations=[MCPIntegration()],
         traces_sample_rate=1.0,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     mcp = FastMCP("Test Server")
@@ -1167,7 +1167,7 @@ async def test_fastmcp_resource_async(
     sentry_init(
         integrations=[MCPIntegration()],
         traces_sample_rate=1.0,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     mcp = FastMCP("Test Server")
@@ -1284,7 +1284,7 @@ async def test_fastmcp_span_origin(
     sentry_init(
         integrations=[MCPIntegration()],
         traces_sample_rate=1.0,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     mcp = FastMCP("Test Server")
@@ -1361,7 +1361,7 @@ async def test_fastmcp_sse_transport(
     sentry_init(
         integrations=[MCPIntegration()],
         traces_sample_rate=1.0,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     mcp = FastMCP("Test Server")
@@ -1486,7 +1486,7 @@ def test_fastmcp_http_transport(
     sentry_init(
         integrations=[MCPIntegration()],
         traces_sample_rate=1.0,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     mcp = FastMCP("Test Server")
@@ -1581,7 +1581,7 @@ async def test_fastmcp_stdio_transport(
     sentry_init(
         integrations=[MCPIntegration()],
         traces_sample_rate=1.0,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     mcp = FastMCP("Test Server")
@@ -1818,7 +1818,7 @@ async def test_fastmcp_mixed_sync_async_tools(
     sentry_init(
         integrations=[MCPIntegration()],
         traces_sample_rate=1.0,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     mcp = FastMCP("Test Server")

--- a/tests/integrations/flask/test_flask.py
+++ b/tests/integrations/flask/test_flask.py
@@ -110,7 +110,7 @@ def test_transaction_or_segment_style(
             flask_sentry.FlaskIntegration(transaction_style=transaction_style)
         ],
         traces_sample_rate=1.0,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     if span_streaming:
@@ -238,7 +238,7 @@ def test_flask_login_configured(
             integrations=[flask_sentry.FlaskIntegration()],
             send_default_pii=send_default_pii,
             traces_sample_rate=1.0,
-            _experiments={"trace_lifecycle": "stream"},
+            trace_lifecycle="stream",
         )
     else:
         sentry_init(send_default_pii=send_default_pii, **integration_enabled_params)
@@ -817,7 +817,7 @@ def test_tracing_success(
     sentry_init(
         traces_sample_rate=1.0,
         integrations=[flask_sentry.FlaskIntegration()],
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     @app.before_request
@@ -878,7 +878,7 @@ def test_tracing_error(sentry_init, capture_events, capture_items, app, span_str
     sentry_init(
         traces_sample_rate=1.0,
         integrations=[flask_sentry.FlaskIntegration()],
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     if span_streaming:
@@ -1103,7 +1103,7 @@ def test_span_origin(sentry_init, app, capture_events, capture_items, span_strea
     sentry_init(
         integrations=[flask_sentry.FlaskIntegration()],
         traces_sample_rate=1.0,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     if span_streaming:
@@ -1139,7 +1139,7 @@ def test_transaction_or_segment_http_method_default(
     sentry_init(
         traces_sample_rate=1.0,
         integrations=[flask_sentry.FlaskIntegration()],
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     if span_streaming:
@@ -1190,7 +1190,7 @@ def test_transaction_or_segment_http_method_custom(
                 )  # capitalization does not matter
             )  # case does not matter
         ],
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     if span_streaming:

--- a/tests/integrations/gcp/test_gcp.py
+++ b/tests/integrations/gcp/test_gcp.py
@@ -598,7 +598,7 @@ def test_span_streaming_no_error(run_cloud_function):
         + FUNCTIONS_PRELUDE
         + dedent(
             """
-        init_sdk(traces_sample_rate=1.0, _experiments={"trace_lifecycle": "stream"})
+        init_sdk(traces_sample_rate=1.0, trace_lifecycle="stream")
         gcp_functions.worker_v1.FunctionHandler.invoke_user_function(functionhandler, event)
         """
         )
@@ -632,7 +632,7 @@ def test_span_streaming_error(run_cloud_function):
         + FUNCTIONS_PRELUDE
         + dedent(
             """
-        init_sdk(traces_sample_rate=1.0, _experiments={"trace_lifecycle": "stream"})
+        init_sdk(traces_sample_rate=1.0, trace_lifecycle="stream")
         gcp_functions.worker_v1.FunctionHandler.invoke_user_function(functionhandler, event)
         """
         )
@@ -684,7 +684,7 @@ def test_span_streaming_existing_trace_context(run_cloud_function):
         + FUNCTIONS_PRELUDE
         + dedent(
             """
-        init_sdk(traces_sample_rate=1.0, _experiments={"trace_lifecycle": "stream"})
+        init_sdk(traces_sample_rate=1.0, trace_lifecycle="stream")
         gcp_functions.worker_v1.FunctionHandler.invoke_user_function(functionhandler, event)
         """
         )
@@ -729,7 +729,7 @@ def test_span_streaming_request_attributes(run_cloud_function):
         + FUNCTIONS_PRELUDE
         + dedent(
             """
-        init_sdk(traces_sample_rate=1.0, send_default_pii=True, _experiments={"trace_lifecycle": "stream"})
+        init_sdk(traces_sample_rate=1.0, send_default_pii=True, trace_lifecycle="stream")
         gcp_functions.worker_v1.FunctionHandler.invoke_user_function(functionhandler, event)
         """
         )
@@ -770,7 +770,7 @@ def test_span_streaming_no_query_string_without_pii(run_cloud_function):
         + FUNCTIONS_PRELUDE
         + dedent(
             """
-        init_sdk(traces_sample_rate=1.0, send_default_pii=False, _experiments={"trace_lifecycle": "stream"})
+        init_sdk(traces_sample_rate=1.0, send_default_pii=False, trace_lifecycle="stream")
         gcp_functions.worker_v1.FunctionHandler.invoke_user_function(functionhandler, event)
         """
         )

--- a/tests/integrations/google_genai/test_google_genai.py
+++ b/tests/integrations/google_genai/test_google_genai.py
@@ -141,7 +141,7 @@ def test_nonstreaming_generate_content(
         traces_sample_rate=1.0,
         send_default_pii=send_default_pii,
         stream_gen_ai_spans=stream_gen_ai_spans,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     # Mock the HTTP response at the _api_client.request() level
@@ -313,7 +313,7 @@ def test_generate_content_with_system_instruction(
         traces_sample_rate=1.0,
         send_default_pii=True,
         stream_gen_ai_spans=stream_gen_ai_spans,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     mock_http_response = create_mock_http_response(EXAMPLE_API_RESPONSE_JSON)
@@ -400,7 +400,7 @@ def test_generate_content_with_tools(
         integrations=[GoogleGenAIIntegration()],
         traces_sample_rate=1.0,
         stream_gen_ai_spans=stream_gen_ai_spans,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     # Create a mock tool function
@@ -520,7 +520,7 @@ def test_tool_execution(
         traces_sample_rate=1.0,
         send_default_pii=True,
         stream_gen_ai_spans=stream_gen_ai_spans,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     # Create a mock tool function
@@ -591,7 +591,7 @@ def test_error_handling(
         integrations=[GoogleGenAIIntegration()],
         traces_sample_rate=1.0,
         stream_gen_ai_spans=stream_gen_ai_spans,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
     if span_streaming or stream_gen_ai_spans:
         items = capture_items("event")
@@ -650,7 +650,7 @@ def test_streaming_generate_content(
         traces_sample_rate=1.0,
         send_default_pii=True,
         stream_gen_ai_spans=stream_gen_ai_spans,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     # Create streaming chunks - simulating a multi-chunk response
@@ -862,7 +862,7 @@ def test_span_origin(
         integrations=[GoogleGenAIIntegration()],
         traces_sample_rate=1.0,
         stream_gen_ai_spans=stream_gen_ai_spans,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     mock_http_response = create_mock_http_response(EXAMPLE_API_RESPONSE_JSON)
@@ -918,7 +918,7 @@ def test_response_without_usage_metadata(
         integrations=[GoogleGenAIIntegration()],
         traces_sample_rate=1.0,
         stream_gen_ai_spans=stream_gen_ai_spans,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     # Response without usage metadata
@@ -990,7 +990,7 @@ def test_multiple_candidates(
         traces_sample_rate=1.0,
         send_default_pii=True,
         stream_gen_ai_spans=stream_gen_ai_spans,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     # Response with multiple candidates
@@ -1098,7 +1098,7 @@ def test_all_configuration_parameters(
         integrations=[GoogleGenAIIntegration()],
         traces_sample_rate=1.0,
         stream_gen_ai_spans=stream_gen_ai_spans,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     mock_http_response = create_mock_http_response(EXAMPLE_API_RESPONSE_JSON)
@@ -1184,7 +1184,7 @@ def test_empty_response(
         integrations=[GoogleGenAIIntegration()],
         traces_sample_rate=1.0,
         stream_gen_ai_spans=stream_gen_ai_spans,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     # Minimal response with empty candidates array
@@ -1243,7 +1243,7 @@ def test_response_with_different_id_fields(
         integrations=[GoogleGenAIIntegration()],
         traces_sample_rate=1.0,
         stream_gen_ai_spans=stream_gen_ai_spans,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     # Response with response_id and model_version
@@ -1337,7 +1337,7 @@ def test_contents_as_none(
         traces_sample_rate=1.0,
         send_default_pii=True,
         stream_gen_ai_spans=stream_gen_ai_spans,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     mock_http_response = create_mock_http_response(EXAMPLE_API_RESPONSE_JSON)
@@ -1392,7 +1392,7 @@ def test_tool_calls_extraction(
         integrations=[GoogleGenAIIntegration()],
         traces_sample_rate=1.0,
         stream_gen_ai_spans=stream_gen_ai_spans,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     # Response with function calls
@@ -1590,7 +1590,7 @@ def test_embed_content(
         traces_sample_rate=1.0,
         send_default_pii=send_default_pii,
         stream_gen_ai_spans=stream_gen_ai_spans,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     # Mock the HTTP response at the _api_client.request() level
@@ -1715,7 +1715,7 @@ def test_embed_content_string_input(
         traces_sample_rate=1.0,
         send_default_pii=True,
         stream_gen_ai_spans=stream_gen_ai_spans,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     # Mock response with single embedding
@@ -1798,7 +1798,7 @@ def test_embed_content_error_handling(
         integrations=[GoogleGenAIIntegration()],
         traces_sample_rate=1.0,
         stream_gen_ai_spans=stream_gen_ai_spans,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
     if span_streaming or stream_gen_ai_spans:
         items = capture_items("event")
@@ -1858,7 +1858,7 @@ def test_embed_content_without_statistics(
         integrations=[GoogleGenAIIntegration()],
         traces_sample_rate=1.0,
         stream_gen_ai_spans=stream_gen_ai_spans,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     # Response without statistics (typical for older google-genai versions)
@@ -1927,7 +1927,7 @@ def test_embed_content_span_origin(
         integrations=[GoogleGenAIIntegration()],
         traces_sample_rate=1.0,
         stream_gen_ai_spans=stream_gen_ai_spans,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     mock_http_response = create_mock_http_response(EXAMPLE_EMBED_RESPONSE_JSON)
@@ -1993,7 +1993,7 @@ async def test_async_embed_content(
         traces_sample_rate=1.0,
         send_default_pii=send_default_pii,
         stream_gen_ai_spans=stream_gen_ai_spans,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     # Mock the async HTTP response
@@ -2120,7 +2120,7 @@ async def test_async_embed_content_string_input(
         traces_sample_rate=1.0,
         send_default_pii=True,
         stream_gen_ai_spans=stream_gen_ai_spans,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     # Mock response with single embedding
@@ -2207,7 +2207,7 @@ async def test_async_embed_content_error_handling(
         integrations=[GoogleGenAIIntegration()],
         traces_sample_rate=1.0,
         stream_gen_ai_spans=stream_gen_ai_spans,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     if span_streaming or stream_gen_ai_spans:
@@ -2269,7 +2269,7 @@ async def test_async_embed_content_without_statistics(
         integrations=[GoogleGenAIIntegration()],
         traces_sample_rate=1.0,
         stream_gen_ai_spans=stream_gen_ai_spans,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     # Response without statistics (typical for older google-genai versions)
@@ -2343,7 +2343,7 @@ async def test_async_embed_content_span_origin(
         integrations=[GoogleGenAIIntegration()],
         traces_sample_rate=1.0,
         stream_gen_ai_spans=stream_gen_ai_spans,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     mock_http_response = create_mock_http_response(EXAMPLE_EMBED_RESPONSE_JSON)
@@ -2405,7 +2405,7 @@ def test_generate_content_with_content_object(
         traces_sample_rate=1.0,
         send_default_pii=True,
         stream_gen_ai_spans=stream_gen_ai_spans,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     mock_http_response = create_mock_http_response(EXAMPLE_API_RESPONSE_JSON)
@@ -2469,7 +2469,7 @@ def test_generate_content_with_dict_format(
         traces_sample_rate=1.0,
         send_default_pii=True,
         stream_gen_ai_spans=stream_gen_ai_spans,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     mock_http_response = create_mock_http_response(EXAMPLE_API_RESPONSE_JSON)
@@ -2531,7 +2531,7 @@ def test_generate_content_with_file_data(
         traces_sample_rate=1.0,
         send_default_pii=True,
         stream_gen_ai_spans=stream_gen_ai_spans,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     mock_http_response = create_mock_http_response(EXAMPLE_API_RESPONSE_JSON)
@@ -2608,7 +2608,7 @@ def test_generate_content_with_inline_data(
         traces_sample_rate=1.0,
         send_default_pii=True,
         stream_gen_ai_spans=stream_gen_ai_spans,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     mock_http_response = create_mock_http_response(EXAMPLE_API_RESPONSE_JSON)
@@ -2782,7 +2782,7 @@ def test_generate_content_with_part_object_directly(
         traces_sample_rate=1.0,
         send_default_pii=True,
         stream_gen_ai_spans=stream_gen_ai_spans,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     mock_http_response = create_mock_http_response(EXAMPLE_API_RESPONSE_JSON)
@@ -2886,7 +2886,7 @@ def test_generate_content_with_dict_inline_data(
         traces_sample_rate=1.0,
         send_default_pii=True,
         stream_gen_ai_spans=stream_gen_ai_spans,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     mock_http_response = create_mock_http_response(EXAMPLE_API_RESPONSE_JSON)
@@ -2958,7 +2958,7 @@ def test_generate_content_without_parts_property_inline_data(
         traces_sample_rate=1.0,
         send_default_pii=True,
         stream_gen_ai_spans=stream_gen_ai_spans,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     mock_http_response = create_mock_http_response(EXAMPLE_API_RESPONSE_JSON)
@@ -3028,7 +3028,7 @@ def test_generate_content_without_parts_property_inline_data_and_binary_data_wit
         traces_sample_rate=1.0,
         send_default_pii=True,
         stream_gen_ai_spans=stream_gen_ai_spans,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     mock_http_response = create_mock_http_response(EXAMPLE_API_RESPONSE_JSON)

--- a/tests/integrations/graphene/test_graphene.py
+++ b/tests/integrations/graphene/test_graphene.py
@@ -267,7 +267,7 @@ def test_graphql_streamed_span_holds_query_information(
         traces_sample_rate=1.0,
         default_integrations=False,
         send_default_pii=send_default_pii,
-        _experiments={"trace_lifecycle": "stream"},
+        trace_lifecycle="stream",
     )
     items = capture_items("span")
 
@@ -361,7 +361,7 @@ def test_breadcrumbs_hold_query_information_on_error_with_span_streaming(
             GrapheneIntegration(),
         ],
         default_integrations=False,
-        _experiments={"trace_lifecycle": "stream"},
+        trace_lifecycle="stream",
     )
     items = capture_items("span", "event")
 

--- a/tests/integrations/grpc/test_grpc.py
+++ b/tests/integrations/grpc/test_grpc.py
@@ -64,7 +64,7 @@ def test_grpc_server_starts_transaction(
     sentry_init(
         traces_sample_rate=1.0,
         integrations=[GRPCIntegration()],
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     server, channel = _set_up()
@@ -119,7 +119,7 @@ def test_grpc_server_other_interceptors(
     sentry_init(
         traces_sample_rate=1.0,
         integrations=[GRPCIntegration()],
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     mock_intercept = lambda continuation, handler_call_details: continuation(
@@ -183,7 +183,7 @@ def test_grpc_server_continues_transaction(
     sentry_init(
         traces_sample_rate=1.0,
         integrations=[GRPCIntegration()],
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     server, channel = _set_up()
@@ -277,7 +277,7 @@ def test_grpc_client_starts_span(
     sentry_init(
         traces_sample_rate=1.0,
         integrations=[GRPCIntegration()],
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     server, channel = _set_up()
@@ -361,7 +361,7 @@ def test_grpc_client_unary_stream_starts_span(
     sentry_init(
         traces_sample_rate=1.0,
         integrations=[GRPCIntegration()],
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     server, channel = _set_up()
@@ -452,7 +452,7 @@ def test_grpc_client_other_interceptor(
     sentry_init(
         traces_sample_rate=1.0,
         integrations=[GRPCIntegration()],
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     server, channel = _set_up()
@@ -541,7 +541,7 @@ def test_prevent_dual_client_interceptor(
     sentry_init(
         traces_sample_rate=1.0,
         integrations=[GRPCIntegration()],
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     server, channel = _set_up()
@@ -615,7 +615,7 @@ def test_grpc_client_and_servers_interceptors_integration(
     sentry_init(
         traces_sample_rate=1.0,
         integrations=[GRPCIntegration()],
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     server, channel = _set_up()
@@ -700,7 +700,7 @@ def test_span_origin(
     sentry_init(
         traces_sample_rate=1.0,
         integrations=[GRPCIntegration()],
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     server, channel = _set_up()

--- a/tests/integrations/grpc/test_grpc_aio.py
+++ b/tests/integrations/grpc/test_grpc_aio.py
@@ -35,7 +35,7 @@ async def grpc_server_and_channel(sentry_init):
         sentry_init(
             traces_sample_rate=1.0,
             integrations=[GRPCIntegration()],
-            _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+            trace_lifecycle="stream" if span_streaming else "static",
         )
 
         # Create server
@@ -76,7 +76,7 @@ async def test_noop_for_unimplemented_method(
     sentry_init(
         traces_sample_rate=1.0,
         integrations=[GRPCIntegration()],
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     # Create empty server with no services

--- a/tests/integrations/httpx/test_httpx.py
+++ b/tests/integrations/httpx/test_httpx.py
@@ -732,7 +732,7 @@ def test_outgoing_trace_headers_span_streaming(
     sentry_init(
         traces_sample_rate=1.0,
         integrations=[HttpxIntegration()],
-        _experiments={"trace_lifecycle": "stream"},
+        trace_lifecycle="stream",
     )
 
     url = "http://example.com/"
@@ -776,7 +776,7 @@ def test_outgoing_trace_headers_append_to_baggage_span_streaming(
         traces_sample_rate=1.0,
         integrations=[HttpxIntegration()],
         release="d08ebdb9309e1b004c6f52202de58a09c2268e42",
-        _experiments={"trace_lifecycle": "stream"},
+        trace_lifecycle="stream",
     )
 
     url = "http://example.com/"
@@ -820,7 +820,7 @@ def test_outgoing_trace_headers_span_streaming_no_current_span(sentry_init, http
         traces_sample_rate=1.0,
         trace_propagation_targets=[MATCH_ALL],
         integrations=[HttpxIntegration()],
-        _experiments={"trace_lifecycle": "stream"},
+        trace_lifecycle="stream",
     )
 
     url = "http://example.com/"
@@ -859,7 +859,7 @@ def test_outgoing_trace_headers_span_streaming_no_current_span_async(
         traces_sample_rate=1.0,
         trace_propagation_targets=[MATCH_ALL],
         integrations=[HttpxIntegration()],
-        _experiments={"trace_lifecycle": "stream"},
+        trace_lifecycle="stream",
     )
 
     url = "http://example.com/"
@@ -898,7 +898,7 @@ def test_request_source_disabled_span_streaming(
         traces_sample_rate=1.0,
         enable_http_request_source=False,
         http_request_source_threshold_ms=0,
-        _experiments={"trace_lifecycle": "stream"},
+        trace_lifecycle="stream",
     )
 
     items = capture_items("span")
@@ -939,7 +939,7 @@ def test_request_source_enabled_span_streaming(
         "integrations": [HttpxIntegration()],
         "traces_sample_rate": 1.0,
         "http_request_source_threshold_ms": 0,
-        "_experiments": {"trace_lifecycle": "stream"},
+        "trace_lifecycle": "stream",
     }
     if enable_http_request_source is not None:
         sentry_options["enable_http_request_source"] = enable_http_request_source
@@ -980,7 +980,7 @@ def test_request_source_span_streaming(
         traces_sample_rate=1.0,
         enable_http_request_source=True,
         http_request_source_threshold_ms=0,
-        _experiments={"trace_lifecycle": "stream"},
+        trace_lifecycle="stream",
     )
 
     items = capture_items("span")
@@ -1038,7 +1038,7 @@ def test_request_source_with_module_in_search_path_span_streaming(
         traces_sample_rate=1.0,
         enable_http_request_source=True,
         http_request_source_threshold_ms=0,
-        _experiments={"trace_lifecycle": "stream"},
+        trace_lifecycle="stream",
     )
 
     items = capture_items("span")
@@ -1100,7 +1100,7 @@ def test_no_request_source_if_duration_too_short_span_streaming(
         enable_http_request_source=True,
         # Threshold so high no real request will ever exceed it
         http_request_source_threshold_ms=9999999,
-        _experiments={"trace_lifecycle": "stream"},
+        trace_lifecycle="stream",
     )
 
     items = capture_items("span")
@@ -1138,7 +1138,7 @@ def test_request_source_if_duration_over_threshold_span_streaming(
         enable_http_request_source=True,
         # Threshold of 0 means any non-zero duration qualifies
         http_request_source_threshold_ms=0,
-        _experiments={"trace_lifecycle": "stream"},
+        trace_lifecycle="stream",
     )
 
     items = capture_items("span")
@@ -1191,7 +1191,7 @@ def test_span_origin_span_streaming(
     sentry_init(
         integrations=[HttpxIntegration()],
         traces_sample_rate=1.0,
-        _experiments={"trace_lifecycle": "stream"},
+        trace_lifecycle="stream",
     )
 
     items = capture_items("span")
@@ -1225,7 +1225,7 @@ def test_http_url_attributes_span_streaming(
         integrations=[HttpxIntegration()],
         traces_sample_rate=1.0,
         send_default_pii=send_default_pii,
-        _experiments={"trace_lifecycle": "stream"},
+        trace_lifecycle="stream",
     )
 
     items = capture_items("span")
@@ -1269,7 +1269,7 @@ def test_http_url_attributes_no_query_or_fragment_span_streaming(
         integrations=[HttpxIntegration()],
         traces_sample_rate=1.0,
         send_default_pii=send_default_pii,
-        _experiments={"trace_lifecycle": "stream"},
+        trace_lifecycle="stream",
     )
 
     items = capture_items("span")

--- a/tests/integrations/httpx2/test_httpx2.py
+++ b/tests/integrations/httpx2/test_httpx2.py
@@ -726,7 +726,7 @@ def test_outgoing_trace_headers_span_streaming(
     sentry_init(
         traces_sample_rate=1.0,
         integrations=[Httpx2Integration()],
-        _experiments={"trace_lifecycle": "stream"},
+        trace_lifecycle="stream",
     )
 
     url = "http://example.com/"
@@ -768,7 +768,7 @@ def test_outgoing_trace_headers_append_to_baggage_span_streaming(
         traces_sample_rate=1.0,
         integrations=[Httpx2Integration()],
         release="d08ebdb9309e1b004c6f52202de58a09c2268e42",
-        _experiments={"trace_lifecycle": "stream"},
+        trace_lifecycle="stream",
     )
 
     url = "http://example.com/"
@@ -814,7 +814,7 @@ def test_outgoing_trace_headers_span_streaming_no_current_span(
         traces_sample_rate=1.0,
         trace_propagation_targets=[MATCH_ALL],
         integrations=[Httpx2Integration()],
-        _experiments={"trace_lifecycle": "stream"},
+        trace_lifecycle="stream",
     )
 
     url = "http://example.com/"
@@ -853,7 +853,7 @@ def test_outgoing_trace_headers_span_streaming_no_current_span_async(
         traces_sample_rate=1.0,
         trace_propagation_targets=[MATCH_ALL],
         integrations=[Httpx2Integration()],
-        _experiments={"trace_lifecycle": "stream"},
+        trace_lifecycle="stream",
     )
 
     url = "http://example.com/"
@@ -892,7 +892,7 @@ def test_request_source_disabled_span_streaming(
         traces_sample_rate=1.0,
         enable_http_request_source=False,
         http_request_source_threshold_ms=0,
-        _experiments={"trace_lifecycle": "stream"},
+        trace_lifecycle="stream",
     )
 
     items = capture_items("span")
@@ -933,7 +933,7 @@ def test_request_source_enabled_span_streaming(
         "integrations": [Httpx2Integration()],
         "traces_sample_rate": 1.0,
         "http_request_source_threshold_ms": 0,
-        "_experiments": {"trace_lifecycle": "stream"},
+        "trace_lifecycle": "stream",
     }
     if enable_http_request_source is not None:
         sentry_options["enable_http_request_source"] = enable_http_request_source
@@ -974,7 +974,7 @@ def test_request_source_span_streaming(
         traces_sample_rate=1.0,
         enable_http_request_source=True,
         http_request_source_threshold_ms=0,
-        _experiments={"trace_lifecycle": "stream"},
+        trace_lifecycle="stream",
     )
 
     items = capture_items("span")
@@ -1032,7 +1032,7 @@ def test_request_source_with_module_in_search_path_span_streaming(
         traces_sample_rate=1.0,
         enable_http_request_source=True,
         http_request_source_threshold_ms=0,
-        _experiments={"trace_lifecycle": "stream"},
+        trace_lifecycle="stream",
     )
 
     items = capture_items("span")
@@ -1092,7 +1092,7 @@ def test_no_request_source_if_duration_too_short_span_streaming(
         enable_http_request_source=True,
         # Threshold so high no real request will ever exceed it
         http_request_source_threshold_ms=9999999,
-        _experiments={"trace_lifecycle": "stream"},
+        trace_lifecycle="stream",
     )
 
     items = capture_items("span")
@@ -1130,7 +1130,7 @@ def test_request_source_if_duration_over_threshold_span_streaming(
         enable_http_request_source=True,
         # Threshold of 0 means any non-zero duration qualifies
         http_request_source_threshold_ms=0,
-        _experiments={"trace_lifecycle": "stream"},
+        trace_lifecycle="stream",
     )
 
     items = capture_items("span")
@@ -1183,7 +1183,7 @@ def test_span_origin_span_streaming(
     sentry_init(
         integrations=[Httpx2Integration()],
         traces_sample_rate=1.0,
-        _experiments={"trace_lifecycle": "stream"},
+        trace_lifecycle="stream",
     )
 
     items = capture_items("span")
@@ -1216,7 +1216,7 @@ def test_http_url_attributes_span_streaming(
         integrations=[Httpx2Integration()],
         traces_sample_rate=1.0,
         send_default_pii=True,
-        _experiments={"trace_lifecycle": "stream"},
+        trace_lifecycle="stream",
     )
 
     items = capture_items("span")
@@ -1253,7 +1253,7 @@ def test_http_url_attributes_no_query_or_fragment_span_streaming(
         integrations=[Httpx2Integration()],
         traces_sample_rate=1.0,
         send_default_pii=True,
-        _experiments={"trace_lifecycle": "stream"},
+        trace_lifecycle="stream",
     )
 
     items = capture_items("span")
@@ -1289,7 +1289,7 @@ def test_http_url_attributes_pii_disabled_span_streaming(
     sentry_init(
         integrations=[Httpx2Integration()],
         traces_sample_rate=1.0,
-        _experiments={"trace_lifecycle": "stream"},
+        trace_lifecycle="stream",
     )
 
     items = capture_items("span")

--- a/tests/integrations/huey/test_huey.py
+++ b/tests/integrations/huey/test_huey.py
@@ -28,7 +28,7 @@ def init_huey(sentry_init):
             integrations=[HueyIntegration()],
             traces_sample_rate=1.0,
             send_default_pii=True,
-            _experiments={"trace_lifecycle": "stream"} if has_span_streaming else {},
+            trace_lifecycle="stream" if has_span_streaming else "static",
         )
 
         return MemoryHuey(name="sentry_sdk")

--- a/tests/integrations/langchain/test_langchain.py
+++ b/tests/integrations/langchain/test_langchain.py
@@ -255,7 +255,7 @@ def test_langchain_text_completion(
         traces_sample_rate=1.0,
         send_default_pii=True,
         stream_gen_ai_spans=stream_gen_ai_spans,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     model_response = get_model_response(
@@ -377,7 +377,7 @@ def test_langchain_chat_with_run_name(
         traces_sample_rate=1.0,
         send_default_pii=True,
         stream_gen_ai_spans=stream_gen_ai_spans,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     request_headers = {}
@@ -470,7 +470,7 @@ def test_langchain_tool_call_with_run_name(
         traces_sample_rate=1.0,
         send_default_pii=True,
         stream_gen_ai_spans=stream_gen_ai_spans,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
     if span_streaming or stream_gen_ai_spans:
         items = capture_items("span")
@@ -575,7 +575,7 @@ def test_langchain_create_agent(
         traces_sample_rate=1.0,
         send_default_pii=send_default_pii,
         stream_gen_ai_spans=stream_gen_ai_spans,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     model_response = get_model_response(
@@ -753,7 +753,7 @@ def test_tool_execution_span(
         traces_sample_rate=1.0,
         send_default_pii=send_default_pii,
         stream_gen_ai_spans=stream_gen_ai_spans,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     responses = responses_tool_call_model_responses(
@@ -1045,7 +1045,7 @@ def test_langchain_openai_tools_agent_no_prompts(
         traces_sample_rate=1.0,
         send_default_pii=send_default_pii,
         stream_gen_ai_spans=stream_gen_ai_spans,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     prompt = ChatPromptTemplate.from_messages(
@@ -1350,7 +1350,7 @@ def test_langchain_openai_tools_agent(
         traces_sample_rate=1.0,
         send_default_pii=True,
         stream_gen_ai_spans=stream_gen_ai_spans,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     prompt = ChatPromptTemplate.from_messages(
@@ -1609,7 +1609,7 @@ def test_langchain_openai_tools_agent_with_config(
         traces_sample_rate=1.0,
         send_default_pii=True,
         stream_gen_ai_spans=stream_gen_ai_spans,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     prompt = ChatPromptTemplate.from_messages(
@@ -1732,7 +1732,7 @@ def test_langchain_openai_tools_agent_stream_no_prompts(
         traces_sample_rate=1.0,
         send_default_pii=send_default_pii,
         stream_gen_ai_spans=stream_gen_ai_spans,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     prompt = ChatPromptTemplate.from_messages(
@@ -2041,7 +2041,7 @@ def test_langchain_openai_tools_agent_stream(
         traces_sample_rate=1.0,
         send_default_pii=True,
         stream_gen_ai_spans=stream_gen_ai_spans,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     prompt = ChatPromptTemplate.from_messages(
@@ -2312,7 +2312,7 @@ def test_langchain_openai_tools_agent_stream_with_config(
         traces_sample_rate=1.0,
         send_default_pii=True,
         stream_gen_ai_spans=stream_gen_ai_spans,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     prompt = ChatPromptTemplate.from_messages(
@@ -2435,7 +2435,7 @@ def test_langchain_error(
         traces_sample_rate=1.0,
         send_default_pii=True,
         stream_gen_ai_spans=stream_gen_ai_spans,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     prompt = ChatPromptTemplate.from_messages(
@@ -2504,7 +2504,7 @@ def test_span_status_error(
         integrations=[LangchainIntegration(include_prompts=True)],
         traces_sample_rate=1.0,
         stream_gen_ai_spans=stream_gen_ai_spans,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
     if span_streaming or stream_gen_ai_spans:
         items = capture_items("event", "transaction", "span")
@@ -2835,7 +2835,7 @@ def test_langchain_message_role_mapping(
         traces_sample_rate=1.0,
         send_default_pii=True,
         stream_gen_ai_spans=stream_gen_ai_spans,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     prompt = ChatPromptTemplate.from_messages(
@@ -3122,7 +3122,7 @@ def test_langchain_embeddings_sync(
         traces_sample_rate=1.0,
         send_default_pii=send_default_pii,
         stream_gen_ai_spans=stream_gen_ai_spans,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
     if span_streaming or stream_gen_ai_spans:
         items = capture_items("span")
@@ -3272,7 +3272,7 @@ def test_langchain_embeddings_embed_query(
         traces_sample_rate=1.0,
         send_default_pii=send_default_pii,
         stream_gen_ai_spans=stream_gen_ai_spans,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
     if span_streaming or stream_gen_ai_spans:
         items = capture_items("span")
@@ -3413,7 +3413,7 @@ async def test_langchain_embeddings_async(
         traces_sample_rate=1.0,
         send_default_pii=send_default_pii,
         stream_gen_ai_spans=stream_gen_ai_spans,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     async def mock_aembed_documents(self, texts):
@@ -3566,7 +3566,7 @@ async def test_langchain_embeddings_aembed_query(
         traces_sample_rate=1.0,
         send_default_pii=True,
         stream_gen_ai_spans=stream_gen_ai_spans,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     async def mock_aembed_query(self, text):
@@ -3685,7 +3685,7 @@ def test_langchain_embeddings_no_model_name(
         integrations=[LangchainIntegration(include_prompts=False)],
         traces_sample_rate=1.0,
         stream_gen_ai_spans=stream_gen_ai_spans,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
     if span_streaming or stream_gen_ai_spans:
         items = capture_items("span")
@@ -3788,7 +3788,7 @@ def test_langchain_embeddings_integration_disabled(
     sentry_init(
         traces_sample_rate=1.0,
         stream_gen_ai_spans=stream_gen_ai_spans,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     # Initialize without LangchainIntegration
@@ -3864,7 +3864,7 @@ def test_langchain_embeddings_multiple_providers(
         traces_sample_rate=1.0,
         send_default_pii=True,
         stream_gen_ai_spans=stream_gen_ai_spans,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
     if span_streaming or stream_gen_ai_spans:
         items = capture_items("span")
@@ -4021,7 +4021,7 @@ def test_langchain_embeddings_multiple_calls(
         traces_sample_rate=1.0,
         send_default_pii=True,
         stream_gen_ai_spans=stream_gen_ai_spans,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
     if span_streaming or stream_gen_ai_spans:
         items = capture_items("span")
@@ -4149,7 +4149,7 @@ def test_langchain_embeddings_span_hierarchy(
         traces_sample_rate=1.0,
         send_default_pii=True,
         stream_gen_ai_spans=stream_gen_ai_spans,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
     if span_streaming:
         items = capture_items("span")
@@ -4307,7 +4307,7 @@ def test_langchain_embeddings_with_list_and_string_inputs(
         traces_sample_rate=1.0,
         send_default_pii=True,
         stream_gen_ai_spans=stream_gen_ai_spans,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
     if span_streaming or stream_gen_ai_spans:
         items = capture_items("span")
@@ -4433,7 +4433,7 @@ def test_langchain_response_model_extraction(
         traces_sample_rate=1.0,
         send_default_pii=True,
         stream_gen_ai_spans=stream_gen_ai_spans,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     callback = SentryLangchainCallback(max_span_map_size=100, include_prompts=True)
@@ -4792,7 +4792,7 @@ def test_langchain_ai_system_detection(
         integrations=[LangchainIntegration()],
         traces_sample_rate=1.0,
         stream_gen_ai_spans=stream_gen_ai_spans,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     callback = SentryLangchainCallback(max_span_map_size=100, include_prompts=True)

--- a/tests/integrations/langgraph/test_langgraph.py
+++ b/tests/integrations/langgraph/test_langgraph.py
@@ -279,7 +279,7 @@ def test_pregel_invoke(
         traces_sample_rate=1.0,
         send_default_pii=send_default_pii,
         stream_gen_ai_spans=stream_gen_ai_spans,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     test_state = {
@@ -465,7 +465,7 @@ def test_pregel_ainvoke(
         traces_sample_rate=1.0,
         send_default_pii=send_default_pii,
         stream_gen_ai_spans=stream_gen_ai_spans,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     test_state = {"messages": [MockMessage("What's the weather like?", name="user")]}
@@ -613,7 +613,7 @@ def test_pregel_invoke_error(
         traces_sample_rate=1.0,
         send_default_pii=True,
         stream_gen_ai_spans=stream_gen_ai_spans,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     test_state = {"messages": [MockMessage("This will fail")]}
@@ -677,7 +677,7 @@ def test_pregel_ainvoke_error(
         traces_sample_rate=1.0,
         send_default_pii=True,
         stream_gen_ai_spans=stream_gen_ai_spans,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     test_state = {"messages": [MockMessage("This will fail async")]}
@@ -793,7 +793,7 @@ def test_pregel_invoke_with_different_graph_names(
         traces_sample_rate=1.0,
         send_default_pii=True,
         stream_gen_ai_spans=stream_gen_ai_spans,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     pregel = MockPregelInstance(graph_name) if graph_name else MockPregelInstance()
@@ -876,7 +876,7 @@ def test_pregel_invoke_span_includes_usage_data(
         integrations=[LanggraphIntegration()],
         traces_sample_rate=1.0,
         stream_gen_ai_spans=stream_gen_ai_spans,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     test_state = {
@@ -994,7 +994,7 @@ def test_pregel_ainvoke_span_includes_usage_data(
         integrations=[LanggraphIntegration()],
         traces_sample_rate=1.0,
         stream_gen_ai_spans=stream_gen_ai_spans,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     test_state = {
@@ -1112,7 +1112,7 @@ def test_pregel_invoke_multiple_llm_calls_aggregate_usage(
         integrations=[LanggraphIntegration()],
         traces_sample_rate=1.0,
         stream_gen_ai_spans=stream_gen_ai_spans,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     test_state = {
@@ -1229,7 +1229,7 @@ def test_pregel_ainvoke_multiple_llm_calls_aggregate_usage(
         integrations=[LanggraphIntegration()],
         traces_sample_rate=1.0,
         stream_gen_ai_spans=stream_gen_ai_spans,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     test_state = {
@@ -1346,7 +1346,7 @@ def test_pregel_invoke_span_includes_response_model(
         integrations=[LanggraphIntegration()],
         traces_sample_rate=1.0,
         stream_gen_ai_spans=stream_gen_ai_spans,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     test_state = {
@@ -1457,7 +1457,7 @@ def test_pregel_ainvoke_span_includes_response_model(
         integrations=[LanggraphIntegration()],
         traces_sample_rate=1.0,
         stream_gen_ai_spans=stream_gen_ai_spans,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     test_state = {
@@ -1568,7 +1568,7 @@ def test_pregel_invoke_span_uses_last_response_model(
         integrations=[LanggraphIntegration()],
         traces_sample_rate=1.0,
         stream_gen_ai_spans=stream_gen_ai_spans,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     test_state = {
@@ -1690,7 +1690,7 @@ def test_pregel_ainvoke_span_uses_last_response_model(
         integrations=[LanggraphIntegration()],
         traces_sample_rate=1.0,
         stream_gen_ai_spans=stream_gen_ai_spans,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     test_state = {
@@ -1857,7 +1857,7 @@ def test_extraction_functions_complex_scenario(
         traces_sample_rate=1.0,
         send_default_pii=True,
         stream_gen_ai_spans=stream_gen_ai_spans,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     pregel = MockPregelInstance("complex_graph")
@@ -1970,7 +1970,7 @@ def test_langgraph_message_role_mapping(
         traces_sample_rate=1.0,
         send_default_pii=True,
         stream_gen_ai_spans=stream_gen_ai_spans,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     # Mock a langgraph message with mixed roles

--- a/tests/integrations/launchdarkly/test_launchdarkly.py
+++ b/tests/integrations/launchdarkly/test_launchdarkly.py
@@ -240,7 +240,7 @@ def test_launchdarkly_span_integration(
         sentry_init(
             traces_sample_rate=1.0,
             integrations=[LaunchDarklyIntegration()],
-            _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+            trace_lifecycle="stream" if span_streaming else "static",
         )
         client = ldclient.get()
     else:
@@ -248,7 +248,7 @@ def test_launchdarkly_span_integration(
         sentry_init(
             traces_sample_rate=1.0,
             integrations=[LaunchDarklyIntegration(ld_client=client)],
-            _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+            trace_lifecycle="stream" if span_streaming else "static",
         )
 
     if span_streaming:

--- a/tests/integrations/litellm/test_litellm.py
+++ b/tests/integrations/litellm/test_litellm.py
@@ -164,7 +164,7 @@ def test_nonstreaming_chat_completion(
         traces_sample_rate=1.0,
         send_default_pii=send_default_pii,
         stream_gen_ai_spans=stream_gen_ai_spans,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     messages = [
@@ -321,7 +321,7 @@ async def test_async_nonstreaming_chat_completion(
         traces_sample_rate=1.0,
         send_default_pii=send_default_pii,
         stream_gen_ai_spans=stream_gen_ai_spans,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     messages = [
@@ -481,7 +481,7 @@ def test_streaming_chat_completion(
         traces_sample_rate=1.0,
         send_default_pii=send_default_pii,
         stream_gen_ai_spans=stream_gen_ai_spans,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     messages = [
@@ -597,7 +597,7 @@ async def test_async_streaming_chat_completion(
         traces_sample_rate=1.0,
         send_default_pii=send_default_pii,
         stream_gen_ai_spans=stream_gen_ai_spans,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     messages = [
@@ -710,7 +710,7 @@ def test_embeddings_create(
         traces_sample_rate=1.0,
         send_default_pii=True,
         stream_gen_ai_spans=stream_gen_ai_spans,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     client = OpenAI(api_key="test-key")
@@ -831,7 +831,7 @@ async def test_async_embeddings_create(
         traces_sample_rate=1.0,
         send_default_pii=True,
         stream_gen_ai_spans=stream_gen_ai_spans,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     client = AsyncOpenAI(api_key="test-key")
@@ -948,7 +948,7 @@ def test_embeddings_create_with_list_input(
         traces_sample_rate=1.0,
         send_default_pii=True,
         stream_gen_ai_spans=stream_gen_ai_spans,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     client = OpenAI(api_key="test-key")
@@ -1062,7 +1062,7 @@ async def test_async_embeddings_create_with_list_input(
         traces_sample_rate=1.0,
         send_default_pii=True,
         stream_gen_ai_spans=stream_gen_ai_spans,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     client = AsyncOpenAI(api_key="test-key")
@@ -1176,7 +1176,7 @@ def test_embeddings_no_pii(
         traces_sample_rate=1.0,
         send_default_pii=False,  # PII disabled
         stream_gen_ai_spans=stream_gen_ai_spans,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     client = OpenAI(api_key="test-key")
@@ -1276,7 +1276,7 @@ async def test_async_embeddings_no_pii(
         traces_sample_rate=1.0,
         send_default_pii=False,  # PII disabled
         stream_gen_ai_spans=stream_gen_ai_spans,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     client = AsyncOpenAI(api_key="test-key")
@@ -1374,7 +1374,7 @@ def test_exception_handling(
         disabled_integrations=[StdlibIntegration],
         traces_sample_rate=1.0,
         stream_gen_ai_spans=stream_gen_ai_spans,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     messages = [{"role": "user", "content": "Hello!"}]
@@ -1440,7 +1440,7 @@ async def test_async_exception_handling(
         disabled_integrations=[StdlibIntegration],
         traces_sample_rate=1.0,
         stream_gen_ai_spans=stream_gen_ai_spans,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     messages = [{"role": "user", "content": "Hello!"}]
@@ -1507,7 +1507,7 @@ def test_span_origin(
         disabled_integrations=[StdlibIntegration],
         traces_sample_rate=1.0,
         stream_gen_ai_spans=stream_gen_ai_spans,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     messages = [{"role": "user", "content": "Hello!"}]
@@ -1614,7 +1614,7 @@ def test_multiple_providers(
         disabled_integrations=[StdlibIntegration],
         traces_sample_rate=1.0,
         stream_gen_ai_spans=stream_gen_ai_spans,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     messages = [{"role": "user", "content": "Hello!"}]
@@ -1862,7 +1862,7 @@ async def test_async_multiple_providers(
         disabled_integrations=[StdlibIntegration],
         traces_sample_rate=1.0,
         stream_gen_ai_spans=stream_gen_ai_spans,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     messages = [{"role": "user", "content": "Hello!"}]
@@ -2046,7 +2046,7 @@ def test_additional_parameters(
         disabled_integrations=[StdlibIntegration],
         traces_sample_rate=1.0,
         stream_gen_ai_spans=stream_gen_ai_spans,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     messages = [{"role": "user", "content": "Hello!"}]
@@ -2160,7 +2160,7 @@ async def test_async_additional_parameters(
         disabled_integrations=[StdlibIntegration],
         traces_sample_rate=1.0,
         stream_gen_ai_spans=stream_gen_ai_spans,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     messages = [{"role": "user", "content": "Hello!"}]
@@ -2275,7 +2275,7 @@ def test_no_integration(
         disabled_integrations=[StdlibIntegration],
         traces_sample_rate=1.0,
         stream_gen_ai_spans=stream_gen_ai_spans,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     messages = [{"role": "user", "content": "Hello!"}]
@@ -2365,7 +2365,7 @@ async def test_async_no_integration(
         disabled_integrations=[StdlibIntegration],
         traces_sample_rate=1.0,
         stream_gen_ai_spans=stream_gen_ai_spans,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     messages = [{"role": "user", "content": "Hello!"}]
@@ -2455,7 +2455,7 @@ def test_response_without_usage(
         disabled_integrations=[StdlibIntegration],
         traces_sample_rate=1.0,
         stream_gen_ai_spans=stream_gen_ai_spans,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     messages = [{"role": "user", "content": "Hello!"}]
@@ -2614,7 +2614,7 @@ def test_binary_content_encoding_image_url(
         traces_sample_rate=1.0,
         send_default_pii=True,
         stream_gen_ai_spans=stream_gen_ai_spans,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     messages = [
@@ -2739,7 +2739,7 @@ async def test_async_binary_content_encoding_image_url(
         traces_sample_rate=1.0,
         send_default_pii=True,
         stream_gen_ai_spans=stream_gen_ai_spans,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     messages = [
@@ -2866,7 +2866,7 @@ def test_binary_content_encoding_mixed_content(
         traces_sample_rate=1.0,
         send_default_pii=True,
         stream_gen_ai_spans=stream_gen_ai_spans,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     messages = [
@@ -2980,7 +2980,7 @@ async def test_async_binary_content_encoding_mixed_content(
         traces_sample_rate=1.0,
         send_default_pii=True,
         stream_gen_ai_spans=stream_gen_ai_spans,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     messages = [
@@ -3096,7 +3096,7 @@ def test_binary_content_encoding_uri_type(
         traces_sample_rate=1.0,
         send_default_pii=True,
         stream_gen_ai_spans=stream_gen_ai_spans,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     messages = [
@@ -3214,7 +3214,7 @@ async def test_async_binary_content_encoding_uri_type(
         traces_sample_rate=1.0,
         send_default_pii=True,
         stream_gen_ai_spans=stream_gen_ai_spans,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     messages = [

--- a/tests/integrations/litestar/test_litestar.py
+++ b/tests/integrations/litestar/test_litestar.py
@@ -103,7 +103,7 @@ def test_catch_exceptions(
 ):
     sentry_init(
         integrations=[LitestarIntegration()],
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
     litestar_app = litestar_app_factory()
     client = TestClient(litestar_app)
@@ -211,7 +211,7 @@ def test_middleware_spans(
     sentry_init(
         traces_sample_rate=1.0,
         integrations=[LitestarIntegration()],
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     logging_config = LoggingMiddlewareConfig()
@@ -293,7 +293,7 @@ def test_middleware_callback_spans(
     sentry_init(
         traces_sample_rate=1.0,
         integrations=[LitestarIntegration()],
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     litestar_app = litestar_app_factory(middleware=[SampleMiddleware])
@@ -411,7 +411,7 @@ def test_middleware_receive_send(sentry_init, capture_items, span_streaming):
     sentry_init(
         traces_sample_rate=1.0,
         integrations=[LitestarIntegration()],
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
     litestar_app = litestar_app_factory(middleware=[SampleReceiveSendMiddleware])
 
@@ -450,7 +450,7 @@ def test_middleware_partial_receive_send(
     sentry_init(
         traces_sample_rate=1.0,
         integrations=[LitestarIntegration()],
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     litestar_app = litestar_app_factory(middleware=[SamplePartialReceiveSendMiddleware])
@@ -569,7 +569,7 @@ def test_span_origin(
     sentry_init(
         integrations=[LitestarIntegration()],
         traces_sample_rate=1.0,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     logging_config = LoggingMiddlewareConfig()
@@ -642,7 +642,7 @@ def test_litestar_scope_user_on_exception_event(
     sentry_init(
         integrations=[LitestarIntegration()],
         send_default_pii=is_send_default_pii,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     litestar_app = litestar_app_factory(middleware=[TestUserMiddleware])
@@ -701,7 +701,7 @@ def test_configurable_status_codes_handler(
     )
     sentry_init(
         integrations=[LitestarIntegration(**integration_kwargs)],
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     @get("/error")
@@ -744,7 +744,7 @@ def test_configurable_status_codes_middleware(
 
     sentry_init(
         integrations=[LitestarIntegration(**integration_kwargs)],
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     def create_raising_middleware(app):
@@ -782,7 +782,7 @@ def test_catch_non_http_exceptions_in_middleware(
 ):
     sentry_init(
         integrations=[LitestarIntegration()],
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     def create_raising_middleware(app):

--- a/tests/integrations/openai/test_openai.py
+++ b/tests/integrations/openai/test_openai.py
@@ -133,7 +133,7 @@ def test_nonstreaming_chat_completion_no_prompts(
         traces_sample_rate=1.0,
         send_default_pii=send_default_pii,
         stream_gen_ai_spans=stream_gen_ai_spans,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     client = OpenAI(api_key="z")
@@ -334,7 +334,7 @@ def test_nonstreaming_chat_completion(
         traces_sample_rate=1.0,
         send_default_pii=True,
         stream_gen_ai_spans=stream_gen_ai_spans,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     client = OpenAI(api_key="z")
@@ -472,7 +472,7 @@ async def test_nonstreaming_chat_completion_async_no_prompts(
         traces_sample_rate=1.0,
         send_default_pii=send_default_pii,
         stream_gen_ai_spans=stream_gen_ai_spans,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     client = AsyncOpenAI(api_key="z")
@@ -668,7 +668,7 @@ async def test_nonstreaming_chat_completion_async(
         traces_sample_rate=1.0,
         send_default_pii=True,
         stream_gen_ai_spans=stream_gen_ai_spans,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     client = AsyncOpenAI(api_key="z")
@@ -815,7 +815,7 @@ def test_streaming_chat_completion_no_prompts(
         traces_sample_rate=1.0,
         send_default_pii=send_default_pii,
         stream_gen_ai_spans=stream_gen_ai_spans,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     client = OpenAI(api_key="z")
@@ -997,7 +997,7 @@ def test_streaming_chat_completion_with_usage_in_stream(
         traces_sample_rate=1.0,
         send_default_pii=False,
         stream_gen_ai_spans=stream_gen_ai_spans,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     client = OpenAI(api_key="z")
@@ -1111,7 +1111,7 @@ def test_streaming_chat_completion_empty_content_preserves_token_usage(
         traces_sample_rate=1.0,
         send_default_pii=False,
         stream_gen_ai_spans=stream_gen_ai_spans,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     client = OpenAI(api_key="z")
@@ -1208,7 +1208,7 @@ async def test_streaming_chat_completion_empty_content_preserves_token_usage_asy
         traces_sample_rate=1.0,
         send_default_pii=False,
         stream_gen_ai_spans=stream_gen_ai_spans,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     client = AsyncOpenAI(api_key="z")
@@ -1307,7 +1307,7 @@ async def test_streaming_chat_completion_async_with_usage_in_stream(
         traces_sample_rate=1.0,
         send_default_pii=False,
         stream_gen_ai_spans=stream_gen_ai_spans,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     client = AsyncOpenAI(api_key="z")
@@ -1512,7 +1512,7 @@ def test_streaming_chat_completion(
         traces_sample_rate=1.0,
         send_default_pii=True,
         stream_gen_ai_spans=stream_gen_ai_spans,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     client = OpenAI(api_key="z")
@@ -1724,7 +1724,7 @@ async def test_streaming_chat_completion_async_no_prompts(
         traces_sample_rate=1.0,
         send_default_pii=send_default_pii,
         stream_gen_ai_spans=stream_gen_ai_spans,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     client = AsyncOpenAI(api_key="z")
@@ -2003,7 +2003,7 @@ async def test_streaming_chat_completion_async(
         traces_sample_rate=1.0,
         send_default_pii=True,
         stream_gen_ai_spans=stream_gen_ai_spans,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     client = AsyncOpenAI(api_key="z")
@@ -2201,7 +2201,7 @@ def test_bad_chat_completion(
         disabled_integrations=[StdlibIntegration],
         traces_sample_rate=1.0,
         stream_gen_ai_spans=stream_gen_ai_spans,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     if span_streaming:
@@ -2271,7 +2271,7 @@ def test_span_status_error(
         disabled_integrations=[StdlibIntegration],
         traces_sample_rate=1.0,
         stream_gen_ai_spans=stream_gen_ai_spans,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     if span_streaming or stream_gen_ai_spans:
@@ -2329,7 +2329,7 @@ async def test_bad_chat_completion_async(
         disabled_integrations=[StdlibIntegration],
         traces_sample_rate=1.0,
         stream_gen_ai_spans=stream_gen_ai_spans,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     client = AsyncOpenAI(api_key="z")
@@ -2400,7 +2400,7 @@ def test_embeddings_create_no_pii(
         traces_sample_rate=1.0,
         send_default_pii=send_default_pii,
         stream_gen_ai_spans=stream_gen_ai_spans,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     client = OpenAI(api_key="z")
@@ -2549,7 +2549,7 @@ def test_embeddings_create(
         traces_sample_rate=1.0,
         send_default_pii=True,
         stream_gen_ai_spans=stream_gen_ai_spans,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     client = OpenAI(api_key="z")
@@ -2644,7 +2644,7 @@ async def test_embeddings_create_async_no_pii(
         traces_sample_rate=1.0,
         send_default_pii=send_default_pii,
         stream_gen_ai_spans=stream_gen_ai_spans,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     client = AsyncOpenAI(api_key="z")
@@ -2794,7 +2794,7 @@ async def test_embeddings_create_async(
         traces_sample_rate=1.0,
         send_default_pii=True,
         stream_gen_ai_spans=stream_gen_ai_spans,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     client = AsyncOpenAI(api_key="z")
@@ -2884,7 +2884,7 @@ def test_embeddings_create_raises_error(
         traces_sample_rate=1.0,
         send_default_pii=send_default_pii,
         stream_gen_ai_spans=stream_gen_ai_spans,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     client = OpenAI(api_key="z")
@@ -2947,7 +2947,7 @@ async def test_embeddings_create_raises_error_async(
         traces_sample_rate=1.0,
         send_default_pii=send_default_pii,
         stream_gen_ai_spans=stream_gen_ai_spans,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     client = AsyncOpenAI(api_key="z")
@@ -3008,7 +3008,7 @@ def test_span_origin_nonstreaming_chat(
         integrations=[OpenAIIntegration()],
         traces_sample_rate=1.0,
         stream_gen_ai_spans=stream_gen_ai_spans,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     client = OpenAI(api_key="z")
@@ -3070,7 +3070,7 @@ async def test_span_origin_nonstreaming_chat_async(
         disabled_integrations=[StdlibIntegration],
         traces_sample_rate=1.0,
         stream_gen_ai_spans=stream_gen_ai_spans,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     client = AsyncOpenAI(api_key="z")
@@ -3130,7 +3130,7 @@ def test_span_origin_streaming_chat(
         disabled_integrations=[StdlibIntegration],
         traces_sample_rate=1.0,
         stream_gen_ai_spans=stream_gen_ai_spans,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     client = OpenAI(api_key="z")
@@ -3221,7 +3221,7 @@ async def test_span_origin_streaming_chat_async(
         disabled_integrations=[StdlibIntegration],
         traces_sample_rate=1.0,
         stream_gen_ai_spans=stream_gen_ai_spans,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     client = AsyncOpenAI(api_key="z")
@@ -3318,7 +3318,7 @@ def test_span_origin_embeddings(
         disabled_integrations=[StdlibIntegration],
         traces_sample_rate=1.0,
         stream_gen_ai_spans=stream_gen_ai_spans,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     client = OpenAI(api_key="z")
@@ -3374,7 +3374,7 @@ async def test_span_origin_embeddings_async(
         disabled_integrations=[StdlibIntegration],
         traces_sample_rate=1.0,
         stream_gen_ai_spans=stream_gen_ai_spans,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     client = AsyncOpenAI(api_key="z")
@@ -3796,7 +3796,7 @@ def test_ai_client_span_responses_api_no_pii(
         disabled_integrations=[StdlibIntegration],
         traces_sample_rate=1.0,
         stream_gen_ai_spans=stream_gen_ai_spans,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     client = OpenAI(api_key="z")
@@ -4092,7 +4092,7 @@ def test_ai_client_span_responses_api(
         traces_sample_rate=1.0,
         send_default_pii=True,
         stream_gen_ai_spans=stream_gen_ai_spans,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     client = OpenAI(api_key="z")
@@ -4264,7 +4264,7 @@ def test_responses_api_conversation_id(
         disabled_integrations=[StdlibIntegration],
         traces_sample_rate=1.0,
         stream_gen_ai_spans=stream_gen_ai_spans,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     client = OpenAI(api_key="z")
@@ -4322,7 +4322,7 @@ def test_error_in_responses_api(
         traces_sample_rate=1.0,
         send_default_pii=True,
         stream_gen_ai_spans=stream_gen_ai_spans,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     client = OpenAI(api_key="z")
@@ -4566,7 +4566,7 @@ async def test_ai_client_span_responses_async_api(
         traces_sample_rate=1.0,
         send_default_pii=True,
         stream_gen_ai_spans=stream_gen_ai_spans,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     client = AsyncOpenAI(api_key="z")
@@ -4879,7 +4879,7 @@ async def test_ai_client_span_streaming_responses_async_api(
         traces_sample_rate=1.0,
         send_default_pii=True,
         stream_gen_ai_spans=stream_gen_ai_spans,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     client = AsyncOpenAI(api_key="z")
@@ -5026,7 +5026,7 @@ async def test_error_in_responses_async_api(
         traces_sample_rate=1.0,
         send_default_pii=True,
         stream_gen_ai_spans=stream_gen_ai_spans,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     client = AsyncOpenAI(api_key="z")
@@ -5208,7 +5208,7 @@ def test_streaming_responses_api(
         traces_sample_rate=1.0,
         send_default_pii=send_default_pii,
         stream_gen_ai_spans=stream_gen_ai_spans,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     client = OpenAI(api_key="z")
@@ -5338,7 +5338,7 @@ async def test_streaming_responses_api_async(
         traces_sample_rate=1.0,
         send_default_pii=send_default_pii,
         stream_gen_ai_spans=stream_gen_ai_spans,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     client = AsyncOpenAI(api_key="z")
@@ -5460,7 +5460,7 @@ def test_empty_tools_in_chat_completion(
         disabled_integrations=[StdlibIntegration],
         traces_sample_rate=1.0,
         stream_gen_ai_spans=stream_gen_ai_spans,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     client = OpenAI(api_key="z")
@@ -5543,7 +5543,7 @@ def test_openai_message_role_mapping(
         traces_sample_rate=1.0,
         send_default_pii=True,
         stream_gen_ai_spans=stream_gen_ai_spans,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     client = OpenAI(api_key="z")
@@ -5679,7 +5679,7 @@ def test_streaming_chat_completion_ttft(
         disabled_integrations=[StdlibIntegration],
         traces_sample_rate=1.0,
         stream_gen_ai_spans=stream_gen_ai_spans,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     client = OpenAI(api_key="z")
@@ -5792,7 +5792,7 @@ async def test_streaming_chat_completion_ttft_async(
         disabled_integrations=[StdlibIntegration],
         traces_sample_rate=1.0,
         stream_gen_ai_spans=stream_gen_ai_spans,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     client = AsyncOpenAI(api_key="z")
@@ -5906,7 +5906,7 @@ def test_streaming_responses_api_ttft(
         disabled_integrations=[StdlibIntegration],
         traces_sample_rate=1.0,
         stream_gen_ai_spans=stream_gen_ai_spans,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     client = OpenAI(api_key="z")
@@ -5990,7 +5990,7 @@ async def test_streaming_responses_api_ttft_async(
         disabled_integrations=[StdlibIntegration],
         traces_sample_rate=1.0,
         stream_gen_ai_spans=stream_gen_ai_spans,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     client = AsyncOpenAI(api_key="z")

--- a/tests/integrations/openai_agents/test_openai_agents.py
+++ b/tests/integrations/openai_agents/test_openai_agents.py
@@ -206,7 +206,7 @@ async def test_agent_invocation_span_no_pii(
                 traces_sample_rate=1.0,
                 send_default_pii=False,
                 stream_gen_ai_spans=stream_gen_ai_spans,
-                _experiments={"trace_lifecycle": "stream"},
+                trace_lifecycle="stream",
             )
 
             items = capture_items("span")
@@ -606,7 +606,7 @@ async def test_agent_invocation_span(
                 traces_sample_rate=1.0,
                 send_default_pii=True,
                 stream_gen_ai_spans=stream_gen_ai_spans,
-                _experiments={"trace_lifecycle": "stream"},
+                trace_lifecycle="stream",
             )
 
             items = capture_items("span")
@@ -924,7 +924,7 @@ def test_agent_invocation_span_sync_no_pii(
                 traces_sample_rate=1.0,
                 send_default_pii=False,
                 stream_gen_ai_spans=stream_gen_ai_spans,
-                _experiments={"trace_lifecycle": "stream"},
+                trace_lifecycle="stream",
             )
 
             items = capture_items("span")
@@ -1316,7 +1316,7 @@ def test_agent_invocation_span_sync(
                 traces_sample_rate=1.0,
                 send_default_pii=True,
                 stream_gen_ai_spans=stream_gen_ai_spans,
-                _experiments={"trace_lifecycle": "stream"},
+                trace_lifecycle="stream",
             )
 
             items = capture_items("span")
@@ -1928,7 +1928,7 @@ async def test_tool_execution_span(
                 traces_sample_rate=1.0,
                 send_default_pii=True,
                 stream_gen_ai_spans=stream_gen_ai_spans,
-                _experiments={"trace_lifecycle": "stream"},
+                trace_lifecycle="stream",
             )
 
             items = capture_items("span")
@@ -2888,7 +2888,7 @@ async def test_model_behavior_error(
                 traces_sample_rate=1.0,
                 send_default_pii=True,
                 stream_gen_ai_spans=stream_gen_ai_spans,
-                _experiments={"trace_lifecycle": "stream"},
+                trace_lifecycle="stream",
             )
 
             items = capture_items("span")
@@ -3055,7 +3055,7 @@ async def test_error_handling(
                 disabled_integrations=[StdlibIntegration],
                 traces_sample_rate=1.0,
                 stream_gen_ai_spans=stream_gen_ai_spans,
-                _experiments={"trace_lifecycle": "stream"},
+                trace_lifecycle="stream",
             )
 
             items = capture_items("event", "span")
@@ -3331,7 +3331,7 @@ async def test_span_status_error(
                 disabled_integrations=[StdlibIntegration],
                 traces_sample_rate=1.0,
                 stream_gen_ai_spans=stream_gen_ai_spans,
-                _experiments={"trace_lifecycle": "stream"},
+                trace_lifecycle="stream",
             )
 
             items = capture_items("event", "span")
@@ -3446,7 +3446,7 @@ async def test_multiple_agents_asyncio(
                 disabled_integrations=[StdlibIntegration],
                 traces_sample_rate=1.0,
                 stream_gen_ai_spans=stream_gen_ai_spans,
-                _experiments={"trace_lifecycle": "stream"},
+                trace_lifecycle="stream",
             )
 
             items = capture_items("span")
@@ -4257,7 +4257,7 @@ async def test_multiple_llm_calls_aggregate_usage(
                 traces_sample_rate=1.0,
                 send_default_pii=True,
                 stream_gen_ai_spans=stream_gen_ai_spans,
-                _experiments={"trace_lifecycle": "stream"},
+                trace_lifecycle="stream",
             )
 
             items = capture_items("span")
@@ -4622,7 +4622,7 @@ async def test_invoke_agent_span_uses_last_response_model(
                 traces_sample_rate=1.0,
                 send_default_pii=True,
                 stream_gen_ai_spans=stream_gen_ai_spans,
-                _experiments={"trace_lifecycle": "stream"},
+                trace_lifecycle="stream",
             )
 
             items = capture_items("span")
@@ -5027,7 +5027,7 @@ async def test_conversation_id_on_all_spans(
                 disabled_integrations=[StdlibIntegration],
                 traces_sample_rate=1.0,
                 stream_gen_ai_spans=stream_gen_ai_spans,
-                _experiments={"trace_lifecycle": "stream"},
+                trace_lifecycle="stream",
             )
 
             items = capture_items("span")
@@ -5268,7 +5268,7 @@ async def test_conversation_id_on_tool_span(
                 disabled_integrations=[StdlibIntegration],
                 traces_sample_rate=1.0,
                 stream_gen_ai_spans=stream_gen_ai_spans,
-                _experiments={"trace_lifecycle": "stream"},
+                trace_lifecycle="stream",
             )
 
             items = capture_items("span")
@@ -5426,7 +5426,7 @@ async def test_no_conversation_id_when_not_provided(
                 disabled_integrations=[StdlibIntegration],
                 traces_sample_rate=1.0,
                 stream_gen_ai_spans=stream_gen_ai_spans,
-                _experiments={"trace_lifecycle": "stream"},
+                trace_lifecycle="stream",
             )
 
             items = capture_items("span")

--- a/tests/integrations/openfeature/test_openfeature.py
+++ b/tests/integrations/openfeature/test_openfeature.py
@@ -169,7 +169,7 @@ def test_openfeature_span_integration(
     sentry_init(
         traces_sample_rate=1.0,
         integrations=[OpenFeatureIntegration()],
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     api.set_provider(

--- a/tests/integrations/opentelemetry/test_experimental.py
+++ b/tests/integrations/opentelemetry/test_experimental.py
@@ -52,6 +52,6 @@ def test_integration_disabled_with_span_streaming(sentry_init, reset_integration
     ):
         sentry_init(
             integrations=[OpenTelemetryIntegration()],
-            _experiments={"trace_lifecycle": "stream"},
+            trace_lifecycle="stream",
         )
         mocked_setup_sentry_tracing.assert_not_called()

--- a/tests/integrations/pydantic_ai/test_pydantic_ai.py
+++ b/tests/integrations/pydantic_ai/test_pydantic_ai.py
@@ -88,7 +88,7 @@ async def test_agent_run_async(
         traces_sample_rate=1.0,
         send_default_pii=True,
         stream_gen_ai_spans=stream_gen_ai_spans,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     test_agent = get_test_agent()
@@ -236,7 +236,7 @@ async def test_agent_run_async_model_error(
         integrations=[PydanticAIIntegration()],
         traces_sample_rate=1.0,
         stream_gen_ai_spans=stream_gen_ai_spans,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     def failing_model(messages, info):
@@ -308,7 +308,7 @@ def test_agent_run_sync(
         traces_sample_rate=1.0,
         send_default_pii=True,
         stream_gen_ai_spans=stream_gen_ai_spans,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     test_agent = get_test_agent()
@@ -402,7 +402,7 @@ def test_agent_run_sync_model_error(
         integrations=[PydanticAIIntegration()],
         traces_sample_rate=1.0,
         stream_gen_ai_spans=stream_gen_ai_spans,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     def failing_model(messages, info):
@@ -474,7 +474,7 @@ async def test_agent_run_stream(
         traces_sample_rate=1.0,
         send_default_pii=True,
         stream_gen_ai_spans=stream_gen_ai_spans,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     test_agent = get_test_agent()
@@ -626,7 +626,7 @@ async def test_agent_run_stream_events(
         traces_sample_rate=1.0,
         send_default_pii=True,
         stream_gen_ai_spans=stream_gen_ai_spans,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     # Consume all events
@@ -736,7 +736,7 @@ async def test_agent_with_tools(
         traces_sample_rate=1.0,
         send_default_pii=True,
         stream_gen_ai_spans=stream_gen_ai_spans,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     test_agent = get_test_agent()
@@ -846,7 +846,7 @@ async def test_agent_with_tool_model_retry(
         traces_sample_rate=1.0,
         send_default_pii=True,
         stream_gen_ai_spans=stream_gen_ai_spans,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     retries = 0
@@ -989,7 +989,7 @@ async def test_agent_with_tool_validation_error(
         traces_sample_rate=1.0,
         send_default_pii=True,
         stream_gen_ai_spans=stream_gen_ai_spans,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     test_agent = get_test_agent()
@@ -1113,7 +1113,7 @@ async def test_agent_with_tools_streaming(
         traces_sample_rate=1.0,
         send_default_pii=True,
         stream_gen_ai_spans=stream_gen_ai_spans,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     test_agent = get_test_agent()
@@ -1201,7 +1201,7 @@ async def test_model_settings(
         integrations=[PydanticAIIntegration()],
         traces_sample_rate=1.0,
         stream_gen_ai_spans=stream_gen_ai_spans,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     test_agent_with_settings = get_test_agent_with_settings()
@@ -1279,7 +1279,7 @@ async def test_system_prompt_attribute(
         traces_sample_rate=1.0,
         send_default_pii=send_default_pii,
         stream_gen_ai_spans=stream_gen_ai_spans,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     if span_streaming or stream_gen_ai_spans:
@@ -1360,7 +1360,7 @@ async def test_error_handling(
         integrations=[PydanticAIIntegration()],
         traces_sample_rate=1.0,
         stream_gen_ai_spans=stream_gen_ai_spans,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     if span_streaming:
@@ -1422,7 +1422,7 @@ async def test_without_pii(
         traces_sample_rate=1.0,
         send_default_pii=False,
         stream_gen_ai_spans=stream_gen_ai_spans,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     if span_streaming or stream_gen_ai_spans:
@@ -1480,7 +1480,7 @@ async def test_without_pii_tools(
         traces_sample_rate=1.0,
         send_default_pii=False,
         stream_gen_ai_spans=stream_gen_ai_spans,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     test_agent = get_test_agent()
@@ -1544,7 +1544,7 @@ async def test_multiple_agents_concurrent(
         integrations=[PydanticAIIntegration()],
         traces_sample_rate=1.0,
         stream_gen_ai_spans=stream_gen_ai_spans,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     test_agent = get_test_agent()
@@ -1619,7 +1619,7 @@ async def test_message_history(
         traces_sample_rate=1.0,
         send_default_pii=True,
         stream_gen_ai_spans=stream_gen_ai_spans,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     # Second message with history
@@ -1697,7 +1697,7 @@ async def test_gen_ai_system(
         integrations=[PydanticAIIntegration()],
         traces_sample_rate=1.0,
         stream_gen_ai_spans=stream_gen_ai_spans,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     test_agent = get_test_agent()
@@ -1757,7 +1757,7 @@ async def test_include_prompts_false(
         traces_sample_rate=1.0,
         send_default_pii=True,  # Even with PII enabled, prompts should not be captured
         stream_gen_ai_spans=stream_gen_ai_spans,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     test_agent = get_test_agent()
@@ -1815,7 +1815,7 @@ async def test_include_prompts_true(
         traces_sample_rate=1.0,
         send_default_pii=True,
         stream_gen_ai_spans=stream_gen_ai_spans,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     test_agent = get_test_agent()
@@ -1873,7 +1873,7 @@ async def test_include_prompts_false_with_tools(
         traces_sample_rate=1.0,
         send_default_pii=True,
         stream_gen_ai_spans=stream_gen_ai_spans,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     test_agent = get_test_agent()
@@ -1938,7 +1938,7 @@ async def test_include_prompts_requires_pii(
         traces_sample_rate=1.0,
         send_default_pii=False,  # PII disabled
         stream_gen_ai_spans=stream_gen_ai_spans,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     test_agent = get_test_agent()
@@ -2158,7 +2158,7 @@ async def test_invoke_agent_with_list_user_prompt(
         traces_sample_rate=1.0,
         send_default_pii=True,
         stream_gen_ai_spans=stream_gen_ai_spans,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     if span_streaming:
@@ -2249,7 +2249,7 @@ async def test_invoke_agent_with_instructions(
         traces_sample_rate=1.0,
         send_default_pii=send_default_pii,
         stream_gen_ai_spans=stream_gen_ai_spans,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     if span_streaming or stream_gen_ai_spans:
@@ -2415,7 +2415,7 @@ async def test_usage_data_partial(
         integrations=[PydanticAIIntegration()],
         traces_sample_rate=1.0,
         stream_gen_ai_spans=stream_gen_ai_spans,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     if span_streaming or stream_gen_ai_spans:
@@ -2470,7 +2470,7 @@ async def test_agent_data_from_scope(
         integrations=[PydanticAIIntegration()],
         traces_sample_rate=1.0,
         stream_gen_ai_spans=stream_gen_ai_spans,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     if span_streaming:
@@ -2525,7 +2525,7 @@ async def test_available_tools_without_description(
         integrations=[PydanticAIIntegration()],
         traces_sample_rate=1.0,
         stream_gen_ai_spans=stream_gen_ai_spans,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     test_agent = get_test_agent()
@@ -2586,7 +2586,7 @@ async def test_output_with_tool_calls(
         traces_sample_rate=1.0,
         send_default_pii=True,
         stream_gen_ai_spans=stream_gen_ai_spans,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     test_agent = get_test_agent()
@@ -2661,7 +2661,7 @@ async def test_message_formatting_with_different_parts(
         traces_sample_rate=1.0,
         send_default_pii=True,
         stream_gen_ai_spans=stream_gen_ai_spans,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     # Create message history with different part types
@@ -2791,7 +2791,7 @@ async def test_agent_without_name(
         integrations=[PydanticAIIntegration()],
         traces_sample_rate=1.0,
         stream_gen_ai_spans=stream_gen_ai_spans,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     if span_streaming:
@@ -3007,7 +3007,7 @@ async def test_message_parts_with_tool_return(
         traces_sample_rate=1.0,
         send_default_pii=True,
         stream_gen_ai_spans=stream_gen_ai_spans,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     if span_streaming or stream_gen_ai_spans:
@@ -3954,7 +3954,7 @@ async def test_binary_content_encoding_image(
         traces_sample_rate=1.0,
         send_default_pii=True,
         stream_gen_ai_spans=stream_gen_ai_spans,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     if span_streaming:
@@ -4041,7 +4041,7 @@ async def test_binary_content_encoding_mixed_content(
         traces_sample_rate=1.0,
         send_default_pii=True,
         stream_gen_ai_spans=stream_gen_ai_spans,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     if span_streaming:
@@ -4163,7 +4163,7 @@ async def test_binary_content_in_agent_run(
         traces_sample_rate=1.0,
         send_default_pii=True,
         stream_gen_ai_spans=stream_gen_ai_spans,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     binary_content = BinaryContent(
@@ -4221,7 +4221,7 @@ async def test_set_usage_data_with_cache_tokens(
         integrations=[PydanticAIIntegration()],
         traces_sample_rate=1.0,
         stream_gen_ai_spans=stream_gen_ai_spans,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     if span_streaming:
@@ -4347,7 +4347,7 @@ def test_image_url_base64_content_in_span(
         traces_sample_rate=1.0,
         send_default_pii=True,
         stream_gen_ai_spans=stream_gen_ai_spans,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     found_image = False
@@ -4455,7 +4455,7 @@ async def test_invoke_agent_image_url(
         traces_sample_rate=1.0,
         send_default_pii=True,
         stream_gen_ai_spans=stream_gen_ai_spans,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     agent = Agent("test", name="test_image_url_agent")
@@ -4535,7 +4535,7 @@ async def test_tool_description_in_execute_tool_span(
         traces_sample_rate=1.0,
         send_default_pii=True,
         stream_gen_ai_spans=stream_gen_ai_spans,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     if span_streaming or stream_gen_ai_spans:

--- a/tests/integrations/pymongo/test_pymongo.py
+++ b/tests/integrations/pymongo/test_pymongo.py
@@ -116,7 +116,7 @@ def test_segment_span_streaming(sentry_init, capture_items, mongo_server, with_p
         integrations=[PyMongoIntegration()],
         traces_sample_rate=1.0,
         send_default_pii=with_pii,
-        _experiments={"trace_lifecycle": "stream"},
+        trace_lifecycle="stream",
     )
     items = capture_items("span")
 
@@ -222,7 +222,7 @@ def test_breadcrumbs_span_streaming(sentry_init, capture_items, mongo_server, wi
         integrations=[PyMongoIntegration()],
         traces_sample_rate=1.0,
         send_default_pii=with_pii,
-        _experiments={"trace_lifecycle": "stream"},
+        trace_lifecycle="stream",
     )
     items = capture_items("event")
 
@@ -577,7 +577,7 @@ def test_span_origin_span_streaming(sentry_init, capture_items, mongo_server):
     sentry_init(
         integrations=[PyMongoIntegration()],
         traces_sample_rate=1.0,
-        _experiments={"trace_lifecycle": "stream"},
+        trace_lifecycle="stream",
     )
     items = capture_items("span")
 
@@ -600,7 +600,7 @@ def test_span_streaming_status_on_success(sentry_init, capture_items, mongo_serv
     sentry_init(
         integrations=[PyMongoIntegration()],
         traces_sample_rate=1.0,
-        _experiments={"trace_lifecycle": "stream"},
+        trace_lifecycle="stream",
     )
     items = capture_items("span")
 
@@ -621,7 +621,7 @@ def test_span_streaming_status_on_failure(sentry_init, capture_items, mongo_serv
     sentry_init(
         integrations=[PyMongoIntegration()],
         traces_sample_rate=1.0,
-        _experiments={"trace_lifecycle": "stream"},
+        trace_lifecycle="stream",
     )
     items = capture_items("span")
 

--- a/tests/integrations/pyramid/test_pyramid.py
+++ b/tests/integrations/pyramid/test_pyramid.py
@@ -152,7 +152,7 @@ def test_transaction_style(
     sentry_init(
         integrations=[PyramidIntegration(transaction_style=transaction_style)],
         traces_sample_rate=1.0,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     if span_streaming:
@@ -481,7 +481,7 @@ def test_tracing_error(
     sentry_init(
         integrations=[PyramidIntegration()],
         traces_sample_rate=1.0,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     if span_streaming:
@@ -537,7 +537,7 @@ def test_span_origin(
     sentry_init(
         integrations=[PyramidIntegration()],
         traces_sample_rate=1.0,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     if span_streaming:
@@ -571,7 +571,7 @@ def test_span_sets_user_id_on_segment(
         integrations=[PyramidIntegration()],
         traces_sample_rate=1.0,
         send_default_pii=send_default_pii,
-        _experiments={"trace_lifecycle": "stream"},
+        trace_lifecycle="stream",
     )
 
     class AuthenticationPolicy:

--- a/tests/integrations/pyreqwest/test_pyreqwest.py
+++ b/tests/integrations/pyreqwest/test_pyreqwest.py
@@ -73,7 +73,7 @@ def test_sync_client_spans(
         integrations=[PyreqwestIntegration()],
         traces_sample_rate=1.0,
         send_default_pii=send_default_pii,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     url = f"http://localhost:{server_port}/hello?q=test#frag"
@@ -142,7 +142,7 @@ async def test_async_client_spans(
         integrations=[PyreqwestIntegration()],
         traces_sample_rate=1.0,
         send_default_pii=send_default_pii,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     url = f"http://localhost:{server_port}/hello"
@@ -201,7 +201,7 @@ def test_sync_simple_request_spans(
         integrations=[PyreqwestIntegration()],
         traces_sample_rate=1.0,
         send_default_pii=send_default_pii,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     url = f"http://localhost:{server_port}/hello-simple"
@@ -259,7 +259,7 @@ async def test_async_simple_request_spans(
         integrations=[PyreqwestIntegration()],
         traces_sample_rate=1.0,
         send_default_pii=send_default_pii,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     url = f"http://localhost:{server_port}/hello-simple-async"
@@ -313,7 +313,7 @@ def test_span_origin(
     sentry_init(
         integrations=[PyreqwestIntegration()],
         traces_sample_rate=1.0,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     url = f"http://localhost:{server_port}/origin"
@@ -349,7 +349,7 @@ def test_outgoing_trace_headers(
         integrations=[PyreqwestIntegration()],
         traces_sample_rate=1.0,
         trace_propagation_targets=["localhost"],
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     url = f"http://localhost:{server_port}/trace"
@@ -407,7 +407,7 @@ def test_outgoing_trace_headers_append_to_baggage(
         traces_sample_rate=1.0,
         trace_propagation_targets=["localhost"],
         release="d08ebdb9309e1b004c6f52202de58a09c2268e42",
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     url = f"http://localhost:{server_port}/baggage"
@@ -490,7 +490,7 @@ def test_trace_propagation_targets(
         integrations=[PyreqwestIntegration()],
         trace_propagation_targets=trace_propagation_targets,
         traces_sample_rate=1.0,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     url = f"http://localhost:{server_port}/propagation"
@@ -520,7 +520,7 @@ def test_omit_url_data_if_parsing_fails(
     sentry_init(
         integrations=[PyreqwestIntegration()],
         traces_sample_rate=1.0,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     url = f"http://localhost:{server_port}/parse-fail"
@@ -580,7 +580,7 @@ def test_request_source_disabled(
         traces_sample_rate=1.0,
         enable_http_request_source=False,
         http_request_source_threshold_ms=0,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     url = f"http://localhost:{server_port}/hello"
@@ -630,7 +630,7 @@ def test_request_source_enabled(
         "integrations": [PyreqwestIntegration()],
         "traces_sample_rate": 1.0,
         "http_request_source_threshold_ms": 0,
-        "_experiments": {"trace_lifecycle": "stream" if span_streaming else "static"},
+        "trace_lifecycle": "stream" if span_streaming else "static",
     }
     if enable_http_request_source is not None:
         sentry_options["enable_http_request_source"] = enable_http_request_source
@@ -683,7 +683,7 @@ def test_request_source(
         traces_sample_rate=1.0,
         enable_http_request_source=True,
         http_request_source_threshold_ms=0,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     url = f"http://localhost:{server_port}/hello"
@@ -750,7 +750,7 @@ def test_request_source_with_module_in_search_path(
         traces_sample_rate=1.0,
         enable_http_request_source=True,
         http_request_source_threshold_ms=0,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     url = f"http://localhost:{server_port}/hello"
@@ -811,7 +811,7 @@ def test_no_request_source_if_duration_too_short(
         traces_sample_rate=1.0,
         enable_http_request_source=True,
         http_request_source_threshold_ms=100,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     url = f"http://localhost:{server_port}/hello"
@@ -891,7 +891,7 @@ def test_request_source_if_duration_over_threshold(
         traces_sample_rate=1.0,
         enable_http_request_source=True,
         http_request_source_threshold_ms=100,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     url = f"http://localhost:{server_port}/hello"

--- a/tests/integrations/quart/test_quart.py
+++ b/tests/integrations/quart/test_quart.py
@@ -644,7 +644,7 @@ async def test_active_thread_id_span_streaming(
         sentry_init(
             traces_sample_rate=1.0,
             profiles_sample_rate=1.0,
-            _experiments={"trace_lifecycle": "stream"},
+            trace_lifecycle="stream",
         )
         app = quart_app_factory()
 
@@ -687,7 +687,7 @@ async def test_span_streaming_basic(sentry_init, capture_items):
     sentry_init(
         integrations=[quart_sentry.QuartIntegration()],
         traces_sample_rate=1.0,
-        _experiments={"trace_lifecycle": "stream"},
+        trace_lifecycle="stream",
     )
     items = capture_items("span")
 
@@ -734,7 +734,7 @@ async def test_span_streaming_transaction_style(
             quart_sentry.QuartIntegration(transaction_style=transaction_style)
         ],
         traces_sample_rate=1.0,
-        _experiments={"trace_lifecycle": "stream"},
+        trace_lifecycle="stream",
     )
     items = capture_items("span")
 
@@ -759,7 +759,7 @@ async def test_span_streaming_with_error(sentry_init, capture_items):
     sentry_init(
         integrations=[quart_sentry.QuartIntegration()],
         traces_sample_rate=1.0,
-        _experiments={"trace_lifecycle": "stream"},
+        trace_lifecycle="stream",
     )
     items = capture_items("event", "span")
 
@@ -803,7 +803,7 @@ async def test_span_streaming_request_attributes_no_pii(sentry_init, capture_ite
         integrations=[quart_sentry.QuartIntegration()],
         traces_sample_rate=1.0,
         send_default_pii=False,
-        _experiments={"trace_lifecycle": "stream"},
+        trace_lifecycle="stream",
     )
     items = capture_items("span")
 
@@ -834,7 +834,7 @@ async def test_span_streaming_request_attributes_with_pii(sentry_init, capture_i
         integrations=[quart_sentry.QuartIntegration()],
         traces_sample_rate=1.0,
         send_default_pii=True,
-        _experiments={"trace_lifecycle": "stream"},
+        trace_lifecycle="stream",
     )
     items = capture_items("span")
 
@@ -867,7 +867,7 @@ async def test_span_streaming_sensitive_header_scrubbing(sentry_init, capture_it
         integrations=[quart_sentry.QuartIntegration()],
         traces_sample_rate=1.0,
         send_default_pii=False,
-        _experiments={"trace_lifecycle": "stream"},
+        trace_lifecycle="stream",
     )
     items = capture_items("span")
 
@@ -910,7 +910,7 @@ async def test_span_streaming_quart_auth_user_id(
         integrations=[quart_sentry.QuartIntegration()],
         traces_sample_rate=1.0,
         send_default_pii=send_default_pii,
-        _experiments={"trace_lifecycle": "stream"},
+        trace_lifecycle="stream",
     )
     items = capture_items("span")
 
@@ -946,7 +946,7 @@ async def test_span_streaming_sensitive_header_passthrough_with_pii(
         integrations=[quart_sentry.QuartIntegration()],
         traces_sample_rate=1.0,
         send_default_pii=True,
-        _experiments={"trace_lifecycle": "stream"},
+        trace_lifecycle="stream",
     )
     items = capture_items("span")
 

--- a/tests/integrations/ray/test_ray.py
+++ b/tests/integrations/ray/test_ray.py
@@ -51,7 +51,7 @@ def setup_sentry(span_streaming=False, transport=None):
         integrations=[RayIntegration()],
         transport=RayTestTransport() if transport is None else transport,
         traces_sample_rate=1.0,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
 
@@ -185,7 +185,7 @@ def test_tracing_in_ray_tasks(task_options, task, span_streaming):
         disabled_integrations=[StdlibIntegration],
         transport=RayTestTransport(),
         traces_sample_rate=1.0,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     # Setup ray task, calling decorator directly instead of @,
@@ -314,7 +314,7 @@ def test_errors_in_ray_tasks(span_streaming):
         disabled_integrations=[StdlibIntegration],
         transport=RayTestTransport(),
         traces_sample_rate=1.0,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     ray_temp_dir = os.path.join("/tmp", f"ray_test_{uuid.uuid4().hex[:8]}")
@@ -374,7 +374,7 @@ def test_tracing_in_ray_actors(remote_kwargs, span_streaming):
         disabled_integrations=[StdlibIntegration],
         transport=RayTestTransport(),
         traces_sample_rate=1.0,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     # Setup ray actor
@@ -489,7 +489,7 @@ def test_errors_in_ray_actors(span_streaming):
         disabled_integrations=[StdlibIntegration],
         transport=RayLoggingTransport(),
         traces_sample_rate=1.0,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     ray_temp_dir = os.path.join("/tmp", f"ray_test_{uuid.uuid4().hex[:8]}")

--- a/tests/integrations/redis/asyncio/test_redis_asyncio.py
+++ b/tests/integrations/redis/asyncio/test_redis_asyncio.py
@@ -57,7 +57,7 @@ async def test_async_redis_pipeline(
         integrations=[RedisIntegration()],
         traces_sample_rate=1.0,
         send_default_pii=send_default_pii,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     connection = FakeRedis()
@@ -127,7 +127,7 @@ async def test_async_span_origin(
     sentry_init(
         integrations=[RedisIntegration()],
         traces_sample_rate=1.0,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     connection = FakeRedis()

--- a/tests/integrations/redis/cluster/test_redis_cluster.py
+++ b/tests/integrations/redis/cluster/test_redis_cluster.py
@@ -74,7 +74,7 @@ def test_rediscluster_basic(
         integrations=[RedisIntegration()],
         traces_sample_rate=1.0,
         send_default_pii=send_default_pii,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     if span_streaming:
@@ -156,7 +156,7 @@ def test_rediscluster_pipeline(
         integrations=[RedisIntegration()],
         traces_sample_rate=1.0,
         send_default_pii=send_default_pii,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     rc = redis.RedisCluster(host="localhost", port=6379)
@@ -226,7 +226,7 @@ def test_rediscluster_span_origin(
     sentry_init(
         integrations=[RedisIntegration()],
         traces_sample_rate=1.0,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     rc = redis.RedisCluster(host="localhost", port=6379)

--- a/tests/integrations/redis/cluster_asyncio/test_redis_cluster_asyncio.py
+++ b/tests/integrations/redis/cluster_asyncio/test_redis_cluster_asyncio.py
@@ -82,7 +82,7 @@ async def test_async_basic(
         integrations=[RedisIntegration()],
         traces_sample_rate=1.0,
         send_default_pii=send_default_pii,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     connection = cluster.RedisCluster(host="localhost", port=6379)
@@ -152,7 +152,7 @@ async def test_async_redis_pipeline(
         integrations=[RedisIntegration()],
         traces_sample_rate=1.0,
         send_default_pii=send_default_pii,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     connection = cluster.RedisCluster(host="localhost", port=6379)
@@ -217,7 +217,7 @@ async def test_async_span_origin(
     sentry_init(
         integrations=[RedisIntegration()],
         traces_sample_rate=1.0,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     connection = cluster.RedisCluster(host="localhost", port=6379)

--- a/tests/integrations/redis/test_redis.py
+++ b/tests/integrations/redis/test_redis.py
@@ -63,7 +63,7 @@ def test_redis_pipeline(
         integrations=[RedisIntegration()],
         traces_sample_rate=1.0,
         send_default_pii=send_default_pii,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     connection = FakeStrictRedis()
@@ -123,7 +123,7 @@ def test_sensitive_data(sentry_init, capture_events, capture_items, span_streami
             integrations=[RedisIntegration()],
             traces_sample_rate=1.0,
             send_default_pii=True,
-            _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+            trace_lifecycle="stream" if span_streaming else "static",
         )
 
         connection = FakeStrictRedis()
@@ -159,7 +159,7 @@ def test_pii_data_redacted(sentry_init, capture_events, capture_items, span_stre
     sentry_init(
         integrations=[RedisIntegration()],
         traces_sample_rate=1.0,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     connection = FakeStrictRedis()
@@ -207,7 +207,7 @@ def test_pii_data_sent(sentry_init, capture_events, capture_items, span_streamin
         integrations=[RedisIntegration()],
         traces_sample_rate=1.0,
         send_default_pii=True,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     connection = FakeStrictRedis()
@@ -263,7 +263,7 @@ def test_no_data_truncation_by_default(
         integrations=[RedisIntegration()],
         traces_sample_rate=1.0,
         send_default_pii=True,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     connection = FakeStrictRedis()
@@ -313,7 +313,7 @@ def test_data_truncation_custom(
         integrations=[RedisIntegration(max_data_size=30)],
         traces_sample_rate=1.0,
         send_default_pii=True,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     connection = FakeStrictRedis()
@@ -411,7 +411,7 @@ def test_db_connection_attributes_client(
     sentry_init(
         traces_sample_rate=1.0,
         integrations=[RedisIntegration()],
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     if span_streaming:
@@ -459,7 +459,7 @@ def test_db_connection_attributes_pipeline(
     sentry_init(
         traces_sample_rate=1.0,
         integrations=[RedisIntegration()],
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     if span_streaming:
@@ -512,7 +512,7 @@ def test_span_origin(sentry_init, capture_events, capture_items, span_streaming)
     sentry_init(
         integrations=[RedisIntegration()],
         traces_sample_rate=1.0,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     connection = FakeStrictRedis()

--- a/tests/integrations/redis/test_redis_cache_module.py
+++ b/tests/integrations/redis/test_redis_cache_module.py
@@ -20,7 +20,7 @@ def test_no_cache_basic(sentry_init, capture_events, capture_items, span_streami
             RedisIntegration(),
         ],
         traces_sample_rate=1.0,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     connection = FakeStrictRedis()
@@ -55,7 +55,7 @@ def test_cache_basic(sentry_init, capture_events, capture_items, span_streaming)
             ),
         ],
         traces_sample_rate=1.0,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     connection = FakeStrictRedis()
@@ -156,7 +156,7 @@ def test_cache_keys(sentry_init, capture_events, capture_items, span_streaming):
             ),
         ],
         traces_sample_rate=1.0,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     connection = FakeStrictRedis()
@@ -233,7 +233,7 @@ def test_cache_data(sentry_init, capture_events, capture_items, span_streaming):
             ),
         ],
         traces_sample_rate=1.0,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     # Use a unique host per parametrized run so fakeredis (which shares state
@@ -386,7 +386,7 @@ def test_cache_prefixes(sentry_init, capture_events, capture_items, span_streami
             ),
         ],
         traces_sample_rate=1.0,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     connection = FakeStrictRedis()

--- a/tests/integrations/redis/test_redis_cache_module_async.py
+++ b/tests/integrations/redis/test_redis_cache_module_async.py
@@ -32,7 +32,7 @@ async def test_no_cache_basic(
             RedisIntegration(),
         ],
         traces_sample_rate=1.0,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     connection = FakeRedisAsync()
@@ -68,7 +68,7 @@ async def test_cache_basic(sentry_init, capture_events, capture_items, span_stre
             ),
         ],
         traces_sample_rate=1.0,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     connection = FakeRedisAsync()
@@ -108,7 +108,7 @@ async def test_cache_keys(sentry_init, capture_events, capture_items, span_strea
             ),
         ],
         traces_sample_rate=1.0,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     connection = FakeRedisAsync()
@@ -186,7 +186,7 @@ async def test_cache_data(sentry_init, capture_events, capture_items, span_strea
             ),
         ],
         traces_sample_rate=1.0,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     # Use a unique host per parametrized run so fakeredis (which shares state

--- a/tests/integrations/rq/test_rq.py
+++ b/tests/integrations/rq/test_rq.py
@@ -59,7 +59,7 @@ def test_basic(
     sentry_init(
         integrations=[RqIntegration()],
         send_default_pii=send_default_pii,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     queue = rq.Queue(connection=FakeStrictRedis())
@@ -114,7 +114,7 @@ def test_transport_shutdown(
 ):
     sentry_init(
         integrations=[RqIntegration()],
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     queue = rq.Queue(connection=FakeStrictRedis())
@@ -159,7 +159,7 @@ def test_transaction_with_error(
         integrations=[RqIntegration()],
         traces_sample_rate=1.0,
         send_default_pii=send_default_pii,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     queue = rq.Queue(connection=FakeStrictRedis())
@@ -250,7 +250,7 @@ def test_error_has_trace_context_if_tracing_disabled(
 ):
     sentry_init(
         integrations=[RqIntegration()],
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     queue = rq.Queue(connection=FakeStrictRedis())
@@ -284,7 +284,7 @@ def test_tracing_enabled(
     sentry_init(
         integrations=[RqIntegration()],
         traces_sample_rate=1.0,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     queue = rq.Queue(connection=FakeStrictRedis())
@@ -347,7 +347,7 @@ def test_tracing_disabled(
 ):
     sentry_init(
         integrations=[RqIntegration()],
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     queue = rq.Queue(connection=FakeStrictRedis())
@@ -394,7 +394,7 @@ def test_transaction_no_error(
         integrations=[RqIntegration()],
         traces_sample_rate=1.0,
         send_default_pii=send_default_pii,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     queue = rq.Queue(connection=FakeStrictRedis())
@@ -457,7 +457,7 @@ def test_traces_sampler_gets_correct_values_in_sampling_context(
     sentry_init(
         integrations=[RqIntegration()],
         traces_sampler=traces_sampler,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     queue = rq.Queue(connection=FakeStrictRedis())
@@ -496,7 +496,7 @@ def test_job_with_retries(
 ):
     sentry_init(
         integrations=[RqIntegration()],
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     queue = rq.Queue(connection=FakeStrictRedis())
@@ -527,7 +527,7 @@ def test_span_origin(
     sentry_init(
         integrations=[RqIntegration()],
         traces_sample_rate=1.0,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     queue = rq.Queue(connection=FakeStrictRedis())

--- a/tests/integrations/rust_tracing/test_rust_tracing.py
+++ b/tests/integrations/rust_tracing/test_rust_tracing.py
@@ -79,7 +79,7 @@ def test_on_new_span_on_close(
     sentry_init(
         integrations=[integration],
         traces_sample_rate=1.0,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
     if span_streaming:
         items = capture_items("span")
@@ -165,7 +165,7 @@ def test_nested_on_new_span_on_close(
     sentry_init(
         integrations=[integration],
         traces_sample_rate=1.0,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
     if span_streaming:
         items = capture_items("span")
@@ -303,7 +303,7 @@ def test_on_new_span_without_transaction(sentry_init, span_streaming):
     sentry_init(
         integrations=[integration],
         traces_sample_rate=1.0,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     if span_streaming:
@@ -339,7 +339,7 @@ def test_on_event_exception(
     sentry_init(
         integrations=[integration],
         traces_sample_rate=1.0,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
     if span_streaming:
         items = capture_items("event")
@@ -399,7 +399,7 @@ def test_on_event_breadcrumb(
     sentry_init(
         integrations=[integration],
         traces_sample_rate=1.0,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
     if span_streaming:
         items = capture_items("event")
@@ -454,7 +454,7 @@ def test_on_event_event(
     sentry_init(
         integrations=[integration],
         traces_sample_rate=1.0,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
     if span_streaming:
         items = capture_items("event")
@@ -514,7 +514,7 @@ def test_on_event_ignored(
     sentry_init(
         integrations=[integration],
         traces_sample_rate=1.0,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
     if span_streaming:
         items = capture_items("span")
@@ -574,7 +574,7 @@ def test_span_filter(
     sentry_init(
         integrations=[integration],
         traces_sample_rate=1.0,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
     if span_streaming:
         items = capture_items("span")
@@ -638,7 +638,7 @@ def test_record(sentry_init, span_streaming):
     sentry_init(
         integrations=[integration],
         traces_sample_rate=1.0,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     if span_streaming:
@@ -681,7 +681,7 @@ def test_record_in_ignored_span(sentry_init, span_streaming):
     sentry_init(
         integrations=[integration],
         traces_sample_rate=1.0,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     if span_streaming:
@@ -742,7 +742,7 @@ def test_include_tracing_fields(
         integrations=[integration],
         traces_sample_rate=1.0,
         send_default_pii=send_default_pii,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     if span_streaming:

--- a/tests/integrations/sanic/test_sanic.py
+++ b/tests/integrations/sanic/test_sanic.py
@@ -435,7 +435,7 @@ def test_transactions(
         integrations=[SanicIntegration(*test_config.integration_args)],
         traces_sample_rate=1.0,
         send_default_pii=send_pii,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     if span_streaming:
@@ -530,7 +530,7 @@ def test_span_origin(sentry_init, app, capture_events, capture_items, span_strea
     sentry_init(
         integrations=[SanicIntegration()],
         traces_sample_rate=1.0,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     if span_streaming:
@@ -576,7 +576,7 @@ def test_user_ip_address_on_all_spans(
         default_integrations=False,
         traces_sample_rate=1.0,
         send_default_pii=send_default_pii,
-        _experiments={"trace_lifecycle": "stream"},
+        trace_lifecycle="stream",
     )
 
     items = capture_items("span")

--- a/tests/integrations/socket/test_socket.py
+++ b/tests/integrations/socket/test_socket.py
@@ -15,7 +15,7 @@ def test_getaddrinfo_trace(sentry_init, capture_events, capture_items, span_stre
     sentry_init(
         integrations=[SocketIntegration()],
         traces_sample_rate=1.0,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     if span_streaming:
@@ -60,7 +60,7 @@ def test_create_connection_trace(
     sentry_init(
         integrations=[SocketIntegration()],
         traces_sample_rate=1.0,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     if span_streaming:
@@ -118,7 +118,7 @@ def test_span_origin(sentry_init, capture_events, capture_items, span_streaming)
     sentry_init(
         integrations=[SocketIntegration()],
         traces_sample_rate=1.0,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     if span_streaming:

--- a/tests/integrations/sqlalchemy/test_sqlalchemy.py
+++ b/tests/integrations/sqlalchemy/test_sqlalchemy.py
@@ -324,7 +324,7 @@ def test_long_sql_query_preserved(
     sentry_init(
         traces_sample_rate=1,
         integrations=[SqlalchemyIntegration()],
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     engine = create_engine(
@@ -425,7 +425,7 @@ def test_engine_name_not_string(
 ):
     sentry_init(
         integrations=[SqlalchemyIntegration()],
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     engine = create_engine(
@@ -449,7 +449,7 @@ def test_query_source_disabled(
         "traces_sample_rate": 1.0,
         "enable_db_query_source": False,
         "db_query_source_threshold_ms": 0,
-        "_experiments": {"trace_lifecycle": "stream" if span_streaming else "static"},
+        "trace_lifecycle": "stream" if span_streaming else "static",
     }
 
     sentry_init(**sentry_options)
@@ -548,7 +548,7 @@ def test_query_source_enabled(
         "integrations": [SqlalchemyIntegration()],
         "traces_sample_rate": 1.0,
         "db_query_source_threshold_ms": 0,
-        "_experiments": {"trace_lifecycle": "stream" if span_streaming else "static"},
+        "trace_lifecycle": "stream" if span_streaming else "static",
     }
 
     if enable_db_query_source is not None:
@@ -648,7 +648,7 @@ def test_query_source(
         traces_sample_rate=1.0,
         enable_db_query_source=True,
         db_query_source_threshold_ms=0,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
     if span_streaming:
         items = capture_items("span")
@@ -775,7 +775,7 @@ def test_query_source_with_module_in_search_path(
         traces_sample_rate=1.0,
         enable_db_query_source=True,
         db_query_source_threshold_ms=0,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     from sqlalchemy_helpers.helpers import (
@@ -908,7 +908,7 @@ def test_no_query_source_if_duration_too_short(
         traces_sample_rate=1.0,
         enable_db_query_source=True,
         db_query_source_threshold_ms=100,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
     if span_streaming:
         items = capture_items("span")
@@ -1038,7 +1038,7 @@ def test_query_source_if_duration_over_threshold(
         traces_sample_rate=1.0,
         enable_db_query_source=True,
         db_query_source_threshold_ms=100,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     if span_streaming:
@@ -1202,7 +1202,7 @@ def test_span_origin(
     sentry_init(
         integrations=[SqlalchemyIntegration()],
         traces_sample_rate=1.0,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     engine = create_engine(

--- a/tests/integrations/starlette/test_starlette.py
+++ b/tests/integrations/starlette/test_starlette.py
@@ -1136,7 +1136,7 @@ def test_active_thread_id_span_streaming(sentry_init, capture_items, endpoint):
         auto_enabling_integrations=False,  # avoid legacy spans from auto-enabled integrations leaking into streaming mode
         integrations=[StarletteIntegration()],
         traces_sample_rate=1.0,
-        _experiments={"trace_lifecycle": "stream"},
+        trace_lifecycle="stream",
     )
     app = starlette_app_factory()
 

--- a/tests/integrations/statsig/test_statsig.py
+++ b/tests/integrations/statsig/test_statsig.py
@@ -198,7 +198,7 @@ def test_statsig_span_integration(
         sentry_init(
             traces_sample_rate=1.0,
             integrations=[StatsigIntegration()],
-            _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+            trace_lifecycle="stream" if span_streaming else "static",
         )
         user = StatsigUser(user_id="user-id")
 

--- a/tests/integrations/stdlib/test_httplib.py
+++ b/tests/integrations/stdlib/test_httplib.py
@@ -192,7 +192,7 @@ def test_empty_realurl(
 
     sentry_init(
         dsn="",
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
     HTTPConnection("localhost", port=PORT).putrequest("POST", None)
 
@@ -255,7 +255,7 @@ def test_outgoing_trace_headers(
 ):
     sentry_init(
         traces_sample_rate=1.0,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     already_patched_getresponse = HTTPSConnection.getresponse
@@ -370,7 +370,7 @@ def test_outgoing_trace_headers_head_sdk(
     sentry_init(
         traces_sample_rate=0.5,
         release="foo",
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     already_patched_getresponse = HTTPSConnection.getresponse
@@ -468,7 +468,7 @@ def test_outgoing_trace_headers_span_streaming_no_current_span(sentry_init):
     """
     sentry_init(
         traces_sample_rate=1.0,
-        _experiments={"trace_lifecycle": "stream"},
+        trace_lifecycle="stream",
     )
 
     already_patched_getresponse = HTTPSConnection.getresponse
@@ -599,7 +599,7 @@ def test_option_trace_propagation_targets(
     sentry_init(
         trace_propagation_targets=trace_propagation_targets,
         traces_sample_rate=1.0,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     already_patched_getresponse = HTTPSConnection.getresponse
@@ -677,7 +677,7 @@ def test_request_source_disabled(
 
     sentry_init(
         **sentry_options,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     if span_streaming:
@@ -731,7 +731,7 @@ def test_request_source_enabled(
     sentry_options = {
         "traces_sample_rate": 1.0,
         "http_request_source_threshold_ms": 0,
-        "_experiments": {"trace_lifecycle": "stream" if span_streaming else "static"},
+        "trace_lifecycle": "stream" if span_streaming else "static",
     }
 
     if enable_http_request_source is not None:
@@ -793,7 +793,7 @@ def test_request_source(
         traces_sample_rate=1.0,
         enable_http_request_source=True,
         http_request_source_threshold_ms=0,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
     if span_streaming:
         items = capture_items("span")
@@ -878,7 +878,7 @@ def test_request_source_with_module_in_search_path(
         traces_sample_rate=1.0,
         enable_http_request_source=True,
         http_request_source_threshold_ms=0,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
     if span_streaming:
         items = capture_items("span")
@@ -952,7 +952,7 @@ def test_no_request_source_if_duration_too_short(
         traces_sample_rate=1.0,
         enable_http_request_source=True,
         http_request_source_threshold_ms=100,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     add_http_request_source = sentry_sdk.tracing_utils.add_http_request_source
@@ -1026,7 +1026,7 @@ def test_request_source_if_duration_over_threshold(
         traces_sample_rate=1.0,
         enable_http_request_source=True,
         http_request_source_threshold_ms=100,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     add_http_request_source = sentry_sdk.tracing_utils.add_http_request_source
@@ -1136,7 +1136,7 @@ def test_span_origin(
     sentry_init(
         traces_sample_rate=1.0,
         debug=True,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     if span_streaming:
@@ -1181,7 +1181,7 @@ def test_http_timeout(
 
     sentry_init(
         traces_sample_rate=1.0,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     if span_streaming:
@@ -1236,7 +1236,7 @@ def test_proxy_http_tunnel(
     sentry_init(
         traces_sample_rate=1.0,
         send_default_pii=send_default_pii,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     if span_streaming:
@@ -1301,7 +1301,7 @@ def test_chunked_response_span_covers_body_read(
 ):
     sentry_init(
         traces_sample_rate=1.0,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     min_expected_duration = CHUNK_DELAY * NUM_CHUNKS

--- a/tests/integrations/stdlib/test_subprocess.py
+++ b/tests/integrations/stdlib/test_subprocess.py
@@ -63,7 +63,7 @@ def test_subprocess_basic(
     sentry_init(
         integrations=[StdlibIntegration()],
         traces_sample_rate=1.0,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     if span_streaming:
@@ -298,7 +298,7 @@ def test_subprocess_empty_env(
     sentry_init(
         integrations=[StdlibIntegration()],
         traces_sample_rate=1.0,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
     if span_streaming:
         with sentry_sdk.traces.start_span(name="custom parent"):
@@ -327,7 +327,7 @@ def test_subprocess_invalid_args(
 ):
     sentry_init(
         integrations=[StdlibIntegration()],
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     with pytest.raises(TypeError) as excinfo:
@@ -346,7 +346,7 @@ def test_subprocess_span_origin(
     sentry_init(
         integrations=[StdlibIntegration()],
         traces_sample_rate=1.0,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     if span_streaming:

--- a/tests/integrations/strawberry/test_strawberry.py
+++ b/tests/integrations/strawberry/test_strawberry.py
@@ -308,7 +308,7 @@ def test_capture_transaction_on_error(
         ]
         + framework_integrations,
         traces_sample_rate=1,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     if span_streaming:
@@ -447,7 +447,7 @@ def test_capture_transaction_on_success(
         + framework_integrations,
         traces_sample_rate=1,
         send_default_pii=send_default_pii,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     if span_streaming:
@@ -583,7 +583,7 @@ def test_transaction_no_operation_name(
         + framework_integrations,
         traces_sample_rate=1,
         send_default_pii=send_default_pii,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     if span_streaming:
@@ -724,7 +724,7 @@ def test_transaction_mutation(
         + framework_integrations,
         traces_sample_rate=1,
         send_default_pii=send_default_pii,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     if span_streaming:
@@ -884,7 +884,7 @@ def test_span_origin(
         ]
         + framework_integrations,
         traces_sample_rate=1,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     if span_streaming:
@@ -951,7 +951,7 @@ def test_span_origin2(
         ]
         + framework_integrations,
         traces_sample_rate=1,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     if span_streaming:
@@ -1018,7 +1018,7 @@ def test_span_origin3(
         ]
         + framework_integrations,
         traces_sample_rate=1,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     if span_streaming:

--- a/tests/integrations/tornado/test_tornado.py
+++ b/tests/integrations/tornado/test_tornado.py
@@ -133,7 +133,7 @@ def test_transactions(
         integrations=[TornadoIntegration()],
         traces_sample_rate=1.0,
         send_default_pii=send_pii,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     if span_streaming:
@@ -525,7 +525,7 @@ def test_span_origin(
     sentry_init(
         integrations=[TornadoIntegration()],
         traces_sample_rate=1.0,
-        _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+        trace_lifecycle="stream" if span_streaming else "static",
     )
 
     if span_streaming:
@@ -557,7 +557,7 @@ def test_user_ip_address_on_all_spans(
         integrations=[TornadoIntegration()],
         traces_sample_rate=1.0,
         send_default_pii=send_default_pii,
-        _experiments={"trace_lifecycle": "stream"},
+        trace_lifecycle="stream",
     )
 
     items = capture_items("span")

--- a/tests/integrations/unleash/test_unleash.py
+++ b/tests/integrations/unleash/test_unleash.py
@@ -181,7 +181,7 @@ def test_unleash_span_integration(
         sentry_init(
             traces_sample_rate=1.0,
             integrations=[UnleashIntegration()],
-            _experiments={"trace_lifecycle": "stream" if span_streaming else "static"},
+            trace_lifecycle="stream" if span_streaming else "static",
         )
 
         client = UnleashClient()  # type: ignore[arg-type]

--- a/tests/integrations/wsgi/test_wsgi.py
+++ b/tests/integrations/wsgi/test_wsgi.py
@@ -855,7 +855,7 @@ def test_user_ip_address_on_all_spans(sentry_init, capture_items, send_default_p
     sentry_init(
         send_default_pii=send_default_pii,
         traces_sample_rate=1.0,
-        _experiments={"trace_lifecycle": "stream"},
+        trace_lifecycle="stream",
     )
     app = SentryWsgiMiddleware(dogpark)
     client = Client(app)

--- a/tests/test_scope.py
+++ b/tests/test_scope.py
@@ -87,7 +87,7 @@ def test_set_user_none_values_are_dropped_when_copying_to_attributes(
     sentry_init(
         traces_sample_rate=1.0,
         send_default_pii=True,
-        _experiments={"trace_lifecycle": "stream"},
+        trace_lifecycle="stream",
     )
     items = capture_items("span")
 

--- a/tests/tracing/test_decorator.py
+++ b/tests/tracing/test_decorator.py
@@ -88,7 +88,7 @@ async def test_trace_decorator_async_no_trx():
 def test_trace_decorator_span_streaming(sentry_init, capture_items):
     sentry_init(
         traces_sample_rate=1.0,
-        _experiments={"trace_lifecycle": "stream"},
+        trace_lifecycle="stream",
     )
 
     items = capture_items("span")
@@ -117,7 +117,7 @@ def test_trace_decorator_span_streaming(sentry_init, capture_items):
 def test_trace_decorator_arguments_span_streaming(sentry_init, capture_items):
     sentry_init(
         traces_sample_rate=1.0,
-        _experiments={"trace_lifecycle": "stream"},
+        trace_lifecycle="stream",
     )
 
     items = capture_items("span")
@@ -144,7 +144,7 @@ def test_trace_decorator_arguments_span_streaming(sentry_init, capture_items):
 def test_trace_decorator_inactive_span_streaming(sentry_init, capture_items):
     sentry_init(
         traces_sample_rate=1.0,
-        _experiments={"trace_lifecycle": "stream"},
+        trace_lifecycle="stream",
     )
 
     items = capture_items("span")
@@ -173,7 +173,7 @@ def test_trace_decorator_inactive_span_streaming(sentry_init, capture_items):
 async def test_trace_decorator_async_span_streaming(sentry_init, capture_items):
     sentry_init(
         traces_sample_rate=1.0,
-        _experiments={"trace_lifecycle": "stream"},
+        trace_lifecycle="stream",
     )
 
     items = capture_items("span")
@@ -205,7 +205,7 @@ async def test_trace_decorator_async_arguments_span_streaming(
 ):
     sentry_init(
         traces_sample_rate=1.0,
-        _experiments={"trace_lifecycle": "stream"},
+        trace_lifecycle="stream",
     )
 
     items = capture_items("span")
@@ -235,7 +235,7 @@ async def test_trace_decorator_async_inactive_span_streaming(
 ):
     sentry_init(
         traces_sample_rate=1.0,
-        _experiments={"trace_lifecycle": "stream"},
+        trace_lifecycle="stream",
     )
 
     items = capture_items("span")

--- a/tests/tracing/test_misc.py
+++ b/tests/tracing/test_misc.py
@@ -180,7 +180,7 @@ def test_finds_transaction_on_scope(sentry_init):
 def test_finds_segment_on_scope(sentry_init):
     sentry_init(
         traces_sample_rate=1.0,
-        _experiments={"trace_lifecycle": "stream"},
+        trace_lifecycle="stream",
     )
 
     with sentry_sdk.traces.start_span(name="dogpark"):
@@ -250,7 +250,7 @@ def test_finds_non_orphan_span_on_scope(sentry_init):
 def test_finds_non_orphan_span_on_scope_span_streaming(sentry_init):
     sentry_init(
         traces_sample_rate=1.0,
-        _experiments={"trace_lifecycle": "stream"},
+        trace_lifecycle="stream",
     )
 
     segment = sentry_sdk.traces.start_span(name="dogpark")
@@ -342,7 +342,7 @@ def test_circular_references_span_streaming(monkeypatch, sentry_init, request):
 
     sentry_init(
         traces_sample_rate=1.0,
-        _experiments={"trace_lifecycle": "stream"},
+        trace_lifecycle="stream",
     )
 
     # Make sure that we're starting with a clean slate before we start creating

--- a/tests/tracing/test_propagation.py
+++ b/tests/tracing/test_propagation.py
@@ -32,7 +32,7 @@ def test_span_in_transaction(sentry_init):
 
 
 def test_span_in_transaction_span_streaming(sentry_init):
-    sentry_init(traces_sample_rate=1.0, _experiments={"trace_lifecycle": "stream"})
+    sentry_init(traces_sample_rate=1.0, trace_lifecycle="stream")
 
     with sentry_sdk.traces.start_span(name="test"):
         with sentry_sdk.traces.start_span(name="test2") as span:
@@ -51,7 +51,7 @@ def test_span_in_span_in_transaction(sentry_init):
 
 
 def test_span_in_span_in_transaction_span_streaming(sentry_init):
-    sentry_init(traces_sample_rate=1.0, _experiments={"trace_lifecycle": "stream"})
+    sentry_init(traces_sample_rate=1.0, trace_lifecycle="stream")
 
     with sentry_sdk.traces.start_span(name="test"):
         with sentry_sdk.traces.start_span(name="test2"):

--- a/tests/tracing/test_sample_rand_propagation.py
+++ b/tests/tracing/test_sample_rand_propagation.py
@@ -29,7 +29,7 @@ def test_continue_trace_with_sample_rand_span_streaming(sentry_init):
     """
     Test that an incoming sample_rand is propagated onto the segment's baggage.
     """
-    sentry_init(traces_sample_rate=1.0, _experiments={"trace_lifecycle": "stream"})
+    sentry_init(traces_sample_rate=1.0, trace_lifecycle="stream")
 
     headers = {
         "sentry-trace": "00000000000000000000000000000000-0000000000000000-1",
@@ -64,7 +64,7 @@ def test_continue_trace_missing_sample_rand_span_streaming(sentry_init):
     Test that a missing sample_rand is filled in onto the segment's baggage.
     """
 
-    sentry_init(traces_sample_rate=1.0, _experiments={"trace_lifecycle": "stream"})
+    sentry_init(traces_sample_rate=1.0, trace_lifecycle="stream")
 
     headers = {
         "sentry-trace": "00000000000000000000000000000000-0000000000000000",

--- a/tests/tracing/test_sampling.py
+++ b/tests/tracing/test_sampling.py
@@ -26,7 +26,7 @@ def test_sampling_decided_only_for_transactions(sentry_init, capture_events):
 def test_sampling_decided_only_for_segments(sentry_init, capture_events):
     sentry_init(
         traces_sample_rate=0.5,
-        _experiments={"trace_lifecycle": "stream"},
+        trace_lifecycle="stream",
     )
 
     with sentry_sdk.traces.start_span(name="hi") as segment:
@@ -67,7 +67,7 @@ def test_no_double_sampling_span_streaming(sentry_init, capture_items):
     sentry_init(
         traces_sample_rate=1.0,
         sample_rate=0.0,
-        _experiments={"trace_lifecycle": "stream"},
+        trace_lifecycle="stream",
     )
     items = capture_items()
 
@@ -308,7 +308,7 @@ def test_ignores_inherited_sample_decision_when_traces_sampler_defined_span_stre
     traces_sampler = mock.Mock(return_value=not bool(int(parent_sampling_decision)))
     sentry_init(
         traces_sampler=traces_sampler,
-        _experiments={"trace_lifecycle": "stream"},
+        trace_lifecycle="stream",
     )
 
     sentry_sdk.traces.continue_trace(
@@ -356,7 +356,7 @@ def test_inherits_parent_sampling_decision_when_traces_sampler_undefined_span_st
 ):
     sentry_init(
         traces_sample_rate=0.5,
-        _experiments={"trace_lifecycle": "stream"},
+        trace_lifecycle="stream",
     )
 
     sentry_sdk.traces.continue_trace(
@@ -430,7 +430,7 @@ def test_custom_sampling_context(sentry_init):
 
     sentry_init(
         traces_sampler=traces_sampler,
-        _experiments={"trace_lifecycle": "stream"},
+        trace_lifecycle="stream",
     )
 
     sentry_sdk.get_current_scope().set_custom_sampling_context(
@@ -454,7 +454,7 @@ def test_custom_sampling_context_update_to_context_value_persists(sentry_init):
 
     sentry_init(
         traces_sampler=traces_sampler,
-        _experiments={"trace_lifecycle": "stream"},
+        trace_lifecycle="stream",
     )
 
     sentry_sdk.traces.new_trace()
@@ -532,7 +532,7 @@ def test_warns_and_sets_sampled_to_false_on_invalid_traces_sampler_return_value_
 ):
     sentry_init(
         traces_sampler=mock.Mock(return_value=traces_sampler_return_value),
-        _experiments={"trace_lifecycle": "stream"},
+        trace_lifecycle="stream",
     )
 
     with mock.patch.object(logger, "warning", mock.Mock()):
@@ -606,7 +606,7 @@ def test_unsampled_spans_produce_client_report_if_traces_sample_rate_defined(
 ):
     sentry_init(
         traces_sample_rate=0.0,
-        _experiments={"trace_lifecycle": "stream"},
+        trace_lifecycle="stream",
     )
 
     items = capture_items("span")
@@ -635,7 +635,7 @@ def test_unsampled_spans_produce_client_report_if_traces_sampler_defined(
 ):
     sentry_init(
         traces_sampler=lambda _: 0.0,
-        _experiments={"trace_lifecycle": "stream"},
+        trace_lifecycle="stream",
     )
 
     items = capture_items("span")
@@ -664,7 +664,7 @@ def test_no_client_reports_if_tracing_is_off(
 ):
     sentry_init(
         traces_sample_rate=None,
-        _experiments={"trace_lifecycle": "stream"},
+        trace_lifecycle="stream",
     )
 
     items = capture_items("span")

--- a/tests/tracing/test_span_batcher.py
+++ b/tests/tracing/test_span_batcher.py
@@ -13,7 +13,7 @@ def test_envelope_by_trace_id(sentry_init, capture_envelopes, monkeypatch):
     """Envelopes only contain spans of one trace ID."""
     sentry_init(
         traces_sample_rate=1.0,
-        _experiments={"trace_lifecycle": "stream"},
+        trace_lifecycle="stream",
     )
 
     envelopes = capture_envelopes()
@@ -60,7 +60,7 @@ def test_max_envelope_size(sentry_init, capture_envelopes, monkeypatch):
 
     sentry_init(
         traces_sample_rate=1.0,
-        _experiments={"trace_lifecycle": "stream"},
+        trace_lifecycle="stream",
     )
 
     envelopes = capture_envelopes()
@@ -101,7 +101,7 @@ def test_drop_after_max_reached(
 
     sentry_init(
         traces_sample_rate=1.0,
-        _experiments={"trace_lifecycle": "stream"},
+        trace_lifecycle="stream",
     )
 
     envelopes = capture_envelopes()
@@ -134,7 +134,7 @@ def test_drop_isolated_per_bucket(
 
     sentry_init(
         traces_sample_rate=1.0,
-        _experiments={"trace_lifecycle": "stream"},
+        trace_lifecycle="stream",
     )
 
     envelopes = capture_envelopes()
@@ -180,7 +180,7 @@ def test_length_based_flushing(sentry_init, capture_items, monkeypatch):
 
     sentry_init(
         traces_sample_rate=1.0,
-        _experiments={"trace_lifecycle": "stream"},
+        trace_lifecycle="stream",
     )
 
     items = capture_items("span")
@@ -203,7 +203,7 @@ def test_weight_based_flushing(sentry_init, capture_envelopes, monkeypatch):
 
     sentry_init(
         traces_sample_rate=1.0,
-        _experiments={"trace_lifecycle": "stream"},
+        trace_lifecycle="stream",
     )
 
     envelopes = capture_envelopes()
@@ -228,7 +228,7 @@ def test_weight_based_flushing_by_attribute_size(
 
     sentry_init(
         traces_sample_rate=1.0,
-        _experiments={"trace_lifecycle": "stream"},
+        trace_lifecycle="stream",
     )
 
     envelopes = capture_envelopes()
@@ -263,7 +263,7 @@ def test_bucket_recreated_after_flush(sentry_init, capture_envelopes, monkeypatc
 
     sentry_init(
         traces_sample_rate=1.0,
-        _experiments={"trace_lifecycle": "stream"},
+        trace_lifecycle="stream",
     )
 
     envelopes = capture_envelopes()
@@ -312,7 +312,7 @@ def test_quiet_buckets_flush_eventually(sentry_init, capture_envelopes, monkeypa
 
     sentry_init(
         traces_sample_rate=1.0,
-        _experiments={"trace_lifecycle": "stream"},
+        trace_lifecycle="stream",
     )
 
     envelopes = capture_envelopes()
@@ -337,7 +337,7 @@ def test_quiet_buckets_flushed_with_busy_neighbors(
 
     sentry_init(
         traces_sample_rate=1.0,
-        _experiments={"trace_lifecycle": "stream"},
+        trace_lifecycle="stream",
     )
 
     envelopes = capture_envelopes()
@@ -385,7 +385,7 @@ def test_transport_format(sentry_init, capture_envelopes):
         server_name="test-server",
         release="1.0.0",
         traces_sample_rate=1.0,
-        _experiments={"trace_lifecycle": "stream"},
+        trace_lifecycle="stream",
     )
 
     envelopes = capture_envelopes()
@@ -451,7 +451,7 @@ def test_span_batcher_lock_reset_in_child_after_fork(sentry_init):
     """
     sentry_init(
         traces_sample_rate=1.0,
-        _experiments={"trace_lifecycle": "stream"},
+        trace_lifecycle="stream",
     )
     batcher = sentry_sdk.get_client().span_batcher
     assert batcher is not None

--- a/tests/tracing/test_span_origin.py
+++ b/tests/tracing/test_span_origin.py
@@ -39,7 +39,7 @@ def test_span_origin_custom(sentry_init, capture_events):
 
 
 def test_span_origin_manual_span_streaming(sentry_init, capture_items):
-    sentry_init(_experiments={"trace_lifecycle": "stream"}, traces_sample_rate=1.0)
+    sentry_init(trace_lifecycle="stream", traces_sample_rate=1.0)
     items = capture_items("span")
 
     with sentry_sdk.traces.start_span(name="hi"):
@@ -54,7 +54,7 @@ def test_span_origin_manual_span_streaming(sentry_init, capture_items):
 
 
 def test_span_origin_custom_span_streaming(sentry_init, capture_items):
-    sentry_init(_experiments={"trace_lifecycle": "stream"}, traces_sample_rate=1.0)
+    sentry_init(trace_lifecycle="stream", traces_sample_rate=1.0)
     items = capture_items("span")
 
     with sentry_sdk.traces.start_span(

--- a/tests/tracing/test_span_streaming.py
+++ b/tests/tracing/test_span_streaming.py
@@ -23,7 +23,7 @@ minimum_python_38 = pytest.mark.skipif(
 def test_start_span(sentry_init, capture_items):
     sentry_init(
         traces_sample_rate=1.0,
-        _experiments={"trace_lifecycle": "stream"},
+        trace_lifecycle="stream",
     )
 
     items = capture_items("span")
@@ -63,7 +63,7 @@ def test_start_span(sentry_init, capture_items):
 def test_start_span_no_context_manager(sentry_init, capture_items):
     sentry_init(
         traces_sample_rate=1.0,
-        _experiments={"trace_lifecycle": "stream"},
+        trace_lifecycle="stream",
     )
 
     items = capture_items("span")
@@ -111,7 +111,7 @@ def test_span_sampled_when_created(sentry_init, capture_items):
 
     sentry_init(
         traces_sampler=traces_sampler,
-        _experiments={"trace_lifecycle": "stream"},
+        trace_lifecycle="stream",
     )
 
     items = capture_items("span")
@@ -133,7 +133,7 @@ def test_span_sampled_when_created(sentry_init, capture_items):
 def test_start_span_attributes(sentry_init, capture_items):
     sentry_init(
         traces_sample_rate=1.0,
-        _experiments={"trace_lifecycle": "stream"},
+        trace_lifecycle="stream",
     )
 
     items = capture_items("span")
@@ -165,7 +165,7 @@ def test_start_span_attributes_in_traces_sampler(sentry_init, capture_items):
 
     sentry_init(
         traces_sampler=traces_sampler,
-        _experiments={"trace_lifecycle": "stream"},
+        trace_lifecycle="stream",
     )
 
     items = capture_items("span")
@@ -206,7 +206,7 @@ def test_sampling_context(sentry_init, capture_items):
 
     sentry_init(
         traces_sampler=traces_sampler,
-        _experiments={"trace_lifecycle": "stream"},
+        trace_lifecycle="stream",
     )
 
     items = capture_items("span")
@@ -362,7 +362,7 @@ def test_before_send_span_doesnt_receive_ignored_spans(sentry_init, capture_item
 def test_span_attributes(sentry_init, capture_items):
     sentry_init(
         traces_sample_rate=1.0,
-        _experiments={"trace_lifecycle": "stream"},
+        trace_lifecycle="stream",
     )
 
     items = capture_items("span")
@@ -396,7 +396,7 @@ def test_span_attributes(sentry_init, capture_items):
 def test_span_attributes_serialize_early(sentry_init, capture_items):
     sentry_init(
         traces_sample_rate=1.0,
-        _experiments={"trace_lifecycle": "stream"},
+        trace_lifecycle="stream",
     )
 
     items = capture_items("span")
@@ -441,7 +441,7 @@ def test_traces_sampler_drops_span(sentry_init, capture_items):
 
     sentry_init(
         traces_sampler=traces_sampler,
-        _experiments={"trace_lifecycle": "stream"},
+        trace_lifecycle="stream",
     )
 
     items = capture_items("span")
@@ -473,7 +473,7 @@ def test_traces_sampler_called_once_per_segment(sentry_init):
 
     sentry_init(
         traces_sampler=traces_sampler,
-        _experiments={"trace_lifecycle": "stream"},
+        trace_lifecycle="stream",
     )
 
     with sentry_sdk.traces.start_span(name="segment") as segment:
@@ -490,7 +490,7 @@ def test_traces_sampler_called_once_per_segment(sentry_init):
 def test_start_inactive_span(sentry_init, capture_items):
     sentry_init(
         traces_sample_rate=1.0,
-        _experiments={"trace_lifecycle": "stream"},
+        trace_lifecycle="stream",
     )
 
     items = capture_items("span")
@@ -527,7 +527,7 @@ def test_start_inactive_span(sentry_init, capture_items):
 def test_start_span_override_parent(sentry_init, capture_items):
     sentry_init(
         traces_sample_rate=1.0,
-        _experiments={"trace_lifecycle": "stream"},
+        trace_lifecycle="stream",
     )
 
     items = capture_items("span")
@@ -566,7 +566,7 @@ def test_start_span_override_parent(sentry_init, capture_items):
 def test_sibling_segments(sentry_init, capture_items):
     sentry_init(
         traces_sample_rate=1.0,
-        _experiments={"trace_lifecycle": "stream"},
+        trace_lifecycle="stream",
     )
 
     items = capture_items("span")
@@ -599,7 +599,7 @@ def test_sibling_segments(sentry_init, capture_items):
 def test_sibling_segments_new_trace(sentry_init, capture_items):
     sentry_init(
         traces_sample_rate=1.0,
-        _experiments={"trace_lifecycle": "stream"},
+        trace_lifecycle="stream",
     )
 
     items = capture_items("span")
@@ -635,7 +635,7 @@ def test_continue_trace_sampled(sentry_init, capture_items):
     sentry_init(
         # parent sampling decision takes precedence over traces_sample_rate
         traces_sample_rate=0.0,
-        _experiments={"trace_lifecycle": "stream"},
+        trace_lifecycle="stream",
     )
 
     items = capture_items("span")
@@ -675,7 +675,7 @@ def test_continue_trace_unsampled(sentry_init, capture_items):
     sentry_init(
         # parent sampling decision takes precedence over traces_sample_rate
         traces_sample_rate=1.0,
-        _experiments={"trace_lifecycle": "stream"},
+        trace_lifecycle="stream",
     )
 
     items = capture_items("span")
@@ -727,7 +727,7 @@ def test_backpressure_outcome(
     sentry_init(
         traces_sample_rate=0.5,
         enable_backpressure_handling=True,
-        _experiments={"trace_lifecycle": "stream"},
+        trace_lifecycle="stream",
     )
 
     items = capture_items("span")
@@ -773,7 +773,7 @@ def test_continue_trace_no_sample_rand(sentry_init, capture_items):
     sentry_init(
         # parent sampling decision takes precedence over traces_sample_rate
         traces_sample_rate=0.0,
-        _experiments={"trace_lifecycle": "stream"},
+        trace_lifecycle="stream",
     )
 
     items = capture_items("span")
@@ -828,7 +828,7 @@ def test_outgoing_traceparent_and_baggage_head_sdk(sentry_init, traces_sample_ra
 
     sentry_init(
         traces_sample_rate=traces_sample_rate,
-        _experiments={"trace_lifecycle": "stream"},
+        trace_lifecycle="stream",
     )
 
     sentry_sdk.traces.new_trace()
@@ -895,7 +895,7 @@ def test_outgoing_traceparent_and_baggage_incoming_trace(
     # test_outgoing_traceparent_and_baggage_incoming_trace_deferred
     sentry_init(
         traces_sample_rate=traces_sample_rate,
-        _experiments={"trace_lifecycle": "stream"},
+        trace_lifecycle="stream",
     )
 
     trace_id = "0af7651916cd43dd8448eb211c80319c"
@@ -976,7 +976,7 @@ def test_outgoing_traceparent_and_baggage_incoming_trace_deferred(
     """The SDK handles a deferred incoming sampling decision correctly."""
     sentry_init(
         traces_sample_rate=traces_sample_rate,
-        _experiments={"trace_lifecycle": "stream"},
+        trace_lifecycle="stream",
     )
 
     if traces_sample_rate == 0.0:
@@ -1120,7 +1120,7 @@ def test_outgoing_traceparent_and_baggage_ignored_child_span(sentry_init):
 def test_set_span_status(sentry_init, capture_items):
     sentry_init(
         traces_sample_rate=1.0,
-        _experiments={"trace_lifecycle": "stream"},
+        trace_lifecycle="stream",
     )
 
     items = capture_items("span")
@@ -1144,7 +1144,7 @@ def test_set_span_status(sentry_init, capture_items):
 def test_set_span_status_on_error(sentry_init, capture_items):
     sentry_init(
         traces_sample_rate=1.0,
-        _experiments={"trace_lifecycle": "stream"},
+        trace_lifecycle="stream",
     )
 
     items = capture_items("span")
@@ -1165,7 +1165,8 @@ def test_set_span_status_on_error(sentry_init, capture_items):
 def test_set_span_status_on_ignored_span(sentry_init, capture_items):
     sentry_init(
         traces_sample_rate=1.0,
-        _experiments={"trace_lifecycle": "stream", "ignore_spans": ["ignored"]},
+        trace_lifecycle="stream",
+        ignore_spans=["ignored"],
     )
 
     items = capture_items("span")
@@ -1550,7 +1551,8 @@ def test_ignored_spans_produce_client_report(
 ):
     sentry_init(
         traces_sample_rate=1.0,
-        _experiments={"trace_lifecycle": "stream", "ignore_spans": ["ignored"]},
+        trace_lifecycle="stream",
+        ignore_spans=["ignored"],
     )
 
     items = capture_items("span")
@@ -1679,7 +1681,7 @@ def test_default_attributes(sentry_init, capture_envelopes):
         release="1.0.0",
         dist="1.0",
         traces_sample_rate=1.0,
-        _experiments={"trace_lifecycle": "stream"},
+        trace_lifecycle="stream",
     )
 
     envelopes = capture_envelopes()


### PR DESCRIPTION
## Summary
- Replaced all `_experiments={"trace_lifecycle": ...}` with top-level `trace_lifecycle=...` across 77 test files
- Replaced `_experiments={"ignore_spans": ...}` with top-level `ignore_spans=...`
- Kept backwards-compat tests in `test_client.py` and `test_span_streaming.py` that specifically verify `_experiments` still works and that top-level takes precedence