### PR TITLE
feat(aws-lambda): Enable Python 3.14 support to the Lambda layer

### DIFF
--- a/.craft.yml
+++ b/.craft.yml
@@ -1,4 +1,4 @@
-minVersion: 2.21.1
+minVersion: 2.28.0
 preReleaseCommand: bash scripts/bump-version.sh
 targets:
   - name: pypi

--- a/.craft.yml
+++ b/.craft.yml
@@ -28,6 +28,11 @@ targets:
           - python3.11
           - python3.12
           - python3.13
+          - python3.14
+    compatibleArchitectures:
+      # Both x86_64 and arm64 are supported by default; explicitly listing for better visibility
+      - x86_64
+      - arm64
     license: MIT
   - name: sentry-pypi
     internalPypiRepo: getsentry/pypi

--- a/.craft.yml
+++ b/.craft.yml
@@ -12,6 +12,8 @@ targets:
     # This regex that matches the version is taken from craft:
     # https://github.com/getsentry/craft/blob/8d77c38ddbe4be59f98f61b6e42952ca087d3acd/src/utils/version.ts#L11
     includeNames: /^sentry-python-serverless-\bv?(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(?:-?([\da-z-]+(?:\.[\da-z-]+)*))?(?:\+([\da-z-]+(?:\.[\da-z-]+)*))?\b.zip$/
+    # If we ever want per-major layer names like JavaScript's
+    # SentryNodeServerlessSDKv10:84, craft supports {{{major}}} templating.
     layerName: SentryPythonServerlessSDK
     compatibleRuntimes:
       - name: python

--- a/scripts/aws/aws-configure-layer-on-lambda-function.sh
+++ b/scripts/aws/aws-configure-layer-on-lambda-function.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+#
+# Attach the layer first with: ./scripts/aws/aws-attach-layer-to-lambda-function.sh
+#
+# Replaces handler, SENTRY_DSN, SENTRY_INITIAL_HANDLER and SENTRY_TRACES_SAMPLE_RATE.
+
+# Usage: ./scripts/aws/aws-configure-layer-on-lambda-function.sh <lambda-function-name> <dsn> <region (optional)>
+
+set -euo pipefail
+
+if [ $# -lt 2 ] || [ $# -gt 3 ]; then
+	SCRIPT_NAME=$(basename "$0")
+	echo "ERROR: Missing arguments."
+	echo "Usage: $SCRIPT_NAME <lambda-function-name> <dsn> <region (optional)>"
+	exit 1
+fi
+
+FUNCTION_NAME=$1
+DSN=$2
+SENTRY_HANDLER="sentry_sdk.integrations.init_serverless_sdk.sentry_lambda_handler"
+REGION=${3:-"eu-north-1"}
+TRACES_SAMPLE_RATE="1.0"
+
+echo "Fetching current configuration for function '$FUNCTION_NAME'..."
+CONFIG=$(aws lambda get-function-configuration \
+	--function-name "$FUNCTION_NAME" \
+	--region "$REGION" \
+	--no-cli-pager)
+CURRENT_HANDLER=$(echo "$CONFIG" | jq -r '.Handler')
+
+if [ "$CURRENT_HANDLER" = "$SENTRY_HANDLER" ]; then
+	INITIAL_HANDLER=$(echo "$CONFIG" | jq -r '.Environment.Variables.SENTRY_INITIAL_HANDLER // empty')
+	if [ -z "$INITIAL_HANDLER" ] || [ "$INITIAL_HANDLER" = "$SENTRY_HANDLER" ]; then
+		echo "Handler is already set to '$SENTRY_HANDLER' but SENTRY_INITIAL_HANDLER is missing or points at it."
+		echo "Set SENTRY_INITIAL_HANDLER to real handler first."
+		exit 1
+	fi
+	echo "SENTRY_INITIAL_HANDLER already set to $INITIAL_HANDLER."
+else
+	INITIAL_HANDLER=$CURRENT_HANDLER
+fi
+
+ENV_JSON=$(echo "$CONFIG" | jq -c \
+	--arg dsn "$DSN" \
+	--arg initial "$INITIAL_HANDLER" \
+	--arg traces_sample_rate "$TRACES_SAMPLE_RATE" \
+	'
+    ((.Environment.Variables // {})
+     | del(.SENTRY_DSN, .SENTRY_INITIAL_HANDLER, .SENTRY_TRACES_SAMPLE_RATE))
+    + {
+        SENTRY_DSN: $dsn,
+        SENTRY_INITIAL_HANDLER: $initial,
+        SENTRY_TRACES_SAMPLE_RATE: $traces_sample_rate
+    }
+    | {Variables: .}
+    ')
+
+echo "Updating function configuration..."
+aws lambda update-function-configuration \
+	--function-name "$FUNCTION_NAME" \
+	--region "$REGION" \
+	--handler "$SENTRY_HANDLER" \
+	--environment "$ENV_JSON" \
+	--no-cli-pager

--- a/scripts/aws/aws-deploy-local-layer.sh
+++ b/scripts/aws/aws-deploy-local-layer.sh
@@ -9,7 +9,8 @@ set -euo pipefail
 
 # Creating Lambda layer
 echo "Creating Lambda layer in ./dist ..."
-make aws-lambda-layer
+uv build
+uv run --group aws --with-editable . python scripts/build_aws_lambda_layer.py
 echo "Done creating Lambda layer in ./dist"
 
 # Deploying zipped Lambda layer to AWS
@@ -17,12 +18,14 @@ ZIP=$(ls dist | grep serverless | head -n 1)
 echo "Deploying zipped Lambda layer $ZIP to AWS..."
 
 aws lambda publish-layer-version \
-    --layer-name "SentryPythonServerlessSDK-local-dev" \
-    --region "eu-central-1" \
-    --zip-file "fileb://dist/$ZIP" \
-    --description "Local test build of SentryPythonServerlessSDK (can be deleted)" \
-    --compatible-runtimes python3.7 python3.8 python3.9 python3.10 python3.11 \
-    --no-cli-pager
+	--layer-name "SentryPythonServerlessSDK-local-dev" \
+	--region "eu-central-1" \
+	--zip-file "fileb://dist/$ZIP" \
+	--description "Local test build of SentryPythonServerlessSDK (can be deleted)" \
+	--compatible-runtimes python3.7 python3.8 python3.9 python3.10 python3.11 python3.12 python3.13 python3.14 \
+	--compatible-architectures x86_64 arm64 \
+	--license-info "MIT" \
+	--no-cli-pager
 
 echo "Done deploying zipped Lambda layer to AWS as 'SentryPythonServerlessSDK-local-dev'."
 


### PR DESCRIPTION
### Description
Adds `python3.14` to the AWS Lambda layer compatible runtimes in `.craft.yml`, and declares `x86-64` / `arm64` architectures. Also updated/fixed broken scripts for ease of testing in the future:
* Added `aws-configure-layer-on-lambda-function.sh`: setup sentry handler and required env vars after attaching the layer with `aws-deploy-local-layer.sh`.

Verified that it works with layer built from this branch (`arn:aws:lambda:eu-north-1:431451851189:layer:SentryPythonServerlessSDK-local-dev:3`):
* [py3.14 & arm64 trace](https://pablotest-nd.sentry.io/explore/traces/trace/adba4a6e642f4b24a5cb63a17cf0463a/?node=span-ad464a1513c944c5&project=4511789445021776&source=traces&statsPeriod=24h&targetId=ad464a1513c944c5&timestamp=1785244588)
* [py3.14 & arm64 issue (public)](https://pablotest-nd.sentry.io/share/issue/4cc994b7f3ea41a2864fcc0dafaecd02/)
* [py3.14 & x86-64 runtime trace](https://pablotest-nd.sentry.io/explore/traces/trace/c6bb43fe9bbd408193276602c3122791/?node=span-a0835b0a6f85ec1a&project=4511789445021776&source=traces&statsPeriod=24h&targetId=a0835b0a6f85ec1a&timestamp=1785244573)
* [py3.14 & x86-64 issue (public)](https://pablotest-nd.sentry.io/share/issue/347edf9075b14da89b52e0fe709b523d/)


#### Issues
* resolves: #6908
* resolves: PY-2629

#### Reminders
- Please add tests to validate your changes, and lint your code using `uv run ruff`.
- Add GH Issue ID _&_ Linear ID (if applicable)
- PR title should use [conventional commit](https://develop.sentry.dev/engineering-practices/commit-messages/#type) style (`feat:`, `fix:`, `ref:`, `meta:`)
- For external contributors: [CONTRIBUTING.md](https://github.com/getsentry/sentry-python/blob/master/CONTRIBUTING.md), [Sentry SDK development docs](https://develop.sentry.dev/sdk/), [Discord community](https://discord.gg/Ww9hbqr)
