### PR TITLE
feat(openai): Add `gen_ai.request.reasoning.level` to OpenAI spans

### DIFF
--- a/sentry_sdk/consts.py
+++ b/sentry_sdk/consts.py
@@ -695,6 +695,12 @@ class SPANDATA:
     Example: 0.1
     """
 
+    GEN_AI_REQUEST_REASONING_LEVEL = "gen_ai.request.reasoning_level"
+    """
+    The reasoning or thinking effort level requested for a GenAI model.
+    Example: "high"
+    """
+
     GEN_AI_REQUEST_SEED = "gen_ai.request.seed"
     """
     The seed, ideally models given the same seed and same other parameters will produce the exact same output.

--- a/sentry_sdk/consts.py
+++ b/sentry_sdk/consts.py
@@ -695,7 +695,7 @@ class SPANDATA:
     Example: 0.1
     """
 
-    GEN_AI_REQUEST_REASONING_LEVEL = "gen_ai.request.reasoning_level"
+    GEN_AI_REQUEST_REASONING_LEVEL = "gen_ai.request.reasoning.level"
     """
     The reasoning or thinking effort level requested for a GenAI model.
     Example: "high"

--- a/sentry_sdk/integrations/openai.py
+++ b/sentry_sdk/integrations/openai.py
@@ -363,14 +363,11 @@ def _set_responses_api_input_data(
             set_on_span(SPANDATA.GEN_AI_CONVERSATION_ID, conversation_id)
 
     reasoning = kwargs.get("reasoning")
-    if reasoning is not None and _is_given(reasoning):
-        reasoning_effort: "Optional[str]" = None
-        if isinstance(reasoning, dict):
-            reasoning_effort = reasoning.get("effort")
-        else:
-            reasoning_effort = getattr(reasoning, "effort", None)
-        if reasoning_effort is not None:
-            set_on_span(SPANDATA.GEN_AI_REQUEST_REASONING_LEVEL, reasoning_effort)
+    if isinstance(reasoning, dict) and "effort" in reasoning:
+        set_on_span(
+            SPANDATA.GEN_AI_REQUEST_REASONING_LEVEL,
+            reasoning["effort"],
+        )
 
     if not should_send_default_pii() or not integration.include_prompts:
         set_data_normalized(span, SPANDATA.GEN_AI_OPERATION_NAME, "responses")

--- a/sentry_sdk/integrations/openai.py
+++ b/sentry_sdk/integrations/openai.py
@@ -499,6 +499,10 @@ def _set_completions_api_input_data(
     if top_p is not None and _is_given(top_p):
         set_on_span(SPANDATA.GEN_AI_REQUEST_TOP_P, top_p)
 
+    reasoning_level = kwargs.get("reasoning_effort")
+    if reasoning_level is not None and _is_given(reasoning_level):
+        set_on_span(SPANDATA.GEN_AI_REQUEST_REASONING_LEVEL, reasoning_level)
+
     if (
         not should_send_default_pii()
         or not integration.include_prompts

--- a/sentry_sdk/integrations/openai.py
+++ b/sentry_sdk/integrations/openai.py
@@ -362,6 +362,16 @@ def _set_responses_api_input_data(
         if conversation_id is not None:
             set_on_span(SPANDATA.GEN_AI_CONVERSATION_ID, conversation_id)
 
+    reasoning = kwargs.get("reasoning")
+    if reasoning is not None and _is_given(reasoning):
+        reasoning_effort: "Optional[str]" = None
+        if isinstance(reasoning, dict):
+            reasoning_effort = reasoning.get("effort")
+        else:
+            reasoning_effort = getattr(reasoning, "effort", None)
+        if reasoning_effort is not None:
+            set_on_span(SPANDATA.GEN_AI_REQUEST_REASONING_LEVEL, reasoning_effort)
+
     if not should_send_default_pii() or not integration.include_prompts:
         set_data_normalized(span, SPANDATA.GEN_AI_OPERATION_NAME, "responses")
         return

--- a/tests/integrations/openai/test_openai.py
+++ b/tests/integrations/openai/test_openai.py
@@ -39,8 +39,10 @@ try:
         InputTokensDetails,
         OutputTokensDetails,
     )
+    from openai.types.shared.reasoning import Reasoning
 except ImportError:
     SKIP_RESPONSES_TESTS = True
+    Reasoning = None
 
 from unittest import mock  # python 3.3 and above
 
@@ -4381,6 +4383,85 @@ def test_responses_api_conversation_id(
             assert "gen_ai.conversation.id" not in span["data"]
         else:
             assert span["data"]["gen_ai.conversation.id"] == expected_id
+
+
+@pytest.mark.parametrize("span_streaming", [True, False])
+@pytest.mark.parametrize("stream_gen_ai_spans", [True, False])
+@pytest.mark.parametrize(
+    "reasoning, expected_level",
+    [
+        pytest.param(omit, None, id="omit"),
+        pytest.param(None, None, id="none"),
+        pytest.param({"summary": "auto"}, None, id="dict_without_effort"),
+        pytest.param({"effort": "high"}, "high", id="dict"),
+        pytest.param(
+            Reasoning(effort="low") if Reasoning is not None else None,
+            "low" if Reasoning is not None else None,
+            id="object",
+        ),
+    ],
+)
+@pytest.mark.skipif(SKIP_RESPONSES_TESTS, reason="Responses API not available")
+def test_responses_api_reasoning_level(
+    sentry_init,
+    capture_events,
+    capture_items,
+    reasoning,
+    expected_level,
+    stream_gen_ai_spans,
+    span_streaming,
+):
+    sentry_init(
+        integrations=[OpenAIIntegration()],
+        disabled_integrations=[StdlibIntegration],
+        traces_sample_rate=1.0,
+        stream_gen_ai_spans=stream_gen_ai_spans,
+        trace_lifecycle="stream" if span_streaming else "static",
+    )
+
+    client = OpenAI(api_key="z")
+    client.responses._post = mock.Mock(return_value=EXAMPLE_RESPONSE)
+
+    if span_streaming or stream_gen_ai_spans:
+        items = capture_items("span")
+
+        with start_transaction(name="openai tx"):
+            client.responses.create(
+                model="gpt-4o",
+                input="hello",
+                reasoning=reasoning,
+            )
+
+        sentry_sdk.flush()
+        span = next(item.payload for item in items if item.type == "span")
+
+        if expected_level is None:
+            assert SPANDATA.GEN_AI_REQUEST_REASONING_LEVEL not in span["attributes"]
+        else:
+            assert (
+                span["attributes"][SPANDATA.GEN_AI_REQUEST_REASONING_LEVEL]
+                == expected_level
+            )
+
+    else:
+        events = capture_events()
+
+        with start_transaction(name="openai tx"):
+            client.responses.create(
+                model="gpt-4o",
+                input="hello",
+                reasoning=reasoning,
+            )
+
+        (transaction,) = events
+        span = transaction["spans"][0]
+
+        if expected_level is None:
+            assert SPANDATA.GEN_AI_REQUEST_REASONING_LEVEL not in span["data"]
+        else:
+            assert (
+                span["data"][SPANDATA.GEN_AI_REQUEST_REASONING_LEVEL] == expected_level
+            )
 
 
 @pytest.mark.parametrize("span_streaming", [True, False])

--- a/tests/integrations/openai/test_openai.py
+++ b/tests/integrations/openai/test_openai.py
@@ -39,10 +39,8 @@ try:
         InputTokensDetails,
         OutputTokensDetails,
     )
-    from openai.types.shared.reasoning import Reasoning
 except ImportError:
     SKIP_RESPONSES_TESTS = True
-    Reasoning = None
 
 from unittest import mock  # python 3.3 and above
 
@@ -4394,11 +4392,6 @@ def test_responses_api_conversation_id(
         pytest.param(None, None, id="none"),
         pytest.param({"summary": "auto"}, None, id="dict_without_effort"),
         pytest.param({"effort": "high"}, "high", id="dict"),
-        pytest.param(
-            Reasoning(effort="low") if Reasoning is not None else None,
-            "low" if Reasoning is not None else None,
-            id="object",
-        ),
     ],
 )
 @pytest.mark.skipif(SKIP_RESPONSES_TESTS, reason="Responses API not available")

--- a/tests/integrations/openai/test_openai.py
+++ b/tests/integrations/openai/test_openai.py
@@ -167,6 +167,7 @@ def test_nonstreaming_chat_completion_no_prompts(
                     frequency_penalty=0.2,
                     temperature=0.7,
                     top_p=0.9,
+                    reasoning_effort="high",
                 )
                 .choices[0]
                 .message.content
@@ -185,6 +186,7 @@ def test_nonstreaming_chat_completion_no_prompts(
         assert span["attributes"][SPANDATA.GEN_AI_REQUEST_FREQUENCY_PENALTY] == 0.2
         assert span["attributes"][SPANDATA.GEN_AI_REQUEST_TEMPERATURE] == 0.7
         assert span["attributes"][SPANDATA.GEN_AI_REQUEST_TOP_P] == 0.9
+        assert span["attributes"][SPANDATA.GEN_AI_REQUEST_REASONING_LEVEL] == "high"
 
         assert SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS not in span["attributes"]
         assert SPANDATA.GEN_AI_REQUEST_MESSAGES not in span["attributes"]
@@ -209,6 +211,7 @@ def test_nonstreaming_chat_completion_no_prompts(
                     frequency_penalty=0.2,
                     temperature=0.7,
                     top_p=0.9,
+                    reasoning_effort="high",
                 )
                 .choices[0]
                 .message.content
@@ -228,6 +231,7 @@ def test_nonstreaming_chat_completion_no_prompts(
         assert span["data"][SPANDATA.GEN_AI_REQUEST_FREQUENCY_PENALTY] == 0.2
         assert span["data"][SPANDATA.GEN_AI_REQUEST_TEMPERATURE] == 0.7
         assert span["data"][SPANDATA.GEN_AI_REQUEST_TOP_P] == 0.9
+        assert span["data"][SPANDATA.GEN_AI_REQUEST_REASONING_LEVEL] == "high"
 
         assert SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS not in span["data"]
         assert SPANDATA.GEN_AI_REQUEST_MESSAGES not in span["data"]
@@ -365,6 +369,7 @@ def test_nonstreaming_chat_completion(
                     frequency_penalty=0.2,
                     temperature=0.7,
                     top_p=0.9,
+                    reasoning_effort="high",
                 )
                 .choices[0]
                 .message.content
@@ -383,6 +388,7 @@ def test_nonstreaming_chat_completion(
         assert span["attributes"][SPANDATA.GEN_AI_REQUEST_FREQUENCY_PENALTY] == 0.2
         assert span["attributes"][SPANDATA.GEN_AI_REQUEST_TEMPERATURE] == 0.7
         assert span["attributes"][SPANDATA.GEN_AI_REQUEST_TOP_P] == 0.9
+        assert span["attributes"][SPANDATA.GEN_AI_REQUEST_REASONING_LEVEL] == "high"
 
         assert (
             json.loads(span["attributes"][SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS])
@@ -412,6 +418,7 @@ def test_nonstreaming_chat_completion(
                     frequency_penalty=0.2,
                     temperature=0.7,
                     top_p=0.9,
+                    reasoning_effort="high",
                 )
                 .choices[0]
                 .message.content
@@ -431,6 +438,7 @@ def test_nonstreaming_chat_completion(
         assert span["data"][SPANDATA.GEN_AI_REQUEST_FREQUENCY_PENALTY] == 0.2
         assert span["data"][SPANDATA.GEN_AI_REQUEST_TEMPERATURE] == 0.7
         assert span["data"][SPANDATA.GEN_AI_REQUEST_TOP_P] == 0.9
+        assert span["data"][SPANDATA.GEN_AI_REQUEST_REASONING_LEVEL] == "high"
 
         assert (
             json.loads(span["data"][SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS])
@@ -505,6 +513,7 @@ async def test_nonstreaming_chat_completion_async_no_prompts(
                 frequency_penalty=0.2,
                 temperature=0.7,
                 top_p=0.9,
+                reasoning_effort="high",
             )
             response = response.choices[0].message.content
 
@@ -521,6 +530,7 @@ async def test_nonstreaming_chat_completion_async_no_prompts(
         assert span["attributes"][SPANDATA.GEN_AI_REQUEST_FREQUENCY_PENALTY] == 0.2
         assert span["attributes"][SPANDATA.GEN_AI_REQUEST_TEMPERATURE] == 0.7
         assert span["attributes"][SPANDATA.GEN_AI_REQUEST_TOP_P] == 0.9
+        assert span["attributes"][SPANDATA.GEN_AI_REQUEST_REASONING_LEVEL] == "high"
 
         assert SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS not in span["attributes"]
         assert SPANDATA.GEN_AI_REQUEST_MESSAGES not in span["attributes"]
@@ -544,6 +554,7 @@ async def test_nonstreaming_chat_completion_async_no_prompts(
                 frequency_penalty=0.2,
                 temperature=0.7,
                 top_p=0.9,
+                reasoning_effort="high",
             )
             response = response.choices[0].message.content
 
@@ -561,6 +572,7 @@ async def test_nonstreaming_chat_completion_async_no_prompts(
         assert span["data"][SPANDATA.GEN_AI_REQUEST_FREQUENCY_PENALTY] == 0.2
         assert span["data"][SPANDATA.GEN_AI_REQUEST_TEMPERATURE] == 0.7
         assert span["data"][SPANDATA.GEN_AI_REQUEST_TOP_P] == 0.9
+        assert span["data"][SPANDATA.GEN_AI_REQUEST_REASONING_LEVEL] == "high"
 
         assert SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS not in span["data"]
         assert SPANDATA.GEN_AI_REQUEST_MESSAGES not in span["data"]
@@ -698,6 +710,7 @@ async def test_nonstreaming_chat_completion_async(
                 frequency_penalty=0.2,
                 temperature=0.7,
                 top_p=0.9,
+                reasoning_effort="high",
             )
             response = response.choices[0].message.content
 
@@ -714,6 +727,7 @@ async def test_nonstreaming_chat_completion_async(
         assert span["attributes"][SPANDATA.GEN_AI_REQUEST_FREQUENCY_PENALTY] == 0.2
         assert span["attributes"][SPANDATA.GEN_AI_REQUEST_TEMPERATURE] == 0.7
         assert span["attributes"][SPANDATA.GEN_AI_REQUEST_TOP_P] == 0.9
+        assert span["attributes"][SPANDATA.GEN_AI_REQUEST_REASONING_LEVEL] == "high"
 
         assert (
             json.loads(span["attributes"][SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS])
@@ -742,6 +756,7 @@ async def test_nonstreaming_chat_completion_async(
                 frequency_penalty=0.2,
                 temperature=0.7,
                 top_p=0.9,
+                reasoning_effort="high",
             )
             response = response.choices[0].message.content
 
@@ -759,6 +774,7 @@ async def test_nonstreaming_chat_completion_async(
         assert span["data"][SPANDATA.GEN_AI_REQUEST_FREQUENCY_PENALTY] == 0.2
         assert span["data"][SPANDATA.GEN_AI_REQUEST_TEMPERATURE] == 0.7
         assert span["data"][SPANDATA.GEN_AI_REQUEST_TOP_P] == 0.9
+        assert span["data"][SPANDATA.GEN_AI_REQUEST_REASONING_LEVEL] == "high"
 
         assert (
             json.loads(span["data"][SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS])
@@ -886,6 +902,7 @@ def test_streaming_chat_completion_no_prompts(
                 frequency_penalty=0.2,
                 temperature=0.7,
                 top_p=0.9,
+                reasoning_effort="high",
             )
             response_string = "".join(
                 map(lambda x: x.choices[0].delta.content, response_stream)
@@ -904,6 +921,7 @@ def test_streaming_chat_completion_no_prompts(
         assert span["attributes"][SPANDATA.GEN_AI_REQUEST_FREQUENCY_PENALTY] == 0.2
         assert span["attributes"][SPANDATA.GEN_AI_REQUEST_TEMPERATURE] == 0.7
         assert span["attributes"][SPANDATA.GEN_AI_REQUEST_TOP_P] == 0.9
+        assert span["attributes"][SPANDATA.GEN_AI_REQUEST_REASONING_LEVEL] == "high"
 
         assert span["attributes"][SPANDATA.GEN_AI_RESPONSE_MODEL] == "model-id"
 
@@ -939,6 +957,7 @@ def test_streaming_chat_completion_no_prompts(
                 frequency_penalty=0.2,
                 temperature=0.7,
                 top_p=0.9,
+                reasoning_effort="high",
             )
             response_string = "".join(
                 map(lambda x: x.choices[0].delta.content, response_stream)
@@ -958,6 +977,7 @@ def test_streaming_chat_completion_no_prompts(
         assert span["data"][SPANDATA.GEN_AI_REQUEST_FREQUENCY_PENALTY] == 0.2
         assert span["data"][SPANDATA.GEN_AI_REQUEST_TEMPERATURE] == 0.7
         assert span["data"][SPANDATA.GEN_AI_REQUEST_TOP_P] == 0.9
+        assert span["data"][SPANDATA.GEN_AI_REQUEST_REASONING_LEVEL] == "high"
 
         assert span["data"][SPANDATA.GEN_AI_RESPONSE_MODEL] == "model-id"
 
@@ -1580,6 +1600,7 @@ def test_streaming_chat_completion(
                 frequency_penalty=0.2,
                 temperature=0.7,
                 top_p=0.9,
+                reasoning_effort="high",
             )
             response_string = "".join(
                 map(lambda x: x.choices[0].delta.content, response_stream)
@@ -1597,6 +1618,7 @@ def test_streaming_chat_completion(
         assert span["attributes"][SPANDATA.GEN_AI_REQUEST_FREQUENCY_PENALTY] == 0.2
         assert span["attributes"][SPANDATA.GEN_AI_REQUEST_TEMPERATURE] == 0.7
         assert span["attributes"][SPANDATA.GEN_AI_REQUEST_TOP_P] == 0.9
+        assert span["attributes"][SPANDATA.GEN_AI_REQUEST_REASONING_LEVEL] == "high"
 
         assert (
             json.loads(span["attributes"][SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS])
@@ -1646,6 +1668,7 @@ def test_streaming_chat_completion(
                 frequency_penalty=0.2,
                 temperature=0.7,
                 top_p=0.9,
+                reasoning_effort="high",
             )
             response_string = "".join(
                 map(lambda x: x.choices[0].delta.content, response_stream)
@@ -1664,6 +1687,7 @@ def test_streaming_chat_completion(
         assert span["data"][SPANDATA.GEN_AI_REQUEST_FREQUENCY_PENALTY] == 0.2
         assert span["data"][SPANDATA.GEN_AI_REQUEST_TEMPERATURE] == 0.7
         assert span["data"][SPANDATA.GEN_AI_REQUEST_TOP_P] == 0.9
+        assert span["data"][SPANDATA.GEN_AI_REQUEST_REASONING_LEVEL] == "high"
 
         assert (
             json.loads(span["data"][SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS])
@@ -1797,6 +1821,7 @@ async def test_streaming_chat_completion_async_no_prompts(
                 frequency_penalty=0.2,
                 temperature=0.7,
                 top_p=0.9,
+                reasoning_effort="high",
             )
 
             response_string = ""
@@ -1816,6 +1841,7 @@ async def test_streaming_chat_completion_async_no_prompts(
         assert span["attributes"][SPANDATA.GEN_AI_REQUEST_FREQUENCY_PENALTY] == 0.2
         assert span["attributes"][SPANDATA.GEN_AI_REQUEST_TEMPERATURE] == 0.7
         assert span["attributes"][SPANDATA.GEN_AI_REQUEST_TOP_P] == 0.9
+        assert span["attributes"][SPANDATA.GEN_AI_REQUEST_REASONING_LEVEL] == "high"
 
         assert span["attributes"][SPANDATA.GEN_AI_RESPONSE_MODEL] == "model-id"
 
@@ -1852,6 +1878,7 @@ async def test_streaming_chat_completion_async_no_prompts(
                 frequency_penalty=0.2,
                 temperature=0.7,
                 top_p=0.9,
+                reasoning_effort="high",
             )
 
             response_string = ""
@@ -1872,6 +1899,7 @@ async def test_streaming_chat_completion_async_no_prompts(
         assert span["data"][SPANDATA.GEN_AI_REQUEST_FREQUENCY_PENALTY] == 0.2
         assert span["data"][SPANDATA.GEN_AI_REQUEST_TEMPERATURE] == 0.7
         assert span["data"][SPANDATA.GEN_AI_REQUEST_TOP_P] == 0.9
+        assert span["data"][SPANDATA.GEN_AI_REQUEST_REASONING_LEVEL] == "high"
 
         assert span["data"][SPANDATA.GEN_AI_RESPONSE_MODEL] == "model-id"
 
@@ -2074,6 +2102,7 @@ async def test_streaming_chat_completion_async(
                 frequency_penalty=0.2,
                 temperature=0.7,
                 top_p=0.9,
+                reasoning_effort="high",
             )
 
             response_string = ""
@@ -2093,6 +2122,7 @@ async def test_streaming_chat_completion_async(
         assert span["attributes"][SPANDATA.GEN_AI_REQUEST_FREQUENCY_PENALTY] == 0.2
         assert span["attributes"][SPANDATA.GEN_AI_REQUEST_TEMPERATURE] == 0.7
         assert span["attributes"][SPANDATA.GEN_AI_REQUEST_TOP_P] == 0.9
+        assert span["attributes"][SPANDATA.GEN_AI_REQUEST_REASONING_LEVEL] == "high"
 
         assert span["attributes"][SPANDATA.GEN_AI_RESPONSE_MODEL] == "model-id"
 
@@ -2142,6 +2172,7 @@ async def test_streaming_chat_completion_async(
                 frequency_penalty=0.2,
                 temperature=0.7,
                 top_p=0.9,
+                reasoning_effort="high",
             )
 
             response_string = ""
@@ -2162,6 +2193,7 @@ async def test_streaming_chat_completion_async(
         assert span["data"][SPANDATA.GEN_AI_REQUEST_FREQUENCY_PENALTY] == 0.2
         assert span["data"][SPANDATA.GEN_AI_REQUEST_TEMPERATURE] == 0.7
         assert span["data"][SPANDATA.GEN_AI_REQUEST_TOP_P] == 0.9
+        assert span["data"][SPANDATA.GEN_AI_REQUEST_REASONING_LEVEL] == "high"
 
         assert span["data"][SPANDATA.GEN_AI_RESPONSE_MODEL] == "model-id"
 
@@ -3890,6 +3922,7 @@ def test_ai_client_span_responses_api_no_pii(
                 max_output_tokens=100,
                 temperature=0.7,
                 top_p=0.9,
+                reasoning={"effort": "high"},
             )
 
         sentry_sdk.flush()
@@ -3901,6 +3934,7 @@ def test_ai_client_span_responses_api_no_pii(
             "gen_ai.request.max_tokens": 100,
             "gen_ai.request.temperature": 0.7,
             "gen_ai.request.top_p": 0.9,
+            "gen_ai.request.reasoning.level": "high",
             "gen_ai.request.model": "gpt-4o",
             "gen_ai.response.model": "response-model-id",
             "gen_ai.response.streaming": False,
@@ -3933,6 +3967,7 @@ def test_ai_client_span_responses_api_no_pii(
                 max_output_tokens=100,
                 temperature=0.7,
                 top_p=0.9,
+                reasoning={"effort": "high"},
             )
 
         spans = [item.payload for item in items]
@@ -3943,6 +3978,7 @@ def test_ai_client_span_responses_api_no_pii(
             "gen_ai.request.max_tokens": 100,
             "gen_ai.request.temperature": 0.7,
             "gen_ai.request.top_p": 0.9,
+            "gen_ai.request.reasoning.level": "high",
             "gen_ai.request.model": "gpt-4o",
             "gen_ai.response.model": "response-model-id",
             "gen_ai.response.streaming": False,
@@ -3974,6 +4010,7 @@ def test_ai_client_span_responses_api_no_pii(
                 max_output_tokens=100,
                 temperature=0.7,
                 top_p=0.9,
+                reasoning={"effort": "high"},
             )
 
         (transaction,) = events
@@ -3987,6 +4024,7 @@ def test_ai_client_span_responses_api_no_pii(
             "gen_ai.request.max_tokens": 100,
             "gen_ai.request.temperature": 0.7,
             "gen_ai.request.top_p": 0.9,
+            "gen_ai.request.reasoning.level": "high",
             "gen_ai.request.model": "gpt-4o",
             "gen_ai.response.model": "response-model-id",
             "gen_ai.response.streaming": False,
@@ -4186,6 +4224,7 @@ def test_ai_client_span_responses_api(
                 max_output_tokens=100,
                 temperature=0.7,
                 top_p=0.9,
+                reasoning={"effort": "high"},
             )
 
         sentry_sdk.flush()
@@ -4198,6 +4237,7 @@ def test_ai_client_span_responses_api(
             "gen_ai.request.max_tokens": 100,
             "gen_ai.request.temperature": 0.7,
             "gen_ai.request.top_p": 0.9,
+            "gen_ai.request.reasoning.level": "high",
             "gen_ai.system": "openai",
             "gen_ai.response.model": "response-model-id",
             "gen_ai.response.streaming": False,
@@ -4233,6 +4273,7 @@ def test_ai_client_span_responses_api(
                 max_output_tokens=100,
                 temperature=0.7,
                 top_p=0.9,
+                reasoning={"effort": "high"},
             )
 
         spans = [item.payload for item in items]
@@ -4244,6 +4285,7 @@ def test_ai_client_span_responses_api(
             "gen_ai.request.max_tokens": 100,
             "gen_ai.request.temperature": 0.7,
             "gen_ai.request.top_p": 0.9,
+            "gen_ai.request.reasoning.level": "high",
             "gen_ai.system": "openai",
             "gen_ai.response.model": "response-model-id",
             "gen_ai.response.streaming": False,
@@ -4279,6 +4321,7 @@ def test_ai_client_span_responses_api(
                 max_output_tokens=100,
                 temperature=0.7,
                 top_p=0.9,
+                reasoning={"effort": "high"},
             )
 
         (transaction,) = events
@@ -4293,6 +4336,7 @@ def test_ai_client_span_responses_api(
             "gen_ai.request.max_tokens": 100,
             "gen_ai.request.temperature": 0.7,
             "gen_ai.request.top_p": 0.9,
+            "gen_ai.request.reasoning.level": "high",
             "gen_ai.system": "openai",
             "gen_ai.response.model": "response-model-id",
             "gen_ai.response.streaming": False,
@@ -4734,6 +4778,7 @@ async def test_ai_client_span_responses_async_api(
                 max_output_tokens=100,
                 temperature=0.7,
                 top_p=0.9,
+                reasoning={"effort": "high"},
             )
 
         sentry_sdk.flush()
@@ -4746,6 +4791,7 @@ async def test_ai_client_span_responses_async_api(
             "gen_ai.request.max_tokens": 100,
             "gen_ai.request.temperature": 0.7,
             "gen_ai.request.top_p": 0.9,
+            "gen_ai.request.reasoning.level": "high",
             "gen_ai.request.messages": safe_serialize(expected_request_messages),
             "gen_ai.request.model": "gpt-4o",
             "gen_ai.response.model": "response-model-id",
@@ -4781,6 +4827,7 @@ async def test_ai_client_span_responses_async_api(
                 max_output_tokens=100,
                 temperature=0.7,
                 top_p=0.9,
+                reasoning={"effort": "high"},
             )
 
         spans = [item.payload for item in items]
@@ -4792,6 +4839,7 @@ async def test_ai_client_span_responses_async_api(
             "gen_ai.request.max_tokens": 100,
             "gen_ai.request.temperature": 0.7,
             "gen_ai.request.top_p": 0.9,
+            "gen_ai.request.reasoning.level": "high",
             "gen_ai.request.messages": safe_serialize(expected_request_messages),
             "gen_ai.request.model": "gpt-4o",
             "gen_ai.response.model": "response-model-id",
@@ -4827,6 +4875,7 @@ async def test_ai_client_span_responses_async_api(
                 max_output_tokens=100,
                 temperature=0.7,
                 top_p=0.9,
+                reasoning={"effort": "high"},
             )
 
         (transaction,) = events
@@ -4841,6 +4890,7 @@ async def test_ai_client_span_responses_async_api(
             "gen_ai.request.max_tokens": 100,
             "gen_ai.request.temperature": 0.7,
             "gen_ai.request.top_p": 0.9,
+            "gen_ai.request.reasoning.level": "high",
             "gen_ai.request.messages": safe_serialize(expected_request_messages[-1:]),
             "gen_ai.request.model": "gpt-4o",
             "gen_ai.response.model": "response-model-id",
@@ -5059,6 +5109,7 @@ async def test_ai_client_span_streaming_responses_async_api(
                 max_output_tokens=100,
                 temperature=0.7,
                 top_p=0.9,
+                reasoning={"effort": "high"},
             )
             async for _ in result:
                 pass
@@ -5079,6 +5130,7 @@ async def test_ai_client_span_streaming_responses_async_api(
             "gen_ai.request.messages": safe_serialize(expected_request_messages),
             "gen_ai.request.temperature": 0.7,
             "gen_ai.request.top_p": 0.9,
+            "gen_ai.request.reasoning.level": "high",
             "gen_ai.response.model": "response-model-id",
             "gen_ai.response.streaming": True,
             "gen_ai.system": "openai",
@@ -5120,6 +5172,7 @@ async def test_ai_client_span_streaming_responses_async_api(
                 max_output_tokens=100,
                 temperature=0.7,
                 top_p=0.9,
+                reasoning={"effort": "high"},
             )
             async for _ in result:
                 pass
@@ -5138,6 +5191,7 @@ async def test_ai_client_span_streaming_responses_async_api(
             "gen_ai.request.messages": safe_serialize(expected_request_messages[-1:]),
             "gen_ai.request.temperature": 0.7,
             "gen_ai.request.top_p": 0.9,
+            "gen_ai.request.reasoning.level": "high",
             "gen_ai.response.model": "response-model-id",
             "gen_ai.response.streaming": True,
             "gen_ai.system": "openai",
@@ -5384,6 +5438,7 @@ def test_streaming_responses_api(
                 max_output_tokens=100,
                 temperature=0.7,
                 top_p=0.9,
+                reasoning={"effort": "high"},
             )
 
             response_string = ""
@@ -5400,6 +5455,7 @@ def test_streaming_responses_api(
         assert span["attributes"][SPANDATA.GEN_AI_REQUEST_MAX_TOKENS] == 100
         assert span["attributes"][SPANDATA.GEN_AI_REQUEST_TEMPERATURE] == 0.7
         assert span["attributes"][SPANDATA.GEN_AI_REQUEST_TOP_P] == 0.9
+        assert span["attributes"][SPANDATA.GEN_AI_REQUEST_REASONING_LEVEL] == "high"
 
         assert span["attributes"][SPANDATA.GEN_AI_RESPONSE_MODEL] == "response-model-id"
 
@@ -5428,6 +5484,7 @@ def test_streaming_responses_api(
                 max_output_tokens=100,
                 temperature=0.7,
                 top_p=0.9,
+                reasoning={"effort": "high"},
             )
 
             response_string = ""
@@ -5444,6 +5501,7 @@ def test_streaming_responses_api(
         assert span["data"][SPANDATA.GEN_AI_REQUEST_MAX_TOKENS] == 100
         assert span["data"][SPANDATA.GEN_AI_REQUEST_TEMPERATURE] == 0.7
         assert span["data"][SPANDATA.GEN_AI_REQUEST_TOP_P] == 0.9
+        assert span["data"][SPANDATA.GEN_AI_REQUEST_REASONING_LEVEL] == "high"
 
         assert span["data"][SPANDATA.GEN_AI_RESPONSE_MODEL] == "response-model-id"
 
@@ -5512,6 +5570,7 @@ async def test_streaming_responses_api_async(
                 max_output_tokens=100,
                 temperature=0.7,
                 top_p=0.9,
+                reasoning={"effort": "high"},
             )
 
             response_string = ""
@@ -5528,6 +5587,7 @@ async def test_streaming_responses_api_async(
         assert span["attributes"][SPANDATA.GEN_AI_REQUEST_MAX_TOKENS] == 100
         assert span["attributes"][SPANDATA.GEN_AI_REQUEST_TEMPERATURE] == 0.7
         assert span["attributes"][SPANDATA.GEN_AI_REQUEST_TOP_P] == 0.9
+        assert span["attributes"][SPANDATA.GEN_AI_REQUEST_REASONING_LEVEL] == "high"
 
         assert span["attributes"][SPANDATA.GEN_AI_RESPONSE_MODEL] == "response-model-id"
 
@@ -5556,6 +5616,7 @@ async def test_streaming_responses_api_async(
                 max_output_tokens=100,
                 temperature=0.7,
                 top_p=0.9,
+                reasoning={"effort": "high"},
             )
 
             response_string = ""
@@ -5572,6 +5633,7 @@ async def test_streaming_responses_api_async(
         assert span["data"][SPANDATA.GEN_AI_REQUEST_MAX_TOKENS] == 100
         assert span["data"][SPANDATA.GEN_AI_REQUEST_TEMPERATURE] == 0.7
         assert span["data"][SPANDATA.GEN_AI_REQUEST_TOP_P] == 0.9
+        assert span["data"][SPANDATA.GEN_AI_REQUEST_REASONING_LEVEL] == "high"
 
         assert span["data"][SPANDATA.GEN_AI_RESPONSE_MODEL] == "response-model-id"
 

--- a/tests/integrations/openai/test_openai.py
+++ b/tests/integrations/openai/test_openai.py
@@ -5666,6 +5666,96 @@ def test_empty_tools_in_chat_completion(
         assert "gen_ai.request.available_tools" not in span["data"]
 
 
+@pytest.mark.parametrize("span_streaming", [True, False])
+@pytest.mark.parametrize("stream_gen_ai_spans", [True, False])
+# Feature added in https://github.com/openai/openai-python/pull/1952
+@pytest.mark.skipif(
+    OPENAI_VERSION < (1, 58, 0),
+    reason="OpenAI versions <1.58.0 do not support the reasoning_effort parameter.",
+)
+@pytest.mark.parametrize(
+    "reasoning_effort,expected_level",
+    [
+        pytest.param(omit, None, id="omit"),
+        pytest.param(None, None, id="none"),
+        pytest.param("high", "high", id="high"),
+        pytest.param("minimal", "minimal", id="minimal"),
+    ],
+)
+def test_chat_completion_reasoning_level(
+    sentry_init,
+    capture_events,
+    capture_items,
+    reasoning_effort,
+    expected_level,
+    nonstreaming_chat_completions_model_response,
+    stream_gen_ai_spans,
+    span_streaming,
+):
+    sentry_init(
+        integrations=[OpenAIIntegration()],
+        disabled_integrations=[StdlibIntegration],
+        traces_sample_rate=1.0,
+        stream_gen_ai_spans=stream_gen_ai_spans,
+        trace_lifecycle="stream" if span_streaming else "static",
+    )
+
+    client = OpenAI(api_key="z")
+    client.chat.completions._post = mock.Mock(
+        return_value=nonstreaming_chat_completions_model_response(
+            response_id="chat-id",
+            response_model="gpt-3.5-turbo",
+            message_content="the model response",
+            created=10000000,
+            usage=CompletionUsage(
+                prompt_tokens=20,
+                completion_tokens=10,
+                total_tokens=30,
+            ),
+        )
+    )
+
+    if span_streaming or stream_gen_ai_spans:
+        items = capture_items("span")
+
+        with start_transaction(name="openai tx"):
+            client.chat.completions.create(
+                model="some-model",
+                messages=[{"role": "system", "content": "hello"}],
+                reasoning_effort=reasoning_effort,
+            )
+
+        sentry_sdk.flush()
+        span = next(item.payload for item in items if item.type == "span")
+
+        if expected_level is None:
+            assert SPANDATA.GEN_AI_REQUEST_REASONING_LEVEL not in span["attributes"]
+        else:
+            assert (
+                span["attributes"][SPANDATA.GEN_AI_REQUEST_REASONING_LEVEL]
+                == expected_level
+            )
+    else:
+        events = capture_events()
+
+        with start_transaction(name="openai tx"):
+            client.chat.completions.create(
+                model="some-model",
+                messages=[{"role": "system", "content": "hello"}],
+                reasoning_effort=reasoning_effort,
+            )
+
+        (event,) = events
+        span = event["spans"][0]
+
+        if expected_level is None:
+            assert SPANDATA.GEN_AI_REQUEST_REASONING_LEVEL not in span["data"]
+        else:
+            assert (
+                span["data"][SPANDATA.GEN_AI_REQUEST_REASONING_LEVEL] == expected_level
+            )
+
+
 # Test messages with mixed roles including "ai" that should be mapped to "assistant"
 @pytest.mark.parametrize("span_streaming", [True, False])
 @pytest.mark.parametrize("stream_gen_ai_spans", [True, False])

--- a/tests/integrations/openai/test_openai.py
+++ b/tests/integrations/openai/test_openai.py
@@ -167,7 +167,6 @@ def test_nonstreaming_chat_completion_no_prompts(
                     frequency_penalty=0.2,
                     temperature=0.7,
                     top_p=0.9,
-                    reasoning_effort="high",
                 )
                 .choices[0]
                 .message.content
@@ -186,7 +185,6 @@ def test_nonstreaming_chat_completion_no_prompts(
         assert span["attributes"][SPANDATA.GEN_AI_REQUEST_FREQUENCY_PENALTY] == 0.2
         assert span["attributes"][SPANDATA.GEN_AI_REQUEST_TEMPERATURE] == 0.7
         assert span["attributes"][SPANDATA.GEN_AI_REQUEST_TOP_P] == 0.9
-        assert span["attributes"][SPANDATA.GEN_AI_REQUEST_REASONING_LEVEL] == "high"
 
         assert SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS not in span["attributes"]
         assert SPANDATA.GEN_AI_REQUEST_MESSAGES not in span["attributes"]
@@ -211,7 +209,6 @@ def test_nonstreaming_chat_completion_no_prompts(
                     frequency_penalty=0.2,
                     temperature=0.7,
                     top_p=0.9,
-                    reasoning_effort="high",
                 )
                 .choices[0]
                 .message.content
@@ -231,7 +228,6 @@ def test_nonstreaming_chat_completion_no_prompts(
         assert span["data"][SPANDATA.GEN_AI_REQUEST_FREQUENCY_PENALTY] == 0.2
         assert span["data"][SPANDATA.GEN_AI_REQUEST_TEMPERATURE] == 0.7
         assert span["data"][SPANDATA.GEN_AI_REQUEST_TOP_P] == 0.9
-        assert span["data"][SPANDATA.GEN_AI_REQUEST_REASONING_LEVEL] == "high"
 
         assert SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS not in span["data"]
         assert SPANDATA.GEN_AI_REQUEST_MESSAGES not in span["data"]
@@ -369,7 +365,6 @@ def test_nonstreaming_chat_completion(
                     frequency_penalty=0.2,
                     temperature=0.7,
                     top_p=0.9,
-                    reasoning_effort="high",
                 )
                 .choices[0]
                 .message.content
@@ -388,7 +383,6 @@ def test_nonstreaming_chat_completion(
         assert span["attributes"][SPANDATA.GEN_AI_REQUEST_FREQUENCY_PENALTY] == 0.2
         assert span["attributes"][SPANDATA.GEN_AI_REQUEST_TEMPERATURE] == 0.7
         assert span["attributes"][SPANDATA.GEN_AI_REQUEST_TOP_P] == 0.9
-        assert span["attributes"][SPANDATA.GEN_AI_REQUEST_REASONING_LEVEL] == "high"
 
         assert (
             json.loads(span["attributes"][SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS])
@@ -418,7 +412,6 @@ def test_nonstreaming_chat_completion(
                     frequency_penalty=0.2,
                     temperature=0.7,
                     top_p=0.9,
-                    reasoning_effort="high",
                 )
                 .choices[0]
                 .message.content
@@ -438,7 +431,6 @@ def test_nonstreaming_chat_completion(
         assert span["data"][SPANDATA.GEN_AI_REQUEST_FREQUENCY_PENALTY] == 0.2
         assert span["data"][SPANDATA.GEN_AI_REQUEST_TEMPERATURE] == 0.7
         assert span["data"][SPANDATA.GEN_AI_REQUEST_TOP_P] == 0.9
-        assert span["data"][SPANDATA.GEN_AI_REQUEST_REASONING_LEVEL] == "high"
 
         assert (
             json.loads(span["data"][SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS])
@@ -513,7 +505,6 @@ async def test_nonstreaming_chat_completion_async_no_prompts(
                 frequency_penalty=0.2,
                 temperature=0.7,
                 top_p=0.9,
-                reasoning_effort="high",
             )
             response = response.choices[0].message.content
 
@@ -530,7 +521,6 @@ async def test_nonstreaming_chat_completion_async_no_prompts(
         assert span["attributes"][SPANDATA.GEN_AI_REQUEST_FREQUENCY_PENALTY] == 0.2
         assert span["attributes"][SPANDATA.GEN_AI_REQUEST_TEMPERATURE] == 0.7
         assert span["attributes"][SPANDATA.GEN_AI_REQUEST_TOP_P] == 0.9
-        assert span["attributes"][SPANDATA.GEN_AI_REQUEST_REASONING_LEVEL] == "high"
 
         assert SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS not in span["attributes"]
         assert SPANDATA.GEN_AI_REQUEST_MESSAGES not in span["attributes"]
@@ -554,7 +544,6 @@ async def test_nonstreaming_chat_completion_async_no_prompts(
                 frequency_penalty=0.2,
                 temperature=0.7,
                 top_p=0.9,
-                reasoning_effort="high",
             )
             response = response.choices[0].message.content
 
@@ -572,7 +561,6 @@ async def test_nonstreaming_chat_completion_async_no_prompts(
         assert span["data"][SPANDATA.GEN_AI_REQUEST_FREQUENCY_PENALTY] == 0.2
         assert span["data"][SPANDATA.GEN_AI_REQUEST_TEMPERATURE] == 0.7
         assert span["data"][SPANDATA.GEN_AI_REQUEST_TOP_P] == 0.9
-        assert span["data"][SPANDATA.GEN_AI_REQUEST_REASONING_LEVEL] == "high"
 
         assert SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS not in span["data"]
         assert SPANDATA.GEN_AI_REQUEST_MESSAGES not in span["data"]
@@ -710,7 +698,6 @@ async def test_nonstreaming_chat_completion_async(
                 frequency_penalty=0.2,
                 temperature=0.7,
                 top_p=0.9,
-                reasoning_effort="high",
             )
             response = response.choices[0].message.content
 
@@ -727,7 +714,6 @@ async def test_nonstreaming_chat_completion_async(
         assert span["attributes"][SPANDATA.GEN_AI_REQUEST_FREQUENCY_PENALTY] == 0.2
         assert span["attributes"][SPANDATA.GEN_AI_REQUEST_TEMPERATURE] == 0.7
         assert span["attributes"][SPANDATA.GEN_AI_REQUEST_TOP_P] == 0.9
-        assert span["attributes"][SPANDATA.GEN_AI_REQUEST_REASONING_LEVEL] == "high"
 
         assert (
             json.loads(span["attributes"][SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS])
@@ -756,7 +742,6 @@ async def test_nonstreaming_chat_completion_async(
                 frequency_penalty=0.2,
                 temperature=0.7,
                 top_p=0.9,
-                reasoning_effort="high",
             )
             response = response.choices[0].message.content
 
@@ -774,7 +759,6 @@ async def test_nonstreaming_chat_completion_async(
         assert span["data"][SPANDATA.GEN_AI_REQUEST_FREQUENCY_PENALTY] == 0.2
         assert span["data"][SPANDATA.GEN_AI_REQUEST_TEMPERATURE] == 0.7
         assert span["data"][SPANDATA.GEN_AI_REQUEST_TOP_P] == 0.9
-        assert span["data"][SPANDATA.GEN_AI_REQUEST_REASONING_LEVEL] == "high"
 
         assert (
             json.loads(span["data"][SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS])
@@ -902,7 +886,6 @@ def test_streaming_chat_completion_no_prompts(
                 frequency_penalty=0.2,
                 temperature=0.7,
                 top_p=0.9,
-                reasoning_effort="high",
             )
             response_string = "".join(
                 map(lambda x: x.choices[0].delta.content, response_stream)
@@ -921,7 +904,6 @@ def test_streaming_chat_completion_no_prompts(
         assert span["attributes"][SPANDATA.GEN_AI_REQUEST_FREQUENCY_PENALTY] == 0.2
         assert span["attributes"][SPANDATA.GEN_AI_REQUEST_TEMPERATURE] == 0.7
         assert span["attributes"][SPANDATA.GEN_AI_REQUEST_TOP_P] == 0.9
-        assert span["attributes"][SPANDATA.GEN_AI_REQUEST_REASONING_LEVEL] == "high"
 
         assert span["attributes"][SPANDATA.GEN_AI_RESPONSE_MODEL] == "model-id"
 
@@ -957,7 +939,6 @@ def test_streaming_chat_completion_no_prompts(
                 frequency_penalty=0.2,
                 temperature=0.7,
                 top_p=0.9,
-                reasoning_effort="high",
             )
             response_string = "".join(
                 map(lambda x: x.choices[0].delta.content, response_stream)
@@ -977,7 +958,6 @@ def test_streaming_chat_completion_no_prompts(
         assert span["data"][SPANDATA.GEN_AI_REQUEST_FREQUENCY_PENALTY] == 0.2
         assert span["data"][SPANDATA.GEN_AI_REQUEST_TEMPERATURE] == 0.7
         assert span["data"][SPANDATA.GEN_AI_REQUEST_TOP_P] == 0.9
-        assert span["data"][SPANDATA.GEN_AI_REQUEST_REASONING_LEVEL] == "high"
 
         assert span["data"][SPANDATA.GEN_AI_RESPONSE_MODEL] == "model-id"
 
@@ -1600,7 +1580,6 @@ def test_streaming_chat_completion(
                 frequency_penalty=0.2,
                 temperature=0.7,
                 top_p=0.9,
-                reasoning_effort="high",
             )
             response_string = "".join(
                 map(lambda x: x.choices[0].delta.content, response_stream)
@@ -1618,7 +1597,6 @@ def test_streaming_chat_completion(
         assert span["attributes"][SPANDATA.GEN_AI_REQUEST_FREQUENCY_PENALTY] == 0.2
         assert span["attributes"][SPANDATA.GEN_AI_REQUEST_TEMPERATURE] == 0.7
         assert span["attributes"][SPANDATA.GEN_AI_REQUEST_TOP_P] == 0.9
-        assert span["attributes"][SPANDATA.GEN_AI_REQUEST_REASONING_LEVEL] == "high"
 
         assert (
             json.loads(span["attributes"][SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS])
@@ -1668,7 +1646,6 @@ def test_streaming_chat_completion(
                 frequency_penalty=0.2,
                 temperature=0.7,
                 top_p=0.9,
-                reasoning_effort="high",
             )
             response_string = "".join(
                 map(lambda x: x.choices[0].delta.content, response_stream)
@@ -1687,7 +1664,6 @@ def test_streaming_chat_completion(
         assert span["data"][SPANDATA.GEN_AI_REQUEST_FREQUENCY_PENALTY] == 0.2
         assert span["data"][SPANDATA.GEN_AI_REQUEST_TEMPERATURE] == 0.7
         assert span["data"][SPANDATA.GEN_AI_REQUEST_TOP_P] == 0.9
-        assert span["data"][SPANDATA.GEN_AI_REQUEST_REASONING_LEVEL] == "high"
 
         assert (
             json.loads(span["data"][SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS])
@@ -1821,7 +1797,6 @@ async def test_streaming_chat_completion_async_no_prompts(
                 frequency_penalty=0.2,
                 temperature=0.7,
                 top_p=0.9,
-                reasoning_effort="high",
             )
 
             response_string = ""
@@ -1841,7 +1816,6 @@ async def test_streaming_chat_completion_async_no_prompts(
         assert span["attributes"][SPANDATA.GEN_AI_REQUEST_FREQUENCY_PENALTY] == 0.2
         assert span["attributes"][SPANDATA.GEN_AI_REQUEST_TEMPERATURE] == 0.7
         assert span["attributes"][SPANDATA.GEN_AI_REQUEST_TOP_P] == 0.9
-        assert span["attributes"][SPANDATA.GEN_AI_REQUEST_REASONING_LEVEL] == "high"
 
         assert span["attributes"][SPANDATA.GEN_AI_RESPONSE_MODEL] == "model-id"
 
@@ -1878,7 +1852,6 @@ async def test_streaming_chat_completion_async_no_prompts(
                 frequency_penalty=0.2,
                 temperature=0.7,
                 top_p=0.9,
-                reasoning_effort="high",
             )
 
             response_string = ""
@@ -1899,7 +1872,6 @@ async def test_streaming_chat_completion_async_no_prompts(
         assert span["data"][SPANDATA.GEN_AI_REQUEST_FREQUENCY_PENALTY] == 0.2
         assert span["data"][SPANDATA.GEN_AI_REQUEST_TEMPERATURE] == 0.7
         assert span["data"][SPANDATA.GEN_AI_REQUEST_TOP_P] == 0.9
-        assert span["data"][SPANDATA.GEN_AI_REQUEST_REASONING_LEVEL] == "high"
 
         assert span["data"][SPANDATA.GEN_AI_RESPONSE_MODEL] == "model-id"
 
@@ -2102,7 +2074,6 @@ async def test_streaming_chat_completion_async(
                 frequency_penalty=0.2,
                 temperature=0.7,
                 top_p=0.9,
-                reasoning_effort="high",
             )
 
             response_string = ""
@@ -2122,7 +2093,6 @@ async def test_streaming_chat_completion_async(
         assert span["attributes"][SPANDATA.GEN_AI_REQUEST_FREQUENCY_PENALTY] == 0.2
         assert span["attributes"][SPANDATA.GEN_AI_REQUEST_TEMPERATURE] == 0.7
         assert span["attributes"][SPANDATA.GEN_AI_REQUEST_TOP_P] == 0.9
-        assert span["attributes"][SPANDATA.GEN_AI_REQUEST_REASONING_LEVEL] == "high"
 
         assert span["attributes"][SPANDATA.GEN_AI_RESPONSE_MODEL] == "model-id"
 
@@ -2172,7 +2142,6 @@ async def test_streaming_chat_completion_async(
                 frequency_penalty=0.2,
                 temperature=0.7,
                 top_p=0.9,
-                reasoning_effort="high",
             )
 
             response_string = ""
@@ -2193,7 +2162,6 @@ async def test_streaming_chat_completion_async(
         assert span["data"][SPANDATA.GEN_AI_REQUEST_FREQUENCY_PENALTY] == 0.2
         assert span["data"][SPANDATA.GEN_AI_REQUEST_TEMPERATURE] == 0.7
         assert span["data"][SPANDATA.GEN_AI_REQUEST_TOP_P] == 0.9
-        assert span["data"][SPANDATA.GEN_AI_REQUEST_REASONING_LEVEL] == "high"
 
         assert span["data"][SPANDATA.GEN_AI_RESPONSE_MODEL] == "model-id"
 
@@ -5725,7 +5693,7 @@ def test_empty_tools_in_chat_completion(
 @pytest.mark.parametrize("stream_gen_ai_spans", [True, False])
 # Feature added in https://github.com/openai/openai-python/pull/1952
 @pytest.mark.skipif(
-    OPENAI_VERSION < (1, 58, 0),
+    OPENAI_VERSION is None or OPENAI_VERSION < (1, 58, 0),
     reason="OpenAI versions <1.58.0 do not support the reasoning_effort parameter.",
 )
 @pytest.mark.parametrize(


### PR DESCRIPTION
### Description
Add `gen_ai.request.reasoning.level` to OpenAI spans for:
- Responses API via `reasoning.effort`
- Chat Completions API via `reasoning_effort`

#### Issues
Refs: #6877 & #6878; PY-2620 & PY-2621

#### Reminders
- Please add tests to validate your changes, and lint your code using `uv run ruff`.
- Add GH Issue ID _&_ Linear ID (if applicable)
- PR title should use [conventional commit](https://develop.sentry.dev/engineering-practices/commit-messages/#type) style (`feat:`, `fix:`, `ref:`, `meta:`)
- For external contributors: [CONTRIBUTING.md](https://github.com/getsentry/sentry-python/blob/master/CONTRIBUTING.md), [Sentry SDK development docs](https://develop.sentry.dev/sdk/), [Discord community](https://discord.gg/Ww9hbqr)
