### PR TITLE
test(profiler): Remove wall-clock race in continuous profiler auto-start tests

### DIFF
--- a/tests/profiler/test_continuous_profiler.py
+++ b/tests/profiler/test_continuous_profiler.py
@@ -1,12 +1,14 @@
 import threading
 import time
 from collections import defaultdict
+from contextlib import contextmanager
 from unittest import mock
 
 import pytest
 
 import sentry_sdk
 from sentry_sdk.consts import VERSION
+from sentry_sdk.profiler import continuous_profiler as continuous_profiler_module
 from sentry_sdk.profiler.continuous_profiler import (
     get_profiler_id,
     is_profile_session_sampled,
@@ -27,7 +29,7 @@ except ImportError:
 requires_gevent = pytest.mark.skipif(gevent is None, reason="gevent not enabled")
 
 
-def wait_for_profiler_to_stop(envelopes, timeout=1.0):
+def wait_for_profiler_to_stop(envelopes, timeout=5.0):
     deadline = time.monotonic() + timeout
     while time.monotonic() < deadline:
         profiler_stopped = get_profiler_id() is None
@@ -46,6 +48,36 @@ def wait_for_profiler_to_stop(envelopes, timeout=1.0):
         for envelope in envelopes
         for item in envelope.items
     ), "profiler should have flushed a profile chunk"
+
+
+@contextmanager
+def suspend_profiler_sampling():
+    """
+    Pause the continuous profiler's sampler thread until sampling is resumed.
+
+    While suspended, the scheduler cannot observe stopped profiles, so it
+    neither removes them nor enters soft shutdown: the profiler stays up no
+    matter how long the test is preempted for. This removes the need to race
+    the profiler's shutdown grace period with a fixed sleep.
+
+    Yields a callable that resumes sampling. Sampling is also resumed, and
+    the original sampler restored, when the block exits.
+    """
+    scheduler = continuous_profiler_module._scheduler
+    assert scheduler is not None, "profiler should have been set up"
+    resumed = threading.Event()
+    real_sampler = scheduler.sampler
+
+    def suspended_sampler(*args, **kwargs):
+        resumed.wait()
+        return real_sampler(*args, **kwargs)
+
+    scheduler.sampler = suspended_sampler
+    try:
+        yield resumed.set
+    finally:
+        resumed.set()
+        scheduler.sampler = real_sampler
 
 
 def get_client_options(use_top_level_profiler_mode):
