### PR TITLE
feat(clickhouse_driver): Set breadcrumbs in the streaming trace lifecycle

### DIFF
--- a/sentry_sdk/integrations/clickhouse_driver.py
+++ b/sentry_sdk/integrations/clickhouse_driver.py
@@ -89,12 +89,18 @@ def _wrap_start(f: "Callable[P, T]") -> "Callable[P, T]":
         breadcrumb_data = {
             SPANDATA.DB_SYSTEM: "clickhouse",
             SPANDATA.DB_NAME: connection.database,
-            SPANDATA.DB_DRIVER_NAME: "clickhouse-driver",
             SPANDATA.SERVER_ADDRESS: connection.host,
             SPANDATA.SERVER_PORT: connection.port,
             SPANDATA.DB_USER: connection.user,
         }
-        if params:
+        if params and (
+            (
+                has_data_collection_enabled(client.options)
+                and client.options["data_collection"]["database_query_data"]
+            )
+            or not has_data_collection_enabled(client.options)
+            and should_send_default_pii()
+        ):
             breadcrumb_data["db.params"] = params
 
         connection._breadcrumb_data = breadcrumb_data
@@ -157,7 +163,9 @@ def _wrap_end(f: "Callable[P, T]") -> "Callable[P, T]":
             if (
                 has_data_collection_enabled(client_options)
                 and client_options["data_collection"]["database_query_data"]
-                or should_send_default_pii()
+            ) or (
+                not has_data_collection_enabled(client_options)
+                and should_send_default_pii()
             ):
                 breadcrumb_data = {"db.result": res, **breadcrumb_data}
 

--- a/sentry_sdk/integrations/clickhouse_driver.py
+++ b/sentry_sdk/integrations/clickhouse_driver.py
@@ -85,15 +85,19 @@ def _wrap_start(f: "Callable[P, T]") -> "Callable[P, T]":
         params = args[3] if len(args) > 3 else kwargs.get("params")
 
         connection._query = query
-        connection._breadcrumb_data = {
+
+        breadcrumb_data = {
             SPANDATA.DB_SYSTEM: "clickhouse",
             SPANDATA.DB_NAME: connection.database,
             SPANDATA.DB_DRIVER_NAME: "clickhouse-driver",
             SPANDATA.SERVER_ADDRESS: connection.host,
             SPANDATA.SERVER_PORT: connection.port,
             SPANDATA.DB_USER: connection.user,
-            "db.params": params,
         }
+        if params:
+            breadcrumb_data["db.params"] = params
+
+        connection._breadcrumb_data = breadcrumb_data
 
         if has_span_streaming_enabled(client.options):
             span = None
@@ -160,7 +164,7 @@ def _wrap_end(f: "Callable[P, T]") -> "Callable[P, T]":
             sentry_sdk.get_isolation_scope().add_breadcrumb(
                 message=query,
                 category="query",
-                data={"db.result": res, **breadcrumb_data},
+                data=breadcrumb_data,
             )
 
         span = getattr(instance.connection, "_sentry_span", None)

--- a/sentry_sdk/integrations/clickhouse_driver.py
+++ b/sentry_sdk/integrations/clickhouse_driver.py
@@ -84,6 +84,17 @@ def _wrap_start(f: "Callable[P, T]") -> "Callable[P, T]":
         query_id = args[2] if len(args) > 2 else kwargs.get("query_id")
         params = args[3] if len(args) > 3 else kwargs.get("params")
 
+        connection._query = query
+        connection._breadcrumb_data = {
+            SPANDATA.DB_SYSTEM: "clickhouse",
+            SPANDATA.DB_NAME: connection.database,
+            SPANDATA.DB_DRIVER_NAME: "clickhouse-driver",
+            SPANDATA.SERVER_ADDRESS: connection.host,
+            SPANDATA.SERVER_PORT: connection.port,
+            SPANDATA.DB_USER: connection.user,
+            "db.params": params,
+        }
+
         if has_span_streaming_enabled(client.options):
             span = None
             if sentry_sdk.traces.get_current_span() is not None:
@@ -95,16 +106,6 @@ def _wrap_start(f: "Callable[P, T]") -> "Callable[P, T]":
                         SPANDATA.DB_QUERY_TEXT: str(query),
                     },
                 )
-
-            connection._query = query
-            connection._breadcrumb_data = {
-                SPANDATA.DB_SYSTEM: "clickhouse",
-                SPANDATA.DB_NAME: connection.database,
-                SPANDATA.DB_DRIVER_NAME: "clickhouse-driver",
-                SPANDATA.SERVER_ADDRESS: connection.host,
-                SPANDATA.SERVER_PORT: connection.port,
-                SPANDATA.DB_USER: connection.user,
-            }
         else:
             span = sentry_sdk.start_span(
                 op=OP.DB,

--- a/sentry_sdk/integrations/clickhouse_driver.py
+++ b/sentry_sdk/integrations/clickhouse_driver.py
@@ -15,7 +15,7 @@ from sentry_sdk.utils import capture_internal_exceptions, has_data_collection_en
 # from: https://stackoverflow.com/a/71944042/300572
 if TYPE_CHECKING:
     from collections.abc import Iterator
-    from typing import Any, Callable, ParamSpec, Union
+    from typing import Any, Callable, Optional, ParamSpec, Union
 else:
     # Fake ParamSpec
     class ParamSpec:
@@ -96,18 +96,15 @@ def _wrap_start(f: "Callable[P, T]") -> "Callable[P, T]":
                     },
                 )
 
-            sentry_sdk.get_isolation_scope().add_breadcrumb(
-                message=query,
-                category="query",
-                data={
-                    SPANDATA.DB_SYSTEM: "clickhouse",
-                    SPANDATA.DB_NAME: connection.database,
-                    SPANDATA.DB_DRIVER_NAME: "clickhouse-driver",
-                    SPANDATA.SERVER_ADDRESS: connection.host,
-                    SPANDATA.SERVER_PORT: connection.port,
-                    SPANDATA.DB_USER: connection.user,
-                },
-            )
+            connection._query = query  # type: ignore[attr-defined]
+            connection._breadcrumb_data = {  # type: ignore[attr-defined]
+                SPANDATA.DB_SYSTEM: "clickhouse",
+                SPANDATA.DB_NAME: connection.database,
+                SPANDATA.DB_DRIVER_NAME: "clickhouse-driver",
+                SPANDATA.SERVER_ADDRESS: connection.host,
+                SPANDATA.SERVER_PORT: connection.port,
+                SPANDATA.DB_USER: connection.user,
+            }
         else:
             span = sentry_sdk.start_span(
                 op=OP.DB,
@@ -150,6 +147,18 @@ def _wrap_end(f: "Callable[P, T]") -> "Callable[P, T]":
             return res
 
         if isinstance(span, StreamedSpan):
+            query = getattr(instance.connection, "_query", None)  # type: ignore[attr-defined]
+            breadcrumb_data: "Optional[dict[str, Any]]" = getattr(
+                instance.connection, "_breadcrumb_data", None
+            )  # type: ignore[attr-defined]
+
+            if query is not None and breadcrumb_data is not None:
+                sentry_sdk.get_isolation_scope().add_breadcrumb(
+                    message=query,
+                    category="query",
+                    data={"db.result": res, **breadcrumb_data},
+                )
+
             span.end()
         else:
             if res is not None:

--- a/sentry_sdk/integrations/clickhouse_driver.py
+++ b/sentry_sdk/integrations/clickhouse_driver.py
@@ -8,7 +8,7 @@ from sentry_sdk.scope import should_send_default_pii
 from sentry_sdk.traces import StreamedSpan
 from sentry_sdk.tracing import Span
 from sentry_sdk.tracing_utils import has_span_streaming_enabled
-from sentry_sdk.utils import has_data_collection_enabled
+from sentry_sdk.utils import capture_internal_exceptions, has_data_collection_enabled
 
 # Hack to get new Python features working in older versions
 # without introducing a hard dependency on `typing_extensions`
@@ -179,6 +179,11 @@ def _wrap_end(f: "Callable[P, T]") -> "Callable[P, T]":
                         span.set_data("db.result", res)
                 elif should_send_default_pii():
                     span.set_data("db.result", res)
+
+            with capture_internal_exceptions():
+                span.scope.add_breadcrumb(
+                    message=span._data.pop("query"), category="query", data=span._data
+                )
 
             span.finish()
 

--- a/sentry_sdk/integrations/clickhouse_driver.py
+++ b/sentry_sdk/integrations/clickhouse_driver.py
@@ -88,6 +88,7 @@ def _wrap_start(f: "Callable[P, T]") -> "Callable[P, T]":
 
         breadcrumb_data = {
             SPANDATA.DB_SYSTEM: "clickhouse",
+            SPANDATA.DB_DRIVER_NAME: "clickhouse-driver",
             SPANDATA.DB_NAME: connection.database,
             SPANDATA.SERVER_ADDRESS: connection.host,
             SPANDATA.SERVER_PORT: connection.port,

--- a/sentry_sdk/integrations/clickhouse_driver.py
+++ b/sentry_sdk/integrations/clickhouse_driver.py
@@ -96,8 +96,8 @@ def _wrap_start(f: "Callable[P, T]") -> "Callable[P, T]":
                     },
                 )
 
-            connection._query = query  # type: ignore[attr-defined]
-            connection._breadcrumb_data = {  # type: ignore[attr-defined]
+            connection._query = query
+            connection._breadcrumb_data = {
                 SPANDATA.DB_SYSTEM: "clickhouse",
                 SPANDATA.DB_NAME: connection.database,
                 SPANDATA.DB_DRIVER_NAME: "clickhouse-driver",
@@ -124,7 +124,7 @@ def _wrap_start(f: "Callable[P, T]") -> "Callable[P, T]":
                 elif should_send_default_pii():
                     span.set_data("db.params", params)
 
-        connection._sentry_span = span  # type: ignore[attr-defined]
+        connection._sentry_span = span
 
         if span is not None:
             _set_db_data(span, connection)
@@ -140,17 +140,17 @@ def _wrap_start(f: "Callable[P, T]") -> "Callable[P, T]":
 def _wrap_end(f: "Callable[P, T]") -> "Callable[P, T]":
     def _inner_end(*args: "P.args", **kwargs: "P.kwargs") -> "T":
         res = f(*args, **kwargs)
-        instance = args[0]
-        span = getattr(instance.connection, "_sentry_span", None)  # type: ignore[attr-defined]
+        instance: "Client" = args[0]
+        span = getattr(instance.connection, "_sentry_span", None)
 
         if span is None:
             return res
 
         if isinstance(span, StreamedSpan):
-            query = getattr(instance.connection, "_query", None)  # type: ignore[attr-defined]
+            query = getattr(instance.connection, "_query", None)
             breadcrumb_data: "Optional[dict[str, Any]]" = getattr(
                 instance.connection, "_breadcrumb_data", None
-            )  # type: ignore[attr-defined]
+            )
 
             if query is not None and breadcrumb_data is not None:
                 sentry_sdk.get_isolation_scope().add_breadcrumb(

--- a/sentry_sdk/integrations/clickhouse_driver.py
+++ b/sentry_sdk/integrations/clickhouse_driver.py
@@ -95,6 +95,19 @@ def _wrap_start(f: "Callable[P, T]") -> "Callable[P, T]":
                         SPANDATA.DB_QUERY_TEXT: str(query),
                     },
                 )
