### PR TITLE
fix(tests): Remove redundant type filters after `capture_items` with args

### DIFF
--- a/tests/integrations/anthropic/test_anthropic.py
+++ b/tests/integrations/anthropic/test_anthropic.py
@@ -4219,7 +4219,7 @@ def test_exception_message_create(
                 max_tokens=1024,
             )
 
-        (event,) = (item.payload for item in items if item.type == "event")
+        (event,) = (item.payload for item in items)
         assert event["level"] == "error"
     elif stream_gen_ai_spans:
         items = capture_items("event", "transaction")
@@ -4469,7 +4469,7 @@ async def test_exception_message_create_async(
                 max_tokens=1024,
             )
 
-        (event,) = (item.payload for item in items if item.type == "event")
+        (event,) = (item.payload for item in items)
         assert event["level"] == "error"
     elif stream_gen_ai_spans:
         items = capture_items("event", "transaction")
@@ -4772,7 +4772,7 @@ def test_anthropic_message_role_mapping(
             )
 
         sentry_sdk.flush()
-        span = next(item.payload for item in items if item.type == "span")
+        span = next(item.payload for item in items)
 
         # Verify that the span was created correctly
         assert span["attributes"]["sentry.op"] == "gen_ai.chat"
@@ -7467,7 +7467,7 @@ def test_cache_tokens_nonstreaming(
             )
 
         sentry_sdk.flush()
-        (span,) = (item.payload for item in items if item.type == "span")
+        (span,) = (item.payload for item in items)
         # input_tokens normalized: 100 + 80 (cache_read) + 20 (cache_write) = 200
         assert span["attributes"][SPANDATA.GEN_AI_USAGE_INPUT_TOKENS] == 200
         assert span["attributes"][SPANDATA.GEN_AI_USAGE_OUTPUT_TOKENS] == 50
@@ -7550,7 +7550,7 @@ def test_input_tokens_include_cache_write_nonstreaming(
             )
 
         sentry_sdk.flush()
-        (span,) = (item.payload for item in items if item.type == "span")
+        (span,) = (item.payload for item in items)
 
         # input_tokens should be total: 19 (non-cached) + 2846 (cache_write) = 2865
         assert span["attributes"][SPANDATA.GEN_AI_USAGE_INPUT_TOKENS] == 2865
