### PR TITLE
test(openai-agents): Assert subset of expected dictionary is in `gen_ai.response.tool_calls`

### DIFF
--- a/tests/integrations/openai_agents/test_openai_agents.py
+++ b/tests/integrations/openai_agents/test_openai_agents.py
@@ -2348,9 +2348,11 @@ async def test_tool_execution_span(
         if OPENAI_VERSION >= (2, 25, 0):
             tool_call["namespace"] = None
 
-        assert json.loads(
+        parsed_tool_calls = json.loads(
             ai_client_span1["attributes"]["gen_ai.response.tool_calls"]
-        ) == [tool_call]
+        )
+        assert len(parsed_tool_calls) == 1
+        assert tool_call.items() <= parsed_tool_calls[0].items()
 
         assert tool_span["name"] == "execute_tool simple_test_tool"
         assert tool_span["attributes"]["gen_ai.agent.name"] == "test_agent"
@@ -2539,12 +2541,11 @@ async def test_tool_execution_span(
             "status": None,
         }
 
-        if OPENAI_VERSION >= (2, 25, 0):
-            tool_call["namespace"] = None
-
-        assert json.loads(
+        parsed_tool_calls = json.loads(
             ai_client_span1["attributes"]["gen_ai.response.tool_calls"]
-        ) == [tool_call]
+        )
+        assert len(parsed_tool_calls) == 1
+        assert tool_call.items() <= parsed_tool_calls[0].items()
 
         assert tool_span["name"] == "execute_tool simple_test_tool"
         assert tool_span["attributes"]["gen_ai.agent.name"] == "test_agent"

--- a/tests/integrations/openai_agents/test_openai_agents.py
+++ b/tests/integrations/openai_agents/test_openai_agents.py
@@ -2724,7 +2724,7 @@ async def test_tool_execution_span(
         }
 
         parsed_tool_calls = json.loads(
-            ai_client_span1["attributes"]["gen_ai.response.tool_calls"]
+            ai_client_span1["data"]["gen_ai.response.tool_calls"]
         )
         assert len(parsed_tool_calls) == 1
         assert tool_call.items() <= parsed_tool_calls[0].items()

--- a/tests/integrations/openai_agents/test_openai_agents.py
+++ b/tests/integrations/openai_agents/test_openai_agents.py
@@ -2723,12 +2723,11 @@ async def test_tool_execution_span(
             "status": None,
         }
 
-        if OPENAI_VERSION >= (2, 25, 0):
-            tool_call["namespace"] = None
-
-        assert json.loads(ai_client_span1["data"]["gen_ai.response.tool_calls"]) == [
-            tool_call
-        ]
+        parsed_tool_calls = json.loads(
+            ai_client_span1["attributes"]["gen_ai.response.tool_calls"]
+        )
+        assert len(parsed_tool_calls) == 1
+        assert tool_call.items() <= parsed_tool_calls[0].items()
 
         assert tool_span["description"] == "execute_tool simple_test_tool"
         assert tool_span["data"]["gen_ai.agent.name"] == "test_agent"


### PR DESCRIPTION
### Description
<!-- What changed and why? -->

Make the test more robust so it doesn't fail in weekly runs such as

https://github.com/getsentry/sentry-python/pull/6891

#### Issues
Closes https://github.com/getsentry/sentry-python/issues/6900

#### Reminders
- Please add tests to validate your changes, and lint your code using `uv run ruff`.
- Add GH Issue ID _&_ Linear ID (if applicable)
- PR title should use [conventional commit](https://develop.sentry.dev/engineering-practices/commit-messages/#type) style (`feat:`, `fix:`, `ref:`, `meta:`)
- For external contributors: [CONTRIBUTING.md](https://github.com/getsentry/sentry-python/blob/master/CONTRIBUTING.md), [Sentry SDK development docs](https://develop.sentry.dev/sdk/), [Discord community](https://discord.gg/Ww9hbqr)
