### PR TITLE
chore: Replace deprecated `gen_ai.system` with `gen_ai.provider.name`

### DIFF
--- a/sentry_sdk/integrations/anthropic.py
+++ b/sentry_sdk/integrations/anthropic.py
@@ -455,7 +455,7 @@ def _set_common_input_data(
     """
     Set input data for the span based on the provided keyword arguments for the anthropic message creation.
     """
-    span.set_attribute(SPANDATA.GEN_AI_SYSTEM, "anthropic")
+    span.set_attribute(SPANDATA.GEN_AI_PROVIDER_NAME, "anthropic")
     span.set_attribute(SPANDATA.GEN_AI_OPERATION_NAME, "chat")
 
     if max_tokens is not None and _is_given(max_tokens):
@@ -498,7 +498,7 @@ def _set_common_input_data(
     if record_inputs:
         if isinstance(system, str) or isinstance(system, Iterable):
             span.set_attribute(
-                SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS,
+                SPANDATA.GEN_AI_PROVIDER_NAME_INSTRUCTIONS,
                 json.dumps(_transform_system_instructions(system)),
             )
 

--- a/sentry_sdk/integrations/anthropic.py
+++ b/sentry_sdk/integrations/anthropic.py
@@ -455,7 +455,7 @@ def _set_common_input_data(
     """
     Set input data for the span based on the provided keyword arguments for the anthropic message creation.
     """
-    span.set_attribute(SPANDATA.GEN_AI_PROVIDER_NAME, "anthropic")
+    span.set_attribute(SPANDATA.GEN_AI_SYSTEM, "anthropic")
     span.set_attribute(SPANDATA.GEN_AI_OPERATION_NAME, "chat")
 
     if max_tokens is not None and _is_given(max_tokens):
@@ -498,7 +498,7 @@ def _set_common_input_data(
     if record_inputs:
         if isinstance(system, str) or isinstance(system, Iterable):
             span.set_attribute(
-                SPANDATA.GEN_AI_PROVIDER_NAME_INSTRUCTIONS,
+                SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS,
                 json.dumps(_transform_system_instructions(system)),
             )
 

--- a/sentry_sdk/integrations/anthropic.py
+++ b/sentry_sdk/integrations/anthropic.py
@@ -455,7 +455,7 @@ def _set_common_input_data(
     """
     Set input data for the span based on the provided keyword arguments for the anthropic message creation.
     """
-    span.set_attribute(SPANDATA.GEN_AI_SYSTEM, "anthropic")
+    span.set_attribute(SPANDATA.GEN_AI_PROVIDER_NAME, "anthropic")
     span.set_attribute(SPANDATA.GEN_AI_OPERATION_NAME, "chat")
 
     if max_tokens is not None and _is_given(max_tokens):

--- a/sentry_sdk/integrations/google_genai/__init__.py
+++ b/sentry_sdk/integrations/google_genai/__init__.py
@@ -83,7 +83,7 @@ def _wrap_generate_content_stream(f: "Callable[..., Any]") -> "Callable[..., Any
                 "sentry.op": OP.GEN_AI_CHAT,
                 "sentry.origin": ORIGIN,
                 SPANDATA.GEN_AI_OPERATION_NAME: "chat",
-                SPANDATA.GEN_AI_SYSTEM: GEN_AI_SYSTEM,
+                SPANDATA.GEN_AI_PROVIDER_NAME: GEN_AI_SYSTEM,
                 SPANDATA.GEN_AI_REQUEST_MODEL: model_name,
                 SPANDATA.GEN_AI_RESPONSE_STREAMING: True,
             },
@@ -144,7 +144,7 @@ def _wrap_async_generate_content_stream(
                 "sentry.op": OP.GEN_AI_CHAT,
                 "sentry.origin": ORIGIN,
                 SPANDATA.GEN_AI_OPERATION_NAME: "chat",
-                SPANDATA.GEN_AI_SYSTEM: GEN_AI_SYSTEM,
+                SPANDATA.GEN_AI_PROVIDER_NAME: GEN_AI_SYSTEM,
                 SPANDATA.GEN_AI_REQUEST_MODEL: model_name,
                 SPANDATA.GEN_AI_RESPONSE_STREAMING: True,
             },
@@ -201,7 +201,7 @@ def _wrap_generate_content(f: "Callable[..., Any]") -> "Callable[..., Any]":
                 "sentry.op": OP.GEN_AI_CHAT,
                 "sentry.origin": ORIGIN,
                 SPANDATA.GEN_AI_OPERATION_NAME: "chat",
-                SPANDATA.GEN_AI_SYSTEM: GEN_AI_SYSTEM,
+                SPANDATA.GEN_AI_PROVIDER_NAME: GEN_AI_SYSTEM,
                 SPANDATA.GEN_AI_REQUEST_MODEL: model_name,
             },
         ) as chat_span:
@@ -241,7 +241,7 @@ def _wrap_async_generate_content(f: "Callable[..., Any]") -> "Callable[..., Any]
                 "sentry.op": OP.GEN_AI_CHAT,
                 "sentry.origin": ORIGIN,
                 SPANDATA.GEN_AI_OPERATION_NAME: "chat",
-                SPANDATA.GEN_AI_SYSTEM: GEN_AI_SYSTEM,
+                SPANDATA.GEN_AI_PROVIDER_NAME: GEN_AI_SYSTEM,
                 SPANDATA.GEN_AI_REQUEST_MODEL: model_name,
             },
         ) as chat_span:
@@ -278,7 +278,7 @@ def _wrap_embed_content(f: "Callable[..., Any]") -> "Callable[..., Any]":
                 "sentry.op": OP.GEN_AI_EMBEDDINGS,
                 "sentry.origin": ORIGIN,
                 SPANDATA.GEN_AI_OPERATION_NAME: "embeddings",
-                SPANDATA.GEN_AI_SYSTEM: GEN_AI_SYSTEM,
+                SPANDATA.GEN_AI_PROVIDER_NAME: GEN_AI_SYSTEM,
                 SPANDATA.GEN_AI_REQUEST_MODEL: model_name,
             },
         ) as span:
@@ -316,7 +316,7 @@ def _wrap_async_embed_content(f: "Callable[..., Any]") -> "Callable[..., Any]":
                 "sentry.op": OP.GEN_AI_EMBEDDINGS,
                 "sentry.origin": ORIGIN,
                 SPANDATA.GEN_AI_OPERATION_NAME: "embeddings",
-                SPANDATA.GEN_AI_SYSTEM: GEN_AI_SYSTEM,
+                SPANDATA.GEN_AI_PROVIDER_NAME: GEN_AI_SYSTEM,
                 SPANDATA.GEN_AI_REQUEST_MODEL: model_name,
             },
         ) as span:

--- a/sentry_sdk/integrations/google_genai/__init__.py
+++ b/sentry_sdk/integrations/google_genai/__init__.py
@@ -83,7 +83,7 @@ def _wrap_generate_content_stream(f: "Callable[..., Any]") -> "Callable[..., Any
                 "sentry.op": OP.GEN_AI_CHAT,
                 "sentry.origin": ORIGIN,
                 SPANDATA.GEN_AI_OPERATION_NAME: "chat",
-                SPANDATA.GEN_AI_PROVIDER_NAME: GEN_AI_SYSTEM,
+                SPANDATA.GEN_AI_SYSTEM: GEN_AI_SYSTEM,
                 SPANDATA.GEN_AI_REQUEST_MODEL: model_name,
                 SPANDATA.GEN_AI_RESPONSE_STREAMING: True,
             },
@@ -144,7 +144,7 @@ def _wrap_async_generate_content_stream(
                 "sentry.op": OP.GEN_AI_CHAT,
                 "sentry.origin": ORIGIN,
                 SPANDATA.GEN_AI_OPERATION_NAME: "chat",
-                SPANDATA.GEN_AI_PROVIDER_NAME: GEN_AI_SYSTEM,
+                SPANDATA.GEN_AI_SYSTEM: GEN_AI_SYSTEM,
                 SPANDATA.GEN_AI_REQUEST_MODEL: model_name,
                 SPANDATA.GEN_AI_RESPONSE_STREAMING: True,
             },
@@ -201,7 +201,7 @@ def _wrap_generate_content(f: "Callable[..., Any]") -> "Callable[..., Any]":
                 "sentry.op": OP.GEN_AI_CHAT,
                 "sentry.origin": ORIGIN,
                 SPANDATA.GEN_AI_OPERATION_NAME: "chat",
-                SPANDATA.GEN_AI_PROVIDER_NAME: GEN_AI_SYSTEM,
+                SPANDATA.GEN_AI_SYSTEM: GEN_AI_SYSTEM,
                 SPANDATA.GEN_AI_REQUEST_MODEL: model_name,
             },
         ) as chat_span:
@@ -241,7 +241,7 @@ def _wrap_async_generate_content(f: "Callable[..., Any]") -> "Callable[..., Any]
                 "sentry.op": OP.GEN_AI_CHAT,
                 "sentry.origin": ORIGIN,
                 SPANDATA.GEN_AI_OPERATION_NAME: "chat",
-                SPANDATA.GEN_AI_PROVIDER_NAME: GEN_AI_SYSTEM,
+                SPANDATA.GEN_AI_SYSTEM: GEN_AI_SYSTEM,
                 SPANDATA.GEN_AI_REQUEST_MODEL: model_name,
             },
         ) as chat_span:
@@ -278,7 +278,7 @@ def _wrap_embed_content(f: "Callable[..., Any]") -> "Callable[..., Any]":
                 "sentry.op": OP.GEN_AI_EMBEDDINGS,
                 "sentry.origin": ORIGIN,
                 SPANDATA.GEN_AI_OPERATION_NAME: "embeddings",
-                SPANDATA.GEN_AI_PROVIDER_NAME: GEN_AI_SYSTEM,
+                SPANDATA.GEN_AI_SYSTEM: GEN_AI_SYSTEM,
                 SPANDATA.GEN_AI_REQUEST_MODEL: model_name,
             },
         ) as span:
@@ -316,7 +316,7 @@ def _wrap_async_embed_content(f: "Callable[..., Any]") -> "Callable[..., Any]":
                 "sentry.op": OP.GEN_AI_EMBEDDINGS,
                 "sentry.origin": ORIGIN,
                 SPANDATA.GEN_AI_OPERATION_NAME: "embeddings",
-                SPANDATA.GEN_AI_PROVIDER_NAME: GEN_AI_SYSTEM,
+                SPANDATA.GEN_AI_SYSTEM: GEN_AI_SYSTEM,
                 SPANDATA.GEN_AI_REQUEST_MODEL: model_name,
             },
         ) as span:

--- a/sentry_sdk/integrations/google_genai/utils.py
+++ b/sentry_sdk/integrations/google_genai/utils.py
@@ -907,7 +907,7 @@ def set_span_data_for_request(
 ) -> None:
     """Set span data for the request."""
     client = sentry_sdk.get_client()
-    span.set_attribute(SPANDATA.GEN_AI_SYSTEM, GEN_AI_SYSTEM)
+    span.set_attribute(SPANDATA.GEN_AI_PROVIDER_NAME, GEN_AI_SYSTEM)
     span.set_attribute(SPANDATA.GEN_AI_REQUEST_MODEL, model)
 
     if kwargs.get("stream", False):

--- a/sentry_sdk/integrations/google_genai/utils.py
+++ b/sentry_sdk/integrations/google_genai/utils.py
@@ -907,7 +907,7 @@ def set_span_data_for_request(
 ) -> None:
     """Set span data for the request."""
     client = sentry_sdk.get_client()
-    span.set_attribute(SPANDATA.GEN_AI_PROVIDER_NAME, GEN_AI_SYSTEM)
+    span.set_attribute(SPANDATA.GEN_AI_SYSTEM, GEN_AI_SYSTEM)
     span.set_attribute(SPANDATA.GEN_AI_REQUEST_MODEL, model)
 
     if kwargs.get("stream", False):
