### PR TITLE
ref: Move HTTP client breadcrumbs to integrations (1)

### DIFF
--- a/sentry_sdk/integrations/aiohttp.py
+++ b/sentry_sdk/integrations/aiohttp.py
@@ -507,16 +507,22 @@ def create_trace_config() -> "TraceConfig":
 
         with capture_internal_exceptions():
             parsed_url = parse_url(str(params.url), sanitize=False)
+            breadcrumb_data = {
+                SPANDATA.HTTP_METHOD: params.method.upper(),
+                SPANDATA.HTTP_STATUS_CODE: status,
+                "reason": params.response.reason,
+            }
+            if parsed_url:
+                breadcrumb_data.update(
+                    {
+                        "url": parsed_url.url,
+                        SPANDATA.HTTP_QUERY: parsed_url.query,
+                        SPANDATA.HTTP_FRAGMENT: parsed_url.fragment,
+                    }
+                )
             add_http_breadcrumb(
                 status,
-                {
-                    SPANDATA.HTTP_METHOD: params.method.upper(),
-                    "url": parsed_url.url if parsed_url else None,
-                    SPANDATA.HTTP_QUERY: parsed_url.query if parsed_url else None,
-                    SPANDATA.HTTP_FRAGMENT: parsed_url.fragment if parsed_url else None,
-                    SPANDATA.HTTP_STATUS_CODE: status,
-                    "reason": params.response.reason,
-                },
+                breadcrumb_data,
             )
 
     trace_config = TraceConfig()

