### PR TITLE
feat(flask): Add `http.route` attribute

### DIFF
--- a/sentry_sdk/integrations/flask.py
+++ b/sentry_sdk/integrations/flask.py
@@ -1,6 +1,7 @@
 from typing import TYPE_CHECKING
 
 import sentry_sdk
+from sentry_sdk.consts import SPANDATA
 from sentry_sdk.integrations import DidNotEnable, Integration, _check_minimum_version
 from sentry_sdk.integrations._wsgi_common import (
     DEFAULT_HTTP_METHODS_TO_CAPTURE,
@@ -149,6 +150,10 @@ def _request_started(app: "Flask", **kwargs: "Any") -> None:
         return
 
     request = flask_request._get_current_object()
+
+    server_span = sentry_sdk.get_current_scope()._server_segment_span
+    if server_span is not None:
+        server_span.set_attribute(SPANDATA.HTTP_ROUTE, request.url_rule.rule)
 
     # Set the transaction name and source here,
     # but rely on WSGI middleware to actually start the transaction

--- a/sentry_sdk/integrations/flask.py
+++ b/sentry_sdk/integrations/flask.py
@@ -19,7 +19,7 @@ from sentry_sdk.utils import (
 )
 
 if TYPE_CHECKING:
-    from typing import Any, Callable, Dict, Union
+    from typing import Any, Callable, Dict, Optional, Union
 
     from werkzeug.datastructures import FileStorage, ImmutableMultiDict
 
@@ -151,9 +151,15 @@ def _request_started(app: "Flask", **kwargs: "Any") -> None:
 
     request = flask_request._get_current_object()
 
+    route_path: "Optional[str]" = None
+    try:
+        route_path = request.url_rule.rule
+    except Exception:
+        pass
+
     server_span = sentry_sdk.get_current_scope()._server_segment_span
     if server_span is not None:
-        server_span.set_attribute(SPANDATA.HTTP_ROUTE, request.url_rule.rule)
+        server_span.set_attribute(SPANDATA.HTTP_ROUTE, route_path)
 
     # Set the transaction name and source here,
     # but rely on WSGI middleware to actually start the transaction

--- a/sentry_sdk/integrations/flask.py
+++ b/sentry_sdk/integrations/flask.py
@@ -158,7 +158,7 @@ def _request_started(app: "Flask", **kwargs: "Any") -> None:
         pass
 
     server_span = sentry_sdk.get_current_scope()._server_segment_span
-    if server_span is not None:
+    if server_span is not None and route_path is not None:
         server_span.set_attribute(SPANDATA.HTTP_ROUTE, route_path)
 
     # Set the transaction name and source here,

--- a/tests/integrations/flask/test_flask.py
+++ b/tests/integrations/flask/test_flask.py
@@ -159,7 +159,7 @@ def test_http_route(
     sentry_sdk.flush()
 
     (segment,) = (item.payload for item in items if item.payload.get("is_segment"))
-    assert segment["attributes"]["http.route"] == "/message/<int:message_id>"
+    assert segment["attributes"][SPANDATA.HTTP_ROUTE] == "/message/<int:message_id>"
 
 
 @pytest.mark.parametrize("debug", (True, False))

--- a/tests/integrations/flask/test_flask.py
+++ b/tests/integrations/flask/test_flask.py
@@ -141,6 +141,27 @@ def test_transaction_or_segment_style(
         assert event["transaction_info"] == {"source": expected_source}
 
 
+def test_http_route(
+    sentry_init,
+    app,
+    capture_items,
+):
+    sentry_init(
+        integrations=[flask_sentry.FlaskIntegration()],
+        traces_sample_rate=1.0,
+        trace_lifecycle="stream",
+    )
+    items = capture_items("span")
+
+    client = app.test_client()
+    client.get("/message/123456")
+
+    sentry_sdk.flush()
+
+    (segment,) = (item.payload for item in items if item.payload.get("is_segment"))
+    assert segment["attributes"]["http.route"] == "/message/<int:message_id>"
+
+
 @pytest.mark.parametrize("debug", (True, False))
 @pytest.mark.parametrize("testing", (True, False))
 def test_errors(


### PR DESCRIPTION
### Description
<!-- What changed and why? -->

Set the `http.route` attribute on the server span in patches for Flask endpoints.

#### Issues
<!--
* resolves: #1234
* resolves: LIN-1234
-->

#### Reminders
- Please add tests to validate your changes, and lint your code using `uv run ruff`.
- Add GH Issue ID _&_ Linear ID (if applicable)
- PR title should use [conventional commit](https://develop.sentry.dev/engineering-practices/commit-messages/#type) style (`feat:`, `fix:`, `ref:`, `meta:`)
- For external contributors: [CONTRIBUTING.md](https://github.com/getsentry/sentry-python/blob/master/CONTRIBUTING.md), [Sentry SDK development docs](https://develop.sentry.dev/sdk/), [Discord community](https://discord.gg/Ww9hbqr)
