### PR TITLE
chore: Adapt more tests

### DIFF
--- a/tests/integrations/celery/test_update_celery_task_headers.py
+++ b/tests/integrations/celery/test_update_celery_task_headers.py
@@ -70,41 +70,41 @@ def test_monitor_beat_tasks_with_headers(monitor_beat_tasks):
 
 
 def test_span_with_transaction(sentry_init):
-    sentry_init(traces_sample_rate=1.0)
+    sentry_init(traces_sample_rate=1.0, trace_lifecycle="stream")
     headers = {}
     monitor_beat_tasks = False
 
-    with sentry_sdk.start_transaction(name="test_transaction") as transaction:
-        with sentry_sdk.start_span(op="test_span") as span:
+    with sentry_sdk.traces.start_span(name="test_segment") as segment:
+        with sentry_sdk.traces.start_span(name="test_span") as span:
             outgoing_headers = _update_celery_task_headers(
                 headers, span, monitor_beat_tasks
             )
 
-            assert outgoing_headers["sentry-trace"] == span.to_traceparent()
-            assert outgoing_headers["headers"]["sentry-trace"] == span.to_traceparent()
-            assert outgoing_headers["baggage"] == transaction.get_baggage().serialize()
+            assert outgoing_headers["sentry-trace"] == span._to_traceparent()
+            assert outgoing_headers["headers"]["sentry-trace"] == span._to_traceparent()
+            assert outgoing_headers["baggage"] == segment._get_baggage().serialize()
             assert (
                 outgoing_headers["headers"]["baggage"]
-                == transaction.get_baggage().serialize()
+                == segment._get_baggage().serialize()
             )
 
 
 def test_span_with_transaction_custom_headers(sentry_init):
-    sentry_init(traces_sample_rate=1.0)
+    sentry_init(traces_sample_rate=1.0, trace_lifecycle="stream")
     headers = {
         "baggage": BAGGAGE_VALUE,
         "sentry-trace": SENTRY_TRACE_VALUE,
     }
 
-    with sentry_sdk.start_transaction(name="test_transaction") as transaction:
-        with sentry_sdk.start_span(op="test_span") as span:
+    with sentry_sdk.traces.start_span(name="test_segment") as segment:
+        with sentry_sdk.traces.start_span(name="test_span") as span:
             outgoing_headers = _update_celery_task_headers(headers, span, False)
 
-            assert outgoing_headers["sentry-trace"] == span.to_traceparent()
-            assert outgoing_headers["headers"]["sentry-trace"] == span.to_traceparent()
+            assert outgoing_headers["sentry-trace"] == span._to_traceparent()
+            assert outgoing_headers["headers"]["sentry-trace"] == span._to_traceparent()
 
             incoming_baggage = Baggage.from_incoming_header(headers["baggage"])
