### PR TITLE
Skip formatting log records when Sentry logs are off

### DIFF
--- a/sentry_sdk/integrations/logging.py
+++ b/sentry_sdk/integrations/logging.py
@@ -395,7 +395,6 @@ class SentryLogsHandler(_BaseHandler):
 
     def emit(self, record: "LogRecord") -> "Any":
         with capture_internal_exceptions():
-            self.format(record)
             if not self._can_record(record):
                 return
 
@@ -420,6 +419,7 @@ class SentryLogsHandler(_BaseHandler):
             if not should_capture_logs:
                 return
 
+            self.format(record)
             self._capture_log_from_record(client, record)
 
     def _capture_log_from_record(

--- a/tests/integrations/logging/test_logging.py
+++ b/tests/integrations/logging/test_logging.py
@@ -8,6 +8,7 @@ from sentry_sdk import get_client
 from sentry_sdk.consts import VERSION
 from sentry_sdk.integrations.logging import (
     LoggingIntegration,
+    SentryLogsHandler,
     ignore_logger,
     ignore_logger_for_sentry_logs,
     unignore_logger,
@@ -242,6 +243,23 @@ def test_sentry_logs_collection_off_by_default(sentry_init, capture_items, reque
     get_client().flush()
 
     assert not items
+
+
+def test_sentry_logs_handler_skips_format_when_disabled(sentry_init):
+    sentry_init()
+    handler = SentryLogsHandler()
+    record = logging.LogRecord(
+        name="test-logger",
+        level=logging.INFO,
+        pathname=__file__,
+        lineno=1,
+        msg="hello %s",
+        args=("world",),
+        exc_info=None,
+    )
+    with mock.patch.object(handler, "format") as formatted:
+        handler.emit(record)
+    formatted.assert_not_called()
 
 
 def test_sentry_logs_collection_opt_in(sentry_init, capture_items, request):

--- a/tests/integrations/logging/test_logging.py
+++ b/tests/integrations/logging/test_logging.py
@@ -246,7 +246,7 @@ def test_sentry_logs_collection_off_by_default(sentry_init, capture_items, reque
 
 
 def test_sentry_logs_handler_skips_format_when_disabled(sentry_init):
-    sentry_init()
+    sentry_init(integrations=[LoggingIntegration(capture_sentry_logs=False)])
     handler = SentryLogsHandler()
     record = logging.LogRecord(
         name="test-logger",


### PR DESCRIPTION
`SentryLogsHandler.emit` called `format()` before checking whether logs are enabled. Every stdlib record paid for a Formatter even with the feature off.

Format after the capture check.

Fixes #7402