### PR TITLE
ci: Reference renamed coverage action

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -115,7 +115,7 @@ jobs:
           uv run coverage combine .coverage-sentry-*
           uv run coverage xml
       - name: Report coverage and test results
-        uses: getsentry/codecov-action@eb2b4a6c4be3ecb42867043570579fa3b6879f6e # v0.3.8
+        uses: getsentry/coverage-action@eb2b4a6c4be3ecb42867043570579fa3b6879f6e # v0.3.8
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           files: coverage.xml

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -115,7 +115,7 @@ jobs:
           uv run coverage combine .coverage-sentry-*
           uv run coverage xml
       - name: Report coverage and test results
-        uses: getsentry/coverage-action@eb2b4a6c4be3ecb42867043570579fa3b6879f6e # v0.3.8
+        uses: getsentry/coverage-action@5f3f449cf9e909fd63513a48f27c57f090a5f321 # v0.4.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           files: coverage.xml

--- a/scripts/split_tox_gh_actions/templates/test_orchestrator.jinja
+++ b/scripts/split_tox_gh_actions/templates/test_orchestrator.jinja
@@ -69,7 +69,7 @@ jobs:
           uv run coverage combine .coverage-sentry-*
           uv run coverage xml
       - name: Report coverage and test results
-        uses: getsentry/coverage-action@eb2b4a6c4be3ecb42867043570579fa3b6879f6e # v0.3.8
+        uses: getsentry/coverage-action@5f3f449cf9e909fd63513a48f27c57f090a5f321 # v0.4.0
         with:
           token: {% raw %}${{ secrets.GITHUB_TOKEN }}{% endraw %}
           files: coverage.xml

--- a/scripts/split_tox_gh_actions/templates/test_orchestrator.jinja
+++ b/scripts/split_tox_gh_actions/templates/test_orchestrator.jinja
@@ -69,7 +69,7 @@ jobs:
           uv run coverage combine .coverage-sentry-*
           uv run coverage xml
       - name: Report coverage and test results
-        uses: getsentry/codecov-action@eb2b4a6c4be3ecb42867043570579fa3b6879f6e # v0.3.8
+        uses: getsentry/coverage-action@eb2b4a6c4be3ecb42867043570579fa3b6879f6e # v0.3.8
         with:
           token: {% raw %}${{ secrets.GITHUB_TOKEN }}{% endraw %}
           files: coverage.xml


### PR DESCRIPTION
The coverage-report job now references the canonical `getsentry/coverage-action` repository at the immutable `v0.4.0` release SHA. The template and generated Test workflow stay in sync.
