### PR TITLE
test(quart): Fix flake caused by flushing spans on segment end

### DIFF
--- a/tests/integrations/quart/test_quart.py
+++ b/tests/integrations/quart/test_quart.py
@@ -1113,7 +1113,7 @@ async def test_span_streaming_quart_auth_user_id(
     spans = [item.payload for item in items]
     assert len(spans) == 2
 
-    segment = spans[1]
+    segment = next(s for s in spans if s["name"] == "hi")
     if send_default_pii and user_id is not None:
         assert segment["attributes"]["user.id"] == user_id
     else:


### PR DESCRIPTION
### Description
<!-- What changed and why? -->

The background flush on segment end is asynchronous, and spans from different traces are not guaranteed to be ordered.

The error is

```
_______________ test_span_streaming_quart_auth_user_id[42-True] ________________
tests/integrations/quart/test_quart.py:1118: in test_span_streaming_quart_auth_user_id
    assert segment["attributes"]["user.id"] == user_id
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
E   KeyError: 'user.id'
```

Analogous to https://github.com/getsentry/sentry-python/commit/4ada8f12ecd78f66d82a9260700f149ea2e49e1e

#### Issues
<!--
* resolves: #1234
* resolves: LIN-1234
-->

#### Reminders
- Please add tests to validate your changes, and lint your code using `uv run ruff`.
- Add GH Issue ID _&_ Linear ID (if applicable)
- PR title should use [conventional commit](https://develop.sentry.dev/engineering-practices/commit-messages/#type) style (`feat:`, `fix:`, `ref:`, `meta:`)
- For external contributors: [CONTRIBUTING.md](https://github.com/getsentry/sentry-python/blob/master/CONTRIBUTING.md), [Sentry SDK development docs](https://develop.sentry.dev/sdk/), [Discord community](https://discord.gg/Ww9hbqr)
