### PR TITLE
feat: Add possibility to allowlist integrations in toxgen

### DIFF
--- a/scripts/populate_tox/populate_tox.py
+++ b/scripts/populate_tox/populate_tox.py
@@ -1215,6 +1215,12 @@ def parse_args() -> argparse.Namespace:
         default=[],
         help="Integrations to skip version updates for.",
     )
+    parser.add_argument(
+        "--only-update",
+        nargs="*",
+        default=[],
+        help="Only update versions for these integrations (all others will be skipped).",
+    )
     return parser.parse_args()
 
 
@@ -1277,6 +1283,11 @@ def main() -> dict[str, list]:
             }
 
     args = parse_args()
+    if args.skip_version_update and args.only_update:
+        print("--skip-version-update and --only-update are mutually exclusive.")
+        sys.exit(1)
+
+    only_update = set(args.only_update)
     skip_version_updates = set(args.skip_version_update)
 
     # Process packages
@@ -1292,7 +1303,10 @@ def main() -> dict[str, list]:
             package, extra = _get_package_name(integration)
 
             test_releases = None
-            if integration in skip_version_updates:
+            skip = integration in skip_version_updates or (
+                only_update and integration not in only_update
+            )
+            if skip:
                 test_releases = get_existing_releases_to_test(integration)
             else:
                 test_releases = get_releases_to_test(integration, package)


### PR DESCRIPTION
We can already skip specific integrations. Add the opposite, too -- only updating specific integrations and skipping everything else.