### PR TITLE
test: Close clients created by `sentry_init`

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -287,9 +287,12 @@ def uninstall_integration():
 
 @pytest.fixture
 def sentry_init(request):
+    clients = []
+
     def inner(*a, **kw):
         kw.setdefault("transport", TestTransport())
         client = sentry_sdk.Client(*a, **kw)
+        clients.append(client)
         sentry_sdk.get_global_scope().set_client(client)
 
     if request.node.get_closest_marker("forked"):
@@ -303,6 +306,8 @@ def sentry_init(request):
             sentry_sdk.get_current_scope().set_client(None)
             yield inner
         finally:
+            for client in clients:
+                client.close()
             sentry_sdk.get_global_scope().set_client(old_client)
 
 
@@ -449,8 +454,16 @@ def capture_events_forksafe(monkeypatch, capture_events, request):
                 events_w.write(b"\n")
             return old_capture_envelope(envelope)
 
+        real_flush = test_client.flush
+
         def flush(timeout=None, callback=None):
             events_w.write(b"flush\n")
+
+        def cleanup():
+            test_client.flush = real_flush
+            test_client.transport.capture_envelope = old_capture_envelope
+
+        request.addfinalizer(cleanup)
 
         monkeypatch.setattr(test_client.transport, "capture_envelope", append)
         monkeypatch.setattr(test_client, "flush", flush)
@@ -497,6 +510,12 @@ def capture_items_forksafe(monkeypatch, capture_items, request):
             real_flush(timeout=timeout, callback=callback)
             items_w.write(json.dumps(telemetry).encode("utf-8") + b"\n")
             items_w.write(b"flush\n")
+
+        def cleanup():
+            test_client.flush = real_flush
+            test_client.transport.capture_envelope = old_capture_envelope
+
+        request.addfinalizer(cleanup)
 
         monkeypatch.setattr(test_client.transport, "capture_envelope", append)
         monkeypatch.setattr(test_client, "flush", flush)

--- a/tests/test_logs.py
+++ b/tests/test_logs.py
@@ -835,7 +835,17 @@ def test_log_batcher_lock_reset_in_child_after_fork(sentry_init):
     original_lock = batcher._lock
     original_lock.acquire()
 
-    batcher._buffer.append(object())
+    batcher._buffer.append(
+        {
+            "severity_text": "info",
+            "severity_number": 9,
+            "body": "fork-reset sentinel",
+            "attributes": {},
+            "time_unix_nano": 0,
+            "trace_id": None,
+            "span_id": None,
+        }
+    )
     batcher._active.flag = True
     batcher._flush_event.set()
     batcher._running = False

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -525,7 +525,18 @@ def test_metrics_batcher_lock_reset_in_child_after_fork(sentry_init):
     original_lock = batcher._lock
     original_lock.acquire()
 
-    batcher._buffer.append(object())
+    batcher._buffer.append(
+        {
+            "timestamp": 0.0,
+            "name": "fork-reset-sentinel",
+            "type": "counter",
+            "value": 1.0,
+            "unit": None,
+            "attributes": {},
+            "trace_id": None,
+            "span_id": None,
+        }
+    )
     batcher._active.flag = True
     batcher._flush_event.set()
     batcher._running = False


### PR DESCRIPTION
### Description
<!-- What changed and why? -->

The tests for https://github.com/getsentry/sentry-python/pull/6844 failed due to client leakage between tests. Close the client so that background threads and batchers are cleaned up in tests relying on `sentry_init()`.

#### Issues
<!--
* resolves: #1234
* resolves: LIN-1234
-->

#### Reminders
- Please add tests to validate your changes, and lint your code using `uv run ruff`.
- Add GH Issue ID _&_ Linear ID (if applicable)
- PR title should use [conventional commit](https://develop.sentry.dev/engineering-practices/commit-messages/#type) style (`feat:`, `fix:`, `ref:`, `meta:`)
- For external contributors: [CONTRIBUTING.md](https://github.com/getsentry/sentry-python/blob/master/CONTRIBUTING.md), [Sentry SDK development docs](https://develop.sentry.dev/sdk/), [Discord community](https://discord.gg/Ww9hbqr)
