### PR TITLE
feat(stdlib): Support data_collection filtering for URL query params

### DIFF
--- a/sentry_sdk/integrations/boto3.py
+++ b/sentry_sdk/integrations/boto3.py
@@ -3,22 +3,18 @@ from typing import TYPE_CHECKING
 
 import sentry_sdk
 from sentry_sdk.consts import OP, SPANDATA
-from sentry_sdk.data_collection import (
-    _apply_data_collection_filtering_to_query_string,
-)
 from sentry_sdk.integrations import DidNotEnable, Integration, _check_minimum_version
-from sentry_sdk.scope import should_send_default_pii
 from sentry_sdk.traces import StreamedSpan
 from sentry_sdk.tracing import BAGGAGE_HEADER_NAME, Span
 from sentry_sdk.tracing_utils import (
     add_http_breadcrumb,
     add_sentry_baggage_to_headers,
+    get_url_attributes,
     has_span_streaming_enabled,
     should_propagate_trace,
 )
 from sentry_sdk.utils import (
     capture_internal_exceptions,
-    has_data_collection_enabled,
     parse_url,
     parse_version,
 )
@@ -28,9 +24,6 @@ if TYPE_CHECKING:
 
     from botocore.model import ServiceId
 
-    from sentry_sdk._types import Attributes
-    from sentry_sdk.client import BaseClient as SentryClient
-    from sentry_sdk.utils import ParsedUrl
 
 try:
     from botocore import __version__ as BOTOCORE_VERSION
@@ -70,40 +63,6 @@ class Boto3Integration(Integration):
         BaseClient.__init__ = sentry_patched_init  # type: ignore
 
 
-def _get_url_attributes(
-    client: "SentryClient", parsed_url: "Optional[ParsedUrl]"
-) -> "Attributes":
-    attributes: "Attributes" = {}
-    if parsed_url is None:
-        return attributes
-
-    query: "Optional[str]"
-    if has_data_collection_enabled(client.options):
-        query = None
-        if parsed_url.query:
-            query = _apply_data_collection_filtering_to_query_string(
-                query_string=parsed_url.query,
-                behaviour=client.options["data_collection"]["url_query_params"],
-            )
-    elif should_send_default_pii():
-        query = parsed_url.query
-    else:
-        return attributes
-
-    url_full = parsed_url.url
-    if query:
-        attributes[SPANDATA.URL_QUERY] = query
-        url_full += "?" + query
-
-    if parsed_url.fragment:
-        attributes[SPANDATA.URL_FRAGMENT] = parsed_url.fragment
-        url_full += "#" + parsed_url.fragment
-
-    attributes[SPANDATA.URL_FULL] = url_full
-
-    return attributes
-
-
 def _sentry_request_created(
     service_id: "ServiceId", request: "AWSRequest", operation_name: str, **kwargs: "Any"
 ) -> None:
