### PR TITLE
feat(api): Add top-level `set_attributes` API

### DIFF
--- a/sentry_sdk/__init__.py
+++ b/sentry_sdk/__init__.py
@@ -40,6 +40,7 @@ __all__ = [  # noqa
     "push_scope",
     "remove_attribute",
     "set_attribute",
+    "set_attributes",
     "set_context",
     "set_extra",
     "set_level",

--- a/sentry_sdk/api.py
+++ b/sentry_sdk/api.py
@@ -76,6 +76,7 @@ __all__ = [
     "push_scope",
     "remove_attribute",
     "set_attribute",
+    "set_attributes",
     "set_context",
     "set_extra",
     "set_level",
@@ -298,10 +299,21 @@ def set_attribute(attribute: str, value: "Any") -> None:
     """
     Set an attribute.
 
-    Any attributes-based telemetry (logs, metrics) captured in this scope will
-    include this attribute.
+    Any attributes-based telemetry (logs, metrics, streamed spans) captured in
+    this scope will include this attribute.
     """
     return get_isolation_scope().set_attribute(attribute, value)
+
+
+@scopemethod
+def set_attributes(attributes: "dict[str, Any]") -> None:
+    """
+    Set multiple attributes.
+
+    Any attributes-based telemetry (logs, metrics, streamed spans) captured in
+    this scope will include these attributes.
+    """
+    return get_isolation_scope().set_attributes(attributes)
 
 
 @scopemethod

--- a/sentry_sdk/scope.py
+++ b/sentry_sdk/scope.py
@@ -2040,7 +2040,7 @@ class Scope:
         while this scope is active will inherit attributes set on the scope.
         """
         for attribute, value in attributes.items():
-            self._attributes[attribute] = format_attribute(value)
+            self.set_attribute(attribute, value)
 
     def remove_attribute(self, attribute: str) -> None:
         """Remove an attribute if set on the scope. No-op if there is no such attribute."""

--- a/sentry_sdk/scope.py
+++ b/sentry_sdk/scope.py
@@ -2027,10 +2027,20 @@ class Scope:
         """
         Set an attribute on the scope.
 
-        Any attributes-based telemetry (logs, metrics) captured while this scope
-        is active will inherit attributes set on the scope.
+        Any attributes-based telemetry (logs, metrics, streamed spans) captured
+        while this scope is active will inherit attributes set on the scope.
         """
         self._attributes[attribute] = format_attribute(value)
+
+    def set_attributes(self, attributes: "dict[str, AttributeValue]") -> None:
+        """
+        Set multiple attributes on the scope.
+
+        Any attributes-based telemetry (logs, metrics, streamed spans) captured
+        while this scope is active will inherit attributes set on the scope.
+        """
+        for attribute, value in attributes.items():
+            self._attributes[attribute] = format_attribute(value)
 
     def remove_attribute(self, attribute: str) -> None:
         """Remove an attribute if set on the scope. No-op if there is no such attribute."""

--- a/tests/test_attributes.py
+++ b/tests/test_attributes.py
@@ -7,8 +7,16 @@ def test_top_level_api(sentry_init, capture_items):
     items = capture_items("trace_metric")
 
     sentry_sdk.set_attribute("set", "value")
+    sentry_sdk.set_attributes(
+        {
+            "set1": "value1",
+            "set2": "value2",
+            "discarded": 47,
+        }
+    )
     sentry_sdk.set_attribute("removed", "value")
     sentry_sdk.remove_attribute("removed")
+    sentry_sdk.remove_attribute("discarded")
     # Attempting to remove a nonexistent attribute should not raise
     sentry_sdk.remove_attribute("nonexistent")
 
@@ -19,7 +27,10 @@ def test_top_level_api(sentry_init, capture_items):
     (metric,) = metrics
 
     assert metric["attributes"]["set"] == "value"
+    assert metric["attributes"]["set1"] == "value1"
+    assert metric["attributes"]["set2"] == "value2"
     assert "removed" not in metric["attributes"]
+    assert "discarded" not in metric["attributes"]
 
 
 def test_scope_precedence(sentry_init, capture_items):


### PR DESCRIPTION
### Description
Streamed spans have both a `set_attribute` as well as a `set_attributes` API.

On the top level, for setting attributes on the scope, we only have `set_attribute`. This is a bit confusing.

Align the two APIs by adding the missing top-level `set_attributes`.

See also [dev docs](https://develop.sentry.dev/sdk/foundations/state-management/scopes/attributes/#python).

#### Issues
<!--
* resolves: #1234
* resolves: LIN-1234
-->

#### Reminders
- Please add tests to validate your changes, and lint your code using `uv run ruff`.
- Add GH Issue ID _&_ Linear ID (if applicable)
- PR title should use [conventional commit](https://develop.sentry.dev/engineering-practices/commit-messages/#type) style (`feat:`, `fix:`, `ref:`, `meta:`)
- For external contributors: [CONTRIBUTING.md](https://github.com/getsentry/sentry-python/blob/master/CONTRIBUTING.md), [Sentry SDK development docs](https://develop.sentry.dev/sdk/), [Discord community](https://discord.gg/Ww9hbqr)
