### PR TITLE
feat: Set the segment name on the scope with `NoOpStreamedSpan`

### DIFF
--- a/sentry_sdk/scope.py
+++ b/sentry_sdk/scope.py
@@ -925,15 +925,19 @@ class Scope:
 
         # Also set _transaction and _transaction_info in streaming mode as this
         # is used for populating events and linking them to segments
-        if isinstance(span, StreamedSpan) and span._is_segment():
-            if span.name is not None:
-                self._transaction = span.name
-            if type(span) is StreamedSpan and span._attributes.get(
-                "sentry.segment.name.source"
-            ):
+        if not isinstance(span, StreamedSpan) or not span._is_segment():
+            return
+
+        if type(span) is StreamedSpan:
+            self._transaction = span.name
+            if span._attributes.get("sentry.segment.name.source"):
                 self._transaction_info["source"] = str(
                     span._attributes["sentry.segment.name.source"]
                 )
+            return
+
+        if type(span) is NoOpStreamedSpan and span._noop_name is not None:
+            self._transaction = span.name
 
     @property
     def profile(self) -> "Optional[Profile]":

--- a/sentry_sdk/scope.py
+++ b/sentry_sdk/scope.py
@@ -926,7 +926,8 @@ class Scope:
         # Also set _transaction and _transaction_info in streaming mode as this
         # is used for populating events and linking them to segments
         if isinstance(span, StreamedSpan) and span._is_segment():
