### PR TITLE
feat(quart): Add `http.route` attribute

### DIFF
--- a/sentry_sdk/integrations/quart.py
+++ b/sentry_sdk/integrations/quart.py
@@ -5,6 +5,7 @@ from functools import wraps
 from typing import TYPE_CHECKING
 
 import sentry_sdk
+from sentry_sdk.consts import SPANDATA
 from sentry_sdk.data_collection import _apply_data_collection_filtering_to_query_string
 from sentry_sdk.integrations import DidNotEnable, Integration
 from sentry_sdk.integrations._wsgi_common import _filter_headers
@@ -180,6 +181,10 @@ async def _request_websocket_started(app: "Quart", **kwargs: "Any") -> None:
         request_websocket = request._get_current_object()
     if has_websocket_context():
         request_websocket = websocket._get_current_object()
+
+    server_span = sentry_sdk.get_current_scope()._server_segment_span
+    if server_span is not None:
+        server_span.set_attribute(SPANDATA.HTTP_ROUTE, request.url_rule.rule)
 
     # Set the transaction name here, but rely on ASGI middleware
     # to actually start the transaction

--- a/sentry_sdk/integrations/quart.py
+++ b/sentry_sdk/integrations/quart.py
@@ -182,9 +182,15 @@ async def _request_websocket_started(app: "Quart", **kwargs: "Any") -> None:
     if has_websocket_context():
         request_websocket = websocket._get_current_object()
 
+    route_path = None
+    try:
+        route_path = request.url_rule.rule
+    except Exception:
+        pass
+
     server_span = sentry_sdk.get_current_scope()._server_segment_span
-    if server_span is not None:
-        server_span.set_attribute(SPANDATA.HTTP_ROUTE, request.url_rule.rule)
+    if server_span is not None and route_path is not None:
+        server_span.set_attribute(SPANDATA.HTTP_ROUTE, route_path)
 
     # Set the transaction name here, but rely on ASGI middleware
     # to actually start the transaction

--- a/tests/integrations/quart/test_quart.py
+++ b/tests/integrations/quart/test_quart.py
@@ -14,6 +14,7 @@ from sentry_sdk import (
     set_tag,
 )
 from sentry_sdk._types import SENSITIVE_DATA_SUBSTITUTE
+from sentry_sdk.consts import SPANDATA
 from sentry_sdk.integrations.logging import LoggingIntegration
 from sentry_sdk.utils import parse_version
 
@@ -174,6 +175,29 @@ async def test_transaction_style(
 
     (event,) = events
     assert event["transaction"] == expected_transaction
+
+
+@pytest.mark.asyncio
+async def test_http_route(
+    sentry_init,
+    capture_items,
+):
+    sentry_init(
+        integrations=[quart_sentry.QuartIntegration()],
+        traces_sample_rate=1.0,
+        trace_lifecycle="stream",
+    )
+
+    app = quart_app_factory()
+    items = capture_items("span")
+
+    client = app.test_client()
+    await client.get("/message/123456")
+
+    sentry_sdk.flush()
+
+    (segment,) = [item.payload for item in items if item.payload.get("is_segment")]
+    assert segment["attributes"][SPANDATA.HTTP_ROUTE] == "/message/<message_id>"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
### Description
<!-- What changed and why? -->

Set the `http.route` attribute on the ASGI server span in patches for Quart endpoints.

#### Issues
<!--
* resolves: #1234
* resolves: LIN-1234
-->

#### Reminders
- Please add tests to validate your changes, and lint your code using `uv run ruff`.
- Add GH Issue ID _&_ Linear ID (if applicable)
- PR title should use [conventional commit](https://develop.sentry.dev/engineering-practices/commit-messages/#type) style (`feat:`, `fix:`, `ref:`, `meta:`)
- For external contributors: [CONTRIBUTING.md](https://github.com/getsentry/sentry-python/blob/master/CONTRIBUTING.md), [Sentry SDK development docs](https://develop.sentry.dev/sdk/), [Discord community](https://discord.gg/Ww9hbqr)
