### PR TITLE
feat(aiomysql): Gate query parameters on data_collection option

### DIFF
--- a/sentry_sdk/integrations/aiomysql.py
+++ b/sentry_sdk/integrations/aiomysql.py
@@ -14,6 +14,7 @@ from sentry_sdk.tracing_utils import (
 )
 from sentry_sdk.utils import (
     capture_internal_exceptions,
+    has_data_collection_enabled,
     parse_version,
 )
 
@@ -82,7 +83,16 @@ def _wrap_execute(f: Callable[..., Awaitable[T]]) -> Callable[..., Awaitable[T]]
         conn = _get_connection(cursor)
 
         integration = sentry_sdk.get_client().get_integration(AioMySQLIntegration)
-        params_list = params if integration and integration._record_params else None
+
+        client = sentry_sdk.get_client()
+        should_record_params = False
+        if has_data_collection_enabled(client.options):
+            if client.options["data_collection"]["database_query_data"]:
+                should_record_params = True
+        else:
+            should_record_params = integration._record_params if integration else False
+
+        params_list = params if integration and should_record_params else None
         param_style = "pyformat" if params_list else None
 
         with record_sql_queries(
@@ -124,9 +134,15 @@ def _wrap_executemany(f: Callable[..., Awaitable[T]]) -> Callable[..., Awaitable
         conn = _get_connection(cursor)
 
         integration = sentry_sdk.get_client().get_integration(AioMySQLIntegration)
-        params_list = (
-            seq_of_params if integration and integration._record_params else None
-        )
+        client = sentry_sdk.get_client()
+        should_record_params = False
+        if has_data_collection_enabled(client.options):
+            if client.options["data_collection"]["database_query_data"]:
+                should_record_params = True
+        else:
+            should_record_params = integration._record_params if integration else False
+
+        params_list = seq_of_params if integration and should_record_params else None
         param_style = "pyformat" if params_list else None
 
         # Prevent double-recording: _do_execute_many calls self.execute internally

--- a/tests/integrations/aiomysql/test_aiomysql.py
+++ b/tests/integrations/aiomysql/test_aiomysql.py
@@ -213,6 +213,143 @@ async def test_execute_many(sentry_init, capture_events) -> None:
 
 
 @pytest.mark.asyncio
+async def test_execute_many_record_params_with_data_collection_enabled(
+    sentry_init, capture_events
+) -> None:
+    sentry_init(
+        integrations=[AioMySQLIntegration()],
+        _experiments={"data_collection": {"database_query_data": True}},
+    )
+    events = capture_events()
+
+    conn = await aiomysql.connect(**_connect_args())
+
+    async with conn.cursor() as cur:
+        await cur.executemany(
+            "INSERT INTO users(name, password, dob) VALUES (%s, %s, %s)",
+            [
+                ("Bob", "secret_pw", datetime.date(1984, 3, 1)),
+                ("Alice", "pw", datetime.date(1990, 12, 25)),
+            ],
+        )
+
+    conn.close()
+
+    capture_message("hi")
+
+    (event,) = events
+
+    for crumb in event["breadcrumbs"]["values"]:
+        del crumb["timestamp"]
+
+    assert event["breadcrumbs"]["values"] == [
+        CRUMBS_CONNECT,
+        {
+            "category": "query",
+            "data": {
+                "db.params": [
+                    ["Bob", "secret_pw", "datetime.date(1984, 3, 1)"],
+                    ["Alice", "pw", "datetime.date(1990, 12, 25)"],
+                ],
+                "db.paramstyle": "format",
+                "db.executemany": True,
+            },
+            "message": "INSERT INTO users(name, password, dob) VALUES (%s, %s, %s)",
+            "type": "default",
+        },
+    ]
+
+
+@pytest.mark.asyncio
+async def test_execute_many_record_params_with_data_collection_disabled(
+    sentry_init, capture_events
+) -> None:
+    sentry_init(
+        integrations=[AioMySQLIntegration(record_params=True)],
+        _experiments={"data_collection": {"database_query_data": False}},
+    )
+    events = capture_events()
+
+    conn = await aiomysql.connect(**_connect_args())
+
+    async with conn.cursor() as cur:
+        await cur.executemany(
+            "INSERT INTO users(name, password, dob) VALUES (%s, %s, %s)",
+            [
+                ("Bob", "secret_pw", datetime.date(1984, 3, 1)),
+                ("Alice", "pw", datetime.date(1990, 12, 25)),
+            ],
+        )
+
+    conn.close()
+
+    capture_message("hi")
+
+    (event,) = events
+
+    for crumb in event["breadcrumbs"]["values"]:
+        del crumb["timestamp"]
+
+    assert event["breadcrumbs"]["values"] == [
+        CRUMBS_CONNECT,
+        {
+            "category": "query",
+            "data": {"db.executemany": True},
+            "message": "INSERT INTO users(name, password, dob) VALUES (%s, %s, %s)",
+            "type": "default",
+        },
+    ]
+
+
+@pytest.mark.asyncio
+async def test_execute_many_record_params_with_data_collection_default(
+    sentry_init, capture_events
+) -> None:
+    sentry_init(
+        integrations=[AioMySQLIntegration()],
+        _experiments={"data_collection": {}},
+    )
+    events = capture_events()
+
+    conn = await aiomysql.connect(**_connect_args())
+
+    async with conn.cursor() as cur:
+        await cur.executemany(
+            "INSERT INTO users(name, password, dob) VALUES (%s, %s, %s)",
+            [
+                ("Bob", "secret_pw", datetime.date(1984, 3, 1)),
+                ("Alice", "pw", datetime.date(1990, 12, 25)),
+            ],
+        )
+
+    conn.close()
+
+    capture_message("hi")
+
+    (event,) = events
+
+    for crumb in event["breadcrumbs"]["values"]:
+        del crumb["timestamp"]
+
+    assert event["breadcrumbs"]["values"] == [
+        CRUMBS_CONNECT,
+        {
+            "category": "query",
+            "data": {
+                "db.params": [
+                    ["Bob", "secret_pw", "datetime.date(1984, 3, 1)"],
+                    ["Alice", "pw", "datetime.date(1990, 12, 25)"],
+                ],
+                "db.paramstyle": "format",
+                "db.executemany": True,
+            },
+            "message": "INSERT INTO users(name, password, dob) VALUES (%s, %s, %s)",
+            "type": "default",
+        },
+    ]
+
+
+@pytest.mark.asyncio
 async def test_execute_many_non_insert(sentry_init, capture_events) -> None:
     """Test executemany with non-INSERT queries (falls back to row-by-row)."""
     sentry_init(
@@ -267,6 +404,126 @@ async def test_record_params(sentry_init, capture_events) -> None:
     sentry_init(
         integrations=[AioMySQLIntegration(record_params=True)],
         _experiments={"record_sql_params": True},
+    )
+    events = capture_events()
+
+    conn = await aiomysql.connect(**_connect_args())
+
+    async with conn.cursor() as cur:
+        await cur.execute(
+            "INSERT INTO users(name, password, dob) VALUES (%s, %s, %s)",
+            ("Bob", "secret_pw", datetime.date(1984, 3, 1)),
+        )
+
+    conn.close()
+
+    capture_message("hi")
+
+    (event,) = events
+
+    for crumb in event["breadcrumbs"]["values"]:
+        del crumb["timestamp"]
+
+    assert event["breadcrumbs"]["values"] == [
+        CRUMBS_CONNECT,
+        {
+            "category": "query",
+            "data": {
+                "db.params": ["Bob", "secret_pw", "datetime.date(1984, 3, 1)"],
+                "db.paramstyle": "format",
+            },
+            "message": "INSERT INTO users(name, password, dob) VALUES (%s, %s, %s)",
+            "type": "default",
+        },
+    ]
+
+
+@pytest.mark.asyncio
+async def test_execute_record_params_with_data_collection_enabled(
+    sentry_init, capture_events
+) -> None:
+    sentry_init(
+        integrations=[AioMySQLIntegration()],
+        _experiments={"data_collection": {"database_query_data": True}},
+    )
+    events = capture_events()
+
+    conn = await aiomysql.connect(**_connect_args())
+
+    async with conn.cursor() as cur:
+        await cur.execute(
+            "INSERT INTO users(name, password, dob) VALUES (%s, %s, %s)",
+            ("Bob", "secret_pw", datetime.date(1984, 3, 1)),
+        )
+
+    conn.close()
+
+    capture_message("hi")
+
+    (event,) = events
+
+    for crumb in event["breadcrumbs"]["values"]:
+        del crumb["timestamp"]
+
+    assert event["breadcrumbs"]["values"] == [
+        CRUMBS_CONNECT,
+        {
+            "category": "query",
+            "data": {
+                "db.params": ["Bob", "secret_pw", "datetime.date(1984, 3, 1)"],
+                "db.paramstyle": "format",
+            },
+            "message": "INSERT INTO users(name, password, dob) VALUES (%s, %s, %s)",
+            "type": "default",
+        },
+    ]
+
+
+@pytest.mark.asyncio
+async def test_execute_record_params_with_data_collection_disabled(
+    sentry_init, capture_events
+) -> None:
+    sentry_init(
+        integrations=[AioMySQLIntegration(record_params=True)],
+        _experiments={"data_collection": {"database_query_data": False}},
+    )
+    events = capture_events()
+
+    conn = await aiomysql.connect(**_connect_args())
+
+    async with conn.cursor() as cur:
+        await cur.execute(
+            "INSERT INTO users(name, password, dob) VALUES (%s, %s, %s)",
+            ("Bob", "secret_pw", datetime.date(1984, 3, 1)),
+        )
+
+    conn.close()
+
+    capture_message("hi")
+
+    (event,) = events
+
+    for crumb in event["breadcrumbs"]["values"]:
+        del crumb["timestamp"]
+
+    assert event["breadcrumbs"]["values"] == [
+        CRUMBS_CONNECT,
+        {
+            "category": "query",
+            "data": {},
+            "message": "INSERT INTO users(name, password, dob) VALUES (%s, %s, %s)",
+            "type": "default",
+        },
+    ]
+
+
+@pytest.mark.asyncio
+async def test_execute_record_params_with_data_collection_default(
+    sentry_init, capture_events
+) -> None:
+    sentry_init(
+        integrations=[AioMySQLIntegration()],
+        _experiments={"data_collection": {}},
     )
     events = capture_events()
 


### PR DESCRIPTION
Refactor aiomysql integration to respect the data_collection.database_query_data configuration option for recording query parameters. When data_collection is enabled, parameters are recorded based on that setting. When disabled or not set, fall back to the deprecated record_params parameter for backwards compatibility.

Add comprehensive test coverage for parameter recording under all configuration combinations: data_collection enabled/disabled, with record_params set/unset, and with data_collection using default values.

Fixes PY-2670
Fixes #7046