### PR TITLE
ref: Remove deprecated `set_measurement` in new major

### DIFF
--- a/MIGRATION_GUIDE.md
+++ b/MIGRATION_GUIDE.md
@@ -30,6 +30,7 @@ Looking to upgrade from Sentry SDK 2.x to 3.x? Here's a comprehensive list of wh
 - Removed the deprecated Hub class and all uses of hub throughout the SDK in arguments, options, etc. Use a scope instead.
 - The `SentrySpanProcessor`, `SentryPropagator`, `instrumenter`, and associated OpenTelemetry compatibility code was removed along with the `opentelemetry` extra and the `SentryPropagator` entrypoint. Use the `OTLPIntegration` instead.
 - Removed the `auto_session_tracing` decorator. Use `track_session` instead.
+- The deprecated `set_measurement` API was removed.
 - The experimental option `otel_powered_performance` has been removed together with the associated `OpenTelemetryIntegration` and `opentelemetry-experimental` extra.
 
 ## Deprecated

--- a/sentry_sdk/__init__.py
+++ b/sentry_sdk/__init__.py
@@ -43,7 +43,6 @@ __all__ = [  # noqa
     "set_context",
     "set_extra",
     "set_level",
-    "set_measurement",
     "set_tag",
     "set_tags",
     "set_user",

--- a/sentry_sdk/_types.py
+++ b/sentry_sdk/_types.py
@@ -236,17 +236,6 @@ if TYPE_CHECKING:
         "exbibyte",
     ]
 
