### PR TITLE
perf: Avoid scanning installed packages when MCP SDK is not installed

### DIFF
--- a/sentry_sdk/integrations/mcp.py
+++ b/sentry_sdk/integrations/mcp.py
@@ -20,13 +20,13 @@ from sentry_sdk.traces import StreamedSpan
 from sentry_sdk.tracing_utils import has_span_streaming_enabled
 from sentry_sdk.utils import nullcontext, package_version, safe_serialize
 
-MCP_PACKAGE_VERSION = package_version("mcp")
-
 try:
     from mcp.server.lowlevel import Server
     from mcp.server.streamable_http import (
         StreamableHTTPServerTransport,
     )
+
+    MCP_PACKAGE_VERSION = package_version("mcp")
 
     if MCP_PACKAGE_VERSION and MCP_PACKAGE_VERSION < (2, 0, 0):
         from mcp.server.lowlevel.server import (  # type: ignore[attr-defined]


### PR DESCRIPTION
## WHY

When the MCP SDK is not installed, module-level `package_version("mcp")` at the top of `sentry_sdk/integrations/mcp.py` scans every installed distribution via `_get_installed_modules()`. This slows `sentry_sdk.init()` by ~0.2s in environments with hundreds of packages.

Issue #6769 reports that this regression was introduced by #6583, which added a module-level `MCP_PACKAGE_VERSION = package_version("mcp")` above the `try/except ImportError` guard.

## HOW

Move `MCP_PACKAGE_VERSION = package_version("mcp")` from module-level (above the guard) to inside the `try` block, after the successful `import mcp`. When `import mcp` fails and `DidNotEnable` is raised, `package_version()` is never called — so environments without MCP skip the expensive distribution scan entirely.