### PR TITLE
fix(pydantic-ai): Stop capturing tool execution spans when validation fails

### DIFF
--- a/sentry_sdk/integrations/pydantic_ai/__init__.py
+++ b/sentry_sdk/integrations/pydantic_ai/__init__.py
@@ -51,41 +51,6 @@ def register_hooks(hooks: "Hooks") -> None:
             update_ai_client_span(span, response)
             return response
 
-    # @hooks.on.tool_execute
-    # async def sentry_wrap_tool_execute(
-    #     ctx: "RunContext[Any]",
-    #     *,
-    #     call: "ToolCallPart",
-    #     tool_def: "ToolDefinition",
-    #     args: "ValidatedToolArgs",
-    #     handler: "WrapToolExecuteHandler",
-    # ) -> "Any":
-    #     with execute_tool_span(
-    #         call.tool_name,
-    #         args,
-    #         ctx.agent,
-    #         tool_definition=tool_def,
-    #     ) as span:
-    #         try:
-    #             result = await handler(args)
-    #             update_execute_tool_span(span, result)
-    #             return result
-    #         except ToolRetryError as exc:
-    #             exc_info = sys.exc_info()
-    #             with capture_internal_exceptions():
-    #                 from sentry_sdk.integrations.pydantic_ai import (
-    #                     PydanticAIIntegration,
-    #                 )
-    #                 integration = sentry_sdk.get_client().get_integration(
-    #                     PydanticAIIntegration,
-    #                 )
-    #                 if (
-    #                     integration is not None
-    #                     and integration.handled_tool_call_exceptions
-    #                 ):
-    #                     _capture_exception(exc, handled=True)
-    #             reraise(*exc_info)
-
     original_init = Agent.__init__
 
     @functools.wraps(original_init)

--- a/sentry_sdk/integrations/pydantic_ai/__init__.py
+++ b/sentry_sdk/integrations/pydantic_ai/__init__.py
@@ -51,6 +51,41 @@ def register_hooks(hooks: "Hooks") -> None:
             update_ai_client_span(span, response)
             return response
 
+    # @hooks.on.tool_execute
+    # async def sentry_wrap_tool_execute(
+    #     ctx: "RunContext[Any]",
+    #     *,
+    #     call: "ToolCallPart",
+    #     tool_def: "ToolDefinition",
+    #     args: "ValidatedToolArgs",
+    #     handler: "WrapToolExecuteHandler",
+    # ) -> "Any":
+    #     with execute_tool_span(
+    #         call.tool_name,
+    #         args,
+    #         ctx.agent,
+    #         tool_definition=tool_def,
+    #     ) as span:
+    #         try:
+    #             result = await handler(args)
+    #             update_execute_tool_span(span, result)
+    #             return result
+    #         except ToolRetryError as exc:
+    #             exc_info = sys.exc_info()
+    #             with capture_internal_exceptions():
+    #                 from sentry_sdk.integrations.pydantic_ai import (
+    #                     PydanticAIIntegration,
+    #                 )
+    #                 integration = sentry_sdk.get_client().get_integration(
+    #                     PydanticAIIntegration,
+    #                 )
+    #                 if (
+    #                     integration is not None
+    #                     and integration.handled_tool_call_exceptions
+    #                 ):
+    #                     _capture_exception(exc, handled=True)
+    #             reraise(*exc_info)
+
     original_init = Agent.__init__
 
     @functools.wraps(original_init)

--- a/sentry_sdk/integrations/pydantic_ai/patches/tools.py
+++ b/sentry_sdk/integrations/pydantic_ai/patches/tools.py
@@ -1,4 +1,5 @@
 import sys
+from contextlib import nullcontext
 from functools import wraps
 from typing import TYPE_CHECKING
 
@@ -60,11 +61,15 @@ def _patch_execute_tool_call() -> None:
             # Create execute_tool span
             # Nesting is handled by isolation_scope() to ensure proper parent-child relationships
             with sentry_sdk.isolation_scope():
