### PR TITLE
test(asgi): Remove transaction tests

### DIFF
--- a/tests/integrations/asgi/test_asgi.py
+++ b/tests/integrations/asgi/test_asgi.py
@@ -171,104 +171,63 @@ def test_invalid_transaction_style(asgi3_app):
     "should_send_pii",
     [True, False],
 )
-@pytest.mark.parametrize(
-    "span_streaming",
-    [True, False],
-)
 async def test_capture_transaction(
     sentry_init,
     asgi3_app,
-    capture_events,
     capture_items,
-    span_streaming,
     should_send_pii,
 ):
     sentry_init(
         send_default_pii=should_send_pii,
         traces_sample_rate=1.0,
-        trace_lifecycle="stream" if span_streaming else "static",
+        trace_lifecycle="stream",
     )
     app = SentryAsgiMiddleware(asgi3_app)
 
     async with TestClient(app) as client:
-        if span_streaming:
-            items = capture_items("span")
-        else:
-            events = capture_events()
+        items = capture_items("span")
         await client.get("/some_url?somevalue=123")
 
     sentry_sdk.flush()
 
-    if span_streaming:
-        assert len(items) == 1
-        span = items[0].payload
+    assert len(items) == 1
+    span = items[0].payload
 
-        assert span["is_segment"] is True
-        assert span["name"] == "/some_url"
+    assert span["is_segment"] is True
+    assert span["name"] == "/some_url"
 
-        assert span["attributes"]["sentry.segment.name.source"] == "url"
-        assert span["attributes"]["sentry.op"] == "http.server"
+    assert span["attributes"]["sentry.segment.name.source"] == "url"
+    assert span["attributes"]["sentry.op"] == "http.server"
 
-        assert span["attributes"]["network.protocol.name"] == "http"
-        assert span["attributes"]["http.request.method"] == "GET"
-        assert span["attributes"]["http.request.header.host"] == "localhost"
-        assert span["attributes"]["http.request.header.remote-addr"] == "127.0.0.1"
+    assert span["attributes"]["network.protocol.name"] == "http"
+    assert span["attributes"]["http.request.method"] == "GET"
+    assert span["attributes"]["http.request.header.host"] == "localhost"
+    assert span["attributes"]["http.request.header.remote-addr"] == "127.0.0.1"
+    assert span["attributes"]["http.request.header.user-agent"] == "ASGI-Test-Client"
+
+    if should_send_pii:
         assert (
-            span["attributes"]["http.request.header.user-agent"] == "ASGI-Test-Client"
+            span["attributes"]["url.full"] == "http://localhost/some_url?somevalue=123"
         )
-
-        if should_send_pii:
-            assert (
-                span["attributes"]["url.full"]
-                == "http://localhost/some_url?somevalue=123"
-            )
-            assert span["attributes"]["url.path"] == "/some_url"
-            assert span["attributes"]["http.query"] == "somevalue=123"
-
-    else:
-        (transaction_event,) = events
-
-        assert transaction_event["type"] == "transaction"
-        assert transaction_event["transaction"] == "/some_url"
-        assert transaction_event["transaction_info"] == {"source": "url"}
-        assert transaction_event["contexts"]["trace"]["op"] == "http.server"
-        assert transaction_event["request"] == {
-            "headers": {
-                "host": "localhost",
-                "remote-addr": "127.0.0.1",
-                "user-agent": "ASGI-Test-Client",
-            },
-            "method": "GET",
-            "query_string": "somevalue=123",
-            "url": "http://localhost/some_url",
-        }
+        assert span["attributes"]["url.path"] == "/some_url"
+        assert span["attributes"]["http.query"] == "somevalue=123"
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize(
-    "span_streaming",
-    [True, False],
-)
 async def test_capture_transaction_with_error(
     sentry_init,
     asgi3_app_with_error,
-    capture_events,
     capture_items,
-    DictionaryContaining,  # noqa: N803
-    span_streaming,
 ):
     sentry_init(
         send_default_pii=True,
         traces_sample_rate=1.0,
-        trace_lifecycle="stream" if span_streaming else "static",
+        trace_lifecycle="stream",
     )
 
     app = SentryAsgiMiddleware(asgi3_app_with_error)
 
-    if span_streaming:
-        items = capture_items("event", "span")
-    else:
-        events = capture_events()
+    items = capture_items("event", "span")
 
     with pytest.raises(ZeroDivisionError):
         async with TestClient(app) as client:
