### PR TITLE
fix(openai): Check `Response.output` is a `list` before iterating

### DIFF
--- a/sentry_sdk/integrations/openai.py
+++ b/sentry_sdk/integrations/openai.py
@@ -1,7 +1,7 @@
 import json
 import sys
 import time
-from collections.abc import Iterable
+from collections.abc import Iterable, Sequence
 from functools import wraps
 from typing import TYPE_CHECKING, cast
 
@@ -711,7 +711,9 @@ def _set_common_output_data(
             "tool": [],
         }
 
-        if has_data_collection_enabled(client.options):
+        if has_data_collection_enabled(client.options) and isinstance(
+            response.output, Sequence
+        ):
             record_outputs = client.options["data_collection"]["gen_ai"]["outputs"]
 
             if record_outputs:

--- a/sentry_sdk/integrations/openai.py
+++ b/sentry_sdk/integrations/openai.py
@@ -743,7 +743,11 @@ def _set_common_output_data(
                         span, SPANDATA.GEN_AI_RESPONSE_TEXT, output_messages["response"]
                     )
 
-        elif should_send_default_pii() and integration.include_prompts:
+        elif (
+            should_send_default_pii()
+            and integration.include_prompts
+            and isinstance(response.output, Sequence)
+        ):
             for output in response.output:
                 if output.type == "function_call":
                     output_messages["tool"].append(output.dict())

--- a/sentry_sdk/integrations/openai.py
+++ b/sentry_sdk/integrations/openai.py
@@ -301,7 +301,7 @@ def _calculate_responses_token_usage(
         if streaming_message_responses is not None:
             for message in streaming_message_responses:
                 output_tokens += count_tokens(message)
-        elif hasattr(response, "output"):
+        elif hasattr(response, "output") and isinstance(response.output, Sequence):
             for output_item in response.output:
                 if hasattr(output_item, "content"):
                     for content_item in output_item.content:

--- a/sentry_sdk/integrations/openai.py
+++ b/sentry_sdk/integrations/openai.py
@@ -1,7 +1,7 @@
 import json
 import sys
 import time
-from collections.abc import Iterable, Sequence
+from collections.abc import Iterable
 from functools import wraps
 from typing import TYPE_CHECKING, cast
 
@@ -301,7 +301,7 @@ def _calculate_responses_token_usage(
         if streaming_message_responses is not None:
             for message in streaming_message_responses:
                 output_tokens += count_tokens(message)
-        elif hasattr(response, "output") and isinstance(response.output, Sequence):
+        elif hasattr(response, "output") and isinstance(response.output, list):
             for output_item in response.output:
                 if hasattr(output_item, "content"):
                     for content_item in output_item.content:
@@ -712,7 +712,7 @@ def _set_common_output_data(
         }
 
         if has_data_collection_enabled(client.options) and isinstance(
-            response.output, Sequence
+            response.output, list
         ):
             record_outputs = client.options["data_collection"]["gen_ai"]["outputs"]
 
@@ -746,7 +746,7 @@ def _set_common_output_data(
         elif (
             should_send_default_pii()
             and integration.include_prompts
-            and isinstance(response.output, Sequence)
+            and isinstance(response.output, list)
         ):
             for output in response.output:
                 if output.type == "function_call":


### PR DESCRIPTION
### Description
<!-- What changed and why? -->

Check that the output can be iterated so the SDK does not raise an exception.

#### Issues

Closes https://github.com/getsentry/sentry-python/issues/7222

#### Reminders
- Please add tests to validate your changes, and lint your code using `uv run ruff`.
- Add GH Issue ID _&_ Linear ID (if applicable)
- PR title should use [conventional commit](https://develop.sentry.dev/engineering-practices/commit-messages/#type) style (`feat:`, `fix:`, `ref:`, `meta:`)
- For external contributors: [CONTRIBUTING.md](https://github.com/getsentry/sentry-python/blob/master/CONTRIBUTING.md), [Sentry SDK development docs](https://develop.sentry.dev/sdk/), [Discord community](https://discord.gg/Ww9hbqr)
