### PR TITLE
ci(anthropic): Include `StreamedSpan` in type annotations

### DIFF
--- a/sentry_sdk/integrations/anthropic.py
+++ b/sentry_sdk/integrations/anthropic.py
@@ -89,7 +89,7 @@ if TYPE_CHECKING:
     from sentry_sdk._types import TextPart
 
     class _PatchedRawMessageStream(Stream[RawMessageStreamEvent]):
-        _span: Span
+        _span: Union[Span, StreamedSpan]
         _integration: "AnthropicIntegration"
 
         _model: Optional[ModelParam]
@@ -99,7 +99,7 @@ if TYPE_CHECKING:
         _finish_reason: Optional[str]
 
     class _PatchedMessageStream(MessageStream):
-        _span: Span
+        _span: Union[Span, StreamedSpan]
         _integration: "AnthropicIntegration"
 
         _model: Optional[ModelParam]
@@ -109,7 +109,7 @@ if TYPE_CHECKING:
         _finish_reason: Optional[str]
 
     class _PatchedRawAsyncMessageStream(AsyncStream[RawMessageStreamEvent]):
-        _span: Span
+        _span: Union[Span, StreamedSpan]
         _integration: "AnthropicIntegration"
 
         _model: Optional[ModelParam]
@@ -119,7 +119,7 @@ if TYPE_CHECKING:
         _finish_reason: Optional[str]
 
     class _PatchedAsyncMessageStream(AsyncMessageStream):
-        _span: Span
+        _span: Union[Span, StreamedSpan]
         _integration: "AnthropicIntegration"
 
         _model: Optional[ModelParam]
@@ -966,7 +966,7 @@ def _accumulate_event_data(
 
 
 def _set_streaming_output_data(
-    span: "Span",
+    span: "Union[Span, StreamedSpan]",
     integration: "AnthropicIntegration",
     model: "Optional[str]",
     usage: "_RecordedUsage",


### PR DESCRIPTION
### Description
<!-- What changed and why? -->

Noticed this while working on the major branch.
Because we use `cast()` the types were still internally consistent previously.

#### Issues
<!--
* resolves: #1234
* resolves: LIN-1234
-->

#### Reminders
- Please add tests to validate your changes, and lint your code using `uv run ruff`.
- Add GH Issue ID _&_ Linear ID (if applicable)
- PR title should use [conventional commit](https://develop.sentry.dev/engineering-practices/commit-messages/#type) style (`feat:`, `fix:`, `ref:`, `meta:`)
- For external contributors: [CONTRIBUTING.md](https://github.com/getsentry/sentry-python/blob/master/CONTRIBUTING.md), [Sentry SDK development docs](https://develop.sentry.dev/sdk/), [Discord community](https://discord.gg/Ww9hbqr)