-    FractionUnit = Literal["ratio", "percent"]
-    MeasurementUnit = Union[DurationUnit, InformationUnit, FractionUnit, str]
-
-    MeasurementValue = TypedDict(
-        "MeasurementValue",
-        {
-            "value": float,
-            "unit": NotRequired[Optional[MeasurementUnit]],
-        },
-    )
-
     Event = TypedDict(
         "Event",
         {
@@ -268,7 +257,6 @@ if TYPE_CHECKING:
             "level": LogLevelStr,
             "logentry": Mapping[str, object],
             "logger": str,
-            "measurements": dict[str, MeasurementValue],
             "message": str,
             "modules": dict[str, str],
             "monitor_config": Mapping[str, object],

--- a/sentry_sdk/api.py
+++ b/sentry_sdk/api.py
@@ -34,7 +34,6 @@ if TYPE_CHECKING:
         ExcInfo,
         Hint,
         LogLevelStr,
-        MeasurementUnit,
         SamplingContext,
     )
     from sentry_sdk.client import BaseClient
@@ -79,7 +78,6 @@ __all__ = [
     "set_context",
     "set_extra",
     "set_level",
-    "set_measurement",
     "set_tag",
     "set_tags",
     "set_user",
@@ -417,16 +415,6 @@ def start_transaction(
     return get_current_scope().start_transaction(
         transaction, custom_sampling_context, **kwargs
     )
-
-
-def set_measurement(name: str, value: float, unit: "MeasurementUnit" = "") -> None:
-    """
-    .. deprecated:: 2.28.0
-        This function is deprecated and will be removed in the next major release.
-    """
-    transaction = get_current_scope().transaction
-    if transaction is not None:
-        transaction.set_measurement(name, value, unit)
 
 
 def get_current_span(

--- a/sentry_sdk/tracing.py
+++ b/sentry_sdk/tracing.py
@@ -38,8 +38,6 @@ if TYPE_CHECKING:
 
     from sentry_sdk._types import (
         Event,
-        MeasurementUnit,
-        MeasurementValue,
         SamplingContext,
     )
     from sentry_sdk.profiler.continuous_profiler import ContinuousProfile
@@ -255,7 +253,6 @@ class Span:
         "sampled",
         "op",
         "description",
-        "_measurements",
         "start_timestamp",
         "_start_timestamp_monotonic_ns",
         "status",
@@ -298,7 +295,6 @@ class Span:
         self.status = status
         self.scope = scope
         self.origin = origin
-        self._measurements: "Dict[str, MeasurementValue]" = {}
         self._tags: "MutableMapping[str, str]" = {}
         self._data: "Dict[str, Any]" = {}
         self._containing_transaction = containing_transaction
@@ -586,21 +582,6 @@ class Span:
     def set_status(self, value: str) -> None:
         self.status = value
 
-    def set_measurement(
-        self, name: str, value: float, unit: "MeasurementUnit" = ""
-    ) -> None:
-        """
-        .. deprecated:: 2.28.0
-            This function is deprecated and will be removed in the next major release.
-        """
-
-        warnings.warn(
-            "`set_measurement()` is deprecated and will be removed in the next major version. Please use `set_data()` instead.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        self._measurements[name] = {"value": value, "unit": unit}
-
     def set_thread(
         self, thread_id: "Optional[int]", thread_name: "Optional[str]"
     ) -> None:
@@ -696,9 +677,6 @@ class Span:
             # TODO-neel remove redundant tag in major
             self._tags["status"] = self.status
 
-        if len(self._measurements) > 0:
-            rv["measurements"] = self._measurements
-
         tags = self._tags
         if tags:
             rv["tags"] = tags
@@ -787,7 +765,6 @@ class Transaction(Span):
         "parent_sampled",
         # used to create baggage value for head SDKs in dynamic sampling
         "sample_rate",
-        "_measurements",
         "_contexts",
         "_continuous_profile",
         "_baggage",
@@ -808,7 +785,6 @@ class Transaction(Span):
         self.source = source
         self.sample_rate: "Optional[float]" = None
         self.parent_sampled = parent_sampled
-        self._measurements: "Dict[str, MeasurementValue]" = {}
         self._contexts: "Dict[str, Any]" = {}
         self._continuous_profile: "Optional[ContinuousProfile]" = None
         self._baggage = baggage
@@ -1028,24 +1004,7 @@ class Transaction(Span):
         if has_gen_ai_span:
             event["_has_gen_ai_span"] = True
 
-        event["measurements"] = self._measurements
-
         return scope.capture_event(event)
-
-    def set_measurement(
-        self, name: str, value: float, unit: "MeasurementUnit" = ""
-    ) -> None:
-        """
-        .. deprecated:: 2.28.0
-            This function is deprecated and will be removed in the next major release.
-        """
-
-        warnings.warn(
-            "`set_measurement()` is deprecated and will be removed in the next major version. Please use `set_data()` instead.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        self._measurements[name] = {"value": value, "unit": unit}
 
     def set_context(self, key: str, value: "dict[str, Any]") -> None:
         """Sets a context. Transactions can have multiple contexts
@@ -1263,11 +1222,6 @@ class NoOpSpan(Span):
         scope: "Optional[sentry_sdk.Scope]" = None,
         end_timestamp: "Optional[Union[float, datetime]]" = None,
     ) -> "Optional[str]":
-        pass
-
-    def set_measurement(
-        self, name: str, value: float, unit: "MeasurementUnit" = ""
-    ) -> None:
         pass
 
     def set_context(self, key: str, value: "dict[str, Any]") -> None:

--- a/tests/tracing/test_misc.py
+++ b/tests/tracing/test_misc.py
@@ -4,7 +4,7 @@ from unittest.mock import MagicMock
 import pytest
 
 import sentry_sdk
-from sentry_sdk import set_measurement, start_span, start_transaction
+from sentry_sdk import start_span, start_transaction
 from sentry_sdk.consts import MATCH_ALL
 from sentry_sdk.traces import StreamedSpan
 from sentry_sdk.tracing import Span, Transaction
@@ -258,90 +258,6 @@ def test_finds_non_orphan_span_on_scope_span_streaming(sentry_init):
     assert scope._span is not None
     assert isinstance(scope._span, StreamedSpan)
     assert scope._span.name == "sniffing"
-
-
-def test_set_measurement(sentry_init, capture_events):
-    sentry_init(traces_sample_rate=1.0)
-
-    events = capture_events()
-
-    transaction = start_transaction(name="measuring stuff")
-
-    with pytest.raises(TypeError):
-        transaction.set_measurement()
-
-    with pytest.raises(TypeError):
-        transaction.set_measurement("metric.foo")
-
-    transaction.set_measurement("metric.foo", 123)
-    transaction.set_measurement("metric.bar", 456, unit="second")
-    transaction.set_measurement("metric.baz", 420.69, unit="custom")
-    transaction.set_measurement("metric.foobar", 12, unit="percent")
-    transaction.set_measurement("metric.foobar", 17.99, unit="percent")
-
-    transaction.finish()
-
-    (event,) = events
-    assert event["measurements"]["metric.foo"] == {"value": 123, "unit": ""}
-    assert event["measurements"]["metric.bar"] == {"value": 456, "unit": "second"}
-    assert event["measurements"]["metric.baz"] == {"value": 420.69, "unit": "custom"}
-    assert event["measurements"]["metric.foobar"] == {"value": 17.99, "unit": "percent"}
-
-
-def test_set_measurement_public_api(sentry_init, capture_events):
-    sentry_init(traces_sample_rate=1.0)
-
-    events = capture_events()
-
-    with start_transaction(name="measuring stuff"):
-        set_measurement("metric.foo", 123)
-        set_measurement("metric.bar", 456, unit="second")
-
-    (event,) = events
-    assert event["measurements"]["metric.foo"] == {"value": 123, "unit": ""}
-    assert event["measurements"]["metric.bar"] == {"value": 456, "unit": "second"}
-
-
-def test_set_measurement_deprecated(sentry_init):
-    sentry_init(traces_sample_rate=1.0)
-
-    with start_transaction(name="measuring stuff") as trx:
-        with pytest.warns(DeprecationWarning):
-            set_measurement("metric.foo", 123)
-
-        with pytest.warns(DeprecationWarning):
-            trx.set_measurement("metric.bar", 456)
-
-        with start_span(op="measuring span") as span:
-            with pytest.warns(DeprecationWarning):
-                span.set_measurement("metric.baz", 420.69, unit="custom")
-
-
-def test_set_meaurement_compared_to_set_data(sentry_init, capture_events):
-    """
-    This is just a test to see the difference
-    between measurements and data in the resulting event payload.
-    """
-    sentry_init(traces_sample_rate=1.0)
-
-    events = capture_events()
-
-    with start_transaction(name="measuring stuff") as transaction:
-        transaction.set_measurement("metric.foo", 123)
-        transaction.set_data("metric.bar", 456)
-
-        with start_span(op="measuring span") as span:
-            span.set_measurement("metric.baz", 420.69, unit="custom")
-            span.set_data("metric.qux", 789)
-
-    (event,) = events
-    assert event["measurements"]["metric.foo"] == {"value": 123, "unit": ""}
-    assert event["contexts"]["trace"]["data"]["metric.bar"] == 456
-    assert event["spans"][0]["measurements"]["metric.baz"] == {
-        "value": 420.69,
-        "unit": "custom",
-    }
-    assert event["spans"][0]["data"]["metric.qux"] == 789
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
### Description
The API is deprecated and slated for removal in 3.0.

#### Issues
Closes https://github.com/getsentry/sentry-python/issues/5019

#### Reminders
- Please add tests to validate your changes, and lint your code using `uv run ruff`.
- Add GH Issue ID _&_ Linear ID (if applicable)
- PR title should use [conventional commit](https://develop.sentry.dev/engineering-practices/commit-messages/#type) style (`feat:`, `fix:`, `ref:`, `meta:`)
- For external contributors: [CONTRIBUTING.md](https://github.com/getsentry/sentry-python/blob/master/CONTRIBUTING.md), [Sentry SDK development docs](https://develop.sentry.dev/sdk/), [Discord community](https://discord.gg/Ww9hbqr)