-                with execute_tool_span(
-                    name,
-                    args_dict,
-                    agent,
-                    tool_definition=selected_tool_definition,
+                with (
+                    execute_tool_span(
+                        name,
+                        args_dict,
+                        agent,
+                        tool_definition=selected_tool_definition,
+                    )
+                    if validated.args_valid
+                    else nullcontext()
                 ) as span:
                     try:
                         result = await original_execute_tool_call(
@@ -73,7 +78,8 @@ def _patch_execute_tool_call() -> None:
                             *args,
                             **kwargs,
                         )
-                        update_execute_tool_span(span, result)
+                        if span is not None:
+                            update_execute_tool_span(span, result)
                         return result
                     except ToolRetryError as exc:
                         exc_info = sys.exc_info()

--- a/tests/integrations/pydantic_ai/test_pydantic_ai.py
+++ b/tests/integrations/pydantic_ai/test_pydantic_ai.py
@@ -1022,24 +1022,6 @@ async def test_agent_with_tool_validation_error(
         chat_spans = [
             s for s in spans if s["attributes"].get("sentry.op", "") == "gen_ai.chat"
         ]
-        tool_spans = [
-            s
-            for s in spans
-            if s["attributes"].get("sentry.op", "") == "gen_ai.execute_tool"
-        ]
-
-        # Should have tool spans
-        assert len(tool_spans) >= 1
-
-        # Check tool spans
-        model_retry_tool_span = tool_spans[0]
-        assert "execute_tool" in model_retry_tool_span["name"]
-        assert (
-            model_retry_tool_span["attributes"]["gen_ai.operation.name"]
-            == "execute_tool"
-        )
-        assert model_retry_tool_span["attributes"]["gen_ai.tool.name"] == "add_numbers"
-        assert "gen_ai.tool.input" in model_retry_tool_span["attributes"]
 
         # Check chat spans have available_tools
         assert "gen_ai.request.available_tools" in chat_spans[0]["attributes"]
@@ -1073,17 +1055,6 @@ async def test_agent_with_tool_validation_error(
 
         # Find child span types (invoke_agent is the transaction, not a child span)
         chat_spans = [s for s in spans if s["op"] == "gen_ai.chat"]
-        tool_spans = [s for s in spans if s["op"] == "gen_ai.execute_tool"]
-
-        # Should have tool spans
-        assert len(tool_spans) >= 1
-
-        # Check tool spans
-        model_retry_tool_span = tool_spans[0]
-        assert "execute_tool" in model_retry_tool_span["description"]
-        assert model_retry_tool_span["data"]["gen_ai.operation.name"] == "execute_tool"
-        assert model_retry_tool_span["data"]["gen_ai.tool.name"] == "add_numbers"
-        assert "gen_ai.tool.input" in model_retry_tool_span["data"]
 
         # Check chat spans have available_tools
         assert "gen_ai.request.available_tools" in chat_spans[0]["data"]


### PR DESCRIPTION
### Description
<!-- What changed and why? -->

Do not capture a tool execution span when the tool doesn't execute because the arguments are invalid.

The tool is never executed when validation fails, as `ToolHandler` short circuits by raising an exception in this case. See https://github.com/pydantic/pydantic-ai/blob/0ec8a5dcc9c30e82e91d63af20e5d92f1456fac5/pydantic_ai_slim/pydantic_ai/tool_manager.py#L977

#### Issues
<!--
* resolves: #1234
* resolves: LIN-1234
-->

#### Reminders
- Please add tests to validate your changes, and lint your code using `uv run ruff`.
- Add GH Issue ID _&_ Linear ID (if applicable)
- PR title should use [conventional commit](https://develop.sentry.dev/engineering-practices/commit-messages/#type) style (`feat:`, `fix:`, `ref:`, `meta:`)
- For external contributors: [CONTRIBUTING.md](https://github.com/getsentry/sentry-python/blob/master/CONTRIBUTING.md), [Sentry SDK development docs](https://develop.sentry.dev/sdk/), [Discord community](https://discord.gg/Ww9hbqr)
