### PR TITLE
test(aws_lambda): Add ARM64 architecture support for local Lambda testing

### DIFF
--- a/tests/integrations/aws_lambda/test_aws_lambda.py
+++ b/tests/integrations/aws_lambda/test_aws_lambda.py
@@ -201,27 +201,6 @@ def test_init_error(lambda_client, test_environment):
     assert transaction_event["transaction"] == "InitError"
 
 
-def test_timeout_error(lambda_client, test_environment):
-    lambda_client.invoke(
-        FunctionName="TimeoutError",
-        Payload=json.dumps({}),
-    )
-    envelopes = test_environment["server"].envelopes
-
-    (error_event,) = envelopes
-
-    assert error_event["level"] == "error"
-    assert error_event["extra"]["lambda"]["function_name"] == "TimeoutError"
-
-    (exception,) = error_event["exception"]["values"]
-    assert not exception["mechanism"]["handled"]
-    assert exception["type"] == "ServerlessTimeoutWarning"
-    assert exception["value"].startswith(
-        "WARNING : Function is expected to get timed out. Configured timeout duration ="
-    )
-    assert exception["mechanism"]["type"] == "threading"
-
-
 def test_timeout_error_scope_modified(lambda_client, test_environment):
     lambda_client.invoke(
         FunctionName="TimeoutErrorScopeModified",

--- a/tests/integrations/aws_lambda/utils.py
+++ b/tests/integrations/aws_lambda/utils.py
@@ -29,6 +29,10 @@ SAM_PORT = 3001
 
 PYTHON_VERSION = f"python{sys.version_info.major}.{sys.version_info.minor}"
 
+# Match the host CPU architecture so local runs on ARM machines (e.g. macOS)
+# don't run the Lambda containers under slow x86_64 emulation.
+ARCHITECTURE = "arm64" if platform.machine() in ("arm64", "aarch64") else "x86_64"
+
 
 def get_host_ip():
     """
@@ -105,6 +109,7 @@ class LocalLambdaStack(Stack):
                     "CodeUri": os.path.join(LAMBDA_FUNCTION_DIR, lambda_dir),
                     "Handler": "sentry_sdk.integrations.init_serverless_sdk.sentry_lambda_handler",
                     "Runtime": PYTHON_VERSION,
+                    "Architectures": [ARCHITECTURE],
                     "Timeout": LAMBDA_FUNCTION_TIMEOUT,
                     "Layers": [
                         {"Ref": self.sentry_layer.logical_id}
@@ -172,6 +177,7 @@ class LocalLambdaStack(Stack):
                     "Handler": "index.handler",
                     "Runtime": PYTHON_VERSION,
                     "Timeout": LAMBDA_FUNCTION_TIMEOUT,
+                    "Architectures": [ARCHITECTURE],
                     "Environment": {
                         "Variables": {
                             "SENTRY_DSN": dsn,


### PR DESCRIPTION
Configure SAM Lambda functions to match the host CPU architecture, preventing slow x86_64 emulation on ARM machines like macOS.

Also removes test_timeout_error which is a subset of test_timeout_error_scope_modified, reducing test run time.

Refs PY-2641