### PR TITLE
fix(sanic): Remove more non-span-streaming code

### DIFF
--- a/MIGRATION_GUIDE.md
+++ b/MIGRATION_GUIDE.md
@@ -149,6 +149,7 @@ Looking to upgrade from Sentry SDK 2.x to 3.x? Here's a comprehensive list of wh
 - `Scope.iter_headers` was removed.
 - The SDK won't set any tags on its own anymore.
 - The `update_current_span` API was removed.
+- `SanicIntegration` no longer accepts `unsampled_statuses`.
 
 
 ## Deprecated

--- a/sentry_sdk/integrations/sanic.py
+++ b/sentry_sdk/integrations/sanic.py
@@ -12,20 +12,18 @@ from sentry_sdk.data_collection import (
 from sentry_sdk.integrations import DidNotEnable, Integration, _check_minimum_version
 from sentry_sdk.integrations._wsgi_common import RequestExtractor, _filter_headers
 from sentry_sdk.scope import should_send_default_pii
-from sentry_sdk.traces import SegmentNameSource, StreamedSpan
+from sentry_sdk.traces import SegmentNameSource
 from sentry_sdk.tracing import TransactionSource
 from sentry_sdk.utils import (
     capture_internal_exceptions,
     ensure_integration_enabled,
     event_from_exception,
     has_data_collection_enabled,
-    logger,
     parse_version,
     reraise,
 )
 
 if TYPE_CHECKING:
-    from collections.abc import Container
     from typing import Any, Callable, Dict, Optional, Union
 
     from sanic.request import Request, RequestParameters
@@ -58,17 +56,6 @@ class SanicIntegration(Integration):
     identifier = "sanic"
     origin = f"auto.http.{identifier}"
     version: "Optional[tuple[int, ...]]" = None
-
-    def __init__(
-        self, unsampled_statuses: "Optional[Container[int]]" = frozenset({404})
-    ) -> None:
-        """
-        The unsampled_statuses parameter can be used to specify for which HTTP statuses the
-        transactions should not be sent to Sentry. By default, transactions are sent for all
-        HTTP statuses, except 404. Set unsampled_statuses to None to send transactions for all
-        HTTP statuses, including 404.
-        """
-        self._unsampled_statuses = unsampled_statuses or set()
 
     @staticmethod
     def setup_once() -> None:
@@ -146,12 +133,6 @@ async def _context_enter(request: "Request") -> None:
     scope.clear_breadcrumbs()
     scope.add_event_processor(_make_request_processor(weak_request))
 
-    integration = client.get_integration(SanicIntegration)
-    if isinstance(integration, SanicIntegration) and integration._unsampled_statuses:
-        logger.warning(
-            "The `unsampled_statuses` option of SanicIntegration has no effect when span streaming is enabled.",
-        )
-
     sentry_sdk.traces.continue_trace(dict(request.headers))
     scope.set_custom_sampling_context({"sanic_request": request})
 
@@ -183,32 +164,22 @@ async def _context_exit(
         if not request.ctx._sentry_do_integration:
             return
 
-        integration = sentry_sdk.get_client().get_integration(SanicIntegration)
-
         response_status = None if response is None else response.status
 
         # This capture_internal_exceptions block has been intentionally nested here, so that in case an exception
         # happens while trying to end the transaction, we still attempt to exit the scope.
         with capture_internal_exceptions():
             span = request.ctx._sentry_root_span
-            if isinstance(span, StreamedSpan):
-                with capture_internal_exceptions():
-                    for attr, value in _get_request_attributes(request).items():
-                        span.set_attribute(attr, value)
-                if response_status is not None:
-                    span.set_attribute(SPANDATA.HTTP_STATUS_CODE, response_status)
-                    span.status = "error" if response_status >= 400 else "ok"
 
-                span.end()
+            with capture_internal_exceptions():
+                for attr, value in _get_request_attributes(request).items():
+                    span.set_attribute(attr, value)
 
-            else:
-                span.set_http_status(response_status)
-                span.sampled &= (
-                    isinstance(integration, SanicIntegration)
-                    and response_status not in integration._unsampled_statuses
-                )
+            if response_status is not None:
+                span.set_attribute(SPANDATA.HTTP_STATUS_CODE, response_status)
+                span.status = "error" if response_status >= 400 else "ok"
 
-                span.__exit__(None, None, None)
+            span.end()
 
         request.ctx._sentry_scope.__exit__(None, None, None)
 

--- a/tests/integrations/sanic/test_sanic.py
+++ b/tests/integrations/sanic/test_sanic.py
@@ -34,7 +34,6 @@ except ImportError:
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from collections.abc import Container, Iterable
     from typing import Any, Optional
 
 SANIC_VERSION = tuple(map(int, SANIC_VERSION_RAW.split(".")))
@@ -355,7 +354,6 @@ class TransactionTestConfig:
 
     def __init__(
         self,
-        integration_args: "Iterable[Optional[Container[int]]]",
         url: str,
         expected_status: int,
         expected_transaction_name: "Optional[str]",
@@ -364,7 +362,6 @@ class TransactionTestConfig:
         """
         expected_transaction_name of None indicates we expect to not receive a transaction
         """
-        self.integration_args = integration_args
         self.url = url
         self.expected_status = expected_status
         self.expected_transaction_name = expected_transaction_name
@@ -377,7 +374,6 @@ class TransactionTestConfig:
     [
         TransactionTestConfig(
             # Transaction for successful page load
-            integration_args=(),
             url="/message",
             expected_status=200,
             expected_transaction_name="hi",
@@ -385,7 +381,6 @@ class TransactionTestConfig:
         ),
         TransactionTestConfig(
             # Transaction for successful page load with query string
-            integration_args=(),
             url="/message?foo=bar",
             expected_status=200,
             expected_transaction_name="hi",
@@ -393,15 +388,13 @@ class TransactionTestConfig:
         ),
         TransactionTestConfig(
             # Transaction still recorded when we have an internal server error
-            integration_args=(),
             url="/500",
             expected_status=500,
             expected_transaction_name="fivehundred",
             expected_source=TransactionSource.COMPONENT,
         ),
         TransactionTestConfig(
-            # With no ignored HTTP statuses, we should get transactions for 404 errors
-            integration_args=(None,),
+            # We should get transactions for 404 errors
             url="/404",
             expected_status=404,
             expected_transaction_name="/404",
@@ -418,7 +411,7 @@ def test_transactions(
 ) -> None:
     # Init the SanicIntegration with the desired arguments
     sentry_init(
-        integrations=[SanicIntegration(*test_config.integration_args)],
+        integrations=[SanicIntegration()],
         traces_sample_rate=1.0,
         send_default_pii=send_pii,
         trace_lifecycle="stream",


### PR DESCRIPTION
Remove `SanicIntegration.unsampled_statuses` that was no-op in span streaming.

Also remove another unused non-span-streaming branch that I missed before.