### PR TITLE
test: Adapt threading tests to span streaming

### DIFF
--- a/tests/integrations/threading/test_threading.py
+++ b/tests/integrations/threading/test_threading.py
@@ -129,26 +129,30 @@ def test_scope_data_not_leaked_in_threads(sentry_init, propagate_scope):
     ids=["propagate_scope=True", "propagate_scope=False"],
 )
 def test_spans_from_multiple_threads(
-    sentry_init, capture_events, render_span_tree, propagate_scope
+    sentry_init, capture_items, render_span_tree, propagate_scope
 ):
     sentry_init(
         traces_sample_rate=1.0,
+        trace_lifecycle="stream",
         integrations=[ThreadingIntegration(propagate_scope=propagate_scope)],
     )
-    events = capture_events()
+    items = capture_items("span")
 
     def do_some_work(number):
-        with sentry_sdk.start_span(
-            op=f"inner-run-{number}", name=f"Thread: child-{number}"
+        with sentry_sdk.traces.start_span(
+            attributes={"sentry.op": f"inner-run-{number}"},
+            name=f"Thread: child-{number}",
         ):
             pass
 
     threads = []
 
-    with sentry_sdk.start_transaction(op="outer-trx"):
+    with sentry_sdk.traces.start_span(
+        name="root", parent_span=None, attributes={"sentry.op": "outer-trx"}
+    ):
         for number in range(5):
-            with sentry_sdk.start_span(
-                op=f"outer-submit-{number}", name="Thread: main"
+            with sentry_sdk.traces.start_span(
+                attributes={"sentry.op": f"outer-submit-{number}"}, name="Thread: main"
             ):
                 t = Thread(target=do_some_work, args=(number,))
                 t.start()
@@ -157,37 +161,37 @@ def test_spans_from_multiple_threads(
         for t in threads:
             t.join()
 
-    (event,) = events
+    sentry_sdk.flush()
+
+    spans = [item.payload for item in items]
 
     # Free-threaded builds set thread_inherit_context to True, otherwise thread_inherit_context is False
     if propagate_scope or getattr(sys.flags, "thread_inherit_context", None):
-        assert event["type"] == "transaction"
-        assert render_span_tree(event["spans"], event["contexts"]["trace"]) == dedent(
+        assert render_span_tree(spans) == dedent(
             """\
-            - op="outer-trx": description=null
-              - op="outer-submit-0": description="Thread: main"
-                - op="inner-run-0": description="Thread: child-0"
-              - op="outer-submit-1": description="Thread: main"
-                - op="inner-run-1": description="Thread: child-1"
-              - op="outer-submit-2": description="Thread: main"
-                - op="inner-run-2": description="Thread: child-2"
-              - op="outer-submit-3": description="Thread: main"
-                - op="inner-run-3": description="Thread: child-3"
-              - op="outer-submit-4": description="Thread: main"
-                - op="inner-run-4": description="Thread: child-4"\
+            - sentry.op="outer-trx": name="root"
+              - sentry.op="outer-submit-0": name="Thread: main"
+                - sentry.op="inner-run-0": name="Thread: child-0"
+              - sentry.op="outer-submit-1": name="Thread: main"
+                - sentry.op="inner-run-1": name="Thread: child-1"
+              - sentry.op="outer-submit-2": name="Thread: main"
+                - sentry.op="inner-run-2": name="Thread: child-2"
+              - sentry.op="outer-submit-3": name="Thread: main"
+                - sentry.op="inner-run-3": name="Thread: child-3"
+              - sentry.op="outer-submit-4": name="Thread: main"
+                - sentry.op="inner-run-4": name="Thread: child-4"\
 """
         )
 
     elif not propagate_scope:
-        assert event["type"] == "transaction"
-        assert render_span_tree(event["spans"], event["contexts"]["trace"]) == dedent(
+        assert render_span_tree(spans) == dedent(
             """\
-            - op="outer-trx": description=null
-              - op="outer-submit-0": description="Thread: main"
-              - op="outer-submit-1": description="Thread: main"
-              - op="outer-submit-2": description="Thread: main"
-              - op="outer-submit-3": description="Thread: main"
-              - op="outer-submit-4": description="Thread: main"\
+            - sentry.op="outer-trx": name="root"
+              - sentry.op="outer-submit-0": name="Thread: main"
+              - sentry.op="outer-submit-1": name="Thread: main"
+              - sentry.op="outer-submit-2": name="Thread: main"
+              - sentry.op="outer-submit-3": name="Thread: main"
+              - sentry.op="outer-submit-4": name="Thread: main"\
 """
         )
 

--- a/tests/integrations/threading/test_threading.py
+++ b/tests/integrations/threading/test_threading.py
@@ -139,24 +139,20 @@ def test_spans_from_multiple_threads(
     items = capture_items("span")
 
     def do_some_work(number):
-        with sentry_sdk.traces.start_span(
-            attributes={"sentry.op": f"inner-run-{number}"},
-            name=f"Thread: child-{number}",
-        ):
-            pass
+        with sentry_sdk.traces.start_span(name=f"inner-run-{number}") as span:
+            inner_run_spans[number] = span
 
     threads = []
+    outer_submit_spans = {}
+    inner_run_spans = {}
 
-    with sentry_sdk.traces.start_span(
-        name="root", parent_span=None, attributes={"sentry.op": "outer-trx"}
-    ):
+    with sentry_sdk.traces.start_span(name="outer-seg", parent_span=None) as outer:
         for number in range(5):
-            with sentry_sdk.traces.start_span(
-                attributes={"sentry.op": f"outer-submit-{number}"}, name="Thread: main"
-            ):
+            with sentry_sdk.traces.start_span(name=f"outer-submit-{number}") as span:
                 t = Thread(target=do_some_work, args=(number,))
                 t.start()
                 threads.append(t)
+                outer_submit_spans[number] = span
 
         for t in threads:
             t.join()
@@ -165,35 +161,29 @@ def test_spans_from_multiple_threads(
 
     spans = [item.payload for item in items]
 
+    for span in spans:
+        if span["name"] == "outer-seg":
+            assert span["is_segment"] is True
+            assert "parent_span_id" not in span
+
+        if span["name"].startswith("outer-submit-"):
+            assert span["is_segment"] is False
+            assert span["parent_span_id"] == outer.span_id
+
     # Free-threaded builds set thread_inherit_context to True, otherwise thread_inherit_context is False
     if propagate_scope or getattr(sys.flags, "thread_inherit_context", None):
-        assert render_span_tree(spans) == dedent(
-            """\
-            - sentry.op="outer-trx": name="root"
-              - sentry.op="outer-submit-0": name="Thread: main"
-                - sentry.op="inner-run-0": name="Thread: child-0"
-              - sentry.op="outer-submit-1": name="Thread: main"
-                - sentry.op="inner-run-1": name="Thread: child-1"
-              - sentry.op="outer-submit-2": name="Thread: main"
-                - sentry.op="inner-run-2": name="Thread: child-2"
-              - sentry.op="outer-submit-3": name="Thread: main"
-                - sentry.op="inner-run-3": name="Thread: child-3"
-              - sentry.op="outer-submit-4": name="Thread: main"
-                - sentry.op="inner-run-4": name="Thread: child-4"\
-"""
-        )
+        for span in spans:
+            if span["name"].startswith("inner-run-"):
+                num = int(span["name"][-1])
+                assert span["is_segment"] is False
+                assert span["parent_span_id"] == outer_submit_spans[num].span_id
 
     elif not propagate_scope:
-        assert render_span_tree(spans) == dedent(
-            """\
-            - sentry.op="outer-trx": name="root"
-              - sentry.op="outer-submit-0": name="Thread: main"
-              - sentry.op="outer-submit-1": name="Thread: main"
-              - sentry.op="outer-submit-2": name="Thread: main"
-              - sentry.op="outer-submit-3": name="Thread: main"
-              - sentry.op="outer-submit-4": name="Thread: main"\
-"""
-        )
+        for span in spans:
+            if span["name"].startswith("inner-run-"):
+                num = int(span["name"][-1])
+                assert span["is_segment"] is True
+                assert "parent_span_id" not in span
 
 
 @pytest.mark.parametrize(

--- a/tests/integrations/threading/test_threading.py
+++ b/tests/integrations/threading/test_threading.py
@@ -160,6 +160,7 @@ def test_spans_from_multiple_threads(
     sentry_sdk.flush()
 
     spans = [item.payload for item in items]
+    assert len(spans) == 11
 
     for span in spans:
         if span["name"] == "outer-seg":


### PR DESCRIPTION
The threading integration itself doesn't have any streaming branching, which is probably why these two threading tests that have to do with tracing got overlooked.

In streaming, the behavior in the `propagate_scope=False` case has changed -- all spans will be emitted. Previously, some of the spans wouldn't be emitted because they would be orphaned child spans.