-            self._transaction = span.name
+            if span.name is not None:
+                self._transaction = span.name
             if span._attributes.get("sentry.segment.name.source"):
                 self._transaction_info["source"] = str(
                     span._attributes["sentry.segment.name.source"]
@@ -1309,6 +1310,7 @@ class Scope:
 
             if is_ignored_span(name, attributes):
                 return NoOpStreamedSpan(
+                    name=name,
                     scope=self,
                     segment=None,
                     trace_id=propagation_context.trace_id,

--- a/sentry_sdk/scope.py
+++ b/sentry_sdk/scope.py
@@ -925,7 +925,7 @@ class Scope:
 
         # Also set _transaction and _transaction_info in streaming mode as this
         # is used for populating events and linking them to segments
-        if type(span) is StreamedSpan and span._is_segment():
+        if isinstance(span, StreamedSpan) and span._is_segment():
             self._transaction = span.name
             if span._attributes.get("sentry.segment.name.source"):
                 self._transaction_info["source"] = str(

--- a/sentry_sdk/scope.py
+++ b/sentry_sdk/scope.py
@@ -936,7 +936,7 @@ class Scope:
                 )
             return
 
-        if type(span) is NoOpStreamedSpan and span._noop_name is not None:
+        if type(span) is NoOpStreamedSpan and span._name is not None:
             self._transaction = span.name
 
     @property

--- a/sentry_sdk/scope.py
+++ b/sentry_sdk/scope.py
@@ -1329,6 +1329,7 @@ class Scope:
 
             if sampled is False or sampled is None:
                 return NoOpStreamedSpan(
+                    name=name,
                     scope=self,
                     segment=None,
                     trace_id=propagation_context.trace_id,
@@ -1359,6 +1360,7 @@ class Scope:
         with new_scope():
             if is_ignored_span(name, attributes):
                 return NoOpStreamedSpan(
+                    name=name,
                     segment=parent_span._segment,
                     trace_id=parent_span.trace_id,
                     parent_span_id=parent_span.span_id,
@@ -1368,6 +1370,7 @@ class Scope:
 
             if isinstance(parent_span, NoOpStreamedSpan):
                 return NoOpStreamedSpan(
+                    name=name,
                     segment=parent_span._segment,
                     trace_id=parent_span.trace_id,
                     parent_span_id=parent_span.span_id,

--- a/sentry_sdk/scope.py
+++ b/sentry_sdk/scope.py
@@ -928,7 +928,9 @@ class Scope:
         if isinstance(span, StreamedSpan) and span._is_segment():
             if span.name is not None:
                 self._transaction = span.name
-            if span._attributes.get("sentry.segment.name.source"):
+            if type(span) is StreamedSpan and span._attributes.get(
+                "sentry.segment.name.source"
+            ):
                 self._transaction_info["source"] = str(
                     span._attributes["sentry.segment.name.source"]
                 )

--- a/sentry_sdk/traces.py
+++ b/sentry_sdk/traces.py
@@ -625,6 +625,7 @@ class StreamedSpan:
 
 class NoOpStreamedSpan(StreamedSpan):
     __slots__ = (
+        "_name",
         "_sampled",
         "_finished",
         "_unsampled_reason",
@@ -632,6 +633,7 @@ class NoOpStreamedSpan(StreamedSpan):
 
     def __init__(
         self,
+        name: "str",
         segment: "Optional[StreamedSpan]" = None,
         trace_id: "Optional[str]" = None,
         parent_span_id: "Optional[str]" = None,
@@ -643,6 +645,8 @@ class NoOpStreamedSpan(StreamedSpan):
         sample_rand: "Optional[float]" = None,
         sample_rate: "Optional[float]" = None,
     ) -> None:
+        self._name = name
+
         self._span_id: "Optional[str]" = None
 
         self._sampled = sampled

--- a/sentry_sdk/traces.py
+++ b/sentry_sdk/traces.py
@@ -625,7 +625,6 @@ class StreamedSpan:
 
 class NoOpStreamedSpan(StreamedSpan):
     __slots__ = (
-        "_noop_name",
         "_sampled",
         "_finished",
         "_unsampled_reason",
@@ -645,7 +644,7 @@ class NoOpStreamedSpan(StreamedSpan):
         sample_rand: "Optional[float]" = None,
         sample_rate: "Optional[float]" = None,
     ) -> None:
-        self._noop_name = name
+        self._name = name  # type: ignore[assignment]
 
         self._span_id: "Optional[str]" = None
 
@@ -743,11 +742,11 @@ class NoOpStreamedSpan(StreamedSpan):
 
     @property
     def name(self) -> str:
-        return self._noop_name or ""
+        return self._name or ""
 
     @name.setter
     def name(self, name: str) -> None:
-        self._noop_name = name
+        self._name = name
 
     @property
     def active(self) -> bool:

--- a/sentry_sdk/traces.py
+++ b/sentry_sdk/traces.py
@@ -633,7 +633,7 @@ class NoOpStreamedSpan(StreamedSpan):
 
     def __init__(
         self,
-        name: "str",
+        name: "Optional[str]" = None,
         segment: "Optional[StreamedSpan]" = None,
         trace_id: "Optional[str]" = None,
         parent_span_id: "Optional[str]" = None,
@@ -742,12 +742,8 @@ class NoOpStreamedSpan(StreamedSpan):
         pass
 
     @property
-    def name(self) -> str:
-        return ""
-
-    @name.setter
-    def name(self, value: str) -> None:
-        pass
+    def name(self) -> "Optional[str]":
+        return self._name
 
     @property
     def active(self) -> bool:

--- a/sentry_sdk/traces.py
+++ b/sentry_sdk/traces.py
@@ -625,7 +625,7 @@ class StreamedSpan:
 
 class NoOpStreamedSpan(StreamedSpan):
     __slots__ = (
-        "_name",
+        "_noop_name",
         "_sampled",
         "_finished",
         "_unsampled_reason",
@@ -645,7 +645,7 @@ class NoOpStreamedSpan(StreamedSpan):
         sample_rand: "Optional[float]" = None,
         sample_rate: "Optional[float]" = None,
     ) -> None:
-        self._name = name
+        self._noop_name = name
 
         self._span_id: "Optional[str]" = None
 
@@ -742,8 +742,12 @@ class NoOpStreamedSpan(StreamedSpan):
         pass
 
     @property
-    def name(self) -> "Optional[str]":
-        return self._name
+    def name(self) -> str:
+        return self._noop_name or ""
+
+    @name.setter
+    def name(self, name: str) -> None:
+        self._noop_name = name
 
     @property
     def active(self) -> bool:

--- a/tests/integrations/django/test_basic.py
+++ b/tests/integrations/django/test_basic.py
@@ -1293,6 +1293,56 @@ def test_transaction_style(
     assert event["transaction"] == expected_transaction
 
 
+@pytest.mark.parametrize(
+    "transaction_style,client_url,expected_transaction,expected_source,expected_response",
+    [
+        (
+            "function_name",
+            "/message",
+            "tests.integrations.django.myapp.views.message",
+            "component",
+            b"ok",
+        ),
+        ("url", "/message", "/message", "route", b"ok"),
+        ("url", "/404", "/404", "url", b"404"),
+    ],
+)
+@pytest.mark.parametrize("span_streaming", [True, False])
+def test_transaction_style_tracing_disabled(
+    sentry_init,
+    client,
+    capture_events,
+    capture_items,
+    transaction_style,
+    client_url,
+    expected_transaction,
+    expected_source,
+    expected_response,
+    span_streaming,
+):
+    sentry_init(
+        integrations=[DjangoIntegration(transaction_style=transaction_style)],
+        send_default_pii=True,
+        trace_lifecycle="stream" if span_streaming else "static",
+    )
+    if span_streaming:
+        items = capture_items("event")
+
+        content, status, headers = unpack_werkzeug_response(client.get(client_url))
+        assert content == expected_response
+
+        (event,) = (item.payload for item in items if item.type == "event")
+    else:
+        events = capture_events()
+
+        content, status, headers = unpack_werkzeug_response(client.get(client_url))
+        assert content == expected_response
+
+        (event,) = events
+
+    assert event["transaction"] == expected_transaction
+
+
 @pytest.mark.parametrize("span_streaming", [True, False])
 def test_request_body(
     sentry_init,

--- a/tests/tracing/test_integration_tests.py
+++ b/tests/tracing/test_integration_tests.py
@@ -91,6 +91,21 @@ def test_basic_span_streaming(sentry_init, capture_items, sample_rate):
         assert not items
 
 
+def test_error_event_linked_without_performance_span_streaming(
+    sentry_init, capture_items
+):
+    sentry_init(traces_sample_rate=None, trace_lifecycle="stream")
+    items = capture_items("event")
+
+    with sentry_sdk.traces.start_span(name="no-op span"):
+        sentry_sdk.capture_message("hi")
+
+    sentry_sdk.flush()
+
+    (event,) = (item.payload for item in items)
+    assert event["transaction"] == "no-op span"
+
+
 @pytest.mark.parametrize("parent_sampled", [True, False, None])
 @pytest.mark.parametrize("sample_rate", [0.0, 1.0])
 def test_continue_trace(sentry_init, capture_envelopes, parent_sampled, sample_rate):

--- a/tests/tracing/test_span_streaming.py
+++ b/tests/tracing/test_span_streaming.py
@@ -799,7 +799,7 @@ def test_continue_trace_unsampled(sentry_init, capture_items):
         ...
 
     assert span.sampled is False
-    assert span.name == ""
+    assert span.name == "segment"
     assert span.trace_id == trace_id
     assert span.span_id != "0000000000000000"
 


### PR DESCRIPTION
### Description
<!-- What changed and why? -->

Add the `name` parameter to `NoOpStreamedSpan.__init__()`.

Set the transaction name on the scope when a segment `NoOpStreamedSpan` is set on the scope.

The commit https://github.com/getsentry/sentry-python/commit/11c1e90d4adbce533f7c220ff83ae6295f53f31d removed validation of tracing without performance, so I've added a new test where tracing is disabled.

#### Issues
<!--
* resolves: #1234
* resolves: LIN-1234
-->

#### Reminders
- Please add tests to validate your changes, and lint your code using `uv run ruff`.
- Add GH Issue ID _&_ Linear ID (if applicable)
- PR title should use [conventional commit](https://develop.sentry.dev/engineering-practices/commit-messages/#type) style (`feat:`, `fix:`, `ref:`, `meta:`)
- For external contributors: [CONTRIBUTING.md](https://github.com/getsentry/sentry-python/blob/master/CONTRIBUTING.md), [Sentry SDK development docs](https://develop.sentry.dev/sdk/), [Discord community](https://discord.gg/Ww9hbqr)
