### PR TITLE
test(integrations): Deduplicate data_collection.queues test matrix

### DIFF
--- a/tests/integrations/arq/test_arq.py
+++ b/tests/integrations/arq/test_arq.py
@@ -13,7 +13,7 @@ import sentry_sdk
 from sentry_sdk import get_client, start_transaction
 from sentry_sdk.consts import SPANDATA
 from sentry_sdk.integrations.arq import ArqIntegration
-from sentry_sdk.utils import SENSITIVE_DATA_SUBSTITUTE
+from tests.integrations.utils import DATA_COLLECTION_QUEUES_CASES
 
 
 def async_partial(async_fn, *args, **kwargs):
@@ -459,50 +459,7 @@ async def test_job_transaction(
 
 @pytest.mark.parametrize(
     "init_kwargs,expected_args,expected_kwargs",
-    [
-        pytest.param(
-            {"_experiments": {"data_collection": {}}},
-            [1],
-            {"b": 0},
-            id="data_collection_default",
-        ),
-        pytest.param(
-            {"_experiments": {"data_collection": {"queues": True}}},
-            [1],
-            {"b": 0},
-            id="data_collection_queues_on",
-        ),
-        pytest.param(
-            {"_experiments": {"data_collection": {"queues": False}}},
-            None,
-            None,
-            id="data_collection_queues_off",
-        ),
-        pytest.param(
-            {"send_default_pii": False},
-            SENSITIVE_DATA_SUBSTITUTE,
-            SENSITIVE_DATA_SUBSTITUTE,
-            id="no_pii",
-        ),
-        pytest.param(
-            {
-                "_experiments": {"data_collection": {"queues": False}},
-                "send_default_pii": False,
-            },
-            None,
-            None,
-            id="data_collection_queues_off_with_no_pii",
-        ),
-        pytest.param(
-            {
-                "_experiments": {"data_collection": {"queues": True}},
-                "send_default_pii": False,
-            },
-            [1],
-            {"b": 0},
-            id="data_collection_queues_on_with_no_pii",
-        ),
-    ],
+    DATA_COLLECTION_QUEUES_CASES,
 )
 @pytest.mark.asyncio
 @pytest.mark.parametrize("span_streaming", [True, False])

--- a/tests/integrations/huey/test_huey.py
+++ b/tests/integrations/huey/test_huey.py
@@ -10,7 +10,8 @@ from sentry_sdk import start_transaction
 from sentry_sdk.consts import OP, SPANDATA
 from sentry_sdk.integrations.huey import HueyIntegration
 from sentry_sdk.traces import SegmentNameSource, SpanStatus
-from sentry_sdk.utils import SENSITIVE_DATA_SUBSTITUTE, parse_version
+from sentry_sdk.utils import parse_version
+from tests.integrations.utils import DATA_COLLECTION_QUEUES_CASES
 
 HUEY_VERSION = parse_version(HUEY_VERSION)
 
@@ -301,50 +302,7 @@ def test_task_lock(
 
 @pytest.mark.parametrize(
     "init_kwargs,expected_args,expected_kwargs",
-    [
-        pytest.param(
-            {"_experiments": {"data_collection": {}}},
-            [1],
-            {"b": 0},
-            id="data_collection_default",
-        ),
-        pytest.param(
-            {"_experiments": {"data_collection": {"queues": True}}},
-            [1],
-            {"b": 0},
-            id="data_collection_queues_on",
-        ),
-        pytest.param(
-            {"_experiments": {"data_collection": {"queues": False}}},
-            None,
-            None,
-            id="data_collection_queues_off",
-        ),
-        pytest.param(
-            {"send_default_pii": False},
-            SENSITIVE_DATA_SUBSTITUTE,
-            SENSITIVE_DATA_SUBSTITUTE,
-            id="no_pii",
-        ),
-        pytest.param(
-            {
-                "_experiments": {"data_collection": {"queues": False}},
-                "send_default_pii": False,
-            },
-            None,
-            None,
-            id="data_collection_queues_off_with_no_pii",
-        ),
-        pytest.param(
-            {
-                "_experiments": {"data_collection": {"queues": True}},
-                "send_default_pii": False,
-            },
-            [1],
-            {"b": 0},
-            id="data_collection_queues_on_with_no_pii",
-        ),
-    ],
+    DATA_COLLECTION_QUEUES_CASES,
 )
 @pytest.mark.parametrize(
     "has_span_streaming", [True, False], ids=["streaming", "no_streaming"]

--- a/tests/integrations/rq/test_rq.py
+++ b/tests/integrations/rq/test_rq.py
@@ -9,6 +9,7 @@ from sentry_sdk import start_transaction
 from sentry_sdk.consts import SPANDATA
 from sentry_sdk.integrations.rq import RqIntegration
 from sentry_sdk.utils import SENSITIVE_DATA_SUBSTITUTE, parse_version
+from tests.integrations.utils import DATA_COLLECTION_QUEUES_CASES
 
 
 @pytest.fixture(autouse=True)
@@ -110,50 +111,7 @@ def test_basic(
 
 @pytest.mark.parametrize(
     "init_kwargs,expected_args,expected_kwargs",
-    [
-        pytest.param(
-            {"_experiments": {"data_collection": {}}},
-            [1],
-            {"b": 0},
-            id="data_collection_default",
-        ),
-        pytest.param(
-            {"_experiments": {"data_collection": {"queues": True}}},
-            [1],
-            {"b": 0},
-            id="data_collection_queues_on",
-        ),
-        pytest.param(
-            {"_experiments": {"data_collection": {"queues": False}}},
-            None,
-            None,
-            id="data_collection_queues_off",
-        ),
-        pytest.param(
-            {"send_default_pii": False},
-            SENSITIVE_DATA_SUBSTITUTE,
-            SENSITIVE_DATA_SUBSTITUTE,
-            id="no_pii",
-        ),
-        pytest.param(
-            {
-                "_experiments": {"data_collection": {"queues": False}},
-                "send_default_pii": False,
-            },
-            None,
-            None,
-            id="data_collection_queues_off_with_no_pii",
-        ),
-        pytest.param(
-            {
-                "_experiments": {"data_collection": {"queues": True}},
-                "send_default_pii": False,
-            },
-            [1],
-            {"b": 0},
-            id="data_collection_queues_on_with_no_pii",
-        ),
-    ],
+    DATA_COLLECTION_QUEUES_CASES,
 )
 @pytest.mark.parametrize("span_streaming", [True, False])
 def test_job_args_kwargs_data_collection(

--- a/tests/integrations/utils.py
+++ b/tests/integrations/utils.py
@@ -1,5 +1,7 @@
 import pytest
 
+from sentry_sdk.utils import SENSITIVE_DATA_SUBSTITUTE
+
 # Shared parametrization test matrix exercising the precedence between the legacy
 # ``send_default_pii`` boolean and the ``data_collection.user_info`` setting.
 # Each case is ``(init_kwargs, expect_user_info)`` where the second element indicates
@@ -34,5 +36,55 @@ DATA_COLLECTION_USER_INFO_CASES = [
         },
         True,
         id="data_collection_wins_over_send_default_pii_false",
+    ),
+]
+
+# Shared parametrization test matrix exercising the interaction between the
+# ``data_collection.queues`` experiment and the legacy ``send_default_pii`` boolean
+# for job/task args and kwargs collected by queue integrations (rq, arq, huey).
+# Each case is ``(init_kwargs, expected_args, expected_kwargs)`` where ``None`` for
+# the expected values means args/kwargs are not collected at all.
+DATA_COLLECTION_QUEUES_CASES = [
+    pytest.param(
+        {"_experiments": {"data_collection": {}}},
+        [1],
+        {"b": 0},
+        id="data_collection_default",
+    ),
+    pytest.param(
+        {"_experiments": {"data_collection": {"queues": True}}},
+        [1],
+        {"b": 0},
+        id="data_collection_queues_on",
+    ),
+    pytest.param(
+        {"_experiments": {"data_collection": {"queues": False}}},
+        None,
+        None,
+        id="data_collection_queues_off",
+    ),
+    pytest.param(
+        {"send_default_pii": False},
+        SENSITIVE_DATA_SUBSTITUTE,
+        SENSITIVE_DATA_SUBSTITUTE,
+        id="no_pii",
+    ),
+    pytest.param(
+        {
+            "_experiments": {"data_collection": {"queues": False}},
+            "send_default_pii": False,
+        },
+        None,
+        None,
+        id="data_collection_queues_off_with_no_pii",
+    ),
+    pytest.param(
+        {
+            "_experiments": {"data_collection": {"queues": True}},
+            "send_default_pii": False,
+        },
+        [1],
+        {"b": 0},
+        id="data_collection_queues_on_with_no_pii",
     ),
 ]


### PR DESCRIPTION
The rq, arq, and huey test suites each defined an identical six-case
parametrization covering the interaction between the
data_collection.queues experiment and send_default_pii for collected
job/task args and kwargs.

Move the cases into a shared DATA_COLLECTION_QUEUES_CASES constant in
tests/integrations/utils.py, mirroring the existing
DATA_COLLECTION_USER_INFO_CASES pattern, and import it from the three
test files.

Refs PY-2591
Refs #6751