### PR TITLE
test(httpx): Replace deprecated `asyncio.iscoroutinefunction`

### DIFF
--- a/tests/integrations/httpx/test_httpx.py
+++ b/tests/integrations/httpx/test_httpx.py
@@ -1,4 +1,5 @@
 import asyncio
+import inspect
 import os
 from unittest import mock
 
@@ -30,7 +31,7 @@ def test_crumb_capture_and_hint(sentry_init, capture_events, httpx_client, httpx
     with start_transaction():
         events = capture_events()
 
-        if asyncio.iscoroutinefunction(httpx_client.get):
+        if inspect.iscoroutinefunction(httpx_client.get):
             response = asyncio.get_event_loop().run_until_complete(
                 httpx_client.get(url)
             )
@@ -84,7 +85,7 @@ def test_crumb_capture_client_error(
     with start_transaction():
         events = capture_events()
 
-        if asyncio.iscoroutinefunction(httpx_client.get):
+        if inspect.iscoroutinefunction(httpx_client.get):
             response = asyncio.get_event_loop().run_until_complete(
                 httpx_client.get(url)
             )
@@ -135,7 +136,7 @@ def test_outgoing_trace_headers_legacy(sentry_init, httpx_client, httpx_mock):
         op="greeting.sniff",
         trace_id="01234567890123456789012345678901",
     ) as transaction:
-        if asyncio.iscoroutinefunction(httpx_client.get):
+        if inspect.iscoroutinefunction(httpx_client.get):
             response = asyncio.get_event_loop().run_until_complete(
                 httpx_client.get(url)
             )
@@ -178,7 +179,7 @@ def test_outgoing_trace_headers_append_to_baggage_legacy(
             op="greeting.sniff",
             trace_id="01234567890123456789012345678901",
         ) as transaction:
-            if asyncio.iscoroutinefunction(httpx_client.get):
+            if inspect.iscoroutinefunction(httpx_client.get):
                 response = asyncio.get_event_loop().run_until_complete(
                     httpx_client.get(url, headers={"baGGage": "custom=data"})
                 )
@@ -331,7 +332,7 @@ def test_option_trace_propagation_targets(
 
     # Must be in a transaction to propagate headers
     with sentry_sdk.start_transaction():
-        if asyncio.iscoroutinefunction(httpx_client.get):
+        if inspect.iscoroutinefunction(httpx_client.get):
             asyncio.get_event_loop().run_until_complete(httpx_client.get(url))
         else:
             httpx_client.get(url)
@@ -416,7 +417,7 @@ def test_request_source_disabled_legacy(
     url = "http://example.com/"
 
     with start_transaction(name="test_transaction"):
-        if asyncio.iscoroutinefunction(httpx_client.get):
+        if inspect.iscoroutinefunction(httpx_client.get):
             asyncio.get_event_loop().run_until_complete(httpx_client.get(url))
         else:
             httpx_client.get(url)
@@ -462,7 +463,7 @@ def test_request_source_enabled_legacy(
     url = "http://example.com/"
 
     with start_transaction(name="test_transaction"):
-        if asyncio.iscoroutinefunction(httpx_client.get):
+        if inspect.iscoroutinefunction(httpx_client.get):
             asyncio.get_event_loop().run_until_complete(httpx_client.get(url))
         else:
             httpx_client.get(url)
@@ -499,7 +500,7 @@ def test_request_source_legacy(sentry_init, capture_events, httpx_client, httpx_
     url = "http://example.com/"
 
     with start_transaction(name="test_transaction"):
-        if asyncio.iscoroutinefunction(httpx_client.get):
+        if inspect.iscoroutinefunction(httpx_client.get):
             asyncio.get_event_loop().run_until_complete(httpx_client.get(url))
         else:
             httpx_client.get(url)
@@ -552,7 +553,7 @@ def test_request_source_with_module_in_search_path_legacy(
     url = "http://example.com/"
 
     with start_transaction(name="test_transaction"):
-        if asyncio.iscoroutinefunction(httpx_client.get):
+        if inspect.iscoroutinefunction(httpx_client.get):
             from httpx_helpers.helpers import async_get_request_with_client
 
             asyncio.get_event_loop().run_until_complete(
@@ -583,7 +584,7 @@ def test_request_source_with_module_in_search_path_legacy(
     is_relative_path = data.get(SPANDATA.CODE_FILEPATH)[0] != os.sep
     assert is_relative_path
 
-    if asyncio.iscoroutinefunction(httpx_client.get):
+    if inspect.iscoroutinefunction(httpx_client.get):
         assert data.get(SPANDATA.CODE_FUNCTION) == "async_get_request_with_client"
     else:
         assert data.get(SPANDATA.CODE_FUNCTION) == "get_request_with_client"
@@ -611,7 +612,7 @@ def test_no_request_source_if_duration_too_short_legacy(
     url = "http://example.com/"
 
     with start_transaction(name="test_transaction"):
-        if asyncio.iscoroutinefunction(httpx_client.get):
+        if inspect.iscoroutinefunction(httpx_client.get):
             asyncio.get_event_loop().run_until_complete(httpx_client.get(url))
         else:
             httpx_client.get(url)
@@ -651,7 +652,7 @@ def test_request_source_if_duration_over_threshold_legacy(
     url = "http://example.com/"
 
     with start_transaction(name="test_transaction"):
-        if asyncio.iscoroutinefunction(httpx_client.get):
+        if inspect.iscoroutinefunction(httpx_client.get):
             asyncio.get_event_loop().run_until_complete(httpx_client.get(url))
         else:
             httpx_client.get(url)
@@ -701,7 +702,7 @@ def test_span_origin_legacy(sentry_init, capture_events, httpx_client, httpx_moc
     url = "http://example.com/"
 
     with start_transaction(name="test_transaction"):
-        if asyncio.iscoroutinefunction(httpx_client.get):
+        if inspect.iscoroutinefunction(httpx_client.get):
             asyncio.get_event_loop().run_until_complete(httpx_client.get(url))
         else:
             httpx_client.get(url)
@@ -740,7 +741,7 @@ def test_outgoing_trace_headers_span_streaming(
     items = capture_items("span")
 
     with sentry_sdk.traces.start_span(name="test"):
-        if asyncio.iscoroutinefunction(httpx_client.get):
+        if inspect.iscoroutinefunction(httpx_client.get):
             response = asyncio.get_event_loop().run_until_complete(
                 httpx_client.get(url)
             )
@@ -785,7 +786,7 @@ def test_outgoing_trace_headers_append_to_baggage_span_streaming(
 
     with mock.patch("sentry_sdk.tracing_utils.Random.randrange", return_value=500000):
         with sentry_sdk.traces.start_span(name="test"):
-            if asyncio.iscoroutinefunction(httpx_client.get):
+            if inspect.iscoroutinefunction(httpx_client.get):
                 response = asyncio.get_event_loop().run_until_complete(
                     httpx_client.get(url, headers={"baGGage": "custom=data"})
                 )
@@ -906,7 +907,7 @@ def test_request_source_disabled_span_streaming(
     url = "http://example.com/"
 
     with sentry_sdk.traces.start_span(name="test"):
-        if asyncio.iscoroutinefunction(httpx_client.get):
+        if inspect.iscoroutinefunction(httpx_client.get):
             asyncio.get_event_loop().run_until_complete(httpx_client.get(url))
         else:
             httpx_client.get(url)
@@ -951,7 +952,7 @@ def test_request_source_enabled_span_streaming(
     url = "http://example.com/"
 
     with sentry_sdk.traces.start_span(name="test"):
-        if asyncio.iscoroutinefunction(httpx_client.get):
+        if inspect.iscoroutinefunction(httpx_client.get):
             asyncio.get_event_loop().run_until_complete(httpx_client.get(url))
         else:
             httpx_client.get(url)
@@ -988,7 +989,7 @@ def test_request_source_span_streaming(
     url = "http://example.com/"
 
     with sentry_sdk.traces.start_span(name="test"):
-        if asyncio.iscoroutinefunction(httpx_client.get):
+        if inspect.iscoroutinefunction(httpx_client.get):
             asyncio.get_event_loop().run_until_complete(httpx_client.get(url))
         else:
             httpx_client.get(url)
@@ -1046,7 +1047,7 @@ def test_request_source_with_module_in_search_path_span_streaming(
     url = "http://example.com/"
 
     with sentry_sdk.traces.start_span(name="test"):
-        if asyncio.iscoroutinefunction(httpx_client.get):
+        if inspect.iscoroutinefunction(httpx_client.get):
             from httpx_helpers.helpers import async_get_request_with_client
 
             asyncio.get_event_loop().run_until_complete(
@@ -1074,7 +1075,7 @@ def test_request_source_with_module_in_search_path_span_streaming(
     is_relative_path = http_span["attributes"]["code.file.path"][0] != os.sep
     assert is_relative_path
 
-    if asyncio.iscoroutinefunction(httpx_client.get):
+    if inspect.iscoroutinefunction(httpx_client.get):
         assert (
             http_span["attributes"][SPANDATA.CODE_FUNCTION]
             == "async_get_request_with_client"
@@ -1108,7 +1109,7 @@ def test_no_request_source_if_duration_too_short_span_streaming(
     url = "http://example.com/"
 
     with sentry_sdk.traces.start_span(name="test"):
-        if asyncio.iscoroutinefunction(httpx_client.get):
+        if inspect.iscoroutinefunction(httpx_client.get):
             asyncio.get_event_loop().run_until_complete(httpx_client.get(url))
         else:
             httpx_client.get(url)
@@ -1146,7 +1147,7 @@ def test_request_source_if_duration_over_threshold_span_streaming(
     url = "http://example.com/"
 
     with sentry_sdk.traces.start_span(name="test"):
-        if asyncio.iscoroutinefunction(httpx_client.get):
+        if inspect.iscoroutinefunction(httpx_client.get):
             asyncio.get_event_loop().run_until_complete(httpx_client.get(url))
         else:
             httpx_client.get(url)
@@ -1199,7 +1200,7 @@ def test_span_origin_span_streaming(
     url = "http://example.com/"
 
     with sentry_sdk.traces.start_span(name="test"):
-        if asyncio.iscoroutinefunction(httpx_client.get):
+        if inspect.iscoroutinefunction(httpx_client.get):
             asyncio.get_event_loop().run_until_complete(httpx_client.get(url))
         else:
             httpx_client.get(url)
@@ -1233,7 +1234,7 @@ def test_http_url_attributes_span_streaming(
     url = "http://example.com/?foo=bar#frag"
 
     with sentry_sdk.traces.start_span(name="test"):
-        if asyncio.iscoroutinefunction(httpx_client.get):
+        if inspect.iscoroutinefunction(httpx_client.get):
             asyncio.get_event_loop().run_until_complete(httpx_client.get(url))
         else:
             httpx_client.get(url)
@@ -1277,7 +1278,7 @@ def test_http_url_attributes_no_query_or_fragment_span_streaming(
     url = "http://example.com/"
 
     with sentry_sdk.traces.start_span(name="test"):
-        if asyncio.iscoroutinefunction(httpx_client.get):
+        if inspect.iscoroutinefunction(httpx_client.get):
             asyncio.get_event_loop().run_until_complete(httpx_client.get(url))
         else:
             httpx_client.get(url)

--- a/tests/integrations/httpx2/test_httpx2.py
+++ b/tests/integrations/httpx2/test_httpx2.py
@@ -1,4 +1,5 @@
 import asyncio
+import inspect
 import os
 from unittest import mock
 
@@ -32,7 +33,7 @@ def test_crumb_capture_and_hint(
     with start_transaction():
         events = capture_events()
 
-        if asyncio.iscoroutinefunction(httpx2_client.get):
+        if inspect.iscoroutinefunction(httpx2_client.get):
             response = asyncio.run(httpx2_client.get(url))
         else:
             response = httpx2_client.get(url)
@@ -84,7 +85,7 @@ def test_crumb_capture_client_error(
     with start_transaction():
         events = capture_events()
 
-        if asyncio.iscoroutinefunction(httpx2_client.get):
+        if inspect.iscoroutinefunction(httpx2_client.get):
             response = asyncio.run(httpx2_client.get(url))
         else:
             response = httpx2_client.get(url)
@@ -133,7 +134,7 @@ def test_outgoing_trace_headers_legacy(sentry_init, httpx2_client, httpx2_mock):
         op="greeting.sniff",
         trace_id="01234567890123456789012345678901",
     ) as transaction:
-        if asyncio.iscoroutinefunction(httpx2_client.get):
+        if inspect.iscoroutinefunction(httpx2_client.get):
             response = asyncio.run(httpx2_client.get(url))
         else:
             response = httpx2_client.get(url)
@@ -174,7 +175,7 @@ def test_outgoing_trace_headers_append_to_baggage_legacy(
             op="greeting.sniff",
             trace_id="01234567890123456789012345678901",
         ) as transaction:
-            if asyncio.iscoroutinefunction(httpx2_client.get):
+            if inspect.iscoroutinefunction(httpx2_client.get):
                 response = asyncio.run(
                     httpx2_client.get(url, headers={"baGGage": "custom=data"})
                 )
@@ -327,7 +328,7 @@ def test_option_trace_propagation_targets(
 
     # Must be in a transaction to propagate headers
     with sentry_sdk.start_transaction():
-        if asyncio.iscoroutinefunction(httpx2_client.get):
+        if inspect.iscoroutinefunction(httpx2_client.get):
             asyncio.run(httpx2_client.get(url))
         else:
             httpx2_client.get(url)
@@ -412,7 +413,7 @@ def test_request_source_disabled_legacy(
     url = "http://example.com/"
 
     with start_transaction(name="test_transaction"):
-        if asyncio.iscoroutinefunction(httpx2_client.get):
+        if inspect.iscoroutinefunction(httpx2_client.get):
             asyncio.run(httpx2_client.get(url))
         else:
             httpx2_client.get(url)
@@ -458,7 +459,7 @@ def test_request_source_enabled_legacy(
     url = "http://example.com/"
 
     with start_transaction(name="test_transaction"):
-        if asyncio.iscoroutinefunction(httpx2_client.get):
+        if inspect.iscoroutinefunction(httpx2_client.get):
             asyncio.run(httpx2_client.get(url))
         else:
             httpx2_client.get(url)
@@ -495,7 +496,7 @@ def test_request_source_legacy(sentry_init, capture_events, httpx2_client, httpx
     url = "http://example.com/"
 
     with start_transaction(name="test_transaction"):
-        if asyncio.iscoroutinefunction(httpx2_client.get):
+        if inspect.iscoroutinefunction(httpx2_client.get):
             asyncio.run(httpx2_client.get(url))
         else:
             httpx2_client.get(url)
@@ -548,7 +549,7 @@ def test_request_source_with_module_in_search_path_legacy(
     url = "http://example.com/"
 
     with start_transaction(name="test_transaction"):
-        if asyncio.iscoroutinefunction(httpx2_client.get):
+        if inspect.iscoroutinefunction(httpx2_client.get):
             from httpx2_helpers.helpers import async_get_request_with_client
 
             asyncio.run(async_get_request_with_client(httpx2_client, url))
@@ -577,7 +578,7 @@ def test_request_source_with_module_in_search_path_legacy(
     is_relative_path = data.get(SPANDATA.CODE_FILEPATH)[0] != os.sep
     assert is_relative_path
 
-    if asyncio.iscoroutinefunction(httpx2_client.get):
+    if inspect.iscoroutinefunction(httpx2_client.get):
         assert data.get(SPANDATA.CODE_FUNCTION) == "async_get_request_with_client"
     else:
         assert data.get(SPANDATA.CODE_FUNCTION) == "get_request_with_client"
@@ -605,7 +606,7 @@ def test_no_request_source_if_duration_too_short_legacy(
     url = "http://example.com/"
 
     with start_transaction(name="test_transaction"):
-        if asyncio.iscoroutinefunction(httpx2_client.get):
+        if inspect.iscoroutinefunction(httpx2_client.get):
             asyncio.run(httpx2_client.get(url))
         else:
             httpx2_client.get(url)
@@ -645,7 +646,7 @@ def test_request_source_if_duration_over_threshold_legacy(
     url = "http://example.com/"
 
     with start_transaction(name="test_transaction"):
-        if asyncio.iscoroutinefunction(httpx2_client.get):
+        if inspect.iscoroutinefunction(httpx2_client.get):
             asyncio.run(httpx2_client.get(url))
         else:
             httpx2_client.get(url)
@@ -695,7 +696,7 @@ def test_span_origin_legacy(sentry_init, capture_events, httpx2_client, httpx2_m
     url = "http://example.com/"
 
     with start_transaction(name="test_transaction"):
-        if asyncio.iscoroutinefunction(httpx2_client.get):
+        if inspect.iscoroutinefunction(httpx2_client.get):
             asyncio.run(httpx2_client.get(url))
         else:
             httpx2_client.get(url)
@@ -734,7 +735,7 @@ def test_outgoing_trace_headers_span_streaming(
     items = capture_items("span")
 
     with sentry_sdk.traces.start_span(name="test"):
-        if asyncio.iscoroutinefunction(httpx2_client.get):
+        if inspect.iscoroutinefunction(httpx2_client.get):
             response = asyncio.run(httpx2_client.get(url))
         else:
             response = httpx2_client.get(url)
@@ -777,7 +778,7 @@ def test_outgoing_trace_headers_append_to_baggage_span_streaming(
 
     with mock.patch("sentry_sdk.tracing_utils.Random.randrange", return_value=500000):
         with sentry_sdk.traces.start_span(name="test"):
-            if asyncio.iscoroutinefunction(httpx2_client.get):
+            if inspect.iscoroutinefunction(httpx2_client.get):
                 response = asyncio.run(
                     httpx2_client.get(url, headers={"baGGage": "custom=data"})
                 )
@@ -900,7 +901,7 @@ def test_request_source_disabled_span_streaming(
     url = "http://example.com/"
 
     with sentry_sdk.traces.start_span(name="test"):
-        if asyncio.iscoroutinefunction(httpx2_client.get):
+        if inspect.iscoroutinefunction(httpx2_client.get):
             asyncio.run(httpx2_client.get(url))
         else:
             httpx2_client.get(url)
@@ -945,7 +946,7 @@ def test_request_source_enabled_span_streaming(
     url = "http://example.com/"
 
     with sentry_sdk.traces.start_span(name="test"):
-        if asyncio.iscoroutinefunction(httpx2_client.get):
+        if inspect.iscoroutinefunction(httpx2_client.get):
             asyncio.run(httpx2_client.get(url))
         else:
             httpx2_client.get(url)
@@ -982,7 +983,7 @@ def test_request_source_span_streaming(
     url = "http://example.com/"
 
     with sentry_sdk.traces.start_span(name="test"):
-        if asyncio.iscoroutinefunction(httpx2_client.get):
+        if inspect.iscoroutinefunction(httpx2_client.get):
             asyncio.run(httpx2_client.get(url))
         else:
             httpx2_client.get(url)
@@ -1040,7 +1041,7 @@ def test_request_source_with_module_in_search_path_span_streaming(
     url = "http://example.com/"
 
     with sentry_sdk.traces.start_span(name="test"):
-        if asyncio.iscoroutinefunction(httpx2_client.get):
+        if inspect.iscoroutinefunction(httpx2_client.get):
             from httpx2_helpers.helpers import async_get_request_with_client
 
             asyncio.run(async_get_request_with_client(httpx2_client, url))
@@ -1066,7 +1067,7 @@ def test_request_source_with_module_in_search_path_span_streaming(
     is_relative_path = http_span["attributes"]["code.file.path"][0] != os.sep
     assert is_relative_path
 
-    if asyncio.iscoroutinefunction(httpx2_client.get):
+    if inspect.iscoroutinefunction(httpx2_client.get):
         assert (
             http_span["attributes"][SPANDATA.CODE_FUNCTION]
             == "async_get_request_with_client"
@@ -1100,7 +1101,7 @@ def test_no_request_source_if_duration_too_short_span_streaming(
     url = "http://example.com/"
 
     with sentry_sdk.traces.start_span(name="test"):
-        if asyncio.iscoroutinefunction(httpx2_client.get):
+        if inspect.iscoroutinefunction(httpx2_client.get):
             asyncio.run(httpx2_client.get(url))
         else:
             httpx2_client.get(url)
@@ -1138,7 +1139,7 @@ def test_request_source_if_duration_over_threshold_span_streaming(
     url = "http://example.com/"
 
     with sentry_sdk.traces.start_span(name="test"):
-        if asyncio.iscoroutinefunction(httpx2_client.get):
+        if inspect.iscoroutinefunction(httpx2_client.get):
             asyncio.run(httpx2_client.get(url))
         else:
             httpx2_client.get(url)
@@ -1191,7 +1192,7 @@ def test_span_origin_span_streaming(
     url = "http://example.com/"
 
     with sentry_sdk.traces.start_span(name="test"):
-        if asyncio.iscoroutinefunction(httpx2_client.get):
+        if inspect.iscoroutinefunction(httpx2_client.get):
             asyncio.run(httpx2_client.get(url))
         else:
             httpx2_client.get(url)
@@ -1224,7 +1225,7 @@ def test_http_url_attributes_span_streaming(
     url = "http://example.com/?foo=bar#frag"
 
     with sentry_sdk.traces.start_span(name="test"):
-        if asyncio.iscoroutinefunction(httpx2_client.get):
+        if inspect.iscoroutinefunction(httpx2_client.get):
             asyncio.run(httpx2_client.get(url))
         else:
             httpx2_client.get(url)
@@ -1261,7 +1262,7 @@ def test_http_url_attributes_no_query_or_fragment_span_streaming(
     url = "http://example.com/"
 
     with sentry_sdk.traces.start_span(name="test"):
-        if asyncio.iscoroutinefunction(httpx2_client.get):
+        if inspect.iscoroutinefunction(httpx2_client.get):
             asyncio.run(httpx2_client.get(url))
         else:
             httpx2_client.get(url)
@@ -1297,7 +1298,7 @@ def test_http_url_attributes_pii_disabled_span_streaming(
     url = "http://example.com/?foo=bar#frag"
 
     with sentry_sdk.traces.start_span(name="test"):
-        if asyncio.iscoroutinefunction(httpx2_client.get):
+        if inspect.iscoroutinefunction(httpx2_client.get):
             asyncio.run(httpx2_client.get(url))
         else:
             httpx2_client.get(url)


### PR DESCRIPTION
### Description
<!-- What changed and why? -->

For the purpose of the test, `inspect.iscoroutinefunction` is equivalent to `asyncio.iscoroutinefunction`.

#### Issues

Contributes to https://github.com/getsentry/sentry-python/issues/4900

#### Reminders
- Please add tests to validate your changes, and lint your code using `uv run ruff`.
- Add GH Issue ID _&_ Linear ID (if applicable)
- PR title should use [conventional commit](https://develop.sentry.dev/engineering-practices/commit-messages/#type) style (`feat:`, `fix:`, `ref:`, `meta:`)
- For external contributors: [CONTRIBUTING.md](https://github.com/getsentry/sentry-python/blob/master/CONTRIBUTING.md), [Sentry SDK development docs](https://develop.sentry.dev/sdk/), [Discord community](https://discord.gg/Ww9hbqr)
