### PR TITLE
feat(bottle): Add `http.route` attribute

### DIFF
--- a/sentry_sdk/integrations/bottle.py
+++ b/sentry_sdk/integrations/bottle.py
@@ -107,9 +107,14 @@ class BottleIntegration(Integration):
 
             server_span = sentry_sdk.get_current_scope()._server_segment_span
             if server_span is not None:
-                server_span.set_attribute(
-                    SPANDATA.HTTP_ROUTE, bottle_request.route.rule
-                )
+                route_path = None
+                try:
+                    route_path = bottle_request.route.rule
+                except RuntimeError:
+                    pass
+
+                if route_path is not None:
+                    server_span.set_attribute(SPANDATA.HTTP_ROUTE, route_path)
 
             if has_span_streaming_enabled(sentry_sdk.get_client().options):
                 _set_segment_name_and_source(

--- a/sentry_sdk/integrations/bottle.py
+++ b/sentry_sdk/integrations/bottle.py
@@ -2,6 +2,7 @@ import functools
 from typing import TYPE_CHECKING
 
 import sentry_sdk
+from sentry_sdk.consts import SPANDATA
 from sentry_sdk.integrations import (
     _DEFAULT_FAILED_REQUEST_STATUS_CODES,
     DidNotEnable,
@@ -103,6 +104,12 @@ class BottleIntegration(Integration):
                 _make_request_event_processor(self, bottle_request, integration)
             )
             res = old_handle(self, environ)
+
+            server_span = sentry_sdk.get_current_scope()._server_segment_span
+            if server_span is not None:
+                server_span.set_attribute(
+                    SPANDATA.HTTP_ROUTE, bottle_request.route.rule
+                )
 
             if has_span_streaming_enabled(sentry_sdk.get_client().options):
                 _set_segment_name_and_source(

--- a/tests/integrations/bottle/test_bottle.py
+++ b/tests/integrations/bottle/test_bottle.py
@@ -10,6 +10,7 @@ from werkzeug.wrappers import Response
 
 import sentry_sdk
 from sentry_sdk import capture_message
+from sentry_sdk.consts import SPANDATA
 from sentry_sdk.integrations.bottle import BottleIntegration
 from sentry_sdk.integrations.logging import LoggingIntegration
 from sentry_sdk.serializer import MAX_DATABAG_BREADTH
@@ -660,6 +661,32 @@ def test_span_streaming_transaction_style(
 
     assert segment["name"].endswith(expected_name)
     assert segment["attributes"]["sentry.segment.name.source"] == expected_source
+
+
+def test_http_route(
+    sentry_init,
+    capture_items,
+):
+    sentry_init(
+        integrations=[BottleIntegration()],
+        traces_sample_rate=1.0,
+        trace_lifecycle="stream",
+    )
+    items = capture_items("span")
+
+    app = Bottle()
+
+    @app.route("/message/<message_id>")
+    def hi_with_id(message_id):
+        return "ok"
+
+    client = Client(app)
+    client.get("/message/123456")
+
+    sentry_sdk.flush()
+
+    (segment,) = (item.payload for item in items if item.payload.get("is_segment"))
+    assert segment["attributes"][SPANDATA.HTTP_ROUTE] == "/message/<message_id>"
 
 
 def test_span_streaming_with_error(sentry_init, capture_items):


### PR DESCRIPTION
### Description
<!-- What changed and why? -->

Set the `http.route` attribute on the WSGI server span in patches for Bottle endpoints.

#### Issues
<!--
* resolves: #1234
* resolves: LIN-1234
-->

#### Reminders
- Please add tests to validate your changes, and lint your code using `uv run ruff`.
- Add GH Issue ID _&_ Linear ID (if applicable)
- PR title should use [conventional commit](https://develop.sentry.dev/engineering-practices/commit-messages/#type) style (`feat:`, `fix:`, `ref:`, `meta:`)
- For external contributors: [CONTRIBUTING.md](https://github.com/getsentry/sentry-python/blob/master/CONTRIBUTING.md), [Sentry SDK development docs](https://develop.sentry.dev/sdk/), [Discord community](https://discord.gg/Ww9hbqr)
