### PR TITLE
fix(openai): Don't let instrumentation raise into user code

### DIFF
--- a/sentry_sdk/integrations/openai.py
+++ b/sentry_sdk/integrations/openai.py
@@ -301,7 +301,7 @@ def _calculate_responses_token_usage(
         if streaming_message_responses is not None:
             for message in streaming_message_responses:
                 output_tokens += count_tokens(message)
-        elif hasattr(response, "output"):
+        elif hasattr(response, "output") and response.output is not None:
             for output_item in response.output:
                 if hasattr(output_item, "content"):
                     for content_item in output_item.content:
@@ -326,6 +326,16 @@ def _calculate_responses_token_usage(
 
 
 def _set_responses_api_input_data(
+    span: "Union[Span, StreamedSpan]",
+    kwargs: "dict[str, Any]",
+    integration: "OpenAIIntegration",
+) -> None:
+    # Instrumentation must never raise into the calling application.
+    with capture_internal_exceptions():
+        _record_responses_api_input_data(span, kwargs, integration)
+
+
+def _record_responses_api_input_data(
     span: "Union[Span, StreamedSpan]",
     kwargs: "dict[str, Any]",
     integration: "OpenAIIntegration",
@@ -477,6 +487,16 @@ def _set_completions_api_input_data(
     kwargs: "dict[str, Any]",
     integration: "OpenAIIntegration",
 ) -> None:
+    # Instrumentation must never raise into the calling application.
+    with capture_internal_exceptions():
+        _record_completions_api_input_data(span, kwargs, integration)
+
+
+def _record_completions_api_input_data(
+    span: "Union[Span, StreamedSpan]",
+    kwargs: "dict[str, Any]",
+    integration: "OpenAIIntegration",
+) -> None:
     set_on_span = (
         span.set_attribute if isinstance(span, StreamedSpan) else span.set_data
     )
@@ -598,6 +618,16 @@ def _set_embeddings_input_data(
     kwargs: "dict[str, Any]",
     integration: "OpenAIIntegration",
 ) -> None:
+    # Instrumentation must never raise into the calling application.
+    with capture_internal_exceptions():
+        _record_embeddings_input_data(span, kwargs, integration)
+
+
+def _record_embeddings_input_data(
+    span: "Union[Span, StreamedSpan]",
+    kwargs: "dict[str, Any]",
+    integration: "OpenAIIntegration",
+) -> None:
 
     set_data_normalized(span, SPANDATA.GEN_AI_OPERATION_NAME, "embeddings")
 
@@ -666,6 +696,22 @@ def _set_common_output_data(
     integration: "OpenAIIntegration",
     finish_span: bool = True,
 ) -> None:
+    # Instrumentation must never raise into the calling application, so any
+    # error while reading the response is swallowed here. The span is still
+    # finished afterwards so that a failure cannot leak an unfinished span.
+    with capture_internal_exceptions():
+        _record_common_output_data(span, response, input, integration)
+
+    if finish_span:
+        span.__exit__(None, None, None)
+
+
+def _record_common_output_data(
+    span: "Union[Span, StreamedSpan]",
+    response: "Any",
+    input: "Any",
+    integration: "OpenAIIntegration",
+) -> None:
     client = sentry_sdk.get_client()
     if hasattr(response, "model"):
         set_data_normalized(span, SPANDATA.GEN_AI_RESPONSE_MODEL, response.model)
@@ -701,11 +747,8 @@ def _set_common_output_data(
             count_tokens=integration.count_tokens,
         )
 
-        if finish_span:
-            span.__exit__(None, None, None)
-
     # Responses API
-    elif hasattr(response, "output"):
+    elif hasattr(response, "output") and response.output is not None:
         output_messages: "dict[str, list[Any]]" = {
             "response": [],
             "tool": [],
@@ -775,8 +818,6 @@ def _set_common_output_data(
             count_tokens=integration.count_tokens,
         )
 
-        if finish_span:
-            span.__exit__(None, None, None)
     # Embeddings API (fallback for responses with neither choices nor output)
     else:
         _calculate_completions_token_usage(
@@ -787,8 +828,6 @@ def _set_common_output_data(
             streaming_message_total_token_usage=None,
             count_tokens=integration.count_tokens,
         )
-        if finish_span:
-            span.__exit__(None, None, None)
 
 
 def _new_sync_chat_completion(f: "Any", *args: "Any", **kwargs: "Any") -> "Any":

--- a/tests/integrations/openai/test_openai.py
+++ b/tests/integrations/openai/test_openai.py
@@ -8208,3 +8208,220 @@ async def test_streaming_responses_api_ttft_async(
 
     assert isinstance(ttft, float)
     assert ttft > 0
+
+
+@pytest.mark.skipif(SKIP_RESPONSES_TESTS, reason="Responses API not available")
+def test_responses_api_none_output_does_not_crash(sentry_init, capture_events):
+    """
+    An OpenAI-compatible endpoint may return a response whose `output` is
+    `None` (for example a gateway that already sent `200 OK` and can only
+    report the upstream failure in the body). Instrumenting such a response
+    must not raise into the calling application.
+    """
+    sentry_init(
+        integrations=[OpenAIIntegration(include_prompts=True)],
+        disabled_integrations=[StdlibIntegration],
+        traces_sample_rate=1.0,
+        send_default_pii=True,
+        stream_gen_ai_spans=False,
+    )
+    events = capture_events()
+
+    response_with_no_output = Response.construct(
+        id="chat-id",
+        model="response-model-id",
+        object="response",
+        output=None,
+        error={"code": "server_error", "message": "upstream failed"},
+    )
+
+    client = OpenAI(api_key="z")
+    client.responses._post = mock.Mock(return_value=response_with_no_output)
+
+    with start_transaction(name="openai tx"):
+        response = client.responses.create(model="some-model", input="hello")
+
+    # The caller gets the response back and can inspect the real error
+    assert response.output is None
+    assert response.error.message == "upstream failed"
+
+    # The span was still recorded and finished
+    (tx,) = events
+    (span,) = tx["spans"]
+    assert span["op"] == "gen_ai.responses"
+    assert span["data"][SPANDATA.GEN_AI_RESPONSE_MODEL] == "response-model-id"
+    assert SPANDATA.GEN_AI_RESPONSE_TEXT not in span["data"]
+
+
+@pytest.mark.skipif(SKIP_RESPONSES_TESTS, reason="Responses API not available")
+@pytest.mark.asyncio
+async def test_responses_api_none_output_does_not_crash_async(
+    sentry_init, capture_events
+):
+    """Same as the sync test above, for the async client."""
+    sentry_init(
+        integrations=[OpenAIIntegration(include_prompts=True)],
+        disabled_integrations=[StdlibIntegration],
+        traces_sample_rate=1.0,
+        send_default_pii=True,
+        stream_gen_ai_spans=False,
+    )
+    events = capture_events()
+
+    response_with_no_output = Response.construct(
+        id="chat-id",
+        model="response-model-id",
+        object="response",
+        output=None,
+        error={"code": "server_error", "message": "upstream failed"},
+    )
+
+    client = AsyncOpenAI(api_key="z")
+    client.responses._post = AsyncMock(return_value=response_with_no_output)
+
+    with start_transaction(name="openai tx"):
+        response = await client.responses.create(model="some-model", input="hello")
+
+    assert response.output is None
+
+    (tx,) = events
+    (span,) = tx["spans"]
+    assert span["op"] == "gen_ai.responses"
+
+
+def test_chat_completion_none_choices_does_not_crash(sentry_init, capture_events):
+    """
+    A Chat Completions response whose `choices` is `None` must not raise into
+    the calling application.
+    """
+    sentry_init(
+        integrations=[OpenAIIntegration(include_prompts=True)],
+        disabled_integrations=[StdlibIntegration],
+        traces_sample_rate=1.0,
+        send_default_pii=True,
+        stream_gen_ai_spans=False,
+    )
+    events = capture_events()
+
+    completion_with_no_choices = ChatCompletion.construct(
+        id="chat-id",
+        model="response-model-id",
+        object="chat.completion",
+        choices=None,
+        error={"code": "server_error", "message": "upstream failed"},
+    )
+
+    client = OpenAI(api_key="z")
+    client.chat.completions._post = mock.Mock(return_value=completion_with_no_choices)
+
+    with start_transaction(name="openai tx"):
+        response = client.chat.completions.create(
+            model="some-model", messages=[{"role": "user", "content": "hello"}]
+        )
+
+    assert response.choices is None
+    assert response.error["message"] == "upstream failed"
+
+    (tx,) = events
+    (span,) = tx["spans"]
+    assert span["op"] == "gen_ai.chat"
+    assert SPANDATA.GEN_AI_RESPONSE_TEXT not in span["data"]
+
+
+@pytest.mark.tests_internal_exceptions
+def test_instrumentation_output_error_does_not_propagate(
+    sentry_init, capture_events, nonstreaming_chat_completions_model_response
+):
+    """
+    An unexpected error raised while recording response data must be swallowed
+    rather than surfacing inside the user's `create()` call, and the span must
+    still be finished.
+    """
+    sentry_init(
+        integrations=[OpenAIIntegration(include_prompts=True)],
+        disabled_integrations=[StdlibIntegration],
+        traces_sample_rate=1.0,
+        send_default_pii=True,
+        stream_gen_ai_spans=False,
+    )
+    events = capture_events()
+
+    client = OpenAI(api_key="z")
+    client.chat.completions._post = mock.Mock(
+        return_value=nonstreaming_chat_completions_model_response(
+            response_id="chat-id",
+            response_model="gpt-3.5-turbo",
+            message_content="the model response",
+            created=10000000,
+            usage=CompletionUsage(
+                prompt_tokens=20,
+                completion_tokens=10,
+                total_tokens=30,
+            ),
+        )
+    )
+
+    with mock.patch(
+        "sentry_sdk.integrations.openai._calculate_completions_token_usage",
+        side_effect=ValueError("boom"),
+    ):
+        with start_transaction(name="openai tx"):
+            response = client.chat.completions.create(
+                model="some-model", messages=[{"role": "user", "content": "hello"}]
+            )
+
+    # The caller still gets its response
+    assert response.choices[0].message.content == "the model response"
+
+    # The span was still finished, so it is part of the transaction
+    (tx,) = events
+    (span,) = tx["spans"]
+    assert span["op"] == "gen_ai.chat"
+
+
+@pytest.mark.tests_internal_exceptions
+def test_instrumentation_input_error_does_not_propagate(
+    sentry_init, capture_events, nonstreaming_chat_completions_model_response
+):
+    """
+    An unexpected error raised while recording request data must not surface
+    inside the user's `create()` call either.
+    """
+    sentry_init(
+        integrations=[OpenAIIntegration(include_prompts=True)],
+        disabled_integrations=[StdlibIntegration],
+        traces_sample_rate=1.0,
+        send_default_pii=True,
+        stream_gen_ai_spans=False,
+    )
+    events = capture_events()
+
+    client = OpenAI(api_key="z")
+    client.chat.completions._post = mock.Mock(
+        return_value=nonstreaming_chat_completions_model_response(
+            response_id="chat-id",
+            response_model="gpt-3.5-turbo",
+            message_content="the model response",
+            created=10000000,
+            usage=CompletionUsage(
+                prompt_tokens=20,
+                completion_tokens=10,
+                total_tokens=30,
+            ),
+        )
+    )
+
+    with mock.patch(
+        "sentry_sdk.integrations.openai.normalize_message_roles",
+        side_effect=ValueError("boom"),
+    ):
+        with start_transaction(name="openai tx"):
+            response = client.chat.completions.create(
+                model="some-model", messages=[{"role": "user", "content": "hello"}]
+            )
+
+    assert response.choices[0].message.content == "the model response"
+
+    (tx,) = events
+    (span,) = tx["spans"]
+    assert span["op"] == "gen_ai.chat"


### PR DESCRIPTION
Fixes #7222

## What

The OpenAI integration can raise out of the instrumented `create()` call, so an SDK problem surfaces as an application error and replaces whatever the API actually returned:

```
  File "sentry_sdk/integrations/openai.py", line 1532, in _new_sync_responses_create
    _set_responses_api_output_data(
  File "sentry_sdk/integrations/openai.py", line 746, in _set_common_output_data
    for output in response.output:
                  ^^^^^^^^^^^^^^^
TypeError: 'NoneType' object is not iterable
```

## Why

Two independent causes, both addressed here.

**1. `response.output` is never checked for `None`.** `response.choices` got an `is not None` check after #5071, but the Responses API branch still does a bare `hasattr(response, "output")` in `_set_common_output_data` and `_calculate_responses_token_usage`.

**2. The non-streaming paths lost their `capture_internal_exceptions()` wrapper.** Before #4612 the whole response-handling block ran inside `with capture_internal_exceptions():`. Splitting it into `_set_*_input_data` / `_set_*_output_data` moved that code out from under the wrapper, so errors there now propagate into user code. The streaming iterators kept their protection; the non-streaming paths did not — which is why `<2.34` is unaffected.

(1) fixes the crash that was actually hit; (2) makes this class of bug degrade to a missing span attribute rather than an application crash, per the SDK contract in `CONTRIBUTING.md` ("Users do not expect their application to crash").

## How it is reached in practice

Through an OpenAI-compatible gateway. When a gateway has already flushed `200 OK` — for example after sending keep-alive padding while it buffers a large request — and only then learns the upstream call failed, it cannot change the status code, so it reports the failure in the body:

```json
{"error": {"message": "... At least one of the image dimensions exceed max allowed size: 8000 pixels", "code": 400}}
```

The `openai` client parses this into a model object with `output` / `choices` unset. Instrumenting it raises, and the application sees `TypeError: 'NoneType' object is not iterable` instead of the real message — so retry and fallback logic keyed on the upstream error stops working.

Minimal reproduction, no network needed:

```python
from unittest import mock

import sentry_sdk
from openai import OpenAI
from openai.types.responses import Response
from sentry_sdk.integrations.openai import OpenAIIntegration

sentry_sdk.init(
    dsn="https://public@o1.ingest.sentry.io/1",
    traces_sample_rate=1.0,
    integrations=[OpenAIIntegration()],
    transport=lambda event: None,
)

gateway_error = Response.construct(
    error={"message": "upstream failed", "code": 400},
    output=None,
)

client = OpenAI(api_key="z")
client.responses._post = mock.Mock(return_value=gateway_error)

with sentry_sdk.start_transaction(name="tx"):
    response = client.responses.create(model="gpt-4o", input="hello")
    print(response.error)  # raises TypeError before this line on master
```

## Changes

- `_calculate_responses_token_usage` and `_set_common_output_data`: require `response.output is not None`, mirroring the existing `response.choices is not None` check. A response with `output=None` now falls through to the same branch a response with `choices=None` already does.
- `_set_responses_api_input_data`, `_set_completions_api_input_data`, `_set_embeddings_input_data` and `_set_common_output_data` are now thin wrappers that run the recording work inside `capture_internal_exceptions()`. The bodies moved unchanged into `_record_*` helpers.
- `_set_common_output_data` finishes the span *after* the guarded block rather than at the end of each branch, so a failure while recording cannot leave an unfinished span behind.

Regarding #4853 (`asyncio.CancelledError` swallowed by `capture_internal_exceptions()`): that report concerned a wrapper spanning the user's iterator consumption. The blocks wrapped here contain only synchronous instrumentation code with no `await` points and no calls back into user code, so a task cancellation cannot be absorbed by them.

## Testing

Added to `tests/integrations/openai/test_openai.py`:

- `test_responses_api_none_output_does_not_crash` / `..._async` — a Responses object with `output=None` is returned to the caller, and the span is still recorded and finished.
- `test_chat_completion_none_choices_does_not_crash` — regression guard for the `choices=None` path fixed in #5081.
- `test_instrumentation_output_error_does_not_propagate` / `test_instrumentation_input_error_does_not_propagate` — an unexpected error while recording request or response data does not reach the caller, and the span is still finished.

4 of the 5 fail on `master` and pass with this change; the fifth guards the already-fixed `choices=None` path.

```
$ pytest tests/integrations/openai -q
699 passed
```
(694 before this change, 5 new.) `ruff format --check` and `ruff check` are clean on both touched files, and `mypy` reports no new errors relative to `master`.
