### PR TITLE
feat(fastapi): Add `http.route` attribute

### DIFF
--- a/sentry_sdk/consts.py
+++ b/sentry_sdk/consts.py
@@ -878,6 +878,12 @@ class SPANDATA:
     Example: GET
     """
 
+    HTTP_ROUTE = "http.route"
+    """
+    The matched route, that is, the path template used to match the request.
+    Example: /users/{id}
+    """
+
     HTTP_QUERY = "http.query"
     """
     The Query string present in the URL.

--- a/sentry_sdk/integrations/asgi.py
+++ b/sentry_sdk/integrations/asgi.py
@@ -412,7 +412,7 @@ class SentryAsgiMiddleware:
                                         span.set_attribute(
                                             "sentry.segment.name.source", source
                                         )
-                                http_route = getattr(sentry_sdk.get_current_scope(), "_http_route", None)
+                                http_route = sentry_scope._http_route
                                 if http_route is not None:
                                     span.set_attribute(SPANDATA.HTTP_ROUTE, http_route)
         finally:

--- a/sentry_sdk/integrations/asgi.py
+++ b/sentry_sdk/integrations/asgi.py
@@ -412,6 +412,9 @@ class SentryAsgiMiddleware:
                                         span.set_attribute(
                                             "sentry.segment.name.source", source
                                         )
+                                http_route = getattr(sentry_sdk.get_current_scope(), "_http_route", None)
+                                if http_route is not None:
+                                    span.set_attribute(SPANDATA.HTTP_ROUTE, http_route)
         finally:
             _asgi_middleware_applied.set(False)
 

--- a/sentry_sdk/integrations/asgi.py
+++ b/sentry_sdk/integrations/asgi.py
@@ -293,7 +293,9 @@ class SentryAsgiMiddleware:
                                 attributes=attributes,
                                 parent_span=None,
                             )
-                            sentry_scope.get_current_scope()._server_segment_span = segment
+                            sentry_scope.get_current_scope()._server_segment_span = (
+                                segment
+                            )
 
                         span_ctx = segment or nullcontext()
 

--- a/sentry_sdk/integrations/asgi.py
+++ b/sentry_sdk/integrations/asgi.py
@@ -281,6 +281,7 @@ class SentryAsgiMiddleware:
                                     attributes=attributes,
                                     parent_span=None,
                                 )
+                                sentry_scope.get_current_scope()._server_segment_span = segment
                         else:
                             sentry_sdk.traces.new_trace()
 
@@ -292,6 +293,7 @@ class SentryAsgiMiddleware:
                                 attributes=attributes,
                                 parent_span=None,
                             )
+                            sentry_scope.get_current_scope()._server_segment_span = segment
 
                         span_ctx = segment or nullcontext()
 
@@ -412,9 +414,6 @@ class SentryAsgiMiddleware:
                                         span.set_attribute(
                                             "sentry.segment.name.source", source
                                         )
-                                http_route = sentry_scope._http_route
-                                if http_route is not None:
-                                    span.set_attribute(SPANDATA.HTTP_ROUTE, http_route)
         finally:
             _asgi_middleware_applied.set(False)
 

