### PR TITLE
feat(sqlalchemy): Add more db system names for span data

### DIFF
--- a/sentry_sdk/integrations/sqlalchemy.py
+++ b/sentry_sdk/integrations/sqlalchemy.py
@@ -140,6 +140,18 @@ def _get_db_system(name: str) -> "Optional[str]":
     if "oracle" in name:
         return "oracle"
 
+    if "snowflake" in name:
+        return "snowflake"
+
+    if "clickhouse" in name:
+        return "clickhouse"
+
+    if "mongodb" in name:
+        return "mongodb"
+
+    if "cockroachdb" in name:
+        return "cockroachdb"
+
     return None
 
 


### PR DESCRIPTION
Recognize snowflake, clickhouse, mongodb, and cockroachdb as db.system values when inferring the database system from the SQLAlchemy dialect name.

Refs PY-2531
Refs #6573