### PR TITLE
fix(starlette): Set transaction name on current scope in sync handler

### DIFF
--- a/sentry_sdk/integrations/starlette.py
+++ b/sentry_sdk/integrations/starlette.py
@@ -632,7 +632,7 @@ def patch_request_response() -> None:
                 request = args[0]
 
                 _set_transaction_name_and_source(
-                    sentry_scope, integration.transaction_style, request
+                    current_scope, integration.transaction_style, request
                 )
 
                 extractor = StarletteRequestExtractor(request)

--- a/tests/integrations/starlette/test_starlette.py
+++ b/tests/integrations/starlette/test_starlette.py
@@ -1499,6 +1499,47 @@ def test_active_thread_id_span_streaming(sentry_init, capture_items, endpoint):
     assert str(data["active"]) == segments[0]["attributes"]["thread.id"]
 
 
+@pytest.mark.parametrize("endpoint", ["/sync/thread_ids", "/async/thread_ids"])
+def test_transaction_name_span_streaming(sentry_init, capture_items, endpoint):
+    sentry_init(
+        auto_enabling_integrations=False,
+        integrations=[StarletteIntegration(transaction_style="url")],
+        traces_sample_rate=1.0,
+        trace_lifecycle="stream",
+    )
+    app = starlette_app_factory()
+
+    items = capture_items("span")
+
+    client = TestClient(app)
+    response = client.get(endpoint)
+    assert response.status_code == 200
+
+    sentry_sdk.flush()
+
+    segments = [item.payload for item in items if item.payload.get("is_segment")]
+    assert len(segments) == 1
+    assert segments[0]["name"] == endpoint
+    assert segments[0]["attributes"]["sentry.segment.name.source"] == "route"
+
+
+@pytest.mark.parametrize("endpoint", ["/sync/thread_ids", "/async/thread_ids"])
+def test_transaction_name_static(sentry_init, capture_events, endpoint):
+    sentry_init(
+        integrations=[StarletteIntegration(transaction_style="url")],
+        traces_sample_rate=1.0,
+    )
+    events = capture_events()
+
+    client = TestClient(starlette_app_factory())
+    response = client.get(endpoint)
+    assert response.status_code == 200
+
+    (transaction,) = [e for e in events if e.get("type") == "transaction"]
+    assert transaction["transaction"] == endpoint
+    assert transaction["transaction_info"] == {"source": "route"}
+
+
 def test_original_request_not_scrubbed(sentry_init, capture_events):
     sentry_init(integrations=[StarletteIntegration()])
 

--- a/tests/integrations/starlette/test_starlette.py
+++ b/tests/integrations/starlette/test_starlette.py
@@ -1500,7 +1500,9 @@ def test_active_thread_id_span_streaming(sentry_init, capture_items, endpoint):
 
 
 @pytest.mark.parametrize("endpoint", ["/sync/thread_ids", "/async/thread_ids"])
-def test_transaction_name_span_streaming(sentry_init, capture_items, endpoint):
+def test_segment_name_is_route_resolved_name_span_streaming(
+    sentry_init, capture_items, endpoint
+):
     sentry_init(
         auto_enabling_integrations=False,
         integrations=[StarletteIntegration(transaction_style="url")],
@@ -1524,7 +1526,9 @@ def test_transaction_name_span_streaming(sentry_init, capture_items, endpoint):
 
 
 @pytest.mark.parametrize("endpoint", ["/sync/thread_ids", "/async/thread_ids"])
-def test_transaction_name_static(sentry_init, capture_events, endpoint):
+def test_transaction_name_is_route_resolved_name_static(
+    sentry_init, capture_events, endpoint
+):
     sentry_init(
         integrations=[StarletteIntegration(transaction_style="url")],
         traces_sample_rate=1.0,


### PR DESCRIPTION
The sync request/response handler passed the _isolation_ scope to `_set_transaction_name_and_source`, but the transaction/segment span lives on the _current_ scope. As a result the route-resolved name never reached the span for sync endpoints, which were instead named by the raw URL from the ASGI middleware (`transaction_info.source` of `url` rather than `route`). Async handlers already used the current scope and were unaffected.

Pass the current scope (already computed above) so sync and async handlers behave identically:
- streaming: the segment name / `sentry.segment.name.source` are route-based
- static: the transaction event name / source are route-based

For parametrized routes this also removes high-cardinality URL transaction names for sync endpoints.

Found while working on https://github.com/getsentry/sentry-python/pull/7183.