### PR TITLE
test: Run tracing tests in stream mode

### DIFF
--- a/tests/integrations/boto3/test_trace_propagation.py
+++ b/tests/integrations/boto3/test_trace_propagation.py
@@ -176,6 +176,7 @@ def test_presigned_urls_do_not_require_sentry_headers(sentry_init):
         traces_sample_rate=1.0,
         default_integrations=False,
         integrations=[Boto3Integration(), StdlibIntegration()],
+        trace_lifecycle="stream",
     )
     client = boto3.client(  # type: ignore[attr-defined]
         "s3",

--- a/tests/integrations/django/test_basic.py
+++ b/tests/integrations/django/test_basic.py
@@ -1514,6 +1514,7 @@ def test_render_spans_queryset_in_data(sentry_init, client, capture_events):
             )
         ],
         traces_sample_rate=1.0,
+        trace_lifecycle="stream",
     )
     events = capture_events()
 

--- a/tests/integrations/django/test_tasks.py
+++ b/tests/integrations/django/test_tasks.py
@@ -95,6 +95,7 @@ def test_task_enqueue_returns_result(sentry_init, immediate_backend):
     sentry_init(
         integrations=[DjangoIntegration()],
         traces_sample_rate=1.0,
+        trace_lifecycle="stream",
     )
 
     result = add_numbers.enqueue(3, 5)

