### PR TITLE
test(arq): Avoid race between the exception and transaction events

### DIFF
--- a/tests/integrations/arq/test_arq.py
+++ b/tests/integrations/arq/test_arq.py
@@ -742,7 +742,7 @@ async def test_job_concurrency(
 
         await worker.close()
 
-        (exception_event,) = (event for event in events if "exception" in "event")
+        (exception_event,) = (event for event in events if "exception" in event)
         assert exception_event["exception"]["values"][0]["type"] == "ZeroDivisionError"
         assert exception_event["transaction"] == "division"
 

--- a/tests/integrations/arq/test_arq.py
+++ b/tests/integrations/arq/test_arq.py
@@ -730,6 +730,7 @@ async def test_job_concurrency(
         events = [item.payload for item in items]
         exception_event = events[0]
         assert exception_event["exception"]["values"][0]["type"] == "ZeroDivisionError"
+        assert exception_event["transaction"] == "division"
     else:
         events = capture_events()
 
@@ -742,6 +743,7 @@ async def test_job_concurrency(
         await worker.close()
 
         (exception_event,) = (event for event in events if "exception" in "event")
+        assert exception_event["exception"]["values"][0]["type"] == "ZeroDivisionError"
         assert exception_event["transaction"] == "division"
 
     assert exception_event["extra"]["arq-job"]["task"] == "division"

--- a/tests/integrations/arq/test_arq.py
+++ b/tests/integrations/arq/test_arq.py
@@ -730,7 +730,6 @@ async def test_job_concurrency(
         events = [item.payload for item in items]
         exception_event = events[0]
         assert exception_event["exception"]["values"][0]["type"] == "ZeroDivisionError"
-        assert exception_event["transaction"] == "division"
     else:
         events = capture_events()
 
@@ -742,8 +741,7 @@ async def test_job_concurrency(
 
         await worker.close()
 
-        exception_event = events[1]
-        assert exception_event["exception"]["values"][0]["type"] == "ZeroDivisionError"
+        (exception_event,) = (event for event in events if "exception" in "event")
         assert exception_event["transaction"] == "division"
 
     assert exception_event["extra"]["arq-job"]["task"] == "division"


### PR DESCRIPTION
### Description
<!-- What changed and why? -->

The failure

```
=================================== FAILURES ===================================
_________________________ test_job_concurrency[False] __________________________
tests/integrations/arq/test_arq.py:746: in test_job_concurrency
    assert exception_event["exception"]["values"][0]["type"] == "ZeroDivisionError"
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
E   KeyError: 'exception'
```

indicates that we're capturing a transaction before an error object. Filter for the error to eliminate the flake.

#### Issues
<!--
* resolves: #1234
* resolves: LIN-1234
-->

#### Reminders
- Please add tests to validate your changes, and lint your code using `uv run ruff`.
- Add GH Issue ID _&_ Linear ID (if applicable)
- PR title should use [conventional commit](https://develop.sentry.dev/engineering-practices/commit-messages/#type) style (`feat:`, `fix:`, `ref:`, `meta:`)
- For external contributors: [CONTRIBUTING.md](https://github.com/getsentry/sentry-python/blob/master/CONTRIBUTING.md), [Sentry SDK development docs](https://develop.sentry.dev/sdk/), [Discord community](https://discord.gg/Ww9hbqr)
