### PR TITLE
feat(huey): Respect data_collection.queues option for task args/kwargs

### DIFF
--- a/sentry_sdk/integrations/huey.py
+++ b/sentry_sdk/integrations/huey.py
@@ -20,6 +20,7 @@ from sentry_sdk.utils import (
     capture_internal_exceptions,
     ensure_integration_enabled,
     event_from_exception,
+    has_data_collection_enabled,
     reraise,
 )
 
@@ -133,20 +134,25 @@ def _make_event_processor(task: "Any") -> "EventProcessor":
             tags["huey_task_id"] = task.id
             tags["huey_task_retry"] = task.default_retries > task.retries
             extra = event.setdefault("extra", {})
-            extra["huey-job"] = {
+
+            huey_job = {
                 "task": task.name,
-                "args": (
-                    task.args
-                    if should_send_default_pii()
-                    else SENSITIVE_DATA_SUBSTITUTE
-                ),
-                "kwargs": (
-                    task.kwargs
-                    if should_send_default_pii()
-                    else SENSITIVE_DATA_SUBSTITUTE
-                ),
                 "retry": (task.default_retries or 0) - task.retries,
             }
+
+            client_options = sentry_sdk.get_client().options
+            if has_data_collection_enabled(client_options):
+                if client_options["data_collection"]["queues"]:
+                    huey_job["args"] = task.args
+                    huey_job["kwargs"] = task.kwargs
+            elif should_send_default_pii():
+                huey_job["args"] = task.args
+                huey_job["kwargs"] = task.kwargs
+            else:
+                huey_job["args"] = SENSITIVE_DATA_SUBSTITUTE
+                huey_job["kwargs"] = SENSITIVE_DATA_SUBSTITUTE
+
+            extra["huey-job"] = huey_job
 
         return event
 

--- a/tests/integrations/huey/test_huey.py
+++ b/tests/integrations/huey/test_huey.py
@@ -10,7 +10,7 @@ from sentry_sdk import start_transaction
 from sentry_sdk.consts import OP, SPANDATA
 from sentry_sdk.integrations.huey import HueyIntegration
 from sentry_sdk.traces import SegmentNameSource, SpanStatus
-from sentry_sdk.utils import parse_version
+from sentry_sdk.utils import SENSITIVE_DATA_SUBSTITUTE, parse_version
 
 HUEY_VERSION = parse_version(HUEY_VERSION)
 
@@ -23,13 +23,15 @@ except ImportError:
 
 @pytest.fixture
 def init_huey(sentry_init):
-    def inner(has_span_streaming=None):
-        sentry_init(
-            integrations=[HueyIntegration()],
-            traces_sample_rate=1.0,
-            send_default_pii=True,
-            trace_lifecycle="stream" if has_span_streaming else "static",
-        )
+    def inner(has_span_streaming=None, init_kwargs=None):
+        sentry_init_kwargs = {
+            "integrations": [HueyIntegration()],
+            "traces_sample_rate": 1.0,
+            "send_default_pii": True,
+            "trace_lifecycle": "stream" if has_span_streaming else "static",
+        }
+        sentry_init_kwargs.update(init_kwargs or {})
+        sentry_init(**sentry_init_kwargs)
 
         return MemoryHuey(name="sentry_sdk")
 
@@ -295,6 +297,92 @@ def test_task_lock(
             else event["contexts"]["trace"]["status"] == "ok"
         )
     assert len(huey) == 0
+
+
+@pytest.mark.parametrize(
+    "init_kwargs,expected_args,expected_kwargs",
+    [
+        pytest.param(
+            {"_experiments": {"data_collection": {}}},
+            [1],
+            {"b": 0},
+            id="data_collection_default",
+        ),
+        pytest.param(
+            {"_experiments": {"data_collection": {"queues": True}}},
+            [1],
+            {"b": 0},
+            id="data_collection_queues_on",
+        ),
+        pytest.param(
+            {"_experiments": {"data_collection": {"queues": False}}},
+            None,
+            None,
+            id="data_collection_queues_off",
+        ),
+        pytest.param(
+            {"send_default_pii": False},
+            SENSITIVE_DATA_SUBSTITUTE,
+            SENSITIVE_DATA_SUBSTITUTE,
+            id="no_pii",
+        ),
+        pytest.param(
+            {
+                "_experiments": {"data_collection": {"queues": False}},
+                "send_default_pii": False,
+            },
+            None,
+            None,
+            id="data_collection_queues_off_with_no_pii",
+        ),
+        pytest.param(
+            {
+                "_experiments": {"data_collection": {"queues": True}},
+                "send_default_pii": False,
+            },
+            [1],
+            {"b": 0},
+            id="data_collection_queues_on_with_no_pii",
+        ),
+    ],
+)
+@pytest.mark.parametrize(
+    "has_span_streaming", [True, False], ids=["streaming", "no_streaming"]
+)
+def test_task_args_kwargs_data_collection(
+    capture_events,
+    capture_items,
+    init_huey,
+    has_span_streaming,
+    init_kwargs,
+    expected_args,
+    expected_kwargs,
+):
+    huey = init_huey(has_span_streaming=has_span_streaming, init_kwargs=init_kwargs)
+
+    @huey.task()
+    def division(a, b):
+        return a / b
+
+    if has_span_streaming:
+        items = capture_items("event")
+        execute_huey_task(huey, division, 1, b=0, exceptions=(DivisionByZero,))
+        sentry_sdk.get_client().flush()
+        events = [item.payload for item in items]
+    else:
+        events = capture_events()
+        execute_huey_task(huey, division, 1, b=0, exceptions=(DivisionByZero,))
+
+    (event,) = [event for event in events if "exception" in event]
+
+    huey_job = event["extra"]["huey-job"]
+
+    if expected_args is None:
+        assert "args" not in huey_job
+        assert "kwargs" not in huey_job
+    else:
+        assert huey_job["args"] == expected_args
+        assert huey_job["kwargs"] == expected_kwargs
 
 
 def test_huey_enqueue(init_huey, capture_events):


### PR DESCRIPTION
The Huey integration now gates task `args`/`kwargs` in the `huey-job` event extra behind the `data_collection["queues"]` option, matching the arq and rq behavior. When the experiment is enabled and `"queues"` is off, the keys are omitted entirely; when the experiment isn't configured, the existing `send_default_pii` behavior is unchanged (values or `[Filtered]`).

Covered by a new parametrized test exercising the data_collection/PII combinations under both span streaming and static trace lifecycle modes.

Refs PY-2591
Refs #6751
