### PR TITLE
ref(langchain): Remove `on_agent_finish()` hook

### DIFF
--- a/sentry_sdk/integrations/langchain.py
+++ b/sentry_sdk/integrations/langchain.py
@@ -44,7 +44,6 @@ if TYPE_CHECKING:
 
 
 try:
-    from langchain_core.agents import AgentFinish
     from langchain_core.callbacks import (
         BaseCallbackHandler,
         BaseCallbackManager,
@@ -617,26 +616,6 @@ class SentryLangchainCallback(BaseCallbackHandler):
     ) -> "Any":
         """Run when Chat Model errors."""
         self._handle_error(run_id, error)
-
-    def on_agent_finish(
-        self: "SentryLangchainCallback",
-        finish: "AgentFinish",
-        *,
-        run_id: "UUID",
-        **kwargs: "Any",
-    ) -> "Any":
-        with capture_internal_exceptions():
-            if not run_id or run_id not in self.span_map:
-                return
-
-            span = self.span_map[run_id]
-
-            if should_send_default_pii() and self.include_prompts:
-                set_data_normalized(
-                    span, SPANDATA.GEN_AI_RESPONSE_TEXT, finish.return_values.items()
-                )
-
-            self._exit_span(span, run_id)
 
     def on_tool_start(
         self: "SentryLangchainCallback",


### PR DESCRIPTION
### Description
<!-- What changed and why? -->

 There is no hook that stores a span corresponding to the `run_id`.

#### Issues
<!--
* resolves: #1234
* resolves: LIN-1234
-->

#### Reminders
- Please add tests to validate your changes, and lint your code using `uv run ruff`.
- Add GH Issue ID _&_ Linear ID (if applicable)
- PR title should use [conventional commit](https://develop.sentry.dev/engineering-practices/commit-messages/#type) style (`feat:`, `fix:`, `ref:`, `meta:`)
- For external contributors: [CONTRIBUTING.md](https://github.com/getsentry/sentry-python/blob/master/CONTRIBUTING.md), [Sentry SDK development docs](https://develop.sentry.dev/sdk/), [Discord community](https://discord.gg/Ww9hbqr)
