### PR TITLE
feat(aiohttp): Add `http.route` attribute

### DIFF
--- a/sentry_sdk/integrations/aiohttp.py
+++ b/sentry_sdk/integrations/aiohttp.py
@@ -233,6 +233,7 @@ class AioHttpIntegration(Integration):
                             },
                             parent_span=None,
                         )
+                        scope.get_current_scope()._server_segment_span = span_ctx
                     else:
                         transaction = continue_trace(
                             headers,
@@ -323,14 +324,19 @@ class AioHttpIntegration(Integration):
             if integration is None:
                 return rv
 
+            route_info = rv.get_info()
+            pattern = route_info.get("path") or route_info.get("formatter")
+
+            server_span = sentry_sdk.get_current_scope()._server_segment_span
+            if server_span is not None:
+                server_span.set_attribute(SPANDATA.HTTP_ROUTE, pattern)
+
             name = None
 
             try:
                 if integration.transaction_style == "handler_name":
                     name = transaction_from_function(rv.handler)
                 elif integration.transaction_style == "method_and_path_pattern":
-                    route_info = rv.get_info()
-                    pattern = route_info.get("path") or route_info.get("formatter")
                     name = "{} {}".format(request.method, pattern)
             except Exception:
                 pass

--- a/sentry_sdk/integrations/aiohttp.py
+++ b/sentry_sdk/integrations/aiohttp.py
@@ -328,7 +328,7 @@ class AioHttpIntegration(Integration):
             pattern = route_info.get("path") or route_info.get("formatter")
 
             server_span = sentry_sdk.get_current_scope()._server_segment_span
-            if server_span is not None:
+            if server_span is not None and pattern is not None:
                 server_span.set_attribute(SPANDATA.HTTP_ROUTE, pattern)
 
             name = None

--- a/tests/integrations/aiohttp/test_aiohttp.py
+++ b/tests/integrations/aiohttp/test_aiohttp.py
@@ -1883,6 +1883,42 @@ async def test_transaction_style_span_streaming(
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "url,expected_route",
+    [
+        ("/message", "/{var}"),
+    ],
+)
+async def test_http_route(
+    sentry_init,
+    aiohttp_client,
+    capture_items,
+    url,
+    expected_route,
+):
+    sentry_init(
+        integrations=[AioHttpIntegration()],
+        traces_sample_rate=1.0,
+        trace_lifecycle="stream",
+    )
+
+    async def hello(request):
+        return web.Response(text="hello")
+
+    app = web.Application()
+    app.router.add_get(r"/{var}", hello)
+
+    items = capture_items("span")
+
+    client = await aiohttp_client(app)
+    await client.get(url)
+
+    sentry_sdk.flush()
+    (segment,) = (item.payload for item in items if item.payload.get("is_segment"))
+    assert segment["attributes"]["http.route"] == expected_route
+
+
+@pytest.mark.asyncio
 async def test_server_error_span_streaming(sentry_init, aiohttp_client, capture_items):
     sentry_init(
         integrations=[AioHttpIntegration()],

--- a/tests/integrations/aiohttp/test_aiohttp.py
+++ b/tests/integrations/aiohttp/test_aiohttp.py
@@ -1915,7 +1915,7 @@ async def test_http_route(
 
     sentry_sdk.flush()
     (segment,) = (item.payload for item in items if item.payload.get("is_segment"))
-    assert segment["attributes"]["http.route"] == expected_route
+    assert segment["attributes"][SPANDATA.HTTP_ROUTE] == expected_route
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
### Description
<!-- What changed and why? -->

Set the `http.route` attribute on the server span in patches for aiohttp endpoints.

#### Issues
<!--
* resolves: #1234
* resolves: LIN-1234
-->

#### Reminders
- Please add tests to validate your changes, and lint your code using `uv run ruff`.
- Add GH Issue ID _&_ Linear ID (if applicable)
- PR title should use [conventional commit](https://develop.sentry.dev/engineering-practices/commit-messages/#type) style (`feat:`, `fix:`, `ref:`, `meta:`)
- For external contributors: [CONTRIBUTING.md](https://github.com/getsentry/sentry-python/blob/master/CONTRIBUTING.md), [Sentry SDK development docs](https://develop.sentry.dev/sdk/), [Discord community](https://discord.gg/Ww9hbqr)