+
+            sentry_sdk.get_isolation_scope().add_breadcrumb(
+                message=query,
+                category="query",
+                data={
+                    SPANDATA.DB_SYSTEM: "clickhouse",
+                    SPANDATA.DB_NAME: connection.database,
+                    SPANDATA.DB_DRIVER_NAME: "clickhouse-driver",
+                    SPANDATA.SERVER_ADDRESS: connection.host,
+                    SPANDATA.SERVER_PORT: connection.port,
+                    SPANDATA.DB_USER: connection.user,
+                },
+            )
         else:
             span = sentry_sdk.start_span(
                 op=OP.DB,

--- a/sentry_sdk/integrations/clickhouse_driver.py
+++ b/sentry_sdk/integrations/clickhouse_driver.py
@@ -79,7 +79,7 @@ def _wrap_start(f: "Callable[P, T]") -> "Callable[P, T]":
         if client.get_integration(ClickhouseDriverIntegration) is None:
             return f(*args, **kwargs)
 
-        connection = args[0]
+        connection: "Connection" = args[0]
         query = args[1]
         query_id = args[2] if len(args) > 2 else kwargs.get("query_id")
         params = args[3] if len(args) > 3 else kwargs.get("params")

--- a/sentry_sdk/integrations/clickhouse_driver.py
+++ b/sentry_sdk/integrations/clickhouse_driver.py
@@ -8,7 +8,7 @@ from sentry_sdk.scope import should_send_default_pii
 from sentry_sdk.traces import StreamedSpan
 from sentry_sdk.tracing import Span
 from sentry_sdk.tracing_utils import has_span_streaming_enabled
-from sentry_sdk.utils import capture_internal_exceptions, has_data_collection_enabled
+from sentry_sdk.utils import has_data_collection_enabled
 
 # Hack to get new Python features working in older versions
 # without introducing a hard dependency on `typing_extensions`
@@ -141,24 +141,33 @@ def _wrap_end(f: "Callable[P, T]") -> "Callable[P, T]":
     def _inner_end(*args: "P.args", **kwargs: "P.kwargs") -> "T":
         res = f(*args, **kwargs)
         instance: "Client" = args[0]
+
+        query = getattr(instance.connection, "_query", None)
+        breadcrumb_data: "Optional[dict[str, Any]]" = getattr(
+            instance.connection, "_breadcrumb_data", None
+        )
+
+        if query is not None and breadcrumb_data is not None:
+            client_options = sentry_sdk.get_client().options
+            if (
+                has_data_collection_enabled(client_options)
+                and client_options["data_collection"]["database_query_data"]
+                or should_send_default_pii()
+            ):
+                breadcrumb_data = {"db.result": res, **breadcrumb_data}
+
+            sentry_sdk.get_isolation_scope().add_breadcrumb(
+                message=query,
+                category="query",
+                data={"db.result": res, **breadcrumb_data},
+            )
+
         span = getattr(instance.connection, "_sentry_span", None)
 
         if span is None:
             return res
 
         if isinstance(span, StreamedSpan):
-            query = getattr(instance.connection, "_query", None)
-            breadcrumb_data: "Optional[dict[str, Any]]" = getattr(
-                instance.connection, "_breadcrumb_data", None
-            )
-
-            if query is not None and breadcrumb_data is not None:
-                sentry_sdk.get_isolation_scope().add_breadcrumb(
-                    message=query,
-                    category="query",
-                    data={"db.result": res, **breadcrumb_data},
-                )
-
             span.end()
         else:
             if res is not None:
@@ -168,11 +177,6 @@ def _wrap_end(f: "Callable[P, T]") -> "Callable[P, T]":
                         span.set_data("db.result", res)
                 elif should_send_default_pii():
                     span.set_data("db.result", res)
-
-            with capture_internal_exceptions():
-                span.scope.add_breadcrumb(
-                    message=span._data.pop("query"), category="query", data=span._data
-                )
 
             span.finish()
 

--- a/sentry_sdk/integrations/clickhouse_driver.py
+++ b/sentry_sdk/integrations/clickhouse_driver.py
@@ -84,28 +84,6 @@ def _wrap_start(f: "Callable[P, T]") -> "Callable[P, T]":
         query_id = args[2] if len(args) > 2 else kwargs.get("query_id")
         params = args[3] if len(args) > 3 else kwargs.get("params")
 
-        connection._query = query
-
-        breadcrumb_data = {
-            SPANDATA.DB_SYSTEM: "clickhouse",
-            SPANDATA.DB_DRIVER_NAME: "clickhouse-driver",
-            SPANDATA.DB_NAME: connection.database,
-            SPANDATA.SERVER_ADDRESS: connection.host,
-            SPANDATA.SERVER_PORT: connection.port,
-            SPANDATA.DB_USER: connection.user,
-        }
-        if params and (
-            (
-                has_data_collection_enabled(client.options)
-                and client.options["data_collection"]["database_query_data"]
-            )
-            or not has_data_collection_enabled(client.options)
-            and should_send_default_pii()
-        ):
-            breadcrumb_data["db.params"] = params
-
-        connection._breadcrumb_data = breadcrumb_data
-
         if has_span_streaming_enabled(client.options):
             span = None
             if sentry_sdk.traces.get_current_span() is not None:
@@ -117,6 +95,16 @@ def _wrap_start(f: "Callable[P, T]") -> "Callable[P, T]":
                         SPANDATA.DB_QUERY_TEXT: str(query),
                     },
                 )