@@ -957,7 +957,7 @@ def set_span_data_for_request(
 
         if system_instructions is not None:
             span.set_attribute(
-                SPANDATA.GEN_AI_PROVIDER_NAME_INSTRUCTIONS,
+                SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS,
                 json.dumps(_transform_system_instructions(system_instructions)),
             )
 

--- a/sentry_sdk/integrations/google_genai/utils.py
+++ b/sentry_sdk/integrations/google_genai/utils.py
@@ -907,7 +907,7 @@ def set_span_data_for_request(
 ) -> None:
     """Set span data for the request."""
     client = sentry_sdk.get_client()
-    span.set_attribute(SPANDATA.GEN_AI_SYSTEM, GEN_AI_SYSTEM)
+    span.set_attribute(SPANDATA.GEN_AI_PROVIDER_NAME, GEN_AI_SYSTEM)
     span.set_attribute(SPANDATA.GEN_AI_REQUEST_MODEL, model)
 
     if kwargs.get("stream", False):
@@ -957,7 +957,7 @@ def set_span_data_for_request(
 
         if system_instructions is not None:
             span.set_attribute(
-                SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS,
+                SPANDATA.GEN_AI_PROVIDER_NAME_INSTRUCTIONS,
                 json.dumps(_transform_system_instructions(system_instructions)),
             )
 

--- a/sentry_sdk/integrations/langchain.py
+++ b/sentry_sdk/integrations/langchain.py
@@ -384,7 +384,7 @@ class SentryLangchainCallback(BaseCallbackHandler):
 
             ai_system = _get_ai_system(all_params)
             if ai_system:
-                span.set_attribute(SPANDATA.GEN_AI_PROVIDER_NAME, ai_system)
+                span.set_attribute(SPANDATA.GEN_AI_SYSTEM, ai_system)
 
             client = sentry_sdk.get_client()
 
@@ -466,7 +466,7 @@ class SentryLangchainCallback(BaseCallbackHandler):
 
             ai_system = _get_ai_system(all_params)
             if ai_system:
-                span.set_attribute(SPANDATA.GEN_AI_PROVIDER_NAME, ai_system)
+                span.set_attribute(SPANDATA.GEN_AI_SYSTEM, ai_system)
 
             agent_metadata = kwargs.get("metadata")
             if isinstance(agent_metadata, dict) and "lc_agent_name" in agent_metadata:
@@ -512,7 +512,7 @@ class SentryLangchainCallback(BaseCallbackHandler):
                 system_instructions = _get_system_instructions(messages)
                 if len(system_instructions) > 0:
                     span.set_attribute(
-                        SPANDATA.GEN_AI_PROVIDER_NAME_INSTRUCTIONS,
+                        SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS,
                         json.dumps(_transform_system_instructions(system_instructions)),
                     )
 

--- a/sentry_sdk/integrations/langchain.py
+++ b/sentry_sdk/integrations/langchain.py
@@ -384,7 +384,7 @@ class SentryLangchainCallback(BaseCallbackHandler):
 
             ai_system = _get_ai_system(all_params)
             if ai_system:
-                span.set_attribute(SPANDATA.GEN_AI_SYSTEM, ai_system)
+                span.set_attribute(SPANDATA.GEN_AI_PROVIDER_NAME, ai_system)
 
             client = sentry_sdk.get_client()
 
@@ -466,7 +466,7 @@ class SentryLangchainCallback(BaseCallbackHandler):
 
             ai_system = _get_ai_system(all_params)
             if ai_system:
-                span.set_attribute(SPANDATA.GEN_AI_SYSTEM, ai_system)
+                span.set_attribute(SPANDATA.GEN_AI_PROVIDER_NAME, ai_system)
 
             agent_metadata = kwargs.get("metadata")
             if isinstance(agent_metadata, dict) and "lc_agent_name" in agent_metadata:
@@ -512,7 +512,7 @@ class SentryLangchainCallback(BaseCallbackHandler):
                 system_instructions = _get_system_instructions(messages)
                 if len(system_instructions) > 0:
                     span.set_attribute(
-                        SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS,
+                        SPANDATA.GEN_AI_PROVIDER_NAME_INSTRUCTIONS,
                         json.dumps(_transform_system_instructions(system_instructions)),
                     )
 

--- a/sentry_sdk/integrations/langchain.py
+++ b/sentry_sdk/integrations/langchain.py
@@ -384,7 +384,7 @@ class SentryLangchainCallback(BaseCallbackHandler):
 
             ai_system = _get_ai_system(all_params)
             if ai_system:
-                span.set_attribute(SPANDATA.GEN_AI_SYSTEM, ai_system)
+                span.set_attribute(SPANDATA.GEN_AI_PROVIDER_NAME, ai_system)
 
             client = sentry_sdk.get_client()
 
@@ -466,7 +466,7 @@ class SentryLangchainCallback(BaseCallbackHandler):
 
             ai_system = _get_ai_system(all_params)
             if ai_system:
-                span.set_attribute(SPANDATA.GEN_AI_SYSTEM, ai_system)
+                span.set_attribute(SPANDATA.GEN_AI_PROVIDER_NAME, ai_system)
 
             agent_metadata = kwargs.get("metadata")
             if isinstance(agent_metadata, dict) and "lc_agent_name" in agent_metadata:

--- a/sentry_sdk/integrations/litellm.py
+++ b/sentry_sdk/integrations/litellm.py
@@ -110,7 +110,7 @@ def _input_callback(kwargs: "Dict[str, Any]") -> None:
     _store_span(kwargs, span)
 
     # Set basic data
-    set_data_normalized(span, SPANDATA.GEN_AI_SYSTEM, provider)
+    set_data_normalized(span, SPANDATA.GEN_AI_PROVIDER_NAME, provider)
     set_data_normalized(span, SPANDATA.GEN_AI_OPERATION_NAME, operation)
 
     # Record input/messages if allowed

--- a/sentry_sdk/integrations/litellm.py
+++ b/sentry_sdk/integrations/litellm.py
@@ -110,7 +110,7 @@ def _input_callback(kwargs: "Dict[str, Any]") -> None:
     _store_span(kwargs, span)
 
     # Set basic data
-    set_data_normalized(span, SPANDATA.GEN_AI_PROVIDER_NAME, provider)
+    set_data_normalized(span, SPANDATA.GEN_AI_SYSTEM, provider)
     set_data_normalized(span, SPANDATA.GEN_AI_OPERATION_NAME, operation)
 
     # Record input/messages if allowed

--- a/sentry_sdk/integrations/openai.py
+++ b/sentry_sdk/integrations/openai.py
@@ -408,7 +408,7 @@ def _set_responses_api_input_data(
     if messages is None:
         if has_explicit_instructions:
             span.set_attribute(
-                SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS,
+                SPANDATA.GEN_AI_PROVIDER_NAME_INSTRUCTIONS,
                 json.dumps(
                     [
                         {
@@ -435,7 +435,7 @@ def _set_responses_api_input_data(
     )
     if len(instructions_text_parts) > 0:
         span.set_attribute(
-            SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS,
+            SPANDATA.GEN_AI_PROVIDER_NAME_INSTRUCTIONS,
             json.dumps(instructions_text_parts),
         )
 
@@ -553,7 +553,7 @@ def _set_completions_api_input_data(
     system_instructions = _get_system_instructions_completions(messages)
     if len(system_instructions) > 0:
         span.set_attribute(
-            SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS,
+            SPANDATA.GEN_AI_PROVIDER_NAME_INSTRUCTIONS,
             json.dumps(_transform_system_instructions_completions(system_instructions)),
         )
 
@@ -798,7 +798,7 @@ def _new_sync_chat_completion(
         attributes={
             "sentry.op": consts.OP.GEN_AI_CHAT,
             "sentry.origin": OpenAIIntegration.origin,
-            SPANDATA.GEN_AI_SYSTEM: "openai",
+            SPANDATA.GEN_AI_PROVIDER_NAME: "openai",
             SPANDATA.GEN_AI_RESPONSE_STREAMING: is_streaming_response,
         },
     )
@@ -873,7 +873,7 @@ async def _new_async_chat_completion(
         attributes={
             "sentry.op": consts.OP.GEN_AI_CHAT,
             "sentry.origin": OpenAIIntegration.origin,
-            SPANDATA.GEN_AI_SYSTEM: "openai",
+            SPANDATA.GEN_AI_PROVIDER_NAME: "openai",
             SPANDATA.GEN_AI_RESPONSE_STREAMING: is_streaming_response,
         },
     )
@@ -1299,7 +1299,7 @@ def _new_sync_embeddings_create(f: "Any", *args: "Any", **kwargs: "Any") -> "Any
         attributes={
             "sentry.op": consts.OP.GEN_AI_EMBEDDINGS,
             "sentry.origin": OpenAIIntegration.origin,
-            SPANDATA.GEN_AI_SYSTEM: "openai",
+            SPANDATA.GEN_AI_PROVIDER_NAME: "openai",
         },
     ) as span:
         _set_embeddings_input_data(span, kwargs, integration)
@@ -1336,7 +1336,7 @@ async def _new_async_embeddings_create(
         attributes={
             "sentry.op": consts.OP.GEN_AI_EMBEDDINGS,
             "sentry.origin": OpenAIIntegration.origin,
-            SPANDATA.GEN_AI_SYSTEM: "openai",
+            SPANDATA.GEN_AI_PROVIDER_NAME: "openai",
         },
     ) as span:
         _set_embeddings_input_data(span, kwargs, integration)
@@ -1400,7 +1400,7 @@ def _new_sync_responses_create(
         attributes={
             "sentry.op": consts.OP.GEN_AI_RESPONSES,
             "sentry.origin": OpenAIIntegration.origin,
-            SPANDATA.GEN_AI_SYSTEM: "openai",
+            SPANDATA.GEN_AI_PROVIDER_NAME: "openai",
             SPANDATA.GEN_AI_RESPONSE_STREAMING: is_streaming_response,
         },
     )
@@ -1465,7 +1465,7 @@ async def _new_async_responses_create(
         attributes={
             "sentry.op": consts.OP.GEN_AI_RESPONSES,
             "sentry.origin": OpenAIIntegration.origin,
-            SPANDATA.GEN_AI_SYSTEM: "openai",
+            SPANDATA.GEN_AI_PROVIDER_NAME: "openai",
             SPANDATA.GEN_AI_RESPONSE_STREAMING: is_streaming_response,
         },
     )

--- a/sentry_sdk/integrations/openai.py
+++ b/sentry_sdk/integrations/openai.py
@@ -798,7 +798,7 @@ def _new_sync_chat_completion(
         attributes={
             "sentry.op": consts.OP.GEN_AI_CHAT,
             "sentry.origin": OpenAIIntegration.origin,
-            SPANDATA.GEN_AI_SYSTEM: "openai",
+            SPANDATA.GEN_AI_PROVIDER_NAME: "openai",
             SPANDATA.GEN_AI_RESPONSE_STREAMING: is_streaming_response,
         },
     )
@@ -873,7 +873,7 @@ async def _new_async_chat_completion(
         attributes={
             "sentry.op": consts.OP.GEN_AI_CHAT,
             "sentry.origin": OpenAIIntegration.origin,
-            SPANDATA.GEN_AI_SYSTEM: "openai",
+            SPANDATA.GEN_AI_PROVIDER_NAME: "openai",
             SPANDATA.GEN_AI_RESPONSE_STREAMING: is_streaming_response,
         },
     )
@@ -1299,7 +1299,7 @@ def _new_sync_embeddings_create(f: "Any", *args: "Any", **kwargs: "Any") -> "Any
         attributes={
             "sentry.op": consts.OP.GEN_AI_EMBEDDINGS,
             "sentry.origin": OpenAIIntegration.origin,
-            SPANDATA.GEN_AI_SYSTEM: "openai",
+            SPANDATA.GEN_AI_PROVIDER_NAME: "openai",
         },
     ) as span:
         _set_embeddings_input_data(span, kwargs, integration)
@@ -1336,7 +1336,7 @@ async def _new_async_embeddings_create(
         attributes={
             "sentry.op": consts.OP.GEN_AI_EMBEDDINGS,
             "sentry.origin": OpenAIIntegration.origin,
-            SPANDATA.GEN_AI_SYSTEM: "openai",
+            SPANDATA.GEN_AI_PROVIDER_NAME: "openai",
         },
     ) as span:
         _set_embeddings_input_data(span, kwargs, integration)
@@ -1400,7 +1400,7 @@ def _new_sync_responses_create(
         attributes={
             "sentry.op": consts.OP.GEN_AI_RESPONSES,
             "sentry.origin": OpenAIIntegration.origin,
-            SPANDATA.GEN_AI_SYSTEM: "openai",
+            SPANDATA.GEN_AI_PROVIDER_NAME: "openai",
             SPANDATA.GEN_AI_RESPONSE_STREAMING: is_streaming_response,
         },
     )
@@ -1465,7 +1465,7 @@ async def _new_async_responses_create(
         attributes={
             "sentry.op": consts.OP.GEN_AI_RESPONSES,
             "sentry.origin": OpenAIIntegration.origin,
-            SPANDATA.GEN_AI_SYSTEM: "openai",
+            SPANDATA.GEN_AI_PROVIDER_NAME: "openai",
             SPANDATA.GEN_AI_RESPONSE_STREAMING: is_streaming_response,
         },
     )

--- a/sentry_sdk/integrations/openai.py
+++ b/sentry_sdk/integrations/openai.py
@@ -408,7 +408,7 @@ def _set_responses_api_input_data(
     if messages is None:
         if has_explicit_instructions:
             span.set_attribute(
-                SPANDATA.GEN_AI_PROVIDER_NAME_INSTRUCTIONS,
+                SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS,
                 json.dumps(
                     [
                         {
@@ -435,7 +435,7 @@ def _set_responses_api_input_data(
     )
     if len(instructions_text_parts) > 0:
         span.set_attribute(
-            SPANDATA.GEN_AI_PROVIDER_NAME_INSTRUCTIONS,
+            SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS,
             json.dumps(instructions_text_parts),
         )
 
@@ -553,7 +553,7 @@ def _set_completions_api_input_data(
     system_instructions = _get_system_instructions_completions(messages)
     if len(system_instructions) > 0:
         span.set_attribute(
-            SPANDATA.GEN_AI_PROVIDER_NAME_INSTRUCTIONS,
+            SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS,
             json.dumps(_transform_system_instructions_completions(system_instructions)),
         )
 
@@ -798,7 +798,7 @@ def _new_sync_chat_completion(
         attributes={
             "sentry.op": consts.OP.GEN_AI_CHAT,
             "sentry.origin": OpenAIIntegration.origin,
-            SPANDATA.GEN_AI_PROVIDER_NAME: "openai",
+            SPANDATA.GEN_AI_SYSTEM: "openai",
             SPANDATA.GEN_AI_RESPONSE_STREAMING: is_streaming_response,
         },
     )
@@ -873,7 +873,7 @@ async def _new_async_chat_completion(
         attributes={
             "sentry.op": consts.OP.GEN_AI_CHAT,
             "sentry.origin": OpenAIIntegration.origin,
-            SPANDATA.GEN_AI_PROVIDER_NAME: "openai",
+            SPANDATA.GEN_AI_SYSTEM: "openai",
             SPANDATA.GEN_AI_RESPONSE_STREAMING: is_streaming_response,
         },
     )
@@ -1299,7 +1299,7 @@ def _new_sync_embeddings_create(f: "Any", *args: "Any", **kwargs: "Any") -> "Any
         attributes={
             "sentry.op": consts.OP.GEN_AI_EMBEDDINGS,
             "sentry.origin": OpenAIIntegration.origin,
-            SPANDATA.GEN_AI_PROVIDER_NAME: "openai",
+            SPANDATA.GEN_AI_SYSTEM: "openai",
         },
     ) as span:
         _set_embeddings_input_data(span, kwargs, integration)
@@ -1336,7 +1336,7 @@ async def _new_async_embeddings_create(
         attributes={
             "sentry.op": consts.OP.GEN_AI_EMBEDDINGS,
             "sentry.origin": OpenAIIntegration.origin,
-            SPANDATA.GEN_AI_PROVIDER_NAME: "openai",
+            SPANDATA.GEN_AI_SYSTEM: "openai",
         },
     ) as span:
         _set_embeddings_input_data(span, kwargs, integration)
@@ -1400,7 +1400,7 @@ def _new_sync_responses_create(
         attributes={
             "sentry.op": consts.OP.GEN_AI_RESPONSES,
             "sentry.origin": OpenAIIntegration.origin,
-            SPANDATA.GEN_AI_PROVIDER_NAME: "openai",
+            SPANDATA.GEN_AI_SYSTEM: "openai",
             SPANDATA.GEN_AI_RESPONSE_STREAMING: is_streaming_response,
         },
     )
@@ -1465,7 +1465,7 @@ async def _new_async_responses_create(
         attributes={
             "sentry.op": consts.OP.GEN_AI_RESPONSES,
             "sentry.origin": OpenAIIntegration.origin,
-            SPANDATA.GEN_AI_PROVIDER_NAME: "openai",
+            SPANDATA.GEN_AI_SYSTEM: "openai",
             SPANDATA.GEN_AI_RESPONSE_STREAMING: is_streaming_response,
         },
     )

--- a/sentry_sdk/integrations/openai_agents/utils.py
+++ b/sentry_sdk/integrations/openai_agents/utils.py
@@ -48,7 +48,7 @@ def _capture_exception(exc: "Any") -> None:
 
 def _set_agent_data(span: "StreamedSpan", agent: "agents.Agent") -> None:
     span.set_attribute(
-        SPANDATA.GEN_AI_SYSTEM, "openai"
+        SPANDATA.GEN_AI_PROVIDER_NAME, "openai"
     )  # See footnote for  https://opentelemetry.io/docs/specs/semconv/registry/attributes/gen-ai/#gen-ai-system for explanation why.
 
     span.set_attribute(SPANDATA.GEN_AI_AGENT_NAME, agent.name)
@@ -134,7 +134,7 @@ def _set_input_data(
 
     if len(instructions_text_parts) > 0:
         span.set_attribute(
-            SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS,
+            SPANDATA.GEN_AI_PROVIDER_NAME_INSTRUCTIONS,
             json.dumps(instructions_text_parts),
         )
 

--- a/sentry_sdk/integrations/openai_agents/utils.py
+++ b/sentry_sdk/integrations/openai_agents/utils.py
@@ -48,7 +48,7 @@ def _capture_exception(exc: "Any") -> None:
 
 def _set_agent_data(span: "StreamedSpan", agent: "agents.Agent") -> None:
     span.set_attribute(
-        SPANDATA.GEN_AI_SYSTEM, "openai"
+        SPANDATA.GEN_AI_PROVIDER_NAME, "openai"
     )  # See footnote for  https://opentelemetry.io/docs/specs/semconv/registry/attributes/gen-ai/#gen-ai-system for explanation why.
 
     span.set_attribute(SPANDATA.GEN_AI_AGENT_NAME, agent.name)

--- a/sentry_sdk/integrations/openai_agents/utils.py
+++ b/sentry_sdk/integrations/openai_agents/utils.py
@@ -48,7 +48,7 @@ def _capture_exception(exc: "Any") -> None:
 
 def _set_agent_data(span: "StreamedSpan", agent: "agents.Agent") -> None:
     span.set_attribute(
-        SPANDATA.GEN_AI_PROVIDER_NAME, "openai"
+        SPANDATA.GEN_AI_SYSTEM, "openai"
     )  # See footnote for  https://opentelemetry.io/docs/specs/semconv/registry/attributes/gen-ai/#gen-ai-system for explanation why.
 
     span.set_attribute(SPANDATA.GEN_AI_AGENT_NAME, agent.name)
@@ -134,7 +134,7 @@ def _set_input_data(
 
     if len(instructions_text_parts) > 0:
         span.set_attribute(
-            SPANDATA.GEN_AI_PROVIDER_NAME_INSTRUCTIONS,
+            SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS,
             json.dumps(instructions_text_parts),
         )
 

--- a/sentry_sdk/integrations/pydantic_ai/spans/ai_client.py
+++ b/sentry_sdk/integrations/pydantic_ai/spans/ai_client.py
@@ -111,7 +111,7 @@ def _set_input_messages(span: "StreamedSpan", messages: "list[ModelMessage]") ->
     permanent_instructions, current_instructions = _get_system_instructions(messages)
     if len(permanent_instructions) > 0 or len(current_instructions) > 0:
         span.set_attribute(
-            SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS,
+            SPANDATA.GEN_AI_PROVIDER_NAME_INSTRUCTIONS,
             json.dumps(
                 _transform_system_instructions(
                     permanent_instructions, current_instructions

--- a/sentry_sdk/integrations/pydantic_ai/spans/ai_client.py
+++ b/sentry_sdk/integrations/pydantic_ai/spans/ai_client.py
@@ -111,7 +111,7 @@ def _set_input_messages(span: "StreamedSpan", messages: "list[ModelMessage]") ->
     permanent_instructions, current_instructions = _get_system_instructions(messages)
     if len(permanent_instructions) > 0 or len(current_instructions) > 0:
         span.set_attribute(
-            SPANDATA.GEN_AI_PROVIDER_NAME_INSTRUCTIONS,
+            SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS,
             json.dumps(
                 _transform_system_instructions(
                     permanent_instructions, current_instructions

--- a/sentry_sdk/integrations/pydantic_ai/utils.py
+++ b/sentry_sdk/integrations/pydantic_ai/utils.py
@@ -115,7 +115,7 @@ def _set_model_data(
     if model_obj:
         # Set system from model
         if hasattr(model_obj, "system"):
-            span.set_attribute(SPANDATA.GEN_AI_PROVIDER_NAME, model_obj.system)
+            span.set_attribute(SPANDATA.GEN_AI_SYSTEM, model_obj.system)
 
         # Set model name
         model_name = _get_model_name(model_obj)

--- a/sentry_sdk/integrations/pydantic_ai/utils.py
+++ b/sentry_sdk/integrations/pydantic_ai/utils.py
@@ -115,7 +115,7 @@ def _set_model_data(
     if model_obj:
         # Set system from model
         if hasattr(model_obj, "system"):
-            span.set_attribute(SPANDATA.GEN_AI_SYSTEM, model_obj.system)
+            span.set_attribute(SPANDATA.GEN_AI_PROVIDER_NAME, model_obj.system)
 
         # Set model name
         model_name = _get_model_name(model_obj)

--- a/tests/integrations/anthropic/test_anthropic.py
+++ b/tests/integrations/anthropic/test_anthropic.py
@@ -95,7 +95,7 @@ DATA_COLLECTION_EXAMPLE_TOOLS = [
 ]
 
 DATA_COLLECTION_EXPECTED_INPUT_DATA = {
-    SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS: [
+    SPANDATA.GEN_AI_PROVIDER_NAME_INSTRUCTIONS: [
         {"type": "text", "content": "You are a helpful assistant."}
     ],
     SPANDATA.GEN_AI_REQUEST_MESSAGES: [{"role": "user", "content": "Hello, Claude"}],
@@ -189,7 +189,7 @@ def test_nonstreaming_create_message(
 
     assert span["attributes"]["sentry.op"] == OP.GEN_AI_CHAT
     assert span["name"] == "chat model"
-    assert span["attributes"][SPANDATA.GEN_AI_SYSTEM] == "anthropic"
+    assert span["attributes"][SPANDATA.GEN_AI_PROVIDER_NAME] == "anthropic"
     assert span["attributes"][SPANDATA.GEN_AI_OPERATION_NAME] == "chat"
     assert span["attributes"][SPANDATA.GEN_AI_REQUEST_MODEL] == "model"
 
@@ -295,7 +295,7 @@ def test_nonstreaming_create_message_data_collection(
     (span,) = [s for s in spans if s["attributes"]["sentry.op"] == OP.GEN_AI_CHAT]
     span_data = span["attributes"]
 
-    assert span_data[SPANDATA.GEN_AI_SYSTEM] == "anthropic"
+    assert span_data[SPANDATA.GEN_AI_PROVIDER_NAME] == "anthropic"
     assert span_data[SPANDATA.GEN_AI_OPERATION_NAME] == "chat"
     assert span_data[SPANDATA.GEN_AI_REQUEST_MODEL] == "model"
     assert span_data[SPANDATA.GEN_AI_REQUEST_MAX_TOKENS] == 1024
@@ -443,7 +443,7 @@ async def test_nonstreaming_create_message_data_collection_async(
     (span,) = [s for s in spans if s["attributes"]["sentry.op"] == OP.GEN_AI_CHAT]
     span_data = span["attributes"]
 
-    assert span_data[SPANDATA.GEN_AI_SYSTEM] == "anthropic"
+    assert span_data[SPANDATA.GEN_AI_PROVIDER_NAME] == "anthropic"
     assert span_data[SPANDATA.GEN_AI_OPERATION_NAME] == "chat"
     assert span_data[SPANDATA.GEN_AI_REQUEST_MODEL] == "model"
     assert span_data[SPANDATA.GEN_AI_REQUEST_MAX_TOKENS] == 1024
@@ -731,7 +731,7 @@ async def test_nonstreaming_create_message_async(
 
     assert span["attributes"]["sentry.op"] == OP.GEN_AI_CHAT
     assert span["name"] == "chat model"
-    assert span["attributes"][SPANDATA.GEN_AI_SYSTEM] == "anthropic"
+    assert span["attributes"][SPANDATA.GEN_AI_PROVIDER_NAME] == "anthropic"
     assert span["attributes"][SPANDATA.GEN_AI_OPERATION_NAME] == "chat"
     assert span["attributes"][SPANDATA.GEN_AI_REQUEST_MODEL] == "model"
 
@@ -857,7 +857,7 @@ def test_streaming_create_message(
 
     assert span["attributes"]["sentry.op"] == OP.GEN_AI_CHAT
     assert span["name"] == "chat model"
-    assert span["attributes"][SPANDATA.GEN_AI_SYSTEM] == "anthropic"
+    assert span["attributes"][SPANDATA.GEN_AI_PROVIDER_NAME] == "anthropic"
     assert span["attributes"][SPANDATA.GEN_AI_OPERATION_NAME] == "chat"
     assert span["attributes"][SPANDATA.GEN_AI_REQUEST_MODEL] == "model"
 
@@ -992,7 +992,7 @@ def test_streaming_create_message_data_collection(
     (span,) = [s for s in spans if s["attributes"]["sentry.op"] == OP.GEN_AI_CHAT]
     span_data = span["attributes"]
 
-    assert span_data[SPANDATA.GEN_AI_SYSTEM] == "anthropic"
+    assert span_data[SPANDATA.GEN_AI_PROVIDER_NAME] == "anthropic"
     assert span_data[SPANDATA.GEN_AI_OPERATION_NAME] == "chat"
     assert span_data[SPANDATA.GEN_AI_REQUEST_MODEL] == "model"
     assert span_data[SPANDATA.GEN_AI_REQUEST_MAX_TOKENS] == 1024
@@ -1218,7 +1218,7 @@ def test_streaming_create_message_close(
 
     assert span["attributes"]["sentry.op"] == OP.GEN_AI_CHAT
     assert span["name"] == "chat model"
-    assert span["attributes"][SPANDATA.GEN_AI_SYSTEM] == "anthropic"
+    assert span["attributes"][SPANDATA.GEN_AI_PROVIDER_NAME] == "anthropic"
     assert span["attributes"][SPANDATA.GEN_AI_OPERATION_NAME] == "chat"
     assert span["attributes"][SPANDATA.GEN_AI_REQUEST_MODEL] == "model"
 
@@ -1318,7 +1318,7 @@ def test_streaming_create_message_api_error(
 
     assert span["attributes"]["sentry.op"] == OP.GEN_AI_CHAT
     assert span["name"] == "chat model"
-    assert span["attributes"][SPANDATA.GEN_AI_SYSTEM] == "anthropic"
+    assert span["attributes"][SPANDATA.GEN_AI_PROVIDER_NAME] == "anthropic"
     assert span["attributes"][SPANDATA.GEN_AI_OPERATION_NAME] == "chat"
     assert span["attributes"][SPANDATA.GEN_AI_REQUEST_MODEL] == "model"
 
@@ -1436,7 +1436,7 @@ def test_stream_messages(
 
     assert span["attributes"]["sentry.op"] == OP.GEN_AI_CHAT
     assert span["name"] == "chat model"
-    assert span["attributes"][SPANDATA.GEN_AI_SYSTEM] == "anthropic"
+    assert span["attributes"][SPANDATA.GEN_AI_PROVIDER_NAME] == "anthropic"
     assert span["attributes"][SPANDATA.GEN_AI_OPERATION_NAME] == "chat"
     assert span["attributes"][SPANDATA.GEN_AI_REQUEST_MODEL] == "model"
 
@@ -1683,7 +1683,7 @@ def test_stream_messages_close(
 
     assert span["attributes"]["sentry.op"] == OP.GEN_AI_CHAT
     assert span["name"] == "chat model"
-    assert span["attributes"][SPANDATA.GEN_AI_SYSTEM] == "anthropic"
+    assert span["attributes"][SPANDATA.GEN_AI_PROVIDER_NAME] == "anthropic"
     assert span["attributes"][SPANDATA.GEN_AI_OPERATION_NAME] == "chat"
     assert span["attributes"][SPANDATA.GEN_AI_REQUEST_MODEL] == "model"
 
@@ -1783,7 +1783,7 @@ def test_stream_messages_api_error(
 
     assert span["attributes"]["sentry.op"] == OP.GEN_AI_CHAT
     assert span["name"] == "chat model"
-    assert span["attributes"][SPANDATA.GEN_AI_SYSTEM] == "anthropic"
+    assert span["attributes"][SPANDATA.GEN_AI_PROVIDER_NAME] == "anthropic"
     assert span["attributes"][SPANDATA.GEN_AI_OPERATION_NAME] == "chat"
     assert span["attributes"][SPANDATA.GEN_AI_REQUEST_MODEL] == "model"
 
@@ -1906,7 +1906,7 @@ async def test_streaming_create_message_async(
 
     assert span["attributes"]["sentry.op"] == OP.GEN_AI_CHAT
     assert span["name"] == "chat model"
-    assert span["attributes"][SPANDATA.GEN_AI_SYSTEM] == "anthropic"
+    assert span["attributes"][SPANDATA.GEN_AI_PROVIDER_NAME] == "anthropic"
     assert span["attributes"][SPANDATA.GEN_AI_OPERATION_NAME] == "chat"
     assert span["attributes"][SPANDATA.GEN_AI_REQUEST_MODEL] == "model"
 
@@ -2158,7 +2158,7 @@ async def test_streaming_create_message_async_close(
 
     assert span["attributes"]["sentry.op"] == OP.GEN_AI_CHAT
     assert span["name"] == "chat model"
-    assert span["attributes"][SPANDATA.GEN_AI_SYSTEM] == "anthropic"
+    assert span["attributes"][SPANDATA.GEN_AI_PROVIDER_NAME] == "anthropic"
     assert span["attributes"][SPANDATA.GEN_AI_OPERATION_NAME] == "chat"
     assert span["attributes"][SPANDATA.GEN_AI_REQUEST_MODEL] == "model"
 
@@ -2262,7 +2262,7 @@ async def test_streaming_create_message_async_api_error(
 
     assert span["attributes"]["sentry.op"] == OP.GEN_AI_CHAT
     assert span["name"] == "chat model"
-    assert span["attributes"][SPANDATA.GEN_AI_SYSTEM] == "anthropic"
+    assert span["attributes"][SPANDATA.GEN_AI_PROVIDER_NAME] == "anthropic"
     assert span["attributes"][SPANDATA.GEN_AI_OPERATION_NAME] == "chat"
     assert span["attributes"][SPANDATA.GEN_AI_REQUEST_MODEL] == "model"
 
@@ -2385,7 +2385,7 @@ async def test_stream_message_async(
 
     assert span["attributes"]["sentry.op"] == OP.GEN_AI_CHAT
     assert span["name"] == "chat model"
-    assert span["attributes"][SPANDATA.GEN_AI_SYSTEM] == "anthropic"
+    assert span["attributes"][SPANDATA.GEN_AI_PROVIDER_NAME] == "anthropic"
     assert span["attributes"][SPANDATA.GEN_AI_OPERATION_NAME] == "chat"
     assert span["attributes"][SPANDATA.GEN_AI_REQUEST_MODEL] == "model"
 
@@ -2634,7 +2634,7 @@ async def test_stream_messages_async_api_error(
 
     assert span["attributes"]["sentry.op"] == OP.GEN_AI_CHAT
     assert span["name"] == "chat model"
-    assert span["attributes"][SPANDATA.GEN_AI_SYSTEM] == "anthropic"
+    assert span["attributes"][SPANDATA.GEN_AI_PROVIDER_NAME] == "anthropic"
     assert span["attributes"][SPANDATA.GEN_AI_OPERATION_NAME] == "chat"
     assert span["attributes"][SPANDATA.GEN_AI_REQUEST_MODEL] == "model"
 
@@ -2750,7 +2750,7 @@ async def test_stream_messages_async_close(
 
     assert span["attributes"]["sentry.op"] == OP.GEN_AI_CHAT
     assert span["name"] == "chat model"
-    assert span["attributes"][SPANDATA.GEN_AI_SYSTEM] == "anthropic"
+    assert span["attributes"][SPANDATA.GEN_AI_PROVIDER_NAME] == "anthropic"
     assert span["attributes"][SPANDATA.GEN_AI_OPERATION_NAME] == "chat"
     assert span["attributes"][SPANDATA.GEN_AI_REQUEST_MODEL] == "model"
 
@@ -2896,7 +2896,7 @@ def test_streaming_create_message_with_input_json_delta(
 
     assert span["attributes"]["sentry.op"] == OP.GEN_AI_CHAT
     assert span["name"] == "chat model"
-    assert span["attributes"][SPANDATA.GEN_AI_SYSTEM] == "anthropic"
+    assert span["attributes"][SPANDATA.GEN_AI_PROVIDER_NAME] == "anthropic"
     assert span["attributes"][SPANDATA.GEN_AI_OPERATION_NAME] == "chat"
     assert span["attributes"][SPANDATA.GEN_AI_REQUEST_MODEL] == "model"
 
@@ -3045,7 +3045,7 @@ def test_stream_messages_with_input_json_delta(
 
     assert span["attributes"]["sentry.op"] == OP.GEN_AI_CHAT
     assert span["name"] == "chat model"
-    assert span["attributes"][SPANDATA.GEN_AI_SYSTEM] == "anthropic"
+    assert span["attributes"][SPANDATA.GEN_AI_PROVIDER_NAME] == "anthropic"
     assert span["attributes"][SPANDATA.GEN_AI_OPERATION_NAME] == "chat"
     assert span["attributes"][SPANDATA.GEN_AI_REQUEST_MODEL] == "model"
 
@@ -3201,7 +3201,7 @@ async def test_streaming_create_message_with_input_json_delta_async(
 
     assert span["attributes"]["sentry.op"] == OP.GEN_AI_CHAT
     assert span["name"] == "chat model"
-    assert span["attributes"][SPANDATA.GEN_AI_SYSTEM] == "anthropic"
+    assert span["attributes"][SPANDATA.GEN_AI_PROVIDER_NAME] == "anthropic"
     assert span["attributes"][SPANDATA.GEN_AI_OPERATION_NAME] == "chat"
     assert span["attributes"][SPANDATA.GEN_AI_REQUEST_MODEL] == "model"
 
@@ -3359,7 +3359,7 @@ async def test_stream_message_with_input_json_delta_async(
 
     assert span["attributes"]["sentry.op"] == OP.GEN_AI_CHAT
     assert span["name"] == "chat model"
-    assert span["attributes"][SPANDATA.GEN_AI_SYSTEM] == "anthropic"
+    assert span["attributes"][SPANDATA.GEN_AI_PROVIDER_NAME] == "anthropic"
     assert span["attributes"][SPANDATA.GEN_AI_OPERATION_NAME] == "chat"
     assert span["attributes"][SPANDATA.GEN_AI_REQUEST_MODEL] == "model"
 
@@ -3439,7 +3439,7 @@ def test_span_status_error(
     sentry_sdk.flush()
     spans = [item.payload for item in items if item.type == "span"]
     assert spans[0]["status"] == "error"
-    assert spans[0]["attributes"][SPANDATA.GEN_AI_SYSTEM] == "anthropic"
+    assert spans[0]["attributes"][SPANDATA.GEN_AI_PROVIDER_NAME] == "anthropic"
     assert spans[0]["attributes"][SPANDATA.GEN_AI_OPERATION_NAME] == "chat"
 
 
@@ -3473,7 +3473,7 @@ async def test_span_status_error_async(
     sentry_sdk.flush()
     spans = [item.payload for item in items if item.type == "span"]
     assert spans[0]["status"] == "error"
-    assert spans[0]["attributes"][SPANDATA.GEN_AI_SYSTEM] == "anthropic"
+    assert spans[0]["attributes"][SPANDATA.GEN_AI_PROVIDER_NAME] == "anthropic"
     assert spans[0]["attributes"][SPANDATA.GEN_AI_OPERATION_NAME] == "chat"
 
 
@@ -3533,7 +3533,7 @@ def test_span_origin(
     sentry_sdk.flush()
     spans = [item.payload for item in items]
     assert spans[0]["attributes"]["sentry.origin"] == "auto.ai.anthropic"
-    assert spans[0]["attributes"][SPANDATA.GEN_AI_SYSTEM] == "anthropic"
+    assert spans[0]["attributes"][SPANDATA.GEN_AI_PROVIDER_NAME] == "anthropic"
     assert spans[0]["attributes"][SPANDATA.GEN_AI_OPERATION_NAME] == "chat"
 
 
@@ -3565,7 +3565,7 @@ async def test_span_origin_async(
     sentry_sdk.flush()
     spans = [item.payload for item in items]
     assert spans[0]["attributes"]["sentry.origin"] == "auto.ai.anthropic"
-    assert spans[0]["attributes"][SPANDATA.GEN_AI_SYSTEM] == "anthropic"
+    assert spans[0]["attributes"][SPANDATA.GEN_AI_PROVIDER_NAME] == "anthropic"
     assert spans[0]["attributes"][SPANDATA.GEN_AI_OPERATION_NAME] == "chat"
 
 
@@ -3691,7 +3691,7 @@ def test_anthropic_message_role_mapping(
 
     # Verify that the span was created correctly
     assert span["attributes"]["sentry.op"] == "gen_ai.chat"
-    assert span["attributes"][SPANDATA.GEN_AI_SYSTEM] == "anthropic"
+    assert span["attributes"][SPANDATA.GEN_AI_PROVIDER_NAME] == "anthropic"
     assert span["attributes"][SPANDATA.GEN_AI_OPERATION_NAME] == "chat"
     assert SPANDATA.GEN_AI_REQUEST_MESSAGES in span["attributes"]
 
@@ -3757,14 +3757,14 @@ def test_nonstreaming_create_message_with_system_prompt(
 
     assert span["attributes"]["sentry.op"] == OP.GEN_AI_CHAT
     assert span["name"] == "chat model"
-    assert span["attributes"][SPANDATA.GEN_AI_SYSTEM] == "anthropic"
+    assert span["attributes"][SPANDATA.GEN_AI_PROVIDER_NAME] == "anthropic"
     assert span["attributes"][SPANDATA.GEN_AI_OPERATION_NAME] == "chat"
     assert span["attributes"][SPANDATA.GEN_AI_REQUEST_MODEL] == "model"
 
     if send_default_pii and include_prompts:
-        assert SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS in span["attributes"]
+        assert SPANDATA.GEN_AI_PROVIDER_NAME_INSTRUCTIONS in span["attributes"]
         system_instructions = json.loads(
-            span["attributes"][SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS]
+            span["attributes"][SPANDATA.GEN_AI_PROVIDER_NAME_INSTRUCTIONS]
         )
         assert system_instructions == [
             {"type": "text", "content": "You are a helpful assistant."}
@@ -3779,7 +3779,7 @@ def test_nonstreaming_create_message_with_system_prompt(
         assert stored_messages[0]["content"] == "Hello, Claude"
         assert span["attributes"][SPANDATA.GEN_AI_RESPONSE_TEXT] == "Hi, I'm Claude."
     else:
-        assert SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS not in span["attributes"]
+        assert SPANDATA.GEN_AI_PROVIDER_NAME_INSTRUCTIONS not in span["attributes"]
         assert SPANDATA.GEN_AI_REQUEST_MESSAGES not in span["attributes"]
         assert SPANDATA.GEN_AI_RESPONSE_TEXT not in span["attributes"]
 
@@ -3847,14 +3847,14 @@ async def test_nonstreaming_create_message_with_system_prompt_async(
 
     assert span["attributes"]["sentry.op"] == OP.GEN_AI_CHAT
     assert span["name"] == "chat model"
-    assert span["attributes"][SPANDATA.GEN_AI_SYSTEM] == "anthropic"
+    assert span["attributes"][SPANDATA.GEN_AI_PROVIDER_NAME] == "anthropic"
     assert span["attributes"][SPANDATA.GEN_AI_OPERATION_NAME] == "chat"
     assert span["attributes"][SPANDATA.GEN_AI_REQUEST_MODEL] == "model"
 
     if send_default_pii and include_prompts:
-        assert SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS in span["attributes"]
+        assert SPANDATA.GEN_AI_PROVIDER_NAME_INSTRUCTIONS in span["attributes"]
         system_instructions = json.loads(
-            span["attributes"][SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS]
+            span["attributes"][SPANDATA.GEN_AI_PROVIDER_NAME_INSTRUCTIONS]
         )
         assert system_instructions == [
             {"type": "text", "content": "You are a helpful assistant."}
@@ -3869,7 +3869,7 @@ async def test_nonstreaming_create_message_with_system_prompt_async(
         assert stored_messages[0]["content"] == "Hello, Claude"
         assert span["attributes"][SPANDATA.GEN_AI_RESPONSE_TEXT] == "Hi, I'm Claude."
     else:
-        assert SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS not in span["attributes"]
+        assert SPANDATA.GEN_AI_PROVIDER_NAME_INSTRUCTIONS not in span["attributes"]
         assert SPANDATA.GEN_AI_REQUEST_MESSAGES not in span["attributes"]
         assert SPANDATA.GEN_AI_RESPONSE_TEXT not in span["attributes"]
 
@@ -3977,14 +3977,14 @@ def test_streaming_create_message_with_system_prompt(
 
     assert span["attributes"]["sentry.op"] == OP.GEN_AI_CHAT
     assert span["name"] == "chat model"
-    assert span["attributes"][SPANDATA.GEN_AI_SYSTEM] == "anthropic"
+    assert span["attributes"][SPANDATA.GEN_AI_PROVIDER_NAME] == "anthropic"
     assert span["attributes"][SPANDATA.GEN_AI_OPERATION_NAME] == "chat"
     assert span["attributes"][SPANDATA.GEN_AI_REQUEST_MODEL] == "model"
 
     if send_default_pii and include_prompts:
-        assert SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS in span["attributes"]
+        assert SPANDATA.GEN_AI_PROVIDER_NAME_INSTRUCTIONS in span["attributes"]
         system_instructions = json.loads(
-            span["attributes"][SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS]
+            span["attributes"][SPANDATA.GEN_AI_PROVIDER_NAME_INSTRUCTIONS]
         )
         assert system_instructions == [
             {"type": "text", "content": "You are a helpful assistant."}
@@ -4000,7 +4000,7 @@ def test_streaming_create_message_with_system_prompt(
         assert span["attributes"][SPANDATA.GEN_AI_RESPONSE_TEXT] == "Hi! I'm Claude!"
 
     else:
-        assert SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS not in span["attributes"]
+        assert SPANDATA.GEN_AI_PROVIDER_NAME_INSTRUCTIONS not in span["attributes"]
         assert SPANDATA.GEN_AI_REQUEST_MESSAGES not in span["attributes"]
         assert SPANDATA.GEN_AI_RESPONSE_TEXT not in span["attributes"]
 
@@ -4104,14 +4104,14 @@ def test_stream_messages_with_system_prompt(
 
     assert span["attributes"]["sentry.op"] == OP.GEN_AI_CHAT
     assert span["name"] == "chat model"
-    assert span["attributes"][SPANDATA.GEN_AI_SYSTEM] == "anthropic"
+    assert span["attributes"][SPANDATA.GEN_AI_PROVIDER_NAME] == "anthropic"
     assert span["attributes"][SPANDATA.GEN_AI_OPERATION_NAME] == "chat"
     assert span["attributes"][SPANDATA.GEN_AI_REQUEST_MODEL] == "model"
 
     if send_default_pii and include_prompts:
-        assert SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS in span["attributes"]
+        assert SPANDATA.GEN_AI_PROVIDER_NAME_INSTRUCTIONS in span["attributes"]
         system_instructions = json.loads(
-            span["attributes"][SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS]
+            span["attributes"][SPANDATA.GEN_AI_PROVIDER_NAME_INSTRUCTIONS]
         )
         assert system_instructions == [
             {"type": "text", "content": "You are a helpful assistant."}
@@ -4125,7 +4125,7 @@ def test_stream_messages_with_system_prompt(
         assert stored_messages[0]["content"] == "Hello, Claude"
         assert span["attributes"][SPANDATA.GEN_AI_RESPONSE_TEXT] == "Hi! I'm Claude!"
     else:
-        assert SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS not in span["attributes"]
+        assert SPANDATA.GEN_AI_PROVIDER_NAME_INSTRUCTIONS not in span["attributes"]
         assert SPANDATA.GEN_AI_REQUEST_MESSAGES not in span["attributes"]
         assert SPANDATA.GEN_AI_RESPONSE_TEXT not in span["attributes"]
 
@@ -4234,14 +4234,14 @@ async def test_stream_message_with_system_prompt_async(
 
     assert span["attributes"]["sentry.op"] == OP.GEN_AI_CHAT
     assert span["name"] == "chat model"
-    assert span["attributes"][SPANDATA.GEN_AI_SYSTEM] == "anthropic"
+    assert span["attributes"][SPANDATA.GEN_AI_PROVIDER_NAME] == "anthropic"
     assert span["attributes"][SPANDATA.GEN_AI_OPERATION_NAME] == "chat"
     assert span["attributes"][SPANDATA.GEN_AI_REQUEST_MODEL] == "model"
 
     if send_default_pii and include_prompts:
-        assert SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS in span["attributes"]
+        assert SPANDATA.GEN_AI_PROVIDER_NAME_INSTRUCTIONS in span["attributes"]
         system_instructions = json.loads(
-            span["attributes"][SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS]
+            span["attributes"][SPANDATA.GEN_AI_PROVIDER_NAME_INSTRUCTIONS]
         )
         assert system_instructions == [
             {"type": "text", "content": "You are a helpful assistant."}
@@ -4256,7 +4256,7 @@ async def test_stream_message_with_system_prompt_async(
         assert stored_messages[0]["content"] == "Hello, Claude"
         assert span["attributes"][SPANDATA.GEN_AI_RESPONSE_TEXT] == "Hi! I'm Claude!"
     else:
-        assert SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS not in span["attributes"]
+        assert SPANDATA.GEN_AI_PROVIDER_NAME_INSTRUCTIONS not in span["attributes"]
         assert SPANDATA.GEN_AI_REQUEST_MESSAGES not in span["attributes"]
         assert SPANDATA.GEN_AI_RESPONSE_TEXT not in span["attributes"]
 
@@ -4367,14 +4367,14 @@ async def test_streaming_create_message_with_system_prompt_async(
 
     assert span["attributes"]["sentry.op"] == OP.GEN_AI_CHAT
     assert span["name"] == "chat model"
-    assert span["attributes"][SPANDATA.GEN_AI_SYSTEM] == "anthropic"
+    assert span["attributes"][SPANDATA.GEN_AI_PROVIDER_NAME] == "anthropic"
     assert span["attributes"][SPANDATA.GEN_AI_OPERATION_NAME] == "chat"
     assert span["attributes"][SPANDATA.GEN_AI_REQUEST_MODEL] == "model"
 
     if send_default_pii and include_prompts:
-        assert SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS in span["attributes"]
+        assert SPANDATA.GEN_AI_PROVIDER_NAME_INSTRUCTIONS in span["attributes"]
         system_instructions = json.loads(
-            span["attributes"][SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS]
+            span["attributes"][SPANDATA.GEN_AI_PROVIDER_NAME_INSTRUCTIONS]
         )
         assert system_instructions == [
             {"type": "text", "content": "You are a helpful assistant."}
@@ -4391,7 +4391,7 @@ async def test_streaming_create_message_with_system_prompt_async(
         assert span["attributes"][SPANDATA.GEN_AI_RESPONSE_TEXT] == "Hi! I'm Claude!"
 
     else:
-        assert SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS not in span["attributes"]
+        assert SPANDATA.GEN_AI_PROVIDER_NAME_INSTRUCTIONS not in span["attributes"]
         assert SPANDATA.GEN_AI_REQUEST_MESSAGES not in span["attributes"]
         assert SPANDATA.GEN_AI_RESPONSE_TEXT not in span["attributes"]
 
@@ -4442,12 +4442,12 @@ def test_system_prompt_with_complex_structure(
 
     (span,) = spans
 
-    assert span["attributes"][SPANDATA.GEN_AI_SYSTEM] == "anthropic"
+    assert span["attributes"][SPANDATA.GEN_AI_PROVIDER_NAME] == "anthropic"
     assert span["attributes"][SPANDATA.GEN_AI_OPERATION_NAME] == "chat"
 
-    assert SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS in span["attributes"]
+    assert SPANDATA.GEN_AI_PROVIDER_NAME_INSTRUCTIONS in span["attributes"]
     system_instructions = json.loads(
-        span["attributes"][SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS]
+        span["attributes"][SPANDATA.GEN_AI_PROVIDER_NAME_INSTRUCTIONS]
     )
 
     # System content should be a list of text blocks

--- a/tests/integrations/anthropic/test_anthropic.py
+++ b/tests/integrations/anthropic/test_anthropic.py
@@ -189,7 +189,7 @@ def test_nonstreaming_create_message(
 
     assert span["attributes"]["sentry.op"] == OP.GEN_AI_CHAT
     assert span["name"] == "chat model"
-    assert span["attributes"][SPANDATA.GEN_AI_SYSTEM] == "anthropic"
+    assert span["attributes"][SPANDATA.GEN_AI_PROVIDER_NAME] == "anthropic"
     assert span["attributes"][SPANDATA.GEN_AI_OPERATION_NAME] == "chat"
     assert span["attributes"][SPANDATA.GEN_AI_REQUEST_MODEL] == "model"
 
@@ -295,7 +295,7 @@ def test_nonstreaming_create_message_data_collection(
     (span,) = [s for s in spans if s["attributes"]["sentry.op"] == OP.GEN_AI_CHAT]
     span_data = span["attributes"]
 
-    assert span_data[SPANDATA.GEN_AI_SYSTEM] == "anthropic"
+    assert span_data[SPANDATA.GEN_AI_PROVIDER_NAME] == "anthropic"
     assert span_data[SPANDATA.GEN_AI_OPERATION_NAME] == "chat"
     assert span_data[SPANDATA.GEN_AI_REQUEST_MODEL] == "model"
     assert span_data[SPANDATA.GEN_AI_REQUEST_MAX_TOKENS] == 1024
@@ -443,7 +443,7 @@ async def test_nonstreaming_create_message_data_collection_async(
     (span,) = [s for s in spans if s["attributes"]["sentry.op"] == OP.GEN_AI_CHAT]
     span_data = span["attributes"]
 
-    assert span_data[SPANDATA.GEN_AI_SYSTEM] == "anthropic"
+    assert span_data[SPANDATA.GEN_AI_PROVIDER_NAME] == "anthropic"
     assert span_data[SPANDATA.GEN_AI_OPERATION_NAME] == "chat"
     assert span_data[SPANDATA.GEN_AI_REQUEST_MODEL] == "model"
     assert span_data[SPANDATA.GEN_AI_REQUEST_MAX_TOKENS] == 1024
@@ -731,7 +731,7 @@ async def test_nonstreaming_create_message_async(
 
     assert span["attributes"]["sentry.op"] == OP.GEN_AI_CHAT
     assert span["name"] == "chat model"
-    assert span["attributes"][SPANDATA.GEN_AI_SYSTEM] == "anthropic"
+    assert span["attributes"][SPANDATA.GEN_AI_PROVIDER_NAME] == "anthropic"
     assert span["attributes"][SPANDATA.GEN_AI_OPERATION_NAME] == "chat"
     assert span["attributes"][SPANDATA.GEN_AI_REQUEST_MODEL] == "model"
 
@@ -857,7 +857,7 @@ def test_streaming_create_message(
 
     assert span["attributes"]["sentry.op"] == OP.GEN_AI_CHAT
     assert span["name"] == "chat model"
-    assert span["attributes"][SPANDATA.GEN_AI_SYSTEM] == "anthropic"
+    assert span["attributes"][SPANDATA.GEN_AI_PROVIDER_NAME] == "anthropic"
     assert span["attributes"][SPANDATA.GEN_AI_OPERATION_NAME] == "chat"
     assert span["attributes"][SPANDATA.GEN_AI_REQUEST_MODEL] == "model"
 
@@ -992,7 +992,7 @@ def test_streaming_create_message_data_collection(
     (span,) = [s for s in spans if s["attributes"]["sentry.op"] == OP.GEN_AI_CHAT]
     span_data = span["attributes"]
 
-    assert span_data[SPANDATA.GEN_AI_SYSTEM] == "anthropic"
+    assert span_data[SPANDATA.GEN_AI_PROVIDER_NAME] == "anthropic"
     assert span_data[SPANDATA.GEN_AI_OPERATION_NAME] == "chat"
     assert span_data[SPANDATA.GEN_AI_REQUEST_MODEL] == "model"
     assert span_data[SPANDATA.GEN_AI_REQUEST_MAX_TOKENS] == 1024
@@ -1218,7 +1218,7 @@ def test_streaming_create_message_close(
 
     assert span["attributes"]["sentry.op"] == OP.GEN_AI_CHAT
     assert span["name"] == "chat model"
-    assert span["attributes"][SPANDATA.GEN_AI_SYSTEM] == "anthropic"
+    assert span["attributes"][SPANDATA.GEN_AI_PROVIDER_NAME] == "anthropic"
     assert span["attributes"][SPANDATA.GEN_AI_OPERATION_NAME] == "chat"
     assert span["attributes"][SPANDATA.GEN_AI_REQUEST_MODEL] == "model"
 
@@ -1318,7 +1318,7 @@ def test_streaming_create_message_api_error(
 
     assert span["attributes"]["sentry.op"] == OP.GEN_AI_CHAT
     assert span["name"] == "chat model"
-    assert span["attributes"][SPANDATA.GEN_AI_SYSTEM] == "anthropic"
+    assert span["attributes"][SPANDATA.GEN_AI_PROVIDER_NAME] == "anthropic"
     assert span["attributes"][SPANDATA.GEN_AI_OPERATION_NAME] == "chat"
     assert span["attributes"][SPANDATA.GEN_AI_REQUEST_MODEL] == "model"
 
@@ -1436,7 +1436,7 @@ def test_stream_messages(
 
     assert span["attributes"]["sentry.op"] == OP.GEN_AI_CHAT
     assert span["name"] == "chat model"
-    assert span["attributes"][SPANDATA.GEN_AI_SYSTEM] == "anthropic"
+    assert span["attributes"][SPANDATA.GEN_AI_PROVIDER_NAME] == "anthropic"
     assert span["attributes"][SPANDATA.GEN_AI_OPERATION_NAME] == "chat"
     assert span["attributes"][SPANDATA.GEN_AI_REQUEST_MODEL] == "model"
 
@@ -1683,7 +1683,7 @@ def test_stream_messages_close(
 
     assert span["attributes"]["sentry.op"] == OP.GEN_AI_CHAT
     assert span["name"] == "chat model"
-    assert span["attributes"][SPANDATA.GEN_AI_SYSTEM] == "anthropic"
+    assert span["attributes"][SPANDATA.GEN_AI_PROVIDER_NAME] == "anthropic"
     assert span["attributes"][SPANDATA.GEN_AI_OPERATION_NAME] == "chat"
     assert span["attributes"][SPANDATA.GEN_AI_REQUEST_MODEL] == "model"
 
@@ -1783,7 +1783,7 @@ def test_stream_messages_api_error(
 
     assert span["attributes"]["sentry.op"] == OP.GEN_AI_CHAT
     assert span["name"] == "chat model"
-    assert span["attributes"][SPANDATA.GEN_AI_SYSTEM] == "anthropic"
+    assert span["attributes"][SPANDATA.GEN_AI_PROVIDER_NAME] == "anthropic"
     assert span["attributes"][SPANDATA.GEN_AI_OPERATION_NAME] == "chat"
     assert span["attributes"][SPANDATA.GEN_AI_REQUEST_MODEL] == "model"
 
@@ -1906,7 +1906,7 @@ async def test_streaming_create_message_async(
 
     assert span["attributes"]["sentry.op"] == OP.GEN_AI_CHAT
     assert span["name"] == "chat model"
-    assert span["attributes"][SPANDATA.GEN_AI_SYSTEM] == "anthropic"
+    assert span["attributes"][SPANDATA.GEN_AI_PROVIDER_NAME] == "anthropic"
     assert span["attributes"][SPANDATA.GEN_AI_OPERATION_NAME] == "chat"
     assert span["attributes"][SPANDATA.GEN_AI_REQUEST_MODEL] == "model"
 
@@ -2158,7 +2158,7 @@ async def test_streaming_create_message_async_close(
 
     assert span["attributes"]["sentry.op"] == OP.GEN_AI_CHAT
     assert span["name"] == "chat model"
-    assert span["attributes"][SPANDATA.GEN_AI_SYSTEM] == "anthropic"
+    assert span["attributes"][SPANDATA.GEN_AI_PROVIDER_NAME] == "anthropic"
     assert span["attributes"][SPANDATA.GEN_AI_OPERATION_NAME] == "chat"
     assert span["attributes"][SPANDATA.GEN_AI_REQUEST_MODEL] == "model"
 
@@ -2262,7 +2262,7 @@ async def test_streaming_create_message_async_api_error(
 
     assert span["attributes"]["sentry.op"] == OP.GEN_AI_CHAT
     assert span["name"] == "chat model"
-    assert span["attributes"][SPANDATA.GEN_AI_SYSTEM] == "anthropic"
+    assert span["attributes"][SPANDATA.GEN_AI_PROVIDER_NAME] == "anthropic"
     assert span["attributes"][SPANDATA.GEN_AI_OPERATION_NAME] == "chat"
     assert span["attributes"][SPANDATA.GEN_AI_REQUEST_MODEL] == "model"
 
@@ -2385,7 +2385,7 @@ async def test_stream_message_async(
 
     assert span["attributes"]["sentry.op"] == OP.GEN_AI_CHAT
     assert span["name"] == "chat model"
-    assert span["attributes"][SPANDATA.GEN_AI_SYSTEM] == "anthropic"
+    assert span["attributes"][SPANDATA.GEN_AI_PROVIDER_NAME] == "anthropic"
     assert span["attributes"][SPANDATA.GEN_AI_OPERATION_NAME] == "chat"
     assert span["attributes"][SPANDATA.GEN_AI_REQUEST_MODEL] == "model"
 
@@ -2634,7 +2634,7 @@ async def test_stream_messages_async_api_error(
 
     assert span["attributes"]["sentry.op"] == OP.GEN_AI_CHAT
     assert span["name"] == "chat model"
-    assert span["attributes"][SPANDATA.GEN_AI_SYSTEM] == "anthropic"
+    assert span["attributes"][SPANDATA.GEN_AI_PROVIDER_NAME] == "anthropic"
     assert span["attributes"][SPANDATA.GEN_AI_OPERATION_NAME] == "chat"
     assert span["attributes"][SPANDATA.GEN_AI_REQUEST_MODEL] == "model"
 
@@ -2750,7 +2750,7 @@ async def test_stream_messages_async_close(
 
     assert span["attributes"]["sentry.op"] == OP.GEN_AI_CHAT
     assert span["name"] == "chat model"
-    assert span["attributes"][SPANDATA.GEN_AI_SYSTEM] == "anthropic"
+    assert span["attributes"][SPANDATA.GEN_AI_PROVIDER_NAME] == "anthropic"
     assert span["attributes"][SPANDATA.GEN_AI_OPERATION_NAME] == "chat"
     assert span["attributes"][SPANDATA.GEN_AI_REQUEST_MODEL] == "model"
 
@@ -2896,7 +2896,7 @@ def test_streaming_create_message_with_input_json_delta(
 
     assert span["attributes"]["sentry.op"] == OP.GEN_AI_CHAT
     assert span["name"] == "chat model"
-    assert span["attributes"][SPANDATA.GEN_AI_SYSTEM] == "anthropic"
+    assert span["attributes"][SPANDATA.GEN_AI_PROVIDER_NAME] == "anthropic"
     assert span["attributes"][SPANDATA.GEN_AI_OPERATION_NAME] == "chat"
     assert span["attributes"][SPANDATA.GEN_AI_REQUEST_MODEL] == "model"
 
@@ -3045,7 +3045,7 @@ def test_stream_messages_with_input_json_delta(
 
     assert span["attributes"]["sentry.op"] == OP.GEN_AI_CHAT
     assert span["name"] == "chat model"
-    assert span["attributes"][SPANDATA.GEN_AI_SYSTEM] == "anthropic"
+    assert span["attributes"][SPANDATA.GEN_AI_PROVIDER_NAME] == "anthropic"
     assert span["attributes"][SPANDATA.GEN_AI_OPERATION_NAME] == "chat"
     assert span["attributes"][SPANDATA.GEN_AI_REQUEST_MODEL] == "model"
 
@@ -3201,7 +3201,7 @@ async def test_streaming_create_message_with_input_json_delta_async(
 
     assert span["attributes"]["sentry.op"] == OP.GEN_AI_CHAT
     assert span["name"] == "chat model"
-    assert span["attributes"][SPANDATA.GEN_AI_SYSTEM] == "anthropic"
+    assert span["attributes"][SPANDATA.GEN_AI_PROVIDER_NAME] == "anthropic"
     assert span["attributes"][SPANDATA.GEN_AI_OPERATION_NAME] == "chat"
     assert span["attributes"][SPANDATA.GEN_AI_REQUEST_MODEL] == "model"
 
@@ -3359,7 +3359,7 @@ async def test_stream_message_with_input_json_delta_async(
 
     assert span["attributes"]["sentry.op"] == OP.GEN_AI_CHAT
     assert span["name"] == "chat model"
-    assert span["attributes"][SPANDATA.GEN_AI_SYSTEM] == "anthropic"
+    assert span["attributes"][SPANDATA.GEN_AI_PROVIDER_NAME] == "anthropic"
     assert span["attributes"][SPANDATA.GEN_AI_OPERATION_NAME] == "chat"
     assert span["attributes"][SPANDATA.GEN_AI_REQUEST_MODEL] == "model"
 
@@ -3439,7 +3439,7 @@ def test_span_status_error(
     sentry_sdk.flush()
     spans = [item.payload for item in items if item.type == "span"]
     assert spans[0]["status"] == "error"
-    assert spans[0]["attributes"][SPANDATA.GEN_AI_SYSTEM] == "anthropic"
+    assert spans[0]["attributes"][SPANDATA.GEN_AI_PROVIDER_NAME] == "anthropic"
     assert spans[0]["attributes"][SPANDATA.GEN_AI_OPERATION_NAME] == "chat"
 
 
@@ -3473,7 +3473,7 @@ async def test_span_status_error_async(
     sentry_sdk.flush()
     spans = [item.payload for item in items if item.type == "span"]
     assert spans[0]["status"] == "error"
-    assert spans[0]["attributes"][SPANDATA.GEN_AI_SYSTEM] == "anthropic"
+    assert spans[0]["attributes"][SPANDATA.GEN_AI_PROVIDER_NAME] == "anthropic"
     assert spans[0]["attributes"][SPANDATA.GEN_AI_OPERATION_NAME] == "chat"
 
 
@@ -3533,7 +3533,7 @@ def test_span_origin(
     sentry_sdk.flush()
     spans = [item.payload for item in items]
     assert spans[0]["attributes"]["sentry.origin"] == "auto.ai.anthropic"
-    assert spans[0]["attributes"][SPANDATA.GEN_AI_SYSTEM] == "anthropic"
+    assert spans[0]["attributes"][SPANDATA.GEN_AI_PROVIDER_NAME] == "anthropic"
     assert spans[0]["attributes"][SPANDATA.GEN_AI_OPERATION_NAME] == "chat"
 
 
@@ -3565,7 +3565,7 @@ async def test_span_origin_async(
     sentry_sdk.flush()
     spans = [item.payload for item in items]
     assert spans[0]["attributes"]["sentry.origin"] == "auto.ai.anthropic"
-    assert spans[0]["attributes"][SPANDATA.GEN_AI_SYSTEM] == "anthropic"
+    assert spans[0]["attributes"][SPANDATA.GEN_AI_PROVIDER_NAME] == "anthropic"
     assert spans[0]["attributes"][SPANDATA.GEN_AI_OPERATION_NAME] == "chat"
 
 
@@ -3691,7 +3691,7 @@ def test_anthropic_message_role_mapping(
 
     # Verify that the span was created correctly
     assert span["attributes"]["sentry.op"] == "gen_ai.chat"
-    assert span["attributes"][SPANDATA.GEN_AI_SYSTEM] == "anthropic"
+    assert span["attributes"][SPANDATA.GEN_AI_PROVIDER_NAME] == "anthropic"
     assert span["attributes"][SPANDATA.GEN_AI_OPERATION_NAME] == "chat"
     assert SPANDATA.GEN_AI_REQUEST_MESSAGES in span["attributes"]
 
@@ -3757,7 +3757,7 @@ def test_nonstreaming_create_message_with_system_prompt(
 
     assert span["attributes"]["sentry.op"] == OP.GEN_AI_CHAT
     assert span["name"] == "chat model"
-    assert span["attributes"][SPANDATA.GEN_AI_SYSTEM] == "anthropic"
+    assert span["attributes"][SPANDATA.GEN_AI_PROVIDER_NAME] == "anthropic"
     assert span["attributes"][SPANDATA.GEN_AI_OPERATION_NAME] == "chat"
     assert span["attributes"][SPANDATA.GEN_AI_REQUEST_MODEL] == "model"
 
@@ -3847,7 +3847,7 @@ async def test_nonstreaming_create_message_with_system_prompt_async(
 
     assert span["attributes"]["sentry.op"] == OP.GEN_AI_CHAT
     assert span["name"] == "chat model"
-    assert span["attributes"][SPANDATA.GEN_AI_SYSTEM] == "anthropic"
+    assert span["attributes"][SPANDATA.GEN_AI_PROVIDER_NAME] == "anthropic"
     assert span["attributes"][SPANDATA.GEN_AI_OPERATION_NAME] == "chat"
     assert span["attributes"][SPANDATA.GEN_AI_REQUEST_MODEL] == "model"
 
@@ -3977,7 +3977,7 @@ def test_streaming_create_message_with_system_prompt(
 
     assert span["attributes"]["sentry.op"] == OP.GEN_AI_CHAT
     assert span["name"] == "chat model"
-    assert span["attributes"][SPANDATA.GEN_AI_SYSTEM] == "anthropic"
+    assert span["attributes"][SPANDATA.GEN_AI_PROVIDER_NAME] == "anthropic"
     assert span["attributes"][SPANDATA.GEN_AI_OPERATION_NAME] == "chat"
     assert span["attributes"][SPANDATA.GEN_AI_REQUEST_MODEL] == "model"
 
@@ -4104,7 +4104,7 @@ def test_stream_messages_with_system_prompt(
 
     assert span["attributes"]["sentry.op"] == OP.GEN_AI_CHAT
     assert span["name"] == "chat model"
-    assert span["attributes"][SPANDATA.GEN_AI_SYSTEM] == "anthropic"
+    assert span["attributes"][SPANDATA.GEN_AI_PROVIDER_NAME] == "anthropic"
     assert span["attributes"][SPANDATA.GEN_AI_OPERATION_NAME] == "chat"
     assert span["attributes"][SPANDATA.GEN_AI_REQUEST_MODEL] == "model"
 
@@ -4234,7 +4234,7 @@ async def test_stream_message_with_system_prompt_async(
 
     assert span["attributes"]["sentry.op"] == OP.GEN_AI_CHAT
     assert span["name"] == "chat model"
-    assert span["attributes"][SPANDATA.GEN_AI_SYSTEM] == "anthropic"
+    assert span["attributes"][SPANDATA.GEN_AI_PROVIDER_NAME] == "anthropic"
     assert span["attributes"][SPANDATA.GEN_AI_OPERATION_NAME] == "chat"
     assert span["attributes"][SPANDATA.GEN_AI_REQUEST_MODEL] == "model"
 
@@ -4367,7 +4367,7 @@ async def test_streaming_create_message_with_system_prompt_async(
 
     assert span["attributes"]["sentry.op"] == OP.GEN_AI_CHAT
     assert span["name"] == "chat model"
-    assert span["attributes"][SPANDATA.GEN_AI_SYSTEM] == "anthropic"
+    assert span["attributes"][SPANDATA.GEN_AI_PROVIDER_NAME] == "anthropic"
     assert span["attributes"][SPANDATA.GEN_AI_OPERATION_NAME] == "chat"
     assert span["attributes"][SPANDATA.GEN_AI_REQUEST_MODEL] == "model"
 
@@ -4442,7 +4442,7 @@ def test_system_prompt_with_complex_structure(
 
     (span,) = spans
 
-    assert span["attributes"][SPANDATA.GEN_AI_SYSTEM] == "anthropic"
+    assert span["attributes"][SPANDATA.GEN_AI_PROVIDER_NAME] == "anthropic"
     assert span["attributes"][SPANDATA.GEN_AI_OPERATION_NAME] == "chat"
 
     assert SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS in span["attributes"]

--- a/tests/integrations/anthropic/test_anthropic.py
+++ b/tests/integrations/anthropic/test_anthropic.py
@@ -95,7 +95,7 @@ DATA_COLLECTION_EXAMPLE_TOOLS = [
 ]
 
 DATA_COLLECTION_EXPECTED_INPUT_DATA = {
-    SPANDATA.GEN_AI_PROVIDER_NAME_INSTRUCTIONS: [
+    SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS: [
         {"type": "text", "content": "You are a helpful assistant."}
     ],
     SPANDATA.GEN_AI_REQUEST_MESSAGES: [{"role": "user", "content": "Hello, Claude"}],
@@ -189,7 +189,7 @@ def test_nonstreaming_create_message(
 
     assert span["attributes"]["sentry.op"] == OP.GEN_AI_CHAT
     assert span["name"] == "chat model"
-    assert span["attributes"][SPANDATA.GEN_AI_PROVIDER_NAME] == "anthropic"
+    assert span["attributes"][SPANDATA.GEN_AI_SYSTEM] == "anthropic"
     assert span["attributes"][SPANDATA.GEN_AI_OPERATION_NAME] == "chat"
     assert span["attributes"][SPANDATA.GEN_AI_REQUEST_MODEL] == "model"
 
@@ -295,7 +295,7 @@ def test_nonstreaming_create_message_data_collection(
     (span,) = [s for s in spans if s["attributes"]["sentry.op"] == OP.GEN_AI_CHAT]
     span_data = span["attributes"]
 
-    assert span_data[SPANDATA.GEN_AI_PROVIDER_NAME] == "anthropic"
+    assert span_data[SPANDATA.GEN_AI_SYSTEM] == "anthropic"
     assert span_data[SPANDATA.GEN_AI_OPERATION_NAME] == "chat"
     assert span_data[SPANDATA.GEN_AI_REQUEST_MODEL] == "model"
     assert span_data[SPANDATA.GEN_AI_REQUEST_MAX_TOKENS] == 1024
@@ -443,7 +443,7 @@ async def test_nonstreaming_create_message_data_collection_async(
     (span,) = [s for s in spans if s["attributes"]["sentry.op"] == OP.GEN_AI_CHAT]
     span_data = span["attributes"]
 
-    assert span_data[SPANDATA.GEN_AI_PROVIDER_NAME] == "anthropic"
+    assert span_data[SPANDATA.GEN_AI_SYSTEM] == "anthropic"
     assert span_data[SPANDATA.GEN_AI_OPERATION_NAME] == "chat"
     assert span_data[SPANDATA.GEN_AI_REQUEST_MODEL] == "model"
     assert span_data[SPANDATA.GEN_AI_REQUEST_MAX_TOKENS] == 1024
@@ -731,7 +731,7 @@ async def test_nonstreaming_create_message_async(
 
     assert span["attributes"]["sentry.op"] == OP.GEN_AI_CHAT
     assert span["name"] == "chat model"
-    assert span["attributes"][SPANDATA.GEN_AI_PROVIDER_NAME] == "anthropic"
+    assert span["attributes"][SPANDATA.GEN_AI_SYSTEM] == "anthropic"
     assert span["attributes"][SPANDATA.GEN_AI_OPERATION_NAME] == "chat"
     assert span["attributes"][SPANDATA.GEN_AI_REQUEST_MODEL] == "model"
 
@@ -857,7 +857,7 @@ def test_streaming_create_message(
 
     assert span["attributes"]["sentry.op"] == OP.GEN_AI_CHAT
     assert span["name"] == "chat model"
-    assert span["attributes"][SPANDATA.GEN_AI_PROVIDER_NAME] == "anthropic"
+    assert span["attributes"][SPANDATA.GEN_AI_SYSTEM] == "anthropic"
     assert span["attributes"][SPANDATA.GEN_AI_OPERATION_NAME] == "chat"
     assert span["attributes"][SPANDATA.GEN_AI_REQUEST_MODEL] == "model"
 
@@ -992,7 +992,7 @@ def test_streaming_create_message_data_collection(
     (span,) = [s for s in spans if s["attributes"]["sentry.op"] == OP.GEN_AI_CHAT]
     span_data = span["attributes"]
 
-    assert span_data[SPANDATA.GEN_AI_PROVIDER_NAME] == "anthropic"
+    assert span_data[SPANDATA.GEN_AI_SYSTEM] == "anthropic"
     assert span_data[SPANDATA.GEN_AI_OPERATION_NAME] == "chat"
     assert span_data[SPANDATA.GEN_AI_REQUEST_MODEL] == "model"
     assert span_data[SPANDATA.GEN_AI_REQUEST_MAX_TOKENS] == 1024
@@ -1218,7 +1218,7 @@ def test_streaming_create_message_close(
 
     assert span["attributes"]["sentry.op"] == OP.GEN_AI_CHAT
     assert span["name"] == "chat model"
-    assert span["attributes"][SPANDATA.GEN_AI_PROVIDER_NAME] == "anthropic"
+    assert span["attributes"][SPANDATA.GEN_AI_SYSTEM] == "anthropic"
     assert span["attributes"][SPANDATA.GEN_AI_OPERATION_NAME] == "chat"
     assert span["attributes"][SPANDATA.GEN_AI_REQUEST_MODEL] == "model"
 
@@ -1318,7 +1318,7 @@ def test_streaming_create_message_api_error(
 
     assert span["attributes"]["sentry.op"] == OP.GEN_AI_CHAT
     assert span["name"] == "chat model"
-    assert span["attributes"][SPANDATA.GEN_AI_PROVIDER_NAME] == "anthropic"
+    assert span["attributes"][SPANDATA.GEN_AI_SYSTEM] == "anthropic"
     assert span["attributes"][SPANDATA.GEN_AI_OPERATION_NAME] == "chat"
     assert span["attributes"][SPANDATA.GEN_AI_REQUEST_MODEL] == "model"
 
@@ -1436,7 +1436,7 @@ def test_stream_messages(
 
     assert span["attributes"]["sentry.op"] == OP.GEN_AI_CHAT
     assert span["name"] == "chat model"
-    assert span["attributes"][SPANDATA.GEN_AI_PROVIDER_NAME] == "anthropic"
+    assert span["attributes"][SPANDATA.GEN_AI_SYSTEM] == "anthropic"
     assert span["attributes"][SPANDATA.GEN_AI_OPERATION_NAME] == "chat"
     assert span["attributes"][SPANDATA.GEN_AI_REQUEST_MODEL] == "model"
 
@@ -1683,7 +1683,7 @@ def test_stream_messages_close(
 
     assert span["attributes"]["sentry.op"] == OP.GEN_AI_CHAT
     assert span["name"] == "chat model"
-    assert span["attributes"][SPANDATA.GEN_AI_PROVIDER_NAME] == "anthropic"
+    assert span["attributes"][SPANDATA.GEN_AI_SYSTEM] == "anthropic"
     assert span["attributes"][SPANDATA.GEN_AI_OPERATION_NAME] == "chat"
     assert span["attributes"][SPANDATA.GEN_AI_REQUEST_MODEL] == "model"
 
@@ -1783,7 +1783,7 @@ def test_stream_messages_api_error(
 
     assert span["attributes"]["sentry.op"] == OP.GEN_AI_CHAT
     assert span["name"] == "chat model"
-    assert span["attributes"][SPANDATA.GEN_AI_PROVIDER_NAME] == "anthropic"
+    assert span["attributes"][SPANDATA.GEN_AI_SYSTEM] == "anthropic"
     assert span["attributes"][SPANDATA.GEN_AI_OPERATION_NAME] == "chat"
     assert span["attributes"][SPANDATA.GEN_AI_REQUEST_MODEL] == "model"
 
@@ -1906,7 +1906,7 @@ async def test_streaming_create_message_async(
 
     assert span["attributes"]["sentry.op"] == OP.GEN_AI_CHAT
     assert span["name"] == "chat model"
-    assert span["attributes"][SPANDATA.GEN_AI_PROVIDER_NAME] == "anthropic"
+    assert span["attributes"][SPANDATA.GEN_AI_SYSTEM] == "anthropic"
     assert span["attributes"][SPANDATA.GEN_AI_OPERATION_NAME] == "chat"
     assert span["attributes"][SPANDATA.GEN_AI_REQUEST_MODEL] == "model"
 
@@ -2158,7 +2158,7 @@ async def test_streaming_create_message_async_close(
 
     assert span["attributes"]["sentry.op"] == OP.GEN_AI_CHAT
     assert span["name"] == "chat model"
-    assert span["attributes"][SPANDATA.GEN_AI_PROVIDER_NAME] == "anthropic"
+    assert span["attributes"][SPANDATA.GEN_AI_SYSTEM] == "anthropic"
     assert span["attributes"][SPANDATA.GEN_AI_OPERATION_NAME] == "chat"
     assert span["attributes"][SPANDATA.GEN_AI_REQUEST_MODEL] == "model"
 
@@ -2262,7 +2262,7 @@ async def test_streaming_create_message_async_api_error(
 
     assert span["attributes"]["sentry.op"] == OP.GEN_AI_CHAT
     assert span["name"] == "chat model"
-    assert span["attributes"][SPANDATA.GEN_AI_PROVIDER_NAME] == "anthropic"
+    assert span["attributes"][SPANDATA.GEN_AI_SYSTEM] == "anthropic"
     assert span["attributes"][SPANDATA.GEN_AI_OPERATION_NAME] == "chat"
     assert span["attributes"][SPANDATA.GEN_AI_REQUEST_MODEL] == "model"
 
@@ -2385,7 +2385,7 @@ async def test_stream_message_async(
 
     assert span["attributes"]["sentry.op"] == OP.GEN_AI_CHAT
     assert span["name"] == "chat model"
-    assert span["attributes"][SPANDATA.GEN_AI_PROVIDER_NAME] == "anthropic"
+    assert span["attributes"][SPANDATA.GEN_AI_SYSTEM] == "anthropic"
     assert span["attributes"][SPANDATA.GEN_AI_OPERATION_NAME] == "chat"
     assert span["attributes"][SPANDATA.GEN_AI_REQUEST_MODEL] == "model"
 
@@ -2634,7 +2634,7 @@ async def test_stream_messages_async_api_error(
 
     assert span["attributes"]["sentry.op"] == OP.GEN_AI_CHAT
     assert span["name"] == "chat model"
-    assert span["attributes"][SPANDATA.GEN_AI_PROVIDER_NAME] == "anthropic"
+    assert span["attributes"][SPANDATA.GEN_AI_SYSTEM] == "anthropic"
     assert span["attributes"][SPANDATA.GEN_AI_OPERATION_NAME] == "chat"
     assert span["attributes"][SPANDATA.GEN_AI_REQUEST_MODEL] == "model"
 
@@ -2750,7 +2750,7 @@ async def test_stream_messages_async_close(
 
     assert span["attributes"]["sentry.op"] == OP.GEN_AI_CHAT
     assert span["name"] == "chat model"
-    assert span["attributes"][SPANDATA.GEN_AI_PROVIDER_NAME] == "anthropic"
+    assert span["attributes"][SPANDATA.GEN_AI_SYSTEM] == "anthropic"
     assert span["attributes"][SPANDATA.GEN_AI_OPERATION_NAME] == "chat"
     assert span["attributes"][SPANDATA.GEN_AI_REQUEST_MODEL] == "model"
 
@@ -2896,7 +2896,7 @@ def test_streaming_create_message_with_input_json_delta(
 
     assert span["attributes"]["sentry.op"] == OP.GEN_AI_CHAT
     assert span["name"] == "chat model"
-    assert span["attributes"][SPANDATA.GEN_AI_PROVIDER_NAME] == "anthropic"
+    assert span["attributes"][SPANDATA.GEN_AI_SYSTEM] == "anthropic"
     assert span["attributes"][SPANDATA.GEN_AI_OPERATION_NAME] == "chat"
     assert span["attributes"][SPANDATA.GEN_AI_REQUEST_MODEL] == "model"
 
@@ -3045,7 +3045,7 @@ def test_stream_messages_with_input_json_delta(
 
     assert span["attributes"]["sentry.op"] == OP.GEN_AI_CHAT
     assert span["name"] == "chat model"
-    assert span["attributes"][SPANDATA.GEN_AI_PROVIDER_NAME] == "anthropic"
+    assert span["attributes"][SPANDATA.GEN_AI_SYSTEM] == "anthropic"
     assert span["attributes"][SPANDATA.GEN_AI_OPERATION_NAME] == "chat"
     assert span["attributes"][SPANDATA.GEN_AI_REQUEST_MODEL] == "model"
 
@@ -3201,7 +3201,7 @@ async def test_streaming_create_message_with_input_json_delta_async(
 
     assert span["attributes"]["sentry.op"] == OP.GEN_AI_CHAT
     assert span["name"] == "chat model"
-    assert span["attributes"][SPANDATA.GEN_AI_PROVIDER_NAME] == "anthropic"
+    assert span["attributes"][SPANDATA.GEN_AI_SYSTEM] == "anthropic"
     assert span["attributes"][SPANDATA.GEN_AI_OPERATION_NAME] == "chat"
     assert span["attributes"][SPANDATA.GEN_AI_REQUEST_MODEL] == "model"
 
@@ -3359,7 +3359,7 @@ async def test_stream_message_with_input_json_delta_async(
 
     assert span["attributes"]["sentry.op"] == OP.GEN_AI_CHAT
     assert span["name"] == "chat model"
-    assert span["attributes"][SPANDATA.GEN_AI_PROVIDER_NAME] == "anthropic"
+    assert span["attributes"][SPANDATA.GEN_AI_SYSTEM] == "anthropic"
     assert span["attributes"][SPANDATA.GEN_AI_OPERATION_NAME] == "chat"
     assert span["attributes"][SPANDATA.GEN_AI_REQUEST_MODEL] == "model"
 
@@ -3439,7 +3439,7 @@ def test_span_status_error(
     sentry_sdk.flush()
     spans = [item.payload for item in items if item.type == "span"]
     assert spans[0]["status"] == "error"
-    assert spans[0]["attributes"][SPANDATA.GEN_AI_PROVIDER_NAME] == "anthropic"
+    assert spans[0]["attributes"][SPANDATA.GEN_AI_SYSTEM] == "anthropic"
     assert spans[0]["attributes"][SPANDATA.GEN_AI_OPERATION_NAME] == "chat"
 
 
@@ -3473,7 +3473,7 @@ async def test_span_status_error_async(
     sentry_sdk.flush()
     spans = [item.payload for item in items if item.type == "span"]
     assert spans[0]["status"] == "error"
-    assert spans[0]["attributes"][SPANDATA.GEN_AI_PROVIDER_NAME] == "anthropic"
+    assert spans[0]["attributes"][SPANDATA.GEN_AI_SYSTEM] == "anthropic"
     assert spans[0]["attributes"][SPANDATA.GEN_AI_OPERATION_NAME] == "chat"
 
 
@@ -3533,7 +3533,7 @@ def test_span_origin(
     sentry_sdk.flush()
     spans = [item.payload for item in items]
     assert spans[0]["attributes"]["sentry.origin"] == "auto.ai.anthropic"
-    assert spans[0]["attributes"][SPANDATA.GEN_AI_PROVIDER_NAME] == "anthropic"
+    assert spans[0]["attributes"][SPANDATA.GEN_AI_SYSTEM] == "anthropic"
     assert spans[0]["attributes"][SPANDATA.GEN_AI_OPERATION_NAME] == "chat"
 
 
@@ -3565,7 +3565,7 @@ async def test_span_origin_async(
     sentry_sdk.flush()
     spans = [item.payload for item in items]
     assert spans[0]["attributes"]["sentry.origin"] == "auto.ai.anthropic"
-    assert spans[0]["attributes"][SPANDATA.GEN_AI_PROVIDER_NAME] == "anthropic"
+    assert spans[0]["attributes"][SPANDATA.GEN_AI_SYSTEM] == "anthropic"
     assert spans[0]["attributes"][SPANDATA.GEN_AI_OPERATION_NAME] == "chat"
 
 
@@ -3691,7 +3691,7 @@ def test_anthropic_message_role_mapping(
 
     # Verify that the span was created correctly
     assert span["attributes"]["sentry.op"] == "gen_ai.chat"
-    assert span["attributes"][SPANDATA.GEN_AI_PROVIDER_NAME] == "anthropic"
+    assert span["attributes"][SPANDATA.GEN_AI_SYSTEM] == "anthropic"
     assert span["attributes"][SPANDATA.GEN_AI_OPERATION_NAME] == "chat"
     assert SPANDATA.GEN_AI_REQUEST_MESSAGES in span["attributes"]
 
@@ -3757,14 +3757,14 @@ def test_nonstreaming_create_message_with_system_prompt(
 
     assert span["attributes"]["sentry.op"] == OP.GEN_AI_CHAT
     assert span["name"] == "chat model"
-    assert span["attributes"][SPANDATA.GEN_AI_PROVIDER_NAME] == "anthropic"
+    assert span["attributes"][SPANDATA.GEN_AI_SYSTEM] == "anthropic"
     assert span["attributes"][SPANDATA.GEN_AI_OPERATION_NAME] == "chat"
     assert span["attributes"][SPANDATA.GEN_AI_REQUEST_MODEL] == "model"
 
     if send_default_pii and include_prompts:
-        assert SPANDATA.GEN_AI_PROVIDER_NAME_INSTRUCTIONS in span["attributes"]
+        assert SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS in span["attributes"]
         system_instructions = json.loads(
-            span["attributes"][SPANDATA.GEN_AI_PROVIDER_NAME_INSTRUCTIONS]
+            span["attributes"][SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS]
         )
         assert system_instructions == [
             {"type": "text", "content": "You are a helpful assistant."}
@@ -3779,7 +3779,7 @@ def test_nonstreaming_create_message_with_system_prompt(
         assert stored_messages[0]["content"] == "Hello, Claude"
         assert span["attributes"][SPANDATA.GEN_AI_RESPONSE_TEXT] == "Hi, I'm Claude."
     else:
-        assert SPANDATA.GEN_AI_PROVIDER_NAME_INSTRUCTIONS not in span["attributes"]
+        assert SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS not in span["attributes"]
         assert SPANDATA.GEN_AI_REQUEST_MESSAGES not in span["attributes"]
         assert SPANDATA.GEN_AI_RESPONSE_TEXT not in span["attributes"]
 
@@ -3847,14 +3847,14 @@ async def test_nonstreaming_create_message_with_system_prompt_async(
 
     assert span["attributes"]["sentry.op"] == OP.GEN_AI_CHAT
     assert span["name"] == "chat model"
-    assert span["attributes"][SPANDATA.GEN_AI_PROVIDER_NAME] == "anthropic"
+    assert span["attributes"][SPANDATA.GEN_AI_SYSTEM] == "anthropic"
     assert span["attributes"][SPANDATA.GEN_AI_OPERATION_NAME] == "chat"
     assert span["attributes"][SPANDATA.GEN_AI_REQUEST_MODEL] == "model"
 
     if send_default_pii and include_prompts:
-        assert SPANDATA.GEN_AI_PROVIDER_NAME_INSTRUCTIONS in span["attributes"]
+        assert SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS in span["attributes"]
         system_instructions = json.loads(
-            span["attributes"][SPANDATA.GEN_AI_PROVIDER_NAME_INSTRUCTIONS]
+            span["attributes"][SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS]
         )
         assert system_instructions == [
             {"type": "text", "content": "You are a helpful assistant."}
@@ -3869,7 +3869,7 @@ async def test_nonstreaming_create_message_with_system_prompt_async(
         assert stored_messages[0]["content"] == "Hello, Claude"
         assert span["attributes"][SPANDATA.GEN_AI_RESPONSE_TEXT] == "Hi, I'm Claude."
     else:
-        assert SPANDATA.GEN_AI_PROVIDER_NAME_INSTRUCTIONS not in span["attributes"]
+        assert SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS not in span["attributes"]
         assert SPANDATA.GEN_AI_REQUEST_MESSAGES not in span["attributes"]
         assert SPANDATA.GEN_AI_RESPONSE_TEXT not in span["attributes"]
 
@@ -3977,14 +3977,14 @@ def test_streaming_create_message_with_system_prompt(
 
     assert span["attributes"]["sentry.op"] == OP.GEN_AI_CHAT
     assert span["name"] == "chat model"
-    assert span["attributes"][SPANDATA.GEN_AI_PROVIDER_NAME] == "anthropic"
+    assert span["attributes"][SPANDATA.GEN_AI_SYSTEM] == "anthropic"
     assert span["attributes"][SPANDATA.GEN_AI_OPERATION_NAME] == "chat"
     assert span["attributes"][SPANDATA.GEN_AI_REQUEST_MODEL] == "model"
 
     if send_default_pii and include_prompts:
-        assert SPANDATA.GEN_AI_PROVIDER_NAME_INSTRUCTIONS in span["attributes"]
+        assert SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS in span["attributes"]
         system_instructions = json.loads(
-            span["attributes"][SPANDATA.GEN_AI_PROVIDER_NAME_INSTRUCTIONS]
+            span["attributes"][SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS]
         )
         assert system_instructions == [
             {"type": "text", "content": "You are a helpful assistant."}
@@ -4000,7 +4000,7 @@ def test_streaming_create_message_with_system_prompt(
         assert span["attributes"][SPANDATA.GEN_AI_RESPONSE_TEXT] == "Hi! I'm Claude!"
 
     else:
-        assert SPANDATA.GEN_AI_PROVIDER_NAME_INSTRUCTIONS not in span["attributes"]
+        assert SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS not in span["attributes"]
         assert SPANDATA.GEN_AI_REQUEST_MESSAGES not in span["attributes"]
         assert SPANDATA.GEN_AI_RESPONSE_TEXT not in span["attributes"]
 
@@ -4104,14 +4104,14 @@ def test_stream_messages_with_system_prompt(
 
     assert span["attributes"]["sentry.op"] == OP.GEN_AI_CHAT
     assert span["name"] == "chat model"
-    assert span["attributes"][SPANDATA.GEN_AI_PROVIDER_NAME] == "anthropic"
+    assert span["attributes"][SPANDATA.GEN_AI_SYSTEM] == "anthropic"
     assert span["attributes"][SPANDATA.GEN_AI_OPERATION_NAME] == "chat"
     assert span["attributes"][SPANDATA.GEN_AI_REQUEST_MODEL] == "model"
 
     if send_default_pii and include_prompts:
-        assert SPANDATA.GEN_AI_PROVIDER_NAME_INSTRUCTIONS in span["attributes"]
+        assert SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS in span["attributes"]
         system_instructions = json.loads(
-            span["attributes"][SPANDATA.GEN_AI_PROVIDER_NAME_INSTRUCTIONS]
+            span["attributes"][SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS]
         )
         assert system_instructions == [
             {"type": "text", "content": "You are a helpful assistant."}
@@ -4125,7 +4125,7 @@ def test_stream_messages_with_system_prompt(
         assert stored_messages[0]["content"] == "Hello, Claude"
         assert span["attributes"][SPANDATA.GEN_AI_RESPONSE_TEXT] == "Hi! I'm Claude!"
     else:
-        assert SPANDATA.GEN_AI_PROVIDER_NAME_INSTRUCTIONS not in span["attributes"]
+        assert SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS not in span["attributes"]
         assert SPANDATA.GEN_AI_REQUEST_MESSAGES not in span["attributes"]
         assert SPANDATA.GEN_AI_RESPONSE_TEXT not in span["attributes"]
 
@@ -4234,14 +4234,14 @@ async def test_stream_message_with_system_prompt_async(
 
     assert span["attributes"]["sentry.op"] == OP.GEN_AI_CHAT
     assert span["name"] == "chat model"
-    assert span["attributes"][SPANDATA.GEN_AI_PROVIDER_NAME] == "anthropic"
+    assert span["attributes"][SPANDATA.GEN_AI_SYSTEM] == "anthropic"
     assert span["attributes"][SPANDATA.GEN_AI_OPERATION_NAME] == "chat"
     assert span["attributes"][SPANDATA.GEN_AI_REQUEST_MODEL] == "model"
 
     if send_default_pii and include_prompts:
-        assert SPANDATA.GEN_AI_PROVIDER_NAME_INSTRUCTIONS in span["attributes"]
+        assert SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS in span["attributes"]
         system_instructions = json.loads(
-            span["attributes"][SPANDATA.GEN_AI_PROVIDER_NAME_INSTRUCTIONS]
+            span["attributes"][SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS]
         )
         assert system_instructions == [
             {"type": "text", "content": "You are a helpful assistant."}
@@ -4256,7 +4256,7 @@ async def test_stream_message_with_system_prompt_async(
         assert stored_messages[0]["content"] == "Hello, Claude"
         assert span["attributes"][SPANDATA.GEN_AI_RESPONSE_TEXT] == "Hi! I'm Claude!"
     else:
-        assert SPANDATA.GEN_AI_PROVIDER_NAME_INSTRUCTIONS not in span["attributes"]
+        assert SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS not in span["attributes"]
         assert SPANDATA.GEN_AI_REQUEST_MESSAGES not in span["attributes"]
         assert SPANDATA.GEN_AI_RESPONSE_TEXT not in span["attributes"]
 
@@ -4367,14 +4367,14 @@ async def test_streaming_create_message_with_system_prompt_async(
 
     assert span["attributes"]["sentry.op"] == OP.GEN_AI_CHAT
     assert span["name"] == "chat model"
-    assert span["attributes"][SPANDATA.GEN_AI_PROVIDER_NAME] == "anthropic"
+    assert span["attributes"][SPANDATA.GEN_AI_SYSTEM] == "anthropic"
     assert span["attributes"][SPANDATA.GEN_AI_OPERATION_NAME] == "chat"
     assert span["attributes"][SPANDATA.GEN_AI_REQUEST_MODEL] == "model"
 
     if send_default_pii and include_prompts:
-        assert SPANDATA.GEN_AI_PROVIDER_NAME_INSTRUCTIONS in span["attributes"]
+        assert SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS in span["attributes"]
         system_instructions = json.loads(
-            span["attributes"][SPANDATA.GEN_AI_PROVIDER_NAME_INSTRUCTIONS]
+            span["attributes"][SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS]
         )
         assert system_instructions == [
             {"type": "text", "content": "You are a helpful assistant."}
@@ -4391,7 +4391,7 @@ async def test_streaming_create_message_with_system_prompt_async(
         assert span["attributes"][SPANDATA.GEN_AI_RESPONSE_TEXT] == "Hi! I'm Claude!"
 
     else:
-        assert SPANDATA.GEN_AI_PROVIDER_NAME_INSTRUCTIONS not in span["attributes"]
+        assert SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS not in span["attributes"]
         assert SPANDATA.GEN_AI_REQUEST_MESSAGES not in span["attributes"]
         assert SPANDATA.GEN_AI_RESPONSE_TEXT not in span["attributes"]
 
@@ -4442,12 +4442,12 @@ def test_system_prompt_with_complex_structure(
 
     (span,) = spans
 
-    assert span["attributes"][SPANDATA.GEN_AI_PROVIDER_NAME] == "anthropic"
+    assert span["attributes"][SPANDATA.GEN_AI_SYSTEM] == "anthropic"
     assert span["attributes"][SPANDATA.GEN_AI_OPERATION_NAME] == "chat"
 
-    assert SPANDATA.GEN_AI_PROVIDER_NAME_INSTRUCTIONS in span["attributes"]
+    assert SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS in span["attributes"]
     system_instructions = json.loads(
-        span["attributes"][SPANDATA.GEN_AI_PROVIDER_NAME_INSTRUCTIONS]
+        span["attributes"][SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS]
     )
 
     # System content should be a list of text blocks

--- a/tests/integrations/google_genai/test_google_genai.py
+++ b/tests/integrations/google_genai/test_google_genai.py
@@ -165,7 +165,7 @@ def test_nonstreaming_generate_content(
     assert chat_span["attributes"]["sentry.op"] == OP.GEN_AI_CHAT
     assert chat_span["name"] == "chat gemini-1.5-flash"
     assert chat_span["attributes"][SPANDATA.GEN_AI_OPERATION_NAME] == "chat"
-    assert chat_span["attributes"][SPANDATA.GEN_AI_SYSTEM] == "gcp.gemini"
+    assert chat_span["attributes"][SPANDATA.GEN_AI_PROVIDER_NAME] == "gcp.gemini"
     assert chat_span["attributes"][SPANDATA.GEN_AI_REQUEST_MODEL] == "gemini-1.5-flash"
 
     if send_default_pii and include_prompts:
@@ -1075,7 +1075,7 @@ def test_embed_content(
     assert embed_span["attributes"]["sentry.op"] == OP.GEN_AI_EMBEDDINGS
     assert embed_span["name"] == "embeddings text-embedding-004"
     assert embed_span["attributes"][SPANDATA.GEN_AI_OPERATION_NAME] == "embeddings"
-    assert embed_span["attributes"][SPANDATA.GEN_AI_SYSTEM] == "gcp.gemini"
+    assert embed_span["attributes"][SPANDATA.GEN_AI_PROVIDER_NAME] == "gcp.gemini"
     assert (
         embed_span["attributes"][SPANDATA.GEN_AI_REQUEST_MODEL] == "text-embedding-004"
     )
@@ -1307,7 +1307,7 @@ async def test_async_embed_content(
     assert embed_span["attributes"]["sentry.op"] == OP.GEN_AI_EMBEDDINGS
     assert embed_span["name"] == "embeddings text-embedding-004"
     assert embed_span["attributes"][SPANDATA.GEN_AI_OPERATION_NAME] == "embeddings"
-    assert embed_span["attributes"][SPANDATA.GEN_AI_SYSTEM] == "gcp.gemini"
+    assert embed_span["attributes"][SPANDATA.GEN_AI_PROVIDER_NAME] == "gcp.gemini"
     assert (
         embed_span["attributes"][SPANDATA.GEN_AI_REQUEST_MODEL] == "text-embedding-004"
     )
@@ -2488,7 +2488,7 @@ def test_generate_content_data_collection(
         assert key not in span_data, f"{key} should not have been collected"
 
     # Data collection never gates non-PII attributes
-    assert span_data[SPANDATA.GEN_AI_SYSTEM] == "gcp.gemini"
+    assert span_data[SPANDATA.GEN_AI_PROVIDER_NAME] == "gcp.gemini"
     assert span_data[SPANDATA.GEN_AI_REQUEST_MODEL] == "gemini-1.5-flash"
     assert span_data[SPANDATA.GEN_AI_REQUEST_TEMPERATURE] == 0.7
     assert span_data[SPANDATA.GEN_AI_REQUEST_MAX_TOKENS] == 100

--- a/tests/integrations/google_genai/test_google_genai.py
+++ b/tests/integrations/google_genai/test_google_genai.py
@@ -165,7 +165,7 @@ def test_nonstreaming_generate_content(
     assert chat_span["attributes"]["sentry.op"] == OP.GEN_AI_CHAT
     assert chat_span["name"] == "chat gemini-1.5-flash"
     assert chat_span["attributes"][SPANDATA.GEN_AI_OPERATION_NAME] == "chat"
-    assert chat_span["attributes"][SPANDATA.GEN_AI_PROVIDER_NAME] == "gcp.gemini"
+    assert chat_span["attributes"][SPANDATA.GEN_AI_SYSTEM] == "gcp.gemini"
     assert chat_span["attributes"][SPANDATA.GEN_AI_REQUEST_MODEL] == "gemini-1.5-flash"
 
     if send_default_pii and include_prompts:
@@ -272,14 +272,12 @@ def test_generate_content_with_system_instruction(
     invoke_span = next(item.payload for item in items)
 
     if expected_texts is None:
-        assert (
-            SPANDATA.GEN_AI_PROVIDER_NAME_INSTRUCTIONS not in invoke_span["attributes"]
-        )
+        assert SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS not in invoke_span["attributes"]
         return
 
     # (PII is enabled and include_prompts is True in this test)
     system_instructions = json.loads(
-        invoke_span["attributes"][SPANDATA.GEN_AI_PROVIDER_NAME_INSTRUCTIONS]
+        invoke_span["attributes"][SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS]
     )
 
     assert system_instructions == [
@@ -1077,7 +1075,7 @@ def test_embed_content(
     assert embed_span["attributes"]["sentry.op"] == OP.GEN_AI_EMBEDDINGS
     assert embed_span["name"] == "embeddings text-embedding-004"
     assert embed_span["attributes"][SPANDATA.GEN_AI_OPERATION_NAME] == "embeddings"
-    assert embed_span["attributes"][SPANDATA.GEN_AI_PROVIDER_NAME] == "gcp.gemini"
+    assert embed_span["attributes"][SPANDATA.GEN_AI_SYSTEM] == "gcp.gemini"
     assert (
         embed_span["attributes"][SPANDATA.GEN_AI_REQUEST_MODEL] == "text-embedding-004"
     )
@@ -1309,7 +1307,7 @@ async def test_async_embed_content(
     assert embed_span["attributes"]["sentry.op"] == OP.GEN_AI_EMBEDDINGS
     assert embed_span["name"] == "embeddings text-embedding-004"
     assert embed_span["attributes"][SPANDATA.GEN_AI_OPERATION_NAME] == "embeddings"
-    assert embed_span["attributes"][SPANDATA.GEN_AI_PROVIDER_NAME] == "gcp.gemini"
+    assert embed_span["attributes"][SPANDATA.GEN_AI_SYSTEM] == "gcp.gemini"
     assert (
         embed_span["attributes"][SPANDATA.GEN_AI_REQUEST_MODEL] == "text-embedding-004"
     )
@@ -2335,7 +2333,7 @@ def test_extract_contents_messages_object_with_text_attribute():
 
 DATA_COLLECTION_CHAT_EXPECTED_VALUES = {
     SPANDATA.GEN_AI_REQUEST_MESSAGES: [{"role": "user", "content": "Tell me a joke"}],
-    SPANDATA.GEN_AI_PROVIDER_NAME_INSTRUCTIONS: [
+    SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS: [
         {"type": "text", "content": "You are a helpful assistant."}
     ],
     SPANDATA.GEN_AI_RESPONSE_TEXT: ["Hello! How can I help you today?"],
@@ -2358,7 +2356,7 @@ DATA_COLLECTION_EMBED_EXPECTED_VALUES = {
             False,
             [
                 SPANDATA.GEN_AI_REQUEST_MESSAGES,
-                SPANDATA.GEN_AI_PROVIDER_NAME_INSTRUCTIONS,
+                SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS,
                 SPANDATA.GEN_AI_RESPONSE_TEXT,
             ],
             [],
@@ -2371,7 +2369,7 @@ DATA_COLLECTION_EMBED_EXPECTED_VALUES = {
             [],
             [
                 SPANDATA.GEN_AI_REQUEST_MESSAGES,
-                SPANDATA.GEN_AI_PROVIDER_NAME_INSTRUCTIONS,
+                SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS,
                 SPANDATA.GEN_AI_RESPONSE_TEXT,
             ],
             id="gen-ai-inputs-and-outputs-disabled-override-legacy-on",
@@ -2382,7 +2380,7 @@ DATA_COLLECTION_EMBED_EXPECTED_VALUES = {
             False,
             [
                 SPANDATA.GEN_AI_REQUEST_MESSAGES,
-                SPANDATA.GEN_AI_PROVIDER_NAME_INSTRUCTIONS,
+                SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS,
             ],
             [
                 SPANDATA.GEN_AI_RESPONSE_TEXT,
@@ -2398,7 +2396,7 @@ DATA_COLLECTION_EMBED_EXPECTED_VALUES = {
             ],
             [
                 SPANDATA.GEN_AI_REQUEST_MESSAGES,
-                SPANDATA.GEN_AI_PROVIDER_NAME_INSTRUCTIONS,
+                SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS,
             ],
             id="gen-ai-outputs-enabled-inputs-disabled",
         ),
@@ -2408,7 +2406,7 @@ DATA_COLLECTION_EMBED_EXPECTED_VALUES = {
             False,
             [
                 SPANDATA.GEN_AI_REQUEST_MESSAGES,
-                SPANDATA.GEN_AI_PROVIDER_NAME_INSTRUCTIONS,
+                SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS,
                 SPANDATA.GEN_AI_RESPONSE_TEXT,
             ],
             [],
@@ -2420,7 +2418,7 @@ DATA_COLLECTION_EMBED_EXPECTED_VALUES = {
             True,
             [
                 SPANDATA.GEN_AI_REQUEST_MESSAGES,
-                SPANDATA.GEN_AI_PROVIDER_NAME_INSTRUCTIONS,
+                SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS,
                 SPANDATA.GEN_AI_RESPONSE_TEXT,
             ],
             [],
@@ -2433,7 +2431,7 @@ DATA_COLLECTION_EMBED_EXPECTED_VALUES = {
             [],
             [
                 SPANDATA.GEN_AI_REQUEST_MESSAGES,
-                SPANDATA.GEN_AI_PROVIDER_NAME_INSTRUCTIONS,
+                SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS,
                 SPANDATA.GEN_AI_RESPONSE_TEXT,
             ],
             id="no-gen-ai-config-legacy-pii-disabled",
@@ -2490,7 +2488,7 @@ def test_generate_content_data_collection(
         assert key not in span_data, f"{key} should not have been collected"
 
     # Data collection never gates non-PII attributes
-    assert span_data[SPANDATA.GEN_AI_PROVIDER_NAME] == "gcp.gemini"
+    assert span_data[SPANDATA.GEN_AI_SYSTEM] == "gcp.gemini"
     assert span_data[SPANDATA.GEN_AI_REQUEST_MODEL] == "gemini-1.5-flash"
     assert span_data[SPANDATA.GEN_AI_REQUEST_TEMPERATURE] == 0.7
     assert span_data[SPANDATA.GEN_AI_REQUEST_MAX_TOKENS] == 100
@@ -2653,7 +2651,7 @@ def test_generate_content_data_collection_tools(
             False,
             [
                 SPANDATA.GEN_AI_REQUEST_MESSAGES,
-                SPANDATA.GEN_AI_PROVIDER_NAME_INSTRUCTIONS,
+                SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS,
                 SPANDATA.GEN_AI_RESPONSE_TEXT,
             ],
             [],
@@ -2666,7 +2664,7 @@ def test_generate_content_data_collection_tools(
             [],
             [
                 SPANDATA.GEN_AI_REQUEST_MESSAGES,
-                SPANDATA.GEN_AI_PROVIDER_NAME_INSTRUCTIONS,
+                SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS,
                 SPANDATA.GEN_AI_RESPONSE_TEXT,
             ],
             id="gen-ai-inputs-and-outputs-disabled-override-legacy-on",
@@ -2677,7 +2675,7 @@ def test_generate_content_data_collection_tools(
             False,
             [
                 SPANDATA.GEN_AI_REQUEST_MESSAGES,
-                SPANDATA.GEN_AI_PROVIDER_NAME_INSTRUCTIONS,
+                SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS,
             ],
             [
                 SPANDATA.GEN_AI_RESPONSE_TEXT,
@@ -2693,7 +2691,7 @@ def test_generate_content_data_collection_tools(
             ],
             [
                 SPANDATA.GEN_AI_REQUEST_MESSAGES,
-                SPANDATA.GEN_AI_PROVIDER_NAME_INSTRUCTIONS,
+                SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS,
             ],
             id="gen-ai-outputs-enabled-inputs-disabled",
         ),
@@ -2703,7 +2701,7 @@ def test_generate_content_data_collection_tools(
             False,
             [
                 SPANDATA.GEN_AI_REQUEST_MESSAGES,
-                SPANDATA.GEN_AI_PROVIDER_NAME_INSTRUCTIONS,
+                SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS,
                 SPANDATA.GEN_AI_RESPONSE_TEXT,
             ],
             [],
@@ -2715,7 +2713,7 @@ def test_generate_content_data_collection_tools(
             True,
             [
                 SPANDATA.GEN_AI_REQUEST_MESSAGES,
-                SPANDATA.GEN_AI_PROVIDER_NAME_INSTRUCTIONS,
+                SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS,
                 SPANDATA.GEN_AI_RESPONSE_TEXT,
             ],
             [],
@@ -2728,7 +2726,7 @@ def test_generate_content_data_collection_tools(
             [],
             [
                 SPANDATA.GEN_AI_REQUEST_MESSAGES,
-                SPANDATA.GEN_AI_PROVIDER_NAME_INSTRUCTIONS,
+                SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS,
                 SPANDATA.GEN_AI_RESPONSE_TEXT,
             ],
             id="no-gen-ai-config-legacy-pii-disabled",
@@ -3110,7 +3108,7 @@ def test_embed_content_data_collection(
             False,
             [
                 SPANDATA.GEN_AI_REQUEST_MESSAGES,
-                SPANDATA.GEN_AI_PROVIDER_NAME_INSTRUCTIONS,
+                SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS,
                 SPANDATA.GEN_AI_RESPONSE_TEXT,
             ],
             [],
@@ -3123,7 +3121,7 @@ def test_embed_content_data_collection(
             [],
             [
                 SPANDATA.GEN_AI_REQUEST_MESSAGES,
-                SPANDATA.GEN_AI_PROVIDER_NAME_INSTRUCTIONS,
+                SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS,
                 SPANDATA.GEN_AI_RESPONSE_TEXT,
             ],
             id="gen-ai-inputs-and-outputs-disabled-override-legacy-on",
@@ -3134,7 +3132,7 @@ def test_embed_content_data_collection(
             False,
             [
                 SPANDATA.GEN_AI_REQUEST_MESSAGES,
-                SPANDATA.GEN_AI_PROVIDER_NAME_INSTRUCTIONS,
+                SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS,
             ],
             [
                 SPANDATA.GEN_AI_RESPONSE_TEXT,
@@ -3150,7 +3148,7 @@ def test_embed_content_data_collection(
             ],
             [
                 SPANDATA.GEN_AI_REQUEST_MESSAGES,
-                SPANDATA.GEN_AI_PROVIDER_NAME_INSTRUCTIONS,
+                SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS,
             ],
             id="gen-ai-outputs-enabled-inputs-disabled",
         ),
@@ -3160,7 +3158,7 @@ def test_embed_content_data_collection(
             False,
             [
                 SPANDATA.GEN_AI_REQUEST_MESSAGES,
-                SPANDATA.GEN_AI_PROVIDER_NAME_INSTRUCTIONS,
+                SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS,
                 SPANDATA.GEN_AI_RESPONSE_TEXT,
             ],
             [],
@@ -3172,7 +3170,7 @@ def test_embed_content_data_collection(
             True,
             [
                 SPANDATA.GEN_AI_REQUEST_MESSAGES,
-                SPANDATA.GEN_AI_PROVIDER_NAME_INSTRUCTIONS,
+                SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS,
                 SPANDATA.GEN_AI_RESPONSE_TEXT,
             ],
             [],
@@ -3185,7 +3183,7 @@ def test_embed_content_data_collection(
             [],
             [
                 SPANDATA.GEN_AI_REQUEST_MESSAGES,
-                SPANDATA.GEN_AI_PROVIDER_NAME_INSTRUCTIONS,
+                SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS,
                 SPANDATA.GEN_AI_RESPONSE_TEXT,
             ],
             id="no-gen-ai-config-legacy-pii-disabled",

--- a/tests/integrations/google_genai/test_google_genai.py
+++ b/tests/integrations/google_genai/test_google_genai.py
@@ -165,7 +165,7 @@ def test_nonstreaming_generate_content(
     assert chat_span["attributes"]["sentry.op"] == OP.GEN_AI_CHAT
     assert chat_span["name"] == "chat gemini-1.5-flash"
     assert chat_span["attributes"][SPANDATA.GEN_AI_OPERATION_NAME] == "chat"
-    assert chat_span["attributes"][SPANDATA.GEN_AI_SYSTEM] == "gcp.gemini"
+    assert chat_span["attributes"][SPANDATA.GEN_AI_PROVIDER_NAME] == "gcp.gemini"
     assert chat_span["attributes"][SPANDATA.GEN_AI_REQUEST_MODEL] == "gemini-1.5-flash"
 
     if send_default_pii and include_prompts:
@@ -272,12 +272,14 @@ def test_generate_content_with_system_instruction(
     invoke_span = next(item.payload for item in items)
 
     if expected_texts is None:
-        assert SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS not in invoke_span["attributes"]
+        assert (
+            SPANDATA.GEN_AI_PROVIDER_NAME_INSTRUCTIONS not in invoke_span["attributes"]
+        )
         return
 
     # (PII is enabled and include_prompts is True in this test)
     system_instructions = json.loads(
-        invoke_span["attributes"][SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS]
+        invoke_span["attributes"][SPANDATA.GEN_AI_PROVIDER_NAME_INSTRUCTIONS]
     )
 
     assert system_instructions == [
@@ -1075,7 +1077,7 @@ def test_embed_content(
     assert embed_span["attributes"]["sentry.op"] == OP.GEN_AI_EMBEDDINGS
     assert embed_span["name"] == "embeddings text-embedding-004"
     assert embed_span["attributes"][SPANDATA.GEN_AI_OPERATION_NAME] == "embeddings"
-    assert embed_span["attributes"][SPANDATA.GEN_AI_SYSTEM] == "gcp.gemini"
+    assert embed_span["attributes"][SPANDATA.GEN_AI_PROVIDER_NAME] == "gcp.gemini"
     assert (
         embed_span["attributes"][SPANDATA.GEN_AI_REQUEST_MODEL] == "text-embedding-004"
     )
@@ -1307,7 +1309,7 @@ async def test_async_embed_content(
     assert embed_span["attributes"]["sentry.op"] == OP.GEN_AI_EMBEDDINGS
     assert embed_span["name"] == "embeddings text-embedding-004"
     assert embed_span["attributes"][SPANDATA.GEN_AI_OPERATION_NAME] == "embeddings"
-    assert embed_span["attributes"][SPANDATA.GEN_AI_SYSTEM] == "gcp.gemini"
+    assert embed_span["attributes"][SPANDATA.GEN_AI_PROVIDER_NAME] == "gcp.gemini"
     assert (
         embed_span["attributes"][SPANDATA.GEN_AI_REQUEST_MODEL] == "text-embedding-004"
     )
@@ -2333,7 +2335,7 @@ def test_extract_contents_messages_object_with_text_attribute():
 
 DATA_COLLECTION_CHAT_EXPECTED_VALUES = {
     SPANDATA.GEN_AI_REQUEST_MESSAGES: [{"role": "user", "content": "Tell me a joke"}],
-    SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS: [
+    SPANDATA.GEN_AI_PROVIDER_NAME_INSTRUCTIONS: [
         {"type": "text", "content": "You are a helpful assistant."}
     ],
     SPANDATA.GEN_AI_RESPONSE_TEXT: ["Hello! How can I help you today?"],
@@ -2356,7 +2358,7 @@ DATA_COLLECTION_EMBED_EXPECTED_VALUES = {
             False,
             [
                 SPANDATA.GEN_AI_REQUEST_MESSAGES,
-                SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS,
+                SPANDATA.GEN_AI_PROVIDER_NAME_INSTRUCTIONS,
                 SPANDATA.GEN_AI_RESPONSE_TEXT,
             ],
             [],
@@ -2369,7 +2371,7 @@ DATA_COLLECTION_EMBED_EXPECTED_VALUES = {
             [],
             [
                 SPANDATA.GEN_AI_REQUEST_MESSAGES,
-                SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS,
+                SPANDATA.GEN_AI_PROVIDER_NAME_INSTRUCTIONS,
                 SPANDATA.GEN_AI_RESPONSE_TEXT,
             ],
             id="gen-ai-inputs-and-outputs-disabled-override-legacy-on",
@@ -2380,7 +2382,7 @@ DATA_COLLECTION_EMBED_EXPECTED_VALUES = {
             False,
             [
                 SPANDATA.GEN_AI_REQUEST_MESSAGES,
-                SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS,
+                SPANDATA.GEN_AI_PROVIDER_NAME_INSTRUCTIONS,
             ],
             [
                 SPANDATA.GEN_AI_RESPONSE_TEXT,
@@ -2396,7 +2398,7 @@ DATA_COLLECTION_EMBED_EXPECTED_VALUES = {
             ],
             [
                 SPANDATA.GEN_AI_REQUEST_MESSAGES,
-                SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS,
+                SPANDATA.GEN_AI_PROVIDER_NAME_INSTRUCTIONS,
             ],
             id="gen-ai-outputs-enabled-inputs-disabled",
         ),
@@ -2406,7 +2408,7 @@ DATA_COLLECTION_EMBED_EXPECTED_VALUES = {
             False,
             [
                 SPANDATA.GEN_AI_REQUEST_MESSAGES,
-                SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS,
+                SPANDATA.GEN_AI_PROVIDER_NAME_INSTRUCTIONS,
                 SPANDATA.GEN_AI_RESPONSE_TEXT,
             ],
             [],
@@ -2418,7 +2420,7 @@ DATA_COLLECTION_EMBED_EXPECTED_VALUES = {
             True,
             [
                 SPANDATA.GEN_AI_REQUEST_MESSAGES,
-                SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS,
+                SPANDATA.GEN_AI_PROVIDER_NAME_INSTRUCTIONS,
                 SPANDATA.GEN_AI_RESPONSE_TEXT,
             ],
             [],
@@ -2431,7 +2433,7 @@ DATA_COLLECTION_EMBED_EXPECTED_VALUES = {
             [],
             [
                 SPANDATA.GEN_AI_REQUEST_MESSAGES,
-                SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS,
+                SPANDATA.GEN_AI_PROVIDER_NAME_INSTRUCTIONS,
                 SPANDATA.GEN_AI_RESPONSE_TEXT,
             ],
             id="no-gen-ai-config-legacy-pii-disabled",
@@ -2488,7 +2490,7 @@ def test_generate_content_data_collection(
         assert key not in span_data, f"{key} should not have been collected"
 
     # Data collection never gates non-PII attributes
-    assert span_data[SPANDATA.GEN_AI_SYSTEM] == "gcp.gemini"
+    assert span_data[SPANDATA.GEN_AI_PROVIDER_NAME] == "gcp.gemini"
     assert span_data[SPANDATA.GEN_AI_REQUEST_MODEL] == "gemini-1.5-flash"
     assert span_data[SPANDATA.GEN_AI_REQUEST_TEMPERATURE] == 0.7
     assert span_data[SPANDATA.GEN_AI_REQUEST_MAX_TOKENS] == 100
@@ -2651,7 +2653,7 @@ def test_generate_content_data_collection_tools(
             False,
             [
                 SPANDATA.GEN_AI_REQUEST_MESSAGES,
-                SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS,
+                SPANDATA.GEN_AI_PROVIDER_NAME_INSTRUCTIONS,
                 SPANDATA.GEN_AI_RESPONSE_TEXT,
             ],
             [],
@@ -2664,7 +2666,7 @@ def test_generate_content_data_collection_tools(
             [],
             [
                 SPANDATA.GEN_AI_REQUEST_MESSAGES,
-                SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS,
+                SPANDATA.GEN_AI_PROVIDER_NAME_INSTRUCTIONS,
                 SPANDATA.GEN_AI_RESPONSE_TEXT,
             ],
             id="gen-ai-inputs-and-outputs-disabled-override-legacy-on",
@@ -2675,7 +2677,7 @@ def test_generate_content_data_collection_tools(
             False,
             [
                 SPANDATA.GEN_AI_REQUEST_MESSAGES,
-                SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS,
+                SPANDATA.GEN_AI_PROVIDER_NAME_INSTRUCTIONS,
             ],
             [
                 SPANDATA.GEN_AI_RESPONSE_TEXT,
@@ -2691,7 +2693,7 @@ def test_generate_content_data_collection_tools(
             ],
             [
                 SPANDATA.GEN_AI_REQUEST_MESSAGES,
-                SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS,
+                SPANDATA.GEN_AI_PROVIDER_NAME_INSTRUCTIONS,
             ],
             id="gen-ai-outputs-enabled-inputs-disabled",
         ),
@@ -2701,7 +2703,7 @@ def test_generate_content_data_collection_tools(
             False,
             [
                 SPANDATA.GEN_AI_REQUEST_MESSAGES,
-                SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS,
+                SPANDATA.GEN_AI_PROVIDER_NAME_INSTRUCTIONS,
                 SPANDATA.GEN_AI_RESPONSE_TEXT,
             ],
             [],
@@ -2713,7 +2715,7 @@ def test_generate_content_data_collection_tools(
             True,
             [
                 SPANDATA.GEN_AI_REQUEST_MESSAGES,
-                SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS,
+                SPANDATA.GEN_AI_PROVIDER_NAME_INSTRUCTIONS,
                 SPANDATA.GEN_AI_RESPONSE_TEXT,
             ],
             [],
@@ -2726,7 +2728,7 @@ def test_generate_content_data_collection_tools(
             [],
             [
                 SPANDATA.GEN_AI_REQUEST_MESSAGES,
-                SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS,
+                SPANDATA.GEN_AI_PROVIDER_NAME_INSTRUCTIONS,
                 SPANDATA.GEN_AI_RESPONSE_TEXT,
             ],
             id="no-gen-ai-config-legacy-pii-disabled",
@@ -3108,7 +3110,7 @@ def test_embed_content_data_collection(
             False,
             [
                 SPANDATA.GEN_AI_REQUEST_MESSAGES,
-                SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS,
+                SPANDATA.GEN_AI_PROVIDER_NAME_INSTRUCTIONS,
                 SPANDATA.GEN_AI_RESPONSE_TEXT,
             ],
             [],
@@ -3121,7 +3123,7 @@ def test_embed_content_data_collection(
             [],
             [
                 SPANDATA.GEN_AI_REQUEST_MESSAGES,
-                SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS,
+                SPANDATA.GEN_AI_PROVIDER_NAME_INSTRUCTIONS,
                 SPANDATA.GEN_AI_RESPONSE_TEXT,
             ],
             id="gen-ai-inputs-and-outputs-disabled-override-legacy-on",
@@ -3132,7 +3134,7 @@ def test_embed_content_data_collection(
             False,
             [
                 SPANDATA.GEN_AI_REQUEST_MESSAGES,
-                SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS,
+                SPANDATA.GEN_AI_PROVIDER_NAME_INSTRUCTIONS,
             ],
             [
                 SPANDATA.GEN_AI_RESPONSE_TEXT,
@@ -3148,7 +3150,7 @@ def test_embed_content_data_collection(
             ],
             [
                 SPANDATA.GEN_AI_REQUEST_MESSAGES,
-                SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS,
+                SPANDATA.GEN_AI_PROVIDER_NAME_INSTRUCTIONS,
             ],
             id="gen-ai-outputs-enabled-inputs-disabled",
         ),
@@ -3158,7 +3160,7 @@ def test_embed_content_data_collection(
             False,
             [
                 SPANDATA.GEN_AI_REQUEST_MESSAGES,
-                SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS,
+                SPANDATA.GEN_AI_PROVIDER_NAME_INSTRUCTIONS,
                 SPANDATA.GEN_AI_RESPONSE_TEXT,
             ],
             [],
@@ -3170,7 +3172,7 @@ def test_embed_content_data_collection(
             True,
             [
                 SPANDATA.GEN_AI_REQUEST_MESSAGES,
-                SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS,
+                SPANDATA.GEN_AI_PROVIDER_NAME_INSTRUCTIONS,
                 SPANDATA.GEN_AI_RESPONSE_TEXT,
             ],
             [],
@@ -3183,7 +3185,7 @@ def test_embed_content_data_collection(
             [],
             [
                 SPANDATA.GEN_AI_REQUEST_MESSAGES,
-                SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS,
+                SPANDATA.GEN_AI_PROVIDER_NAME_INSTRUCTIONS,
                 SPANDATA.GEN_AI_RESPONSE_TEXT,
             ],
             id="no-gen-ai-config-legacy-pii-disabled",

--- a/tests/integrations/langchain/test_langchain.py
+++ b/tests/integrations/langchain/test_langchain.py
@@ -348,7 +348,7 @@ def test_langchain_text_completion(
 
     llm_span = llm_spans[0]
     assert llm_span["name"] == "text_completion gpt-3.5-turbo"
-    assert llm_span["attributes"]["gen_ai.system"] == "openai"
+    assert llm_span["attributes"][SPANDATA.GEN_AI_PROVIDER_NAME] == "openai"
     assert llm_span["attributes"]["gen_ai.function_id"] == "my-snazzy-pipeline"
     assert llm_span["attributes"]["gen_ai.request.model"] == "gpt-3.5-turbo"
     assert (
@@ -626,7 +626,7 @@ def test_langchain_create_agent(
     assert len(chat_spans) == 1
     assert chat_spans[0]["attributes"]["sentry.origin"] == "auto.ai.langchain"
 
-    assert chat_spans[0]["attributes"]["gen_ai.system"] == "openai-chat"
+    assert chat_spans[0]["attributes"][SPANDATA.GEN_AI_PROVIDER_NAME] == "openai-chat"
     assert chat_spans[0]["attributes"]["gen_ai.agent.name"] == "word_length_agent"
 
     assert chat_spans[0]["attributes"]["gen_ai.usage.input_tokens"] == 10
@@ -823,7 +823,7 @@ def test_tool_execution_span(
     assert (
         chat_spans[0]["attributes"][SPANDATA.GEN_AI_USAGE_REASONING_OUTPUT_TOKENS] == 10
     )
-    assert chat_spans[0]["attributes"]["gen_ai.system"] == "openai-chat"
+    assert chat_spans[0]["attributes"][SPANDATA.GEN_AI_PROVIDER_NAME] == "openai-chat"
 
     assert chat_spans[1]["attributes"]["gen_ai.usage.input_tokens"] == 89
     assert chat_spans[1]["attributes"]["gen_ai.usage.output_tokens"] == 28
@@ -838,7 +838,7 @@ def test_tool_execution_span(
     assert (
         chat_spans[1]["attributes"][SPANDATA.GEN_AI_USAGE_REASONING_OUTPUT_TOKENS] == 11
     )
-    assert chat_spans[1]["attributes"]["gen_ai.system"] == "openai-chat"
+    assert chat_spans[1]["attributes"][SPANDATA.GEN_AI_PROVIDER_NAME] == "openai-chat"
 
     if LANGCHAIN_OPENAI_VERSION >= (0, 3, 13):
         assert (
@@ -3237,9 +3237,9 @@ def test_langchain_ai_system_detection(
     llm_span = llm_spans[0]
 
     if expected_system is not None:
-        assert llm_span["attributes"][SPANDATA.GEN_AI_SYSTEM] == expected_system
+        assert llm_span["attributes"][SPANDATA.GEN_AI_PROVIDER_NAME] == expected_system
     else:
-        assert SPANDATA.GEN_AI_SYSTEM not in llm_span.get("attributes", {})
+        assert SPANDATA.GEN_AI_PROVIDER_NAME not in llm_span.get("attributes", {})
 
 
 class TestTransformLangchainMessageContent:
@@ -3543,7 +3543,7 @@ def test_langchain_chat_data_collection(
 
     # Data collection never gates non-PII attributes
     assert span_data[SPANDATA.GEN_AI_REQUEST_MODEL] == "gpt-3.5-turbo"
-    assert span_data[SPANDATA.GEN_AI_SYSTEM] == "openai-chat"
+    assert span_data[SPANDATA.GEN_AI_PROVIDER_NAME] == "openai-chat"
     assert span_data[SPANDATA.GEN_AI_USAGE_TOTAL_TOKENS] == 30
 
 
@@ -3737,7 +3737,7 @@ def test_langchain_text_completion_data_collection(
 
     # Data collection never gates non-PII attributes
     assert span_data[SPANDATA.GEN_AI_REQUEST_MODEL] == "gpt-3.5-turbo"
-    assert span_data[SPANDATA.GEN_AI_SYSTEM] == "openai"
+    assert span_data[SPANDATA.GEN_AI_PROVIDER_NAME] == "openai"
     assert span_data[SPANDATA.GEN_AI_REQUEST_TEMPERATURE] == 0.7
     assert span_data[SPANDATA.GEN_AI_USAGE_TOTAL_TOKENS] == 25
 

--- a/tests/integrations/langchain/test_langchain.py
+++ b/tests/integrations/langchain/test_langchain.py
@@ -348,7 +348,7 @@ def test_langchain_text_completion(
 
     llm_span = llm_spans[0]
     assert llm_span["name"] == "text_completion gpt-3.5-turbo"
-    assert llm_span["attributes"]["gen_ai.system"] == "openai"
+    assert llm_span["attributes"][SPANDATA.GEN_AI_PROVIDER_NAME] == "openai"
     assert llm_span["attributes"]["gen_ai.function_id"] == "my-snazzy-pipeline"
     assert llm_span["attributes"]["gen_ai.request.model"] == "gpt-3.5-turbo"
     assert (
@@ -626,7 +626,7 @@ def test_langchain_create_agent(
     assert len(chat_spans) == 1
     assert chat_spans[0]["attributes"]["sentry.origin"] == "auto.ai.langchain"
 
-    assert chat_spans[0]["attributes"]["gen_ai.system"] == "openai-chat"
+    assert chat_spans[0]["attributes"][SPANDATA.GEN_AI_PROVIDER_NAME] == "openai-chat"
     assert chat_spans[0]["attributes"]["gen_ai.agent.name"] == "word_length_agent"
 
     assert chat_spans[0]["attributes"]["gen_ai.usage.input_tokens"] == 10
@@ -668,10 +668,10 @@ def test_langchain_create_agent(
         ]
 
         assert expected_system_instructions == json.loads(
-            chat_spans[0]["attributes"][SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS]
+            chat_spans[0]["attributes"][SPANDATA.GEN_AI_PROVIDER_NAME_INSTRUCTIONS]
         )
     else:
-        assert SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS not in chat_spans[0].get(
+        assert SPANDATA.GEN_AI_PROVIDER_NAME_INSTRUCTIONS not in chat_spans[0].get(
             "attributes", {}
         )
         assert SPANDATA.GEN_AI_REQUEST_MESSAGES not in chat_spans[0].get(
@@ -823,7 +823,7 @@ def test_tool_execution_span(
     assert (
         chat_spans[0]["attributes"][SPANDATA.GEN_AI_USAGE_REASONING_OUTPUT_TOKENS] == 10
     )
-    assert chat_spans[0]["attributes"]["gen_ai.system"] == "openai-chat"
+    assert chat_spans[0]["attributes"][SPANDATA.GEN_AI_PROVIDER_NAME] == "openai-chat"
 
     assert chat_spans[1]["attributes"]["gen_ai.usage.input_tokens"] == 89
     assert chat_spans[1]["attributes"]["gen_ai.usage.output_tokens"] == 28
@@ -838,7 +838,7 @@ def test_tool_execution_span(
     assert (
         chat_spans[1]["attributes"][SPANDATA.GEN_AI_USAGE_REASONING_OUTPUT_TOKENS] == 11
     )
-    assert chat_spans[1]["attributes"]["gen_ai.system"] == "openai-chat"
+    assert chat_spans[1]["attributes"][SPANDATA.GEN_AI_PROVIDER_NAME] == "openai-chat"
 
     if LANGCHAIN_OPENAI_VERSION >= (0, 3, 13):
         assert (
@@ -1023,12 +1023,12 @@ def test_langchain_openai_tools_agent_no_prompts(
             == "gpt-3.5-turbo"
         )
 
-    assert SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS not in chat_spans[0].get(
+    assert SPANDATA.GEN_AI_PROVIDER_NAME_INSTRUCTIONS not in chat_spans[0].get(
         "attributes", {}
     )
     assert SPANDATA.GEN_AI_REQUEST_MESSAGES not in chat_spans[0].get("attributes", {})
     assert SPANDATA.GEN_AI_RESPONSE_TEXT not in chat_spans[0].get("attributes", {})
-    assert SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS not in chat_spans[1].get(
+    assert SPANDATA.GEN_AI_PROVIDER_NAME_INSTRUCTIONS not in chat_spans[1].get(
         "attributes", {}
     )
     assert SPANDATA.GEN_AI_REQUEST_MESSAGES not in chat_spans[1].get("attributes", {})
@@ -1245,7 +1245,7 @@ def test_langchain_openai_tools_agent(
     ]
 
     assert expected_system_instructions == json.loads(
-        chat_spans[0]["attributes"][SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS]
+        chat_spans[0]["attributes"][SPANDATA.GEN_AI_PROVIDER_NAME_INSTRUCTIONS]
     )
 
     assert "5" in chat_spans[1]["attributes"][SPANDATA.GEN_AI_RESPONSE_TEXT]
@@ -1487,12 +1487,12 @@ def test_langchain_openai_tools_agent_stream_no_prompts(
             == "gpt-3.5-turbo"
         )
 
-    assert SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS not in chat_spans[0].get(
+    assert SPANDATA.GEN_AI_PROVIDER_NAME_INSTRUCTIONS not in chat_spans[0].get(
         "attributes", {}
     )
     assert SPANDATA.GEN_AI_REQUEST_MESSAGES not in chat_spans[0].get("attributes", {})
     assert SPANDATA.GEN_AI_RESPONSE_TEXT not in chat_spans[0].get("attributes", {})
-    assert SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS not in chat_spans[1].get(
+    assert SPANDATA.GEN_AI_PROVIDER_NAME_INSTRUCTIONS not in chat_spans[1].get(
         "attributes", {}
     )
     assert SPANDATA.GEN_AI_REQUEST_MESSAGES not in chat_spans[1].get("attributes", {})
@@ -1714,7 +1714,7 @@ def test_langchain_openai_tools_agent_stream(
     ]
 
     assert expected_system_instructions == json.loads(
-        chat_spans[0]["attributes"][SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS]
+        chat_spans[0]["attributes"][SPANDATA.GEN_AI_PROVIDER_NAME_INSTRUCTIONS]
     )
 
     assert "5" in chat_spans[1]["attributes"][SPANDATA.GEN_AI_RESPONSE_TEXT]
@@ -3237,9 +3237,9 @@ def test_langchain_ai_system_detection(
     llm_span = llm_spans[0]
 
     if expected_system is not None:
-        assert llm_span["attributes"][SPANDATA.GEN_AI_SYSTEM] == expected_system
+        assert llm_span["attributes"][SPANDATA.GEN_AI_PROVIDER_NAME] == expected_system
     else:
-        assert SPANDATA.GEN_AI_SYSTEM not in llm_span.get("attributes", {})
+        assert SPANDATA.GEN_AI_PROVIDER_NAME not in llm_span.get("attributes", {})
 
 
 class TestTransformLangchainMessageContent:
@@ -3369,7 +3369,7 @@ class TestTransformLangchainMessageContent:
                 SPANDATA.GEN_AI_REQUEST_MESSAGES: [
                     {"role": "user", "content": "How many letters in the word eudca"}
                 ],
-                SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS: [
+                SPANDATA.GEN_AI_PROVIDER_NAME_INSTRUCTIONS: [
                     {"type": "text", "content": "You are a helpful assistant."}
                 ],
                 SPANDATA.GEN_AI_RESPONSE_TEXT: "the model response",
@@ -3384,7 +3384,7 @@ class TestTransformLangchainMessageContent:
             {},
             [
                 SPANDATA.GEN_AI_REQUEST_MESSAGES,
-                SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS,
+                SPANDATA.GEN_AI_PROVIDER_NAME_INSTRUCTIONS,
                 SPANDATA.GEN_AI_RESPONSE_TEXT,
             ],
             id="gen-ai-inputs-and-outputs-disabled-override-legacy-on",
@@ -3397,7 +3397,7 @@ class TestTransformLangchainMessageContent:
                 SPANDATA.GEN_AI_REQUEST_MESSAGES: [
                     {"role": "user", "content": "How many letters in the word eudca"}
                 ],
-                SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS: [
+                SPANDATA.GEN_AI_PROVIDER_NAME_INSTRUCTIONS: [
                     {"type": "text", "content": "You are a helpful assistant."}
                 ],
             },
@@ -3411,7 +3411,7 @@ class TestTransformLangchainMessageContent:
             {SPANDATA.GEN_AI_RESPONSE_TEXT: "the model response"},
             [
                 SPANDATA.GEN_AI_REQUEST_MESSAGES,
-                SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS,
+                SPANDATA.GEN_AI_PROVIDER_NAME_INSTRUCTIONS,
             ],
             id="gen-ai-outputs-enabled-inputs-disabled",
         ),
@@ -3423,7 +3423,7 @@ class TestTransformLangchainMessageContent:
                 SPANDATA.GEN_AI_REQUEST_MESSAGES: [
                     {"role": "user", "content": "How many letters in the word eudca"}
                 ],
-                SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS: [
+                SPANDATA.GEN_AI_PROVIDER_NAME_INSTRUCTIONS: [
                     {"type": "text", "content": "You are a helpful assistant."}
                 ],
                 SPANDATA.GEN_AI_RESPONSE_TEXT: "the model response",
@@ -3439,7 +3439,7 @@ class TestTransformLangchainMessageContent:
                 SPANDATA.GEN_AI_REQUEST_MESSAGES: [
                     {"role": "user", "content": "How many letters in the word eudca"}
                 ],
-                SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS: [
+                SPANDATA.GEN_AI_PROVIDER_NAME_INSTRUCTIONS: [
                     {"type": "text", "content": "You are a helpful assistant."}
                 ],
                 SPANDATA.GEN_AI_RESPONSE_TEXT: "the model response",
@@ -3454,7 +3454,7 @@ class TestTransformLangchainMessageContent:
             {},
             [
                 SPANDATA.GEN_AI_REQUEST_MESSAGES,
-                SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS,
+                SPANDATA.GEN_AI_PROVIDER_NAME_INSTRUCTIONS,
                 SPANDATA.GEN_AI_RESPONSE_TEXT,
             ],
             id="no-gen-ai-config-legacy-pii-disabled",
@@ -3543,7 +3543,7 @@ def test_langchain_chat_data_collection(
 
     # Data collection never gates non-PII attributes
     assert span_data[SPANDATA.GEN_AI_REQUEST_MODEL] == "gpt-3.5-turbo"
-    assert span_data[SPANDATA.GEN_AI_SYSTEM] == "openai-chat"
+    assert span_data[SPANDATA.GEN_AI_PROVIDER_NAME] == "openai-chat"
     assert span_data[SPANDATA.GEN_AI_USAGE_TOTAL_TOKENS] == 30
 
 
@@ -3737,7 +3737,7 @@ def test_langchain_text_completion_data_collection(
 
     # Data collection never gates non-PII attributes
     assert span_data[SPANDATA.GEN_AI_REQUEST_MODEL] == "gpt-3.5-turbo"
-    assert span_data[SPANDATA.GEN_AI_SYSTEM] == "openai"
+    assert span_data[SPANDATA.GEN_AI_PROVIDER_NAME] == "openai"
     assert span_data[SPANDATA.GEN_AI_REQUEST_TEMPERATURE] == 0.7
     assert span_data[SPANDATA.GEN_AI_USAGE_TOTAL_TOKENS] == 25
 

--- a/tests/integrations/langchain/test_langchain.py
+++ b/tests/integrations/langchain/test_langchain.py
@@ -348,7 +348,7 @@ def test_langchain_text_completion(
 
     llm_span = llm_spans[0]
     assert llm_span["name"] == "text_completion gpt-3.5-turbo"
-    assert llm_span["attributes"][SPANDATA.GEN_AI_PROVIDER_NAME] == "openai"
+    assert llm_span["attributes"]["gen_ai.system"] == "openai"
     assert llm_span["attributes"]["gen_ai.function_id"] == "my-snazzy-pipeline"
     assert llm_span["attributes"]["gen_ai.request.model"] == "gpt-3.5-turbo"
     assert (
@@ -626,7 +626,7 @@ def test_langchain_create_agent(
     assert len(chat_spans) == 1
     assert chat_spans[0]["attributes"]["sentry.origin"] == "auto.ai.langchain"
 
-    assert chat_spans[0]["attributes"][SPANDATA.GEN_AI_PROVIDER_NAME] == "openai-chat"
+    assert chat_spans[0]["attributes"]["gen_ai.system"] == "openai-chat"
     assert chat_spans[0]["attributes"]["gen_ai.agent.name"] == "word_length_agent"
 
     assert chat_spans[0]["attributes"]["gen_ai.usage.input_tokens"] == 10
@@ -668,10 +668,10 @@ def test_langchain_create_agent(
         ]
 
         assert expected_system_instructions == json.loads(
-            chat_spans[0]["attributes"][SPANDATA.GEN_AI_PROVIDER_NAME_INSTRUCTIONS]
+            chat_spans[0]["attributes"][SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS]
         )
     else:
-        assert SPANDATA.GEN_AI_PROVIDER_NAME_INSTRUCTIONS not in chat_spans[0].get(
+        assert SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS not in chat_spans[0].get(
             "attributes", {}
         )
         assert SPANDATA.GEN_AI_REQUEST_MESSAGES not in chat_spans[0].get(
@@ -823,7 +823,7 @@ def test_tool_execution_span(
     assert (
         chat_spans[0]["attributes"][SPANDATA.GEN_AI_USAGE_REASONING_OUTPUT_TOKENS] == 10
     )
-    assert chat_spans[0]["attributes"][SPANDATA.GEN_AI_PROVIDER_NAME] == "openai-chat"
+    assert chat_spans[0]["attributes"]["gen_ai.system"] == "openai-chat"
 
     assert chat_spans[1]["attributes"]["gen_ai.usage.input_tokens"] == 89
     assert chat_spans[1]["attributes"]["gen_ai.usage.output_tokens"] == 28
@@ -838,7 +838,7 @@ def test_tool_execution_span(
     assert (
         chat_spans[1]["attributes"][SPANDATA.GEN_AI_USAGE_REASONING_OUTPUT_TOKENS] == 11
     )
-    assert chat_spans[1]["attributes"][SPANDATA.GEN_AI_PROVIDER_NAME] == "openai-chat"
+    assert chat_spans[1]["attributes"]["gen_ai.system"] == "openai-chat"
 
     if LANGCHAIN_OPENAI_VERSION >= (0, 3, 13):
         assert (
@@ -1023,12 +1023,12 @@ def test_langchain_openai_tools_agent_no_prompts(
             == "gpt-3.5-turbo"
         )
 
-    assert SPANDATA.GEN_AI_PROVIDER_NAME_INSTRUCTIONS not in chat_spans[0].get(
+    assert SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS not in chat_spans[0].get(
         "attributes", {}
     )
     assert SPANDATA.GEN_AI_REQUEST_MESSAGES not in chat_spans[0].get("attributes", {})
     assert SPANDATA.GEN_AI_RESPONSE_TEXT not in chat_spans[0].get("attributes", {})
-    assert SPANDATA.GEN_AI_PROVIDER_NAME_INSTRUCTIONS not in chat_spans[1].get(
+    assert SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS not in chat_spans[1].get(
         "attributes", {}
     )
     assert SPANDATA.GEN_AI_REQUEST_MESSAGES not in chat_spans[1].get("attributes", {})
@@ -1245,7 +1245,7 @@ def test_langchain_openai_tools_agent(
     ]
 
     assert expected_system_instructions == json.loads(
-        chat_spans[0]["attributes"][SPANDATA.GEN_AI_PROVIDER_NAME_INSTRUCTIONS]
+        chat_spans[0]["attributes"][SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS]
     )
 
     assert "5" in chat_spans[1]["attributes"][SPANDATA.GEN_AI_RESPONSE_TEXT]
@@ -1487,12 +1487,12 @@ def test_langchain_openai_tools_agent_stream_no_prompts(
             == "gpt-3.5-turbo"
         )
 
-    assert SPANDATA.GEN_AI_PROVIDER_NAME_INSTRUCTIONS not in chat_spans[0].get(
+    assert SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS not in chat_spans[0].get(
         "attributes", {}
     )
     assert SPANDATA.GEN_AI_REQUEST_MESSAGES not in chat_spans[0].get("attributes", {})
     assert SPANDATA.GEN_AI_RESPONSE_TEXT not in chat_spans[0].get("attributes", {})
-    assert SPANDATA.GEN_AI_PROVIDER_NAME_INSTRUCTIONS not in chat_spans[1].get(
+    assert SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS not in chat_spans[1].get(
         "attributes", {}
     )
     assert SPANDATA.GEN_AI_REQUEST_MESSAGES not in chat_spans[1].get("attributes", {})
@@ -1714,7 +1714,7 @@ def test_langchain_openai_tools_agent_stream(
     ]
 
     assert expected_system_instructions == json.loads(
-        chat_spans[0]["attributes"][SPANDATA.GEN_AI_PROVIDER_NAME_INSTRUCTIONS]
+        chat_spans[0]["attributes"][SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS]
     )
 
     assert "5" in chat_spans[1]["attributes"][SPANDATA.GEN_AI_RESPONSE_TEXT]
@@ -3237,9 +3237,9 @@ def test_langchain_ai_system_detection(
     llm_span = llm_spans[0]
 
     if expected_system is not None:
-        assert llm_span["attributes"][SPANDATA.GEN_AI_PROVIDER_NAME] == expected_system
+        assert llm_span["attributes"][SPANDATA.GEN_AI_SYSTEM] == expected_system
     else:
-        assert SPANDATA.GEN_AI_PROVIDER_NAME not in llm_span.get("attributes", {})
+        assert SPANDATA.GEN_AI_SYSTEM not in llm_span.get("attributes", {})
 
 
 class TestTransformLangchainMessageContent:
@@ -3369,7 +3369,7 @@ class TestTransformLangchainMessageContent:
                 SPANDATA.GEN_AI_REQUEST_MESSAGES: [
                     {"role": "user", "content": "How many letters in the word eudca"}
                 ],
-                SPANDATA.GEN_AI_PROVIDER_NAME_INSTRUCTIONS: [
+                SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS: [
                     {"type": "text", "content": "You are a helpful assistant."}
                 ],
                 SPANDATA.GEN_AI_RESPONSE_TEXT: "the model response",
@@ -3384,7 +3384,7 @@ class TestTransformLangchainMessageContent:
             {},
             [
                 SPANDATA.GEN_AI_REQUEST_MESSAGES,
-                SPANDATA.GEN_AI_PROVIDER_NAME_INSTRUCTIONS,
+                SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS,
                 SPANDATA.GEN_AI_RESPONSE_TEXT,
             ],
             id="gen-ai-inputs-and-outputs-disabled-override-legacy-on",
@@ -3397,7 +3397,7 @@ class TestTransformLangchainMessageContent:
                 SPANDATA.GEN_AI_REQUEST_MESSAGES: [
                     {"role": "user", "content": "How many letters in the word eudca"}
                 ],
-                SPANDATA.GEN_AI_PROVIDER_NAME_INSTRUCTIONS: [
+                SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS: [
                     {"type": "text", "content": "You are a helpful assistant."}
                 ],
             },
@@ -3411,7 +3411,7 @@ class TestTransformLangchainMessageContent:
             {SPANDATA.GEN_AI_RESPONSE_TEXT: "the model response"},
             [
                 SPANDATA.GEN_AI_REQUEST_MESSAGES,
-                SPANDATA.GEN_AI_PROVIDER_NAME_INSTRUCTIONS,
+                SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS,
             ],
             id="gen-ai-outputs-enabled-inputs-disabled",
         ),
@@ -3423,7 +3423,7 @@ class TestTransformLangchainMessageContent:
                 SPANDATA.GEN_AI_REQUEST_MESSAGES: [
                     {"role": "user", "content": "How many letters in the word eudca"}
                 ],
-                SPANDATA.GEN_AI_PROVIDER_NAME_INSTRUCTIONS: [
+                SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS: [
                     {"type": "text", "content": "You are a helpful assistant."}
                 ],
                 SPANDATA.GEN_AI_RESPONSE_TEXT: "the model response",
@@ -3439,7 +3439,7 @@ class TestTransformLangchainMessageContent:
                 SPANDATA.GEN_AI_REQUEST_MESSAGES: [
                     {"role": "user", "content": "How many letters in the word eudca"}
                 ],
-                SPANDATA.GEN_AI_PROVIDER_NAME_INSTRUCTIONS: [
+                SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS: [
                     {"type": "text", "content": "You are a helpful assistant."}
                 ],
                 SPANDATA.GEN_AI_RESPONSE_TEXT: "the model response",
@@ -3454,7 +3454,7 @@ class TestTransformLangchainMessageContent:
             {},
             [
                 SPANDATA.GEN_AI_REQUEST_MESSAGES,
-                SPANDATA.GEN_AI_PROVIDER_NAME_INSTRUCTIONS,
+                SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS,
                 SPANDATA.GEN_AI_RESPONSE_TEXT,
             ],
             id="no-gen-ai-config-legacy-pii-disabled",
@@ -3543,7 +3543,7 @@ def test_langchain_chat_data_collection(
 
     # Data collection never gates non-PII attributes
     assert span_data[SPANDATA.GEN_AI_REQUEST_MODEL] == "gpt-3.5-turbo"
-    assert span_data[SPANDATA.GEN_AI_PROVIDER_NAME] == "openai-chat"
+    assert span_data[SPANDATA.GEN_AI_SYSTEM] == "openai-chat"
     assert span_data[SPANDATA.GEN_AI_USAGE_TOTAL_TOKENS] == 30
 
 
@@ -3737,7 +3737,7 @@ def test_langchain_text_completion_data_collection(
 
     # Data collection never gates non-PII attributes
     assert span_data[SPANDATA.GEN_AI_REQUEST_MODEL] == "gpt-3.5-turbo"
-    assert span_data[SPANDATA.GEN_AI_PROVIDER_NAME] == "openai"
+    assert span_data[SPANDATA.GEN_AI_SYSTEM] == "openai"
     assert span_data[SPANDATA.GEN_AI_REQUEST_TEMPERATURE] == 0.7
     assert span_data[SPANDATA.GEN_AI_USAGE_TOTAL_TOKENS] == 25
 

--- a/tests/integrations/litellm/test_litellm.py
+++ b/tests/integrations/litellm/test_litellm.py
@@ -212,7 +212,7 @@ def test_nonstreaming_chat_completion(
     assert span["name"] == "chat gpt-3.5-turbo"
     assert span["attributes"][SPANDATA.GEN_AI_REQUEST_MODEL] == "gpt-3.5-turbo"
     assert span["attributes"][SPANDATA.GEN_AI_RESPONSE_MODEL] == "gpt-3.5-turbo"
-    assert span["attributes"][SPANDATA.GEN_AI_SYSTEM] == "openai"
+    assert span["attributes"][SPANDATA.GEN_AI_PROVIDER_NAME] == "openai"
     assert span["attributes"][SPANDATA.GEN_AI_OPERATION_NAME] == "chat"
 
     if send_default_pii and include_prompts:
@@ -312,7 +312,7 @@ async def test_async_nonstreaming_chat_completion(
     assert span["name"] == "chat gpt-3.5-turbo"
     assert span["attributes"][SPANDATA.GEN_AI_REQUEST_MODEL] == "gpt-3.5-turbo"
     assert span["attributes"][SPANDATA.GEN_AI_RESPONSE_MODEL] == "gpt-3.5-turbo"
-    assert span["attributes"][SPANDATA.GEN_AI_SYSTEM] == "openai"
+    assert span["attributes"][SPANDATA.GEN_AI_PROVIDER_NAME] == "openai"
     assert span["attributes"][SPANDATA.GEN_AI_OPERATION_NAME] == "chat"
 
     if send_default_pii and include_prompts:
@@ -1094,7 +1094,7 @@ def test_multiple_providers(
     spans = [item.payload for item in items]
     for span in spans:
         # The provider should be detected by litellm.get_llm_provider
-        assert SPANDATA.GEN_AI_SYSTEM in span["attributes"]
+        assert SPANDATA.GEN_AI_PROVIDER_NAME in span["attributes"]
 
 
 @pytest.mark.asyncio(loop_scope="session")
@@ -1199,7 +1199,7 @@ async def test_async_multiple_providers(
     spans = [item.payload for item in items]
     for span in spans:
         # The provider should be detected by litellm.get_llm_provider
-        assert SPANDATA.GEN_AI_SYSTEM in span["attributes"]
+        assert SPANDATA.GEN_AI_PROVIDER_NAME in span["attributes"]
 
 
 def test_additional_parameters(

--- a/tests/integrations/litellm/test_litellm.py
+++ b/tests/integrations/litellm/test_litellm.py
@@ -212,7 +212,7 @@ def test_nonstreaming_chat_completion(
     assert span["name"] == "chat gpt-3.5-turbo"
     assert span["attributes"][SPANDATA.GEN_AI_REQUEST_MODEL] == "gpt-3.5-turbo"
     assert span["attributes"][SPANDATA.GEN_AI_RESPONSE_MODEL] == "gpt-3.5-turbo"
-    assert span["attributes"][SPANDATA.GEN_AI_PROVIDER_NAME] == "openai"
+    assert span["attributes"][SPANDATA.GEN_AI_SYSTEM] == "openai"
     assert span["attributes"][SPANDATA.GEN_AI_OPERATION_NAME] == "chat"
 
     if send_default_pii and include_prompts:
@@ -312,7 +312,7 @@ async def test_async_nonstreaming_chat_completion(
     assert span["name"] == "chat gpt-3.5-turbo"
     assert span["attributes"][SPANDATA.GEN_AI_REQUEST_MODEL] == "gpt-3.5-turbo"
     assert span["attributes"][SPANDATA.GEN_AI_RESPONSE_MODEL] == "gpt-3.5-turbo"
-    assert span["attributes"][SPANDATA.GEN_AI_PROVIDER_NAME] == "openai"
+    assert span["attributes"][SPANDATA.GEN_AI_SYSTEM] == "openai"
     assert span["attributes"][SPANDATA.GEN_AI_OPERATION_NAME] == "chat"
 
     if send_default_pii and include_prompts:
@@ -1094,7 +1094,7 @@ def test_multiple_providers(
     spans = [item.payload for item in items]
     for span in spans:
         # The provider should be detected by litellm.get_llm_provider
-        assert SPANDATA.GEN_AI_PROVIDER_NAME in span["attributes"]
+        assert SPANDATA.GEN_AI_SYSTEM in span["attributes"]
 
 
 @pytest.mark.asyncio(loop_scope="session")
@@ -1199,7 +1199,7 @@ async def test_async_multiple_providers(
     spans = [item.payload for item in items]
     for span in spans:
         # The provider should be detected by litellm.get_llm_provider
-        assert SPANDATA.GEN_AI_PROVIDER_NAME in span["attributes"]
+        assert SPANDATA.GEN_AI_SYSTEM in span["attributes"]
 
 
 def test_additional_parameters(

--- a/tests/integrations/openai/test_openai.py
+++ b/tests/integrations/openai/test_openai.py
@@ -315,7 +315,7 @@ def test_nonstreaming_chat_completion_no_prompts(
     sentry_sdk.flush()
     span = next(item.payload for item in items)
     assert span["attributes"]["sentry.op"] == "gen_ai.chat"
-    assert span["attributes"][SPANDATA.GEN_AI_SYSTEM] == "openai"
+    assert span["attributes"][SPANDATA.GEN_AI_PROVIDER_NAME] == "openai"
     assert span["attributes"][SPANDATA.GEN_AI_RESPONSE_STREAMING] is False
 
     assert span["attributes"][SPANDATA.GEN_AI_REQUEST_MODEL] == "some-model"
@@ -461,7 +461,7 @@ def test_nonstreaming_chat_completion(
     sentry_sdk.flush()
     span = next(item.payload for item in items)
     assert span["attributes"]["sentry.op"] == "gen_ai.chat"
-    assert span["attributes"][SPANDATA.GEN_AI_SYSTEM] == "openai"
+    assert span["attributes"][SPANDATA.GEN_AI_PROVIDER_NAME] == "openai"
     assert span["attributes"][SPANDATA.GEN_AI_RESPONSE_STREAMING] is False
 
     assert span["attributes"][SPANDATA.GEN_AI_REQUEST_MODEL] == "some-model"
@@ -594,7 +594,7 @@ def test_completions_api_data_collection(
     assert span_data[SPANDATA.GEN_AI_REQUEST_FREQUENCY_PENALTY] == 0.2
     assert span_data[SPANDATA.GEN_AI_REQUEST_TEMPERATURE] == 0.7
     assert span_data[SPANDATA.GEN_AI_REQUEST_TOP_P] == 0.9
-    assert span_data[SPANDATA.GEN_AI_SYSTEM] == "openai"
+    assert span_data[SPANDATA.GEN_AI_PROVIDER_NAME] == "openai"
 
     for key, value in expected_present.items():
         assert span_data[key] == value
@@ -1064,7 +1064,7 @@ async def test_nonstreaming_chat_completion_async_no_prompts(
     sentry_sdk.flush()
     span = next(item.payload for item in items)
     assert span["attributes"]["sentry.op"] == "gen_ai.chat"
-    assert span["attributes"][SPANDATA.GEN_AI_SYSTEM] == "openai"
+    assert span["attributes"][SPANDATA.GEN_AI_PROVIDER_NAME] == "openai"
     assert span["attributes"][SPANDATA.GEN_AI_RESPONSE_STREAMING] is False
 
     assert span["attributes"][SPANDATA.GEN_AI_REQUEST_MODEL] == "some-model"
@@ -1208,7 +1208,7 @@ async def test_nonstreaming_chat_completion_async(
     sentry_sdk.flush()
     span = next(item.payload for item in items)
     assert span["attributes"]["sentry.op"] == "gen_ai.chat"
-    assert span["attributes"][SPANDATA.GEN_AI_SYSTEM] == "openai"
+    assert span["attributes"][SPANDATA.GEN_AI_PROVIDER_NAME] == "openai"
     assert span["attributes"][SPANDATA.GEN_AI_RESPONSE_STREAMING] is False
 
     assert span["attributes"][SPANDATA.GEN_AI_REQUEST_MODEL] == "some-model"
@@ -1349,7 +1349,7 @@ def test_streaming_chat_completion_no_prompts(
     sentry_sdk.flush()
     span = next(item.payload for item in items)
     assert span["attributes"]["sentry.op"] == "gen_ai.chat"
-    assert span["attributes"][SPANDATA.GEN_AI_SYSTEM] == "openai"
+    assert span["attributes"][SPANDATA.GEN_AI_PROVIDER_NAME] == "openai"
     assert span["attributes"][SPANDATA.GEN_AI_RESPONSE_STREAMING] is True
 
     assert span["attributes"][SPANDATA.GEN_AI_REQUEST_MODEL] == "some-model"
@@ -1852,7 +1852,7 @@ def test_streaming_chat_completion(
     sentry_sdk.flush()
     span = next(item.payload for item in items)
     assert span["attributes"]["sentry.op"] == "gen_ai.chat"
-    assert span["attributes"][SPANDATA.GEN_AI_SYSTEM] == "openai"
+    assert span["attributes"][SPANDATA.GEN_AI_PROVIDER_NAME] == "openai"
     assert span["attributes"][SPANDATA.GEN_AI_RESPONSE_STREAMING] is True
 
     assert span["attributes"][SPANDATA.GEN_AI_REQUEST_MODEL] == "some-model"
@@ -2002,7 +2002,7 @@ async def test_streaming_chat_completion_async_no_prompts(
     sentry_sdk.flush()
     span = next(item.payload for item in items)
     assert span["attributes"]["sentry.op"] == "gen_ai.chat"
-    assert span["attributes"][SPANDATA.GEN_AI_SYSTEM] == "openai"
+    assert span["attributes"][SPANDATA.GEN_AI_PROVIDER_NAME] == "openai"
     assert span["attributes"][SPANDATA.GEN_AI_RESPONSE_STREAMING] is True
 
     assert span["attributes"][SPANDATA.GEN_AI_REQUEST_MODEL] == "some-model"
@@ -2215,7 +2215,7 @@ async def test_streaming_chat_completion_async(
     sentry_sdk.flush()
     span = next(item.payload for item in items)
     assert span["attributes"]["sentry.op"] == "gen_ai.chat"
-    assert span["attributes"][SPANDATA.GEN_AI_SYSTEM] == "openai"
+    assert span["attributes"][SPANDATA.GEN_AI_PROVIDER_NAME] == "openai"
     assert span["attributes"][SPANDATA.GEN_AI_RESPONSE_STREAMING] is True
 
     assert span["attributes"][SPANDATA.GEN_AI_REQUEST_MODEL] == "some-model"
@@ -2388,7 +2388,7 @@ def test_embeddings_create_no_pii(
     sentry_sdk.flush()
     span = next(item.payload for item in items)
     assert span["attributes"]["sentry.op"] == "gen_ai.embeddings"
-    assert span["attributes"][SPANDATA.GEN_AI_SYSTEM] == "openai"
+    assert span["attributes"][SPANDATA.GEN_AI_PROVIDER_NAME] == "openai"
     assert span["attributes"][SPANDATA.GEN_AI_REQUEST_MODEL] == "text-embedding-3-large"
 
     assert SPANDATA.GEN_AI_EMBEDDINGS_INPUT not in span["attributes"]
@@ -2504,7 +2504,7 @@ def test_embeddings_create(
     sentry_sdk.flush()
     span = next(item.payload for item in items)
     assert span["attributes"]["sentry.op"] == "gen_ai.embeddings"
-    assert span["attributes"][SPANDATA.GEN_AI_SYSTEM] == "openai"
+    assert span["attributes"][SPANDATA.GEN_AI_PROVIDER_NAME] == "openai"
     assert span["attributes"][SPANDATA.GEN_AI_REQUEST_MODEL] == "text-embedding-3-large"
 
     assert (
@@ -2604,7 +2604,7 @@ def test_embeddings_create_data_collection(
         lambda: client.embeddings.create(input="hello", model="text-embedding-3-large"),
     )
 
-    assert span_data[SPANDATA.GEN_AI_SYSTEM] == "openai"
+    assert span_data[SPANDATA.GEN_AI_PROVIDER_NAME] == "openai"
     assert span_data[SPANDATA.GEN_AI_OPERATION_NAME] == "embeddings"
     assert span_data[SPANDATA.GEN_AI_REQUEST_MODEL] == "text-embedding-3-large"
 
@@ -2715,7 +2715,7 @@ async def test_embeddings_create_async_no_pii(
     sentry_sdk.flush()
     span = next(item.payload for item in items)
     assert span["attributes"]["sentry.op"] == "gen_ai.embeddings"
-    assert span["attributes"][SPANDATA.GEN_AI_SYSTEM] == "openai"
+    assert span["attributes"][SPANDATA.GEN_AI_PROVIDER_NAME] == "openai"
     assert span["attributes"][SPANDATA.GEN_AI_REQUEST_MODEL] == "text-embedding-3-large"
 
     assert SPANDATA.GEN_AI_EMBEDDINGS_INPUT not in span["attributes"]
@@ -2832,7 +2832,7 @@ async def test_embeddings_create_async(
     sentry_sdk.flush()
     span = next(item.payload for item in items)
     assert span["attributes"]["sentry.op"] == "gen_ai.embeddings"
-    assert span["attributes"][SPANDATA.GEN_AI_SYSTEM] == "openai"
+    assert span["attributes"][SPANDATA.GEN_AI_PROVIDER_NAME] == "openai"
     assert span["attributes"][SPANDATA.GEN_AI_REQUEST_MODEL] == "text-embedding-3-large"
 
     assert (
@@ -2921,7 +2921,7 @@ async def test_embeddings_create_async_data_collection(
     assert span["attributes"]["sentry.op"] == "gen_ai.embeddings"
     span_data = span["attributes"]
 
-    assert span_data[SPANDATA.GEN_AI_SYSTEM] == "openai"
+    assert span_data[SPANDATA.GEN_AI_PROVIDER_NAME] == "openai"
     assert span_data[SPANDATA.GEN_AI_OPERATION_NAME] == "embeddings"
     assert span_data[SPANDATA.GEN_AI_REQUEST_MODEL] == "text-embedding-3-large"
 
@@ -3680,7 +3680,7 @@ def test_ai_client_span_responses_api_no_pii(
         "gen_ai.request.model": "gpt-4o",
         "gen_ai.response.model": "response-model-id",
         "gen_ai.response.streaming": False,
-        "gen_ai.system": "openai",
+        SPANDATA.GEN_AI_PROVIDER_NAME: "openai",
         "gen_ai.usage.input_tokens": 20,
         "gen_ai.usage.input_tokens.cached": 5,
         "gen_ai.usage.output_tokens": 10,
@@ -3951,7 +3951,7 @@ def test_ai_client_span_responses_api(
         "gen_ai.request.temperature": 0.7,
         "gen_ai.request.top_p": 0.9,
         "gen_ai.request.reasoning.level": "high",
-        "gen_ai.system": "openai",
+        SPANDATA.GEN_AI_PROVIDER_NAME: "openai",
         "gen_ai.response.model": "response-model-id",
         "gen_ai.response.streaming": False,
         "gen_ai.usage.input_tokens": 20,
@@ -4144,7 +4144,7 @@ def test_responses_api_data_collection(
     assert span_data["gen_ai.request.temperature"] == 0.7
     assert span_data["gen_ai.request.top_p"] == 0.9
     assert span_data["gen_ai.request.reasoning.level"] == "high"
-    assert span_data["gen_ai.system"] == "openai"
+    assert span_data[SPANDATA.GEN_AI_PROVIDER_NAME] == "openai"
 
     for key, value in expected_present.items():
         assert span_data[key] == value
@@ -4763,7 +4763,7 @@ async def test_ai_client_span_responses_async_api(
         "gen_ai.request.model": "gpt-4o",
         "gen_ai.response.model": "response-model-id",
         "gen_ai.response.streaming": False,
-        "gen_ai.system": "openai",
+        SPANDATA.GEN_AI_PROVIDER_NAME: "openai",
         "gen_ai.usage.input_tokens": 20,
         "gen_ai.usage.input_tokens.cached": 5,
         "gen_ai.usage.output_tokens": 10,
@@ -4990,7 +4990,7 @@ async def test_ai_client_span_streaming_responses_async_api(
         "gen_ai.request.reasoning.level": "high",
         "gen_ai.response.model": "response-model-id",
         "gen_ai.response.streaming": True,
-        "gen_ai.system": "openai",
+        SPANDATA.GEN_AI_PROVIDER_NAME: "openai",
         "gen_ai.response.time_to_first_token": mock.ANY,
         "gen_ai.usage.input_tokens": 20,
         "gen_ai.usage.input_tokens.cached": 5,
@@ -5185,7 +5185,7 @@ def test_streaming_responses_api(
     sentry_sdk.flush()
     (span,) = (item.payload for item in items)
     assert span["attributes"]["sentry.op"] == "gen_ai.responses"
-    assert span["attributes"][SPANDATA.GEN_AI_SYSTEM] == "openai"
+    assert span["attributes"][SPANDATA.GEN_AI_PROVIDER_NAME] == "openai"
     assert span["attributes"][SPANDATA.GEN_AI_REQUEST_MAX_TOKENS] == 100
     assert span["attributes"][SPANDATA.GEN_AI_REQUEST_TEMPERATURE] == 0.7
     assert span["attributes"][SPANDATA.GEN_AI_REQUEST_TOP_P] == 0.9
@@ -5263,7 +5263,7 @@ async def test_streaming_responses_api_async(
     sentry_sdk.flush()
     (span,) = (item.payload for item in items)
     assert span["attributes"]["sentry.op"] == "gen_ai.responses"
-    assert span["attributes"][SPANDATA.GEN_AI_SYSTEM] == "openai"
+    assert span["attributes"][SPANDATA.GEN_AI_PROVIDER_NAME] == "openai"
     assert span["attributes"][SPANDATA.GEN_AI_REQUEST_MAX_TOKENS] == 100
     assert span["attributes"][SPANDATA.GEN_AI_REQUEST_TEMPERATURE] == 0.7
     assert span["attributes"][SPANDATA.GEN_AI_REQUEST_TOP_P] == 0.9

--- a/tests/integrations/openai/test_openai.py
+++ b/tests/integrations/openai/test_openai.py
@@ -315,7 +315,7 @@ def test_nonstreaming_chat_completion_no_prompts(
     sentry_sdk.flush()
     span = next(item.payload for item in items)
     assert span["attributes"]["sentry.op"] == "gen_ai.chat"
-    assert span["attributes"][SPANDATA.GEN_AI_SYSTEM] == "openai"
+    assert span["attributes"][SPANDATA.GEN_AI_PROVIDER_NAME] == "openai"
     assert span["attributes"][SPANDATA.GEN_AI_RESPONSE_STREAMING] is False
 
     assert span["attributes"][SPANDATA.GEN_AI_REQUEST_MODEL] == "some-model"
@@ -325,7 +325,7 @@ def test_nonstreaming_chat_completion_no_prompts(
     assert span["attributes"][SPANDATA.GEN_AI_REQUEST_TEMPERATURE] == 0.7
     assert span["attributes"][SPANDATA.GEN_AI_REQUEST_TOP_P] == 0.9
 
-    assert SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS not in span["attributes"]
+    assert SPANDATA.GEN_AI_PROVIDER_NAME_INSTRUCTIONS not in span["attributes"]
     assert SPANDATA.GEN_AI_REQUEST_MESSAGES not in span["attributes"]
     assert SPANDATA.GEN_AI_RESPONSE_TEXT not in span["attributes"]
 
@@ -461,7 +461,7 @@ def test_nonstreaming_chat_completion(
     sentry_sdk.flush()
     span = next(item.payload for item in items)
     assert span["attributes"]["sentry.op"] == "gen_ai.chat"
-    assert span["attributes"][SPANDATA.GEN_AI_SYSTEM] == "openai"
+    assert span["attributes"][SPANDATA.GEN_AI_PROVIDER_NAME] == "openai"
     assert span["attributes"][SPANDATA.GEN_AI_RESPONSE_STREAMING] is False
 
     assert span["attributes"][SPANDATA.GEN_AI_REQUEST_MODEL] == "some-model"
@@ -472,7 +472,7 @@ def test_nonstreaming_chat_completion(
     assert span["attributes"][SPANDATA.GEN_AI_REQUEST_TOP_P] == 0.9
 
     assert (
-        json.loads(span["attributes"][SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS])
+        json.loads(span["attributes"][SPANDATA.GEN_AI_PROVIDER_NAME_INSTRUCTIONS])
         == expected_system_instructions
     )
 
@@ -498,7 +498,7 @@ def test_nonstreaming_chat_completion(
         pytest.param(
             {"gen_ai": {"inputs": True}},
             {
-                SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS: json.dumps(
+                SPANDATA.GEN_AI_PROVIDER_NAME_INSTRUCTIONS: json.dumps(
                     [{"type": "text", "content": "You are a helpful assistant."}]
                 ),
                 SPANDATA.GEN_AI_REQUEST_MESSAGES: safe_serialize(
@@ -513,7 +513,7 @@ def test_nonstreaming_chat_completion(
             {"gen_ai": {"inputs": False}},
             {},
             [
-                SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS,
+                SPANDATA.GEN_AI_PROVIDER_NAME_INSTRUCTIONS,
                 SPANDATA.GEN_AI_REQUEST_MESSAGES,
                 SPANDATA.GEN_AI_TOOL_DEFINITIONS,
             ],
@@ -522,7 +522,7 @@ def test_nonstreaming_chat_completion(
         pytest.param(
             {},
             {
-                SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS: json.dumps(
+                SPANDATA.GEN_AI_PROVIDER_NAME_INSTRUCTIONS: json.dumps(
                     [{"type": "text", "content": "You are a helpful assistant."}]
                 ),
                 SPANDATA.GEN_AI_REQUEST_MESSAGES: safe_serialize(
@@ -594,7 +594,7 @@ def test_completions_api_data_collection(
     assert span_data[SPANDATA.GEN_AI_REQUEST_FREQUENCY_PENALTY] == 0.2
     assert span_data[SPANDATA.GEN_AI_REQUEST_TEMPERATURE] == 0.7
     assert span_data[SPANDATA.GEN_AI_REQUEST_TOP_P] == 0.9
-    assert span_data[SPANDATA.GEN_AI_SYSTEM] == "openai"
+    assert span_data[SPANDATA.GEN_AI_PROVIDER_NAME] == "openai"
 
     for key, value in expected_present.items():
         assert span_data[key] == value
@@ -1064,7 +1064,7 @@ async def test_nonstreaming_chat_completion_async_no_prompts(
     sentry_sdk.flush()
     span = next(item.payload for item in items)
     assert span["attributes"]["sentry.op"] == "gen_ai.chat"
-    assert span["attributes"][SPANDATA.GEN_AI_SYSTEM] == "openai"
+    assert span["attributes"][SPANDATA.GEN_AI_PROVIDER_NAME] == "openai"
     assert span["attributes"][SPANDATA.GEN_AI_RESPONSE_STREAMING] is False
 
     assert span["attributes"][SPANDATA.GEN_AI_REQUEST_MODEL] == "some-model"
@@ -1074,7 +1074,7 @@ async def test_nonstreaming_chat_completion_async_no_prompts(
     assert span["attributes"][SPANDATA.GEN_AI_REQUEST_TEMPERATURE] == 0.7
     assert span["attributes"][SPANDATA.GEN_AI_REQUEST_TOP_P] == 0.9
 
-    assert SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS not in span["attributes"]
+    assert SPANDATA.GEN_AI_PROVIDER_NAME_INSTRUCTIONS not in span["attributes"]
     assert SPANDATA.GEN_AI_REQUEST_MESSAGES not in span["attributes"]
     assert SPANDATA.GEN_AI_RESPONSE_TEXT not in span["attributes"]
 
@@ -1208,7 +1208,7 @@ async def test_nonstreaming_chat_completion_async(
     sentry_sdk.flush()
     span = next(item.payload for item in items)
     assert span["attributes"]["sentry.op"] == "gen_ai.chat"
-    assert span["attributes"][SPANDATA.GEN_AI_SYSTEM] == "openai"
+    assert span["attributes"][SPANDATA.GEN_AI_PROVIDER_NAME] == "openai"
     assert span["attributes"][SPANDATA.GEN_AI_RESPONSE_STREAMING] is False
 
     assert span["attributes"][SPANDATA.GEN_AI_REQUEST_MODEL] == "some-model"
@@ -1219,7 +1219,7 @@ async def test_nonstreaming_chat_completion_async(
     assert span["attributes"][SPANDATA.GEN_AI_REQUEST_TOP_P] == 0.9
 
     assert (
-        json.loads(span["attributes"][SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS])
+        json.loads(span["attributes"][SPANDATA.GEN_AI_PROVIDER_NAME_INSTRUCTIONS])
         == expected_system_instructions
     )
 
@@ -1349,7 +1349,7 @@ def test_streaming_chat_completion_no_prompts(
     sentry_sdk.flush()
     span = next(item.payload for item in items)
     assert span["attributes"]["sentry.op"] == "gen_ai.chat"
-    assert span["attributes"][SPANDATA.GEN_AI_SYSTEM] == "openai"
+    assert span["attributes"][SPANDATA.GEN_AI_PROVIDER_NAME] == "openai"
     assert span["attributes"][SPANDATA.GEN_AI_RESPONSE_STREAMING] is True
 
     assert span["attributes"][SPANDATA.GEN_AI_REQUEST_MODEL] == "some-model"
@@ -1361,7 +1361,7 @@ def test_streaming_chat_completion_no_prompts(
 
     assert span["attributes"][SPANDATA.GEN_AI_RESPONSE_MODEL] == "model-id"
 
-    assert SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS not in span["attributes"]
+    assert SPANDATA.GEN_AI_PROVIDER_NAME_INSTRUCTIONS not in span["attributes"]
     assert SPANDATA.GEN_AI_REQUEST_MESSAGES not in span["attributes"]
     assert SPANDATA.GEN_AI_RESPONSE_TEXT not in span["attributes"]
 
@@ -1852,7 +1852,7 @@ def test_streaming_chat_completion(
     sentry_sdk.flush()
     span = next(item.payload for item in items)
     assert span["attributes"]["sentry.op"] == "gen_ai.chat"
-    assert span["attributes"][SPANDATA.GEN_AI_SYSTEM] == "openai"
+    assert span["attributes"][SPANDATA.GEN_AI_PROVIDER_NAME] == "openai"
     assert span["attributes"][SPANDATA.GEN_AI_RESPONSE_STREAMING] is True
 
     assert span["attributes"][SPANDATA.GEN_AI_REQUEST_MODEL] == "some-model"
@@ -1863,7 +1863,7 @@ def test_streaming_chat_completion(
     assert span["attributes"][SPANDATA.GEN_AI_REQUEST_TOP_P] == 0.9
 
     assert (
-        json.loads(span["attributes"][SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS])
+        json.loads(span["attributes"][SPANDATA.GEN_AI_PROVIDER_NAME_INSTRUCTIONS])
         == expected_system_instructions
     )
 
@@ -2002,7 +2002,7 @@ async def test_streaming_chat_completion_async_no_prompts(
     sentry_sdk.flush()
     span = next(item.payload for item in items)
     assert span["attributes"]["sentry.op"] == "gen_ai.chat"
-    assert span["attributes"][SPANDATA.GEN_AI_SYSTEM] == "openai"
+    assert span["attributes"][SPANDATA.GEN_AI_PROVIDER_NAME] == "openai"
     assert span["attributes"][SPANDATA.GEN_AI_RESPONSE_STREAMING] is True
 
     assert span["attributes"][SPANDATA.GEN_AI_REQUEST_MODEL] == "some-model"
@@ -2014,7 +2014,7 @@ async def test_streaming_chat_completion_async_no_prompts(
 
     assert span["attributes"][SPANDATA.GEN_AI_RESPONSE_MODEL] == "model-id"
 
-    assert SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS not in span["attributes"]
+    assert SPANDATA.GEN_AI_PROVIDER_NAME_INSTRUCTIONS not in span["attributes"]
     assert SPANDATA.GEN_AI_REQUEST_MESSAGES not in span["attributes"]
     assert SPANDATA.GEN_AI_RESPONSE_TEXT not in span["attributes"]
 
@@ -2215,7 +2215,7 @@ async def test_streaming_chat_completion_async(
     sentry_sdk.flush()
     span = next(item.payload for item in items)
     assert span["attributes"]["sentry.op"] == "gen_ai.chat"
-    assert span["attributes"][SPANDATA.GEN_AI_SYSTEM] == "openai"
+    assert span["attributes"][SPANDATA.GEN_AI_PROVIDER_NAME] == "openai"
     assert span["attributes"][SPANDATA.GEN_AI_RESPONSE_STREAMING] is True
 
     assert span["attributes"][SPANDATA.GEN_AI_REQUEST_MODEL] == "some-model"
@@ -2228,7 +2228,7 @@ async def test_streaming_chat_completion_async(
     assert span["attributes"][SPANDATA.GEN_AI_RESPONSE_MODEL] == "model-id"
 
     assert (
-        json.loads(span["attributes"][SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS])
+        json.loads(span["attributes"][SPANDATA.GEN_AI_PROVIDER_NAME_INSTRUCTIONS])
         == expected_system_instructions
     )
 
@@ -2388,7 +2388,7 @@ def test_embeddings_create_no_pii(
     sentry_sdk.flush()
     span = next(item.payload for item in items)
     assert span["attributes"]["sentry.op"] == "gen_ai.embeddings"
-    assert span["attributes"][SPANDATA.GEN_AI_SYSTEM] == "openai"
+    assert span["attributes"][SPANDATA.GEN_AI_PROVIDER_NAME] == "openai"
     assert span["attributes"][SPANDATA.GEN_AI_REQUEST_MODEL] == "text-embedding-3-large"
 
     assert SPANDATA.GEN_AI_EMBEDDINGS_INPUT not in span["attributes"]
@@ -2504,7 +2504,7 @@ def test_embeddings_create(
     sentry_sdk.flush()
     span = next(item.payload for item in items)
     assert span["attributes"]["sentry.op"] == "gen_ai.embeddings"
-    assert span["attributes"][SPANDATA.GEN_AI_SYSTEM] == "openai"
+    assert span["attributes"][SPANDATA.GEN_AI_PROVIDER_NAME] == "openai"
     assert span["attributes"][SPANDATA.GEN_AI_REQUEST_MODEL] == "text-embedding-3-large"
 
     assert (
@@ -2604,7 +2604,7 @@ def test_embeddings_create_data_collection(
         lambda: client.embeddings.create(input="hello", model="text-embedding-3-large"),
     )
 
-    assert span_data[SPANDATA.GEN_AI_SYSTEM] == "openai"
+    assert span_data[SPANDATA.GEN_AI_PROVIDER_NAME] == "openai"
     assert span_data[SPANDATA.GEN_AI_OPERATION_NAME] == "embeddings"
     assert span_data[SPANDATA.GEN_AI_REQUEST_MODEL] == "text-embedding-3-large"
 
@@ -2715,7 +2715,7 @@ async def test_embeddings_create_async_no_pii(
     sentry_sdk.flush()
     span = next(item.payload for item in items)
     assert span["attributes"]["sentry.op"] == "gen_ai.embeddings"
-    assert span["attributes"][SPANDATA.GEN_AI_SYSTEM] == "openai"
+    assert span["attributes"][SPANDATA.GEN_AI_PROVIDER_NAME] == "openai"
     assert span["attributes"][SPANDATA.GEN_AI_REQUEST_MODEL] == "text-embedding-3-large"
 
     assert SPANDATA.GEN_AI_EMBEDDINGS_INPUT not in span["attributes"]
@@ -2832,7 +2832,7 @@ async def test_embeddings_create_async(
     sentry_sdk.flush()
     span = next(item.payload for item in items)
     assert span["attributes"]["sentry.op"] == "gen_ai.embeddings"
-    assert span["attributes"][SPANDATA.GEN_AI_SYSTEM] == "openai"
+    assert span["attributes"][SPANDATA.GEN_AI_PROVIDER_NAME] == "openai"
     assert span["attributes"][SPANDATA.GEN_AI_REQUEST_MODEL] == "text-embedding-3-large"
 
     assert (
@@ -2921,7 +2921,7 @@ async def test_embeddings_create_async_data_collection(
     assert span["attributes"]["sentry.op"] == "gen_ai.embeddings"
     span_data = span["attributes"]
 
-    assert span_data[SPANDATA.GEN_AI_SYSTEM] == "openai"
+    assert span_data[SPANDATA.GEN_AI_PROVIDER_NAME] == "openai"
     assert span_data[SPANDATA.GEN_AI_OPERATION_NAME] == "embeddings"
     assert span_data[SPANDATA.GEN_AI_REQUEST_MODEL] == "text-embedding-3-large"
 
@@ -3680,7 +3680,7 @@ def test_ai_client_span_responses_api_no_pii(
         "gen_ai.request.model": "gpt-4o",
         "gen_ai.response.model": "response-model-id",
         "gen_ai.response.streaming": False,
-        "gen_ai.system": "openai",
+        SPANDATA.GEN_AI_PROVIDER_NAME: "openai",
         "gen_ai.usage.input_tokens": 20,
         "gen_ai.usage.input_tokens.cached": 5,
         "gen_ai.usage.output_tokens": 10,
@@ -3951,7 +3951,7 @@ def test_ai_client_span_responses_api(
         "gen_ai.request.temperature": 0.7,
         "gen_ai.request.top_p": 0.9,
         "gen_ai.request.reasoning.level": "high",
-        "gen_ai.system": "openai",
+        SPANDATA.GEN_AI_PROVIDER_NAME: "openai",
         "gen_ai.response.model": "response-model-id",
         "gen_ai.response.streaming": False,
         "gen_ai.usage.input_tokens": 20,
@@ -3989,7 +3989,7 @@ def test_ai_client_span_responses_api(
                 SPANDATA.GEN_AI_REQUEST_MESSAGES: safe_serialize(
                     ["How do I check if a Python object is an instance of a class?"]
                 ),
-                SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS: safe_serialize(
+                SPANDATA.GEN_AI_PROVIDER_NAME_INSTRUCTIONS: safe_serialize(
                     [
                         {
                             "type": "text",
@@ -4009,7 +4009,7 @@ def test_ai_client_span_responses_api(
                 "instructions": "You are a coding assistant that talks like a pirate.",
             },
             {
-                SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS: safe_serialize(
+                SPANDATA.GEN_AI_PROVIDER_NAME_INSTRUCTIONS: safe_serialize(
                     [
                         {
                             "type": "text",
@@ -4035,7 +4035,7 @@ def test_ai_client_span_responses_api(
                 ],
             },
             {
-                SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS: safe_serialize(
+                SPANDATA.GEN_AI_PROVIDER_NAME_INSTRUCTIONS: safe_serialize(
                     [
                         {
                             "type": "text",
@@ -4062,7 +4062,7 @@ def test_ai_client_span_responses_api(
             {},
             [
                 SPANDATA.GEN_AI_REQUEST_MESSAGES,
-                SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS,
+                SPANDATA.GEN_AI_PROVIDER_NAME_INSTRUCTIONS,
                 SPANDATA.GEN_AI_TOOL_DEFINITIONS,
             ],
             True,
@@ -4080,7 +4080,7 @@ def test_ai_client_span_responses_api(
                 ),
                 SPANDATA.GEN_AI_TOOL_DEFINITIONS: safe_serialize(EXAMPLE_TOOLS),
             },
-            [SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS],
+            [SPANDATA.GEN_AI_PROVIDER_NAME_INSTRUCTIONS],
             True,
             id="gen-ai-omitted-defaults-to-enabled",
         ),
@@ -4090,7 +4090,7 @@ def test_ai_client_span_responses_api(
             {},
             [
                 SPANDATA.GEN_AI_REQUEST_MESSAGES,
-                SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS,
+                SPANDATA.GEN_AI_PROVIDER_NAME_INSTRUCTIONS,
                 SPANDATA.GEN_AI_TOOL_DEFINITIONS,
             ],
             True,
@@ -4144,7 +4144,7 @@ def test_responses_api_data_collection(
     assert span_data["gen_ai.request.temperature"] == 0.7
     assert span_data["gen_ai.request.top_p"] == 0.9
     assert span_data["gen_ai.request.reasoning.level"] == "high"
-    assert span_data["gen_ai.system"] == "openai"
+    assert span_data[SPANDATA.GEN_AI_PROVIDER_NAME] == "openai"
 
     for key, value in expected_present.items():
         assert span_data[key] == value
@@ -4763,7 +4763,7 @@ async def test_ai_client_span_responses_async_api(
         "gen_ai.request.model": "gpt-4o",
         "gen_ai.response.model": "response-model-id",
         "gen_ai.response.streaming": False,
-        "gen_ai.system": "openai",
+        SPANDATA.GEN_AI_PROVIDER_NAME: "openai",
         "gen_ai.usage.input_tokens": 20,
         "gen_ai.usage.input_tokens.cached": 5,
         "gen_ai.usage.output_tokens": 10,
@@ -4990,7 +4990,7 @@ async def test_ai_client_span_streaming_responses_async_api(
         "gen_ai.request.reasoning.level": "high",
         "gen_ai.response.model": "response-model-id",
         "gen_ai.response.streaming": True,
-        "gen_ai.system": "openai",
+        SPANDATA.GEN_AI_PROVIDER_NAME: "openai",
         "gen_ai.response.time_to_first_token": mock.ANY,
         "gen_ai.usage.input_tokens": 20,
         "gen_ai.usage.input_tokens.cached": 5,
@@ -5185,7 +5185,7 @@ def test_streaming_responses_api(
     sentry_sdk.flush()
     (span,) = (item.payload for item in items)
     assert span["attributes"]["sentry.op"] == "gen_ai.responses"
-    assert span["attributes"][SPANDATA.GEN_AI_SYSTEM] == "openai"
+    assert span["attributes"][SPANDATA.GEN_AI_PROVIDER_NAME] == "openai"
     assert span["attributes"][SPANDATA.GEN_AI_REQUEST_MAX_TOKENS] == 100
     assert span["attributes"][SPANDATA.GEN_AI_REQUEST_TEMPERATURE] == 0.7
     assert span["attributes"][SPANDATA.GEN_AI_REQUEST_TOP_P] == 0.9
@@ -5263,7 +5263,7 @@ async def test_streaming_responses_api_async(
     sentry_sdk.flush()
     (span,) = (item.payload for item in items)
     assert span["attributes"]["sentry.op"] == "gen_ai.responses"
-    assert span["attributes"][SPANDATA.GEN_AI_SYSTEM] == "openai"
+    assert span["attributes"][SPANDATA.GEN_AI_PROVIDER_NAME] == "openai"
     assert span["attributes"][SPANDATA.GEN_AI_REQUEST_MAX_TOKENS] == 100
     assert span["attributes"][SPANDATA.GEN_AI_REQUEST_TEMPERATURE] == 0.7
     assert span["attributes"][SPANDATA.GEN_AI_REQUEST_TOP_P] == 0.9

--- a/tests/integrations/openai/test_openai.py
+++ b/tests/integrations/openai/test_openai.py
@@ -315,7 +315,7 @@ def test_nonstreaming_chat_completion_no_prompts(
     sentry_sdk.flush()
     span = next(item.payload for item in items)
     assert span["attributes"]["sentry.op"] == "gen_ai.chat"
-    assert span["attributes"][SPANDATA.GEN_AI_PROVIDER_NAME] == "openai"
+    assert span["attributes"][SPANDATA.GEN_AI_SYSTEM] == "openai"
     assert span["attributes"][SPANDATA.GEN_AI_RESPONSE_STREAMING] is False
 
     assert span["attributes"][SPANDATA.GEN_AI_REQUEST_MODEL] == "some-model"
@@ -325,7 +325,7 @@ def test_nonstreaming_chat_completion_no_prompts(
     assert span["attributes"][SPANDATA.GEN_AI_REQUEST_TEMPERATURE] == 0.7
     assert span["attributes"][SPANDATA.GEN_AI_REQUEST_TOP_P] == 0.9
 
-    assert SPANDATA.GEN_AI_PROVIDER_NAME_INSTRUCTIONS not in span["attributes"]
+    assert SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS not in span["attributes"]
     assert SPANDATA.GEN_AI_REQUEST_MESSAGES not in span["attributes"]
     assert SPANDATA.GEN_AI_RESPONSE_TEXT not in span["attributes"]
 
@@ -461,7 +461,7 @@ def test_nonstreaming_chat_completion(
     sentry_sdk.flush()
     span = next(item.payload for item in items)
     assert span["attributes"]["sentry.op"] == "gen_ai.chat"
-    assert span["attributes"][SPANDATA.GEN_AI_PROVIDER_NAME] == "openai"
+    assert span["attributes"][SPANDATA.GEN_AI_SYSTEM] == "openai"
     assert span["attributes"][SPANDATA.GEN_AI_RESPONSE_STREAMING] is False
 
     assert span["attributes"][SPANDATA.GEN_AI_REQUEST_MODEL] == "some-model"
@@ -472,7 +472,7 @@ def test_nonstreaming_chat_completion(
     assert span["attributes"][SPANDATA.GEN_AI_REQUEST_TOP_P] == 0.9
 
     assert (
-        json.loads(span["attributes"][SPANDATA.GEN_AI_PROVIDER_NAME_INSTRUCTIONS])
+        json.loads(span["attributes"][SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS])
         == expected_system_instructions
     )
 
@@ -498,7 +498,7 @@ def test_nonstreaming_chat_completion(
         pytest.param(
             {"gen_ai": {"inputs": True}},
             {
-                SPANDATA.GEN_AI_PROVIDER_NAME_INSTRUCTIONS: json.dumps(
+                SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS: json.dumps(
                     [{"type": "text", "content": "You are a helpful assistant."}]
                 ),
                 SPANDATA.GEN_AI_REQUEST_MESSAGES: safe_serialize(
@@ -513,7 +513,7 @@ def test_nonstreaming_chat_completion(
             {"gen_ai": {"inputs": False}},
             {},
             [
-                SPANDATA.GEN_AI_PROVIDER_NAME_INSTRUCTIONS,
+                SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS,
                 SPANDATA.GEN_AI_REQUEST_MESSAGES,
                 SPANDATA.GEN_AI_TOOL_DEFINITIONS,
             ],
@@ -522,7 +522,7 @@ def test_nonstreaming_chat_completion(
         pytest.param(
             {},
             {
-                SPANDATA.GEN_AI_PROVIDER_NAME_INSTRUCTIONS: json.dumps(
+                SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS: json.dumps(
                     [{"type": "text", "content": "You are a helpful assistant."}]
                 ),
                 SPANDATA.GEN_AI_REQUEST_MESSAGES: safe_serialize(
@@ -594,7 +594,7 @@ def test_completions_api_data_collection(
     assert span_data[SPANDATA.GEN_AI_REQUEST_FREQUENCY_PENALTY] == 0.2
     assert span_data[SPANDATA.GEN_AI_REQUEST_TEMPERATURE] == 0.7
     assert span_data[SPANDATA.GEN_AI_REQUEST_TOP_P] == 0.9
-    assert span_data[SPANDATA.GEN_AI_PROVIDER_NAME] == "openai"
+    assert span_data[SPANDATA.GEN_AI_SYSTEM] == "openai"
 
     for key, value in expected_present.items():
         assert span_data[key] == value
@@ -1064,7 +1064,7 @@ async def test_nonstreaming_chat_completion_async_no_prompts(
     sentry_sdk.flush()
     span = next(item.payload for item in items)
     assert span["attributes"]["sentry.op"] == "gen_ai.chat"
-    assert span["attributes"][SPANDATA.GEN_AI_PROVIDER_NAME] == "openai"
+    assert span["attributes"][SPANDATA.GEN_AI_SYSTEM] == "openai"
     assert span["attributes"][SPANDATA.GEN_AI_RESPONSE_STREAMING] is False
 
     assert span["attributes"][SPANDATA.GEN_AI_REQUEST_MODEL] == "some-model"
@@ -1074,7 +1074,7 @@ async def test_nonstreaming_chat_completion_async_no_prompts(
     assert span["attributes"][SPANDATA.GEN_AI_REQUEST_TEMPERATURE] == 0.7
     assert span["attributes"][SPANDATA.GEN_AI_REQUEST_TOP_P] == 0.9
 
-    assert SPANDATA.GEN_AI_PROVIDER_NAME_INSTRUCTIONS not in span["attributes"]
+    assert SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS not in span["attributes"]
     assert SPANDATA.GEN_AI_REQUEST_MESSAGES not in span["attributes"]
     assert SPANDATA.GEN_AI_RESPONSE_TEXT not in span["attributes"]
 
@@ -1208,7 +1208,7 @@ async def test_nonstreaming_chat_completion_async(
     sentry_sdk.flush()
     span = next(item.payload for item in items)
     assert span["attributes"]["sentry.op"] == "gen_ai.chat"
-    assert span["attributes"][SPANDATA.GEN_AI_PROVIDER_NAME] == "openai"
+    assert span["attributes"][SPANDATA.GEN_AI_SYSTEM] == "openai"
     assert span["attributes"][SPANDATA.GEN_AI_RESPONSE_STREAMING] is False
 
     assert span["attributes"][SPANDATA.GEN_AI_REQUEST_MODEL] == "some-model"
@@ -1219,7 +1219,7 @@ async def test_nonstreaming_chat_completion_async(
     assert span["attributes"][SPANDATA.GEN_AI_REQUEST_TOP_P] == 0.9
 
     assert (
-        json.loads(span["attributes"][SPANDATA.GEN_AI_PROVIDER_NAME_INSTRUCTIONS])
+        json.loads(span["attributes"][SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS])
         == expected_system_instructions
     )
 
@@ -1349,7 +1349,7 @@ def test_streaming_chat_completion_no_prompts(
     sentry_sdk.flush()
     span = next(item.payload for item in items)
     assert span["attributes"]["sentry.op"] == "gen_ai.chat"
-    assert span["attributes"][SPANDATA.GEN_AI_PROVIDER_NAME] == "openai"
+    assert span["attributes"][SPANDATA.GEN_AI_SYSTEM] == "openai"
     assert span["attributes"][SPANDATA.GEN_AI_RESPONSE_STREAMING] is True
 
     assert span["attributes"][SPANDATA.GEN_AI_REQUEST_MODEL] == "some-model"
@@ -1361,7 +1361,7 @@ def test_streaming_chat_completion_no_prompts(
 
     assert span["attributes"][SPANDATA.GEN_AI_RESPONSE_MODEL] == "model-id"
 
-    assert SPANDATA.GEN_AI_PROVIDER_NAME_INSTRUCTIONS not in span["attributes"]
+    assert SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS not in span["attributes"]
     assert SPANDATA.GEN_AI_REQUEST_MESSAGES not in span["attributes"]
     assert SPANDATA.GEN_AI_RESPONSE_TEXT not in span["attributes"]
 
@@ -1852,7 +1852,7 @@ def test_streaming_chat_completion(
     sentry_sdk.flush()
     span = next(item.payload for item in items)
     assert span["attributes"]["sentry.op"] == "gen_ai.chat"
-    assert span["attributes"][SPANDATA.GEN_AI_PROVIDER_NAME] == "openai"
+    assert span["attributes"][SPANDATA.GEN_AI_SYSTEM] == "openai"
     assert span["attributes"][SPANDATA.GEN_AI_RESPONSE_STREAMING] is True
 
     assert span["attributes"][SPANDATA.GEN_AI_REQUEST_MODEL] == "some-model"
@@ -1863,7 +1863,7 @@ def test_streaming_chat_completion(
     assert span["attributes"][SPANDATA.GEN_AI_REQUEST_TOP_P] == 0.9
 
     assert (
-        json.loads(span["attributes"][SPANDATA.GEN_AI_PROVIDER_NAME_INSTRUCTIONS])
+        json.loads(span["attributes"][SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS])
         == expected_system_instructions
     )
 
@@ -2002,7 +2002,7 @@ async def test_streaming_chat_completion_async_no_prompts(
     sentry_sdk.flush()
     span = next(item.payload for item in items)
     assert span["attributes"]["sentry.op"] == "gen_ai.chat"
-    assert span["attributes"][SPANDATA.GEN_AI_PROVIDER_NAME] == "openai"
+    assert span["attributes"][SPANDATA.GEN_AI_SYSTEM] == "openai"
     assert span["attributes"][SPANDATA.GEN_AI_RESPONSE_STREAMING] is True
 
     assert span["attributes"][SPANDATA.GEN_AI_REQUEST_MODEL] == "some-model"
@@ -2014,7 +2014,7 @@ async def test_streaming_chat_completion_async_no_prompts(
 
     assert span["attributes"][SPANDATA.GEN_AI_RESPONSE_MODEL] == "model-id"
 
-    assert SPANDATA.GEN_AI_PROVIDER_NAME_INSTRUCTIONS not in span["attributes"]
+    assert SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS not in span["attributes"]
     assert SPANDATA.GEN_AI_REQUEST_MESSAGES not in span["attributes"]
     assert SPANDATA.GEN_AI_RESPONSE_TEXT not in span["attributes"]
 
@@ -2215,7 +2215,7 @@ async def test_streaming_chat_completion_async(
     sentry_sdk.flush()
     span = next(item.payload for item in items)
     assert span["attributes"]["sentry.op"] == "gen_ai.chat"
-    assert span["attributes"][SPANDATA.GEN_AI_PROVIDER_NAME] == "openai"
+    assert span["attributes"][SPANDATA.GEN_AI_SYSTEM] == "openai"
     assert span["attributes"][SPANDATA.GEN_AI_RESPONSE_STREAMING] is True
 
     assert span["attributes"][SPANDATA.GEN_AI_REQUEST_MODEL] == "some-model"
@@ -2228,7 +2228,7 @@ async def test_streaming_chat_completion_async(
     assert span["attributes"][SPANDATA.GEN_AI_RESPONSE_MODEL] == "model-id"
 
     assert (
-        json.loads(span["attributes"][SPANDATA.GEN_AI_PROVIDER_NAME_INSTRUCTIONS])
+        json.loads(span["attributes"][SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS])
         == expected_system_instructions
     )
 
@@ -2388,7 +2388,7 @@ def test_embeddings_create_no_pii(
     sentry_sdk.flush()
     span = next(item.payload for item in items)
     assert span["attributes"]["sentry.op"] == "gen_ai.embeddings"
-    assert span["attributes"][SPANDATA.GEN_AI_PROVIDER_NAME] == "openai"
+    assert span["attributes"][SPANDATA.GEN_AI_SYSTEM] == "openai"
     assert span["attributes"][SPANDATA.GEN_AI_REQUEST_MODEL] == "text-embedding-3-large"
 
     assert SPANDATA.GEN_AI_EMBEDDINGS_INPUT not in span["attributes"]
@@ -2504,7 +2504,7 @@ def test_embeddings_create(
     sentry_sdk.flush()
     span = next(item.payload for item in items)
     assert span["attributes"]["sentry.op"] == "gen_ai.embeddings"
-    assert span["attributes"][SPANDATA.GEN_AI_PROVIDER_NAME] == "openai"
+    assert span["attributes"][SPANDATA.GEN_AI_SYSTEM] == "openai"
     assert span["attributes"][SPANDATA.GEN_AI_REQUEST_MODEL] == "text-embedding-3-large"
 
     assert (
@@ -2604,7 +2604,7 @@ def test_embeddings_create_data_collection(
         lambda: client.embeddings.create(input="hello", model="text-embedding-3-large"),
     )
 
-    assert span_data[SPANDATA.GEN_AI_PROVIDER_NAME] == "openai"
+    assert span_data[SPANDATA.GEN_AI_SYSTEM] == "openai"
     assert span_data[SPANDATA.GEN_AI_OPERATION_NAME] == "embeddings"
     assert span_data[SPANDATA.GEN_AI_REQUEST_MODEL] == "text-embedding-3-large"
 
@@ -2715,7 +2715,7 @@ async def test_embeddings_create_async_no_pii(
     sentry_sdk.flush()
     span = next(item.payload for item in items)
     assert span["attributes"]["sentry.op"] == "gen_ai.embeddings"
-    assert span["attributes"][SPANDATA.GEN_AI_PROVIDER_NAME] == "openai"
+    assert span["attributes"][SPANDATA.GEN_AI_SYSTEM] == "openai"
     assert span["attributes"][SPANDATA.GEN_AI_REQUEST_MODEL] == "text-embedding-3-large"
 
     assert SPANDATA.GEN_AI_EMBEDDINGS_INPUT not in span["attributes"]
@@ -2832,7 +2832,7 @@ async def test_embeddings_create_async(
     sentry_sdk.flush()
     span = next(item.payload for item in items)
     assert span["attributes"]["sentry.op"] == "gen_ai.embeddings"
-    assert span["attributes"][SPANDATA.GEN_AI_PROVIDER_NAME] == "openai"
+    assert span["attributes"][SPANDATA.GEN_AI_SYSTEM] == "openai"
     assert span["attributes"][SPANDATA.GEN_AI_REQUEST_MODEL] == "text-embedding-3-large"
 
     assert (
@@ -2921,7 +2921,7 @@ async def test_embeddings_create_async_data_collection(
     assert span["attributes"]["sentry.op"] == "gen_ai.embeddings"
     span_data = span["attributes"]
 
-    assert span_data[SPANDATA.GEN_AI_PROVIDER_NAME] == "openai"
+    assert span_data[SPANDATA.GEN_AI_SYSTEM] == "openai"
     assert span_data[SPANDATA.GEN_AI_OPERATION_NAME] == "embeddings"
     assert span_data[SPANDATA.GEN_AI_REQUEST_MODEL] == "text-embedding-3-large"
 
@@ -3680,7 +3680,7 @@ def test_ai_client_span_responses_api_no_pii(
         "gen_ai.request.model": "gpt-4o",
         "gen_ai.response.model": "response-model-id",
         "gen_ai.response.streaming": False,
-        SPANDATA.GEN_AI_PROVIDER_NAME: "openai",
+        "gen_ai.system": "openai",
         "gen_ai.usage.input_tokens": 20,
         "gen_ai.usage.input_tokens.cached": 5,
         "gen_ai.usage.output_tokens": 10,
@@ -3951,7 +3951,7 @@ def test_ai_client_span_responses_api(
         "gen_ai.request.temperature": 0.7,
         "gen_ai.request.top_p": 0.9,
         "gen_ai.request.reasoning.level": "high",
-        SPANDATA.GEN_AI_PROVIDER_NAME: "openai",
+        "gen_ai.system": "openai",
         "gen_ai.response.model": "response-model-id",
         "gen_ai.response.streaming": False,
         "gen_ai.usage.input_tokens": 20,
@@ -3989,7 +3989,7 @@ def test_ai_client_span_responses_api(
                 SPANDATA.GEN_AI_REQUEST_MESSAGES: safe_serialize(
                     ["How do I check if a Python object is an instance of a class?"]
                 ),
-                SPANDATA.GEN_AI_PROVIDER_NAME_INSTRUCTIONS: safe_serialize(
+                SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS: safe_serialize(
                     [
                         {
                             "type": "text",
@@ -4009,7 +4009,7 @@ def test_ai_client_span_responses_api(
                 "instructions": "You are a coding assistant that talks like a pirate.",
             },
             {
-                SPANDATA.GEN_AI_PROVIDER_NAME_INSTRUCTIONS: safe_serialize(
+                SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS: safe_serialize(
                     [
                         {
                             "type": "text",
@@ -4035,7 +4035,7 @@ def test_ai_client_span_responses_api(
                 ],
             },
             {
-                SPANDATA.GEN_AI_PROVIDER_NAME_INSTRUCTIONS: safe_serialize(
+                SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS: safe_serialize(
                     [
                         {
                             "type": "text",
@@ -4062,7 +4062,7 @@ def test_ai_client_span_responses_api(
             {},
             [
                 SPANDATA.GEN_AI_REQUEST_MESSAGES,
-                SPANDATA.GEN_AI_PROVIDER_NAME_INSTRUCTIONS,
+                SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS,
                 SPANDATA.GEN_AI_TOOL_DEFINITIONS,
             ],
             True,
@@ -4080,7 +4080,7 @@ def test_ai_client_span_responses_api(
                 ),
                 SPANDATA.GEN_AI_TOOL_DEFINITIONS: safe_serialize(EXAMPLE_TOOLS),
             },
-            [SPANDATA.GEN_AI_PROVIDER_NAME_INSTRUCTIONS],
+            [SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS],
             True,
             id="gen-ai-omitted-defaults-to-enabled",
         ),
@@ -4090,7 +4090,7 @@ def test_ai_client_span_responses_api(
             {},
             [
                 SPANDATA.GEN_AI_REQUEST_MESSAGES,
-                SPANDATA.GEN_AI_PROVIDER_NAME_INSTRUCTIONS,
+                SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS,
                 SPANDATA.GEN_AI_TOOL_DEFINITIONS,
             ],
             True,
@@ -4144,7 +4144,7 @@ def test_responses_api_data_collection(
     assert span_data["gen_ai.request.temperature"] == 0.7
     assert span_data["gen_ai.request.top_p"] == 0.9
     assert span_data["gen_ai.request.reasoning.level"] == "high"
-    assert span_data[SPANDATA.GEN_AI_PROVIDER_NAME] == "openai"
+    assert span_data["gen_ai.system"] == "openai"
 
     for key, value in expected_present.items():
         assert span_data[key] == value
@@ -4763,7 +4763,7 @@ async def test_ai_client_span_responses_async_api(
         "gen_ai.request.model": "gpt-4o",
         "gen_ai.response.model": "response-model-id",
         "gen_ai.response.streaming": False,
-        SPANDATA.GEN_AI_PROVIDER_NAME: "openai",
+        "gen_ai.system": "openai",
         "gen_ai.usage.input_tokens": 20,
         "gen_ai.usage.input_tokens.cached": 5,
         "gen_ai.usage.output_tokens": 10,
@@ -4990,7 +4990,7 @@ async def test_ai_client_span_streaming_responses_async_api(
         "gen_ai.request.reasoning.level": "high",
         "gen_ai.response.model": "response-model-id",
         "gen_ai.response.streaming": True,
-        SPANDATA.GEN_AI_PROVIDER_NAME: "openai",
+        "gen_ai.system": "openai",
         "gen_ai.response.time_to_first_token": mock.ANY,
         "gen_ai.usage.input_tokens": 20,
         "gen_ai.usage.input_tokens.cached": 5,
@@ -5185,7 +5185,7 @@ def test_streaming_responses_api(
     sentry_sdk.flush()
     (span,) = (item.payload for item in items)
     assert span["attributes"]["sentry.op"] == "gen_ai.responses"
-    assert span["attributes"][SPANDATA.GEN_AI_PROVIDER_NAME] == "openai"
+    assert span["attributes"][SPANDATA.GEN_AI_SYSTEM] == "openai"
     assert span["attributes"][SPANDATA.GEN_AI_REQUEST_MAX_TOKENS] == 100
     assert span["attributes"][SPANDATA.GEN_AI_REQUEST_TEMPERATURE] == 0.7
     assert span["attributes"][SPANDATA.GEN_AI_REQUEST_TOP_P] == 0.9
@@ -5263,7 +5263,7 @@ async def test_streaming_responses_api_async(
     sentry_sdk.flush()
     (span,) = (item.payload for item in items)
     assert span["attributes"]["sentry.op"] == "gen_ai.responses"
-    assert span["attributes"][SPANDATA.GEN_AI_PROVIDER_NAME] == "openai"
+    assert span["attributes"][SPANDATA.GEN_AI_SYSTEM] == "openai"
     assert span["attributes"][SPANDATA.GEN_AI_REQUEST_MAX_TOKENS] == 100
     assert span["attributes"][SPANDATA.GEN_AI_REQUEST_TEMPERATURE] == 0.7
     assert span["attributes"][SPANDATA.GEN_AI_REQUEST_TOP_P] == 0.9

--- a/tests/integrations/openai_agents/test_openai_agents.py
+++ b/tests/integrations/openai_agents/test_openai_agents.py
@@ -480,7 +480,7 @@ async def test_agent_invocation_span_no_pii(
     assert "gen_ai.response.text" not in invoke_agent_span["attributes"]
 
     assert invoke_agent_span["attributes"]["gen_ai.operation.name"] == "invoke_agent"
-    assert invoke_agent_span["attributes"]["gen_ai.system"] == "openai"
+    assert invoke_agent_span["attributes"][SPANDATA.GEN_AI_PROVIDER_NAME] == "openai"
     assert invoke_agent_span["attributes"]["gen_ai.agent.name"] == "test_agent"
     assert invoke_agent_span["attributes"]["gen_ai.request.max_tokens"] == 100
     assert invoke_agent_span["attributes"]["gen_ai.request.model"] == "gpt-4"
@@ -489,7 +489,7 @@ async def test_agent_invocation_span_no_pii(
 
     assert ai_client_span["name"] == "chat gpt-4"
     assert ai_client_span["attributes"]["gen_ai.operation.name"] == "chat"
-    assert ai_client_span["attributes"]["gen_ai.system"] == "openai"
+    assert ai_client_span["attributes"][SPANDATA.GEN_AI_PROVIDER_NAME] == "openai"
     assert ai_client_span["attributes"]["gen_ai.agent.name"] == "test_agent"
     assert ai_client_span["attributes"]["gen_ai.request.max_tokens"] == 100
     assert ai_client_span["attributes"]["gen_ai.request.model"] == "gpt-4"
@@ -1228,7 +1228,7 @@ async def test_agent_invocation_span(
     )
 
     assert invoke_agent_span["attributes"]["gen_ai.operation.name"] == "invoke_agent"
-    assert invoke_agent_span["attributes"]["gen_ai.system"] == "openai"
+    assert invoke_agent_span["attributes"][SPANDATA.GEN_AI_PROVIDER_NAME] == "openai"
     assert invoke_agent_span["attributes"]["gen_ai.agent.name"] == "test_agent"
     assert invoke_agent_span["attributes"]["gen_ai.request.max_tokens"] == 100
     assert invoke_agent_span["attributes"]["gen_ai.request.model"] == "gpt-4"
@@ -1237,7 +1237,7 @@ async def test_agent_invocation_span(
 
     assert ai_client_span["name"] == "chat gpt-4"
     assert ai_client_span["attributes"]["gen_ai.operation.name"] == "chat"
-    assert ai_client_span["attributes"]["gen_ai.system"] == "openai"
+    assert ai_client_span["attributes"][SPANDATA.GEN_AI_PROVIDER_NAME] == "openai"
     assert ai_client_span["attributes"]["gen_ai.agent.name"] == "test_agent"
     assert ai_client_span["attributes"]["gen_ai.request.max_tokens"] == 100
     assert ai_client_span["attributes"]["gen_ai.request.model"] == "gpt-4"
@@ -1350,7 +1350,7 @@ def test_agent_invocation_span_sync_no_pii(
 
     assert invoke_agent_span["name"] == "invoke_agent test_agent"
     assert invoke_agent_span["attributes"]["gen_ai.operation.name"] == "invoke_agent"
-    assert invoke_agent_span["attributes"]["gen_ai.system"] == "openai"
+    assert invoke_agent_span["attributes"][SPANDATA.GEN_AI_PROVIDER_NAME] == "openai"
     assert invoke_agent_span["attributes"]["gen_ai.agent.name"] == "test_agent"
     assert invoke_agent_span["attributes"]["gen_ai.request.max_tokens"] == 100
     assert invoke_agent_span["attributes"]["gen_ai.request.model"] == "gpt-4"
@@ -1359,7 +1359,7 @@ def test_agent_invocation_span_sync_no_pii(
 
     assert ai_client_span["name"] == "chat gpt-4"
     assert ai_client_span["attributes"]["gen_ai.operation.name"] == "chat"
-    assert ai_client_span["attributes"]["gen_ai.system"] == "openai"
+    assert ai_client_span["attributes"][SPANDATA.GEN_AI_PROVIDER_NAME] == "openai"
     assert ai_client_span["attributes"]["gen_ai.agent.name"] == "test_agent"
     assert ai_client_span["attributes"]["gen_ai.request.max_tokens"] == 100
     assert ai_client_span["attributes"]["gen_ai.request.model"] == "gpt-4"
@@ -1614,7 +1614,7 @@ def test_agent_invocation_span_sync(
 
     assert invoke_agent_span["name"] == "invoke_agent test_agent"
     assert invoke_agent_span["attributes"]["gen_ai.operation.name"] == "invoke_agent"
-    assert invoke_agent_span["attributes"]["gen_ai.system"] == "openai"
+    assert invoke_agent_span["attributes"][SPANDATA.GEN_AI_PROVIDER_NAME] == "openai"
     assert invoke_agent_span["attributes"]["gen_ai.agent.name"] == "test_agent"
     assert invoke_agent_span["attributes"]["gen_ai.request.max_tokens"] == 100
     assert invoke_agent_span["attributes"]["gen_ai.request.model"] == "gpt-4"
@@ -1623,7 +1623,7 @@ def test_agent_invocation_span_sync(
 
     assert ai_client_span["name"] == "chat gpt-4"
     assert ai_client_span["attributes"]["gen_ai.operation.name"] == "chat"
-    assert ai_client_span["attributes"]["gen_ai.system"] == "openai"
+    assert ai_client_span["attributes"][SPANDATA.GEN_AI_PROVIDER_NAME] == "openai"
     assert ai_client_span["attributes"]["gen_ai.agent.name"] == "test_agent"
     assert ai_client_span["attributes"]["gen_ai.request.max_tokens"] == 100
     assert ai_client_span["attributes"]["gen_ai.request.model"] == "gpt-4"
@@ -2039,11 +2039,11 @@ async def test_tool_execution_span(
     assert agent_span["attributes"]["gen_ai.request.model"] == "gpt-4"
     assert agent_span["attributes"]["gen_ai.request.temperature"] == 0.7
     assert agent_span["attributes"]["gen_ai.request.top_p"] == 1.0
-    assert agent_span["attributes"]["gen_ai.system"] == "openai"
+    assert agent_span["attributes"][SPANDATA.GEN_AI_PROVIDER_NAME] == "openai"
 
     assert ai_client_span1["name"] == "chat gpt-4"
     assert ai_client_span1["attributes"]["gen_ai.operation.name"] == "chat"
-    assert ai_client_span1["attributes"]["gen_ai.system"] == "openai"
+    assert ai_client_span1["attributes"][SPANDATA.GEN_AI_PROVIDER_NAME] == "openai"
     assert ai_client_span1["attributes"]["gen_ai.agent.name"] == "test_agent"
 
     ai_client_span1_available_tool = json.loads(
@@ -2100,7 +2100,7 @@ async def test_tool_execution_span(
     assert tool_span["attributes"]["gen_ai.request.model"] == "gpt-4"
     assert tool_span["attributes"]["gen_ai.request.temperature"] == 0.7
     assert tool_span["attributes"]["gen_ai.request.top_p"] == 1.0
-    assert tool_span["attributes"]["gen_ai.system"] == "openai"
+    assert tool_span["attributes"][SPANDATA.GEN_AI_PROVIDER_NAME] == "openai"
     assert tool_span["attributes"]["gen_ai.tool.description"] == "A simple tool"
     assert tool_span["attributes"]["gen_ai.tool.input"] == '{"message": "hello"}'
     assert tool_span["attributes"]["gen_ai.tool.name"] == "simple_test_tool"
@@ -2157,7 +2157,7 @@ async def test_tool_execution_span(
         ai_client_span2["attributes"]["gen_ai.response.text"]
         == "Task completed using the tool"
     )
-    assert ai_client_span2["attributes"]["gen_ai.system"] == "openai"
+    assert ai_client_span2["attributes"][SPANDATA.GEN_AI_PROVIDER_NAME] == "openai"
     assert ai_client_span2["attributes"]["gen_ai.usage.input_tokens.cached"] == 0
     assert ai_client_span2["attributes"]["gen_ai.usage.input_tokens"] == 15
     assert ai_client_span2["attributes"]["gen_ai.usage.output_tokens.reasoning"] == 0
@@ -2289,7 +2289,7 @@ async def test_run_streamed_tool_execution_span(
     assert agent_span["attributes"]["gen_ai.request.model"] == "gpt-4"
     assert agent_span["attributes"]["gen_ai.request.temperature"] == 0.7
     assert agent_span["attributes"]["gen_ai.request.top_p"] == 1.0
-    assert agent_span["attributes"]["gen_ai.system"] == "openai"
+    assert agent_span["attributes"][SPANDATA.GEN_AI_PROVIDER_NAME] == "openai"
 
     assert tool_span["name"] == "execute_tool simple_test_tool"
     assert tool_span["attributes"]["gen_ai.agent.name"] == "test_agent"
@@ -2299,7 +2299,7 @@ async def test_run_streamed_tool_execution_span(
     assert tool_span["attributes"]["gen_ai.request.model"] == "gpt-4"
     assert tool_span["attributes"]["gen_ai.request.temperature"] == 0.7
     assert tool_span["attributes"]["gen_ai.request.top_p"] == 1.0
-    assert tool_span["attributes"]["gen_ai.system"] == "openai"
+    assert tool_span["attributes"][SPANDATA.GEN_AI_PROVIDER_NAME] == "openai"
     assert tool_span["attributes"]["gen_ai.tool.description"] == "A simple tool"
     assert tool_span["attributes"]["gen_ai.tool.input"] == '{"message": "hello"}'
     assert tool_span["attributes"]["gen_ai.tool.name"] == "simple_test_tool"

--- a/tests/integrations/openai_agents/test_openai_agents.py
+++ b/tests/integrations/openai_agents/test_openai_agents.py
@@ -475,15 +475,12 @@ async def test_agent_invocation_span_no_pii(
 
     assert invoke_agent_span["name"] == "invoke_agent test_agent"
 
-    assert (
-        SPANDATA.GEN_AI_PROVIDER_NAME_INSTRUCTIONS
-        not in invoke_agent_span["attributes"]
-    )
+    assert SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS not in invoke_agent_span["attributes"]
     assert "gen_ai.request.messages" not in invoke_agent_span["attributes"]
     assert "gen_ai.response.text" not in invoke_agent_span["attributes"]
 
     assert invoke_agent_span["attributes"]["gen_ai.operation.name"] == "invoke_agent"
-    assert invoke_agent_span["attributes"][SPANDATA.GEN_AI_PROVIDER_NAME] == "openai"
+    assert invoke_agent_span["attributes"]["gen_ai.system"] == "openai"
     assert invoke_agent_span["attributes"]["gen_ai.agent.name"] == "test_agent"
     assert invoke_agent_span["attributes"]["gen_ai.request.max_tokens"] == 100
     assert invoke_agent_span["attributes"]["gen_ai.request.model"] == "gpt-4"
@@ -492,7 +489,7 @@ async def test_agent_invocation_span_no_pii(
 
     assert ai_client_span["name"] == "chat gpt-4"
     assert ai_client_span["attributes"]["gen_ai.operation.name"] == "chat"
-    assert ai_client_span["attributes"][SPANDATA.GEN_AI_PROVIDER_NAME] == "openai"
+    assert ai_client_span["attributes"]["gen_ai.system"] == "openai"
     assert ai_client_span["attributes"]["gen_ai.agent.name"] == "test_agent"
     assert ai_client_span["attributes"]["gen_ai.request.max_tokens"] == 100
     assert ai_client_span["attributes"]["gen_ai.request.model"] == "gpt-4"
@@ -810,12 +807,11 @@ async def test_data_collection_inputs(
     if expect_input:
         assert "Test input" in span_data[SPANDATA.GEN_AI_REQUEST_MESSAGES]
         assert (
-            "helpful test assistant"
-            in span_data[SPANDATA.GEN_AI_PROVIDER_NAME_INSTRUCTIONS]
+            "helpful test assistant" in span_data[SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS]
         )
     else:
         assert SPANDATA.GEN_AI_REQUEST_MESSAGES not in span_data
-        assert SPANDATA.GEN_AI_PROVIDER_NAME_INSTRUCTIONS not in span_data
+        assert SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS not in span_data
 
     # Tool definitions are only gated once data_collection is configured; without it
     # they are set unconditionally, as they were before data_collection existed.
@@ -1232,7 +1228,7 @@ async def test_agent_invocation_span(
     )
 
     assert invoke_agent_span["attributes"]["gen_ai.operation.name"] == "invoke_agent"
-    assert invoke_agent_span["attributes"][SPANDATA.GEN_AI_PROVIDER_NAME] == "openai"
+    assert invoke_agent_span["attributes"]["gen_ai.system"] == "openai"
     assert invoke_agent_span["attributes"]["gen_ai.agent.name"] == "test_agent"
     assert invoke_agent_span["attributes"]["gen_ai.request.max_tokens"] == 100
     assert invoke_agent_span["attributes"]["gen_ai.request.model"] == "gpt-4"
@@ -1241,7 +1237,7 @@ async def test_agent_invocation_span(
 
     assert ai_client_span["name"] == "chat gpt-4"
     assert ai_client_span["attributes"]["gen_ai.operation.name"] == "chat"
-    assert ai_client_span["attributes"][SPANDATA.GEN_AI_PROVIDER_NAME] == "openai"
+    assert ai_client_span["attributes"]["gen_ai.system"] == "openai"
     assert ai_client_span["attributes"]["gen_ai.agent.name"] == "test_agent"
     assert ai_client_span["attributes"]["gen_ai.request.max_tokens"] == 100
     assert ai_client_span["attributes"]["gen_ai.request.model"] == "gpt-4"
@@ -1354,7 +1350,7 @@ def test_agent_invocation_span_sync_no_pii(
 
     assert invoke_agent_span["name"] == "invoke_agent test_agent"
     assert invoke_agent_span["attributes"]["gen_ai.operation.name"] == "invoke_agent"
-    assert invoke_agent_span["attributes"][SPANDATA.GEN_AI_PROVIDER_NAME] == "openai"
+    assert invoke_agent_span["attributes"]["gen_ai.system"] == "openai"
     assert invoke_agent_span["attributes"]["gen_ai.agent.name"] == "test_agent"
     assert invoke_agent_span["attributes"]["gen_ai.request.max_tokens"] == 100
     assert invoke_agent_span["attributes"]["gen_ai.request.model"] == "gpt-4"
@@ -1363,17 +1359,14 @@ def test_agent_invocation_span_sync_no_pii(
 
     assert ai_client_span["name"] == "chat gpt-4"
     assert ai_client_span["attributes"]["gen_ai.operation.name"] == "chat"
-    assert ai_client_span["attributes"][SPANDATA.GEN_AI_PROVIDER_NAME] == "openai"
+    assert ai_client_span["attributes"]["gen_ai.system"] == "openai"
     assert ai_client_span["attributes"]["gen_ai.agent.name"] == "test_agent"
     assert ai_client_span["attributes"]["gen_ai.request.max_tokens"] == 100
     assert ai_client_span["attributes"]["gen_ai.request.model"] == "gpt-4"
     assert ai_client_span["attributes"]["gen_ai.request.temperature"] == 0.7
     assert ai_client_span["attributes"]["gen_ai.request.top_p"] == 1.0
 
-    assert (
-        SPANDATA.GEN_AI_PROVIDER_NAME_INSTRUCTIONS
-        not in invoke_agent_span["attributes"]
-    )
+    assert SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS not in invoke_agent_span["attributes"]
 
 
 @pytest.mark.parametrize(
@@ -1621,7 +1614,7 @@ def test_agent_invocation_span_sync(
 
     assert invoke_agent_span["name"] == "invoke_agent test_agent"
     assert invoke_agent_span["attributes"]["gen_ai.operation.name"] == "invoke_agent"
-    assert invoke_agent_span["attributes"][SPANDATA.GEN_AI_PROVIDER_NAME] == "openai"
+    assert invoke_agent_span["attributes"]["gen_ai.system"] == "openai"
     assert invoke_agent_span["attributes"]["gen_ai.agent.name"] == "test_agent"
     assert invoke_agent_span["attributes"]["gen_ai.request.max_tokens"] == 100
     assert invoke_agent_span["attributes"]["gen_ai.request.model"] == "gpt-4"
@@ -1630,7 +1623,7 @@ def test_agent_invocation_span_sync(
 
     assert ai_client_span["name"] == "chat gpt-4"
     assert ai_client_span["attributes"]["gen_ai.operation.name"] == "chat"
-    assert ai_client_span["attributes"][SPANDATA.GEN_AI_PROVIDER_NAME] == "openai"
+    assert ai_client_span["attributes"]["gen_ai.system"] == "openai"
     assert ai_client_span["attributes"]["gen_ai.agent.name"] == "test_agent"
     assert ai_client_span["attributes"]["gen_ai.request.max_tokens"] == 100
     assert ai_client_span["attributes"]["gen_ai.request.model"] == "gpt-4"
@@ -2046,11 +2039,11 @@ async def test_tool_execution_span(
     assert agent_span["attributes"]["gen_ai.request.model"] == "gpt-4"
     assert agent_span["attributes"]["gen_ai.request.temperature"] == 0.7
     assert agent_span["attributes"]["gen_ai.request.top_p"] == 1.0
-    assert agent_span["attributes"][SPANDATA.GEN_AI_PROVIDER_NAME] == "openai"
+    assert agent_span["attributes"]["gen_ai.system"] == "openai"
 
     assert ai_client_span1["name"] == "chat gpt-4"
     assert ai_client_span1["attributes"]["gen_ai.operation.name"] == "chat"
-    assert ai_client_span1["attributes"][SPANDATA.GEN_AI_PROVIDER_NAME] == "openai"
+    assert ai_client_span1["attributes"]["gen_ai.system"] == "openai"
     assert ai_client_span1["attributes"]["gen_ai.agent.name"] == "test_agent"
 
     ai_client_span1_available_tool = json.loads(
@@ -2107,7 +2100,7 @@ async def test_tool_execution_span(
     assert tool_span["attributes"]["gen_ai.request.model"] == "gpt-4"
     assert tool_span["attributes"]["gen_ai.request.temperature"] == 0.7
     assert tool_span["attributes"]["gen_ai.request.top_p"] == 1.0
-    assert tool_span["attributes"][SPANDATA.GEN_AI_PROVIDER_NAME] == "openai"
+    assert tool_span["attributes"]["gen_ai.system"] == "openai"
     assert tool_span["attributes"]["gen_ai.tool.description"] == "A simple tool"
     assert tool_span["attributes"]["gen_ai.tool.input"] == '{"message": "hello"}'
     assert tool_span["attributes"]["gen_ai.tool.name"] == "simple_test_tool"
@@ -2164,7 +2157,7 @@ async def test_tool_execution_span(
         ai_client_span2["attributes"]["gen_ai.response.text"]
         == "Task completed using the tool"
     )
-    assert ai_client_span2["attributes"][SPANDATA.GEN_AI_PROVIDER_NAME] == "openai"
+    assert ai_client_span2["attributes"]["gen_ai.system"] == "openai"
     assert ai_client_span2["attributes"]["gen_ai.usage.input_tokens.cached"] == 0
     assert ai_client_span2["attributes"]["gen_ai.usage.input_tokens"] == 15
     assert ai_client_span2["attributes"]["gen_ai.usage.output_tokens.reasoning"] == 0
@@ -2296,7 +2289,7 @@ async def test_run_streamed_tool_execution_span(
     assert agent_span["attributes"]["gen_ai.request.model"] == "gpt-4"
     assert agent_span["attributes"]["gen_ai.request.temperature"] == 0.7
     assert agent_span["attributes"]["gen_ai.request.top_p"] == 1.0
-    assert agent_span["attributes"][SPANDATA.GEN_AI_PROVIDER_NAME] == "openai"
+    assert agent_span["attributes"]["gen_ai.system"] == "openai"
 
     assert tool_span["name"] == "execute_tool simple_test_tool"
     assert tool_span["attributes"]["gen_ai.agent.name"] == "test_agent"
@@ -2306,7 +2299,7 @@ async def test_run_streamed_tool_execution_span(
     assert tool_span["attributes"]["gen_ai.request.model"] == "gpt-4"
     assert tool_span["attributes"]["gen_ai.request.temperature"] == 0.7
     assert tool_span["attributes"]["gen_ai.request.top_p"] == 1.0
-    assert tool_span["attributes"][SPANDATA.GEN_AI_PROVIDER_NAME] == "openai"
+    assert tool_span["attributes"]["gen_ai.system"] == "openai"
     assert tool_span["attributes"]["gen_ai.tool.description"] == "A simple tool"
     assert tool_span["attributes"]["gen_ai.tool.input"] == '{"message": "hello"}'
     assert tool_span["attributes"]["gen_ai.tool.name"] == "simple_test_tool"

--- a/tests/integrations/openai_agents/test_openai_agents.py
+++ b/tests/integrations/openai_agents/test_openai_agents.py
@@ -475,12 +475,15 @@ async def test_agent_invocation_span_no_pii(
 
     assert invoke_agent_span["name"] == "invoke_agent test_agent"
 
-    assert SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS not in invoke_agent_span["attributes"]
+    assert (
+        SPANDATA.GEN_AI_PROVIDER_NAME_INSTRUCTIONS
+        not in invoke_agent_span["attributes"]
+    )
     assert "gen_ai.request.messages" not in invoke_agent_span["attributes"]
     assert "gen_ai.response.text" not in invoke_agent_span["attributes"]
 
     assert invoke_agent_span["attributes"]["gen_ai.operation.name"] == "invoke_agent"
-    assert invoke_agent_span["attributes"]["gen_ai.system"] == "openai"
+    assert invoke_agent_span["attributes"][SPANDATA.GEN_AI_PROVIDER_NAME] == "openai"
     assert invoke_agent_span["attributes"]["gen_ai.agent.name"] == "test_agent"
     assert invoke_agent_span["attributes"]["gen_ai.request.max_tokens"] == 100
     assert invoke_agent_span["attributes"]["gen_ai.request.model"] == "gpt-4"
@@ -489,7 +492,7 @@ async def test_agent_invocation_span_no_pii(
 
     assert ai_client_span["name"] == "chat gpt-4"
     assert ai_client_span["attributes"]["gen_ai.operation.name"] == "chat"
-    assert ai_client_span["attributes"]["gen_ai.system"] == "openai"
+    assert ai_client_span["attributes"][SPANDATA.GEN_AI_PROVIDER_NAME] == "openai"
     assert ai_client_span["attributes"]["gen_ai.agent.name"] == "test_agent"
     assert ai_client_span["attributes"]["gen_ai.request.max_tokens"] == 100
     assert ai_client_span["attributes"]["gen_ai.request.model"] == "gpt-4"
@@ -807,11 +810,12 @@ async def test_data_collection_inputs(
     if expect_input:
         assert "Test input" in span_data[SPANDATA.GEN_AI_REQUEST_MESSAGES]
         assert (
-            "helpful test assistant" in span_data[SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS]
+            "helpful test assistant"
+            in span_data[SPANDATA.GEN_AI_PROVIDER_NAME_INSTRUCTIONS]
         )
     else:
         assert SPANDATA.GEN_AI_REQUEST_MESSAGES not in span_data
-        assert SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS not in span_data
+        assert SPANDATA.GEN_AI_PROVIDER_NAME_INSTRUCTIONS not in span_data
 
     # Tool definitions are only gated once data_collection is configured; without it
     # they are set unconditionally, as they were before data_collection existed.
@@ -1228,7 +1232,7 @@ async def test_agent_invocation_span(
     )
 
     assert invoke_agent_span["attributes"]["gen_ai.operation.name"] == "invoke_agent"
-    assert invoke_agent_span["attributes"]["gen_ai.system"] == "openai"
+    assert invoke_agent_span["attributes"][SPANDATA.GEN_AI_PROVIDER_NAME] == "openai"
     assert invoke_agent_span["attributes"]["gen_ai.agent.name"] == "test_agent"
     assert invoke_agent_span["attributes"]["gen_ai.request.max_tokens"] == 100
     assert invoke_agent_span["attributes"]["gen_ai.request.model"] == "gpt-4"
@@ -1237,7 +1241,7 @@ async def test_agent_invocation_span(
 
     assert ai_client_span["name"] == "chat gpt-4"
     assert ai_client_span["attributes"]["gen_ai.operation.name"] == "chat"
-    assert ai_client_span["attributes"]["gen_ai.system"] == "openai"
+    assert ai_client_span["attributes"][SPANDATA.GEN_AI_PROVIDER_NAME] == "openai"
     assert ai_client_span["attributes"]["gen_ai.agent.name"] == "test_agent"
     assert ai_client_span["attributes"]["gen_ai.request.max_tokens"] == 100
     assert ai_client_span["attributes"]["gen_ai.request.model"] == "gpt-4"
@@ -1350,7 +1354,7 @@ def test_agent_invocation_span_sync_no_pii(
 
     assert invoke_agent_span["name"] == "invoke_agent test_agent"
     assert invoke_agent_span["attributes"]["gen_ai.operation.name"] == "invoke_agent"
-    assert invoke_agent_span["attributes"]["gen_ai.system"] == "openai"
+    assert invoke_agent_span["attributes"][SPANDATA.GEN_AI_PROVIDER_NAME] == "openai"
     assert invoke_agent_span["attributes"]["gen_ai.agent.name"] == "test_agent"
     assert invoke_agent_span["attributes"]["gen_ai.request.max_tokens"] == 100
     assert invoke_agent_span["attributes"]["gen_ai.request.model"] == "gpt-4"
@@ -1359,14 +1363,17 @@ def test_agent_invocation_span_sync_no_pii(
 
     assert ai_client_span["name"] == "chat gpt-4"
     assert ai_client_span["attributes"]["gen_ai.operation.name"] == "chat"
-    assert ai_client_span["attributes"]["gen_ai.system"] == "openai"
+    assert ai_client_span["attributes"][SPANDATA.GEN_AI_PROVIDER_NAME] == "openai"
     assert ai_client_span["attributes"]["gen_ai.agent.name"] == "test_agent"
     assert ai_client_span["attributes"]["gen_ai.request.max_tokens"] == 100
     assert ai_client_span["attributes"]["gen_ai.request.model"] == "gpt-4"
     assert ai_client_span["attributes"]["gen_ai.request.temperature"] == 0.7
     assert ai_client_span["attributes"]["gen_ai.request.top_p"] == 1.0
 
-    assert SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS not in invoke_agent_span["attributes"]
+    assert (
+        SPANDATA.GEN_AI_PROVIDER_NAME_INSTRUCTIONS
+        not in invoke_agent_span["attributes"]
+    )
 
 
 @pytest.mark.parametrize(
@@ -1614,7 +1621,7 @@ def test_agent_invocation_span_sync(
 
     assert invoke_agent_span["name"] == "invoke_agent test_agent"
     assert invoke_agent_span["attributes"]["gen_ai.operation.name"] == "invoke_agent"
-    assert invoke_agent_span["attributes"]["gen_ai.system"] == "openai"
+    assert invoke_agent_span["attributes"][SPANDATA.GEN_AI_PROVIDER_NAME] == "openai"
     assert invoke_agent_span["attributes"]["gen_ai.agent.name"] == "test_agent"
     assert invoke_agent_span["attributes"]["gen_ai.request.max_tokens"] == 100
     assert invoke_agent_span["attributes"]["gen_ai.request.model"] == "gpt-4"
@@ -1623,7 +1630,7 @@ def test_agent_invocation_span_sync(
 
     assert ai_client_span["name"] == "chat gpt-4"
     assert ai_client_span["attributes"]["gen_ai.operation.name"] == "chat"
-    assert ai_client_span["attributes"]["gen_ai.system"] == "openai"
+    assert ai_client_span["attributes"][SPANDATA.GEN_AI_PROVIDER_NAME] == "openai"
     assert ai_client_span["attributes"]["gen_ai.agent.name"] == "test_agent"
     assert ai_client_span["attributes"]["gen_ai.request.max_tokens"] == 100
     assert ai_client_span["attributes"]["gen_ai.request.model"] == "gpt-4"
@@ -2039,11 +2046,11 @@ async def test_tool_execution_span(
     assert agent_span["attributes"]["gen_ai.request.model"] == "gpt-4"
     assert agent_span["attributes"]["gen_ai.request.temperature"] == 0.7
     assert agent_span["attributes"]["gen_ai.request.top_p"] == 1.0
-    assert agent_span["attributes"]["gen_ai.system"] == "openai"
+    assert agent_span["attributes"][SPANDATA.GEN_AI_PROVIDER_NAME] == "openai"
 
     assert ai_client_span1["name"] == "chat gpt-4"
     assert ai_client_span1["attributes"]["gen_ai.operation.name"] == "chat"
-    assert ai_client_span1["attributes"]["gen_ai.system"] == "openai"
+    assert ai_client_span1["attributes"][SPANDATA.GEN_AI_PROVIDER_NAME] == "openai"
     assert ai_client_span1["attributes"]["gen_ai.agent.name"] == "test_agent"
 
     ai_client_span1_available_tool = json.loads(
@@ -2100,7 +2107,7 @@ async def test_tool_execution_span(
     assert tool_span["attributes"]["gen_ai.request.model"] == "gpt-4"
     assert tool_span["attributes"]["gen_ai.request.temperature"] == 0.7
     assert tool_span["attributes"]["gen_ai.request.top_p"] == 1.0
-    assert tool_span["attributes"]["gen_ai.system"] == "openai"
+    assert tool_span["attributes"][SPANDATA.GEN_AI_PROVIDER_NAME] == "openai"
     assert tool_span["attributes"]["gen_ai.tool.description"] == "A simple tool"
     assert tool_span["attributes"]["gen_ai.tool.input"] == '{"message": "hello"}'
     assert tool_span["attributes"]["gen_ai.tool.name"] == "simple_test_tool"
@@ -2157,7 +2164,7 @@ async def test_tool_execution_span(
         ai_client_span2["attributes"]["gen_ai.response.text"]
         == "Task completed using the tool"
     )
-    assert ai_client_span2["attributes"]["gen_ai.system"] == "openai"
+    assert ai_client_span2["attributes"][SPANDATA.GEN_AI_PROVIDER_NAME] == "openai"
     assert ai_client_span2["attributes"]["gen_ai.usage.input_tokens.cached"] == 0
     assert ai_client_span2["attributes"]["gen_ai.usage.input_tokens"] == 15
     assert ai_client_span2["attributes"]["gen_ai.usage.output_tokens.reasoning"] == 0
@@ -2289,7 +2296,7 @@ async def test_run_streamed_tool_execution_span(
     assert agent_span["attributes"]["gen_ai.request.model"] == "gpt-4"
     assert agent_span["attributes"]["gen_ai.request.temperature"] == 0.7
     assert agent_span["attributes"]["gen_ai.request.top_p"] == 1.0
-    assert agent_span["attributes"]["gen_ai.system"] == "openai"
+    assert agent_span["attributes"][SPANDATA.GEN_AI_PROVIDER_NAME] == "openai"
 
     assert tool_span["name"] == "execute_tool simple_test_tool"
     assert tool_span["attributes"]["gen_ai.agent.name"] == "test_agent"
@@ -2299,7 +2306,7 @@ async def test_run_streamed_tool_execution_span(
     assert tool_span["attributes"]["gen_ai.request.model"] == "gpt-4"
     assert tool_span["attributes"]["gen_ai.request.temperature"] == 0.7
     assert tool_span["attributes"]["gen_ai.request.top_p"] == 1.0
-    assert tool_span["attributes"]["gen_ai.system"] == "openai"
+    assert tool_span["attributes"][SPANDATA.GEN_AI_PROVIDER_NAME] == "openai"
     assert tool_span["attributes"]["gen_ai.tool.description"] == "A simple tool"
     assert tool_span["attributes"]["gen_ai.tool.input"] == '{"message": "hello"}'
     assert tool_span["attributes"]["gen_ai.tool.name"] == "simple_test_tool"

--- a/tests/integrations/pydantic_ai/test_pydantic_ai.py
+++ b/tests/integrations/pydantic_ai/test_pydantic_ai.py
@@ -692,7 +692,7 @@ async def test_system_prompt_attribute(
 
     if send_default_pii and include_prompts:
         system_instructions = chat_span["attributes"][
-            SPANDATA.GEN_AI_PROVIDER_NAME_INSTRUCTIONS
+            SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS
         ]
         assert json.loads(system_instructions) == [
             {
@@ -701,7 +701,7 @@ async def test_system_prompt_attribute(
             }
         ]
     else:
-        assert SPANDATA.GEN_AI_PROVIDER_NAME_INSTRUCTIONS not in chat_span["attributes"]
+        assert SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS not in chat_span["attributes"]
 
 
 @pytest.mark.asyncio
@@ -932,8 +932,8 @@ async def test_gen_ai_system(
 
     chat_span = chat_spans[0]
     # gen_ai.system should be set from the model (TestModel -> 'test')
-    assert SPANDATA.GEN_AI_PROVIDER_NAME in chat_span["attributes"]
-    assert chat_span["attributes"][SPANDATA.GEN_AI_PROVIDER_NAME] == "test"
+    assert "gen_ai.system" in chat_span["attributes"]
+    assert chat_span["attributes"]["gen_ai.system"] == "test"
 
 
 @pytest.mark.asyncio
@@ -1328,7 +1328,7 @@ async def test_invoke_agent_with_instructions(
 
     if send_default_pii and include_prompts:
         system_instructions = chat_span["attributes"][
-            SPANDATA.GEN_AI_PROVIDER_NAME_INSTRUCTIONS
+            SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS
         ]
         assert json.loads(system_instructions) == [
             {"type": "text", "content": "System prompt"},
@@ -1338,7 +1338,7 @@ async def test_invoke_agent_with_instructions(
             },
         ]
     else:
-        assert SPANDATA.GEN_AI_PROVIDER_NAME_INSTRUCTIONS not in chat_span["attributes"]
+        assert SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS not in chat_span["attributes"]
 
 
 @pytest.mark.asyncio
@@ -3008,11 +3008,11 @@ async def test_data_collection_gen_ai_inputs_gates_request_messages_tool_inputs_
             assert SPANDATA.GEN_AI_REQUEST_MESSAGES in chat_span
             assert (
                 "helpful test assistant"
-                in chat_span[SPANDATA.GEN_AI_PROVIDER_NAME_INSTRUCTIONS]
+                in chat_span[SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS]
             )
         else:
             assert SPANDATA.GEN_AI_REQUEST_MESSAGES not in chat_span
-            assert SPANDATA.GEN_AI_PROVIDER_NAME_INSTRUCTIONS not in chat_span
+            assert SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS not in chat_span
 
         # Non-PII data is unaffected by the gate
         assert SPANDATA.GEN_AI_REQUEST_MODEL in chat_span

--- a/tests/integrations/pydantic_ai/test_pydantic_ai.py
+++ b/tests/integrations/pydantic_ai/test_pydantic_ai.py
@@ -692,7 +692,7 @@ async def test_system_prompt_attribute(
 
     if send_default_pii and include_prompts:
         system_instructions = chat_span["attributes"][
-            SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS
+            SPANDATA.GEN_AI_PROVIDER_NAME_INSTRUCTIONS
         ]
         assert json.loads(system_instructions) == [
             {
@@ -701,7 +701,7 @@ async def test_system_prompt_attribute(
             }
         ]
     else:
-        assert SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS not in chat_span["attributes"]
+        assert SPANDATA.GEN_AI_PROVIDER_NAME_INSTRUCTIONS not in chat_span["attributes"]
 
 
 @pytest.mark.asyncio
@@ -932,8 +932,8 @@ async def test_gen_ai_system(
 
     chat_span = chat_spans[0]
     # gen_ai.system should be set from the model (TestModel -> 'test')
-    assert "gen_ai.system" in chat_span["attributes"]
-    assert chat_span["attributes"]["gen_ai.system"] == "test"
+    assert SPANDATA.GEN_AI_PROVIDER_NAME in chat_span["attributes"]
+    assert chat_span["attributes"][SPANDATA.GEN_AI_PROVIDER_NAME] == "test"
 
 
 @pytest.mark.asyncio
@@ -1328,7 +1328,7 @@ async def test_invoke_agent_with_instructions(
 
     if send_default_pii and include_prompts:
         system_instructions = chat_span["attributes"][
-            SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS
+            SPANDATA.GEN_AI_PROVIDER_NAME_INSTRUCTIONS
         ]
         assert json.loads(system_instructions) == [
             {"type": "text", "content": "System prompt"},
@@ -1338,7 +1338,7 @@ async def test_invoke_agent_with_instructions(
             },
         ]
     else:
-        assert SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS not in chat_span["attributes"]
+        assert SPANDATA.GEN_AI_PROVIDER_NAME_INSTRUCTIONS not in chat_span["attributes"]
 
 
 @pytest.mark.asyncio
@@ -3008,11 +3008,11 @@ async def test_data_collection_gen_ai_inputs_gates_request_messages_tool_inputs_
             assert SPANDATA.GEN_AI_REQUEST_MESSAGES in chat_span
             assert (
                 "helpful test assistant"
-                in chat_span[SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS]
+                in chat_span[SPANDATA.GEN_AI_PROVIDER_NAME_INSTRUCTIONS]
             )
         else:
             assert SPANDATA.GEN_AI_REQUEST_MESSAGES not in chat_span
-            assert SPANDATA.GEN_AI_SYSTEM_INSTRUCTIONS not in chat_span
+            assert SPANDATA.GEN_AI_PROVIDER_NAME_INSTRUCTIONS not in chat_span
 
         # Non-PII data is unaffected by the gate
         assert SPANDATA.GEN_AI_REQUEST_MODEL in chat_span

--- a/tests/integrations/pydantic_ai/test_pydantic_ai.py
+++ b/tests/integrations/pydantic_ai/test_pydantic_ai.py
@@ -932,8 +932,8 @@ async def test_gen_ai_system(
 
     chat_span = chat_spans[0]
     # gen_ai.system should be set from the model (TestModel -> 'test')
-    assert "gen_ai.system" in chat_span["attributes"]
-    assert chat_span["attributes"]["gen_ai.system"] == "test"
+    assert SPANDATA.GEN_AI_PROVIDER_NAME in chat_span["attributes"]
+    assert chat_span["attributes"][SPANDATA.GEN_AI_PROVIDER_NAME] == "test"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
### Description
<!-- What changed and why? -->

See the deprecation in `sentry-conventions`:

https://github.com/getsentry/sentry-conventions/blob/4311c7eda54367489251df327008fffedee5001d/model/attributes/gen_ai/gen_ai__system.json

#### Issues
<!--
* resolves: #1234
* resolves: LIN-1234
-->

#### Reminders
- Please add tests to validate your changes, and lint your code using `uv run ruff`.
- Add GH Issue ID _&_ Linear ID (if applicable)
- PR title should use [conventional commit](https://develop.sentry.dev/engineering-practices/commit-messages/#type) style (`feat:`, `fix:`, `ref:`, `meta:`)
- For external contributors: [CONTRIBUTING.md](https://github.com/getsentry/sentry-python/blob/master/CONTRIBUTING.md), [Sentry SDK development docs](https://develop.sentry.dev/sdk/), [Discord community](https://discord.gg/Ww9hbqr)