--- a/tests/integrations/grpc/test_grpc.py
+++ b/tests/integrations/grpc/test_grpc.py
@@ -426,7 +426,11 @@ def test_grpc_client_and_servers_interceptors_integration(
 
 @pytest.mark.forked
 def test_stream_stream(sentry_init):
-    sentry_init(traces_sample_rate=1.0, integrations=[GRPCIntegration()])
+    sentry_init(
+        traces_sample_rate=1.0,
+        integrations=[GRPCIntegration()],
+        trace_lifecycle="stream",
+    )
     server, channel = _set_up()
 
     # Use the provided channel
@@ -444,7 +448,11 @@ def test_stream_unary(sentry_init):
     Test to verify stream-stream works.
     Tracing not supported for it yet.
     """
-    sentry_init(traces_sample_rate=1.0, integrations=[GRPCIntegration()])
+    sentry_init(
+        traces_sample_rate=1.0,
+        integrations=[GRPCIntegration()],
+        trace_lifecycle="stream",
+    )
     server, channel = _set_up()
 
     # Use the provided channel

--- a/tests/integrations/threading/test_threading.py
+++ b/tests/integrations/threading/test_threading.py
@@ -1,4 +1,5 @@
 import sys
+import time
 from concurrent import futures
 from textwrap import dedent
 from threading import Thread
@@ -162,6 +163,7 @@ def test_spans_from_multiple_threads(
         for t in threads:
             t.join()
 
+    time.sleep(0.1)
     sentry_sdk.flush()
 
     spans = [item.payload for item in items]

--- a/tests/integrations/threading/test_threading.py
+++ b/tests/integrations/threading/test_threading.py
@@ -129,72 +129,66 @@ def test_scope_data_not_leaked_in_threads(sentry_init, propagate_scope):
     ids=["propagate_scope=True", "propagate_scope=False"],
 )
 def test_spans_from_multiple_threads(
-    sentry_init, capture_items, render_span_tree, propagate_scope
+    sentry_init, capture_events, render_span_tree, propagate_scope
 ):
     sentry_init(
         traces_sample_rate=1.0,
         integrations=[ThreadingIntegration(propagate_scope=propagate_scope)],
         trace_lifecycle="stream",
     )
-    items = capture_items("span")
+    events = capture_events()
 
     def do_some_work(number):
-        with sentry_sdk.traces.start_span(
-            name=f"Thread: child-{number}",
-            attributes={"sentry.op": f"inner-run-{number}"},
+        with sentry_sdk.start_span(
+            op=f"inner-run-{number}", name=f"Thread: child-{number}"
         ):
             pass
 
-    with sentry_sdk.traces.start_span(
-        name="root span", attributes={"sentry.op": "outer-trx"}, parent_span=None
-    ):
+    threads = []
+
+    with sentry_sdk.start_transaction(op="outer-trx"):
         for number in range(5):
-            with sentry_sdk.traces.start_span(
-                name="Thread: main",
-                attributes={"sentry.op": f"outer-submit-{number}"},
+            with sentry_sdk.start_span(
+                op=f"outer-submit-{number}", name="Thread: main"
             ):
                 t = Thread(target=do_some_work, args=(number,))
                 t.start()
-                t.join()
+                threads.append(t)
 
-    sentry_sdk.flush()
+        for t in threads:
+            t.join()
 
-    spans = [item.payload for item in items]
+    (event,) = events
 
-    # Filter to the main trace only (child threads with propagate_scope=False
-    # create spans on a separate trace that confuse render_span_tree).
-    root = next(s for s in spans if s.get("is_segment") and s["name"] == "root span")
-    spans = [s for s in spans if s["trace_id"] == root["trace_id"]]
-
-    expects_child_spans = propagate_scope or getattr(
-        sys.flags, "thread_inherit_context", None
-    )
-    if expects_child_spans:
-        assert render_span_tree(spans) == dedent(
+    # Free-threaded builds set thread_inherit_context to True, otherwise thread_inherit_context is False
+    if propagate_scope or getattr(sys.flags, "thread_inherit_context", None):
+        assert event["type"] == "transaction"
+        assert render_span_tree(event["spans"], event["contexts"]["trace"]) == dedent(
             """\
-            - sentry.op="outer-trx": name="root span"
-              - sentry.op="outer-submit-0": name="Thread: main"
-                - sentry.op="inner-run-0": name="Thread: child-0"
-              - sentry.op="outer-submit-1": name="Thread: main"
-                - sentry.op="inner-run-1": name="Thread: child-1"
-              - sentry.op="outer-submit-2": name="Thread: main"
-                - sentry.op="inner-run-2": name="Thread: child-2"
-              - sentry.op="outer-submit-3": name="Thread: main"
-                - sentry.op="inner-run-3": name="Thread: child-3"
-              - sentry.op="outer-submit-4": name="Thread: main"
-                - sentry.op="inner-run-4": name="Thread: child-4"\
+            - op="outer-trx": description=null
+              - op="outer-submit-0": description="Thread: main"
+                - op="inner-run-0": description="Thread: child-0"
+              - op="outer-submit-1": description="Thread: main"
+                - op="inner-run-1": description="Thread: child-1"
+              - op="outer-submit-2": description="Thread: main"
+                - op="inner-run-2": description="Thread: child-2"
+              - op="outer-submit-3": description="Thread: main"
+                - op="inner-run-3": description="Thread: child-3"
+              - op="outer-submit-4": description="Thread: main"
+                - op="inner-run-4": description="Thread: child-4"\
 """
         )
 
     elif not propagate_scope:
-        assert render_span_tree(spans) == dedent(
+        assert event["type"] == "transaction"
+        assert render_span_tree(event["spans"], event["contexts"]["trace"]) == dedent(
             """\
-            - sentry.op="outer-trx": name="root span"
-              - sentry.op="outer-submit-0": name="Thread: main"
-              - sentry.op="outer-submit-1": name="Thread: main"
-              - sentry.op="outer-submit-2": name="Thread: main"
-              - sentry.op="outer-submit-3": name="Thread: main"
-              - sentry.op="outer-submit-4": name="Thread: main"\
+            - op="outer-trx": description=null
+              - op="outer-submit-0": description="Thread: main"
+              - op="outer-submit-1": description="Thread: main"
+              - op="outer-submit-2": description="Thread: main"
+              - op="outer-submit-3": description="Thread: main"
+              - op="outer-submit-4": description="Thread: main"\
 """
         )
 
@@ -205,68 +199,60 @@ def test_spans_from_multiple_threads(
     ids=["propagate_scope=True", "propagate_scope=False"],
 )
 def test_spans_from_threadpool(
-    sentry_init, capture_items, render_span_tree, propagate_scope
+    sentry_init, capture_events, render_span_tree, propagate_scope
 ):
     sentry_init(
         traces_sample_rate=1.0,
         integrations=[ThreadingIntegration(propagate_scope=propagate_scope)],
         trace_lifecycle="stream",
     )
-    items = capture_items("span")
+    events = capture_events()
 
     def do_some_work(number):
-        with sentry_sdk.traces.start_span(
-            name=f"Thread: child-{number}",
-            attributes={"sentry.op": f"inner-run-{number}"},
+        with sentry_sdk.start_span(
+            op=f"inner-run-{number}", name=f"Thread: child-{number}"
         ):
             pass
 
-    with sentry_sdk.traces.start_span(
-        name="root span", attributes={"sentry.op": "outer-trx"}, parent_span=None
-    ):
+    with sentry_sdk.start_transaction(op="outer-trx"):
         with futures.ThreadPoolExecutor(max_workers=1) as executor:
             for number in range(5):
-                with sentry_sdk.traces.start_span(
-                    name="Thread: main",
-                    attributes={"sentry.op": f"outer-submit-{number}"},
+                with sentry_sdk.start_span(
+                    op=f"outer-submit-{number}", name="Thread: main"
                 ):
                     future = executor.submit(do_some_work, number)
                     future.result()
 
-    sentry_sdk.flush()
+    (event,) = events
 
-    spans = [item.payload for item in items]
-    root = next(s for s in spans if s.get("is_segment") and s["name"] == "root span")
-    spans = [s for s in spans if s["trace_id"] == root["trace_id"]]
-
-    expects_child_spans = propagate_scope or getattr(
-        sys.flags, "thread_inherit_context", None
-    )
-    if expects_child_spans:
-        assert render_span_tree(spans) == dedent(
+    # Free-threaded builds set thread_inherit_context to True, otherwise thread_inherit_context is False
+    if propagate_scope or getattr(sys.flags, "thread_inherit_context", None):
+        assert event["type"] == "transaction"
+        assert render_span_tree(event["spans"], event["contexts"]["trace"]) == dedent(
             """\
-            - sentry.op="outer-trx": name="root span"
-              - sentry.op="outer-submit-0": name="Thread: main"
-                - sentry.op="inner-run-0": name="Thread: child-0"
-              - sentry.op="outer-submit-1": name="Thread: main"
-                - sentry.op="inner-run-1": name="Thread: child-1"
-              - sentry.op="outer-submit-2": name="Thread: main"
-                - sentry.op="inner-run-2": name="Thread: child-2"
-              - sentry.op="outer-submit-3": name="Thread: main"
-                - sentry.op="inner-run-3": name="Thread: child-3"
-              - sentry.op="outer-submit-4": name="Thread: main"
-                - sentry.op="inner-run-4": name="Thread: child-4"\
+            - op="outer-trx": description=null
+              - op="outer-submit-0": description="Thread: main"
+                - op="inner-run-0": description="Thread: child-0"
+              - op="outer-submit-1": description="Thread: main"
+                - op="inner-run-1": description="Thread: child-1"
+              - op="outer-submit-2": description="Thread: main"
+                - op="inner-run-2": description="Thread: child-2"
+              - op="outer-submit-3": description="Thread: main"
+                - op="inner-run-3": description="Thread: child-3"
+              - op="outer-submit-4": description="Thread: main"
+                - op="inner-run-4": description="Thread: child-4"\
 """
         )
 
     elif not propagate_scope:
-        assert render_span_tree(spans) == dedent(
+        assert event["type"] == "transaction"
+        assert render_span_tree(event["spans"], event["contexts"]["trace"]) == dedent(
             """\
-            - sentry.op="outer-trx": name="root span"
-              - sentry.op="outer-submit-0": name="Thread: main"
-              - sentry.op="outer-submit-1": name="Thread: main"
-              - sentry.op="outer-submit-2": name="Thread: main"
-              - sentry.op="outer-submit-3": name="Thread: main"
-              - sentry.op="outer-submit-4": name="Thread: main"\
+            - op="outer-trx": description=null
+              - op="outer-submit-0": description="Thread: main"
+              - op="outer-submit-1": description="Thread: main"
+              - op="outer-submit-2": description="Thread: main"
+              - op="outer-submit-3": description="Thread: main"
+              - op="outer-submit-4": description="Thread: main"\
 """
         )

--- a/tests/integrations/threading/test_threading.py
+++ b/tests/integrations/threading/test_threading.py
@@ -134,7 +134,6 @@ def test_spans_from_multiple_threads(
     sentry_init(
         traces_sample_rate=1.0,
         integrations=[ThreadingIntegration(propagate_scope=propagate_scope)],
-        trace_lifecycle="stream",
     )
     events = capture_events()
 
@@ -204,7 +203,6 @@ def test_spans_from_threadpool(
     sentry_init(
         traces_sample_rate=1.0,
         integrations=[ThreadingIntegration(propagate_scope=propagate_scope)],
-        trace_lifecycle="stream",
     )
     events = capture_events()
 

--- a/tests/integrations/threading/test_threading.py
+++ b/tests/integrations/threading/test_threading.py
@@ -1,5 +1,4 @@
 import sys
-import time
 from concurrent import futures
 from textwrap import dedent
 from threading import Thread
@@ -146,8 +145,6 @@ def test_spans_from_multiple_threads(
         ):
             pass
 
-    threads = []
-
     with sentry_sdk.traces.start_span(
         name="root span", attributes={"sentry.op": "outer-trx"}, parent_span=None
     ):
@@ -158,18 +155,21 @@ def test_spans_from_multiple_threads(
             ):
                 t = Thread(target=do_some_work, args=(number,))
                 t.start()
-                threads.append(t)
+                t.join()
 
-        for t in threads:
-            t.join()
-
-    time.sleep(0.1)
     sentry_sdk.flush()
 
     spans = [item.payload for item in items]
 
-    # Free-threaded builds set thread_inherit_context to True, otherwise thread_inherit_context is False
-    if propagate_scope or getattr(sys.flags, "thread_inherit_context", None):
+    # Filter to the main trace only (child threads with propagate_scope=False
+    # create spans on a separate trace that confuse render_span_tree).
+    root = next(s for s in spans if s.get("is_segment") and s["name"] == "root span")
+    spans = [s for s in spans if s["trace_id"] == root["trace_id"]]
+
+    expects_child_spans = propagate_scope or getattr(
+        sys.flags, "thread_inherit_context", None
+    )
+    if expects_child_spans:
         assert render_span_tree(spans) == dedent(
             """\
             - sentry.op="outer-trx": name="root span"
@@ -236,9 +236,13 @@ def test_spans_from_threadpool(
     sentry_sdk.flush()
 
     spans = [item.payload for item in items]
+    root = next(s for s in spans if s.get("is_segment") and s["name"] == "root span")
+    spans = [s for s in spans if s["trace_id"] == root["trace_id"]]
 
-    # Free-threaded builds set thread_inherit_context to True, otherwise thread_inherit_context is False
-    if propagate_scope or getattr(sys.flags, "thread_inherit_context", None):
+    expects_child_spans = propagate_scope or getattr(
+        sys.flags, "thread_inherit_context", None
+    )
+    if expects_child_spans:
         assert render_span_tree(spans) == dedent(
             """\
             - sentry.op="outer-trx": name="root span"

--- a/tests/integrations/threading/test_threading.py
+++ b/tests/integrations/threading/test_threading.py
@@ -134,6 +134,7 @@ def test_spans_from_multiple_threads(
     sentry_init(
         traces_sample_rate=1.0,
         integrations=[ThreadingIntegration(propagate_scope=propagate_scope)],
+        trace_lifecycle="stream",
     )
     events = capture_events()
 
@@ -203,6 +204,7 @@ def test_spans_from_threadpool(
     sentry_init(
         traces_sample_rate=1.0,
         integrations=[ThreadingIntegration(propagate_scope=propagate_scope)],
+        trace_lifecycle="stream",
     )
     events = capture_events()
 

--- a/tests/integrations/threading/test_threading.py
+++ b/tests/integrations/threading/test_threading.py
@@ -129,27 +129,31 @@ def test_scope_data_not_leaked_in_threads(sentry_init, propagate_scope):
     ids=["propagate_scope=True", "propagate_scope=False"],
 )
 def test_spans_from_multiple_threads(
-    sentry_init, capture_events, render_span_tree, propagate_scope
+    sentry_init, capture_items, render_span_tree, propagate_scope
 ):
     sentry_init(
         traces_sample_rate=1.0,
         integrations=[ThreadingIntegration(propagate_scope=propagate_scope)],
         trace_lifecycle="stream",
     )
-    events = capture_events()
+    items = capture_items("span")
 
     def do_some_work(number):
-        with sentry_sdk.start_span(
-            op=f"inner-run-{number}", name=f"Thread: child-{number}"
+        with sentry_sdk.traces.start_span(
+            name=f"Thread: child-{number}",
+            attributes={"sentry.op": f"inner-run-{number}"},
         ):
             pass
 
     threads = []
 
-    with sentry_sdk.start_transaction(op="outer-trx"):
+    with sentry_sdk.traces.start_span(
+        name="<unlabeled span>", attributes={"sentry.op": "outer-trx"}
+    ):
         for number in range(5):
-            with sentry_sdk.start_span(
-                op=f"outer-submit-{number}", name="Thread: main"
+            with sentry_sdk.traces.start_span(
+                name="Thread: main",
+                attributes={"sentry.op": f"outer-submit-{number}"},
             ):
                 t = Thread(target=do_some_work, args=(number,))
                 t.start()
@@ -158,37 +162,37 @@ def test_spans_from_multiple_threads(
         for t in threads:
             t.join()
 
-    (event,) = events
+    sentry_sdk.flush()
+
+    spans = [item.payload for item in items]
 
     # Free-threaded builds set thread_inherit_context to True, otherwise thread_inherit_context is False
     if propagate_scope or getattr(sys.flags, "thread_inherit_context", None):
-        assert event["type"] == "transaction"
-        assert render_span_tree(event["spans"], event["contexts"]["trace"]) == dedent(
+        assert render_span_tree(spans) == dedent(
             """\
-            - op="outer-trx": description=null
-              - op="outer-submit-0": description="Thread: main"
-                - op="inner-run-0": description="Thread: child-0"
-              - op="outer-submit-1": description="Thread: main"
-                - op="inner-run-1": description="Thread: child-1"
-              - op="outer-submit-2": description="Thread: main"
-                - op="inner-run-2": description="Thread: child-2"
-              - op="outer-submit-3": description="Thread: main"
-                - op="inner-run-3": description="Thread: child-3"
-              - op="outer-submit-4": description="Thread: main"
-                - op="inner-run-4": description="Thread: child-4"\
+            - sentry.op="outer-trx": name="<unlabeled span>"
+              - sentry.op="outer-submit-0": name="Thread: main"
+                - sentry.op="inner-run-0": name="Thread: child-0"
+              - sentry.op="outer-submit-1": name="Thread: main"
+                - sentry.op="inner-run-1": name="Thread: child-1"
+              - sentry.op="outer-submit-2": name="Thread: main"
+                - sentry.op="inner-run-2": name="Thread: child-2"
+              - sentry.op="outer-submit-3": name="Thread: main"
+                - sentry.op="inner-run-3": name="Thread: child-3"
+              - sentry.op="outer-submit-4": name="Thread: main"
+                - sentry.op="inner-run-4": name="Thread: child-4"\
 """
         )
 
     elif not propagate_scope:
-        assert event["type"] == "transaction"
-        assert render_span_tree(event["spans"], event["contexts"]["trace"]) == dedent(
+        assert render_span_tree(spans) == dedent(
             """\
-            - op="outer-trx": description=null
-              - op="outer-submit-0": description="Thread: main"
-              - op="outer-submit-1": description="Thread: main"
-              - op="outer-submit-2": description="Thread: main"
-              - op="outer-submit-3": description="Thread: main"
-              - op="outer-submit-4": description="Thread: main"\
+            - sentry.op="outer-trx": name="<unlabeled span>"
+              - sentry.op="outer-submit-0": name="Thread: main"
+              - sentry.op="outer-submit-1": name="Thread: main"
+              - sentry.op="outer-submit-2": name="Thread: main"
+              - sentry.op="outer-submit-3": name="Thread: main"
+              - sentry.op="outer-submit-4": name="Thread: main"\
 """
         )
 
@@ -199,60 +203,64 @@ def test_spans_from_multiple_threads(
     ids=["propagate_scope=True", "propagate_scope=False"],
 )
 def test_spans_from_threadpool(
-    sentry_init, capture_events, render_span_tree, propagate_scope
+    sentry_init, capture_items, render_span_tree, propagate_scope
 ):
     sentry_init(
         traces_sample_rate=1.0,
         integrations=[ThreadingIntegration(propagate_scope=propagate_scope)],
         trace_lifecycle="stream",
     )
-    events = capture_events()
+    items = capture_items("span")
 
     def do_some_work(number):
-        with sentry_sdk.start_span(
-            op=f"inner-run-{number}", name=f"Thread: child-{number}"
+        with sentry_sdk.traces.start_span(
+            name=f"Thread: child-{number}",
+            attributes={"sentry.op": f"inner-run-{number}"},
         ):
             pass
 
-    with sentry_sdk.start_transaction(op="outer-trx"):
+    with sentry_sdk.traces.start_span(
+        name="<unlabeled span>", attributes={"sentry.op": "outer-trx"}
+    ):
         with futures.ThreadPoolExecutor(max_workers=1) as executor:
             for number in range(5):
-                with sentry_sdk.start_span(
-                    op=f"outer-submit-{number}", name="Thread: main"
+                with sentry_sdk.traces.start_span(
+                    name="Thread: main",
+                    attributes={"sentry.op": f"outer-submit-{number}"},
                 ):
                     future = executor.submit(do_some_work, number)
                     future.result()
 
-    (event,) = events
+    sentry_sdk.flush()
+
+    spans = [item.payload for item in items]
 
     # Free-threaded builds set thread_inherit_context to True, otherwise thread_inherit_context is False
     if propagate_scope or getattr(sys.flags, "thread_inherit_context", None):
-        assert event["type"] == "transaction"
-        assert render_span_tree(event["spans"], event["contexts"]["trace"]) == dedent(
+        assert render_span_tree(spans) == dedent(
             """\
-            - op="outer-trx": description=null
-              - op="outer-submit-0": description="Thread: main"
-                - op="inner-run-0": description="Thread: child-0"
-              - op="outer-submit-1": description="Thread: main"
-                - op="inner-run-1": description="Thread: child-1"
-              - op="outer-submit-2": description="Thread: main"
-                - op="inner-run-2": description="Thread: child-2"
-              - op="outer-submit-3": description="Thread: main"
-                - op="inner-run-3": description="Thread: child-3"
-              - op="outer-submit-4": description="Thread: main"
-                - op="inner-run-4": description="Thread: child-4"\
+            - sentry.op="outer-trx": name="<unlabeled span>"
+              - sentry.op="outer-submit-0": name="Thread: main"
+                - sentry.op="inner-run-0": name="Thread: child-0"
+              - sentry.op="outer-submit-1": name="Thread: main"
+                - sentry.op="inner-run-1": name="Thread: child-1"
+              - sentry.op="outer-submit-2": name="Thread: main"
+                - sentry.op="inner-run-2": name="Thread: child-2"
+              - sentry.op="outer-submit-3": name="Thread: main"
+                - sentry.op="inner-run-3": name="Thread: child-3"
+              - sentry.op="outer-submit-4": name="Thread: main"
+                - sentry.op="inner-run-4": name="Thread: child-4"\
 """
         )
 
     elif not propagate_scope:
-        assert event["type"] == "transaction"
-        assert render_span_tree(event["spans"], event["contexts"]["trace"]) == dedent(
+        assert render_span_tree(spans) == dedent(
             """\
-            - op="outer-trx": description=null
-              - op="outer-submit-0": description="Thread: main"
-              - op="outer-submit-1": description="Thread: main"
-              - op="outer-submit-2": description="Thread: main"
-              - op="outer-submit-3": description="Thread: main"
-              - op="outer-submit-4": description="Thread: main"\
+            - sentry.op="outer-trx": name="<unlabeled span>"
+              - sentry.op="outer-submit-0": name="Thread: main"
+              - sentry.op="outer-submit-1": name="Thread: main"
+              - sentry.op="outer-submit-2": name="Thread: main"
+              - sentry.op="outer-submit-3": name="Thread: main"
+              - sentry.op="outer-submit-4": name="Thread: main"\
 """
         )

--- a/tests/integrations/threading/test_threading.py
+++ b/tests/integrations/threading/test_threading.py
@@ -148,7 +148,7 @@ def test_spans_from_multiple_threads(
     threads = []
 
     with sentry_sdk.traces.start_span(
-        name="<unlabeled span>", attributes={"sentry.op": "outer-trx"}
+        name="root span", attributes={"sentry.op": "outer-trx"}, parent_span=None
     ):
         for number in range(5):
             with sentry_sdk.traces.start_span(
@@ -170,7 +170,7 @@ def test_spans_from_multiple_threads(
     if propagate_scope or getattr(sys.flags, "thread_inherit_context", None):
         assert render_span_tree(spans) == dedent(
             """\
-            - sentry.op="outer-trx": name="<unlabeled span>"
+            - sentry.op="outer-trx": name="root span"
               - sentry.op="outer-submit-0": name="Thread: main"
                 - sentry.op="inner-run-0": name="Thread: child-0"
               - sentry.op="outer-submit-1": name="Thread: main"
@@ -187,7 +187,7 @@ def test_spans_from_multiple_threads(
     elif not propagate_scope:
         assert render_span_tree(spans) == dedent(
             """\
-            - sentry.op="outer-trx": name="<unlabeled span>"
+            - sentry.op="outer-trx": name="root span"
               - sentry.op="outer-submit-0": name="Thread: main"
               - sentry.op="outer-submit-1": name="Thread: main"
               - sentry.op="outer-submit-2": name="Thread: main"
@@ -220,7 +220,7 @@ def test_spans_from_threadpool(
             pass
 
     with sentry_sdk.traces.start_span(
-        name="<unlabeled span>", attributes={"sentry.op": "outer-trx"}
+        name="root span", attributes={"sentry.op": "outer-trx"}, parent_span=None
     ):
         with futures.ThreadPoolExecutor(max_workers=1) as executor:
             for number in range(5):
@@ -239,7 +239,7 @@ def test_spans_from_threadpool(
     if propagate_scope or getattr(sys.flags, "thread_inherit_context", None):
         assert render_span_tree(spans) == dedent(
             """\
-            - sentry.op="outer-trx": name="<unlabeled span>"
+            - sentry.op="outer-trx": name="root span"
               - sentry.op="outer-submit-0": name="Thread: main"
                 - sentry.op="inner-run-0": name="Thread: child-0"
               - sentry.op="outer-submit-1": name="Thread: main"
@@ -256,7 +256,7 @@ def test_spans_from_threadpool(
     elif not propagate_scope:
         assert render_span_tree(spans) == dedent(
             """\
-            - sentry.op="outer-trx": name="<unlabeled span>"
+            - sentry.op="outer-trx": name="root span"
               - sentry.op="outer-submit-0": name="Thread: main"
               - sentry.op="outer-submit-1": name="Thread: main"
               - sentry.op="outer-submit-2": name="Thread: main"


### PR DESCRIPTION
Adapt tests of integrations we've already fully ported to span streaming so that they actually use span streaming everytime they define a `traces_sampler` or `traces_sample_rate`. Otherwise, they're implicitly using static tracing, and they'll break the moment we remove it.

Note: there are at least two tests in `test_threading.py` that also need this change but I'll submit them separately because those will need additional changes.