### PR TITLE
fix(mcp,langchain): Add mechanism to captured exceptions

### DIFF
--- a/sentry_sdk/integrations/langchain.py
+++ b/sentry_sdk/integrations/langchain.py
@@ -26,6 +26,7 @@ from sentry_sdk.tracing_utils import (
 )
 from sentry_sdk.utils import (
     capture_internal_exceptions,
+    event_from_exception,
     has_data_collection_enabled,
     logger,
 )
@@ -265,6 +266,15 @@ class LangchainIntegration(Integration):
         _patch_embeddings_provider(OllamaEmbeddings)
 
 
+def _capture_exception(exc: "Any", scope: "Optional[Any]" = None) -> None:
+    event, hint = event_from_exception(
+        exc,
+        client_options=sentry_sdk.get_client().options,
+        mechanism={"type": "langchain", "handled": False},
+    )
+    sentry_sdk.capture_event(event, hint=hint, scope=scope)
+
+
 class SentryLangchainCallback(BaseCallbackHandler):
     """Callback handler that creates Sentry spans."""
 
@@ -293,7 +303,7 @@ class SentryLangchainCallback(BaseCallbackHandler):
             if is_ignored:
                 span.__exit__(None, None, None)
             else:
-                sentry_sdk.capture_exception(
+                _capture_exception(
                     error, span._scope if isinstance(span, StreamedSpan) else span.scope
                 )
                 span.__exit__(type(error), error, error.__traceback__)

--- a/sentry_sdk/integrations/mcp.py
+++ b/sentry_sdk/integrations/mcp.py
@@ -21,6 +21,8 @@ from sentry_sdk.scope import should_send_default_pii
 from sentry_sdk.traces import StreamedSpan
 from sentry_sdk.tracing_utils import has_span_streaming_enabled
 from sentry_sdk.utils import (
+    capture_internal_exceptions,
+    event_from_exception,
     has_data_collection_enabled,
     nullcontext,
     package_version,
@@ -98,6 +100,15 @@ class MCPIntegration(Integration):
 
         if FastMCP is not None:
             _patch_fastmcp()
+
+
+def _capture_exception(exc: "Any") -> None:
+    event, hint = event_from_exception(
+        exc,
+        client_options=sentry_sdk.get_client().options,
+        mechanism={"type": "mcp", "handled": False},
+    )
+    sentry_sdk.capture_event(event, hint=hint)
 
 
 @contextmanager
@@ -394,7 +405,8 @@ async def _tool_handler_wrapper(
                     result = await result
 
             except Exception as e:
-                sentry_sdk.capture_exception(e)
+                with capture_internal_exceptions():
+                    _capture_exception(e)
                 raise
 
             if result is None:
@@ -490,7 +502,8 @@ async def _instrument_v2_tool_call(
                 result = await call_next(ctx)
 
             except Exception as e:
-                sentry_sdk.capture_exception(e)
+                with capture_internal_exceptions():
+                    _capture_exception(e)
                 raise
 
             if not isinstance(result, dict):
@@ -615,7 +628,8 @@ async def _prompt_handler_wrapper(
                     result = await result
 
             except Exception as e:
-                sentry_sdk.capture_exception(e)
+                with capture_internal_exceptions():
+                    _capture_exception(e)
                 raise
 
             if result is None:
@@ -764,7 +778,8 @@ async def _instrument_v2_prompt_get(
             try:
                 result = await call_next(ctx)
             except Exception as e:
-                sentry_sdk.capture_exception(e)
+                with capture_internal_exceptions():
+                    _capture_exception(e)
                 raise
 
             if not isinstance(result, dict):
@@ -919,7 +934,8 @@ async def _resource_handler_wrapper(
                     result = await result
 
             except Exception as e:
-                sentry_sdk.capture_exception(e)
+                with capture_internal_exceptions():
+                    _capture_exception(e)
                 raise
 
     return result
@@ -984,7 +1000,8 @@ async def _instrument_v2_resource_read(
                 result = await call_next(ctx)
 
             except Exception as e:
-                sentry_sdk.capture_exception(e)
+                with capture_internal_exceptions():
+                    _capture_exception(e)
                 raise
 
     return result

--- a/tests/integrations/langchain/test_langchain.py
+++ b/tests/integrations/langchain/test_langchain.py
@@ -3693,6 +3693,8 @@ def test_span_status_error(
 
         (error,) = (item.payload for item in items if item.type == "event")
         assert error["level"] == "error"
+        assert error["exception"]["values"][0]["mechanism"]["type"] == "langchain"
+        assert not error["exception"]["values"][0]["mechanism"]["handled"]
         sentry_sdk.flush()
         spans = [item.payload for item in items if item.type == "span"]
         assert spans[0]["status"] == "error"
@@ -3730,6 +3732,8 @@ def test_span_status_error(
 
         (error,) = (item.payload for item in items if item.type == "event")
         assert error["level"] == "error"
+        assert error["exception"]["values"][0]["mechanism"]["type"] == "langchain"
+        assert not error["exception"]["values"][0]["mechanism"]["handled"]
         sentry_sdk.flush()
         spans = [item.payload for item in items if item.type == "span"]
         assert spans[0]["status"] == "error"
@@ -3768,8 +3772,81 @@ def test_span_status_error(
 
         (error, transaction) = events
         assert error["level"] == "error"
+        assert error["exception"]["values"][0]["mechanism"]["type"] == "langchain"
+        assert not error["exception"]["values"][0]["mechanism"]["handled"]
         assert transaction["spans"][0]["status"] == "internal_error"
         assert transaction["spans"][0]["tags"]["status"] == "internal_error"
+
+
+@tool
+def failing_tool(word: str) -> int:
+    """Raises instead of returning a length."""
+    raise ValueError("Tool execution failed")
+
+
+def test_langchain_tool_error(
+    sentry_init,
+    capture_events,
+    get_model_response,
+    nonstreaming_responses_tool_call_model_responses,
+):
+    sentry_init(
+        integrations=[LangchainIntegration(include_prompts=True)],
+        disabled_integrations=[StdlibIntegration],
+        traces_sample_rate=1.0,
+    )
+
+    responses = nonstreaming_responses_tool_call_model_responses(
+        tool_name="failing_tool",
+        arguments='{"word": "eudca"}',
+        response_model="gpt-4-0613",
+        response_text="",
+        response_ids=iter(["resp_1"]),
+        usages=iter(
+            [
+                ResponseUsage(
+                    input_tokens=0,
+                    input_tokens_details=InputTokensDetails(
+                        cached_tokens=0,
+                        cache_write_tokens=0,
+                    ),
+                    output_tokens=0,
+                    output_tokens_details=OutputTokensDetails(
+                        reasoning_tokens=0,
+                    ),
+                    total_tokens=0,
+                ),
+            ]
+        ),
+    )
+    tool_response = get_model_response(
+        next(responses),
+        serialize_pydantic=True,
+        request_headers={
+            "X-Stainless-Raw-Response": "True",
+        },
+    )
+
+    llm = ChatOpenAI(
+        model_name="gpt-4",
+        temperature=0,
+        openai_api_key="badkey",
+        use_responses_api=True,
+    )
+    agent = create_agent(model=llm, tools=[failing_tool], name="failing_agent")
+
+    events = capture_events()
+
+    with patch.object(
+        llm.client._client._client, "send", side_effect=[tool_response]
+    ), start_transaction(name="tx"), pytest.raises(ValueError):
+        agent.invoke({"messages": [HumanMessage(content="hi")]})
+
+    error_events = [event for event in events if event.get("level") == "error"]
+    assert len(error_events) == 1
+    assert error_events[0]["exception"]["values"][0]["type"] == "ValueError"
+    assert error_events[0]["exception"]["values"][0]["mechanism"]["type"] == "langchain"
+    assert not error_events[0]["exception"]["values"][0]["mechanism"]["handled"]
 
 
 def test_manual_callback_no_duplication(sentry_init):

--- a/tests/integrations/langchain/test_langchain.py
+++ b/tests/integrations/langchain/test_langchain.py
@@ -3784,6 +3784,10 @@ def failing_tool(word: str) -> int:
     raise ValueError("Tool execution failed")
 
 
+@pytest.mark.skipif(
+    LANGCHAIN_VERSION < (1,),
+    reason="LangChain 1.0+ required (ONE AGENT refactor)",
+)
 def test_langchain_tool_error(
     sentry_init,
     capture_events,

--- a/tests/integrations/langchain/test_langchain.py
+++ b/tests/integrations/langchain/test_langchain.py
@@ -3621,6 +3621,8 @@ def test_langchain_error(
 
         error = events[0]
     assert error["level"] == "error"
+    assert error["exception"]["values"][0]["mechanism"]["type"] == "langchain"
+    assert not error["exception"]["values"][0]["mechanism"]["handled"]
 
 
 @pytest.mark.parametrize("span_streaming", [True, False])

--- a/tests/integrations/mcp/test_mcp.py
+++ b/tests/integrations/mcp/test_mcp.py
@@ -618,6 +618,8 @@ async def test_tool_handler_with_error(
         assert (
             error_payload["exception"]["values"][0]["value"] == "Tool execution failed"
         )
+        assert error_payload["exception"]["values"][0]["mechanism"]["type"] == "mcp"
+        assert not error_payload["exception"]["values"][0]["mechanism"]["handled"]
 
         assert span["status"] == "error"
     else:
@@ -647,6 +649,8 @@ async def test_tool_handler_with_error(
         assert error_event["level"] == "error"
         assert error_event["exception"]["values"][0]["type"] == "ValueError"
         assert error_event["exception"]["values"][0]["value"] == "Tool execution failed"
+        assert error_event["exception"]["values"][0]["mechanism"]["type"] == "mcp"
+        assert not error_event["exception"]["values"][0]["mechanism"]["handled"]
 
         # Check transaction and span
         assert tx["type"] == "transaction"
@@ -944,6 +948,8 @@ async def test_prompt_handler_with_error(
 
         assert error_payload["level"] == "error"
         assert error_payload["exception"]["values"][0]["type"] == "RuntimeError"
+        assert error_payload["exception"]["values"][0]["mechanism"]["type"] == "mcp"
+        assert not error_payload["exception"]["values"][0]["mechanism"]["handled"]
         assert span["status"] == "error"
     else:
         events = capture_events()
@@ -966,6 +972,8 @@ async def test_prompt_handler_with_error(
 
         assert error_event["level"] == "error"
         assert error_event["exception"]["values"][0]["type"] == "RuntimeError"
+        assert error_event["exception"]["values"][0]["mechanism"]["type"] == "mcp"
+        assert not error_event["exception"]["values"][0]["mechanism"]["handled"]
 
         # Check transaction and span
         assert tx["type"] == "transaction"
@@ -1229,6 +1237,8 @@ async def test_resource_handler_with_error(
 
         assert error_payload["level"] == "error"
         assert error_payload["exception"]["values"][0]["type"] == "FileNotFoundError"
+        assert error_payload["exception"]["values"][0]["mechanism"]["type"] == "mcp"
+        assert not error_payload["exception"]["values"][0]["mechanism"]["handled"]
         assert span["status"] == "error"
     else:
         events = capture_events()
@@ -1248,6 +1258,8 @@ async def test_resource_handler_with_error(
 
         assert error_event["level"] == "error"
         assert error_event["exception"]["values"][0]["type"] == "FileNotFoundError"
+        assert error_event["exception"]["values"][0]["mechanism"]["type"] == "mcp"
+        assert not error_event["exception"]["values"][0]["mechanism"]["handled"]
 
         # Check transaction and span
         assert tx["type"] == "transaction"

--- a/tests/integrations/mcp/test_mcp.py
+++ b/tests/integrations/mcp/test_mcp.py
@@ -2020,6 +2020,8 @@ async def test_streamable_http_scope_propagation(sentry_init, capture_events, js
 
     error_event = error_events[0]
     assert error_event["exception"]["values"][0]["type"] == "ValueError"
+    assert error_event["exception"]["values"][0]["mechanism"]["type"] == "mcp"
+    assert not error_event["exception"]["values"][0]["mechanism"]["handled"]
 
     # The captured error shares the trace of the MCP transaction, proving the
     # handler executed under the propagated request scope.


### PR DESCRIPTION
Fixes #5242

### What

Errors captured by the MCP and LangChain instrumentation reach Sentry with the
default mechanism `{"type": "generic", "handled": True}`.

The issue title says the mechanism is missing. It isn't — it's wrong, in two
separate ways:

1. **`type: "generic"`** — the error isn't attributed to the integration that
   captured it, which is what the issue asks for: *"so capture data is
   available, and the popularity of integrations can be determined."*

2. **`handled: True`** — all six MCP call sites re-raise (`mcp.py` lines 398,
   494, 619, 768, 923, 988), so the exception reaches the user's code. Marking
   it handled keeps these errors out of the unhandled-issue signals and out of
   the crash-free rate. This part isn't mentioned in the issue.

### How

A module-level `_capture_exception` helper in each integration, following the
pattern already used by the other eight AI integrations (`openai.py:151`,
`anthropic.py:202`, `cohere.py:86`, `huggingface_hub.py:66`,
`google_genai/utils.py:157`, `openai_agents/utils.py:42`,
`pydantic_ai/utils.py:253`, and inline in `litellm.py:311`). The seven capture
sites route through it.

`handled=False` at all seven: the MCP sites re-raise, and the LangChain
`_handle_error` callback is a notification point, not a swallow point — the
existing test wraps the call in `pytest.raises(ValueError)`. `flask.py:240`
sets the precedent for errors a framework later turns into a response. I did
not add a `handled` parameter: the only `handled=True` among the AI
integrations (`pydantic_ai/patches/tools.py:93,166`) is gated behind an option
that has no equivalent here.

The MCP call sites are wrapped in `capture_internal_exceptions()`.
`Scope.capture_exception` wrapped its `capture_event` call in
`try/except → capture_internal_exception` (`scope.py:1593-1596`); the helper
drops that, and the sibling integrations restore it at the call site
(`openai.py:845-846`). Without it, a failure inside the SDK would replace the
user's exception, which the integration contract forbids. `langchain.py`
doesn't need it — `_handle_error` already runs inside that context manager.

### Tests

Assertions added to the error tests that already existed, plus one new test.

`test_langchain_tool_error` covers `on_tool_error` (`langchain.py:783`), which
reaches the capture but **no test exercised** — the only tool in the file
never raises. Coverage confirms it hits `on_tool_error` and the capture at
`langchain.py:296`, and neither `on_llm_error` nor `on_chat_model_error`.

Coverage over the six MCP call sites, measured rather than assumed:

| call site | mcp v1.29.0 | mcp v2.0.0 |
|---|---|---|
| 397 `_tool_handler_wrapper` | executed | — |
| 493 `_instrument_v2_tool_call` | — | executed |
| 618 `_prompt_handler_wrapper` | executed | — |
| 767 `_instrument_v2_prompt_get` | — | executed |
| 922 `_resource_handler_wrapper` | executed | — |
| 987 `_instrument_v2_resource_read` | — | executed |

v1 and v2 are mutually exclusive paths, so both versions are needed to cover
all six.

Suites run green: `mcp-v1.29.0` (100), `mcp-v2.0.0` (105),
`langchain-base-v1.3.14` (626), `langgraph-v0.6.11` (146), `fastmcp-v1.0` (88),
`fastmcp-v4.0.0b2` (42). `mypy sentry_sdk` clean, `ruff` clean.

`test_graph_bubble_up_ignored` (langgraph) still passes: the
`_ignored_exceptions` branch never reaches the capture, so ignored exceptions
still produce no event.

### Two things found along the way, both out of scope here

**FastMCP v4 bypasses the MCP instrumentation.** With `fastmcp==4.0.0b2` +
`mcp==2.0.0`, a failing tool never reaches any of the six capture sites
(measured: zero executed). fastmcp catches and logs it itself, and the only
reason Sentry sees the error is `LoggingIntegration` picking up that
`logger.error` — the event arrives with `mechanism.type == "logging"`. This
also means `test_fastmcp_tool_with_error` is not currently testing MCP error
capture on that env, and its `assert len(error_events) >= 1` hides it. I left
`test_fastmcp.py` untouched for that reason: adding the mechanism assertions
there would fail permanently on that env for an unrelated cause.

**The integration's patches fire when it's disabled.** `MCPIntegration.setup_once`
patches `Server.call_tool/get_prompt/read_resource`, the `Server.__init__`
middleware and `StreamableHTTPServerTransport.handle_request` globally and
permanently per process, and `get_integration(MCPIntegration)` is only checked
*after* the `try/except` (e.g. `mcp.py:404`, `:500`, `:625`). So errors are
captured even when the integration isn't enabled. **This PR is neutral on
that** — `sentry_sdk.capture_exception(e)` was equally unguarded, only the
mechanism payload changes. A real fix moves a guard to the top of all six
wrappers, which also changes span emission; happy to open a separate issue.

### Note on process

CONTRIBUTING asks to discuss the approach with a maintainer first. I wrote this
for the DEV Bug Smash challenge and its deadline didn't allow for that, so I'm
opening it as a draft and left a comment on the issue. Happy to close it or
rework it if the approach doesn't fit.
