### PR TITLE
ci: Use tagged versions for `getsentry/codecov-action`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -115,7 +115,7 @@ jobs:
           uv run coverage combine .coverage-sentry-*
           uv run coverage xml
       - name: Report coverage and test results
-        uses: getsentry/codecov-action@d90e69cdf071dfbb0430159125321dc09c424d4c # main
+        uses: getsentry/codecov-action@eb2b4a6c4be3ecb42867043570579fa3b6879f6e # v0.3.8
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           files: coverage.xml

--- a/scripts/split_tox_gh_actions/templates/test_orchestrator.jinja
+++ b/scripts/split_tox_gh_actions/templates/test_orchestrator.jinja
@@ -69,7 +69,7 @@ jobs:
           uv run coverage combine .coverage-sentry-*
           uv run coverage xml
       - name: Report coverage and test results
-        uses: getsentry/codecov-action@d90e69cdf071dfbb0430159125321dc09c424d4c # main
+        uses: getsentry/codecov-action@eb2b4a6c4be3ecb42867043570579fa3b6879f6e # v0.3.8
         with:
           token: {% raw %}${{ secrets.GITHUB_TOKEN }}{% endraw %}
           files: coverage.xml


### PR DESCRIPTION
### Description
<!-- What changed and why? -->

The renovate regex manager is configured to use GitHub tags.

Currently, `getsentry/codecov-action` is not updated in the `test_orchestrator.jinja` template.

https://github.com/getsentry/sentry-python/blob/4899d4f9b1968b67a8907ec5a9cb985cad9db70a/renovate.json#L38-L50

#### Issues
<!--
* resolves: #1234
* resolves: LIN-1234
-->

#### Reminders
- Please add tests to validate your changes, and lint your code using `uv run ruff`.
- Add GH Issue ID _&_ Linear ID (if applicable)
- PR title should use [conventional commit](https://develop.sentry.dev/engineering-practices/commit-messages/#type) style (`feat:`, `fix:`, `ref:`, `meta:`)
- For external contributors: [CONTRIBUTING.md](https://github.com/getsentry/sentry-python/blob/master/CONTRIBUTING.md), [Sentry SDK development docs](https://develop.sentry.dev/sdk/), [Discord community](https://discord.gg/Ww9hbqr)