@@ -123,7 +82,7 @@ def _sentry_request_created(
     is_span_streaming_enabled = has_span_streaming_enabled(client.options)
     span: "Union[Span, StreamedSpan, None]" = None
     if is_span_streaming_enabled:
-        url_attributes = _get_url_attributes(client, parsed_url)
+        url_attributes = get_url_attributes(client, parsed_url)
         breadcrumb.update(url_attributes)
 
         if request.method is not None:

--- a/sentry_sdk/integrations/httpx.py
+++ b/sentry_sdk/integrations/httpx.py
@@ -2,14 +2,11 @@ from typing import TYPE_CHECKING
 
 import sentry_sdk
 from sentry_sdk.consts import OP, SPANDATA
-from sentry_sdk.data_collection import (
-    _apply_data_collection_filtering_to_query_string,
-)
 from sentry_sdk.integrations import DidNotEnable, Integration
-from sentry_sdk.scope import should_send_default_pii
 from sentry_sdk.tracing_utils import (
     add_http_breadcrumb,
     add_http_request_source,
+    get_url_attributes,
     has_span_streaming_enabled,
     propagate_trace_headers,
 )
@@ -17,16 +14,13 @@ from sentry_sdk.utils import (
     SENSITIVE_DATA_SUBSTITUTE,
     capture_internal_exceptions,
     ensure_integration_enabled,
-    has_data_collection_enabled,
     parse_url,
 )
 
 if TYPE_CHECKING:
-    from typing import Any, Optional
+    from typing import Any
 
     from sentry_sdk._types import Attributes
-    from sentry_sdk.client import BaseClient
-    from sentry_sdk.utils import ParsedUrl
 
 
 try:
@@ -51,45 +45,6 @@ class HttpxIntegration(Integration):
         _install_httpx_async_client()
 
 
-def _get_url_attributes(
-    client: "BaseClient", parsed_url: "Optional[ParsedUrl]"
-) -> "Attributes":
-    attributes: "Attributes" = {}
-    if parsed_url is None:
-        return attributes
-
-    url_full = parsed_url.url
-
-    if has_data_collection_enabled(client.options):
-        if parsed_url.query:
-            filtered_query = _apply_data_collection_filtering_to_query_string(
-                query_string=parsed_url.query,
-                behaviour=client.options["data_collection"]["url_query_params"],
-            )
-            if filtered_query:
-                attributes["url.query"] = filtered_query
-                url_full += "?" + filtered_query
-
-        if parsed_url.fragment:
-            attributes["url.fragment"] = parsed_url.fragment
-            url_full += "#" + parsed_url.fragment
-
-        attributes["url.full"] = url_full
-
-    elif should_send_default_pii():
-        if parsed_url.query:
-            attributes["url.query"] = parsed_url.query
-            url_full += "?" + parsed_url.query
-
-        if parsed_url.fragment:
-            attributes["url.fragment"] = parsed_url.fragment
-            url_full += "#" + parsed_url.fragment
-
-        attributes["url.full"] = url_full
-
-    return attributes
-
-
 def _install_httpx_client() -> None:
     real_send = Client.send
 
@@ -109,7 +64,7 @@ def _install_httpx_client() -> None:
                 propagate_trace_headers(client, request)
                 return real_send(self, request, **kwargs)
 
-            url_attributes = _get_url_attributes(client, parsed_url)
+            url_attributes = get_url_attributes(client, parsed_url)
 
             with sentry_sdk.traces.start_span(
                 name="%s %s"
@@ -218,7 +173,7 @@ def _install_httpx_async_client() -> None:
                 propagate_trace_headers(client, request)
                 return await real_send(self, request, **kwargs)
 
-            url_attributes = _get_url_attributes(client, parsed_url)
+            url_attributes = get_url_attributes(client, parsed_url)
 
             with sentry_sdk.traces.start_span(
                 name="%s %s"

--- a/sentry_sdk/integrations/httpx2.py
+++ b/sentry_sdk/integrations/httpx2.py
@@ -2,14 +2,11 @@ from typing import TYPE_CHECKING
 
 import sentry_sdk
 from sentry_sdk.consts import OP, SPANDATA
-from sentry_sdk.data_collection import (
-    _apply_data_collection_filtering_to_query_string,
-)
 from sentry_sdk.integrations import DidNotEnable, Integration
-from sentry_sdk.scope import should_send_default_pii
 from sentry_sdk.tracing_utils import (
     add_http_breadcrumb,
     add_http_request_source,
+    get_url_attributes,
     has_span_streaming_enabled,
     propagate_trace_headers,
 )
@@ -17,16 +14,13 @@ from sentry_sdk.utils import (
     SENSITIVE_DATA_SUBSTITUTE,
     capture_internal_exceptions,
     ensure_integration_enabled,
-    has_data_collection_enabled,
     parse_url,
 )
 
 if TYPE_CHECKING:
-    from typing import Any, Optional
+    from typing import Any
 
     from sentry_sdk._types import Attributes
-    from sentry_sdk.client import BaseClient
-    from sentry_sdk.utils import ParsedUrl
 
 
 try:
@@ -51,45 +45,6 @@ class Httpx2Integration(Integration):
         _install_httpx2_async_client()
 
 
-def _get_url_attributes(
-    client: "BaseClient", parsed_url: "Optional[ParsedUrl]"
-) -> "Attributes":
-    attributes: "Attributes" = {}
-    if parsed_url is None:
-        return attributes
-
-    url_full = parsed_url.url
-
-    if has_data_collection_enabled(client.options):
-        if parsed_url.query:
-            filtered_query = _apply_data_collection_filtering_to_query_string(
-                query_string=parsed_url.query,
-                behaviour=client.options["data_collection"]["url_query_params"],
-            )
-            if filtered_query:
-                attributes["url.query"] = filtered_query
-                url_full += "?" + filtered_query
-
-        if parsed_url.fragment:
-            attributes["url.fragment"] = parsed_url.fragment
-            url_full += "#" + parsed_url.fragment
-
-        attributes["url.full"] = url_full
-
-    elif should_send_default_pii():
-        if parsed_url.query:
-            attributes["url.query"] = parsed_url.query
-            url_full += "?" + parsed_url.query
-
-        if parsed_url.fragment:
-            attributes["url.fragment"] = parsed_url.fragment
-            url_full += "#" + parsed_url.fragment
-
-        attributes["url.full"] = url_full
-
-    return attributes
-
-
 def _install_httpx2_client() -> None:
     real_send = Client.send
 
@@ -109,7 +64,7 @@ def _install_httpx2_client() -> None:
                 propagate_trace_headers(client, request)
                 return real_send(self, request, **kwargs)
 
-            url_attributes = _get_url_attributes(client, parsed_url)
+            url_attributes = get_url_attributes(client, parsed_url)
 
             with sentry_sdk.traces.start_span(
                 name="%s %s"
@@ -218,7 +173,7 @@ def _install_httpx2_async_client() -> None:
                 propagate_trace_headers(client, request)
                 return await real_send(self, request, **kwargs)
 
-            url_attributes = _get_url_attributes(client, parsed_url)
+            url_attributes = get_url_attributes(client, parsed_url)
 
             with sentry_sdk.traces.start_span(
                 name="%s %s"

--- a/sentry_sdk/integrations/pyreqwest.py
+++ b/sentry_sdk/integrations/pyreqwest.py
@@ -4,17 +4,14 @@ from typing import TYPE_CHECKING, Any, Generator
 import sentry_sdk
 from sentry_sdk import start_span
 from sentry_sdk.consts import OP, SPANDATA
-from sentry_sdk.data_collection import (
-    _apply_data_collection_filtering_to_query_string,
-)
 from sentry_sdk.integrations import DidNotEnable, Integration
-from sentry_sdk.scope import should_send_default_pii
 from sentry_sdk.traces import StreamedSpan
 from sentry_sdk.tracing import BAGGAGE_HEADER_NAME
 from sentry_sdk.tracing_utils import (
     add_http_breadcrumb,
     add_http_request_source,
     add_sentry_baggage_to_headers,
+    get_url_attributes,
     has_span_streaming_enabled,
     propagate_trace_headers,
     should_propagate_trace,
@@ -22,7 +19,6 @@ from sentry_sdk.tracing_utils import (
 from sentry_sdk.utils import (
     SENSITIVE_DATA_SUBSTITUTE,
     capture_internal_exceptions,
-    has_data_collection_enabled,
     logger,
     parse_url,
 )
@@ -31,7 +27,6 @@ if TYPE_CHECKING:
     from typing import Optional
 
     from sentry_sdk._types import Attributes
-    from sentry_sdk.client import BaseClient
     from sentry_sdk.utils import ParsedUrl
 
 try:
@@ -95,40 +90,6 @@ def _patch_builder_method(cls: type, method_name: str, middleware: "Any") -> Non
         return original_method(self, *args, **kwargs)
 
     setattr(cls, method_name, sentry_patched_method)
-
-
-def _get_url_attributes(
-    client: "BaseClient", parsed_url: "Optional[ParsedUrl]"
-) -> "Attributes":
-    attributes: "Attributes" = {}
-    if parsed_url is None:
-        return attributes
-
-    query: "Optional[str]"
-    if has_data_collection_enabled(client.options):
-        query = None
-        if parsed_url.query:
-            query = _apply_data_collection_filtering_to_query_string(
-                query_string=parsed_url.query,
-                behaviour=client.options["data_collection"]["url_query_params"],
-            )
-    elif should_send_default_pii():
-        query = parsed_url.query
-    else:
-        return attributes
-
-    url_full = parsed_url.url
-    if query:
-        attributes[SPANDATA.URL_QUERY] = query
-        url_full += "?" + query
-
-    if parsed_url.fragment:
-        attributes[SPANDATA.URL_FRAGMENT] = parsed_url.fragment
-        url_full += "#" + parsed_url.fragment
-
-    attributes[SPANDATA.URL_FULL] = url_full
-
-    return attributes
 
 
 def _get_breadcrumb_url_data(
@@ -233,7 +194,7 @@ async def sentry_async_middleware(
         # after the request has been sent
         parsed_url = parse_url(str(request.url), sanitize=False)
 
-    url_attributes = _get_url_attributes(sentry_sdk.get_client(), parsed_url)
+    url_attributes = get_url_attributes(sentry_sdk.get_client(), parsed_url)
 
     response = None
     with _sentry_pyreqwest_span(request, url_attributes) as span:
@@ -273,7 +234,7 @@ def sentry_sync_middleware(
         # after the request has been sent
         parsed_url = parse_url(str(request.url), sanitize=False)
 
-    url_attributes = _get_url_attributes(sentry_sdk.get_client(), parsed_url)
+    url_attributes = get_url_attributes(sentry_sdk.get_client(), parsed_url)
 
     response = None
     with _sentry_pyreqwest_span(request, url_attributes) as span:

--- a/sentry_sdk/integrations/stdlib.py
+++ b/sentry_sdk/integrations/stdlib.py
@@ -7,6 +7,9 @@ from typing import TYPE_CHECKING
 
 import sentry_sdk
 from sentry_sdk.consts import OP, SPANDATA
+from sentry_sdk.data_collection import (
+    _apply_data_collection_filtering_to_query_string,
+)
 from sentry_sdk.integrations import Integration
 from sentry_sdk.scope import add_global_event_processor, should_send_default_pii
 from sentry_sdk.traces import StreamedSpan
@@ -24,6 +27,7 @@ from sentry_sdk.utils import (
     _get_aws_sigv4_signed_headers_from_url_query_string,
     capture_internal_exceptions,
     ensure_integration_enabled,
+    has_data_collection_enabled,
     is_sentry_url,
     logger,
     parse_url,
@@ -33,7 +37,9 @@ from sentry_sdk.utils import (
 if TYPE_CHECKING:
     from typing import Any, Callable, Dict, List, Optional, Set, Union
 
-    from sentry_sdk._types import Event, Hint
+    from sentry_sdk._types import Attributes, Event, Hint
+    from sentry_sdk.client import BaseClient
+    from sentry_sdk.utils import ParsedUrl
 
 
 _RUNTIME_CONTEXT: "dict[str, object]" = {
@@ -81,6 +87,40 @@ def _complete_span(span: "Union[Span, StreamedSpan]") -> None:
         span.finish()
         with capture_internal_exceptions():
             add_http_request_source(span)
+
+
+def _get_url_attributes(
+    client: "BaseClient", parsed_url: "Optional[ParsedUrl]"
+) -> "Attributes":
+    attributes: "Attributes" = {}
+    if parsed_url is None:
+        return attributes
+
+    query: "Optional[str]"
+    if has_data_collection_enabled(client.options):
+        query = None
+        if parsed_url.query:
+            query = _apply_data_collection_filtering_to_query_string(
+                query_string=parsed_url.query,
+                behaviour=client.options["data_collection"]["url_query_params"],
+            )
+    elif should_send_default_pii():
+        query = parsed_url.query
+    else:
+        return attributes
+
+    url_full = parsed_url.url
+    if query:
+        attributes[SPANDATA.URL_QUERY] = query
+        url_full += "?" + query
+
+    if parsed_url.fragment:
+        attributes[SPANDATA.URL_FRAGMENT] = parsed_url.fragment
+        url_full += "#" + parsed_url.fragment
+
+    attributes[SPANDATA.URL_FULL] = url_full
+
+    return attributes
 
 
 def _get_wrapped_putheader(
@@ -285,15 +325,10 @@ def _install_httplib() -> None:
         breadcrumb: "dict[str, Any]" = {}
 
         if span_streaming:
+            url_attributes = _get_url_attributes(client, parsed_url)
+
             breadcrumb[SPANDATA.HTTP_REQUEST_METHOD] = method
-            if parsed_url is not None and should_send_default_pii():
-                breadcrumb.update(
-                    {
-                        SPANDATA.URL_FRAGMENT: parsed_url.fragment,
-                        SPANDATA.URL_FULL: parsed_url.url,
-                        SPANDATA.URL_QUERY: parsed_url.query,
-                    }
-                )
+            breadcrumb.update(url_attributes)
 
             if sentry_sdk.traces.get_current_span() is not None:
                 span = sentry_sdk.traces.start_span(
@@ -309,10 +344,8 @@ def _install_httplib() -> None:
                     },
                 )
 
-                if parsed_url is not None and should_send_default_pii():
-                    span.set_attribute(SPANDATA.URL_FRAGMENT, parsed_url.fragment)
-                    span.set_attribute(SPANDATA.URL_FULL, parsed_url.url)
-                    span.set_attribute(SPANDATA.URL_QUERY, parsed_url.query)
+                for key, value in url_attributes.items():
+                    span.set_attribute(key, value)
 
                 set_on_span = span.set_attribute
 

--- a/sentry_sdk/integrations/stdlib.py
+++ b/sentry_sdk/integrations/stdlib.py
@@ -7,17 +7,15 @@ from typing import TYPE_CHECKING
 
 import sentry_sdk
 from sentry_sdk.consts import OP, SPANDATA
-from sentry_sdk.data_collection import (
-    _apply_data_collection_filtering_to_query_string,
-)
 from sentry_sdk.integrations import Integration
-from sentry_sdk.scope import add_global_event_processor, should_send_default_pii
+from sentry_sdk.scope import add_global_event_processor
 from sentry_sdk.traces import StreamedSpan
 from sentry_sdk.tracing import BAGGAGE_HEADER_NAME, SENTRY_TRACE_HEADER_NAME, Span
 from sentry_sdk.tracing_utils import (
     EnvironHeaders,
     add_http_breadcrumb,
     add_http_request_source,
+    get_url_attributes,
     has_span_streaming_enabled,
     should_propagate_trace,
 )
@@ -27,7 +25,6 @@ from sentry_sdk.utils import (
     _get_aws_sigv4_signed_headers_from_url_query_string,
     capture_internal_exceptions,
     ensure_integration_enabled,
-    has_data_collection_enabled,
     is_sentry_url,
     logger,
     parse_url,
@@ -37,9 +34,7 @@ from sentry_sdk.utils import (
 if TYPE_CHECKING:
     from typing import Any, Callable, Dict, List, Optional, Set, Union
 
-    from sentry_sdk._types import Attributes, Event, Hint
-    from sentry_sdk.client import BaseClient
-    from sentry_sdk.utils import ParsedUrl
+    from sentry_sdk._types import Event, Hint
 
 
 _RUNTIME_CONTEXT: "dict[str, object]" = {
@@ -87,40 +82,6 @@ def _complete_span(span: "Union[Span, StreamedSpan]") -> None:
         span.finish()
         with capture_internal_exceptions():
             add_http_request_source(span)
-
-
-def _get_url_attributes(
-    client: "BaseClient", parsed_url: "Optional[ParsedUrl]"
-) -> "Attributes":
-    attributes: "Attributes" = {}
-    if parsed_url is None:
-        return attributes
-
-    query: "Optional[str]"
-    if has_data_collection_enabled(client.options):
-        query = None
-        if parsed_url.query:
-            query = _apply_data_collection_filtering_to_query_string(
-                query_string=parsed_url.query,
-                behaviour=client.options["data_collection"]["url_query_params"],
-            )
-    elif should_send_default_pii():
-        query = parsed_url.query
-    else:
-        return attributes
-
-    url_full = parsed_url.url
-    if query:
-        attributes[SPANDATA.URL_QUERY] = query
-        url_full += "?" + query
-
-    if parsed_url.fragment:
-        attributes[SPANDATA.URL_FRAGMENT] = parsed_url.fragment
-        url_full += "#" + parsed_url.fragment
-
-    attributes[SPANDATA.URL_FULL] = url_full
-
-    return attributes
 
 
 def _get_wrapped_putheader(
@@ -325,7 +286,7 @@ def _install_httplib() -> None:
         breadcrumb: "dict[str, Any]" = {}
 
         if span_streaming:
-            url_attributes = _get_url_attributes(client, parsed_url)
+            url_attributes = get_url_attributes(client, parsed_url)
 
             breadcrumb[SPANDATA.HTTP_REQUEST_METHOD] = method
             breadcrumb.update(url_attributes)

--- a/sentry_sdk/tracing_utils.py
+++ b/sentry_sdk/tracing_utils.py
@@ -46,7 +46,6 @@ if TYPE_CHECKING:
     from typing import Any, Dict, Generator, Iterator, Optional, Tuple, Union
 
     from sentry_sdk._types import Attributes
-    from sentry_sdk.client import BaseClient
     from sentry_sdk.utils import ParsedUrl
 
 
@@ -231,7 +230,7 @@ def add_http_breadcrumb(status_code: "Optional[int]", data: "dict[str, Any]") ->
 
 
 def get_url_attributes(
-    client: "BaseClient", parsed_url: "Optional[ParsedUrl]"
+    client: "sentry_sdk.client.BaseClient", parsed_url: "Optional[ParsedUrl]"
 ) -> "Attributes":
     """Build the `url.*` span attributes for an outgoing HTTP request.
 

--- a/sentry_sdk/tracing_utils.py
+++ b/sentry_sdk/tracing_utils.py
@@ -21,6 +21,9 @@ from typing import TYPE_CHECKING
 
 import sentry_sdk
 from sentry_sdk.consts import OP, SPANDATA, SPANTEMPLATE
+from sentry_sdk.data_collection import (
+    _apply_data_collection_filtering_to_query_string,
+)
 from sentry_sdk.utils import (
     _is_external_source,
     _is_in_project_root,
@@ -43,6 +46,8 @@ if TYPE_CHECKING:
     from typing import Any, Dict, Generator, Iterator, Optional, Tuple, Union
 
     from sentry_sdk._types import Attributes
+    from sentry_sdk.client import BaseClient
+    from sentry_sdk.utils import ParsedUrl
 
 
 SENTRY_TRACE_REGEX = re.compile(
@@ -223,6 +228,46 @@ def add_http_breadcrumb(status_code: "Optional[int]", data: "dict[str, Any]") ->
         kwargs["level"] = level
 
     sentry_sdk.add_breadcrumb(**kwargs)
+
+
+def get_url_attributes(
+    client: "BaseClient", parsed_url: "Optional[ParsedUrl]"
+) -> "Attributes":
+    """Build the `url.*` span attributes for an outgoing HTTP request.
+
+    The query string is only included when the user has opted into collecting
+    it, either through `data_collection` (in which case the configured
+    filtering is applied) or through the legacy `send_default_pii`.
+    """
+    attributes: "Attributes" = {}
+    if parsed_url is None:
+        return attributes
+
+    query: "Optional[str]"
+    if has_data_collection_enabled(client.options):
+        query = None
+        if parsed_url.query:
+            query = _apply_data_collection_filtering_to_query_string(
+                query_string=parsed_url.query,
+                behaviour=client.options["data_collection"]["url_query_params"],
+            )
+    elif client.should_send_default_pii():
+        query = parsed_url.query
+    else:
+        return attributes
+
+    url_full = parsed_url.url
+    if query:
+        attributes[SPANDATA.URL_QUERY] = query
+        url_full += "?" + query
+
+    if parsed_url.fragment:
+        attributes[SPANDATA.URL_FRAGMENT] = parsed_url.fragment
+        url_full += "#" + parsed_url.fragment
+
+    attributes[SPANDATA.URL_FULL] = url_full
+
+    return attributes
 
 
 def _get_frame_module_abs_path(frame: "FrameType") -> "Optional[str]":

--- a/tests/integrations/requests/test_requests.py
+++ b/tests/integrations/requests/test_requests.py
@@ -59,8 +59,6 @@ def test_crumb_capture_span_streaming(sentry_init, capture_events, send_default_
             {
                 SPANDATA.URL_FULL: url,
                 SPANDATA.HTTP_REQUEST_METHOD: "GET",
-                SPANDATA.URL_FRAGMENT: "",
-                SPANDATA.URL_QUERY: "",
                 SPANDATA.HTTP_STATUS_CODE: response.status_code,
             }
         )
@@ -169,8 +167,6 @@ def test_crumb_capture_client_error_span_streaming(
             {
                 SPANDATA.URL_FULL: url,
                 SPANDATA.HTTP_REQUEST_METHOD: "GET",
-                SPANDATA.URL_FRAGMENT: "",
-                SPANDATA.URL_QUERY: "",
                 SPANDATA.HTTP_STATUS_CODE: response.status_code,
             }
         )

--- a/tests/integrations/stdlib/test_httplib.py
+++ b/tests/integrations/stdlib/test_httplib.py
@@ -128,8 +128,6 @@ def test_crumb_capture_span_streaming(sentry_init, capture_events, send_default_
                 SPANDATA.URL_FULL: url,
                 SPANDATA.HTTP_REQUEST_METHOD: "GET",
                 SPANDATA.HTTP_STATUS_CODE: 200,
-                SPANDATA.URL_FRAGMENT: "",
-                SPANDATA.URL_QUERY: "",
             }
         )
     else:
@@ -231,8 +229,6 @@ def test_crumb_capture_client_error_span_streaming(
                 SPANDATA.URL_FULL: url,
                 SPANDATA.HTTP_REQUEST_METHOD: "GET",
                 SPANDATA.HTTP_STATUS_CODE: status_code,
-                SPANDATA.URL_FRAGMENT: "",
-                SPANDATA.URL_QUERY: "",
             }
         )
     else:
@@ -311,8 +307,6 @@ def test_crumb_capture_hint_span_streaming(
                 SPANDATA.HTTP_REQUEST_METHOD: "GET",
                 SPANDATA.HTTP_STATUS_CODE: 200,
                 "extra": "foo",
-                SPANDATA.URL_FRAGMENT: "",
-                SPANDATA.URL_QUERY: "",
             }
         )
     else:
@@ -1408,7 +1402,7 @@ def test_proxy_http_tunnel(
         if send_default_pii:
             assert (
                 span["attributes"][SPANDATA.URL_FULL]
-                == f"http://api.example.com{port_modifier}/foo"
+                == f"http://api.example.com{port_modifier}/foo?bar=1"
             )
             assert span["attributes"][SPANDATA.URL_QUERY] == "bar=1"
         else:
@@ -1480,3 +1474,241 @@ def test_chunked_response_span_covers_body_read(
         end = datetime.datetime.strptime(span["timestamp"], fmt)
         duration = (end - start).total_seconds()
         assert duration >= min_expected_duration
+
+
+@pytest.mark.parametrize(
+    "init_kwargs, expected_query",
+    [
+        pytest.param(
+            {"send_default_pii": True},
+            "toy=tennisball&color=red&auth=secret",
+            id="send_default_pii_true",
+        ),
+        pytest.param(
+            {"send_default_pii": False},
+            None,
+            id="send_default_pii_false",
+        ),
+        pytest.param(
+            {},
+            None,
+            id="defaults",
+        ),
+        pytest.param(
+            {"_experiments": {"data_collection": {}}},
+            "toy=tennisball&color=red&auth=%5BFiltered%5D",
+            id="data_collection_denylist_default",
+        ),
+        pytest.param(
+            {
+                "_experiments": {
+                    "data_collection": {
+                        "url_query_params": {"mode": "denylist", "terms": ["toy"]}
+                    }
+                }
+            },
+            "toy=%5BFiltered%5D&color=red&auth=%5BFiltered%5D",
+            id="data_collection_denylist_custom_terms",
+        ),
+        pytest.param(
+            {
+                "_experiments": {
+                    "data_collection": {
+                        "url_query_params": {"mode": "allowlist", "terms": ["toy"]}
+                    }
+                }
+            },
+            "toy=tennisball&color=%5BFiltered%5D&auth=%5BFiltered%5D",
+            id="data_collection_allowlist",
+        ),
+        pytest.param(
+            {
+                "_experiments": {
+                    "data_collection": {
+                        "url_query_params": {"mode": "allowlist", "terms": ["auth"]}
+                    }
+                }
+            },
+            "toy=%5BFiltered%5D&color=%5BFiltered%5D&auth=%5BFiltered%5D",
+            id="data_collection_allowlist_sensitive_term",
+        ),
+        pytest.param(
+            {
+                "_experiments": {
+                    "data_collection": {"url_query_params": {"mode": "off"}}
+                }
+            },
+            None,
+            id="data_collection_off",
+        ),
+        pytest.param(
+            {
+                "send_default_pii": True,
+                "_experiments": {
+                    "data_collection": {"url_query_params": {"mode": "off"}}
+                },
+            },
+            None,
+            id="data_collection_wins_over_send_default_pii",
+        ),
+    ],
+)
+def test_url_query_data_collection_span_streaming(
+    sentry_init, capture_items, init_kwargs, expected_query
+):
+    sentry_init(
+        integrations=[StdlibIntegration()],
+        traces_sample_rate=1.0,
+        trace_lifecycle="stream",
+        **init_kwargs,
+    )
+
+    items = capture_items("span")
+
+    with sentry_sdk.traces.start_span(name="custom parent"):
+        conn = HTTPConnection("localhost", PORT)
+        conn.request(
+            "GET", "/some/random/url?toy=tennisball&color=red&auth=secret#frag"
+        )
+        conn.getresponse()
+
+    sentry_sdk.flush()
+
+    (span,) = (
+        item.payload
+        for item in items
+        if item.payload["attributes"].get("sentry.origin") == "auto.http.stdlib.httplib"
+    )
+
+    if expected_query is None:
+        assert SPANDATA.URL_QUERY not in span["attributes"]
+    else:
+        assert span["attributes"][SPANDATA.URL_QUERY] == expected_query
+
+
+@pytest.mark.parametrize(
+    "init_kwargs, expected_suffix",
+    [
+        pytest.param(
+            {"_experiments": {"data_collection": {}}},
+            "?toy=tennisball&color=red&auth=%5BFiltered%5D#frag",
+            id="data_collection_denylist_default",
+        ),
+        pytest.param(
+            {
+                "_experiments": {
+                    "data_collection": {
+                        "url_query_params": {"mode": "allowlist", "terms": ["toy"]}
+                    }
+                }
+            },
+            "?toy=tennisball&color=%5BFiltered%5D&auth=%5BFiltered%5D#frag",
+            id="data_collection_allowlist",
+        ),
+        pytest.param(
+            {"send_default_pii": True},
+            "?toy=tennisball&color=red&auth=secret#frag",
+            id="send_default_pii_true",
+        ),
+    ],
+)
+def test_url_full_reassembly_span_streaming(
+    sentry_init, capture_items, init_kwargs, expected_suffix
+):
+    sentry_init(
+        integrations=[StdlibIntegration()],
+        traces_sample_rate=1.0,
+        trace_lifecycle="stream",
+        **init_kwargs,
+    )
+
+    items = capture_items("span")
+
+    with sentry_sdk.traces.start_span(name="custom parent"):
+        conn = HTTPConnection("localhost", PORT)
+        conn.request(
+            "GET", "/some/random/url?toy=tennisball&color=red&auth=secret#frag"
+        )
+        conn.getresponse()
+
+    sentry_sdk.flush()
+
+    (span,) = (
+        item.payload
+        for item in items
+        if item.payload["attributes"].get("sentry.origin") == "auto.http.stdlib.httplib"
+    )
+
+    base_url = "http://localhost:{}/some/random/url".format(PORT)
+    assert span["attributes"][SPANDATA.URL_FULL] == base_url + expected_suffix
+
+
+@pytest.mark.parametrize(
+    "init_kwargs, expected_query, expects_url",
+    [
+        pytest.param(
+            {"send_default_pii": True},
+            "toy=tennisball&color=red&auth=secret",
+            True,
+            id="send_default_pii_true",
+        ),
+        pytest.param(
+            {},
+            None,
+            False,
+            id="defaults",
+        ),
+        pytest.param(
+            {"_experiments": {"data_collection": {}}},
+            "toy=tennisball&color=red&auth=%5BFiltered%5D",
+            True,
+            id="data_collection_denylist_default",
+        ),
+        pytest.param(
+            {
+                "_experiments": {
+                    "data_collection": {"url_query_params": {"mode": "off"}}
+                }
+            },
+            None,
+            True,
+            id="data_collection_off",
+        ),
+    ],
+)
+def test_crumb_url_query_data_collection_span_streaming(
+    sentry_init, capture_events, init_kwargs, expected_query, expects_url
+):
+    sentry_init(
+        integrations=[StdlibIntegration()],
+        trace_lifecycle="stream",
+        **init_kwargs,
+    )
+    events = capture_events()
+
+    conn = HTTPConnection("localhost", PORT)
+    conn.request("GET", "/some/random/url?toy=tennisball&color=red&auth=secret#frag")
+    conn.getresponse()
+
+    capture_message("Testing!")
+
+    (event,) = events
+    (crumb,) = event["breadcrumbs"]["values"]
+
+    base_url = "http://localhost:{}/some/random/url".format(PORT)
+
+    if not expects_url:
+        assert SPANDATA.URL_QUERY not in crumb["data"]
+        assert SPANDATA.URL_FULL not in crumb["data"]
+        return
+
+    assert crumb["data"][SPANDATA.URL_FRAGMENT] == "frag"
+
+    if expected_query is None:
+        assert SPANDATA.URL_QUERY not in crumb["data"]
+        assert crumb["data"][SPANDATA.URL_FULL] == f"{base_url}#frag"
+    else:
+        assert crumb["data"][SPANDATA.URL_QUERY] == expected_query
+        assert (
+            crumb["data"][SPANDATA.URL_FULL] == f"{base_url}?{expected_query}#frag"  # noqa: E231
+        )


### PR DESCRIPTION
Previously the stdlib httplib integration only gated url.full, url.query and
url.fragment on send_default_pii, so with data_collection configured the URL
data was dropped entirely and no allow/denylist filtering was ever applied.
The data_collection experiment's url_query_params behaviour is now applied to
span streaming spans and breadcrumbs, matching httpx and pyreqwest.

url.full is now reassembled with the filtered query and fragment, and empty
url.query/url.fragment attributes are no longer emitted. The legacy
(non span-streaming) path is left unchanged.

Fixes PY-2744
Fixes https://github.com/getsentry/sentry-python/issues/7279