### PR TITLE
fix(tracing): Respect parent_sampled=False in span streaming sampling decision (#6856)

### DIFF
--- a/sentry_sdk/tracing_utils.py
+++ b/sentry_sdk/tracing_utils.py
@@ -1579,12 +1579,15 @@ def _get_effective_sample_rate(
     client: "Any", propagation_context: "PropagationContext"
 ) -> "Union[float, bool]":
     if propagation_context.parent_sampled is not None:
-        propagation_context_sample_rate = propagation_context._sample_rate()
+        if propagation_context.parent_sampled:
+            propagation_context_sample_rate = propagation_context._sample_rate()
 
-        if propagation_context_sample_rate is not None:
-            return propagation_context_sample_rate
+            if propagation_context_sample_rate is not None:
+                return propagation_context_sample_rate
+            else:
+                return propagation_context.parent_sampled
         else:
-            return propagation_context.parent_sampled
+            return False
     else:
         return client.options["traces_sample_rate"]
 

--- a/tests/tracing/test_span_streaming.py
+++ b/tests/tracing/test_span_streaming.py
@@ -741,6 +741,37 @@ def test_continue_trace_unsampled(sentry_init, capture_items):
     assert len(spans) == 0
 
 
+def test_continue_trace_unsampled_respects_parent_decision(sentry_init, capture_items):
+    sentry_init(
+        traces_sample_rate=1.0,
+        _experiments={"trace_lifecycle": "stream"},
+    )
+
+    items = capture_items("span")
+
+    trace_id = "0af7651916cd43dd8448eb211c80319c"
+    parent_span_id = "b7ad6b7169203331"
+    sample_rand = "0.100000"
+    sampled = "0"
+
+    sentry_sdk.traces.continue_trace(
+        {
+            "sentry-trace": f"{trace_id}-{parent_span_id}-{sampled}",
+            "baggage": f"sentry-trace_id={trace_id},sentry-sample_rate=0.5,sentry-sample_rand={sample_rand}",
+        }
+    )
+
+    with sentry_sdk.traces.start_span(name="segment") as span:
+        ...
+
+    assert span.sampled is False
+
+    sentry_sdk.get_client().flush()
+    spans = [item.payload for item in items]
+
+    assert len(spans) == 0
+
+
 @pytest.mark.parametrize(
     ("sample_rand", "expected_sampled", "expected_outcome"),
     [


### PR DESCRIPTION
Respect incoming `parent_sampled=False` in the span streaming model — do not override it with baggage `sample_rate`/`sample_rand`.

**WHY**

When `sampled=0` arrives in the `sentry-trace` header but baggage contains a positive `sample_rate` with a `sample_rand` that happens to fall below it, `_get_effective_sample_rate` ignored the explicit `parent_sampled=False` and used the baggage rate instead. The downstream `sampled = sample_rand < sample_rate` check could then incorrectly mark the span as sampled.

The existing `test_continue_trace_unsampled` was masked: it used `sample_rand=0.999999` with `sample_rate=0.5`, so `0.999999 < 0.5 = False` — the bug didn't surface.

**HOW**

`_get_effective_sample_rate` now checks `parent_sampled` before consulting baggage. If `parent_sampled` is `False`, it returns `False` immediately. The baggage `sample_rate` is only used when the parent was explicitly sampled (`True`).

**Verify**
```
python -m pytest tests/tracing/test_span_streaming.py -k "test_continue_trace_unsampled" -v
```

Fixes #6856
