### PR TITLE
test: Restore wrapped functions in `functions_to_trace` tests

### DIFF
--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -919,18 +919,26 @@ def test_functions_to_trace(sentry_init, capture_events):
         {"qualified_name": "time.sleep"},
     ]
 
-    sentry_init(
-        traces_sample_rate=1.0,
-        functions_to_trace=functions_to_trace,
-    )
+    global _hello_world
+    original_hello_world = _hello_world
+    original_sleep = time.sleep
 
-    events = capture_events()
+    try:
+        sentry_init(
+            traces_sample_rate=1.0,
+            functions_to_trace=functions_to_trace,
+        )
 
-    with start_transaction(name="something"):
-        time.sleep(0)
+        events = capture_events()
 
-        for word in ["World", "You"]:
-            _hello_world(word)
+        with start_transaction(name="something"):
+            time.sleep(0)
+
+            for word in ["World", "You"]:
+                _hello_world(word)
+    finally:
+        _hello_world = original_hello_world
+        time.sleep = original_sleep
 
     assert len(events) == 1
 
@@ -955,17 +963,22 @@ def test_functions_to_trace_with_class(sentry_init, capture_events):
         {"qualified_name": "tests.test_basics.WorldGreeter.greet"},
     ]
 
-    sentry_init(
-        traces_sample_rate=1.0,
-        functions_to_trace=functions_to_trace,
-    )
+    original_function = WorldGreeter.greet
 
-    events = capture_events()
+    try:
+        sentry_init(
+            traces_sample_rate=1.0,
+            functions_to_trace=functions_to_trace,
+        )
 
-    with start_transaction(name="something"):
-        wg = WorldGreeter("World")
-        wg.greet()
-        wg.greet("You")
+        events = capture_events()
+
+        with start_transaction(name="something"):
+            wg = WorldGreeter("World")
+            wg.greet()
+            wg.greet("You")
+    finally:
+        WorldGreeter.greet = original_function
 
     assert len(events) == 1
 


### PR DESCRIPTION
### Description
<!-- What changed and why? -->

Remove the global patch after the span has finished in a `finally` block.

Based on the flake below

https://github.com/getsentry/sentry-python/actions/runs/30455774959/job/90588843197

with console output

```
FAILED tests/tracing/test_decorator.py::test_trace_decorator_no_trx - AssertionError: Expected 'mock' to be called once. Called 3 times.
Calls: [call('Cannot create a child span for %s. Please start a Sentry transaction before calling this function.', 'test_decorator.my_example_function'),
 call('[Monitor] health check negative, downsampling with a factor of %d', 10),
 call('Cannot create a child span for %s. Please start a Sentry transaction before calling this function.', 'time.sleep')].
```

it looks like `time.sleep` is wrapped with `start_span()`.

#### Issues
<!--
* resolves: #1234
* resolves: LIN-1234
-->

#### Reminders
- Please add tests to validate your changes, and lint your code using `uv run ruff`.
- Add GH Issue ID _&_ Linear ID (if applicable)
- PR title should use [conventional commit](https://develop.sentry.dev/engineering-practices/commit-messages/#type) style (`feat:`, `fix:`, `ref:`, `meta:`)
- For external contributors: [CONTRIBUTING.md](https://github.com/getsentry/sentry-python/blob/master/CONTRIBUTING.md), [Sentry SDK development docs](https://develop.sentry.dev/sdk/), [Discord community](https://discord.gg/Ww9hbqr)
