### PR TITLE
feat(pyramid): Add `http.route` attribute

### DIFF
--- a/sentry_sdk/integrations/pyramid.py
+++ b/sentry_sdk/integrations/pyramid.py
@@ -82,8 +82,14 @@ class PyramidIntegration(Integration):
             if integration is None:
                 return old_call_view(registry, request, *args, **kwargs)
 
+            route_path = None
+            try:
+                route_path = request.matched_route.pattern
+            except Exception:
+                pass
+
             server_span = sentry_sdk.get_current_scope()._server_segment_span
-            if server_span is not None:
+            if server_span is not None and route_path is not None:
                 server_span.set_attribute(
                     SPANDATA.HTTP_ROUTE, request.matched_route.pattern
                 )

--- a/sentry_sdk/integrations/pyramid.py
+++ b/sentry_sdk/integrations/pyramid.py
@@ -4,6 +4,7 @@ import sys
 import weakref
 
 import sentry_sdk
+from sentry_sdk.consts import SPANDATA
 from sentry_sdk.integrations import DidNotEnable, Integration
 from sentry_sdk.integrations._wsgi_common import RequestExtractor
 from sentry_sdk.integrations.wsgi import SentryWsgiMiddleware
@@ -80,6 +81,12 @@ class PyramidIntegration(Integration):
             integration = client.get_integration(PyramidIntegration)
             if integration is None:
                 return old_call_view(registry, request, *args, **kwargs)
+
+            server_span = sentry_sdk.get_current_scope()._server_segment_span
+            if server_span is not None:
+                server_span.set_attribute(
+                    SPANDATA.HTTP_ROUTE, request.matched_route.pattern
+                )
 
             _set_transaction_name_and_source(
                 sentry_sdk.get_current_scope(), integration.transaction_style, request

--- a/tests/integrations/pyramid/test_pyramid.py
+++ b/tests/integrations/pyramid/test_pyramid.py
@@ -11,6 +11,7 @@ from werkzeug.test import Client
 
 import sentry_sdk
 from sentry_sdk import add_breadcrumb, capture_message
+from sentry_sdk.consts import SPANDATA
 from sentry_sdk.integrations.pyramid import PyramidIntegration
 from sentry_sdk.serializer import MAX_DATABAG_BREADTH
 from sentry_sdk.traces import SpanStatus
@@ -175,6 +176,28 @@ def test_transaction_style(
         (_, transaction_event) = events
         assert transaction_event["transaction"] == expected_transaction
         assert transaction_event["transaction_info"] == {"source": expected_source}
+
+
+def test_http_route(
+    sentry_init,
+    get_client,
+    capture_items,
+):
+    sentry_init(
+        integrations=[PyramidIntegration()],
+        traces_sample_rate=1.0,
+        trace_lifecycle="stream",
+    )
+
+    items = capture_items("span")
+
+    client = get_client()
+    client.get("/message/123456")
+
+    sentry_sdk.flush()
+
+    (segment,) = [item.payload for item in items if item.payload.get("is_segment")]
+    assert segment["attributes"][SPANDATA.HTTP_ROUTE] == "/message/{message_id}"
 
 
 @pytest.mark.parametrize("max_value_length", [1024, None])


### PR DESCRIPTION
### Description
<!-- What changed and why? -->

Set the `http.route` attribute on the server span in patches for Pyramid endpoints.

#### Issues
<!--
* resolves: #1234
* resolves: LIN-1234
-->

#### Reminders
- Please add tests to validate your changes, and lint your code using `uv run ruff`.
- Add GH Issue ID _&_ Linear ID (if applicable)
- PR title should use [conventional commit](https://develop.sentry.dev/engineering-practices/commit-messages/#type) style (`feat:`, `fix:`, `ref:`, `meta:`)
- For external contributors: [CONTRIBUTING.md](https://github.com/getsentry/sentry-python/blob/master/CONTRIBUTING.md), [Sentry SDK development docs](https://develop.sentry.dev/sdk/), [Discord community](https://discord.gg/Ww9hbqr)
