### PR TITLE
chore: Remove `get_start_span_function()`

### DIFF
--- a/sentry_sdk/ai/utils.py
+++ b/sentry_sdk/ai/utils.py
@@ -7,7 +7,7 @@ from sentry_sdk._types import BLOB_DATA_SUBSTITUTE
 from sentry_sdk.ai.consts import DATA_URL_BASE64_REGEX
 
 if TYPE_CHECKING:
-    from typing import Any, Callable, Dict, List, Optional, Tuple, Union
+    from typing import Any, Dict, List, Optional, Tuple, Union
 
     from sentry_sdk.tracing import Span
 
@@ -534,15 +534,6 @@ def normalize_message_roles(messages: "list[dict[str, Any]]") -> "list[dict[str,
         normalized_messages.append(normalized_message)
 
     return normalized_messages
-
-
-def get_start_span_function() -> "Callable[..., Any]":
-    current_span = sentry_sdk.get_current_span()
-
-    transaction_exists = (
-        current_span is not None and current_span.containing_transaction is not None
-    )
-    return sentry_sdk.start_span if transaction_exists else sentry_sdk.start_transaction
 
 
 def _truncate_single_message_content_if_present(


### PR DESCRIPTION
### Description
<!-- What changed and why? -->

The new `traces.start_span()` API promotes spans to segments spans.
There is no need for the helper anymore.

#### Issues
<!--
* resolves: #1234
* resolves: LIN-1234
-->

#### Reminders
- Please add tests to validate your changes, and lint your code using `uv run ruff`.
- Add GH Issue ID _&_ Linear ID (if applicable)
- PR title should use [conventional commit](https://develop.sentry.dev/engineering-practices/commit-messages/#type) style (`feat:`, `fix:`, `ref:`, `meta:`)
- For external contributors: [CONTRIBUTING.md](https://github.com/getsentry/sentry-python/blob/master/CONTRIBUTING.md), [Sentry SDK development docs](https://develop.sentry.dev/sdk/), [Discord community](https://discord.gg/Ww9hbqr)
