### PR TITLE
fix: Include query string and fragment in `url.full` span attribute

### DIFF
--- a/sentry_sdk/integrations/aiohttp.py
+++ b/sentry_sdk/integrations/aiohttp.py
@@ -161,11 +161,15 @@ class AioHttpIntegration(Integration):
 
                         url_attributes = {}
                         if should_send_default_pii():
-                            url_attributes["url.full"] = "%s://%s%s" % (
+                            url_full = "%s://%s%s" % (
                                 request.scheme,
                                 request.host,
                                 request.path,
                             )
+                            if request.query_string:
+                                url_full += "?" + request.query_string
+
+                            url_attributes["url.full"] = url_full
                             url_attributes["url.path"] = request.path
 
                             if request.query_string:
@@ -362,7 +366,13 @@ def create_trace_config() -> "TraceConfig":
                     "http.request.method": method,
                 }
                 if parsed_url is not None and should_send_default_pii():
-                    attributes["url.full"] = parsed_url.url
+                    url_full = parsed_url.url
+                    if parsed_url.query:
+                        url_full += "?" + parsed_url.query
+                    if parsed_url.fragment:
+                        url_full += "#" + parsed_url.fragment
+
+                    attributes["url.full"] = url_full
                     attributes["url.path"] = params.url.path
 
                     if parsed_url.query:

--- a/sentry_sdk/integrations/aiohttp.py
+++ b/sentry_sdk/integrations/aiohttp.py
@@ -187,19 +187,17 @@ class AioHttpIntegration(Integration):
                                     url_attributes["url.full"] += "?" + filtered_query_string
 
                         elif should_send_default_pii():
-                            url_attributes["url.full"] = "%s://%s%s" % (
+                            url_full = "%s://%s%s" % (
                                 request.scheme,
                                 request.host,
                                 request.path,
                             )
                             if request.query_string:
                                 url_full += "?" + request.query_string
+                                url_attributes["url.query"] = request.query_string
 
                             url_attributes["url.full"] = url_full
                             url_attributes["url.path"] = request.path
-
-                            if request.query_string:
-                                url_attributes["url.query"] = request.query_string
 
                         client_address_attributes = {}
                         if should_send_default_pii() and request.remote:
@@ -391,25 +389,10 @@ def create_trace_config() -> "TraceConfig":
                     "sentry.origin": AioHttpIntegration.origin,
                     "http.request.method": method,
                 }
-<<<<<<< HEAD
-                if parsed_url is not None and should_send_default_pii():
-                    url_full = parsed_url.url
-                    if parsed_url.query:
-                        url_full += "?" + parsed_url.query
-                    if parsed_url.fragment:
-                        url_full += "#" + parsed_url.fragment
-
-                    attributes["url.full"] = url_full
-                    attributes["url.path"] = params.url.path
-=======
                 if parsed_url is not None:
                     if has_data_collection_enabled(client.options):
-                        attributes["url.full"] = parsed_url.url
+                        url_full = parsed_url.url
                         attributes["url.path"] = params.url.path
->>>>>>> master
-
-                        if parsed_url.fragment:
-                            attributes["url.fragment"] = parsed_url.fragment
 
                         if parsed_url.query:
                             filtered_query = (
@@ -422,14 +405,25 @@ def create_trace_config() -> "TraceConfig":
                             )
                             if filtered_query:
                                 attributes["url.query"] = filtered_query
+                                url_full += "?" + filtered_query
+
+                        if parsed_url.fragment:
+                            attributes["url.fragment"] = parsed_url.fragment
+                            url_full += "#" + parsed_url.fragment
+
+                        attributes["url.full"] = url_full
                     elif should_send_default_pii():
-                        attributes["url.full"] = parsed_url.url
+                        url_full = parsed_url.url
                         attributes["url.path"] = params.url.path
 
                         if parsed_url.query:
+                            url_full += "?" + parsed_url.query
                             attributes["url.query"] = parsed_url.query
                         if parsed_url.fragment:
+                            url_full += "#" + parsed_url.fragment
                             attributes["url.fragment"] = parsed_url.fragment
+
+                        attributes["url.full"] = url_full
 
                 span = sentry_sdk.traces.start_span(
                     name=span_name, attributes=attributes

--- a/sentry_sdk/integrations/aiohttp.py
+++ b/sentry_sdk/integrations/aiohttp.py
@@ -184,7 +184,9 @@ class AioHttpIntegration(Integration):
                                 )
                                 if filtered_query_string:
                                     url_attributes["url.query"] = filtered_query_string
