### PR TITLE
test: Access the 'type' in an event using `.get`

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1039,7 +1039,7 @@ def select_transactions_with_mcp_spans():
         return [
             transaction
             for transaction in events
-            if transaction["type"] == "transaction"
+            if transaction.get("type") == "transaction"
             and any(
                 span["data"].get("mcp.method.name") == method_name
                 for span in transaction.get("spans", [])


### PR DESCRIPTION
`select_transactions_with_mcp_spans` assumes that all events provided to the helper are transactions and contain a `type` key.

However, not all events contain 'type's and so passing events that may contain a log would raise a KeyError.

Relates to #7224