### PR TITLE
ref(aws,gcp): Change timeout message

### DIFF
--- a/MIGRATION_GUIDE.md
+++ b/MIGRATION_GUIDE.md
@@ -23,6 +23,7 @@ Looking to upgrade from Sentry SDK 2.x to 3.x? Here's a comprehensive list of wh
 
 - The UnraisableHookIntegration is now enabled by default.
 - We now don't suppress chained exceptions in the ASGI and asyncio integrations by default. The related `suppress_asgi_chained_exceptions` experimental option was removed.
+- In the AWS Lambda and GCP integrations, the message of the warning the SDK optionally emits if a function is about to time out has changed.
 
 ## Removed
 

--- a/sentry_sdk/utils.py
+++ b/sentry_sdk/utils.py
@@ -1427,12 +1427,6 @@ class TimeoutThread(threading.Thread):
         if self._stop_event.is_set():
             return
 
-        integer_configured_timeout = int(self.configured_timeout)
-
-        # Setting up the exact integer value of configured time(in seconds)
-        if integer_configured_timeout < self.configured_timeout:
-            integer_configured_timeout = integer_configured_timeout + 1
-
         # Raising Exception after timeout duration is reached
         if self.isolation_scope is not None and self.current_scope is not None:
             with sentry_sdk.scope.use_isolation_scope(self.isolation_scope):

--- a/sentry_sdk/utils.py
+++ b/sentry_sdk/utils.py
@@ -1439,18 +1439,12 @@ class TimeoutThread(threading.Thread):
                 with sentry_sdk.scope.use_scope(self.current_scope):
                     try:
                         raise ServerlessTimeoutWarning(
-                            "WARNING : Function is expected to get timed out. Configured timeout duration = {} seconds.".format(
-                                integer_configured_timeout
-                            )
+                            "WARNING: Function is about to time out."
                         )
                     except Exception:
                         reraise(*self._capture_exception())
 
-        raise ServerlessTimeoutWarning(
-            "WARNING : Function is expected to get timed out. Configured timeout duration = {} seconds.".format(
-                integer_configured_timeout
-            )
-        )
+        raise ServerlessTimeoutWarning("WARNING: Function is about to time out.")
 
 
 def to_base64(original: str) -> "Optional[str]":

--- a/tests/integrations/aws_lambda/test_aws_lambda.py
+++ b/tests/integrations/aws_lambda/test_aws_lambda.py
@@ -218,9 +218,7 @@ def test_timeout_error_scope_modified(lambda_client, test_environment):
     (exception,) = error_event["exception"]["values"]
     assert not exception["mechanism"]["handled"]
     assert exception["type"] == "ServerlessTimeoutWarning"
-    assert exception["value"].startswith(
-        "WARNING : Function is expected to get timed out. Configured timeout duration ="
-    )
+    assert exception["value"] == "WARNING: Function is about to time out."
     assert exception["mechanism"]["type"] == "threading"
 
     assert error_event["tags"]["custom_tag"] == "custom_value"

--- a/tests/integrations/gcp/test_gcp.py
+++ b/tests/integrations/gcp/test_gcp.py
@@ -231,10 +231,7 @@ def test_timeout_error(run_cloud_function):
     (exception,) = envelope_items[0]["exception"]["values"]
 
     assert exception["type"] == "ServerlessTimeoutWarning"
-    assert (
-        exception["value"]
-        == "WARNING : Function is expected to get timed out. Configured timeout duration = 3 seconds."
-    )
+    assert exception["value"] == "WARNING: Function is about to time out."
     assert exception["mechanism"]["type"] == "threading"
     assert not exception["mechanism"]["handled"]
 


### PR DESCRIPTION
### Description
The timeout in the AWS Lambda (and GCP, by extension) timeout warning is wrong, remove it and slightly rephrase.

This is on the new major branch since it breaks grouping. (Even just removing the number from the original message, without modifying it further, causes regrouping. Since that's the case I took the liberty to update the message a bit more.)

Original POTel PR: https://github.com/getsentry/sentry-python/pull/4671

#### Issues
Closes https://linear.app/getsentry/issue/PY-1937/change-aws-lambda-timeout-message

#### Reminders
- Please add tests to validate your changes, and lint your code using `uv run ruff`.
- Add GH Issue ID _&_ Linear ID (if applicable)
- PR title should use [conventional commit](https://develop.sentry.dev/engineering-practices/commit-messages/#type) style (`feat:`, `fix:`, `ref:`, `meta:`)
- For external contributors: [CONTRIBUTING.md](https://github.com/getsentry/sentry-python/blob/master/CONTRIBUTING.md), [Sentry SDK development docs](https://develop.sentry.dev/sdk/), [Discord community](https://discord.gg/Ww9hbqr)