+
+            connection._query = query
+            connection._breadcrumb_data = {
+                SPANDATA.DB_SYSTEM: "clickhouse",
+                SPANDATA.DB_NAME: connection.database,
+                SPANDATA.DB_DRIVER_NAME: "clickhouse-driver",
+                SPANDATA.SERVER_ADDRESS: connection.host,
+                SPANDATA.SERVER_PORT: connection.port,
+                SPANDATA.DB_USER: connection.user,
+            }
         else:
             span = sentry_sdk.start_span(
                 op=OP.DB,
@@ -161,22 +149,19 @@ def _wrap_end(f: "Callable[P, T]") -> "Callable[P, T]":
 
         if query is not None and breadcrumb_data is not None:
             client_options = sentry_sdk.get_client().options
-            if res is not None and (
-                (
-                    has_data_collection_enabled(client_options)
-                    and client_options["data_collection"]["database_query_data"]
-                )
-                or (
-                    not has_data_collection_enabled(client_options)
-                    and should_send_default_pii()
-                )
+            if (
+                has_data_collection_enabled(client_options)
+                and client_options["data_collection"]["database_query_data"]
+            ) or (
+                not has_data_collection_enabled(client_options)
+                and should_send_default_pii()
             ):
                 breadcrumb_data = {"db.result": res, **breadcrumb_data}
 
             sentry_sdk.get_isolation_scope().add_breadcrumb(
                 message=query,
                 category="query",
-                data=breadcrumb_data,
+                data={"db.result": res, **breadcrumb_data},
             )
 
         span = getattr(instance.connection, "_sentry_span", None)
@@ -241,9 +226,6 @@ def _wrap_send_data() -> None:
                         data = wrapped_generator()
 
                     span.set_data("db.params", db_params)
-                    breadcrumb_data = getattr(self.connection, "_breadcrumb_data", None)
-                    if breadcrumb_data is not None:
-                        breadcrumb_data["db.params"] = db_params
             elif should_send_default_pii():
                 db_params = span._data.get("db.params", [])
 
@@ -265,9 +247,6 @@ def _wrap_send_data() -> None:
                     data = wrapped_generator()
 
                 span.set_data("db.params", db_params)
-                breadcrumb_data = getattr(self.connection, "_breadcrumb_data", None)
-                if breadcrumb_data is not None:
-                    breadcrumb_data["db.params"] = db_params
 
         return original_send_data(
             self, sample_block, data, types_check, columnar, *args, **kwargs

--- a/sentry_sdk/integrations/clickhouse_driver.py
+++ b/sentry_sdk/integrations/clickhouse_driver.py
@@ -160,12 +160,15 @@ def _wrap_end(f: "Callable[P, T]") -> "Callable[P, T]":
 
         if query is not None and breadcrumb_data is not None:
             client_options = sentry_sdk.get_client().options
-            if (
-                has_data_collection_enabled(client_options)
-                and client_options["data_collection"]["database_query_data"]
-            ) or (
-                not has_data_collection_enabled(client_options)
-                and should_send_default_pii()
+            if res is not None and (
+                (
+                    has_data_collection_enabled(client_options)
+                    and client_options["data_collection"]["database_query_data"]
+                )
+                or (
+                    not has_data_collection_enabled(client_options)
+                    and should_send_default_pii()
+                )
             ):
                 breadcrumb_data = {"db.result": res, **breadcrumb_data}
 
@@ -237,6 +240,9 @@ def _wrap_send_data() -> None:
                         data = wrapped_generator()
 
                     span.set_data("db.params", db_params)
+                    breadcrumb_data = getattr(self.connection, "_breadcrumb_data", None)
+                    if breadcrumb_data is not None:
+                        breadcrumb_data["db.params"] = db_params
             elif should_send_default_pii():
                 db_params = span._data.get("db.params", [])
 
@@ -258,6 +264,9 @@ def _wrap_send_data() -> None:
                     data = wrapped_generator()
 
                 span.set_data("db.params", db_params)
+                breadcrumb_data = getattr(self.connection, "_breadcrumb_data", None)
+                if breadcrumb_data is not None:
+                    breadcrumb_data["db.params"] = db_params
 
         return original_send_data(
             self, sample_block, data, types_check, columnar, *args, **kwargs

--- a/tests/integrations/clickhouse_driver/test_clickhouse_driver.py
+++ b/tests/integrations/clickhouse_driver/test_clickhouse_driver.py
@@ -131,14 +131,10 @@ def test_clickhouse_client_breadcrumbs(
     assert actual_query_breadcrumbs == expected_breadcrumbs
 
 
-@pytest.mark.parametrize("span_streaming", [True, False])
-def test_clickhouse_client_breadcrumbs_with_pii(
-    sentry_init, capture_events, span_streaming
-) -> None:
+def test_clickhouse_client_breadcrumbs_with_pii(sentry_init, capture_events) -> None:
     sentry_init(
         integrations=[ClickhouseDriverIntegration()],
         send_default_pii=True,
-        trace_lifecycle="stream" if span_streaming else "static",
         _experiments={"record_sql_params": True},
     )
     events = capture_events()
@@ -237,13 +233,11 @@ def test_clickhouse_client_breadcrumbs_with_pii(
     assert event["breadcrumbs"]["values"] == expected_breadcrumbs
 
 
-@pytest.mark.parametrize("span_streaming", [True, False])
 def test_clickhouse_client_breadcrumbs_with_data_collection(
-    sentry_init, capture_events, span_streaming
+    sentry_init, capture_events
 ) -> None:
     sentry_init(
         integrations=[ClickhouseDriverIntegration()],
-        trace_lifecycle="stream" if span_streaming else "static",
         _experiments={"data_collection": {"database_query_data": True}},
     )
     events = capture_events()
@@ -342,13 +336,11 @@ def test_clickhouse_client_breadcrumbs_with_data_collection(
     assert event["breadcrumbs"]["values"] == expected_breadcrumbs
 
 
-@pytest.mark.parametrize("span_streaming", [True, False])
 def test_clickhouse_client_breadcrumbs_with_data_collection_disabled(
-    sentry_init, capture_events, span_streaming
+    sentry_init, capture_events
 ) -> None:
     sentry_init(
         integrations=[ClickhouseDriverIntegration()],
-        trace_lifecycle="stream" if span_streaming else "static",
         _experiments={"data_collection": {"database_query_data": False}},
     )
     events = capture_events()
@@ -443,14 +435,12 @@ def test_clickhouse_client_breadcrumbs_with_data_collection_disabled(
         assert "db.result" not in crumb["data"]
 
 
-@pytest.mark.parametrize("span_streaming", [True, False])
 def test_clickhouse_client_breadcrumbs_data_collection_overrides_pii(
-    sentry_init, capture_events, span_streaming
+    sentry_init, capture_events
 ) -> None:
     sentry_init(
         integrations=[ClickhouseDriverIntegration()],
         send_default_pii=True,
-        trace_lifecycle="stream" if span_streaming else "static",
         _experiments={"data_collection": {"database_query_data": False}},
     )
     events = capture_events()
@@ -545,13 +535,11 @@ def test_clickhouse_client_breadcrumbs_data_collection_overrides_pii(
         assert "db.result" not in crumb["data"]
 
 
-@pytest.mark.parametrize("span_streaming", [True, False])
 def test_clickhouse_client_breadcrumbs_with_data_collection_default(
-    sentry_init, capture_events, span_streaming
+    sentry_init, capture_events
 ) -> None:
     sentry_init(
         integrations=[ClickhouseDriverIntegration()],
-        trace_lifecycle="stream" if span_streaming else "static",
         _experiments={"data_collection": {}},
     )
     events = capture_events()
@@ -2046,3 +2034,383 @@ def test_span_origin(
 
         assert event["contexts"]["trace"]["origin"] == "manual"
         assert event["spans"][0]["origin"] == "auto.db.clickhouse_driver"
+
+
+# ---- Span-first (streaming) breadcrumb tests ----
+# These mirror the breadcrumb tests above but specifically target the
+# span-first code path (trace_lifecycle="stream").  In span-first mode
+# breadcrumbs are emitted from the dedicated breadcrumb_data dict set on
+# the connection, NOT derived from the span.  db.params and db.result are
+# never attached to breadcrumbs in this mode.
+
+
+def test_clickhouse_client_breadcrumbs_span_streaming(
+    sentry_init, capture_events
+) -> None:
+    sentry_init(
+        integrations=[ClickhouseDriverIntegration()],
+        trace_lifecycle="stream",
+    )
+    events = capture_events()
+
+    client = Client("localhost")
+    client.execute("DROP TABLE IF EXISTS test")
+    client.execute("CREATE TABLE test (x Int32) ENGINE = Memory")
+    client.execute("INSERT INTO test (x) VALUES", [{"x": 100}])
+    client.execute("INSERT INTO test (x) VALUES", [[170], [200]])
+
+    res = client.execute("SELECT sum(x) FROM test WHERE x > %(minv)i", {"minv": 150})
+    assert res[0][0] == 370
+
+    capture_message("hi")
+
+    (event,) = events
+
+    expected_base = {
+        "db.system": "clickhouse",
+        "db.driver.name": "clickhouse-driver",
+        "db.name": "",
+        "db.user": "default",
+        "server.address": "localhost",
+        "server.port": 9000,
+    }
+
+    expected_breadcrumbs = [
+        {
+            "category": "query",
+            "data": {**expected_base},
+            "message": "DROP TABLE IF EXISTS test",
+            "type": "default",
+        },
+        {
+            "category": "query",
+            "data": {**expected_base},
+            "message": "CREATE TABLE test (x Int32) ENGINE = Memory",
+            "type": "default",
+        },
+        {
+            "category": "query",
+            "data": {**expected_base},
+            "message": "INSERT INTO test (x) VALUES",
+            "type": "default",
+        },
+        {
+            "category": "query",
+            "data": {**expected_base},
+            "message": "INSERT INTO test (x) VALUES",
+            "type": "default",
+        },
+        {
+            "category": "query",
+            "data": {**expected_base},
+            "message": "SELECT sum(x) FROM test WHERE x > 150",
+            "type": "default",
+        },
+    ]
+
+    for crumb in expected_breadcrumbs:
+        crumb["data"] = ApproxDict(crumb["data"])
+
+    for crumb in event["breadcrumbs"]["values"]:
+        crumb.pop("timestamp", None)
+
+    actual_query_breadcrumbs = [
+        breadcrumb
+        for breadcrumb in event["breadcrumbs"]["values"]
+        if breadcrumb["category"] == "query"
+    ]
+
+    assert actual_query_breadcrumbs == expected_breadcrumbs
+
+    # Span-first breadcrumbs never carry db.params
+    for crumb in actual_query_breadcrumbs:
+        assert "db.params" not in crumb["data"]
+
+
+@pytest.mark.parametrize("send_default_pii", [True, False])
+def test_clickhouse_client_breadcrumbs_span_streaming_with_pii(
+    sentry_init, capture_events, send_default_pii
+) -> None:
+    sentry_init(
+        integrations=[ClickhouseDriverIntegration()],
+        send_default_pii=send_default_pii,
+        trace_lifecycle="stream",
+    )
+    events = capture_events()
+
+    client = Client("localhost")
+    client.execute("DROP TABLE IF EXISTS test")
+    client.execute("CREATE TABLE test (x Int32) ENGINE = Memory")
+    client.execute("INSERT INTO test (x) VALUES", [{"x": 100}])
+    client.execute("INSERT INTO test (x) VALUES", [[170], [200]])
+
+    res = client.execute("SELECT sum(x) FROM test WHERE x > %(minv)i", {"minv": 150})
+    assert res[0][0] == 370
+
+    capture_message("hi")
+
+    (event,) = events
+
+    expected_base = {
+        "db.system": "clickhouse",
+        "db.driver.name": "clickhouse-driver",
+        "db.name": "",
+        "db.user": "default",
+        "server.address": "localhost",
+        "server.port": 9000,
+    }
+
+    actual_query_breadcrumbs = [
+        crumb
+        for crumb in event["breadcrumbs"]["values"]
+        if crumb["category"] == "query"
+    ]
+
+    assert len(actual_query_breadcrumbs) == 5
+
+    for crumb in actual_query_breadcrumbs:
+        crumb.pop("timestamp", None)
+        assert crumb["type"] == "default"
+        assert crumb["category"] == "query"
+        assert crumb["data"] == ApproxDict(expected_base)
+
+    assert actual_query_breadcrumbs[0]["message"] == "DROP TABLE IF EXISTS test"
+    assert (
+        actual_query_breadcrumbs[1]["message"]
+        == "CREATE TABLE test (x Int32) ENGINE = Memory"
+    )
+    assert actual_query_breadcrumbs[2]["message"] == "INSERT INTO test (x) VALUES"
+    assert actual_query_breadcrumbs[3]["message"] == "INSERT INTO test (x) VALUES"
+    assert (
+        actual_query_breadcrumbs[4]["message"]
+        == "SELECT sum(x) FROM test WHERE x > 150"
+    )
+
+    # Span-first breadcrumbs never carry db.params regardless of PII setting
+    for crumb in actual_query_breadcrumbs:
+        assert "db.params" not in crumb["data"]
+
+
+@pytest.mark.parametrize(
+    "data_collection_setting",
+    [
+        pytest.param({"database_query_data": True}, id="enabled"),
+        pytest.param({"database_query_data": False}, id="disabled"),
+        pytest.param({}, id="default"),
+    ],
+)
+def test_clickhouse_client_breadcrumbs_span_streaming_data_collection(
+    sentry_init, capture_events, data_collection_setting
+) -> None:
+    sentry_init(
+        integrations=[ClickhouseDriverIntegration()],
+        trace_lifecycle="stream",
+        _experiments={"data_collection": data_collection_setting},
+    )
+    events = capture_events()
+
+    client = Client("localhost")
+    client.execute("DROP TABLE IF EXISTS test")
+    client.execute("CREATE TABLE test (x Int32) ENGINE = Memory")
+    client.execute("INSERT INTO test (x) VALUES", [{"x": 100}])
+    client.execute("INSERT INTO test (x) VALUES", [[170], [200]])
+
+    res = client.execute("SELECT sum(x) FROM test WHERE x > %(minv)i", {"minv": 150})
+    assert res[0][0] == 370
+
+    capture_message("hi")
+
+    (event,) = events
+
+    expected_base = {
+        "db.system": "clickhouse",
+        "db.driver.name": "clickhouse-driver",
+        "db.name": "",
+        "db.user": "default",
+        "server.address": "localhost",
+        "server.port": 9000,
+    }
+
+    actual_query_breadcrumbs = [
+        crumb
+        for crumb in event["breadcrumbs"]["values"]
+        if crumb["category"] == "query"
+    ]
+
+    assert len(actual_query_breadcrumbs) == 5
+
+    for crumb in actual_query_breadcrumbs:
+        crumb.pop("timestamp", None)
+        assert crumb["data"] == ApproxDict(expected_base)
+
+    # Span-first breadcrumbs never carry db.params regardless of data_collection
+    for crumb in actual_query_breadcrumbs:
+        assert "db.params" not in crumb["data"]
+
+
+def test_clickhouse_client_breadcrumbs_span_streaming_data_collection_overrides_pii(
+    sentry_init, capture_events
+) -> None:
+    """data_collection disabled takes precedence over send_default_pii=True."""
+    sentry_init(
+        integrations=[ClickhouseDriverIntegration()],
+        send_default_pii=True,
+        trace_lifecycle="stream",
+        _experiments={"data_collection": {"database_query_data": False}},
+    )
+    events = capture_events()
+
+    client = Client("localhost")
+    client.execute("DROP TABLE IF EXISTS test")
+    client.execute("CREATE TABLE test (x Int32) ENGINE = Memory")
+    client.execute("INSERT INTO test (x) VALUES", [{"x": 100}])
+    client.execute("INSERT INTO test (x) VALUES", [[170], [200]])
+
+    res = client.execute("SELECT sum(x) FROM test WHERE x > %(minv)i", {"minv": 150})
+    assert res[0][0] == 370
+
+    capture_message("hi")
+
+    (event,) = events
+
+    actual_query_breadcrumbs = [
+        crumb
+        for crumb in event["breadcrumbs"]["values"]
+        if crumb["category"] == "query"
+    ]
+
+    assert len(actual_query_breadcrumbs) == 5
+
+    for crumb in actual_query_breadcrumbs:
+        assert "db.params" not in crumb["data"]
+
+
+def test_clickhouse_dbapi_breadcrumbs_span_streaming(
+    sentry_init, capture_events
+) -> None:
+    sentry_init(
+        integrations=[ClickhouseDriverIntegration()],
+        trace_lifecycle="stream",
+    )
+    events = capture_events()
+
+    conn = connect("clickhouse://localhost")
+    cursor = conn.cursor()
+    cursor.execute("DROP TABLE IF EXISTS test")
+    cursor.execute("CREATE TABLE test (x Int32) ENGINE = Memory")
+    cursor.executemany("INSERT INTO test (x) VALUES", [{"x": 100}])
+    cursor.executemany("INSERT INTO test (x) VALUES", [[170], [200]])
+    cursor.execute("SELECT sum(x) FROM test WHERE x > %(minv)i", {"minv": 150})
+    res = cursor.fetchall()
+
+    assert res[0][0] == 370
+
+    capture_message("hi")
+
+    (event,) = events
+
+    expected_base = {
+        "db.system": "clickhouse",
+        "db.driver.name": "clickhouse-driver",
+        "db.name": "",
+        "db.user": "default",
+        "server.address": "localhost",
+        "server.port": 9000,
+    }
+
+    expected_breadcrumbs = [
+        {
+            "category": "query",
+            "data": {**expected_base},
+            "message": "DROP TABLE IF EXISTS test",
+            "type": "default",
+        },
+        {
+            "category": "query",
+            "data": {**expected_base},
+            "message": "CREATE TABLE test (x Int32) ENGINE = Memory",
+            "type": "default",
+        },
+        {
+            "category": "query",
+            "data": {**expected_base},
+            "message": "INSERT INTO test (x) VALUES",
+            "type": "default",
+        },
+        {
+            "category": "query",
+            "data": {**expected_base},
+            "message": "INSERT INTO test (x) VALUES",
+            "type": "default",
+        },
+        {
+            "category": "query",
+            "data": {**expected_base},
+            "message": "SELECT sum(x) FROM test WHERE x > 150",
+            "type": "default",
+        },
+    ]
+
+    for crumb in expected_breadcrumbs:
+        crumb["data"] = ApproxDict(crumb["data"])
+
+    for crumb in event["breadcrumbs"]["values"]:
+        crumb.pop("timestamp", None)
+
+    assert event["breadcrumbs"]["values"] == expected_breadcrumbs
+
+    # Span-first breadcrumbs never carry db.params
+    for crumb in event["breadcrumbs"]["values"]:
+        assert "db.params" not in crumb["data"]
+
+
+@pytest.mark.parametrize("send_default_pii", [True, False])
+def test_clickhouse_dbapi_breadcrumbs_span_streaming_with_pii(
+    sentry_init, capture_events, send_default_pii
+) -> None:
+    sentry_init(
+        integrations=[ClickhouseDriverIntegration()],
+        send_default_pii=send_default_pii,
+        trace_lifecycle="stream",
+    )
+    events = capture_events()
+
+    conn = connect("clickhouse://localhost")
+    cursor = conn.cursor()
+    cursor.execute("DROP TABLE IF EXISTS test")
+    cursor.execute("CREATE TABLE test (x Int32) ENGINE = Memory")
+    cursor.executemany("INSERT INTO test (x) VALUES", [{"x": 100}])
+    cursor.executemany("INSERT INTO test (x) VALUES", [[170], [200]])
+    cursor.execute("SELECT sum(x) FROM test WHERE x > %(minv)i", {"minv": 150})
+    res = cursor.fetchall()
+
+    assert res[0][0] == 370
+
+    capture_message("hi")
+
+    (event,) = events
+
+    expected_base = {
+        "db.system": "clickhouse",
+        "db.driver.name": "clickhouse-driver",
+        "db.name": "",
+        "db.user": "default",
+        "server.address": "localhost",
+        "server.port": 9000,
+    }
+
+    actual_query_breadcrumbs = [
+        crumb
+        for crumb in event["breadcrumbs"]["values"]
+        if crumb["category"] == "query"
+    ]
+
+    assert len(actual_query_breadcrumbs) == 5
+
+    for crumb in actual_query_breadcrumbs:
+        crumb.pop("timestamp", None)
+        assert crumb["data"] == ApproxDict(expected_base)
+
+    # Span-first breadcrumbs never carry db.params regardless of PII setting
+    for crumb in actual_query_breadcrumbs:
+        assert "db.params" not in crumb["data"]

--- a/tests/integrations/clickhouse_driver/test_clickhouse_driver.py
+++ b/tests/integrations/clickhouse_driver/test_clickhouse_driver.py
@@ -21,9 +21,13 @@ if clickhouse_driver.VERSION < (0, 2, 6):
     EXPECT_PARAMS_IN_SELECT = False
 
 
-def test_clickhouse_client_breadcrumbs(sentry_init, capture_events) -> None:
+@pytest.mark.parametrize("span_streaming", [True, False])
+def test_clickhouse_client_breadcrumbs(
+    sentry_init, capture_events, span_streaming
+) -> None:
     sentry_init(
         integrations=[ClickhouseDriverIntegration()],
+        trace_lifecycle="stream" if span_streaming else "static",
         _experiments={"record_sql_params": True},
     )
     events = capture_events()
@@ -127,10 +131,14 @@ def test_clickhouse_client_breadcrumbs(sentry_init, capture_events) -> None:
     assert actual_query_breadcrumbs == expected_breadcrumbs
 
 
-def test_clickhouse_client_breadcrumbs_with_pii(sentry_init, capture_events) -> None:
+@pytest.mark.parametrize("span_streaming", [True, False])
+def test_clickhouse_client_breadcrumbs_with_pii(
+    sentry_init, capture_events, span_streaming
+) -> None:
     sentry_init(
         integrations=[ClickhouseDriverIntegration()],
         send_default_pii=True,
+        trace_lifecycle="stream" if span_streaming else "static",
         _experiments={"record_sql_params": True},
     )
     events = capture_events()
@@ -229,11 +237,13 @@ def test_clickhouse_client_breadcrumbs_with_pii(sentry_init, capture_events) -> 
     assert event["breadcrumbs"]["values"] == expected_breadcrumbs
 
 
+@pytest.mark.parametrize("span_streaming", [True, False])
 def test_clickhouse_client_breadcrumbs_with_data_collection(
-    sentry_init, capture_events
+    sentry_init, capture_events, span_streaming
 ) -> None:
     sentry_init(
         integrations=[ClickhouseDriverIntegration()],
+        trace_lifecycle="stream" if span_streaming else "static",
         _experiments={"data_collection": {"database_query_data": True}},
     )
     events = capture_events()
@@ -332,11 +342,13 @@ def test_clickhouse_client_breadcrumbs_with_data_collection(
     assert event["breadcrumbs"]["values"] == expected_breadcrumbs
 
 
+@pytest.mark.parametrize("span_streaming", [True, False])
 def test_clickhouse_client_breadcrumbs_with_data_collection_disabled(
-    sentry_init, capture_events
+    sentry_init, capture_events, span_streaming
 ) -> None:
     sentry_init(
         integrations=[ClickhouseDriverIntegration()],
+        trace_lifecycle="stream" if span_streaming else "static",
         _experiments={"data_collection": {"database_query_data": False}},
     )
     events = capture_events()
@@ -431,12 +443,14 @@ def test_clickhouse_client_breadcrumbs_with_data_collection_disabled(
         assert "db.result" not in crumb["data"]
 
 
+@pytest.mark.parametrize("span_streaming", [True, False])
 def test_clickhouse_client_breadcrumbs_data_collection_overrides_pii(
-    sentry_init, capture_events
+    sentry_init, capture_events, span_streaming
 ) -> None:
     sentry_init(
         integrations=[ClickhouseDriverIntegration()],
         send_default_pii=True,
+        trace_lifecycle="stream" if span_streaming else "static",
         _experiments={"data_collection": {"database_query_data": False}},
     )
     events = capture_events()
@@ -531,11 +545,13 @@ def test_clickhouse_client_breadcrumbs_data_collection_overrides_pii(
         assert "db.result" not in crumb["data"]
 
 
+@pytest.mark.parametrize("span_streaming", [True, False])
 def test_clickhouse_client_breadcrumbs_with_data_collection_default(
-    sentry_init, capture_events
+    sentry_init, capture_events, span_streaming
 ) -> None:
     sentry_init(
         integrations=[ClickhouseDriverIntegration()],
+        trace_lifecycle="stream" if span_streaming else "static",
         _experiments={"data_collection": {}},
     )
     events = capture_events()

--- a/tests/integrations/clickhouse_driver/test_clickhouse_driver.py
+++ b/tests/integrations/clickhouse_driver/test_clickhouse_driver.py
@@ -236,10 +236,6 @@ def test_clickhouse_client_breadcrumbs_span_streaming(
 
     assert actual_query_breadcrumbs == expected_breadcrumbs
 
-    # In span streaming mode, db.params is never present
-    for crumb in actual_query_breadcrumbs:
-        assert "db.params" not in crumb["data"]
-
 
 def test_clickhouse_client_breadcrumbs_with_pii(sentry_init, capture_events) -> None:
     sentry_init(
@@ -343,7 +339,7 @@ def test_clickhouse_client_breadcrumbs_with_pii(sentry_init, capture_events) -> 
     assert event["breadcrumbs"]["values"] == expected_breadcrumbs
 
 
-def test_clickhouse_client_breadcrumbs_span_streaming_with_pii(
+def test_clickhouse_client_breadcrumbs_with_pii_span_streaming(
     sentry_init, capture_events
 ) -> None:
     sentry_init(
@@ -442,10 +438,6 @@ def test_clickhouse_client_breadcrumbs_span_streaming_with_pii(
         crumb.pop("timestamp", None)
 
     assert event["breadcrumbs"]["values"] == expected_breadcrumbs
-
-    # In span streaming mode, db.params is never present
-    for crumb in event["breadcrumbs"]["values"]:
-        assert "db.params" not in crumb["data"]
 
 
 def test_clickhouse_client_breadcrumbs_with_data_collection(
@@ -551,7 +543,7 @@ def test_clickhouse_client_breadcrumbs_with_data_collection(
     assert event["breadcrumbs"]["values"] == expected_breadcrumbs
 
 
-def test_clickhouse_client_breadcrumbs_span_streaming_with_data_collection(
+def test_clickhouse_client_breadcrumbs_with_data_collection_span_streaming(
     sentry_init, capture_events
 ) -> None:
     sentry_init(
@@ -649,10 +641,6 @@ def test_clickhouse_client_breadcrumbs_span_streaming_with_data_collection(
         crumb.pop("timestamp", None)
 
     assert event["breadcrumbs"]["values"] == expected_breadcrumbs
-
-    # In span streaming mode, db.params is never present
-    for crumb in event["breadcrumbs"]["values"]:
-        assert "db.params" not in crumb["data"]
 
 
 def test_clickhouse_client_breadcrumbs_with_data_collection_disabled(
@@ -754,7 +742,7 @@ def test_clickhouse_client_breadcrumbs_with_data_collection_disabled(
         assert "db.result" not in crumb["data"]
 
 
-def test_clickhouse_client_breadcrumbs_span_streaming_with_data_collection_disabled(
+def test_clickhouse_client_breadcrumbs_with_data_collection_disabled_span_streaming(
     sentry_init, capture_events
 ) -> None:
     sentry_init(
@@ -852,10 +840,6 @@ def test_clickhouse_client_breadcrumbs_span_streaming_with_data_collection_disab
         crumb.pop("timestamp", None)
 
     assert event["breadcrumbs"]["values"] == expected_breadcrumbs
-
-    # In span streaming mode, db.params is never present
-    for crumb in event["breadcrumbs"]["values"]:
-        assert "db.params" not in crumb["data"]
 
 
 def test_clickhouse_client_breadcrumbs_data_collection_overrides_pii(
@@ -958,7 +942,7 @@ def test_clickhouse_client_breadcrumbs_data_collection_overrides_pii(
         assert "db.result" not in crumb["data"]
 
 
-def test_clickhouse_client_breadcrumbs_span_streaming_data_collection_overrides_pii(
+def test_clickhouse_client_breadcrumbs_data_collection_overrides_pii_span_streaming(
     sentry_init, capture_events
 ) -> None:
     sentry_init(
@@ -1057,10 +1041,6 @@ def test_clickhouse_client_breadcrumbs_span_streaming_data_collection_overrides_
         crumb.pop("timestamp", None)
 
     assert event["breadcrumbs"]["values"] == expected_breadcrumbs
-
-    # In span streaming mode, db.params is never present
-    for crumb in event["breadcrumbs"]["values"]:
-        assert "db.params" not in crumb["data"]
 
 
 def test_clickhouse_client_breadcrumbs_with_data_collection_default(
@@ -1166,7 +1146,7 @@ def test_clickhouse_client_breadcrumbs_with_data_collection_default(
     assert event["breadcrumbs"]["values"] == expected_breadcrumbs
 
 
-def test_clickhouse_client_breadcrumbs_span_streaming_with_data_collection_default(
+def test_clickhouse_client_breadcrumbs_with_data_collection_default_span_streaming(
     sentry_init, capture_events
 ) -> None:
     sentry_init(
@@ -1264,10 +1244,6 @@ def test_clickhouse_client_breadcrumbs_span_streaming_with_data_collection_defau
         crumb.pop("timestamp", None)
 
     assert event["breadcrumbs"]["values"] == expected_breadcrumbs
-
-    # In span streaming mode, db.params is never present
-    for crumb in event["breadcrumbs"]["values"]:
-        assert "db.params" not in crumb["data"]
 
 
 def test_clickhouse_client_span_streaming_with_data_collection(
@@ -2174,10 +2150,6 @@ def test_clickhouse_dbapi_breadcrumbs_span_streaming(
 
     assert event["breadcrumbs"]["values"] == expected_breadcrumbs
 
-    # In span streaming mode, db.params is never present
-    for crumb in event["breadcrumbs"]["values"]:
-        assert "db.params" not in crumb["data"]
-
 
 def test_clickhouse_dbapi_breadcrumbs_with_pii(sentry_init, capture_events) -> None:
     sentry_init(
@@ -2282,7 +2254,7 @@ def test_clickhouse_dbapi_breadcrumbs_with_pii(sentry_init, capture_events) -> N
     assert event["breadcrumbs"]["values"] == expected_breadcrumbs
 
 
-def test_clickhouse_dbapi_breadcrumbs_span_streaming_with_pii(
+def test_clickhouse_dbapi_breadcrumbs_with_pii_span_streaming(
     sentry_init, capture_events
 ) -> None:
     sentry_init(
@@ -2382,10 +2354,6 @@ def test_clickhouse_dbapi_breadcrumbs_span_streaming_with_pii(
         crumb.pop("timestamp", None)
 
     assert event["breadcrumbs"]["values"] == expected_breadcrumbs
-
-    # In span streaming mode, db.params is never present
-    for crumb in event["breadcrumbs"]["values"]:
-        assert "db.params" not in crumb["data"]
 
 
 @pytest.mark.parametrize("span_streaming", [True, False])

--- a/tests/integrations/clickhouse_driver/test_clickhouse_driver.py
+++ b/tests/integrations/clickhouse_driver/test_clickhouse_driver.py
@@ -131,6 +131,116 @@ def test_clickhouse_client_breadcrumbs(
     assert actual_query_breadcrumbs == expected_breadcrumbs
 
 
+def test_clickhouse_client_breadcrumbs_span_streaming(
+    sentry_init, capture_events
+) -> None:
+    sentry_init(
+        integrations=[ClickhouseDriverIntegration()],
+        trace_lifecycle="stream",
+        _experiments={"record_sql_params": True},
+    )
+    events = capture_events()
+
+    client = Client("localhost")
+    client.execute("DROP TABLE IF EXISTS test")
+    client.execute("CREATE TABLE test (x Int32) ENGINE = Memory")
+    client.execute("INSERT INTO test (x) VALUES", [{"x": 100}])
+    client.execute("INSERT INTO test (x) VALUES", [[170], [200]])
+
+    res = client.execute("SELECT sum(x) FROM test WHERE x > %(minv)i", {"minv": 150})
+    assert res[0][0] == 370
+
+    capture_message("hi")
+
+    (event,) = events
+
+    expected_breadcrumbs = [
+        {
+            "category": "query",
+            "data": {
+                "db.system": "clickhouse",
+                "db.driver.name": "clickhouse-driver",
+                "db.name": "",
+                "db.user": "default",
+                "server.address": "localhost",
+                "server.port": 9000,
+            },
+            "message": "DROP TABLE IF EXISTS test",
+            "type": "default",
+        },
+        {
+            "category": "query",
+            "data": {
+                "db.system": "clickhouse",
+                "db.driver.name": "clickhouse-driver",
+                "db.name": "",
+                "db.user": "default",
+                "server.address": "localhost",
+                "server.port": 9000,
+            },
+            "message": "CREATE TABLE test (x Int32) ENGINE = Memory",
+            "type": "default",
+        },
+        {
+            "category": "query",
+            "data": {
+                "db.system": "clickhouse",
+                "db.driver.name": "clickhouse-driver",
+                "db.name": "",
+                "db.user": "default",
+                "server.address": "localhost",
+                "server.port": 9000,
+            },
+            "message": "INSERT INTO test (x) VALUES",
+            "type": "default",
+        },
+        {
+            "category": "query",
+            "data": {
+                "db.system": "clickhouse",
+                "db.driver.name": "clickhouse-driver",
+                "db.name": "",
+                "db.user": "default",
+                "server.address": "localhost",
+                "server.port": 9000,
+            },
+            "message": "INSERT INTO test (x) VALUES",
+            "type": "default",
+        },
+        {
+            "category": "query",
+            "data": {
+                "db.system": "clickhouse",
+                "db.driver.name": "clickhouse-driver",
+                "db.name": "",
+                "db.user": "default",
+                "server.address": "localhost",
+                "server.port": 9000,
+            },
+            "message": "SELECT sum(x) FROM test WHERE x > 150",
+            "type": "default",
+        },
+    ]
+
+    for crumb in expected_breadcrumbs:
+        crumb["data"] = ApproxDict(crumb["data"])
+
+    for crumb in event["breadcrumbs"]["values"]:
+        crumb.pop("timestamp", None)
+
+    actual_query_breadcrumbs = [
+        breadcrumb
+        for breadcrumb in event["breadcrumbs"]["values"]
+        if breadcrumb["category"] == "query"
+    ]
+
+    assert actual_query_breadcrumbs == expected_breadcrumbs
+
+    # In span streaming mode, db.params is never present
+    for crumb in actual_query_breadcrumbs:
+        assert "db.params" not in crumb["data"]
+
+
 def test_clickhouse_client_breadcrumbs_with_pii(sentry_init, capture_events) -> None:
     sentry_init(
         integrations=[ClickhouseDriverIntegration()],
@@ -231,6 +341,111 @@ def test_clickhouse_client_breadcrumbs_with_pii(sentry_init, capture_events) -> 
         crumb.pop("timestamp", None)
 
     assert event["breadcrumbs"]["values"] == expected_breadcrumbs
+
+
+def test_clickhouse_client_breadcrumbs_span_streaming_with_pii(
+    sentry_init, capture_events
+) -> None:
+    sentry_init(
+        integrations=[ClickhouseDriverIntegration()],
+        send_default_pii=True,
+        trace_lifecycle="stream",
+        _experiments={"record_sql_params": True},
+    )
+    events = capture_events()
+
+    client = Client("localhost")
+    client.execute("DROP TABLE IF EXISTS test")
+    client.execute("CREATE TABLE test (x Int32) ENGINE = Memory")
+    client.execute("INSERT INTO test (x) VALUES", [{"x": 100}])
+    client.execute("INSERT INTO test (x) VALUES", [[170], [200]])
+
+    res = client.execute("SELECT sum(x) FROM test WHERE x > %(minv)i", {"minv": 150})
+    assert res[0][0] == 370
+
+    capture_message("hi")
+
+    (event,) = events
+
+    expected_breadcrumbs = [
+        {
+            "category": "query",
+            "data": {
+                "db.system": "clickhouse",
+                "db.driver.name": "clickhouse-driver",
+                "db.name": "",
+                "db.user": "default",
+                "server.address": "localhost",
+                "server.port": 9000,
+            },
+            "message": "DROP TABLE IF EXISTS test",
+            "type": "default",
+        },
+        {
+            "category": "query",
+            "data": {
+                "db.system": "clickhouse",
+                "db.driver.name": "clickhouse-driver",
+                "db.name": "",
+                "db.user": "default",
+                "server.address": "localhost",
+                "server.port": 9000,
+            },
+            "message": "CREATE TABLE test (x Int32) ENGINE = Memory",
+            "type": "default",
+        },
+        {
+            "category": "query",
+            "data": {
+                "db.system": "clickhouse",
+                "db.driver.name": "clickhouse-driver",
+                "db.name": "",
+                "db.user": "default",
+                "server.address": "localhost",
+                "server.port": 9000,
+            },
+            "message": "INSERT INTO test (x) VALUES",
+            "type": "default",
+        },
+        {
+            "category": "query",
+            "data": {
+                "db.system": "clickhouse",
+                "db.driver.name": "clickhouse-driver",
+                "db.name": "",
+                "db.user": "default",
+                "server.address": "localhost",
+                "server.port": 9000,
+            },
+            "message": "INSERT INTO test (x) VALUES",
+            "type": "default",
+        },
+        {
+            "category": "query",
+            "data": {
+                "db.system": "clickhouse",
+                "db.driver.name": "clickhouse-driver",
+                "db.name": "",
+                "db.user": "default",
+                "server.address": "localhost",
+                "server.port": 9000,
+            },
+            "message": "SELECT sum(x) FROM test WHERE x > 150",
+            "type": "default",
+        },
+    ]
+
+    for crumb in expected_breadcrumbs:
+        crumb["data"] = ApproxDict(crumb["data"])
+
+    for crumb in event["breadcrumbs"]["values"]:
+        crumb.pop("timestamp", None)
+
+    assert event["breadcrumbs"]["values"] == expected_breadcrumbs
+
+    # In span streaming mode, db.params is never present
+    for crumb in event["breadcrumbs"]["values"]:
+        assert "db.params" not in crumb["data"]
 
 
 def test_clickhouse_client_breadcrumbs_with_data_collection(
@@ -336,6 +551,110 @@ def test_clickhouse_client_breadcrumbs_with_data_collection(
     assert event["breadcrumbs"]["values"] == expected_breadcrumbs
 
 
+def test_clickhouse_client_breadcrumbs_span_streaming_with_data_collection(
+    sentry_init, capture_events
+) -> None:
+    sentry_init(
+        integrations=[ClickhouseDriverIntegration()],
+        trace_lifecycle="stream",
+        _experiments={"data_collection": {"database_query_data": True}},
+    )
+    events = capture_events()
+
+    client = Client("localhost")
+    client.execute("DROP TABLE IF EXISTS test")
+    client.execute("CREATE TABLE test (x Int32) ENGINE = Memory")
+    client.execute("INSERT INTO test (x) VALUES", [{"x": 100}])
+    client.execute("INSERT INTO test (x) VALUES", [[170], [200]])
+
+    res = client.execute("SELECT sum(x) FROM test WHERE x > %(minv)i", {"minv": 150})
+    assert res[0][0] == 370
+
+    capture_message("hi")
+
+    (event,) = events
+
+    expected_breadcrumbs = [
+        {
+            "category": "query",
+            "data": {
+                "db.system": "clickhouse",
+                "db.driver.name": "clickhouse-driver",
+                "db.name": "",
+                "db.user": "default",
+                "server.address": "localhost",
+                "server.port": 9000,
+            },
+            "message": "DROP TABLE IF EXISTS test",
+            "type": "default",
+        },
+        {
+            "category": "query",
+            "data": {
+                "db.system": "clickhouse",
+                "db.driver.name": "clickhouse-driver",
+                "db.name": "",
+                "db.user": "default",
+                "server.address": "localhost",
+                "server.port": 9000,
+            },
+            "message": "CREATE TABLE test (x Int32) ENGINE = Memory",
+            "type": "default",
+        },
+        {
+            "category": "query",
+            "data": {
+                "db.system": "clickhouse",
+                "db.driver.name": "clickhouse-driver",
+                "db.name": "",
+                "db.user": "default",
+                "server.address": "localhost",
+                "server.port": 9000,
+            },
+            "message": "INSERT INTO test (x) VALUES",
+            "type": "default",
+        },
+        {
+            "category": "query",
+            "data": {
+                "db.system": "clickhouse",
+                "db.driver.name": "clickhouse-driver",
+                "db.name": "",
+                "db.user": "default",
+                "server.address": "localhost",
+                "server.port": 9000,
+            },
+            "message": "INSERT INTO test (x) VALUES",
+            "type": "default",
+        },
+        {
+            "category": "query",
+            "data": {
+                "db.system": "clickhouse",
+                "db.driver.name": "clickhouse-driver",
+                "db.name": "",
+                "db.user": "default",
+                "server.address": "localhost",
+                "server.port": 9000,
+            },
+            "message": "SELECT sum(x) FROM test WHERE x > 150",
+            "type": "default",
+        },
+    ]
+
+    for crumb in expected_breadcrumbs:
+        crumb["data"] = ApproxDict(crumb["data"])
+
+    for crumb in event["breadcrumbs"]["values"]:
+        crumb.pop("timestamp", None)
+
+    assert event["breadcrumbs"]["values"] == expected_breadcrumbs
+
+    # In span streaming mode, db.params is never present
+    for crumb in event["breadcrumbs"]["values"]:
+        assert "db.params" not in crumb["data"]
+
+
 def test_clickhouse_client_breadcrumbs_with_data_collection_disabled(
     sentry_init, capture_events
 ) -> None:
@@ -433,6 +752,110 @@ def test_clickhouse_client_breadcrumbs_with_data_collection_disabled(
     for crumb in event["breadcrumbs"]["values"]:
         assert "db.params" not in crumb["data"]
         assert "db.result" not in crumb["data"]
+
+
+def test_clickhouse_client_breadcrumbs_span_streaming_with_data_collection_disabled(
+    sentry_init, capture_events
+) -> None:
+    sentry_init(
+        integrations=[ClickhouseDriverIntegration()],
+        trace_lifecycle="stream",
+        _experiments={"data_collection": {"database_query_data": False}},
+    )
+    events = capture_events()
+
+    client = Client("localhost")
+    client.execute("DROP TABLE IF EXISTS test")
+    client.execute("CREATE TABLE test (x Int32) ENGINE = Memory")
+    client.execute("INSERT INTO test (x) VALUES", [{"x": 100}])
+    client.execute("INSERT INTO test (x) VALUES", [[170], [200]])
+
+    res = client.execute("SELECT sum(x) FROM test WHERE x > %(minv)i", {"minv": 150})
+    assert res[0][0] == 370
+
+    capture_message("hi")
+
+    (event,) = events
+
+    expected_breadcrumbs = [
+        {
+            "category": "query",
+            "data": {
+                "db.system": "clickhouse",
+                "db.driver.name": "clickhouse-driver",
+                "db.name": "",
+                "db.user": "default",
+                "server.address": "localhost",
+                "server.port": 9000,
+            },
+            "message": "DROP TABLE IF EXISTS test",
+            "type": "default",
+        },
+        {
+            "category": "query",
+            "data": {
+                "db.system": "clickhouse",
+                "db.driver.name": "clickhouse-driver",
+                "db.name": "",
+                "db.user": "default",
+                "server.address": "localhost",
+                "server.port": 9000,
+            },
+            "message": "CREATE TABLE test (x Int32) ENGINE = Memory",
+            "type": "default",
+        },
+        {
+            "category": "query",
+            "data": {
+                "db.system": "clickhouse",
+                "db.driver.name": "clickhouse-driver",
+                "db.name": "",
+                "db.user": "default",
+                "server.address": "localhost",
+                "server.port": 9000,
+            },
+            "message": "INSERT INTO test (x) VALUES",
+            "type": "default",
+        },
+        {
+            "category": "query",
+            "data": {
+                "db.system": "clickhouse",
+                "db.driver.name": "clickhouse-driver",
+                "db.name": "",
+                "db.user": "default",
+                "server.address": "localhost",
+                "server.port": 9000,
+            },
+            "message": "INSERT INTO test (x) VALUES",
+            "type": "default",
+        },
+        {
+            "category": "query",
+            "data": {
+                "db.system": "clickhouse",
+                "db.driver.name": "clickhouse-driver",
+                "db.name": "",
+                "db.user": "default",
+                "server.address": "localhost",
+                "server.port": 9000,
+            },
+            "message": "SELECT sum(x) FROM test WHERE x > 150",
+            "type": "default",
+        },
+    ]
+
+    for crumb in expected_breadcrumbs:
+        crumb["data"] = ApproxDict(crumb["data"])
+
+    for crumb in event["breadcrumbs"]["values"]:
+        crumb.pop("timestamp", None)
+
+    assert event["breadcrumbs"]["values"] == expected_breadcrumbs
+
+    # In span streaming mode, db.params is never present
+    for crumb in event["breadcrumbs"]["values"]:
+        assert "db.params" not in crumb["data"]
 
 
 def test_clickhouse_client_breadcrumbs_data_collection_overrides_pii(
@@ -533,6 +956,111 @@ def test_clickhouse_client_breadcrumbs_data_collection_overrides_pii(
     for crumb in event["breadcrumbs"]["values"]:
         assert "db.params" not in crumb["data"]
         assert "db.result" not in crumb["data"]
+
+
+def test_clickhouse_client_breadcrumbs_span_streaming_data_collection_overrides_pii(
+    sentry_init, capture_events
+) -> None:
+    sentry_init(
+        integrations=[ClickhouseDriverIntegration()],
+        send_default_pii=True,
+        trace_lifecycle="stream",
+        _experiments={"data_collection": {"database_query_data": False}},
+    )
+    events = capture_events()
+
+    client = Client("localhost")
+    client.execute("DROP TABLE IF EXISTS test")
+    client.execute("CREATE TABLE test (x Int32) ENGINE = Memory")
+    client.execute("INSERT INTO test (x) VALUES", [{"x": 100}])
+    client.execute("INSERT INTO test (x) VALUES", [[170], [200]])
+
+    res = client.execute("SELECT sum(x) FROM test WHERE x > %(minv)i", {"minv": 150})
+    assert res[0][0] == 370
+
+    capture_message("hi")
+
+    (event,) = events
+
+    expected_breadcrumbs = [
+        {
+            "category": "query",
+            "data": {
+                "db.system": "clickhouse",
+                "db.driver.name": "clickhouse-driver",
+                "db.name": "",
+                "db.user": "default",
+                "server.address": "localhost",
+                "server.port": 9000,
+            },
+            "message": "DROP TABLE IF EXISTS test",
+            "type": "default",
+        },
+        {
+            "category": "query",
+            "data": {
+                "db.system": "clickhouse",
+                "db.driver.name": "clickhouse-driver",
+                "db.name": "",
+                "db.user": "default",
+                "server.address": "localhost",
+                "server.port": 9000,
+            },
+            "message": "CREATE TABLE test (x Int32) ENGINE = Memory",
+            "type": "default",
+        },
+        {
+            "category": "query",
+            "data": {
+                "db.system": "clickhouse",
+                "db.driver.name": "clickhouse-driver",
+                "db.name": "",
+                "db.user": "default",
+                "server.address": "localhost",
+                "server.port": 9000,
+            },
+            "message": "INSERT INTO test (x) VALUES",
+            "type": "default",
+        },
+        {
+            "category": "query",
+            "data": {
+                "db.system": "clickhouse",
+                "db.driver.name": "clickhouse-driver",
+                "db.name": "",
+                "db.user": "default",
+                "server.address": "localhost",
+                "server.port": 9000,
+            },
+            "message": "INSERT INTO test (x) VALUES",
+            "type": "default",
+        },
+        {
+            "category": "query",
+            "data": {
+                "db.system": "clickhouse",
+                "db.driver.name": "clickhouse-driver",
+                "db.name": "",
+                "db.user": "default",
+                "server.address": "localhost",
+                "server.port": 9000,
+            },
+            "message": "SELECT sum(x) FROM test WHERE x > 150",
+            "type": "default",
+        },
+    ]
+
+    for crumb in expected_breadcrumbs:
+        crumb["data"] = ApproxDict(crumb["data"])
+
+    for crumb in event["breadcrumbs"]["values"]:
+        crumb.pop("timestamp", None)
+
+    assert event["breadcrumbs"]["values"] == expected_breadcrumbs
+
+    # In span streaming mode, db.params is never present
+    for crumb in event["breadcrumbs"]["values"]:
+        assert "db.params" not in crumb["data"]
 
 
 def test_clickhouse_client_breadcrumbs_with_data_collection_default(
@@ -638,6 +1166,110 @@ def test_clickhouse_client_breadcrumbs_with_data_collection_default(
     assert event["breadcrumbs"]["values"] == expected_breadcrumbs
 
 
+def test_clickhouse_client_breadcrumbs_span_streaming_with_data_collection_default(
+    sentry_init, capture_events
+) -> None:
+    sentry_init(
+        integrations=[ClickhouseDriverIntegration()],
+        trace_lifecycle="stream",
+        _experiments={"data_collection": {}},
+    )
+    events = capture_events()
+
+    client = Client("localhost")
+    client.execute("DROP TABLE IF EXISTS test")
+    client.execute("CREATE TABLE test (x Int32) ENGINE = Memory")
+    client.execute("INSERT INTO test (x) VALUES", [{"x": 100}])
+    client.execute("INSERT INTO test (x) VALUES", [[170], [200]])
+
+    res = client.execute("SELECT sum(x) FROM test WHERE x > %(minv)i", {"minv": 150})
+    assert res[0][0] == 370
+
+    capture_message("hi")
+
+    (event,) = events
+
+    expected_breadcrumbs = [
+        {
+            "category": "query",
+            "data": {
+                "db.system": "clickhouse",
+                "db.driver.name": "clickhouse-driver",
+                "db.name": "",
+                "db.user": "default",
+                "server.address": "localhost",
+                "server.port": 9000,
+            },
+            "message": "DROP TABLE IF EXISTS test",
+            "type": "default",
+        },
+        {
+            "category": "query",
+            "data": {
+                "db.system": "clickhouse",
+                "db.driver.name": "clickhouse-driver",
+                "db.name": "",
+                "db.user": "default",
+                "server.address": "localhost",
+                "server.port": 9000,
+            },
+            "message": "CREATE TABLE test (x Int32) ENGINE = Memory",
+            "type": "default",
+        },
+        {
+            "category": "query",
+            "data": {
+                "db.system": "clickhouse",
+                "db.driver.name": "clickhouse-driver",
+                "db.name": "",
+                "db.user": "default",
+                "server.address": "localhost",
+                "server.port": 9000,
+            },
+            "message": "INSERT INTO test (x) VALUES",
+            "type": "default",
+        },
+        {
+            "category": "query",
+            "data": {
+                "db.system": "clickhouse",
+                "db.driver.name": "clickhouse-driver",
+                "db.name": "",
+                "db.user": "default",
+                "server.address": "localhost",
+                "server.port": 9000,
+            },
+            "message": "INSERT INTO test (x) VALUES",
+            "type": "default",
+        },
+        {
+            "category": "query",
+            "data": {
+                "db.system": "clickhouse",
+                "db.driver.name": "clickhouse-driver",
+                "db.name": "",
+                "db.user": "default",
+                "server.address": "localhost",
+                "server.port": 9000,
+            },
+            "message": "SELECT sum(x) FROM test WHERE x > 150",
+            "type": "default",
+        },
+    ]
+
+    for crumb in expected_breadcrumbs:
+        crumb["data"] = ApproxDict(crumb["data"])
+
+    for crumb in event["breadcrumbs"]["values"]:
+        crumb.pop("timestamp", None)
+
+    assert event["breadcrumbs"]["values"] == expected_breadcrumbs
+
+    # In span streaming mode, db.params is never present
+    for crumb in event["breadcrumbs"]["values"]:
+        assert "db.params" not in crumb["data"]
+
+
 def test_clickhouse_client_span_streaming_with_data_collection(
     sentry_init, capture_items
 ) -> None:
@@ -712,6 +1344,68 @@ def test_clickhouse_client_send_data_generator_with_data_collection_disabled(
 ) -> None:
     sentry_init(
         integrations=[ClickhouseDriverIntegration()],
+        _experiments={"data_collection": {"database_query_data": False}},
+    )
+    events = capture_events()
+
+    client = Client("localhost")
+    client.execute("DROP TABLE IF EXISTS test")
+    client.execute("CREATE TABLE test (x Int32) ENGINE = Memory")
+    client.execute("INSERT INTO test (x) VALUES", ((i,) for i in range(3)))
+
+    res = client.execute("SELECT sum(x) FROM test")
+    assert res[0][0] == 3
+
+    capture_message("hi")
+
+    (event,) = events
+
+    (insert_breadcrumb,) = [
+        crumb
+        for crumb in event["breadcrumbs"]["values"]
+        if crumb["message"] == "INSERT INTO test (x) VALUES"
+    ]
+
+    assert "db.params" not in insert_breadcrumb["data"]
+
+
+def test_clickhouse_client_send_data_generator_span_streaming_with_data_collection(
+    sentry_init, capture_events
+) -> None:
+    sentry_init(
+        integrations=[ClickhouseDriverIntegration()],
+        trace_lifecycle="stream",
+        _experiments={"data_collection": {"database_query_data": True}},
+    )
+    events = capture_events()
+
+    client = Client("localhost")
+    client.execute("DROP TABLE IF EXISTS test")
+    client.execute("CREATE TABLE test (x Int32) ENGINE = Memory")
+    client.execute("INSERT INTO test (x) VALUES", ((i,) for i in range(3)))
+
+    res = client.execute("SELECT sum(x) FROM test")
+    assert res[0][0] == 3
+
+    capture_message("hi")
+
+    (event,) = events
+
+    (insert_breadcrumb,) = [
+        crumb
+        for crumb in event["breadcrumbs"]["values"]
+        if crumb["message"] == "INSERT INTO test (x) VALUES"
+    ]
+
+    assert "db.params" not in insert_breadcrumb["data"]
+
+
+def test_clickhouse_client_send_data_generator_span_streaming_with_data_collection_disabled(
+    sentry_init, capture_events
+) -> None:
+    sentry_init(
+        integrations=[ClickhouseDriverIntegration()],
+        trace_lifecycle="stream",
         _experiments={"data_collection": {"database_query_data": False}},
     )
     events = capture_events()
@@ -1380,6 +2074,111 @@ def test_clickhouse_dbapi_breadcrumbs(sentry_init, capture_events) -> None:
     assert event["breadcrumbs"]["values"] == expected_breadcrumbs
 
 
+def test_clickhouse_dbapi_breadcrumbs_span_streaming(
+    sentry_init, capture_events
+) -> None:
+    sentry_init(
+        integrations=[ClickhouseDriverIntegration()],
+        trace_lifecycle="stream",
+    )
+    events = capture_events()
+
+    conn = connect("clickhouse://localhost")
+    cursor = conn.cursor()
+    cursor.execute("DROP TABLE IF EXISTS test")
+    cursor.execute("CREATE TABLE test (x Int32) ENGINE = Memory")
+    cursor.executemany("INSERT INTO test (x) VALUES", [{"x": 100}])
+    cursor.executemany("INSERT INTO test (x) VALUES", [[170], [200]])
+    cursor.execute("SELECT sum(x) FROM test WHERE x > %(minv)i", {"minv": 150})
+    res = cursor.fetchall()
+
+    assert res[0][0] == 370
+
+    capture_message("hi")
+
+    (event,) = events
+
+    expected_breadcrumbs = [
+        {
+            "category": "query",
+            "data": {
+                "db.system": "clickhouse",
+                "db.driver.name": "clickhouse-driver",
+                "db.name": "",
+                "db.user": "default",
+                "server.address": "localhost",
+                "server.port": 9000,
+            },
+            "message": "DROP TABLE IF EXISTS test",
+            "type": "default",
+        },
+        {
+            "category": "query",
+            "data": {
+                "db.system": "clickhouse",
+                "db.driver.name": "clickhouse-driver",
+                "db.name": "",
+                "db.user": "default",
+                "server.address": "localhost",
+                "server.port": 9000,
+            },
+            "message": "CREATE TABLE test (x Int32) ENGINE = Memory",
+            "type": "default",
+        },
+        {
+            "category": "query",
+            "data": {
+                "db.system": "clickhouse",
+                "db.driver.name": "clickhouse-driver",
+                "db.name": "",
+                "db.user": "default",
+                "server.address": "localhost",
+                "server.port": 9000,
+            },
+            "message": "INSERT INTO test (x) VALUES",
+            "type": "default",
+        },
+        {
+            "category": "query",
+            "data": {
+                "db.system": "clickhouse",
+                "db.driver.name": "clickhouse-driver",
+                "db.name": "",
+                "db.user": "default",
+                "server.address": "localhost",
+                "server.port": 9000,
+            },
+            "message": "INSERT INTO test (x) VALUES",
+            "type": "default",
+        },
+        {
+            "category": "query",
+            "data": {
+                "db.system": "clickhouse",
+                "db.driver.name": "clickhouse-driver",
+                "db.name": "",
+                "db.user": "default",
+                "server.address": "localhost",
+                "server.port": 9000,
+            },
+            "message": "SELECT sum(x) FROM test WHERE x > 150",
+            "type": "default",
+        },
+    ]
+
+    for crumb in expected_breadcrumbs:
+        crumb["data"] = ApproxDict(crumb["data"])
+
+    for crumb in event["breadcrumbs"]["values"]:
+        crumb.pop("timestamp", None)
+
+    assert event["breadcrumbs"]["values"] == expected_breadcrumbs
+
+    # In span streaming mode, db.params is never present
+    for crumb in event["breadcrumbs"]["values"]:
+        assert "db.params" not in crumb["data"]
+
+
 def test_clickhouse_dbapi_breadcrumbs_with_pii(sentry_init, capture_events) -> None:
     sentry_init(
         integrations=[ClickhouseDriverIntegration()],
@@ -1481,6 +2280,112 @@ def test_clickhouse_dbapi_breadcrumbs_with_pii(sentry_init, capture_events) -> N
         crumb.pop("timestamp", None)
 
     assert event["breadcrumbs"]["values"] == expected_breadcrumbs
+
+
+def test_clickhouse_dbapi_breadcrumbs_span_streaming_with_pii(
+    sentry_init, capture_events
+) -> None:
+    sentry_init(
+        integrations=[ClickhouseDriverIntegration()],
+        send_default_pii=True,
+        trace_lifecycle="stream",
+    )
+    events = capture_events()
+
+    conn = connect("clickhouse://localhost")
+    cursor = conn.cursor()
+    cursor.execute("DROP TABLE IF EXISTS test")
+    cursor.execute("CREATE TABLE test (x Int32) ENGINE = Memory")
+    cursor.executemany("INSERT INTO test (x) VALUES", [{"x": 100}])
+    cursor.executemany("INSERT INTO test (x) VALUES", [[170], [200]])
+    cursor.execute("SELECT sum(x) FROM test WHERE x > %(minv)i", {"minv": 150})
+    res = cursor.fetchall()
+
+    assert res[0][0] == 370
+
+    capture_message("hi")
+
+    (event,) = events
+
+    expected_breadcrumbs = [
+        {
+            "category": "query",
+            "data": {
+                "db.system": "clickhouse",
+                "db.driver.name": "clickhouse-driver",
+                "db.name": "",
+                "db.user": "default",
+                "server.address": "localhost",
+                "server.port": 9000,
+            },
+            "message": "DROP TABLE IF EXISTS test",
+            "type": "default",
+        },
+        {
+            "category": "query",
+            "data": {
+                "db.system": "clickhouse",
+                "db.driver.name": "clickhouse-driver",
+                "db.name": "",
+                "db.user": "default",
+                "server.address": "localhost",
+                "server.port": 9000,
+            },
+            "message": "CREATE TABLE test (x Int32) ENGINE = Memory",
+            "type": "default",
+        },
+        {
+            "category": "query",
+            "data": {
+                "db.system": "clickhouse",
+                "db.driver.name": "clickhouse-driver",
+                "db.name": "",
+                "db.user": "default",
+                "server.address": "localhost",
+                "server.port": 9000,
+            },
+            "message": "INSERT INTO test (x) VALUES",
+            "type": "default",
+        },
+        {
+            "category": "query",
+            "data": {
+                "db.system": "clickhouse",
+                "db.driver.name": "clickhouse-driver",
+                "db.name": "",
+                "db.user": "default",
+                "server.address": "localhost",
+                "server.port": 9000,
+            },
+            "message": "INSERT INTO test (x) VALUES",
+            "type": "default",
+        },
+        {
+            "category": "query",
+            "data": {
+                "db.system": "clickhouse",
+                "db.driver.name": "clickhouse-driver",
+                "db.name": "",
+                "db.user": "default",
+                "server.address": "localhost",
+                "server.port": 9000,
+            },
+            "message": "SELECT sum(x) FROM test WHERE x > 150",
+            "type": "default",
+        },
+    ]
+
+    for crumb in expected_breadcrumbs:
+        crumb["data"] = ApproxDict(crumb["data"])
+
+    for crumb in event["breadcrumbs"]["values"]:
+        crumb.pop("timestamp", None)
+
+    assert event["breadcrumbs"]["values"] == expected_breadcrumbs
+
+    # In span streaming mode, db.params is never present
+    for crumb in event["breadcrumbs"]["values"]:
+        assert "db.params" not in crumb["data"]
 
 
 @pytest.mark.parametrize("span_streaming", [True, False])
@@ -2034,383 +2939,3 @@ def test_span_origin(
 
         assert event["contexts"]["trace"]["origin"] == "manual"
         assert event["spans"][0]["origin"] == "auto.db.clickhouse_driver"
-
-
-# ---- Span-first (streaming) breadcrumb tests ----
-# These mirror the breadcrumb tests above but specifically target the
-# span-first code path (trace_lifecycle="stream").  In span-first mode
-# breadcrumbs are emitted from the dedicated breadcrumb_data dict set on
-# the connection, NOT derived from the span.  db.params and db.result are
-# never attached to breadcrumbs in this mode.
-
-
-def test_clickhouse_client_breadcrumbs_span_streaming(
-    sentry_init, capture_events
-) -> None:
-    sentry_init(
-        integrations=[ClickhouseDriverIntegration()],
-        trace_lifecycle="stream",
-    )
-    events = capture_events()
-
-    client = Client("localhost")
-    client.execute("DROP TABLE IF EXISTS test")
-    client.execute("CREATE TABLE test (x Int32) ENGINE = Memory")
-    client.execute("INSERT INTO test (x) VALUES", [{"x": 100}])
-    client.execute("INSERT INTO test (x) VALUES", [[170], [200]])
-
-    res = client.execute("SELECT sum(x) FROM test WHERE x > %(minv)i", {"minv": 150})
-    assert res[0][0] == 370
-
-    capture_message("hi")
-
-    (event,) = events
-
-    expected_base = {
-        "db.system": "clickhouse",
-        "db.driver.name": "clickhouse-driver",
-        "db.name": "",
-        "db.user": "default",
-        "server.address": "localhost",
-        "server.port": 9000,
-    }
-
-    expected_breadcrumbs = [
-        {
-            "category": "query",
-            "data": {**expected_base},
-            "message": "DROP TABLE IF EXISTS test",
-            "type": "default",
-        },
-        {
-            "category": "query",
-            "data": {**expected_base},
-            "message": "CREATE TABLE test (x Int32) ENGINE = Memory",
-            "type": "default",
-        },
-        {
-            "category": "query",
-            "data": {**expected_base},
-            "message": "INSERT INTO test (x) VALUES",
-            "type": "default",
-        },
-        {
-            "category": "query",
-            "data": {**expected_base},
-            "message": "INSERT INTO test (x) VALUES",
-            "type": "default",
-        },
-        {
-            "category": "query",
-            "data": {**expected_base},
-            "message": "SELECT sum(x) FROM test WHERE x > 150",
-            "type": "default",
-        },
-    ]
-
-    for crumb in expected_breadcrumbs:
-        crumb["data"] = ApproxDict(crumb["data"])
-
-    for crumb in event["breadcrumbs"]["values"]:
-        crumb.pop("timestamp", None)
-
-    actual_query_breadcrumbs = [
-        breadcrumb
-        for breadcrumb in event["breadcrumbs"]["values"]
-        if breadcrumb["category"] == "query"
-    ]
-
-    assert actual_query_breadcrumbs == expected_breadcrumbs
-
-    # Span-first breadcrumbs never carry db.params
-    for crumb in actual_query_breadcrumbs:
-        assert "db.params" not in crumb["data"]
-
-
-@pytest.mark.parametrize("send_default_pii", [True, False])
-def test_clickhouse_client_breadcrumbs_span_streaming_with_pii(
-    sentry_init, capture_events, send_default_pii
-) -> None:
-    sentry_init(
-        integrations=[ClickhouseDriverIntegration()],
-        send_default_pii=send_default_pii,
-        trace_lifecycle="stream",
-    )
-    events = capture_events()
-
-    client = Client("localhost")
-    client.execute("DROP TABLE IF EXISTS test")
-    client.execute("CREATE TABLE test (x Int32) ENGINE = Memory")
-    client.execute("INSERT INTO test (x) VALUES", [{"x": 100}])
-    client.execute("INSERT INTO test (x) VALUES", [[170], [200]])
-
-    res = client.execute("SELECT sum(x) FROM test WHERE x > %(minv)i", {"minv": 150})
-    assert res[0][0] == 370
-
-    capture_message("hi")
-
-    (event,) = events
-
-    expected_base = {
-        "db.system": "clickhouse",
-        "db.driver.name": "clickhouse-driver",
-        "db.name": "",
-        "db.user": "default",
-        "server.address": "localhost",
-        "server.port": 9000,
-    }
-
-    actual_query_breadcrumbs = [
-        crumb
-        for crumb in event["breadcrumbs"]["values"]
-        if crumb["category"] == "query"
-    ]
-
-    assert len(actual_query_breadcrumbs) == 5
-
-    for crumb in actual_query_breadcrumbs:
-        crumb.pop("timestamp", None)
-        assert crumb["type"] == "default"
-        assert crumb["category"] == "query"
-        assert crumb["data"] == ApproxDict(expected_base)
-
-    assert actual_query_breadcrumbs[0]["message"] == "DROP TABLE IF EXISTS test"
-    assert (
-        actual_query_breadcrumbs[1]["message"]
-        == "CREATE TABLE test (x Int32) ENGINE = Memory"
-    )
-    assert actual_query_breadcrumbs[2]["message"] == "INSERT INTO test (x) VALUES"
-    assert actual_query_breadcrumbs[3]["message"] == "INSERT INTO test (x) VALUES"
-    assert (
-        actual_query_breadcrumbs[4]["message"]
-        == "SELECT sum(x) FROM test WHERE x > 150"
-    )
-
-    # Span-first breadcrumbs never carry db.params regardless of PII setting
-    for crumb in actual_query_breadcrumbs:
-        assert "db.params" not in crumb["data"]
-
-
-@pytest.mark.parametrize(
-    "data_collection_setting",
-    [
-        pytest.param({"database_query_data": True}, id="enabled"),
-        pytest.param({"database_query_data": False}, id="disabled"),
-        pytest.param({}, id="default"),
-    ],
-)
-def test_clickhouse_client_breadcrumbs_span_streaming_data_collection(
-    sentry_init, capture_events, data_collection_setting
-) -> None:
-    sentry_init(
-        integrations=[ClickhouseDriverIntegration()],
-        trace_lifecycle="stream",
-        _experiments={"data_collection": data_collection_setting},
-    )
-    events = capture_events()
-
-    client = Client("localhost")
-    client.execute("DROP TABLE IF EXISTS test")
-    client.execute("CREATE TABLE test (x Int32) ENGINE = Memory")
-    client.execute("INSERT INTO test (x) VALUES", [{"x": 100}])
-    client.execute("INSERT INTO test (x) VALUES", [[170], [200]])
-
-    res = client.execute("SELECT sum(x) FROM test WHERE x > %(minv)i", {"minv": 150})
-    assert res[0][0] == 370
-
-    capture_message("hi")
-
-    (event,) = events
-
-    expected_base = {
-        "db.system": "clickhouse",
-        "db.driver.name": "clickhouse-driver",
-        "db.name": "",
-        "db.user": "default",
-        "server.address": "localhost",
-        "server.port": 9000,
-    }
-
-    actual_query_breadcrumbs = [
-        crumb
-        for crumb in event["breadcrumbs"]["values"]
-        if crumb["category"] == "query"
-    ]
-
-    assert len(actual_query_breadcrumbs) == 5
-
-    for crumb in actual_query_breadcrumbs:
-        crumb.pop("timestamp", None)
-        assert crumb["data"] == ApproxDict(expected_base)
-
-    # Span-first breadcrumbs never carry db.params regardless of data_collection
-    for crumb in actual_query_breadcrumbs:
-        assert "db.params" not in crumb["data"]
-
-
-def test_clickhouse_client_breadcrumbs_span_streaming_data_collection_overrides_pii(
-    sentry_init, capture_events
-) -> None:
-    """data_collection disabled takes precedence over send_default_pii=True."""
-    sentry_init(
-        integrations=[ClickhouseDriverIntegration()],
-        send_default_pii=True,
-        trace_lifecycle="stream",
-        _experiments={"data_collection": {"database_query_data": False}},
-    )
-    events = capture_events()
-
-    client = Client("localhost")
-    client.execute("DROP TABLE IF EXISTS test")
-    client.execute("CREATE TABLE test (x Int32) ENGINE = Memory")
-    client.execute("INSERT INTO test (x) VALUES", [{"x": 100}])
-    client.execute("INSERT INTO test (x) VALUES", [[170], [200]])
-
-    res = client.execute("SELECT sum(x) FROM test WHERE x > %(minv)i", {"minv": 150})
-    assert res[0][0] == 370
-
-    capture_message("hi")
-
-    (event,) = events
-
-    actual_query_breadcrumbs = [
-        crumb
-        for crumb in event["breadcrumbs"]["values"]
-        if crumb["category"] == "query"
-    ]
-
-    assert len(actual_query_breadcrumbs) == 5
-
-    for crumb in actual_query_breadcrumbs:
-        assert "db.params" not in crumb["data"]
-
-
-def test_clickhouse_dbapi_breadcrumbs_span_streaming(
-    sentry_init, capture_events
-) -> None:
-    sentry_init(
-        integrations=[ClickhouseDriverIntegration()],
-        trace_lifecycle="stream",
-    )
-    events = capture_events()
-
-    conn = connect("clickhouse://localhost")
-    cursor = conn.cursor()
-    cursor.execute("DROP TABLE IF EXISTS test")
-    cursor.execute("CREATE TABLE test (x Int32) ENGINE = Memory")
-    cursor.executemany("INSERT INTO test (x) VALUES", [{"x": 100}])
-    cursor.executemany("INSERT INTO test (x) VALUES", [[170], [200]])
-    cursor.execute("SELECT sum(x) FROM test WHERE x > %(minv)i", {"minv": 150})
-    res = cursor.fetchall()
-
-    assert res[0][0] == 370
-
-    capture_message("hi")
-
-    (event,) = events
-
-    expected_base = {
-        "db.system": "clickhouse",
-        "db.driver.name": "clickhouse-driver",
-        "db.name": "",
-        "db.user": "default",
-        "server.address": "localhost",
-        "server.port": 9000,
-    }
-
-    expected_breadcrumbs = [
-        {
-            "category": "query",
-            "data": {**expected_base},
-            "message": "DROP TABLE IF EXISTS test",
-            "type": "default",
-        },
-        {
-            "category": "query",
-            "data": {**expected_base},
-            "message": "CREATE TABLE test (x Int32) ENGINE = Memory",
-            "type": "default",
-        },
-        {
-            "category": "query",
-            "data": {**expected_base},
-            "message": "INSERT INTO test (x) VALUES",
-            "type": "default",
-        },
-        {
-            "category": "query",
-            "data": {**expected_base},
-            "message": "INSERT INTO test (x) VALUES",
-            "type": "default",
-        },
-        {
-            "category": "query",
-            "data": {**expected_base},
-            "message": "SELECT sum(x) FROM test WHERE x > 150",
-            "type": "default",
-        },
-    ]
-
-    for crumb in expected_breadcrumbs:
-        crumb["data"] = ApproxDict(crumb["data"])
-
-    for crumb in event["breadcrumbs"]["values"]:
-        crumb.pop("timestamp", None)
-
-    assert event["breadcrumbs"]["values"] == expected_breadcrumbs
-
-    # Span-first breadcrumbs never carry db.params
-    for crumb in event["breadcrumbs"]["values"]:
-        assert "db.params" not in crumb["data"]
-
-
-@pytest.mark.parametrize("send_default_pii", [True, False])
-def test_clickhouse_dbapi_breadcrumbs_span_streaming_with_pii(
-    sentry_init, capture_events, send_default_pii
-) -> None:
-    sentry_init(
-        integrations=[ClickhouseDriverIntegration()],
-        send_default_pii=send_default_pii,
-        trace_lifecycle="stream",
-    )
-    events = capture_events()
-
-    conn = connect("clickhouse://localhost")
-    cursor = conn.cursor()
-    cursor.execute("DROP TABLE IF EXISTS test")
-    cursor.execute("CREATE TABLE test (x Int32) ENGINE = Memory")
-    cursor.executemany("INSERT INTO test (x) VALUES", [{"x": 100}])
-    cursor.executemany("INSERT INTO test (x) VALUES", [[170], [200]])
-    cursor.execute("SELECT sum(x) FROM test WHERE x > %(minv)i", {"minv": 150})
-    res = cursor.fetchall()
-
-    assert res[0][0] == 370
-
-    capture_message("hi")
-
-    (event,) = events
-
-    expected_base = {
-        "db.system": "clickhouse",
-        "db.driver.name": "clickhouse-driver",
-        "db.name": "",
-        "db.user": "default",
-        "server.address": "localhost",
-        "server.port": 9000,
-    }
-
-    actual_query_breadcrumbs = [
-        crumb
-        for crumb in event["breadcrumbs"]["values"]
-        if crumb["category"] == "query"
-    ]
-
-    assert len(actual_query_breadcrumbs) == 5
-
-    for crumb in actual_query_breadcrumbs:
-        crumb.pop("timestamp", None)
-        assert crumb["data"] == ApproxDict(expected_base)
-
-    # Span-first breadcrumbs never carry db.params regardless of PII setting
-    for crumb in actual_query_breadcrumbs:
-        assert "db.params" not in crumb["data"]


### PR DESCRIPTION
### Description
<!-- What changed and why? -->

This is analogous to adding breadcrumbs to Redis and HTTP client integrations, so that breadcrumbs are not lost when users enable the streaming trace lifecycle.

Set the (non-deprected) attributes used by streamed spans as breadcrumbs when the streaming trace lifecycle is enabled.

Adds tests with the `_span_streaming` suffix based on existing tests.

#### Issues

Closes https://github.com/getsentry/sentry-python/issues/7317

#### Reminders
- Please add tests to validate your changes, and lint your code using `uv run ruff`.
- Add GH Issue ID _&_ Linear ID (if applicable)
- PR title should use [conventional commit](https://develop.sentry.dev/engineering-practices/commit-messages/#type) style (`feat:`, `fix:`, `ref:`, `meta:`)
- For external contributors: [CONTRIBUTING.md](https://github.com/getsentry/sentry-python/blob/master/CONTRIBUTING.md), [Sentry SDK development docs](https://develop.sentry.dev/sdk/), [Discord community](https://discord.gg/Ww9hbqr)
