### PR TITLE
chore(django): Use `iscoroutinefunction` shim in `patch_views()`

### DIFF
--- a/sentry_sdk/integrations/django/views.py
+++ b/sentry_sdk/integrations/django/views.py
@@ -52,14 +52,13 @@ def patch_views() -> None:
         # efficient way to wrap views (or build a cache?)
 
         integration = sentry_sdk.get_client().get_integration(DjangoIntegration)
-        if integration is not None and iscoroutinefunction(callback):
-            sentry_wrapped_callback = wrap_async_view(callback)
-        elif integration is not None:
-            sentry_wrapped_callback = _wrap_sync_view(callback)
-        else:
-            sentry_wrapped_callback = callback
+        if integration is None:
+            return callback
 
-        return sentry_wrapped_callback
+        if iscoroutinefunction(callback):
+            return wrap_async_view(callback)
+
+        return _wrap_sync_view(callback)
 
     SimpleTemplateResponse.render = sentry_patched_render
     BaseHandler.make_view_atomic = sentry_patched_make_view_atomic

--- a/sentry_sdk/integrations/django/views.py
+++ b/sentry_sdk/integrations/django/views.py
@@ -9,17 +9,7 @@ from sentry_sdk.tracing_utils import has_span_streaming_enabled
 if TYPE_CHECKING:
     from typing import Any
 
-
-try:
-    from asyncio import iscoroutinefunction
-except ImportError:
-    iscoroutinefunction = None  # type: ignore
-
-
-try:
-    from sentry_sdk.integrations.django.asgi import wrap_async_view
-except (ImportError, SyntaxError):
-    wrap_async_view = None  # type: ignore
+from sentry_sdk.integrations.django.asgi import iscoroutinefunction, wrap_async_view
 
 
 def patch_views() -> None:
@@ -62,17 +52,10 @@ def patch_views() -> None:
         # efficient way to wrap views (or build a cache?)
 
         integration = sentry_sdk.get_client().get_integration(DjangoIntegration)
-        if integration is not None:
-            is_async_view = (
-                iscoroutinefunction is not None
-                and wrap_async_view is not None
-                and iscoroutinefunction(callback)
-            )
-            if is_async_view:
-                sentry_wrapped_callback = wrap_async_view(callback)
-            else:
-                sentry_wrapped_callback = _wrap_sync_view(callback)
-
+        if integration is not None and iscoroutinefunction(callback):
+            sentry_wrapped_callback = wrap_async_view(callback)
+        elif integration is not None:
+            sentry_wrapped_callback = _wrap_sync_view(callback)
         else:
             sentry_wrapped_callback = callback
 


### PR DESCRIPTION
### Description
<!-- What changed and why? -->

Re-use the existing shim in `django.asgi` that vendors `asgiref.sync.iscoroutinefunction()`.

The `views.py` and `asgi.py` files were split to keep Python 2 compatibility in https://github.com/getsentry/sentry-python/pull/851.

As we no longer support Python 2, we can unconditionally import `asgi.py` in `views.py`.

#### Issues

Closes https://github.com/getsentry/sentry-python/issues/4900

#### Reminders
- Please add tests to validate your changes, and lint your code using `uv run ruff`.
- Add GH Issue ID _&_ Linear ID (if applicable)
- PR title should use [conventional commit](https://develop.sentry.dev/engineering-practices/commit-messages/#type) style (`feat:`, `fix:`, `ref:`, `meta:`)
- For external contributors: [CONTRIBUTING.md](https://github.com/getsentry/sentry-python/blob/master/CONTRIBUTING.md), [Sentry SDK development docs](https://develop.sentry.dev/sdk/), [Discord community](https://discord.gg/Ww9hbqr)
