### PR TITLE
chore(strawberry): Remove guard

### DIFF
--- a/sentry_sdk/integrations/strawberry.py
+++ b/sentry_sdk/integrations/strawberry.py
@@ -20,15 +20,6 @@ from sentry_sdk.utils import (
 )
 
 try:
-    from functools import cached_property
-except ImportError:
-    # The strawberry integration requires Python 3.8+. functools.cached_property
-    # was added in 3.8, so this check is technically not needed, but since this
-    # is an auto-enabling integration, we might get to executing this import in
-    # lower Python versions, so we need to deal with it.
-    raise DidNotEnable("strawberry-graphql integration requires Python 3.8 or newer")
-
-try:
     from strawberry import Schema
     from strawberry.extensions import SchemaExtension
     from strawberry.extensions.tracing.utils import (
@@ -142,7 +133,7 @@ class SentryAsyncExtension(SchemaExtension):
         if execution_context:
             self.execution_context = execution_context
 
-    @cached_property
+    @functools.cached_property
     def _resource_name(self) -> str:
         query_hash = self.hash_query(self.execution_context.query)  # type: ignore
 


### PR DESCRIPTION
Strawberry is not auto-enabling in 3.0 anymore, so this guard is not necessary.