--- a/sentry_sdk/integrations/fastapi.py
+++ b/sentry_sdk/integrations/fastapi.py
@@ -79,6 +79,8 @@ def _set_transaction_name_and_source(
                 if path is not None:
                     name = path
 
+            scope._http_route = route
+
     if not name:
         name = _DEFAULT_TRANSACTION_NAME
         source = TransactionSource.ROUTE

--- a/sentry_sdk/integrations/fastapi.py
+++ b/sentry_sdk/integrations/fastapi.py
@@ -79,7 +79,7 @@ def _set_transaction_name_and_source(
                 if path is not None:
                     name = path
 
-            scope._http_route = route
+            sentry_sdk.get_isolation_scope()._http_route = name
 
     if not name:
         name = _DEFAULT_TRANSACTION_NAME

--- a/sentry_sdk/integrations/fastapi.py
+++ b/sentry_sdk/integrations/fastapi.py
@@ -12,7 +12,7 @@ from sentry_sdk.tracing_utils import has_span_streaming_enabled
 from sentry_sdk.utils import has_data_collection_enabled, transaction_from_function
 
 if TYPE_CHECKING:
-    from typing import Any, Awaitable, Callable, Dict
+    from typing import Any, Awaitable, Callable, Dict, Optional
 
     from sentry_sdk._types import Event
 
@@ -50,38 +50,18 @@ class FastApiIntegration(StarletteIntegration):
 
 
 def _set_transaction_name_and_source(
-    scope: "sentry_sdk.Scope", transaction_style: str, request: "Any"
+    scope: "sentry_sdk.Scope",
+    transaction_style: str,
+    endpoint: "Optional[Callable[..., Any]]",
+    route_path: "Optional[str]",
 ) -> None:
     name = ""
 
-    if transaction_style == "endpoint":
-        endpoint = request.scope.get("endpoint")
-        if endpoint:
-            name = transaction_from_function(endpoint) or ""
+    if transaction_style == "endpoint" and endpoint:
+        name = transaction_from_function(endpoint) or ""
 
-    elif transaction_style == "url":
-        route = request.scope.get("route")
-
-        if route:
-            # FastAPI >= 0.137 stores the prefix-resolved path on an
-            # effective_route_context in scope["fastapi"], while
-            # scope["route"].path holds the unprefixed original.
-            # Prefer the effective context path when available.
-            effective_route_context = request.scope.get("fastapi", {}).get(
-                "effective_route_context"
-            )
-            context_path = getattr(effective_route_context, "path", None)
-
-            if context_path:
-                name = context_path
-            else:
-                path = getattr(route, "path", None)
-                if path is not None:
-                    name = path
-
-            server_span = sentry_sdk.get_current_scope()._server_segment_span
-            if server_span is not None:
-                server_span.set_attribute(SPANDATA.HTTP_ROUTE, name)
+    elif transaction_style == "url" and route_path is not None:
+        name = route_path
 
     if not name:
         name = _DEFAULT_TRANSACTION_NAME
@@ -107,8 +87,35 @@ async def _wrap_async_handler(
 
     request = args[0]
 
+    route = request.scope.get("route")
+
+    route_path = None
+    if route:
+        # FastAPI >= 0.137 stores the prefix-resolved path on an
+        # effective_route_context in scope["fastapi"], while
+        # scope["route"].path holds the unprefixed original.
+        # Prefer the effective context path when available.
+        effective_route_context = request.scope.get("fastapi", {}).get(
+            "effective_route_context"
+        )
+        context_path = getattr(effective_route_context, "path", None)
+
+        if context_path:
+            route_path = context_path
+        else:
+            path = getattr(route, "path", None)
+            if path is not None:
+                route_path = path
+
+    server_span = sentry_sdk.get_current_scope()._server_segment_span
+    if server_span is not None and route_path is not None:
+        server_span.set_attribute(SPANDATA.HTTP_ROUTE, route_path)
+
     _set_transaction_name_and_source(
-        sentry_sdk.get_current_scope(), integration.transaction_style, request
+        sentry_sdk.get_current_scope(),
+        integration.transaction_style,
+        endpoint=request.scope.get("endpoint"),
+        route_path=route_path,
     )
     sentry_scope = sentry_sdk.get_isolation_scope()
     extractor = StarletteRequestExtractor(request)

--- a/sentry_sdk/integrations/fastapi.py
+++ b/sentry_sdk/integrations/fastapi.py
@@ -79,7 +79,9 @@ def _set_transaction_name_and_source(
                 if path is not None:
                     name = path
 
-            sentry_sdk.get_isolation_scope()._http_route = name
+            server_span = sentry_sdk.get_current_scope()._server_segment_span
+            if server_span is not None:
+                server_span.set_attribute(SPANDATA.HTTP_ROUTE, name)
 
     if not name:
         name = _DEFAULT_TRANSACTION_NAME

--- a/sentry_sdk/scope.py
+++ b/sentry_sdk/scope.py
@@ -254,6 +254,7 @@ class Scope:
         self._error_processors: "List[ErrorProcessor]" = []
 
         self._name: "Optional[str]" = None
+        self._http_route: "Optional[str]" = None 
         self._propagation_context: "Optional[PropagationContext]" = None
         self._n_breadcrumbs_truncated: int = 0
         self._gen_ai_original_message_count: "Dict[str, int]" = {}
@@ -279,6 +280,7 @@ class Scope:
         rv.client = self.client
         rv._level = self._level
         rv._name = self._name
+        rv._http_route = self._http_route
         rv._fingerprint = self._fingerprint
         rv._transaction = self._transaction
         rv._transaction_info = self._transaction_info.copy()

--- a/sentry_sdk/scope.py
+++ b/sentry_sdk/scope.py
@@ -254,7 +254,7 @@ class Scope:
         self._error_processors: "List[ErrorProcessor]" = []
 
         self._name: "Optional[str]" = None
-        self._http_route: "Optional[str]" = None 
+        self._http_route: "Optional[str]" = None
         self._propagation_context: "Optional[PropagationContext]" = None
         self._n_breadcrumbs_truncated: int = 0
         self._gen_ai_original_message_count: "Dict[str, int]" = {}

--- a/sentry_sdk/scope.py
+++ b/sentry_sdk/scope.py
@@ -230,6 +230,7 @@ class Scope:
         "_error_processors",
         "_should_capture",
         "_span",
+        "_server_segment_span",
         "_session",
         "_attachments",
         "_force_auto_session_tracking",
@@ -240,7 +241,6 @@ class Scope:
         "_last_event_id",
         "_flags",
         "_attributes",
-        "_http_route",
     )
 
     def __init__(
@@ -254,10 +254,11 @@ class Scope:
         self._error_processors: "List[ErrorProcessor]" = []
 
         self._name: "Optional[str]" = None
-        self._http_route: "Optional[str]" = None
         self._propagation_context: "Optional[PropagationContext]" = None
         self._n_breadcrumbs_truncated: int = 0
         self._gen_ai_original_message_count: "Dict[str, int]" = {}
+
+        self._server_segment_span: "Optional[StreamedSpan]" = None
 
         self.client: "sentry_sdk.client.BaseClient" = NonRecordingClient()
 
@@ -280,7 +281,6 @@ class Scope:
         rv.client = self.client
         rv._level = self._level
         rv._name = self._name
-        rv._http_route = self._http_route
         rv._fingerprint = self._fingerprint
         rv._transaction = self._transaction
         rv._transaction_info = self._transaction_info.copy()
@@ -299,6 +299,7 @@ class Scope:
 
         rv._should_capture = self._should_capture
         rv._span = self._span
+        rv._server_segment_span = self._server_segment_span
         rv._session = self._session
         rv._force_auto_session_tracking = self._force_auto_session_tracking
         rv._attachments = self._attachments.copy()

--- a/sentry_sdk/scope.py
+++ b/sentry_sdk/scope.py
@@ -240,6 +240,7 @@ class Scope:
         "_last_event_id",
         "_flags",
         "_attributes",
+        "_http_route",
     )
 
     def __init__(

--- a/tests/integrations/fastapi/test_fastapi.py
+++ b/tests/integrations/fastapi/test_fastapi.py
@@ -883,6 +883,7 @@ def test_transaction_name_with_prefix(
         segment = segments[0]
         assert segment["name"] == "/api/users/{user_id}"
         assert segment["attributes"]["sentry.segment.name.source"] == "route"
+        assert segment["attributes"]["http.route"] == "/api/users/{user_id}"
     else:
         (transaction_envelope,) = envelopes
         transaction_event = transaction_envelope.get_transaction_event()

--- a/tests/integrations/fastapi/test_fastapi.py
+++ b/tests/integrations/fastapi/test_fastapi.py
@@ -843,7 +843,7 @@ def test_transaction_name(
 
 
 @pytest.mark.parametrize("span_streaming", [True, False])
-def test_transaction_name_with_prefix(
+def test_http_route_with_prefix(
     sentry_init,
     capture_envelopes,
     capture_items,


### PR DESCRIPTION
### Description
<!-- What changed and why? -->

Set the `http.route` attribute on the ASGI server span in patches for FastAPI endpoints.

Add the `_server_segment_span` field on the `Scope` class so HTTP framework integrations have a reference to the server span. The reference is used to set the parametrized route as the `http.route` attribute.

#### Issues
<!--
* resolves: #1234
* resolves: LIN-1234
-->

#### Reminders
- Please add tests to validate your changes, and lint your code using `uv run ruff`.
- Add GH Issue ID _&_ Linear ID (if applicable)
- PR title should use [conventional commit](https://develop.sentry.dev/engineering-practices/commit-messages/#type) style (`feat:`, `fix:`, `ref:`, `meta:`)
- For external contributors: [CONTRIBUTING.md](https://github.com/getsentry/sentry-python/blob/master/CONTRIBUTING.md), [Sentry SDK development docs](https://develop.sentry.dev/sdk/), [Discord community](https://discord.gg/Ww9hbqr)
