### PR TITLE
fix(aiohttp): Gate server request query_string via data_collection option

### DIFF
--- a/sentry_sdk/integrations/aiohttp.py
+++ b/sentry_sdk/integrations/aiohttp.py
@@ -564,7 +564,21 @@ def _make_request_processor(
                 request.path,
             )
 
-            request_info["query_string"] = request.query_string
+            if has_data_collection_enabled(client_options):
+                if request.query_string:
+                    filtered_query_string = (
+                        _apply_data_collection_filtering_to_query_string(
+                            query_string=request.query_string,
+                            behaviour=client_options["data_collection"][
+                                "url_query_params"
+                            ],
+                        )
+                    )
+                    if filtered_query_string:
+                        request_info["query_string"] = filtered_query_string
+            else:
+                request_info["query_string"] = request.query_string
+
             request_info["method"] = request.method
             request_info["env"] = {"REMOTE_ADDR": request.remote}
             request_info["headers"] = _filter_headers(dict(request.headers))

--- a/tests/integrations/aiohttp/test_aiohttp.py
+++ b/tests/integrations/aiohttp/test_aiohttp.py
@@ -2268,3 +2268,41 @@ async def test_client_url_query_data_collection_span_streaming(
         assert "url.query" not in inner_client_span["attributes"]
     else:
         assert inner_client_span["attributes"]["url.query"] == expected_query
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "init_kwargs, expected_query", _QUERY_PARAM_DATA_COLLECTION_CASES
+)
+async def test_server_url_query_data_collection_event_processor(
+    sentry_init, aiohttp_client, capture_events, init_kwargs, expected_query
+):
+    init_kwargs = dict(init_kwargs)
+    sentry_init(integrations=[AioHttpIntegration()], **init_kwargs)
+
+    async def hello(request):
+        1 / 0
+
+    app = web.Application()
+    app.router.add_get("/", hello)
+
+    events = capture_events()
+
+    client = await aiohttp_client(app)
+    resp = await client.get("/?toy=tennisball&color=red&auth=secret")
+    assert resp.status == 500
+
+    (event,) = events
+
+    host = event["request"]["headers"]["Host"]
+    assert event["request"]["url"] == "http://{host}/".format(host=host)
+    assert event["request"]["method"] == "GET"
+
+    if "data_collection" not in init_kwargs.get("_experiments", {}):
+        assert (
+            event["request"]["query_string"] == "toy=tennisball&color=red&auth=secret"
+        )
+    elif expected_query is None:
+        assert "query_string" not in event["request"]
+    else:
+        assert event["request"]["query_string"] == expected_query


### PR DESCRIPTION
Filter the request event's query_string through the url_query_params data_collection behaviour, mirroring the existing gating for the client span's url.query attribute.

Fixes PY-2752
Fixes #7299