### PR TITLE
chore: Make `enable_logs`, `enable_metrics` no-op

### DIFF
--- a/sentry_sdk/client.py
+++ b/sentry_sdk/client.py
@@ -12,6 +12,7 @@ from importlib import import_module
 from typing import TYPE_CHECKING, Dict, List, cast, overload
 
 from sentry_sdk._compat import check_uwsgi_thread_support
+from sentry_sdk._log_batcher import LogBatcher
 from sentry_sdk._metrics_batcher import MetricsBatcher
 from sentry_sdk._span_batcher import SpanBatcher
 from sentry_sdk.consts import (
@@ -64,8 +65,6 @@ from sentry_sdk.utils import (
     get_type_name,
     handle_in_app,
     has_data_collection_enabled,
-    has_logs_enabled,
-    has_metrics_enabled,
     logger,
 )
 
@@ -649,22 +648,27 @@ class _Client(BaseClient):
 
             self.session_flusher = SessionFlusher(capture_func=_capture_envelope)
 
-            self.log_batcher = None
-
-            if has_logs_enabled(self.options):
-                from sentry_sdk._log_batcher import LogBatcher
-
-                self.log_batcher = LogBatcher(
-                    capture_func=_capture_envelope,
-                    record_lost_func=_record_lost_event,
+            if self.options.get("enable_logs", False) or self.options[
+                "_experiments"
+            ].get("enable_logs", False):
+                logger.warning(
+                    "The enable_logs option has no effect and will be removed in the next major."
                 )
 
-            self.metrics_batcher = None
-            if has_metrics_enabled(self.options):
-                self.metrics_batcher = MetricsBatcher(
-                    capture_func=_capture_envelope,
-                    record_lost_func=_record_lost_event,
+            self.log_batcher = LogBatcher(
+                capture_func=_capture_envelope,
+                record_lost_func=_record_lost_event,
+            )
+
+            if self.options.get("enable_metrics", False):
+                logger.warning(
+                    "The enable_metrics option has no effect and will be removed in the next major."
                 )
+
+            self.metrics_batcher = MetricsBatcher(
+                capture_func=_capture_envelope,
+                record_lost_func=_record_lost_event,
+            )
 
             self.span_batcher = None
             if has_span_streaming_enabled(self.options):

--- a/sentry_sdk/client.py
+++ b/sentry_sdk/client.py
@@ -660,7 +660,7 @@ class _Client(BaseClient):
                 record_lost_func=_record_lost_event,
             )
 
-            if self.options.get("enable_metrics", False):
+            if self.options.get("enable_metrics", True) is False:
                 logger.warning(
                     "The enable_metrics option has no effect and will be removed in the next major."
                 )

--- a/sentry_sdk/integrations/logging.py
+++ b/sentry_sdk/integrations/logging.py
@@ -12,7 +12,6 @@ from sentry_sdk.utils import (
     capture_internal_exceptions,
     current_stacktrace,
     event_from_exception,
-    has_logs_enabled,
     safe_repr,
     to_string,
 )
@@ -121,7 +120,10 @@ class LoggingIntegration(Integration):
         level: "Optional[int]" = DEFAULT_LEVEL,
         event_level: "Optional[int]" = DEFAULT_EVENT_LEVEL,
         sentry_logs_level: "Optional[int]" = DEFAULT_LEVEL,
+        capture_sentry_logs: "Optional[bool]" = False,
     ) -> None:
+        LoggingIntegration.capture_sentry_logs = capture_sentry_logs
+
         self._handler = None
         self._breadcrumb_handler = None
         self._sentry_logs_handler = None
@@ -378,7 +380,7 @@ class SentryLogsHandler(_BaseHandler):
     """
     A logging handler that records Sentry logs for each Python log record.
 
-    Note that you do not have to use this class if the logging integration is enabled, which it is by default.
+    Note that you do not have to use this class if the LoggingIntegration's capture_sentry_logs option is enabled.
     """
 
     def _can_record(self, record: "LogRecord") -> bool:
@@ -398,7 +400,7 @@ class SentryLogsHandler(_BaseHandler):
             if not client.is_active():
                 return
 
-            if not has_logs_enabled(client.options):
+            if not LoggingIntegration.capture_sentry_logs:
                 return
 
             self._capture_log_from_record(client, record)
@@ -462,7 +464,6 @@ class SentryLogsHandler(_BaseHandler):
         if record.name:
             attrs["logger.name"] = record.name
 
-        # noinspection PyProtectedMember
         sentry_sdk.get_current_scope()._capture_log(
             {
                 "severity_text": otel_severity_text,

--- a/sentry_sdk/integrations/logging.py
+++ b/sentry_sdk/integrations/logging.py
@@ -114,6 +114,7 @@ def unignore_logger_for_sentry_logs(
 
 class LoggingIntegration(Integration):
     identifier = "logging"
+    capture_sentry_logs: "Optional[bool]" = False
 
     def __init__(
         self,

--- a/sentry_sdk/integrations/loguru.py
+++ b/sentry_sdk/integrations/loguru.py
@@ -9,7 +9,7 @@ from sentry_sdk.integrations.logging import (
     _BaseHandler,
 )
 from sentry_sdk.logger import _log_level_to_otel
-from sentry_sdk.utils import has_logs_enabled, safe_repr
+from sentry_sdk.utils import safe_repr
 
 if TYPE_CHECKING:
     from logging import LogRecord
@@ -70,6 +70,7 @@ class LoguruIntegration(Integration):
     breadcrumb_format = DEFAULT_FORMAT
     event_format = DEFAULT_FORMAT
     sentry_logs_level: "Optional[int]" = DEFAULT_LEVEL
+    capture_sentry_logs: "Optional[bool]" = False
 
     def __init__(
         self,
@@ -78,12 +79,14 @@ class LoguruIntegration(Integration):
         breadcrumb_format: "str | loguru.FormatFunction" = DEFAULT_FORMAT,
         event_format: "str | loguru.FormatFunction" = DEFAULT_FORMAT,
         sentry_logs_level: "Optional[int]" = DEFAULT_LEVEL,
+        capture_sentry_logs: Optional[bool] = False,
     ) -> None:
         LoguruIntegration.level = level
         LoguruIntegration.event_level = event_level
         LoguruIntegration.breadcrumb_format = breadcrumb_format
         LoguruIntegration.event_format = event_format
         LoguruIntegration.sentry_logs_level = sentry_logs_level
+        LoguruIntegration.capture_sentry_logs = capture_sentry_logs
 
     @staticmethod
     def setup_once() -> None:
@@ -142,11 +145,10 @@ def loguru_sentry_logs_handler(message: "Message") -> None:
     # This is intentionally a callable sink instead of a standard logging handler
     # since otherwise we wouldn't get direct access to message.record
     client = sentry_sdk.get_client()
-
     if not client.is_active():
         return
 
-    if not has_logs_enabled(client.options):
+    if not LoguruIntegration.capture_sentry_logs:
         return
 
     record = message.record

--- a/sentry_sdk/integrations/loguru.py
+++ b/sentry_sdk/integrations/loguru.py
@@ -79,7 +79,7 @@ class LoguruIntegration(Integration):
         breadcrumb_format: "str | loguru.FormatFunction" = DEFAULT_FORMAT,
         event_format: "str | loguru.FormatFunction" = DEFAULT_FORMAT,
         sentry_logs_level: "Optional[int]" = DEFAULT_LEVEL,
-        capture_sentry_logs: Optional[bool] = False,
+        capture_sentry_logs: "Optional[bool]" = False,
     ) -> None:
         LoguruIntegration.level = level
         LoguruIntegration.event_level = event_level

--- a/sentry_sdk/scope.py
+++ b/sentry_sdk/scope.py
@@ -58,8 +58,6 @@ from sentry_sdk.utils import (
     exc_info_from_error,
     format_attribute,
     has_data_collection_enabled,
-    has_logs_enabled,
-    has_metrics_enabled,
     logger,
 )
 
@@ -1470,8 +1468,6 @@ class Scope:
             return
 
         client = self.get_client()
-        if not has_logs_enabled(client.options):
-            return
 
         merged_scope = self._merge_scopes()
 
@@ -1488,8 +1484,6 @@ class Scope:
             return
 
         client = self.get_client()
-        if not has_metrics_enabled(client.options):
-            return
 
         merged_scope = self._merge_scopes()
 

--- a/sentry_sdk/utils.py
+++ b/sentry_sdk/utils.py
@@ -2070,16 +2070,6 @@ def safe_serialize(data: "Any") -> str:
         return str(data)
 
 
-def has_logs_enabled(options: "Optional[dict[str, Any]]") -> bool:
-    if options is None:
-        return False
-
-    return bool(
-        options.get("enable_logs", False)
-        or options["_experiments"].get("enable_logs", False)
-    )
-
-
 def has_data_collection_enabled(options: "Optional[dict[str, Any]]") -> bool:
     if options is None:
         return False
@@ -2096,13 +2086,6 @@ def get_before_send_log(
     return options.get("before_send_log") or options["_experiments"].get(
         "before_send_log"
     )
-
-
-def has_metrics_enabled(options: "Optional[dict[str, Any]]") -> bool:
-    if options is None:
-        return False
-
-    return bool(options.get("enable_metrics", True))
 
 
 def get_before_send_metric(

--- a/tests/integrations/logging/test_logging.py
+++ b/tests/integrations/logging/test_logging.py
@@ -231,6 +231,37 @@ def test_logging_captured_warnings(sentry_init, capture_events, recwarn):
     assert len(third_warnings) == 1
 
 
+def test_sentry_logs_collection_off_by_default(sentry_init, capture_items, request):
+    """Automatic logs capture by Sentry logs needs explicit opt-in via capture_sentry_logs."""
+    sentry_init()
+    items = capture_items("log")
+
+    python_logger = logging.Logger("test-logger")
+    python_logger.warning("this is %s a template %s", "1", "2")
+
+    get_client().flush()
+
+    assert not items
+
+
+def test_sentry_logs_collection_opt_in(sentry_init, capture_items, request):
+    """Automatic logs capture by Sentry logs needs explicit opt-in via capture_sentry_logs."""
+    sentry_init(integrations=[LoggingIntegration(capture_sentry_logs=True)])
+    items = capture_items("log")
+
+    python_logger = logging.Logger("test-logger")
+    python_logger.warning("this is %s a template %s", "1", "2")
+
+    get_client().flush()
+
+    assert len(items) == 1
+
+    log = items[0].payload
+    assert log["attributes"]["sentry.message.template"] == "this is %s a template %s"
+    assert log["attributes"]["sentry.severity_number"] == 13
+    assert log["attributes"]["sentry.severity_text"] == "warn"
+
+
 def test_ignore_logger(sentry_init, capture_events, request):
     sentry_init(integrations=[LoggingIntegration()], default_integrations=False)
     events = capture_events()
@@ -276,7 +307,7 @@ def test_ignore_logger_wildcard(sentry_init, capture_events, request):
 
 def test_ignore_logger_does_not_affect_sentry_logs(sentry_init, capture_items, request):
     """ignore_logger should suppress events/breadcrumbs but not Sentry Logs."""
-    sentry_init(enable_logs=True)
+    sentry_init(integrations=[LoggingIntegration(capture_sentry_logs=True)])
     items = capture_items("log")
 
     ignore_logger("testfoo")
@@ -355,7 +386,7 @@ def test_sentry_logs_warning(sentry_init, capture_items):
     """
     The python logger module should create 'warn' sentry logs if the flag is on.
     """
-    sentry_init(enable_logs=True)
+    sentry_init(integrations=[LoggingIntegration(capture_sentry_logs=True)])
     items = capture_items("log")
 
     python_logger = logging.Logger("test-logger")
@@ -395,8 +426,11 @@ def test_no_log_infinite_loop(sentry_init, capture_envelopes):
     If 'debug' mode is true, and you set a low log level in the logging integration, there should be no infinite loops.
     """
     sentry_init(
-        enable_logs=True,
-        integrations=[LoggingIntegration(sentry_logs_level=logging.DEBUG)],
+        integrations=[
+            LoggingIntegration(
+                capture_sentry_logs=True, sentry_logs_level=logging.DEBUG
+            )
+        ],
         debug=True,
     )
     envelopes = capture_envelopes()
@@ -448,8 +482,8 @@ def test_log_strips_project_root(sentry_init, capture_items):
     The python logger should strip project roots from the log record path
     """
     sentry_init(
-        enable_logs=True,
         project_root="/custom/test",
+        integrations=[LoggingIntegration(capture_sentry_logs=True)],
     )
     items = capture_items("log")
 
@@ -477,7 +511,7 @@ def test_logger_with_all_attributes(sentry_init, capture_items):
     """
     The python logger should be able to log all attributes, including extra data.
     """
-    sentry_init(enable_logs=True)
+    sentry_init(integrations=[LoggingIntegration(capture_sentry_logs=True)])
     items = capture_items("log")
 
     python_logger = logging.Logger("test-logger")
@@ -554,7 +588,7 @@ def test_sentry_logs_named_parameters(sentry_init, capture_items):
     """
     The python logger module should capture named parameters from dictionary arguments in Sentry logs.
     """
-    sentry_init(enable_logs=True)
+    sentry_init(integrations=[LoggingIntegration(capture_sentry_logs=True)])
     items = capture_items("log")
 
     python_logger = logging.Logger("test-logger")
@@ -599,7 +633,7 @@ def test_sentry_logs_named_parameters_complex_values(sentry_init, capture_items)
     """
     The python logger module should handle complex values in named parameters using safe_repr.
     """
-    sentry_init(enable_logs=True)
+    sentry_init(integrations=[LoggingIntegration(capture_sentry_logs=True)])
     items = capture_items("log")
 
     python_logger = logging.Logger("test-logger")
@@ -633,7 +667,7 @@ def test_sentry_logs_no_parameters_no_template(sentry_init, capture_items):
     """
     There shouldn't be a template if there are no parameters.
     """
-    sentry_init(enable_logs=True)
+    sentry_init(integrations=[LoggingIntegration(capture_sentry_logs=True)])
     items = capture_items("log")
 
     python_logger = logging.Logger("test-logger")

--- a/tests/integrations/logging/test_logging.py
+++ b/tests/integrations/logging/test_logging.py
@@ -325,7 +325,7 @@ def test_ignore_logger_for_sentry_logs(
     sentry_init, capture_envelopes, capture_items, request
 ):
     """ignore_logger_for_sentry_logs should suppress Sentry Logs but not events."""
-    sentry_init(enable_logs=True)
+    sentry_init(integrations=[LoggingIntegration(capture_sentry_logs=True)])
     envelopes = capture_envelopes()
     items = capture_items("log")
 
@@ -446,7 +446,7 @@ def test_logging_errors(sentry_init, capture_envelopes, capture_items):
     """
     The python logger module should be able to log errors without erroring
     """
-    sentry_init(enable_logs=True)
+    sentry_init(integrations=[LoggingIntegration(capture_sentry_logs=True)])
     envelopes = capture_envelopes()
     items = capture_items("log")
 

--- a/tests/integrations/logging/test_logging.py
+++ b/tests/integrations/logging/test_logging.py
@@ -411,7 +411,7 @@ def test_sentry_logs_debug(sentry_init, capture_envelopes):
     """
     The python logger module should not create 'debug' sentry logs if the flag is on by default
     """
-    sentry_init(enable_logs=True)
+    sentry_init(integrations=[LoggingIntegration(capture_sentry_logs=True)])
     envelopes = capture_envelopes()
 
     python_logger = logging.Logger("test-logger")

--- a/tests/integrations/loguru/test_loguru.py
+++ b/tests/integrations/loguru/test_loguru.py
@@ -140,7 +140,7 @@ def test_sentry_logs_warning(
     uninstall_integration("loguru")
     request.addfinalizer(logger.remove)
 
-    sentry_init(enable_logs=True)
+    sentry_init(integrations=[LoguruIntegration(capture_sentry_logs=True)])
     items = capture_items("log")
 
     logger.warning("this is {} a {}", "just", "template")
@@ -164,7 +164,7 @@ def test_sentry_logs_debug(
     uninstall_integration("loguru")
     request.addfinalizer(logger.remove)
 
-    sentry_init(enable_logs=True)
+    sentry_init(integrations=[LoguruIntegration(capture_sentry_logs=True)])
     envelopes = capture_envelopes()
 
     logger.debug("this is %s a template %s", "1", "2")
@@ -178,8 +178,11 @@ def test_sentry_log_levels(sentry_init, capture_items, uninstall_integration, re
     request.addfinalizer(logger.remove)
 
     sentry_init(
-        integrations=[LoguruIntegration(sentry_logs_level=LoggingLevels.SUCCESS)],
-        enable_logs=True,
+        integrations=[
+            LoguruIntegration(
+                capture_sentry_logs=True, sentry_logs_level=LoggingLevels.SUCCESS
+            )
+        ],
     )
     items = capture_items("log")
 
@@ -212,8 +215,9 @@ def test_disable_loguru_logs(
     request.addfinalizer(logger.remove)
 
     sentry_init(
-        integrations=[LoguruIntegration(sentry_logs_level=None)],
-        enable_logs=True,
+        integrations=[
+            LoguruIntegration(capture_sentry_logs=True, sentry_logs_level=None)
+        ],
     )
     items = capture_items("log")
 
@@ -230,14 +234,36 @@ def test_disable_loguru_logs(
     assert len(logs) == 0
 
 
-def test_disable_sentry_logs(
+def test_disable_sentry_logs_by_default(
+    sentry_init, capture_items, uninstall_integration, request
+):
+    uninstall_integration("loguru")
+    request.addfinalizer(logger.remove)
+
+    sentry_init()
+    items = capture_items("log")
+
+    logger.trace("this is a log")
+    logger.debug("this is a log")
+    logger.info("this is a log")
+    logger.success("this is a log")
+    logger.warning("this is a log")
+    logger.error("this is a log")
+    logger.critical("this is a log")
+
+    sentry_sdk.get_client().flush()
+    logs = [item.payload for item in items]
+    assert len(logs) == 0
+
+
+def test_disable_sentry_logs_explicitly(
     sentry_init, capture_items, uninstall_integration, request
 ):
     uninstall_integration("loguru")
     request.addfinalizer(logger.remove)
 
     sentry_init(
-        _experiments={"enable_logs": False},
+        integrations=[LoguruIntegration(capture_sentry_logs=False)],
     )
     items = capture_items("log")
 
@@ -264,8 +290,11 @@ def test_no_log_infinite_loop(
     request.addfinalizer(logger.remove)
 
     sentry_init(
-        enable_logs=True,
-        integrations=[LoguruIntegration(sentry_logs_level=LoggingLevels.DEBUG)],
+        integrations=[
+            LoguruIntegration(
+                capture_sentry_logs=True, sentry_logs_level=LoggingLevels.DEBUG
+            )
+        ],
         debug=True,
     )
     envelopes = capture_envelopes()
@@ -283,7 +312,7 @@ def test_logging_errors(
     uninstall_integration("loguru")
     request.addfinalizer(logger.remove)
 
-    sentry_init(enable_logs=True)
+    sentry_init(integrations=[LoguruIntegration(capture_sentry_logs=True)])
     envelopes = capture_envelopes()
     items = capture_items("log")
 
@@ -313,7 +342,7 @@ def test_log_strips_project_root(
     request.addfinalizer(logger.remove)
 
     sentry_init(
-        enable_logs=True,
+        integrations=[LoguruIntegration(capture_sentry_logs=True)],
         project_root="/custom/test",
     )
     items = capture_items("log")
@@ -362,7 +391,7 @@ def test_log_keeps_full_path_if_not_in_project_root(
     request.addfinalizer(logger.remove)
 
     sentry_init(
-        enable_logs=True,
+        integrations=[LoguruIntegration(capture_sentry_logs=True)],
         project_root="/custom/test",
     )
     items = capture_items("log")
@@ -410,7 +439,7 @@ def test_logger_with_all_attributes(
     uninstall_integration("loguru")
     request.addfinalizer(logger.remove)
 
-    sentry_init(enable_logs=True)
+    sentry_init(integrations=[LoguruIntegration(capture_sentry_logs=True)])
     items = capture_items("log")
 
     logger.warning("log #{}", 1)
@@ -482,7 +511,7 @@ def test_logger_capture_parameters_from_args(
     uninstall_integration("loguru")
     request.addfinalizer(logger.remove)
 
-    sentry_init(enable_logs=True)
+    sentry_init(integrations=[LoguruIntegration(capture_sentry_logs=True)])
     items = capture_items("log")
 
     logger.warning("Task ID: {}", 123)
@@ -501,7 +530,7 @@ def test_logger_capture_parameters_from_kwargs(
     uninstall_integration("loguru")
     request.addfinalizer(logger.remove)
 
-    sentry_init(enable_logs=True)
+    sentry_init(integrations=[LoguruIntegration(capture_sentry_logs=True)])
     items = capture_items("log")
 
     logger.warning("Task ID: {task_id}", task_id=123)
@@ -520,7 +549,7 @@ def test_logger_capture_parameters_from_contextualize(
     uninstall_integration("loguru")
     request.addfinalizer(logger.remove)
 
-    sentry_init(enable_logs=True)
+    sentry_init(integrations=[LoguruIntegration(capture_sentry_logs=True)])
     items = capture_items("log")
 
     with logger.contextualize(task_id=123):
@@ -540,7 +569,7 @@ def test_logger_capture_parameters_from_bind(
     uninstall_integration("loguru")
     request.addfinalizer(logger.remove)
 
-    sentry_init(enable_logs=True)
+    sentry_init(integrations=[LoguruIntegration(capture_sentry_logs=True)])
     items = capture_items("log")
 
     logger.bind(task_id=123).warning("Log")
@@ -558,7 +587,7 @@ def test_logger_capture_parameters_from_patch(
     uninstall_integration("loguru")
     request.addfinalizer(logger.remove)
 
-    sentry_init(enable_logs=True)
+    sentry_init(integrations=[LoguruIntegration(capture_sentry_logs=True)])
     items = capture_items("log")
 
     logger.patch(lambda record: record["extra"].update(task_id=123)).warning("Log")
@@ -576,7 +605,7 @@ def test_no_parameters_no_template(
     uninstall_integration("loguru")
     request.addfinalizer(logger.remove)
 
-    sentry_init(enable_logs=True)
+    sentry_init(integrations=[LoguruIntegration(capture_sentry_logs=True)])
     items = capture_items("log")
 
     logger.warning("Logging a hardcoded warning")

--- a/tests/test_logs.py
+++ b/tests/test_logs.py
@@ -1,4 +1,3 @@
-import logging
 import os
 import sys
 import time
@@ -17,10 +16,8 @@ minimum_python_37 = pytest.mark.skipif(
 
 
 @minimum_python_37
-def test_logs_disabled_by_default(sentry_init, capture_envelopes):
+def test_logs_enabled_by_default(sentry_init, capture_envelopes):
     sentry_init()
-
-    python_logger = logging.Logger("some-logger")
 
     envelopes = capture_envelopes()
 
@@ -30,14 +27,33 @@ def test_logs_disabled_by_default(sentry_init, capture_envelopes):
     sentry_sdk.logger.warning("This is a 'warning' log...")
     sentry_sdk.logger.error("This is a 'error' log...")
     sentry_sdk.logger.fatal("This is a 'fatal' log...")
-    python_logger.warning("sad")
 
-    assert len(envelopes) == 0
+    sentry_sdk.flush()
+
+    assert envelopes
+
+
+@minimum_python_37
+def test_enable_logs_noop(sentry_init, capture_envelopes):
+    sentry_init(enable_logs=False)
+
+    envelopes = capture_envelopes()
+
+    sentry_sdk.logger.trace("This is a 'trace' log.")
+    sentry_sdk.logger.debug("This is a 'debug' log...")
+    sentry_sdk.logger.info("This is a 'info' log...")
+    sentry_sdk.logger.warning("This is a 'warning' log...")
+    sentry_sdk.logger.error("This is a 'error' log...")
+    sentry_sdk.logger.fatal("This is a 'fatal' log...")
+
+    sentry_sdk.flush()
+
+    assert envelopes
 
 
 @minimum_python_37
 def test_logs_basics(sentry_init, capture_items):
-    sentry_init(enable_logs=True)
+    sentry_init()
     items = capture_items("log")
 
     sentry_sdk.logger.trace("This is a 'trace' log...")
@@ -69,22 +85,6 @@ def test_logs_basics(sentry_init, capture_items):
 
 
 @minimum_python_37
-def test_logs_experimental_option_still_works(sentry_init, capture_items):
-    sentry_init(_experiments={"enable_logs": True})
-    items = capture_items("log")
-
-    sentry_sdk.logger.error("This is an error log...")
-
-    get_client().flush()
-
-    logs = [item.payload for item in items]
-    assert len(logs) == 1
-
-    assert logs[0]["attributes"]["sentry.severity_text"] == "error"
-    assert logs[0]["attributes"]["sentry.severity_number"] == 17
-
-
-@minimum_python_37
 def test_logs_before_send_log(sentry_init, capture_items):
     before_log_called = False
 
@@ -109,7 +109,6 @@ def test_logs_before_send_log(sentry_init, capture_items):
         return record
 
     sentry_init(
-        enable_logs=True,
         before_send_log=_before_log,
     )
     items = capture_items("log")
@@ -145,7 +144,6 @@ def test_logs_before_send_log_experimental_option_still_works(
         return record
 
     sentry_init(
-        enable_logs=True,
         _experiments={
             "before_send_log": _before_log,
         },
@@ -171,7 +169,6 @@ def test_logs_before_send_log_raises_does_not_crash_application(
         raise ValueError("before_send_log error")
 
     sentry_init(
-        enable_logs=True,
         before_send_log=_before_log,
     )
     items = capture_items("log")
@@ -190,7 +187,7 @@ def test_logs_attributes(sentry_init, capture_items):
     """
     Passing arbitrary attributes to log messages.
     """
-    sentry_init(enable_logs=True, server_name="test-server")
+    sentry_init(server_name="test-server")
     items = capture_items("log")
 
     attrs = {
@@ -224,7 +221,7 @@ def test_logs_message_params(sentry_init, capture_items):
     """
     This is the official way of how to pass vars to log messages.
     """
-    sentry_init(enable_logs=True)
+    sentry_init()
     items = capture_items("log")
 
     sentry_sdk.logger.warning("The recorded value was '{int_var}'", int_var=1)
@@ -291,7 +288,7 @@ def test_logs_tied_to_transactions(sentry_init, capture_items):
     """
     Log messages are also tied to transactions.
     """
-    sentry_init(enable_logs=True, traces_sample_rate=1.0)
+    sentry_init(traces_sample_rate=1.0)
     items = capture_items("log")
 
     with sentry_sdk.start_transaction(name="test-transaction") as trx:
@@ -309,7 +306,7 @@ def test_logs_tied_to_segments(sentry_init, capture_items):
     """
     Log messages are also tied to segments.
     """
-    sentry_init(enable_logs=True, traces_sample_rate=1.0, trace_lifecycle="stream")
+    sentry_init(traces_sample_rate=1.0, trace_lifecycle="stream")
     items = capture_items("log")
 
     with sentry_sdk.traces.start_span(name="test-segment") as sgmt:
@@ -329,7 +326,7 @@ def test_logs_no_span_id_without_active_span(sentry_init, capture_items):
     when the telemetry is emitted. The propagation context's synthesized
     span_id must not be used as a fallback.
     """
-    sentry_init(enable_logs=True)
+    sentry_init()
     items = capture_items("log")
 
     sentry_sdk.logger.warning("This is a log without an active span")
@@ -345,7 +342,7 @@ def test_logs_tied_to_spans(sentry_init, capture_items):
     """
     Log messages are also tied to spans.
     """
-    sentry_init(enable_logs=True, traces_sample_rate=1.0)
+    sentry_init(traces_sample_rate=1.0)
     items = capture_items("log")
 
     with sentry_sdk.start_transaction(name="test-transaction"):
@@ -362,7 +359,7 @@ def test_logs_tied_to_spans_span_streaming(sentry_init, capture_items):
     """
     Log messages are also tied to spans.
     """
-    sentry_init(enable_logs=True, traces_sample_rate=1.0, trace_lifecycle="stream")
+    sentry_init(traces_sample_rate=1.0, trace_lifecycle="stream")
     items = capture_items("log")
 
     with sentry_sdk.traces.start_span(name="test-segment"):
@@ -379,7 +376,7 @@ def test_auto_flush_logs_after_100(sentry_init, capture_envelopes):
     """
     If you log >100 logs, it should automatically trigger a flush.
     """
-    sentry_init(enable_logs=True)
+    sentry_init()
     envelopes = capture_envelopes()
 
     for i in range(200):
@@ -395,8 +392,8 @@ def test_auto_flush_logs_after_100(sentry_init, capture_envelopes):
 
 @minimum_python_37
 def test_log_user_attributes(sentry_init, capture_items):
-    """User attributes are sent if enable_logs is True and send_default_pii is True."""
-    sentry_init(enable_logs=True, send_default_pii=True)
+    """User attributes are sent if send_default_pii is True."""
+    sentry_init(send_default_pii=True)
 
     sentry_sdk.set_user({"id": "1", "email": "test@example.com", "username": "test"})
     items = capture_items("log")
@@ -419,7 +416,7 @@ def test_log_user_attributes(sentry_init, capture_items):
 @minimum_python_37
 def test_log_no_user_attributes_if_no_pii(sentry_init, capture_items):
     """User attributes are not if PII sending is off."""
-    sentry_init(enable_logs=True, send_default_pii=False)
+    sentry_init(send_default_pii=False)
 
     sentry_sdk.set_user({"id": "1", "email": "test@example.com", "username": "test"})
     items = capture_items("log")
@@ -441,7 +438,7 @@ def test_auto_flush_logs_after_5s(sentry_init, capture_envelopes):
     """
     If you log a single log, it should automatically flush after 5 seconds, at most 10 seconds.
     """
-    sentry_init(enable_logs=True)
+    sentry_init()
     envelopes = capture_envelopes()
 
     sentry_sdk.logger.warning("log")
@@ -482,7 +479,7 @@ def test_logs_with_literal_braces(
     Test that log messages with literal braces (like JSON) work without crashing.
     This is a regression test for issue #4975.
     """
-    sentry_init(enable_logs=True)
+    sentry_init()
     items = capture_items("log")
 
     if params:
@@ -505,7 +502,7 @@ def test_logs_with_literal_braces(
 
 @minimum_python_37
 def test_transport_format(sentry_init, capture_envelopes):
-    sentry_init(enable_logs=True, server_name="test-server", release="1.0.0")
+    sentry_init(server_name="test-server", release="1.0.0")
 
     envelopes = capture_envelopes()
 
@@ -576,7 +573,7 @@ def test_transport_format(sentry_init, capture_envelopes):
 
 @minimum_python_37
 def test_batcher_drops_logs(sentry_init, monkeypatch):
-    sentry_init(enable_logs=True, server_name="test-server", release="1.0.0")
+    sentry_init(server_name="test-server", release="1.0.0")
     client = sentry_sdk.get_client()
 
     def no_op_flush():
@@ -662,7 +659,7 @@ def test_batcher_drops_logs(sentry_init, monkeypatch):
 
 @minimum_python_37
 def test_log_gets_attributes_from_scopes(sentry_init, capture_items):
-    sentry_init(enable_logs=True)
+    sentry_init()
 
     items = capture_items("log")
 
@@ -689,7 +686,7 @@ def test_log_gets_attributes_from_scopes(sentry_init, capture_items):
 
 @minimum_python_37
 def test_log_attributes_override_scope_attributes(sentry_init, capture_items):
-    sentry_init(enable_logs=True)
+    sentry_init()
 
     items = capture_items("log")
 
@@ -713,7 +710,7 @@ def test_log_attributes_override_scope_attributes(sentry_init, capture_items):
 def test_log_array_attributes(sentry_init, capture_envelopes):
     """Test homogeneous list and tuple attributes, and fallback for inhomogeneous collections."""
 
-    sentry_init(enable_logs=True)
+    sentry_init()
 
     envelopes = capture_envelopes()
 
@@ -777,7 +774,7 @@ def test_attributes_preserialized_in_before_send(sentry_init, capture_items):
 
         return log
 
-    sentry_init(enable_logs=True, before_send_log=before_send_log)
+    sentry_init(before_send_log=before_send_log)
 
     items = capture_items("log")
 
@@ -821,7 +818,7 @@ def test_array_attributes_deep_copied_in_before_send(sentry_init, capture_envelo
 
         return log
 
-    sentry_init(enable_logs=True, before_send_log=before_send_log)
+    sentry_init(before_send_log=before_send_log)
 
     sentry_sdk.logger.warning(
         "Hello world!",
@@ -844,7 +841,7 @@ def test_reentrant_add_does_not_deadlock(sentry_init, capture_envelopes):
     routed through the logging integration back into batcher.add().
     See https://github.com/getsentry/sentry-python/issues/5681
     """
-    sentry_init(enable_logs=True)
+    sentry_init()
     capture_envelopes()
 
     client = sentry_sdk.get_client()
@@ -886,7 +883,7 @@ def test_log_batcher_lock_reset_in_child_after_fork(sentry_init):
     fresh one in the child and reset
     _flusher / _flusher_pid / _buffer / _active / _flush_event.
     """
-    sentry_init(enable_logs=True)
+    sentry_init()
     batcher = sentry_sdk.get_client().log_batcher
     assert batcher is not None
 

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -19,7 +19,9 @@ def test_metrics_enable_metrics_noop(sentry_init, capture_envelopes):
     sentry_sdk.metrics.gauge("test.gauge", 42)
     sentry_sdk.metrics.distribution("test.distribution", 200)
 
-    assert len(envelopes) == 3
+    sentry_sdk.flush()
+
+    assert envelopes
 
 
 def test_metrics_basics(sentry_init, capture_items):

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -9,7 +9,8 @@ from sentry_sdk import get_client
 from sentry_sdk.consts import SPANDATA, VERSION
 
 
-def test_metrics_disabled(sentry_init, capture_envelopes):
+def test_metrics_enable_metrics_noop(sentry_init, capture_envelopes):
+    # The enable_metrics option has no effect anymore.
     sentry_init(enable_metrics=False)
 
     envelopes = capture_envelopes()
@@ -18,7 +19,7 @@ def test_metrics_disabled(sentry_init, capture_envelopes):
     sentry_sdk.metrics.gauge("test.gauge", 42)
     sentry_sdk.metrics.distribution("test.distribution", 200)
 
-    assert len(envelopes) == 0
+    assert len(envelopes) == 3
 
 
 def test_metrics_basics(sentry_init, capture_items):


### PR DESCRIPTION
### Description
We're making `enable_logs` and `enable_metrics` no-op with this change, and they'll be dropped in the next major.

There's no need for an additional hurdle for using the logs and metrics APIs -- opting to use the API is opt-in enough.

Previously, `enable_logs` also controlled automatic logs collection from the logging and Loguru integrations. These integrations now get an integration-level `capture_sentry_logs` boolean option to allow for more control over the auto-collection. These options are `False` by default, i.e., **nothing is auto-collected without your explicit opt-in**.

If you want to enable auto-collection, do:

```python
import sentry_sdk
from sentry_sdk.integrations.logging import LoggingIntegration
from sentry_sdk.integrations.loguru import LoguruIntegration

sentry_sdk.init(
    integrations=[
        LoggingIntegration(capture_sentry_logs=True),
        LoguruIntegration(capture_sentry_logs=True),
    ]
)
```

#### Issues
Closes https://github.com/getsentry/sentry-python/issues/6195