--- a/sentry_sdk/integrations/aiohttp.py
+++ b/sentry_sdk/integrations/aiohttp.py
@@ -36,6 +36,7 @@ from sentry_sdk.tracing import (
     TransactionSource,
 )
 from sentry_sdk.tracing_utils import (
+    add_http_breadcrumb,
     add_http_request_source,
     has_span_streaming_enabled,
     should_propagate_trace,
@@ -503,6 +504,20 @@ def create_trace_config() -> "TraceConfig":
             span.finish()
             with capture_internal_exceptions():
                 add_http_request_source(span)
+
+        with capture_internal_exceptions():
+            parsed_url = parse_url(str(params.url), sanitize=False)
+            add_http_breadcrumb(
+                status,
+                {
+                    SPANDATA.HTTP_METHOD: params.method.upper(),
+                    "url": parsed_url.url if parsed_url else None,
+                    SPANDATA.HTTP_QUERY: parsed_url.query if parsed_url else None,
+                    SPANDATA.HTTP_FRAGMENT: parsed_url.fragment if parsed_url else None,
+                    SPANDATA.HTTP_STATUS_CODE: status,
+                    "reason": params.response.reason,
+                },
+            )
 
     trace_config = TraceConfig()
 

--- a/sentry_sdk/integrations/boto3.py
+++ b/sentry_sdk/integrations/boto3.py
@@ -7,7 +7,7 @@ from sentry_sdk.integrations import DidNotEnable, Integration, _check_minimum_ve
 from sentry_sdk.scope import should_send_default_pii
 from sentry_sdk.traces import StreamedSpan
 from sentry_sdk.tracing import Span
-from sentry_sdk.tracing_utils import has_span_streaming_enabled
+from sentry_sdk.tracing_utils import add_http_breadcrumb, has_span_streaming_enabled
 from sentry_sdk.utils import (
     capture_internal_exceptions,
     parse_url,
@@ -112,17 +112,31 @@ def _sentry_request_created(
     # request.context is an open-ended data-structure
     # where we can add anything useful in request life cycle.
     request.context["_sentrysdk_span"] = span
+    request.context["_sentrysdk_breadcrumb_data"] = {
+        SPANDATA.HTTP_METHOD: request.method,
+        "url": request.url,
+    }
 
 
 def _sentry_after_call(
     context: "Dict[str, Any]", parsed: "Dict[str, Any]", **kwargs: "Any"
 ) -> None:
     span: "Optional[Union[Span, StreamedSpan]]" = context.pop("_sentrysdk_span", None)
+    breadcrumb_data: "Optional[Dict[str, Any]]" = context.pop(
+        "_sentrysdk_breadcrumb_data", None
+    )
 
     # Span could be absent if the integration is disabled.
     if span is None:
         return
     span.__exit__(None, None, None)
+
+    with capture_internal_exceptions():
+        status_code = parsed.get("ResponseMetadata", {}).get("HTTPStatusCode")
+        data = breadcrumb_data or {}
+        if status_code is not None:
+            data[SPANDATA.HTTP_STATUS_CODE] = status_code
+        add_http_breadcrumb(status_code, data)
 
     body = parsed.get("Body")
     if not isinstance(body, StreamingBody):

--- a/sentry_sdk/integrations/httpx.py
+++ b/sentry_sdk/integrations/httpx.py
@@ -5,6 +5,7 @@ from sentry_sdk.consts import OP, SPANDATA
 from sentry_sdk.integrations import DidNotEnable, Integration
 from sentry_sdk.scope import should_send_default_pii
 from sentry_sdk.tracing_utils import (
+    add_http_breadcrumb,
     add_http_request_source,
     has_span_streaming_enabled,
     propagate_trace_headers,
@@ -128,6 +129,19 @@ def _install_httpx_client() -> None:
             with capture_internal_exceptions():
                 add_http_request_source(span)
 
+        with capture_internal_exceptions():
+            add_http_breadcrumb(
+                rv.status_code,
+                {
+                    SPANDATA.HTTP_METHOD: request.method,
+                    "url": parsed_url.url if parsed_url else None,
+                    SPANDATA.HTTP_QUERY: parsed_url.query if parsed_url else None,
+                    SPANDATA.HTTP_FRAGMENT: parsed_url.fragment if parsed_url else None,
+                    SPANDATA.HTTP_STATUS_CODE: rv.status_code,
+                    "reason": rv.reason_phrase,
+                },
+            )
+
         return rv
 
     Client.send = send  # type: ignore
@@ -219,6 +233,19 @@ def _install_httpx_async_client() -> None:
 
             with capture_internal_exceptions():
                 add_http_request_source(span)
+
+        with capture_internal_exceptions():
+            add_http_breadcrumb(
+                rv.status_code,
+                {
+                    SPANDATA.HTTP_METHOD: request.method,
+                    "url": parsed_url.url if parsed_url else None,
+                    SPANDATA.HTTP_QUERY: parsed_url.query if parsed_url else None,
+                    SPANDATA.HTTP_FRAGMENT: parsed_url.fragment if parsed_url else None,
+                    SPANDATA.HTTP_STATUS_CODE: rv.status_code,
+                    "reason": rv.reason_phrase,
+                },
+            )
 
         return rv
 

--- a/sentry_sdk/integrations/httpx.py
+++ b/sentry_sdk/integrations/httpx.py
@@ -129,18 +129,20 @@ def _install_httpx_client() -> None:
             with capture_internal_exceptions():
                 add_http_request_source(span)
 
-        with capture_internal_exceptions():
-            add_http_breadcrumb(
-                rv.status_code,
+        breadcrumb_data = {
+            SPANDATA.HTTP_METHOD: request.method,
+            SPANDATA.HTTP_STATUS_CODE: rv.status_code,
+            "reason": rv.reason_phrase,
+        }
+        if parsed_url:
+            breadcrumb_data.update(
                 {
-                    SPANDATA.HTTP_METHOD: request.method,
-                    "url": parsed_url.url if parsed_url else None,
-                    SPANDATA.HTTP_QUERY: parsed_url.query if parsed_url else None,
-                    SPANDATA.HTTP_FRAGMENT: parsed_url.fragment if parsed_url else None,
-                    SPANDATA.HTTP_STATUS_CODE: rv.status_code,
-                    "reason": rv.reason_phrase,
-                },
+                    "url": parsed_url.url,
+                    SPANDATA.HTTP_QUERY: parsed_url.query,
+                    SPANDATA.HTTP_FRAGMENT: parsed_url.fragment,
+                }
             )
+        add_http_breadcrumb(rv.status_code, breadcrumb_data)
 
         return rv
 
@@ -234,18 +236,20 @@ def _install_httpx_async_client() -> None:
             with capture_internal_exceptions():
                 add_http_request_source(span)
 
-        with capture_internal_exceptions():
-            add_http_breadcrumb(
-                rv.status_code,
+        breadcrumb_data = {
+            SPANDATA.HTTP_METHOD: request.method,
+            SPANDATA.HTTP_STATUS_CODE: rv.status_code,
+            "reason": rv.reason_phrase,
+        }
+        if parsed_url:
+            breadcrumb_data.update(
                 {
-                    SPANDATA.HTTP_METHOD: request.method,
-                    "url": parsed_url.url if parsed_url else None,
-                    SPANDATA.HTTP_QUERY: parsed_url.query if parsed_url else None,
-                    SPANDATA.HTTP_FRAGMENT: parsed_url.fragment if parsed_url else None,
-                    SPANDATA.HTTP_STATUS_CODE: rv.status_code,
-                    "reason": rv.reason_phrase,
-                },
+                    "url": parsed_url.url,
+                    SPANDATA.HTTP_QUERY: parsed_url.query,
+                    SPANDATA.HTTP_FRAGMENT: parsed_url.fragment,
+                }
             )
+        add_http_breadcrumb(rv.status_code, breadcrumb_data)
 
         return rv
 

--- a/sentry_sdk/integrations/httpx2.py
+++ b/sentry_sdk/integrations/httpx2.py
@@ -130,18 +130,20 @@ def _install_httpx2_client() -> None:
             with capture_internal_exceptions():
                 add_http_request_source(span)
 
-        with capture_internal_exceptions():
-            add_http_breadcrumb(
-                rv.status_code,
+        breadcrumb_data = {
+            SPANDATA.HTTP_METHOD: request.method,
+            SPANDATA.HTTP_STATUS_CODE: rv.status_code,
+            "reason": rv.reason_phrase,
+        }
+        if parsed_url:
+            breadcrumb_data.update(
                 {
-                    SPANDATA.HTTP_METHOD: request.method,
-                    "url": parsed_url.url if parsed_url else None,
-                    SPANDATA.HTTP_QUERY: parsed_url.query if parsed_url else None,
-                    SPANDATA.HTTP_FRAGMENT: parsed_url.fragment if parsed_url else None,
-                    SPANDATA.HTTP_STATUS_CODE: rv.status_code,
-                    "reason": rv.reason_phrase,
-                },
+                    "url": parsed_url.url,
+                    SPANDATA.HTTP_QUERY: parsed_url.query,
+                    SPANDATA.HTTP_FRAGMENT: parsed_url.fragment,
+                }
             )
+        add_http_breadcrumb(rv.status_code, breadcrumb_data)
 
         return rv
 
@@ -236,18 +238,20 @@ def _install_httpx2_async_client() -> None:
             with capture_internal_exceptions():
                 add_http_request_source(span)
 
-        with capture_internal_exceptions():
-            add_http_breadcrumb(
-                rv.status_code,
+        breadcrumb_data = {
+            SPANDATA.HTTP_METHOD: request.method,
+            SPANDATA.HTTP_STATUS_CODE: rv.status_code,
+            "reason": rv.reason_phrase,
+        }
+        if parsed_url:
+            breadcrumb_data.update(
                 {
-                    SPANDATA.HTTP_METHOD: request.method,
-                    "url": parsed_url.url if parsed_url else None,
-                    SPANDATA.HTTP_QUERY: parsed_url.query if parsed_url else None,
-                    SPANDATA.HTTP_FRAGMENT: parsed_url.fragment if parsed_url else None,
-                    SPANDATA.HTTP_STATUS_CODE: rv.status_code,
-                    "reason": rv.reason_phrase,
-                },
+                    "url": parsed_url.url,
+                    SPANDATA.HTTP_QUERY: parsed_url.query,
+                    SPANDATA.HTTP_FRAGMENT: parsed_url.fragment,
+                }
             )
+        add_http_breadcrumb(rv.status_code, breadcrumb_data)
 
         return rv
 

--- a/sentry_sdk/integrations/httpx2.py
+++ b/sentry_sdk/integrations/httpx2.py
@@ -5,6 +5,7 @@ from sentry_sdk.consts import OP, SPANDATA
 from sentry_sdk.integrations import DidNotEnable, Integration
 from sentry_sdk.scope import should_send_default_pii
 from sentry_sdk.tracing_utils import (
+    add_http_breadcrumb,
     add_http_request_source,
     has_span_streaming_enabled,
     propagate_trace_headers,
@@ -129,6 +130,19 @@ def _install_httpx2_client() -> None:
             with capture_internal_exceptions():
                 add_http_request_source(span)
 
+        with capture_internal_exceptions():
+            add_http_breadcrumb(
+                rv.status_code,
+                {
+                    SPANDATA.HTTP_METHOD: request.method,
+                    "url": parsed_url.url if parsed_url else None,
+                    SPANDATA.HTTP_QUERY: parsed_url.query if parsed_url else None,
+                    SPANDATA.HTTP_FRAGMENT: parsed_url.fragment if parsed_url else None,
+                    SPANDATA.HTTP_STATUS_CODE: rv.status_code,
+                    "reason": rv.reason_phrase,
+                },
+            )
+
         return rv
 
     Client.send = send  # type: ignore
@@ -221,6 +235,19 @@ def _install_httpx2_async_client() -> None:
 
             with capture_internal_exceptions():
                 add_http_request_source(span)
+
+        with capture_internal_exceptions():
+            add_http_breadcrumb(
+                rv.status_code,
+                {
+                    SPANDATA.HTTP_METHOD: request.method,
+                    "url": parsed_url.url if parsed_url else None,
+                    SPANDATA.HTTP_QUERY: parsed_url.query if parsed_url else None,
+                    SPANDATA.HTTP_FRAGMENT: parsed_url.fragment if parsed_url else None,
+                    SPANDATA.HTTP_STATUS_CODE: rv.status_code,
+                    "reason": rv.reason_phrase,
+                },
+            )
 
         return rv
 

--- a/sentry_sdk/integrations/pyreqwest.py
+++ b/sentry_sdk/integrations/pyreqwest.py
@@ -157,9 +157,6 @@ async def sentry_async_middleware(
     if sentry_sdk.get_client().get_integration(PyreqwestIntegration) is None:
         return await next_handler.run(request)
 
-    parsed_url = None
-    with capture_internal_exceptions():
-        parsed_url = parse_url(str(request.url), sanitize=False)
     method = request.method
 
     with _sentry_pyreqwest_span(request) as span:
@@ -173,17 +170,24 @@ async def sentry_async_middleware(
         elif span is not None:
             span.set_http_status(response.status)
 
+    breadcrumb_data = {
+        SPANDATA.HTTP_METHOD: method,
+        SPANDATA.HTTP_STATUS_CODE: response.status,
+    }
+
+    parsed_url = None
     with capture_internal_exceptions():
-        add_http_breadcrumb(
-            response.status,
+        parsed_url = parse_url(str(request.url), sanitize=False)
+    if parsed_url:
+        breadcrumb_data.update(
             {
-                SPANDATA.HTTP_METHOD: method,
-                "url": parsed_url.url if parsed_url else None,
-                SPANDATA.HTTP_QUERY: parsed_url.query if parsed_url else None,
-                SPANDATA.HTTP_FRAGMENT: parsed_url.fragment if parsed_url else None,
-                SPANDATA.HTTP_STATUS_CODE: response.status,
-            },
+                "url": parsed_url.url,
+                SPANDATA.HTTP_QUERY: parsed_url.query,
+                SPANDATA.HTTP_FRAGMENT: parsed_url.fragment,
+            }
         )
+
+    add_http_breadcrumb(response.status, breadcrumb_data)
 
     return response
 
@@ -194,9 +198,6 @@ def sentry_sync_middleware(
     if sentry_sdk.get_client().get_integration(PyreqwestIntegration) is None:
         return next_handler.run(request)
 
-    parsed_url = None
-    with capture_internal_exceptions():
-        parsed_url = parse_url(str(request.url), sanitize=False)
     method = request.method
 
     with _sentry_pyreqwest_span(request) as span:
@@ -210,16 +211,23 @@ def sentry_sync_middleware(
         elif span is not None:
             span.set_http_status(response.status)
 
+    breadcrumb_data = {
+        SPANDATA.HTTP_METHOD: method,
+        SPANDATA.HTTP_STATUS_CODE: response.status,
+    }
+
+    parsed_url = None
     with capture_internal_exceptions():
-        add_http_breadcrumb(
-            response.status,
+        parsed_url = parse_url(str(request.url), sanitize=False)
+    if parsed_url:
+        breadcrumb_data.update(
             {
-                SPANDATA.HTTP_METHOD: method,
-                "url": parsed_url.url if parsed_url else None,
-                SPANDATA.HTTP_QUERY: parsed_url.query if parsed_url else None,
-                SPANDATA.HTTP_FRAGMENT: parsed_url.fragment if parsed_url else None,
-                SPANDATA.HTTP_STATUS_CODE: response.status,
-            },
+                "url": parsed_url.url,
+                SPANDATA.HTTP_QUERY: parsed_url.query,
+                SPANDATA.HTTP_FRAGMENT: parsed_url.fragment,
+            }
         )
+
+    add_http_breadcrumb(response.status, breadcrumb_data)
 
     return response

--- a/sentry_sdk/integrations/pyreqwest.py
+++ b/sentry_sdk/integrations/pyreqwest.py
@@ -159,6 +159,12 @@ async def sentry_async_middleware(
 
     method = request.method
 
+    # If we want to access request.url, we need to do it early. It can't be
+    # retrieved after the request has been sent
+    parsed_url = None
+    with capture_internal_exceptions():
+        parsed_url = parse_url(str(request.url), sanitize=False)
+
     with _sentry_pyreqwest_span(request) as span:
         response = await next_handler.run(request)
         if isinstance(span, StreamedSpan):
@@ -174,10 +180,6 @@ async def sentry_async_middleware(
         SPANDATA.HTTP_METHOD: method,
         SPANDATA.HTTP_STATUS_CODE: response.status,
     }
-
-    parsed_url = None
-    with capture_internal_exceptions():
-        parsed_url = parse_url(str(request.url), sanitize=False)
     if parsed_url:
         breadcrumb_data.update(
             {
@@ -200,6 +202,12 @@ def sentry_sync_middleware(
 
     method = request.method
 
+    # If we want to access request.url, we need to do it early. It can't be
+    # retrieved after the request has been sent
+    parsed_url = None
+    with capture_internal_exceptions():
+        parsed_url = parse_url(str(request.url), sanitize=False)
+
     with _sentry_pyreqwest_span(request) as span:
         response = next_handler.run(request)
         if isinstance(span, StreamedSpan):
@@ -216,9 +224,6 @@ def sentry_sync_middleware(
         SPANDATA.HTTP_STATUS_CODE: response.status,
     }
 
-    parsed_url = None
-    with capture_internal_exceptions():
-        parsed_url = parse_url(str(request.url), sanitize=False)
     if parsed_url:
         breadcrumb_data.update(
             {

--- a/sentry_sdk/integrations/pyreqwest.py
+++ b/sentry_sdk/integrations/pyreqwest.py
@@ -9,6 +9,7 @@ from sentry_sdk.scope import should_send_default_pii
 from sentry_sdk.traces import StreamedSpan
 from sentry_sdk.tracing import BAGGAGE_HEADER_NAME
 from sentry_sdk.tracing_utils import (
+    add_http_breadcrumb,
     add_http_request_source,
     add_sentry_baggage_to_headers,
     has_span_streaming_enabled,
@@ -156,6 +157,11 @@ async def sentry_async_middleware(
     if sentry_sdk.get_client().get_integration(PyreqwestIntegration) is None:
         return await next_handler.run(request)
 
+    parsed_url = None
+    with capture_internal_exceptions():
+        parsed_url = parse_url(str(request.url), sanitize=False)
+    method = request.method
+
     with _sentry_pyreqwest_span(request) as span:
         response = await next_handler.run(request)
         if isinstance(span, StreamedSpan):
@@ -167,6 +173,18 @@ async def sentry_async_middleware(
         elif span is not None:
             span.set_http_status(response.status)
 
+    with capture_internal_exceptions():
+        add_http_breadcrumb(
+            response.status,
+            {
+                SPANDATA.HTTP_METHOD: method,
+                "url": parsed_url.url if parsed_url else None,
+                SPANDATA.HTTP_QUERY: parsed_url.query if parsed_url else None,
+                SPANDATA.HTTP_FRAGMENT: parsed_url.fragment if parsed_url else None,
+                SPANDATA.HTTP_STATUS_CODE: response.status,
+            },
+        )
+
     return response
 
 
@@ -175,6 +193,11 @@ def sentry_sync_middleware(
 ) -> "SyncResponse":
     if sentry_sdk.get_client().get_integration(PyreqwestIntegration) is None:
         return next_handler.run(request)
+
+    parsed_url = None
+    with capture_internal_exceptions():
+        parsed_url = parse_url(str(request.url), sanitize=False)
+    method = request.method
 
     with _sentry_pyreqwest_span(request) as span:
         response = next_handler.run(request)
@@ -186,5 +209,17 @@ def sentry_sync_middleware(
             )
         elif span is not None:
             span.set_http_status(response.status)
+
+    with capture_internal_exceptions():
+        add_http_breadcrumb(
+            response.status,
+            {
+                SPANDATA.HTTP_METHOD: method,
+                "url": parsed_url.url if parsed_url else None,
+                SPANDATA.HTTP_QUERY: parsed_url.query if parsed_url else None,
+                SPANDATA.HTTP_FRAGMENT: parsed_url.fragment if parsed_url else None,
+                SPANDATA.HTTP_STATUS_CODE: response.status,
+            },
+        )
 
     return response

--- a/sentry_sdk/tracing_utils.py
+++ b/sentry_sdk/tracing_utils.py
@@ -222,6 +222,7 @@ def add_http_breadcrumb(status_code, data):
     kwargs = {"type": "http", "category": "httplib", "data": data}
     if level:
         kwargs["level"] = level
+
     sentry_sdk.add_breadcrumb(**kwargs)
 
 

--- a/sentry_sdk/tracing_utils.py
+++ b/sentry_sdk/tracing_utils.py
@@ -219,7 +219,7 @@ def add_http_breadcrumb(status_code, data):
         elif 400 <= status_code <= 499:
             level = "warning"
 
-    kwargs = {"type": "http", "category": "httplib", "data": data}
+    kwargs: "dict[str, Any]" = {"type": "http", "category": "httplib", "data": data}
     if level:
         kwargs["level"] = level
 

--- a/sentry_sdk/tracing_utils.py
+++ b/sentry_sdk/tracing_utils.py
@@ -210,6 +210,21 @@ def record_sql_queries(
             yield span
 
 
+def add_http_breadcrumb(status_code, data):
+    # type: (Optional[int], dict[str, Any]) -> None
+    level = None
+    if status_code:
+        if 500 <= status_code <= 599:
+            level = "error"
+        elif 400 <= status_code <= 499:
+            level = "warning"
+
+    kwargs = {"type": "http", "category": "httplib", "data": data}
+    if level:
+        kwargs["level"] = level
+    sentry_sdk.add_breadcrumb(**kwargs)
+
+
 def maybe_create_breadcrumbs_from_span(
     scope: "sentry_sdk.Scope", span: "sentry_sdk.tracing.Span"
 ) -> None:


### PR DESCRIPTION
### Description
Move breadcrumbs created by HTTP client integrations to the integrations themselves, instead of relying on span data.

This PR has everything but stdlib in it.

#### Issues
Part 1/2 of https://github.com/getsentry/sentry-python/issues/7067

#### Reminders
- Please add tests to validate your changes, and lint your code using `uv run ruff`.
- Add GH Issue ID _&_ Linear ID (if applicable)
- PR title should use [conventional commit](https://develop.sentry.dev/engineering-practices/commit-messages/#type) style (`feat:`, `fix:`, `ref:`, `meta:`)
- For external contributors: [CONTRIBUTING.md](https://github.com/getsentry/sentry-python/blob/master/CONTRIBUTING.md), [Sentry SDK development docs](https://develop.sentry.dev/sdk/), [Discord community](https://discord.gg/Ww9hbqr)
