### PR TITLE
fix(logs): Don't stop sending auto-collected logs when `enable_logs=True`

### DIFF
--- a/sentry_sdk/client.py
+++ b/sentry_sdk/client.py
@@ -648,13 +648,6 @@ class _Client(BaseClient):
 
             self.session_flusher = SessionFlusher(capture_func=_capture_envelope)
 
-            if self.options.get("enable_logs", False) or self.options[
-                "_experiments"
-            ].get("enable_logs", False):
-                logger.warning(
-                    "The enable_logs option has no effect and will be removed in the next major."
-                )
-
             self.log_batcher = LogBatcher(
                 capture_func=_capture_envelope,
                 record_lost_func=_record_lost_event,

--- a/sentry_sdk/integrations/logging.py
+++ b/sentry_sdk/integrations/logging.py
@@ -21,6 +21,8 @@ if TYPE_CHECKING:
     from logging import LogRecord
     from typing import Any, Dict, Optional
 
+_SENTINEL = object()
+
 DEFAULT_LEVEL = logging.INFO
 DEFAULT_EVENT_LEVEL = logging.ERROR
 LOGGING_TO_EVENT_LEVEL = {
@@ -114,14 +116,14 @@ def unignore_logger_for_sentry_logs(
 
 class LoggingIntegration(Integration):
     identifier = "logging"
-    capture_sentry_logs: "Optional[bool]" = False
+    capture_sentry_logs: "Optional[bool]" = _SENTINEL
 
     def __init__(
         self,
         level: "Optional[int]" = DEFAULT_LEVEL,
         event_level: "Optional[int]" = DEFAULT_EVENT_LEVEL,
         sentry_logs_level: "Optional[int]" = DEFAULT_LEVEL,
-        capture_sentry_logs: "Optional[bool]" = False,
+        capture_sentry_logs: "Optional[bool]" = _SENTINEL,
     ) -> None:
         LoggingIntegration.capture_sentry_logs = capture_sentry_logs
 
@@ -401,7 +403,21 @@ class SentryLogsHandler(_BaseHandler):
             if not client.is_active():
                 return
 
-            if not LoggingIntegration.capture_sentry_logs:
+            # TODO: remove this compat hack in the next major. Capture should
+            # only depend on capture_sentry_logs being True.
+            compat_logs_enabled = client.options.get(
+                "enable_logs", False
+            ) or client.options["_experiments"].get("enable_logs", False)
+            should_capture_logs = False
+            if LoggingIntegration.capture_sentry_logs is True:
+                should_capture_logs = True
+            elif (
+                LoggingIntegration.capture_sentry_logs is _SENTINEL
+                and compat_logs_enabled
+            ):
+                should_capture_logs = True
+
+            if not should_capture_logs:
                 return
 
             self._capture_log_from_record(client, record)

--- a/sentry_sdk/integrations/logging.py
+++ b/sentry_sdk/integrations/logging.py
@@ -19,7 +19,7 @@ from sentry_sdk.utils import (
 if TYPE_CHECKING:
     from collections.abc import MutableMapping
     from logging import LogRecord
-    from typing import Any, Dict, Optional
+    from typing import Any, Dict, Optional, Union
 
 _SENTINEL = object()
 
@@ -116,14 +116,14 @@ def unignore_logger_for_sentry_logs(
 
 class LoggingIntegration(Integration):
     identifier = "logging"
-    capture_sentry_logs: "Optional[bool]" = _SENTINEL
+    capture_sentry_logs: "Optional[Union[bool, object]]" = _SENTINEL
 
     def __init__(
         self,
         level: "Optional[int]" = DEFAULT_LEVEL,
         event_level: "Optional[int]" = DEFAULT_EVENT_LEVEL,
         sentry_logs_level: "Optional[int]" = DEFAULT_LEVEL,
-        capture_sentry_logs: "Optional[bool]" = _SENTINEL,
+        capture_sentry_logs: "Optional[Union[bool, object]]" = _SENTINEL,
     ) -> None:
         LoggingIntegration.capture_sentry_logs = capture_sentry_logs
 

--- a/sentry_sdk/integrations/loguru.py
+++ b/sentry_sdk/integrations/loguru.py
@@ -13,7 +13,7 @@ from sentry_sdk.utils import safe_repr
 
 if TYPE_CHECKING:
     from logging import LogRecord
-    from typing import Any, Optional
+    from typing import Any, Optional, Union
 
 try:
     import loguru
@@ -73,7 +73,7 @@ class LoguruIntegration(Integration):
     breadcrumb_format = DEFAULT_FORMAT
     event_format = DEFAULT_FORMAT
     sentry_logs_level: "Optional[int]" = DEFAULT_LEVEL
-    capture_sentry_logs: "Optional[bool]" = _SENTINEL
+    capture_sentry_logs: "Optional[Union[bool, object]]" = _SENTINEL
 
     def __init__(
         self,
@@ -82,7 +82,7 @@ class LoguruIntegration(Integration):
         breadcrumb_format: "str | loguru.FormatFunction" = DEFAULT_FORMAT,
         event_format: "str | loguru.FormatFunction" = DEFAULT_FORMAT,
         sentry_logs_level: "Optional[int]" = DEFAULT_LEVEL,
-        capture_sentry_logs: "Optional[bool]" = _SENTINEL,
+        capture_sentry_logs: "Optional[Union[bool, object]]" = _SENTINEL,
     ) -> None:
         LoguruIntegration.level = level
         LoguruIntegration.event_level = event_level

--- a/sentry_sdk/integrations/loguru.py
+++ b/sentry_sdk/integrations/loguru.py
@@ -26,6 +26,9 @@ except ImportError:
     raise DidNotEnable("LOGURU is not installed")
 
 
+_SENTINEL = object()
+
+
 class LoggingLevels(enum.IntEnum):
     TRACE = 5
     DEBUG = 10
@@ -70,7 +73,7 @@ class LoguruIntegration(Integration):
     breadcrumb_format = DEFAULT_FORMAT
     event_format = DEFAULT_FORMAT
     sentry_logs_level: "Optional[int]" = DEFAULT_LEVEL
-    capture_sentry_logs: "Optional[bool]" = False
+    capture_sentry_logs: "Optional[bool]" = _SENTINEL
 
     def __init__(
         self,
@@ -79,7 +82,7 @@ class LoguruIntegration(Integration):
         breadcrumb_format: "str | loguru.FormatFunction" = DEFAULT_FORMAT,
         event_format: "str | loguru.FormatFunction" = DEFAULT_FORMAT,
         sentry_logs_level: "Optional[int]" = DEFAULT_LEVEL,
-        capture_sentry_logs: "Optional[bool]" = False,
+        capture_sentry_logs: "Optional[bool]" = _SENTINEL,
     ) -> None:
         LoguruIntegration.level = level
         LoguruIntegration.event_level = event_level
@@ -148,7 +151,18 @@ def loguru_sentry_logs_handler(message: "Message") -> None:
     if not client.is_active():
         return
 
-    if not LoguruIntegration.capture_sentry_logs:
+    # TODO: remove this compat hack in the next major. Capture should
+    # only depend on capture_sentry_logs being True.
+    compat_logs_enabled = client.options.get("enable_logs", False) or client.options[
+        "_experiments"
+    ].get("enable_logs", False)
+    should_capture_logs = False
+    if LoguruIntegration.capture_sentry_logs is True:
+        should_capture_logs = True
+    elif LoguruIntegration.capture_sentry_logs is _SENTINEL and compat_logs_enabled:
+        should_capture_logs = True
+
+    if not should_capture_logs:
         return
 
     record = message.record

--- a/tests/integrations/logging/test_logging.py
+++ b/tests/integrations/logging/test_logging.py
@@ -286,7 +286,7 @@ def test_sentry_logs_collection_opt_in_compat_does_not_override_explicit_opt_out
 ):
     # This should be removed in the next major.
     sentry_init(
-        enable_logs=True, integrations=[LoggingIntegration(sentry_logs_level=None)]
+        enable_logs=True, integrations=[LoggingIntegration(capture_sentry_logs=False)]
     )
     items = capture_items("log")
 

--- a/tests/integrations/logging/test_logging.py
+++ b/tests/integrations/logging/test_logging.py
@@ -262,6 +262,42 @@ def test_sentry_logs_collection_opt_in(sentry_init, capture_items, request):
     assert log["attributes"]["sentry.severity_text"] == "warn"
 
 
+def test_sentry_logs_collection_opt_in_compat(sentry_init, capture_items, request):
+    """Automatic logs capture by Sentry logs needs explicit opt-in via enable_logs."""
+    # This should be removed in the next major.
+    sentry_init(enable_logs=True)
+    items = capture_items("log")
+
+    python_logger = logging.Logger("test-logger")
+    python_logger.warning("this is %s a template %s", "1", "2")
+
+    get_client().flush()
+
+    assert len(items) == 1
+
+    log = items[0].payload
+    assert log["attributes"]["sentry.message.template"] == "this is %s a template %s"
+    assert log["attributes"]["sentry.severity_number"] == 13
+    assert log["attributes"]["sentry.severity_text"] == "warn"
+
+
+def test_sentry_logs_collection_opt_in_compat_does_not_override_explicit_opt_out(
+    sentry_init, capture_items, request
+):
+    # This should be removed in the next major.
+    sentry_init(
+        enable_logs=True, integrations=[LoggingIntegration(sentry_logs_level=None)]
+    )
+    items = capture_items("log")
+
+    python_logger = logging.Logger("test-logger")
+    python_logger.warning("this is %s a template %s", "1", "2")
+
+    get_client().flush()
+
+    assert len(items) == 0
+
+
 def test_ignore_logger(sentry_init, capture_events, request):
     sentry_init(integrations=[LoggingIntegration()], default_integrations=False)
     events = capture_events()

--- a/tests/integrations/loguru/test_loguru.py
+++ b/tests/integrations/loguru/test_loguru.py
@@ -256,6 +256,52 @@ def test_disable_sentry_logs_by_default(
     assert len(logs) == 0
 
 
+def test_enable_sentry_logs_if_enable_logs_is_true(
+    sentry_init, capture_items, uninstall_integration, request
+):
+    uninstall_integration("loguru")
+    request.addfinalizer(logger.remove)
+
+    sentry_init(enable_logs=True)
+    items = capture_items("log")
+
+    logger.trace("this is a log")
+    logger.debug("this is a log")
+    logger.info("this is a log")
+    logger.success("this is a log")
+    logger.warning("this is a log")
+    logger.error("this is a log")
+    logger.critical("this is a log")
+
+    sentry_sdk.get_client().flush()
+    logs = [item.payload for item in items]
+    assert len(logs) == 5
+
+
+def test_disable_sentry_logs_if_enable_logs_is_true_but_integration_option_is_false(
+    sentry_init, capture_items, uninstall_integration, request
+):
+    uninstall_integration("loguru")
+    request.addfinalizer(logger.remove)
+
+    sentry_init(
+        enable_logs=True, integrations=[LoguruIntegration(capture_sentry_logs=False)]
+    )
+    items = capture_items("log")
+
+    logger.trace("this is a log")
+    logger.debug("this is a log")
+    logger.info("this is a log")
+    logger.success("this is a log")
+    logger.warning("this is a log")
+    logger.error("this is a log")
+    logger.critical("this is a log")
+
+    sentry_sdk.get_client().flush()
+    logs = [item.payload for item in items]
+    assert not logs
+
+
 def test_disable_sentry_logs_explicitly(
     sentry_init, capture_items, uninstall_integration, request
 ):

--- a/tests/integrations/loguru/test_loguru.py
+++ b/tests/integrations/loguru/test_loguru.py
@@ -259,6 +259,7 @@ def test_disable_sentry_logs_by_default(
 def test_enable_sentry_logs_if_enable_logs_is_true(
     sentry_init, capture_items, uninstall_integration, request
 ):
+    # This should be removed in the next major.
     uninstall_integration("loguru")
     request.addfinalizer(logger.remove)
 
@@ -281,6 +282,7 @@ def test_enable_sentry_logs_if_enable_logs_is_true(
 def test_disable_sentry_logs_if_enable_logs_is_true_but_integration_option_is_false(
     sentry_init, capture_items, uninstall_integration, request
 ):
+    # This should be removed in the next major.
     uninstall_integration("loguru")
     request.addfinalizer(logger.remove)
 


### PR DESCRIPTION
Easing the transition to an `enable_logs`-free world.

Folks who currently have `enable_logs=True` can use our logging API, and they'll have auto-collection of logs from the stdlib logging and Loguru integrations on by default.

In the last release, since we made `enable_logs` no-op, they'd lose their auto-collected logs until they'd explicitly opted in via the new integration options.

Make the transition easier for users who have `enable_logs=True` now: consider the option in both the Logging and Loguru integrations and make them auto-collect unless explicitly opted-out via one of the integration-level options.