### PR TITLE
test(quart): Fix flake caused by flushing the span batcher on segment end

### DIFF
--- a/tests/integrations/quart/test_quart.py
+++ b/tests/integrations/quart/test_quart.py
@@ -1218,7 +1218,9 @@ async def test_span_streaming_quart_auth_user_id_data_collection(
     spans = [item.payload for item in items]
     assert len(spans) == 2
 
-    segment = spans[1]
+    (segment,) = (
+        span for span in spans if span["attributes"]["url.path"] == "/message"
+    )
     if expect_user_info:
         assert segment["attributes"]["user.id"] == "42"
     else:


### PR DESCRIPTION
### Description
<!-- What changed and why? -->

The background flush on segment end is asynchronous.

The error is

```
=================================== FAILURES ===================================
_ test_span_streaming_quart_auth_user_id_data_collection[dc_default_user_info] _
tests/integrations/quart/test_quart.py:1223: in test_span_streaming_quart_auth_user_id_data_collection
    assert segment["attributes"]["user.id"] == "42"
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
E   KeyError: 'user.id'
```

#### Issues
<!--
* resolves: #1234
* resolves: LIN-1234
-->

#### Reminders
- Please add tests to validate your changes, and lint your code using `uv run ruff`.
- Add GH Issue ID _&_ Linear ID (if applicable)
- PR title should use [conventional commit](https://develop.sentry.dev/engineering-practices/commit-messages/#type) style (`feat:`, `fix:`, `ref:`, `meta:`)
- For external contributors: [CONTRIBUTING.md](https://github.com/getsentry/sentry-python/blob/master/CONTRIBUTING.md), [Sentry SDK development docs](https://develop.sentry.dev/sdk/), [Discord community](https://discord.gg/Ww9hbqr)