@@ -810,23 +842,25 @@ def test_continuous_profiler_auto_start_and_stop_sampled(
             assert profiler_id is not None, "profiler should be running"
             profiler_ids.add(profiler_id)
 
-        time.sleep(0.03)
-
-        # the profiler takes a while to stop in auto mode so if we start
-        # a transaction immediately, it'll be part of the same chunk
-        profiler_id = get_profiler_id()
-        assert profiler_id is not None, "profiler should be running"
-        profiler_ids.add(profiler_id)
-
-        with sentry_sdk.start_transaction(name="profiling 2"):
+        # While the sampler is suspended it cannot observe that the
+        # transaction's profile was stopped, so the scheduler cannot
+        # soft-shutdown: the profiler stays up and the next transaction
+        # deterministically reuses the same profiler session and chunk.
+        with suspend_profiler_sampling() as resume_sampling:
             profiler_id = get_profiler_id()
             assert profiler_id is not None, "profiler should be running"
             profiler_ids.add(profiler_id)
-            with sentry_sdk.start_span(op="op"):
-                time.sleep(0.1)
-            profiler_id = get_profiler_id()
-            assert profiler_id is not None, "profiler should be running"
-            profiler_ids.add(profiler_id)
+
+            with sentry_sdk.start_transaction(name="profiling 2"):
+                resume_sampling()
+                profiler_id = get_profiler_id()
+                assert profiler_id is not None, "profiler should be running"
+                profiler_ids.add(profiler_id)
+                with sentry_sdk.start_span(op="op"):
+                    time.sleep(0.1)
+                profiler_id = get_profiler_id()
+                assert profiler_id is not None, "profiler should be running"
+                profiler_ids.add(profiler_id)
 
         wait_for_profiler_to_stop(envelopes)
 
@@ -892,23 +926,25 @@ def test_continuous_profiler_auto_start_and_stop_sampled_span_streaming(
             assert profiler_id is not None, "profiler should be running"
             profiler_ids.add(profiler_id)
 
-        time.sleep(0.03)
-
-        # the profiler takes a while to stop in auto mode so if we start
-        # a transaction immediately, it'll be part of the same chunk
-        profiler_id = get_profiler_id()
-        assert profiler_id is not None, "profiler should be running"
-        profiler_ids.add(profiler_id)
-
-        with sentry_sdk.traces.start_span(name="profiling 2"):
+        # While the sampler is suspended it cannot observe that the
+        # segment's profile was stopped, so the scheduler cannot
+        # soft-shutdown: the profiler stays up and the next segment
+        # deterministically reuses the same profiler session and chunk.
+        with suspend_profiler_sampling() as resume_sampling:
             profiler_id = get_profiler_id()
             assert profiler_id is not None, "profiler should be running"
             profiler_ids.add(profiler_id)
-            with sentry_sdk.traces.start_span(name="op"):
-                time.sleep(0.1)
-            profiler_id = get_profiler_id()
-            assert profiler_id is not None, "profiler should be running"
-            profiler_ids.add(profiler_id)
+
+            with sentry_sdk.traces.start_span(name="profiling 2"):
+                resume_sampling()
+                profiler_id = get_profiler_id()
+                assert profiler_id is not None, "profiler should be running"
+                profiler_ids.add(profiler_id)
+                with sentry_sdk.traces.start_span(name="op"):
+                    time.sleep(0.1)
+                profiler_id = get_profiler_id()
+                assert profiler_id is not None, "profiler should be running"
+                profiler_ids.add(profiler_id)
 
         wait_for_profiler_to_stop(envelopes)
 


### PR DESCRIPTION
### Description

Refs #6957.

**Source of the flake**

In `test_continuous_profiler_auto_start_and_stop_sampled{,_span_streaming}`, the block between the first and second transaction/segment relied on `time.sleep(0.03)` followed by `assert get_profiler_id() is not None` and, later, `len(profiler_ids) == 1` / `max_chunks=1`. Those assertions only hold if the test thread wakes before the sampler's soft shutdown commits.

Soft shutdown needs at least two sampler cycles after the last profile stops — the first observes and removes the inactive profile, the next sees empty queues and returns `True`, and `running` is set to `False` at the end of that cycle's interval. At the mocked 21 Hz frequency that is >= ~47.6 ms after `profile.stop()`, so the 30 ms sleep had only ~17 ms of margin: if the test thread oversleeps or is preempted past the window (routine on a loaded CI runner), the profiler legitimately stops, and either `profiler should be running` fails or transaction 2 spins up a *new* profiler session, breaking the single-profiler-id/single-chunk assertions. This is the same class of race as the originally reported `assert get_profiler_id() is None` failure (fixed in #7364), just in the other direction. Reproduced deterministically by lengthening the gap sleep past the shutdown window.

**Fix**

Added `suspend_profiler_sampling()`, a small helper that wraps `scheduler.sampler` with a gate (`threading.Event`). While suspended, the sampler thread parks inside `self.sampler()` and cannot observe stopped profiles or complete soft shutdown, so `get_profiler_id()` keeps reporting the running profiler regardless of test-thread scheduling. Transaction/segment 2's profile is already queued by `auto_start()` before the gate is released inside its body, so the same buffer/profiler session is reused deterministically — no wall-clock assumptions remain in the critical section. The original sampler is restored in a `finally`, so the parked thread always resumes and self-terminates normally even on failure.

This does not mask genuine profiler failures: an early/unexpected shutdown still fails `profiler should be running`, and a profiler that never stops still fails `wait_for_profiler_to_stop()`'s bounded poll. That poll's ceiling was raised to 5 s — it waits for an event that must occur once the queues are empty, so the bound only guards against scheduler starvation, not timing.

**Test coverage / verification**

- `TESTPATH=tests/profiler/test_continuous_profiler.py uv run tox -e py3.12-gevent` — 92 passed (covers `thread` and `gevent` params)
- `pytest tests/profiler/` — 105 passed
- Formerly flaky tests repeated 45x, including 15x under full CPU saturation (`nproc` busy loops) — all green
- Before the fix, the same test deterministically fails when the inter-transaction gap exceeds the shutdown window; with the gate, injected 0.5 s+0.3 s delays inside the suspended window still pass
- `uv run ruff check` / `ruff format` — clean; `uv run --group typing mypy sentry_sdk` — no issues

#### Reminders

- Please add tests to validate your changes, and lint your code using `uv run ruff`.
- Add GH Issue ID _&_ Linear ID (if applicable)
- PR title should use [conventional commit](https://develop.sentry.dev/engineering-practices/commit-messages/#type) style (`feat:`, `fix:`, `ref:`, `meta:`)