### PR TITLE
ref(aiohttp): Remove dead segment name code

### DIFF
--- a/sentry_sdk/integrations/aiohttp.py
+++ b/sentry_sdk/integrations/aiohttp.py
@@ -22,9 +22,6 @@ from sentry_sdk.integrations.logging import ignore_logger
 from sentry_sdk.scope import Scope, should_send_default_pii
 from sentry_sdk.sessions import track_session
 from sentry_sdk.traces import (
-    SOURCE_FOR_STYLE as SEGMENT_SOURCE_FOR_STYLE,
-)
-from sentry_sdk.traces import (
     NoOpStreamedSpan,
     SegmentNameSource,
     SpanStatus,
@@ -339,21 +336,11 @@ class AioHttpIntegration(Integration):
                 pass
 
             if name is not None:
-                current_span = sentry_sdk.get_current_span()
-                if isinstance(current_span, StreamedSpan) and not isinstance(
-                    current_span, NoOpStreamedSpan
-                ):
-                    current_span._segment.name = name
-                    current_span._segment.set_attribute(
-                        "sentry.segment.name.source",
-                        SEGMENT_SOURCE_FOR_STYLE[integration.transaction_style].value,
-                    )
-                else:
-                    current_scope = sentry_sdk.get_current_scope()
-                    current_scope.set_transaction_name(
-                        name,
-                        source=SOURCE_FOR_STYLE[integration.transaction_style],
-                    )
+                current_scope = sentry_sdk.get_current_scope()
+                current_scope.set_transaction_name(
+                    name,
+                    source=SOURCE_FOR_STYLE[integration.transaction_style],
+                )
 
             return rv
 


### PR DESCRIPTION
The `aiohttp` integration currently has a dead branch that looks live:

https://github.com/getsentry/sentry-python/blob/8e6d73b6ca64b810393516a84aecd3817045c452/sentry_sdk/integrations/aiohttp.py#L341-L356

`isinstance(current_span, StreamedSpan)` is **always false**, so the first branch never matches. `sentry_sdk.get_current_span()` does not return `StreamedSpan`s. (It reads from `scope.span`, but the streamed span is in `scope.streamed_span`).

This doesn't functionally matter, because even though we always fall through to the `else` branch, `set_transaction_name` already handles the streamed span case (including the name and source). This is tested in [`test_transaction_style_span_streaming`](https://github.com/getsentry/sentry-python/blob/45e02e7e28c6aa7da56510124c8a4ee4999682a8/tests/integrations/aiohttp/test_aiohttp.py#L1845) already.

Remove the misleading branch.