@@ -7736,7 +7736,7 @@ def test_input_tokens_include_cache_read_streaming(
                 pass
 
         sentry_sdk.flush()
-        (span,) = (item.payload for item in items if item.type == "span")
+        (span,) = (item.payload for item in items)
 
         # input_tokens should be total: 19 + 2846 = test_stream_messages_input_tokens_include_cache_read_streaming
         assert span["attributes"][SPANDATA.GEN_AI_USAGE_INPUT_TOKENS] == 2865
@@ -7839,7 +7839,7 @@ def test_stream_messages_input_tokens_include_cache_read_streaming(
                 pass
 
         sentry_sdk.flush()
-        (span,) = (item.payload for item in items if item.type == "span")
+        (span,) = (item.payload for item in items)
 
         # input_tokens should be total: 19 + 2846 = 2865
         assert span["attributes"][SPANDATA.GEN_AI_USAGE_INPUT_TOKENS] == 2865
@@ -7922,7 +7922,7 @@ def test_input_tokens_unchanged_without_caching(
             )
 
         sentry_sdk.flush()
-        (span,) = (item.payload for item in items if item.type == "span")
+        (span,) = (item.payload for item in items)
 
         assert span["attributes"][SPANDATA.GEN_AI_USAGE_INPUT_TOKENS] == 20
         assert span["attributes"][SPANDATA.GEN_AI_USAGE_TOTAL_TOKENS] == 32  # 20 + 12
@@ -8009,7 +8009,7 @@ def test_cache_tokens_streaming(
                 pass
 
         sentry_sdk.flush()
-        (span,) = (item.payload for item in items if item.type == "span")
+        (span,) = (item.payload for item in items)
         # input_tokens normalized: 100 + 80 (cache_read) + 20 (cache_write) = 200
         assert span["attributes"][SPANDATA.GEN_AI_USAGE_INPUT_TOKENS] == 200
         assert span["attributes"][SPANDATA.GEN_AI_USAGE_OUTPUT_TOKENS] == 10
@@ -8107,7 +8107,7 @@ def test_stream_messages_cache_tokens(
                 pass
 
         sentry_sdk.flush()
-        (span,) = (item.payload for item in items if item.type == "span")
+        (span,) = (item.payload for item in items)
         # input_tokens normalized: 100 + 80 (cache_read) + 20 (cache_write) = 200
         assert span["attributes"][SPANDATA.GEN_AI_USAGE_INPUT_TOKENS] == 200
         assert span["attributes"][SPANDATA.GEN_AI_USAGE_OUTPUT_TOKENS] == 10

--- a/tests/integrations/django/asgi/test_asgi.py
+++ b/tests/integrations/django/asgi/test_asgi.py
@@ -642,9 +642,7 @@ async def test_trace_from_headers_if_performance_disabled(
 
         assert response["status"] == 500
 
-        (msg_event, error_event) = (
-            item.payload for item in items
-        )
+        (msg_event, error_event) = (item.payload for item in items)
     else:
         events = capture_events()
 

--- a/tests/integrations/django/asgi/test_asgi.py
+++ b/tests/integrations/django/asgi/test_asgi.py
@@ -83,7 +83,7 @@ async def test_basic(
 
         assert response["status"] == 500
 
-        (event,) = (item.payload for item in items if item.type == "event")
+        (event,) = (item.payload for item in items)
 
         (exception,) = event["exception"]["values"]
         assert exception["type"] == "ZeroDivisionError"
@@ -174,7 +174,7 @@ async def test_async_views(
 
         assert response["status"] == 200
 
-        (event,) = (item.payload for item in items if item.type == "event")
+        (event,) = (item.payload for item in items)
     else:
         events = capture_events()
 
@@ -524,7 +524,7 @@ async def test_has_trace_if_performance_disabled(
         (
             msg_event,
             error_event,
-        ) = (item.payload for item in items if item.type == "event")
+        ) = (item.payload for item in items)
     else:
         events = capture_events()
 
@@ -643,7 +643,7 @@ async def test_trace_from_headers_if_performance_disabled(
         assert response["status"] == 500
 
         (msg_event, error_event) = (
-            item.payload for item in items if item.type == "event"
+            item.payload for item in items
         )
     else:
         events = capture_events()
@@ -800,7 +800,7 @@ async def test_asgi_request_body(
         assert response["body"] == body
 
         sentry_sdk.flush()
-        (event,) = (item.payload for item in items if item.type == "event")
+        (event,) = (item.payload for item in items)
     else:
         envelopes = capture_envelopes()
 

--- a/tests/integrations/django/test_basic.py
+++ b/tests/integrations/django/test_basic.py
@@ -69,7 +69,7 @@ def test_view_exceptions(
         (error,) = exceptions
         assert isinstance(error, ZeroDivisionError)
 
-        (event,) = (item.payload for item in items if item.type == "event")
+        (event,) = (item.payload for item in items)
     else:
         events = capture_events()
         client.get(reverse("view_exc"))
@@ -111,7 +111,7 @@ def test_ensures_x_forwarded_header_is_honored_in_sdk_when_enabled_in_django(
         (error,) = exceptions
         assert isinstance(error, ZeroDivisionError)
 
-        (event,) = (item.payload for item in items if item.type == "event")
+        (event,) = (item.payload for item in items)
     else:
         events = capture_events()
         client.get(reverse("view_exc"), headers={"X_FORWARDED_HOST": "example.com"})
@@ -149,7 +149,7 @@ def test_ensures_x_forwarded_header_is_not_honored_when_unenabled_in_django(
 
         (error,) = exceptions
         assert isinstance(error, ZeroDivisionError)
-        (event,) = (item.payload for item in items if item.type == "event")
+        (event,) = (item.payload for item in items)
     else:
         events = capture_events()
         client.get(reverse("view_exc"), headers={"X_FORWARDED_HOST": "example.com"})
@@ -191,7 +191,7 @@ def test_request_captured(
 
         assert content == b"ok"
 
-        (event,) = (item.payload for item in items if item.type == "event")
+        (event,) = (item.payload for item in items)
 
         assert event["transaction"] == "/message"
         assert event["request"] == {
@@ -242,7 +242,7 @@ def test_transaction_with_class_view(
         )
         assert status.lower() == "200 ok"
 
-        (event,) = (item.payload for item in items if item.type == "event")
+        (event,) = (item.payload for item in items)
     else:
         events = capture_events()
         content, status, headers = unpack_werkzeug_response(
@@ -341,7 +341,7 @@ def test_has_trace_if_performance_disabled(
         (
             msg_event,
             error_event,
-        ) = (item.payload for item in items if item.type == "event")
+        ) = (item.payload for item in items)
     else:
         events = capture_events()
         client.head(reverse("view_exc_with_msg"))
@@ -457,7 +457,7 @@ def test_trace_from_headers_if_performance_disabled(
         (
             msg_event,
             error_event,
-        ) = (item.payload for item in items if item.type == "event")
+        ) = (item.payload for item in items)
     else:
         events = capture_events()
         client.head(
@@ -506,7 +506,7 @@ def test_user_captured(
         )
         assert content == b"ok"
 
-        (event,) = (item.payload for item in items if item.type == "event")
+        (event,) = (item.payload for item in items)
     else:
         events = capture_events()
         content, status, headers = unpack_werkzeug_response(
@@ -587,7 +587,7 @@ def test_queryset_repr(
         except Exception:
             capture_exception()
 
-        (event,) = (item.payload for item in items if item.type == "event")
+        (event,) = (item.payload for item in items)
     else:
         events = capture_events()
 
@@ -630,7 +630,7 @@ def test_context_nested_queryset_repr(
         except Exception:
             capture_exception()
 
-        (event,) = (item.payload for item in items if item.type == "event")
+        (event,) = (item.payload for item in items)
     else:
         events = capture_events()
 
@@ -665,7 +665,7 @@ def test_custom_error_handler_request_context(
         content, status, headers = unpack_werkzeug_response(client.post("/404"))
         assert status.lower() == "404 not found"
 
-        (event,) = (item.payload for item in items if item.type == "event")
+        (event,) = (item.payload for item in items)
     else:
         events = capture_events()
         content, status, headers = unpack_werkzeug_response(client.post("/404"))
@@ -735,7 +735,7 @@ def test_sql_queries(
 
         capture_message("HI")
 
-        (event,) = (item.payload for item in items if item.type == "event")
+        (event,) = (item.payload for item in items)
     else:
         events = capture_events()
 
@@ -792,7 +792,7 @@ def test_sql_dict_query_params(
 
         capture_message("HI")
 
-        (event,) = (item.payload for item in items if item.type == "event")
+        (event,) = (item.payload for item in items)
     else:
         events = capture_events()
         sentry_sdk.get_isolation_scope().clear_breadcrumbs()
@@ -905,7 +905,7 @@ def test_sql_psycopg2_string_composition(
 
         capture_message("HI")
 
-        (event,) = (item.payload for item in items if item.type == "event")
+        (event,) = (item.payload for item in items)
     else:
         events = capture_events()
 
@@ -969,7 +969,7 @@ def test_sql_psycopg2_placeholders(
 
         capture_message("HI")
 
-        (event,) = (item.payload for item in items if item.type == "event")
+        (event,) = (item.payload for item in items)
     else:
         events = capture_events()
         sentry_sdk.get_isolation_scope().clear_breadcrumbs()
@@ -1117,7 +1117,7 @@ def test_django_connect_breadcrumbs(
 
         # trigger recording of event.
         capture_message("HI")
-        (event,) = (item.payload for item in items if item.type == "event")
+        (event,) = (item.payload for item in items)
     else:
         events = capture_events()
 
@@ -1313,7 +1313,7 @@ def test_request_body(
         assert status.lower() == "200 ok"
         assert content == b"heyooo"
 
-        (event,) = (item.payload for item in items if item.type == "event")
+        (event,) = (item.payload for item in items)
 
         assert event["message"] == "hi"
         assert event["request"]["data"] == ""
@@ -1333,7 +1333,7 @@ def test_request_body(
         assert status.lower() == "200 ok"
         assert content == b'{"hey": 42}'
 
-        (event,) = (item.payload for item in items if item.type == "event")
+        (event,) = (item.payload for item in items)
     else:
         events = capture_events()
         content, status, headers = unpack_werkzeug_response(
@@ -1395,7 +1395,7 @@ def test_read_request(
 
         assert status.lower() == "500 internal server error"
 
-        (event,) = (item.payload for item in items if item.type == "event")
+        (event,) = (item.payload for item in items)
     else:
         events = capture_events()
 
@@ -1443,7 +1443,7 @@ def test_request_body_already_read(
                 content_type="application/json",
             )
 
-            (event,) = (item.payload for item in items if item.type == "event")
+            (event,) = (item.payload for item in items)
 
     else:
         events = capture_events()
@@ -1525,7 +1525,7 @@ def test_template_exception(
         )
         assert status.lower() == "500 internal server error"
 
-        (event,) = (item.payload for item in items if item.type == "event")
+        (event,) = (item.payload for item in items)
     else:
         events = capture_events()
 
@@ -1617,7 +1617,7 @@ def test_rest_framework_basic(
         (error,) = exceptions
         assert isinstance(error, ZeroDivisionError)
 
-        (event,) = (item.payload for item in items if item.type == "event")
+        (event,) = (item.payload for item in items)
     else:
         exceptions = capture_exceptions()
         events = capture_events()

--- a/tests/integrations/django/test_data_scrubbing.py
+++ b/tests/integrations/django/test_data_scrubbing.py
@@ -39,7 +39,7 @@ def test_scrub_django_session_cookies_removed(
     werkzeug_set_cookie(client, "localhost", "foo", "bar")
     client.get(reverse("view_exc"))
 
-    (event,) = (item.payload for item in items if item.type == "event")
+    (event,) = (item.payload for item in items)
     assert "cookies" not in event["request"]
 
 
@@ -63,7 +63,7 @@ def test_scrub_django_session_cookies_filtered(
     werkzeug_set_cookie(client, "localhost", "foo", "bar")
     client.get(reverse("view_exc"))
 
-    (event,) = (item.payload for item in items if item.type == "event")
+    (event,) = (item.payload for item in items)
     assert event["request"]["cookies"] == {
         "sessionid": "[Filtered]",
         "csrftoken": "[Filtered]",
@@ -95,7 +95,7 @@ def test_scrub_django_custom_session_cookies_filtered(
     werkzeug_set_cookie(client, "localhost", "foo", "bar")
     client.get(reverse("view_exc"))
 
-    (event,) = (item.payload for item in items if item.type == "event")
+    (event,) = (item.payload for item in items)
     assert event["request"]["cookies"] == {
         "my_sess": "[Filtered]",
         "csrf_secret": "[Filtered]",
@@ -185,7 +185,7 @@ def test_data_collection_cookies(
         werkzeug_set_cookie(client, "localhost", name, value)
     client.get(reverse("view_exc"))
 
-    (event,) = (item.payload for item in items if item.type == "event")
+    (event,) = (item.payload for item in items)
     if expected_cookies is None:
         assert "cookies" not in event["request"]
     else:
@@ -210,7 +210,7 @@ def test_data_collection_cookies_precedence_over_send_default_pii(
     werkzeug_set_cookie(client, "localhost", "foo", "bar")
     client.get(reverse("view_exc"))
 
-    (event,) = (item.payload for item in items if item.type == "event")
+    (event,) = (item.payload for item in items)
     assert event["request"]["cookies"] == {
         "sessionid": "[Filtered]",
         "csrftoken": "[Filtered]",

--- a/tests/integrations/fastmcp/test_fastmcp.py
+++ b/tests/integrations/fastmcp/test_fastmcp.py
@@ -324,7 +324,7 @@ async def test_fastmcp_tool_sync(
         }
 
         sentry_sdk.flush()
-        spans = [item.payload for item in items if item.type == "span"]
+        spans = [item.payload for item in items]
         assert len(spans) == 2
 
         # Verify span structure
@@ -446,7 +446,7 @@ async def test_fastmcp_tool_async(
         }
 
         sentry_sdk.flush()
-        spans = [item.payload for item in items if item.type == "span"]
+        spans = [item.payload for item in items]
         spans = [
             span
             for span in spans
@@ -685,7 +685,7 @@ async def test_fastmcp_multiple_tools(
 
         sentry_sdk.flush()
         # Verify three spans were created
-        spans = [item.payload for item in items if item.type == "span"]
+        spans = [item.payload for item in items]
         tool_spans = [
             s for s in spans if s["attributes"].get("sentry.op") == OP.MCP_SERVER
         ]
@@ -798,7 +798,7 @@ async def test_fastmcp_tool_with_complex_return(
 
         sentry_sdk.flush()
         # Verify span was created with complex data
-        spans = [item.payload for item in items if item.type == "span"]
+        spans = [item.payload for item in items]
         tool_spans = [
             s for s in spans if s["attributes"].get("sentry.op") == OP.MCP_SERVER
         ]
@@ -911,7 +911,7 @@ async def test_fastmcp_prompt_sync(
 
             sentry_sdk.flush()
             # Verify prompt span was created
-            spans = [item.payload for item in items if item.type == "span"]
+            spans = [item.payload for item in items]
             prompt_spans = [
                 s for s in spans if s["attributes"].get("sentry.op") == OP.MCP_SERVER
             ]
@@ -1099,7 +1099,7 @@ async def test_fastmcp_resource_sync(
 
                 sentry_sdk.flush()
                 # Verify resource span was created
-                spans = [item.payload for item in items if item.type == "span"]
+                spans = [item.payload for item in items]
                 resource_spans = [
                     s
                     for s in spans
@@ -1214,7 +1214,7 @@ async def test_fastmcp_resource_async(
                 assert "resource data" in result.json()["result"]["contents"][0]["text"]
 
                 sentry_sdk.flush()
-                spans = [item.payload for item in items if item.type == "span"]
+                spans = [item.payload for item in items]
                 spans = [
                     span
                     for span in spans
@@ -1309,7 +1309,7 @@ async def test_fastmcp_span_origin(
 
         sentry_sdk.flush()
 
-        spans = [item.payload for item in items if item.type == "span"]
+        spans = [item.payload for item in items]
         assert spans[-1]["attributes"]["sentry.origin"] == "manual"
 
         # Verify MCP span has correct origin
@@ -1424,7 +1424,7 @@ async def test_fastmcp_sse_transport(
 
         sentry_sdk.flush()
         # Find MCP spans
-        spans = [item.payload for item in items if item.type == "span"]
+        spans = [item.payload for item in items]
         mcp_spans = [
             s for s in spans if s["attributes"].get("sentry.op") == OP.MCP_SERVER
         ]
@@ -1526,7 +1526,7 @@ def test_fastmcp_http_transport(
         }
 
         sentry_sdk.flush()
-        spans = [item.payload for item in items if item.type == "span"]
+        spans = [item.payload for item in items]
         spans = [
             span
             for span in spans
@@ -1610,7 +1610,7 @@ async def test_fastmcp_stdio_transport(
 
         sentry_sdk.flush()
         # Find MCP spans
-        spans = [item.payload for item in items if item.type == "span"]
+        spans = [item.payload for item in items]
         mcp_spans = [
             s for s in spans if s["attributes"].get("sentry.op") == OP.MCP_SERVER
         ]
@@ -1861,7 +1861,7 @@ async def test_fastmcp_mixed_sync_async_tools(
 
         sentry_sdk.flush()
         # Verify both sync and async tool spans were created
-        spans = [item.payload for item in items if item.type == "span"]
+        spans = [item.payload for item in items]
         mcp_spans = [
             s for s in spans if s["attributes"].get("sentry.op") == OP.MCP_SERVER
         ]

--- a/tests/integrations/flask/test_flask.py
+++ b/tests/integrations/flask/test_flask.py
@@ -129,7 +129,7 @@ def test_transaction_or_segment_style(
 
     if span_streaming:
         sentry_sdk.flush()
-        spans = [i.payload for i in items if i.type == "span"]
+        spans = [i.payload for i in items]
         assert len(spans) == 1
         (segment,) = spans
         assert segment["name"] == expected_transaction
@@ -1121,7 +1121,7 @@ def test_span_origin(sentry_init, app, capture_events, capture_items, span_strea
 
     if span_streaming:
         sentry_sdk.flush()
-        spans = [i.payload for i in items if i.type == "span"]
+        spans = [i.payload for i in items]
         assert len(spans) == 1
         (segment,) = spans
         assert segment["attributes"]["sentry.origin"] == "auto.http.flask"
@@ -1164,7 +1164,7 @@ def test_transaction_or_segment_http_method_default(
 
     if span_streaming:
         sentry_sdk.flush()
-        spans = [i.payload for i in items if i.type == "span"]
+        spans = [i.payload for i in items]
         assert len(spans) == 1
         (segment,) = spans
         assert segment["attributes"]["http.request.method"] == "GET"
@@ -1215,7 +1215,7 @@ def test_transaction_or_segment_http_method_custom(
 
     if span_streaming:
         sentry_sdk.flush()
-        spans = [i.payload for i in items if i.type == "span"]
+        spans = [i.payload for i in items]
         assert len(spans) == 2
         (options_segment, head_segment) = spans
         assert options_segment["attributes"]["http.request.method"] == "OPTIONS"
@@ -1359,7 +1359,7 @@ def test_span_http_query_data_collection(
 
     sentry_sdk.flush()
 
-    spans = [item.payload for item in items if item.type == "span"]
+    spans = [item.payload for item in items]
     (segment,) = spans
 
     if expected_query is None:
@@ -1461,7 +1461,7 @@ def test_user_info_span_attributes_data_collection(
 
     sentry_sdk.flush()
 
-    spans = [item.payload for item in items if item.type == "span"]
+    spans = [item.payload for item in items]
     (segment,) = spans
 
     if expect_ip:
@@ -1612,7 +1612,7 @@ def test_flask_login_user_identity_span_attributes_data_collection(
 
     sentry_sdk.flush()
 
-    spans = [item.payload for item in items if item.type == "span"]
+    spans = [item.payload for item in items]
     segment = next(s for s in spans if s["name"] == "hi")
 
     if expect_user:

--- a/tests/integrations/google_genai/test_google_genai.py
+++ b/tests/integrations/google_genai/test_google_genai.py
@@ -409,7 +409,7 @@ def test_generate_content_with_system_instruction(
             )
 
         sentry_sdk.flush()
-        invoke_span = next(item.payload for item in items if item.type == "span")
+        invoke_span = next(item.payload for item in items)
 
         if expected_texts is None:
             assert SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS not in invoke_span["attributes"]
@@ -528,7 +528,7 @@ def test_generate_content_with_tools(
             )
 
         sentry_sdk.flush()
-        invoke_span = next(item.payload for item in items if item.type == "span")
+        invoke_span = next(item.payload for item in items)
 
         # Check that tools are recorded (data is serialized as a string)
         tools_data_str = invoke_span["attributes"][
@@ -616,7 +616,7 @@ def test_tool_execution(
         spans = [item.payload for item in items]
         assert len(spans) == 1
         sentry_sdk.flush()
-        tool_span = next(item.payload for item in items if item.type == "span")
+        tool_span = next(item.payload for item in items)
 
         assert tool_span["attributes"]["sentry.op"] == OP.GEN_AI_EXECUTE_TOOL
         assert tool_span["name"] == "execute_tool get_weather"
@@ -678,7 +678,7 @@ def test_error_handling(
                 config=create_test_config(),
             )
 
-        (error_event,) = (item.payload for item in items if item.type == "event")
+        (error_event,) = (item.payload for item in items)
     else:
         events = capture_events()
 
@@ -816,7 +816,7 @@ def test_streaming_generate_content(
         spans = [item.payload for item in items]
         assert len(spans) == 1
         sentry_sdk.flush()
-        chat_span = next(item.payload for item in items if item.type == "span")
+        chat_span = next(item.payload for item in items)
 
         assert json.loads(
             chat_span["attributes"][SPANDATA.GEN_AI_REQUEST_MESSAGES]
@@ -1037,7 +1037,7 @@ def test_response_without_usage_metadata(
             )
 
         sentry_sdk.flush()
-        chat_span = next(item.payload for item in items if item.type == "span")
+        chat_span = next(item.payload for item in items)
 
         # Usage data should not be present
         assert SPANDATA.GEN_AI_USAGE_INPUT_TOKENS not in chat_span["attributes"]
@@ -1121,7 +1121,7 @@ def test_multiple_candidates(
             )
 
         sentry_sdk.flush()
-        chat_span = next(item.payload for item in items if item.type == "span")
+        chat_span = next(item.payload for item in items)
 
         # Should capture all responses
         # Response text is stored as a JSON string when there are multiple responses
@@ -1212,7 +1212,7 @@ def test_all_configuration_parameters(
             )
 
         sentry_sdk.flush()
-        invoke_span = next(item.payload for item in items if item.type == "span")
+        invoke_span = next(item.payload for item in items)
 
         # Check all parameters are recorded
         assert invoke_span["attributes"][SPANDATA.GEN_AI_REQUEST_TEMPERATURE] == 0.8
@@ -1363,7 +1363,7 @@ def test_response_with_different_id_fields(
             )
 
         sentry_sdk.flush()
-        chat_span = next(item.payload for item in items if item.type == "span")
+        chat_span = next(item.payload for item in items)
 
         assert chat_span["attributes"][SPANDATA.GEN_AI_RESPONSE_ID] == "resp-456"
         assert (
@@ -1442,7 +1442,7 @@ def test_contents_as_none(
             )
 
         sentry_sdk.flush()
-        invoke_span = next(item.payload for item in items if item.type == "span")
+        invoke_span = next(item.payload for item in items)
 
         # Should handle None contents gracefully
         messages = invoke_span["attributes"].get(SPANDATA.GEN_AI_REQUEST_MESSAGES, [])
@@ -1535,7 +1535,7 @@ def test_tool_calls_extraction(
 
         sentry_sdk.flush()
         chat_span = next(
-            item.payload for item in items if item.type == "span"
+            item.payload for item in items
         )  # The chat span
 
         # Check that tool calls are extracted and stored
@@ -1954,7 +1954,7 @@ def test_embed_content_error_handling(
                 contents=["This will fail"],
             )
 
-        (error_event,) = (item.payload for item in items if item.type == "event")
+        (error_event,) = (item.payload for item in items)
     else:
         events = capture_events()
 
@@ -2431,7 +2431,7 @@ async def test_async_embed_content_error_handling(
                 contents=["This will fail"],
             )
 
-        (error_event,) = (item.payload for item in items if item.type == "event")
+        (error_event,) = (item.payload for item in items)
     else:
         events = capture_events()
 
@@ -2653,7 +2653,7 @@ def test_generate_content_with_content_object(
             )
 
         sentry_sdk.flush()
-        invoke_span = next(item.payload for item in items if item.type == "span")
+        invoke_span = next(item.payload for item in items)
 
         messages = json.loads(
             invoke_span["attributes"][SPANDATA.GEN_AI_REQUEST_MESSAGES]
@@ -2715,7 +2715,7 @@ def test_generate_content_with_dict_format(
             )
 
         sentry_sdk.flush()
-        invoke_span = next(item.payload for item in items if item.type == "span")
+        invoke_span = next(item.payload for item in items)
 
         messages = json.loads(
             invoke_span["attributes"][SPANDATA.GEN_AI_REQUEST_MESSAGES]
@@ -2786,7 +2786,7 @@ def test_generate_content_with_file_data(
             )
 
         sentry_sdk.flush()
-        invoke_span = next(item.payload for item in items if item.type == "span")
+        invoke_span = next(item.payload for item in items)
 
         messages = json.loads(
             invoke_span["attributes"][SPANDATA.GEN_AI_REQUEST_MESSAGES]
@@ -2862,7 +2862,7 @@ def test_generate_content_with_inline_data(
             )
 
         sentry_sdk.flush()
-        invoke_span = next(item.payload for item in items if item.type == "span")
+        invoke_span = next(item.payload for item in items)
 
         messages = json.loads(
             invoke_span["attributes"][SPANDATA.GEN_AI_REQUEST_MESSAGES]
@@ -3028,7 +3028,7 @@ def test_generate_content_with_part_object_directly(
             )
 
         sentry_sdk.flush()
-        invoke_span = next(item.payload for item in items if item.type == "span")
+        invoke_span = next(item.payload for item in items)
 
         messages = json.loads(
             invoke_span["attributes"][SPANDATA.GEN_AI_REQUEST_MESSAGES]
@@ -3138,7 +3138,7 @@ def test_generate_content_with_dict_inline_data(
             )
 
         sentry_sdk.flush()
-        invoke_span = next(item.payload for item in items if item.type == "span")
+        invoke_span = next(item.payload for item in items)
 
         messages = json.loads(
             invoke_span["attributes"][SPANDATA.GEN_AI_REQUEST_MESSAGES]
@@ -3206,7 +3206,7 @@ def test_generate_content_without_parts_property_inline_data(
             )
 
         sentry_sdk.flush()
-        invoke_span = next(item.payload for item in items if item.type == "span")
+        invoke_span = next(item.payload for item in items)
 
         messages = json.loads(
             invoke_span["attributes"][SPANDATA.GEN_AI_REQUEST_MESSAGES]
@@ -3281,7 +3281,7 @@ def test_generate_content_without_parts_property_inline_data_and_binary_data_wit
             )
 
         sentry_sdk.flush()
-        invoke_span = next(item.payload for item in items if item.type == "span")
+        invoke_span = next(item.payload for item in items)
 
         messages = json.loads(
             invoke_span["attributes"][SPANDATA.GEN_AI_REQUEST_MESSAGES]

--- a/tests/integrations/google_genai/test_google_genai.py
+++ b/tests/integrations/google_genai/test_google_genai.py
@@ -1534,9 +1534,7 @@ def test_tool_calls_extraction(
             )
 
         sentry_sdk.flush()
-        chat_span = next(
-            item.payload for item in items
-        )  # The chat span
+        chat_span = next(item.payload for item in items)  # The chat span
 
         # Check that tool calls are extracted and stored
         assert SPANDATA.GEN_AI_RESPONSE_TOOL_CALLS in chat_span["attributes"]

--- a/tests/integrations/grpc/test_grpc_aio.py
+++ b/tests/integrations/grpc/test_grpc_aio.py
@@ -262,7 +262,7 @@ async def test_grpc_server_exception(
         except Exception:
             pass
 
-        (event,) = (item.payload for item in items if item.type == "event")
+        (event,) = (item.payload for item in items)
     else:
         events = capture_events()
 

--- a/tests/integrations/langchain/test_langchain.py
+++ b/tests/integrations/langchain/test_langchain.py
@@ -3211,7 +3211,7 @@ def test_langchain_error(
         with start_transaction(), pytest.raises(ValueError):
             list(agent_executor.stream({"input": "How many letters in the word eudca"}))
 
-        (error,) = (item.payload for item in items if item.type == "event")
+        (error,) = (item.payload for item in items)
     else:
         events = capture_events()
 

--- a/tests/integrations/langgraph/test_langgraph.py
+++ b/tests/integrations/langgraph/test_langgraph.py
@@ -2005,7 +2005,7 @@ def test_langgraph_message_role_mapping(
             wrapped_invoke(pregel, state_data)
 
         sentry_sdk.flush()
-        span = next(item.payload for item in items if item.type == "span")
+        span = next(item.payload for item in items)
 
         # Verify that the span was created correctly
         assert span["attributes"]["sentry.op"] == "gen_ai.invoke_agent"

--- a/tests/integrations/litellm/test_litellm.py
+++ b/tests/integrations/litellm/test_litellm.py
@@ -2662,7 +2662,7 @@ def test_response_without_usage(
             )
 
         sentry_sdk.flush()
-        (span,) = (item.payload for item in items if item.type == "span")
+        (span,) = (item.payload for item in items)
 
         # Span should still be created even without usage info
         assert span["attributes"]["sentry.op"] == OP.GEN_AI_CHAT

--- a/tests/integrations/openai/test_openai.py
+++ b/tests/integrations/openai/test_openai.py
@@ -174,7 +174,7 @@ def test_nonstreaming_chat_completion_no_prompts(
 
         assert response == "the model response"
         sentry_sdk.flush()
-        span = next(item.payload for item in items if item.type == "span")
+        span = next(item.payload for item in items)
         assert span["attributes"]["sentry.op"] == "gen_ai.chat"
         assert span["attributes"][SPANDATA.GEN_AI_SYSTEM] == "openai"
         assert span["attributes"][SPANDATA.GEN_AI_RESPONSE_STREAMING] is False
@@ -372,7 +372,7 @@ def test_nonstreaming_chat_completion(
 
         assert response == "the model response"
         sentry_sdk.flush()
-        span = next(item.payload for item in items if item.type == "span")
+        span = next(item.payload for item in items)
         assert span["attributes"]["sentry.op"] == "gen_ai.chat"
         assert span["attributes"][SPANDATA.GEN_AI_SYSTEM] == "openai"
         assert span["attributes"][SPANDATA.GEN_AI_RESPONSE_STREAMING] is False
@@ -510,7 +510,7 @@ async def test_nonstreaming_chat_completion_async_no_prompts(
 
         assert response == "the model response"
         sentry_sdk.flush()
-        span = next(item.payload for item in items if item.type == "span")
+        span = next(item.payload for item in items)
         assert span["attributes"]["sentry.op"] == "gen_ai.chat"
         assert span["attributes"][SPANDATA.GEN_AI_SYSTEM] == "openai"
         assert span["attributes"][SPANDATA.GEN_AI_RESPONSE_STREAMING] is False
@@ -703,7 +703,7 @@ async def test_nonstreaming_chat_completion_async(
 
         assert response == "the model response"
         sentry_sdk.flush()
-        span = next(item.payload for item in items if item.type == "span")
+        span = next(item.payload for item in items)
         assert span["attributes"]["sentry.op"] == "gen_ai.chat"
         assert span["attributes"][SPANDATA.GEN_AI_SYSTEM] == "openai"
         assert span["attributes"][SPANDATA.GEN_AI_RESPONSE_STREAMING] is False
@@ -893,7 +893,7 @@ def test_streaming_chat_completion_no_prompts(
 
         assert response_string == "hello world"
         sentry_sdk.flush()
-        span = next(item.payload for item in items if item.type == "span")
+        span = next(item.payload for item in items)
         assert span["attributes"]["sentry.op"] == "gen_ai.chat"
         assert span["attributes"][SPANDATA.GEN_AI_SYSTEM] == "openai"
         assert span["attributes"][SPANDATA.GEN_AI_RESPONSE_STREAMING] is True
@@ -1058,7 +1058,7 @@ def test_streaming_chat_completion_with_usage_in_stream(
                 pass
 
         sentry_sdk.flush()
-        span = next(item.payload for item in items if item.type == "span")
+        span = next(item.payload for item in items)
         assert span["attributes"]["sentry.op"] == "gen_ai.chat"
         assert span["attributes"]["gen_ai.usage.input_tokens"] == 20
         assert span["attributes"]["gen_ai.usage.output_tokens"] == 10
@@ -1153,7 +1153,7 @@ def test_streaming_chat_completion_empty_content_preserves_token_usage(
                 pass
 
         sentry_sdk.flush()
-        span = next(item.payload for item in items if item.type == "span")
+        span = next(item.payload for item in items)
         assert span["attributes"]["sentry.op"] == "gen_ai.chat"
         assert span["attributes"]["gen_ai.usage.input_tokens"] == 20
         assert "gen_ai.usage.output_tokens" not in span["attributes"]
@@ -1252,7 +1252,7 @@ async def test_streaming_chat_completion_empty_content_preserves_token_usage_asy
                 pass
 
         sentry_sdk.flush()
-        span = next(item.payload for item in items if item.type == "span")
+        span = next(item.payload for item in items)
         assert span["attributes"]["sentry.op"] == "gen_ai.chat"
         assert span["attributes"]["gen_ai.usage.input_tokens"] == 20
         assert "gen_ai.usage.output_tokens" not in span["attributes"]
@@ -1370,7 +1370,7 @@ async def test_streaming_chat_completion_async_with_usage_in_stream(
                 pass
 
         sentry_sdk.flush()
-        span = next(item.payload for item in items if item.type == "span")
+        span = next(item.payload for item in items)
         assert span["attributes"]["sentry.op"] == "gen_ai.chat"
         assert span["attributes"]["gen_ai.usage.input_tokens"] == 20
         assert span["attributes"]["gen_ai.usage.output_tokens"] == 10
@@ -1586,7 +1586,7 @@ def test_streaming_chat_completion(
             )
         assert response_string == "hello world"
         sentry_sdk.flush()
-        span = next(item.payload for item in items if item.type == "span")
+        span = next(item.payload for item in items)
         assert span["attributes"]["sentry.op"] == "gen_ai.chat"
         assert span["attributes"][SPANDATA.GEN_AI_SYSTEM] == "openai"
         assert span["attributes"][SPANDATA.GEN_AI_RESPONSE_STREAMING] is True
@@ -1805,7 +1805,7 @@ async def test_streaming_chat_completion_async_no_prompts(
 
         assert response_string == "hello world"
         sentry_sdk.flush()
-        span = next(item.payload for item in items if item.type == "span")
+        span = next(item.payload for item in items)
         assert span["attributes"]["sentry.op"] == "gen_ai.chat"
         assert span["attributes"][SPANDATA.GEN_AI_SYSTEM] == "openai"
         assert span["attributes"][SPANDATA.GEN_AI_RESPONSE_STREAMING] is True
@@ -2082,7 +2082,7 @@ async def test_streaming_chat_completion_async(
 
         assert response_string == "hello world"
         sentry_sdk.flush()
-        span = next(item.payload for item in items if item.type == "span")
+        span = next(item.payload for item in items)
         assert span["attributes"]["sentry.op"] == "gen_ai.chat"
         assert span["attributes"][SPANDATA.GEN_AI_SYSTEM] == "openai"
         assert span["attributes"][SPANDATA.GEN_AI_RESPONSE_STREAMING] is True
@@ -2428,7 +2428,7 @@ def test_embeddings_create_no_pii(
         assert len(response.data[0].embedding) == 3
 
         sentry_sdk.flush()
-        span = next(item.payload for item in items if item.type == "span")
+        span = next(item.payload for item in items)
         assert span["attributes"]["sentry.op"] == "gen_ai.embeddings"
         assert span["attributes"][SPANDATA.GEN_AI_SYSTEM] == "openai"
         assert (
@@ -2577,7 +2577,7 @@ def test_embeddings_create(
         assert len(response.data[0].embedding) == 3
 
         sentry_sdk.flush()
-        span = next(item.payload for item in items if item.type == "span")
+        span = next(item.payload for item in items)
         assert span["attributes"]["sentry.op"] == "gen_ai.embeddings"
         assert span["attributes"][SPANDATA.GEN_AI_SYSTEM] == "openai"
         assert (
@@ -2672,7 +2672,7 @@ async def test_embeddings_create_async_no_pii(
         assert len(response.data[0].embedding) == 3
 
         sentry_sdk.flush()
-        span = next(item.payload for item in items if item.type == "span")
+        span = next(item.payload for item in items)
         assert span["attributes"]["sentry.op"] == "gen_ai.embeddings"
         assert span["attributes"][SPANDATA.GEN_AI_SYSTEM] == "openai"
         assert (
@@ -2822,7 +2822,7 @@ async def test_embeddings_create_async(
         assert len(response.data[0].embedding) == 3
 
         sentry_sdk.flush()
-        span = next(item.payload for item in items if item.type == "span")
+        span = next(item.payload for item in items)
         assert span["attributes"]["sentry.op"] == "gen_ai.embeddings"
         assert span["attributes"][SPANDATA.GEN_AI_SYSTEM] == "openai"
         assert (
@@ -4358,7 +4358,7 @@ def test_responses_api_conversation_id(
             )
 
         sentry_sdk.flush()
-        (span,) = (item.payload for item in items if item.type == "span")
+        (span,) = (item.payload for item in items)
 
         if expected_id is None:
             assert "gen_ai.conversation.id" not in span["attributes"]
@@ -5320,7 +5320,7 @@ def test_streaming_responses_api(
         assert response_string == "hello world"
 
         sentry_sdk.flush()
-        (span,) = (item.payload for item in items if item.type == "span")
+        (span,) = (item.payload for item in items)
         assert span["attributes"]["sentry.op"] == "gen_ai.responses"
         assert span["attributes"][SPANDATA.GEN_AI_SYSTEM] == "openai"
         assert span["attributes"][SPANDATA.GEN_AI_REQUEST_MAX_TOKENS] == 100
@@ -5448,7 +5448,7 @@ async def test_streaming_responses_api_async(
         assert response_string == "hello world"
 
         sentry_sdk.flush()
-        (span,) = (item.payload for item in items if item.type == "span")
+        (span,) = (item.payload for item in items)
         assert span["attributes"]["sentry.op"] == "gen_ai.responses"
         assert span["attributes"][SPANDATA.GEN_AI_SYSTEM] == "openai"
         assert span["attributes"][SPANDATA.GEN_AI_REQUEST_MAX_TOKENS] == 100
@@ -5566,7 +5566,7 @@ def test_empty_tools_in_chat_completion(
             )
 
         sentry_sdk.flush()
-        span = next(item.payload for item in items if item.type == "span")
+        span = next(item.payload for item in items)
 
         assert "gen_ai.request.available_tools" not in span["attributes"]
     else:
@@ -5648,7 +5648,7 @@ def test_openai_message_role_mapping(
 
         # Verify that the span was created correctly
         sentry_sdk.flush()
-        span = next(item.payload for item in items if item.type == "span")
+        span = next(item.payload for item in items)
         assert span["attributes"]["sentry.op"] == "gen_ai.chat"
         assert SPANDATA.GEN_AI_REQUEST_MESSAGES in span["attributes"]
 
@@ -5812,7 +5812,7 @@ def test_streaming_chat_completion_ttft(
                 pass
 
         sentry_sdk.flush()
-        span = next(item.payload for item in items if item.type == "span")
+        span = next(item.payload for item in items)
         assert span["attributes"]["sentry.op"] == "gen_ai.chat"
 
         # Verify TTFT is captured
@@ -5927,7 +5927,7 @@ async def test_streaming_chat_completion_ttft_async(
                 pass
 
         sentry_sdk.flush()
-        span = next(item.payload for item in items if item.type == "span")
+        span = next(item.payload for item in items)
         assert span["attributes"]["sentry.op"] == "gen_ai.chat"
 
         # Verify TTFT is captured
@@ -6009,7 +6009,7 @@ def test_streaming_responses_api_ttft(
                 pass
 
         sentry_sdk.flush()
-        span = next(item.payload for item in items if item.type == "span")
+        span = next(item.payload for item in items)
         assert span["attributes"]["sentry.op"] == "gen_ai.responses"
 
         # Verify TTFT is captured
@@ -6093,7 +6093,7 @@ async def test_streaming_responses_api_ttft_async(
                 pass
 
         sentry_sdk.flush()
-        span = next(item.payload for item in items if item.type == "span")
+        span = next(item.payload for item in items)
         assert span["attributes"]["sentry.op"] == "gen_ai.responses"
 
         # Verify TTFT is captured

--- a/tests/integrations/openai_agents/test_openai_agents.py
+++ b/tests/integrations/openai_agents/test_openai_agents.py
@@ -853,7 +853,7 @@ async def test_client_span_custom_model(
             assert result.final_output == "Hello, how can I help you?"
 
         sentry_sdk.flush()
-        spans = [item.payload for item in items if item.type == "span"]
+        spans = [item.payload for item in items]
         ai_client_span = next(
             span for span in spans if span["attributes"]["sentry.op"] == OP.GEN_AI_CHAT
         )

--- a/tests/integrations/pydantic_ai/test_pydantic_ai.py
+++ b/tests/integrations/pydantic_ai/test_pydantic_ai.py
@@ -1381,7 +1381,7 @@ async def test_error_handling(
         await agent.run("Hello")
 
         # At minimum, we should have a transaction
-        transaction = next(item.payload for item in items if item.type == "transaction")
+        transaction = next(item.payload for item in items)
 
         assert transaction["transaction"] == "invoke_agent test_error"
         # Transaction should complete successfully (status key may not exist if no error)
@@ -2490,7 +2490,7 @@ async def test_agent_data_from_scope(
         await agent.run("Test input")
 
         # Verify agent name is capture
-        (transaction,) = (item.payload for item in items if item.type == "transaction")
+        (transaction,) = (item.payload for item in items)
 
         # Verify agent name is captured
         assert transaction["transaction"] == "invoke_agent test_scope_agent"
@@ -2809,7 +2809,7 @@ async def test_agent_without_name(
         await agent.run("Test input")
 
         # Should still create transaction, just with default name
-        (transaction,) = (item.payload for item in items if item.type == "transaction")
+        (transaction,) = (item.payload for item in items)
 
         # Transaction name should be "invoke_agent agent" or similar default
         assert "invoke_agent" in transaction["transaction"]
@@ -3999,7 +3999,7 @@ async def test_binary_content_encoding_image(
             _set_input_messages(span, [mock_msg])
             span.finish()
 
-        (event,) = (item.payload for item in items if item.type == "transaction")
+        (event,) = (item.payload for item in items)
         span_data = event["spans"][0]["data"]
         messages_data = _get_messages_from_span(span_data)
         assert _find_binary_content(messages_data, "image", "image/png")
@@ -4099,7 +4099,7 @@ async def test_binary_content_encoding_mixed_content(
             _set_input_messages(span, [mock_msg])
             span.finish()
 
-        (event,) = (item.payload for item in items if item.type == "transaction")
+        (event,) = (item.payload for item in items)
         span_data = event["spans"][0]["data"]
         messages_data = _get_messages_from_span(span_data)
 
@@ -4263,7 +4263,7 @@ async def test_set_usage_data_with_cache_tokens(
             _set_usage_data(span, usage)
             span.finish()
 
-        (event,) = (item.payload for item in items if item.type == "transaction")
+        (event,) = (item.payload for item in items)
         (span_data,) = event["spans"]
         assert span_data["data"][SPANDATA.GEN_AI_USAGE_INPUT_TOKENS_CACHED] == 80
         assert span_data["data"][SPANDATA.GEN_AI_USAGE_INPUT_TOKENS_CACHE_WRITE] == 20

--- a/tests/integrations/pyramid/test_pyramid.py
+++ b/tests/integrations/pyramid/test_pyramid.py
@@ -587,7 +587,7 @@ def test_span_sets_user_id_on_segment(
     client.get("/message")
 
     sentry_sdk.flush()
-    spans = [i.payload for i in items if i.type == "span"]
+    spans = [i.payload for i in items]
 
     assert len(spans) == 1
     (segment,) = spans

--- a/tests/integrations/rust_tracing/test_rust_tracing.py
+++ b/tests/integrations/rust_tracing/test_rust_tracing.py
@@ -353,7 +353,7 @@ def test_on_event_exception(
 
             rust_tracing.close_span(3)
 
-        (exc,) = (item.payload for item in items if item.type == "event")
+        (exc,) = (item.payload for item in items)
     else:
         events = capture_events()
         sentry_sdk.get_isolation_scope().clear_breadcrumbs()
@@ -414,7 +414,7 @@ def test_on_event_breadcrumb(
             rust_tracing.close_span(3)
             capture_message("test message")
 
-        (message,) = (item.payload for item in items if item.type == "event")
+        (message,) = (item.payload for item in items)
     else:
         events = capture_events()
         sentry_sdk.get_isolation_scope().clear_breadcrumbs()
@@ -468,7 +468,7 @@ def test_on_event_event(
 
             rust_tracing.close_span(3)
 
-        (event,) = (item.payload for item in items if item.type == "event")
+        (event,) = (item.payload for item in items)
     else:
         events = capture_events()
         sentry_sdk.get_isolation_scope().clear_breadcrumbs()

--- a/tests/integrations/socket/test_socket.py
+++ b/tests/integrations/socket/test_socket.py
@@ -24,7 +24,7 @@ def test_getaddrinfo_trace(sentry_init, capture_events, capture_items, span_stre
             socket.getaddrinfo("localhost", PORT)
         sentry_sdk.flush()
 
-        spans = [item.payload for item in items if item.type == "span"]
+        spans = [item.payload for item in items]
         dns_span, _root = spans
 
         assert dns_span["attributes"]["sentry.op"] == "socket.dns"
@@ -69,7 +69,7 @@ def test_create_connection_trace(
             socket.create_connection(("localhost", PORT), timeout, None)
         sentry_sdk.flush()
 
-        spans = [item.payload for item in items if item.type == "span"]
+        spans = [item.payload for item in items]
         # as getaddrinfo gets called in create_connection it should also contain a dns span
         # spans finish in order: dns (inner) ends first, connect ends, then root
         dns_span, connect_span, _root = spans
@@ -127,7 +127,7 @@ def test_span_origin(sentry_init, capture_events, capture_items, span_streaming)
             socket.create_connection(("localhost", PORT), 1, None)
         sentry_sdk.flush()
 
-        spans = [item.payload for item in items if item.type == "span"]
+        spans = [item.payload for item in items]
         dns_span, connect_span, _root = spans
 
         assert connect_span["attributes"]["sentry.op"] == "socket.connection"

--- a/tests/integrations/sqlalchemy/test_sqlalchemy.py
+++ b/tests/integrations/sqlalchemy/test_sqlalchemy.py
@@ -64,7 +64,7 @@ def test_orm_queries(
     if span_streaming:
         items = capture_items("event")
         capture_message("hi")
-        (event,) = (item.payload for item in items if item.type == "event")
+        (event,) = (item.payload for item in items)
     else:
         events = capture_events()
         capture_message("hi")

--- a/tests/integrations/stdlib/test_httplib.py
+++ b/tests/integrations/stdlib/test_httplib.py
@@ -308,7 +308,7 @@ def test_outgoing_trace_headers(
             connection.getresponse()
 
         sentry_sdk.flush()
-        request_span = next(item.payload for item in items if item.type == "span")
+        request_span = next(item.payload for item in items)
         expected_sentry_trace = "{trace_id}-{parent_span_id}-{sampled}".format(
             trace_id=request_span["trace_id"],
             parent_span_id=request_span["span_id"],
@@ -408,7 +408,7 @@ def test_outgoing_trace_headers_head_sdk(
                 connection.getresponse()
 
         sentry_sdk.flush()
-        request_span = next(item.payload for item in items if item.type == "span")
+        request_span = next(item.payload for item in items)
         expected_sentry_trace = "{trace_id}-{parent_span_id}-{sampled}".format(
             trace_id=request_span["trace_id"],
             parent_span_id=request_span["span_id"],
@@ -689,7 +689,7 @@ def test_request_source_disabled(
             conn.getresponse()
 
         sentry_sdk.flush()
-        span = next(item.payload for item in items if item.type == "span")
+        span = next(item.payload for item in items)
         assert span["name"].startswith("GET")
 
         attributes = span["attributes"]
@@ -750,7 +750,7 @@ def test_request_source_enabled(
             conn.getresponse()
 
         sentry_sdk.flush()
-        span = next(item.payload for item in items if item.type == "span")
+        span = next(item.payload for item in items)
         assert span["name"].startswith("GET")
 
         attributes = span["attributes"]
@@ -804,7 +804,7 @@ def test_request_source(
             conn.getresponse()
 
         sentry_sdk.flush()
-        span = next(item.payload for item in items if item.type == "span")
+        span = next(item.payload for item in items)
         assert span["name"].startswith("GET")
 
         attributes = span["attributes"]
@@ -890,7 +890,7 @@ def test_request_source_with_module_in_search_path(
             get_request_with_connection(conn, "/foo")
 
         sentry_sdk.flush()
-        span = next(item.payload for item in items if item.type == "span")
+        span = next(item.payload for item in items)
         assert span["name"].startswith("GET")
 
         attributes = span["attributes"]
@@ -981,7 +981,7 @@ def test_no_request_source_if_duration_too_short(
                 conn.getresponse()
 
         sentry_sdk.flush()
-        span = next(item.payload for item in items if item.type == "span")
+        span = next(item.payload for item in items)
         assert span["name"].startswith("GET")
 
         attributes = span["attributes"]
@@ -1056,7 +1056,7 @@ def test_request_source_if_duration_over_threshold(
                 conn.getresponse()
 
         sentry_sdk.flush()
-        span = next(item.payload for item in items if item.type == "span")
+        span = next(item.payload for item in items)
         assert span["name"].startswith("GET")
 
         attributes = span["attributes"]

--- a/tests/tracing/test_conversation_id.py
+++ b/tests/tracing/test_conversation_id.py
@@ -60,7 +60,7 @@ def test_conversation_id_propagates_to_span_with_gen_ai_op(
             with start_span(op="gen_ai.invoke_agent"):
                 pass
 
-        spans = [item.payload for item in items if item.type == "span"]
+        spans = [item.payload for item in items]
         span_data = spans[0]["attributes"]
     else:
         events = capture_events()

--- a/tests/tracing/test_decorator.py
+++ b/tests/tracing/test_decorator.py
@@ -434,9 +434,7 @@ def test_span_templates_ai_dicts(
         with sentry_sdk.start_transaction(name="test-transaction"):
             my_agent()
 
-        (agent_span, tool_span, chat_span) = (
-            item.payload for item in items
-        )
+        (agent_span, tool_span, chat_span) = (item.payload for item in items)
 
         assert (
             agent_span["name"]
@@ -637,9 +635,7 @@ def test_span_templates_ai_objects(
         with sentry_sdk.start_transaction(name="test-transaction"):
             my_agent()
 
-        (agent_span, tool_span, chat_span) = (
-            item.payload for item in items
-        )
+        (agent_span, tool_span, chat_span) = (item.payload for item in items)
 
         assert (
             agent_span["name"]

--- a/tests/tracing/test_decorator.py
+++ b/tests/tracing/test_decorator.py
@@ -435,7 +435,7 @@ def test_span_templates_ai_dicts(
             my_agent()
 
         (agent_span, tool_span, chat_span) = (
-            item.payload for item in items if item.type == "span"
+            item.payload for item in items
         )
 
         assert (
@@ -638,7 +638,7 @@ def test_span_templates_ai_objects(
             my_agent()
 
         (agent_span, tool_span, chat_span) = (
-            item.payload for item in items if item.type == "span"
+            item.payload for item in items
         )
 
         assert (
@@ -822,7 +822,7 @@ def test_span_templates_ai_pii(
         with sentry_sdk.start_transaction(name="test-transaction"):
             my_agent(22, 33, arg1=44, arg2=55)
 
-        (_, tool_span, _) = (item.payload for item in items if item.type == "span")
+        (_, tool_span, _) = (item.payload for item in items)
 
         if send_default_pii:
             assert (


### PR DESCRIPTION
`capture_items` already filters by type if provided as arg(s), so the subsequent `if item.type == "xxx"` in list comprehensions was redundant.

