### PR TITLE
ci: Isolate `httpx` test suite from `httpx2`

### DIFF
--- a/.github/workflows/test-integrations-network.yml
+++ b/.github/workflows/test-integrations-network.yml
@@ -41,10 +41,10 @@ jobs:
         run: |
           set -x # print commands that are executed
           ./scripts/runtox.sh "py${{ matrix.python-version }}-grpc"
-      - name: Test httpx
+      - name: Test httpx0
         run: |
           set -x # print commands that are executed
-          ./scripts/runtox.sh "py${{ matrix.python-version }}-httpx"
+          ./scripts/runtox.sh "py${{ matrix.python-version }}-httpx0"
       - name: Test httpx2
         run: |
           set -x # print commands that are executed

--- a/scripts/populate_tox/README.md
+++ b/scripts/populate_tox/README.md
@@ -146,7 +146,7 @@ a Python version older than 3.9 if the HTTPX version is 0.28 or higher, you can
 say:
 
 ```python
-"httpx": {
+"httpx0": {
     "python": {
         # run the test suite for httpx v0.28+ on Python 3.9+ only
         ">=0.28": ">=3.9",

--- a/scripts/populate_tox/config.py
+++ b/scripts/populate_tox/config.py
@@ -205,8 +205,9 @@ TEST_SUITE_CONFIG = {
         },
         "python": ">=3.7",
     },
-    "httpx": {
+    "httpx0": {
         "package": "httpx",
+        "integration_name": "httpx",
         "deps": {
             "*": ["anyio>=3,<5", "pytest-asyncio"],
             "<0.24": ["anyio<4"],

--- a/scripts/split_tox_gh_actions/split_tox_gh_actions.py
+++ b/scripts/split_tox_gh_actions/split_tox_gh_actions.py
@@ -128,7 +128,7 @@ GROUPS = {
     ],
     "Network": [
         "grpc",
-        "httpx",
+        "httpx0",
         "httpx2",
         "pyreqwest",
         "requests",

--- a/tox.ini
+++ b/tox.ini
@@ -235,11 +235,11 @@ envlist =
     {py3.10,py3.13,py3.14}-grpc-v1.83.1
     {py3.10,py3.13,py3.14}-grpc-latest
 
-    {py3.6,py3.8,py3.9}-httpx-v0.16.1
-    {py3.6,py3.9,py3.10}-httpx-v0.20.0
-    {py3.7,py3.10,py3.11}-httpx-v0.24.1
-    {py3.9,py3.11,py3.12}-httpx-v0.28.1
-    {py3.9,py3.11,py3.12}-httpx-latest
+    {py3.6,py3.8,py3.9}-httpx0-v0.16.1
+    {py3.6,py3.9,py3.10}-httpx0-v0.20.0
+    {py3.7,py3.10,py3.11}-httpx0-v0.24.1
+    {py3.9,py3.11,py3.12}-httpx0-v0.28.1
+    {py3.9,py3.11,py3.12}-httpx0-latest
 
     {py3.10,py3.12,py3.13}-httpx2-v2.0.0
     {py3.10,py3.13,py3.14,py3.14t}-httpx2-v2.4.0
@@ -13727,225 +13727,225 @@ deps =
     grpc: pytest-asyncio
     grpc: pytest-forked
 
-    httpx-v0.16.1: httpx==0.16.1
+    httpx0-v0.16.1: httpx==0.16.1
 
-    py3.8-httpx-v0.16.1: pytest-httpx==0.10.0
-    py3.8-httpx-v0.16.1: httpcore==0.12.3
-    py3.8-httpx-v0.16.1: pytest==6.2.5
-    py3.8-httpx-v0.16.1: sniffio==1.3.1
-    py3.8-httpx-v0.16.1: h11==0.16.0
-    py3.8-httpx-v0.16.1: anyio==3.7.1
-    py3.8-httpx-v0.16.1: pytest-asyncio==0.20.3
-    py3.8-httpx-v0.16.1: idna==3.15
-    py3.8-httpx-v0.16.1: rfc3986==1.5.0
-    py3.8-httpx-v0.16.1: certifi==2026.7.22
-    py3.8-httpx-v0.16.1: exceptiongroup==1.3.1
-    py3.8-httpx-v0.16.1: attrs==25.3.0
-    py3.8-httpx-v0.16.1: pluggy==1.5.0
-    py3.8-httpx-v0.16.1: py==1.11.0
-    py3.8-httpx-v0.16.1: typing_extensions==4.13.2
-    py3.8-httpx-v0.16.1: iniconfig==2.1.0
-    py3.8-httpx-v0.16.1: packaging==26.2
-    py3.8-httpx-v0.16.1: toml==0.10.2
+    py3.8-httpx0-v0.16.1: pytest-httpx==0.10.0
+    py3.8-httpx0-v0.16.1: httpcore==0.12.3
+    py3.8-httpx0-v0.16.1: pytest==6.2.5
+    py3.8-httpx0-v0.16.1: sniffio==1.3.1
+    py3.8-httpx0-v0.16.1: h11==0.16.0
+    py3.8-httpx0-v0.16.1: anyio==3.7.1
+    py3.8-httpx0-v0.16.1: pytest-asyncio==0.20.3
+    py3.8-httpx0-v0.16.1: idna==3.15
+    py3.8-httpx0-v0.16.1: rfc3986==1.5.0
+    py3.8-httpx0-v0.16.1: certifi==2026.7.22
+    py3.8-httpx0-v0.16.1: exceptiongroup==1.3.1
+    py3.8-httpx0-v0.16.1: attrs==25.3.0
+    py3.8-httpx0-v0.16.1: pluggy==1.5.0
+    py3.8-httpx0-v0.16.1: py==1.11.0
+    py3.8-httpx0-v0.16.1: typing_extensions==4.13.2
+    py3.8-httpx0-v0.16.1: iniconfig==2.1.0
+    py3.8-httpx0-v0.16.1: packaging==26.2
+    py3.8-httpx0-v0.16.1: toml==0.10.2
 
-    py3.9-httpx-v0.16.1: pytest-httpx==0.10.0
-    py3.9-httpx-v0.16.1: anyio==3.7.1
-    py3.9-httpx-v0.16.1: httpcore==0.12.3
-    py3.9-httpx-v0.16.1: h11==0.16.0
-    py3.9-httpx-v0.16.1: pytest==6.2.5
-    py3.9-httpx-v0.16.1: pluggy==1.6.0
-    py3.9-httpx-v0.16.1: rfc3986==1.5.0
-    py3.9-httpx-v0.16.1: sniffio==1.3.1
-    py3.9-httpx-v0.16.1: pytest-asyncio==0.20.3
-    py3.9-httpx-v0.16.1: attrs==26.1.0
-    py3.9-httpx-v0.16.1: idna==3.18
-    py3.9-httpx-v0.16.1: py==1.11.0
-    py3.9-httpx-v0.16.1: certifi==2026.7.22
-    py3.9-httpx-v0.16.1: exceptiongroup==1.3.1
-    py3.9-httpx-v0.16.1: typing_extensions==4.16.0
-    py3.9-httpx-v0.16.1: iniconfig==2.1.0
-    py3.9-httpx-v0.16.1: packaging==26.3
-    py3.9-httpx-v0.16.1: toml==0.10.2
+    py3.9-httpx0-v0.16.1: pytest-httpx==0.10.0
+    py3.9-httpx0-v0.16.1: anyio==3.7.1
+    py3.9-httpx0-v0.16.1: httpcore==0.12.3
+    py3.9-httpx0-v0.16.1: h11==0.16.0
+    py3.9-httpx0-v0.16.1: pytest==6.2.5
+    py3.9-httpx0-v0.16.1: pluggy==1.6.0
+    py3.9-httpx0-v0.16.1: rfc3986==1.5.0
+    py3.9-httpx0-v0.16.1: sniffio==1.3.1
+    py3.9-httpx0-v0.16.1: pytest-asyncio==0.20.3
+    py3.9-httpx0-v0.16.1: attrs==26.1.0
+    py3.9-httpx0-v0.16.1: idna==3.18
+    py3.9-httpx0-v0.16.1: py==1.11.0
+    py3.9-httpx0-v0.16.1: certifi==2026.7.22
+    py3.9-httpx0-v0.16.1: exceptiongroup==1.3.1
+    py3.9-httpx0-v0.16.1: typing_extensions==4.16.0
+    py3.9-httpx0-v0.16.1: iniconfig==2.1.0
+    py3.9-httpx0-v0.16.1: packaging==26.3
+    py3.9-httpx0-v0.16.1: toml==0.10.2
 
-    httpx-v0.20.0: httpx==0.20.0
+    httpx0-v0.20.0: httpx==0.20.0
 
-    py3.9-httpx-v0.20.0: pytest-httpx==0.14.0
-    py3.9-httpx-v0.20.0: anyio==3.7.1
-    py3.9-httpx-v0.20.0: httpcore==0.13.7
-    py3.9-httpx-v0.20.0: h11==0.12.0
-    py3.9-httpx-v0.20.0: pytest==6.2.5
-    py3.9-httpx-v0.20.0: pluggy==1.6.0
-    py3.9-httpx-v0.20.0: rfc3986==1.5.0
-    py3.9-httpx-v0.20.0: sniffio==1.3.1
-    py3.9-httpx-v0.20.0: pytest-asyncio==0.20.3
-    py3.9-httpx-v0.20.0: attrs==26.1.0
-    py3.9-httpx-v0.20.0: idna==3.18
-    py3.9-httpx-v0.20.0: py==1.11.0
-    py3.9-httpx-v0.20.0: certifi==2026.7.22
-    py3.9-httpx-v0.20.0: charset-normalizer==3.4.9
-    py3.9-httpx-v0.20.0: exceptiongroup==1.3.1
-    py3.9-httpx-v0.20.0: typing_extensions==4.16.0
-    py3.9-httpx-v0.20.0: iniconfig==2.1.0
-    py3.9-httpx-v0.20.0: packaging==26.3
-    py3.9-httpx-v0.20.0: toml==0.10.2
+    py3.9-httpx0-v0.20.0: pytest-httpx==0.14.0
+    py3.9-httpx0-v0.20.0: anyio==3.7.1
+    py3.9-httpx0-v0.20.0: httpcore==0.13.7
+    py3.9-httpx0-v0.20.0: h11==0.12.0
+    py3.9-httpx0-v0.20.0: pytest==6.2.5
+    py3.9-httpx0-v0.20.0: pluggy==1.6.0
+    py3.9-httpx0-v0.20.0: rfc3986==1.5.0
+    py3.9-httpx0-v0.20.0: sniffio==1.3.1
+    py3.9-httpx0-v0.20.0: pytest-asyncio==0.20.3
+    py3.9-httpx0-v0.20.0: attrs==26.1.0
+    py3.9-httpx0-v0.20.0: idna==3.18
+    py3.9-httpx0-v0.20.0: py==1.11.0
+    py3.9-httpx0-v0.20.0: certifi==2026.7.22
+    py3.9-httpx0-v0.20.0: charset-normalizer==3.4.9
+    py3.9-httpx0-v0.20.0: exceptiongroup==1.3.1
+    py3.9-httpx0-v0.20.0: typing_extensions==4.16.0
+    py3.9-httpx0-v0.20.0: iniconfig==2.1.0
+    py3.9-httpx0-v0.20.0: packaging==26.3
+    py3.9-httpx0-v0.20.0: toml==0.10.2
 
-    py3.10-httpx-v0.20.0: pytest-httpx==0.14.0
-    py3.10-httpx-v0.20.0: anyio==3.7.1
-    py3.10-httpx-v0.20.0: httpcore==0.13.7
-    py3.10-httpx-v0.20.0: h11==0.12.0
-    py3.10-httpx-v0.20.0: pytest==6.2.5
-    py3.10-httpx-v0.20.0: pluggy==1.6.0
-    py3.10-httpx-v0.20.0: rfc3986==1.5.0
-    py3.10-httpx-v0.20.0: sniffio==1.3.1
-    py3.10-httpx-v0.20.0: pytest-asyncio==0.20.3
-    py3.10-httpx-v0.20.0: attrs==26.1.0
-    py3.10-httpx-v0.20.0: idna==3.18
-    py3.10-httpx-v0.20.0: py==1.11.0
-    py3.10-httpx-v0.20.0: certifi==2026.7.22
-    py3.10-httpx-v0.20.0: charset-normalizer==3.4.9
-    py3.10-httpx-v0.20.0: exceptiongroup==1.3.1
-    py3.10-httpx-v0.20.0: typing_extensions==4.16.0
-    py3.10-httpx-v0.20.0: iniconfig==2.3.0
-    py3.10-httpx-v0.20.0: packaging==26.3
-    py3.10-httpx-v0.20.0: toml==0.10.2
+    py3.10-httpx0-v0.20.0: pytest-httpx==0.14.0
+    py3.10-httpx0-v0.20.0: anyio==3.7.1
+    py3.10-httpx0-v0.20.0: httpcore==0.13.7
+    py3.10-httpx0-v0.20.0: h11==0.12.0
+    py3.10-httpx0-v0.20.0: pytest==6.2.5
+    py3.10-httpx0-v0.20.0: pluggy==1.6.0
+    py3.10-httpx0-v0.20.0: rfc3986==1.5.0
+    py3.10-httpx0-v0.20.0: sniffio==1.3.1
+    py3.10-httpx0-v0.20.0: pytest-asyncio==0.20.3
+    py3.10-httpx0-v0.20.0: attrs==26.1.0
+    py3.10-httpx0-v0.20.0: idna==3.18
+    py3.10-httpx0-v0.20.0: py==1.11.0
+    py3.10-httpx0-v0.20.0: certifi==2026.7.22
+    py3.10-httpx0-v0.20.0: charset-normalizer==3.4.9
+    py3.10-httpx0-v0.20.0: exceptiongroup==1.3.1
+    py3.10-httpx0-v0.20.0: typing_extensions==4.16.0
+    py3.10-httpx0-v0.20.0: iniconfig==2.3.0
+    py3.10-httpx0-v0.20.0: packaging==26.3
+    py3.10-httpx0-v0.20.0: toml==0.10.2
 
-    httpx-v0.24.1: httpx==0.24.1
+    httpx0-v0.24.1: httpx==0.24.1
 
-    py3.10-httpx-v0.24.1: pytest-httpx==0.22.0
-    py3.10-httpx-v0.24.1: anyio==4.14.2
-    py3.10-httpx-v0.24.1: httpcore==0.17.3
-    py3.10-httpx-v0.24.1: h11==0.14.0
-    py3.10-httpx-v0.24.1: pytest==7.4.4
-    py3.10-httpx-v0.24.1: pluggy==1.6.0
-    py3.10-httpx-v0.24.1: sniffio==1.3.1
-    py3.10-httpx-v0.24.1: pytest-asyncio==0.23.8
-    py3.10-httpx-v0.24.1: exceptiongroup==1.3.1
-    py3.10-httpx-v0.24.1: idna==3.18
-    py3.10-httpx-v0.24.1: tomli==2.4.1
-    py3.10-httpx-v0.24.1: typing_extensions==4.16.0
-    py3.10-httpx-v0.24.1: certifi==2026.7.22
-    py3.10-httpx-v0.24.1: iniconfig==2.3.0
-    py3.10-httpx-v0.24.1: packaging==26.3
+    py3.10-httpx0-v0.24.1: pytest-httpx==0.22.0
+    py3.10-httpx0-v0.24.1: anyio==4.14.2
+    py3.10-httpx0-v0.24.1: httpcore==0.17.3
+    py3.10-httpx0-v0.24.1: h11==0.14.0
+    py3.10-httpx0-v0.24.1: pytest==7.4.4
+    py3.10-httpx0-v0.24.1: pluggy==1.6.0
+    py3.10-httpx0-v0.24.1: sniffio==1.3.1
+    py3.10-httpx0-v0.24.1: pytest-asyncio==0.23.8
+    py3.10-httpx0-v0.24.1: exceptiongroup==1.3.1
+    py3.10-httpx0-v0.24.1: idna==3.18
+    py3.10-httpx0-v0.24.1: tomli==2.4.1
+    py3.10-httpx0-v0.24.1: typing_extensions==4.16.0
+    py3.10-httpx0-v0.24.1: certifi==2026.7.22
+    py3.10-httpx0-v0.24.1: iniconfig==2.3.0
+    py3.10-httpx0-v0.24.1: packaging==26.3
 
-    py3.11-httpx-v0.24.1: pytest-httpx==0.22.0
-    py3.11-httpx-v0.24.1: anyio==4.14.2
-    py3.11-httpx-v0.24.1: pytest-asyncio==0.23.8
-    py3.11-httpx-v0.24.1: httpcore==0.17.3
-    py3.11-httpx-v0.24.1: sniffio==1.3.1
-    py3.11-httpx-v0.24.1: idna==3.18
-    py3.11-httpx-v0.24.1: pytest==7.4.4
-    py3.11-httpx-v0.24.1: typing_extensions==4.16.0
-    py3.11-httpx-v0.24.1: certifi==2026.7.22
-    py3.11-httpx-v0.24.1: h11==0.14.0
-    py3.11-httpx-v0.24.1: pluggy==1.6.0
-    py3.11-httpx-v0.24.1: iniconfig==2.3.0
-    py3.11-httpx-v0.24.1: packaging==26.3
+    py3.11-httpx0-v0.24.1: pytest-httpx==0.22.0
+    py3.11-httpx0-v0.24.1: anyio==4.14.2
+    py3.11-httpx0-v0.24.1: pytest-asyncio==0.23.8
+    py3.11-httpx0-v0.24.1: httpcore==0.17.3
+    py3.11-httpx0-v0.24.1: sniffio==1.3.1
+    py3.11-httpx0-v0.24.1: idna==3.18
+    py3.11-httpx0-v0.24.1: pytest==7.4.4
+    py3.11-httpx0-v0.24.1: typing_extensions==4.16.0
+    py3.11-httpx0-v0.24.1: certifi==2026.7.22
+    py3.11-httpx0-v0.24.1: h11==0.14.0
+    py3.11-httpx0-v0.24.1: pluggy==1.6.0
+    py3.11-httpx0-v0.24.1: iniconfig==2.3.0
+    py3.11-httpx0-v0.24.1: packaging==26.3
 
-    httpx-v0.28.1: httpx==0.28.1
+    httpx0-v0.28.1: httpx==0.28.1
 
-    py3.9-httpx-v0.28.1: pytest-httpx==0.35.0
-    py3.9-httpx-v0.28.1: anyio==4.12.1
-    py3.9-httpx-v0.28.1: httpcore==1.0.9
-    py3.9-httpx-v0.28.1: pytest==8.4.2
-    py3.9-httpx-v0.28.1: pluggy==1.6.0
-    py3.9-httpx-v0.28.1: pytest-asyncio==1.2.0
-    py3.9-httpx-v0.28.1: backports.asyncio.runner==1.2.0
-    py3.9-httpx-v0.28.1: exceptiongroup==1.3.1
-    py3.9-httpx-v0.28.1: h11==0.16.0
-    py3.9-httpx-v0.28.1: idna==3.18
-    py3.9-httpx-v0.28.1: iniconfig==2.1.0
-    py3.9-httpx-v0.28.1: packaging==26.3
-    py3.9-httpx-v0.28.1: Pygments==2.20.0
-    py3.9-httpx-v0.28.1: tomli==2.4.1
-    py3.9-httpx-v0.28.1: typing_extensions==4.16.0
-    py3.9-httpx-v0.28.1: certifi==2026.7.22
+    py3.9-httpx0-v0.28.1: pytest-httpx==0.35.0
+    py3.9-httpx0-v0.28.1: anyio==4.12.1
+    py3.9-httpx0-v0.28.1: httpcore==1.0.9
+    py3.9-httpx0-v0.28.1: pytest==8.4.2
+    py3.9-httpx0-v0.28.1: pluggy==1.6.0
+    py3.9-httpx0-v0.28.1: pytest-asyncio==1.2.0
+    py3.9-httpx0-v0.28.1: backports.asyncio.runner==1.2.0
+    py3.9-httpx0-v0.28.1: exceptiongroup==1.3.1
+    py3.9-httpx0-v0.28.1: h11==0.16.0
+    py3.9-httpx0-v0.28.1: idna==3.18
+    py3.9-httpx0-v0.28.1: iniconfig==2.1.0
+    py3.9-httpx0-v0.28.1: packaging==26.3
+    py3.9-httpx0-v0.28.1: Pygments==2.20.0
+    py3.9-httpx0-v0.28.1: tomli==2.4.1
+    py3.9-httpx0-v0.28.1: typing_extensions==4.16.0
+    py3.9-httpx0-v0.28.1: certifi==2026.7.22
 
-    py3.11-httpx-v0.28.1: pytest-httpx==0.35.0
-    py3.11-httpx-v0.28.1: httpcore==1.0.9
-    py3.11-httpx-v0.28.1: pytest==8.4.2
-    py3.11-httpx-v0.28.1: anyio==4.14.2
-    py3.11-httpx-v0.28.1: pytest-asyncio==1.4.0
-    py3.11-httpx-v0.28.1: idna==3.18
-    py3.11-httpx-v0.28.1: typing_extensions==4.16.0
-    py3.11-httpx-v0.28.1: certifi==2026.7.22
-    py3.11-httpx-v0.28.1: h11==0.16.0
-    py3.11-httpx-v0.28.1: iniconfig==2.3.0
-    py3.11-httpx-v0.28.1: packaging==26.3
-    py3.11-httpx-v0.28.1: pluggy==1.6.0
-    py3.11-httpx-v0.28.1: Pygments==2.20.0
+    py3.11-httpx0-v0.28.1: pytest-httpx==0.35.0
+    py3.11-httpx0-v0.28.1: httpcore==1.0.9
+    py3.11-httpx0-v0.28.1: pytest==8.4.2
+    py3.11-httpx0-v0.28.1: anyio==4.14.2
+    py3.11-httpx0-v0.28.1: pytest-asyncio==1.4.0
+    py3.11-httpx0-v0.28.1: idna==3.18
+    py3.11-httpx0-v0.28.1: typing_extensions==4.16.0
+    py3.11-httpx0-v0.28.1: certifi==2026.7.22
+    py3.11-httpx0-v0.28.1: h11==0.16.0
+    py3.11-httpx0-v0.28.1: iniconfig==2.3.0
+    py3.11-httpx0-v0.28.1: packaging==26.3
+    py3.11-httpx0-v0.28.1: pluggy==1.6.0
+    py3.11-httpx0-v0.28.1: Pygments==2.20.0
 
-    py3.12-httpx-v0.28.1: pytest-httpx==0.35.0
-    py3.12-httpx-v0.28.1: anyio==4.14.2
-    py3.12-httpx-v0.28.1: httpcore==1.0.9
-    py3.12-httpx-v0.28.1: pytest==8.4.2
-    py3.12-httpx-v0.28.1: pluggy==1.6.0
-    py3.12-httpx-v0.28.1: pytest-asyncio==1.4.0
-    py3.12-httpx-v0.28.1: h11==0.16.0
-    py3.12-httpx-v0.28.1: idna==3.18
-    py3.12-httpx-v0.28.1: iniconfig==2.3.0
-    py3.12-httpx-v0.28.1: packaging==26.3
-    py3.12-httpx-v0.28.1: Pygments==2.20.0
-    py3.12-httpx-v0.28.1: typing_extensions==4.16.0
-    py3.12-httpx-v0.28.1: certifi==2026.7.22
+    py3.12-httpx0-v0.28.1: pytest-httpx==0.35.0
+    py3.12-httpx0-v0.28.1: anyio==4.14.2
+    py3.12-httpx0-v0.28.1: httpcore==1.0.9
+    py3.12-httpx0-v0.28.1: pytest==8.4.2
+    py3.12-httpx0-v0.28.1: pluggy==1.6.0
+    py3.12-httpx0-v0.28.1: pytest-asyncio==1.4.0
+    py3.12-httpx0-v0.28.1: h11==0.16.0
+    py3.12-httpx0-v0.28.1: idna==3.18
+    py3.12-httpx0-v0.28.1: iniconfig==2.3.0
+    py3.12-httpx0-v0.28.1: packaging==26.3
+    py3.12-httpx0-v0.28.1: Pygments==2.20.0
+    py3.12-httpx0-v0.28.1: typing_extensions==4.16.0
+    py3.12-httpx0-v0.28.1: certifi==2026.7.22
 
-    httpx-latest: httpx==0.28.1
+    httpx0-latest: httpx==0.28.1
 
-    httpx-latest: pytest-httpx==0.35.0
+    httpx0-latest: pytest-httpx==0.35.0
 
-    py3.9-httpx-latest: pytest-httpx==0.35.0
-    py3.9-httpx-latest: anyio==4.12.1
-    py3.9-httpx-latest: httpcore==1.0.9
-    py3.9-httpx-latest: pytest==8.4.2
-    py3.9-httpx-latest: pluggy==1.6.0
-    py3.9-httpx-latest: pytest-asyncio==1.2.0
-    py3.9-httpx-latest: backports.asyncio.runner==1.2.0
-    py3.9-httpx-latest: exceptiongroup==1.3.1
-    py3.9-httpx-latest: h11==0.16.0
-    py3.9-httpx-latest: idna==3.18
-    py3.9-httpx-latest: iniconfig==2.1.0
-    py3.9-httpx-latest: packaging==26.3
-    py3.9-httpx-latest: Pygments==2.20.0
-    py3.9-httpx-latest: tomli==2.4.1
-    py3.9-httpx-latest: typing_extensions==4.16.0
-    py3.9-httpx-latest: certifi==2026.7.22
+    py3.9-httpx0-latest: pytest-httpx==0.35.0
+    py3.9-httpx0-latest: anyio==4.12.1
+    py3.9-httpx0-latest: httpcore==1.0.9
+    py3.9-httpx0-latest: pytest==8.4.2
+    py3.9-httpx0-latest: pluggy==1.6.0
+    py3.9-httpx0-latest: pytest-asyncio==1.2.0
+    py3.9-httpx0-latest: backports.asyncio.runner==1.2.0
+    py3.9-httpx0-latest: exceptiongroup==1.3.1
+    py3.9-httpx0-latest: h11==0.16.0
+    py3.9-httpx0-latest: idna==3.18
+    py3.9-httpx0-latest: iniconfig==2.1.0
+    py3.9-httpx0-latest: packaging==26.3
+    py3.9-httpx0-latest: Pygments==2.20.0
+    py3.9-httpx0-latest: tomli==2.4.1
+    py3.9-httpx0-latest: typing_extensions==4.16.0
+    py3.9-httpx0-latest: certifi==2026.7.22
 
-    py3.11-httpx-latest: pytest-httpx==0.35.0
-    py3.11-httpx-latest: httpcore==1.0.9
-    py3.11-httpx-latest: pytest==8.4.2
-    py3.11-httpx-latest: anyio==4.14.2
-    py3.11-httpx-latest: pytest-asyncio==1.4.0
-    py3.11-httpx-latest: idna==3.18
-    py3.11-httpx-latest: typing_extensions==4.16.0
-    py3.11-httpx-latest: certifi==2026.7.22
-    py3.11-httpx-latest: h11==0.16.0
-    py3.11-httpx-latest: iniconfig==2.3.0
-    py3.11-httpx-latest: packaging==26.3
-    py3.11-httpx-latest: pluggy==1.6.0
-    py3.11-httpx-latest: Pygments==2.20.0
+    py3.11-httpx0-latest: pytest-httpx==0.35.0
+    py3.11-httpx0-latest: httpcore==1.0.9
+    py3.11-httpx0-latest: pytest==8.4.2
+    py3.11-httpx0-latest: anyio==4.14.2
+    py3.11-httpx0-latest: pytest-asyncio==1.4.0
+    py3.11-httpx0-latest: idna==3.18
+    py3.11-httpx0-latest: typing_extensions==4.16.0
+    py3.11-httpx0-latest: certifi==2026.7.22
+    py3.11-httpx0-latest: h11==0.16.0
+    py3.11-httpx0-latest: iniconfig==2.3.0
+    py3.11-httpx0-latest: packaging==26.3
+    py3.11-httpx0-latest: pluggy==1.6.0
+    py3.11-httpx0-latest: Pygments==2.20.0
 
-    py3.12-httpx-latest: pytest-httpx==0.35.0
-    py3.12-httpx-latest: anyio==4.14.2
-    py3.12-httpx-latest: httpcore==1.0.9
-    py3.12-httpx-latest: pytest==8.4.2
-    py3.12-httpx-latest: pluggy==1.6.0
-    py3.12-httpx-latest: pytest-asyncio==1.4.0
-    py3.12-httpx-latest: h11==0.16.0
-    py3.12-httpx-latest: idna==3.18
-    py3.12-httpx-latest: iniconfig==2.3.0
-    py3.12-httpx-latest: packaging==26.3
-    py3.12-httpx-latest: Pygments==2.20.0
-    py3.12-httpx-latest: typing_extensions==4.16.0
-    py3.12-httpx-latest: certifi==2026.7.22
+    py3.12-httpx0-latest: pytest-httpx==0.35.0
+    py3.12-httpx0-latest: anyio==4.14.2
+    py3.12-httpx0-latest: httpcore==1.0.9
+    py3.12-httpx0-latest: pytest==8.4.2
+    py3.12-httpx0-latest: pluggy==1.6.0
+    py3.12-httpx0-latest: pytest-asyncio==1.4.0
+    py3.12-httpx0-latest: h11==0.16.0
+    py3.12-httpx0-latest: idna==3.18
+    py3.12-httpx0-latest: iniconfig==2.3.0
+    py3.12-httpx0-latest: packaging==26.3
+    py3.12-httpx0-latest: Pygments==2.20.0
+    py3.12-httpx0-latest: typing_extensions==4.16.0
+    py3.12-httpx0-latest: certifi==2026.7.22
 
-    httpx: anyio>=3,<5
-    httpx: pytest-asyncio
-    httpx-v0.16.1: anyio<4
-    httpx-v0.20.0: anyio<4
-    httpx-v0.16.1: pytest-httpx==0.10.0
-    httpx-v0.20.0: pytest-httpx==0.14.0
-    httpx-v0.24.1: pytest-httpx==0.22.0
-    httpx-v0.28.1: pytest-httpx==0.35.0
-    httpx-latest: pytest-httpx==0.35.0
+    httpx0: anyio>=3,<5
+    httpx0: pytest-asyncio
+    httpx0-v0.16.1: anyio<4
+    httpx0-v0.20.0: anyio<4
+    httpx0-v0.16.1: pytest-httpx==0.10.0
+    httpx0-v0.20.0: pytest-httpx==0.14.0
+    httpx0-v0.24.1: pytest-httpx==0.22.0
+    httpx0-v0.28.1: pytest-httpx==0.35.0
+    httpx0-latest: pytest-httpx==0.35.0
 
     httpx2-v2.0.0: httpx2==2.0.0
 
@@ -19276,7 +19276,7 @@ setenv =
     gql: _TESTPATH=tests/integrations/gql
     graphene: _TESTPATH=tests/integrations/graphene
     grpc: _TESTPATH=tests/integrations/grpc
-    httpx: _TESTPATH=tests/integrations/httpx
+    httpx0: _TESTPATH=tests/integrations/httpx
     httpx2: _TESTPATH=tests/integrations/httpx2
     huey: _TESTPATH=tests/integrations/huey
     huggingface_hub: _TESTPATH=tests/integrations/huggingface_hub


### PR DESCRIPTION
Closes #7151

### Problem

`scripts/runtox.sh` selects tox environments with an unanchored `grep` over `tox -l`:

```sh
ENV="$(uv run tox -l | grep -- "$searchstring" | grep -v -- '-latest$' | tr $'\n' ',')"
```

The Network workflow's `Test httpx` step passes `py<version>-httpx`, which therefore also matches the `py<version>-httpx2-*` environments.

The result:

- On versions where both suites exist (e.g. 3.12), the `httpx` job ran the httpx2 suite as well as its own, duplicating the work already done by the `httpx2` job.
- On 3.14 / 3.14t / 3.15, where there are no `httpx` environments at all, the `httpx` job ran **only** httpx2 environments — which is what the issue reports.

### Fix

Rename the tox test suite from `httpx` to `httpx0` (httpx is still on 0.x), so the `httpx0` and `httpx2` selectors can no longer collide. This follows the precedent set for `openai-base` in #4730, where the suite was renamed rather than making the selector boundary-aware.

`integration_name: "httpx"` is added alongside the rename so the suite keeps resolving to the existing integration:

- `_TESTPATH` stays `tests/integrations/httpx` (the test directory is unchanged)
- the minimum supported version lookup against `_MIN_VERSIONS` in `sentry_sdk/integrations/__init__.py` keeps working, so the suite still floors at httpx 0.16.0

Without `integration_name` the suite would point at a nonexistent `tests/integrations/httpx0` directory and lose its version floor.

### Changes

- `scripts/populate_tox/config.py` — rename the suite, add `integration_name`
- `scripts/split_tox_gh_actions/split_tox_gh_actions.py` — update the `Network` group
- `scripts/populate_tox/README.md` — the `python` key example documents this suite; updated to match
- `tox.ini` and `.github/workflows/test-integrations-network.yml` — regenerated

The `tox.ini` diff is a pure rename: 207 lines removed, 207 added, no version or dependency changes.

### Note

The same class of collision still exists for `redis`, which is a prefix of `redis_py_cluster_legacy`, so the `Test redis` step also runs the cluster-legacy suite. Left out of this PR to keep it scoped to #7151 — happy to open a separate issue for it.