### PR TITLE
fix(aws_lambda): Gate request body collection on data_collection experiment

### DIFF
--- a/sentry_sdk/integrations/aws_lambda.py
+++ b/sentry_sdk/integrations/aws_lambda.py
@@ -453,6 +453,11 @@ def _make_request_event_processor(
                 ip = identity.get("sourceIp")
                 if ip is not None:
                     user_info.setdefault("ip_address", ip)
+
+            if "incoming_request" in client_options["data_collection"]["http_bodies"]:
+                if "body" in aws_event:
+                    request["data"] = aws_event.get("body", "")
+
         elif should_send_default_pii():
             user_info = sentry_event.setdefault("user", {})
 

--- a/tests/integrations/aws_lambda/test_aws_lambda.py
+++ b/tests/integrations/aws_lambda/test_aws_lambda.py
@@ -530,7 +530,7 @@ def test_request_data_with_data_collection_allowlist(lambda_client, test_environ
               "userArn": "42"
             }
           },
-          "body": null,
+          "body": "{\\"toy\\": \\"tennisball\\"}",
           "isBase64Encoded": false
         }
     """
@@ -560,6 +560,7 @@ def test_request_data_with_data_collection_allowlist(lambda_client, test_environ
         "method": "GET",
         "query_string": {"bonkers": "true"},
         "url": "https://iwsz2c7uwi.execute-api.us-east-1.amazonaws.com/asd",
+        "data": '{"toy": "tennisball"}',
     }
 
 
@@ -588,7 +589,7 @@ def test_request_data_with_data_collection_denylist(lambda_client, test_environm
               "userArn": "42"
             }
           },
-          "body": null,
+          "body": "{\\"toy\\": \\"tennisball\\"}",
           "isBase64Encoded": false
         }
     """
@@ -617,6 +618,7 @@ def test_request_data_with_data_collection_denylist(lambda_client, test_environm
         "method": "GET",
         "query_string": {"bonkers": "true"},
         "url": "https://iwsz2c7uwi.execute-api.us-east-1.amazonaws.com/asd",
+        "data": '{"toy": "tennisball"}',
     }
 
 
@@ -644,7 +646,7 @@ def test_request_data_with_data_collection_off(lambda_client, test_environment):
               "userArn": "42"
             }
           },
-          "body": null,
+          "body": "{\\"toy\\": \\"tennisball\\"}",
           "isBase64Encoded": false
         }
     """
@@ -663,6 +665,7 @@ def test_request_data_with_data_collection_off(lambda_client, test_environment):
         "method": "GET",
         "query_string": {"bonkers": "true"},
         "url": "https://iwsz2c7uwi.execute-api.us-east-1.amazonaws.com/asd",
+        "data": '{"toy": "tennisball"}',
     }
 
 


### PR DESCRIPTION
Attach request.data from the API Gateway event body when "incoming_request" is present in the data_collection.http_bodies experiment option.

Refs PY-2419
Refs #6283
