### PR TITLE
ref: Remove `_ai_pipeline_name` context variable

### DIFF
--- a/sentry_sdk/ai/monitoring.py
+++ b/sentry_sdk/ai/monitoring.py
@@ -1,4 +1,3 @@
-from contextvars import ContextVar
 from typing import TYPE_CHECKING
 
 from sentry_sdk.ai.utils import _set_span_data_attribute
@@ -11,18 +10,6 @@ if TYPE_CHECKING:
 
     F = TypeVar("F", bound=Union[Callable[..., Any], Callable[..., Awaitable[Any]]])
 
-_ai_pipeline_name: "ContextVar[Optional[str]]" = ContextVar(
-    "ai_pipeline_name", default=None
-)
-
-
-def set_ai_pipeline_name(name: "Optional[str]") -> None:
-    _ai_pipeline_name.set(name)
-
-
-def get_ai_pipeline_name() -> "Optional[str]":
-    return _ai_pipeline_name.get()
-
 
 def record_token_usage(
     span: "Union[Span, StreamedSpan]",
@@ -33,11 +20,6 @@ def record_token_usage(
     output_tokens_reasoning: "Optional[int]" = None,
     total_tokens: "Optional[int]" = None,
 ) -> None:
-    # TODO: move pipeline name elsewhere
-    ai_pipeline_name = get_ai_pipeline_name()
-    if ai_pipeline_name:
-        _set_span_data_attribute(span, SPANDATA.GEN_AI_PIPELINE_NAME, ai_pipeline_name)
-
     if input_tokens is not None:
         _set_span_data_attribute(span, SPANDATA.GEN_AI_USAGE_INPUT_TOKENS, input_tokens)
 


### PR DESCRIPTION
### Description
<!-- What changed and why? -->

The `set_ai_pipeline_name()` function is not used anywhere in the SDK.

#### Issues
<!--
* resolves: #1234
* resolves: LIN-1234
-->

#### Reminders
- Please add tests to validate your changes, and lint your code using `uv run ruff`.
- Add GH Issue ID _&_ Linear ID (if applicable)
- PR title should use [conventional commit](https://develop.sentry.dev/engineering-practices/commit-messages/#type) style (`feat:`, `fix:`, `ref:`, `meta:`)
- For external contributors: [CONTRIBUTING.md](https://github.com/getsentry/sentry-python/blob/master/CONTRIBUTING.md), [Sentry SDK development docs](https://develop.sentry.dev/sdk/), [Discord community](https://discord.gg/Ww9hbqr)
