### PR TITLE
chore(graphene): Drop transaction-based tracing

### DIFF
--- a/sentry_sdk/integrations/graphene.py
+++ b/sentry_sdk/integrations/graphene.py
@@ -178,4 +178,4 @@ def graphql_span(
     try:
         yield
     finally:
-        _graphql_span.end()  # type: ignore
+        _graphql_span.end()

--- a/sentry_sdk/integrations/graphene.py
+++ b/sentry_sdk/integrations/graphene.py
@@ -4,7 +4,6 @@ import sentry_sdk
 from sentry_sdk.consts import OP
 from sentry_sdk.integrations import DidNotEnable, Integration, _check_minimum_version
 from sentry_sdk.scope import should_send_default_pii
-from sentry_sdk.tracing_utils import has_span_streaming_enabled
 from sentry_sdk.utils import (
     capture_internal_exceptions,
     ensure_integration_enabled,
@@ -154,47 +153,29 @@ def graphql_span(
     )
 
     client_options = sentry_sdk.get_client().options
-    is_span_streaming_enabled = has_span_streaming_enabled(client_options)
 
-    if is_span_streaming_enabled:
-        if sentry_sdk.traces.get_current_span() is None:
-            yield
-            return
+    if sentry_sdk.traces.get_current_span() is None:
+        yield
+        return
 
-        additional_attributes = {}
-        if has_data_collection_enabled(client_options):
-            if client_options["data_collection"]["graphql"]["document"]:
-                additional_attributes["graphql.document"] = source
-        elif should_send_default_pii():
+    additional_attributes = {}
+    if has_data_collection_enabled(client_options):
+        if client_options["data_collection"]["graphql"]["document"]:
             additional_attributes["graphql.document"] = source
+    elif should_send_default_pii():
+        additional_attributes["graphql.document"] = source
 
-        _graphql_span = sentry_sdk.traces.start_span(
-            name=operation_name,
-            attributes={
-                "sentry.op": op,
-                "graphql.operation.name": operation_name,
-                "graphql.operation.type": operation_type,
-                **additional_attributes,
-            },
-        )
-    else:
-        _graphql_span = sentry_sdk.start_span(op=op, name=operation_name)
-
-        if has_data_collection_enabled(client_options):
-            if client_options["data_collection"]["graphql"]["document"]:
-                _graphql_span.set_data("graphql.document", source)
-        elif should_send_default_pii():
-            _graphql_span.set_data("graphql.document", source)
-
-        _graphql_span.set_data("graphql.operation.name", operation_name)
-        _graphql_span.set_data("graphql.operation.type", operation_type)
-
-        _graphql_span.__enter__()
+    _graphql_span = sentry_sdk.traces.start_span(
+        name=operation_name,
+        attributes={
+            "sentry.op": op,
+            "graphql.operation.name": operation_name,
+            "graphql.operation.type": operation_type,
+            **additional_attributes,
+        },
+    )
 
     try:
         yield
     finally:
-        if is_span_streaming_enabled:
-            _graphql_span.end()  # type: ignore
-        else:
-            _graphql_span.__exit__(None, None, None)
+        _graphql_span.end()  # type: ignore

--- a/tests/integrations/graphene/test_graphene.py
+++ b/tests/integrations/graphene/test_graphene.py
@@ -441,9 +441,7 @@ def test_graphql_span_data_collection(
     assert graphql_span["parent_span_id"] == flask_segment["span_id"]
 
 
-def test_breadcrumbs_hold_query_information_on_error(
-    sentry_init, capture_items
-):
+def test_breadcrumbs_hold_query_information_on_error(sentry_init, capture_items):
     sentry_init(
         integrations=[
             GrapheneIntegration(),

--- a/tests/integrations/graphene/test_graphene.py
+++ b/tests/integrations/graphene/test_graphene.py
@@ -329,107 +329,6 @@ def test_no_event_if_no_errors_sync(sentry_init, capture_events):
     [True, False],
 )
 def test_graphql_span_holds_query_information(
-    sentry_init, capture_events, send_default_pii
-):
-    sentry_init(
-        integrations=[GrapheneIntegration(), FlaskIntegration()],
-        traces_sample_rate=1.0,
-        default_integrations=False,
-        send_default_pii=send_default_pii,
-    )
-    events = capture_events()
-
-    schema = Schema(query=Query)
-
-    sync_app = Flask(__name__)
-
-    @sync_app.route("/graphql", methods=["POST"])
-    def graphql_server_sync():
-        data = request.get_json()
-        result = schema.execute(data["query"], operation_name=data.get("operationName"))
-        return jsonify(result.data), 200
-
-    query = {
-        "query": "query GreetingQuery { hello }",
-        "operationName": "GreetingQuery",
-    }
-    client = sync_app.test_client()
-    client.post("/graphql", json=query)
-
-    assert len(events) == 1
-
-    (event,) = events
-    assert len(event["spans"]) == 1
-
-    (span,) = event["spans"]
-    assert span["op"] == OP.GRAPHQL_QUERY
-    assert span["description"] == query["operationName"]
-    assert span["data"]["graphql.operation.name"] == query["operationName"]
-    assert span["data"]["graphql.operation.type"] == "query"
-
-    if send_default_pii is True:
-        assert span["data"]["graphql.document"] == query["query"]
-    else:
-        assert "graphql.document" not in span["data"]
-
-
-@pytest.mark.parametrize(
-    "data_collection,send_default_pii,expect_document",
-    DATA_COLLECTION_GRAPHQL_DOCUMENTS_PARAMS,
-)
-def test_graphql_span_data_collection(
-    sentry_init, capture_events, data_collection, send_default_pii, expect_document
-):
-    init_kwargs = {
-        "integrations": [GrapheneIntegration(), FlaskIntegration()],
-        "traces_sample_rate": 1.0,
-        "default_integrations": False,
-        "_experiments": {"data_collection": data_collection},
-    }
-    if send_default_pii is not None:
-        init_kwargs["send_default_pii"] = send_default_pii
-    sentry_init(**init_kwargs)
-    events = capture_events()
-
-    schema = Schema(query=Query)
-
-    sync_app = Flask(__name__)
-
-    @sync_app.route("/graphql", methods=["POST"])
-    def graphql_server_sync():
-        data = request.get_json()
-        result = schema.execute(data["query"], operation_name=data.get("operationName"))
-        return jsonify(result.data), 200
-
-    query = {
-        "query": "query GreetingQuery { hello }",
-        "operationName": "GreetingQuery",
-    }
-    client = sync_app.test_client()
-    client.post("/graphql", json=query)
-
-    assert len(events) == 1
-
-    (event,) = events
-    assert len(event["spans"]) == 1
-
-    (span,) = event["spans"]
-    assert span["op"] == OP.GRAPHQL_QUERY
-    assert span["description"] == query["operationName"]
-    assert span["data"]["graphql.operation.name"] == query["operationName"]
-    assert span["data"]["graphql.operation.type"] == "query"
-
-    if expect_document:
-        assert span["data"]["graphql.document"] == query["query"]
-    else:
-        assert "graphql.document" not in span["data"]
-
-
-@pytest.mark.parametrize(
-    "send_default_pii",
-    [True, False],
-)
-def test_graphql_streamed_span_holds_query_information(
     sentry_init, capture_items, send_default_pii
 ):
     sentry_init(
@@ -486,7 +385,7 @@ def test_graphql_streamed_span_holds_query_information(
     "data_collection,send_default_pii,expect_document",
     DATA_COLLECTION_GRAPHQL_DOCUMENTS_PARAMS,
 )
-def test_graphql_streamed_span_data_collection(
+def test_graphql_span_data_collection(
     sentry_init, capture_items, data_collection, send_default_pii, expect_document
 ):
     init_kwargs = {
@@ -542,48 +441,7 @@ def test_graphql_streamed_span_data_collection(
     assert graphql_span["parent_span_id"] == flask_segment["span_id"]
 
 
-def test_breadcrumbs_hold_query_information_on_error(sentry_init, capture_events):
-    sentry_init(
-        integrations=[
-            GrapheneIntegration(),
-        ],
-        default_integrations=False,
-    )
-    events = capture_events()
-
-    schema = Schema(query=Query)
-
-    sync_app = Flask(__name__)
-
-    @sync_app.route("/graphql", methods=["POST"])
-    def graphql_server_sync():
-        data = request.get_json()
-        result = schema.execute(data["query"], operation_name=data.get("operationName"))
-        return jsonify(result.data), 200
-
-    query = {
-        "query": "query ErrorQuery { goodbye }",
-        "operationName": "ErrorQuery",
-    }
-    client = sync_app.test_client()
-    client.post("/graphql", json=query)
-
-    assert len(events) == 1
-
-    (event,) = events
-    assert len(event["breadcrumbs"]) == 1
-
-    breadcrumbs = event["breadcrumbs"]["values"]
-    assert len(breadcrumbs) == 1
-
-    (breadcrumb,) = breadcrumbs
-    assert breadcrumb["category"] == "graphql.operation"
-    assert breadcrumb["data"]["operation_name"] == query["operationName"]
-    assert breadcrumb["data"]["operation_type"] == "query"
-    assert breadcrumb["type"] == "default"
-
-
-def test_breadcrumbs_hold_query_information_on_error_with_span_streaming(
+def test_breadcrumbs_hold_query_information_on_error(
     sentry_init, capture_items
 ):
     sentry_init(


### PR DESCRIPTION
### Description
<!-- What changed and why? -->

I removed the transaction-based tracing fallback from the graphene integration - I did this by doing the following

- Removed all `is_span_streaming_enabled` branching and enforces the unconditional use of `sentry_sdk.traces.start_span`
- Removed legacy compatibility utilities like the `else:` fallback blocks and the legacy `__exit__` context manager calls
- Deleted obsolete transaction-based tests and promotes the span streaming tests to standard tests by removing their `_span_streaming` suffixes

#### Issues

* resolves: #7091 


#### Reminders
- Please add tests to validate your changes, and lint your code using `uv run ruff`.
- Add GH Issue ID _&_ Linear ID (if applicable)
- PR title should use [conventional commit](https://develop.sentry.dev/engineering-practices/commit-messages/#type) style (`feat:`, `fix:`, `ref:`, `meta:`)
- For external contributors: [CONTRIBUTING.md](https://github.com/getsentry/sentry-python/blob/master/CONTRIBUTING.md), [Sentry SDK development docs](https://develop.sentry.dev/sdk/), [Discord community](https://discord.gg/Ww9hbqr)
