### PR TITLE
test: Remove `test_langchain_embeddings_error_handling()`

### DIFF
--- a/tests/integrations/langchain/test_langchain.py
+++ b/tests/integrations/langchain/test_langchain.py
@@ -5166,45 +5166,6 @@ def test_langchain_embeddings_multiple_providers(
             assert SPANDATA.GEN_AI_EMBEDDINGS_INPUT in span["data"]
 
 
-def test_langchain_embeddings_error_handling(sentry_init, capture_events):
-    """Test that errors in embeddings are properly captured."""
-    try:
-        from langchain_openai import OpenAIEmbeddings
-    except ImportError:
-        pytest.skip("langchain_openai not installed")
-
-    sentry_init(
-        integrations=[LangchainIntegration(include_prompts=True)],
-        disabled_integrations=[StdlibIntegration],
-        traces_sample_rate=1.0,
-        send_default_pii=True,
-    )
-    events = capture_events()
-
-    # Mock the API call to raise an error
-    with mock.patch.object(
-        OpenAIEmbeddings,
-        "embed_documents",
-        side_effect=ValueError("API error"),
-    ):
-        embeddings = OpenAIEmbeddings(
-            model="text-embedding-ada-002", openai_api_key="test-key"
-        )
-
-        # Force setup to re-run
-        LangchainIntegration.setup_once()
-
-        with start_transaction(name="test_embeddings_error"), pytest.raises(ValueError):
-            embeddings.embed_documents(["Test"])
-
-    # The error should be captured
-    assert len(events) >= 1
-    # We should have both the transaction and potentially an error event
-    [e for e in events if e.get("level") == "error"]
-    # Note: errors might not be auto-captured depending on SDK settings,
-    # but the span should still be created
-
-
 @pytest.mark.parametrize("span_streaming", [True, False])
 @pytest.mark.parametrize("stream_gen_ai_spans", [True, False])
 def test_langchain_embeddings_multiple_calls(


### PR DESCRIPTION
### Description
<!-- What changed and why? -->

No error event is even captured for embeddings. This is the terminal output of a print:

```
[{'type': 'transaction', 'transaction': 'test_embeddings_error', 'transaction_info': {'source': <TransactionSource.CUSTOM: 'custom'>}, 'contexts': {'trace': {'trace_id': '723cb2df93794ae690c8cc0aed97b4ce', 'span_id': '85fe962aa35cf00b', 'parent_span_id': None, 'op': None, 'description': None, 'origin': 'manual', 'data': {'thread.id': '8356520512', 'thread.name': 'MainThread'}}}, 'tags': {}, 'timestamp': '2026-09-04T13:01:30.480024Z', 'start_timestamp': '2026-09-04T13:01:30.479447Z', 'spans': [], 'measurements': {}, 'event_id': '9b9d39f539b34936a5b57b3aa3d5405f', 'extra': {'sys.argv': ['/Users/alex/code/sentry-repos/mypy-sentry-python/.tox/py3.14-langchain-base-latest/lib/python3.14/site-packages/pytest/__main__.py', '-W', 'error::pytest.PytestUnraisableExceptionWarning', 'tests/integrations/langchain', '-o', 'junit_suite_name=py3.14-langchain-base-latest', '--junitxml=.junitxml-py3.14-langchain-base-latest']}, 'release': '692cca25116a5c44a31ab3f79c0641309924954d', 'environment': 'production', 'server_name': 'MKM6R7QWQJ.local', 'sdk': {'name': 'sentry.python.aiohttp', 'version': '2.68.1', 'packages': [{'name': 'pypi:sentry-sdk', 'version': '2.68.1'}], 'integrations': ['aiohttp', 'argv', 'atexit', 'dedupe', 'excepthook', 'httpx', 'httpx2', 'langchain', 'langgraph', 'logging', 'modules', 'sqlalchemy', 'threading']}, 'platform': 'python'}]
```

#### Issues
<!--
* resolves: #1234
* resolves: LIN-1234
-->

#### Reminders
- Please add tests to validate your changes, and lint your code using `uv run ruff`.
- Add GH Issue ID _&_ Linear ID (if applicable)
- PR title should use [conventional commit](https://develop.sentry.dev/engineering-practices/commit-messages/#type) style (`feat:`, `fix:`, `ref:`, `meta:`)
- For external contributors: [CONTRIBUTING.md](https://github.com/getsentry/sentry-python/blob/master/CONTRIBUTING.md), [Sentry SDK development docs](https://develop.sentry.dev/sdk/), [Discord community](https://discord.gg/Ww9hbqr)
