### PR TITLE
fix(openai-agents): Use `isinstance` to determine tool type

### DIFF
--- a/sentry_sdk/integrations/openai_agents/patches/tools.py
+++ b/sentry_sdk/integrations/openai_agents/patches/tools.py
@@ -15,6 +15,7 @@ if TYPE_CHECKING:
 
 try:
     import agents
+    from agents import FunctionTool
 except ImportError:
     raise DidNotEnable("OpenAI Agents not installed")
 
@@ -33,7 +34,7 @@ async def _get_all_tools(
     wrapped_tools = []
     for tool in tools:
         # Wrap only the function tools (for now)
-        if tool.__class__.__name__ != "FunctionTool":
+        if not isinstance(tool, FunctionTool):
             wrapped_tools.append(tool)
             continue
 


### PR DESCRIPTION
### Description
<!-- What changed and why? -->

The patch depends on the `Tool.on_invoke_tool()` method, so an `isinstance()` check is appropriate.

#### Issues
<!--
* resolves: #1234
* resolves: LIN-1234
-->

#### Reminders
- Please add tests to validate your changes, and lint your code using `uv run ruff`.
- Add GH Issue ID _&_ Linear ID (if applicable)
- PR title should use [conventional commit](https://develop.sentry.dev/engineering-practices/commit-messages/#type) style (`feat:`, `fix:`, `ref:`, `meta:`)
- For external contributors: [CONTRIBUTING.md](https://github.com/getsentry/sentry-python/blob/master/CONTRIBUTING.md), [Sentry SDK development docs](https://develop.sentry.dev/sdk/), [Discord community](https://discord.gg/Ww9hbqr)
