### PR TITLE
feat(toxgen): Forward args from generate-test-files script

### DIFF
--- a/scripts/generate-test-files.sh
+++ b/scripts/generate-test-files.sh
@@ -8,5 +8,5 @@ cd "$(dirname "$0")"
 
 export UV_PROJECT_ENVIRONMENT=toxgen.venv
 
-uv run --python 3.14t --group toxgen --with-editable .. python populate_tox/populate_tox.py
+uv run --python 3.14t --group toxgen --with-editable .. python populate_tox/populate_tox.py "$@"
 uv run --python 3.14t --group toxgen --with-editable .. python split_tox_gh_actions/split_tox_gh_actions.py

--- a/scripts/populate_tox/populate_tox.py
+++ b/scripts/populate_tox/populate_tox.py
@@ -1210,13 +1210,13 @@ def get_releases_to_test(integration, package) -> list[Version] | None:
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser()
     parser.add_argument(
-        "--skip-version-update",
+        "--skip",
         nargs="*",
         default=[],
         help="Integrations to skip version updates for.",
     )
     parser.add_argument(
-        "--only-update",
+        "--only",
         nargs="*",
         default=[],
         help="Only update versions for these integrations (all others will be skipped).",
@@ -1283,12 +1283,17 @@ def main() -> dict[str, list]:
             }
 
     args = parse_args()
-    if args.skip_version_update and args.only_update:
-        print("--skip-version-update and --only-update are mutually exclusive.")
+    if args.skip and args.only:
+        print("--skip and --only are mutually exclusive.")
         sys.exit(1)
 
-    only_update = set(args.only_update)
-    skip_version_updates = set(args.skip_version_update)
+    only_update = set(args.only)
+    if only_update:
+        print(f"Only updating {' '.join(only_update)}.")
+
+    skip_update = set(args.skip)
+    if skip_update:
+        print(f"Skipping updates for {' '.join(skip_update)}.")
 
     # Process packages
     packages = defaultdict(list)
@@ -1303,7 +1308,7 @@ def main() -> dict[str, list]:
             package, extra = _get_package_name(integration)
 
             test_releases = None
-            skip = integration in skip_version_updates or (
+            skip = integration in skip_update or (
                 only_update and integration not in only_update
             )
             if skip:


### PR DESCRIPTION
- Forward any args provided to `generate-test-files.sh` to toxgen, so you can do e.g. `./scripts/generate-test-files.sh --only django` and only django test matrix entries will be updated.
- Rename the two existing options from `--skip-version-update` and `--only-update` to `--skip` and `--only`, respectively, to simplify.
- Print an info message if either is set.