### PR TITLE
test(pydantic_ai): Fix instructions test for pydantic-ai >=2.36.0

### DIFF
--- a/tests/integrations/pydantic_ai/test_pydantic_ai.py
+++ b/tests/integrations/pydantic_ai/test_pydantic_ai.py
@@ -2268,7 +2268,10 @@ async def test_invoke_agent_with_instructions(
             ]
             assert json.loads(system_instructions) == [
                 {"type": "text", "content": "System prompt"},
-                {"type": "text", "content": f"Instruction 1{instructions_separator}Instruction 2"},
+                {
+                    "type": "text",
+                    "content": f"Instruction 1{instructions_separator}Instruction 2",
+                },
             ]
         else:
             assert SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS not in chat_span["attributes"]
@@ -2291,7 +2294,10 @@ async def test_invoke_agent_with_instructions(
             system_instructions = chat_span["data"][SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS]
             assert json.loads(system_instructions) == [
                 {"type": "text", "content": "System prompt"},
-                {"type": "text", "content": f"Instruction 1{instructions_separator}Instruction 2"},
+                {
+                    "type": "text",
+                    "content": f"Instruction 1{instructions_separator}Instruction 2",
+                },
             ]
         else:
             assert SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS not in chat_span["data"]

--- a/tests/integrations/pydantic_ai/test_pydantic_ai.py
+++ b/tests/integrations/pydantic_ai/test_pydantic_ai.py
@@ -2228,7 +2228,6 @@ async def test_invoke_agent_with_instructions(
     """
     from pydantic_ai import Agent
 
-    # Create agent with instructions (can be string or list) and system prompt
     agent = Agent(
         "test",
         name="test_instructions",

--- a/tests/integrations/pydantic_ai/test_pydantic_ai.py
+++ b/tests/integrations/pydantic_ai/test_pydantic_ai.py
@@ -2228,15 +2228,16 @@ async def test_invoke_agent_with_instructions(
     """
     from pydantic_ai import Agent
 
-    # Create agent with instructions (can be string or list)
+    # Create agent with instructions (can be string or list) and system prompt
     agent = Agent(
         "test",
         name="test_instructions",
+        instructions=["Instruction 1", "Instruction 2"],
+        system_prompt="System prompt",
     )
 
-    # Add instructions via _instructions attribute (internal API)
-    agent._instructions = ["Instruction 1", "Instruction 2"]
-    agent._system_prompts = ["System prompt"]
+    # pydantic-ai >=2.36.0 joins multiple instructions with a blank line, earlier versions with a single newline
+    instructions_separator = "\n\n" if PYDANTIC_AI_VERSION >= (2, 36) else "\n"
 
     sentry_init(
         integrations=[PydanticAIIntegration(include_prompts=include_prompts)],
@@ -2268,7 +2269,7 @@ async def test_invoke_agent_with_instructions(
             ]
             assert json.loads(system_instructions) == [
                 {"type": "text", "content": "System prompt"},
-                {"type": "text", "content": "Instruction 1\nInstruction 2"},
+                {"type": "text", "content": f"Instruction 1{instructions_separator}Instruction 2"},
             ]
         else:
             assert SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS not in chat_span["attributes"]
@@ -2291,7 +2292,7 @@ async def test_invoke_agent_with_instructions(
             system_instructions = chat_span["data"][SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS]
             assert json.loads(system_instructions) == [
                 {"type": "text", "content": "System prompt"},
-                {"type": "text", "content": "Instruction 1\nInstruction 2"},
+                {"type": "text", "content": f"Instruction 1{instructions_separator}Instruction 2"},
             ]
         else:
             assert SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS not in chat_span["data"]


### PR DESCRIPTION
Build the agent with public `instructions`/`system_prompt` kwargs instead of poking internal `_instructions`/`_system_prompts` attributes, and account for the joiner between multiple instructions changing from a single newline to a blank line in pydantic-ai 2.36.0.

[There's normalization of instructions occurring under the hood as of 2.36.0](https://github.com/pydantic/pydantic-ai/blame/6246795faf941937e1759f51b0dfc65d82a4667b/pydantic_ai_slim/pydantic_ai/agent/__init__.py#L673-L676) that we don't have a reason to interfere with within the tests, so moving the configuration of instructions and the system prompt to using the public `Agent` API.

Fixes PY-2755
Fixes #7306