### PR TITLE
test(django): Remove dead code and stale markers from the Django test suite

### DIFF
--- a/tests/integrations/django/myapp/urls.py
+++ b/tests/integrations/django/myapp/urls.py
@@ -149,7 +149,6 @@ try:
             name="rest_framework_read_body_and_exc",
         )
     )
-    urlpatterns.append(path("rest-hello", views.rest_hello, name="rest_hello"))
     urlpatterns.append(
         path(
             "rest-authenticated-hello",

--- a/tests/integrations/django/myapp/views.py
+++ b/tests/integrations/django/myapp/views.py
@@ -50,10 +50,6 @@ try:
         1 / 0
 
     @api_view(["GET"])
-    def rest_hello(request):
-        return HttpResponse("ok")
-
-    @api_view(["GET"])
     def rest_permission_denied_exc(request):
         raise PermissionDenied("bye")
 

--- a/tests/integrations/django/test_basic.py
+++ b/tests/integrations/django/test_basic.py
@@ -1369,7 +1369,6 @@ def test_request_body(
     assert "" not in event
 
 
-@pytest.mark.xfail
 @pytest.mark.parametrize("span_streaming", [True, False])
 def test_read_request(
     sentry_init,

--- a/tests/integrations/django/test_basic.py
+++ b/tests/integrations/django/test_basic.py
@@ -535,7 +535,6 @@ def test_user_captured(
 def test_materialized_user_captured(
     sentry_init,
     client,
-    capture_events,
     capture_items,
 ):
     sentry_init(

--- a/tests/integrations/django/test_basic.py
+++ b/tests/integrations/django/test_basic.py
@@ -815,7 +815,6 @@ def test_sql_dict_query_params(
 
 
 @pytest.mark.forked
-@pytest_mark_django_db_decorator()
 @pytest.mark.parametrize("span_streaming", [True, False])
 def test_response_trace(
     sentry_init,

--- a/tests/integrations/django/test_db_query_data.py
+++ b/tests/integrations/django/test_db_query_data.py
@@ -900,7 +900,6 @@ def test_db_span_origin_execute(
 @pytest.mark.parametrize("span_streaming", [True, False])
 def test_db_span_origin_executemany(
     sentry_init,
-    client,
     capture_events,
     capture_items,
     span_streaming,

--- a/tests/integrations/django/test_db_transactions.py
+++ b/tests/integrations/django/test_db_transactions.py
@@ -617,7 +617,6 @@ def test_db_no_autocommit_execute(
 @pytest.mark.parametrize("span_streaming", [True, False])
 def test_db_no_autocommit_executemany(
     sentry_init,
-    client,
     capture_events,
     capture_items,
     span_streaming,
@@ -900,7 +899,6 @@ def test_db_no_autocommit_rollback_execute(
 @pytest.mark.parametrize("span_streaming", [True, False])
 def test_db_no_autocommit_rollback_executemany(
     sentry_init,
-    client,
     capture_events,
     capture_items,
     span_streaming,
@@ -1181,7 +1179,6 @@ def test_db_atomic_execute(
 @pytest.mark.parametrize("span_streaming", [True, False])
 def test_db_atomic_executemany(
     sentry_init,
-    client,
     capture_events,
     capture_items,
     span_streaming,
@@ -1457,7 +1454,6 @@ def test_db_atomic_rollback_execute(
 @pytest.mark.parametrize("span_streaming", [True, False])
 def test_db_atomic_rollback_executemany(
     sentry_init,
-    client,
     capture_events,
     capture_items,
     span_streaming,
@@ -1737,7 +1733,6 @@ def test_db_atomic_execute_exception(
 @pytest.mark.parametrize("span_streaming", [True, False])
 def test_db_atomic_executemany_exception(
     sentry_init,
-    client,
     capture_events,
     capture_items,
     span_streaming,


### PR DESCRIPTION
### Description

Cleanup pass over the Django test suite, no change in what is covered:

- stale `xfail` on `test_read_request` (the test passes — it currently reports as `xpass`)
- spurious `django_db` marker on `test_response_trace`
- dead `rest_hello` view and its URL entry in the test app
- unused `client` fixture argument on 7 test signatures

First of four PRs trimming redundancy from this suite (391 -> 312 cases overall). This one doesn't change this, is a cleanup PR.

Refs PY-2641
Refs #6975