### PR TITLE
fix(django): Use inspect.iscoroutinefunction on Python 3.14+

### DIFF
--- a/sentry_sdk/integrations/django/asgi.py
+++ b/sentry_sdk/integrations/django/asgi.py
@@ -1,9 +1,8 @@
 """
 Instrumentation for Django 3.0
 
-Since this file contains `async def` it is conditionally imported in
-`sentry_sdk.integrations.django` (depending on the existence of
-`django.core.handlers.asgi`.
+Since this file imports `django.core.handlers.asgi` (Django >= 3)
+it is conditionally imported in `sentry_sdk.integrations.django`.
 """
 
 import asyncio

--- a/sentry_sdk/integrations/django/views.py
+++ b/sentry_sdk/integrations/django/views.py
@@ -10,15 +10,12 @@ if TYPE_CHECKING:
     from typing import Any
 
 
-try:
-    from asyncio import iscoroutinefunction
-except ImportError:
-    iscoroutinefunction = None  # type: ignore
+from asyncio import iscoroutinefunction
 
 
 try:
     from sentry_sdk.integrations.django.asgi import wrap_async_view
-except (ImportError, SyntaxError):
+except ImportError:  # Django < 3.0
     wrap_async_view = None  # type: ignore
 
 
@@ -63,12 +60,7 @@ def patch_views() -> None:
 
         integration = sentry_sdk.get_client().get_integration(DjangoIntegration)
         if integration is not None:
-            is_async_view = (
-                iscoroutinefunction is not None
-                and wrap_async_view is not None
-                and iscoroutinefunction(callback)
-            )
-            if is_async_view:
+            if wrap_async_view is not None and iscoroutinefunction(callback):
                 sentry_wrapped_callback = wrap_async_view(callback)
             else:
                 sentry_wrapped_callback = _wrap_sync_view(callback)

--- a/sentry_sdk/integrations/django/views.py
+++ b/sentry_sdk/integrations/django/views.py
@@ -1,4 +1,5 @@
 import functools
+import sys
 from typing import TYPE_CHECKING
 
 import sentry_sdk
@@ -10,7 +11,10 @@ if TYPE_CHECKING:
     from typing import Any
 
 
-from asyncio import iscoroutinefunction
+if sys.version_info >= (3, 14):
+    from inspect import iscoroutinefunction
+else:
+    from asyncio import iscoroutinefunction
 
 
 try:


### PR DESCRIPTION
### Description

Fix asyncio.iscoroutinefunction deprecation warning as mentioned in #6085.

This PR touches code that had Python < 3.5 compatibility leftovers
so I dropped them in a preceding commit to reduce churn.

#### Issues

* contributes to: #6085

#### Notes

Sibling to #3027