-                                    url_attributes["url.full"] += "?" + filtered_query_string
+                                    url_attributes["url.full"] += (
+                                        "?" + filtered_query_string
+                                    )
 
                         elif should_send_default_pii():
                             url_full = "%s://%s%s" % (

--- a/sentry_sdk/integrations/httpx.py
+++ b/sentry_sdk/integrations/httpx.py
@@ -76,7 +76,13 @@ def _install_httpx_client() -> None:
                 attributes: "Attributes" = {}
 
                 if parsed_url is not None and should_send_default_pii():
-                    attributes["url.full"] = parsed_url.url
+                    url_full = parsed_url.url
+                    if parsed_url.query:
+                        url_full += "?" + parsed_url.query
+                    if parsed_url.fragment:
+                        url_full += "#" + parsed_url.fragment
+
+                    attributes["url.full"] = url_full
                     if parsed_url.query:
                         attributes["url.query"] = parsed_url.query
                     if parsed_url.fragment:
@@ -162,7 +168,13 @@ def _install_httpx_async_client() -> None:
                 attributes: "Attributes" = {}
 
                 if parsed_url is not None and should_send_default_pii():
-                    attributes["url.full"] = parsed_url.url
+                    url_full = parsed_url.url
+                    if parsed_url.query:
+                        url_full += "?" + parsed_url.query
+                    if parsed_url.fragment:
+                        url_full += "#" + parsed_url.fragment
+
+                    attributes["url.full"] = url_full
                     if parsed_url.query:
                         attributes["url.query"] = parsed_url.query
                     if parsed_url.fragment:

--- a/sentry_sdk/integrations/httpx2.py
+++ b/sentry_sdk/integrations/httpx2.py
@@ -77,7 +77,13 @@ def _install_httpx2_client() -> None:
                 attributes: "Attributes" = {}
 
                 if parsed_url is not None and should_send_default_pii():
-                    attributes["url.full"] = parsed_url.url
+                    url_full = parsed_url.url
+                    if parsed_url.query:
+                        url_full += "?" + parsed_url.query
+                    if parsed_url.fragment:
+                        url_full += "#" + parsed_url.fragment
+
+                    attributes["url.full"] = url_full
                     if parsed_url.query:
                         attributes["url.query"] = parsed_url.query
                     if parsed_url.fragment:
@@ -164,7 +170,13 @@ def _install_httpx2_async_client() -> None:
                 attributes: "Attributes" = {}
 
                 if parsed_url is not None and should_send_default_pii():
-                    attributes["url.full"] = parsed_url.url
+                    url_full = parsed_url.url
+                    if parsed_url.query:
+                        url_full += "?" + parsed_url.query
+                    if parsed_url.fragment:
+                        url_full += "#" + parsed_url.fragment
+
+                    attributes["url.full"] = url_full
                     if parsed_url.query:
                         attributes["url.query"] = parsed_url.query
                     if parsed_url.fragment:

--- a/sentry_sdk/integrations/wsgi.py
+++ b/sentry_sdk/integrations/wsgi.py
@@ -422,6 +422,9 @@ def _get_request_attributes(
         if path:
             attributes["url.path"] = path
 
-        attributes["url.full"] = get_request_url(environ, use_x_forwarded_for)
+        url_full = get_request_url(environ, use_x_forwarded_for)
+        if query_string:
+            url_full += "?" + query_string
+        attributes["url.full"] = url_full
 
     return attributes

--- a/sentry_sdk/integrations/wsgi.py
+++ b/sentry_sdk/integrations/wsgi.py
@@ -444,6 +444,7 @@ def _get_request_attributes(
 
     if has_data_collection_enabled(client_options):
         query_string = environ.get("QUERY_STRING")
+        filtered_qs = None
         if query_string:
             filtered_qs = _apply_data_collection_filtering_to_query_string(
                 query_string=query_string,
@@ -458,6 +459,8 @@ def _get_request_attributes(
             attributes["url.path"] = path
 
         attributes["url.full"] = get_request_url(environ, use_x_forwarded_for)
+        if filtered_qs is not None:
+            attributes["url.full"] += f"?{filtered_qs}"
 
         if client_options["data_collection"]["user_info"]:
             client_ip = get_client_ip(environ)

--- a/tests/integrations/aiohttp/test_aiohttp.py
+++ b/tests/integrations/aiohttp/test_aiohttp.py
@@ -1540,10 +1540,8 @@ async def test_outgoing_client_span_span_streaming(
 
         url_full = inner_client_span["attributes"]["url.full"]
 
-        # parse_url() splits the URL — url.full is the base URL only, with the
-        # query string captured separately on url.query.
         assert url_full.startswith("http://127.0.0.1:")
-        assert url_full.endswith("/")
+        assert "?foo=bar" in url_full
 
         assert inner_client_span["attributes"]["url.path"] == "/"
 

--- a/tests/integrations/httpx/test_httpx.py
+++ b/tests/integrations/httpx/test_httpx.py
@@ -1246,7 +1246,7 @@ def test_http_url_attributes_span_streaming(
     assert http_span["attributes"]["http.response.status_code"] == 200
 
     if send_default_pii:
-        assert http_span["attributes"]["url.full"] == "http://example.com/"
+        assert http_span["attributes"]["url.full"] == "http://example.com/?foo=bar#frag"
         assert http_span["attributes"]["url.query"] == "foo=bar"
         assert http_span["attributes"]["url.fragment"] == "frag"
     else:

--- a/tests/integrations/httpx2/test_httpx2.py
+++ b/tests/integrations/httpx2/test_httpx2.py
@@ -1234,7 +1234,7 @@ def test_http_url_attributes_span_streaming(
     http_span = _get_http_client_span(items)
 
     assert http_span["attributes"]["http.request.method"] == "GET"
-    assert http_span["attributes"]["url.full"] == "http://example.com/"
+    assert http_span["attributes"]["url.full"] == "http://example.com/?foo=bar#frag"
     assert http_span["attributes"]["url.query"] == "foo=bar"
     assert http_span["attributes"]["url.fragment"] == "frag"
     assert http_span["attributes"]["http.response.status_code"] == 200

--- a/tests/integrations/wsgi/test_wsgi.py
+++ b/tests/integrations/wsgi/test_wsgi.py
@@ -254,7 +254,10 @@ def test_transaction_no_error(
         assert span["status"] == "ok"
 
         if send_pii:
-            assert span["attributes"]["url.full"] == "http://localhost/dogs/are/great"
+            assert (
+                span["attributes"]["url.full"]
+                == "http://localhost/dogs/are/great?toy=tennisball"
+            )
             assert span["attributes"]["url.path"] == "/dogs/are/great"
             assert span["attributes"]["http.query"] == "toy=tennisball"
         else:


### PR DESCRIPTION
The `url.full` span attribute was only being set to the base URL (scheme + host + path), omitting query string and fragment.

Closes https://github.com/getsentry/sentry-python/issues/6860