### PR TITLE
test: Clean up tests

### DIFF
--- a/tests/integrations/django/test_basic.py
+++ b/tests/integrations/django/test_basic.py
@@ -1736,7 +1736,6 @@ def test_render_spans(
             )
 
 
-@pytest.mark.skipif(DJANGO_VERSION < (1, 9), reason="Requires Django >= 1.9")
 @pytest.mark.forked
 @pytest_mark_django_db_decorator()
 def test_render_spans_queryset_in_data(sentry_init, client, capture_events):
@@ -2123,7 +2122,6 @@ def test_csrf(sentry_init, client):
     assert content == b"ok"
 
 
-@pytest.mark.skipif(DJANGO_VERSION < (2, 0), reason="Requires Django > 2.0")
 @pytest.mark.parametrize("middleware_spans", [False, True])
 @pytest.mark.parametrize("span_streaming", [True, False])
 def test_custom_urlconf_middleware(
@@ -2248,7 +2246,6 @@ def test_get_receiver_name():
         assert name == "partial(<function " + a_partial.func.__name__ + ">)"
 
 
-@pytest.mark.skipif(DJANGO_VERSION <= (1, 11), reason="Requires Django > 1.11")
 @pytest.mark.parametrize("span_streaming", [True, False])
 def test_span_origin(
     sentry_init,

--- a/tests/integrations/django/test_cache_module.py
+++ b/tests/integrations/django/test_cache_module.py
@@ -91,7 +91,6 @@ def use_django_caching_with_cluster(settings):
 
 @pytest.mark.forked
 @pytest_mark_django_db_decorator()
-@pytest.mark.skipif(DJANGO_VERSION < (1, 9), reason="Requires Django >= 1.9")
 @pytest.mark.parametrize("span_streaming", [True, False])
 def test_cache_spans_disabled_middleware(
     sentry_init,
@@ -134,7 +133,6 @@ def test_cache_spans_disabled_middleware(
 
 @pytest.mark.forked
 @pytest_mark_django_db_decorator()
-@pytest.mark.skipif(DJANGO_VERSION < (1, 9), reason="Requires Django >= 1.9")
 @pytest.mark.parametrize("span_streaming", [True, False])
 def test_cache_spans_disabled_decorator(
     sentry_init,
@@ -177,7 +175,6 @@ def test_cache_spans_disabled_decorator(
 
 @pytest.mark.forked
 @pytest_mark_django_db_decorator()
-@pytest.mark.skipif(DJANGO_VERSION < (1, 9), reason="Requires Django >= 1.9")
 @pytest.mark.parametrize("span_streaming", [True, False])
 def test_cache_spans_disabled_templatetag(
     sentry_init,
@@ -220,7 +217,6 @@ def test_cache_spans_disabled_templatetag(
 
 @pytest.mark.forked
 @pytest_mark_django_db_decorator()
-@pytest.mark.skipif(DJANGO_VERSION < (1, 9), reason="Requires Django >= 1.9")
 @pytest.mark.parametrize("span_streaming", [True, False])
 def test_cache_spans_middleware(
     sentry_init,
@@ -342,7 +338,6 @@ def test_cache_spans_middleware(
 
 @pytest.mark.forked
 @pytest_mark_django_db_decorator()
-@pytest.mark.skipif(DJANGO_VERSION < (1, 9), reason="Requires Django >= 1.9")
 @pytest.mark.parametrize("span_streaming", [True, False])
 def test_cache_spans_decorator(
     sentry_init,
@@ -442,7 +437,6 @@ def test_cache_spans_decorator(
 
 @pytest.mark.forked
 @pytest_mark_django_db_decorator()
-@pytest.mark.skipif(DJANGO_VERSION < (1, 9), reason="Requires Django >= 1.9")
 @pytest.mark.parametrize("span_streaming", [True, False])
 def test_cache_spans_templatetag(
     sentry_init,
@@ -1097,7 +1091,6 @@ def test_cache_spans_set_many(
 
 @pytest.mark.forked
 @pytest_mark_django_db_decorator()
-@pytest.mark.skipif(DJANGO_VERSION <= (1, 11), reason="Requires Django > 1.11")
 @pytest.mark.parametrize("span_streaming", [True, False])
 def test_span_origin_cache(
     sentry_init,

--- a/tests/integrations/django/test_transactions.py
+++ b/tests/integrations/django/test_transactions.py
@@ -68,10 +68,6 @@ def test_resolver_re_path_multiple_groups():
     assert result == "/api/{project_id}/product/{pid}/"
 
 
-@pytest.mark.skipif(
-    django.VERSION < (2, 0),
-    reason="Django>=2.0 required for <converter:parameter> patterns",
-)
 def test_resolver_path_group():
     url_conf = (path("api/v2/<int:project_id>/store/", lambda x: ""),)
     resolver = RavenResolver()
@@ -79,10 +75,6 @@ def test_resolver_path_group():
     assert result == "/api/v2/{project_id}/store/"
 
 
-@pytest.mark.skipif(
-    django.VERSION < (2, 0),
-    reason="Django>=2.0 required for <converter:parameter> patterns",
-)
 def test_resolver_path_multiple_groups():
     url_conf = (path("api/v2/<str:project_id>/product/<int:pid>", lambda x: ""),)
     resolver = RavenResolver()
@@ -90,10 +82,6 @@ def test_resolver_path_multiple_groups():
     assert result == "/api/v2/{project_id}/product/{pid}"
 
 
-@pytest.mark.skipif(
-    django.VERSION < (2, 0),
-    reason="Django>=2.0 required for <converter:parameter> patterns",
-)
 @pytest.mark.skipif(
     django.VERSION > (5, 1),
     reason="get_converter removed in 5.1",
@@ -130,10 +118,6 @@ def test_resolver_path_complex_path():
         assert result == "/api/v3/{my_path}"
 
 
-@pytest.mark.skipif(
-    django.VERSION < (2, 0),
-    reason="Django>=2.0 required for <converter:parameter> patterns",
-)
 def test_resolver_path_no_converter():
     url_conf = (path("api/v4/<project_id>", lambda x: ""),)
     resolver = RavenResolver()
@@ -141,10 +125,6 @@ def test_resolver_path_no_converter():
     assert result == "/api/v4/{project_id}"
 
 
-@pytest.mark.skipif(
-    django.VERSION < (2, 0),
-    reason="Django>=2.0 required for path patterns",
-)
 def test_resolver_path_with_i18n():
     url_conf = (path(pgettext_lazy("url", "pgettext"), lambda x: ""),)
     resolver = RavenResolver()

--- a/tests/integrations/falcon/test_falcon.py
+++ b/tests/integrations/falcon/test_falcon.py
@@ -7,7 +7,6 @@ import pytest
 import sentry_sdk
 from sentry_sdk.integrations.falcon import FalconIntegration
 from sentry_sdk.integrations.logging import LoggingIntegration
-from sentry_sdk.utils import parse_version
 
 try:
     import falcon.asgi
@@ -15,9 +14,6 @@ except ImportError:
     pass
 else:
     import falcon.inspect  # We only need this module for the ASGI test
-
-
-FALCON_VERSION = parse_version(falcon.__version__)
 
 
 @pytest.fixture

--- a/tests/integrations/falcon/test_falcon.py
+++ b/tests/integrations/falcon/test_falcon.py
@@ -647,9 +647,6 @@ def test_does_not_leak_scope(
     assert not sentry_sdk.get_isolation_scope()._tags["request_data"]
 
 
-@pytest.mark.skipif(
-    not hasattr(falcon, "asgi"), reason="This Falcon version lacks ASGI support."
-)
 @pytest.mark.parametrize("span_streaming", [True, False])
 def test_falcon_not_breaking_asgi(sentry_init, span_streaming):
     """
@@ -672,10 +669,6 @@ def test_falcon_not_breaking_asgi(sentry_init, span_streaming):
         pytest.fail("Falcon integration causing errors in ASGI apps.")
 
 
-@pytest.mark.skipif(
-    (FALCON_VERSION or ()) < (3,),
-    reason="The Sentry Falcon integration only supports custom error handlers on Falcon 3+",
-)
 @pytest.mark.parametrize("span_streaming", [True, False])
 def test_falcon_custom_error_handler(
     sentry_init,

--- a/tests/integrations/pyramid/test_pyramid.py
+++ b/tests/integrations/pyramid/test_pyramid.py
@@ -348,10 +348,6 @@ def test_errorhandler_ok(
     assert not errors
 
 
-@pytest.mark.skipif(
-    PYRAMID_VERSION < (1, 9),
-    reason="We don't have the right hooks in older Pyramid versions",
-)
 def test_errorhandler_500(
     sentry_init, pyramid_config, capture_exceptions, route, get_client
 ):

--- a/tests/integrations/pyramid/test_pyramid.py
+++ b/tests/integrations/pyramid/test_pyramid.py
@@ -4,7 +4,6 @@ from io import BytesIO
 
 import pyramid.testing
 import pytest
-from packaging.version import Version
 from pyramid.authorization import ACLAuthorizationPolicy
 from pyramid.response import Response
 from werkzeug.test import Client
@@ -16,19 +15,6 @@ from sentry_sdk.serializer import MAX_DATABAG_BREADTH
 from sentry_sdk.traces import SpanStatus
 from tests.conftest import unpack_werkzeug_response
 from tests.integrations.utils import DATA_COLLECTION_USER_INFO_CASES
-
-try:
-    from importlib.metadata import version
-
-    PYRAMID_VERSION = Version(version("pyramid")).release
-
-except ImportError:
-    # < py3.8
-    import pkg_resources
-
-    PYRAMID_VERSION = tuple(
-        map(int, pkg_resources.get_distribution("pyramid").version.split("."))
-    )
 
 
 def hi(request):

--- a/tests/integrations/sanic/test_sanic.py
+++ b/tests/integrations/sanic/test_sanic.py
@@ -35,7 +35,6 @@ if TYPE_CHECKING:
     from typing import Any, Optional
 
 SANIC_VERSION = tuple(map(int, SANIC_VERSION_RAW.split(".")))
-PERFORMANCE_SUPPORTED = SANIC_VERSION >= (21, 9)
 
 
 @pytest.fixture
@@ -371,9 +370,6 @@ class TransactionTestConfig:
         self.streaming_compatible = streaming_compatible
 
 
-@pytest.mark.skipif(
-    not PERFORMANCE_SUPPORTED, reason="Performance not supported on this Sanic version"
-)
 @pytest.mark.parametrize("send_pii", [True, False])
 @pytest.mark.parametrize("span_streaming", [True, False])
 @pytest.mark.parametrize(
@@ -533,9 +529,6 @@ def test_transactions(
         )
 
 
-@pytest.mark.skipif(
-    not PERFORMANCE_SUPPORTED, reason="Performance not supported on this Sanic version"
-)
 @pytest.mark.parametrize("span_streaming", [True, False])
 def test_span_origin(sentry_init, app, capture_events, capture_items, span_streaming):
     sentry_init(
@@ -567,9 +560,6 @@ def test_span_origin(sentry_init, app, capture_events, capture_items, span_strea
         assert event["contexts"]["trace"]["origin"] == "auto.http.sanic"
 
 
-@pytest.mark.skipif(
-    not PERFORMANCE_SUPPORTED, reason="Performance not supported on this Sanic version"
-)
 @pytest.mark.parametrize("init_kwargs, expect_ip", DATA_COLLECTION_USER_INFO_CASES)
 def test_user_ip_address_on_all_spans(
     sentry_init, app, capture_items, init_kwargs, expect_ip
@@ -611,9 +601,6 @@ def test_user_ip_address_on_all_spans(
         assert "user.ip_address" not in child_span["attributes"]
 
 
-@pytest.mark.skipif(
-    not PERFORMANCE_SUPPORTED, reason="Performance not supported on this Sanic version"
-)
 @pytest.mark.parametrize("init_kwargs, expect_ip", DATA_COLLECTION_USER_INFO_CASES)
 def test_client_address_span_attribute_data_collection(
     sentry_init, app, capture_items, init_kwargs, expect_ip
@@ -721,9 +708,6 @@ _QUERY_PARAM_DATA_COLLECTION_CASES = [
 ]
 
 
-@pytest.mark.skipif(
-    not PERFORMANCE_SUPPORTED, reason="Performance not supported on this Sanic version"
-)
 @pytest.mark.parametrize(
     "init_kwargs, expected_query", _QUERY_PARAM_DATA_COLLECTION_CASES
 )

--- a/tests/integrations/threading/test_threading.py
+++ b/tests/integrations/threading/test_threading.py
@@ -1,4 +1,3 @@
-import gc
 import sys
 from concurrent import futures
 from textwrap import dedent
@@ -36,26 +35,6 @@ def test_handles_exceptions(sentry_init, capture_events, integrations):
         assert not exception["mechanism"]["handled"]
     else:
         assert not events
-
-
-def test_circular_references(sentry_init, request):
-    sentry_init(default_integrations=False, integrations=[ThreadingIntegration()])
-
-    gc.collect()
-    gc.disable()
-    request.addfinalizer(gc.enable)
-
-    class MyThread(Thread):
-        def run(self):
-            pass
-
-    t = MyThread()
-    t.start()
-    t.join()
-    del t
-
-    unreachable_objects = gc.collect()
-    assert unreachable_objects == 0
 
 
 @pytest.mark.filterwarnings("ignore:.*:pytest.PytestUnhandledThreadExceptionWarning")

--- a/tests/integrations/threading/test_threading.py
+++ b/tests/integrations/threading/test_threading.py
@@ -38,7 +38,6 @@ def test_handles_exceptions(sentry_init, capture_events, integrations):
         assert not events
 
 
-@pytest.mark.skip(reason="Temporarily disable to release SDK 2.0a1.")
 def test_circular_references(sentry_init, request):
     sentry_init(default_integrations=False, integrations=[ThreadingIntegration()])
 

--- a/tests/integrations/trytond_wsgi/test_trytond.py
+++ b/tests/integrations/trytond_wsgi/test_trytond.py
@@ -2,7 +2,6 @@ import json
 import unittest.mock
 
 import pytest
-import trytond
 from trytond.exceptions import LoginException
 from trytond.exceptions import TrytonException as TrytondBaseException
 from trytond.exceptions import UserError as TrytondUserError
@@ -75,9 +74,6 @@ def test_trytonderrors_not_captured(
     assert not exceptions
 
 
-@pytest.mark.skipif(
-    trytond.__version__.split(".") < ["5", "4"], reason="At least Trytond-5.4 required"
-)
 def test_rpc_error_page(sentry_init, app, get_client):
     """Test that, after initializing the Trytond-SentrySDK integration
     a custom error handler can be registered to the Trytond WSGI app so as to


### PR DESCRIPTION
- Remove `skipif`s that are not necessary anymore (because they skip running the test case against framework versions we've now dropped)
- Remove flaky skipped threading test