### PR TITLE
ref(anthropic): Drop support for `stream_gen_ai_spans`

### DIFF
--- a/sentry_sdk/integrations/anthropic.py
+++ b/sentry_sdk/integrations/anthropic.py
@@ -21,7 +21,6 @@ from sentry_sdk.traces import StreamedSpan
 from sentry_sdk.tracing import Span
 from sentry_sdk.tracing_utils import (
     has_span_streaming_enabled,
-    should_truncate_gen_ai_input,
 )
 from sentry_sdk.utils import (
     capture_internal_exceptions,
@@ -558,7 +557,7 @@ def _set_common_input_data(
         scope = sentry_sdk.get_current_scope()
         messages_data = (
             truncate_and_annotate_messages(role_normalized_messages, span, scope)
-            if should_truncate_gen_ai_input(client.options)
+            if not has_span_streaming_enabled(client.options)
             else role_normalized_messages
         )
         if messages_data is not None:

--- a/tests/integrations/anthropic/test_anthropic.py
+++ b/tests/integrations/anthropic/test_anthropic.py
@@ -139,7 +139,6 @@ def data_collection_tool_use_message():
 
 
 @pytest.mark.parametrize("span_streaming", [True, False])
-@pytest.mark.parametrize("stream_gen_ai_spans", [True, False])
 @pytest.mark.parametrize(
     "send_default_pii, include_prompts",
     [
@@ -155,7 +154,6 @@ def test_nonstreaming_create_message(
     capture_items,
     send_default_pii,
     include_prompts,
-    stream_gen_ai_spans,
     span_streaming,
 ):
     sentry_init(
@@ -163,7 +161,6 @@ def test_nonstreaming_create_message(
         disabled_integrations=[StdlibIntegration],
         traces_sample_rate=1.0,
         send_default_pii=send_default_pii,
-        stream_gen_ai_spans=stream_gen_ai_spans,
         trace_lifecycle="stream" if span_streaming else "static",
     )
 
@@ -201,63 +198,6 @@ def test_nonstreaming_create_message(
 
         assert spans[1]["name"] == "anthropic"
         (span, _) = spans
-
-        assert span["attributes"]["sentry.op"] == OP.GEN_AI_CHAT
-        assert span["name"] == "chat model"
-        assert span["attributes"][SPANDATA.GEN_AI_SYSTEM] == "anthropic"
-        assert span["attributes"][SPANDATA.GEN_AI_OPERATION_NAME] == "chat"
-        assert span["attributes"][SPANDATA.GEN_AI_REQUEST_MODEL] == "model"
-
-        if send_default_pii and include_prompts:
-            assert json.loads(span["attributes"][SPANDATA.GEN_AI_REQUEST_MESSAGES]) == [
-                {
-                    "role": "user",
-                    "content": "Message demonstrating the absence of truncation.",
-                },
-                {
-                    "role": "user",
-                    "content": "Hello, Claude",
-                },
-            ]
-            assert (
-                span["attributes"][SPANDATA.GEN_AI_RESPONSE_TEXT] == "Hi, I'm Claude."
-            )
-        else:
-            assert SPANDATA.GEN_AI_REQUEST_MESSAGES not in span["attributes"]
-            assert SPANDATA.GEN_AI_RESPONSE_TEXT not in span["attributes"]
-
-        assert span["attributes"][SPANDATA.GEN_AI_USAGE_INPUT_TOKENS] == 10
-        assert span["attributes"][SPANDATA.GEN_AI_USAGE_OUTPUT_TOKENS] == 20
-        assert span["attributes"][SPANDATA.GEN_AI_USAGE_TOTAL_TOKENS] == 30
-        assert span["attributes"][SPANDATA.GEN_AI_RESPONSE_STREAMING] is False
-        assert (
-            span["attributes"][SPANDATA.GEN_AI_RESPONSE_ID]
-            == "msg_01XFDUDYJgAACzvnptvVoYEL"
-        )
-        assert span["attributes"][SPANDATA.GEN_AI_RESPONSE_FINISH_REASONS] == [
-            "end_turn"
-        ]
-    elif stream_gen_ai_spans:
-        items = capture_items("transaction", "span")
-
-        with start_transaction(name="anthropic"):
-            response = client.messages.create(
-                max_tokens=1024, messages=messages, model="model"
-            )
-
-        assert response == EXAMPLE_MESSAGE
-        usage = response.usage
-
-        assert usage.input_tokens == 10
-        assert usage.output_tokens == 20
-
-        (event,) = (item.payload for item in items if item.type == "transaction")
-        assert event["transaction"] == "anthropic"
-
-        sentry_sdk.flush()
-        spans = [item.payload for item in items if item.type == "span"]
-        assert len(spans) == 1
-        (span,) = spans
 
         assert span["attributes"]["sentry.op"] == OP.GEN_AI_CHAT
         assert span["name"] == "chat model"
@@ -344,7 +284,6 @@ def test_nonstreaming_create_message(
 
 
 @pytest.mark.parametrize("span_streaming", [True, False])
-@pytest.mark.parametrize("stream_gen_ai_spans", [True, False])
 @pytest.mark.parametrize(
     "data_collection,send_default_pii,include_prompts,expected_present,expected_absent",
     [
@@ -391,7 +330,6 @@ def test_nonstreaming_create_message_data_collection(
     include_prompts,
     expected_present,
     expected_absent,
-    stream_gen_ai_spans,
     span_streaming,
 ):
     sentry_init_kwargs = dict(
@@ -399,7 +337,6 @@ def test_nonstreaming_create_message_data_collection(
         disabled_integrations=[StdlibIntegration],
         traces_sample_rate=1.0,
         send_default_pii=send_default_pii,
-        stream_gen_ai_spans=stream_gen_ai_spans,
         trace_lifecycle="stream" if span_streaming else "static",
     )
     if data_collection is not None:
@@ -416,7 +353,7 @@ def test_nonstreaming_create_message_data_collection(
         messages=[{"role": "user", "content": "Hello, Claude"}],
     )
 
-    if span_streaming or stream_gen_ai_spans:
+    if span_streaming:
         items = capture_items("transaction", "span")
 
         with start_transaction(name="anthropic"):
@@ -453,7 +390,6 @@ def test_nonstreaming_create_message_data_collection(
     reason="Tools are not supported in this version of the anthropic package",
 )
 @pytest.mark.parametrize("span_streaming", [True, False])
-@pytest.mark.parametrize("stream_gen_ai_spans", [True, False])
 @pytest.mark.parametrize(
     "data_collection,tools_collected",
     [
@@ -480,7 +416,6 @@ def test_nonstreaming_create_message_data_collection_tools(
     capture_items,
     data_collection,
     tools_collected,
-    stream_gen_ai_spans,
     span_streaming,
 ):
     sentry_init_kwargs = dict(
@@ -488,7 +423,6 @@ def test_nonstreaming_create_message_data_collection_tools(
         disabled_integrations=[StdlibIntegration],
         traces_sample_rate=1.0,
         send_default_pii=False,
-        stream_gen_ai_spans=stream_gen_ai_spans,
         trace_lifecycle="stream" if span_streaming else "static",
     )
     if data_collection is not None:
@@ -505,7 +439,7 @@ def test_nonstreaming_create_message_data_collection_tools(
         tools=DATA_COLLECTION_EXAMPLE_TOOLS,
     )
 
-    if span_streaming or stream_gen_ai_spans:
+    if span_streaming:
         items = capture_items("transaction", "span")
 
         with start_transaction(name="anthropic"):
@@ -535,7 +469,6 @@ def test_nonstreaming_create_message_data_collection_tools(
 
 
 @pytest.mark.parametrize("span_streaming", [True, False])
-@pytest.mark.parametrize("stream_gen_ai_spans", [True, False])
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
     "data_collection,send_default_pii,include_prompts,expected_present,expected_absent",
@@ -575,7 +508,6 @@ async def test_nonstreaming_create_message_data_collection_async(
     include_prompts,
     expected_present,
     expected_absent,
-    stream_gen_ai_spans,
     span_streaming,
 ):
     sentry_init_kwargs = dict(
@@ -583,7 +515,6 @@ async def test_nonstreaming_create_message_data_collection_async(
         disabled_integrations=[StdlibIntegration],
         traces_sample_rate=1.0,
         send_default_pii=send_default_pii,
-        stream_gen_ai_spans=stream_gen_ai_spans,
         trace_lifecycle="stream" if span_streaming else "static",
     )
     if data_collection is not None:
@@ -600,7 +531,7 @@ async def test_nonstreaming_create_message_data_collection_async(
         messages=[{"role": "user", "content": "Hello, Claude"}],
     )
 
-    if span_streaming or stream_gen_ai_spans:
+    if span_streaming:
         items = capture_items("transaction", "span")
 
         with start_transaction(name="anthropic"):
@@ -637,7 +568,6 @@ async def test_nonstreaming_create_message_data_collection_async(
     reason="anthropic.types.ToolUseBlock was added in 0.27.0. Before that, tool use was only available under the beta namespace and could not appear in a standard Message.",
 )
 @pytest.mark.parametrize("span_streaming", [True, False])
-@pytest.mark.parametrize("stream_gen_ai_spans", [True, False])
 @pytest.mark.parametrize(
     "data_collection,send_default_pii,include_prompts,outputs_collected",
     [
@@ -693,7 +623,6 @@ def test_nonstreaming_create_message_data_collection_outputs(
     send_default_pii,
     include_prompts,
     outputs_collected,
-    stream_gen_ai_spans,
     span_streaming,
 ):
     sentry_init_kwargs = dict(
@@ -701,7 +630,6 @@ def test_nonstreaming_create_message_data_collection_outputs(
         disabled_integrations=[StdlibIntegration],
         traces_sample_rate=1.0,
         send_default_pii=send_default_pii,
-        stream_gen_ai_spans=stream_gen_ai_spans,
         trace_lifecycle="stream" if span_streaming else "static",
     )
     if data_collection is not None:
@@ -718,7 +646,7 @@ def test_nonstreaming_create_message_data_collection_outputs(
         tools=DATA_COLLECTION_EXAMPLE_TOOLS,
     )
 
-    if span_streaming or stream_gen_ai_spans:
+    if span_streaming:
         items = capture_items("transaction", "span")
 
         with start_transaction(name="anthropic"):
@@ -764,7 +692,6 @@ def test_nonstreaming_create_message_data_collection_outputs(
     reason="anthropic.types.ToolUseBlock was added in 0.27.0. Before that, tool use was only available under the beta namespace and could not appear in a standard Message.",
 )
 @pytest.mark.parametrize("span_streaming", [True, False])
-@pytest.mark.parametrize("stream_gen_ai_spans", [True, False])
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
     "data_collection,send_default_pii,include_prompts,outputs_collected",
@@ -821,7 +748,6 @@ async def test_nonstreaming_create_message_data_collection_outputs_async(
     send_default_pii,
     include_prompts,
     outputs_collected,
-    stream_gen_ai_spans,
     span_streaming,
 ):
     sentry_init_kwargs = dict(
@@ -829,7 +755,6 @@ async def test_nonstreaming_create_message_data_collection_outputs_async(
         disabled_integrations=[StdlibIntegration],
         traces_sample_rate=1.0,
         send_default_pii=send_default_pii,
-        stream_gen_ai_spans=stream_gen_ai_spans,
         trace_lifecycle="stream" if span_streaming else "static",
     )
     if data_collection is not None:
@@ -846,7 +771,7 @@ async def test_nonstreaming_create_message_data_collection_outputs_async(
         tools=DATA_COLLECTION_EXAMPLE_TOOLS,
     )
 
-    if span_streaming or stream_gen_ai_spans:
+    if span_streaming:
         items = capture_items("transaction", "span")
 
         with start_transaction(name="anthropic"):
@@ -888,7 +813,6 @@ async def test_nonstreaming_create_message_data_collection_outputs_async(
 
 
 @pytest.mark.parametrize("span_streaming", [True, False])
-@pytest.mark.parametrize("stream_gen_ai_spans", [True, False])
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
     "send_default_pii, include_prompts",
@@ -905,7 +829,6 @@ async def test_nonstreaming_create_message_async(
     capture_items,
     send_default_pii,
     include_prompts,
-    stream_gen_ai_spans,
     span_streaming,
 ):
     sentry_init(
@@ -913,7 +836,6 @@ async def test_nonstreaming_create_message_async(
         disabled_integrations=[StdlibIntegration],
         traces_sample_rate=1.0,
         send_default_pii=send_default_pii,
-        stream_gen_ai_spans=stream_gen_ai_spans,
         trace_lifecycle="stream" if span_streaming else "static",
     )
 
@@ -951,61 +873,6 @@ async def test_nonstreaming_create_message_async(
 
         assert spans[1]["name"] == "anthropic"
         (span, _) = spans
-
-        assert span["attributes"]["sentry.op"] == OP.GEN_AI_CHAT
-        assert span["name"] == "chat model"
-        assert span["attributes"][SPANDATA.GEN_AI_SYSTEM] == "anthropic"
-        assert span["attributes"][SPANDATA.GEN_AI_OPERATION_NAME] == "chat"
-        assert span["attributes"][SPANDATA.GEN_AI_REQUEST_MODEL] == "model"
-
-        if send_default_pii and include_prompts:
-            assert json.loads(span["attributes"][SPANDATA.GEN_AI_REQUEST_MESSAGES]) == [
-                {
-                    "role": "user",
-                    "content": "Message demonstrating the absence of truncation.",
-                },
-                {
-                    "role": "user",
-                    "content": "Hello, Claude",
-                },
-            ]
-            assert (
-                span["attributes"][SPANDATA.GEN_AI_RESPONSE_TEXT] == "Hi, I'm Claude."
-            )
-        else:
-            assert SPANDATA.GEN_AI_REQUEST_MESSAGES not in span["attributes"]
-            assert SPANDATA.GEN_AI_RESPONSE_TEXT not in span["attributes"]
-
-        assert span["attributes"][SPANDATA.GEN_AI_USAGE_INPUT_TOKENS] == 10
-        assert span["attributes"][SPANDATA.GEN_AI_USAGE_OUTPUT_TOKENS] == 20
-        assert span["attributes"][SPANDATA.GEN_AI_USAGE_TOTAL_TOKENS] == 30
-        assert span["attributes"][SPANDATA.GEN_AI_RESPONSE_STREAMING] is False
-        assert (
-            span["attributes"][SPANDATA.GEN_AI_RESPONSE_ID]
-            == "msg_01XFDUDYJgAACzvnptvVoYEL"
-        )
-
-    elif stream_gen_ai_spans:
-        items = capture_items("transaction", "span")
-
-        with start_transaction(name="anthropic"):
-            response = await client.messages.create(
-                max_tokens=1024, messages=messages, model="model"
-            )
-
-        assert response == EXAMPLE_MESSAGE
-        usage = response.usage
-
-        assert usage.input_tokens == 10
-        assert usage.output_tokens == 20
-
-        (event,) = (item.payload for item in items if item.type == "transaction")
-        assert event["transaction"] == "anthropic"
-
-        sentry_sdk.flush()
-        spans = [item.payload for item in items if item.type == "span"]
-        assert len(spans) == 1
-        (span,) = spans
 
         assert span["attributes"]["sentry.op"] == OP.GEN_AI_CHAT
         assert span["name"] == "chat model"
@@ -1088,7 +955,6 @@ async def test_nonstreaming_create_message_async(
 
 
 @pytest.mark.parametrize("span_streaming", [True, False])
-@pytest.mark.parametrize("stream_gen_ai_spans", [True, False])
 @pytest.mark.parametrize(
     "send_default_pii, include_prompts",
     [
@@ -1106,7 +972,6 @@ def test_streaming_create_message(
     include_prompts,
     get_model_response,
     server_side_event_chunks,
-    stream_gen_ai_spans,
     span_streaming,
 ):
     client = Anthropic(api_key="z")
@@ -1153,7 +1018,6 @@ def test_streaming_create_message(
         disabled_integrations=[StdlibIntegration],
         traces_sample_rate=1.0,
         send_default_pii=send_default_pii,
-        stream_gen_ai_spans=stream_gen_ai_spans,
         trace_lifecycle="stream" if span_streaming else "static",
     )
 
@@ -1186,66 +1050,6 @@ def test_streaming_create_message(
         sentry_sdk.flush()
         spans = [item.payload for item in items if item.type == "span"]
         assert spans[1]["name"] == "anthropic"
-        span = next(
-            span for span in spans if span["attributes"]["sentry.op"] == OP.GEN_AI_CHAT
-        )
-
-        assert span["attributes"]["sentry.op"] == OP.GEN_AI_CHAT
-        assert span["name"] == "chat model"
-        assert span["attributes"][SPANDATA.GEN_AI_SYSTEM] == "anthropic"
-        assert span["attributes"][SPANDATA.GEN_AI_OPERATION_NAME] == "chat"
-        assert span["attributes"][SPANDATA.GEN_AI_REQUEST_MODEL] == "model"
-
-        if send_default_pii and include_prompts:
-            assert json.loads(span["attributes"][SPANDATA.GEN_AI_REQUEST_MESSAGES]) == [
-                {
-                    "role": "user",
-                    "content": "Message demonstrating the absence of truncation.",
-                },
-                {
-                    "role": "user",
-                    "content": "Hello, Claude",
-                },
-            ]
-            assert (
-                span["attributes"][SPANDATA.GEN_AI_RESPONSE_TEXT] == "Hi! I'm Claude!"
-            )
-
-        else:
-            assert SPANDATA.GEN_AI_REQUEST_MESSAGES not in span["attributes"]
-            assert SPANDATA.GEN_AI_RESPONSE_TEXT not in span["attributes"]
-
-        assert span["attributes"][SPANDATA.GEN_AI_USAGE_INPUT_TOKENS] == 10
-        assert span["attributes"][SPANDATA.GEN_AI_USAGE_OUTPUT_TOKENS] == 10
-        assert span["attributes"][SPANDATA.GEN_AI_USAGE_TOTAL_TOKENS] == 20
-        assert span["attributes"][SPANDATA.GEN_AI_RESPONSE_STREAMING] is True
-        assert (
-            span["attributes"][SPANDATA.GEN_AI_RESPONSE_ID]
-            == "msg_01XFDUDYJgAACzvnptvVoYEL"
-        )
-        assert span["attributes"][SPANDATA.GEN_AI_RESPONSE_FINISH_REASONS] == [
-            "max_tokens"
-        ]
-    elif stream_gen_ai_spans:
-        items = capture_items("transaction", "span")
-
-        with mock.patch.object(
-            client._client,
-            "send",
-            return_value=response,
-        ) as _, start_transaction(name="anthropic"):
-            message = client.messages.create(
-                max_tokens=1024, messages=messages, model="model", stream=True
-            )
-
-            for _ in message:
-                pass
-
-        (event,) = (item.payload for item in items if item.type == "transaction")
-        assert event["transaction"] == "anthropic"
-
-        sentry_sdk.flush()
-        spans = [item.payload for item in items if item.type == "span"]
         span = next(
             span for span in spans if span["attributes"]["sentry.op"] == OP.GEN_AI_CHAT
         )
@@ -1337,7 +1141,6 @@ def test_streaming_create_message(
 
 
 @pytest.mark.parametrize("span_streaming", [True, False])
-@pytest.mark.parametrize("stream_gen_ai_spans", [True, False])
 @pytest.mark.parametrize(
     "data_collection,send_default_pii,include_prompts,expected_present,expected_absent",
     [
@@ -1378,7 +1181,6 @@ def test_streaming_create_message_data_collection(
     expected_absent,
     get_model_response,
     server_side_event_chunks,
-    stream_gen_ai_spans,
     span_streaming,
 ):
     sentry_init_kwargs = dict(
@@ -1386,7 +1188,6 @@ def test_streaming_create_message_data_collection(
         disabled_integrations=[StdlibIntegration],
         traces_sample_rate=1.0,
         send_default_pii=send_default_pii,
-        stream_gen_ai_spans=stream_gen_ai_spans,
         trace_lifecycle="stream" if span_streaming else "static",
     )
     if data_collection is not None:
@@ -1430,7 +1231,7 @@ def test_streaming_create_message_data_collection(
         stream=True,
     )
 
-    if span_streaming or stream_gen_ai_spans:
+    if span_streaming:
         items = capture_items("transaction", "span")
 
         with mock.patch.object(
@@ -1476,7 +1277,6 @@ def test_streaming_create_message_data_collection(
 
 
 @pytest.mark.parametrize("span_streaming", [True, False])
-@pytest.mark.parametrize("stream_gen_ai_spans", [True, False])
 @pytest.mark.parametrize(
     "data_collection,send_default_pii,include_prompts,outputs_collected",
     [
@@ -1527,7 +1327,6 @@ def test_streaming_create_message_data_collection_outputs(
     outputs_collected,
     get_model_response,
     server_side_event_chunks,
-    stream_gen_ai_spans,
     span_streaming,
 ):
     sentry_init_kwargs = dict(
@@ -1535,7 +1334,6 @@ def test_streaming_create_message_data_collection_outputs(
         disabled_integrations=[StdlibIntegration],
         traces_sample_rate=1.0,
         send_default_pii=send_default_pii,
-        stream_gen_ai_spans=stream_gen_ai_spans,
         trace_lifecycle="stream" if span_streaming else "static",
     )
     if data_collection is not None:
@@ -1583,7 +1381,7 @@ def test_streaming_create_message_data_collection_outputs(
         stream=True,
     )
 
-    if span_streaming or stream_gen_ai_spans:
+    if span_streaming:
         items = capture_items("transaction", "span")
 
         with mock.patch.object(
@@ -1629,14 +1427,12 @@ def test_streaming_create_message_data_collection_outputs(
 
 
 @pytest.mark.parametrize("span_streaming", [True, False])
-@pytest.mark.parametrize("stream_gen_ai_spans", [True, False])
 def test_streaming_create_message_close(
     sentry_init,
     capture_events,
     capture_items,
     get_model_response,
     server_side_event_chunks,
-    stream_gen_ai_spans,
     span_streaming,
 ):
     client = Anthropic(api_key="z")
@@ -1683,7 +1479,6 @@ def test_streaming_create_message_close(
         disabled_integrations=[StdlibIntegration],
         traces_sample_rate=1.0,
         send_default_pii=True,
-        stream_gen_ai_spans=stream_gen_ai_spans,
         trace_lifecycle="stream" if span_streaming else "static",
     )
 
@@ -1714,52 +1509,6 @@ def test_streaming_create_message_close(
         sentry_sdk.flush()
         spans = [item.payload for item in items if item.type == "span"]
         assert spans[1]["name"] == "anthropic"
-        span = next(
-            span for span in spans if span["attributes"]["sentry.op"] == OP.GEN_AI_CHAT
-        )
-
-        assert span["attributes"]["sentry.op"] == OP.GEN_AI_CHAT
-        assert span["name"] == "chat model"
-        assert span["attributes"][SPANDATA.GEN_AI_SYSTEM] == "anthropic"
-        assert span["attributes"][SPANDATA.GEN_AI_OPERATION_NAME] == "chat"
-        assert span["attributes"][SPANDATA.GEN_AI_REQUEST_MODEL] == "model"
-
-        assert (
-            span["attributes"][SPANDATA.GEN_AI_REQUEST_MESSAGES]
-            == '[{"role": "user", "content": "Hello, Claude"}]'
-        )
-        assert span["attributes"][SPANDATA.GEN_AI_RESPONSE_TEXT] == "Hi!"
-
-        assert span["attributes"][SPANDATA.GEN_AI_USAGE_INPUT_TOKENS] == 10
-        assert span["attributes"][SPANDATA.GEN_AI_USAGE_OUTPUT_TOKENS] == 20
-        assert span["attributes"][SPANDATA.GEN_AI_USAGE_TOTAL_TOKENS] == 30
-        assert span["attributes"][SPANDATA.GEN_AI_RESPONSE_STREAMING] is True
-        assert (
-            span["attributes"][SPANDATA.GEN_AI_RESPONSE_ID]
-            == "msg_01XFDUDYJgAACzvnptvVoYEL"
-        )
-    elif stream_gen_ai_spans:
-        items = capture_items("transaction", "span")
-
-        with mock.patch.object(
-            client._client,
-            "send",
-            return_value=response,
-        ) as _, start_transaction(name="anthropic"):
-            messages = client.messages.create(
-                max_tokens=1024, messages=messages, model="model", stream=True
-            )
-
-            for _ in range(4):
-                next(messages)
-
-            messages.close()
-
-        (event,) = (item.payload for item in items if item.type == "transaction")
-        assert event["transaction"] == "anthropic"
-
-        sentry_sdk.flush()
-        spans = [item.payload for item in items if item.type == "span"]
         span = next(
             span for span in spans if span["attributes"]["sentry.op"] == OP.GEN_AI_CHAT
         )
@@ -1831,7 +1580,6 @@ def test_streaming_create_message_close(
 
 
 @pytest.mark.parametrize("span_streaming", [True, False])
-@pytest.mark.parametrize("stream_gen_ai_spans", [True, False])
 @pytest.mark.skipif(
     ANTHROPIC_VERSION < (0, 41),
     reason="Error classes moved in https://github.com/anthropics/anthropic-sdk-python/commit/4e0b15e22fe40e9aa513459564f641bf97c90954.",
@@ -1842,7 +1590,6 @@ def test_streaming_create_message_api_error(
     capture_items,
     get_model_response,
     server_side_event_chunks,
-    stream_gen_ai_spans,
     span_streaming,
 ):
     client = Anthropic(api_key="z")
@@ -1884,7 +1631,6 @@ def test_streaming_create_message_api_error(
         disabled_integrations=[StdlibIntegration],
         traces_sample_rate=1.0,
         send_default_pii=True,
-        stream_gen_ai_spans=stream_gen_ai_spans,
         trace_lifecycle="stream" if span_streaming else "static",
     )
 
@@ -1940,52 +1686,6 @@ def test_streaming_create_message_api_error(
         )
 
         assert span["status"] == "error"
-    elif stream_gen_ai_spans:
-        items = capture_items("transaction", "span")
-
-        with pytest.raises(APIStatusError), mock.patch.object(
-            client._client,
-            "send",
-            return_value=response,
-        ) as _, start_transaction(name="anthropic"):
-            message = client.messages.create(
-                max_tokens=1024, messages=messages, model="model", stream=True
-            )
-
-            for _ in message:
-                pass
-        (event,) = (item.payload for item in items if item.type == "transaction")
-        assert event["transaction"] == "anthropic"
-
-        sentry_sdk.flush()
-        spans = [item.payload for item in items if item.type == "span"]
-        span = next(
-            span for span in spans if span["attributes"]["sentry.op"] == OP.GEN_AI_CHAT
-        )
-
-        assert span["attributes"]["sentry.op"] == OP.GEN_AI_CHAT
-        assert span["name"] == "chat model"
-        assert span["attributes"][SPANDATA.GEN_AI_SYSTEM] == "anthropic"
-        assert span["attributes"][SPANDATA.GEN_AI_OPERATION_NAME] == "chat"
-        assert span["attributes"][SPANDATA.GEN_AI_REQUEST_MODEL] == "model"
-
-        assert (
-            span["attributes"][SPANDATA.GEN_AI_REQUEST_MESSAGES]
-            == '[{"role": "user", "content": "Hello, Claude"}]'
-        )
-        assert span["attributes"][SPANDATA.GEN_AI_RESPONSE_TEXT] == "Hi!"
-
-        assert span["attributes"][SPANDATA.GEN_AI_USAGE_INPUT_TOKENS] == 10
-        assert span["attributes"][SPANDATA.GEN_AI_USAGE_OUTPUT_TOKENS] == 20
-        assert span["attributes"][SPANDATA.GEN_AI_USAGE_TOTAL_TOKENS] == 30
-        assert span["attributes"][SPANDATA.GEN_AI_RESPONSE_STREAMING] is True
-        assert (
-            span["attributes"][SPANDATA.GEN_AI_RESPONSE_ID]
-            == "msg_01XFDUDYJgAACzvnptvVoYEL"
-        )
-
-        assert span["status"] == "error"
-        assert event["contexts"]["trace"]["status"] == "internal_error"
     else:
         events = capture_events()
 
@@ -2035,7 +1735,6 @@ def test_streaming_create_message_api_error(
 
 
 @pytest.mark.parametrize("span_streaming", [True, False])
-@pytest.mark.parametrize("stream_gen_ai_spans", [True, False])
 @pytest.mark.parametrize(
     "send_default_pii, include_prompts",
     [
@@ -2053,7 +1752,6 @@ def test_stream_messages(
     include_prompts,
     get_model_response,
     server_side_event_chunks,
-    stream_gen_ai_spans,
     span_streaming,
 ):
     client = Anthropic(api_key="z")
@@ -2100,7 +1798,6 @@ def test_stream_messages(
         disabled_integrations=[StdlibIntegration],
         traces_sample_rate=1.0,
         send_default_pii=send_default_pii,
-        stream_gen_ai_spans=stream_gen_ai_spans,
         trace_lifecycle="stream" if span_streaming else "static",
     )
 
@@ -2133,66 +1830,6 @@ def test_stream_messages(
         sentry_sdk.flush()
         spans = [item.payload for item in items if item.type == "span"]
         assert spans[1]["name"] == "anthropic"
-        span = next(
-            span for span in spans if span["attributes"]["sentry.op"] == OP.GEN_AI_CHAT
-        )
-
-        assert span["attributes"]["sentry.op"] == OP.GEN_AI_CHAT
-        assert span["name"] == "chat model"
-        assert span["attributes"][SPANDATA.GEN_AI_SYSTEM] == "anthropic"
-        assert span["attributes"][SPANDATA.GEN_AI_OPERATION_NAME] == "chat"
-        assert span["attributes"][SPANDATA.GEN_AI_REQUEST_MODEL] == "model"
-
-        if send_default_pii and include_prompts:
-            assert json.loads(span["attributes"][SPANDATA.GEN_AI_REQUEST_MESSAGES]) == [
-                {
-                    "role": "user",
-                    "content": "Message demonstrating the absence of truncation.",
-                },
-                {
-                    "role": "user",
-                    "content": "Hello, Claude",
-                },
-            ]
-            assert (
-                span["attributes"][SPANDATA.GEN_AI_RESPONSE_TEXT] == "Hi! I'm Claude!"
-            )
-
-        else:
-            assert SPANDATA.GEN_AI_REQUEST_MESSAGES not in span["attributes"]
-            assert SPANDATA.GEN_AI_RESPONSE_TEXT not in span["attributes"]
-
-        assert span["attributes"][SPANDATA.GEN_AI_USAGE_INPUT_TOKENS] == 10
-        assert span["attributes"][SPANDATA.GEN_AI_USAGE_OUTPUT_TOKENS] == 10
-        assert span["attributes"][SPANDATA.GEN_AI_USAGE_TOTAL_TOKENS] == 20
-        assert span["attributes"][SPANDATA.GEN_AI_RESPONSE_STREAMING] is True
-        assert (
-            span["attributes"][SPANDATA.GEN_AI_RESPONSE_ID]
-            == "msg_01XFDUDYJgAACzvnptvVoYEL"
-        )
-        assert span["attributes"][SPANDATA.GEN_AI_RESPONSE_FINISH_REASONS] == [
-            "max_tokens"
-        ]
-    elif stream_gen_ai_spans:
-        items = capture_items("transaction", "span")
-
-        with mock.patch.object(
-            client._client,
-            "send",
-            return_value=response,
-        ) as _, start_transaction(name="anthropic"), client.messages.stream(
-            max_tokens=1024,
-            messages=messages,
-            model="model",
-        ) as stream:
-            for event in stream:
-                pass
-
-        (event,) = (item.payload for item in items if item.type == "transaction")
-        assert event["transaction"] == "anthropic"
-
-        sentry_sdk.flush()
-        spans = [item.payload for item in items if item.type == "span"]
         span = next(
             span for span in spans if span["attributes"]["sentry.op"] == OP.GEN_AI_CHAT
         )
@@ -2283,7 +1920,6 @@ def test_stream_messages(
 
 
 @pytest.mark.parametrize("span_streaming", [True, False])
-@pytest.mark.parametrize("stream_gen_ai_spans", [True, False])
 @pytest.mark.parametrize(
     "data_collection,send_default_pii,include_prompts,outputs_collected",
     [
@@ -2334,7 +1970,6 @@ def test_stream_messages_data_collection_outputs(
     outputs_collected,
     get_model_response,
     server_side_event_chunks,
-    stream_gen_ai_spans,
     span_streaming,
 ):
     sentry_init_kwargs = dict(
@@ -2342,7 +1977,6 @@ def test_stream_messages_data_collection_outputs(
         disabled_integrations=[StdlibIntegration],
         traces_sample_rate=1.0,
         send_default_pii=send_default_pii,
-        stream_gen_ai_spans=stream_gen_ai_spans,
         trace_lifecycle="stream" if span_streaming else "static",
     )
     if data_collection is not None:
@@ -2389,7 +2023,7 @@ def test_stream_messages_data_collection_outputs(
         messages=[{"role": "user", "content": "Hello, Claude"}],
     )
 
-    if span_streaming or stream_gen_ai_spans:
+    if span_streaming:
         items = capture_items("transaction", "span")
 
         with mock.patch.object(
@@ -2437,14 +2071,12 @@ def test_stream_messages_data_collection_outputs(
 
 
 @pytest.mark.parametrize("span_streaming", [True, False])
-@pytest.mark.parametrize("stream_gen_ai_spans", [True, False])
 def test_stream_messages_close(
     sentry_init,
     capture_events,
     capture_items,
     get_model_response,
     server_side_event_chunks,
-    stream_gen_ai_spans,
     span_streaming,
 ):
     client = Anthropic(api_key="z")
@@ -2491,7 +2123,6 @@ def test_stream_messages_close(
         disabled_integrations=[StdlibIntegration],
         traces_sample_rate=1.0,
         send_default_pii=True,
-        stream_gen_ai_spans=stream_gen_ai_spans,
         trace_lifecycle="stream" if span_streaming else "static",
     )
 
@@ -2526,56 +2157,6 @@ def test_stream_messages_close(
         sentry_sdk.flush()
         spans = [item.payload for item in items if item.type == "span"]
         assert spans[1]["name"] == "anthropic"
-        span = next(
-            span for span in spans if span["attributes"]["sentry.op"] == OP.GEN_AI_CHAT
-        )
-
-        assert span["attributes"]["sentry.op"] == OP.GEN_AI_CHAT
-        assert span["name"] == "chat model"
-        assert span["attributes"][SPANDATA.GEN_AI_SYSTEM] == "anthropic"
-        assert span["attributes"][SPANDATA.GEN_AI_OPERATION_NAME] == "chat"
-        assert span["attributes"][SPANDATA.GEN_AI_REQUEST_MODEL] == "model"
-
-        assert (
-            span["attributes"][SPANDATA.GEN_AI_REQUEST_MESSAGES]
-            == '[{"role": "user", "content": "Hello, Claude"}]'
-        )
-        assert span["attributes"][SPANDATA.GEN_AI_RESPONSE_TEXT] == "Hi!"
-
-        assert span["attributes"][SPANDATA.GEN_AI_USAGE_INPUT_TOKENS] == 10
-        assert span["attributes"][SPANDATA.GEN_AI_USAGE_OUTPUT_TOKENS] == 20
-        assert span["attributes"][SPANDATA.GEN_AI_USAGE_TOTAL_TOKENS] == 30
-        assert span["attributes"][SPANDATA.GEN_AI_RESPONSE_STREAMING] is True
-        assert (
-            span["attributes"][SPANDATA.GEN_AI_RESPONSE_ID]
-            == "msg_01XFDUDYJgAACzvnptvVoYEL"
-        )
-    elif stream_gen_ai_spans:
-        items = capture_items("transaction", "span")
-
-        with mock.patch.object(
-            client._client,
-            "send",
-            return_value=response,
-        ) as _, start_transaction(name="anthropic"), client.messages.stream(
-            max_tokens=1024,
-            messages=messages,
-            model="model",
-        ) as stream:
-            for _ in range(4):
-                next(stream)
-
-            # New versions add TextEvent, so consume one more event.
-            if TextEvent is not None and isinstance(next(stream), TextEvent):
-                next(stream)
-
-            stream.close()
-
-        (event,) = (item.payload for item in items if item.type == "transaction")
-        assert event["transaction"] == "anthropic"
-
-        sentry_sdk.flush()
-        spans = [item.payload for item in items if item.type == "span"]
         span = next(
             span for span in spans if span["attributes"]["sentry.op"] == OP.GEN_AI_CHAT
         )
@@ -2651,7 +2232,6 @@ def test_stream_messages_close(
 
 
 @pytest.mark.parametrize("span_streaming", [True, False])
-@pytest.mark.parametrize("stream_gen_ai_spans", [True, False])
 @pytest.mark.skipif(
     ANTHROPIC_VERSION < (0, 41),
     reason="Error classes moved in https://github.com/anthropics/anthropic-sdk-python/commit/4e0b15e22fe40e9aa513459564f641bf97c90954.",
@@ -2662,7 +2242,6 @@ def test_stream_messages_api_error(
     capture_items,
     get_model_response,
     server_side_event_chunks,
-    stream_gen_ai_spans,
     span_streaming,
 ):
     client = Anthropic(api_key="z")
@@ -2704,7 +2283,6 @@ def test_stream_messages_api_error(
         disabled_integrations=[StdlibIntegration],
         traces_sample_rate=1.0,
         send_default_pii=True,
-        stream_gen_ai_spans=stream_gen_ai_spans,
         trace_lifecycle="stream" if span_streaming else "static",
     )
 
@@ -2760,53 +2338,6 @@ def test_stream_messages_api_error(
         )
 
         assert span["status"] == "error"
-    elif stream_gen_ai_spans:
-        items = capture_items("transaction", "span")
-
-        with pytest.raises(APIStatusError), mock.patch.object(
-            client._client,
-            "send",
-            return_value=response,
-        ) as _, start_transaction(name="anthropic"), client.messages.stream(
-            max_tokens=1024,
-            messages=messages,
-            model="model",
-        ) as stream:
-            for event in stream:
-                pass
-
-        (event,) = (item.payload for item in items if item.type == "transaction")
-        assert event["transaction"] == "anthropic"
-
-        sentry_sdk.flush()
-        spans = [item.payload for item in items if item.type == "span"]
-        span = next(
-            span for span in spans if span["attributes"]["sentry.op"] == OP.GEN_AI_CHAT
-        )
-
-        assert span["attributes"]["sentry.op"] == OP.GEN_AI_CHAT
-        assert span["name"] == "chat model"
-        assert span["attributes"][SPANDATA.GEN_AI_SYSTEM] == "anthropic"
-        assert span["attributes"][SPANDATA.GEN_AI_OPERATION_NAME] == "chat"
-        assert span["attributes"][SPANDATA.GEN_AI_REQUEST_MODEL] == "model"
-
-        assert (
-            span["attributes"][SPANDATA.GEN_AI_REQUEST_MESSAGES]
-            == '[{"role": "user", "content": "Hello, Claude"}]'
-        )
-        assert span["attributes"][SPANDATA.GEN_AI_RESPONSE_TEXT] == "Hi!"
-
-        assert span["attributes"][SPANDATA.GEN_AI_USAGE_INPUT_TOKENS] == 10
-        assert span["attributes"][SPANDATA.GEN_AI_USAGE_OUTPUT_TOKENS] == 20
-        assert span["attributes"][SPANDATA.GEN_AI_USAGE_TOTAL_TOKENS] == 30
-        assert span["attributes"][SPANDATA.GEN_AI_RESPONSE_STREAMING] is True
-        assert (
-            span["attributes"][SPANDATA.GEN_AI_RESPONSE_ID]
-            == "msg_01XFDUDYJgAACzvnptvVoYEL"
-        )
-
-        assert span["status"] == "error"
-        assert event["contexts"]["trace"]["status"] == "internal_error"
     else:
         events = capture_events()
 
@@ -2856,7 +2387,6 @@ def test_stream_messages_api_error(
 
 
 @pytest.mark.parametrize("span_streaming", [True, False])
-@pytest.mark.parametrize("stream_gen_ai_spans", [True, False])
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
     "send_default_pii, include_prompts",
@@ -2876,7 +2406,6 @@ async def test_streaming_create_message_async(
     get_model_response,
     async_iterator,
     server_side_event_chunks,
-    stream_gen_ai_spans,
     span_streaming,
 ):
     client = AsyncAnthropic(api_key="z")
@@ -2926,7 +2455,6 @@ async def test_streaming_create_message_async(
         traces_sample_rate=1.0,
         default_integrations=False,
         send_default_pii=send_default_pii,
-        stream_gen_ai_spans=stream_gen_ai_spans,
         trace_lifecycle="stream" if span_streaming else "static",
     )
 
@@ -2962,65 +2490,6 @@ async def test_streaming_create_message_async(
 
         assert spans[1]["name"] == "anthropic"
         (span, _) = spans
-
-        assert span["attributes"]["sentry.op"] == OP.GEN_AI_CHAT
-        assert span["name"] == "chat model"
-        assert span["attributes"][SPANDATA.GEN_AI_SYSTEM] == "anthropic"
-        assert span["attributes"][SPANDATA.GEN_AI_OPERATION_NAME] == "chat"
-        assert span["attributes"][SPANDATA.GEN_AI_REQUEST_MODEL] == "model"
-
-        if send_default_pii and include_prompts:
-            assert json.loads(span["attributes"][SPANDATA.GEN_AI_REQUEST_MESSAGES]) == [
-                {
-                    "role": "user",
-                    "content": "Message demonstrating the absence of truncation.",
-                },
-                {
-                    "role": "user",
-                    "content": "Hello, Claude",
-                },
-            ]
-            assert (
-                span["attributes"][SPANDATA.GEN_AI_RESPONSE_TEXT] == "Hi! I'm Claude!"
-            )
-
-        else:
-            assert SPANDATA.GEN_AI_REQUEST_MESSAGES not in span["attributes"]
-            assert SPANDATA.GEN_AI_RESPONSE_TEXT not in span["attributes"]
-
-        assert span["attributes"][SPANDATA.GEN_AI_USAGE_INPUT_TOKENS] == 10
-        assert span["attributes"][SPANDATA.GEN_AI_USAGE_OUTPUT_TOKENS] == 10
-        assert span["attributes"][SPANDATA.GEN_AI_USAGE_TOTAL_TOKENS] == 20
-        assert span["attributes"][SPANDATA.GEN_AI_RESPONSE_STREAMING] is True
-        assert (
-            span["attributes"][SPANDATA.GEN_AI_RESPONSE_ID]
-            == "msg_01XFDUDYJgAACzvnptvVoYEL"
-        )
-        assert span["attributes"][SPANDATA.GEN_AI_RESPONSE_FINISH_REASONS] == [
-            "max_tokens"
-        ]
-    elif stream_gen_ai_spans:
-        items = capture_items("transaction", "span")
-
-        with mock.patch.object(
-            client._client,
-            "send",
-            return_value=response,
-        ) as _, start_transaction(name="anthropic"):
-            message = await client.messages.create(
-                max_tokens=1024, messages=messages, model="model", stream=True
-            )
-
-            async for _ in message:
-                pass
-
-        (event,) = (item.payload for item in items if item.type == "transaction")
-        assert event["transaction"] == "anthropic"
-
-        sentry_sdk.flush()
-        spans = [item.payload for item in items if item.type == "span"]
-        assert len(spans) == 1
-        (span,) = spans
 
         assert span["attributes"]["sentry.op"] == OP.GEN_AI_CHAT
         assert span["name"] == "chat model"
@@ -3110,7 +2579,6 @@ async def test_streaming_create_message_async(
 
 
 @pytest.mark.parametrize("span_streaming", [True, False])
-@pytest.mark.parametrize("stream_gen_ai_spans", [True, False])
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
     "data_collection,send_default_pii,include_prompts,outputs_collected",
@@ -3163,7 +2631,6 @@ async def test_streaming_create_message_data_collection_outputs_async(
     get_model_response,
     async_iterator,
     server_side_event_chunks,
-    stream_gen_ai_spans,
     span_streaming,
 ):
     sentry_init_kwargs = dict(
@@ -3171,7 +2638,6 @@ async def test_streaming_create_message_data_collection_outputs_async(
         disabled_integrations=[StdlibIntegration],
         traces_sample_rate=1.0,
         send_default_pii=send_default_pii,
-        stream_gen_ai_spans=stream_gen_ai_spans,
         trace_lifecycle="stream" if span_streaming else "static",
     )
     if data_collection is not None:
@@ -3221,7 +2687,7 @@ async def test_streaming_create_message_data_collection_outputs_async(
         stream=True,
     )
 
-    if span_streaming or stream_gen_ai_spans:
+    if span_streaming:
         items = capture_items("transaction", "span")
 
         with mock.patch.object(
@@ -3267,7 +2733,6 @@ async def test_streaming_create_message_data_collection_outputs_async(
 
 
 @pytest.mark.parametrize("span_streaming", [True, False])
-@pytest.mark.parametrize("stream_gen_ai_spans", [True, False])
 @pytest.mark.asyncio
 async def test_streaming_create_message_async_close(
     sentry_init,
@@ -3276,7 +2741,6 @@ async def test_streaming_create_message_async_close(
     get_model_response,
     async_iterator,
     server_side_event_chunks,
-    stream_gen_ai_spans,
     span_streaming,
 ):
     client = AsyncAnthropic(api_key="z")
@@ -3325,7 +2789,6 @@ async def test_streaming_create_message_async_close(
         disabled_integrations=[StdlibIntegration],
         traces_sample_rate=1.0,
         send_default_pii=True,
-        stream_gen_ai_spans=stream_gen_ai_spans,
         trace_lifecycle="stream" if span_streaming else "static",
     )
 
@@ -3355,51 +2818,6 @@ async def test_streaming_create_message_async_close(
         sentry_sdk.flush()
         spans = [item.payload for item in items if item.type == "span"]
         assert spans[1]["name"] == "anthropic"
-        span = next(
-            span for span in spans if span["attributes"]["sentry.op"] == OP.GEN_AI_CHAT
-        )
-
-        assert span["attributes"]["sentry.op"] == OP.GEN_AI_CHAT
-        assert span["name"] == "chat model"
-        assert span["attributes"][SPANDATA.GEN_AI_SYSTEM] == "anthropic"
-        assert span["attributes"][SPANDATA.GEN_AI_OPERATION_NAME] == "chat"
-        assert span["attributes"][SPANDATA.GEN_AI_REQUEST_MODEL] == "model"
-
-        assert (
-            span["attributes"][SPANDATA.GEN_AI_REQUEST_MESSAGES]
-            == '[{"role": "user", "content": "Hello, Claude"}]'
-        )
-        assert span["attributes"][SPANDATA.GEN_AI_RESPONSE_TEXT] == "Hi!"
-
-        assert span["attributes"][SPANDATA.GEN_AI_USAGE_INPUT_TOKENS] == 10
-        assert span["attributes"][SPANDATA.GEN_AI_USAGE_OUTPUT_TOKENS] == 20
-        assert span["attributes"][SPANDATA.GEN_AI_USAGE_TOTAL_TOKENS] == 30
-        assert span["attributes"][SPANDATA.GEN_AI_RESPONSE_STREAMING] is True
-        assert (
-            span["attributes"][SPANDATA.GEN_AI_RESPONSE_ID]
-            == "msg_01XFDUDYJgAACzvnptvVoYEL"
-        )
-    elif stream_gen_ai_spans:
-        items = capture_items("transaction", "span")
-
-        with mock.patch.object(
-            client._client,
-            "send",
-            return_value=response,
-        ) as _, start_transaction(name="anthropic"):
-            messages = await client.messages.create(
-                max_tokens=1024, messages=messages, model="model", stream=True
-            )
-
-            for _ in range(4):
-                await messages.__anext__()
-            await messages.close()
-
-        (event,) = (item.payload for item in items if item.type == "transaction")
-        assert event["transaction"] == "anthropic"
-
-        sentry_sdk.flush()
-        spans = [item.payload for item in items if item.type == "span"]
         span = next(
             span for span in spans if span["attributes"]["sentry.op"] == OP.GEN_AI_CHAT
         )
@@ -3470,7 +2888,6 @@ async def test_streaming_create_message_async_close(
 
 
 @pytest.mark.parametrize("span_streaming", [True, False])
-@pytest.mark.parametrize("stream_gen_ai_spans", [True, False])
 @pytest.mark.skipif(
     ANTHROPIC_VERSION < (0, 41),
     reason="Error classes moved in https://github.com/anthropics/anthropic-sdk-python/commit/4e0b15e22fe40e9aa513459564f641bf97c90954.",
@@ -3483,7 +2900,6 @@ async def test_streaming_create_message_async_api_error(
     get_model_response,
     async_iterator,
     server_side_event_chunks,
-    stream_gen_ai_spans,
     span_streaming,
 ):
     client = AsyncAnthropic(api_key="z")
@@ -3527,7 +2943,6 @@ async def test_streaming_create_message_async_api_error(
         disabled_integrations=[StdlibIntegration],
         traces_sample_rate=1.0,
         send_default_pii=True,
-        stream_gen_ai_spans=stream_gen_ai_spans,
         trace_lifecycle="stream" if span_streaming else "static",
     )
 
@@ -3583,53 +2998,6 @@ async def test_streaming_create_message_async_api_error(
         )
 
         assert span["status"] == "error"
-    elif stream_gen_ai_spans:
-        items = capture_items("transaction", "span")
-
-        with pytest.raises(APIStatusError), mock.patch.object(
-            client._client,
-            "send",
-            return_value=response,
-        ) as _, start_transaction(name="anthropic"):
-            message = await client.messages.create(
-                max_tokens=1024, messages=messages, model="model", stream=True
-            )
-
-            async for _ in message:
-                pass
-
-        (event,) = (item.payload for item in items if item.type == "transaction")
-        assert event["transaction"] == "anthropic"
-
-        sentry_sdk.flush()
-        spans = [item.payload for item in items if item.type == "span"]
-        span = next(
-            span for span in spans if span["attributes"]["sentry.op"] == OP.GEN_AI_CHAT
-        )
-
-        assert span["attributes"]["sentry.op"] == OP.GEN_AI_CHAT
-        assert span["name"] == "chat model"
-        assert span["attributes"][SPANDATA.GEN_AI_SYSTEM] == "anthropic"
-        assert span["attributes"][SPANDATA.GEN_AI_OPERATION_NAME] == "chat"
-        assert span["attributes"][SPANDATA.GEN_AI_REQUEST_MODEL] == "model"
-
-        assert (
-            span["attributes"][SPANDATA.GEN_AI_REQUEST_MESSAGES]
-            == '[{"role": "user", "content": "Hello, Claude"}]'
-        )
-        assert span["attributes"][SPANDATA.GEN_AI_RESPONSE_TEXT] == "Hi!"
-
-        assert span["attributes"][SPANDATA.GEN_AI_USAGE_INPUT_TOKENS] == 10
-        assert span["attributes"][SPANDATA.GEN_AI_USAGE_OUTPUT_TOKENS] == 20
-        assert span["attributes"][SPANDATA.GEN_AI_USAGE_TOTAL_TOKENS] == 30
-        assert span["attributes"][SPANDATA.GEN_AI_RESPONSE_STREAMING] is True
-        assert (
-            span["attributes"][SPANDATA.GEN_AI_RESPONSE_ID]
-            == "msg_01XFDUDYJgAACzvnptvVoYEL"
-        )
-
-        assert span["status"] == "error"
-        assert event["contexts"]["trace"]["status"] == "internal_error"
     else:
         events = capture_events()
 
@@ -3679,7 +3047,6 @@ async def test_streaming_create_message_async_api_error(
 
 
 @pytest.mark.parametrize("span_streaming", [True, False])
-@pytest.mark.parametrize("stream_gen_ai_spans", [True, False])
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
     "send_default_pii, include_prompts",
@@ -3699,7 +3066,6 @@ async def test_stream_message_async(
     get_model_response,
     async_iterator,
     server_side_event_chunks,
-    stream_gen_ai_spans,
     span_streaming,
 ):
     client = AsyncAnthropic(api_key="z")
@@ -3748,7 +3114,6 @@ async def test_stream_message_async(
         disabled_integrations=[StdlibIntegration],
         traces_sample_rate=1.0,
         send_default_pii=send_default_pii,
-        stream_gen_ai_spans=stream_gen_ai_spans,
         trace_lifecycle="stream" if span_streaming else "static",
     )
 
@@ -3785,63 +3150,6 @@ async def test_stream_message_async(
 
         assert spans[1]["name"] == "anthropic"
         (span, _) = spans
-
-        assert span["attributes"]["sentry.op"] == OP.GEN_AI_CHAT
-        assert span["name"] == "chat model"
-        assert span["attributes"][SPANDATA.GEN_AI_SYSTEM] == "anthropic"
-        assert span["attributes"][SPANDATA.GEN_AI_OPERATION_NAME] == "chat"
-        assert span["attributes"][SPANDATA.GEN_AI_REQUEST_MODEL] == "model"
-
-        if send_default_pii and include_prompts:
-            assert json.loads(span["attributes"][SPANDATA.GEN_AI_REQUEST_MESSAGES]) == [
-                {
-                    "role": "user",
-                    "content": "Message demonstrating the absence of truncation.",
-                },
-                {
-                    "role": "user",
-                    "content": "Hello, Claude",
-                },
-            ]
-            assert (
-                span["attributes"][SPANDATA.GEN_AI_RESPONSE_TEXT] == "Hi! I'm Claude!"
-            )
-
-        else:
-            assert SPANDATA.GEN_AI_REQUEST_MESSAGES not in span["attributes"]
-            assert SPANDATA.GEN_AI_RESPONSE_TEXT not in span["attributes"]
-
-        assert span["attributes"][SPANDATA.GEN_AI_USAGE_INPUT_TOKENS] == 10
-        assert span["attributes"][SPANDATA.GEN_AI_USAGE_OUTPUT_TOKENS] == 10
-        assert span["attributes"][SPANDATA.GEN_AI_USAGE_TOTAL_TOKENS] == 20
-        assert span["attributes"][SPANDATA.GEN_AI_RESPONSE_STREAMING] is True
-        assert (
-            span["attributes"][SPANDATA.GEN_AI_RESPONSE_ID]
-            == "msg_01XFDUDYJgAACzvnptvVoYEL"
-        )
-    elif stream_gen_ai_spans:
-        items = capture_items("transaction", "span")
-
-        with mock.patch.object(
-            client._client,
-            "send",
-            return_value=response,
-        ) as _, start_transaction(name="anthropic"):
-            async with client.messages.stream(
-                max_tokens=1024,
-                messages=messages,
-                model="model",
-            ) as stream:
-                async for event in stream:
-                    pass
-
-        (event,) = (item.payload for item in items if item.type == "transaction")
-        assert event["transaction"] == "anthropic"
-
-        sentry_sdk.flush()
-        spans = [item.payload for item in items if item.type == "span"]
-        assert len(spans) == 1
-        (span,) = spans
 
         assert span["attributes"]["sentry.op"] == OP.GEN_AI_CHAT
         assert span["name"] == "chat model"
@@ -3927,7 +3235,6 @@ async def test_stream_message_async(
 
 
 @pytest.mark.parametrize("span_streaming", [True, False])
-@pytest.mark.parametrize("stream_gen_ai_spans", [True, False])
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
     "data_collection,send_default_pii,include_prompts,outputs_collected",
@@ -3980,7 +3287,6 @@ async def test_stream_messages_data_collection_outputs_async(
     get_model_response,
     async_iterator,
     server_side_event_chunks,
-    stream_gen_ai_spans,
     span_streaming,
 ):
     sentry_init_kwargs = dict(
@@ -3988,7 +3294,6 @@ async def test_stream_messages_data_collection_outputs_async(
         disabled_integrations=[StdlibIntegration],
         traces_sample_rate=1.0,
         send_default_pii=send_default_pii,
-        stream_gen_ai_spans=stream_gen_ai_spans,
         trace_lifecycle="stream" if span_streaming else "static",
     )
     if data_collection is not None:
@@ -4037,7 +3342,7 @@ async def test_stream_messages_data_collection_outputs_async(
         messages=[{"role": "user", "content": "Hello, Claude"}],
     )
 
-    if span_streaming or stream_gen_ai_spans:
+    if span_streaming:
         items = capture_items("transaction", "span")
 
         with mock.patch.object(
@@ -4083,7 +3388,6 @@ async def test_stream_messages_data_collection_outputs_async(
 
 
 @pytest.mark.parametrize("span_streaming", [True, False])
-@pytest.mark.parametrize("stream_gen_ai_spans", [True, False])
 @pytest.mark.skipif(
     ANTHROPIC_VERSION < (0, 41),
     reason="Error classes moved in https://github.com/anthropics/anthropic-sdk-python/commit/4e0b15e22fe40e9aa513459564f641bf97c90954.",
@@ -4096,7 +3400,6 @@ async def test_stream_messages_async_api_error(
     get_model_response,
     async_iterator,
     server_side_event_chunks,
-    stream_gen_ai_spans,
     span_streaming,
 ):
     client = AsyncAnthropic(api_key="z")
@@ -4140,7 +3443,6 @@ async def test_stream_messages_async_api_error(
         disabled_integrations=[StdlibIntegration],
         traces_sample_rate=1.0,
         send_default_pii=True,
-        stream_gen_ai_spans=stream_gen_ai_spans,
         trace_lifecycle="stream" if span_streaming else "static",
     )
 
@@ -4170,50 +3472,6 @@ async def test_stream_messages_async_api_error(
         sentry_sdk.flush()
         spans = [item.payload for item in items if item.type == "span"]
         assert spans[1]["name"] == "anthropic"
-        span = next(
-            span for span in spans if span["attributes"]["sentry.op"] == OP.GEN_AI_CHAT
-        )
-
-        assert span["attributes"]["sentry.op"] == OP.GEN_AI_CHAT
-        assert span["name"] == "chat model"
-        assert span["attributes"][SPANDATA.GEN_AI_SYSTEM] == "anthropic"
-        assert span["attributes"][SPANDATA.GEN_AI_OPERATION_NAME] == "chat"
-        assert span["attributes"][SPANDATA.GEN_AI_REQUEST_MODEL] == "model"
-
-        assert (
-            span["attributes"][SPANDATA.GEN_AI_REQUEST_MESSAGES]
-            == '[{"role": "user", "content": "Hello, Claude"}]'
-        )
-        assert span["attributes"][SPANDATA.GEN_AI_RESPONSE_TEXT] == "Hi!"
-
-        assert span["attributes"][SPANDATA.GEN_AI_USAGE_INPUT_TOKENS] == 10
-        assert span["attributes"][SPANDATA.GEN_AI_USAGE_OUTPUT_TOKENS] == 20
-        assert span["attributes"][SPANDATA.GEN_AI_USAGE_TOTAL_TOKENS] == 30
-        assert span["attributes"][SPANDATA.GEN_AI_RESPONSE_STREAMING] is True
-        assert (
-            span["attributes"][SPANDATA.GEN_AI_RESPONSE_ID]
-            == "msg_01XFDUDYJgAACzvnptvVoYEL"
-        )
-
-        assert span["status"] == "error"
-    elif stream_gen_ai_spans:
-        items = capture_items("transaction", "span")
-
-        with pytest.raises(APIStatusError), mock.patch.object(
-            client._client,
-            "send",
-            return_value=response,
-        ) as _, start_transaction(name="anthropic"):
-            async with client.messages.stream(
-                max_tokens=1024,
-                messages=messages,
-                model="model",
-            ) as stream:
-                async for event in stream:
-                    pass
-
-        sentry_sdk.flush()
-        spans = [item.payload for item in items if item.type == "span"]
         span = next(
             span for span in spans if span["attributes"]["sentry.op"] == OP.GEN_AI_CHAT
         )
@@ -4290,7 +3548,6 @@ async def test_stream_messages_async_api_error(
 
 
 @pytest.mark.parametrize("span_streaming", [True, False])
-@pytest.mark.parametrize("stream_gen_ai_spans", [True, False])
 @pytest.mark.asyncio
 async def test_stream_messages_async_close(
     sentry_init,
@@ -4299,7 +3556,6 @@ async def test_stream_messages_async_close(
     get_model_response,
     async_iterator,
     server_side_event_chunks,
-    stream_gen_ai_spans,
     span_streaming,
 ):
     client = AsyncAnthropic(api_key="z")
@@ -4348,7 +3604,6 @@ async def test_stream_messages_async_close(
         disabled_integrations=[StdlibIntegration],
         traces_sample_rate=1.0,
         send_default_pii=True,
-        stream_gen_ai_spans=stream_gen_ai_spans,
         trace_lifecycle="stream" if span_streaming else "static",
     )
 
@@ -4386,56 +3641,6 @@ async def test_stream_messages_async_close(
         sentry_sdk.flush()
         spans = [item.payload for item in items if item.type == "span"]
         assert spans[1]["name"] == "anthropic"
-        span = next(
-            span for span in spans if span["attributes"]["sentry.op"] == OP.GEN_AI_CHAT
-        )
-
-        assert span["attributes"]["sentry.op"] == OP.GEN_AI_CHAT
-        assert span["name"] == "chat model"
-        assert span["attributes"][SPANDATA.GEN_AI_SYSTEM] == "anthropic"
-        assert span["attributes"][SPANDATA.GEN_AI_OPERATION_NAME] == "chat"
-        assert span["attributes"][SPANDATA.GEN_AI_REQUEST_MODEL] == "model"
-
-        assert (
-            span["attributes"][SPANDATA.GEN_AI_REQUEST_MESSAGES]
-            == '[{"role": "user", "content": "Hello, Claude"}]'
-        )
-        assert span["attributes"][SPANDATA.GEN_AI_RESPONSE_TEXT] == "Hi!"
-
-        assert span["attributes"][SPANDATA.GEN_AI_USAGE_INPUT_TOKENS] == 10
-        assert span["attributes"][SPANDATA.GEN_AI_USAGE_OUTPUT_TOKENS] == 20
-        assert span["attributes"][SPANDATA.GEN_AI_USAGE_TOTAL_TOKENS] == 30
-        assert span["attributes"][SPANDATA.GEN_AI_RESPONSE_STREAMING] is True
-        assert (
-            span["attributes"][SPANDATA.GEN_AI_RESPONSE_ID]
-            == "msg_01XFDUDYJgAACzvnptvVoYEL"
-        )
-    elif stream_gen_ai_spans:
-        items = capture_items("transaction", "span")
-
-        with mock.patch.object(
-            client._client,
-            "send",
-            return_value=response,
-        ) as _, start_transaction(name="anthropic"):
-            async with client.messages.stream(
-                max_tokens=1024,
-                messages=messages,
-                model="model",
-            ) as stream:
-                for _ in range(4):
-                    await stream.__anext__()
-
-                # New versions add TextEvent, so consume one more event.
-                if TextEvent is not None and isinstance(
-                    await stream.__anext__(), TextEvent
-                ):
-                    await stream.__anext__()
-
-                await stream.close()
-
-        sentry_sdk.flush()
-        spans = [item.payload for item in items if item.type == "span"]
         span = next(
             span for span in spans if span["attributes"]["sentry.op"] == OP.GEN_AI_CHAT
         )
@@ -4514,7 +3719,6 @@ async def test_stream_messages_async_close(
 
 
 @pytest.mark.parametrize("span_streaming", [True, False])
-@pytest.mark.parametrize("stream_gen_ai_spans", [True, False])
 @pytest.mark.skipif(
     ANTHROPIC_VERSION < (0, 27),
     reason="Versions <0.27.0 do not include InputJSONDelta, which was introduced in >=0.27.0 along with a new message delta type for tool calling.",
@@ -4536,7 +3740,6 @@ def test_streaming_create_message_with_input_json_delta(
     include_prompts,
     get_model_response,
     server_side_event_chunks,
-    stream_gen_ai_spans,
     span_streaming,
 ):
     client = Anthropic(api_key="z")
@@ -4613,7 +3816,6 @@ def test_streaming_create_message_with_input_json_delta(
         disabled_integrations=[StdlibIntegration],
         traces_sample_rate=1.0,
         send_default_pii=send_default_pii,
-        stream_gen_ai_spans=stream_gen_ai_spans,
         trace_lifecycle="stream" if span_streaming else "static",
     )
 
@@ -4645,53 +3847,6 @@ def test_streaming_create_message_with_input_json_delta(
 
         assert spans[1]["name"] == "anthropic"
         (span, _) = spans
-
-        assert span["attributes"]["sentry.op"] == OP.GEN_AI_CHAT
-        assert span["name"] == "chat model"
-        assert span["attributes"][SPANDATA.GEN_AI_SYSTEM] == "anthropic"
-        assert span["attributes"][SPANDATA.GEN_AI_OPERATION_NAME] == "chat"
-        assert span["attributes"][SPANDATA.GEN_AI_REQUEST_MODEL] == "model"
-
-        if send_default_pii and include_prompts:
-            assert (
-                span["attributes"][SPANDATA.GEN_AI_REQUEST_MESSAGES]
-                == '[{"role": "user", "content": "What is the weather like in San Francisco?"}]'
-            )
-            assert (
-                span["attributes"][SPANDATA.GEN_AI_RESPONSE_TEXT]
-                == '{"location": "San Francisco, CA"}'
-            )
-        else:
-            assert SPANDATA.GEN_AI_REQUEST_MESSAGES not in span["attributes"]
-            assert SPANDATA.GEN_AI_RESPONSE_TEXT not in span["attributes"]
-
-        assert span["attributes"][SPANDATA.GEN_AI_USAGE_INPUT_TOKENS] == 366
-        assert span["attributes"][SPANDATA.GEN_AI_USAGE_OUTPUT_TOKENS] == 41
-        assert span["attributes"][SPANDATA.GEN_AI_USAGE_TOTAL_TOKENS] == 407
-        assert span["attributes"][SPANDATA.GEN_AI_RESPONSE_STREAMING] is True
-
-    elif stream_gen_ai_spans:
-        items = capture_items("transaction", "span")
-
-        with mock.patch.object(
-            client._client,
-            "send",
-            return_value=response,
-        ) as _, start_transaction(name="anthropic"):
-            message = client.messages.create(
-                max_tokens=1024, messages=messages, model="model", stream=True
-            )
-
-            for _ in message:
-                pass
-
-        (event,) = (item.payload for item in items if item.type == "transaction")
-        assert event["transaction"] == "anthropic"
-
-        sentry_sdk.flush()
-        spans = [item.payload for item in items if item.type == "span"]
-        assert len(spans) == 1
-        (span,) = spans
 
         assert span["attributes"]["sentry.op"] == OP.GEN_AI_CHAT
         assert span["name"] == "chat model"
@@ -4767,7 +3922,6 @@ def test_streaming_create_message_with_input_json_delta(
 
 
 @pytest.mark.parametrize("span_streaming", [True, False])
-@pytest.mark.parametrize("stream_gen_ai_spans", [True, False])
 @pytest.mark.skipif(
     ANTHROPIC_VERSION < (0, 27),
     reason="Versions <0.27.0 do not include InputJSONDelta, which was introduced in >=0.27.0 along with a new message delta type for tool calling.",
@@ -4789,7 +3943,6 @@ def test_stream_messages_with_input_json_delta(
     include_prompts,
     get_model_response,
     server_side_event_chunks,
-    stream_gen_ai_spans,
     span_streaming,
 ):
     client = Anthropic(api_key="z")
@@ -4866,7 +4019,6 @@ def test_stream_messages_with_input_json_delta(
         disabled_integrations=[StdlibIntegration],
         traces_sample_rate=1.0,
         send_default_pii=send_default_pii,
-        stream_gen_ai_spans=stream_gen_ai_spans,
         trace_lifecycle="stream" if span_streaming else "static",
     )
 
@@ -4922,53 +4074,6 @@ def test_stream_messages_with_input_json_delta(
         assert span["attributes"][SPANDATA.GEN_AI_USAGE_OUTPUT_TOKENS] == 41
         assert span["attributes"][SPANDATA.GEN_AI_USAGE_TOTAL_TOKENS] == 407
         assert span["attributes"][SPANDATA.GEN_AI_RESPONSE_STREAMING] is True
-
-    elif stream_gen_ai_spans:
-        items = capture_items("transaction", "span")
-
-        with mock.patch.object(
-            client._client,
-            "send",
-            return_value=response,
-        ) as _, start_transaction(name="anthropic"), client.messages.stream(
-            max_tokens=1024,
-            messages=messages,
-            model="model",
-        ) as stream:
-            for event in stream:
-                pass
-
-        (event,) = (item.payload for item in items if item.type == "transaction")
-        assert event["transaction"] == "anthropic"
-
-        sentry_sdk.flush()
-        spans = [item.payload for item in items if item.type == "span"]
-        assert len(spans) == 1
-        (span,) = spans
-
-        assert span["attributes"]["sentry.op"] == OP.GEN_AI_CHAT
-        assert span["name"] == "chat model"
-        assert span["attributes"][SPANDATA.GEN_AI_SYSTEM] == "anthropic"
-        assert span["attributes"][SPANDATA.GEN_AI_OPERATION_NAME] == "chat"
-        assert span["attributes"][SPANDATA.GEN_AI_REQUEST_MODEL] == "model"
-
-        if send_default_pii and include_prompts:
-            assert (
-                span["attributes"][SPANDATA.GEN_AI_REQUEST_MESSAGES]
-                == '[{"role": "user", "content": "What is the weather like in San Francisco?"}]'
-            )
-            assert (
-                span["attributes"][SPANDATA.GEN_AI_RESPONSE_TEXT]
-                == '{"location": "San Francisco, CA"}'
-            )
-        else:
-            assert SPANDATA.GEN_AI_REQUEST_MESSAGES not in span["attributes"]
-            assert SPANDATA.GEN_AI_RESPONSE_TEXT not in span["attributes"]
-
-        assert span["attributes"][SPANDATA.GEN_AI_USAGE_INPUT_TOKENS] == 366
-        assert span["attributes"][SPANDATA.GEN_AI_USAGE_OUTPUT_TOKENS] == 41
-        assert span["attributes"][SPANDATA.GEN_AI_USAGE_TOTAL_TOKENS] == 407
-        assert span["attributes"][SPANDATA.GEN_AI_RESPONSE_STREAMING] is True
     else:
         events = capture_events()
 
@@ -5019,7 +4124,6 @@ def test_stream_messages_with_input_json_delta(
 
 
 @pytest.mark.parametrize("span_streaming", [True, False])
-@pytest.mark.parametrize("stream_gen_ai_spans", [True, False])
 @pytest.mark.asyncio
 @pytest.mark.skipif(
     ANTHROPIC_VERSION < (0, 27),
@@ -5043,7 +4147,6 @@ async def test_streaming_create_message_with_input_json_delta_async(
     get_model_response,
     async_iterator,
     server_side_event_chunks,
-    stream_gen_ai_spans,
     span_streaming,
 ):
     client = AsyncAnthropic(api_key="z")
@@ -5125,7 +4228,6 @@ async def test_streaming_create_message_with_input_json_delta_async(
         disabled_integrations=[StdlibIntegration],
         traces_sample_rate=1.0,
         send_default_pii=send_default_pii,
-        stream_gen_ai_spans=stream_gen_ai_spans,
         trace_lifecycle="stream" if span_streaming else "static",
     )
 
@@ -5157,54 +4259,6 @@ async def test_streaming_create_message_with_input_json_delta_async(
 
         assert spans[1]["name"] == "anthropic"
         (span, _) = spans
-
-        assert span["attributes"]["sentry.op"] == OP.GEN_AI_CHAT
-        assert span["name"] == "chat model"
-        assert span["attributes"][SPANDATA.GEN_AI_SYSTEM] == "anthropic"
-        assert span["attributes"][SPANDATA.GEN_AI_OPERATION_NAME] == "chat"
-        assert span["attributes"][SPANDATA.GEN_AI_REQUEST_MODEL] == "model"
-
-        if send_default_pii and include_prompts:
-            assert (
-                span["attributes"][SPANDATA.GEN_AI_REQUEST_MESSAGES]
-                == '[{"role": "user", "content": "What is the weather like in San Francisco?"}]'
-            )
-            assert (
-                span["attributes"][SPANDATA.GEN_AI_RESPONSE_TEXT]
-                == '{"location": "San Francisco, CA"}'
-            )
-
-        else:
-            assert SPANDATA.GEN_AI_REQUEST_MESSAGES not in span["attributes"]
-            assert SPANDATA.GEN_AI_RESPONSE_TEXT not in span["attributes"]
-
-        assert span["attributes"][SPANDATA.GEN_AI_USAGE_INPUT_TOKENS] == 366
-        assert span["attributes"][SPANDATA.GEN_AI_USAGE_OUTPUT_TOKENS] == 41
-        assert span["attributes"][SPANDATA.GEN_AI_USAGE_TOTAL_TOKENS] == 407
-        assert span["attributes"][SPANDATA.GEN_AI_RESPONSE_STREAMING] is True
-
-    elif stream_gen_ai_spans:
-        items = capture_items("transaction", "span")
-
-        with mock.patch.object(
-            client._client,
-            "send",
-            return_value=response,
-        ) as _, start_transaction(name="anthropic"):
-            message = await client.messages.create(
-                max_tokens=1024, messages=messages, model="model", stream=True
-            )
-
-            async for _ in message:
-                pass
-
-        (event,) = (item.payload for item in items if item.type == "transaction")
-        assert event["transaction"] == "anthropic"
-
-        sentry_sdk.flush()
-        spans = [item.payload for item in items if item.type == "span"]
-        assert len(spans) == 1
-        (span,) = spans
 
         assert span["attributes"]["sentry.op"] == OP.GEN_AI_CHAT
         assert span["name"] == "chat model"
@@ -5281,7 +4335,6 @@ async def test_streaming_create_message_with_input_json_delta_async(
 
 
 @pytest.mark.parametrize("span_streaming", [True, False])
-@pytest.mark.parametrize("stream_gen_ai_spans", [True, False])
 @pytest.mark.asyncio
 @pytest.mark.skipif(
     ANTHROPIC_VERSION < (0, 27),
@@ -5305,7 +4358,6 @@ async def test_stream_message_with_input_json_delta_async(
     get_model_response,
     async_iterator,
     server_side_event_chunks,
-    stream_gen_ai_spans,
     span_streaming,
 ):
     client = AsyncAnthropic(api_key="z")
@@ -5387,7 +4439,6 @@ async def test_stream_message_with_input_json_delta_async(
         disabled_integrations=[StdlibIntegration],
         traces_sample_rate=1.0,
         send_default_pii=send_default_pii,
-        stream_gen_ai_spans=stream_gen_ai_spans,
         trace_lifecycle="stream" if span_streaming else "static",
     )
 
@@ -5420,54 +4471,6 @@ async def test_stream_message_with_input_json_delta_async(
 
         assert spans[1]["name"] == "anthropic"
         (span, _) = spans
-
-        assert span["attributes"]["sentry.op"] == OP.GEN_AI_CHAT
-        assert span["name"] == "chat model"
-        assert span["attributes"][SPANDATA.GEN_AI_SYSTEM] == "anthropic"
-        assert span["attributes"][SPANDATA.GEN_AI_OPERATION_NAME] == "chat"
-        assert span["attributes"][SPANDATA.GEN_AI_REQUEST_MODEL] == "model"
-
-        if send_default_pii and include_prompts:
-            assert (
-                span["attributes"][SPANDATA.GEN_AI_REQUEST_MESSAGES]
-                == '[{"role": "user", "content": "What is the weather like in San Francisco?"}]'
-            )
-            assert (
-                span["attributes"][SPANDATA.GEN_AI_RESPONSE_TEXT]
-                == '{"location": "San Francisco, CA"}'
-            )
-        else:
-            assert SPANDATA.GEN_AI_REQUEST_MESSAGES not in span["attributes"]
-            assert SPANDATA.GEN_AI_RESPONSE_TEXT not in span["attributes"]
-
-        assert span["attributes"][SPANDATA.GEN_AI_USAGE_INPUT_TOKENS] == 366
-        assert span["attributes"][SPANDATA.GEN_AI_USAGE_OUTPUT_TOKENS] == 41
-        assert span["attributes"][SPANDATA.GEN_AI_USAGE_TOTAL_TOKENS] == 407
-        assert span["attributes"][SPANDATA.GEN_AI_RESPONSE_STREAMING] is True
-
-    elif stream_gen_ai_spans:
-        items = capture_items("transaction", "span")
-
-        with mock.patch.object(
-            client._client,
-            "send",
-            return_value=response,
-        ) as _, start_transaction(name="anthropic"):
-            async with client.messages.stream(
-                max_tokens=1024,
-                messages=messages,
-                model="model",
-            ) as stream:
-                async for event in stream:
-                    pass
-
-        (event,) = (item.payload for item in items if item.type == "transaction")
-        assert event["transaction"] == "anthropic"
-
-        sentry_sdk.flush()
-        spans = [item.payload for item in items if item.type == "span"]
-        assert len(spans) == 1
-        (span,) = spans
 
         assert span["attributes"]["sentry.op"] == OP.GEN_AI_CHAT
         assert span["name"] == "chat model"
@@ -5544,19 +4547,16 @@ async def test_stream_message_with_input_json_delta_async(
 
 
 @pytest.mark.parametrize("span_streaming", [True, False])
-@pytest.mark.parametrize("stream_gen_ai_spans", [True, False])
 def test_exception_message_create(
     sentry_init,
     capture_events,
     capture_items,
-    stream_gen_ai_spans,
     span_streaming,
 ):
     sentry_init(
         integrations=[AnthropicIntegration()],
         disabled_integrations=[StdlibIntegration],
         traces_sample_rate=1.0,
-        stream_gen_ai_spans=stream_gen_ai_spans,
         trace_lifecycle="stream" if span_streaming else "static",
     )
 
@@ -5577,21 +4577,6 @@ def test_exception_message_create(
 
         (event,) = (item.payload for item in items)
         assert event["level"] == "error"
-    elif stream_gen_ai_spans:
-        items = capture_items("event", "transaction")
-
-        with pytest.raises(AnthropicError):
-            client.messages.create(
-                model="some-model",
-                messages=[{"role": "system", "content": "I'm throwing an exception"}],
-                max_tokens=1024,
-            )
-
-        (event,) = (item.payload for item in items if item.type == "event")
-        assert event["level"] == "error"
-
-        (transaction,) = (item.payload for item in items if item.type == "transaction")
-        assert transaction["contexts"]["trace"]["status"] == "internal_error"
     else:
         events = capture_events()
 
@@ -5608,19 +4593,16 @@ def test_exception_message_create(
 
 
 @pytest.mark.parametrize("span_streaming", [True, False])
-@pytest.mark.parametrize("stream_gen_ai_spans", [True, False])
 def test_span_status_error(
     sentry_init,
     capture_events,
     capture_items,
-    stream_gen_ai_spans,
     span_streaming,
 ):
     sentry_init(
         integrations=[AnthropicIntegration()],
         disabled_integrations=[StdlibIntegration],
         traces_sample_rate=1.0,
-        stream_gen_ai_spans=stream_gen_ai_spans,
         trace_lifecycle="stream" if span_streaming else "static",
     )
 
@@ -5628,32 +4610,6 @@ def test_span_status_error(
         items = capture_items("event", "span")
 
         with sentry_sdk.traces.start_span(name="anthropic"):
-            client = Anthropic(api_key="z")
-            client.messages._post = mock.Mock(
-                side_effect=AnthropicError("API rate limit reached")
-            )
-            with pytest.raises(AnthropicError):
-                client.messages.create(
-                    model="some-model",
-                    messages=[
-                        {"role": "system", "content": "I'm throwing an exception"}
-                    ],
-                    max_tokens=1024,
-                )
-
-        (error,) = (item.payload for item in items if item.type == "event")
-        assert error["level"] == "error"
-
-        sentry_sdk.flush()
-        spans = [item.payload for item in items if item.type == "span"]
-        assert spans[0]["status"] == "error"
-        assert spans[0]["attributes"][SPANDATA.GEN_AI_SYSTEM] == "anthropic"
-        assert spans[0]["attributes"][SPANDATA.GEN_AI_OPERATION_NAME] == "chat"
-
-    elif stream_gen_ai_spans:
-        items = capture_items("event", "span")
-
-        with start_transaction(name="anthropic"):
             client = Anthropic(api_key="z")
             client.messages._post = mock.Mock(
                 side_effect=AnthropicError("API rate limit reached")
@@ -5701,51 +4657,23 @@ def test_span_status_error(
 
 
 @pytest.mark.parametrize("span_streaming", [True, False])
-@pytest.mark.parametrize("stream_gen_ai_spans", [True, False])
 @pytest.mark.asyncio
 async def test_span_status_error_async(
     sentry_init,
     capture_events,
     capture_items,
-    stream_gen_ai_spans,
     span_streaming,
 ):
     sentry_init(
         integrations=[AnthropicIntegration()],
         disabled_integrations=[StdlibIntegration],
         traces_sample_rate=1.0,
-        stream_gen_ai_spans=stream_gen_ai_spans,
         trace_lifecycle="stream" if span_streaming else "static",
     )
     if span_streaming:
         items = capture_items("event", "span")
 
         with sentry_sdk.traces.start_span(name="anthropic"):
-            client = AsyncAnthropic(api_key="z")
-            client.messages._post = AsyncMock(
-                side_effect=AnthropicError("API rate limit reached")
-            )
-            with pytest.raises(AnthropicError):
-                await client.messages.create(
-                    model="some-model",
-                    messages=[
-                        {"role": "system", "content": "I'm throwing an exception"}
-                    ],
-                    max_tokens=1024,
-                )
-
-        (error,) = (item.payload for item in items if item.type == "event")
-        assert error["level"] == "error"
-
-        sentry_sdk.flush()
-        spans = [item.payload for item in items if item.type == "span"]
-        assert spans[0]["status"] == "error"
-        assert spans[0]["attributes"][SPANDATA.GEN_AI_SYSTEM] == "anthropic"
-        assert spans[0]["attributes"][SPANDATA.GEN_AI_OPERATION_NAME] == "chat"
-    elif stream_gen_ai_spans:
-        items = capture_items("event", "span")
-
-        with start_transaction(name="anthropic"):
             client = AsyncAnthropic(api_key="z")
             client.messages._post = AsyncMock(
                 side_effect=AnthropicError("API rate limit reached")
@@ -5793,20 +4721,17 @@ async def test_span_status_error_async(
 
 
 @pytest.mark.parametrize("span_streaming", [True, False])
-@pytest.mark.parametrize("stream_gen_ai_spans", [True, False])
 @pytest.mark.asyncio
 async def test_exception_message_create_async(
     sentry_init,
     capture_events,
     capture_items,
-    stream_gen_ai_spans,
     span_streaming,
 ):
     sentry_init(
         integrations=[AnthropicIntegration()],
         disabled_integrations=[StdlibIntegration],
         traces_sample_rate=1.0,
-        stream_gen_ai_spans=stream_gen_ai_spans,
         trace_lifecycle="stream" if span_streaming else "static",
     )
 
@@ -5827,21 +4752,6 @@ async def test_exception_message_create_async(
 
         (event,) = (item.payload for item in items)
         assert event["level"] == "error"
-    elif stream_gen_ai_spans:
-        items = capture_items("event", "transaction")
-
-        with pytest.raises(AnthropicError):
-            await client.messages.create(
-                model="some-model",
-                messages=[{"role": "system", "content": "I'm throwing an exception"}],
-                max_tokens=1024,
-            )
-
-        (event,) = (item.payload for item in items if item.type == "event")
-        assert event["level"] == "error"
-
-        (transaction,) = (item.payload for item in items if item.type == "transaction")
-        assert transaction["contexts"]["trace"]["status"] == "internal_error"
     else:
         events = capture_events()
 
@@ -5858,19 +4768,16 @@ async def test_exception_message_create_async(
 
 
 @pytest.mark.parametrize("span_streaming", [True, False])
-@pytest.mark.parametrize("stream_gen_ai_spans", [True, False])
 def test_span_origin(
     sentry_init,
     capture_events,
     capture_items,
-    stream_gen_ai_spans,
     span_streaming,
 ):
     sentry_init(
         integrations=[AnthropicIntegration()],
         disabled_integrations=[StdlibIntegration],
         traces_sample_rate=1.0,
-        stream_gen_ai_spans=stream_gen_ai_spans,
         trace_lifecycle="stream" if span_streaming else "static",
     )
 
@@ -5896,21 +4803,6 @@ def test_span_origin(
         assert spans[0]["attributes"]["sentry.origin"] == "auto.ai.anthropic"
         assert spans[0]["attributes"][SPANDATA.GEN_AI_SYSTEM] == "anthropic"
         assert spans[0]["attributes"][SPANDATA.GEN_AI_OPERATION_NAME] == "chat"
-
-    elif stream_gen_ai_spans:
-        items = capture_items("transaction", "span")
-
-        with start_transaction(name="anthropic"):
-            client.messages.create(max_tokens=1024, messages=messages, model="model")
-
-        (event,) = (item.payload for item in items if item.type == "transaction")
-        assert event["contexts"]["trace"]["origin"] == "manual"
-
-        sentry_sdk.flush()
-        spans = [item.payload for item in items if item.type == "span"]
-        assert spans[0]["attributes"]["sentry.origin"] == "auto.ai.anthropic"
-        assert spans[0]["attributes"][SPANDATA.GEN_AI_SYSTEM] == "anthropic"
-        assert spans[0]["attributes"][SPANDATA.GEN_AI_OPERATION_NAME] == "chat"
     else:
         events = capture_events()
 
@@ -5925,20 +4817,17 @@ def test_span_origin(
 
 
 @pytest.mark.parametrize("span_streaming", [True, False])
-@pytest.mark.parametrize("stream_gen_ai_spans", [True, False])
 @pytest.mark.asyncio
 async def test_span_origin_async(
     sentry_init,
     capture_events,
     capture_items,
-    stream_gen_ai_spans,
     span_streaming,
 ):
     sentry_init(
         integrations=[AnthropicIntegration()],
         disabled_integrations=[StdlibIntegration],
         traces_sample_rate=1.0,
-        stream_gen_ai_spans=stream_gen_ai_spans,
         trace_lifecycle="stream" if span_streaming else "static",
     )
 
@@ -5963,22 +4852,6 @@ async def test_span_origin_async(
         sentry_sdk.flush()
         spans = [item.payload for item in items if item.type == "span"]
         assert spans[1]["attributes"]["sentry.origin"] == "manual"
-        assert spans[0]["attributes"]["sentry.origin"] == "auto.ai.anthropic"
-        assert spans[0]["attributes"][SPANDATA.GEN_AI_SYSTEM] == "anthropic"
-        assert spans[0]["attributes"][SPANDATA.GEN_AI_OPERATION_NAME] == "chat"
-    elif stream_gen_ai_spans:
-        items = capture_items("transaction", "span")
-
-        with start_transaction(name="anthropic"):
-            await client.messages.create(
-                max_tokens=1024, messages=messages, model="model"
-            )
-
-        (event,) = (item.payload for item in items if item.type == "transaction")
-        assert event["contexts"]["trace"]["origin"] == "manual"
-
-        sentry_sdk.flush()
-        spans = [item.payload for item in items if item.type == "span"]
         assert spans[0]["attributes"]["sentry.origin"] == "auto.ai.anthropic"
         assert spans[0]["attributes"][SPANDATA.GEN_AI_SYSTEM] == "anthropic"
         assert spans[0]["attributes"][SPANDATA.GEN_AI_OPERATION_NAME] == "chat"
@@ -6066,7 +4939,6 @@ def test_set_output_data_with_input_json_delta(sentry_init):
 
 # Test messages with mixed roles including "ai" that should be mapped to "assistant"
 @pytest.mark.parametrize("span_streaming", [True, False])
-@pytest.mark.parametrize("stream_gen_ai_spans", [True, False])
 @pytest.mark.parametrize(
     "test_message,expected_role",
     [
@@ -6088,7 +4960,6 @@ def test_anthropic_message_role_mapping(
     capture_items,
     test_message,
     expected_role,
-    stream_gen_ai_spans,
     span_streaming,
 ):
     """Test that Anthropic integration properly maps message roles like 'ai' to 'assistant'"""
@@ -6097,7 +4968,6 @@ def test_anthropic_message_role_mapping(
         disabled_integrations=[StdlibIntegration],
         traces_sample_rate=1.0,
         send_default_pii=True,
-        stream_gen_ai_spans=stream_gen_ai_spans,
         trace_lifecycle="stream" if span_streaming else "static",
     )
 
@@ -6119,7 +4989,7 @@ def test_anthropic_message_role_mapping(
 
     test_messages = [test_message]
 
-    if span_streaming or stream_gen_ai_spans:
+    if span_streaming:
         items = capture_items("span")
 
         with start_transaction(name="anthropic tx"):
@@ -6170,7 +5040,6 @@ def test_anthropic_message_truncation(sentry_init, capture_events):
         disabled_integrations=[StdlibIntegration],
         traces_sample_rate=1.0,
         send_default_pii=True,
-        stream_gen_ai_spans=False,
     )
     events = capture_events()
 
@@ -6224,7 +5093,6 @@ async def test_anthropic_message_truncation_async(sentry_init, capture_events):
         disabled_integrations=[StdlibIntegration],
         traces_sample_rate=1.0,
         send_default_pii=True,
-        stream_gen_ai_spans=False,
     )
     events = capture_events()
 
@@ -6271,7 +5139,6 @@ async def test_anthropic_message_truncation_async(sentry_init, capture_events):
 
 
 @pytest.mark.parametrize("span_streaming", [True, False])
-@pytest.mark.parametrize("stream_gen_ai_spans", [True, False])
 @pytest.mark.parametrize(
     "send_default_pii, include_prompts",
     [
@@ -6287,7 +5154,6 @@ def test_nonstreaming_create_message_with_system_prompt(
     capture_items,
     send_default_pii,
     include_prompts,
-    stream_gen_ai_spans,
     span_streaming,
 ):
     """Test that system prompts are properly captured in GEN_AI_REQUEST_MESSAGES."""
@@ -6296,7 +5162,6 @@ def test_nonstreaming_create_message_with_system_prompt(
         disabled_integrations=[StdlibIntegration],
         traces_sample_rate=1.0,
         send_default_pii=send_default_pii,
-        stream_gen_ai_spans=stream_gen_ai_spans,
         trace_lifecycle="stream" if span_streaming else "static",
     )
 
@@ -6333,68 +5198,6 @@ def test_nonstreaming_create_message_with_system_prompt(
 
         assert spans[1]["name"] == "anthropic"
         (span, _) = spans
-
-        assert span["attributes"]["sentry.op"] == OP.GEN_AI_CHAT
-        assert span["name"] == "chat model"
-        assert span["attributes"][SPANDATA.GEN_AI_SYSTEM] == "anthropic"
-        assert span["attributes"][SPANDATA.GEN_AI_OPERATION_NAME] == "chat"
-        assert span["attributes"][SPANDATA.GEN_AI_REQUEST_MODEL] == "model"
-
-        if send_default_pii and include_prompts:
-            assert SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS in span["attributes"]
-            system_instructions = json.loads(
-                span["attributes"][SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS]
-            )
-            assert system_instructions == [
-                {"type": "text", "content": "You are a helpful assistant."}
-            ]
-
-            assert SPANDATA.GEN_AI_REQUEST_MESSAGES in span["attributes"]
-            stored_messages = json.loads(
-                span["attributes"][SPANDATA.GEN_AI_REQUEST_MESSAGES]
-            )
-            assert len(stored_messages) == 1
-            assert stored_messages[0]["role"] == "user"
-            assert stored_messages[0]["content"] == "Hello, Claude"
-            assert (
-                span["attributes"][SPANDATA.GEN_AI_RESPONSE_TEXT] == "Hi, I'm Claude."
-            )
-        else:
-            assert SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS not in span["attributes"]
-            assert SPANDATA.GEN_AI_REQUEST_MESSAGES not in span["attributes"]
-            assert SPANDATA.GEN_AI_RESPONSE_TEXT not in span["attributes"]
-
-        assert span["attributes"][SPANDATA.GEN_AI_USAGE_INPUT_TOKENS] == 10
-        assert span["attributes"][SPANDATA.GEN_AI_USAGE_OUTPUT_TOKENS] == 20
-        assert span["attributes"][SPANDATA.GEN_AI_USAGE_TOTAL_TOKENS] == 30
-        assert span["attributes"][SPANDATA.GEN_AI_RESPONSE_STREAMING] is False
-        assert span["attributes"][SPANDATA.GEN_AI_RESPONSE_FINISH_REASONS] == [
-            "end_turn"
-        ]
-    elif stream_gen_ai_spans:
-        items = capture_items("transaction", "span")
-
-        with start_transaction(name="anthropic"):
-            response = client.messages.create(
-                max_tokens=1024,
-                messages=messages,
-                model="model",
-                system="You are a helpful assistant.",
-            )
-
-        assert response == EXAMPLE_MESSAGE
-        usage = response.usage
-
-        assert usage.input_tokens == 10
-        assert usage.output_tokens == 20
-
-        (event,) = (item.payload for item in items if item.type == "transaction")
-        assert event["transaction"] == "anthropic"
-
-        sentry_sdk.flush()
-        spans = [item.payload for item in items if item.type == "span"]
-        assert len(spans) == 1
-        (span,) = spans
 
         assert span["attributes"]["sentry.op"] == OP.GEN_AI_CHAT
         assert span["name"] == "chat model"
@@ -6493,7 +5296,6 @@ def test_nonstreaming_create_message_with_system_prompt(
 
 
 @pytest.mark.parametrize("span_streaming", [True, False])
-@pytest.mark.parametrize("stream_gen_ai_spans", [True, False])
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
     "send_default_pii, include_prompts",
@@ -6510,7 +5312,6 @@ async def test_nonstreaming_create_message_with_system_prompt_async(
     capture_items,
     send_default_pii,
     include_prompts,
-    stream_gen_ai_spans,
     span_streaming,
 ):
     """Test that system prompts are properly captured in GEN_AI_REQUEST_MESSAGES (async)."""
@@ -6519,7 +5320,6 @@ async def test_nonstreaming_create_message_with_system_prompt_async(
         disabled_integrations=[StdlibIntegration],
         traces_sample_rate=1.0,
         send_default_pii=send_default_pii,
-        stream_gen_ai_spans=stream_gen_ai_spans,
         trace_lifecycle="stream" if span_streaming else "static",
     )
 
@@ -6594,68 +5394,6 @@ async def test_nonstreaming_create_message_with_system_prompt_async(
         assert span["attributes"][SPANDATA.GEN_AI_RESPONSE_FINISH_REASONS] == [
             "end_turn"
         ]
-    elif stream_gen_ai_spans:
-        items = capture_items("transaction", "span")
-
-        with start_transaction(name="anthropic"):
-            response = await client.messages.create(
-                max_tokens=1024,
-                messages=messages,
-                model="model",
-                system="You are a helpful assistant.",
-            )
-
-        assert response == EXAMPLE_MESSAGE
-        usage = response.usage
-
-        assert usage.input_tokens == 10
-        assert usage.output_tokens == 20
-
-        (event,) = (item.payload for item in items if item.type == "transaction")
-        assert event["transaction"] == "anthropic"
-
-        sentry_sdk.flush()
-        spans = [item.payload for item in items if item.type == "span"]
-        assert len(spans) == 1
-        (span,) = spans
-
-        assert span["attributes"]["sentry.op"] == OP.GEN_AI_CHAT
-        assert span["name"] == "chat model"
-        assert span["attributes"][SPANDATA.GEN_AI_SYSTEM] == "anthropic"
-        assert span["attributes"][SPANDATA.GEN_AI_OPERATION_NAME] == "chat"
-        assert span["attributes"][SPANDATA.GEN_AI_REQUEST_MODEL] == "model"
-
-        if send_default_pii and include_prompts:
-            assert SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS in span["attributes"]
-            system_instructions = json.loads(
-                span["attributes"][SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS]
-            )
-            assert system_instructions == [
-                {"type": "text", "content": "You are a helpful assistant."}
-            ]
-
-            assert SPANDATA.GEN_AI_REQUEST_MESSAGES in span["attributes"]
-            stored_messages = json.loads(
-                span["attributes"][SPANDATA.GEN_AI_REQUEST_MESSAGES]
-            )
-            assert len(stored_messages) == 1
-            assert stored_messages[0]["role"] == "user"
-            assert stored_messages[0]["content"] == "Hello, Claude"
-            assert (
-                span["attributes"][SPANDATA.GEN_AI_RESPONSE_TEXT] == "Hi, I'm Claude."
-            )
-        else:
-            assert SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS not in span["attributes"]
-            assert SPANDATA.GEN_AI_REQUEST_MESSAGES not in span["attributes"]
-            assert SPANDATA.GEN_AI_RESPONSE_TEXT not in span["attributes"]
-
-        assert span["attributes"][SPANDATA.GEN_AI_USAGE_INPUT_TOKENS] == 10
-        assert span["attributes"][SPANDATA.GEN_AI_USAGE_OUTPUT_TOKENS] == 20
-        assert span["attributes"][SPANDATA.GEN_AI_USAGE_TOTAL_TOKENS] == 30
-        assert span["attributes"][SPANDATA.GEN_AI_RESPONSE_STREAMING] is False
-        assert span["attributes"][SPANDATA.GEN_AI_RESPONSE_FINISH_REASONS] == [
-            "end_turn"
-        ]
     else:
         events = capture_events()
 
@@ -6716,7 +5454,6 @@ async def test_nonstreaming_create_message_with_system_prompt_async(
 
 
 @pytest.mark.parametrize("span_streaming", [True, False])
-@pytest.mark.parametrize("stream_gen_ai_spans", [True, False])
 @pytest.mark.parametrize(
     "send_default_pii, include_prompts",
     [
@@ -6734,7 +5471,6 @@ def test_streaming_create_message_with_system_prompt(
     include_prompts,
     get_model_response,
     server_side_event_chunks,
-    stream_gen_ai_spans,
     span_streaming,
 ):
     """Test that system prompts are properly captured in streaming mode."""
@@ -6782,7 +5518,6 @@ def test_streaming_create_message_with_system_prompt(
         disabled_integrations=[StdlibIntegration],
         traces_sample_rate=1.0,
         send_default_pii=send_default_pii,
-        stream_gen_ai_spans=stream_gen_ai_spans,
         trace_lifecycle="stream" if span_streaming else "static",
     )
 
@@ -6818,69 +5553,6 @@ def test_streaming_create_message_with_system_prompt(
 
         assert spans[1]["name"] == "anthropic"
         (span, _) = spans
-
-        assert span["attributes"]["sentry.op"] == OP.GEN_AI_CHAT
-        assert span["name"] == "chat model"
-        assert span["attributes"][SPANDATA.GEN_AI_SYSTEM] == "anthropic"
-        assert span["attributes"][SPANDATA.GEN_AI_OPERATION_NAME] == "chat"
-        assert span["attributes"][SPANDATA.GEN_AI_REQUEST_MODEL] == "model"
-
-        if send_default_pii and include_prompts:
-            assert SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS in span["attributes"]
-            system_instructions = json.loads(
-                span["attributes"][SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS]
-            )
-            assert system_instructions == [
-                {"type": "text", "content": "You are a helpful assistant."}
-            ]
-
-            assert SPANDATA.GEN_AI_REQUEST_MESSAGES in span["attributes"]
-            stored_messages = json.loads(
-                span["attributes"][SPANDATA.GEN_AI_REQUEST_MESSAGES]
-            )
-            assert len(stored_messages) == 1
-            assert stored_messages[0]["role"] == "user"
-            assert stored_messages[0]["content"] == "Hello, Claude"
-            assert (
-                span["attributes"][SPANDATA.GEN_AI_RESPONSE_TEXT] == "Hi! I'm Claude!"
-            )
-
-        else:
-            assert SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS not in span["attributes"]
-            assert SPANDATA.GEN_AI_REQUEST_MESSAGES not in span["attributes"]
-            assert SPANDATA.GEN_AI_RESPONSE_TEXT not in span["attributes"]
-
-        assert span["attributes"][SPANDATA.GEN_AI_USAGE_INPUT_TOKENS] == 10
-        assert span["attributes"][SPANDATA.GEN_AI_USAGE_OUTPUT_TOKENS] == 10
-        assert span["attributes"][SPANDATA.GEN_AI_USAGE_TOTAL_TOKENS] == 20
-        assert span["attributes"][SPANDATA.GEN_AI_RESPONSE_STREAMING] is True
-
-    elif stream_gen_ai_spans:
-        items = capture_items("transaction", "span")
-
-        with mock.patch.object(
-            client._client,
-            "send",
-            return_value=response,
-        ) as _, start_transaction(name="anthropic"):
-            message = client.messages.create(
-                max_tokens=1024,
-                messages=messages,
-                model="model",
-                stream=True,
-                system="You are a helpful assistant.",
-            )
-
-            for _ in message:
-                pass
-
-        (event,) = (item.payload for item in items if item.type == "transaction")
-        assert event["transaction"] == "anthropic"
-
-        sentry_sdk.flush()
-        spans = [item.payload for item in items if item.type == "span"]
-        assert len(spans) == 1
-        (span,) = spans
 
         assert span["attributes"]["sentry.op"] == OP.GEN_AI_CHAT
         assert span["name"] == "chat model"
@@ -6980,7 +5652,6 @@ def test_streaming_create_message_with_system_prompt(
 
 
 @pytest.mark.parametrize("span_streaming", [True, False])
-@pytest.mark.parametrize("stream_gen_ai_spans", [True, False])
 @pytest.mark.parametrize(
     "send_default_pii, include_prompts",
     [
@@ -6998,7 +5669,6 @@ def test_stream_messages_with_system_prompt(
     include_prompts,
     get_model_response,
     server_side_event_chunks,
-    stream_gen_ai_spans,
     span_streaming,
 ):
     """Test that system prompts are properly captured in streaming mode."""
@@ -7046,7 +5716,6 @@ def test_stream_messages_with_system_prompt(
         disabled_integrations=[StdlibIntegration],
         traces_sample_rate=1.0,
         send_default_pii=send_default_pii,
-        stream_gen_ai_spans=stream_gen_ai_spans,
         trace_lifecycle="stream" if span_streaming else "static",
     )
 
@@ -7113,64 +5782,6 @@ def test_stream_messages_with_system_prompt(
         assert span["attributes"][SPANDATA.GEN_AI_USAGE_OUTPUT_TOKENS] == 10
         assert span["attributes"][SPANDATA.GEN_AI_USAGE_TOTAL_TOKENS] == 20
         assert span["attributes"][SPANDATA.GEN_AI_RESPONSE_STREAMING] is True
-
-    elif stream_gen_ai_spans:
-        items = capture_items("transaction", "span")
-
-        with mock.patch.object(
-            client._client,
-            "send",
-            return_value=response,
-        ) as _, start_transaction(name="anthropic"), client.messages.stream(
-            max_tokens=1024,
-            messages=messages,
-            model="model",
-            system="You are a helpful assistant.",
-        ) as stream:
-            for event in stream:
-                pass
-
-        (event,) = (item.payload for item in items if item.type == "transaction")
-        assert event["transaction"] == "anthropic"
-
-        sentry_sdk.flush()
-        spans = [item.payload for item in items if item.type == "span"]
-        assert len(spans) == 1
-        (span,) = spans
-
-        assert span["attributes"]["sentry.op"] == OP.GEN_AI_CHAT
-        assert span["name"] == "chat model"
-        assert span["attributes"][SPANDATA.GEN_AI_SYSTEM] == "anthropic"
-        assert span["attributes"][SPANDATA.GEN_AI_OPERATION_NAME] == "chat"
-        assert span["attributes"][SPANDATA.GEN_AI_REQUEST_MODEL] == "model"
-
-        if send_default_pii and include_prompts:
-            assert SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS in span["attributes"]
-            system_instructions = json.loads(
-                span["attributes"][SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS]
-            )
-            assert system_instructions == [
-                {"type": "text", "content": "You are a helpful assistant."}
-            ]
-            assert SPANDATA.GEN_AI_REQUEST_MESSAGES in span["attributes"]
-            stored_messages = json.loads(
-                span["attributes"][SPANDATA.GEN_AI_REQUEST_MESSAGES]
-            )
-            assert len(stored_messages) == 1
-            assert stored_messages[0]["role"] == "user"
-            assert stored_messages[0]["content"] == "Hello, Claude"
-            assert (
-                span["attributes"][SPANDATA.GEN_AI_RESPONSE_TEXT] == "Hi! I'm Claude!"
-            )
-        else:
-            assert SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS not in span["attributes"]
-            assert SPANDATA.GEN_AI_REQUEST_MESSAGES not in span["attributes"]
-            assert SPANDATA.GEN_AI_RESPONSE_TEXT not in span["attributes"]
-
-        assert span["attributes"][SPANDATA.GEN_AI_USAGE_INPUT_TOKENS] == 10
-        assert span["attributes"][SPANDATA.GEN_AI_USAGE_OUTPUT_TOKENS] == 10
-        assert span["attributes"][SPANDATA.GEN_AI_USAGE_TOTAL_TOKENS] == 20
-        assert span["attributes"][SPANDATA.GEN_AI_RESPONSE_STREAMING] is True
     else:
         events = capture_events()
 
@@ -7228,7 +5839,6 @@ def test_stream_messages_with_system_prompt(
 
 
 @pytest.mark.parametrize("span_streaming", [True, False])
-@pytest.mark.parametrize("stream_gen_ai_spans", [True, False])
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
     "send_default_pii, include_prompts",
@@ -7248,7 +5858,6 @@ async def test_stream_message_with_system_prompt_async(
     get_model_response,
     async_iterator,
     server_side_event_chunks,
-    stream_gen_ai_spans,
     span_streaming,
 ):
     """Test that system prompts are properly captured in streaming mode (async)."""
@@ -7298,7 +5907,6 @@ async def test_stream_message_with_system_prompt_async(
         disabled_integrations=[StdlibIntegration],
         traces_sample_rate=1.0,
         send_default_pii=send_default_pii,
-        stream_gen_ai_spans=stream_gen_ai_spans,
         trace_lifecycle="stream" if span_streaming else "static",
     )
 
@@ -7332,66 +5940,6 @@ async def test_stream_message_with_system_prompt_async(
 
         assert spans[1]["name"] == "anthropic"
         (span, _) = spans
-
-        assert span["attributes"]["sentry.op"] == OP.GEN_AI_CHAT
-        assert span["name"] == "chat model"
-        assert span["attributes"][SPANDATA.GEN_AI_SYSTEM] == "anthropic"
-        assert span["attributes"][SPANDATA.GEN_AI_OPERATION_NAME] == "chat"
-        assert span["attributes"][SPANDATA.GEN_AI_REQUEST_MODEL] == "model"
-
-        if send_default_pii and include_prompts:
-            assert SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS in span["attributes"]
-            system_instructions = json.loads(
-                span["attributes"][SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS]
-            )
-            assert system_instructions == [
-                {"type": "text", "content": "You are a helpful assistant."}
-            ]
-
-            assert SPANDATA.GEN_AI_REQUEST_MESSAGES in span["attributes"]
-            stored_messages = json.loads(
-                span["attributes"][SPANDATA.GEN_AI_REQUEST_MESSAGES]
-            )
-            assert len(stored_messages) == 1
-            assert stored_messages[0]["role"] == "user"
-            assert stored_messages[0]["content"] == "Hello, Claude"
-            assert (
-                span["attributes"][SPANDATA.GEN_AI_RESPONSE_TEXT] == "Hi! I'm Claude!"
-            )
-        else:
-            assert SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS not in span["attributes"]
-            assert SPANDATA.GEN_AI_REQUEST_MESSAGES not in span["attributes"]
-            assert SPANDATA.GEN_AI_RESPONSE_TEXT not in span["attributes"]
-
-        assert span["attributes"][SPANDATA.GEN_AI_USAGE_INPUT_TOKENS] == 10
-        assert span["attributes"][SPANDATA.GEN_AI_USAGE_OUTPUT_TOKENS] == 10
-        assert span["attributes"][SPANDATA.GEN_AI_USAGE_TOTAL_TOKENS] == 20
-        assert span["attributes"][SPANDATA.GEN_AI_RESPONSE_STREAMING] is True
-
-    elif stream_gen_ai_spans:
-        items = capture_items("transaction", "span")
-
-        with mock.patch.object(
-            client._client,
-            "send",
-            return_value=response,
-        ) as _, start_transaction(name="anthropic"):
-            async with client.messages.stream(
-                max_tokens=1024,
-                messages=messages,
-                model="model",
-                system="You are a helpful assistant.",
-            ) as stream:
-                async for event in stream:
-                    pass
-
-        (event,) = (item.payload for item in items if item.type == "transaction")
-        assert event["transaction"] == "anthropic"
-
-        sentry_sdk.flush()
-        spans = [item.payload for item in items if item.type == "span"]
-        assert len(spans) == 1
-        (span,) = spans
 
         assert span["attributes"]["sentry.op"] == OP.GEN_AI_CHAT
         assert span["name"] == "chat model"
@@ -7487,7 +6035,6 @@ async def test_stream_message_with_system_prompt_async(
 
 
 @pytest.mark.parametrize("span_streaming", [True, False])
-@pytest.mark.parametrize("stream_gen_ai_spans", [True, False])
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
     "send_default_pii, include_prompts",
@@ -7507,7 +6054,6 @@ async def test_streaming_create_message_with_system_prompt_async(
     get_model_response,
     async_iterator,
     server_side_event_chunks,
-    stream_gen_ai_spans,
     span_streaming,
 ):
     """Test that system prompts are properly captured in streaming mode (async)."""
@@ -7557,7 +6103,6 @@ async def test_streaming_create_message_with_system_prompt_async(
         disabled_integrations=[StdlibIntegration],
         traces_sample_rate=1.0,
         send_default_pii=send_default_pii,
-        stream_gen_ai_spans=stream_gen_ai_spans,
         trace_lifecycle="stream" if span_streaming else "static",
     )
 
@@ -7593,70 +6138,6 @@ async def test_streaming_create_message_with_system_prompt_async(
         assert spans[1]["name"] == "anthropic"
         assert len(spans) == 2
         (span, _) = spans
-
-        assert span["attributes"]["sentry.op"] == OP.GEN_AI_CHAT
-        assert span["name"] == "chat model"
-        assert span["attributes"][SPANDATA.GEN_AI_SYSTEM] == "anthropic"
-        assert span["attributes"][SPANDATA.GEN_AI_OPERATION_NAME] == "chat"
-        assert span["attributes"][SPANDATA.GEN_AI_REQUEST_MODEL] == "model"
-
-        if send_default_pii and include_prompts:
-            assert SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS in span["attributes"]
-            system_instructions = json.loads(
-                span["attributes"][SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS]
-            )
-            assert system_instructions == [
-                {"type": "text", "content": "You are a helpful assistant."}
-            ]
-
-            assert SPANDATA.GEN_AI_REQUEST_MESSAGES in span["attributes"]
-            stored_messages = json.loads(
-                span["attributes"][SPANDATA.GEN_AI_REQUEST_MESSAGES]
-            )
-
-            assert len(stored_messages) == 1
-            assert stored_messages[0]["role"] == "user"
-            assert stored_messages[0]["content"] == "Hello, Claude"
-            assert (
-                span["attributes"][SPANDATA.GEN_AI_RESPONSE_TEXT] == "Hi! I'm Claude!"
-            )
-
-        else:
-            assert SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS not in span["attributes"]
-            assert SPANDATA.GEN_AI_REQUEST_MESSAGES not in span["attributes"]
-            assert SPANDATA.GEN_AI_RESPONSE_TEXT not in span["attributes"]
-
-        assert span["attributes"][SPANDATA.GEN_AI_USAGE_INPUT_TOKENS] == 10
-        assert span["attributes"][SPANDATA.GEN_AI_USAGE_OUTPUT_TOKENS] == 10
-        assert span["attributes"][SPANDATA.GEN_AI_USAGE_TOTAL_TOKENS] == 20
-        assert span["attributes"][SPANDATA.GEN_AI_RESPONSE_STREAMING] is True
-
-    elif stream_gen_ai_spans:
-        items = capture_items("transaction", "span")
-
-        with mock.patch.object(
-            client._client,
-            "send",
-            return_value=response,
-        ) as _, start_transaction(name="anthropic"):
-            message = await client.messages.create(
-                max_tokens=1024,
-                messages=messages,
-                model="model",
-                stream=True,
-                system="You are a helpful assistant.",
-            )
-
-            async for _ in message:
-                pass
-
-        (event,) = (item.payload for item in items if item.type == "transaction")
-        assert event["transaction"] == "anthropic"
-
-        sentry_sdk.flush()
-        spans = [item.payload for item in items if item.type == "span"]
-        assert len(spans) == 1
-        (span,) = spans
 
         assert span["attributes"]["sentry.op"] == OP.GEN_AI_CHAT
         assert span["name"] == "chat model"
@@ -7755,12 +6236,10 @@ async def test_streaming_create_message_with_system_prompt_async(
 
 
 @pytest.mark.parametrize("span_streaming", [True, False])
-@pytest.mark.parametrize("stream_gen_ai_spans", [True, False])
 def test_system_prompt_with_complex_structure(
     sentry_init,
     capture_events,
     capture_items,
-    stream_gen_ai_spans,
     span_streaming,
 ):
     """Test that complex system prompt structures (list of text blocks) are properly captured."""
@@ -7769,7 +6248,6 @@ def test_system_prompt_with_complex_structure(
         disabled_integrations=[StdlibIntegration],
         traces_sample_rate=1.0,
         send_default_pii=True,
-        stream_gen_ai_spans=stream_gen_ai_spans,
         trace_lifecycle="stream" if span_streaming else "static",
     )
 
@@ -7805,41 +6283,6 @@ def test_system_prompt_with_complex_structure(
 
         assert spans[1]["name"] == "anthropic"
         (span, _) = spans
-
-        assert span["attributes"][SPANDATA.GEN_AI_SYSTEM] == "anthropic"
-        assert span["attributes"][SPANDATA.GEN_AI_OPERATION_NAME] == "chat"
-
-        assert SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS in span["attributes"]
-        system_instructions = json.loads(
-            span["attributes"][SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS]
-        )
-
-        # System content should be a list of text blocks
-        assert isinstance(system_instructions, list)
-        assert system_instructions == [
-            {"type": "text", "content": "You are a helpful assistant."},
-            {"type": "text", "content": "Be concise and clear."},
-        ]
-
-        assert SPANDATA.GEN_AI_REQUEST_MESSAGES in span["attributes"]
-        stored_messages = json.loads(
-            span["attributes"][SPANDATA.GEN_AI_REQUEST_MESSAGES]
-        )
-
-    elif stream_gen_ai_spans:
-        items = capture_items("span")
-
-        with start_transaction(name="anthropic"):
-            response = client.messages.create(
-                max_tokens=1024, messages=messages, model="model", system=system_prompt
-            )
-
-        assert response == EXAMPLE_MESSAGE
-
-        sentry_sdk.flush()
-        spans = [item.payload for item in items]
-        assert len(spans) == 1
-        (span,) = spans
 
         assert span["attributes"][SPANDATA.GEN_AI_SYSTEM] == "anthropic"
         assert span["attributes"][SPANDATA.GEN_AI_OPERATION_NAME] == "chat"
@@ -8101,7 +6544,6 @@ def test_message_with_base64_image(sentry_init, capture_events):
         disabled_integrations=[StdlibIntegration],
         traces_sample_rate=1.0,
         send_default_pii=True,
-        stream_gen_ai_spans=False,
     )
     events = capture_events()
     client = Anthropic(api_key="z")
@@ -8148,12 +6590,10 @@ def test_message_with_base64_image(sentry_init, capture_events):
 
 
 @pytest.mark.parametrize("span_streaming", [True, False])
-@pytest.mark.parametrize("stream_gen_ai_spans", [True, False])
 def test_message_with_url_image(
     sentry_init,
     capture_events,
     capture_items,
-    stream_gen_ai_spans,
     span_streaming,
 ):
     """Test that messages with URL-referenced images are properly captured."""
@@ -8162,7 +6602,6 @@ def test_message_with_url_image(
         disabled_integrations=[StdlibIntegration],
         traces_sample_rate=1.0,
         send_default_pii=True,
-        stream_gen_ai_spans=stream_gen_ai_spans,
         trace_lifecycle="stream" if span_streaming else "static",
     )
 
@@ -8185,7 +6624,7 @@ def test_message_with_url_image(
         }
     ]
 
-    if span_streaming or stream_gen_ai_spans:
+    if span_streaming:
         items = capture_items("span")
 
         with start_transaction(name="anthropic"):
@@ -8220,12 +6659,10 @@ def test_message_with_url_image(
 
 
 @pytest.mark.parametrize("span_streaming", [True, False])
-@pytest.mark.parametrize("stream_gen_ai_spans", [True, False])
 def test_message_with_file_image(
     sentry_init,
     capture_events,
     capture_items,
-    stream_gen_ai_spans,
     span_streaming,
 ):
     """Test that messages with file_id-referenced images are properly captured."""
@@ -8234,7 +6671,6 @@ def test_message_with_file_image(
         disabled_integrations=[StdlibIntegration],
         traces_sample_rate=1.0,
         send_default_pii=True,
-        stream_gen_ai_spans=stream_gen_ai_spans,
         trace_lifecycle="stream" if span_streaming else "static",
     )
 
@@ -8258,7 +6694,7 @@ def test_message_with_file_image(
         }
     ]
 
-    if span_streaming or stream_gen_ai_spans:
+    if span_streaming:
         items = capture_items("span")
 
         with start_transaction(name="anthropic"):
@@ -8299,7 +6735,6 @@ def test_message_with_base64_pdf(sentry_init, capture_events):
         disabled_integrations=[StdlibIntegration],
         traces_sample_rate=1.0,
         send_default_pii=True,
-        stream_gen_ai_spans=False,
     )
     events = capture_events()
     client = Anthropic(api_key="z")
@@ -8340,12 +6775,10 @@ def test_message_with_base64_pdf(sentry_init, capture_events):
 
 
 @pytest.mark.parametrize("span_streaming", [True, False])
-@pytest.mark.parametrize("stream_gen_ai_spans", [True, False])
 def test_message_with_url_pdf(
     sentry_init,
     capture_events,
     capture_items,
-    stream_gen_ai_spans,
     span_streaming,
 ):
     """Test that messages with URL-referenced PDF documents are properly captured."""
@@ -8354,7 +6787,6 @@ def test_message_with_url_pdf(
         disabled_integrations=[StdlibIntegration],
         traces_sample_rate=1.0,
         send_default_pii=True,
-        stream_gen_ai_spans=stream_gen_ai_spans,
         trace_lifecycle="stream" if span_streaming else "static",
     )
 
@@ -8377,7 +6809,7 @@ def test_message_with_url_pdf(
         }
     ]
 
-    if span_streaming or stream_gen_ai_spans:
+    if span_streaming:
         items = capture_items("span")
 
         with start_transaction(name="anthropic"):
@@ -8412,12 +6844,10 @@ def test_message_with_url_pdf(
 
 
 @pytest.mark.parametrize("span_streaming", [True, False])
-@pytest.mark.parametrize("stream_gen_ai_spans", [True, False])
 def test_message_with_file_document(
     sentry_init,
     capture_events,
     capture_items,
-    stream_gen_ai_spans,
     span_streaming,
 ):
     """Test that messages with file_id-referenced documents are properly captured."""
@@ -8426,7 +6856,6 @@ def test_message_with_file_document(
         disabled_integrations=[StdlibIntegration],
         traces_sample_rate=1.0,
         send_default_pii=True,
-        stream_gen_ai_spans=stream_gen_ai_spans,
         trace_lifecycle="stream" if span_streaming else "static",
     )
 
@@ -8450,7 +6879,7 @@ def test_message_with_file_document(
         }
     ]
 
-    if span_streaming or stream_gen_ai_spans:
+    if span_streaming:
         items = capture_items("span")
 
         with start_transaction(name="anthropic"):
@@ -8491,7 +6920,6 @@ def test_message_with_mixed_content(sentry_init, capture_events):
         disabled_integrations=[StdlibIntegration],
         traces_sample_rate=1.0,
         send_default_pii=True,
-        stream_gen_ai_spans=False,
     )
     events = capture_events()
     client = Anthropic(api_key="z")
@@ -8576,7 +7004,6 @@ def test_message_with_multiple_images_different_formats(sentry_init, capture_eve
         disabled_integrations=[StdlibIntegration],
         traces_sample_rate=1.0,
         send_default_pii=True,
-        stream_gen_ai_spans=False,
     )
     events = capture_events()
     client = Anthropic(api_key="z")
@@ -8647,12 +7074,10 @@ def test_message_with_multiple_images_different_formats(sentry_init, capture_eve
 
 
 @pytest.mark.parametrize("span_streaming", [True, False])
-@pytest.mark.parametrize("stream_gen_ai_spans", [True, False])
 def test_binary_content_not_stored_when_pii_disabled(
     sentry_init,
     capture_events,
     capture_items,
-    stream_gen_ai_spans,
     span_streaming,
 ):
     """Test that binary content is not stored when send_default_pii is False."""
@@ -8661,7 +7086,6 @@ def test_binary_content_not_stored_when_pii_disabled(
         disabled_integrations=[StdlibIntegration],
         traces_sample_rate=1.0,
         send_default_pii=False,
-        stream_gen_ai_spans=stream_gen_ai_spans,
         trace_lifecycle="stream" if span_streaming else "static",
     )
 
@@ -8685,7 +7109,7 @@ def test_binary_content_not_stored_when_pii_disabled(
         }
     ]
 
-    if span_streaming or stream_gen_ai_spans:
+    if span_streaming:
         items = capture_items("span")
 
         with start_transaction(name="anthropic"):
@@ -8712,12 +7136,10 @@ def test_binary_content_not_stored_when_pii_disabled(
 
 
 @pytest.mark.parametrize("span_streaming", [True, False])
-@pytest.mark.parametrize("stream_gen_ai_spans", [True, False])
 def test_binary_content_not_stored_when_prompts_disabled(
     sentry_init,
     capture_events,
     capture_items,
-    stream_gen_ai_spans,
     span_streaming,
 ):
     """Test that binary content is not stored when include_prompts is False."""
@@ -8726,7 +7148,6 @@ def test_binary_content_not_stored_when_prompts_disabled(
         disabled_integrations=[StdlibIntegration],
         traces_sample_rate=1.0,
         send_default_pii=True,
-        stream_gen_ai_spans=stream_gen_ai_spans,
         trace_lifecycle="stream" if span_streaming else "static",
     )
 
@@ -8750,7 +7171,7 @@ def test_binary_content_not_stored_when_prompts_disabled(
         }
     ]
 
-    if span_streaming or stream_gen_ai_spans:
+    if span_streaming:
         items = capture_items("span")
 
         with start_transaction(name="anthropic"):
@@ -8777,12 +7198,10 @@ def test_binary_content_not_stored_when_prompts_disabled(
 
 
 @pytest.mark.parametrize("span_streaming", [True, False])
-@pytest.mark.parametrize("stream_gen_ai_spans", [True, False])
 def test_cache_tokens_nonstreaming(
     sentry_init,
     capture_events,
     capture_items,
-    stream_gen_ai_spans,
     span_streaming,
 ):
     """Test cache read/write tokens are tracked for non-streaming responses."""
@@ -8790,7 +7209,6 @@ def test_cache_tokens_nonstreaming(
         integrations=[AnthropicIntegration()],
         disabled_integrations=[StdlibIntegration],
         traces_sample_rate=1.0,
-        stream_gen_ai_spans=stream_gen_ai_spans,
         trace_lifecycle="stream" if span_streaming else "static",
     )
 
@@ -8812,7 +7230,7 @@ def test_cache_tokens_nonstreaming(
         )
     )
 
-    if span_streaming or stream_gen_ai_spans:
+    if span_streaming:
         items = capture_items("span")
 
         with start_transaction(name="anthropic"):
@@ -8850,12 +7268,10 @@ def test_cache_tokens_nonstreaming(
 
 
 @pytest.mark.parametrize("span_streaming", [True, False])
-@pytest.mark.parametrize("stream_gen_ai_spans", [True, False])
 def test_input_tokens_include_cache_write_nonstreaming(
     sentry_init,
     capture_events,
     capture_items,
-    stream_gen_ai_spans,
     span_streaming,
 ):
     """
@@ -8873,7 +7289,6 @@ def test_input_tokens_include_cache_write_nonstreaming(
         integrations=[AnthropicIntegration()],
         disabled_integrations=[StdlibIntegration],
         traces_sample_rate=1.0,
-        stream_gen_ai_spans=stream_gen_ai_spans,
         trace_lifecycle="stream" if span_streaming else "static",
     )
 
@@ -8895,7 +7310,7 @@ def test_input_tokens_include_cache_write_nonstreaming(
         )
     )
 
-    if span_streaming or stream_gen_ai_spans:
+    if span_streaming:
         items = capture_items("span")
 
         with start_transaction(name="anthropic"):
@@ -8937,12 +7352,10 @@ def test_input_tokens_include_cache_write_nonstreaming(
 
 
 @pytest.mark.parametrize("span_streaming", [True, False])
-@pytest.mark.parametrize("stream_gen_ai_spans", [True, False])
 def test_input_tokens_include_cache_read_nonstreaming(
     sentry_init,
     capture_events,
     capture_items,
-    stream_gen_ai_spans,
     span_streaming,
 ):
     """
@@ -8960,7 +7373,6 @@ def test_input_tokens_include_cache_read_nonstreaming(
         integrations=[AnthropicIntegration()],
         disabled_integrations=[StdlibIntegration],
         traces_sample_rate=1.0,
-        stream_gen_ai_spans=stream_gen_ai_spans,
         trace_lifecycle="stream" if span_streaming else "static",
     )
 
@@ -8982,7 +7394,7 @@ def test_input_tokens_include_cache_read_nonstreaming(
         )
     )
 
-    if span_streaming or stream_gen_ai_spans:
+    if span_streaming:
         items = capture_items("span")
 
         with start_transaction(name="anthropic"):
@@ -9022,14 +7434,12 @@ def test_input_tokens_include_cache_read_nonstreaming(
 
 
 @pytest.mark.parametrize("span_streaming", [True, False])
-@pytest.mark.parametrize("stream_gen_ai_spans", [True, False])
 def test_input_tokens_include_cache_read_streaming(
     sentry_init,
     capture_events,
     capture_items,
     get_model_response,
     server_side_event_chunks,
-    stream_gen_ai_spans,
     span_streaming,
 ):
     """
@@ -9071,11 +7481,10 @@ def test_input_tokens_include_cache_read_streaming(
         integrations=[AnthropicIntegration()],
         disabled_integrations=[StdlibIntegration],
         traces_sample_rate=1.0,
-        stream_gen_ai_spans=stream_gen_ai_spans,
         trace_lifecycle="stream" if span_streaming else "static",
     )
 
-    if span_streaming or stream_gen_ai_spans:
+    if span_streaming:
         items = capture_items("span")
 
         with mock.patch.object(
@@ -9127,14 +7536,12 @@ def test_input_tokens_include_cache_read_streaming(
 
 
 @pytest.mark.parametrize("span_streaming", [True, False])
-@pytest.mark.parametrize("stream_gen_ai_spans", [True, False])
 def test_stream_messages_input_tokens_include_cache_read_streaming(
     sentry_init,
     capture_events,
     capture_items,
     get_model_response,
     server_side_event_chunks,
-    stream_gen_ai_spans,
     span_streaming,
 ):
     """
@@ -9175,11 +7582,10 @@ def test_stream_messages_input_tokens_include_cache_read_streaming(
         integrations=[AnthropicIntegration()],
         disabled_integrations=[StdlibIntegration],
         traces_sample_rate=1.0,
-        stream_gen_ai_spans=stream_gen_ai_spans,
         trace_lifecycle="stream" if span_streaming else "static",
     )
 
-    if span_streaming or stream_gen_ai_spans:
+    if span_streaming:
         items = capture_items("span")
 
         with mock.patch.object(
@@ -9229,12 +7635,10 @@ def test_stream_messages_input_tokens_include_cache_read_streaming(
 
 
 @pytest.mark.parametrize("span_streaming", [True, False])
-@pytest.mark.parametrize("stream_gen_ai_spans", [True, False])
 def test_input_tokens_unchanged_without_caching(
     sentry_init,
     capture_events,
     capture_items,
-    stream_gen_ai_spans,
     span_streaming,
 ):
     """
@@ -9247,7 +7651,6 @@ def test_input_tokens_unchanged_without_caching(
         integrations=[AnthropicIntegration()],
         disabled_integrations=[StdlibIntegration],
         traces_sample_rate=1.0,
-        stream_gen_ai_spans=stream_gen_ai_spans,
         trace_lifecycle="stream" if span_streaming else "static",
     )
 
@@ -9267,7 +7670,7 @@ def test_input_tokens_unchanged_without_caching(
         )
     )
 
-    if span_streaming or stream_gen_ai_spans:
+    if span_streaming:
         items = capture_items("span")
 
         with start_transaction(name="anthropic"):
@@ -9299,14 +7702,12 @@ def test_input_tokens_unchanged_without_caching(
 
 
 @pytest.mark.parametrize("span_streaming", [True, False])
-@pytest.mark.parametrize("stream_gen_ai_spans", [True, False])
 def test_cache_tokens_streaming(
     sentry_init,
     capture_events,
     capture_items,
     get_model_response,
     server_side_event_chunks,
-    stream_gen_ai_spans,
     span_streaming,
 ):
     """Test cache tokens are tracked for streaming responses."""
@@ -9344,11 +7745,10 @@ def test_cache_tokens_streaming(
         integrations=[AnthropicIntegration()],
         disabled_integrations=[StdlibIntegration],
         traces_sample_rate=1.0,
-        stream_gen_ai_spans=stream_gen_ai_spans,
         trace_lifecycle="stream" if span_streaming else "static",
     )
 
-    if span_streaming or stream_gen_ai_spans:
+    if span_streaming:
         items = capture_items("span")
 
         with mock.patch.object(
@@ -9398,14 +7798,12 @@ def test_cache_tokens_streaming(
 
 
 @pytest.mark.parametrize("span_streaming", [True, False])
-@pytest.mark.parametrize("stream_gen_ai_spans", [True, False])
 def test_stream_messages_cache_tokens(
     sentry_init,
     capture_events,
     capture_items,
     get_model_response,
     server_side_event_chunks,
-    stream_gen_ai_spans,
     span_streaming,
 ):
     """Test cache tokens are tracked for streaming responses."""
@@ -9443,11 +7841,10 @@ def test_stream_messages_cache_tokens(
         integrations=[AnthropicIntegration()],
         disabled_integrations=[StdlibIntegration],
         traces_sample_rate=1.0,
-        stream_gen_ai_spans=stream_gen_ai_spans,
         trace_lifecycle="stream" if span_streaming else "static",
     )
 
-    if span_streaming or stream_gen_ai_spans:
+    if span_streaming:
         items = capture_items("span")
 
         with mock.patch.object(

--- a/tests/integrations/anthropic/test_anthropic.py
+++ b/tests/integrations/anthropic/test_anthropic.py
@@ -162,6 +162,7 @@ def test_nonstreaming_create_message(
         traces_sample_rate=1.0,
         send_default_pii=send_default_pii,
         trace_lifecycle="stream" if span_streaming else "static",
+        stream_gen_ai_spans=False,
     )
 
     client = Anthropic(api_key="z")
@@ -338,6 +339,7 @@ def test_nonstreaming_create_message_data_collection(
         traces_sample_rate=1.0,
         send_default_pii=send_default_pii,
         trace_lifecycle="stream" if span_streaming else "static",
+        stream_gen_ai_spans=False,
     )
     if data_collection is not None:
         sentry_init_kwargs["_experiments"] = {"data_collection": data_collection}
@@ -424,6 +426,7 @@ def test_nonstreaming_create_message_data_collection_tools(
         traces_sample_rate=1.0,
         send_default_pii=False,
         trace_lifecycle="stream" if span_streaming else "static",
+        stream_gen_ai_spans=False,
     )
     if data_collection is not None:
         sentry_init_kwargs["_experiments"] = {"data_collection": data_collection}
@@ -516,6 +519,7 @@ async def test_nonstreaming_create_message_data_collection_async(
         traces_sample_rate=1.0,
         send_default_pii=send_default_pii,
         trace_lifecycle="stream" if span_streaming else "static",
+        stream_gen_ai_spans=False,
     )
     if data_collection is not None:
         sentry_init_kwargs["_experiments"] = {"data_collection": data_collection}
@@ -631,6 +635,7 @@ def test_nonstreaming_create_message_data_collection_outputs(
         traces_sample_rate=1.0,
         send_default_pii=send_default_pii,
         trace_lifecycle="stream" if span_streaming else "static",
+        stream_gen_ai_spans=False,
     )
     if data_collection is not None:
         sentry_init_kwargs["_experiments"] = {"data_collection": data_collection}
@@ -756,6 +761,7 @@ async def test_nonstreaming_create_message_data_collection_outputs_async(
         traces_sample_rate=1.0,
         send_default_pii=send_default_pii,
         trace_lifecycle="stream" if span_streaming else "static",
+        stream_gen_ai_spans=False,
     )
     if data_collection is not None:
         sentry_init_kwargs["_experiments"] = {"data_collection": data_collection}
@@ -837,6 +843,7 @@ async def test_nonstreaming_create_message_async(
         traces_sample_rate=1.0,
         send_default_pii=send_default_pii,
         trace_lifecycle="stream" if span_streaming else "static",
+        stream_gen_ai_spans=False,
     )
 
     client = AsyncAnthropic(api_key="z")
@@ -1019,6 +1026,7 @@ def test_streaming_create_message(
         traces_sample_rate=1.0,
         send_default_pii=send_default_pii,
         trace_lifecycle="stream" if span_streaming else "static",
+        stream_gen_ai_spans=False,
     )
 
     messages = [
@@ -1189,6 +1197,7 @@ def test_streaming_create_message_data_collection(
         traces_sample_rate=1.0,
         send_default_pii=send_default_pii,
         trace_lifecycle="stream" if span_streaming else "static",
+        stream_gen_ai_spans=False,
     )
     if data_collection is not None:
         sentry_init_kwargs["_experiments"] = {"data_collection": data_collection}
@@ -1335,6 +1344,7 @@ def test_streaming_create_message_data_collection_outputs(
         traces_sample_rate=1.0,
         send_default_pii=send_default_pii,
         trace_lifecycle="stream" if span_streaming else "static",
+        stream_gen_ai_spans=False,
     )
     if data_collection is not None:
         sentry_init_kwargs["_experiments"] = {"data_collection": data_collection}
@@ -1480,6 +1490,7 @@ def test_streaming_create_message_close(
         traces_sample_rate=1.0,
         send_default_pii=True,
         trace_lifecycle="stream" if span_streaming else "static",
+        stream_gen_ai_spans=False,
     )
 
     messages = [
@@ -1632,6 +1643,7 @@ def test_streaming_create_message_api_error(
         traces_sample_rate=1.0,
         send_default_pii=True,
         trace_lifecycle="stream" if span_streaming else "static",
+        stream_gen_ai_spans=False,
     )
 
     messages = [
@@ -1799,6 +1811,7 @@ def test_stream_messages(
         traces_sample_rate=1.0,
         send_default_pii=send_default_pii,
         trace_lifecycle="stream" if span_streaming else "static",
+        stream_gen_ai_spans=False,
     )
 
     messages = [
@@ -1978,6 +1991,7 @@ def test_stream_messages_data_collection_outputs(
         traces_sample_rate=1.0,
         send_default_pii=send_default_pii,
         trace_lifecycle="stream" if span_streaming else "static",
+        stream_gen_ai_spans=False,
     )
     if data_collection is not None:
         sentry_init_kwargs["_experiments"] = {"data_collection": data_collection}
@@ -2124,6 +2138,7 @@ def test_stream_messages_close(
         traces_sample_rate=1.0,
         send_default_pii=True,
         trace_lifecycle="stream" if span_streaming else "static",
+        stream_gen_ai_spans=False,
     )
 
     messages = [
@@ -2284,6 +2299,7 @@ def test_stream_messages_api_error(
         traces_sample_rate=1.0,
         send_default_pii=True,
         trace_lifecycle="stream" if span_streaming else "static",
+        stream_gen_ai_spans=False,
     )
 
     messages = [
@@ -2456,6 +2472,7 @@ async def test_streaming_create_message_async(
         default_integrations=False,
         send_default_pii=send_default_pii,
         trace_lifecycle="stream" if span_streaming else "static",
+        stream_gen_ai_spans=False,
     )
 
     messages = [
@@ -2639,6 +2656,7 @@ async def test_streaming_create_message_data_collection_outputs_async(
         traces_sample_rate=1.0,
         send_default_pii=send_default_pii,
         trace_lifecycle="stream" if span_streaming else "static",
+        stream_gen_ai_spans=False,
     )
     if data_collection is not None:
         sentry_init_kwargs["_experiments"] = {"data_collection": data_collection}
@@ -2790,6 +2808,7 @@ async def test_streaming_create_message_async_close(
         traces_sample_rate=1.0,
         send_default_pii=True,
         trace_lifecycle="stream" if span_streaming else "static",
+        stream_gen_ai_spans=False,
     )
 
     messages = [
@@ -2944,6 +2963,7 @@ async def test_streaming_create_message_async_api_error(
         traces_sample_rate=1.0,
         send_default_pii=True,
         trace_lifecycle="stream" if span_streaming else "static",
+        stream_gen_ai_spans=False,
     )
 
     messages = [
@@ -3115,6 +3135,7 @@ async def test_stream_message_async(
         traces_sample_rate=1.0,
         send_default_pii=send_default_pii,
         trace_lifecycle="stream" if span_streaming else "static",
+        stream_gen_ai_spans=False,
     )
 
     messages = [
@@ -3295,6 +3316,7 @@ async def test_stream_messages_data_collection_outputs_async(
         traces_sample_rate=1.0,
         send_default_pii=send_default_pii,
         trace_lifecycle="stream" if span_streaming else "static",
+        stream_gen_ai_spans=False,
     )
     if data_collection is not None:
         sentry_init_kwargs["_experiments"] = {"data_collection": data_collection}
@@ -3444,6 +3466,7 @@ async def test_stream_messages_async_api_error(
         traces_sample_rate=1.0,
         send_default_pii=True,
         trace_lifecycle="stream" if span_streaming else "static",
+        stream_gen_ai_spans=False,
     )
 
     messages = [
@@ -3605,6 +3628,7 @@ async def test_stream_messages_async_close(
         traces_sample_rate=1.0,
         send_default_pii=True,
         trace_lifecycle="stream" if span_streaming else "static",
+        stream_gen_ai_spans=False,
     )
 
     messages = [
@@ -3817,6 +3841,7 @@ def test_streaming_create_message_with_input_json_delta(
         traces_sample_rate=1.0,
         send_default_pii=send_default_pii,
         trace_lifecycle="stream" if span_streaming else "static",
+        stream_gen_ai_spans=False,
     )
 
     messages = [
@@ -4020,6 +4045,7 @@ def test_stream_messages_with_input_json_delta(
         traces_sample_rate=1.0,
         send_default_pii=send_default_pii,
         trace_lifecycle="stream" if span_streaming else "static",
+        stream_gen_ai_spans=False,
     )
 
     messages = [
@@ -4229,6 +4255,7 @@ async def test_streaming_create_message_with_input_json_delta_async(
         traces_sample_rate=1.0,
         send_default_pii=send_default_pii,
         trace_lifecycle="stream" if span_streaming else "static",
+        stream_gen_ai_spans=False,
     )
 
     messages = [
@@ -4440,6 +4467,7 @@ async def test_stream_message_with_input_json_delta_async(
         traces_sample_rate=1.0,
         send_default_pii=send_default_pii,
         trace_lifecycle="stream" if span_streaming else "static",
+        stream_gen_ai_spans=False,
     )
 
     messages = [
@@ -4558,6 +4586,7 @@ def test_exception_message_create(
         disabled_integrations=[StdlibIntegration],
         traces_sample_rate=1.0,
         trace_lifecycle="stream" if span_streaming else "static",
+        stream_gen_ai_spans=False,
     )
 
     client = Anthropic(api_key="z")
@@ -4604,6 +4633,7 @@ def test_span_status_error(
         disabled_integrations=[StdlibIntegration],
         traces_sample_rate=1.0,
         trace_lifecycle="stream" if span_streaming else "static",
+        stream_gen_ai_spans=False,
     )
 
     if span_streaming:
@@ -4669,6 +4699,7 @@ async def test_span_status_error_async(
         disabled_integrations=[StdlibIntegration],
         traces_sample_rate=1.0,
         trace_lifecycle="stream" if span_streaming else "static",
+        stream_gen_ai_spans=False,
     )
     if span_streaming:
         items = capture_items("event", "span")
@@ -4733,6 +4764,7 @@ async def test_exception_message_create_async(
         disabled_integrations=[StdlibIntegration],
         traces_sample_rate=1.0,
         trace_lifecycle="stream" if span_streaming else "static",
+        stream_gen_ai_spans=False,
     )
 
     client = AsyncAnthropic(api_key="z")
@@ -4779,6 +4811,7 @@ def test_span_origin(
         disabled_integrations=[StdlibIntegration],
         traces_sample_rate=1.0,
         trace_lifecycle="stream" if span_streaming else "static",
+        stream_gen_ai_spans=False,
     )
 
     client = Anthropic(api_key="z")
@@ -4829,6 +4862,7 @@ async def test_span_origin_async(
         disabled_integrations=[StdlibIntegration],
         traces_sample_rate=1.0,
         trace_lifecycle="stream" if span_streaming else "static",
+        stream_gen_ai_spans=False,
     )
 
     client = AsyncAnthropic(api_key="z")
@@ -4911,6 +4945,7 @@ def test_set_output_data_with_input_json_delta(sentry_init):
         disabled_integrations=[StdlibIntegration],
         traces_sample_rate=1.0,
         send_default_pii=True,
+        stream_gen_ai_spans=False,
     )
 
     with start_transaction(name="test"):
@@ -4969,6 +5004,7 @@ def test_anthropic_message_role_mapping(
         traces_sample_rate=1.0,
         send_default_pii=True,
         trace_lifecycle="stream" if span_streaming else "static",
+        stream_gen_ai_spans=False,
     )
 
     client = Anthropic(api_key="z")
@@ -5040,6 +5076,7 @@ def test_anthropic_message_truncation(sentry_init, capture_events):
         disabled_integrations=[StdlibIntegration],
         traces_sample_rate=1.0,
         send_default_pii=True,
+        stream_gen_ai_spans=False,
     )
     events = capture_events()
 
@@ -5093,6 +5130,7 @@ async def test_anthropic_message_truncation_async(sentry_init, capture_events):
         disabled_integrations=[StdlibIntegration],
         traces_sample_rate=1.0,
         send_default_pii=True,
+        stream_gen_ai_spans=False,
     )
     events = capture_events()
 
@@ -5163,6 +5201,7 @@ def test_nonstreaming_create_message_with_system_prompt(
         traces_sample_rate=1.0,
         send_default_pii=send_default_pii,
         trace_lifecycle="stream" if span_streaming else "static",
+        stream_gen_ai_spans=False,
     )
 
     client = Anthropic(api_key="z")
@@ -5321,6 +5360,7 @@ async def test_nonstreaming_create_message_with_system_prompt_async(
         traces_sample_rate=1.0,
         send_default_pii=send_default_pii,
         trace_lifecycle="stream" if span_streaming else "static",
+        stream_gen_ai_spans=False,
     )
 
     client = AsyncAnthropic(api_key="z")
@@ -5519,6 +5559,7 @@ def test_streaming_create_message_with_system_prompt(
         traces_sample_rate=1.0,
         send_default_pii=send_default_pii,
         trace_lifecycle="stream" if span_streaming else "static",
+        stream_gen_ai_spans=False,
     )
 
     messages = [
@@ -5717,6 +5758,7 @@ def test_stream_messages_with_system_prompt(
         traces_sample_rate=1.0,
         send_default_pii=send_default_pii,
         trace_lifecycle="stream" if span_streaming else "static",
+        stream_gen_ai_spans=False,
     )
 
     messages = [
@@ -5908,6 +5950,7 @@ async def test_stream_message_with_system_prompt_async(
         traces_sample_rate=1.0,
         send_default_pii=send_default_pii,
         trace_lifecycle="stream" if span_streaming else "static",
+        stream_gen_ai_spans=False,
     )
 
     messages = [
@@ -6104,6 +6147,7 @@ async def test_streaming_create_message_with_system_prompt_async(
         traces_sample_rate=1.0,
         send_default_pii=send_default_pii,
         trace_lifecycle="stream" if span_streaming else "static",
+        stream_gen_ai_spans=False,
     )
 
     messages = [
@@ -6249,6 +6293,7 @@ def test_system_prompt_with_complex_structure(
         traces_sample_rate=1.0,
         send_default_pii=True,
         trace_lifecycle="stream" if span_streaming else "static",
+        stream_gen_ai_spans=False,
     )
 
     client = Anthropic(api_key="z")
@@ -6544,6 +6589,7 @@ def test_message_with_base64_image(sentry_init, capture_events):
         disabled_integrations=[StdlibIntegration],
         traces_sample_rate=1.0,
         send_default_pii=True,
+        stream_gen_ai_spans=False,
     )
     events = capture_events()
     client = Anthropic(api_key="z")
@@ -6603,6 +6649,7 @@ def test_message_with_url_image(
         traces_sample_rate=1.0,
         send_default_pii=True,
         trace_lifecycle="stream" if span_streaming else "static",
+        stream_gen_ai_spans=False,
     )
 
     client = Anthropic(api_key="z")
@@ -6672,6 +6719,7 @@ def test_message_with_file_image(
         traces_sample_rate=1.0,
         send_default_pii=True,
         trace_lifecycle="stream" if span_streaming else "static",
+        stream_gen_ai_spans=False,
     )
 
     client = Anthropic(api_key="z")
@@ -6735,6 +6783,7 @@ def test_message_with_base64_pdf(sentry_init, capture_events):
         disabled_integrations=[StdlibIntegration],
         traces_sample_rate=1.0,
         send_default_pii=True,
+        stream_gen_ai_spans=False,
     )
     events = capture_events()
     client = Anthropic(api_key="z")
@@ -6788,6 +6837,7 @@ def test_message_with_url_pdf(
         traces_sample_rate=1.0,
         send_default_pii=True,
         trace_lifecycle="stream" if span_streaming else "static",
+        stream_gen_ai_spans=False,
     )
 
     client = Anthropic(api_key="z")
@@ -6857,6 +6907,7 @@ def test_message_with_file_document(
         traces_sample_rate=1.0,
         send_default_pii=True,
         trace_lifecycle="stream" if span_streaming else "static",
+        stream_gen_ai_spans=False,
     )
 
     client = Anthropic(api_key="z")
@@ -6920,6 +6971,7 @@ def test_message_with_mixed_content(sentry_init, capture_events):
         disabled_integrations=[StdlibIntegration],
         traces_sample_rate=1.0,
         send_default_pii=True,
+        stream_gen_ai_spans=False,
     )
     events = capture_events()
     client = Anthropic(api_key="z")
@@ -7004,6 +7056,7 @@ def test_message_with_multiple_images_different_formats(sentry_init, capture_eve
         disabled_integrations=[StdlibIntegration],
         traces_sample_rate=1.0,
         send_default_pii=True,
+        stream_gen_ai_spans=False,
     )
     events = capture_events()
     client = Anthropic(api_key="z")
@@ -7087,6 +7140,7 @@ def test_binary_content_not_stored_when_pii_disabled(
         traces_sample_rate=1.0,
         send_default_pii=False,
         trace_lifecycle="stream" if span_streaming else "static",
+        stream_gen_ai_spans=False,
     )
 
     client = Anthropic(api_key="z")
@@ -7149,6 +7203,7 @@ def test_binary_content_not_stored_when_prompts_disabled(
         traces_sample_rate=1.0,
         send_default_pii=True,
         trace_lifecycle="stream" if span_streaming else "static",
+        stream_gen_ai_spans=False,
     )
 
     client = Anthropic(api_key="z")
@@ -7210,6 +7265,7 @@ def test_cache_tokens_nonstreaming(
         disabled_integrations=[StdlibIntegration],
         traces_sample_rate=1.0,
         trace_lifecycle="stream" if span_streaming else "static",
+        stream_gen_ai_spans=False,
     )
 
     client = Anthropic(api_key="z")
@@ -7290,6 +7346,7 @@ def test_input_tokens_include_cache_write_nonstreaming(
         disabled_integrations=[StdlibIntegration],
         traces_sample_rate=1.0,
         trace_lifecycle="stream" if span_streaming else "static",
+        stream_gen_ai_spans=False,
     )
 
     client = Anthropic(api_key="z")
@@ -7374,6 +7431,7 @@ def test_input_tokens_include_cache_read_nonstreaming(
         disabled_integrations=[StdlibIntegration],
         traces_sample_rate=1.0,
         trace_lifecycle="stream" if span_streaming else "static",
+        stream_gen_ai_spans=False,
     )
 
     client = Anthropic(api_key="z")
@@ -7482,6 +7540,7 @@ def test_input_tokens_include_cache_read_streaming(
         disabled_integrations=[StdlibIntegration],
         traces_sample_rate=1.0,
         trace_lifecycle="stream" if span_streaming else "static",
+        stream_gen_ai_spans=False,
     )
 
     if span_streaming:
@@ -7583,6 +7642,7 @@ def test_stream_messages_input_tokens_include_cache_read_streaming(
         disabled_integrations=[StdlibIntegration],
         traces_sample_rate=1.0,
         trace_lifecycle="stream" if span_streaming else "static",
+        stream_gen_ai_spans=False,
     )
 
     if span_streaming:
@@ -7652,6 +7712,7 @@ def test_input_tokens_unchanged_without_caching(
         disabled_integrations=[StdlibIntegration],
         traces_sample_rate=1.0,
         trace_lifecycle="stream" if span_streaming else "static",
+        stream_gen_ai_spans=False,
     )
 
     client = Anthropic(api_key="z")
@@ -7746,6 +7807,7 @@ def test_cache_tokens_streaming(
         disabled_integrations=[StdlibIntegration],
         traces_sample_rate=1.0,
         trace_lifecycle="stream" if span_streaming else "static",
+        stream_gen_ai_spans=False,
     )
 
     if span_streaming:
@@ -7842,6 +7904,7 @@ def test_stream_messages_cache_tokens(
         disabled_integrations=[StdlibIntegration],
         traces_sample_rate=1.0,
         trace_lifecycle="stream" if span_streaming else "static",
+        stream_gen_ai_spans=False,
     )
 
     if span_streaming:


### PR DESCRIPTION
### Description
<!-- What changed and why? -->

Set `stream_gen_ai_spans=False` to maintain assertions for the static trace lifecycle.
Transaction support will be removed as a follow up.

#### Issues
<!--
* resolves: #1234
* resolves: LIN-1234
-->

#### Reminders
- Please add tests to validate your changes, and lint your code using `uv run ruff`.
- Add GH Issue ID _&_ Linear ID (if applicable)
- PR title should use [conventional commit](https://develop.sentry.dev/engineering-practices/commit-messages/#type) style (`feat:`, `fix:`, `ref:`, `meta:`)
- For external contributors: [CONTRIBUTING.md](https://github.com/getsentry/sentry-python/blob/master/CONTRIBUTING.md), [Sentry SDK development docs](https://develop.sentry.dev/sdk/), [Discord community](https://discord.gg/Ww9hbqr)