-            combined_baggage = copy(transaction.get_baggage())
+            combined_baggage = copy(segment._get_baggage())
             combined_baggage.sentry_items.update(incoming_baggage.sentry_items)
             combined_baggage.third_party_items = ",".join(
                 [
@@ -169,7 +169,7 @@ def test_celery_trace_propagation_traces_sample_rate(
     The Celery integration has its own mechanism to propagate traces:
     https://docs.sentry.io/platforms/python/integrations/celery/#distributed-traces
     """
-    sentry_init(traces_sample_rate=traces_sample_rate)
+    sentry_init(traces_sample_rate=traces_sample_rate, trace_lifecycle="stream")
 
     headers = {}
     span = None

--- a/tests/integrations/dramatiq/test_dramatiq.py
+++ b/tests/integrations/dramatiq/test_dramatiq.py
@@ -22,6 +22,7 @@ def broker(request, sentry_init):
         sentry_init(
             integrations=[DramatiqIntegration()],
             traces_sample_rate=param,
+            trace_lifecycle="stream",
         )
     broker = StubBroker()
     broker.emit_after("process_boot")

--- a/tests/integrations/google_genai/test_google_genai.py
+++ b/tests/integrations/google_genai/test_google_genai.py
@@ -863,6 +863,7 @@ def test_tool_with_async_function(sentry_init):
     sentry_init(
         integrations=[GoogleGenAIIntegration()],
         traces_sample_rate=1.0,
+        trace_lifecycle="stream",
     )
 
     # Create an async tool function

--- a/tests/integrations/httpx/test_httpx.py
+++ b/tests/integrations/httpx/test_httpx.py
@@ -388,6 +388,7 @@ def test_option_trace_propagation_targets_sync(
         release="test",
         trace_propagation_targets=trace_propagation_targets,
         traces_sample_rate=1.0,
+        trace_lifecycle="stream",
         integrations=[HttpxIntegration()],
     )
 
@@ -466,6 +467,7 @@ async def test_option_trace_propagation_targets_async(
         release="test",
         trace_propagation_targets=trace_propagation_targets,
         traces_sample_rate=1.0,
+        trace_lifecycle="stream",
         integrations=[HttpxIntegration()],
     )
 

--- a/tests/integrations/langchain/test_langchain.py
+++ b/tests/integrations/langchain/test_langchain.py
@@ -1965,6 +1965,7 @@ def test_langchain_tool_error(
         integrations=[LangchainIntegration(include_prompts=True)],
         disabled_integrations=[StdlibIntegration],
         traces_sample_rate=1.0,
+        trace_lifecycle="stream",
     )
 
     responses = nonstreaming_responses_tool_call_model_responses(
@@ -2108,6 +2109,7 @@ def test_langchain_callback_manager(sentry_init):
         integrations=[LangchainIntegration()],
         disabled_integrations=[StdlibIntegration],
         traces_sample_rate=1.0,
+        trace_lifecycle="stream",
     )
     local_manager = BaseCallbackManager(handlers=[])
 
@@ -2141,6 +2143,7 @@ def test_langchain_callback_manager_with_sentry_callback(sentry_init):
         integrations=[LangchainIntegration()],
         disabled_integrations=[StdlibIntegration],
         traces_sample_rate=1.0,
+        trace_lifecycle="stream",
     )
     sentry_callback = SentryLangchainCallback(False)
     local_manager = BaseCallbackManager(handlers=[sentry_callback])
@@ -2174,6 +2177,7 @@ def test_langchain_callback_list(sentry_init):
         integrations=[LangchainIntegration()],
         disabled_integrations=[StdlibIntegration],
         traces_sample_rate=1.0,
+        trace_lifecycle="stream",
     )
     local_callbacks = []
 
@@ -2207,6 +2211,7 @@ def test_langchain_callback_list_existing_callback(sentry_init):
         integrations=[LangchainIntegration()],
         disabled_integrations=[StdlibIntegration],
         traces_sample_rate=1.0,
+        trace_lifecycle="stream",
     )
     sentry_callback = SentryLangchainCallback(False)
     local_callbacks = [sentry_callback]

--- a/tests/integrations/litellm/test_litellm.py
+++ b/tests/integrations/litellm/test_litellm.py
@@ -1514,6 +1514,7 @@ def test_integration_setup(sentry_init):
         integrations=[LiteLLMIntegration()],
         disabled_integrations=[StdlibIntegration],
         traces_sample_rate=1.0,
+        trace_lifecycle="stream",
     )
 
     # Check that callbacks are registered

--- a/tests/integrations/mcp/test_mcp.py
+++ b/tests/integrations/mcp/test_mcp.py
@@ -151,6 +151,7 @@ def test_integration_patches_server(sentry_init):
         sentry_init(
             integrations=[MCPIntegration()],
             traces_sample_rate=1.0,
+            trace_lifecycle="stream",
         )
 
         assert Server.call_tool is not original_call_tool

--- a/tests/integrations/openai_agents/test_openai_agents.py
+++ b/tests/integrations/openai_agents/test_openai_agents.py
@@ -3175,6 +3175,7 @@ def test_openai_agents_message_role_mapping(sentry_init, test_message, expected_
     sentry_init(
         integrations=[OpenAIAgentsIntegration()],
         traces_sample_rate=1.0,
+        trace_lifecycle="stream",
         send_default_pii=True,
     )
 

--- a/tests/integrations/openai_agents/test_openai_agents.py
+++ b/tests/integrations/openai_agents/test_openai_agents.py
@@ -68,7 +68,6 @@ except ImportError:
 from typing import Any, cast
 
 import sentry_sdk
-from sentry_sdk import start_span
 from sentry_sdk.consts import OP, SPANDATA
 from sentry_sdk.integrations.logging import LoggingIntegration
 from sentry_sdk.integrations.openai_agents import OpenAIAgentsIntegration
@@ -3181,13 +3180,13 @@ def test_openai_agents_message_role_mapping(sentry_init, test_message, expected_
 
     get_response_kwargs = {"input": [test_message]}
 
-    with start_span(op="test") as span:
+    with sentry_sdk.traces.start_span(name="test") as span:
         _set_input_data(span, get_response_kwargs)
 
     # Verify that messages were processed and roles were mapped
     from sentry_sdk.consts import SPANDATA
 
-    stored_messages = json.loads(span._data[SPANDATA.GEN_AI_REQUEST_MESSAGES])
+    stored_messages = json.loads(span._attributes[SPANDATA.GEN_AI_REQUEST_MESSAGES])
 
     # Verify roles were properly mapped
     assert stored_messages[0]["role"] == expected_role

--- a/tests/integrations/threading/test_threading.py
+++ b/tests/integrations/threading/test_threading.py
@@ -1,6 +1,5 @@
 import sys
 from concurrent import futures
-from textwrap import dedent
 from threading import Thread
 
 import pytest
@@ -193,60 +192,58 @@ def test_spans_from_multiple_threads(
     ids=["propagate_scope=True", "propagate_scope=False"],
 )
 def test_spans_from_threadpool(
-    sentry_init, capture_events, render_span_tree, propagate_scope
+    sentry_init, capture_items, render_span_tree, propagate_scope
 ):
     sentry_init(
         traces_sample_rate=1.0,
         trace_lifecycle="stream",
         integrations=[ThreadingIntegration(propagate_scope=propagate_scope)],
     )
-    events = capture_events()
+    items = capture_items()
 
     def do_some_work(number):
-        with sentry_sdk.start_span(
-            op=f"inner-run-{number}", name=f"Thread: child-{number}"
-        ):
-            pass
+        with sentry_sdk.traces.start_span(name=f"inner-run-{number}") as span:
+            inner_run_spans[number] = span
 
-    with sentry_sdk.start_transaction(op="outer-trx"):
+    outer_submit_spans = {}
+    inner_run_spans = {}
+
+    with sentry_sdk.traces.start_span(name="outer") as outer:
         with futures.ThreadPoolExecutor(max_workers=1) as executor:
             for number in range(5):
-                with sentry_sdk.start_span(
-                    op=f"outer-submit-{number}", name="Thread: main"
-                ):
+                with sentry_sdk.traces.start_span(
+                    name=f"outer-submit-{number}"
+                ) as span:
+                    outer_submit_spans[number] = span
                     future = executor.submit(do_some_work, number)
                     future.result()
 
-    (event,) = events
+    sentry_sdk.flush()
+
+    spans = [item.payload for item in items]
+    assert len(spans) == 11
+
+    # Free-threaded builds set thread_inherit_context to True, otherwise thread_inherit_context is False
+    for span in spans:
+        if span["name"] == "outer-seg":
+            assert span["is_segment"] is True
+            assert "parent_span_id" not in span
+
+        if span["name"].startswith("outer-submit-"):
+            assert span["is_segment"] is False
+            assert span["parent_span_id"] == outer.span_id
 
     # Free-threaded builds set thread_inherit_context to True, otherwise thread_inherit_context is False
     if propagate_scope or getattr(sys.flags, "thread_inherit_context", None):
-        assert event["type"] == "transaction"
-        assert render_span_tree(event["spans"], event["contexts"]["trace"]) == dedent(
-            """\
-            - op="outer-trx": description=null
-              - op="outer-submit-0": description="Thread: main"
-                - op="inner-run-0": description="Thread: child-0"
-              - op="outer-submit-1": description="Thread: main"
-                - op="inner-run-1": description="Thread: child-1"
-              - op="outer-submit-2": description="Thread: main"
-                - op="inner-run-2": description="Thread: child-2"
-              - op="outer-submit-3": description="Thread: main"
-                - op="inner-run-3": description="Thread: child-3"
-              - op="outer-submit-4": description="Thread: main"
-                - op="inner-run-4": description="Thread: child-4"\
-"""
-        )
+        for span in spans:
+            if span["name"].startswith("inner-run-"):
+                num = int(span["name"][-1])
+                assert span["is_segment"] is False
+                assert span["parent_span_id"] == outer_submit_spans[num].span_id
 
     elif not propagate_scope:
-        assert event["type"] == "transaction"
-        assert render_span_tree(event["spans"], event["contexts"]["trace"]) == dedent(
-            """\
-            - op="outer-trx": description=null
-              - op="outer-submit-0": description="Thread: main"
-              - op="outer-submit-1": description="Thread: main"
-              - op="outer-submit-2": description="Thread: main"
-              - op="outer-submit-3": description="Thread: main"
-              - op="outer-submit-4": description="Thread: main"\
-"""
-        )
+        for span in spans:
+            if span["name"].startswith("inner-run-"):
+                num = int(span["name"][-1])
+                assert span["is_segment"] is True
+                assert "parent_span_id" not in span

--- a/tests/integrations/threading/test_threading.py
+++ b/tests/integrations/threading/test_threading.py
@@ -208,7 +208,7 @@ def test_spans_from_threadpool(
     outer_submit_spans = {}
     inner_run_spans = {}
 
-    with sentry_sdk.traces.start_span(name="outer") as outer:
+    with sentry_sdk.traces.start_span(name="outer-seg") as outer:
         with futures.ThreadPoolExecutor(max_workers=1) as executor:
             for number in range(5):
                 with sentry_sdk.traces.start_span(

--- a/tests/integrations/threading/test_threading.py
+++ b/tests/integrations/threading/test_threading.py
@@ -197,6 +197,7 @@ def test_spans_from_threadpool(
 ):
     sentry_init(
         traces_sample_rate=1.0,
+        trace_lifecycle="stream",
         integrations=[ThreadingIntegration(propagate_scope=propagate_scope)],
     )
     events = capture_events()

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -4,7 +4,6 @@ from unittest import mock
 import sentry_sdk
 from sentry_sdk import (
     capture_exception,
-    continue_trace,
     get_baggage,
     get_client,
     get_current_scope,
@@ -14,7 +13,6 @@ from sentry_sdk import (
     get_traceparent,
     is_initialized,
     set_tags,
-    start_transaction,
 )
 from sentry_sdk.client import Client, NonRecordingClient
 from sentry_sdk.traces import StreamedSpan
@@ -64,15 +62,6 @@ def test_get_current_span_current_scope_span_streaming(sentry_init):
     assert sentry_sdk.traces.get_current_span() == fake_span
 
 
-def test_get_current_span_with_transaction(sentry_init):
-    sentry_init()
-
-    assert get_current_span() is None
-
-    with start_transaction() as new_transaction:
-        assert get_current_span() == new_transaction
-
-
 def test_get_current_span_with_segment(sentry_init):
     sentry_init(trace_lifecycle="stream")
 
@@ -83,17 +72,6 @@ def test_get_current_span_with_segment(sentry_init):
 
 
 def test_traceparent_with_tracing_enabled(sentry_init):
-    sentry_init(traces_sample_rate=1.0)
-
-    with start_transaction() as transaction:
-        expected_traceparent = "%s-%s-1" % (
-            transaction.trace_id,
-            transaction.span_id,
-        )
-        assert get_traceparent() == expected_traceparent
-
-
-def test_traceparent_with_tracing_enabled_span_streaming(sentry_init):
     sentry_init(traces_sample_rate=1.0, trace_lifecycle="stream")
 
     with sentry_sdk.traces.start_span(name="span") as segment:
@@ -149,15 +127,6 @@ def test_baggage_with_tracing_disabled_span_streaming(sentry_init):
 
 
 def test_baggage_with_tracing_enabled(sentry_init):
-    sentry_init(traces_sample_rate=1.0, release="1.0.0", environment="dev")
-    with start_transaction() as transaction:
-        expected_baggage_re = r"^sentry-trace_id={},sentry-sample_rand=0\.\d{{6}},sentry-environment=dev,sentry-release=1\.0\.0,sentry-sample_rate=1\.0,sentry-sampled={}$".format(
-            transaction.trace_id, "true" if transaction.sampled else "false"
-        )
-        assert re.match(expected_baggage_re, get_baggage())
-
-
-def test_baggage_with_tracing_enabled_span_streaming(sentry_init):
     sentry_init(
         traces_sample_rate=1.0,
         trace_lifecycle="stream",
@@ -175,21 +144,6 @@ def test_baggage_with_dsn(sentry_init):
     sentry_init(
         dsn="http://97333d956c9e40989a0139756c121c34@sentry-x.sentry-y.s.c.local/976543210",
         traces_sample_rate=1.0,
-        release="2.0.0",
-        environment="dev",
-        transport=TestTransportWithOptions,
-    )
-    with start_transaction() as transaction:
-        expected_baggage_re = r"^sentry-trace_id={},sentry-sample_rand=0\.\d{{6}},sentry-environment=dev,sentry-release=2\.0\.0,sentry-public_key=97333d956c9e40989a0139756c121c34,sentry-sample_rate=1\.0,sentry-sampled={}$".format(
-            transaction.trace_id, "true" if transaction.sampled else "false"
-        )
-        assert re.match(expected_baggage_re, get_baggage())
-
-
-def test_baggage_with_dsn_span_streaming(sentry_init):
-    sentry_init(
-        dsn="http://97333d956c9e40989a0139756c121c34@sentry-x.sentry-y.s.c.local/976543210",
-        traces_sample_rate=1.0,
         trace_lifecycle="stream",
         release="2.0.0",
         environment="dev",
@@ -203,32 +157,6 @@ def test_baggage_with_dsn_span_streaming(sentry_init):
 
 
 def test_continue_trace(sentry_init):
-    sentry_init()
-
-    trace_id = "471a43a4192642f0b136d5159a501701"
-    parent_span_id = "6e8f22c393e68f19"
-    parent_sampled = 1
-    transaction = continue_trace(
-        {
-            "sentry-trace": "{}-{}-{}".format(trace_id, parent_span_id, parent_sampled),
-            "baggage": "sentry-trace_id=566e3688a61d4bc888951642d6f14a19,sentry-sample_rand=0.123456",
-        },
-        name="some name",
-    )
-    with start_transaction(transaction):
-        assert transaction.name == "some name"
-
-        propagation_context = get_isolation_scope()._propagation_context
-        assert propagation_context.trace_id == transaction.trace_id == trace_id
-        assert propagation_context.parent_span_id == parent_span_id
-        assert propagation_context.parent_sampled == parent_sampled
-        assert propagation_context.dynamic_sampling_context == {
-            "trace_id": "566e3688a61d4bc888951642d6f14a19",
-            "sample_rand": "0.123456",
-        }
-
-
-def test_continue_trace_span_streaming(sentry_init):
     sentry_init(trace_lifecycle="stream")
 
     trace_id = "471a43a4192642f0b136d5159a501701"

--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -630,7 +630,7 @@ def test_dedupe_doesnt_take_into_account_dropped_exception(sentry_init, capture_
 def test_event_processor_drop_records_client_report(
     sentry_init, capture_events, capture_record_lost_event_calls
 ):
-    sentry_init(traces_sample_rate=1.0)
+    sentry_init(traces_sample_rate=1.0, trace_lifecycle="stream")
     events = capture_events()
     record_lost_event_calls = capture_record_lost_event_calls()
 
@@ -654,7 +654,6 @@ def test_event_processor_drop_records_client_report(
         assert Counter(record_lost_event_calls) == Counter(
             [
                 ("event_processor", "error", None, 1),
-                ("event_processor", "span", None, 1),
             ]
         )
 

--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -19,7 +19,6 @@ from sentry_sdk import (
     isolation_scope,
     last_event_id,
     new_scope,
-    start_transaction,
 )
 from sentry_sdk.integrations import (
     _AUTO_ENABLING_INTEGRATIONS,
@@ -157,40 +156,6 @@ def test_option_before_send_discard(sentry_init, capture_events):
     events = capture_events()
 
     do_this()
-
-    assert len(events) == 0
-
-
-def test_option_before_send_transaction(sentry_init, capture_events):
-    def before_send_transaction(event, hint):
-        assert event["type"] == "transaction"
-        event["extra"] = {"before_send_transaction_called": True}
-        return event
-
-    sentry_init(
-        before_send_transaction=before_send_transaction,
-        traces_sample_rate=1.0,
-    )
-    events = capture_events()
-    transaction = start_transaction(name="foo")
-    transaction.finish()
-
-    (event,) = events
-    assert event["transaction"] == "foo"
-    assert event["extra"] == {"before_send_transaction_called": True}
-
-
-def test_option_before_send_transaction_discard(sentry_init, capture_events):
-    def before_send_transaction_discard(event, hint):
-        return None
-
-    sentry_init(
-        before_send_transaction=before_send_transaction_discard,
-        traces_sample_rate=1.0,
-    )
-    events = capture_events()
-    transaction = start_transaction(name="foo")
-    transaction.finish()
 
     assert len(events) == 0
 
@@ -683,16 +648,12 @@ def test_event_processor_drop_records_client_report(
 
         capture_message("dropped")
 
-        with start_transaction(name="dropped"):
-            pass
-
         assert len(events) == 0
 
         # Using Counter because order of record_lost_event calls does not matter
         assert Counter(record_lost_event_calls) == Counter(
             [
                 ("event_processor", "error", None, 1),
-                ("event_processor", "transaction", None, 1),
                 ("event_processor", "span", None, 1),
             ]
         )
@@ -776,8 +737,7 @@ def _hello_world(word):
     return "Hello, {}".format(word)
 
 
-@pytest.mark.parametrize("span_streaming", [True, False])
-def test_functions_to_trace(sentry_init, capture_events, capture_items, span_streaming):
+def test_functions_to_trace(sentry_init, capture_items):
     functions_to_trace = [
         {"qualified_name": "tests.test_basics._hello_world"},
         {"qualified_name": "time.sleep"},
@@ -791,45 +751,26 @@ def test_functions_to_trace(sentry_init, capture_events, capture_items, span_str
         sentry_init(
             traces_sample_rate=1.0,
             functions_to_trace=functions_to_trace,
-            trace_lifecycle="stream" if span_streaming else "static",
+            trace_lifecycle="stream",
         )
 
-        if span_streaming:
-            items = capture_items("span")
-        else:
-            events = capture_events()
+        items = capture_items("span")
 
-        if span_streaming:
-            with sentry_sdk.traces.start_span(name="something"):
-                time.sleep(0)
+        with sentry_sdk.traces.start_span(name="something"):
+            time.sleep(0)
 
-                for word in ["World", "You"]:
-                    _hello_world(word)
+            for word in ["World", "You"]:
+                _hello_world(word)
 
-            sentry_sdk.flush()
-            spans = [item.payload for item in items]
-            child_spans = [s for s in spans if not s.get("is_segment")]
-            child_spans.sort(key=lambda s: s["start_timestamp"])
+        sentry_sdk.flush()
+        spans = [item.payload for item in items]
+        child_spans = [s for s in spans if not s.get("is_segment")]
+        child_spans.sort(key=lambda s: s["start_timestamp"])
 
-            assert len(child_spans) == 3
-            assert child_spans[0]["name"] == "time.sleep"
-            assert child_spans[1]["name"] == "tests.test_basics._hello_world"
-            assert child_spans[2]["name"] == "tests.test_basics._hello_world"
-        else:
-            with start_transaction(name="something"):
-                time.sleep(0)
-
-                for word in ["World", "You"]:
-                    _hello_world(word)
-
-            assert len(events) == 1
-
-            (event,) = events
-
-            assert len(event["spans"]) == 3
-            assert event["spans"][0]["description"] == "time.sleep"
-            assert event["spans"][1]["description"] == "tests.test_basics._hello_world"
-            assert event["spans"][2]["description"] == "tests.test_basics._hello_world"
+        assert len(child_spans) == 3
+        assert child_spans[0]["name"] == "time.sleep"
+        assert child_spans[1]["name"] == "tests.test_basics._hello_world"
+        assert child_spans[2]["name"] == "tests.test_basics._hello_world"
     finally:
         _hello_world = original_hello_world
         time.sleep = original_sleep
@@ -843,10 +784,7 @@ class WorldGreeter:
         return "Hello, {}".format(new_word if new_word else self.word)
 
 
-@pytest.mark.parametrize("span_streaming", [True, False])
-def test_functions_to_trace_with_class(
-    sentry_init, capture_events, capture_items, span_streaming
-):
+def test_functions_to_trace_with_class(sentry_init, capture_items):
     functions_to_trace = [
         {"qualified_name": "tests.test_basics.WorldGreeter.greet"},
     ]
@@ -857,46 +795,24 @@ def test_functions_to_trace_with_class(
         sentry_init(
             traces_sample_rate=1.0,
             functions_to_trace=functions_to_trace,
-            trace_lifecycle="stream" if span_streaming else "static",
+            trace_lifecycle="stream",
         )
 
-        if span_streaming:
-            items = capture_items("span")
-        else:
-            events = capture_events()
+        items = capture_items("span")
 
-        if span_streaming:
-            with sentry_sdk.traces.start_span(name="something"):
-                wg = WorldGreeter("World")
-                wg.greet()
-                wg.greet("You")
+        with sentry_sdk.traces.start_span(name="something"):
+            wg = WorldGreeter("World")
+            wg.greet()
+            wg.greet("You")
 
-            sentry_sdk.flush()
-            spans = [item.payload for item in items]
-            child_spans = [s for s in spans if not s.get("is_segment")]
+        sentry_sdk.flush()
+        spans = [item.payload for item in items]
+        child_spans = [s for s in spans if not s.get("is_segment")]
 
-            assert len(child_spans) == 2
-            assert child_spans[0]["name"] == "tests.test_basics.WorldGreeter.greet"
-            assert child_spans[1]["name"] == "tests.test_basics.WorldGreeter.greet"
-        else:
-            with start_transaction(name="something"):
-                wg = WorldGreeter("World")
-                wg.greet()
-                wg.greet("You")
+        assert len(child_spans) == 2
+        assert child_spans[0]["name"] == "tests.test_basics.WorldGreeter.greet"
+        assert child_spans[1]["name"] == "tests.test_basics.WorldGreeter.greet"
 
-            assert len(events) == 1
-
-            (event,) = events
-
-            assert len(event["spans"]) == 2
-            assert (
-                event["spans"][0]["description"]
-                == "tests.test_basics.WorldGreeter.greet"
-            )
-            assert (
-                event["spans"][1]["description"]
-                == "tests.test_basics.WorldGreeter.greet"
-            )
     finally:
         WorldGreeter.greet = original_function
 
@@ -921,166 +837,103 @@ class TracingTestClass:
 
 # We need to fork here because the test modifies tests.test_basics.TracingTestClass
 @pytest.mark.forked
-@pytest.mark.parametrize("span_streaming", [True, False])
-def test_staticmethod_class_tracing(
-    sentry_init, capture_events, capture_items, span_streaming
-):
+def test_staticmethod_class_tracing(sentry_init, capture_items):
     sentry_init(
         debug=True,
         traces_sample_rate=1.0,
         functions_to_trace=[
             {"qualified_name": "tests.test_basics.TracingTestClass.static"}
         ],
-        trace_lifecycle="stream" if span_streaming else "static",
+        trace_lifecycle="stream",
     )
 
-    if span_streaming:
-        items = capture_items("span")
+    items = capture_items("span")
 
-        with sentry_sdk.traces.start_span(name="test"):
-            assert TracingTestClass.static(1) == 1
+    with sentry_sdk.traces.start_span(name="test"):
+        assert TracingTestClass.static(1) == 1
 
-        sentry_sdk.flush()
-        spans = [item.payload for item in items]
-        child_spans = [s for s in spans if not s.get("is_segment")]
+    sentry_sdk.flush()
 
-        assert len(child_spans) == 1
-        assert child_spans[0]["name"] == "tests.test_basics.TracingTestClass.static"
-    else:
-        events = capture_events()
+    spans = [item.payload for item in items]
+    child_spans = [s for s in spans if not s.get("is_segment")]
 
-        with sentry_sdk.start_transaction(name="test"):
-            assert TracingTestClass.static(1) == 1
-
-        (event,) = events
-        assert event["type"] == "transaction"
-        assert event["transaction"] == "test"
-
-        (span,) = event["spans"]
-        assert span["description"] == "tests.test_basics.TracingTestClass.static"
+    assert len(child_spans) == 1
+    assert child_spans[0]["name"] == "tests.test_basics.TracingTestClass.static"
 
 
 # We need to fork here because the test modifies tests.test_basics.TracingTestClass
 @pytest.mark.forked
-@pytest.mark.parametrize("span_streaming", [True, False])
-def test_staticmethod_instance_tracing(
-    sentry_init, capture_events, capture_items, span_streaming
-):
+def test_staticmethod_instance_tracing(sentry_init, capture_items):
     sentry_init(
         debug=True,
         traces_sample_rate=1.0,
         functions_to_trace=[
             {"qualified_name": "tests.test_basics.TracingTestClass.static"}
         ],
-        trace_lifecycle="stream" if span_streaming else "static",
+        trace_lifecycle="stream",
     )
 
-    if span_streaming:
-        items = capture_items("span")
+    items = capture_items("span")
 
-        with sentry_sdk.traces.start_span(name="test"):
-            assert TracingTestClass().static(1) == 1
+    with sentry_sdk.traces.start_span(name="test"):
+        assert TracingTestClass().static(1) == 1
 
-        sentry_sdk.flush()
-        spans = [item.payload for item in items]
-        child_spans = [s for s in spans if not s.get("is_segment")]
+    sentry_sdk.flush()
+    spans = [item.payload for item in items]
+    child_spans = [s for s in spans if not s.get("is_segment")]
 
-        assert len(child_spans) == 1
-        assert child_spans[0]["name"] == "tests.test_basics.TracingTestClass.static"
-    else:
-        events = capture_events()
-
-        with sentry_sdk.start_transaction(name="test"):
-            assert TracingTestClass().static(1) == 1
-
-        (event,) = events
-        assert event["type"] == "transaction"
-        assert event["transaction"] == "test"
-
-        (span,) = event["spans"]
-        assert span["description"] == "tests.test_basics.TracingTestClass.static"
+    assert len(child_spans) == 1
+    assert child_spans[0]["name"] == "tests.test_basics.TracingTestClass.static"
 
 
 # We need to fork here because the test modifies tests.test_basics.TracingTestClass
 @pytest.mark.forked
-@pytest.mark.parametrize("span_streaming", [True, False])
-def test_classmethod_class_tracing(
-    sentry_init, capture_events, capture_items, span_streaming
-):
+def test_classmethod_class_tracing(sentry_init, capture_items):
     sentry_init(
         debug=True,
         traces_sample_rate=1.0,
         functions_to_trace=[
             {"qualified_name": "tests.test_basics.TracingTestClass.class_"}
         ],
-        trace_lifecycle="stream" if span_streaming else "static",
+        trace_lifecycle="stream",
     )
 
-    if span_streaming:
-        items = capture_items("span")
+    items = capture_items("span")
 
-        with sentry_sdk.traces.start_span(name="test"):
-            assert TracingTestClass.class_(1) == (TracingTestClass, 1)
+    with sentry_sdk.traces.start_span(name="test"):
+        assert TracingTestClass.class_(1) == (TracingTestClass, 1)
 
-        sentry_sdk.flush()
-        spans = [item.payload for item in items]
-        child_spans = [s for s in spans if not s.get("is_segment")]
+    sentry_sdk.flush()
+    spans = [item.payload for item in items]
+    child_spans = [s for s in spans if not s.get("is_segment")]
 
-        assert len(child_spans) == 1
-        assert child_spans[0]["name"] == "tests.test_basics.TracingTestClass.class_"
-    else:
-        events = capture_events()
-
-        with sentry_sdk.start_transaction(name="test"):
-            assert TracingTestClass.class_(1) == (TracingTestClass, 1)
-
-        (event,) = events
-        assert event["type"] == "transaction"
-        assert event["transaction"] == "test"
-
-        (span,) = event["spans"]
-        assert span["description"] == "tests.test_basics.TracingTestClass.class_"
+    assert len(child_spans) == 1
+    assert child_spans[0]["name"] == "tests.test_basics.TracingTestClass.class_"
 
 
 # We need to fork here because the test modifies tests.test_basics.TracingTestClass
 @pytest.mark.forked
-@pytest.mark.parametrize("span_streaming", [True, False])
-def test_classmethod_instance_tracing(
-    sentry_init, capture_events, capture_items, span_streaming
-):
+def test_classmethod_instance_tracing(sentry_init, capture_items):
     sentry_init(
         debug=True,
         traces_sample_rate=1.0,
         functions_to_trace=[
             {"qualified_name": "tests.test_basics.TracingTestClass.class_"}
         ],
-        trace_lifecycle="stream" if span_streaming else "static",
+        trace_lifecycle="stream",
     )
 
-    if span_streaming:
-        items = capture_items("span")
+    items = capture_items("span")
 
-        with sentry_sdk.traces.start_span(name="test"):
-            assert TracingTestClass().class_(1) == (TracingTestClass, 1)
+    with sentry_sdk.traces.start_span(name="test"):
+        assert TracingTestClass().class_(1) == (TracingTestClass, 1)
 
-        sentry_sdk.flush()
-        spans = [item.payload for item in items]
-        child_spans = [s for s in spans if not s.get("is_segment")]
+    sentry_sdk.flush()
+    spans = [item.payload for item in items]
+    child_spans = [s for s in spans if not s.get("is_segment")]
 
-        assert len(child_spans) == 1
-        assert child_spans[0]["name"] == "tests.test_basics.TracingTestClass.class_"
-    else:
-        events = capture_events()
-
-        with sentry_sdk.start_transaction(name="test"):
-            assert TracingTestClass().class_(1) == (TracingTestClass, 1)
-
-        (event,) = events
-        assert event["type"] == "transaction"
-        assert event["transaction"] == "test"
-
-        (span,) = event["spans"]
-        assert span["description"] == "tests.test_basics.TracingTestClass.class_"
+    assert len(child_spans) == 1
+    assert child_spans[0]["name"] == "tests.test_basics.TracingTestClass.class_"
 
 
 def test_functions_to_trace_no_dot_does_not_crash(sentry_init):
@@ -1099,17 +952,6 @@ def test_last_event_id(sentry_init):
     capture_exception(Exception("test"))
 
     assert last_event_id() is not None
-
-
-def test_last_event_id_transaction(sentry_init):
-    sentry_init(traces_sample_rate=1.0)
-
-    assert last_event_id() is None
-
-    with start_transaction(name="test"):
-        pass
-
-    assert last_event_id() is None, "Transaction should not set last_event_id"
 
 
 def test_last_event_id_scope(sentry_init):


### PR DESCRIPTION
- add missing `trace_lifecycle="stream"` to tests that have tracing enabled
- adapt threadpool test the [same way](https://github.com/getsentry/sentry-python/pull/7349/changes) as the threads test
- remove transaction tests where there is a span streaming version
- adapt forgotten celery headers tests


Follow up: https://github.com/getsentry/sentry-python/pull/7455