### PR TITLE
fix(httpx,httpx2): Always capture breadcrumb

### DIFF
--- a/sentry_sdk/integrations/httpx.py
+++ b/sentry_sdk/integrations/httpx.py
@@ -146,7 +146,7 @@ def _install_httpx_client() -> None:
             elif url_attributes:
                 breadcrumb_data.update(
                     {
-                        "url": url_attributes.get("url.full", parsed_url.url),
+                        "url": url_attributes.get("url.full", ""),
                         SPANDATA.HTTP_QUERY: url_attributes.get("url.query", ""),
                         SPANDATA.HTTP_FRAGMENT: url_attributes.get("url.fragment", ""),
                     }

--- a/sentry_sdk/integrations/httpx.py
+++ b/sentry_sdk/integrations/httpx.py
@@ -14,6 +14,7 @@ from sentry_sdk.utils import (
     SENSITIVE_DATA_SUBSTITUTE,
     capture_internal_exceptions,
     ensure_integration_enabled,
+    nullcontext,
     parse_url,
 )
 
@@ -61,39 +62,44 @@ def _install_httpx_client() -> None:
 
         if is_span_streaming_enabled:
             if sentry_sdk.traces.get_current_span() is None:
-                propagate_trace_headers(client, request)
-                return real_send(self, request, **kwargs)
+                span_ctx = nullcontext()
+            else:
+                span_ctx = sentry_sdk.traces.start_span(
+                    name="%s %s"
+                    % (
+                        request.method,
+                        parsed_url.url if parsed_url else SENSITIVE_DATA_SUBSTITUTE,
+                    ),
+                    attributes={
+                        "sentry.op": OP.HTTP_CLIENT,
+                        "sentry.origin": HttpxIntegration.origin,
+                        "http.request.method": request.method,
+                    },
+                )
 
             url_attributes = get_url_attributes(client, parsed_url)
 
-            with sentry_sdk.traces.start_span(
-                name="%s %s"
-                % (
-                    request.method,
-                    parsed_url.url if parsed_url else SENSITIVE_DATA_SUBSTITUTE,
-                ),
-                attributes={
-                    "sentry.op": OP.HTTP_CLIENT,
-                    "sentry.origin": HttpxIntegration.origin,
-                    "http.request.method": request.method,
-                },
-            ) as streamed_span:
-                attributes: "Attributes" = dict(url_attributes)
-
+            with span_ctx as streamed_span:
                 propagate_trace_headers(client, request)
 
                 try:
                     rv = real_send(self, request, **kwargs)
 
-                    streamed_span.status = "error" if rv.status_code >= 400 else "ok"
-                    attributes["http.response.status_code"] = rv.status_code
+                    if streamed_span is not None:
+                        streamed_span.status = (
+                            "error" if rv.status_code >= 400 else "ok"
+                        )
+                        url_attributes["http.response.status_code"] = rv.status_code
                 finally:
-                    streamed_span.set_attributes(attributes)
+                    if streamed_span is not None:
+                        streamed_span.set_attributes(url_attributes)
 
-                # Needs to happen within the context manager as we want to attach the
-                # final data before the span finishes and is sent for ingesting.
-                with capture_internal_exceptions():
-                    add_http_request_source(streamed_span)
+                if streamed_span is not None:
+                    # Needs to happen within the context manager as we want to attach the
+                    # final data before the span finishes and is sent for ingesting.
+                    with capture_internal_exceptions():
+                        add_http_request_source(streamed_span)
+
         else:
             with sentry_sdk.start_span(
                 op=OP.HTTP_CLIENT,
@@ -170,39 +176,43 @@ def _install_httpx_async_client() -> None:
 
         if is_span_streaming_enabled:
             if sentry_sdk.traces.get_current_span() is None:
-                propagate_trace_headers(client, request)
-                return await real_send(self, request, **kwargs)
+                span_ctx = nullcontext()
+            else:
+                span_ctx = sentry_sdk.traces.start_span(
+                    name="%s %s"
+                    % (
+                        request.method,
+                        parsed_url.url if parsed_url else SENSITIVE_DATA_SUBSTITUTE,
+                    ),
+                    attributes={
+                        "sentry.op": OP.HTTP_CLIENT,
+                        "sentry.origin": HttpxIntegration.origin,
+                        "http.request.method": request.method,
+                    },
+                )
 
             url_attributes = get_url_attributes(client, parsed_url)
 
-            with sentry_sdk.traces.start_span(
-                name="%s %s"
-                % (
-                    request.method,
-                    parsed_url.url if parsed_url else SENSITIVE_DATA_SUBSTITUTE,
-                ),
-                attributes={
-                    "sentry.op": OP.HTTP_CLIENT,
-                    "sentry.origin": HttpxIntegration.origin,
-                    "http.request.method": request.method,
-                },
-            ) as streamed_span:
-                attributes: "Attributes" = dict(url_attributes)
-
+            with span_ctx as streamed_span:
                 propagate_trace_headers(client, request)
 
                 try:
                     rv = await real_send(self, request, **kwargs)
 
-                    streamed_span.status = "error" if rv.status_code >= 400 else "ok"
-                    attributes["http.response.status_code"] = rv.status_code
+                    if streamed_span is not None:
+                        streamed_span.status = (
+                            "error" if rv.status_code >= 400 else "ok"
+                        )
+                        url_attributes["http.response.status_code"] = rv.status_code
                 finally:
-                    streamed_span.set_attributes(attributes)
+                    if streamed_span is not None:
+                        streamed_span.set_attributes(url_attributes)
 
-                # Needs to happen within the context manager as we want to attach the
-                # final data before the span finishes and is sent for ingesting.
-                with capture_internal_exceptions():
-                    add_http_request_source(streamed_span)
+                if streamed_span is not None:
+                    # Needs to happen within the context manager as we want to attach the
+                    # final data before the span finishes and is sent for ingesting.
+                    with capture_internal_exceptions():
+                        add_http_request_source(streamed_span)
         else:
             with sentry_sdk.start_span(
                 op=OP.HTTP_CLIENT,

--- a/sentry_sdk/integrations/httpx.py
+++ b/sentry_sdk/integrations/httpx.py
@@ -89,7 +89,9 @@ def _install_httpx_client() -> None:
                         streamed_span.status = (
                             "error" if rv.status_code >= 400 else "ok"
                         )
-                        url_attributes["http.response.status_code"] = rv.status_code
+                        streamed_span.set_attribute(
+                            "http.response.status_code", rv.status_code
+                        )
                 finally:
                     if streamed_span is not None:
                         streamed_span.set_attributes(url_attributes)
@@ -203,7 +205,9 @@ def _install_httpx_async_client() -> None:
                         streamed_span.status = (
                             "error" if rv.status_code >= 400 else "ok"
                         )
-                        url_attributes["http.response.status_code"] = rv.status_code
+                        streamed_span.set_attribute(
+                            "http.response.status_code", rv.status_code
+                        )
                 finally:
                     if streamed_span is not None:
                         streamed_span.set_attributes(url_attributes)
@@ -256,7 +260,7 @@ def _install_httpx_async_client() -> None:
             elif url_attributes:
                 breadcrumb_data.update(
                     {
-                        "url": url_attributes.get("url.full", parsed_url.url),
+                        "url": url_attributes.get("url.full", ""),
                         SPANDATA.HTTP_QUERY: url_attributes.get("url.query", ""),
                         SPANDATA.HTTP_FRAGMENT: url_attributes.get("url.fragment", ""),
                     }

--- a/sentry_sdk/integrations/httpx2.py
+++ b/sentry_sdk/integrations/httpx2.py
@@ -145,7 +145,7 @@ def _install_httpx2_client() -> None:
             elif url_attributes:
                 breadcrumb_data.update(
                     {
-                        "url": url_attributes.get("url.full", parsed_url.url),
+                        "url": url_attributes.get("url.full", ""),
                         SPANDATA.HTTP_QUERY: url_attributes.get("url.query", ""),
                         SPANDATA.HTTP_FRAGMENT: url_attributes.get("url.fragment", ""),
                     }
@@ -259,7 +259,7 @@ def _install_httpx2_async_client() -> None:
             elif url_attributes:
                 breadcrumb_data.update(
                     {
-                        "url": url_attributes.get("url.full", parsed_url.url),
+                        "url": url_attributes.get("url.full", ""),
                         SPANDATA.HTTP_QUERY: url_attributes.get("url.query", ""),
                         SPANDATA.HTTP_FRAGMENT: url_attributes.get("url.fragment", ""),
                     }

--- a/sentry_sdk/integrations/httpx2.py
+++ b/sentry_sdk/integrations/httpx2.py
@@ -14,6 +14,7 @@ from sentry_sdk.utils import (
     SENSITIVE_DATA_SUBSTITUTE,
     capture_internal_exceptions,
     ensure_integration_enabled,
+    nullcontext,
     parse_url,
 )
 
@@ -61,39 +62,45 @@ def _install_httpx2_client() -> None:
 
         if is_span_streaming_enabled:
             if sentry_sdk.traces.get_current_span() is None:
-                propagate_trace_headers(client, request)
-                return real_send(self, request, **kwargs)
+                span_ctx = nullcontext()
+            else:
+                span_ctx = sentry_sdk.traces.start_span(
+                    name="%s %s"
+                    % (
+                        request.method,
+                        parsed_url.url if parsed_url else SENSITIVE_DATA_SUBSTITUTE,
+                    ),
+                    attributes={
+                        "sentry.op": OP.HTTP_CLIENT,
+                        "sentry.origin": Httpx2Integration.origin,
+                        "http.request.method": request.method,
+                    },
+                )
 
             url_attributes = get_url_attributes(client, parsed_url)
 
-            with sentry_sdk.traces.start_span(
-                name="%s %s"
-                % (
-                    request.method,
-                    parsed_url.url if parsed_url else SENSITIVE_DATA_SUBSTITUTE,
-                ),
-                attributes={
-                    "sentry.op": OP.HTTP_CLIENT,
-                    "sentry.origin": Httpx2Integration.origin,
-                    "http.request.method": request.method,
-                },
-            ) as streamed_span:
-                attributes: "Attributes" = dict(url_attributes)
-
+            with span_ctx as streamed_span:
                 propagate_trace_headers(client, request)
 
                 try:
                     rv = real_send(self, request, **kwargs)
 
-                    streamed_span.status = "error" if rv.status_code >= 400 else "ok"
-                    attributes["http.response.status_code"] = rv.status_code
+                    if streamed_span is not None:
+                        streamed_span.status = (
+                            "error" if rv.status_code >= 400 else "ok"
+                        )
+                        streamed_span.set_attribute(
+                            "http.response.status_code", rv.status_code
+                        )
                 finally:
-                    streamed_span.set_attributes(attributes)
+                    if streamed_span is not None:
+                        streamed_span.set_attributes(url_attributes)
 
-                # Needs to happen within the context manager as we want to attach the
-                # final data before the span finishes and is sent for ingesting.
-                with capture_internal_exceptions():
-                    add_http_request_source(streamed_span)
+                if streamed_span is not None:
+                    # Needs to happen within the context manager as we want to attach the
+                    # final data before the span finishes and is sent for ingesting.
+                    with capture_internal_exceptions():
+                        add_http_request_source(streamed_span)
         else:
             with sentry_sdk.start_span(
                 op=OP.HTTP_CLIENT,
@@ -170,39 +177,45 @@ def _install_httpx2_async_client() -> None:
 
         if is_span_streaming_enabled:
             if sentry_sdk.traces.get_current_span() is None:
-                propagate_trace_headers(client, request)
-                return await real_send(self, request, **kwargs)
+                span_ctx = nullcontext()
+            else:
+                span_ctx = sentry_sdk.traces.start_span(
+                    name="%s %s"
+                    % (
+                        request.method,
+                        parsed_url.url if parsed_url else SENSITIVE_DATA_SUBSTITUTE,
+                    ),
+                    attributes={
+                        "sentry.op": OP.HTTP_CLIENT,
+                        "sentry.origin": Httpx2Integration.origin,
+                        "http.request.method": request.method,
+                    },
+                )
 
             url_attributes = get_url_attributes(client, parsed_url)
 
-            with sentry_sdk.traces.start_span(
-                name="%s %s"
-                % (
-                    request.method,
-                    parsed_url.url if parsed_url else SENSITIVE_DATA_SUBSTITUTE,
-                ),
-                attributes={
-                    "sentry.op": OP.HTTP_CLIENT,
-                    "sentry.origin": Httpx2Integration.origin,
-                    "http.request.method": request.method,
-                },
-            ) as streamed_span:
-                attributes: "Attributes" = dict(url_attributes)
-
+            with span_ctx as streamed_span:
                 propagate_trace_headers(client, request)
 
                 try:
                     rv = await real_send(self, request, **kwargs)
 
-                    streamed_span.status = "error" if rv.status_code >= 400 else "ok"
-                    attributes["http.response.status_code"] = rv.status_code
+                    if streamed_span is not None:
+                        streamed_span.status = (
+                            "error" if rv.status_code >= 400 else "ok"
+                        )
+                        streamed_span.set_attribute(
+                            "http.response.status_code", rv.status_code
+                        )
                 finally:
-                    streamed_span.set_attributes(attributes)
+                    if streamed_span is not None:
+                        streamed_span.set_attributes(url_attributes)
 
-                # Needs to happen within the context manager as we want to attach the
-                # final data before the span finishes and is sent for ingesting.
-                with capture_internal_exceptions():
-                    add_http_request_source(streamed_span)
+                if streamed_span is not None:
+                    # Needs to happen within the context manager as we want to attach the
+                    # final data before the span finishes and is sent for ingesting.
+                    with capture_internal_exceptions():
+                        add_http_request_source(streamed_span)
         else:
             with sentry_sdk.start_span(
                 op=OP.HTTP_CLIENT,

--- a/tests/integrations/httpx/test_httpx.py
+++ b/tests/integrations/httpx/test_httpx.py
@@ -201,6 +201,150 @@ async def test_crumb_capture_and_hint_async_span_streaming(
             )
 
 
+def test_crumb_capture_without_span_sync(sentry_init, capture_events, httpx_mock):
+    httpx_mock.add_response()
+
+    sentry_init(
+        integrations=[HttpxIntegration()],
+    )
+
+    url = "http://example.com/"
+
+    events = capture_events()
+
+    response = httpx.Client().get(url)
+
+    assert response.status_code == 200
+    capture_message("Testing!")
+
+    (event,) = events
+
+    crumb = event["breadcrumbs"]["values"][0]
+    assert crumb["type"] == "http"
+    assert crumb["category"] == "httplib"
+    assert crumb["data"] == ApproxDict(
+        {
+            "url": url,
+            SPANDATA.HTTP_METHOD: "GET",
+            SPANDATA.HTTP_FRAGMENT: "",
+            SPANDATA.HTTP_QUERY: "",
+            SPANDATA.HTTP_STATUS_CODE: 200,
+            "reason": "OK",
+        }
+    )
+
+
+def test_crumb_capture_without_span_sync_span_streaming(
+    sentry_init, capture_events, httpx_mock
+):
+    httpx_mock.add_response()
+
+    sentry_init(
+        integrations=[HttpxIntegration()],
+    )
+
+    url = "http://example.com/"
+
+    events = capture_events()
+
+    response = httpx.Client().get(url)
+
+    assert response.status_code == 200
+    capture_message("Testing!")
+
+    sentry_sdk.flush()
+
+    (event,) = events
+
+    crumb = event["breadcrumbs"]["values"][0]
+    assert crumb["type"] == "http"
+    assert crumb["category"] == "httplib"
+    assert crumb["data"] == ApproxDict(
+        {
+            "url": url,
+            SPANDATA.HTTP_METHOD: "GET",
+            SPANDATA.HTTP_FRAGMENT: "",
+            SPANDATA.HTTP_QUERY: "",
+            SPANDATA.HTTP_STATUS_CODE: 200,
+            "reason": "OK",
+        }
+    )
+
+
+@pytest.mark.asyncio
+async def test_crumb_capture_without_span_async(
+    sentry_init, capture_events, httpx_mock
+):
+    httpx_mock.add_response()
+
+    sentry_init(
+        integrations=[HttpxIntegration()],
+    )
+
+    url = "http://example.com/"
+
+    events = capture_events()
+
+    response = await httpx.AsyncClient().get(url)
+
+    assert response.status_code == 200
+    capture_message("Testing!")
+
+    (event,) = events
+
+    crumb = event["breadcrumbs"]["values"][0]
+    assert crumb["type"] == "http"
+    assert crumb["category"] == "httplib"
+    assert crumb["data"] == ApproxDict(
+        {
+            "url": url,
+            SPANDATA.HTTP_METHOD: "GET",
+            SPANDATA.HTTP_FRAGMENT: "",
+            SPANDATA.HTTP_QUERY: "",
+            SPANDATA.HTTP_STATUS_CODE: 200,
+            "reason": "OK",
+        }
+    )
+
+
+@pytest.mark.asyncio
+async def test_crumb_capture_without_span_async_span_streaming(
+    sentry_init, capture_events, httpx_mock
+):
+    httpx_mock.add_response()
+
+    sentry_init(
+        integrations=[HttpxIntegration()],
+    )
+
+    url = "http://example.com/"
+
+    events = capture_events()
+
+    response = await httpx.AsyncClient().get(url)
+
+    assert response.status_code == 200
+    capture_message("Testing!")
+
+    sentry_sdk.flush()
+
+    (event,) = events
+
+    crumb = event["breadcrumbs"]["values"][0]
+    assert crumb["type"] == "http"
+    assert crumb["category"] == "httplib"
+    assert crumb["data"] == ApproxDict(
+        {
+            "url": url,
+            SPANDATA.HTTP_METHOD: "GET",
+            SPANDATA.HTTP_FRAGMENT: "",
+            SPANDATA.HTTP_QUERY: "",
+            SPANDATA.HTTP_STATUS_CODE: 200,
+            "reason": "OK",
+        }
+    )
+
+
 @pytest.mark.parametrize(
     "status_code,level",
     [

--- a/tests/integrations/httpx/test_httpx.py
+++ b/tests/integrations/httpx/test_httpx.py
@@ -241,6 +241,7 @@ def test_crumb_capture_without_span_sync_span_streaming(
 
     sentry_init(
         integrations=[HttpxIntegration()],
+        trace_lifecycle="stream",
     )
 
     url = "http://example.com/"
@@ -261,10 +262,7 @@ def test_crumb_capture_without_span_sync_span_streaming(
     assert crumb["category"] == "httplib"
     assert crumb["data"] == ApproxDict(
         {
-            "url": url,
             SPANDATA.HTTP_METHOD: "GET",
-            SPANDATA.HTTP_FRAGMENT: "",
-            SPANDATA.HTTP_QUERY: "",
             SPANDATA.HTTP_STATUS_CODE: 200,
             "reason": "OK",
         }
@@ -315,6 +313,7 @@ async def test_crumb_capture_without_span_async_span_streaming(
 
     sentry_init(
         integrations=[HttpxIntegration()],
+        trace_lifecycle="stream",
     )
 
     url = "http://example.com/"
@@ -335,10 +334,7 @@ async def test_crumb_capture_without_span_async_span_streaming(
     assert crumb["category"] == "httplib"
     assert crumb["data"] == ApproxDict(
         {
-            "url": url,
             SPANDATA.HTTP_METHOD: "GET",
-            SPANDATA.HTTP_FRAGMENT: "",
-            SPANDATA.HTTP_QUERY: "",
             SPANDATA.HTTP_STATUS_CODE: 200,
             "reason": "OK",
         }

--- a/tests/integrations/httpx2/test_httpx2.py
+++ b/tests/integrations/httpx2/test_httpx2.py
@@ -201,6 +201,150 @@ async def test_crumb_capture_and_hint_async_span_streaming(
             )
 
 
+def test_crumb_capture_without_span_sync(sentry_init, capture_events, httpx2_mock):
+    httpx2_mock.add_response()
+
+    sentry_init(
+        integrations=[Httpx2Integration()],
+    )
+
+    url = "http://example.com/"
+
+    events = capture_events()
+
+    response = httpx2.Client().get(url)
+
+    assert response.status_code == 200
+    capture_message("Testing!")
+
+    (event,) = events
+
+    crumb = event["breadcrumbs"]["values"][0]
+    assert crumb["type"] == "http"
+    assert crumb["category"] == "httplib"
+    assert crumb["data"] == ApproxDict(
+        {
+            "url": url,
+            SPANDATA.HTTP_METHOD: "GET",
+            SPANDATA.HTTP_FRAGMENT: "",
+            SPANDATA.HTTP_QUERY: "",
+            SPANDATA.HTTP_STATUS_CODE: 200,
+            "reason": "OK",
+        }
+    )
+
+
+def test_crumb_capture_without_span_sync_span_streaming(
+    sentry_init, capture_events, httpx2_mock
+):
+    httpx2_mock.add_response()
+
+    sentry_init(
+        integrations=[Httpx2Integration()],
+    )
+
+    url = "http://example.com/"
+
+    events = capture_events()
+
+    response = httpx2.Client().get(url)
+
+    assert response.status_code == 200
+    capture_message("Testing!")
+
+    sentry_sdk.flush()
+
+    (event,) = events
+
+    crumb = event["breadcrumbs"]["values"][0]
+    assert crumb["type"] == "http"
+    assert crumb["category"] == "httplib"
+    assert crumb["data"] == ApproxDict(
+        {
+            "url": url,
+            SPANDATA.HTTP_METHOD: "GET",
+            SPANDATA.HTTP_FRAGMENT: "",
+            SPANDATA.HTTP_QUERY: "",
+            SPANDATA.HTTP_STATUS_CODE: 200,
+            "reason": "OK",
+        }
+    )
+
+
+@pytest.mark.asyncio
+async def test_crumb_capture_without_span_async(
+    sentry_init, capture_events, httpx2_mock
+):
+    httpx2_mock.add_response()
+
+    sentry_init(
+        integrations=[Httpx2Integration()],
+    )
+
+    url = "http://example.com/"
+
+    events = capture_events()
+
+    response = await httpx2.AsyncClient().get(url)
+
+    assert response.status_code == 200
+    capture_message("Testing!")
+
+    (event,) = events
+
+    crumb = event["breadcrumbs"]["values"][0]
+    assert crumb["type"] == "http"
+    assert crumb["category"] == "httplib"
+    assert crumb["data"] == ApproxDict(
+        {
+            "url": url,
+            SPANDATA.HTTP_METHOD: "GET",
+            SPANDATA.HTTP_FRAGMENT: "",
+            SPANDATA.HTTP_QUERY: "",
+            SPANDATA.HTTP_STATUS_CODE: 200,
+            "reason": "OK",
+        }
+    )
+
+
+@pytest.mark.asyncio
+async def test_crumb_capture_without_span_async_span_streaming(
+    sentry_init, capture_events, httpx2_mock
+):
+    httpx2_mock.add_response()
+
+    sentry_init(
+        integrations=[Httpx2Integration()],
+    )
+
+    url = "http://example.com/"
+
+    events = capture_events()
+
+    response = await httpx2.AsyncClient().get(url)
+
+    assert response.status_code == 200
+    capture_message("Testing!")
+
+    sentry_sdk.flush()
+
+    (event,) = events
+
+    crumb = event["breadcrumbs"]["values"][0]
+    assert crumb["type"] == "http"
+    assert crumb["category"] == "httplib"
+    assert crumb["data"] == ApproxDict(
+        {
+            "url": url,
+            SPANDATA.HTTP_METHOD: "GET",
+            SPANDATA.HTTP_FRAGMENT: "",
+            SPANDATA.HTTP_QUERY: "",
+            SPANDATA.HTTP_STATUS_CODE: 200,
+            "reason": "OK",
+        }
+    )
+
+
 @pytest.mark.parametrize(
     "status_code,level",
     [

--- a/tests/integrations/httpx2/test_httpx2.py
+++ b/tests/integrations/httpx2/test_httpx2.py
@@ -241,6 +241,7 @@ def test_crumb_capture_without_span_sync_span_streaming(
 
     sentry_init(
         integrations=[Httpx2Integration()],
+        trace_lifecycle="stream",
     )
 
     url = "http://example.com/"
@@ -261,10 +262,7 @@ def test_crumb_capture_without_span_sync_span_streaming(
     assert crumb["category"] == "httplib"
     assert crumb["data"] == ApproxDict(
         {
-            "url": url,
             SPANDATA.HTTP_METHOD: "GET",
-            SPANDATA.HTTP_FRAGMENT: "",
-            SPANDATA.HTTP_QUERY: "",
             SPANDATA.HTTP_STATUS_CODE: 200,
             "reason": "OK",
         }
@@ -315,6 +313,7 @@ async def test_crumb_capture_without_span_async_span_streaming(
 
     sentry_init(
         integrations=[Httpx2Integration()],
+        trace_lifecycle="stream",
     )
 
     url = "http://example.com/"
@@ -335,10 +334,7 @@ async def test_crumb_capture_without_span_async_span_streaming(
     assert crumb["category"] == "httplib"
     assert crumb["data"] == ApproxDict(
         {
-            "url": url,
             SPANDATA.HTTP_METHOD: "GET",
-            SPANDATA.HTTP_FRAGMENT: "",
-            SPANDATA.HTTP_QUERY: "",
             SPANDATA.HTTP_STATUS_CODE: 200,
             "reason": "OK",
         }


### PR DESCRIPTION
Currently, if there is no current span, we don't capture an HTTP client breadcrumb in HTTPX and HTTPX2 integrations because we return early.

This is essentially the same change 4 times (httpx sync, httpx async, httpx2 sync, http2 async).