### PR TITLE
feat(docs): Add Plausible analytics to Sphinx docs

### DIFF
--- a/docs/_templates/partials/extra-head.html
+++ b/docs/_templates/partials/extra-head.html
@@ -1,0 +1,1 @@
+<script defer data-domain="getsentry.github.io/sentry-python" src="https://plausible.io/js/script.js"></script>


### PR DESCRIPTION
Sphinx docs had no usage analytics, so there was no visibility into which API reference pages get traffic. Overrides the shibuya theme's empty extra-head partial to load the Plausible script.

Fixes PY-2757
Fixes #7318