### PR TITLE
fix: Avoid `IndexError` in `match_regex_list()`

### DIFF
--- a/sentry_sdk/utils.py
+++ b/sentry_sdk/utils.py
@@ -1736,7 +1736,7 @@ def match_regex_list(
         return False
 
     for item_matcher in regex_list:
-        if not substring_matching and item_matcher[-1] != "$":
+        if not substring_matching and (not item_matcher or item_matcher[-1] != "$"):
             item_matcher += "$"
 
         matched = re.search(item_matcher, item)


### PR DESCRIPTION
### Description
<!-- What changed and why? -->

This approach still allows matching empty strings.

#### Issues

Closes https://github.com/getsentry/sentry-python/issues/6504

#### Reminders
- Please add tests to validate your changes, and lint your code using `uv run ruff`.
- Add GH Issue ID _&_ Linear ID (if applicable)
- PR title should use [conventional commit](https://develop.sentry.dev/engineering-practices/commit-messages/#type) style (`feat:`, `fix:`, `ref:`, `meta:`)
- For external contributors: [CONTRIBUTING.md](https://github.com/getsentry/sentry-python/blob/master/CONTRIBUTING.md), [Sentry SDK development docs](https://develop.sentry.dev/sdk/), [Discord community](https://discord.gg/Ww9hbqr)