@@ -276,15 +235,12 @@ async def test_capture_transaction_with_error(
 
     sentry_sdk.flush()
 
-    if span_streaming:
-        assert len(items) == 2
-        assert items[0].type == "event"
-        assert items[1].type == "span"
+    assert len(items) == 2
+    assert items[0].type == "event"
+    assert items[1].type == "span"
 
-        error_event = items[0].payload
-        span_item = items[1].payload
-    else:
-        (error_event, transaction_event) = events
+    error_event = items[0].payload
+    span_item = items[1].payload
 
     assert error_event["transaction"] == "/some_url"
     assert error_event["transaction_info"] == {"source": "url"}
@@ -294,92 +250,54 @@ async def test_capture_transaction_with_error(
     assert error_event["exception"]["values"][0]["mechanism"]["handled"] is False
     assert error_event["exception"]["values"][0]["mechanism"]["type"] == "asgi"
 
-    if span_streaming:
-        assert span_item["trace_id"] == error_event["contexts"]["trace"]["trace_id"]
-        assert span_item["span_id"] == error_event["contexts"]["trace"]["span_id"]
-        assert span_item.get("parent_span_id") == error_event["contexts"]["trace"].get(
-            "parent_span_id"
-        )
-        assert span_item["status"] == "error"
-
-    else:
-        assert transaction_event["type"] == "transaction"
-        assert transaction_event["contexts"]["trace"] == DictionaryContaining(
-            error_event["contexts"]["trace"]
-        )
-        assert transaction_event["contexts"]["trace"]["status"] == "internal_error"
-        assert transaction_event["transaction"] == error_event["transaction"]
-        assert transaction_event["request"] == error_event["request"]
+    assert span_item["trace_id"] == error_event["contexts"]["trace"]["trace_id"]
+    assert span_item["span_id"] == error_event["contexts"]["trace"]["span_id"]
+    assert span_item.get("parent_span_id") == error_event["contexts"]["trace"].get(
+        "parent_span_id"
+    )
+    assert span_item["status"] == "error"
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize(
-    "span_streaming",
-    [True, False],
-)
 async def test_has_trace_if_performance_enabled(
     sentry_init,
     asgi3_app_with_error_and_msg,
-    capture_events,
     capture_items,
-    span_streaming,
 ):
     sentry_init(
         traces_sample_rate=1.0,
-        trace_lifecycle="stream" if span_streaming else "static",
+        trace_lifecycle="stream",
     )
     app = SentryAsgiMiddleware(asgi3_app_with_error_and_msg)
 
     with pytest.raises(ZeroDivisionError):
         async with TestClient(app) as client:
-            if span_streaming:
-                items = capture_items("event", "span")
-            else:
-                events = capture_events()
+            items = capture_items("event", "span")
             await client.get("/")
 
     sentry_sdk.flush()
 
-    if span_streaming:
-        msg_event, error_event, span = items
+    msg_event, error_event, span = items
 
-        assert msg_event.type == "event"
-        msg_event = msg_event.payload
-        assert msg_event["contexts"]["trace"]
-        assert "trace_id" in msg_event["contexts"]["trace"]
+    assert msg_event.type == "event"
+    msg_event = msg_event.payload
+    assert msg_event["contexts"]["trace"]
+    assert "trace_id" in msg_event["contexts"]["trace"]
 
-        assert error_event.type == "event"
-        error_event = error_event.payload
-        assert error_event["contexts"]["trace"]
-        assert "trace_id" in error_event["contexts"]["trace"]
+    assert error_event.type == "event"
+    error_event = error_event.payload
+    assert error_event["contexts"]["trace"]
+    assert "trace_id" in error_event["contexts"]["trace"]
 
-        assert span.type == "span"
-        span = span.payload
-        assert span["trace_id"] is not None
+    assert span.type == "span"
+    span = span.payload
+    assert span["trace_id"] is not None
 
-        assert (
-            error_event["contexts"]["trace"]["trace_id"]
-            == msg_event["contexts"]["trace"]["trace_id"]
-            == span["trace_id"]
-        )
-
-    else:
-        msg_event, error_event, transaction_event = events
-
-        assert msg_event["contexts"]["trace"]
-        assert "trace_id" in msg_event["contexts"]["trace"]
-
-        assert error_event["contexts"]["trace"]
-        assert "trace_id" in error_event["contexts"]["trace"]
-
-        assert transaction_event["contexts"]["trace"]
-        assert "trace_id" in transaction_event["contexts"]["trace"]
-
-        assert (
-            error_event["contexts"]["trace"]["trace_id"]
-            == transaction_event["contexts"]["trace"]["trace_id"]
-            == msg_event["contexts"]["trace"]["trace_id"]
-        )
+    assert (
+        error_event["contexts"]["trace"]["trace_id"]
+        == msg_event["contexts"]["trace"]["trace_id"]
+        == span["trace_id"]
+    )
 
 
 @pytest.mark.asyncio
@@ -405,21 +323,15 @@ async def test_has_trace_if_performance_disabled(
     assert "trace_id" in error_event["contexts"]["trace"]
 
 
-@pytest.mark.parametrize(
-    "span_streaming",
-    [True, False],
-)
 @pytest.mark.asyncio
 async def test_trace_from_headers_if_performance_enabled(
     sentry_init,
     asgi3_app_with_error_and_msg,
-    capture_events,
     capture_items,
-    span_streaming,
 ):
     sentry_init(
         traces_sample_rate=1.0,
-        trace_lifecycle="stream" if span_streaming else "static",
+        trace_lifecycle="stream",
     )
     app = SentryAsgiMiddleware(asgi3_app_with_error_and_msg)
 
@@ -428,50 +340,30 @@ async def test_trace_from_headers_if_performance_enabled(
 
     with pytest.raises(ZeroDivisionError):
         async with TestClient(app) as client:
-            if span_streaming:
-                items = capture_items("event", "span")
-            else:
-                events = capture_events()
+            items = capture_items("event", "span")
             await client.get("/", headers={"sentry-trace": sentry_trace_header})
 
     sentry_sdk.flush()
 
-    if span_streaming:
-        msg_event, error_event, span = items
+    msg_event, error_event, span = items
 
-        assert msg_event.type == "event"
-        msg_event = msg_event.payload
-        assert msg_event["contexts"]["trace"]
-        assert "trace_id" in msg_event["contexts"]["trace"]
+    assert msg_event.type == "event"
+    msg_event = msg_event.payload
+    assert msg_event["contexts"]["trace"]
+    assert "trace_id" in msg_event["contexts"]["trace"]
 
-        assert error_event.type == "event"
-        error_event = error_event.payload
-        assert error_event["contexts"]["trace"]
-        assert "trace_id" in error_event["contexts"]["trace"]
+    assert error_event.type == "event"
+    error_event = error_event.payload
+    assert error_event["contexts"]["trace"]
+    assert "trace_id" in error_event["contexts"]["trace"]
 
-        assert span.type == "span"
-        span = span.payload
-        assert span["trace_id"] is not None
+    assert span.type == "span"
+    span = span.payload
+    assert span["trace_id"] is not None
 
-        assert msg_event["contexts"]["trace"]["trace_id"] == trace_id
-        assert error_event["contexts"]["trace"]["trace_id"] == trace_id
-        assert span["trace_id"] == trace_id
-
-    else:
-        msg_event, error_event, transaction_event = events
-
-        assert msg_event["contexts"]["trace"]
-        assert "trace_id" in msg_event["contexts"]["trace"]
-
-        assert error_event["contexts"]["trace"]
-        assert "trace_id" in error_event["contexts"]["trace"]
-
-        assert transaction_event["contexts"]["trace"]
-        assert "trace_id" in transaction_event["contexts"]["trace"]
-
-        assert msg_event["contexts"]["trace"]["trace_id"] == trace_id
-        assert error_event["contexts"]["trace"]["trace_id"] == trace_id
-        assert transaction_event["contexts"]["trace"]["trace_id"] == trace_id
+    assert msg_event["contexts"]["trace"]["trace_id"] == trace_id
+    assert error_event["contexts"]["trace"]["trace_id"] == trace_id
+    assert span["trace_id"] == trace_id
 
 
 @pytest.mark.asyncio
@@ -503,22 +395,16 @@ async def test_trace_from_headers_if_performance_disabled(
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize(
-    "span_streaming",
-    [True, False],
-)
 async def test_websocket(
     sentry_init,
     asgi3_ws_app,
-    capture_events,
     capture_items,
     request,
-    span_streaming,
 ):
     sentry_init(
         send_default_pii=True,
         traces_sample_rate=1.0,
-        trace_lifecycle="stream" if span_streaming else "static",
+        trace_lifecycle="stream",
     )
 
     asgi3_ws_app = SentryAsgiMiddleware(asgi3_ws_app)
@@ -527,48 +413,30 @@ async def test_websocket(
 
     with pytest.raises(ValueError):
         client = TestClient(asgi3_ws_app)
-        if span_streaming:
-            items = capture_items("event", "span")
-        else:
-            events = capture_events()
+        items = capture_items("event", "span")
         async with client.websocket_connect(request_url) as ws:
             await ws.receive_text()
 
     sentry_sdk.flush()
 
-    if span_streaming:
-        msg_event, error_event, span = items
+    msg_event, error_event, span = items
 
-        assert msg_event.type == "event"
-        msg_event = msg_event.payload
-        assert msg_event["transaction"] == request_url
-        assert msg_event["transaction_info"] == {"source": "url"}
-        assert msg_event["message"] == "Some message to the world!"
+    assert msg_event.type == "event"
+    msg_event = msg_event.payload
+    assert msg_event["transaction"] == request_url
+    assert msg_event["transaction_info"] == {"source": "url"}
+    assert msg_event["message"] == "Some message to the world!"
 
-        assert error_event.type == "event"
-        error_event = error_event.payload
-        (exc,) = error_event["exception"]["values"]
-        assert exc["type"] == "ValueError"
-        assert exc["value"] == "Oh no"
+    assert error_event.type == "event"
+    error_event = error_event.payload
+    (exc,) = error_event["exception"]["values"]
+    assert exc["type"] == "ValueError"
+    assert exc["value"] == "Oh no"
 
-        assert span.type == "span"
-        span = span.payload
-        assert span["name"] == request_url
-        assert span["attributes"]["sentry.segment.name.source"] == "url"
-
-    else:
-        msg_event, error_event, transaction_event = events
-
-        assert msg_event["transaction"] == request_url
-        assert msg_event["transaction_info"] == {"source": "url"}
-        assert msg_event["message"] == "Some message to the world!"
-
-        (exc,) = error_event["exception"]["values"]
-        assert exc["type"] == "ValueError"
-        assert exc["value"] == "Oh no"
-
-        assert transaction_event["transaction"] == request_url
-        assert transaction_event["transaction_info"] == {"source": "url"}
+    assert span.type == "span"
+    span = span.payload
+    assert span["name"] == request_url
+    assert span["attributes"]["sentry.segment.name.source"] == "url"
 
 
 @pytest.mark.asyncio
@@ -626,26 +494,20 @@ async def test_auto_session_tracking_with_aggregates(
         ),
     ],
 )
-@pytest.mark.parametrize(
-    "span_streaming",
-    [True, False],
-)
 @pytest.mark.asyncio
 async def test_transaction_style(
     sentry_init,
     asgi3_app,
-    capture_events,
     capture_items,
     url,
     transaction_style,
     expected_transaction,
     expected_source,
-    span_streaming,
 ):
     sentry_init(
         send_default_pii=True,
         traces_sample_rate=1.0,
-        trace_lifecycle="stream" if span_streaming else "static",
+        trace_lifecycle="stream",
     )
     app = SentryAsgiMiddleware(asgi3_app, transaction_style=transaction_style)
 
@@ -656,26 +518,16 @@ async def test_transaction_style(
     }
 
     async with TestClient(app, scope=scope) as client:
-        if span_streaming:
-            items = capture_items("span")
-        else:
-            events = capture_events()
+        items = capture_items("span")
         await client.get(url)
 
     sentry_sdk.flush()
 
-    if span_streaming:
-        assert len(items) == 1
-        span = items[0].payload
+    assert len(items) == 1
+    span = items[0].payload
 
-        assert span["name"] == expected_transaction
-        assert span["attributes"]["sentry.segment.name.source"] == expected_source
-
-    else:
-        (transaction_event,) = events
-
-        assert transaction_event["transaction"] == expected_transaction
-        assert transaction_event["transaction_info"] == {"source": expected_source}
+    assert span["name"] == expected_transaction
+    assert span["attributes"]["sentry.segment.name.source"] == expected_source
 
 
 def mock_asgi2_app():
@@ -1276,10 +1128,6 @@ async def test_get_request_attributes_client_address_user_info(
         ),
     ],
 )
-@pytest.mark.parametrize(
-    "span_streaming",
-    [True, False],
-)
 async def test_transaction_name(
     sentry_init,
     request_url,
@@ -1287,49 +1135,32 @@ async def test_transaction_name(
     expected_transaction_name,
     expected_transaction_source,
     asgi3_app,
-    capture_envelopes,
     capture_items,
-    span_streaming,
 ):
     """
     Tests that the transaction name is something meaningful.
     """
     sentry_init(
         traces_sample_rate=1.0,
-        trace_lifecycle="stream" if span_streaming else "static",
+        trace_lifecycle="stream",
     )
 
-    if span_streaming:
-        items = capture_items("span")
-    else:
-        envelopes = capture_envelopes()
+    items = capture_items("span")
 
     app = SentryAsgiMiddleware(asgi3_app, transaction_style=transaction_style)
 
     async with TestClient(app) as client:
         await client.get(request_url)
 
-    if span_streaming:
-        sentry_sdk.flush()
+    sentry_sdk.flush()
 
-        assert len(items) == 1
-        span = items[0].payload
+    assert len(items) == 1
+    span = items[0].payload
 
-        assert span["name"] == expected_transaction_name
-        assert (
-            span["attributes"]["sentry.segment.name.source"]
-            == expected_transaction_source
-        )
-
-    else:
-        (transaction_envelope,) = envelopes
-        transaction_event = transaction_envelope.get_transaction_event()
-
-        assert transaction_event["transaction"] == expected_transaction_name
-        assert (
-            transaction_event["transaction_info"]["source"]
-            == expected_transaction_source
-        )
+    assert span["name"] == expected_transaction_name
+    assert (
+        span["attributes"]["sentry.segment.name.source"] == expected_transaction_source
+    )
 
 
 @pytest.mark.asyncio
@@ -1350,10 +1181,6 @@ async def test_transaction_name(
         ),
     ],
 )
-@pytest.mark.parametrize(
-    "span_streaming",
-    [True, False],
-)
 async def test_transaction_name_in_traces_sampler(
     sentry_init,
     request_url,
@@ -1361,7 +1188,6 @@ async def test_transaction_name_in_traces_sampler(
     expected_transaction_name,
     expected_transaction_source,
     asgi3_app,
-    span_streaming,
 ):
     """
     Tests that a custom traces_sampler has a meaningful transaction name.
@@ -1380,7 +1206,7 @@ async def test_transaction_name_in_traces_sampler(
     sentry_init(
         traces_sampler=dummy_traces_sampler,
         traces_sample_rate=1.0,
-        trace_lifecycle="stream" if span_streaming else "static",
+        trace_lifecycle="stream",
     )
 
     app = SentryAsgiMiddleware(asgi3_app, transaction_style=transaction_style)
@@ -1390,45 +1216,29 @@ async def test_transaction_name_in_traces_sampler(
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize(
-    "span_streaming",
-    [True, False],
-)
 async def test_custom_transaction_name(
     sentry_init,
     asgi3_custom_transaction_app,
-    capture_events,
     capture_items,
-    span_streaming,
 ):
     sentry_init(
         traces_sample_rate=1.0,
-        trace_lifecycle="stream" if span_streaming else "static",
+        trace_lifecycle="stream",
     )
     app = SentryAsgiMiddleware(asgi3_custom_transaction_app)
 
     async with TestClient(app) as client:
-        if span_streaming:
-            items = capture_items("span")
-        else:
-            events = capture_events()
+        items = capture_items("span")
         await client.get("/test")
 
     sentry_sdk.flush()
 
-    if span_streaming:
-        assert len(items) == 1
-        span = items[0].payload
+    assert len(items) == 1
+    span = items[0].payload
 
-        assert span["is_segment"] is True
-        assert span["name"] == "foobar"
-        assert span["attributes"]["sentry.segment.name.source"] == "custom"
-
-    else:
-        (transaction_event,) = events
-        assert transaction_event["type"] == "transaction"
-        assert transaction_event["transaction"] == "foobar"
-        assert transaction_event["transaction_info"] == {"source": "custom"}
+    assert span["is_segment"] is True
+    assert span["name"] == "foobar"
+    assert span["attributes"]["sentry.segment.name.source"] == "custom"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Looks like the asgi integration itself doesn't have any span streaming branching, only the tests do.

Closes https://linear.app/getsentry/issue/PY-2679/remove-transaction-based-tracing-from-asgi